### PR TITLE
[cuda] Improve error message when cuda-bindings version is too old

### DIFF
--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -92,6 +92,21 @@ def _probe_tools_id() -> bool:
     does not (bad).
     """
     if not hasattr(_cuda_runtime, "cudaGraphNodeGetToolsId"):
+        # API is missing from cuda-bindings - likely version too old
+        try:
+            import importlib.metadata
+
+            cuda_bindings_version = importlib.metadata.version("cuda-bindings")
+        except Exception:
+            cuda_bindings_version = "unknown"
+
+        logger.warning(
+            "cudaGraphNodeGetToolsId API not found in cuda-bindings. "
+            f"Current version: {cuda_bindings_version}, required: >= 13.3.0. "
+            "CUDA graph kernel annotations will be disabled. "
+            "To enable annotations, upgrade cuda-bindings: "
+            "pip install --upgrade cuda-bindings"
+        )
         return False
     err, *_ = _cuda_runtime.cudaGraphNodeGetToolsId(
         0

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -40,6 +40,7 @@ Usage during capture::
     remap_to_exec_graph(graph)
 """
 
+import importlib.metadata
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import getLogger
@@ -93,19 +94,15 @@ def _probe_tools_id() -> bool:
     """
     if not hasattr(_cuda_runtime, "cudaGraphNodeGetToolsId"):
         # API is missing from cuda-bindings - likely version too old
-        try:
-            import importlib.metadata
-
-            cuda_bindings_version = importlib.metadata.version("cuda-bindings")
-        except Exception:
-            cuda_bindings_version = "unknown"
+        cuda_bindings_version = importlib.metadata.version("cuda-bindings")
 
         logger.warning(
             "cudaGraphNodeGetToolsId API not found in cuda-bindings. "
-            f"Current version: {cuda_bindings_version}, required: >= 13.3.0. "
+            "Current version: %s, required: >= 13.1.0. "
             "CUDA graph kernel annotations will be disabled. "
             "To enable annotations, upgrade cuda-bindings: "
-            "pip install --upgrade cuda-bindings"
+            "pip install --upgrade cuda-bindings",
+            cuda_bindings_version,
         )
         return False
     err, *_ = _cuda_runtime.cudaGraphNodeGetToolsId(


### PR DESCRIPTION
When cudaGraphNodeGetToolsId API is not available in cuda-bindings, provide a clear warning message with:
- Current cuda-bindings version
- Required minimum version (>= 13.3.0)
- Upgrade instructions

This helps users diagnose and fix annotation support issues when they have an outdated cuda-bindings installation that's missing the required API for CUDA graph kernel annotations.

Root cause: cuda-bindings < 13.3.0 does not include cudaGraphNodeGetToolsId, which is required for marking and annotating graph nodes during capture.

Test Plan:
Tested with cuda-bindings 13.3.1 (has API) - annotations work correctly. Simulated old version by mocking missing API - warning message displays with version info and upgrade instructions.

```python
from torch.cuda._graph_annotations import _is_tools_id_unavailable
print(_is_tools_id_unavailable())  # Detects support correctly
```

This change improves user experience by providing actionable guidance when CUDA graph annotations are unavailable due to package version issues.