### PR TITLE
[inductor] Lazily format missing op fallback logs

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8,6 +8,7 @@ import functools
 import gc
 import importlib
 import itertools
+import logging
 import math
 import operator
 import os
@@ -14776,6 +14777,43 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             return c
 
         self.common(fn, (torch.randn((16, 32)),), check_lowp=False)
+
+    @config.patch(implicit_fallbacks=True)
+    def test_missing_op_info_log_is_lazy(self):
+        import torch._inductor.exc as exc
+
+        def foo(x):
+            return x.clone()
+
+        def foo_meta(x):
+            return torch.empty_like(x)
+
+        define_custom_op_for_test("foo_lazy_missing_op_log", foo, foo_meta)
+
+        def fn(x):
+            return torch.ops.test.foo_lazy_missing_op_log(x)
+
+        logger = logging.getLogger("torch._inductor.graph")
+        old_level = logger.level
+        logger.setLevel(logging.WARNING)
+        self.addCleanup(logger.setLevel, old_level)
+
+        operator_str_calls = 0
+        orig_operator_str = exc.MissingOperatorWithoutDecomp.operator_str
+
+        def counted_operator_str(target, args, kwargs):
+            nonlocal operator_str_calls
+            operator_str_calls += 1
+            return orig_operator_str(target, args, kwargs)
+
+        with patch.object(
+            exc.MissingOperatorWithoutDecomp,
+            "operator_str",
+            staticmethod(counted_operator_str),
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(torch.randn(4))
+
+        self.assertEqual(operator_str_calls, 0)
 
     @config.patch(implicit_fallbacks=True)
     def test_custom_op_2(self):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1401,7 +1401,7 @@ class GraphLowering(torch.fx.Interpreter):
                 )
                 log.info(
                     "Creating implicit fallback for:\n%s",
-                    error.operator_str(target, args, kwargs),
+                    LazyString(error.operator_str, target, args, kwargs),
                 )
 
                 tag: torch._C.Tag | None = get_layout_constraint_tag(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185951

Inductor emits an INFO diagnostic when it creates an implicit fallback for
an op without a lowering. The log message passed
MissingOperatorWithoutDecomp.operator_str(...) as a regular argument, so the
expensive diagnostic string was constructed even when the graph logger dropped
INFO records.

Wrap the formatter in LazyString so the diagnostic is only built when the log
record is emitted. This avoids repeated formatting of large IR strings for
custom op fallback chains when INFO logging is disabled.

Test Plan:

```bash
python agent_space/repro_185937.py
```

```bash
python test/inductor/test_torchinductor.py CpuTests.test_missing_op_info_log_is_lazy_cpu
```

```bash
python test/inductor/test_torchinductor.py CpuTests.test_custom_op_1_cpu CpuTests.test_custom_op_2_cpu CpuTests.test_custom_op_3_cpu CpuTests.test_missing_op_info_log_is_lazy_cpu
```

```bash
git diff --check -- torch/_inductor/graph.py test/inductor/test_torchinductor.py
```

```bash
lintrunner -a
```

`lintrunner -a` reports unrelated Pyrefly errors about missing Triton module
attributes in existing files outside this change.

Authored with assistance from an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo