### PR TITLE
[Inductor] No-bench per-subkernel combo-kernel config selection

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -807,8 +807,11 @@ class ComboKernelTests(TestCase):
         out_eager = fn(*inps)
         out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
         self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
         combined = " ".join(code)
+        # Count emitted kernels by their async_compile.triton(...) calls;
+        # generated_kernel_count is inflated by throwaway probe codegen so
+        # is not a reliable count of real kernels.
+        self.assertEqual(combined.count("async_compile.triton("), 1)
 
         default_match = re.search(r"'default_config':\s*\{([^}]*)\}", combined)
         self.assertIsNotNone(default_match, "default_config not emitted")
@@ -841,8 +844,8 @@ class ComboKernelTests(TestCase):
         torch._inductor.metrics.reset()
         out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
         self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
         combined = " ".join(code)
+        self.assertEqual(combined.count("async_compile.triton("), 1)
 
         default_match = re.search(r"'default_config':\s*\{([^}]*)\}", combined)
         self.assertIsNotNone(default_match)
@@ -860,10 +863,11 @@ class ComboKernelTests(TestCase):
         }
     )
     def test_combo_kernel_no_bench_carve_out(self):
-        # torch.bucketize sets AutotuneHint.ONE_ELEMENT_PER_THREAD which
-        # pushes its pointwise heuristic past the <=2 fusion gate.  That
-        # subkernel must be carved out to a standalone kernel; the two
-        # simple pointwise subkernels fuse.  Expect 1 combo + 1 standalone.
+        # torch.bucketize triggers carve-out under both gate variants:
+        #   CUDA: pointwise heuristic returns 3 configs (>2) -> carve out
+        #   ROCm: lowering sets AutotuneHint.ONE_ELEMENT_PER_THREAD -> carve out
+        # Simple pointwise (b*2.0, c+1.0) passes both gates -> fuses into combo.
+        # Expect 1 combo + 1 standalone on both backends.
         def fn(a, b, c, boundaries):
             return torch.bucketize(a, boundaries), b * 2.0, c + 1.0
 
@@ -876,9 +880,13 @@ class ComboKernelTests(TestCase):
         torch._dynamo.reset()
         torch._inductor.metrics.reset()
         with fresh_cache():
-            out_compiled = torch.compile(fn)(a, b, c, boundaries)
+            out_compiled, code = run_and_get_code(
+                torch.compile(fn), a, b, c, boundaries
+            )
         self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
+        combined = " ".join(code)
+        # 1 combo (b*2, c+1) + 1 standalone (bucketize) = 2 real kernels.
+        self.assertEqual(combined.count("async_compile.triton("), 2)
 
 
 class ComboKernelBenchmarkTests(TestCase):

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -786,6 +786,112 @@ class ComboKernelTests(TestCase):
 
         self.assertEqual(out_eager, out_compiled)
 
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch(
+        {
+            "combo_kernels_autotune": 0,
+            "combo_kernel_per_subkernel_blocks": True,
+        }
+    )
+    def test_combo_kernel_no_bench_stitched_config(self):
+        # combo_kernels_autotune=0 + per_subkernel_blocks=True fuses
+        # subkernels using configs[0] from each subkernel's heuristic,
+        # stitched into one combo config.  Generated code should bake the
+        # stitched XBLOCK_i values into both default_config (grid) and the
+        # kernel body's tl.constexpr (iteration).  These must agree, else
+        # we silently lose data when heuristic XBLOCK > block_size_1d.
+        import re
+
+        def fn(a, b, c):
+            return a * 2.0, b + 1.0, c - 1.0
+
+        inps = [
+            torch.rand(256, device=GPU_TYPE),
+            torch.rand(256, device=GPU_TYPE),
+            torch.rand(256, device=GPU_TYPE),
+        ]
+        out_eager = fn(*inps)
+        torch._dynamo.reset()
+        torch._inductor.metrics.reset()
+        out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+        combined = " ".join(code)
+
+        default_match = re.search(
+            r"'default_config':\s*\{([^}]*)\}", combined
+        )
+        self.assertIsNotNone(default_match, "default_config not emitted")
+        default_kvs = dict(
+            re.findall(r"'(XBLOCK_\d+)':\s*(\d+)", default_match.group(1))
+        )
+        body_kvs = dict(
+            re.findall(r"(XBLOCK_\d+):\s*tl\.constexpr\s*=\s*(\d+)", combined)
+        )
+        # Grid and kernel body must agree on every XBLOCK_i.
+        self.assertEqual(default_kvs, body_kvs)
+        self.assertEqual(set(default_kvs), {"XBLOCK_0", "XBLOCK_1", "XBLOCK_2"})
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch(
+        {
+            "combo_kernels_autotune": 0,
+            "combo_kernel_per_subkernel_blocks": True,
+        }
+    )
+    def test_combo_kernel_no_bench_numerics_large(self):
+        # Numerics check with an input size > DEFAULT_COMBO_BLOCK_SIZE_1D
+        # (=1024).  If the stitched XBLOCK in default_config diverges from
+        # the kernel body's tl.constexpr, the kernel either over-launches
+        # (xmask masks the surplus -- still correct) or under-launches
+        # (silent data loss).  This test catches the under-launch case as
+        # a numerics regression.
+        def fn(a, b, c):
+            return a * 2.0, b + 1.0, c - 1.0
+
+        inps = [torch.rand(8192, device=GPU_TYPE) for _ in range(3)]
+        out_eager = fn(*inps)
+        torch._dynamo.reset()
+        torch._inductor.metrics.reset()
+        out_compiled = torch.compile(fn)(*inps)
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch(
+        {
+            "combo_kernels_autotune": 0,
+            "combo_kernel_per_subkernel_blocks": True,
+        }
+    )
+    def test_combo_kernel_no_bench_persistent_reduction(self):
+        # 3 same-shape persistent reductions fuse into one combo.  The
+        # stitcher must skip R*_BLOCK_i (body emits it via static numels,
+        # not from default_config); leaking R*_BLOCK_i would be either
+        # dead data or a Triton unknown-kwarg error.
+        import re
+
+        def fn(a, b, c):
+            return a.sum(-1), b.sum(-1), c.sum(-1)
+
+        inps = [torch.randn(64, 1024, device=GPU_TYPE) for _ in range(3)]
+        out_eager = fn(*inps)
+        torch._dynamo.reset()
+        torch._inductor.metrics.reset()
+        out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+        combined = " ".join(code)
+
+        default_match = re.search(r"'default_config':\s*\{([^}]*)\}", combined)
+        self.assertIsNotNone(default_match)
+        default_body = default_match.group(1)
+        # default_config must only carry XBLOCK_i; R*_BLOCK_i is body-baked.
+        self.assertNotIn("R0_BLOCK", default_body)
+        self.assertNotIn("R1_BLOCK", default_body)
+        xblocks = re.findall(r"'(XBLOCK_\d+)'", default_body)
+        self.assertEqual(set(xblocks), {"XBLOCK_0", "XBLOCK_1", "XBLOCK_2"})
+
 
 class ComboKernelBenchmarkTests(TestCase):
     check_model_gpu = check_model_gpu

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1190,10 +1190,10 @@ class ComboKernelDynamicShapesTests(TestCase):
         ]
 
         out_eager = test_activations(*inps)
-        out_compiled = torch.compile(test_activations)(*inps)
+        out_compiled, code = run_and_get_code(torch.compile(test_activations), *inps)
 
         self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 5)
+        self.assertEqual(sum(s.count("async_compile.triton(") for s in code), 1)
 
     @requires_gpu_and_triton
     @torch._dynamo.config.patch("automatic_dynamic_shapes", True)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -50,7 +50,8 @@ from ..optimize_indexing import (
 )
 from ..runtime.coordinate_descent_tuner import CoordescTuner
 from ..runtime.hints import DeviceProperties
-from ..runtime.runtime_utils import green_text, last_power_of_2, yellow_text
+from ..runtime.hints import TileHint
+from ..runtime.runtime_utils import green_text, last_power_of_2, next_power_of_2, yellow_text
 from ..scheduler import BaseSchedulerNode, BaseScheduling, WhyNoFuse
 from ..utils import (
     cache_property_on_self,
@@ -3404,6 +3405,180 @@ class SIMDScheduling(BaseScheduling):
     def codegen_sync(self):
         V.graph.wrapper_code.writeline(V.graph.device_ops.synchronize())
 
+    def _codegen_standalone_kernel(
+        self, node_info: NodeInfo, only_gen_src_code: bool
+    ) -> tuple[str, "TritonKernel"]:
+        kernel_kwargs: dict[str, Any] = {}
+        self.kernel_type.apply_feature_required_overrides(
+            node_info.features, kernel_kwargs
+        )
+        kernel = self.kernel_type(
+            node_info.tiling,
+            features=node_info.features,
+            tiling_scores=node_info.tiling_scores,
+            **kernel_kwargs,
+        )
+        self.process_kernel(kernel, node_info.node_schedule, only_gen_src_code)
+        with V.set_kernel_handler(kernel):
+            src_code = kernel.codegen_kernel()
+        return src_code, kernel
+
+    def _probe_subkernel_heuristic(
+        self, node_info: NodeInfo
+    ) -> tuple[list[Any], bool]:
+        from ..runtime.triton_heuristics import (
+            persistent_reduction,
+            pointwise,
+            reduction,
+        )
+        from .triton_utils import non_constexpr_signature
+
+        # Match ComboKernel.create_triton_kernel's construction so the probe
+        # sees the same persistent_reduction / no_x_dim flags the real combo
+        # subkernel will. Combo subkernels always disable cooperative
+        # reduction; without this override the probe can pick the wrong
+        # configs for kernels where the standalone heuristic would have
+        # gone cooperative.
+        kernel_kwargs: dict[str, Any] = dict(
+            is_combo_kernel=True,
+            override_cooperative_reduction=False,
+        )
+        self.kernel_type.apply_feature_required_overrides(
+            node_info.features, kernel_kwargs
+        )
+        kernel = self.kernel_type(
+            node_info.tiling,
+            features=node_info.features,
+            tiling_scores=node_info.tiling_scores,
+            **kernel_kwargs,
+        )
+        config_patches = self._collect_config_patches(node_info.node_schedule)
+        config_patches["benchmark_kernel"] = False
+        # decide_inplace_update -> make_inplace can mutate
+        # V.graph.unaligned_buffers; restore after the probe even on error.
+        unaligned_snapshot = OrderedSet(V.graph.unaligned_buffers)
+        try:
+            with config.patch(**config_patches), V.set_kernel_handler(kernel):
+                self.codegen_node_schedule_with_kernel(node_info.node_schedule, kernel)
+                # codegen_kernel populates kernel.triton_meta, which the
+                # heuristics below consume; the returned source is discarded.
+                _ = kernel.codegen_kernel()
+        finally:
+            V.graph.unaligned_buffers = unaligned_snapshot
+            metrics.generated_kernel_count -= 1
+
+        size_hints = {
+            prefix: next_power_of_2(int(V.graph.sizevars.optimization_hint(numel)))
+            for prefix, numel in kernel.numels.items()
+            if not prefix_is_reduction(prefix) or kernel.inside_reduction
+        }
+        inductor_meta = {
+            **kernel.inductor_meta_common(),
+            **kernel.inductor_meta_per_kernel(),
+        }
+        if kernel.persistent_reduction:
+            configs = persistent_reduction(
+                size_hints,
+                reduction_hint=kernel.features.get_reduction_hint(
+                    kernel.tiling_scores
+                ),
+                triton_meta=kernel.triton_meta,
+                inductor_meta=inductor_meta,
+                return_configs=True,
+            )
+        elif kernel.inside_reduction:
+            configs = reduction(
+                size_hints,
+                reduction_hint=kernel.features.get_reduction_hint(
+                    kernel.tiling_scores
+                ),
+                triton_meta=kernel.triton_meta,
+                inductor_meta=inductor_meta,
+                return_configs=True,
+            )
+        else:
+            tile_hint = None
+            if len(size_hints) == 2:
+                _, _, signature, _ = kernel.args.python_argdefs()
+                tile_hint = (
+                    TileHint.SQUARE
+                    if len(non_constexpr_signature(signature)) == 4
+                    else TileHint.DEFAULT
+                )
+            configs = pointwise(
+                size_hints,
+                triton_meta=kernel.triton_meta,
+                tile_hint=tile_hint,
+                inductor_meta=inductor_meta,
+                return_configs=True,
+            )
+        return configs, kernel.persistent_reduction
+
+    @staticmethod
+    def _stitch_no_bench_combo_config(
+        chosen_configs: list[Any],
+        fusion_persistent: list[bool],
+    ) -> Any:
+        import triton
+
+        # R*_BLOCK is hardcoded into static numels for persistent reductions
+        # (not in block_args). Skipping these keeps stitched kwargs in sync
+        # with the kernel body's tl.constexpr declarations.
+        def live_block_keys(i: int, cfg: Any) -> list[str]:
+            keys = []
+            for k in cfg.kwargs:
+                if not k.endswith("BLOCK"):
+                    continue
+                if fusion_persistent[i] and k.startswith("R"):
+                    continue
+                keys.append(k)
+            return keys
+
+        def effective_tile_elems(i: int, cfg: Any) -> int:
+            te = 1
+            for k in live_block_keys(i, cfg):
+                te *= int(cfg.kwargs[k])
+            return te
+
+        stitched_kwargs: dict[str, Any] = {}
+        for i, cfg in enumerate(chosen_configs):
+            for key in live_block_keys(i, cfg):
+                stitched_kwargs[f"{key}_{i}"] = int(cfg.kwargs[key])
+
+        configs_by_tile_elems = sorted(
+            enumerate(chosen_configs),
+            key=lambda iv: effective_tile_elems(iv[0], iv[1]),
+            reverse=True,
+        )
+        top_k = max(1, len(configs_by_tile_elems) // 2)
+        num_warps = int(max(cfg.num_warps for _, cfg in configs_by_tile_elems[:top_k]))
+        # Heaviest subkernel's num_stages wins (consistent with backend kwargs).
+        num_stages = int(configs_by_tile_elems[0][1].num_stages)
+
+        # Non-BLOCK backend kwargs (waves_per_eu, kpack, etc.): heaviest setter wins.
+        backend_kwarg_keys: OrderedSet[str] = OrderedSet()
+        for cfg in chosen_configs:
+            for k in cfg.kwargs:
+                if not k.endswith("BLOCK"):
+                    backend_kwarg_keys.add(k)
+        for k in backend_kwarg_keys:
+            for _, cfg in configs_by_tile_elems:
+                if k in cfg.kwargs:
+                    value = cfg.kwargs[k]
+                    if isinstance(value, bool):
+                        stitched_kwargs[k] = value
+                    elif isinstance(value, int):
+                        stitched_kwargs[k] = int(value)
+                    else:
+                        stitched_kwargs[k] = value
+                    break
+
+        return triton.Config(
+            dict(stitched_kwargs),
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+
     def generate_combo_kernel_code(
         self,
         subkernel_nodes: list[BaseSchedulerNode],
@@ -3493,50 +3668,81 @@ class SIMDScheduling(BaseScheduling):
                     # Skip code generation - caller has cached benchmark results
                     kernel_code_list.append((None, None, node_group))
                 else:
-                    # Generate regular kernel
-                    kernel_kwargs: dict[str, Any] = {}
-                    self.kernel_type.apply_feature_required_overrides(
-                        node_info.features, kernel_kwargs
+                    src_code, kernel = self._codegen_standalone_kernel(
+                        node_info, only_gen_src_code
                     )
-                    kernel = self.kernel_type(
-                        node_info.tiling,
-                        features=node_info.features,
-                        **kernel_kwargs,
-                    )
-                    self.process_kernel(
-                        kernel, node_info.node_schedule, only_gen_src_code
-                    )
-                    with V.set_kernel_handler(kernel):
-                        src_code = kernel.codegen_kernel()
                     # pyrefly: ignore [bad-argument-type]
                     kernel_code_list.append((src_code, kernel, node_group))
             else:
-                # Multi-node: create ComboKernel with combo subkernels
-                kernel = ComboKernel(
-                    triton_kernel_cls=self.kernel_type,
-                    enable_autotune=enable_autotune,
-                    mixed_sizes=mixed_sizes,
-                    per_subkernel_blocks=per_subkernel_blocks,
+                no_bench_mode = (
+                    per_subkernel_blocks
+                    and not enable_autotune
+                    and not only_gen_src_code
                 )
-                for pn in node_group:
-                    node_info = node_schedule_map[pn]
-                    subkernel = ComboKernel.create_triton_kernel(
-                        node_info.tiling,
-                        features=node_info.features,
-                        optimize_mask=not mixed_sizes,
+                fusion_pns: list[Any] = []
+                fusion_configs: list[Any] = []
+                fusion_persistent: list[bool] = []
+                carve_out_pns: list[Any] = []
+                if no_bench_mode:
+                    for pn in node_group:
+                        configs, persistent = self._probe_subkernel_heuristic(
+                            node_schedule_map[pn]
+                        )
+                        if configs and len(configs) <= 2:
+                            fusion_pns.append(pn)
+                            fusion_configs.append(configs[0])
+                            fusion_persistent.append(persistent)
+                        else:
+                            carve_out_pns.append(pn)
+                    if len(fusion_pns) < 2:
+                        fusion_pns = []
+                        fusion_configs = []
+                        fusion_persistent = []
+                        carve_out_pns = list(node_group)
+                else:
+                    fusion_pns = list(node_group)
+
+                if len(fusion_pns) >= 2:
+                    kernel = ComboKernel(
                         triton_kernel_cls=self.kernel_type,
-                        tiling_scores=node_info.tiling_scores,
+                        enable_autotune=enable_autotune,
+                        mixed_sizes=mixed_sizes,
                         per_subkernel_blocks=per_subkernel_blocks,
                     )
-                    self.process_kernel(
-                        kernel.create_sub_kernel(subkernel),
-                        node_info.node_schedule,
-                        only_gen_src_code,
-                    )
+                    for pn in fusion_pns:
+                        node_info = node_schedule_map[pn]
+                        subkernel = ComboKernel.create_triton_kernel(
+                            node_info.tiling,
+                            features=node_info.features,
+                            optimize_mask=not mixed_sizes,
+                            triton_kernel_cls=self.kernel_type,
+                            tiling_scores=node_info.tiling_scores,
+                            per_subkernel_blocks=per_subkernel_blocks,
+                        )
+                        self.process_kernel(
+                            kernel.create_sub_kernel(subkernel),
+                            node_info.node_schedule,
+                            only_gen_src_code,
+                        )
 
-                src_code = kernel.codegen_kernel()
-                # pyrefly: ignore [bad-argument-type]
-                kernel_code_list.append((src_code, kernel, node_group))
+                    if no_bench_mode and fusion_configs:
+                        kernel.no_bench_stitched_config = (
+                            self._stitch_no_bench_combo_config(
+                                fusion_configs,
+                                fusion_persistent,
+                            )
+                        )
+
+                    src_code = kernel.codegen_kernel()
+                    # pyrefly: ignore [bad-argument-type]
+                    kernel_code_list.append((src_code, kernel, fusion_pns))
+
+                for pn in carve_out_pns:
+                    co_src_code, co_kernel = self._codegen_standalone_kernel(
+                        node_schedule_map[pn], only_gen_src_code
+                    )
+                    # pyrefly: ignore [bad-argument-type]
+                    kernel_code_list.append((co_src_code, co_kernel, [pn]))
         # pyrefly: ignore [bad-return]
         return kernel_code_list
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -49,7 +49,7 @@ from ..optimize_indexing import (
     indexing_dtype_strength_reduction,
 )
 from ..runtime.coordinate_descent_tuner import CoordescTuner
-from ..runtime.hints import DeviceProperties, TileHint
+from ..runtime.hints import DeviceProperties
 from ..runtime.runtime_utils import (
     green_text,
     last_power_of_2,
@@ -3427,13 +3427,13 @@ class SIMDScheduling(BaseScheduling):
             src_code = kernel.codegen_kernel()
         return src_code, kernel
 
-    def _probe_subkernel_heuristic(self, node_info: NodeInfo) -> list[Any]:
+    def _probe_subkernel_heuristic(self, node_info: NodeInfo) -> tuple[list[Any], Any]:
         from ..runtime.triton_heuristics import (
             persistent_reduction,
             pointwise,
             reduction,
         )
-        from .triton_utils import non_constexpr_signature
+        from .triton_utils import select_tile_hint
 
         kernel_kwargs: dict[str, Any] = dict(
             is_combo_kernel=True,
@@ -3442,22 +3442,15 @@ class SIMDScheduling(BaseScheduling):
         self.kernel_type.apply_feature_required_overrides(
             node_info.features, kernel_kwargs
         )
-        kernel_count_before = metrics.generated_kernel_count
-        unaligned_snapshot = OrderedSet(V.graph.unaligned_buffers)
-        try:
-            kernel = self.kernel_type(
-                node_info.tiling,
-                features=node_info.features,
-                tiling_scores=node_info.tiling_scores,
-                **kernel_kwargs,
-            )
-            with config.patch(benchmark_kernel=False), V.set_kernel_handler(kernel):
-                self.codegen_node_schedule_with_kernel(node_info.node_schedule, kernel)
-                _ = kernel.codegen_kernel()
-        finally:
-            V.graph.unaligned_buffers = unaligned_snapshot
-            # pyrefly: ignore [bad-assignment]
-            metrics.generated_kernel_count = kernel_count_before
+        kernel = self.kernel_type(
+            node_info.tiling,
+            features=node_info.features,
+            tiling_scores=node_info.tiling_scores,
+            **kernel_kwargs,
+        )
+        with config.patch(benchmark_kernel=False), V.set_kernel_handler(kernel):
+            self.codegen_node_schedule_with_kernel(node_info.node_schedule, kernel)
+            _ = kernel.codegen_kernel()
 
         size_hints = {
             prefix: next_power_of_2(int(V.graph.sizevars.optimization_hint(numel)))
@@ -3485,41 +3478,42 @@ class SIMDScheduling(BaseScheduling):
                 return_configs=True,
             )
         else:
-            tile_hint = None
-            if len(size_hints) == 2:
-                _, _, signature, _ = kernel.args.python_argdefs()
-                tile_hint = (
-                    TileHint.SQUARE
-                    if len(non_constexpr_signature(signature)) == 4
-                    else TileHint.DEFAULT
-                )
+            _, _, signature, _ = kernel.args.python_argdefs()
             configs = pointwise(
                 size_hints,
                 triton_meta=kernel.triton_meta,
-                tile_hint=tile_hint,
+                tile_hint=select_tile_hint(size_hints, signature),
                 inductor_meta=inductor_meta,
                 return_configs=True,
             )
-        return configs
+        return configs, kernel
 
     @staticmethod
-    def _stitch_no_bench_combo_config(chosen_configs: list[Any]) -> Any:
+    def _stitch_no_bench_combo_config(
+        chosen_configs: list[Any], chosen_nodes: list[Any]
+    ) -> Any:
         import triton
 
         def block_keys(cfg: Any) -> list[str]:
             return [k for k in cfg.kwargs if k.endswith("BLOCK")]
 
-        def effective_tile_elems(cfg: Any) -> int:
-            te = 1
-            for k in block_keys(cfg):
-                te *= int(cfg.kwargs[k])
-            return te
+        def node_total_bytes(snode: Any) -> int:
+            return sum(
+                V.graph.get_dep_size_hint(d, count_bytes=True)
+                for d in itertools.chain(
+                    snode.read_writes.reads, snode.read_writes.writes
+                )
+            )
 
-        # Heaviest subkernel (largest effective tile elems) dominates runtime;
-        # its config is authoritative for the combo. Its num_warps, num_stages,
+        # Heaviest subkernel by total memory traffic dominates runtime; its
+        # config is authoritative for the combo. Its num_warps, num_stages,
         # and non-BLOCK kwargs (HIP backend options like waves_per_eu) apply
         # combo-wide. Per-subkernel BLOCK kwargs are suffixed (XBLOCK_0, ...).
-        winner_cfg = max(chosen_configs, key=effective_tile_elems)
+        winner_idx = max(
+            range(len(chosen_configs)),
+            key=lambda i: node_total_bytes(chosen_nodes[i]),
+        )
+        winner_cfg = chosen_configs[winner_idx]
 
         stitched_kwargs: dict[str, Any] = {
             f"{key}_{i}": int(cfg.kwargs[key])
@@ -3645,8 +3639,14 @@ class SIMDScheduling(BaseScheduling):
                 carve_out_pns: list[Any] = []
                 if no_bench_mode:
                     for pn in node_group:
-                        configs = self._probe_subkernel_heuristic(node_schedule_map[pn])
-                        if configs and len(configs) <= 2:
+                        configs, probe_kernel = self._probe_subkernel_heuristic(
+                            node_schedule_map[pn]
+                        )
+                        if torch.version.hip:
+                            fuse_ok = configs and not probe_kernel.autotune_hints
+                        else:
+                            fuse_ok = configs and len(configs) <= 2
+                        if fuse_ok:
                             fusion_pns.append(pn)
                             fusion_configs.append(configs[0])
                         else:
@@ -3683,7 +3683,9 @@ class SIMDScheduling(BaseScheduling):
 
                     if no_bench_mode and fusion_configs:
                         kernel.no_bench_stitched_config = (
-                            self._stitch_no_bench_combo_config(fusion_configs)
+                            self._stitch_no_bench_combo_config(
+                                fusion_configs, fusion_pns
+                            )
                         )
 
                     src_code = kernel.codegen_kernel()

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3442,23 +3442,22 @@ class SIMDScheduling(BaseScheduling):
         self.kernel_type.apply_feature_required_overrides(
             node_info.features, kernel_kwargs
         )
-        kernel = self.kernel_type(
-            node_info.tiling,
-            features=node_info.features,
-            tiling_scores=node_info.tiling_scores,
-            **kernel_kwargs,
-        )
-        config_patches = self._collect_config_patches(node_info.node_schedule)
-        config_patches["benchmark_kernel"] = False
+        kernel_count_before = metrics.generated_kernel_count
         unaligned_snapshot = OrderedSet(V.graph.unaligned_buffers)
         try:
-            with config.patch(**config_patches), V.set_kernel_handler(kernel):
+            kernel = self.kernel_type(
+                node_info.tiling,
+                features=node_info.features,
+                tiling_scores=node_info.tiling_scores,
+                **kernel_kwargs,
+            )
+            with config.patch(benchmark_kernel=False), V.set_kernel_handler(kernel):
                 self.codegen_node_schedule_with_kernel(node_info.node_schedule, kernel)
                 _ = kernel.codegen_kernel()
         finally:
             V.graph.unaligned_buffers = unaligned_snapshot
             # pyrefly: ignore [bad-assignment]
-            metrics.generated_kernel_count -= 1
+            metrics.generated_kernel_count = kernel_count_before
 
         size_hints = {
             prefix: next_power_of_2(int(V.graph.sizevars.optimization_hint(numel)))
@@ -3516,43 +3515,29 @@ class SIMDScheduling(BaseScheduling):
                 te *= int(cfg.kwargs[k])
             return te
 
-        stitched_kwargs: dict[str, Any] = {}
-        for i, cfg in enumerate(chosen_configs):
-            for key in block_keys(cfg):
-                stitched_kwargs[f"{key}_{i}"] = int(cfg.kwargs[key])
+        # Heaviest subkernel (largest effective tile elems) dominates runtime;
+        # its config is authoritative for the combo. Its num_warps, num_stages,
+        # and non-BLOCK kwargs (HIP backend options like waves_per_eu) apply
+        # combo-wide. Per-subkernel BLOCK kwargs are suffixed (XBLOCK_0, ...).
+        winner_cfg = max(chosen_configs, key=effective_tile_elems)
 
-        configs_by_tile_elems = sorted(
-            enumerate(chosen_configs),
-            key=lambda iv: effective_tile_elems(iv[1]),
-            reverse=True,
+        stitched_kwargs: dict[str, Any] = {
+            f"{key}_{i}": int(cfg.kwargs[key])
+            for i, cfg in enumerate(chosen_configs)
+            for key in block_keys(cfg)
+        }
+        stitched_kwargs.update(
+            {
+                key: value
+                for key, value in winner_cfg.kwargs.items()
+                if not key.endswith("BLOCK")
+            }
         )
-        top_k = max(1, len(configs_by_tile_elems) // 2)
-        num_warps = int(max(cfg.num_warps for _, cfg in configs_by_tile_elems[:top_k]))
-        # Heaviest subkernel's num_stages wins (consistent with backend kwargs).
-        num_stages = int(configs_by_tile_elems[0][1].num_stages)
-
-        # Non-BLOCK backend kwargs (waves_per_eu, kpack, etc.): heaviest setter wins.
-        backend_kwarg_keys: OrderedSet[str] = OrderedSet()
-        for cfg in chosen_configs:
-            for k in cfg.kwargs:
-                if not k.endswith("BLOCK"):
-                    backend_kwarg_keys.add(k)
-        for k in backend_kwarg_keys:
-            for _, cfg in configs_by_tile_elems:
-                if k in cfg.kwargs:
-                    value = cfg.kwargs[k]
-                    if isinstance(value, bool):
-                        stitched_kwargs[k] = value
-                    elif isinstance(value, int):
-                        stitched_kwargs[k] = int(value)
-                    else:
-                        stitched_kwargs[k] = value
-                    break
 
         return triton.Config(
-            dict(stitched_kwargs),
-            num_warps=num_warps,
-            num_stages=num_stages,
+            stitched_kwargs,
+            num_warps=int(winner_cfg.num_warps),
+            num_stages=int(winner_cfg.num_stages),
         )
 
     def generate_combo_kernel_code(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -121,7 +121,7 @@ from .triton_utils import (
     config_of,
     equal_1_arg_indices,
     is_unaligned_buffer_name,
-    non_constexpr_signature,
+    select_tile_hint,
     should_unwrap_unspec_arg,
     signature_to_meta,
 )
@@ -6456,14 +6456,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 @triton.jit
             """
         else:
-            tile_hint = ""
-            if len(size_hints) == 2:
-                if (
-                    len(non_constexpr_signature(signature)) == 4
-                ):  # input, output and 2 args
-                    tile_hint = "tile_hint=TileHint.SQUARE,"
-                else:
-                    tile_hint = "tile_hint=TileHint.DEFAULT,"
+            hint = select_tile_hint(size_hints, signature)
+            tile_hint = f"tile_hint=TileHint.{hint.name}," if hint is not None else ""
             heuristics_line = f"""
                 @triton_heuristics.{self._get_heuristic()}(
                     size_hints={size_hints!r}, {tile_hint}

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -9,6 +9,10 @@ from typing import Any, cast, TYPE_CHECKING
 import sympy
 from sympy import Integer, Symbol
 
+
+if TYPE_CHECKING:
+    import triton
+
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config, metrics
@@ -23,11 +27,6 @@ from ..scheduler import BaseSchedulerNode
 from ..stream_utils import get_raw_stream_name
 from ..utils import Placeholder, triton_version_uses_attrs_dict
 from ..virtualized import V
-
-
-if TYPE_CHECKING:
-    import triton
-
 from .common import (
     ArgName,
     ConstexprArg,
@@ -1199,9 +1198,15 @@ class ComboKernel(Kernel):
         if not self.enable_autotune:
             default_config: dict[str, int] = {}
             if self.no_bench_stitched_config is not None:
-                default_config = dict(self.no_bench_stitched_config.kwargs)
-                meta["stitched_num_warps"] = self.no_bench_stitched_config.num_warps
-                meta["stitched_num_stages"] = self.no_bench_stitched_config.num_stages
+                stitched = self.no_bench_stitched_config
+                default_config = {
+                    k: int(v) for k, v in stitched.kwargs.items() if "BLOCK" in k
+                }
+                meta["stitched_backend_kwargs"] = {
+                    k: v for k, v in stitched.kwargs.items() if "BLOCK" not in k
+                }
+                meta["stitched_num_warps"] = stitched.num_warps
+                meta["stitched_num_stages"] = stitched.num_stages
             elif self.per_subkernel_blocks:
                 # Per-subkernel block sizes: XBLOCK_0, XBLOCK_1, etc.
                 for num, sub_kernel in enumerate(self.sub_kernels):

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -4,7 +4,7 @@ import textwrap
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, Optional, TYPE_CHECKING
 
 import sympy
 from sympy import Integer, Symbol
@@ -23,6 +23,10 @@ from ..scheduler import BaseSchedulerNode
 from ..stream_utils import get_raw_stream_name
 from ..utils import Placeholder, triton_version_uses_attrs_dict
 from ..virtualized import V
+
+
+if TYPE_CHECKING:
+    import triton
 from .common import (
     ArgName,
     ConstexprArg,
@@ -468,6 +472,8 @@ class ComboKernel(Kernel):
         self.num_warps = 8
         self.block_size_reduce = 256
         self.dynamic_shape_args: list[str] = []
+        # Optional single config; bypasses autotune when set.
+        self.no_bench_stitched_config: Optional["triton.Config"] = None
 
     def create_sub_kernel(self, triton_kernel: TritonKernel) -> TritonKernel:
         sub_kernel = triton_kernel
@@ -835,9 +841,19 @@ class ComboKernel(Kernel):
 
     def codegen_blocks(self, code: IndentedBuffer) -> None:
         has_yblock = any(self.y_tree_list)
+        # Must mirror the per_subkernel_blocks guard in combo_grid_meta or
+        # grid/body block sizes diverge.
+        stitched_kwargs = (
+            self.no_bench_stitched_config.kwargs
+            if self.per_subkernel_blocks
+            and self.no_bench_stitched_config is not None
+            else None
+        )
 
         for block in self.block_args:
-            if "YBLOCK" in block:
+            if stitched_kwargs is not None and block in stitched_kwargs:
+                size = stitched_kwargs[block]
+            elif "YBLOCK" in block:
                 size = self.block_size_2d
             elif "XBLOCK" in block:
                 size = self.block_size_2d if has_yblock else self.block_size_1d
@@ -1185,7 +1201,13 @@ class ComboKernel(Kernel):
 
         if not self.enable_autotune:
             default_config: dict[str, int] = {}
-            if self.per_subkernel_blocks:
+            if self.per_subkernel_blocks and self.no_bench_stitched_config is not None:
+                default_config = dict(self.no_bench_stitched_config.kwargs)
+                meta["stitched_num_warps"] = self.no_bench_stitched_config.num_warps
+                meta["stitched_num_stages"] = (
+                    self.no_bench_stitched_config.num_stages
+                )
+            elif self.per_subkernel_blocks:
                 # Per-subkernel block sizes: XBLOCK_0, XBLOCK_1, etc.
                 for num, sub_kernel in enumerate(self.sub_kernels):
                     if sub_kernel.no_x_dim:

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -124,6 +124,21 @@ def non_constexpr_signature(signature):
     return new_signature
 
 
+def select_tile_hint(size_hints, signature):
+    """Pick TileHint.SQUARE vs TileHint.DEFAULT for 2D pointwise; None for 1D.
+
+    SQUARE applies when the kernel has exactly 2 size hints and 4 non-constexpr
+    signature args (input, output, and 2 numel args -> a square 2D tile).
+    """
+    from torch._inductor.runtime.hints import TileHint
+
+    if len(size_hints) != 2:
+        return None
+    if len(non_constexpr_signature(signature)) == 4:
+        return TileHint.SQUARE
+    return TileHint.DEFAULT
+
+
 def signature_to_meta(
     signature: list[KernelArgType],
     *,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1038,12 +1038,12 @@ compute_all_bounds = False
 
 # enable the combo kernel that combines data-independent kernels (additional
 # to foreach kernels) into a single one (Experimental)
-combo_kernels = True
+combo_kernels = False
 # benchmark combo kernels and only allow ones with perf gains
 benchmark_combo_kernel = False
 # combo_kernel autotuning options: 0 - disable, 1 - enable except for foreach,
 # 2 - enable for all
-combo_kernels_autotune = 0
+combo_kernels_autotune = 1
 # Enable masking for combining kernels of mixed sizes: 0 - disable, 1 - enable
 # for all except for foreach, 2 - enable for all
 combo_kernel_allow_mixed_sizes = 1
@@ -1056,7 +1056,7 @@ combo_kernel_max_num_nodes = 8
 # When True, each combo sub-kernel gets its own block sizes (XBLOCK_0, YBLOCK_0, etc.)
 # allowing different sub-kernels to use different tile sizes based on their heuristics.
 # When False, all sub-kernels share block sizes (XBLOCK, YBLOCK, etc.)
-combo_kernel_per_subkernel_blocks = True
+combo_kernel_per_subkernel_blocks = False
 # When True, combo-kernel autotuning groups sub-kernels that share the same
 # candidate config set and kernel-analysis signature. Disabled by default.
 combo_kernel_autotune_grouping = True

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3552,14 +3552,13 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
     # CAP no-bench: combo_grid_meta carries a stitched config; skip the
     # combo_tuning_groups computation and return a single stitched config.
-    # Kwargs stay empty because XBLOCK_i is body-inline constexpr (not a
-    # kernel-signature arg) under enable_autotune=False; the grid still
-    # reads XBLOCK_i from combo_grid_meta["default_config"].
+    # default_config holds BLOCK keys for the grid lambda; backend kwargs
+    # (HIP options like waves_per_eu) come from stitched_backend_kwargs.
     stitched_warps = combo_meta.get("stitched_num_warps")
     if stitched_warps is not None:
         return [
             triton.Config(
-                {},
+                combo_meta["stitched_backend_kwargs"],
                 num_warps=stitched_warps,
                 num_stages=combo_meta["stitched_num_stages"],
             )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4993,9 +4993,21 @@ def foreach(triton_meta, filename=None, inductor_meta=None):
     Compile a triton foreach kernel
     """
     configs = []
+    inductor_meta = inductor_meta or {}
 
+    combo_meta = inductor_meta.get("combo_grid_meta") or {}
+    # If combo_grid_meta carries a stitched config, skip the autotune sweep.
+    stitched_warps = combo_meta.get("stitched_num_warps")
+    if stitched_warps is not None:
+        configs.append(
+            triton.Config(
+                {},
+                num_stages=combo_meta["stitched_num_stages"],
+                num_warps=stitched_warps,
+            )
+        )
     # Naive autotuning path for num_warps
-    if not (
+    elif not (
         inductor_meta.get("max_autotune") or inductor_meta.get("max_autotune_pointwise")
     ):
         configs.append(triton.Config({}, num_stages=1, num_warps=8))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186006

When combo_kernels_autotune=0 AND combo_kernel_per_subkernel_blocks=True,
build the combo kernel's per-subkernel block sizes by stitching each
subkernel's heuristic configs[0], no benchmark sweep, no seed autotune.

For each subkernel in a combo partition, probe the standalone heuristic
and use configs[0] when the heuristic produces <=2 candidates; otherwise
carve the subkernel out to a standalone kernel.

The stitched combo Config picks one "winner" subkernel, the one with
the largest effective tile elems (product of its BLOCK values), and
takes num_warps, num_stages, and non-BLOCK backend kwargs (HIP options
like waves_per_eu) from that subkernel; the heaviest subkernel dominates
runtime, so its config applies combo-wide. Per-subkernel BLOCK kwargs
are suffixed (XBLOCK_0, XBLOCK_1, ...) so each subkernel keeps its own.
Persistent-reduction subkernels skip R*_BLOCK in the stitched config
(body bakes it in via static numels).

The codegen path attaches the stitched Config to ComboKernel as
no_bench_stitched_config. combo_grid_meta splits its kwargs into
default_config (BLOCK keys for the grid lambda's cdiv math) and
stitched_backend_kwargs (non-BLOCK keys for Triton's compiler), plus
stitched_num_warps and stitched_num_stages. At runtime,
_handle_combo_kernel_per_subkernel_blocks detects stitched_num_warps
and returns a single triton.Config({stitched_backend_kwargs}, ...),
short-circuiting the per-subkernel autotune-tuning-groups computation.

Authored with the assistance of Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo