### PR TITLE
Fix segfault in replication_pad with overflowing padding

### DIFF
--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -5,6 +5,7 @@
 #include <ATen/TensorMeta.h>
 #include <ATen/native/Padding.h>
 #include <c10/util/irange.h>
+#include <c10/util/safe_numerics.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -20,6 +21,22 @@
 #endif
 
 namespace at::meta {
+
+namespace {
+// Compute an output dimension as input + pad_before + pad_after, reporting a
+// clear error instead of overflowing int64. An overflowed size would otherwise
+// be handed to the kernel and segfault.
+// See https://github.com/pytorch/pytorch/issues/169741.
+inline int64_t replication_pad_output_size(int64_t in, int64_t pad_before, int64_t pad_after) {
+  int64_t out = in;
+  bool overflow = c10::add_overflows(out, pad_before, &out);
+  overflow |= c10::add_overflows(out, pad_after, &out);
+  TORCH_CHECK(!overflow,
+      "Padding (", pad_before, ", ", pad_after, ") is too large; the padded "
+      "output size overflows int64 for an input dimension of size ", in);
+  return out;
+}
+} // namespace
 
 TORCH_META_FUNC(replication_pad1d) (
   const Tensor& input, IntArrayRef paddingSize  // no out argument!
@@ -44,7 +61,7 @@ TORCH_META_FUNC(replication_pad1d) (
   /* sizes */
   int64_t nslices = input.size(dimslices);
   int64_t iwidth = input.size(dimw);
-  int64_t owidth = iwidth + pad_l + pad_r;
+  int64_t owidth = replication_pad_output_size(iwidth, pad_l, pad_r);
 
   TORCH_CHECK(owidth >= 1,
       "input (W: ", iwidth, ") is too small."
@@ -108,8 +125,8 @@ TORCH_META_FUNC(replication_pad2d) (
   int64_t nslices = input.size(dimslices);
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
-  int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
+  int64_t oheight = replication_pad_output_size(iheight, pad_t, pad_b);
+  int64_t owidth  = replication_pad_output_size(iwidth, pad_l, pad_r);
 
   TORCH_CHECK(owidth >= 1 || oheight >= 1,
       "input (H: ", iheight, ", W: ", iwidth, " ) is too small."
@@ -153,9 +170,9 @@ TORCH_META_FUNC(replication_pad3d) (
   int64_t idepth = input.size(dimd);
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
+  int64_t odepth = replication_pad_output_size(idepth, pfront, pback);
+  int64_t oheight = replication_pad_output_size(iheight, ptop, pbottom);
+  int64_t owidth  = replication_pad_output_size(iwidth, pleft, pright);
 
   TORCH_CHECK(owidth >= 1 || oheight >= 1 || odepth >= 1,
       "input (D: ", idepth, " H: ", iheight, ", W: ", iwidth,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9640,6 +9640,19 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'padding size is expected to be 6'):
             torch._C._nn.replication_pad3d(torch.randn([2]), padding=[])
 
+    @onlyNativeDeviceTypes
+    def test_ReplicationPad_overflow(self, device):
+        # A huge padding value overflowed the int64 output-size computation and
+        # segfaulted instead of raising. See
+        # https://github.com/pytorch/pytorch/issues/169741
+        huge = 2 ** 63 - 1
+        with self.assertRaisesRegex(RuntimeError, "overflows int64"):
+            torch.nn.ReplicationPad1d(huge)(torch.randn(1, 3, 10, device=device))
+        with self.assertRaisesRegex(RuntimeError, "overflows int64"):
+            torch.nn.ReplicationPad2d(huge)(torch.randn(1, 3, 10, 10, device=device))
+        with self.assertRaisesRegex(RuntimeError, "overflows int64"):
+            torch.nn.ReplicationPad3d(huge)(torch.randn(1, 3, 10, 10, 10, device=device))
+
     def test_ReplicationPad1d_large(self, device):
         shapes = ([2, 65736, 4], [65736, 2, 4])
         pl, pr = 3, 4


### PR DESCRIPTION
Fixes #169741

`ReplicationPad{1,2,3}d` computes the output size as `input + pad_before + pad_after` in the meta function. With a very large padding (for example INT64_MAX) this addition overflows int64, and the overflowed size is then handed to the kernel, which segfaults.

This adds an overflow-checked helper (`replication_pad_output_size`, using `c10::add_overflows`) and uses it in the 1d, 2d and 3d meta functions, so an overflowing padding now raises a clear error instead of crashing. The repro from the issue now raises "Padding (...) is too large; the padded output size overflows int64 ...".

Added a regression test `test_ReplicationPad_overflow` covering all three.

Note: while here I noticed the existing output-size guard in the 2d and 3d meta functions uses `||` (`owidth >= 1 || oheight >= 1 ...`) where `&&` looks intended (1d correctly uses a single `>= 1`). I left that as-is to keep this PR scoped to the crash, but happy to address it here or in a follow-up if you prefer.
