### PR TITLE
[WIP] Reintroduce ptxas bundling for CUDA 13.0 binaries (revert #174716)

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -119,6 +119,10 @@ def cuda_build_env(cuda_version: str, arch: str) -> dict[str, str]:
         **CUDA_BUILD_ENV_STATIC,
         "TORCH_NVCC_FLAGS": nvcc_flags,
         "TORCH_CUDA_ARCH_LIST": torch_cuda_arch_list(cuda_version, arch),
+        # Bundle ptxas into torch/bin (consumed by
+        # torch._inductor.runtime.compile_tasks._set_triton_ptxas_path) so
+        # Triton uses a known-good assembler on CUDA 13.0.
+        **({"BUILD_BUNDLE_PTXAS": "1"} if cuda_version == "13.0" else {}),
     }
     if arch == "aarch64":
         # Pre-built MAGMA tarballs are x86-only.

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -42,7 +42,7 @@ def _reload_python_module(
 def _set_triton_ptxas_path() -> None:
     if os.environ.get("TRITON_PTXAS_PATH") is not None:
         return
-    ptxas = Path(__file__).absolute().parents[1] / "bin" / "ptxas"
+    ptxas = Path(__file__).absolute().parents[2] / "bin" / "ptxas"
     if not ptxas.exists():
         return
     if ptxas.is_file() and os.access(ptxas, os.X_OK):


### PR DESCRIPTION
Reintroduces the ptxas bundle for CUDA 13.0 binaries -- effectively a revert of #174716, scoped to 13.0.

The bundle was originally added (#163988) to work around https://github.com/pytorch/pytorch/issues/163801, where Triton's `ptxas` could miscompile kernels. #174716 removed it once that issue was believed fixed upstream; we are reinstating it for CUDA 13.0.

A plain `git revert` no longer applies: since #174716 the manywheel build was refactored (`build_cuda.sh` -> `build_env_setup.py`) and the arm sbsa build was unified with x86. The change is reapplied in the new locations:

- **`.ci/manywheel/build_env_setup.py`**: set `BUILD_BUNDLE_PTXAS=1` in the CUDA build env for 13.0. It is written to the env file and sourced by `build.sh`, so it reaches the CMake build, which copies `ptxas` into `torch/bin`.
- **`torch/_inductor/runtime/compile_tasks.py`**: restore the bundled-ptxas lookup path from `parents[1]` back to `parents[2]` (i.e. `torch/bin/ptxas`), which is where CMake installs it (`CMAKE_INSTALL_BINDIR` under the torch package). #174716 had pointed this at the wrong directory.

The CMake bundling option (`BUILD_BUNDLE_PTXAS` in `CMakeLists.txt`) was never removed, so no CMake change is needed.

## Test Plan
```
$ python3 -c "import sys; sys.path.insert(0, '.ci/manywheel'); \
    import build_env_setup as b; \
    print({cv: b.cuda_build_env(cv, 'x86_64').get('BUILD_BUNDLE_PTXAS') \
           for cv in ['12.6', '13.0', '13.2']})"
{'12.6': None, '13.0': '1', '13.2': None}
```
For full validation: build a cu13.0 manywheel, confirm `torch/bin/ptxas` is present in the wheel and that `TRITON_PTXAS_PATH` is set at runtime, matching the unit test from #163988.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo