### PR TITLE
Fix SM121 compute capability corruption in CMake GPU arch detection

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -135,7 +135,7 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
     string(REGEX MATCHALL "[0-9]+\\.[0-9]+" compute_capabilities "${compute_capabilities}")
 
     if(run_result EQUAL 0)
-      string(REPLACE "2.1" "2.1(2.0)" compute_capabilities "${compute_capabilities}")
+      string(REGEX REPLACE "(^|;)2\\.1(;|$)" "\\12.1(2.0)\\2" compute_capabilities "${compute_capabilities}")
       set(CUDA_GPU_DETECT_OUTPUT ${compute_capabilities}
         CACHE INTERNAL "Returned GPU architectures from detect_gpus tool" FORCE)
     endif()


### PR DESCRIPTION
## Problem

The `string(REPLACE)` on line 138 of `select_compute_arch.cmake` uses literal substring matching to rewrite `"2.1"` to `"2.1(2.0)"` for legacy Fermi GPU handling. However, this also matches the `"2.1"` substring within SM121 (compute capability `12.1`), corrupting it into `"12.1(2.0)"` — an invalid arch that causes nvcc compilation failures.

Reproduction:
- Any build machine with a Blackwell SM121 GPU (DGX Atom, DGX B200)
- Auto-detection returns `12.1` which gets corrupted to `12.1(2.0)`
- nvcc fails with invalid `-gencode` flags

## Fix

Replace the literal `string(REPLACE)` with `string(REGEX REPLACE)` anchored to word boundaries (start-of-string or semicolon delimiters), ensuring only the standalone `2.1` token is rewritten.

## Testing

- Hardware verified on DGX Atom (SM121)
- CMake auto-detection correctly generates `-gencode arch=compute_121,code=sm_121`
- No regression for existing Fermi `2.1(2.0)` handling
- No regression for other compute capabilities (5.0, 8.0, 8.6, 9.0, 10.0, 12.0)

## Checklist

- [x] Scope: 1 file changed, 1 line modified
- [x] Safety: No security implications
- [x] Consistency: Uses same REGEX REPLACE pattern as the preceding MATCHALL
- [x] Edge cases: Handles 2.1 at start, middle, and end of semicolon-separated list
- [x] Metadata: Clean commit
- [x] Implementation: Correct CMake regex escaping

Supersedes: #173754 (stale since Jan 2026), #174065 (stale since Feb 2026)