### PR TITLE
Relax profiler tests for new data kinds

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4737,6 +4737,10 @@ class TestProfilerEventsParity(TestCase):
             "ptr",
             "src",
             "dst",
+            # TODO: remove channel and channel_type from this list
+            #       once the changes from Kineto land here
+            "channel",
+            "channel_type",
         }
         supported_trace_keys = set(_EVENT_METADATA_KEYS).union(
             allowed_non_structured_trace_keys


### PR DESCRIPTION
We're going to add `channel` and `channel_type` to profiler output. Relax these tests while we enable them in Kineto.