### PR TITLE
[compile] Support cross-device tensor.data = ... under torch.compile

### DIFF
--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -406,6 +406,7 @@ static at::Tensor& set__functionalize(at::Tensor& self, const at::Tensor& src) {
   return self;
 }
 
+
 TORCH_LIBRARY_IMPL(_, Functionalize, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&functionalizeFallback>());
 }

--- a/aten/src/ATen/native/ShallowCopyData.cpp
+++ b/aten/src/ATen/native/ShallowCopyData.cpp
@@ -1,0 +1,72 @@
+#include <ATen/ATen.h>
+#include <ATen/FunctionalTensorWrapper.h>
+#include <torch/library.h>
+
+namespace at::native {
+
+static at::Tensor& shallow_copy_data_(at::Tensor& self, const at::Tensor& source) {
+  if (self.unsafeGetTensorImpl() != source.unsafeGetTensorImpl()) {
+    self.unsafeGetTensorImpl()->shallow_copy_from(source.getIntrusivePtr());
+  }
+  return self;
+}
+
+static at::Tensor& shallow_copy_data_functionalize(
+    at::Tensor& self,
+    const at::Tensor& src) {
+  TORCH_CHECK(
+      at::functionalization::impl::isFunctionalTensor(self) ||
+          !at::functionalization::impl::isFunctionalTensor(src),
+      "shallow_copy_data_: cannot mutate a non-functional tensor with a functional tensor");
+
+  // Non-functional path: redispatch through the op schema so
+  // ProxyTorchDispatch can record an FX node during make_fx tracing.
+  if (!at::functionalization::impl::isFunctionalTensor(self) &&
+      !at::functionalization::impl::isFunctionalTensor(src)) {
+    at::AutoDispatchSkipFunctionalize guard;
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("aten::shallow_copy_data_", "")
+                         .typed<at::Tensor&(at::Tensor&, const at::Tensor&)>();
+    return op.call(self, src);
+  }
+
+  TORCH_CHECK(
+      at::functionalization::impl::isFunctionalTensor(src),
+      "shallow_copy_data_: source must be a FunctionalTensor");
+
+  auto self_impl =
+      at::functionalization::impl::unsafeGetFunctionalWrapper(self);
+  auto src_impl =
+      at::functionalization::impl::unsafeGetFunctionalWrapper(src);
+  TORCH_CHECK(
+      !self_impl->was_inductor_storage_resized(),
+      "storage_resize_() followed by shallow_copy_data_() is not supported");
+  self_impl->set__impl(src_impl);
+  return self;
+}
+
+TORCH_LIBRARY_FRAGMENT(aten, m) {
+  m.def("shallow_copy_data_(Tensor(a!) self, Tensor source) -> Tensor(a!)");
+}
+
+TORCH_LIBRARY_IMPL(aten, CPU, m) {
+  m.impl("shallow_copy_data_", shallow_copy_data_);
+}
+
+TORCH_LIBRARY_IMPL(aten, CUDA, m) {
+  m.impl("shallow_copy_data_", shallow_copy_data_);
+}
+
+TORCH_LIBRARY_IMPL(aten, Meta, m) {
+  m.impl("shallow_copy_data_", shallow_copy_data_);
+}
+
+TORCH_LIBRARY_IMPL(aten, MPS, m) {
+  m.impl("shallow_copy_data_", shallow_copy_data_);
+}
+
+TORCH_LIBRARY_IMPL(aten, Functionalize, m) {
+  m.impl("shallow_copy_data_", shallow_copy_data_functionalize);
+}
+
+} // namespace at::native

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4697,6 +4697,37 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(x1.data, x2.data)
         self.assertEqual(y1, y2)
 
+    @requires_cuda
+    def test_tensor_set_data_cross_device(self):
+        def func(x):
+            x.data = x.data.to("cuda")
+            return x + 1
+
+        x_eager = torch.randn(4, device="cpu")
+        x_compiled = x_eager.clone()
+
+        out_eager = func(x_eager)
+        out_compiled = torch.compile(func, backend="eager")(x_compiled)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(x_eager.device, x_compiled.device)
+
+    @requires_cuda
+    def test_tensor_set_data_cross_device_inductor(self):
+        def func(x):
+            x.data = x.data.to("cuda")
+            return x + 1
+
+        x_eager = torch.randn(4, device="cpu")
+        x_compiled = x_eager.clone()
+
+        out_eager = func(x_eager)
+        torch._dynamo.reset()
+        out_compiled = torch.compile(func, backend="inductor")(x_compiled)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(x_eager.device, x_compiled.device)
+
     def test_user_ctor_ctx_manager(self):
         class UserCtxManager:
             def __enter__(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1533,6 +1533,23 @@ def forward(self, x_1):
         self.checkType(r3, "cpu", (4, 4))
         self.checkType(out, "cpu", (4, 4))
 
+    @unittest.skipIf(
+        TEST_WITH_TORCHDYNAMO, "isinstance check for FakeTensor won't work with compile"
+    )
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_aten_set_data_multi_device(self):
+        with FakeTensorMode():
+            x1 = torch.rand(4, device="cpu")
+            x2 = torch.rand(4, device="cuda")
+            # cpu -> cuda
+            torch.ops.aten.shallow_copy_data_(x1, x2)
+            self.checkType(x1, "cuda", (4,))
+            # cuda -> cpu
+            x3 = torch.rand(4, device="cuda")
+            x4 = torch.rand(4, device="cpu")
+            torch.ops.aten.shallow_copy_data_(x3, x4)
+            self.checkType(x3, "cpu", (4,))
+
     def test__adaptive_avg_pool2d_backward(self):
         with FakeTensorMode():
             grad_out = torch.rand(2, 3, 4, 4)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3402,8 +3402,6 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
                     )
                 elif name == "data":
                     # [Note: set_data_on_scoped_tensor]
-                    # TODO(azahed98): The plan of record is to introduce a set_data op, entirely subsume the
-                    # operation into a call_function in the fx graph, and let aot_autograd handle it.
                     if obj.source is None:
                         unimplemented(
                             gb_type="Failed to mutate tensor data attribute",
@@ -3440,12 +3438,13 @@ class SetAttrBuiltinVariable(BaseBuiltinVariable):
 
                     # Step 1 - disable grads
                     with dynamo_disable_grad(tx), torch.no_grad():
-                        # Step 2 - call `set_`
+                        # Step 2 - call shallow_copy_data_
+                        # (shallow_copy_from, matching eager .data = behavior)
                         out = wrap_fx_proxy(
                             tx,
                             tx.output.create_proxy(
                                 "call_function",
-                                torch.Tensor.set_,
+                                torch.ops.aten.shallow_copy_data_,
                                 *proxy_args_kwargs([obj, val], {}),
                             ),
                         )

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -561,6 +561,7 @@ def _is_functional_graph(fx_g: torch.fx.Graph) -> tuple[str | None, int]:
     allowed_mutation_ops = [
         torch.ops.aten.copy_.default,
         torch.ops.aten.set_.source_Tensor,
+        torch.ops.aten.shallow_copy_data_.default,
     ]
     if hasattr(torch.ops.fsdp, "copy_"):
         allowed_mutation_ops.append(torch.ops.fsdp.copy_.default)

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -123,6 +123,16 @@ def _create_graph(
             _allow_token_discovery=True,
         )
 
+    # Save original FakeTensor devices before make_fx, which may mutate
+    # them via in-graph set_() (e.g. cross-device tensor.data = ...).
+    # After tracing, we restore them so the backend compiler sees the
+    # correct input devices on placeholder nodes.
+    original_fake_devices = {
+        i: arg.fake_device
+        for i, arg in enumerate(args)
+        if isinstance(arg, torch.Tensor) and hasattr(arg, "fake_device")
+    }
+
     with (
         enable_python_dispatcher(),
         ctx,
@@ -134,6 +144,22 @@ def _create_graph(
             pre_dispatch=aot_config.pre_dispatch,
             _disable_torch_fn_metadata_mode=aot_config._disable_torch_fn_metadata_mode,
         )(*args)
+
+        # Restore FakeTensor devices on both args and placeholder nodes
+        # that may have been mutated by in-graph set_().
+        if original_fake_devices:
+            for i, device in original_fake_devices.items():
+                if args[i].fake_device != device:  # pyrefly: ignore[missing-attribute]
+                    args[i].fake_device = device  # pyrefly: ignore[missing-attribute]
+            arg_idx = 0
+            for node in fx_g.graph.nodes:
+                if node.op != "placeholder":
+                    break
+                ev = node.meta.get("val", None)
+                if ev is not None and hasattr(ev, "fake_device"):
+                    if arg_idx in original_fake_devices:
+                        ev.fake_device = original_fake_devices[arg_idx]
+                    arg_idx += 1
 
         if args_descs is not None:
             flat_args_descs, _ = pytree.tree_flatten(args_descs)

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -753,7 +753,7 @@ def apply_in_graph_mutations(
         if mcs is None or mcs.mc_storage > applied_mcs.mc_storage:  # type: ignore[union-attr]
             with torch.no_grad():
                 # pyrefly: ignore [bad-argument-type, no-matching-overload]
-                inpt_old.set_(inpt_new)
+                torch.ops.aten.shallow_copy_data_(inpt_old, inpt_new)
 
     # Note [Ordering of resize_() and set_()]
     # Importantly: the common usage in FSDP is that we have a dummy parameter

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -681,7 +681,7 @@ class _RuntimeForwardEpilogue:
                         )
                     updated_inpt = updated_inpt.alias
                 with torch.no_grad():
-                    original_inpt.set_(updated_inpt)
+                    torch.ops.aten.shallow_copy_data_(original_inpt, updated_inpt)
                 continue
             if meta.mutates_metadata and not meta.mutates_data:
                 if self.trace_joint:
@@ -1027,7 +1027,9 @@ def _create_runtime_wrapper(
                     mut_lines.append(f"    _u{i} = _unwrap_tensoralias({ui})")
                 else:
                     mut_lines.append(f"    _u{i} = {ui}")
-                mut_lines.append(f"    with torch.no_grad(): {oi}.set_(_u{i})")
+                mut_lines.append(
+                    f"    with torch.no_grad(): torch.ops.aten.shallow_copy_data_({oi}, _u{i})"
+                )
             elif meta.mutates_metadata and not meta.mutates_data:
                 if trace_joint:
                     mut_lines.append(f"    _u{i} = _unwrap_tensoralias({ui})")

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1356,7 +1356,26 @@ class _InProcessFxCompile(FxCompile):
                 # of autograd, so there should be no more autograd-related API's in the
                 # graph.
                 with torch.no_grad():
+                    # Save original example_inputs devices before
+                    # FakeTensorProp, which may mutate them via in-graph
+                    # set_() (e.g. cross-device tensor.data = ...).
+                    orig_input_devices = [
+                        inp.fake_device if hasattr(inp, "fake_device") else None
+                        for inp in example_inputs
+                    ]
+
                     fake_mode = fake_tensor_prop(gm, example_inputs)
+
+                    # Restore example_inputs devices that may have been
+                    # mutated by set_() during FakeTensorProp.
+                    for inp, orig_dev in zip(example_inputs, orig_input_devices):
+                        if orig_dev is not None and hasattr(inp, "fake_device"):
+                            if (
+                                inp.fake_device != orig_dev
+                            ):  # pyrefly: ignore[missing-attribute]
+                                inp.fake_device = (  # pyrefly: ignore[missing-attribute]
+                                    orig_dev
+                                )
 
             _recursive_record_original_output_strides(gm)
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1616,6 +1616,22 @@ def multi_device_op_default(
     return run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs)
 
 
+# _set_data copies all tensor metadata (storage, device, sizes, strides, dtype)
+# from source to self via shallow_copy_from, matching eager tensor.data = behavior.
+@register_op_impl(aten.shallow_copy_data_.default)
+def _set_data_fake(
+    fake_mode: FakeTensorMode, func: OpOverload, *args: Any, **kwargs: Any
+) -> FakeTensor:
+    _, new_kwargs = _normalize_function_or_error(
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+    source_device = new_kwargs["source"].device
+    with in_kernel_invocation_manager(fake_mode):
+        func(*args, **kwargs)
+    new_kwargs["input"].fake_device = source_device
+    return new_kwargs["input"]
+
+
 # same with multi_device_op_default, but return the input
 @register_op_impl(aten.copy.out)
 @register_op_impl(aten.slice_scatter.out)

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -744,13 +744,14 @@ void initTorchFunctions(PyObject* module) {
         // - non-differentiable aliasing: aliasing of subclass_x and subclass_y
         //   is defined recursively based on the aliasing of their inner
         //   tensors.
-        at::native::checkSetStorage(
-            dst,
-            src.storage(),
-            dst.sym_storage_offset(),
-            dst.sym_sizes(),
-            dst.sym_strides(),
-            /*check_offset_in_bounds=*/false);
+        // Use shallow_copy_from for cross-device support.
+        // checkSetStorage rejects cross-device, but _functionalize_unsafe_set
+        // is explicitly meant to bypass safety checks.
+        if (dst.device() != src.device()) {
+          dst.unsafeGetTensorImpl()->_change_backend_component_keys(
+              src.device());
+        }
+        dst.unsafeGetTensorImpl()->set_storage_keep_dtype(src.storage());
       });
   py_module.def("_is_functional_tensor", [](const at::Tensor& t) {
     return at::functionalization::impl::isFunctionalTensor(t);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #186040

Diffusers' group offloading pattern moves parameters between CPU and CUDA
via `tensor.data = tensor.data.to(device)`. This worked in eager mode
(which uses `shallow_copy_from`, a metadata swap that permits cross-device)
but failed under `torch.compile` because Dynamo lowered `.data =` to
`aten.set_.source_Tensor`, which rejects cross-device storage swaps.

This PR introduces `aten::shallow_copy_data_`, a new op that calls
`TensorImpl::shallow_copy_from` -- exactly matching what eager `.data =`
does. Dynamo now emits this op instead of `set_` for `.data =` mutations.

**aten::shallow_copy_data_ (ShallowCopyData.cpp):** Self-contained op
defined via TORCH_LIBRARY_FRAGMENT. Eager impl calls `shallow_copy_from`
which atomically copies storage, device, dispatch keys, sizes, strides,
and dtype. Functionalization kernel redispatches through the op schema
(so ProxyTorchDispatch records FX nodes during make_fx tracing), then
calls `set__impl` on FunctionalTensorWrapper to track the storage swap.

**Dynamo (builtin.py):** `.data =` emits `shallow_copy_data_` instead of
`set_`. This resolves the TODO at [Note: set_data_on_scoped_tensor].

**FakeTensor (fake_impls.py):** Registered op impl that runs the meta
kernel then updates `fake_device` to match the source tensor's device.

**AOTAutograd:** Added to `allowed_mutation_ops` and wired into
`apply_in_graph_mutations` and the runtime epilogue.

**FakeTensor device save/restore (graph_capture.py, compile_fx.py):**
During make_fx tracing and FakeTensorProp, in-graph `shallow_copy_data_`
mutates placeholder FakeTensor devices. We save and restore them so the
backend compiler sees the correct input devices.

Test Plan:

```
python -m pytest test/test_fake_tensor.py -xvs -k test_aten_set_data_multi_device
python -m pytest test/dynamo/test_repros.py -xvs -k test_tensor_set_data
python -m pytest test/test_torch.py -xvs -k test_tensor_set_errors
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98