### PR TITLE
Fix SIGFPE in torch.lcm with the integer type minimum

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1195,7 +1195,22 @@ void lcm_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "lcm_cpu", [&]() {
     cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
       scalar_t g = calc_gcd(a, b);
-      return (g == 0) ? 0 : std::abs(a / g * b);
+      if (g == 0) {
+        return 0;
+      }
+      // Compute the lcm magnitude purely from unsigned magnitudes. The signed
+      // form abs(a / g * b) traps on the type-min / -1 division (calc_gcd can
+      // return a negative gcd for a type-min input because abs of the type
+      // minimum overflows) and can overflow the product; doing it in unsigned
+      // never traps and the wraparound matches NumPy.
+      // See https://github.com/pytorch/pytorch/issues/121343.
+      using unsigned_t = std::make_unsigned_t<scalar_t>;
+      auto umag = [](scalar_t v) -> unsigned_t {
+        unsigned_t uv = static_cast<unsigned_t>(v);
+        return v < 0 ? static_cast<unsigned_t>(0) - uv : uv;
+      };
+      unsigned_t result = (umag(a) / umag(g)) * umag(b);
+      return static_cast<scalar_t>(result);
     });
   });
 }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2999,6 +2999,19 @@ class TestBinaryUfuncs(TestCase):
         self.assertEqual(actual, expected, exact_dtype=False)
 
     @onlyNativeDeviceTypes
+    @dtypes(torch.int16, torch.int32, torch.int64)
+    def test_lcm_int_min(self, device, dtype):
+        # lcm of the type minimum must not raise SIGFPE from the INT_MIN / -1
+        # integer-division trap; it should match NumPy's wraparound.
+        # See https://github.com/pytorch/pytorch/issues/121343
+        info = torch.iinfo(dtype)
+        a = torch.tensor([info.min], dtype=dtype, device=device)
+        b = torch.tensor([215], dtype=dtype, device=device)
+        actual = torch.lcm(a, b)
+        expected = np.lcm(a.cpu().numpy(), b.cpu().numpy())
+        self.assertEqual(actual, expected, exact_dtype=False)
+
+    @onlyNativeDeviceTypes
     @dtypesIfCPU(torch.float32, torch.float64, torch.float16)
     @dtypes(torch.float32, torch.float64)
     def test_nextafter(self, device, dtype):


### PR DESCRIPTION
Fixes #121343

`torch.lcm` raises SIGFPE for the integer type minimum, for example `torch.lcm(torch.tensor([-9223372036854775808]), torch.tensor(215))`.

The CPU `lcm_kernel` computes `std::abs(a / g * b)` where `g = calc_gcd(a, b)`. `calc_gcd` takes `abs` of its inputs, but `abs(INT64_MIN)` overflows and stays negative, so `calc_gcd(INT64_MIN, 215)` returns `-1`. The division `a / g` then becomes `INT64_MIN / -1`, the one signed integer division that traps with SIGFPE. The product also overflows, which is undefined behavior, so a guard that returns a UB expression gets optimized away under -O3 and does not help.

This computes the lcm magnitude from unsigned magnitudes instead, so there is no trapping division and no signed overflow. The result wraps modulo 2^N, matching NumPy (`np.lcm(INT64_MIN, 215) == INT64_MIN`). Normal inputs are unchanged.

Added a regression test covering int16, int32 and int64.

Note: `torch.gcd` also returns a negative gcd for a type-minimum input (`torch.gcd(INT64_MIN, 215)` returns -1) for the same `abs(INT_MIN)` reason. That is a separate latent issue in `calc_gcd`, happy to address it in a follow-up.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01