### PR TITLE
[CUDA] Warn instead of assert in `reportProcessMemoryInfo` to prevent crash on Tegra OOM

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1345,9 +1345,9 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
   }();
   if (!nvml_init) {
     TORCH_WARN_ONCE(
-      "nvmlInit_v2 failed; omitting per-process memory info from CUDA "
-      "out-of-memory messages. This is expected on platforms with partial "
-      "NVML support such as Tegra/Jetson.");
+        "nvmlInit_v2 failed; omitting per-process memory info from CUDA "
+        "out-of-memory messages. This is expected on platforms with partial "
+        "NVML support such as Tegra/Jetson.");
     return "";
   }
 
@@ -1362,12 +1362,12 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
       prop.pciDeviceID);
 
   nvmlDevice_t nvml_device = nullptr;
-  if(NVML_SUCCESS !=
+  if (NVML_SUCCESS !=
       DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
           pci_id, &nvml_device)) {
     TORCH_WARN_ONCE(
-      "nvmlDeviceGetHandleByPciBusId failed; omitting per-process memory "
-      "info from CUDA out-of-memory messages.");
+        "nvmlDeviceGetHandleByPciBusId failed; omitting per-process memory "
+        "info from CUDA out-of-memory messages.");
     return "";
   }
 
@@ -1381,9 +1381,9 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
   }
   if (NVML_SUCCESS != r) {
     TORCH_WARN_ONCE(
-      "nvmlDeviceGetComputeRunningProcesses failed; omitting per-process "
-      "memory info from CUDA out-of-memory messages. This is expected on "
-      "platforms with partial NVML support such as Tegra/Jetson.");
+        "nvmlDeviceGetComputeRunningProcesses failed; omitting per-process "
+        "memory info from CUDA out-of-memory messages. This is expected on "
+        "platforms with partial NVML support such as Tegra/Jetson.");
     return "";
   }
   unsigned int self_pid = get_self_pid();

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1346,8 +1346,7 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
   if (!nvml_init) {
     TORCH_WARN_ONCE(
         "nvmlInit_v2 failed; omitting per-process memory info from CUDA "
-        "out-of-memory messages. This is expected on platforms with partial "
-        "NVML support such as Tegra/Jetson.");
+        "out-of-memory messages.");
     return "";
   }
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1341,9 +1341,15 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
     return "";
   }
   static bool nvml_init [[maybe_unused]] = []() {
-    TORCH_INTERNAL_ASSERT(NVML_SUCCESS == DriverAPI::get()->nvmlInit_v2_());
-    return true;
+    return NVML_SUCCESS == DriverAPI::get()->nvmlInit_v2_();
   }();
+  if (!nvml_init) {
+    TORCH_WARN_ONCE(
+      "nvmlInit_v2 failed; omitting per-process memory info from CUDA "
+      "out-of-memory messages. This is expected on platforms with partial "
+      "NVML support such as Tegra/Jetson.");
+    return "";
+  }
 
   // NOLINTNEXTLINE(*-c-arrays)
   char pci_id[80];
@@ -1356,10 +1362,14 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
       prop.pciDeviceID);
 
   nvmlDevice_t nvml_device = nullptr;
-  TORCH_INTERNAL_ASSERT(
-      NVML_SUCCESS ==
+  if(NVML_SUCCESS !=
       DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
-          pci_id, &nvml_device));
+          pci_id, &nvml_device)) {
+    TORCH_WARN_ONCE(
+      "nvmlDeviceGetHandleByPciBusId failed; omitting per-process memory "
+      "info from CUDA out-of-memory messages.");
+    return "";
+  }
 
   std::vector<nvmlProcessInfo_v1_t> procs(8);
   unsigned int size = procs.size();
@@ -1369,9 +1379,15 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
          NVML_ERROR_INSUFFICIENT_SIZE) {
     procs.resize(size);
   }
+  if (NVML_SUCCESS != r) {
+    TORCH_WARN_ONCE(
+      "nvmlDeviceGetComputeRunningProcesses failed; omitting per-process "
+      "memory info from CUDA out-of-memory messages. This is expected on "
+      "platforms with partial NVML support such as Tegra/Jetson.");
+    return "";
+  }
   unsigned int self_pid = get_self_pid();
   std::stringstream ss;
-  TORCH_INTERNAL_ASSERT(NVML_SUCCESS == r);
   ss << "";
   for (auto i : c10::irange(size)) {
     auto& proc = procs[i];


### PR DESCRIPTION
This PR replaces assertions for successful NVML calls with softer checks and warnings to prevent hard crashes on Tegra, which does not have full NVML support.

Fixes #185240 