### PR TITLE
[Test][PrivateUse1] Enhance `get_all_devices` to include all available devices

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -543,7 +543,12 @@ class DeviceTypeTestBase(TestCase):
     #   mechanism of acquiring all available devices.
     @classmethod
     def get_all_devices(cls):
-        return [cls.get_primary_device()]
+        devices = [cls.get_primary_device()]
+        for i in range(torch.accelerator.device_count()):
+            device_str = f"{cls.device_type}:{i}"
+            if device_str not in devices:
+                devices.append(device_str)
+        return devices
 
     # Returns the dtypes the test has requested.
     # Prefers device-specific dtype specifications over generic ones.


### PR DESCRIPTION
Improve `DeviceTypeTestBase.get_all_devices()` to return all available devices instead of just `cls.primary_device`

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD