### PR TITLE
[Inductor] Fix _log_compute_estimations crash on SymFloat estimates

### DIFF
--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -307,13 +307,20 @@ def _log_compute_estimations(
         "Flops",
     ]
 
+    def _fmt(v: object) -> str:
+        if isinstance(v, torch.types.py_sym_types):
+            if v.node.has_hint():
+                return f"{v}({v.node.hint:.4f})"
+            return str(v)
+        return f"{v:.4f}"
+
     rows = [
         [
             _node_summary(node),
-            f"{est_b * 1e3:.4f}",
-            f"{est_a * 1e3:.4f}",
-            f"{(est_a / est_b) if est_b > 0 else 0:.4f}",
-            f"{(est_a - est_b) * 1e3:.4f}",
+            _fmt(est_b * 1e3),
+            _fmt(est_a * 1e3),
+            _fmt((est_a / est_b) if est_b > 0 else 0),
+            _fmt((est_a - est_b) * 1e3),
             str(count_flops_fx(node)),
         ]
         for node, est_b, est_a in zip(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186054

Fixes https://github.com/pytorch/pytorch/issues/185900

`_log_compute_estimations` formats estimation values with `.4f`, but
`SymFloat.__format__` only accepts the empty format spec. When overlap
scheduling runs with dynamic shapes, compute-node estimates can be
SymFloat (e.g. from a symbolic flop count divided by peak flops), and
the format call raises `TypeError`.

Fix: add a `_fmt` helper that checks for symbolic types via
`torch.types.py_sym_types`. For sym values with a hint, it prints both
the symbolic expression and the hinted concrete value, e.g.
`s0/2(512.0000)`. For unbacked symbols it falls back to `str()`.
Concrete floats/ints format with `.4f` as before. No guards are created.

Test Plan:
```
python -c "
import torch, torch.fx as fx
from torch.fx.experimental.symbolic_shapes import ShapeEnv
from torch._inductor.fx_passes.node_runtime_estimation import _log_compute_estimations
shape_env = ShapeEnv()
sf = shape_env.create_unbacked_symint() / 2.0
g = fx.Graph()
n = g.placeholder('x')
n.meta['val'] = torch.empty(0)
_log_compute_estimations(
    compute_nodes=[n],
    benchmarked_estimations=[0.1],
    analytical_estimations=[sf],
)
print('OK')
"
```

```
lintrunner -a torch/_inductor/fx_passes/node_runtime_estimation.py
```

Co-authored-by: Claude (AI assistant)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo