### PR TITLE
[CD] Enable Triton XPU Windows wheel build for Python 3.15 & 3.15t

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
         device: ["xpu"]
     timeout-minutes: 40
     env:


### PR DESCRIPTION
Part of #184352.
Fixes #190542

Windows `cp315` / `cp315t` nightly wheels were enabled in #190360. This companion PR adds **Triton XPU Windows wheel builds** for Python 3.15 & 3.15t so the XPU variant has its triton dependency available.

## Change

- `build-triton-wheel.yml`: add `"3.15"` and `"3.15t"` to the Windows triton XPU build matrix.

## Test Plan

Verified the matrix entry is correct by inspecting the workflow YAML.
