### PR TITLE
Fix SequentialLR wrong learning rate initialization when milestones contain 0

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -854,6 +854,20 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs)
         self.opt = old_opt
 
+    def test_sequentiallr_skips_preceding_schedulers_with_zero_milestone(self):
+        old_opt = self.opt
+        self.opt = SGD(self.net.parameters(), lr=1.0)
+        schedulers = [
+            LinearLR(self.opt, start_factor=0.1, end_factor=0.1, total_iters=10),
+            LinearLR(self.opt, start_factor=0.2, end_factor=0.2, total_iters=10),
+            LinearLR(self.opt, start_factor=0.3, end_factor=0.3, total_iters=10),
+            LinearLR(self.opt, start_factor=0.4, end_factor=0.4, total_iters=10),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[0, 0, 1])
+        targets = [[0.3, 0.4]]
+        self._test(scheduler, targets, epochs=2)
+        self.opt = old_opt
+
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [
             LinearLR(self.opt, start_factor=0.4, total_iters=3),

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1164,10 +1164,11 @@ class SequentialLR(LRScheduler):
         # "Undo" the step performed by other schedulers
         self.recursive_undo()
 
-        # Perform the initial step for only the first scheduler
-        self._schedulers[0]._initial_step()
+        # Perform the initial step for only the scheduler meant to run at step 0.
+        idx = bisect_right(self._milestones, 0)
+        self._schedulers[idx]._initial_step()
 
-        self._last_lr = schedulers[0].get_last_lr()
+        self._last_lr = schedulers[idx].get_last_lr()
 
     def recursive_undo(self, sched=None) -> None:
         """


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/185872
  
## Summary

### Cause of the Bug:
**Step Offset:** In `SequentialLR.step()`, `last_epoch` is immediately incremented to `1` on the first step. When milestones contain `0`, `self._milestones[idx - 1] == self.last_epoch` compares `0 == 1`, evaluating to `False`. This bypasses the initialization block `_update_lr(0)` and directly executes `scheduler.step()`, causing the second scheduler to skip its initial step 0.

### Fix:
1. Use `idx = bisect_right(self._milestones, 0)` in `__init__` to dynamically identify the correct active scheduler at step 0.
2. Run `_initial_step()` only on the correct starting `self._schedulers[idx]` instead of `self._schedulers[0]`.
3. Correct `self._last_lr` to track the initial learning rate from the starting `schedulers[idx]`.
    
### Testing:
Added `test_sequentiallr_skips_preceding_schedulers_with_zero_milestone` to `test_lrscheduler.py` verifying that multiple skipped schedulers under `milestones=[0, 0, 1]` successfully start at the uncorrupted target rate.
