### PR TITLE
Output Shape Check added to transposed Conv

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -771,11 +771,43 @@ static void check_shape_forward(const at::Tensor& input,
                "Kernel size: (", std::move(kernel_ss).str(), "). Kernel size can't be greater than actual input size");
     }
   } else { // transposed
+    std::vector<T> output_shape;
+    bool output_size_correct = true;
     for (const auto i : c10::irange(2, k)) {
       TORCH_CHECK(padding[i-2] <= (std::numeric_limits<T>::max() - padding[i-2]),
                   "Given padding=", padding[i-2], " at dimension ", i-2, " , expected padding to be at most ",
                   (std::numeric_limits<T>::max() / 2));
+      auto output_size = (at::symint::size<T>(input, i) - 1) * params.stride[i-2]
+          - 2 * padding[i-2]
+          + dilation[i-2] * (weight_sizes[i] - 1) + 1
+          + params.output_padding[i-2];
+      output_shape.push_back(output_size);
+      if constexpr (std::is_same_v<T, c10::SymInt>) {
+        if (TORCH_GUARD_OR_FALSE(output_size.sym_lt(1))) {
+          output_size_correct = false;
+        }
+      } else {
+        if (output_size < 1) {
+          output_size_correct = false;
+        }
+      }
     }
+
+    if (!output_size_correct) {
+      std::ostringstream input_ss;
+      std::ostringstream output_ss;
+      std::string separator;
+      for (int i = 0, len = output_shape.size(); i < len; ++i) {
+        input_ss << separator << at::symint::size<T>(input, i + 2);
+        output_ss << separator << output_shape[i];
+        separator = " x ";
+      }
+      TORCH_CHECK(false,
+          "Given input size per channel: (", input_ss.str(), "). "
+          "Calculated output size per channel: (", output_ss.str(), "). "
+          "Output size is too small");
+    }
+
     if constexpr (std::is_same_v<T, c10::SymInt>) {
       TORCH_SYM_CHECK(at::symint::size<T>(input, 1).sym_eq(weight_sizes[0]),
                "Given transposed=", transposed, ", weight of size ", weight_sizes,

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -788,6 +788,17 @@ class TestConvolutionNN(NNTestCase):
                 else:
                     self.assertRaises(ValueError, lambda: m(i, (h, w)))
 
+    def test_ConvTranspose_output_too_small(self):
+        # Transposed conv with large padding relative to kernel can produce
+        # degenerate (< 1) output sizes. Verify this is caught for all dims
+        # regardless of backend (e.g. MKLDNN, slow).
+        for dim in (1, 2, 3):
+            conv_cls = getattr(nn, f"ConvTranspose{dim}d")
+            m = conv_cls(1, 1, kernel_size=(2,) * dim, padding=(1,) * dim)
+            x = torch.randn((1,) * (dim + 2))
+            with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
+                m(x)
+
     def test_ConvTranspose2d_output_size_downsample_upsample(self):
         b, c, hid_c = 2, 3, 2
         for h in range(13, 24):


### PR DESCRIPTION
Fixes #185581 

Add output size validation for transposed convolution in the common check_shape_forward path in Convolution.cpp.

Previously, the "output size too small" check only existed in NaiveConvolutionTranspose2d.cpp (the SlowTranspose2d backend and was also missing in cpu_template), which is never reached on CPU with float32 because MKLDNN handles the op. This meant degenerate parameter combinations (e.g., kernel_size=2, padding=1 with spatial size 1) would either produce a cryptic backend error or silently misbehave instead of a clear user-facing error.

The fix adds the output size check to the else { // transposed } branch of check_shape_forward, which runs for all backends (MKLDNN, cuDNN, MIOpen, slow) before dispatch. This mirrors the existing output size validation already present for non-transposed convolution in the same function.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01