### PR TITLE
[BE] Decorate test_group_norm_backward_large_input as serialTest

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10467,6 +10467,7 @@ class TestNNMPS(NNTestCase):
         r2_cpu = r2.to("cpu")
         self.assertEqual(r1, r2_cpu)
 
+    @serialTest()
     def test_group_norm_backward(self, device='mps'):
         # See https://github.com/pytorch/pytorch/issues/88331 for more detail
         shape = [1, 4, 16, 16]

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10467,7 +10467,6 @@ class TestNNMPS(NNTestCase):
         r2_cpu = r2.to("cpu")
         self.assertEqual(r1, r2_cpu)
 
-    @serialTest()
     def test_group_norm_backward(self, device='mps'):
         # See https://github.com/pytorch/pytorch/issues/88331 for more detail
         shape = [1, 4, 16, 16]
@@ -15002,6 +15001,7 @@ class TestConsistency(TestCaseMPS):
     # is a little larger than 8 GB. MPS allocations are capped at 16 GB, so it
     # cannot be run on float32.
     @unittest.skipIf(torch._C._mps_maxBufferLength() < int(8.1 * 1024**3), "Need >8 GB buffer")
+    @serialTest()
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("trigger_32bit_overflow", [False, True])
     def test_group_norm_large_input(self, device, dtype, trigger_32bit_overflow):


### PR DESCRIPTION
As it often OOMs if run in parallel with other tests