### PR TITLE
torch/headeronly/util/TypeList.h: simplify contains and find_if with C++20 fold expressions and if constexpr

### DIFF
--- a/torch/headeronly/util/TypeList.h
+++ b/torch/headeronly/util/TypeList.h
@@ -167,24 +167,14 @@ struct count_if final {
  *  contains<typelist<int, string>, double> == false_type
  */
 namespace detail {
-template <class TypeList, class Type, class Enable = void>
-struct contains {};
-template <class Type>
-struct contains<typelist<>, Type, void> : std::false_type {};
-template <class Type, class Head, class... Tail>
-struct contains<
-    typelist<Head, Tail...>,
-    Type,
-    std::enable_if_t<std::is_same_v<Head, Type>>> : std::true_type {};
-template <class Type, class Head, class... Tail>
-struct contains<
-    typelist<Head, Tail...>,
-    Type,
-    std::enable_if_t<!std::is_same_v<Head, Type>>>
-    : contains<typelist<Tail...>, Type> {};
+template <class TypeList, class Type>
+struct contains_impl : std::false_type {};
+template <class Type, class... Types>
+struct contains_impl<typelist<Types...>, Type>
+    : std::bool_constant<(std::is_same_v<Types, Type> || ...)> {};
 } // namespace detail
 template <class TypeList, class Type>
-using contains = typename detail::contains<TypeList, Type>::type;
+using contains = typename detail::contains_impl<TypeList, Type>::type;
 
 /**
  * Returns true iff the type trait is true for all types in the type list
@@ -453,21 +443,14 @@ struct find_if<typelist<>, Condition, void> final {
       "In typelist::find_if<Type/List, Condition>, didn't find any type fulfilling the Condition.");
 };
 template <class Head, class... Tail, template <class> class Condition>
-struct find_if<
-    typelist<Head, Tail...>,
-    Condition,
-    std::enable_if_t<Condition<Head>::value>>
-    final {
-  static constexpr size_t value = 0;
-};
-template <class Head, class... Tail, template <class> class Condition>
-struct find_if<
-    typelist<Head, Tail...>,
-    Condition,
-    std::enable_if_t<!Condition<Head>::value>>
-    final {
-  static constexpr size_t value =
-      1 + find_if<typelist<Tail...>, Condition>::value;
+struct find_if<typelist<Head, Tail...>, Condition, void> final {
+  static constexpr size_t value = [] {
+    if constexpr (Condition<Head>::value) {
+      return size_t{0};
+    } else {
+      return size_t{1} + find_if<typelist<Tail...>, Condition>::value;
+    }
+  }();
 };
 
 /**


### PR DESCRIPTION
Summary:
Two modernizations to the typelist utilities:

1. `contains`: Replace the three-specialization recursive SFINAE pattern (primary + empty-list + two enable_if-discriminated non-empty cases) with a single partial specialization using a C++20 fold expression: `(std::is_same_v<Types, Type> || ...)`. The result is non-recursive and O(1) instantiation depth regardless of list length.

2. `find_if`: Collapse the two enable_if-discriminated non-empty-list specializations (one for `Condition<Head>::value == true`, one for false) into a single specialization using `if constexpr`. The primary (static_assert) and empty-list (static_assert) specializations are unchanged.

Both changes produce identical semantics. The fold-expression form of `contains` also avoids the need for the three-argument `detail::contains<TypeList, Type, Enable>` helper.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.


