### PR TITLE
Fix Dynamo logit with tensor eps

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -210,6 +210,130 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         a_copy = torch.tensor(a)
         return a_copy.addcdiv_(b, c, value=5.0)
 
+    def test_logit_with_tensor_eps(self):
+        for dtype in (torch.float32, torch.float64):
+            cnt = torch._dynamo.testing.CompileCounter()
+            opt_fn = torch.compile(torch.logit, backend=cnt, fullgraph=True)
+
+            input = torch.tensor([0.1, 0.3, 0.95], dtype=dtype)
+            for eps_value in (0.9, 0.1):
+                eps = torch.tensor(eps_value, dtype=dtype)
+                self.assertEqual(opt_fn(input, eps), torch.logit(input, eps))
+
+            self.assertEqual(cnt.frame_count, 1)
+
+            eps = torch.tensor(0.1, dtype=dtype)
+            opt_special = torch.compile(
+                torch.special.logit,
+                backend="eager",
+                fullgraph=True,
+            )
+            self.assertEqual(opt_special(input, eps), torch.special.logit(input, eps))
+
+            opt_fn_out_none = torch.compile(
+                lambda x, e: torch.logit(x, e, out=None),
+                backend="eager",
+                fullgraph=True,
+            )
+            self.assertEqual(
+                opt_fn_out_none(input, eps), torch.logit(input, eps, out=None)
+            )
+
+            out = torch.empty_like(input)
+            expected_out = torch.empty_like(input)
+            opt_fn_out = torch.compile(
+                lambda x, e, o: torch.logit(x, e, out=o),
+                backend="eager",
+                fullgraph=True,
+            )
+            actual = opt_fn_out(input, eps, out)
+            expected = torch.logit(input, eps, out=expected_out)
+            self.assertEqual(actual, expected)
+            self.assertEqual(out, expected_out)
+
+            with torch.no_grad():
+                input_requires_grad = input.detach().clone().requires_grad_()
+                out_requires_grad = torch.empty_like(input, requires_grad=True)
+                opt_fn_out_no_grad = torch.compile(
+                    lambda x, e, o: torch.logit(x, e, out=o),
+                    backend="eager",
+                    fullgraph=True,
+                )
+                actual = opt_fn_out_no_grad(input_requires_grad, eps, out_requires_grad)
+                expected_out = torch.empty_like(input, requires_grad=True)
+                expected = torch.logit(input_requires_grad, eps, out=expected_out)
+                self.assertEqual(actual, expected)
+                self.assertEqual(out_requires_grad, expected_out)
+
+    def test_logit_with_tensor_eps_unsupported_cases(self):
+        input = torch.tensor([0.3 + 0.1j])
+        eps = torch.tensor(0.1)
+        with self.assertRaisesRegex(Unsupported, "logit_cpu.*ComplexFloat"):
+            torch.compile(torch.logit, backend="eager", fullgraph=True)(input, eps)
+
+        input = torch.tensor(0.3)
+        complex_eps = torch.tensor(0.1 + 0.2j)
+        with self.assertRaisesRegex(
+            Unsupported, "local_scalar_dense/item NYI for torch.complex64"
+        ):
+            torch.compile(torch.logit, backend="eager", fullgraph=True)(
+                input, complex_eps
+            )
+
+        with self.assertRaisesRegex(Unsupported, "unexpected keyword argument 'bogus'"):
+            torch.compile(
+                lambda x, e: torch.logit(x, e, bogus=1),
+                backend="eager",
+                fullgraph=True,
+            )(input, eps)
+        with self.assertRaisesRegex(Unsupported, "multiple values for argument 'eps'"):
+            torch.compile(
+                lambda x, e: torch.logit(x, e, eps=e),
+                backend="eager",
+                fullgraph=True,
+            )(input, eps)
+        with self.assertRaisesRegex(
+            Unsupported, "multiple values for argument 'input'"
+        ):
+            torch.compile(
+                lambda x, e: torch.logit(x, input=x, eps=e),
+                backend="eager",
+                fullgraph=True,
+            )(input, eps)
+        with self.assertRaisesRegex(
+            Unsupported, "takes from 1 to 2 positional arguments but 3 were given"
+        ):
+            torch.compile(
+                lambda x, e, o: torch.logit(x, e, o),
+                backend="eager",
+                fullgraph=True,
+            )(input, eps, torch.empty(()))
+        with self.assertRaisesRegex(Unsupported, "resizing out= tensors"):
+            torch.compile(
+                lambda x, e, o: torch.logit(x, e, out=o),
+                backend="eager",
+                fullgraph=True,
+            )(torch.tensor([0.1, 0.3]), eps, torch.empty(0))
+
+        with self.assertRaisesRegex(
+            Unsupported,
+            "out=\\.\\.\\. arguments don't support automatic differentiation",
+        ):
+            torch.compile(
+                lambda x, e, o: torch.logit(x, e, out=o),
+                backend="eager",
+                fullgraph=True,
+            )(torch.tensor(0.3, requires_grad=True), eps, torch.empty(()))
+        with self.assertRaisesRegex(
+            Unsupported,
+            "out=\\.\\.\\. arguments don't support automatic differentiation",
+        ):
+            torch.compile(
+                lambda x, e, o: torch.logit(x, e, out=o),
+                backend="eager",
+                fullgraph=True,
+            )(input, eps, torch.empty((), requires_grad=True))
+
     @make_test
     def test_is_not_null(a, b):
         if a is not None and b is not None:

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1757,6 +1757,17 @@
       "Hints": []
     }
   ],
+  "GB9621": [
+    {
+      "Gb_type": "torch.logit with tensor eps and resizing out=",
+      "Context": "input shape: {fake_input.shape}, out shape: {fake_out.shape}",
+      "Explanation": "Dynamo's tensor-eps logit rewrite does not support resizing out= tensors.",
+      "Hints": [
+        "Pass an out= tensor with the same shape as the input.",
+        "Avoid passing eps as a tensor."
+      ]
+    }
+  ],
   "GB0130": [
     {
       "Gb_type": "Unsupported Tensor.sparse_resize_and_clear_() call",

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -632,6 +632,14 @@ def foreach_pow_scalar(
     return torch._foreach_pow([scalar for _ in exps], exps)
 
 
+def logit_with_tensor_eps(self: torch.Tensor, eps: torch.Tensor) -> torch.Tensor:
+    eps = eps.to(dtype=self.dtype, device=self.device)
+    hi = 1 - eps
+    clamped = torch.where(self < eps, eps, torch.where(self > hi, hi, self))
+    z = torch.where(eps < 0, self, clamped)
+    return torch.log(torch.true_divide(z, torch.sub(1, z)))
+
+
 def predicate(obj: object) -> bool:
     # This will cause the rest of dynamo to handle the if statement correctly, so we don't have to rewrite it here.
     # We can't just use bool() here since we can't trace into that in general.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1648,6 +1648,115 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
             return None
 
+        @register(torch.logit, torch.special.logit)
+        def handle_logit(
+            self,
+            tx: "InstructionTranslatorBase",
+            *args: VariableTracker,
+            **kwargs: VariableTracker,
+        ) -> VariableTracker | None:
+            if len(args) > 2 or any(k not in ("input", "eps", "out") for k in kwargs):
+                return None
+
+            if (args and "input" in kwargs) or (len(args) > 1 and "eps" in kwargs):
+                return None
+
+            input_arg = args[0] if args else kwargs.get("input")
+            eps_arg = args[1] if len(args) > 1 else kwargs.get("eps")
+            out_arg = kwargs.get("out")
+            if (
+                out_arg is not None
+                and out_arg.is_python_constant()
+                and out_arg.as_python_constant() is None
+            ):
+                out_arg = None
+
+            if (
+                input_arg is None
+                or eps_arg is None
+                or not input_arg.is_tensor()
+                or not eps_arg.is_tensor()
+                or (out_arg is not None and not out_arg.is_tensor())
+            ):
+                return None
+
+            fake_input = input_arg.as_proxy().node.meta.get("example_value")
+            fake_eps = eps_arg.as_proxy().node.meta.get("example_value")
+            if (
+                not isinstance(fake_input, torch.Tensor)
+                or not isinstance(fake_eps, torch.Tensor)
+                or fake_input.device.type != "cpu"
+                or fake_eps.device.type != "cpu"
+                or fake_eps.dim() != 0
+                or fake_eps.requires_grad
+            ):
+                return None
+
+            if fake_eps.dtype.is_complex:
+                return None
+
+            if fake_input.dtype.is_complex:
+                dtype_name = {
+                    torch.complex64: "ComplexFloat",
+                    torch.complex128: "ComplexDouble",
+                }.get(fake_input.dtype, str(fake_input.dtype))
+                raise_observed_exception(
+                    NotImplementedError,
+                    tx,
+                    args=[f"\"logit_cpu\" not implemented for '{dtype_name}'"],
+                )
+
+            if fake_input.dtype not in (torch.float32, torch.float64):
+                return None
+
+            if out_arg is not None:
+                fake_out = out_arg.as_proxy().node.meta.get("example_value")
+                if (
+                    not isinstance(fake_out, torch.Tensor)
+                    or fake_out.device.type != "cpu"
+                    or not (
+                        fake_out.dtype.is_floating_point or fake_out.dtype.is_complex
+                    )
+                ):
+                    return None
+                if torch.is_grad_enabled() and (
+                    fake_input.requires_grad or fake_out.requires_grad
+                ):
+                    raise_observed_exception(
+                        RuntimeError,
+                        tx,
+                        args=[
+                            "logit(): functions with out=... arguments don't support "
+                            "automatic differentiation, but one of the arguments "
+                            "requires grad."
+                        ],
+                    )
+                if fake_out.shape != fake_input.shape:
+                    unimplemented(
+                        gb_type="torch.logit with tensor eps and resizing out=",
+                        context=(
+                            f"input shape: {fake_input.shape}, "
+                            f"out shape: {fake_out.shape}"
+                        ),
+                        explanation=(
+                            "Dynamo's tensor-eps logit rewrite does not support "
+                            "resizing out= tensors."
+                        ),
+                        hints=[
+                            "Pass an out= tensor with the same shape as the input.",
+                            "Avoid passing eps as a tensor.",
+                        ],
+                    )
+
+            result = tx.inline_user_function_return(
+                VariableTracker.build(tx, polyfills.logit_with_tensor_eps),
+                [input_arg, eps_arg],
+                {},
+            )
+            if out_arg is not None:
+                return out_arg.call_method(tx, "copy_", [result], {})
+            return result
+
         @register(torch.full)
         def handle_full(
             self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185947

Dynamo traced torch.logit(input, eps_tensor) directly even though the
operator schema takes eps as a float? scalar. Eager accepts a 0-dim tensor
there by scalarizing it. For float64 fake tensor propagation can use an
item_memo-backed hint and specialize, but float32 scalar extraction creates
an unbacked SymFloat and the logit fake path tries to guard on that data-
dependent value. This made fullgraph compile fail with _local_scalar_dense
for CPU float32 tensor eps.

Handle the supported CPU float32/float64 0-dim tensor eps case before fake
execution scalarizes eps. Dynamo now lowers it to an equivalent tensor-op
polyfill, so eps remains a tensor value in the graph and changing eps values
does not force recompilation. The rewrite is deliberately narrow: complex
inputs preserve the native NotImplementedError path, complex eps and non-CPU
or low-precision cases fall back to normal handling, and out= is supported
only when it can preserve eager semantics without resizing.

An alternative would be to rely on capture_scalar_outputs or specialize on
the tensor eps value, but that either requires a global config change or
keeps recompiling for data that should stay in the graph. The tensor rewrite
fixes the root scalarization problem for the reported case directly.

Fixes #145596
Generated by my agent

Test Plan:
- python test/dynamo/test_functions.py -k 'test_logit_with_tensor_eps'
- python repro snippets for CPU float32/float64 torch.compile(torch.logit, fullgraph=True)
- python repro snippets for out=, complex eps/input, invalid signatures, and no_grad out= behavior
- lintrunner -a
- git diff --cached --check

The targeted inductor repro command `python test/inductor/test_cpu_repro.py -k test_torch_logit` could not run in this environment because importing the test suite hits an existing torchvision registration failure: RuntimeError: operator torchvision::nms does not exist.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98