### PR TITLE
Preserve no-op dropout identity in decomposition

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2384,6 +2384,24 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = fn(y)
         self.assertTrue(same(ref, res))
 
+    def test_dropout_eval_setattr_parameter(self):
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(5, 5))
+
+            def forward(self, x):
+                w = torch.nn.functional.dropout(self.weight, training=False)
+                self.foo = w
+                return x + self.weight
+
+        mod = Mod()
+        x = torch.randn(5, 5)
+        mod(x)
+        mod.compile(backend="eager", fullgraph=True)
+        self.assertTrue(same(mod(x), x + mod.weight))
+        self.assertIs(mod.foo, mod.weight)
+
     def test_setitem_boolean_mask_diff(self):
         def fn(x, b, y):
             x = x.clone()

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5034,14 +5034,16 @@ class TestAOTExport(AOTTestCase):
         ):
             aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
 
-        gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=False)
+        gm, graph_sig = aot_export_module(
+            mod, [inp], trace_joint=False, pre_dispatch=False
+        )
+        self.assertEqual(graph_sig.user_inputs_to_mutate, {"add": "arg1_1"})
         self.assertExpectedInline(
             str(gm.code).strip(),
             """\
 def forward(self, arg0_1, arg1_1):
-    clone = torch.ops.aten.clone.default(arg1_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    return (add,)""",
+    add = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
+    return (add, add)""",
         )
 
         fw_graph_cell = [None]
@@ -5061,9 +5063,8 @@ def forward(self, arg0_1, arg1_1):
             str(fw_graph.code).strip(),
             """\
 def forward(self, arg0_1, arg1_1):
-    clone = torch.ops.aten.clone.default(arg1_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    return (add,)""",
+    add = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
+    return (add, add)""",
         )
 
     def test_aot_export_predispatch_func_simple(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1267,7 +1267,7 @@ def dropout(input: Tensor, p: float, train: bool | None):
     if train and p != 0:
         return aten.native_dropout(input, p, train)[0]
     else:
-        return input.clone()
+        return input
 
 
 @register_decomposition(aten.native_dropout)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185981

The aten.dropout decomposition used aten.native_dropout semantics for the no-op branch and returned input.clone() when train was false or p was zero. Eager aten.dropout instead returns the original tensor object for these no-op cases.

That difference matters when Dynamo traces dropout on a Parameter. The cloned FakeTensor no longer preserves the original Parameter identity, so assigning it back through Module.__setattr__ can take the registered-parameter error path and try to format torch.typename, which Dynamo intentionally skips. Return the input directly in the no-op decomposition branch so tracing matches eager dropout aliasing.

Post-dispatch AOT export also now observes the correct alias: mutating the result of eval dropout mutates the input, so the existing dropout mutation test expectation is updated to assert the input-mutation signature instead of the old clone graph.

A narrower alternative would have been to special-case Module.__setattr__ or torch.typename tracing, but that would only hide the symptom. Matching dropout's eager identity semantics fixes the source of the incorrect FakeTensor identity.

Fixes #160241
Generated by my agent

Benchmark Results:
A simple CPU microbenchmark comparing eval dropout identity against the old clone behavior on a 4096x4096 tensor shows the fix removes the clone cost:

- eval_dropout_identity_current: 0.000160s total for 100 iters, 1.60 us/iter
- clone_baseline_old_decomp_behavior: 0.771761s total for 100 iters, 7717.61 us/iter
- speedup_vs_clone_baseline: 4831.36x

Test Plan:
- python test/dynamo/test_repros.py -k test_dropout_eval_setattr_parameter
- PYTHONPATH=test/functorch:test:$PYTHONPATH python - <<'PY' ... run TestAOTExport.test_aot_export_ban_dropout_mut_pre_dispatch with local torchvision import blocked due environment CUDA mismatch
- python test/dynamo/test_repros.py -k dropout
- minimal torch.compile fullgraph repro from #160241
- minimal torch.export.export repro from #160241
- lintrunner -a --skip PYREFLY test/functorch/test_aotdispatch.py test/dynamo/test_repros.py torch/_decomp/decompositions.py
- lintrunner -a currently hits unrelated PYREFLY errors in torch/export/pt2_archive/_package.py and torch/nn/modules/loss.py
- git diff --cached --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98