### PR TITLE
[MTIA] Short-circuit `signbit` for unsigned dtypes (#185985)

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -387,7 +387,8 @@ TORCH_IMPL_FUNC(polygamma_out)
 }
 
 TORCH_IMPL_FUNC(signbit_out) (const Tensor& self, const Tensor& result) {
-  if (self.dtype() == at::kBool) {
+  auto dt = self.scalar_type();
+  if (at::isIntegralType(dt, /*includeBool=*/true) && !at::isSignedType(dt)) {
     result.fill_(false);
   } else {
     signbit_stub(device_type(), *this);

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8577,6 +8577,20 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             (torch.randn([1, 2, 6, 6]),),
         )
 
+    def test_signbit_unsigned_dtypes(self):
+        def fn(x):
+            return torch.signbit(x)
+
+        for dtype in [
+            torch.bool,
+            torch.uint8,
+            torch.uint16,
+            torch.uint32,
+            torch.uint64,
+        ]:
+            x = torch.tensor([0, 1, 1, 0, 1], dtype=dtype)
+            self.common(fn, [x], check_lowp=False)
+
     def test_sign_dtype(self):
         def fn(x):
             y = torch.sign(x)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8137,7 +8137,21 @@ reciprocal = register_pointwise_numeric(aten.reciprocal)
 register_pointwise(aten.remainder)
 sign = register_pointwise(aten.sign, override_fn_when_input_bool="identity")
 register_pointwise(aten.ceil)
-register_pointwise(aten.signbit, override_return_dtype=torch.bool)
+
+
+@register_lowering(aten.signbit)
+def signbit(x):
+    if x.get_dtype() in (
+        torch.bool,
+        torch.uint8,
+        torch.uint16,
+        torch.uint32,
+        torch.uint64,
+    ):
+        return full_like(x, False, dtype=torch.bool)
+    fn = ops_wrapper("signbit")
+    return make_pointwise(fn, override_return_dtype=torch.bool)(x)
+
 
 register_lowering(aten._neg_view)(neg)
 


### PR DESCRIPTION
Summary:

`signbit` on unsigned integer types (`bool`, `uint8`, `uint16`, `uint32`, `uint64`) should trivially returns all-`False`.

Replaced the generic `register_pointwise` for `aten.signbit` in `caffe2/torch/_inductor/lowering.py` with a custom `register_lowering` that short-circuits for unsigned dtypes using `full_like(x, False, dtype=torch.bool)`, following the same pattern as `isinf` and `isnan`. For signed types, the original pointwise codegen path is preserved.

Added `test_signbit_unsigned_dtypes` in `test_torchinductor.py`.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo