### PR TITLE
[Pytorch] Gate (Fake)ScriptObject zero-size handling in partitioner _size_of behind an opt-in flag (#186008)

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9563,6 +9563,25 @@ def forward(self, primals_1, tangents_1):
             node = g.call_function(target, args=())
             self.assertEqual(_size_of(node), 0)
 
+    def test_size_of_fake_script_object(self):
+        import torch._functorch.config as functorch_config
+        from torch._functorch.partitioners import _size_of
+        from torch._library.fake_class_registry import FakeScriptObject
+
+        g = torch.fx.Graph()
+        node = g.call_function(torch.ops.aten.abs.default, args=())
+        node.meta["val"] = FakeScriptObject(None, "test_class", None)
+
+        # A (Fake)ScriptObject may hold tensors internally, so by default
+        # _size_of refuses to guess its memory footprint and raises.
+        with self.assertRaisesRegex(RuntimeError, "Cannot compute the size"):
+            _size_of(node)
+
+        # The unsafe escape hatch makes _size_of assume such objects are
+        # zero size, unblocking compilation at the cost of soundness.
+        with functorch_config.patch(unsafe_treat_script_objects_as_zero_size=True):
+            self.assertEqual(_size_of(node), 0)
+
 
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -55,6 +55,16 @@ treat_parameters_as_free_to_save = True
 # Applies CSE to the graph before partitioning
 cse = True
 
+# When the partitioner's _size_of encounters a (Fake)ScriptObject in node
+# metadata, it has no general way to know the object's true memory footprint:
+# a ScriptObject may hold tensors internally. By default we raise rather than
+# guess. Enabling this flag makes _size_of assume such objects are zero size,
+# which unblocks dynamic-shapes compilation of models containing ScriptObject
+# parameters (e.g. embedding-table configs from FBGEMM) at the cost of
+# soundness. This is a temporary escape hatch until we have a principled way to
+# probe the size of a (Fake)ScriptObject.
+unsafe_treat_script_objects_as_zero_size = False
+
 from torch._environment import is_fbcode
 
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1507,6 +1507,19 @@ def _size_of(node: fx.Node) -> int:
             return sum(object_nbytes(n) for n in val.values())
         elif isinstance(val, torch.Tensor):
             return object_nbytes(val)
+        elif isinstance(val, (torch.ScriptObject, FakeScriptObject)):
+            # A (Fake)ScriptObject may hold tensors internally, so we cannot
+            # soundly compute its size here. Only treat it as zero size when the
+            # user has explicitly opted in via this escape hatch.
+            if config.unsafe_treat_script_objects_as_zero_size:
+                return 0
+            raise RuntimeError(
+                f"Cannot compute the size of {type(val)} on node {node}. A "
+                "ScriptObject may hold tensors internally and the partitioner "
+                "has no general way to measure its memory footprint. Set "
+                "torch._functorch.config.unsafe_treat_script_objects_as_zero_size"
+                " = True to assume such objects are zero size (unsound)."
+            )
 
         raise RuntimeError(f"Unknown metadata type {type(val)} on node {node}")
     if node.op == "get_attr" or (


### PR DESCRIPTION
Summary:

`_size_of` in `min_cut_rematerialization_partition` crashes with `RuntimeError: Unknown metadata type <class FakeScriptObject>` when `dynamic=True` is used with `torch.compile` on models containing ScriptObject parameters (e.g. TBE configs from FBGEMM). This blocks SimpleFSDP memory optimization on large recommendation models.

This change gates the zero-size behavior behind a new, default-off config flag `torch._functorch.config.unsafe_treat_script_objects_as_zero_size`. By default `_size_of` now raises a clear, actionable error instead of the generic `Unknown metadata type`. When the flag is enabled it returns 0, restoring the unblock for jobs that need it. This is a temporary escape hatch until we have a principled way to probe the size of a `(Fake)ScriptObject`.

`_size_of` only feeds the partitioner's save-vs-recompute cost heuristic, so treating script objects as zero size never affects numerical correctness; at worst it slightly under-counts saved-activation memory and yields a marginally suboptimal memory/perf tradeoff.

To enable the flag, set it in your trainer entrypoint before the first compiled step (the value is read lazily during partitioning, at first compile):

```
import torch._functorch.config as functorch_config
functorch_config.unsafe_treat_script_objects_as_zero_size = True
```

Test Plan:
Updated `test_size_of_fake_script_object` in `test_aotdispatch.py` to assert both branches: by default `_size_of` raises on `FakeScriptObject` metadata, and under `functorch_config.patch(unsafe_treat_script_objects_as_zero_size=True)` it returns 0.

```
buck2 test fbcode//caffe2/test/functorch:test_aotdispatch -- -r test_size_of_fake_script_object
```

Reviewed By: ezyang

Differential Revision: D107314490


