### PR TITLE
[Test][CUDA] Filter by formatted name in `test_get_supported_dtypes_cuda`

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -451,7 +451,7 @@ if __name__ == '__main__':
         # Test the `get_supported_dtypes` helper function.
         # We acquire the dtypes for few Ops dynamically and verify them against
         # the correct statically described values.
-        ops_to_test = list(filter(lambda op: op.name in ['atan2', 'topk', 'xlogy'], op_db))
+        ops_to_test = list(filter(lambda op: op.formatted_name in ['atan2', 'topk', 'xlogy'], op_db))
 
         for op in ops_to_test:
             dynamic_dtypes = opinfo.utils.get_supported_dtypes(op, op.sample_inputs_func, self.device_type)


### PR DESCRIPTION
`TestTestingCUDA.test_get_supported_dtypes_cuda` failed in nightly GB200 CI:
```bash
======================================================================
FAIL: test_get_supported_dtypes_cuda (__main__.TestTestingCUDA.test_get_supported_dtypes_cuda)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3551, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3551, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 551, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 1932, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1637, in efail_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1704, in only_fn
    return fn(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/test_testing.py", line 464, in test_get_supported_dtypes
    self.assertTrue(set(dtypes) == set(dynamic_dtypes))
AssertionError: False is not true

To execute this test, run the following from the base repo dir:
    python test/test_testing.py TestTestingCUDA.test_get_supported_dtypes_cuda
```
Note: The nightly CI sets various environment variables, to reproduce this failure standalone you need to run
`TORCHINDUCTOR_CUTLASS_DIR=/opt/pytorch/pytorch/third_party/cutlass python test/test_testing.py TestTestingCUDA.test_get_supported_dtypes_cuda`

The CuTeDSL topk overrides introduced in #184926 are getting pulled into the op list for `test_get_supported_dtypes_cuda` because their `op.name == "topk"`. The test fails for these because the overrides are only valid for fp32 but the dynamic dtype check runs topk with different dtypes, which fall back to the ATen version and then get marked as valid because the function call succeeds. This PR uses `op.formatted_name` instead, which only matches with the ATen topk fallback, restoring previous behavior.

cc @eqy