### PR TITLE
[MPS] Native SVD, eigh, and lstsq via Jacobi kernels

### DIFF
--- a/aten/src/ATen/mps/MPSFallback.mm
+++ b/aten/src/ATen/mps/MPSFallback.mm
@@ -112,8 +112,6 @@ TORCH_LIBRARY_IMPL(aten, MPS, m) {
   // For the rest of unsupported ops the user needs to pass 'PYTORCH_ENABLE_MPS_FALLBACK=1'
   // to fallback on CPU, otherwise we will error out.
   m.impl("embedding_renorm_", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
-  m.impl("linalg_svd", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
-  m.impl("linalg_svd.U", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("_slow_conv2d_forward", slow_conv2d_forward_mps);
 }
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3461,16 +3461,17 @@ static std::string get_default_lstsq_driver(std::optional<std::string_view> driv
     static std::unordered_set<std::string_view> allowed_drivers = {
       "gels", "gelsy", "gelsd", "gelss"
     };
-    if (input.device() == at::kCPU) {
+    // CUDA supports only the 'gels' driver; CPU and MPS support all four.
+    if (input.is_cuda()) {
+      TORCH_CHECK(
+        driver_str == "gels",
+        "torch.linalg.lstsq: `driver` other than `gels` is not supported on CUDA"
+      );
+    } else { // CPU and MPS
       TORCH_CHECK(
         allowed_drivers.find(driver_str) != allowed_drivers.end(),
         "torch.linalg.lstsq: parameter `driver` should be one of "
         "(gels, gelsy, gelsd, gelss)"
-      );
-    } else { // else if (input.is_cuda())
-      TORCH_CHECK(
-        driver_str == "gels",
-        "torch.linalg.lstsq: `driver` other than `gels` is not supported on CUDA"
       );
     }
   } else {

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -26,3 +26,26 @@ struct QrParams {
   uint32_t m;
   uint32_t n;
 };
+
+struct SvdParams {
+  uint32_t m; // staged rows = max(orig m,n) >= n
+  uint32_t n; // staged cols = k = min(orig m,n)
+  uint32_t max_sweeps;
+  uint32_t compute_uv;
+  float tol;
+  uint32_t u_ld;
+  uint32_t u_bstride;
+  uint32_t v_ld;
+  uint32_t v_bstride;
+  uint32_t transposed; // 1 if SVD ran on A^T (left/right vectors swap targets)
+  uint32_t stage_v; // 1: V accumulator in threadgroup mem (Vtg); 0: device mem
+                    // (Vacc)
+};
+
+struct EighParams {
+  uint32_t n;
+  uint32_t max_sweeps;
+  uint32_t compute_v;
+  uint32_t upper; // UPLO: 1 read upper triangle, 0 read lower
+  float tol;
+};

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -1214,3 +1214,590 @@ REGISTER_UNPACK_PIVOTS(int, int);
 REGISTER_UNPACK_PIVOTS(int, long);
 REGISTER_UNPACK_PIVOTS(long, int);
 REGISTER_UNPACK_PIVOTS(long, long);
+
+// One-sided Jacobi SVD: one threadgroup per matrix, one SIMD-group per column
+// pair.
+
+template <typename T>
+struct svd_real {
+  using type = T;
+};
+template <>
+struct svd_real<float2> {
+  using type = float;
+};
+template <typename T>
+using svd_real_t = typename svd_real<T>::type;
+
+inline float svd_abs2(float z) {
+  return z * z;
+}
+inline float svd_abs2(float2 z) {
+  return z.x * z.x + z.y * z.y;
+}
+inline float svd_conjmul(float a, float b) {
+  return a * b;
+}
+inline float2 svd_conjmul(float2 a, float2 b) {
+  return float2(a.x * b.x + a.y * b.y, a.x * b.y - a.y * b.x);
+}
+inline float svd_conj(float z) {
+  return z;
+}
+inline float2 svd_conj(float2 z) {
+  return float2(z.x, -z.y);
+}
+inline float svd_mul(float a, float b) {
+  return a * b;
+}
+inline float2 svd_mul(float2 a, float2 b) {
+  return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+inline float svd_simd_sum(float v) {
+  return c10::metal::simd_sum(v);
+}
+inline float2 svd_simd_sum(float2 v) {
+  return float2(c10::metal::simd_sum(v.x), c10::metal::simd_sum(v.y));
+}
+inline float svd_one(float) {
+  return 1.0f;
+}
+inline float2 svd_one(float2) {
+  return float2(1.0f, 0.0f);
+}
+inline float svd_real_part(float z) {
+  return z;
+}
+inline float svd_real_part(float2 z) {
+  return z.x;
+}
+// NB: float2(x) -> (x,x), so build real T explicitly.
+inline float svd_from_real(float, float x) {
+  return x;
+}
+inline float2 svd_from_real(float2, float x) {
+  return float2(x, 0.0f);
+}
+
+template <typename T>
+kernel void svd_jacobi(
+    device const T* A [[buffer(0)]],
+    device T* U [[buffer(1)]],
+    device svd_real_t<T>* S [[buffer(2)]],
+    device T* V [[buffer(3)]],
+    device T* Vacc [[buffer(4)]], // rotation accumulator when V not staged
+    device int* info [[buffer(5)]],
+    constant SvdParams& params [[buffer(6)]],
+    threadgroup T* Atg [[threadgroup(0)]],
+    threadgroup T* Vtg [[threadgroup(1)]],
+    uint3 thread_pos [[thread_position_in_threadgroup]],
+    uint3 tpg [[threads_per_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]]) {
+  using opmath_t = c10::metal::opmath_t<T>;
+
+  const uint32_t tid = thread_pos.x;
+  const uint32_t group_size = tpg.x;
+  const uint32_t m = params.m;
+  const uint32_t n = params.n;
+  const uint32_t batch_idx = tg_pos.x;
+  const uint32_t kSimd = c10::metal::simdgroup_size;
+  const uint32_t num_sg = group_size / kSimd;
+
+  device const T* A_b = A + batch_idx * m * n;
+  device T* U_b = U + batch_idx * params.u_bstride;
+  device T* V_b = V + batch_idx * params.v_bstride;
+  device T* Vacc_b = Vacc + batch_idx * n * n;
+
+  // Stage A column-major so each lane's row access is contiguous.
+  for (uint32_t idx = tid; idx < m * n; idx += group_size) {
+    uint32_t row = idx / n, col = idx % n;
+    Atg[col * m + row] = A_b[idx];
+  }
+  if (params.compute_uv) {
+    if (params.stage_v) {
+      for (uint32_t i = tid; i < n * n; i += group_size) {
+        uint32_t row = i / n, col = i % n;
+        // NB: float2(1.0) broadcasts to (1,1); use svd_one()/T(0) for a real
+        // 1/0.
+        Vtg[col * n + row] = (row == col) ? svd_one(T(0)) : T(0);
+      }
+    } else {
+      for (uint32_t i = tid; i < n * n; i += group_size) {
+        Vacc_b[i] = (i / n == i % n) ? svd_one(T(0)) : T(0);
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+
+  const float eps = ::metal::numeric_limits<float>::epsilon();
+  // Concurrent SIMD-groups flag "I rotated"; a plain flag races, so use an
+  // atomic.
+  threadgroup ::metal::atomic_uint any_rotation;
+
+  // Round-robin tournament pairing (closed-form circle method): pad to even ne;
+  // each sweep is ne-1 rounds of ne/2 disjoint pairs; index >= n is phantom.
+  const uint32_t ne = n + (n & 1u);
+  const uint32_t n_pairs = ne / 2;
+
+  uint32_t sweep = 0;
+  for (; sweep < params.max_sweeps; ++sweep) {
+    if (tid == 0) {
+      ::metal::atomic_store_explicit(
+          &any_rotation, 0u, ::metal::memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint32_t round = 0; round < ne - 1; ++round) {
+      for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
+        uint32_t p = (k == 0) ? 0u : ((k - 1 + round) % (ne - 1)) + 1u;
+        uint32_t kq = ne - 1 - k;
+        uint32_t q = (kq == 0) ? 0u : ((kq - 1 + round) % (ne - 1)) + 1u;
+        bool act = !(p >= n || q >= n);
+        if (act && p > q) {
+          uint32_t tmp = p;
+          p = q;
+          q = tmp;
+        }
+
+        threadgroup T* colP = Atg + p * m;
+        threadgroup T* colQ = Atg + q * m;
+        float app = 0, aqq = 0;
+        T apq_acc = T(0);
+        if (act) {
+          for (uint32_t i = simd_lane; i < m; i += kSimd) {
+            T vp = colP[i];
+            T vq = colQ[i];
+            app += svd_abs2(vp);
+            aqq += svd_abs2(vq);
+            apq_acc += svd_conjmul(vp, vq);
+          }
+        }
+        app = c10::metal::simd_sum(app);
+        aqq = c10::metal::simd_sum(aqq);
+        apq_acc = svd_simd_sum(apq_acc);
+
+        if (!act) {
+          continue;
+        }
+        float apq_abs = ::metal::precise::sqrt(svd_abs2(apq_acc));
+        float off = ::metal::precise::sqrt(app * aqq);
+        if (off < eps || apq_abs <= params.tol * off) {
+          continue;
+        }
+        if (simd_lane == 0) {
+          ::metal::atomic_store_explicit(
+              &any_rotation, 1u, ::metal::memory_order_relaxed);
+        }
+        T phi = (apq_abs > 0) ? (apq_acc * (1.0f / apq_abs)) : svd_one(T(0));
+        float tau = (aqq - app) / (2 * apq_abs);
+        float t = (tau >= 0 ? 1.0f : -1.0f) /
+            (::metal::fabs(tau) + ::metal::precise::sqrt(1 + tau * tau));
+        float c = 1 / ::metal::precise::sqrt(1 + t * t);
+        float s = c * t;
+        T cphi = svd_conj(phi);
+        for (uint32_t i = simd_lane; i < m; i += kSimd) {
+          T vp = colP[i];
+          T vq = colQ[i];
+          colP[i] = c * vp - svd_mul(cphi, s * vq);
+          colQ[i] = svd_mul(phi, s * vp) + c * vq;
+        }
+        if (params.compute_uv) {
+          if (params.stage_v) {
+            threadgroup T* vP = Vtg + p * n;
+            threadgroup T* vQ = Vtg + q * n;
+            for (uint32_t i = simd_lane; i < n; i += kSimd) {
+              T vp = vP[i];
+              T vq = vQ[i];
+              vP[i] = c * vp - svd_mul(cphi, s * vq);
+              vQ[i] = svd_mul(phi, s * vp) + c * vq;
+            }
+          } else {
+            for (uint32_t i = simd_lane; i < n; i += kSimd) {
+              T vp = Vacc_b[i * n + p];
+              T vq = Vacc_b[i * n + q];
+              Vacc_b[i * n + p] = c * vp - svd_mul(cphi, s * vq);
+              Vacc_b[i * n + q] = svd_mul(phi, s * vp) + c * vq;
+            }
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+    threadgroup uint32_t do_break;
+    if (tid == 0) {
+      do_break = (::metal::atomic_load_explicit(
+                      &any_rotation, ::metal::memory_order_relaxed) == 0u)
+          ? 1u
+          : 0u;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (do_break) {
+      break;
+    }
+  }
+
+  // n <= 90 (host staging gate); 96 gives headroom.
+  threadgroup float sig[96];
+  threadgroup uint32_t ord[96];
+  for (uint32_t j = simd_group; j < n; j += num_sg) {
+    threadgroup T* colj = Atg + j * m;
+    float norm_sq = 0;
+    for (uint32_t i = simd_lane; i < m; i += kSimd) {
+      norm_sq += svd_abs2(colj[i]);
+    }
+    float sigma = ::metal::precise::sqrt(c10::metal::simd_sum(norm_sq));
+    if (simd_lane == 0) {
+      sig[j] = sigma;
+      ord[j] = j;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    for (uint32_t a = 0; a < n; ++a) {
+      uint32_t best = a;
+      for (uint32_t b = a + 1; b < n; ++b) {
+        if (sig[ord[b]] > sig[ord[best]])
+          best = b;
+      }
+      uint32_t tmp = ord[a];
+      ord[a] = ord[best];
+      ord[best] = tmp;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Emit column j from source ord[j]. Transposed run swaps left/right targets;
+  // right vectors written as Vh rows are conjugated (Vh = V^H), left vectors
+  // not.
+  for (uint32_t j = simd_group; j < n; j += num_sg) {
+    uint32_t src = ord[j];
+    float sigma = sig[src];
+    if (simd_lane == 0) {
+      S[batch_idx * n + j] = sigma;
+    }
+    float inv = sigma > eps ? (1 / sigma) : 0.0f;
+    threadgroup T* colsrc = Atg + src * m;
+    if (params.transposed == 0u) {
+      for (uint32_t i = simd_lane; i < m; i += kSimd) {
+        U_b[j * params.u_ld + i] = inv * colsrc[i];
+      }
+      if (params.compute_uv) {
+        threadgroup T* vsrc = Vtg + src * n;
+        for (uint32_t c = simd_lane; c < n; c += kSimd) {
+          T v = params.stage_v ? vsrc[c] : Vacc_b[c * n + src];
+          V_b[c * params.v_ld + j] = svd_conj(v);
+        }
+      }
+    } else {
+      for (uint32_t i = simd_lane; i < m; i += kSimd) {
+        V_b[i * params.v_ld + j] = svd_conj(inv * colsrc[i]);
+      }
+      if (params.compute_uv) {
+        threadgroup T* vsrc = Vtg + src * n;
+        for (uint32_t c = simd_lane; c < n; c += kSimd) {
+          U_b[j * params.u_ld + c] =
+              params.stage_v ? vsrc[c] : Vacc_b[c * n + src];
+        }
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_device);
+
+  if (tid == 0) {
+    // NaN/Inf never triggers a rotation, so flag info to raise like the CPU
+    // path.
+    bool nonfinite = false;
+    for (uint32_t j = 0; j < n; ++j) {
+      if (!isfinite(sig[j])) {
+        nonfinite = true;
+        break;
+      }
+    }
+    info[batch_idx] = (nonfinite || sweep >= params.max_sweeps)
+        ? static_cast<int>(sweep + 1)
+        : 0;
+  }
+}
+
+#define REGISTER_SVD_JACOBI(T)                             \
+  template [[host_name("svd_jacobi_" #T)]]                 \
+  kernel void svd_jacobi<T>(                               \
+      device const T* A [[buffer(0)]],                     \
+      device T* U [[buffer(1)]],                           \
+      device svd_real_t<T>* S [[buffer(2)]],               \
+      device T* V [[buffer(3)]],                           \
+      device T* Vacc [[buffer(4)]],                        \
+      device int* info [[buffer(5)]],                      \
+      constant SvdParams& params [[buffer(6)]],            \
+      threadgroup T* Atg [[threadgroup(0)]],               \
+      threadgroup T* Vtg [[threadgroup(1)]],               \
+      uint3 thread_pos [[thread_position_in_threadgroup]], \
+      uint3 tpg [[threads_per_threadgroup]],               \
+      uint3 tg_pos [[threadgroup_position_in_grid]],       \
+      uint simd_lane [[thread_index_in_simdgroup]],        \
+      uint simd_group [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_SVD_JACOBI(float);
+REGISTER_SVD_JACOBI(float2);
+
+// Two-sided block-Jacobi Hermitian eigensolver (A = Q diag(w) Q^H, w
+// ascending).
+template <typename T>
+kernel void eigh_jacobi(
+    device T* A [[buffer(0)]],
+    device svd_real_t<T>* W [[buffer(1)]],
+    device T* Q [[buffer(2)]],
+    device int* info [[buffer(3)]],
+    constant EighParams& params [[buffer(4)]],
+    threadgroup T* Atg [[threadgroup(0)]],
+    threadgroup T* Qtg [[threadgroup(1)]],
+    uint3 thread_pos [[thread_position_in_threadgroup]],
+    uint3 tpg [[threads_per_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]]) {
+  const uint32_t tid = thread_pos.x;
+  const uint32_t group_size = tpg.x;
+  const uint32_t n = params.n;
+  const uint32_t batch_idx = tg_pos.x;
+  const uint32_t kSimd = c10::metal::simdgroup_size;
+  const uint32_t num_sg = group_size / kSimd;
+  const bool compute_v = params.compute_v != 0u;
+
+  device T* A_b = A + batch_idx * n * n;
+  device T* Q_b = Q + batch_idx * n * n;
+
+  // Stage A into Atg, symmetrizing from the selected UPLO triangle (input may
+  // be non-Hermitian otherwise); two-sided Jacobi needs an exactly Hermitian
+  // matrix.
+  const bool upper = params.upper != 0u;
+  for (uint32_t i = tid; i < n * n; i += group_size) {
+    uint32_t row = i % n, col = i / n;
+    if (row == col) {
+      Atg[i] = svd_from_real(T(0), svd_real_part(A_b[i]));
+    } else {
+      bool in_upper = row < col;
+      if (in_upper == upper) {
+        Atg[i] = A_b[i];
+      } else {
+        Atg[i] = svd_conj(A_b[col + row * n]);
+      }
+    }
+  }
+  if (compute_v) {
+    for (uint32_t i = tid; i < n * n; i += group_size) {
+      uint32_t row = i % n, col = i / n;
+      Qtg[i] = (row == col) ? svd_one(T(0)) : T(0);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+
+  threadgroup float cbuf[48];
+  threadgroup T sbuf[48];
+  threadgroup uint32_t pbuf[48], qbuf[48];
+  // Concurrent SIMD-groups flag "I rotated"; a plain flag races, so use an
+  // atomic.
+  threadgroup ::metal::atomic_uint any_rotation;
+
+  const uint32_t ne = n + (n & 1u);
+  const uint32_t n_pairs = ne / 2;
+
+  // Absolute floor (max |diag|) on the off-diagonal threshold; without it a
+  // rank-deficient cluster of ~0 eigenvalues never converges.
+  threadgroup float gscale;
+
+  uint32_t sweep = 0;
+  for (; sweep < params.max_sweeps; ++sweep) {
+    if (tid == 0) {
+      ::metal::atomic_store_explicit(
+          &any_rotation, 0u, ::metal::memory_order_relaxed);
+      float g = 0.0f;
+      for (uint32_t d = 0; d < n; ++d) {
+        g = ::metal::max(g, ::metal::fabs(svd_real_part(Atg[d * n + d])));
+      }
+      gscale = g;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint32_t round = 0; round < ne - 1; ++round) {
+      for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
+        uint32_t p = (k == 0) ? 0u : ((k - 1 + round) % (ne - 1)) + 1u;
+        uint32_t kq = ne - 1 - k;
+        uint32_t q = (kq == 0) ? 0u : ((kq - 1 + round) % (ne - 1)) + 1u;
+        bool act = !(p >= n || q >= n || p == q);
+        if (act && p > q) {
+          uint32_t t = p;
+          p = q;
+          q = t;
+        }
+        if (!act) {
+          if (simd_lane == 0) {
+            pbuf[k] = n;
+            qbuf[k] = n;
+          }
+          continue;
+        }
+        float app = svd_real_part(Atg[p * n + p]);
+        float aqq = svd_real_part(Atg[q * n + q]);
+        T apq = Atg[q * n + p];
+        float apq_abs = ::metal::precise::sqrt(svd_abs2(apq));
+        float off = ::metal::precise::sqrt(::metal::fabs(app * aqq));
+        float c = 1.0f;
+        T s = T(0);
+        float thresh = ::metal::max(params.tol * off, params.tol * gscale);
+        if (apq_abs > thresh + 1e-30f) {
+          if (simd_lane == 0) {
+            ::metal::atomic_store_explicit(
+                &any_rotation, 1u, ::metal::memory_order_relaxed);
+          }
+          T phi = apq * (1.0f / apq_abs);
+          float tau = (aqq - app) / (2.0f * apq_abs);
+          float t = (tau >= 0 ? 1.0f : -1.0f) /
+              (::metal::fabs(tau) + ::metal::precise::sqrt(1.0f + tau * tau));
+          c = 1.0f / ::metal::precise::sqrt(1.0f + t * t);
+          float sreal = c * t;
+          s = svd_mul(phi, svd_from_real(T(0), sreal));
+        }
+        if (simd_lane == 0) {
+          cbuf[k] = c;
+          sbuf[k] = s;
+          pbuf[k] = p;
+          qbuf[k] = q;
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
+        uint32_t p = pbuf[k], q = qbuf[k];
+        if (p >= n) {
+          continue;
+        }
+        float c = cbuf[k];
+        T s = sbuf[k];
+        T cs = svd_conj(s);
+        threadgroup T* colP = Atg + p * n;
+        threadgroup T* colQ = Atg + q * n;
+        for (uint32_t i = simd_lane; i < n; i += kSimd) {
+          T ap = colP[i], aq = colQ[i];
+          colP[i] = c * ap - svd_mul(cs, aq);
+          colQ[i] = svd_mul(s, ap) + c * aq;
+        }
+        if (compute_v) {
+          threadgroup T* qP = Qtg + p * n;
+          threadgroup T* qQ = Qtg + q * n;
+          for (uint32_t i = simd_lane; i < n; i += kSimd) {
+            T qp = qP[i], qq = qQ[i];
+            qP[i] = c * qp - svd_mul(cs, qq);
+            qQ[i] = svd_mul(s, qp) + c * qq;
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
+        uint32_t p = pbuf[k], q = qbuf[k];
+        if (p >= n) {
+          continue;
+        }
+        float c = cbuf[k];
+        T s = sbuf[k];
+        T cs = svd_conj(s);
+        for (uint32_t col = simd_lane; col < n; col += kSimd) {
+          T ap = Atg[col * n + p], aq = Atg[col * n + q];
+          Atg[col * n + p] = c * ap - svd_mul(s, aq);
+          Atg[col * n + q] = svd_mul(cs, ap) + c * aq;
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+    threadgroup uint32_t do_break;
+    if (tid == 0) {
+      do_break = (::metal::atomic_load_explicit(
+                      &any_rotation, ::metal::memory_order_relaxed) == 0u)
+          ? 1u
+          : 0u;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (do_break) {
+      break;
+    }
+  }
+
+  threadgroup float wv[96];
+  threadgroup uint32_t ord[96];
+  for (uint32_t j = simd_group; j < n; j += num_sg) {
+    if (simd_lane == 0) {
+      wv[j] = svd_real_part(Atg[j * n + j]);
+      ord[j] = j;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (tid == 0) {
+    for (uint32_t a = 0; a < n; ++a) {
+      uint32_t best = a;
+      for (uint32_t b = a + 1; b < n; ++b) {
+        if (wv[ord[b]] < wv[ord[best]])
+          best = b;
+      }
+      uint32_t tmp = ord[a];
+      ord[a] = ord[best];
+      ord[best] = tmp;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint32_t j = simd_group; j < n; j += num_sg) {
+    uint32_t src = ord[j];
+    if (simd_lane == 0) {
+      W[batch_idx * n + j] = wv[src];
+    }
+    if (compute_v) {
+      threadgroup T* qs = Qtg + src * n;
+      for (uint32_t i = simd_lane; i < n; i += kSimd) {
+        Q_b[j * n + i] = qs[i];
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_device);
+
+  if (tid == 0) {
+    // NaN/Inf never triggers a rotation, so flag info to raise like the CPU
+    // path.
+    bool nonfinite = false;
+    for (uint32_t j = 0; j < n; ++j) {
+      if (!isfinite(wv[j])) {
+        nonfinite = true;
+        break;
+      }
+    }
+    info[batch_idx] = (nonfinite || sweep >= params.max_sweeps)
+        ? static_cast<int>(sweep + 1)
+        : 0;
+  }
+}
+
+#define REGISTER_EIGH_JACOBI(T)                            \
+  template [[host_name("eigh_jacobi_" #T)]]                \
+  kernel void eigh_jacobi<T>(                              \
+      device T * A [[buffer(0)]],                          \
+      device svd_real_t<T> * W [[buffer(1)]],              \
+      device T * Q [[buffer(2)]],                          \
+      device int* info [[buffer(3)]],                      \
+      constant EighParams& params [[buffer(4)]],           \
+      threadgroup T* Atg [[threadgroup(0)]],               \
+      threadgroup T* Qtg [[threadgroup(1)]],               \
+      uint3 thread_pos [[thread_position_in_threadgroup]], \
+      uint3 tpg [[threads_per_threadgroup]],               \
+      uint3 tg_pos [[threadgroup_position_in_grid]],       \
+      uint simd_lane [[thread_index_in_simdgroup]],        \
+      uint simd_group [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_EIGH_JACOBI(float);
+REGISTER_EIGH_JACOBI(float2);

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -1414,11 +1414,13 @@ kernel void svd_jacobi(
               vQ[i] = svd_mul(phi, s * vp) + c * vq;
             }
           } else {
+            device T* vP = Vacc_b + p * n;
+            device T* vQ = Vacc_b + q * n;
             for (uint32_t i = simd_lane; i < n; i += kSimd) {
-              T vp = Vacc_b[i * n + p];
-              T vq = Vacc_b[i * n + q];
-              Vacc_b[i * n + p] = c * vp - svd_mul(cphi, s * vq);
-              Vacc_b[i * n + q] = svd_mul(phi, s * vp) + c * vq;
+              T vp = vP[i];
+              T vq = vQ[i];
+              vP[i] = c * vp - svd_mul(cphi, s * vq);
+              vQ[i] = svd_mul(phi, s * vp) + c * vq;
             }
           }
         }
@@ -1489,7 +1491,7 @@ kernel void svd_jacobi(
       if (params.compute_uv) {
         threadgroup T* vsrc = Vtg + src * n;
         for (uint32_t c = simd_lane; c < n; c += kSimd) {
-          T v = params.stage_v ? vsrc[c] : Vacc_b[c * n + src];
+          T v = params.stage_v ? vsrc[c] : Vacc_b[src * n + c];
           V_b[c * params.v_ld + j] = svd_conj(v);
         }
       }
@@ -1501,7 +1503,7 @@ kernel void svd_jacobi(
         threadgroup T* vsrc = Vtg + src * n;
         for (uint32_t c = simd_lane; c < n; c += kSimd) {
           U_b[j * params.u_ld + c] =
-              params.stage_v ? vsrc[c] : Vacc_b[c * n + src];
+              params.stage_v ? vsrc[c] : Vacc_b[src * n + c];
         }
       }
     }
@@ -1607,22 +1609,45 @@ kernel void eigh_jacobi(
   const uint32_t ne = n + (n & 1u);
   const uint32_t n_pairs = ne / 2;
 
-  // Absolute floor (max |diag|) on the off-diagonal threshold; without it a
-  // rank-deficient cluster of ~0 eigenvalues never converges.
-  threadgroup float gscale;
+  threadgroup float red_diag[16];
+  threadgroup float red_off[16];
 
   uint32_t sweep = 0;
   for (; sweep < params.max_sweeps; ++sweep) {
     if (tid == 0) {
       ::metal::atomic_store_explicit(
           &any_rotation, 0u, ::metal::memory_order_relaxed);
-      float g = 0.0f;
-      for (uint32_t d = 0; d < n; ++d) {
-        g = ::metal::max(g, ::metal::fabs(svd_real_part(Atg[d * n + d])));
+    }
+    {
+      float ld = 0.0f;
+      float lo = 0.0f;
+      for (uint32_t i = tid; i < n * n; i += group_size) {
+        uint32_t row = i % n, col = i / n;
+        float a2 = svd_abs2(Atg[i]);
+        if (row == col) {
+          ld = ::metal::max(ld, a2);
+        } else {
+          lo = ::metal::max(lo, a2);
+        }
       }
-      gscale = g;
+      ld = c10::metal::simd_max(ld);
+      lo = c10::metal::simd_max(lo);
+      if (simd_lane == 0) {
+        red_diag[simd_group] = ld;
+        red_off[simd_group] = lo;
+      }
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
+    float g2 = 0.0f;
+    float o2 = 0.0f;
+    for (uint32_t s = 0; s < num_sg; ++s) {
+      g2 = ::metal::max(g2, red_diag[s]);
+      o2 = ::metal::max(o2, red_off[s]);
+    }
+    const float gscale = ::metal::precise::sqrt(g2);
+    if (o2 <= params.tol * params.tol * g2) {
+      break;
+    }
 
     for (uint32_t round = 0; round < ne - 1; ++round) {
       for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
@@ -1650,7 +1675,8 @@ kernel void eigh_jacobi(
         float c = 1.0f;
         T s = T(0);
         float thresh = ::metal::max(params.tol * off, params.tol * gscale);
-        if (apq_abs > thresh + 1e-30f) {
+        bool rotate = apq_abs > thresh + 1e-30f;
+        if (rotate) {
           if (simd_lane == 0) {
             ::metal::atomic_store_explicit(
                 &any_rotation, 1u, ::metal::memory_order_relaxed);
@@ -1666,19 +1692,12 @@ kernel void eigh_jacobi(
         if (simd_lane == 0) {
           cbuf[k] = c;
           sbuf[k] = s;
-          pbuf[k] = p;
+          pbuf[k] = rotate ? p : n;
           qbuf[k] = q;
         }
-      }
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-
-      for (uint32_t k = simd_group; k < n_pairs; k += num_sg) {
-        uint32_t p = pbuf[k], q = qbuf[k];
-        if (p >= n) {
+        if (!rotate) {
           continue;
         }
-        float c = cbuf[k];
-        T s = sbuf[k];
         T cs = svd_conj(s);
         threadgroup T* colP = Atg + p * n;
         threadgroup T* colQ = Atg + q * n;
@@ -1715,19 +1734,11 @@ kernel void eigh_jacobi(
       }
       threadgroup_barrier(mem_flags::mem_threadgroup);
     }
-
-    threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
-    threadgroup uint32_t do_break;
-    if (tid == 0) {
-      do_break = (::metal::atomic_load_explicit(
-                      &any_rotation, ::metal::memory_order_relaxed) == 0u)
-          ? 1u
-          : 0u;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    if (do_break) {
+    if (::metal::atomic_load_explicit(
+            &any_rotation, ::metal::memory_order_relaxed) == 0u) {
       break;
     }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 
   threadgroup float wv[96];
@@ -1739,16 +1750,16 @@ kernel void eigh_jacobi(
     }
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
-  if (tid == 0) {
-    for (uint32_t a = 0; a < n; ++a) {
-      uint32_t best = a;
-      for (uint32_t b = a + 1; b < n; ++b) {
-        if (wv[ord[b]] < wv[ord[best]])
-          best = b;
-      }
-      uint32_t tmp = ord[a];
-      ord[a] = ord[best];
-      ord[best] = tmp;
+  for (uint32_t j = simd_group; j < n; j += num_sg) {
+    float vj = wv[j];
+    uint32_t cnt = 0;
+    for (uint32_t k = simd_lane; k < n; k += kSimd) {
+      float vk = wv[k];
+      cnt += (vk < vj || (vk == vj && k < j)) ? 1u : 0u;
+    }
+    cnt = c10::metal::simd_sum(cnt);
+    if (simd_lane == 0) {
+      ord[cnt] = j;
     }
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -1215,9 +1215,6 @@ REGISTER_UNPACK_PIVOTS(int, long);
 REGISTER_UNPACK_PIVOTS(long, int);
 REGISTER_UNPACK_PIVOTS(long, long);
 
-// One-sided Jacobi SVD: one threadgroup per matrix, one SIMD-group per column
-// pair.
-
 template <typename T>
 struct svd_real {
   using type = T;
@@ -1550,8 +1547,6 @@ kernel void svd_jacobi(
 REGISTER_SVD_JACOBI(float);
 REGISTER_SVD_JACOBI(float2);
 
-// Two-sided block-Jacobi Hermitian eigensolver (A = Q diag(w) Q^H, w
-// ascending).
 template <typename T>
 kernel void eigh_jacobi(
     device T* A [[buffer(0)]],

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -1425,7 +1425,10 @@ kernel void svd_jacobi(
           }
         }
       }
-      threadgroup_barrier(mem_flags::mem_threadgroup);
+      threadgroup_barrier(
+          params.stage_v
+              ? mem_flags::mem_threadgroup
+              : (mem_flags::mem_threadgroup | mem_flags::mem_device));
     }
 
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1550,10 +1550,13 @@ static void svd_kernel_mps(const Tensor& A,
   Tensor in = (transposed ? A.mH() : A).contiguous().reshape({batch, wm, k});
 
   auto opts = A.options();
-  Tensor S_k = at::empty({batch, k}, opts.dtype(c10::toRealValueType(A.scalar_type())));
+  const bool S_direct = S.is_contiguous() && S.scalar_type() == c10::toRealValueType(A.scalar_type());
+  const bool info_direct = info.is_contiguous() && info.scalar_type() == kInt;
+  Tensor S_k =
+      S_direct ? S.reshape({batch, k}) : at::empty({batch, k}, opts.dtype(c10::toRealValueType(A.scalar_type())));
   // Device-memory accumulator only when V is not staged; tiny placeholder otherwise.
   Tensor Vacc_k = stage_v ? at::empty({1}, opts) : at::empty({batch, k, k}, opts);
-  Tensor info_b = at::zeros({batch}, opts.dtype(kInt));
+  Tensor info_b = info_direct ? info.reshape({batch}) : at::empty({batch}, opts.dtype(kInt));
   // svdvals: U/Vh empty, so bind scratch for the kernel's (still-run) U writeback.
   Tensor U_scratch, Vh_scratch;
   if (!compute_uv) {
@@ -1604,8 +1607,12 @@ static void svd_kernel_mps(const Tensor& A,
     }
   });
 
-  const_cast<Tensor&>(S).copy_(S_k.reshape(S.sizes()));
-  const_cast<Tensor&>(info).copy_(info_b.reshape(info.sizes()));
+  if (!S_direct) {
+    const_cast<Tensor&>(S).copy_(S_k.reshape(S.sizes()));
+  }
+  if (!info_direct) {
+    const_cast<Tensor&>(info).copy_(info_b.reshape(info.sizes()));
+  }
 
   if (compute_uv && full_matrices && (m != k || n != k)) {
     // full_matrices: complete cols k.. via an orthonormal basis of (I - Q Q^H).
@@ -1682,8 +1689,11 @@ static void eigh_kernel_mps(const Tensor& eigenvalues,
   }
 
   Tensor V = eigenvectors.reshape({batch, n, n});
-  Tensor W = at::empty({batch, n}, eigenvectors.options().dtype(c10::toRealValueType(dtype)));
-  Tensor info_b = at::zeros({batch}, eigenvectors.options().dtype(kInt));
+  const bool W_direct = eigenvalues.is_contiguous() && eigenvalues.scalar_type() == c10::toRealValueType(dtype);
+  const bool info_direct = infos.is_contiguous() && infos.scalar_type() == kInt;
+  Tensor W = W_direct ? eigenvalues.reshape({batch, n})
+                      : at::empty({batch, n}, eigenvectors.options().dtype(c10::toRealValueType(dtype)));
+  Tensor info_b = info_direct ? infos.reshape({batch}) : at::empty({batch}, eigenvectors.options().dtype(kInt));
 
   EighParams params{static_cast<uint32_t>(n),
                     /*max_sweeps=*/80u,
@@ -1702,7 +1712,7 @@ static void eigh_kernel_mps(const Tensor& eigenvalues,
       // threadgroup memory before any device writeback.
       mtl_setArgs(enc, V, W, V, info_b, params);
       [enc setThreadgroupMemoryLength:n * n * elem_size atIndex:0];
-      [enc setThreadgroupMemoryLength:n * n * elem_size atIndex:1];
+      [enc setThreadgroupMemoryLength:(compute_eigenvectors ? n * n * elem_size : elem_size) atIndex:1];
       const NSUInteger simd = 32;
       const NSUInteger kMaxSimdGroups = 16;
       const NSUInteger maxThreads = pso.maxTotalThreadsPerThreadgroup;
@@ -1714,8 +1724,12 @@ static void eigh_kernel_mps(const Tensor& eigenvalues,
     }
   });
 
-  const_cast<Tensor&>(eigenvalues).copy_(W.reshape(eigenvalues.sizes()));
-  const_cast<Tensor&>(infos).copy_(info_b.reshape(infos.sizes()));
+  if (!W_direct) {
+    const_cast<Tensor&>(eigenvalues).copy_(W.reshape(eigenvalues.sizes()));
+  }
+  if (!info_direct) {
+    const_cast<Tensor&>(infos).copy_(info_b.reshape(infos.sizes()));
+  }
 }
 
 static Tensor& cholesky_inverse_kernel_impl_mps(Tensor& result, Tensor& infos, bool upper) {

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -26,9 +26,6 @@
 #include <ATen/ops/all.h>
 #include <ATen/ops/baddbmm_native.h>
 #include <ATen/ops/bmm_native.h>
-#include <ATen/ops/cat.h>
-#include <ATen/ops/cholesky_native.h>
-#include <ATen/ops/empty.h>
 #include <ATen/ops/eye.h>
 #include <ATen/ops/eye_native.h>
 #include <ATen/ops/linalg_cholesky_ex_native.h>
@@ -1469,8 +1466,6 @@ static Tensor& orgqr_stub_impl(Tensor& self, const Tensor& tau) {
   return self;
 }
 
-// Orthonormal basis for the complement of Q's columns (Gram-Schmidt on proj =
-// I - Q Q^H; complex-capable, unlike float-only linalg_qr). Batched.
 static Tensor mps_orthonormal_complement(const Tensor& proj, int64_t want) {
   const int64_t dim = proj.size(-1);
   auto bsh = proj.sizes().slice(0, proj.dim() - 2).vec();
@@ -1645,8 +1640,6 @@ static void svd_kernel_mps(const Tensor& A,
   }
 }
 
-// Native MPS symmetric/Hermitian eigensolver (two-sided block-Jacobi). On entry
-// `eigenvectors` holds A column-major (the structured wrapper already copied it).
 static void eigh_kernel_mps(const Tensor& eigenvalues,
                             const Tensor& eigenvectors,
                             const Tensor& infos,
@@ -1858,6 +1851,54 @@ static void linalg_qr_out_impl_mps(const Tensor& A, const Tensor& Q, const Tenso
   bool reduced_mode = (mode != "complete");
 
   metal_qr_kernel_impl(A, Q, R, reduced_mode);
+}
+
+static void lstsq_kernel_mps(const Tensor& a,
+                             Tensor& b,
+                             Tensor& rank,
+                             Tensor& singular_values,
+                             Tensor& infos,
+                             double rcond,
+                             std::string driver_name) {
+  const auto scalar_type = a.scalar_type();
+  const auto real_dtype = c10::toRealValueType(scalar_type);
+  const auto m = a.size(-2);
+  const auto n = a.size(-1);
+
+  const bool sets_rank = (driver_name != "gels");
+  const bool sets_singular_values = (driver_name == "gelsd" || driver_name == "gelss");
+
+  const double rcond_value =
+      rcond > 0 ? rcond : _get_epsilon(real_dtype) * static_cast<double>(std::max<int64_t>(m, n));
+
+  // RHS occupies the first m rows of the (.., max(m, n), nrhs) buffer.
+  Tensor rhs = b.narrow(-2, 0, m);
+
+  Tensor U, S, Vh;
+  std::tie(U, S, Vh) = at::linalg_svd(a, /*full_matrices=*/false);
+
+  Tensor s_max = std::get<0>(S.max(/*dim=*/-1, /*keepdim=*/true));
+  Tensor above = S.gt(s_max.mul(rcond_value));
+  Tensor s_inv = at::where(above, S.reciprocal(), at::zeros({}, S.options()));
+
+  Tensor tmp = at::matmul(U.mH(), rhs).mul(s_inv.unsqueeze(-1));
+  Tensor solution = at::matmul(Vh.mH(), tmp); // (.., n, nrhs)
+
+  if (m > n) {
+    Tensor rss = at::matmul(a, solution).sub(rhs).abs().square().sum(/*dim=*/-2, /*keepdim=*/true);
+    Tensor tail = b.narrow(-2, n, m - n);
+    tail.zero_();
+    tail.narrow(-2, 0, 1).copy_(rss.sqrt());
+  }
+  b.narrow(-2, 0, n).copy_(solution);
+
+  if (sets_rank) {
+    rank.copy_(above.sum(/*dim=*/-1).to(at::kLong));
+  }
+  if (sets_singular_values) {
+    singular_values.copy_(S.to(real_dtype));
+  }
+  infos.zero_();
 }
 
 } // namespace mps
@@ -2110,140 +2151,12 @@ TORCH_IMPL_FUNC(linalg_qr_out_mps)(const Tensor& A, c10::string_view mode, const
   mps::linalg_qr_out_impl_mps(A, Q, R, mode);
 }
 
-// SVD-based least-squares (x = V Sigma^+ U^H b); reproduces the per-driver output
-// rules (gels: neither rank nor sv; gelsy: rank; gelsd/gelss: both) to match LAPACK.
-static std::tuple<Tensor, Tensor, Tensor, Tensor> linalg_lstsq_mps(const Tensor& input,
-                                                                   const Tensor& other,
-                                                                   std::optional<double> rcond,
-                                                                   std::optional<std::string_view> driver) {
-  TORCH_CHECK(input.dim() >= 2, "torch.linalg.lstsq: input must have at least 2 dimensions.");
-  TORCH_CHECK(other.dim() >= 1, "torch.linalg.lstsq: other must have at least 1 dimension.");
-  TORCH_CHECK(input.scalar_type() == other.scalar_type(),
-              "torch.linalg.lstsq: Expected input and other to have the same dtype, but got input's dtype ",
-              input.scalar_type(),
-              " and other's dtype ",
-              other.scalar_type());
-  auto dim_diff = input.dim() - other.dim();
-  TORCH_CHECK(
-      0 <= dim_diff && dim_diff <= 1,
-      "torch.linalg.lstsq: input.dim() must be greater or equal to other.dim() and (input.dim() - other.dim()) <= 1");
-
-  std::string driver_name;
-  if (driver.has_value()) {
-    driver_name = std::string(driver.value());
-    std::transform(
-        driver_name.begin(), driver_name.end(), driver_name.begin(), [](unsigned char c) { return std::tolower(c); });
-    static const std::unordered_set<std::string_view> allowed_drivers = {"gels", "gelsy", "gelsd", "gelss"};
-    TORCH_CHECK(allowed_drivers.find(driver_name) != allowed_drivers.end(),
-                "torch.linalg.lstsq: parameter `driver` should be one of (gels, gelsy, gelsd, gelss)");
-  } else {
-    driver_name = "gelsy";
-  }
-
-  const bool sets_rank = (driver_name != "gels");
-  const bool sets_singular_values = (driver_name == "gelsd" || driver_name == "gelss");
-
-  const auto scalar_type = input.scalar_type();
-  const auto real_dtype = c10::toRealValueType(scalar_type);
-
-  bool vector_case = linalg_solve_is_vector_rhs(input, other);
-  Tensor other_2d = vector_case ? other.unsqueeze(-1) : other;
-  TORCH_CHECK(input.size(-2) == other_2d.size(-2),
-              vector_case ? "torch.linalg.lstsq: input.size(-2) should match other.size(-1)"
-                          : "torch.linalg.lstsq: input.size(-2) should match other.size(-2)");
-
-  const auto m = input.size(-2);
-  const auto n = input.size(-1);
-  const auto k = std::min(m, n);
-
-  double rcond_value =
-      rcond.has_value() ? rcond.value() : _get_epsilon(real_dtype) * static_cast<double>(std::max<int64_t>(m, n));
-
-  Tensor U, S, Vh;
-  std::tie(U, S, Vh) = at::linalg_svd(input, /*full_matrices=*/false);
-
-  Tensor s_max = std::get<0>(S.max(/*dim=*/-1, /*keepdim=*/true));
-  Tensor threshold = s_max.mul(rcond_value);
-  Tensor above = S.gt(threshold);
-
-  Tensor s_inv = at::where(above, S.reciprocal(), at::zeros({}, S.options()));
-
-  Tensor tmp = at::matmul(U.mH(), other_2d);
-  tmp = tmp.mul(s_inv.unsqueeze(-1));
-  Tensor solution = at::matmul(Vh.mH(), tmp);
-
-  Tensor rank;
-  if (sets_rank) {
-    rank = above.sum(/*dim=*/-1).to(at::kLong);
-  } else {
-    rank = at::empty({0}, input.options().dtype(at::kLong));
-  }
-
-  Tensor singular_values;
-  if (sets_singular_values) {
-    singular_values = S.to(real_dtype).contiguous();
-  } else {
-    singular_values = at::empty({0}, input.options().dtype(real_dtype));
-  }
-
-  Tensor residuals = at::empty({0}, input.options().dtype(real_dtype));
-  if (m > n && driver_name != "gelsy") {
-    bool compute_residuals = true;
-    if (driver_name == "gelss" || driver_name == "gelsd") {
-      compute_residuals = at::all(rank.eq(n)).item().toBool();
-    }
-    if (compute_residuals) {
-      Tensor resid = at::matmul(input, solution).sub(other_2d);
-      if (resid.is_complex()) {
-        residuals = at::real(resid.mul(resid.conj())).sum(/*dim=*/-2, /*keepdim=*/false).to(real_dtype);
-      } else {
-        residuals = resid.pow(2).sum(/*dim=*/-2, /*keepdim=*/false).to(real_dtype);
-      }
-    }
-  }
-
-  if (m == 0) {
-    solution.zero_();
-  }
-
-  if (vector_case) {
-    solution = solution.squeeze(-1);
-  }
-  solution = solution.contiguous();
-
-  return std::make_tuple(std::move(solution), std::move(residuals), std::move(rank), std::move(singular_values));
-}
-
-std::tuple<Tensor&, Tensor&, Tensor&, Tensor&> linalg_lstsq_out_mps(const Tensor& input,
-                                                                    const Tensor& other,
-                                                                    std::optional<double> rcond,
-                                                                    std::optional<std::string_view> driver,
-                                                                    Tensor& solution,
-                                                                    Tensor& residuals,
-                                                                    Tensor& rank,
-                                                                    Tensor& singular_values) {
-  auto [solution_tmp, residuals_tmp, rank_tmp, singular_values_tmp] = linalg_lstsq_mps(input, other, rcond, driver);
-
-  at::native::resize_output(solution, solution_tmp.sizes());
-  solution.copy_(solution_tmp);
-
-  at::native::resize_output(residuals, residuals_tmp.sizes());
-  residuals.copy_(residuals_tmp);
-
-  at::native::resize_output(rank, rank_tmp.sizes());
-  rank.copy_(rank_tmp);
-
-  at::native::resize_output(singular_values, singular_values_tmp.sizes());
-  singular_values.copy_(singular_values_tmp);
-
-  return std::tuple<Tensor&, Tensor&, Tensor&, Tensor&>(solution, residuals, rank, singular_values);
-}
-
 REGISTER_DISPATCH(cholesky_stub, mps::cholesky_stub_impl)
 REGISTER_DISPATCH(unpack_pivots_stub, mps::unpack_pivots_stub_impl)
 REGISTER_DISPATCH(orgqr_stub, mps::orgqr_stub_impl);
 REGISTER_DISPATCH(cholesky_inverse_stub, mps::cholesky_inverse_kernel_impl_mps);
 REGISTER_DISPATCH(svd_stub, mps::svd_kernel_mps);
 REGISTER_DISPATCH(linalg_eigh_stub, mps::eigh_kernel_mps);
+REGISTER_DISPATCH(lstsq_stub, mps::lstsq_kernel_mps);
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -2112,10 +2112,10 @@ TORCH_IMPL_FUNC(linalg_qr_out_mps)(const Tensor& A, c10::string_view mode, const
 
 // SVD-based least-squares (x = V Sigma^+ U^H b); reproduces the per-driver output
 // rules (gels: neither rank nor sv; gelsy: rank; gelsd/gelss: both) to match LAPACK.
-std::tuple<Tensor, Tensor, Tensor, Tensor> linalg_lstsq_mps(const Tensor& input,
-                                                            const Tensor& other,
-                                                            std::optional<double> rcond,
-                                                            std::optional<std::string_view> driver) {
+static std::tuple<Tensor, Tensor, Tensor, Tensor> linalg_lstsq_mps(const Tensor& input,
+                                                                   const Tensor& other,
+                                                                   std::optional<double> rcond,
+                                                                   std::optional<std::string_view> driver) {
   TORCH_CHECK(input.dim() >= 2, "torch.linalg.lstsq: input must have at least 2 dimensions.");
   TORCH_CHECK(other.dim() >= 1, "torch.linalg.lstsq: other must have at least 1 dimension.");
   TORCH_CHECK(input.scalar_type() == other.scalar_type(),
@@ -2137,7 +2137,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> linalg_lstsq_mps(const Tensor& input,
     TORCH_CHECK(allowed_drivers.find(driver_name) != allowed_drivers.end(),
                 "torch.linalg.lstsq: parameter `driver` should be one of (gels, gelsy, gelsd, gelss)");
   } else {
-    driver_name = "gelsd";
+    driver_name = "gelsy";
   }
 
   const bool sets_rank = (driver_name != "gels");

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1520,20 +1520,23 @@ static void svd_kernel_mps(const Tensor& A,
   const int64_t k = std::min(m, n);
   const int64_t batch = c10::multiply_integers(A.sizes().slice(0, A.dim() - 2));
 
-  // Staging the wm x k matrix must fit the threadgroup-memory limit, else CPU.
   const int64_t elem_size = A.element_size();
   const int64_t wmax = std::max(m, n);
   const int64_t staging_bytes = wmax * k * elem_size;
   const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
-  // Stage the V accumulator too when A+V fit (avoids re-streaming V from DRAM).
   const int64_t v_staging_bytes = k * k * elem_size;
   const bool stage_v = compute_uv && (staging_bytes + v_staging_bytes <= tg_limit);
-  if (staging_bytes > tg_limit) {
-    TORCH_WARN_ONCE("linalg.svd: matrix too large to stage in MPS threadgroup memory (",
-                    staging_bytes,
-                    " > ",
-                    tg_limit,
-                    " bytes); falling back to CPU.");
+  const bool too_large = (staging_bytes > tg_limit);
+  const bool too_small = (batch * m * n < 8192);
+
+  if (too_large || too_small) {
+    if (too_large) {
+      TORCH_WARN_ONCE("linalg.svd: matrix too large to stage in MPS threadgroup memory (",
+                      staging_bytes,
+                      " > ",
+                      tg_limit,
+                      " bytes); falling back to CPU.");
+    }
     auto [U_cpu, S_cpu, Vh_cpu] = at::linalg_svd(A.to(at::kCPU), full_matrices, driver);
     if (compute_uv) {
       const_cast<Tensor&>(U).copy_(U_cpu.to(at::kMPS));
@@ -1661,24 +1664,18 @@ static void eigh_kernel_mps(const Tensor& eigenvalues,
   const int64_t elem_size = eigenvectors.element_size();
   const int64_t staging_bytes = n * n * elem_size;
   const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
-  const bool fits = (2 * staging_bytes) <= tg_limit; // stage A and Q
+  const bool fits = (2 * staging_bytes) <= tg_limit;
+  const bool unsupported_dtype = (dtype != kFloat && dtype != kComplexFloat);
+  const bool too_small = (batch * n * n < 12288);
 
-  // CPU fallback: no Metal double, or staged matrices exceed the tg-memory limit.
-  if (dtype != kFloat && dtype != kComplexFloat) {
-    auto [L_cpu, V_cpu] = at::_linalg_eigh(eigenvectors.to(at::kCPU), upper ? "U" : "L", compute_eigenvectors);
-    const_cast<Tensor&>(eigenvalues).copy_(L_cpu);
-    if (compute_eigenvectors) {
-      const_cast<Tensor&>(eigenvectors).copy_(V_cpu);
+  if (unsupported_dtype || !fits || too_small) {
+    if (!fits) {
+      TORCH_WARN_ONCE("linalg.eigh: matrix too large to stage in MPS threadgroup memory (",
+                      2 * staging_bytes,
+                      " > ",
+                      tg_limit,
+                      " bytes); falling back to CPU.");
     }
-    const_cast<Tensor&>(infos).zero_();
-    return;
-  }
-  if (!fits) {
-    TORCH_WARN_ONCE("linalg.eigh: matrix too large to stage in MPS threadgroup memory (",
-                    2 * staging_bytes,
-                    " > ",
-                    tg_limit,
-                    " bytes); falling back to CPU.");
     auto [L_cpu, V_cpu] = at::_linalg_eigh(eigenvectors.to(at::kCPU), upper ? "U" : "L", compute_eigenvectors);
     const_cast<Tensor&>(eigenvalues).copy_(L_cpu);
     if (compute_eigenvectors) {

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -18,34 +18,47 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_cholesky_solve_helper_native.h>
+#include <ATen/ops/_linalg_eigh.h>
 #include <ATen/ops/_linalg_solve_ex_native.h>
 #include <ATen/ops/addbmm_native.h>
 #include <ATen/ops/addmm_native.h>
 #include <ATen/ops/addr_native.h>
+#include <ATen/ops/all.h>
 #include <ATen/ops/baddbmm_native.h>
 #include <ATen/ops/bmm_native.h>
+#include <ATen/ops/cat.h>
+#include <ATen/ops/cholesky_native.h>
+#include <ATen/ops/empty.h>
 #include <ATen/ops/eye.h>
 #include <ATen/ops/eye_native.h>
 #include <ATen/ops/linalg_cholesky_ex_native.h>
 #include <ATen/ops/linalg_inv_ex_native.h>
+#include <ATen/ops/linalg_lstsq_native.h>
 #include <ATen/ops/linalg_lu_factor_ex_native.h>
 #include <ATen/ops/linalg_lu_factor_native.h>
 #include <ATen/ops/linalg_lu_native.h>
 #include <ATen/ops/linalg_qr.h>
 #include <ATen/ops/linalg_qr_native.h>
 #include <ATen/ops/linalg_solve_triangular_native.h>
+#include <ATen/ops/linalg_svd.h>
+#include <ATen/ops/linalg_vector_norm.h>
 #include <ATen/ops/lu_unpack.h>
 #include <ATen/ops/lu_unpack_native.h>
 #include <ATen/ops/matmul.h>
 #include <ATen/ops/mm_native.h>
 #include <ATen/ops/orgqr_native.h>
+#include <ATen/ops/real.h>
 #include <ATen/ops/slice.h>
 #include <ATen/ops/stack.h>
 #include <ATen/ops/triangular_solve_native.h>
+#include <ATen/ops/where.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 #include <c10/util/env.h>
 #include <algorithm>
+#include <string>
+#include <unordered_set>
 
 namespace at::native {
 namespace mps {
@@ -1456,6 +1469,255 @@ static Tensor& orgqr_stub_impl(Tensor& self, const Tensor& tau) {
   return self;
 }
 
+// Orthonormal basis for the complement of Q's columns (Gram-Schmidt on proj =
+// I - Q Q^H; complex-capable, unlike float-only linalg_qr). Batched.
+static Tensor mps_orthonormal_complement(const Tensor& proj, int64_t want) {
+  const int64_t dim = proj.size(-1);
+  auto bsh = proj.sizes().slice(0, proj.dim() - 2).vec();
+  std::vector<int64_t> out_sh = bsh;
+  out_sh.push_back(dim);
+  out_sh.push_back(want);
+  Tensor out = at::zeros(out_sh, proj.options());
+  int64_t got = 0;
+  for (int64_t c = 0; c < dim && got < want; ++c) {
+    Tensor v = proj.narrow(-1, c, 1);
+    if (got > 0) {
+      Tensor Qc = out.narrow(-1, 0, got);
+      Tensor coeff = Qc.mH().matmul(v);
+      v = v.sub(Qc.matmul(coeff));
+    }
+    Tensor nrm = at::linalg_vector_norm(v, 2, {-2}, true);
+    Tensor safe = nrm.clamp_min(1e-12);
+    Tensor vn = v.div(safe.to(v.dtype()));
+    out.narrow(-1, got, 1).copy_(vn);
+    got += 1;
+  }
+  return out;
+}
+
+static void svd_kernel_mps(const Tensor& A,
+                           const bool full_matrices,
+                           const bool compute_uv,
+                           const std::optional<std::string_view>& driver,
+                           const Tensor& U,
+                           const Tensor& S,
+                           const Tensor& Vh,
+                           const Tensor& info) {
+  using namespace mps;
+  // Metal has no float64; only float32 / complex64 run on GPU.
+  TORCH_CHECK(A.scalar_type() == kFloat || A.scalar_type() == kComplexFloat,
+              "linalg.svd: the MPS backend supports only float32 and complex64. Got ",
+              A.scalar_type(),
+              ". Move the tensor to CPU for other dtypes.");
+  TORCH_CHECK(!driver.has_value(), "linalg.svd: driver= is not supported on MPS.");
+
+  if (A.numel() == 0) {
+    return;
+  }
+
+  const int64_t m = A.size(-2);
+  const int64_t n = A.size(-1);
+  const int64_t k = std::min(m, n);
+  const int64_t batch = c10::multiply_integers(A.sizes().slice(0, A.dim() - 2));
+
+  // Staging the wm x k matrix must fit the threadgroup-memory limit, else CPU.
+  const int64_t elem_size = A.element_size();
+  const int64_t wmax = std::max(m, n);
+  const int64_t staging_bytes = wmax * k * elem_size;
+  const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
+  // Stage the V accumulator too when A+V fit (avoids re-streaming V from DRAM).
+  const int64_t v_staging_bytes = k * k * elem_size;
+  const bool stage_v = compute_uv && (staging_bytes + v_staging_bytes <= tg_limit);
+  if (staging_bytes > tg_limit) {
+    TORCH_WARN_ONCE("linalg.svd: matrix too large to stage in MPS threadgroup memory (",
+                    staging_bytes,
+                    " > ",
+                    tg_limit,
+                    " bytes); falling back to CPU.");
+    auto [U_cpu, S_cpu, Vh_cpu] = at::linalg_svd(A.to(at::kCPU), full_matrices, driver);
+    if (compute_uv) {
+      const_cast<Tensor&>(U).copy_(U_cpu.to(at::kMPS));
+      const_cast<Tensor&>(Vh).copy_(Vh_cpu.to(at::kMPS));
+    }
+    const_cast<Tensor&>(S).copy_(S_cpu.to(at::kMPS));
+    return;
+  }
+
+  const bool transposed = m < n;
+  // Kernel needs rows >= cols. For m<n run it on A^H: SVD(A^H)=(V,S,U^H), and
+  // params.transposed tells the kernel to swap left/right into the right outputs.
+  const int64_t wm = transposed ? n : m;
+  Tensor in = (transposed ? A.mH() : A).contiguous().reshape({batch, wm, k});
+
+  auto opts = A.options();
+  Tensor S_k = at::empty({batch, k}, opts.dtype(c10::toRealValueType(A.scalar_type())));
+  // Device-memory accumulator only when V is not staged; tiny placeholder otherwise.
+  Tensor Vacc_k = stage_v ? at::empty({1}, opts) : at::empty({batch, k, k}, opts);
+  Tensor info_b = at::zeros({batch}, opts.dtype(kInt));
+  // svdvals: U/Vh empty, so bind scratch for the kernel's (still-run) U writeback.
+  Tensor U_scratch, Vh_scratch;
+  if (!compute_uv) {
+    U_scratch = at::empty({batch, wm, wm}, opts);
+    Vh_scratch = at::empty({batch, wm, wm}, opts);
+  }
+
+  // Kernel writes straight into the column-major U/Vh outputs (first k cols/rows;
+  // full_matrices fills the rest below).
+  const int64_t u_ld = compute_uv ? U.size(-2) : wm;
+  const int64_t u_bs = compute_uv ? U.size(-2) * U.size(-1) : wm * wm;
+  const int64_t v_ld = compute_uv ? Vh.size(-2) : wm;
+  const int64_t v_bs = compute_uv ? Vh.size(-2) * Vh.size(-1) : wm * wm;
+
+  SvdParams params{static_cast<uint32_t>(wm),
+                   static_cast<uint32_t>(k),
+                   /*max_sweeps=*/30u,
+                   static_cast<uint32_t>(compute_uv ? 1 : 0),
+                   /*tol=*/1e-6f,
+                   static_cast<uint32_t>(u_ld),
+                   static_cast<uint32_t>(u_bs),
+                   static_cast<uint32_t>(v_ld),
+                   static_cast<uint32_t>(v_bs),
+                   static_cast<uint32_t>(transposed ? 1 : 0),
+                   static_cast<uint32_t>(stage_v ? 1 : 0)};
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(fmt::format("svd_jacobi_{}", scalarToMetalTypeString(A)));
+      getMPSProfiler().beginProfileKernel(pso, "svd_jacobi", {A});
+      [enc setComputePipelineState:pso];
+      Tensor Ubind = compute_uv ? U : U_scratch;
+      Tensor Vbind = compute_uv ? Vh : Vh_scratch;
+      mtl_setArgs(enc, in, Ubind, S_k, Vbind, Vacc_k, info_b, params);
+      [enc setThreadgroupMemoryLength:wm * k * elem_size atIndex:0];
+      [enc setThreadgroupMemoryLength:(stage_v ? k * k * elem_size : elem_size) atIndex:1];
+      // One threadgroup per batch matrix; cap at 32 SIMD-groups (1024 threads).
+      const NSUInteger simd = 32;
+      const NSUInteger kMaxSimdGroups = 32;
+      const NSUInteger maxThreads = pso.maxTotalThreadsPerThreadgroup;
+      const NSUInteger nPairs = (k + 1) / 2;
+      const NSUInteger wantSG = std::min<NSUInteger>(std::max<NSUInteger>(nPairs, 1), kMaxSimdGroups);
+      NSUInteger tgs = std::min<NSUInteger>(maxThreads, wantSG * simd);
+      [enc dispatchThreads:MTLSizeMake(tgs * batch, 1, 1) threadsPerThreadgroup:MTLSizeMake(tgs, 1, 1)];
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+
+  const_cast<Tensor&>(S).copy_(S_k.reshape(S.sizes()));
+  const_cast<Tensor&>(info).copy_(info_b.reshape(info.sizes()));
+
+  if (compute_uv && full_matrices && (m != k || n != k)) {
+    // full_matrices: complete cols k.. via an orthonormal basis of (I - Q Q^H).
+    auto complete = [](Tensor M, int64_t kk) {
+      const int64_t dim = M.size(-1);
+      if (kk == dim)
+        return;
+      Tensor Q = M.narrow(-1, 0, kk);
+      std::vector<int64_t> ish = M.sizes().slice(0, M.dim() - 2).vec();
+      ish.push_back(dim);
+      ish.push_back(dim);
+      Tensor I = at::eye(dim, M.options()).expand(ish);
+      Tensor proj = I.sub(Q.matmul(Q.mH()));
+      // linalg_qr is float-only on MPS, so complex goes through Gram-Schmidt.
+      Tensor comp;
+      if (c10::isComplexType(proj.scalar_type())) {
+        comp = mps_orthonormal_complement(proj, dim - kk);
+      } else {
+        comp = std::get<0>(at::linalg_qr(proj, "reduced")).narrow(-1, 0, dim - kk);
+      }
+      M.narrow(-1, kk, dim - kk).copy_(comp);
+    };
+    if (m > k)
+      complete(const_cast<Tensor&>(U), k);
+    if (n > k)
+      complete(const_cast<Tensor&>(Vh).mH(), k); // V = Vh^H
+  }
+}
+
+// Native MPS symmetric/Hermitian eigensolver (two-sided block-Jacobi). On entry
+// `eigenvectors` holds A column-major (the structured wrapper already copied it).
+static void eigh_kernel_mps(const Tensor& eigenvalues,
+                            const Tensor& eigenvectors,
+                            const Tensor& infos,
+                            bool upper,
+                            bool compute_eigenvectors) {
+  using namespace mps;
+
+  if (eigenvectors.numel() == 0) {
+    return;
+  }
+
+  const auto dtype = eigenvectors.scalar_type();
+  const int64_t n = eigenvectors.size(-1);
+  const int64_t batch = c10::multiply_integers(eigenvectors.sizes().slice(0, eigenvectors.dim() - 2));
+  const int64_t elem_size = eigenvectors.element_size();
+  const int64_t staging_bytes = n * n * elem_size;
+  const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
+  const bool fits = (2 * staging_bytes) <= tg_limit; // stage A and Q
+
+  // CPU fallback: no Metal double, or staged matrices exceed the tg-memory limit.
+  if (dtype != kFloat && dtype != kComplexFloat) {
+    auto [L_cpu, V_cpu] = at::_linalg_eigh(eigenvectors.to(at::kCPU), upper ? "U" : "L", compute_eigenvectors);
+    const_cast<Tensor&>(eigenvalues).copy_(L_cpu);
+    if (compute_eigenvectors) {
+      const_cast<Tensor&>(eigenvectors).copy_(V_cpu);
+    }
+    const_cast<Tensor&>(infos).zero_();
+    return;
+  }
+  if (!fits) {
+    TORCH_WARN_ONCE("linalg.eigh: matrix too large to stage in MPS threadgroup memory (",
+                    2 * staging_bytes,
+                    " > ",
+                    tg_limit,
+                    " bytes); falling back to CPU.");
+    auto [L_cpu, V_cpu] = at::_linalg_eigh(eigenvectors.to(at::kCPU), upper ? "U" : "L", compute_eigenvectors);
+    const_cast<Tensor&>(eigenvalues).copy_(L_cpu);
+    if (compute_eigenvectors) {
+      const_cast<Tensor&>(eigenvectors).copy_(V_cpu);
+    }
+    const_cast<Tensor&>(infos).zero_();
+    return;
+  }
+
+  Tensor V = eigenvectors.reshape({batch, n, n});
+  Tensor W = at::empty({batch, n}, eigenvectors.options().dtype(c10::toRealValueType(dtype)));
+  Tensor info_b = at::zeros({batch}, eigenvectors.options().dtype(kInt));
+
+  EighParams params{static_cast<uint32_t>(n),
+                    /*max_sweeps=*/80u,
+                    static_cast<uint32_t>(compute_eigenvectors ? 1 : 0),
+                    static_cast<uint32_t>(upper ? 1 : 0),
+                    /*tol=*/1e-6f};
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(fmt::format("eigh_jacobi_{}", scalarToMetalTypeString(eigenvectors)));
+      getMPSProfiler().beginProfileKernel(pso, "eigh_jacobi", {eigenvectors});
+      [enc setComputePipelineState:pso];
+      // V binds to both A (in) and Q (out): safe since all reads stage into
+      // threadgroup memory before any device writeback.
+      mtl_setArgs(enc, V, W, V, info_b, params);
+      [enc setThreadgroupMemoryLength:n * n * elem_size atIndex:0];
+      [enc setThreadgroupMemoryLength:n * n * elem_size atIndex:1];
+      const NSUInteger simd = 32;
+      const NSUInteger kMaxSimdGroups = 16;
+      const NSUInteger maxThreads = pso.maxTotalThreadsPerThreadgroup;
+      const NSUInteger nPairs = (n + 1) / 2;
+      const NSUInteger wantSG = std::min<NSUInteger>(std::max<NSUInteger>(nPairs, 1), kMaxSimdGroups);
+      NSUInteger tgs = std::min<NSUInteger>(maxThreads, wantSG * simd);
+      [enc dispatchThreads:MTLSizeMake(tgs * batch, 1, 1) threadsPerThreadgroup:MTLSizeMake(tgs, 1, 1)];
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+
+  const_cast<Tensor&>(eigenvalues).copy_(W.reshape(eigenvalues.sizes()));
+  const_cast<Tensor&>(infos).copy_(info_b.reshape(infos.sizes()));
+}
+
 static Tensor& cholesky_inverse_kernel_impl_mps(Tensor& result, Tensor& infos, bool upper) {
   using namespace mps;
   TORCH_CHECK(result.is_mps(), "Output tensor is not MPS");
@@ -1837,9 +2099,140 @@ TORCH_IMPL_FUNC(linalg_qr_out_mps)(const Tensor& A, c10::string_view mode, const
   mps::linalg_qr_out_impl_mps(A, Q, R, mode);
 }
 
+// SVD-based least-squares (x = V Sigma^+ U^H b); reproduces the per-driver output
+// rules (gels: neither rank nor sv; gelsy: rank; gelsd/gelss: both) to match LAPACK.
+std::tuple<Tensor, Tensor, Tensor, Tensor> linalg_lstsq_mps(const Tensor& input,
+                                                            const Tensor& other,
+                                                            std::optional<double> rcond,
+                                                            std::optional<std::string_view> driver) {
+  TORCH_CHECK(input.dim() >= 2, "torch.linalg.lstsq: input must have at least 2 dimensions.");
+  TORCH_CHECK(other.dim() >= 1, "torch.linalg.lstsq: other must have at least 1 dimension.");
+  TORCH_CHECK(input.scalar_type() == other.scalar_type(),
+              "torch.linalg.lstsq: Expected input and other to have the same dtype, but got input's dtype ",
+              input.scalar_type(),
+              " and other's dtype ",
+              other.scalar_type());
+  auto dim_diff = input.dim() - other.dim();
+  TORCH_CHECK(
+      0 <= dim_diff && dim_diff <= 1,
+      "torch.linalg.lstsq: input.dim() must be greater or equal to other.dim() and (input.dim() - other.dim()) <= 1");
+
+  std::string driver_name;
+  if (driver.has_value()) {
+    driver_name = std::string(driver.value());
+    std::transform(
+        driver_name.begin(), driver_name.end(), driver_name.begin(), [](unsigned char c) { return std::tolower(c); });
+    static const std::unordered_set<std::string_view> allowed_drivers = {"gels", "gelsy", "gelsd", "gelss"};
+    TORCH_CHECK(allowed_drivers.find(driver_name) != allowed_drivers.end(),
+                "torch.linalg.lstsq: parameter `driver` should be one of (gels, gelsy, gelsd, gelss)");
+  } else {
+    driver_name = "gelsd";
+  }
+
+  const bool sets_rank = (driver_name != "gels");
+  const bool sets_singular_values = (driver_name == "gelsd" || driver_name == "gelss");
+
+  const auto scalar_type = input.scalar_type();
+  const auto real_dtype = c10::toRealValueType(scalar_type);
+
+  bool vector_case = linalg_solve_is_vector_rhs(input, other);
+  Tensor other_2d = vector_case ? other.unsqueeze(-1) : other;
+  TORCH_CHECK(input.size(-2) == other_2d.size(-2),
+              vector_case ? "torch.linalg.lstsq: input.size(-2) should match other.size(-1)"
+                          : "torch.linalg.lstsq: input.size(-2) should match other.size(-2)");
+
+  const auto m = input.size(-2);
+  const auto n = input.size(-1);
+  const auto k = std::min(m, n);
+
+  double rcond_value =
+      rcond.has_value() ? rcond.value() : _get_epsilon(real_dtype) * static_cast<double>(std::max<int64_t>(m, n));
+
+  Tensor U, S, Vh;
+  std::tie(U, S, Vh) = at::linalg_svd(input, /*full_matrices=*/false);
+
+  Tensor s_max = std::get<0>(S.max(/*dim=*/-1, /*keepdim=*/true));
+  Tensor threshold = s_max.mul(rcond_value);
+  Tensor above = S.gt(threshold);
+
+  Tensor s_inv = at::where(above, S.reciprocal(), at::zeros({}, S.options()));
+
+  Tensor tmp = at::matmul(U.mH(), other_2d);
+  tmp = tmp.mul(s_inv.unsqueeze(-1));
+  Tensor solution = at::matmul(Vh.mH(), tmp);
+
+  Tensor rank;
+  if (sets_rank) {
+    rank = above.sum(/*dim=*/-1).to(at::kLong);
+  } else {
+    rank = at::empty({0}, input.options().dtype(at::kLong));
+  }
+
+  Tensor singular_values;
+  if (sets_singular_values) {
+    singular_values = S.to(real_dtype).contiguous();
+  } else {
+    singular_values = at::empty({0}, input.options().dtype(real_dtype));
+  }
+
+  Tensor residuals = at::empty({0}, input.options().dtype(real_dtype));
+  if (m > n && driver_name != "gelsy") {
+    bool compute_residuals = true;
+    if (driver_name == "gelss" || driver_name == "gelsd") {
+      compute_residuals = at::all(rank.eq(n)).item().toBool();
+    }
+    if (compute_residuals) {
+      Tensor resid = at::matmul(input, solution).sub(other_2d);
+      if (resid.is_complex()) {
+        residuals = at::real(resid.mul(resid.conj())).sum(/*dim=*/-2, /*keepdim=*/false).to(real_dtype);
+      } else {
+        residuals = resid.pow(2).sum(/*dim=*/-2, /*keepdim=*/false).to(real_dtype);
+      }
+    }
+  }
+
+  if (m == 0) {
+    solution.zero_();
+  }
+
+  if (vector_case) {
+    solution = solution.squeeze(-1);
+  }
+  solution = solution.contiguous();
+
+  return std::make_tuple(std::move(solution), std::move(residuals), std::move(rank), std::move(singular_values));
+}
+
+std::tuple<Tensor&, Tensor&, Tensor&, Tensor&> linalg_lstsq_out_mps(const Tensor& input,
+                                                                    const Tensor& other,
+                                                                    std::optional<double> rcond,
+                                                                    std::optional<std::string_view> driver,
+                                                                    Tensor& solution,
+                                                                    Tensor& residuals,
+                                                                    Tensor& rank,
+                                                                    Tensor& singular_values) {
+  auto [solution_tmp, residuals_tmp, rank_tmp, singular_values_tmp] = linalg_lstsq_mps(input, other, rcond, driver);
+
+  at::native::resize_output(solution, solution_tmp.sizes());
+  solution.copy_(solution_tmp);
+
+  at::native::resize_output(residuals, residuals_tmp.sizes());
+  residuals.copy_(residuals_tmp);
+
+  at::native::resize_output(rank, rank_tmp.sizes());
+  rank.copy_(rank_tmp);
+
+  at::native::resize_output(singular_values, singular_values_tmp.sizes());
+  singular_values.copy_(singular_values_tmp);
+
+  return std::tuple<Tensor&, Tensor&, Tensor&, Tensor&>(solution, residuals, rank, singular_values);
+}
+
 REGISTER_DISPATCH(cholesky_stub, mps::cholesky_stub_impl)
 REGISTER_DISPATCH(unpack_pivots_stub, mps::unpack_pivots_stub_impl)
 REGISTER_DISPATCH(orgqr_stub, mps::orgqr_stub_impl);
 REGISTER_DISPATCH(cholesky_inverse_stub, mps::cholesky_inverse_kernel_impl_mps);
+REGISTER_DISPATCH(svd_stub, mps::svd_kernel_mps);
+REGISTER_DISPATCH(linalg_eigh_stub, mps::eigh_kernel_mps);
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13952,7 +13952,6 @@
   variants: function
   dispatch:
     CompositeExplicitAutograd: linalg_lstsq
-    MPS: linalg_lstsq_mps
   tags: dynamic_output_shape
 
 - func: linalg_lstsq.out(Tensor self, Tensor b, float? rcond=None, *, str? driver=None, Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values) -> (Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13958,8 +13958,7 @@
   python_module: linalg
   variants: function
   dispatch:
-    CPU, CUDA: linalg_lstsq_out
-    MPS: linalg_lstsq_out_mps
+    CPU, CUDA, MPS: linalg_lstsq_out
   tags: dynamic_output_shape
 
 # torch.linalg.matmul, alias for torch.matmul

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13952,6 +13952,7 @@
   variants: function
   dispatch:
     CompositeExplicitAutograd: linalg_lstsq
+    MPS: linalg_lstsq_mps
   tags: dynamic_output_shape
 
 - func: linalg_lstsq.out(Tensor self, Tensor b, float? rcond=None, *, str? driver=None, Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values) -> (Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values)
@@ -13959,6 +13960,7 @@
   variants: function
   dispatch:
     CPU, CUDA: linalg_lstsq_out
+    MPS: linalg_lstsq_out_mps
   tags: dynamic_output_shape
 
 # torch.linalg.matmul, alias for torch.matmul
@@ -14038,7 +14040,7 @@
 - func: _linalg_eigh.eigenvalues(Tensor A, str UPLO="L", bool compute_v=True, *, Tensor(a!) eigenvalues, Tensor(b!) eigenvectors) -> (Tensor(a!) eigenvalues, Tensor(b!) eigenvectors)
   structured: True
   dispatch:
-    CPU, CUDA: _linalg_eigh_out
+    CPU, CUDA, MPS: _linalg_eigh_out
 
 - func: linalg_eigh(Tensor self, str UPLO="L") -> (Tensor eigenvalues, Tensor eigenvectors)
   python_module: linalg
@@ -14162,7 +14164,7 @@
 - func: _linalg_svd.U(Tensor A, bool full_matrices=False, bool compute_uv=True, *, str? driver=None, Tensor(a!) U, Tensor(b!) S, Tensor(c!) Vh) -> (Tensor(a!) U, Tensor(b!) S, Tensor(c!) Vh)
   structured: True
   dispatch:
-    CPU, CUDA: _linalg_svd_out
+    CPU, CUDA, MPS: _linalg_svd_out
 
 - func: linalg_svd(Tensor A, bool full_matrices=True, *, str? driver=None) -> (Tensor U, Tensor S, Tensor Vh)
   python_module: linalg

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11062,15 +11062,7 @@ class TestLinalgMPS(TestCaseMPS):
         shapes = (3, 13)
         batches = ((), (0, ), (4, ), (3, 5, ))
         for (shape0, shape1), batch in zip(itertools.product(shapes, reversed(shapes)), batches):
-            # escape only when NotImplementedError of downstream function is raised
-            # TODO: remove this once the required function is implemented
-            try:
-                run_test(shape0, shape1, batch)
-            except NotImplementedError as e:
-                with self.assertRaisesRegex(
-                        NotImplementedError,
-                        "The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device."):
-                    raise e
+            run_test(shape0, shape1, batch)
 
     def test_pinv(self, device="mps", dtype=torch.float32, precision=1e-4):
         from torch.testing._internal.common_utils import random_hermitian_pd_matrix
@@ -11130,22 +11122,8 @@ class TestLinalgMPS(TestCaseMPS):
                       (0, 0), (3, 0, 0), ]:  # zero numel square matrices
             A = random_hermitian_pd_matrix(sizes[-1], *sizes[:-2], dtype=dtype, device=device)
             hermitian = True
-            # escape only when NotImplementedError of downstream function is raised
-            # TODO: remove this once the required function is implemented
-            try:
-                run_test_main(A, hermitian)
-            except NotImplementedError as e:
-                with self.assertRaisesRegex(
-                        NotImplementedError,
-                        "The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device."):
-                    raise e
-            try:
-                run_test_numpy(A, hermitian)
-            except NotImplementedError as e:
-                with self.assertRaisesRegex(
-                        NotImplementedError,
-                        "The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device."):
-                    raise e
+            run_test_main(A, hermitian)
+            run_test_numpy(A, hermitian)
 
     @parametrize("m", [1, 32, 64])
     @parametrize("n", [48, 64])
@@ -14960,6 +14938,47 @@ class TestConsistency(TestCaseMPS):
                 self._assert_random_op_match(mps_out, cpu_out)
                 continue
 
+            if op.name in ("linalg.svd", "svd"):
+                # Singular vectors are only defined up to a per-mode sign (gauge):
+                # MPS's Jacobi solver and CPU LAPACK pick different but equally valid
+                # signs. Compare gauge-invariantly: singular values exactly, the
+                # vector magnitudes, and the reconstruction == A. linalg.svd returns
+                # (U, S, Vh); legacy torch.svd returns (U, S, V) with V (not V^H).
+                U_m, S_m, W_m = mps_out  # W = Vh (linalg) or V (legacy)
+                U_c, S_c, W_c = cpu_out
+                self.assertEqual(S_c, S_m, atol=atol, rtol=rtol)
+                kk = S_m.shape[-1]
+                self.assertEqual(U_c[..., :kk].abs(), U_m[..., :kk].abs(), atol=atol, rtol=rtol)
+                if op.name == "linalg.svd":
+                    Vh_m, Vh_c = W_m[..., :kk, :], W_c[..., :kk, :]
+                else:
+                    Vh_m, Vh_c = W_m[..., :kk].mH, W_c[..., :kk].mH
+                self.assertEqual(Vh_c.abs(), Vh_m.abs(), atol=atol, rtol=rtol)
+                recon = (U_m[..., :kk] * S_m.unsqueeze(-2)) @ Vh_m
+                self.assertEqual(mps_sample.input, recon, atol=atol, rtol=rtol)
+                continue
+
+            if op.name in ("linalg.eigh",):
+                # Eigenvectors are gauge-ambiguous; compare gauge-invariantly:
+                # eigenvalues, Q^H Q == I, and the reconstruction Q diag(w) Q^H == A.
+                w_m, Q_m = mps_out
+                w_c, _ = cpu_out
+                self.assertEqual(w_c, w_m, atol=atol, rtol=rtol)
+                n = Q_m.shape[-1]
+                eye = torch.eye(n, dtype=Q_m.dtype, device=Q_m.device).expand_as(Q_m)
+                self.assertEqual(Q_m.mH @ Q_m, eye, atol=atol, rtol=rtol)
+                # eigh reads only the UPLO triangle; reconstruct that Hermitian matrix.
+                uplo = mps_sample.kwargs.get("UPLO", "L").strip("'\"").upper()
+                A_in = mps_sample.input
+                diag = torch.diag_embed(A_in.diagonal(dim1=-2, dim2=-1).real.to(A_in.dtype))
+                if uplo == "U":
+                    A_herm = A_in.triu(1) + A_in.triu(1).mH + diag
+                else:
+                    A_herm = A_in.tril(-1) + A_in.tril(-1).mH + diag
+                recon = (Q_m * w_m.to(Q_m.dtype).unsqueeze(-2)) @ Q_m.mH
+                self.assertEqual(A_herm, recon, atol=atol, rtol=rtol)
+                continue
+
             self.assertEqual(cpu_out, mps_out, atol=atol, rtol=rtol)
 
     @ops(mps_ops_grad_modifier(copy.deepcopy(test_consistency_op_db)), allowed_dtypes=MPS_GRAD_DTYPES)
@@ -14989,6 +15008,38 @@ class TestConsistency(TestCaseMPS):
 
             if op.name in self.RANDOM_OP_NAMES:
                 self._assert_random_op_match(mps_out, cpu_out)
+            elif op.name in ("linalg.svd", "svd"):
+                # Gauge-invariant forward check (see test_output_match): vectors carry
+                # an arbitrary per-mode sign; compare S exactly, |U|/|V[h]|, and recon.
+                U_m, S_m, W_m = mps_out
+                U_c, S_c, W_c = cpu_out
+                self.assertEqual(S_c, S_m, atol=atol, rtol=rtol)
+                kk = S_m.shape[-1]
+                self.assertEqual(U_c[..., :kk].abs(), U_m[..., :kk].abs(), atol=atol, rtol=rtol)
+                if op.name == "linalg.svd":
+                    Vh_m, Vh_c = W_m[..., :kk, :], W_c[..., :kk, :]
+                else:
+                    Vh_m, Vh_c = W_m[..., :kk].mH, W_c[..., :kk].mH
+                self.assertEqual(Vh_c.abs(), Vh_m.abs(), atol=atol, rtol=rtol)
+                recon = (U_m[..., :kk] * S_m.to(U_m.dtype).unsqueeze(-2)) @ Vh_m
+                self.assertEqual(mps_sample.input, recon, atol=atol, rtol=rtol)
+            elif op.name in ("linalg.eigh",):
+                # Gauge-invariant forward check (see test_output_match).
+                w_m, Q_m = mps_out
+                w_c, _ = cpu_out
+                self.assertEqual(w_c, w_m, atol=atol, rtol=rtol)
+                n = Q_m.shape[-1]
+                eye = torch.eye(n, dtype=Q_m.dtype, device=Q_m.device).expand_as(Q_m)
+                self.assertEqual(Q_m.mH @ Q_m, eye, atol=atol, rtol=rtol)
+                uplo = mps_sample.kwargs.get("UPLO", "L").strip("'\"").upper()
+                A_in = mps_sample.input
+                diag = torch.diag_embed(A_in.diagonal(dim1=-2, dim2=-1).real.to(A_in.dtype))
+                if uplo == "U":
+                    A_herm = A_in.triu(1) + A_in.triu(1).mH + diag
+                else:
+                    A_herm = A_in.tril(-1) + A_in.tril(-1).mH + diag
+                recon = (Q_m * w_m.to(Q_m.dtype).unsqueeze(-2)) @ Q_m.mH
+                self.assertEqual(A_herm, recon, atol=atol, rtol=rtol)
             else:
                 self.assertEqual(cpu_out, mps_out, atol=atol, rtol=rtol)
 
@@ -15014,6 +15065,25 @@ class TestConsistency(TestCaseMPS):
                 continue
             # rand_like does not work with certain dtypes, so cast to double and cast back
             cpu_grad_outputs = tuple(torch.rand_like(t, dtype=torch.double).to(dtype=t.dtype) for t in diff_cpu_out)
+
+            if op.name in ("linalg.svd", "svd"):
+                # Singular vectors carry an arbitrary per-mode sign/phase (gauge) that
+                # MPS's Jacobi solver fixes differently from CPU LAPACK. The gradients
+                # w.r.t. U and Vh are therefore gauge-dependent and not comparable
+                # element-wise, but the gradient w.r.t. the (gauge-invariant) singular
+                # values IS. Compare only the S-seeded input gradient: zero the U/Vh
+                # grad_outputs (output order is U, S, V[h]).
+                cpu_grad_outputs = tuple(
+                    g if i == 1 else torch.zeros_like(g)
+                    for i, g in enumerate(cpu_grad_outputs))
+
+            if op.name in ("linalg.eigh",):
+                # Only the eigenvalue gradient is gauge-invariant, so seed only it
+                # (output order is eigenvalues, eigenvectors).
+                cpu_grad_outputs = tuple(
+                    g if i == 0 else torch.zeros_like(g)
+                    for i, g in enumerate(cpu_grad_outputs))
+
             mps_grad_outputs = tuple(t.to("mps") for t in cpu_grad_outputs)
 
             # Compare computed gradients with cpu given random grad_output vector

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11024,6 +11024,21 @@ class TestLinalgMPS(TestCaseMPS):
         m2 = torch.randn(25, device=device).to(dtype)
         self._test_addr(torch.addr, M, m1, m2, beta=0)
 
+    def test_linalg_lstsq_default_driver(self, device="mps", dtype=torch.float32):
+        # With no driver= argument MPS should match the CPU default (gelsy), whose
+        # output shapes differ from the other drivers: rank is populated while
+        # residuals and singular_values are left empty. Check all four outputs so a
+        # CPU->MPS move does not silently change them.
+        torch.manual_seed(0)
+        A = torch.randn(6, 4, dtype=dtype)
+        B = torch.randn(6, 3, dtype=dtype)
+        cpu = torch.linalg.lstsq(A, B)
+        mps = torch.linalg.lstsq(A.to(device), B.to(device))
+        self.assertEqual(mps.solution.cpu(), cpu.solution, atol=1e-4, rtol=1e-4)
+        self.assertEqual(mps.residuals.cpu(), cpu.residuals)
+        self.assertEqual(mps.rank.cpu(), cpu.rank)
+        self.assertEqual(mps.singular_values.cpu(), cpu.singular_values)
+
     def test_matrix_rank(self, device="mps", dtype=torch.float32):
         matrix_rank = torch.linalg.matrix_rank
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22565,8 +22565,6 @@ op_db: list[OpInfo] = [
            dtypes=floating_and_complex_types(),
            dtypesIfCUDA=floating_and_complex_types(),
            skips=(
-               # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps'),
                # Dispatches in Python to matrix_norm. Not sure how to make this test happy
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',
                             dtypes=(torch.complex64, torch.float32,)),)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -366,7 +366,6 @@ if torch.backends.mps.is_available():
             "hash_tensor": None,
             "heaviside": None,
             # "kthvalue": None,
-            "lcm": None,
             "linalg.ldl_factor": None,
             "linalg.ldl_factor_ex": None,
             "linalg.ldl_solve": None,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -868,8 +868,6 @@ if torch.backends.mps.is_available():
             "_upsample_bicubic2d_aa": None,  # `_upsample_bilinear2d_aa_backward_out` not implemented for MPS
             "sparse.mmreduce": [torch.float32],  # csr not supported
             "linalg.householder_product": None,
-            "linalg.normsubgradients_at_zero": [torch.float32],
-            "linalg.pinvhermitian": None,
             "linalg.lstsq": [torch.float32],
             "linalg.lstsqgrad_oriented": [torch.float32],
             "unique_consecutive": [torch.float16, torch.float32],

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -95,10 +95,22 @@ if torch.backends.mps.is_available():
             "istft",
             "item",
             "kron",
+            "linalg.cond",
             "linalg.cross",
             "linalg.diagonal",
+            "linalg.eigh",
+            "linalg.eigvalsh",
             "linalg.householder_product",
+            "linalg.lstsq",
+            "linalg.lstsqgrad_oriented",
+            "linalg.matrix_norm",
+            "linalg.matrix_rank",
+            "linalg.matrix_rankhermitian",
+            "linalg.norm",
+            "linalg.normsubgradients_at_zero",
+            "linalg.pinvhermitian",
             "linalg.svd",
+            "linalg.svdvals",
             "linalg.vander",
             "linalg.vecdot",
             "linalg.vector_norm",
@@ -146,6 +158,7 @@ if torch.backends.mps.is_available():
             "norm",
             "normfro",
             "norminf",
+            "normnuc",
             "ones",
             "ones_like",
             "outer",
@@ -353,18 +366,11 @@ if torch.backends.mps.is_available():
             "hash_tensor": None,
             "heaviside": None,
             # "kthvalue": None,
-            "linalg.cond": None,
-            "linalg.eigh": None,
-            "linalg.eigvalsh": None,
+            "lcm": None,
             "linalg.ldl_factor": None,
             "linalg.ldl_factor_ex": None,
             "linalg.ldl_solve": None,
-            "linalg.lstsq": None,
-            "linalg.lstsqgrad_oriented": None,
-            "linalg.matrix_norm": [torch.float32],
-            "linalg.norm": [torch.float32],
-            "linalg.normsubgradients_at_zero": [torch.float32],
-            "linalg.svdvals": None,
+            "masked.median": None,
             "matrix_exp": None,
             "max_pool2d_with_indices_backward": [
                 torch.int8,
@@ -383,7 +389,6 @@ if torch.backends.mps.is_available():
                 torch.int16,
                 torch.int32,
             ],
-            "normnuc": None,
             "nn.functional.avg_pool1d": [
                 torch.int16,
                 torch.int32,
@@ -615,8 +620,6 @@ if torch.backends.mps.is_available():
                 torch.float32,
             ],
             "float_power": None,
-            "linalg.matrix_rankhermitian": None,
-            "linalg.pinvhermitian": None,
             # MPS: input sizes must be divisible by output sizes
             "nn.functional.adaptive_avg_pool1d": None,
             "nn.functional.adaptive_avg_pool2d": None,
@@ -721,9 +724,6 @@ if torch.backends.mps.is_available():
         }
 
         ON_MPS_XFAILLIST: dict[str, list | None] = {
-            # Failures due to lack of implementation of downstream functions on MPS backend
-            # TODO: remove these once downstream function 'aten::_linalg_svd.U' have been implemented
-            "linalg.matrix_rank": None,
             # Exception: Caused by `torch.arange(-8.001, -4.0, dtype=torch.uint8, device="mps")`
             "arange": [torch.uint8],
             # Failure due to precision issue for fp16
@@ -868,6 +868,10 @@ if torch.backends.mps.is_available():
             "_upsample_bicubic2d_aa": None,  # `_upsample_bilinear2d_aa_backward_out` not implemented for MPS
             "sparse.mmreduce": [torch.float32],  # csr not supported
             "linalg.householder_product": None,
+            "linalg.normsubgradients_at_zero": [torch.float32],
+            "linalg.pinvhermitian": None,
+            "linalg.lstsq": [torch.float32],
+            "linalg.lstsqgrad_oriented": [torch.float32],
             "unique_consecutive": [torch.float16, torch.float32],
             "scalar_tensor": [torch.float16, torch.float32],
             "masked.scatter": [torch.float16, torch.float32],
@@ -951,9 +955,6 @@ if torch.backends.mps.is_available():
         }
 
         ON_MPS_XFAILLIST = {
-            # Failures due to lack of implementation of downstream functions on MPS backend
-            # TODO: remove these once downstream function 'aten::_linalg_svd.U' have been implemented
-            "linalg.matrix_rank": None,
             # Exception: Caused by sample input at index 3 on MPS
             "nn.functional.conv3d": [torch.float32],
         }

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -369,7 +369,6 @@ if torch.backends.mps.is_available():
             "linalg.ldl_factor": None,
             "linalg.ldl_factor_ex": None,
             "linalg.ldl_solve": None,
-            "masked.median": None,
             "matrix_exp": None,
             "max_pool2d_with_indices_backward": [
                 torch.int8,

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1629,8 +1629,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
-            # Exception: The operator 'aten::linalg_lstsq.out' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
             # https://github.com/pytorch/pytorch/issues/95412
             # see https://github.com/pytorch/pytorch/issues/177249
             DecorateInfo(
@@ -1670,8 +1668,6 @@ op_db: list[OpInfo] = [
                 "TestOperatorSignatures",
                 "test_get_torch_func_signature_exhaustive",
             ),
-            # Exception: The operator 'aten::linalg_lstsq.out' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1326,8 +1326,6 @@ op_db: list[OpInfo] = [
                 dtypes=[torch.float32],
                 active_if=TEST_WITH_ROCM,
             ),
-            # The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(
@@ -1444,8 +1442,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
-            # Exception: The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(
@@ -1483,8 +1479,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
-            # Exception: The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(
@@ -1808,40 +1802,6 @@ op_db: list[OpInfo] = [
                 dtypes=[torch.float32],
                 active_if=TEST_WITH_ROCM,
             ),
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref_torch_fallback",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
         ),
     ),
     OpInfo(
@@ -1872,40 +1832,6 @@ op_db: list[OpInfo] = [
                 unittest.expectedFailure, "TestFwdGradients", "test_forward_mode_AD"
             ),
             DecorateInfo(unittest.expectedFailure, "TestBwdGradients", "test_fn_grad"),
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref_torch_fallback",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
         ),
     ),
     OpInfo(
@@ -1934,28 +1860,6 @@ op_db: list[OpInfo] = [
                 device_type="cuda",
                 dtypes=[torch.float32],
                 active_if=TEST_WITH_ROCM,
-            ),
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
             ),
         ),
     ),
@@ -2432,25 +2336,6 @@ op_db: list[OpInfo] = [
                 "test_variant_consistency_jit",
                 dtypes=[torch.complex64, torch.float32],
             ),
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
-            ),
         ),
     ),
     OpInfo(
@@ -2475,25 +2360,6 @@ op_db: list[OpInfo] = [
                 "test_variant_consistency_jit",
                 device_type="mps",
                 dtypes=[torch.float32],
-            ),
-            # NotImplementedError: The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
             ),
         ),
     ),
@@ -2610,31 +2476,6 @@ op_db: list[OpInfo] = [
                 "test_fn_fwgrad_bwgrad",
                 device_type="cuda",
             ),
-            # NotImplementedError: The operator 'aten::_linalg_eigh.eigenvalues' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_noncontiguous_samples",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_requires_grad_error",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out_warning",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
-            ),
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=1e-03, rtol=1e-04)}),
                 "TestEagerFusionOpInfo",
@@ -2710,8 +2551,6 @@ op_db: list[OpInfo] = [
                 dtypes=[torch.float32],
                 active_if=TEST_WITH_ROCM,
             ),
-            # The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(
@@ -2857,23 +2696,6 @@ python_ref_db: list[OpInfo] = [
         # https://github.com/pytorch/pytorch/issues/77216
         validate_view_consistency=False,
         op_db=op_db,
-        skips=(
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref_torch_fallback",
-                device_type="mps",
-                dtypes=(torch.float32, torch.complex64),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref",
-                device_type="mps",
-                dtypes=(torch.float32, torch.complex64),
-            ),
-        ),
     ),
     PythonRefInfo(
         "_refs.linalg.norm",
@@ -2883,23 +2705,6 @@ python_ref_db: list[OpInfo] = [
         # https://github.com/pytorch/pytorch/issues/77216
         validate_view_consistency=False,
         op_db=op_db,
-        skips=(
-            # NotImplementedError: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref",
-                device_type="mps",
-                dtypes=(torch.float32, torch.complex64),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref_torch_fallback",
-                device_type="mps",
-                dtypes=(torch.float32, torch.complex64),
-            ),
-        ),
     ),
     PythonRefInfo(
         "_refs.linalg.svd",
@@ -2912,20 +2717,5 @@ python_ref_db: list[OpInfo] = [
         torch_opinfo_name="linalg.svdvals",
         supports_out=True,
         op_db=op_db,
-        skips=(
-            # The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref_torch_fallback",
-                device_type="mps",
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_python_ref",
-                device_type="mps",
-            ),
-        ),
     ),
 ]


### PR DESCRIPTION
Implements linalg.svd/svdvals, linalg.eigh/eigvalsh, and linalg.lstsq natively on MPS for float32 and complex64, replacing the CPU fallback.

SVD uses a one-sided Jacobi kernel; eigh uses a two-sided block-Jacobi kernel (correct on degenerate spectra, where the SVD-of-Hermitian shortcut fails). Both stage the matrix in threadgroup memory and write results straight into the framework's column-major output tensors. Matrices that exceed the threadgroup-memory limit, and double dtypes (no Metal double), fall back to CPU.

lstsq is built on the native SVD (x = V Sigma^+ U^H b) and reproduces the per-driver output rules so results match LAPACK.

Enabling these lights up the downstream ops that compose them: matrix_rank, pinv, cond, matrix_norm, norm, and nuclear norm now run on MPS for both dtypes. Tests compare singular/eigenvectors gauge- invariantly (eigenvalues plus reconstruction, not raw vectors); the few gradients that differentiate the vectors stay xfailed since they are gauge-ambiguous.

eig/eigvals (non-Hermitian) are left for a follow-up.