### PR TITLE
[ROCm][Inductor] Remove skipIfRocm from test_mm_dropout; expand autotuner VERIFY tolerance for fp16 GEMM on ROCm

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -40,7 +40,6 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     MI200_ARCH,
-    skipIfRocm,
     skipIfRocmArch,
     skipIfXpu,
     TEST_WITH_ROCM,
@@ -477,7 +476,6 @@ class TestSelectAlgorithm(TestCase):
         if not torch.version.hip:  # autotuning is not guaranteed to run on ROCm
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
-    @skipIfRocm
     @patches
     def test_mm_dropout(self):
         @torch.compile
@@ -486,7 +484,12 @@ class TestSelectAlgorithm(TestCase):
             rnd = torch.ops.prims.inductor_random.default(mm_4.shape, seed, "rand")
             return mm_4 * rnd
 
-        if GPU_TYPE == "xpu":
+        # Triton MFMA matmul on AMD GPUs and Intel XPUs produces
+        # ~1 ULP fp16 rounding differences vs the aten reference used by the
+        # autotuner's internal VERIFY path. Max abs diff 0.0625 (= 2^-4),
+        # max rel diff 2^-10 (fp16 mantissa LSB). Benign; expand tolerance
+        # to match the existing XPU pattern.
+        if GPU_TYPE == "xpu" or torch.version.hip:
             patcher = patch.object(
                 select_algorithm, "VERIFY", dict(atol=1e-3, rtol=1e-3)
             )


### PR DESCRIPTION
FIXES #168651
FIXES #168652

### Investigation summary

### Test environment
-- PyTorch version: `2.13.0a0+gitf6f4e17`
-- Hip version: `7.2.53211`
-- GPU 0 name: `AMD Instinct MI300X ` (also tested on MI210, observed similar behaviour)

### Command to reproduce (default behaviour)
```
$ PYTORCH_TEST_WITH_ROCM=1 pytest test/inductor/test_select_algorithm.py -k "test_mm_dropout" -v
test/inductor/test_select_algorithm.py::TestSelectAlgorithm::test_mm_dropout SKIPPED [0.4625s] (skipIfRocm: test doesn't currently work on the ROCm stack)                                     [100%]
```

### Behaviour after removing "@skipIfRocm"
```
torch._inductor.exc.InductorError: AssertionError: Incorrect result from choice TritonTemplateCaller(/tmp/tmp3kct_u6v/vt/cvtvbljsz4uwqiagcyimwygwvsuxho7hqmgqj3ki2ernv4gmcf6z.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=256, BLOCK_M=16, BLOCK_N=16, EVEN_K=True, GROUP_M=4, USE_FAST_ACCUM=False, kpack=1, matrix_instr_nonkdim=16, waves_per_eu=8, num_stages=2, num_warps=1)

Tensor-likes are not close!

Mismatched elements: 232 / 393216 (0.1%)
Greatest absolute difference: 0.0625 at index (157, 629) (up to 0.0001 allowed)
Greatest relative difference: 0.0009765625 at index (383, 479) (up to 0.0001 allowed)
```

### Debugging
The 0.0625 absolute difference and 0.0009765625 relative difference figures here are specific and very reproducible.

```
2^-4 = 0.0625
2^-10 = 0.0009765625 
```
Note, 
	• 2^-4 is exactly 1 ULP (space between adjacent representable FPs) for FP16.
	• FP16 has 10 mantissa bits, the smallest fractional change it can represent is 2^-10.

### Minimal reproducible script (min_repro.py) with no dropout and no kernel fusion
```
import torch
torch.manual_seed(0)

def fn(x1, x2):
    return torch.ops.aten.mm.default(x2, x1)

x1 = torch.randn(512, 1024, dtype=torch.float16, device="cuda")
x2 = torch.randn(384, 512,  dtype=torch.float16, device="cuda")

ref = fn(x1, x2)
got = torch.compile(fn, mode="max-autotune")(x1, x2)

diff = (ref - got).abs()
print("max abs diff:", diff.max().item())
print("strict (1e-4):", torch.allclose(ref, got, atol=1e-4, rtol=1e-4))
print("loose  (1e-3):", torch.allclose(ref, got, atol=1e-3, rtol=1e-3))
```

### Experiments
| Command | Backends allowed | Results |
|--------|------------------|---------|
| PYTORCH_TEST_WITH_ROCM=1 python min_repo.py | Triton + Aten | max diff 0.0625 |
| TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS=ATEN PYTORCH_TEST_WITH_ROCM=1 python min_repo.py | Only ATEN | max diff 0.0 |
| TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS=TRITON PYTORCH_TEST_WITH_ROCM=1 python min_repo.py | Only Triton | max diff 0.0625 |
| TORCHINDUCTOR_MAX_AUTOTUNE=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS=TRITON PYTORCH_TEST_WITH_ROCM=1 python min_repo.py | Only Triton (max tuned) | max diff 0.0625 |

Interpretation:
	1. Default behaviour is reproducible without dropout and kernel fusion --> they are not the issue.
	2. When forced to use only ATEN backend, result is identical to the reference -- this is expected.
	3. When forced to use only Triton backend, same 2^-4 difference.
	4. When use Triton with max-autotune, the best candidate still disagrees with reference by exactly 2^-4 difference.

### Conclusion and proposed fix
This is a tolerance test issue related to FP16 GEMM -- not a kernel correctness bug associated with the ROCm stack. 

FP16 matmul + dropout produces at most 1 ULP per-element difference (rounding noise) vs ATEN reference on MI300X due to potentially differing MFMA reduction order -- I believe this is within ML-acceptable error.

The fix in this PR follows the precedent set by XPU (in commit 934eaa503f0a) by expanding both the atol and rtol tolerances to 1e-3.

### Behaviour after fix
```
test/inductor/test_select_algorithm.py::TestSelectAlgorithm::test_mm_dropout PASSED [3.7378s]                                                                             [100%]
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben