### PR TITLE
Fix disabled no-op module pre-hooks in compile

### DIFF
--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1105,6 +1105,197 @@ def forward(self, L_x_ : torch.Tensor):
         self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
 
+    def test_disabled_child_forward_pre_hooks_trace_parent_forward(self):
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embed = torch.nn.Embedding(10, 4)
+                self.layers = torch.nn.ModuleList(
+                    [torch.nn.Linear(4, 4) for _ in range(2)]
+                )
+                self.output = torch.nn.Linear(4, 10)
+
+            def forward(self, x):
+                x = self.embed(x)
+                for layer in self.layers:
+                    x = layer(x)
+                return self.output(x)
+
+        def fn(mod, x):
+            return mod(x)
+
+        @torch.compiler.disable()
+        def hook(mod, inputs):
+            pass
+
+        for compile_mode in ("module.compile", "torch.compile function"):
+            with self.subTest(compile_mode=compile_mode):
+                torch._dynamo.reset()
+                mod = ToyModel()
+                ref_mod = ToyModel()
+                ref_mod.load_state_dict(mod.state_dict())
+                for layer in mod.layers:
+                    layer.register_forward_pre_hook(hook)
+                x = torch.randint(10, (2, 3))
+                ref = ref_mod(x), ref_mod(x)
+                backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+                if compile_mode == "module.compile":
+                    mod.compile(backend=backend)
+                    res = mod(x), mod(x)
+                else:
+                    opt_fn = torch.compile(fn, backend=backend)
+                    res = opt_fn(mod, x), opt_fn(mod, x)
+
+                self.assertEqual(ref, res)
+                self.assertEqual(len(backend.graphs), 1)
+                graph_code = "\n".join(
+                    graph.print_readable(print_output=False) for graph in backend.graphs
+                )
+                self.assertIn("torch.nn.functional.embedding", graph_code)
+                self.assertEqual(graph_code.count("torch._C._nn.linear"), 3)
+
+    def test_disabled_noop_named_forward_pre_hooks_still_graph_breaks(self):
+        @torch.compiler.disable()
+        def disabled():
+            pass
+
+        def fn(_forward_pre_hooks, x):
+            _forward_pre_hooks[0]()
+            return x + 1
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            r"Skip calling `torch.compiler.disable\(\)`d function",
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(
+                [disabled], torch.ones(2, 3)
+            )
+
+    def test_disabled_child_forward_pre_hook_state_mutation_graph_breaks(self):
+        class Scale(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = 1.0
+
+            def forward(self, x):
+                return x * self.scale
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = Scale()
+
+            def forward(self, x):
+                return self.scale(x)
+
+        def fn(mod, x):
+            return mod(x)
+
+        for compile_mode in ("module.compile", "torch.compile function"):
+            with self.subTest(compile_mode=compile_mode):
+                torch._dynamo.reset()
+                calls = {"count": 0}
+
+                @torch.compiler.disable()
+                def hook(mod, inputs):
+                    calls["count"] += 1
+                    mod.scale = 2.0
+                    return None
+
+                mod = Mod()
+                mod.scale.register_forward_pre_hook(hook)
+                x = torch.ones(2, 3)
+
+                if compile_mode == "module.compile":
+                    mod.compile(backend="eager")
+                    res = mod(x)
+                else:
+                    res = torch.compile(fn, backend="eager")(mod, x)
+
+                self.assertEqual(res, torch.full_like(x, 2.0))
+                self.assertEqual(calls["count"], 1)
+
+    def test_disabled_child_forward_pre_hook_input_mutation_graph_breaks(self):
+        class Scale(torch.nn.Module):
+            def forward(self, x):
+                return x * 2.0
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = Scale()
+
+            def forward(self, x):
+                return self.scale(x)
+
+        def fn(mod, x):
+            return mod(x)
+
+        for compile_mode in ("module.compile", "torch.compile function"):
+            with self.subTest(compile_mode=compile_mode):
+                torch._dynamo.reset()
+                calls = {"count": 0}
+
+                @torch.compiler.disable()
+                def hook(mod, inputs):
+                    calls["count"] += 1
+                    inputs[0].add_(1.0)
+                    return None
+
+                mod = Mod()
+                mod.scale.register_forward_pre_hook(hook)
+                x = torch.ones(2, 3)
+
+                if compile_mode == "module.compile":
+                    mod.compile(backend="eager")
+                    res = mod(x)
+                else:
+                    res = torch.compile(fn, backend="eager")(mod, x)
+
+                self.assertEqual(res, torch.full_like(x, 4.0))
+                self.assertEqual(x, torch.full_like(x, 2.0))
+                self.assertEqual(calls["count"], 1)
+
+    def test_disabled_child_forward_pre_hook_returning_input_grad(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2, bias=False)
+                with torch.no_grad():
+                    self.linear.weight.copy_(torch.eye(2))
+
+            def forward(self, x):
+                return self.linear(x)
+
+        def fn(mod, x):
+            return mod(x)
+
+        for compile_mode in ("module.compile", "torch.compile function"):
+            with self.subTest(compile_mode=compile_mode):
+                torch._dynamo.reset()
+                calls = {"count": 0}
+
+                @torch.compiler.disable()
+                def hook(mod, inputs):
+                    calls["count"] += 1
+                    return (inputs[0] * 2,)
+
+                mod = Mod()
+                mod.linear.register_forward_pre_hook(hook)
+                backend = torch._dynamo.testing.EagerAndRecordGraphs()
+                x = torch.ones(1, 2, requires_grad=True)
+
+                if compile_mode == "module.compile":
+                    mod.compile(backend=backend)
+                    y = mod(x)
+                else:
+                    y = torch.compile(fn, backend=backend)(mod, x)
+
+                y.sum().backward()
+                self.assertEqual(x.grad, torch.full_like(x, 2.0))
+                self.assertEqual(calls["count"], 1)
+
     def test_global_module_forward_pre_hook(self):
         class Mod(torch.nn.Module):
             def forward(self, x):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -24,6 +24,7 @@ accurate graph capture while handling Python's various function-related behavior
 import _collections  # type: ignore[import-not-found]
 import builtins
 import collections
+import dis
 import functools
 import importlib.metadata
 import importlib.util
@@ -69,8 +70,10 @@ from ..source import (
     ClosureSource,
     ConstantSource,
     DefaultsSource,
+    DictGetItemSource,
     GetItemSource,
     ImportSource,
+    NNModuleSource,
     SkipGuardSource,
     TypeMROSource,
     TypeSource,
@@ -2190,6 +2193,51 @@ RE_CONSTANT_FOLD_FNS = {
 }
 
 
+_STATIC_NOOP_HOOK_IGNORED_OPS = frozenset(
+    {
+        "CACHE",
+        "COPY_FREE_VARS",
+        "EXTENDED_ARG",
+        "NOP",
+        "RESUME",
+    }
+)
+
+
+def _is_nn_module_forward_pre_hook_source(source: Source | None) -> bool:
+    while source is not None:
+        if (
+            isinstance(source, DictGetItemSource)
+            and isinstance(source.base, AttrSource)
+            and source.base.member == "_forward_pre_hooks"
+            and isinstance(source.base.base, NNModuleSource)
+        ):
+            return True
+        source = getattr(source, "base", None)
+    return False
+
+
+def _is_static_noop_disabled_hook(hook: Callable[..., Any]) -> bool:
+    if not isinstance(hook, types.FunctionType):
+        return False
+
+    instructions = [
+        inst
+        for inst in dis.get_instructions(hook)
+        if inst.opname not in _STATIC_NOOP_HOOK_IGNORED_OPS
+    ]
+    if len(instructions) == 1:
+        return (
+            instructions[0].opname == "RETURN_CONST" and instructions[0].argval is None
+        )
+    return (
+        len(instructions) == 2
+        and instructions[0].opname == "LOAD_CONST"
+        and instructions[0].argval is None
+        and instructions[1].opname == "RETURN_VALUE"
+    )
+
+
 class SkipFunctionVariable(VariableTracker):
     _nonvar_fields = {
         "value",
@@ -2275,6 +2323,19 @@ class SkipFunctionVariable(VariableTracker):
             return VariableTracker.build(tx, result)
 
         if inspect.getattr_static(self.value, "_torchdynamo_disable", False):
+            hook = self.value
+            hook_source = self.source
+            while inspect.getattr_static(hook, "_torchdynamo_orig_callable", False):
+                hook = hook._torchdynamo_orig_callable  # type: ignore[attr-defined]
+                if hook_source is not None:
+                    hook_source = AttrSource(hook_source, "_torchdynamo_orig_callable")
+            if _is_nn_module_forward_pre_hook_source(
+                self.source
+            ) and _is_static_noop_disabled_hook(hook):
+                if hook_source is not None:
+                    install_guard(hook_source.make_guard(GuardBuilder.CLOSURE_MATCH))
+                return variables.ConstantVariable.create(None)
+
             msg = inspect.getattr_static(self.value, "_torchdynamo_disable_msg", None)
             unimplemented(
                 gb_type="Skip calling `torch.compiler.disable()`d function",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186051

Dynamo normally graph-breaks when it calls a function wrapped with torch.compiler.disable(). For nn.Module forward pre-hooks this can happen while Dynamo is tracing nn.Module._call_impl from inside a user module's forward loop. Once that graph break occurs in the loop, Dynamo skips the parent frame, so module.compile() can miss the parent work and only capture a child module graph.

Handle the safe subset of this case by recognizing disabled forward_pre_hooks loaded from an actual module _forward_pre_hooks source whose original Python bytecode is statically pass/return None. Those hooks have no observable effect, so Dynamo can model the hook call as returning None and continue tracing the parent forward. Non-no-op disabled hooks keep the existing graph-break/eager behavior, which preserves side effects, input mutation, replacement inputs, and autograd semantics.

The fix intentionally uses the Source structure rather than matching source debug-name strings, so unrelated locals named _forward_pre_hooks still honor torch.compiler.disable().

Fixes #142358

Generated by my agent

Test Plan:

python test/dynamo/test_hooks.py HooksTests.test_disabled_noop_named_forward_pre_hooks_still_graph_breaks HooksTests.test_disabled_child_forward_pre_hooks_trace_parent_forward HooksTests.test_disabled_child_forward_pre_hook_state_mutation_graph_breaks HooksTests.test_disabled_child_forward_pre_hook_input_mutation_graph_breaks HooksTests.test_disabled_child_forward_pre_hook_returning_input_grad

python test/dynamo/test_hooks.py HooksTests.test_global_module_forward_pre_hook

python test/dynamo/test_modules.py -k test_prepend_hook_ordering

python test/dynamo/test_repros.py ReproTests.test_inbuilt_nn_module_forward_after_hook_graph_break

lintrunner -a

git diff --cached --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98