### PR TITLE
torchtitan: track CUDA_STABLE for build/test env and nightly wheel channel

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+from pathlib import Path
 from typing import Any
 
 from cli.lib.common.cli_helper import BaseRunner
@@ -12,6 +14,23 @@ from cli.lib.core.torchtitan.lib import (
 
 
 logger = logging.getLogger(__name__)
+
+# generate_binary_build_matrix.py is not importable as a package (it lives in
+# .github/scripts, outside the cli package), so add that dir to sys.path the
+# same way .github/scripts/get_ci_variable.py does.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[6] / ".github" / "scripts"
+
+
+def _nightly_index_url() -> str:
+    # torchao and torchcomms nightlies must match the CUDA toolchain of the
+    # build, so reuse CUDA_STABLE from generate_binary_build_matrix.py (the
+    # single source of truth for the stable CUDA version, e.g. "13.0" -> cu130)
+    # rather than hardcoding the wheel channel here.
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from generate_binary_build_matrix import CUDA_STABLE
+
+    return f"https://download.pytorch.org/whl/nightly/cu{CUDA_STABLE.replace('.', '')}"
 
 
 class TorchtitanTestRunner(BaseRunner):
@@ -28,7 +47,7 @@ class TorchtitanTestRunner(BaseRunner):
                 "torchao",
                 "torchcomms",
                 "--index-url",
-                "https://download.pytorch.org/whl/nightly/cu129",
+                _nightly_index_url(),
             ],
         )
         with working_directory(self.work_directory):

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -30,15 +30,37 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: arc,lf
 
+  # Resolve the stable CUDA version from generate_binary_build_matrix.py
+  # (CUDA_STABLE) so the build/test environment tracks it without hardcoding.
+  get-cuda-version:
+    name: get-cuda-version
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'pytorch'
+    outputs:
+      stable-cuda: ${{ steps.get.outputs.stable-cuda }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          submodules: false
+          fetch-depth: 1
+      - name: Get stable CUDA version
+        id: get
+        run: |
+          set -eou pipefail
+          echo "stable-cuda=$(python3 .github/scripts/get_ci_variable.py --cuda-stable-version)" >> "${GITHUB_OUTPUT}"
+
   build:
     name: torchtitan-x-pytorch-build
     if: github.repository_owner == 'pytorch'
     uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
+    needs:
+      - get-label-type
+      - get-cuda-version
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda13.0-py3-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
+      build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-cudnn9-py3-gcc11
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '8.0 8.9 9.0 10.0'
       runner: linux.24xlarge.memory
@@ -51,7 +73,7 @@ jobs:
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
-      cuda-version: "13.0"
+      cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}
     secrets: inherit
 
   test:
@@ -60,12 +82,13 @@ jobs:
     needs:
       - build
       - get-label-type
+      - get-cuda-version
     with:
-      build-environment: linux-jammy-cuda13.0-py3-gcc11
+      build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3-gcc11
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
-      cuda-version: "13.0"
+      cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}
     secrets: inherit


### PR DESCRIPTION
The torchtitan integration workflow built and ran against CUDA 13.0 (`linux-jammy-cuda13.0-py3-gcc11`), but its torchtitan test runner installed the `torchao`/`torchcomms` nightly dependencies from the CUDA 12.9 wheel index (`cu129`). That toolchain mismatch failed the test job. This makes the whole torchtitan workflow track the stable CUDA version instead of hardcoding it in two unrelated places.

Two changes:

1. **`.ci/lumen_cli/.../torchtitan_test.py`**: derive the nightly wheel channel from `CUDA_STABLE` in `.github/scripts/generate_binary_build_matrix.py` (e.g. `13.0` -> `cu130`) instead of the hardcoded `cu129`. `generate_binary_build_matrix.py` lives in `.github/scripts` (outside the `cli` package), so its directory is added to `sys.path` before `from generate_binary_build_matrix import CUDA_STABLE` -- the same approach `.github/scripts/get_ci_variable.py` already uses. This is the actual fix for the failure.

2. **`.github/workflows/torchtitan.yml`**: add a `get-cuda-version` job that resolves `CUDA_STABLE` via `get_ci_variable.py --cuda-stable-version` and feeds it into the build/test `build-environment`, `docker-image-name`, and `cuda-version` inputs, so they track the stable CUDA version. (The Docker image must still exist in `docker-builds.yml` for the resolved version, so a stable-CUDA bump remains gated on that image being built.)

Fixes the failure seen in https://github.com/pytorch/pytorch/actions/runs/26721024930/job/78748449674

Note: the `FSDP+TP+PP+compile with torchcomms` torchtitan flavor fails for an unrelated reason once the suite runs (torchcomms-managed TP process group not resolvable by functional collectives under `torch.compile`); tracked in #186031.

## Test Plan
```
$ python3 -c "import sys; from pathlib import Path; \
    sys.path.insert(0, str(Path('.github/scripts').resolve())); \
    from generate_binary_build_matrix import CUDA_STABLE; \
    print('cu' + CUDA_STABLE.replace('.', ''))"
cu130
$ python3 .github/scripts/get_ci_variable.py --cuda-stable-version
13.0
```
With `CUDA_STABLE=13.0`, the wheel channel resolves to `cu130`, the build-environment to `linux-jammy-cuda13.0-py3-gcc11`, and the image to `ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` -- matching the previous hardcoded values. Trigger `ciflow/torchtitan` and confirm the torchtitan jobs build/run on CUDA 13.0 and install torchcomms from the cu130 index.

Authored by Claude.