### PR TITLE
Dedupe namespaced codegen and annotation parsing in torchgen

### DIFF
--- a/torchgen/api/lazy.py
+++ b/torchgen/api/lazy.py
@@ -190,15 +190,6 @@ def isWrappedScalarType(typ: Type) -> bool:
     return False
 
 
-# TODO: dedupe with Type.is_generator_like
-def isGeneratorType(typ: Type) -> bool:
-    if isinstance(typ, BaseType):
-        return typ.name == BaseTy.Generator
-    elif isinstance(typ, (OptionalType)):
-        return isGeneratorType(typ.elem)
-    return False
-
-
 # This class caches a few derived properties computed from an Argument
 # and LazyIrProperties
 class LazyArgument:
@@ -223,7 +214,7 @@ class LazyArgument:
         self.orig_type = arg.type
         self.symint = symint
         self.is_optional = isinstance(arg.type, OptionalType)
-        self.is_generator = isGeneratorType(arg.type)
+        self.is_generator = arg.type.is_generator_like()
         self.lazy_type_ = process_ir_type(arg.type, properties, symint=symint)
         self.is_wrapped_scalar = isWrappedScalarType(arg.type)
         self.is_symint_or_list = symint and (
@@ -374,7 +365,7 @@ class LazyIrSchema:
                 if isinstance(curr_args, TensorOptionsArguments):
                     curr_args = curr_args.all()
                 for arg in curr_args:
-                    if isGeneratorType(arg.type):
+                    if arg.type.is_generator_like():
                         if self.generator_arg is not None:
                             raise AssertionError(
                                 "We expect there is only one generator arg"

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -14,7 +14,6 @@ from torchgen.api.types import (
     BaseCType,
     Binding,
     ConstRefCType,
-    CppSignature,
     CppSignatureGroup,
     DispatcherSignature,
     Expr,
@@ -312,6 +311,30 @@ class RegisterDispatchKey:
             symint=self.symint,
         )
 
+    def gen_namespaced_target(
+        self,
+        cpp_sig_group: CppSignatureGroup,
+        sig: NativeSignature | DispatcherSignature,
+    ) -> str:
+        # Emit the NAMESPACED_DECLARATION / NAMESPACED_DEFINITION code shared by
+        # the unstructured and structured codegen paths. The definitions forward
+        # to the wrapper kernel named by sig.
+        if self.target is Target.NAMESPACED_DECLARATION:
+            return "".join(
+                f"TORCH_API {cpp_sig.decl()};\n"
+                for cpp_sig in cpp_sig_group.signatures(symint=self.symint)
+            )
+        if self.target is not Target.NAMESPACED_DEFINITION:
+            raise AssertionError(f"unexpected target {self.target}")
+        return "".join(
+            f"""
+{cpp_sig.defn()} {{
+return {sig.name()}({", ".join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments()))});
+}}
+"""
+            for cpp_sig in cpp_sig_group.signatures(symint=self.symint)
+        )
+
     def gen_out_inplace_wrapper(
         self, f: NativeFunction, g: NativeFunctionsGroup | None
     ) -> str | None:
@@ -444,25 +467,11 @@ class RegisterDispatchKey:
                 f, method=False, fallback_binding=False
             )
 
-            # TODO: dedupe this with the structured codegen
-            if self.target is Target.NAMESPACED_DECLARATION:
-                result = ""
-                for cpp_sig in cpp_sig_group.signatures(symint=self.symint):
-                    result += f"TORCH_API {cpp_sig.decl()};\n"
-                return result
-            elif self.target is Target.NAMESPACED_DEFINITION:
-
-                def generate_defn(cpp_sig: CppSignature) -> str:
-                    return f"""
-{cpp_sig.defn()} {{
-return {sig.name()}({", ".join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments()))});
-}}
-"""
-
-                result = ""
-                for cpp_sig in cpp_sig_group.signatures(symint=self.symint):
-                    result += generate_defn(cpp_sig)
-                return result
+            if self.target in (
+                Target.NAMESPACED_DECLARATION,
+                Target.NAMESPACED_DEFINITION,
+            ):
+                return self.gen_namespaced_target(cpp_sig_group, sig)
 
             elif self.target is Target.ANONYMOUS_DEFINITION:
                 # short circuit for inplace_meta
@@ -801,25 +810,11 @@ resize_out(out, sizes, strides, options);
             symint=kern is not None and kern.supports_symint(),
         )
 
-        if self.target is Target.NAMESPACED_DECLARATION:
-            result = ""
-            for cpp_sig in cpp_sig_group.signatures(symint=self.symint):
-                result += f"TORCH_API {cpp_sig.decl()};\n"
-            return result
-
-        elif self.target is Target.NAMESPACED_DEFINITION:
-
-            def generate_defn(cpp_sig: CppSignature) -> str:
-                return f"""
-{cpp_sig.defn()} {{
-return {sig.name()}({", ".join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments()))});
-}}
-"""
-
-            result = ""
-            for cpp_sig in cpp_sig_group.signatures(symint=self.symint):
-                result += generate_defn(cpp_sig)
-            return result
+        if self.target in (
+            Target.NAMESPACED_DECLARATION,
+            Target.NAMESPACED_DEFINITION,
+        ):
+            return self.gen_namespaced_target(cpp_sig_group, sig)
 
         elif self.target is Target.ANONYMOUS_DEFINITION:
             k = f.func.kind()
@@ -833,14 +828,17 @@ return {sig.name()}({", ".join(e.expr for e in translate(cpp_sig.arguments(), si
             # Initialize the class corresponding to this structured
             # operator; feeding it the output argument(s) if it is known
             if self.backend_index.dispatch_key is DispatchKey.Meta:
-                class_name = f"structured_{meta.name(self.g)}_meta_{k.name}"
-                parent_class = f"at::meta::structured_{meta.name(self.g)}"
+                name_infix = "meta"
             elif (
                 self.backend_index.dispatch_key
                 is DispatchKey.CompositeExplicitAutogradNonFunctional
             ):
-                # TODO: dedup this branch
-                class_name = f"structured_{meta.name(self.g)}_default_backend_{k.name}"
+                name_infix = "default_backend"
+            else:
+                name_infix = None
+
+            if name_infix is not None:
+                class_name = f"structured_{meta.name(self.g)}_{name_infix}_{k.name}"
                 parent_class = f"at::meta::structured_{meta.name(self.g)}"
             else:
                 metadata = self.backend_index.get_kernel(self.g)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -2158,6 +2158,21 @@ class ListType(Type):
         return self
 
 
+# Parse a "type and alias annotation" string (e.g. "Tensor(a!)") into the bare
+# type string and its Annotation, if any. Shared by Argument.parse and
+# Return.parse.
+def parse_alias_annotation(type_and_annot: str) -> tuple[str, Annotation | None]:
+    match = re.match(r"Tensor\((.+)\)(.*)", type_and_annot)
+    if match is None:
+        return type_and_annot, None
+    # If you update this, make sure the __str__ still works too
+    if match.group(2) not in ["", "?", "[]"]:
+        raise AssertionError(
+            f"unrecognized alias analysis form with Tensor: {match.group(2)}"
+        )
+    return "Tensor" + match.group(2), Annotation.parse(match.group(1))
+
+
 @dataclass(frozen=True)
 class Argument:
     # NB: I didn't put kwarg_only as a boolean field here, unlike
@@ -2208,20 +2223,7 @@ class Argument:
             type_and_annot, name_and_default = arg.rsplit(" ", 1)
             name = name_and_default
             default = None
-        # TODO: deduplicate annotation matching with Return
-        match = re.match(r"Tensor\((.+)\)(.*)", type_and_annot)
-        annotation: Annotation | None
-        if match:
-            # If you update this, make sure the __str__ still works too
-            if match.group(2) not in ["", "?", "[]"]:
-                raise AssertionError(
-                    f"unrecognized alias analysis form with Tensor: {match.group(2)}"
-                )
-            type_s = "Tensor" + match.group(2)
-            annotation = Annotation.parse(match.group(1))
-        else:
-            type_s = type_and_annot
-            annotation = None
+        type_s, annotation = parse_alias_annotation(type_and_annot)
         type = Type.parse(type_s)
         r = Argument(
             name=name,
@@ -2270,19 +2272,7 @@ class Return:
         else:
             type_and_annot = arg
             name = None
-        match = re.match(r"Tensor\((.+)\)(.*)", type_and_annot)
-        annotation: Annotation | None
-        if match:
-            # If you update this, make sure the __str__ still works too
-            if match.group(2) not in ["", "?", "[]"]:
-                raise AssertionError(
-                    f"unrecognized alias analysis form with Tensor: {match.group(2)}"
-                )
-            type_s = "Tensor" + match.group(2)
-            annotation = Annotation.parse(match.group(1))
-        else:
-            type_s = type_and_annot
-            annotation = None
+        type_s, annotation = parse_alias_annotation(type_and_annot)
         type = Type.parse(type_s)
         r = Return(
             name=name,


### PR DESCRIPTION
This PR removes three duplicated pieces of logic in torchgen, with no change to generated code:

- `register_dispatch_key.py`: collapse the near-identical namespaced declaration/definition codegen paths into a single `gen_namespaced_target` helper.
- `model.py`: share the `Tensor(a!)` alias-annotation parsing between `Argument.parse` and `Return.parse` via a new `parse_alias_annotation`.
- `api/lazy.py`: drop the local `isGeneratorType` in favor of `Type.is_generator_like`.

