### PR TITLE
[DTensor] Disable proxy tracing during ShardingPropagator metadata inference

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -2475,6 +2475,43 @@ class outer_fn(torch.nn.Module):
             "Placeholder dim should be symbolic",
         )
 
+    def test_make_fx_tp_embedding_no_shadow_nodes(self):
+        """make_fx through a TP-sharded embedding must not produce dead shadow nodes.
+
+        DTensor's ShardingPropagator runs each op on fake global-shape tensors
+        to derive output metadata. Without disable_proxy_modes_tracing, make_fx
+        traces those internal metadata ops, leaving dead "shadow" nodes backed
+        by empty_strided placeholders. For aten.embedding, the shadow node reads
+        uninitialized indices and crashes with out-of-bounds access at runtime.
+        """
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        vocab_size, embed_dim = 32, 16
+        weight = distribute_tensor(torch.randn(vocab_size, embed_dim), mesh, [Shard(0)])
+
+        def fn(weight, indices):
+            dt_indices = DTensor.from_local(
+                indices, mesh, [Replicate()], run_check=False
+            )
+            return torch.nn.functional.embedding(dt_indices, weight).to_local()
+
+        indices = torch.randint(0, vocab_size, (4,))
+
+        traced = make_fx(fn, tracing_mode="fake")(weight, indices)
+
+        empty_strided_nodes = [
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function"
+            and n.target == torch.ops.aten.empty_strided.default
+        ]
+        self.assertEqual(
+            len(empty_strided_nodes),
+            0,
+            "Shadow empty_strided nodes from ShardingPropagator leaked into "
+            "the make_fx graph; disable_proxy_modes_tracing is not active",
+        )
+
 
 @instantiate_parametrized_tests
 class TestDTensorCompileE2E(DTensorTestBase):

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -37,6 +37,7 @@ from torch.distributed.tensor._utils import (
     try_find_mesh_from_args,
 )
 from torch.distributed.tensor.placement_types import _StridedShard, Shard
+from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing
 from torch.utils._pytree import tree_map
 
 
@@ -535,7 +536,7 @@ class ShardingPropagator:
         # This is a nullcontext by default.
         with ShardingPropagator._fake_mode_lock:
             fake_mode = detect_fake_mode() or FakeTensorMode()
-            with fake_mode:
+            with fake_mode, disable_proxy_modes_tracing():
                 fake_args = op_schema.gen_fake_args()
                 fake_kwargs = op_schema.gen_fake_kwargs()
                 fake_out = op_schema.op(*fake_args, **fake_kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185928

ShardingPropagator._propagate_tensor_meta_non_cached runs each op on
fake global-shape tensors to derive output metadata (shape, stride,
dtype). When this runs inside a make_fx trace, the proxy dispatch mode
captures these internal metadata ops as real graph nodes, producing dead
"shadow" chains rooted at empty_strided placeholders.

These shadow nodes are usually harmless, but ops with bounds-checking
like aten.embedding read the uninitialized empty_strided index tensor
and trigger out-of-bounds access on TP-sharded weights, crashing with
"device-side assert triggered". Any make_fx-based training loop (e.g.
torchtitan's graph_trainer) with tensor_parallel_degree > 1 hits this.

The fix wraps the fake op execution in disable_proxy_modes_tracing(),
which temporarily removes the ProxyTorchDispatchMode so the metadata
inference ops never enter the FX graph. When no proxy mode is active
(non-tracing paths), disable_proxy_modes_tracing is a no-op.

This is the proper upstream fix for what torchtitan currently works
around with a post-hoc _remove_dead_empty_strided_chains DCE pass.

Test Plan:
```
python test/distributed/tensor/test_dtensor_compile.py \
    TestDTensorCompile.test_make_fx_tp_embedding_no_shadow_nodes
```

Verified without the fix: test fails with 2 empty_strided shadow nodes.
With the fix: test passes (0 empty_strided nodes).

Also verified end-to-end on 8xH100 with torchtitan graph_trainer
(debugmodel, flex_attn, aot_fx_trace) at TP=2/4/8, with the
torchtitan-side DCE pass disabled, confirming this upstream fix is
sufficient on its own.

Authored with Claude Code.