### PR TITLE
Fix CUDA memory leak in chunked linear_cross_entropy backward

### DIFF
--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -32,8 +32,16 @@ def _linear_cross_entropy_batch_chunked_setup_context(ctx, inputs, output):
     ctx.compute_input_grad = compute_input_grad
     ctx.compute_linear_weight_grad = compute_linear_weight_grad
     _, grad_input, grad_linear_weight = output
-    ctx._gi = grad_input if compute_input_grad else None
-    ctx._gw = grad_linear_weight if compute_linear_weight_grad else None
+    # ``.detach()`` the stashed grads: they are forward OUTPUTS, so they
+    # carry ``grad_fn`` back to this custom-op node. Holding them as raw
+    # ctx attributes would form a reference cycle (node -> ctx -> grad ->
+    # grad_fn -> node) that refcounting can't break, leaking the tensors
+    # until a GC pass -- which the CUDA mem-leak check flags. Detaching
+    # drops the grad_fn link so the tensors free promptly when the loss's
+    # graph is. Backward only multiplies them by the upstream grad, so the
+    # lost autograd history is irrelevant (double-backward is unsupported).
+    ctx._gi = grad_input.detach() if compute_input_grad else None
+    ctx._gw = grad_linear_weight.detach() if compute_linear_weight_grad else None
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
The chunked linear_cross_entropy custom op precomputes grad_input and
grad_linear_weight in forward and stashes them on the autograd ctx
(ctx._gi, ctx._gw) for backward to consume. These tensors are forward
outputs, so they carry a grad_fn back to the custom-op node. Stashing
them as raw ctx attributes forms a reference cycle
(node -> ctx -> grad -> grad_fn -> node) that reference counting cannot
break, so the tensors are not freed when the loss graph is released --
only a later GC pass collects them. Under gradcheck
(allow_retain_graph=True, many forward passes, grads never cleared)
these cycles accumulate, which the periodic slow-gradcheck CUDA
memory-leak check flags on test_linear_cross_entropy_chunked_gradcheck.

The fix detaches the stashed grads in setup_context so they no longer
reference the node, breaking the cycle; the tensors then free promptly
via refcounting. Backward only multiplies them by the upstream
gradient, so dropping the (unused, non-differentiable) autograd history
is safe -- double-backward is already unsupported on this path.

Test Plan:

```
PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 python test/test_nn.py \
  TestNNDeviceTypeCUDA.test_linear_cross_entropy_chunked_gradcheck_acc_policy_accurate_cuda
python test/test_nn.py -k linear_cross_entropy
```

All acc_policy variants (accurate/balanced/compact/auto) pass the leak
check; the full linear_cross_entropy suite stays green.

Implementation assisted by Claude.


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki