### PR TITLE
[NVSHMEM] Fix link_whole and -fPIC for nvshmem_device_link_target

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -797,8 +797,6 @@ libtorch_cuda_distributed_extra_sources = [
 ]
 
 libtorch_nvshmem_sources = [
-    "torch/csrc/distributed/c10d/cuda/utils.cpp",
-    "torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp",
     "torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu",
     "torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp",
 ]

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -263,6 +263,13 @@ at::Tensor empty_strided_p2p(
     c10::Device device,
     const std::optional<std::string>& group_name,
     std::optional<uint64_t> alloc_id) {
+  // Ensure device has an explicit index so downstream code (e.g. TeamManager)
+  // sees a consistent device identity.
+  if (!device.has_index()) {
+    device = c10::Device(
+        device.type(),
+        c10::impl::getDeviceGuardImpl(device.type())->getDevice().index());
+  }
   if (alloc_id.has_value()) {
     return empty_strided_p2p_persistent(
         size, stride, dtype, device, group_name, *alloc_id);


### PR DESCRIPTION
Summary:
Four build fixes for NVSHMEM integration with python_binary targets that use Buck link groups:

1. Add `-fPIC` to `compiler_flags` in the nvshmem obj library. Objects go through the `nvcc -dlink` pipeline and end up in the dlink archive, which may be placed in shared libraries (link groups) by `python_binary`. Without `-fPIC`, this causes `R_X86_64_32 relocation` errors.

2. Add `link_whole=True` on the `cpp_library_external` wrapping the device-linked archive and on the final library target. Without this, the linker drops `NVSHMEMSymmetricMemory.cpp` (which registers the NVSHMEM allocator via a C++ static initializer) because nothing directly references symbols from that translation unit.

3. Remove `utils.cpp` and `CUDASymmetricMemoryUtils.cpp` from `libtorch_nvshmem_sources`. These files are already compiled into `libtorch_cuda` and would cause duplicate symbol errors with `link_whole` forcing all objects to be included.

4. Add `rdma_core_deps` to `libnvshmem-headers` `exported_deps`. The nvshmem v3.3.9 headers transitively include `infiniband/mlx5dv.h` via `ibgda_device.cuh`. Without rdma-core in the headers target deps, consumers had to pass `-c nvshmem.use_static_linking=true` just to get the headers to compile.

Test Plan:
buck build fbcode//param_bench/train/comms/pt:comms -c hpc_comms.use_nvshmem=stable

Builds successfully without -c nvshmem.use_static_linking=true. Verified NVSHMEM allocator backend registers (no "SymmetricMemory does not find allocation backend NVSHMEM" error), no duplicate symbol or PIC relocation errors.

Differential Revision: D104474958


