### PR TITLE
Surface ROCm GPU device faults in TorchElastic signal-failure messages (#186010)

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -125,6 +125,24 @@ class ApiTest(unittest.TestCase):
             f"Signal {signal.SIGSEGV} (SIGSEGV) received by PID {pf.pid}", pf.message
         )
 
+    def test_format_msg_enriches_root_signal_failure(self):
+        # The root signal failure's rendered message is passed through the
+        # handler's enrichment seam at format time (no-op base; a build-swapped
+        # handler may append device-fault context). The seam works on the local
+        # rendered string, so the failure's stored message is not mutated.
+        handler = mock.MagicMock()
+        handler.maybe_enrich_signal_failure_message.side_effect = (
+            lambda message, error_file: message + "\n[device fault context]"
+        )
+        with mock.patch(
+            "torch.distributed.elastic.multiprocessing.errors.get_error_handler",
+            return_value=handler,
+        ):
+            pf = self.failure_without_error_file(exitcode=-signal.SIGABRT)
+            rendered = str(ChildFailedError("trainer", {0: pf}))
+        self.assertIn("[device fault context]", rendered)
+        self.assertNotIn("[device fault context]", pf.message)
+
     def test_process_failure_no_error_file(self):
         pf = self.failure_without_error_file(exitcode=138)
         self.assertEqual("<N/A>", pf.signal_name())

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -257,7 +257,7 @@ class ChildFailedError(Exception):
         other_failures_fmt: list[str] = []
         width = len(title)
         for idx, (rank, failure) in enumerate(self.failures.items()):
-            fmt, w = self._format_failure(idx, rank, failure)
+            fmt, w = self._format_failure(idx, rank, failure, rank == root_rank)
             width = max(width, w)
             if rank == root_rank:
                 root_failure_fmt = fmt
@@ -276,7 +276,7 @@ class ChildFailedError(Exception):
         )
 
     def _format_failure(
-        self, idx: int, rank: int, failure: ProcessFailure
+        self, idx: int, rank: int, failure: ProcessFailure, is_root: bool = False
     ) -> tuple[str, int]:
         # failure.message is either a str (when the failure does not generate a traceback - e.g. signals)
         # or a dict (json) of the form
@@ -293,6 +293,19 @@ class ChildFailedError(Exception):
                 .get("py_callstack", failure.message.get("message", "<N/A>"))
                 .replace("\n", "\n  ")  # to properly indent the traceback
             )
+
+        # For the root signal failure, let the (build-swapped) handler append
+        # device-fault context (e.g. ROCm GPU faults) to the rendered message.
+        # Works on the local string, so error_file_data is never mutated, and it
+        # is a no-op in OSS (the base handler returns the message unchanged).
+        # Best-effort: never let a handler override break failure rendering.
+        if is_root and failure.exitcode < 0:
+            try:
+                msg = get_error_handler().maybe_enrich_signal_failure_message(
+                    msg, failure.error_file
+                )
+            except Exception:
+                logger.warning("Failed to enrich signal failure message", exc_info=True)
 
         signal_name = failure.signal_name()
         signal_name_str = f" ({signal_name})" if signal_name != _NOT_AVAILABLE else ""

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -87,6 +87,18 @@ class ErrorHandler:
             with open(file, "w") as fp:
                 json.dump(data, fp)
 
+    def maybe_enrich_signal_failure_message(self, message: str, error_file: str) -> str:
+        """Hook to enrich a signal (no-traceback) failure message.
+
+        Called from ``ProcessFailure`` when a worker fails by signal (negative
+        exitcode). Subclasses may override this to append device-specific fault
+        context (e.g. GPU memory faults) scanned from the worker logs near
+        ``error_file``, so it surfaces in the propagated failure regardless of
+        how the failure is later handled. The base implementation is a no-op
+        that returns ``message`` unchanged.
+        """
+        return message
+
     def override_error_code_in_rootcause_data(
         self,
         rootcause_error_file: str,


### PR DESCRIPTION
Summary:

A worker killed by a signal (e.g. SIGABRT from a GPU fault) produces no Python
traceback, so the propagated ChildFailedError shows only "Signal N (SIG...)".
On AMD the real cause is hidden: ROCr aborts on the fault ("Memory access fault
by GPU" / HSA_STATUS_ERROR_*) before any catchable error is raised, whereas CUDA
surfaces it as a RuntimeError (task T273293357).

Add a generic, no-op ErrorHandler.maybe_enrich_signal_failure_message seam that
ChildFailedError.format_msg calls when rendering the root signal failure. The fb
handler (ErrorHandlerFB) overrides it to scan the failed worker's logs for ROCm
fault lines and append them to the rendered message, so the fault surfaces in the
propagated error (MVAI/Fire's MAST reply is str(ChildFailedError)).

- Render-seam, root failure only, on the local rendered string: never mutates
  error_file_data and is a no-op in OSS. record()/dump_error_file are untouched,
  so error-code/retryability classification is unchanged.
- All ROCm logic lives in errors/fb (device_error_processor + the ErrorHandlerFB
  override), mirroring CUDA's device-error logic.
- Gated by JK debugger/amd_coredumps:enable_rocm_device_error_enrichment (off by
  default) - inert until enabled.

MVAI/Fire half; an APS follow-up extends the same scan to the APS reply path.

Test Plan:
Unit (50 pass):
  buck test //caffe2/torch/distributed/elastic/multiprocessing/errors/fb/test:device_error_processor_test
  buck test //caffe2/torch/distributed/elastic/multiprocessing/errors/fb/test:error_handler_fb_test
  buck test //caffe2/test/distributed/elastic/multiprocessing/errors:api_test
arc lint --take AUTODEPS2 / BLACK / FLAKE8: clean.

e2e (MAST GTT_MI300X, scripts.arbaz.embedding_bag_oob OOB repro): with the JK
enabled, the failed MVAI job Execution Details show the rocdevice.cpp
HSA_STATUS_ERROR_EXCEPTION line instead of a bare "Signal 6 (SIGABRT)".
[re-validation on the reshaped diff pending]

Differential Revision: D106583145




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang