### PR TITLE
Fix dense mkldnn pointwise conv prop kind regression

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -348,7 +348,10 @@ Tensor mkldnn_convolution_pointwise(
       (input_t.requires_grad() || weight_t.requires_grad() ||
        (bias_opt.has_value() && bias_opt->defined() &&
         bias_opt->requires_grad()));
-  if (!maybe_backward) {
+  // With format_tag::any on dense contiguous inputs, oneDNN may choose a
+  // forward_inference primitive with an NHWC-like layout that is slower than
+  // the forward_training primitive and still has to be converted back to dense.
+  if (!maybe_backward && use_channels_last) {
     aprop_kind = ideep::prop_kind::forward_inference;
   }
   return _mkldnn_convolution(

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -260,6 +260,31 @@ class TestMkldnnFusion(JitTestCase):
                         )
                     self.assertEqual(ref, fused)
 
+    def test_conv_unary_fusion_none_attr_reported_shape(self):
+        for memory_format in [torch.contiguous_format, torch.channels_last]:
+            x = torch.randn(5, 1, 28, 28, dtype=torch.float32).to(
+                memory_format=memory_format
+            )
+            weight = torch.randn(64, 1, 3, 3, dtype=torch.float32).to(
+                memory_format=memory_format
+            )
+            bias = torch.randn(64, dtype=torch.float32)
+            with torch.no_grad():
+                ref = torch.nn.functional.conv2d(x, weight, bias)
+                fused = torch.ops.mkldnn._convolution_pointwise(
+                    x,
+                    weight,
+                    bias,
+                    [0, 0],
+                    [1, 1],
+                    [1, 1],
+                    1,
+                    "none",
+                    [],
+                    None,
+                )
+            self.assertEqual(ref, fused)
+
 
     def test_conv_binary_fusion_ops(self):
         class M(nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185997

Commit 28b4992e7a60bb3fbb07c591099fa810557b4e57 changed no-grad
mkldnn_convolution_pointwise to request oneDNN forward_inference. That helps
channels-last and prepacked-weight inference, but it regressed dense contiguous
runtime weights used by dynamic-shape Inductor. For the reported MAML Omniglot
shape, oneDNN picks a brg_conv_fwd inference primitive with an NHWC-like layout
for dense inputs, then PyTorch still converts the result back to dense. The old
forward/forward_training primitive is substantially faster for that path.

Keep the forward_inference optimization for the channels-last/MKLDNN-layout
path, where the selected primitive matches the user layout, and leave dense
contiguous pointwise convolution on the default forward prop kind. This restores
the pre-regression behavior for dynamic dense weights without losing the faster
inference path for channels-last/prepacked layouts.

A broader alternative would be reverting the original prop-kind change entirely,
but that would also drop the intended channels-last/prepacked inference win. A
narrow shape denylist would fix this report but would leave the same root cause
for other dense contiguous shapes.

Benchmark Results:
Before the fix, focused 1-thread direct-op benchmark on
mkldnn._convolution_pointwise with X=(5,1,28,28), W=(64,1,3,3), bias=(64),
stride=1, padding=0, dilation=1:
- contiguous no_grad/no_requires_grad: median 284.609 us
- contiguous grad-enabled/input_requires_grad: median 144.461 us
- channels_last no_grad/no_requires_grad: median 95.650 us
- channels_last grad-enabled/input_requires_grad: median 98.111 us

After the fix, same command:
- contiguous no_grad/no_requires_grad: median 132.217 us
- contiguous grad-enabled/input_requires_grad: median 132.528 us
- channels_last no_grad/no_requires_grad: median 94.855 us
- channels_last grad-enabled/input_requires_grad: median 96.505 us

DNNL_VERBOSE also confirmed contiguous no-grad changed from
brg_conv_fwd forward_inference to jit forward_training for the reported shape,
while channels-last no-grad still uses brg_conv_fwd forward_inference.

Test Plan:
- ninja -C build torch_cpu
- ninja -C build install
- python test/test_mkldnn_fusion.py TestMkldnnFusion.test_conv_unary_fusion_none_attr_reported_shape
- python test/test_mkldnn_fusion.py TestMkldnnFusion.test_conv_unary_fusion_ops
- lintrunner -a

Fixes #144937
Generated by my agent

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01