### PR TITLE
Implement get_stride for PermuteView (#185992)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4358,7 +4358,18 @@ class CommonTemplate:
             a = torch.permute(a, [0, 2, 3, -3])
             return (a,)
 
-        self.common(fn, (torch.randn(4, 4),))
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_permute_unbacked_slice(self):
+        def eager(a, end_t):
+            b = a + 1
+            c = torch.permute(b, [0, 2, 1])
+            end = end_t.item()
+            return c[:, :end, :]
+
+        compiled = torch.compile(eager, backend="inductor")
+        a = torch.randn(4, 16, 8, device=self.device)
+        end_t = torch.tensor([5])
+        self.assertEqual(compiled(a, end_t), eager(a, end_t))
 
     def test_expand(self):
         def fn(a):

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -250,7 +250,6 @@ test_failures = {
     "test_new_empty_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_new_empty_strided_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_new_ones_dynamic_shapes": TestFailure(("cpu",)),
-    "test_permute2_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_pointwise_airy_ai_dynamic_shapes": TestFailure(("cuda", "xpu")),
     "test_pointwise_digamma_dynamic_shapes": TestFailure(("cuda", "xpu")),
     "test_pointwise_gammainc_dynamic_shapes": TestFailure(("cuda", "xpu")),

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3478,6 +3478,13 @@ class PermuteView(BaseView):
         size = self.data.get_size()
         return [size[i] for i in self.dims]
 
+    def get_stride(self) -> Sequence[Expr]:
+        assert OrderedSet(self._map_neg_dims(self.dims)) == OrderedSet(
+            range(len(self.dims))
+        )
+        stride = self.data.get_stride()
+        return [stride[i] for i in self.dims]
+
     def make_reindexer(
         self,
     ) -> Callable[[Sequence[Expr]], Sequence[Expr]]:


### PR DESCRIPTION
Summary:

### What it does:
Adds a get_stride() method to the PermuteView class in torch/_inductor/ir.py. The method permutes the strides of the underlying data in the same order as the dimensions — mirroring the existing get_size() pattern

### Why:
Previously, PermuteView didn't implement get_stride(), which caused a NotImplementedError when downstream operations (like aten.slice.Tensor) needed stride info from a PermuteView wrapping a ComputedBuffer. This was hit during AOTI lowering of models that do compute → permute → slice (e.g., pad → permute → slice in the GR model).

Test Plan:
- internal lowering passed with this patch
- CI for added unit test

Reviewed By: silverlakeli, ColinPeppler

Differential Revision: D107267848




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo