### PR TITLE
[inductor] Account for template subgraph buffers in indexing

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8312,6 +8312,40 @@ class TestLearnableBiases(InductorTestCase):
         )
 
     @skip_on_cpu
+    @largeTensorTest("6GB", device=test_device[0])
+    def test_large_batch_head_bias_uses_int64_indexing(self, device):
+        batch_size = 513
+        num_heads = 1
+        seq_len = 2048
+        head_dim = 16
+        dtype = torch.float16
+
+        query = torch.randn(
+            batch_size, num_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        bias = torch.randn(
+            batch_size, num_heads, seq_len, seq_len, device=device, dtype=dtype
+        )
+
+        def fn(query, key, value, bias):
+            def bias_func(score, b, h, q_idx, kv_idx):
+                return score + bias[b, h, q_idx, kv_idx]
+
+            return flex_attention(
+                query,
+                key,
+                value,
+                score_mod=bias_func,
+                kernel_options={"BACKEND": "TRITON"},
+            )
+
+        out, code = run_and_get_code(torch.compile(fn), query, key, value, bias)
+        self.assertEqual(out.shape, query.shape)
+        FileCheck().check("INDEX_DTYPE : tl.constexpr = tl.int64").run("\n".join(code))
+
+    @skip_on_cpu
     @common_utils.parametrize(
         "params", get_params(device_configs["cuda"].dtypes), name_fn=lambda x: f"{x}"
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2629,9 +2629,25 @@ class TritonTemplate(KernelTemplate):
         kernel_name = f"triton_{self.name}"
 
         numel = sympy_product(layout.size)
-        buffers = itertools.chain(input_nodes, (fake_out,))
+        buffers_for_indexing = list(input_nodes) + [fake_out]
 
-        if TritonScheduling.can_use_32bit_indexing(numel, buffers):
+        def add_subgraph_buffers_for_indexing(subgraph) -> None:
+            if subgraph is None:
+                return
+            if isinstance(subgraph, (list, tuple)):
+                for child in subgraph:
+                    add_subgraph_buffers_for_indexing(child)
+                return
+            for name in subgraph.get_read_writes().buffer_names(
+                ignore_integer_index=False
+            ):
+                buffer = V.graph.try_get_buffer(name)
+                if buffer is not None:
+                    buffers_for_indexing.append(buffer)
+
+        add_subgraph_buffers_for_indexing(subgraphs)
+
+        if TritonScheduling.can_use_32bit_indexing(numel, buffers_for_indexing):
             index_dtype = "tl.int32"
         else:
             index_dtype = "tl.int64"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185924

TritonTemplate decides whether to generate tl.int32 or tl.int64 index math before rendering the template. That decision only considered explicit template inputs and the output buffer. FlexAttention score_mod tensors can be captured through inlined subgraphs instead, so a large captured bias was invisible to the indexing check. The generated kernel then used tl.int32 and overflowed address arithmetic for a 16 x 32 x 4096 x 4096 bias, causing a CUDA illegal memory access during the compiled backward repro.

Include the read/write buffer dependencies from template subgraphs in TritonScheduling.can_use_32bit_indexing. This preserves the existing 32-bit path when all explicit and captured buffers are safe, but promotes the template to tl.int64 when an inlined score_mod or mask_mod touches a large buffer.

The old bias_2 and bias_3 assertion failures from the issue no longer reproduce on current main. This change fixes the remaining reproduced large captured-bias overflow. The related open PR #185264 fixes a different step: using INDEX_DTYPE consistently inside FlexAttention templates after int64 has already been selected.

Fixes #145869

Generated by my agent

Benchmark Results:

Small captured-bias FlexAttention benchmark on CUDA, B=2 H=2 S=256 D=32 fp16, TORCHINDUCTOR_FORCE_DISABLE_CACHES=1, five compile/run repeats. Before/main compile median 1274.98 ms, runtime median 0.06025 ms. After/fix compile median 1274.00 ms, runtime median 0.06227 ms. Raw results are recorded in state/145869/notes.

Test Plan:

- CUDA_LAUNCH_BLOCKING=1 original bias_1 repro with N_BATCH=16, N_HEAD=32, N_CTX=4096, D_QK=128: failed before the fix with illegal memory access, passed after the fix.

- python test/inductor/test_flex_attention.py -k large_batch_head_bias_uses_int64_indexing -v

- python test/inductor/test_flex_attention.py -k batch_head_bias -v

- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo