### PR TITLE
[inductor] Preserve NaNs for CPU libm calls

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6702,6 +6702,13 @@ class CPUReproTests(TestCase):
         fn(math.inf)
         fn(math.nan)
 
+    def test_sin_atan_nan(self):
+        def fn(x):
+            return torch.sin(torch.atan(x))
+
+        x = torch.tensor([float("nan")])
+        self.common(fn, (x,))
+
     def test_pdist_fallback_continuous(self):
         # https://github.com/pytorch/pytorch/issues/170939
         def fn(x):

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -915,7 +915,7 @@ def _get_ffast_math_flags() -> list[str]:
     if _IS_WINDOWS:
         flags = []
     else:
-        # ffast-math is equivalent to these flags as in
+        # This starts from the flags implied by -ffast-math, as in
         # https://github.com/gcc-mirror/gcc/blob/4700ad1c78ccd7767f846802fca148b2ea9a1852/gcc/opts.cc#L3458-L3468
         # however gcc<13 sets the FTZ/DAZ flags for runtime on x86 even if we have
         # -ffast-math -fno-unsafe-math-optimizations because the flags for runtime
@@ -926,12 +926,15 @@ def _get_ffast_math_flags() -> list[str]:
             "funsafe-math-optimizations",
             "ffinite-math-only",
             "fno-signed-zeros",
-            "fno-math-errno",
         ]
 
         flags.append("fno-finite-math-only")
         if not config.cpp.enable_unsafe_math_opt_flag:
             flags.append("fno-unsafe-math-optimizations")
+        # Keep errno-preserving libm semantics.  With -fno-math-errno, GCC can
+        # inline/transform libm call pairs like sin(atan(x)) in ways that do not
+        # preserve NaN values (see https://github.com/pytorch/pytorch/issues/143978).
+        flags.append("fmath-errno")
         flags.append(f"ffp-contract={config.cpp.enable_floating_point_contract_flag}")
 
         if is_gcc():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186018

CPU Inductor builds generated C++ kernels with a fast-math-like flag set. That set included -fno-math-errno, which lets GCC inline and rewrite libm call pairs. For scalar generated code like std::sin(std::atan(x)), GCC 11 can rewrite the expression so a NaN input returns 1 instead of preserving NaN. That made torch.compile disagree with eager for sin(atan(nan)) and for the issue's rsqrt/angle/atan/sin reproducer.

Keep the rest of the fast-math-like flag decomposition, but do not opt out of errno-preserving libm semantics. Add -fmath-errno explicitly so generated CPU C++ keeps eager-compatible NaN behavior. I considered special-casing only the observed sin(atan(x)) pattern, but the root cause is the global compiler permission for errno-unsafe libm transformations, so fixing the flag is the narrower semantic boundary.

Benchmark Results

Compared the staged fmath-errno behavior against the old fno-math-errno behavior by monkeypatching only _get_ffast_math_flags and recompiling in fresh TORCHINDUCTOR_CACHE_DIR directories with OMP_NUM_THREADS=1, MKL_NUM_THREADS=1, and torch.set_num_threads(1). Cases covered sqrt and sin(atan(x)) for n=1 with cpp.simdlen=1, n=17 tail cases, and n=1048576 vectorized cases. No case showed a slowdown; new medians were within noise or faster. Forward-order deltas ranged from about -0.6% to -6.1%, and reverse-order deltas ranged from about -0.1% to -3.0% versus old.

Fixes #143978

Generated by my agent

Test Plan:

- Minimal repro before fix reproduced eager tensor([nan]) vs compiled tensor([1.]); after fix compiled returns tensor([nan]) and equal_nan=True.

- Original issue-shaped repro after fix: eager and compiled both return tensor([0., nan, 0., 0., 0., 0., 0., nan, nan, 0.]) with equal_nan=True.

- TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_fix_143978_unittest.95A8iC python - <<'PY' ... import test_cpu_repro with a torchvision stub and run CPUReproTests.test_sin_atan_nan ... PY: passed, Ran 1 test in 2.078s; OK.

- python test/inductor/test_cpu_repro.py CPUReproTests.test_sin_atan_nan: blocked by this environment's broken optional torchvision install, RuntimeError: operator torchvision::nms does not exist.

- lintrunner -a: passed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo