### PR TITLE
Build dynamo with python 3.15

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -12,7 +12,7 @@
 #undef Py_BUILD_CORE
 #endif
 
-#if IS_PYTHON_3_15_PLUS
+#if IS_PYTHON_3_16_PLUS
 
 const uint8_t* THP_PyOpcode_Caches = NULL;
 int THP_PyOpcode_Caches_size = 0;
@@ -55,7 +55,7 @@ void init_THPCaches() {}
 // As a simple way to reduce the impact of ABI changes on the CPython side, this
 // check forces us to manually re-check that the function didn't change on the
 // next major version
-#if IS_PYTHON_3_15_PLUS
+#if IS_PYTHON_3_16_PLUS
 #error \
     "Please ensure that the functions below still match the CPython implementation for 3.15"
 #endif

--- a/torch/csrc/dynamo/cpython_includes.h
+++ b/torch/csrc/dynamo/cpython_includes.h
@@ -11,6 +11,8 @@
 
 // see https://bugs.python.org/issue35886
 #define Py_BUILD_CORE
+// avoid dependency on _Py_tss_tstate
+#define Py_BUILD_CORE_MODULE
 
 #ifndef __cplusplus
 // C-only headers
@@ -34,6 +36,7 @@
 #endif
 
 #undef Py_BUILD_CORE
+#undef Py_BUILD_CORE_MODULE
 
 #ifdef __cplusplus
 extern "C" {

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -73,8 +73,8 @@ static PyObject* set_eval_frame_isolate_recompiles_id_py(
   return PyLong_FromLongLong(old_id);
 }
 
-// 3.15 Not supported at all. See cpython_defs.c for hints
-#if !(IS_PYTHON_3_15_PLUS)
+// 3.16 Not supported at all. See cpython_defs.c for hints
+#if !(IS_PYTHON_3_16_PLUS)
 
 #define DECLARE_PYOBJ_ATTR(name)                        \
   static PyObject* THPPyInterpreterFrame_##name(        \

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -27,8 +27,8 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   PyCodeObject* co = F_CODE(frame);
   _framelocals.resize(co->co_nlocalsplus, nullptr);
 
-#if IS_PYTHON_3_15_PLUS
-  TORCH_CHECK(false, "Python 3.15+");
+#if IS_PYTHON_3_16_PLUS
+  TORCH_CHECK(false, "Python 3.16+");
 #elif IS_PYTHON_3_14_PLUS
   if (!frame->stackpointer) {
     return;
@@ -62,8 +62,8 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
   };
 
   auto offset = co->co_nlocalsplus - co->co_nfreevars;
-#if IS_PYTHON_3_15_PLUS
-  TORCH_CHECK(false, "Python 3.15+");
+#if IS_PYTHON_3_16_PLUS
+  TORCH_CHECK(false, "Python 3.16+");
 #elif IS_PYTHON_3_14_PLUS
   for (int i = 0; i < offset; i++) {
     update_framelocals(
@@ -76,9 +76,9 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
 #endif
 
   // Get references to closure variables
-#if IS_PYTHON_3_15_PLUS
+#if IS_PYTHON_3_16_PLUS
   PyObject* closure;
-  TORCH_CHECK(false, "Python 3.15+");
+  TORCH_CHECK(false, "Python 3.16+");
 #else
   PyObject* closure = FUNC(frame)->func_closure;
 #endif

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -14,6 +14,7 @@ extern "C" {
 #define IS_PYTHON_3_13_PLUS (PY_VERSION_HEX >= 0x030D0000)
 #define IS_PYTHON_3_14_PLUS (PY_VERSION_HEX >= 0x030E0000)
 #define IS_PYTHON_3_15_PLUS (PY_VERSION_HEX >= 0x030F0000)
+#define IS_PYTHON_3_16_PLUS (PY_VERSION_HEX >= 0x03100000)
 
 static inline int PyCode_GetNCellvars(PyCodeObject* code) {
 // gh-26364 added co_ncellvars to Python 3.11.0rc1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #186017

The version checks on the python side haven't been updated, so users will still get an error when trying to use 3.15.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98