### PR TITLE
[Inductor] Fix TMA compat to check returned options, not class

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3648,7 +3648,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     can_lift=can_lift,
                     stride_sorter_cls=stride_sorter_cls,
                 )
-                if issubclass(options_class, TensorDescriptorOptions):
+                if isinstance(options, TensorDescriptorOptions):
                     tma_compatibility_checker = cast(
                         TMACompatibilityChecker, tma_compatibility_checker
                     )


### PR DESCRIPTION
Summary:
[Inductor] Fix TMA compat to check returned options, not class

**Summary**
Fix a bug in the TMA compatibility check that prevented backends from falling back to BlockPtrOptions, causing unwanted scalar-pointer fallbacks and PE timeouts.

**Problem**
The TMA compatibility check at triton.py:3595 used `issubclass(options_class, TensorDescriptorOptions)` on the *queried* class instead of the *returned* options. When backends like MTIA override `TensorDescriptorOptions.create` to fall back to `BlockPtrOptions` (for shapes incompatible with hardware layout), the check incorrectly fired anyway, rejecting block params and triggering Triton's scalar-pointer fallback.

**Solution**
Changed to `isinstance(options, TensorDescriptorOptions)` to check the actual returned type. Now when a backend's `create` returns `BlockPtrOptions`, the TMA check is correctly skipped, allowing the block pointer to flow to `codegen_block_ptr` and backends to register autotune metadata (e.g., MTIA's `inner_blocks` for bump-to-minimum heuristic).

**Impact**
- Fixes PE timeouts caused by unwanted scalar-pointer fallbacks
- Enables backends to properly use their custom autotune heuristics
- Small change (1 line in 2 files) with targeted fix

Test Plan:
- Ran `buck2 test fbcode//mode/opt fbcode//mtia/compiler/graph_compiler/inductor/test:test_inductor_kernels -- --regex 'test_bump_block_size'`
- Before fix: XBLOCK=2 for int8/float16/float32 (heuristic skipped because `inner_blocks` empty)
- After fix: XBLOCK bumped to 32/16/8 per dtype, matching the 32-byte hardware floor
- **TODO: Paste full test output showing the XBLOCK values before/after**

Differential Revision: D106090810




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo