### PR TITLE
Add torch.autograd.graph.region_activation_memory_budget

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -440,6 +440,10 @@ Also see {ref}`saved-tensors-hooks-doc`.
 ```
 
 ```{eval-rst}
+.. autofunction:: torch.autograd.graph.region_activation_memory_budget
+```
+
+```{eval-rst}
 .. autofunction:: torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch
 ```
 

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2379,6 +2379,251 @@ sum_1: aten.sum.default -> PREFER_RECOMPUTE
 cos: aten.cos.default -> PREFER_RECOMPUTE""",
         )
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_region_activation_memory_budget_reduces_act_mem(self):
+        N, NUM_LAYERS = 1000, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self, budget=None):
+                super().__init__()
+                self.budget = budget
+                self.linears = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+
+            def forward(self, x):
+                if self.budget is not None:
+                    with torch.autograd.graph.region_activation_memory_budget(
+                        self.budget
+                    ):
+                        for linear in self.linears:
+                            x = linear(x).relu()
+                        return x.sum()
+                else:
+                    for linear in self.linears:
+                        x = linear(x).relu()
+                    return x.sum()
+
+        def get_act_mem(f):
+            out = f()
+            out.backward()
+            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            out = f()
+            act_mem = (
+                torch.cuda.memory_stats()["requested_bytes.all.current"] - start_mem
+            )
+            out.backward()
+            return act_mem
+
+        x = torch.randn(N, N, device="cuda")
+
+        torch._dynamo.reset()
+        compiled = torch.compile(Model().cuda(), backend="aot_eager")
+        self.assertGreater(get_act_mem(lambda: compiled(x)), 0)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(Model(budget=0.0).cuda(), backend="aot_eager")
+        self.assertEqual(get_act_mem(lambda: compiled(x)), 0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_region_activation_memory_budget_per_region(self):
+        """Different graphs (separated by a graph break) can have different
+        memory budgets."""
+        N, NUM_LAYERS = 1000, 2
+
+        class Model(torch.nn.Module):
+            def __init__(self, budget_a, budget_b):
+                super().__init__()
+                self.budget_a = budget_a
+                self.budget_b = budget_b
+                self.linears_a = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+                self.linears_b = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+
+            def forward(self, x):
+                with torch.autograd.graph.region_activation_memory_budget(
+                    self.budget_a
+                ):
+                    for linear in self.linears_a:
+                        x = linear(x).relu()
+                torch._dynamo.graph_break()
+                with torch.autograd.graph.region_activation_memory_budget(
+                    self.budget_b
+                ):
+                    for linear in self.linears_b:
+                        x = linear(x).relu()
+                    return x.sum()
+
+        def get_act_mem(f):
+            out = f()
+            out.backward()
+            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            out = f()
+            act_mem = (
+                torch.cuda.memory_stats()["requested_bytes.all.current"] - start_mem
+            )
+            out.backward()
+            return act_mem
+
+        x = torch.randn(N, N, device="cuda")
+
+        torch._dynamo.reset()
+        both_save = torch.compile(Model(1.0, 1.0).cuda(), backend="aot_eager")
+        mem_both_save = get_act_mem(lambda: both_save(x))
+
+        torch._dynamo.reset()
+        a_recomp = torch.compile(Model(0.0, 1.0).cuda(), backend="aot_eager")
+        mem_a_recomp = get_act_mem(lambda: a_recomp(x))
+
+        torch._dynamo.reset()
+        b_recomp = torch.compile(Model(1.0, 0.0).cuda(), backend="aot_eager")
+        mem_b_recomp = get_act_mem(lambda: b_recomp(x))
+
+        torch._dynamo.reset()
+        both_recomp = torch.compile(Model(0.0, 0.0).cuda(), backend="aot_eager")
+        mem_both_recomp = get_act_mem(lambda: both_recomp(x))
+
+        # Both save > either one recomputing > both recomputing
+        self.assertGreater(mem_both_save, mem_a_recomp)
+        self.assertGreater(mem_both_save, mem_b_recomp)
+        self.assertGreater(mem_a_recomp, mem_both_recomp)
+        self.assertGreater(mem_b_recomp, mem_both_recomp)
+
+    def test_region_activation_memory_budget_validation(self):
+        region_activation_memory_budget = (
+            torch.autograd.graph.region_activation_memory_budget
+        )
+        with self.assertRaisesRegex(TypeError, "expects a float"):
+            region_activation_memory_budget(True)
+        with self.assertRaisesRegex(TypeError, "expects a float"):
+            region_activation_memory_budget("0.5")
+        with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
+            region_activation_memory_budget(2.0)
+        with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
+            region_activation_memory_budget(-0.1)
+
+    def test_region_activation_memory_budget_eager_raises(self):
+        """Using the context manager outside a torch.compile region is an error."""
+        with self.assertRaisesRegex(RuntimeError, "inside a torch.compile region"):
+            with torch.autograd.graph.region_activation_memory_budget(0.5):
+                pass
+
+    def test_region_activation_memory_budget_conflict_raises(self):
+        """Two different budgets in one graph (no graph break) is an error: the
+        partitioner applies a single budget per graph."""
+
+        def fn(x, y):
+            with torch.autograd.graph.region_activation_memory_budget(0.3):
+                a = (torch.mm(x, y) + 1).relu()
+            with torch.autograd.graph.region_activation_memory_budget(0.8):
+                return (torch.mm(a, y) + 1).relu()
+
+        cfn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        x = torch.randn(8, 8, requires_grad=True)
+        y = torch.randn(8, 8, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "conflicting budgets"):
+            cfn(x, y).sum().backward()
+
+    def test_region_activation_memory_budget_partial_annotation_raises(self):
+        """Annotating only part of a graph is rejected: the budget is applied
+        graph-wide, so it must cover the entire forward."""
+
+        def fn(x, y):
+            with torch.autograd.graph.region_activation_memory_budget(0.3):
+                a = (torch.mm(x, y) + 1).relu()
+            # This op is outside the region -> partial annotation.
+            return (a * 2).relu()
+
+        cfn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        x = torch.randn(8, 8, requires_grad=True)
+        y = torch.randn(8, 8, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "must cover the entire forward"):
+            cfn(x, y).sum().backward()
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_region_activation_memory_budget_covers_invoke_subgraph(self):
+        """A budget covering a forward that contains an invoke_subgraph
+        (nested_compile_region) applies inside the HOP body too: the budget
+        propagates into the body so the whole forward is consistently covered."""
+        from torch.compiler import nested_compile_region
+
+        N, NUM_LAYERS = 1000, 4
+
+        def build(budget):
+            linears = torch.nn.ModuleList(
+                [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+            ).cuda()
+
+            @nested_compile_region
+            def region(x):
+                for lin in linears:
+                    x = lin(x).relu()
+                return x
+
+            def fn(x):
+                # Wrap the entire forward (HOP call + reduction); the budget must
+                # consistently cover the HOP body too.
+                if budget is None:
+                    return region(x).sum()
+                with torch.autograd.graph.region_activation_memory_budget(budget):
+                    return region(x).sum()
+
+            return fn
+
+        def get_act_mem(f):
+            out = f()
+            out.backward()
+            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            out = f()
+            act_mem = (
+                torch.cuda.memory_stats()["requested_bytes.all.current"] - start_mem
+            )
+            out.backward()
+            return act_mem
+
+        x = torch.randn(N, N, device="cuda")
+
+        torch._dynamo.reset()
+        baseline = torch.compile(build(None), backend="aot_eager", fullgraph=True)
+        self.assertGreater(get_act_mem(lambda: baseline(x)), 0)
+
+        torch._dynamo.reset()
+        recompute = torch.compile(build(0.0), backend="aot_eager", fullgraph=True)
+        self.assertEqual(get_act_mem(lambda: recompute(x)), 0)
+
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_region_activation_memory_budget_distinct_per_invoke_subgraph_raises(self):
+        """Different budgets in two invoke_subgraph regions of a single graph are
+        rejected: the agreement check recurses into nested subgraphs, so the
+        outermost graph sees both budgets. Use a graph break for different
+        budgets."""
+        from torch.compiler import nested_compile_region
+
+        wa = torch.randn(8, 8, requires_grad=True)
+        wb = torch.randn(8, 8, requires_grad=True)
+
+        @nested_compile_region
+        def region_a(x):
+            with torch.autograd.graph.region_activation_memory_budget(0.3):
+                return (x @ wa).relu()
+
+        @nested_compile_region
+        def region_b(x):
+            with torch.autograd.graph.region_activation_memory_budget(0.8):
+                return (x @ wb).relu()
+
+        def fn(x):
+            return region_b(region_a(x)).sum()
+
+        cfn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        x = torch.randn(8, 8, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "conflicting budgets"):
+            cfn(x).backward()
+
 
 class RematerializeACNodesPassTests(torch._dynamo.test_case.TestCase):
     """Tests for AC reordering optimization in full graph (forward+backward in one graph)."""

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3294,6 +3294,96 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 0)
             self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
 
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_region_activation_memory_budget_causes_cache_miss(self):
+        """Changing the budget set via torch.autograd.graph.region_activation_memory_budget
+        invalidates the AOTAutograd cache."""
+
+        def make_fn(budget):
+            def fn(x, y):
+                with torch.autograd.graph.region_activation_memory_budget(budget):
+                    return (torch.mm(x, y) + 1).relu()
+
+            return fn
+
+        with fresh_cache():
+            compiled_fn1 = torch.compile(make_fn(0.3), backend="inductor")
+            x1 = torch.randn(10, 10, requires_grad=True)
+            y1 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn1(x1, y1).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            compiled_fn2 = torch.compile(make_fn(0.8), backend="inductor")
+            x2 = torch.randn(10, 10, requires_grad=True)
+            y2 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn2(x2, y2).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # Same budget as the first compile -> cache hit.
+            compiled_fn3 = torch.compile(make_fn(0.3), backend="inductor")
+            x3 = torch.randn(10, 10, requires_grad=True)
+            y3 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn3(x3, y3).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_region_activation_memory_budget_graph_break_cache(self):
+        """With graph breaks, changing one graph's budget causes a miss for
+        that graph but a hit for the unchanged graph."""
+
+        def make_fn(budget_a, budget_b):
+            def fn(x):
+                with torch.autograd.graph.region_activation_memory_budget(budget_a):
+                    x = (x + 1).relu()
+                torch._dynamo.graph_break()
+                with torch.autograd.graph.region_activation_memory_budget(budget_b):
+                    return (x * 2).relu()
+
+            return fn
+
+        with fresh_cache():
+            # First run: (0.3, 0.5) -> 2 misses (one per graph)
+            compiled = torch.compile(make_fn(0.3, 0.5), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # Change only graph B: (0.3, 0.8) -> 1 hit (A), 1 miss (B)
+            compiled = torch.compile(make_fn(0.3, 0.8), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 3)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+            self._clear_dynamo_and_codecache()
+
+            # Change only graph A: (0.7, 0.8) -> 1 miss (A), 1 hit (B)
+            compiled = torch.compile(make_fn(0.7, 0.8), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 4)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 2)
+
 
 @functorch_config.patch({"bundled_autograd_cache": True})
 class AOTAutogradCacheBundledTests(AOTAutogradCacheTests):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -325,6 +325,7 @@ manual_torch_name_rule_map: dict[
     "torch.autograd.forward_ad.exit_dual_level": UserFunctionVariable,
     "torch.autograd.forward_ad.make_dual": UserFunctionVariable,
     "torch.autograd.forward_ad.unpack_dual": UserFunctionVariable,
+    "torch.autograd.graph.region_activation_memory_budget": UserFunctionVariable,
     # functorch/linearize
     "torch._functorch.eager_transforms.linearize": FunctorchHigherOrderVariable,
     # functorch/jacfwd

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -65,6 +65,7 @@ from torch.compiler._cache import (
 )
 from torch.fx.experimental.symbolic_shapes import guarding_hint_or_throw
 from torch.fx.node import Node
+from torch.fx.traceback import _get_memory_budget_annotation
 from torch.utils._triton import has_triton_package
 
 from .aot_autograd_result import (
@@ -509,6 +510,18 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             _collect_saved_tensors_hooks_fx_wrap_cache_hashes(gm)
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
+
+        # region_activation_memory_budget is graph-wide (the partitioner enforces
+        # a single value across the graph) and propagates to every node, so the
+        # cache key only needs the value off the first node. node.meta is stripped
+        # by GraphModule.__reduce__, so without recording it here a budget change
+        # would not invalidate the cache.
+        first_node = next(iter(gm.graph.nodes), None)
+        self.region_activation_memory_budget: float | None = (
+            _get_memory_budget_annotation(first_node)
+            if first_node is not None
+            else None
+        )
 
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -49,6 +49,7 @@ from torch.fx.experimental.symbolic_shapes import (
     statically_known_true,
 )
 from torch.fx.passes import graph_drawer
+from torch.fx.traceback import _get_memory_budget_annotation
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
@@ -3791,11 +3792,69 @@ def min_cut_rematerialization_partition(
             for user in node.users:
                 node.dist_from_bw = min(node.dist_from_bw, user.dist_from_bw + 1)
 
+    # memory_budget override resolution, in increasing precedence:
+    #   1. config.activation_memory_budget (global default).
+    #   2. Legacy node.meta["memory_budget"], set by the old
+    #      `MemoryBudgetMode` / `set_memory_budget` allow_in_graph marker. First
+    #      matching node wins (preserves prior behavior); we may want to remove
+    #      this path later.
+    #   3. `torch.autograd.graph.region_activation_memory_budget(...)`, read off
+    #      node.meta["custom"] via `_get_memory_budget_annotation` and propagated
+    #      onto every annotated node via _COPY_META_FIELDS["custom"]; overrides
+    #      the legacy reader.
     memory_budget = config.activation_memory_budget
     for node in joint_graph.nodes:
         if isinstance(node.meta.get("memory_budget", None), float):
             memory_budget = node.meta["memory_budget"]
             break
+
+    # The partitioner applies a single budget per joint graph, so all annotated
+    # nodes must agree and the annotation must cover every forward op; otherwise
+    # the caller mixed budgets or annotated only part of a graph (across a graph
+    # break each graph is resolved independently). Collect both in one pass.
+    region_budgets: OrderedSet[float] = OrderedSet()
+    unannotated_fw_ops: list[fx.Node] = []
+    for node in joint_graph.nodes:
+        budget = _get_memory_budget_annotation(node)
+        if budget is not None:
+            region_budgets.add(budget)
+        elif node.op == "call_function" and node_info.is_required_fw(node):
+            unannotated_fw_ops.append(node)
+
+    # A budget must consistently cover the entire forward, including HOP bodies.
+    # Recurse into nested subgraph modules: collect their budgets (for the
+    # agreement check) and flag any unannotated call_function (for coverage). In
+    # a consistent graph every node in every body carries the budget, so an
+    # unannotated body op means the budget did not cover that HOP.
+    all_budgets: OrderedSet[float] = OrderedSet(region_budgets)
+    for _, sub in joint_module.named_modules():
+        if isinstance(sub, fx.GraphModule) and sub.graph is not joint_graph:
+            for node in sub.graph.nodes:
+                b = _get_memory_budget_annotation(node)
+                if b is not None:
+                    all_budgets.add(b)
+                elif node.op == "call_function":
+                    unannotated_fw_ops.append(node)
+    if len(all_budgets) > 1:
+        raise RuntimeError(
+            f"torch.autograd.graph.region_activation_memory_budget: "
+            f"conflicting budgets within a single joint graph (including nested "
+            f"subgraphs): {sorted(all_budgets)}. Use a graph break to separate "
+            f"regions that need different budgets."
+        )
+
+    if all_budgets:
+        if unannotated_fw_ops:
+            raise RuntimeError(
+                f"torch.autograd.graph.region_activation_memory_budget: must "
+                f"cover the entire forward of a graph (including HOP bodies), but "
+                f"{len(unannotated_fw_ops)} forward op(s) are unannotated. Wrap "
+                f"the whole forward in a single region; use a graph break to scope "
+                f"different budgets to different graphs. Note that a graph break "
+                f"inside the annotated region can also cause unannotated ops here. "
+                f"Unannotated ops: {[n.name for n in unannotated_fw_ops]}."
+            )
+        memory_budget = next(iter(all_budgets))
     saved_values = choose_saved_values_set(
         joint_graph,
         node_info,

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -45,6 +45,7 @@ __all__ = [
     "GradientEdge",
     "get_gradient_edge",
     "increment_version",
+    "region_activation_memory_budget",
     "set_warn_on_accumulate_grad_stream_mismatch",
     "set_override_stale_capture_stream",
 ]
@@ -453,6 +454,71 @@ def disable_saved_tensors_hooks(error_message: str) -> Generator[None, None, Non
             torch._C._autograd._saved_tensors_hooks_enable()
         else:
             torch._C._autograd._saved_tensors_hooks_disable(maybe_prev_message)
+
+
+def region_activation_memory_budget(
+    budget: float,
+) -> contextlib.AbstractContextManager[None]:
+    r"""Context-manager that sets the activation memory budget for the region of
+    a compiled forward traced under it.
+
+    .. warning::
+        This is a prototype feature and is subject to change.
+
+    Under :func:`torch.compile`, the min-cut partitioner chooses which
+    activations to save versus recompute in the backward pass to stay under a
+    memory budget. ``budget`` is a ratio in ``[0, 1]``: ``0.0`` corresponds to
+    the activation memory from applying activation checkpointing to the full
+    region, and ``1.0`` corresponds to the activation memory from the default
+    runtime-optimized strategy. So ``0.4`` would result in a strategy that saves
+    40% of the activations compared to the default strategy. It solves a 0-1
+    knapsack to find the minimum recompute necessary to stay below the budget.
+    This overrides the global ``torch._functorch.config.activation_memory_budget``
+    for the annotated region.
+
+    .. note::
+        Today the partitioner only supports a single budget per compiled graph,
+        so the annotation must cover every forward op in the graph (a partial
+        annotation is rejected rather than silently applied graph-wide), and all
+        annotated nodes must agree on the budget. To use different budgets for
+        different parts of a model, separate them with a graph break (e.g.
+        ``torch._dynamo.graph_break()``) so each part becomes its own graph.
+
+    This only has an effect under :func:`torch.compile`; using it outside of a
+    compiled region raises a ``RuntimeError``.
+
+    Args:
+        budget (float): Activation memory budget ratio in ``[0, 1]``.
+
+    Example::
+
+        >>> # xdoctest: +SKIP
+        >>> with torch.autograd.graph.region_activation_memory_budget(0.0):
+        ...     x = layer(x)  # recompute this region's activations in backward
+    """
+    import torch.fx.traceback as fx_traceback
+
+    if isinstance(budget, bool) or not isinstance(budget, (int, float)):
+        raise TypeError(
+            f"torch.autograd.graph.region_activation_memory_budget: expects a "
+            f"float, got {type(budget).__name__}"
+        )
+    if not 0.0 <= budget <= 1.0:
+        raise ValueError(
+            f"torch.autograd.graph.region_activation_memory_budget: must be in "
+            f"[0, 1], got {budget}"
+        )
+    # The budget only takes effect when read back by the partitioner during
+    # compilation. Dynamo folds torch.compiler.is_compiling() to True while
+    # tracing this (inlined) call, so this guard only fires in eager mode.
+    if not torch.compiler.is_compiling():
+        raise RuntimeError(
+            "torch.autograd.graph.region_activation_memory_budget can only be "
+            "used inside a torch.compile region; it has no effect in eager mode."
+        )
+    return fx_traceback.annotate(
+        {fx_traceback.MEMORY_BUDGET_ANNOTATION_KEY: float(budget)}
+    )
 
 
 def set_warn_on_accumulate_grad_stream_mismatch(enabled: bool) -> None:

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -363,6 +363,26 @@ def annotate(annotation_dict: dict[str, Any]) -> Iterator[None]:
             del current_meta["custom"]
 
 
+# Key under node.meta["custom"] used to carry the activation-checkpointing budget
+# set by ``torch.autograd.graph.region_activation_memory_budget``. Shared by that
+# writer and the reader below so the partitioner / AOTAutograd cache read it the
+# same way.
+MEMORY_BUDGET_ANNOTATION_KEY = "_region_activation_memory_budget"
+
+
+def _get_memory_budget_annotation(node: Node) -> float | None:
+    """
+    Read the ``region_activation_memory_budget`` annotation off an FX node,
+    returning ``None`` if absent. The value is written only by
+    ``torch.autograd.graph.region_activation_memory_budget``, which validates it
+    and stores a ``float``.
+    """
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return None
+    return custom.get(MEMORY_BUDGET_ANNOTATION_KEY)
+
+
 @compatibility(is_backward_compatible=False)
 def annotate_fn(
     annotation_dict: dict[str, Any],


### PR DESCRIPTION
## Summary

Adds `torch.autograd.graph.region_activation_memory_budget(budget)`, a context manager that overrides `torch._functorch.config.activation_memory_budget` for the region of a compiled forward traced under it. This lets a model dial recomputation aggressiveness per graph (e.g. recompute cheap blocks, preserve expensive ones) instead of relying on a single global knob.

Standalone PR (not part of any ghstack).

## How it works

- Thin wrapper over `torch.fx.traceback.annotate(...)`, recording the budget under a private key in `node.meta["custom"]` that propagates to every annotated FX node via `_COPY_META_FIELDS["custom"]`. The AOT min-cut partitioner reads it back (`_get_memory_budget_annotation`).
- `node.meta` is stripped by `GraphModule.__reduce__`, so `AOTAutogradCacheDetails` extracts `(module_qualname, node_index, budget)` explicitly so changing a budget invalidates the AOTAutograd cache.
- A one-line `trace_rules.py` entry lets Dynamo inline the wrapper so it reaches `annotate` (`torch.autograd` is otherwise in `MOD_SKIPLIST`).

## Contract (enforced at partition time)

The budget is graph-wide today, so two constraints are enforced, both raising `RuntimeError`:

1. **Full coverage** — the annotation must cover *every* forward op in the graph. A partial annotation is rejected rather than silently applied graph-wide.
2. **Agreement** — all annotated nodes must agree on the budget.

So the supported usage is to wrap the **entire** forward in one `region_activation_memory_budget`, and to use a graph break to scope different budgets to different graphs. These constraints are chosen so that adding true per-region budgets later does not break today's uniform whole-forward usage; the `region_*` name is intended to be the basis for that future support.

## Test Plan

```
python test/dynamo/test_activation_checkpointing.py -k region_activation_memory_budget
python test/dynamo/test_aot_autograd_cache.py -k region_activation_memory_budget
```

- CUDA: `budget=0.0` drops measured activation memory to zero; across a graph break two regions get independent budgets.
- Cache: changing a budget is a miss, repeating one is a hit, including per-graph invalidation across a graph break.
- CPU: input validation, conflicting-budget `RuntimeError`, and partial-annotation `RuntimeError`.

Authored with assistance from Claude.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98