### PR TITLE
Preserve export graph metadata during normalization

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2497,6 +2497,72 @@ def forward(self, x):
         dynamo_result = out_graph(inp)
         self.assertEqual(dynamo_result, m(inp))
 
+    def test_export_preserves_metadata_during_normalization(self):
+        from torch._dynamo.output_graph import OutputGraph
+
+        orig_call_user_compiler = OutputGraph._call_user_compiler
+        graph_meta_key = "_test_export_graph_meta"
+        node_meta_key = "_test_export_node_meta"
+
+        def patched_call_user_compiler(output_graph, gm, example_inputs):
+            gm.meta[graph_meta_key] = {"preserved": True}
+            for node in gm.graph.nodes:
+                if node.op != "output":
+                    node.meta[node_meta_key] = node.name
+            return orig_call_user_compiler(output_graph, gm, example_inputs)
+
+        def f(x):
+            return x.sin() + 1
+
+        for aten_graph in (False, True):
+            with self.subTest(aten_graph=aten_graph):
+                with patch.object(
+                    OutputGraph, "_call_user_compiler", patched_call_user_compiler
+                ):
+                    gm, _ = torch._dynamo.export(f, aten_graph=aten_graph)(
+                        torch.randn(2)
+                    )
+
+                self.assertEqual(gm.meta[graph_meta_key], {"preserved": True})
+                node_meta = [
+                    node.meta[node_meta_key]
+                    for node in gm.graph.nodes
+                    if node.op != "output"
+                ]
+                self.assertEqual(node_meta, ["l_x_", "sin", "add"])
+
+    def test_functional_export_transform_preserves_metadata(self):
+        from torch._dynamo.functional_export import DynamoGraphTransformer
+        from torch._dynamo.output_graph import OutputReturnInfo
+
+        graph_meta_key = "_test_export_graph_meta"
+        node_meta_key = "_test_export_node_meta"
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta[node_meta_key] = "placeholder"
+        y = graph.call_function(torch.sin, (x,))
+        y.meta[node_meta_key] = "call_function"
+        graph.output((y,))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        gm.meta[graph_meta_key] = {"preserved": True}
+
+        transformed = DynamoGraphTransformer(
+            gm,
+            [torch.randn(2)],
+            [set()],
+            {0: 0},
+            {0: OutputReturnInfo("graph_out", 0)},
+        ).transform()
+
+        self.assertEqual(transformed.meta[graph_meta_key], {"preserved": True})
+        node_meta = [
+            node.meta[node_meta_key]
+            for node in transformed.graph.nodes
+            if node.op != "output"
+        ]
+        self.assertEqual(node_meta, ["placeholder", "call_function"])
+
     def test_constraint_violation_error_messages(self):
         class Foo(torch.nn.Module):
             def forward(self, x):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1945,6 +1945,7 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
     ) -> Any:
         arg = next(self.old_args_gen)
+        _preserve_node_meta(self.current_node, arg.node)
         if "val" in self.current_node.meta:
             arg.node.meta["val"] = self.current_node.meta["val"]
         if "tensor_dict" in self.current_node.meta:
@@ -1982,6 +1983,8 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
     def run_node(self, n: Node) -> Any:
         self.current_node = n
         result_proxy = super().run_node(n)
+        if isinstance(result_proxy, torch.fx.Proxy):
+            _preserve_node_meta(self.current_node, result_proxy.node)
         if "val" in self.current_node.meta:
             result_proxy.node.meta["val"] = self.current_node.meta["val"]
         if "example_value" in self.current_node.meta:
@@ -2001,12 +2004,7 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
 
     def transform(self) -> torch.fx.GraphModule:
         result_gm = super().transform()
-        if "dynamo_flat_name_to_original_fqn" in self.module.meta:  # type: ignore[operator]
-            result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[  # type: ignore[index]
-                "dynamo_flat_name_to_original_fqn"  # type: ignore[index]
-            ]
-        if "dynamo_compile_id" in self.module.meta:  # type: ignore[operator]
-            result_gm.meta["dynamo_compile_id"] = self.module.meta["dynamo_compile_id"]  # type: ignore[index]
+        _preserve_graph_module_meta(self.module, result_gm)
         return result_gm
 
 
@@ -2099,6 +2097,56 @@ def check_user_input_output(flat_values: list[Any], error_type: UserErrorType) -
                 "using `torch.utils._pytree.register_pytree_node` or "
                 "`torch.export.register_dataclass`.",
             )
+
+
+_RETRACE_VALUE_META_FIELDS = frozenset(
+    {"val", "example_value", "tensor_meta", "unbacked_bindings", "grapharg"}
+)
+
+
+def _preserve_node_meta(
+    src: Node, dst: Node, skip_fields: frozenset[str] = frozenset()
+) -> None:
+    for k, v in src.meta.items():
+        if k not in skip_fields:
+            dst.meta.setdefault(k, v)
+
+
+def _preserve_graph_module_meta(src: Any, dst: torch.fx.GraphModule) -> None:
+    dst.meta.update(src.meta)
+
+
+def _iter_node_source_keys(node: Node) -> Generator[tuple[int, str], None, None]:
+    sources = list(node.meta.get("from_node", ()))
+    while sources:
+        source = sources.pop(0)
+        node_info = getattr(source, "node_info", None)
+        if node_info is not None:
+            yield node_info.graph_id, node_info.name
+        sources.extend(getattr(source, "from_node", ()))
+
+
+def _preserve_make_fx_meta(
+    src: torch.fx.GraphModule, dst: torch.fx.GraphModule
+) -> None:
+    _preserve_graph_module_meta(src, dst)
+
+    src_nodes = {(id(node.graph), node.name): node for node in src.graph.nodes}
+    for node in dst.graph.nodes:
+        for source_key in _iter_node_source_keys(node):
+            if source := src_nodes.get(source_key):
+                _preserve_node_meta(source, node, _RETRACE_VALUE_META_FIELDS)
+                break
+
+    src_placeholders = list(src.graph.find_nodes(op="placeholder"))
+    dst_placeholders = list(dst.graph.find_nodes(op="placeholder"))
+    for src_node, dst_node in zip(src_placeholders, dst_placeholders):
+        _preserve_node_meta(src_node, dst_node, _RETRACE_VALUE_META_FIELDS)
+
+    src_outputs = list(src.graph.find_nodes(op="output"))
+    dst_outputs = list(dst.graph.find_nodes(op="output"))
+    for src_node, dst_node in zip(src_outputs, dst_outputs):
+        _preserve_node_meta(src_node, dst_node, _RETRACE_VALUE_META_FIELDS)
 
 
 def rewrite_signature(
@@ -2574,10 +2622,12 @@ def export(
         ]
 
         if aten_graph:
+            torch_level_graph = graph
+
             # Running graph with interpreter is needed for propagating the stack_trace
             def graph_with_interpreter(*args: Any) -> Any:
                 with torch.fx.traceback.preserve_node_meta():
-                    return torch.fx.Interpreter(graph).run(*args)  # type: ignore[arg-type]
+                    return torch.fx.Interpreter(torch_level_graph).run(*args)
 
             with unset_fake_temporarily(), enable_python_dispatcher(), fake_mode:
                 try:
@@ -2599,6 +2649,7 @@ def export(
 
             if graph is None:
                 raise AssertionError("graph must not be None after tracing")
+            _preserve_make_fx_meta(torch_level_graph, graph)
             for node in graph.graph.find_nodes(op="get_attr"):
                 if isinstance(getattr(graph, node.target), torch.Tensor):  # type: ignore[arg-type]
                     node.meta["val"] = fake_mode.from_tensor(

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -15,7 +15,12 @@ import torch.fx
 import torch.utils._pytree as pytree
 from torch._dynamo.convert_frame import CaptureOutput, fullgraph_capture, get_traced_fn
 from torch._dynamo.decorators import disable as dynamo_disable
-from torch._dynamo.eval_frame import argument_names, check_user_input_output
+from torch._dynamo.eval_frame import (
+    _preserve_graph_module_meta,
+    _preserve_node_meta,
+    argument_names,
+    check_user_input_output,
+)
 from torch._dynamo.exc import UserErrorType
 from torch._dynamo.source import GetItemSource
 from torch._dynamo.utils import dynamo_timed, get_metrics_context
@@ -289,10 +294,9 @@ class DynamoGraphTransformer(torch.fx.Transformer):
                 graph_placeholder_idx = self.graph_input_order[i]
                 if graph_placeholder_idx < len(self.placeholders):
                     orig_placeholder = self.placeholders[graph_placeholder_idx]
-                    # Copy other metadata but not "val" yet
-                    for key, value in orig_placeholder.meta.items():
-                        if key != "val":
-                            placeholder.node.meta[key] = value
+                    _preserve_node_meta(
+                        orig_placeholder, placeholder.node, frozenset({"val"})
+                    )
 
             # Always ensure we have proper "val" metadata from fake tensor
             if self.fake_mode is not None and isinstance(
@@ -338,10 +342,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
         if self.current_node in self.old_to_new_mapping:
             new_arg = self.old_to_new_mapping[self.current_node]
 
-            # Copy over additional metadata from current node, but don't overwrite "val"
-            for key in ["tensor_dict", "example_value", "unbacked_bindings"]:
-                if key in self.current_node.meta:
-                    new_arg.node.meta[key] = self.current_node.meta[key]
+            _preserve_node_meta(self.current_node, new_arg.node, frozenset({"val"}))
 
             # Only copy "val" if we don't already have a good one
             if "val" in self.current_node.meta and "val" not in new_arg.node.meta:
@@ -398,9 +399,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
 
         # Copy important metadata
         if hasattr(result, "node") and result.node is not n:
-            for key in ["val", "example_value", "unbacked_bindings"]:
-                if key in n.meta:
-                    result.node.meta[key] = n.meta[key]
+            _preserve_node_meta(n, result.node)
 
             # Preserve node names (except output)
             if n.op != "output" and hasattr(n, "name"):
@@ -412,22 +411,8 @@ class DynamoGraphTransformer(torch.fx.Transformer):
         """Perform the graph transformation and copy module metadata."""
         result_gm = super().transform()
 
-        # Copy module metadata like the original implementation
         if hasattr(self.module, "meta"):
-            # pyrefly: ignore [unsupported-operation]
-            if "dynamo_flat_name_to_original_fqn" in self.module.meta:
-                # pyrefly: ignore [bad-index]
-                result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[
-                    # pyrefly: ignore [bad-index]
-                    "dynamo_flat_name_to_original_fqn"
-                ]
-            # pyrefly: ignore [unsupported-operation]
-            if "dynamo_compile_id" in self.module.meta:
-                # pyrefly: ignore [bad-index]
-                result_gm.meta["dynamo_compile_id"] = self.module.meta[
-                    # pyrefly: ignore [bad-index]
-                    "dynamo_compile_id"
-                ]
+            _preserve_graph_module_meta(self.module, result_gm)
 
         return result_gm
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186058

Export's signature normalization rebuilt FX graphs while copying only a small
hard-coded subset of metadata. That dropped graph-level metadata such as
_param_name_to_source when it was stored in GraphModule.meta, and it also
dropped arbitrary node metadata attached before the normalized graph was
returned to callers. The aten_graph=True path had the same issue after make_fx
recreated the graph, and functional export's DynamoGraphTransformer repeated
the hard-coded metadata copy pattern.

Preserve GraphModule.meta and non-regenerated Node.meta when rebuilding these
export graphs. Value metadata owned by the retraced graph, such as val,
example_value, tensor_meta, unbacked_bindings, and grapharg, remains generated
by the new graph where appropriate. For make_fx retracing, restore metadata via
from_node provenance and placeholder/output order fallback.

I considered adding individual allowlisted keys, but that would keep repeating
the bug whenever another internal export metadata field is added. Preserving
non-value metadata matches the intended FX metadata behavior while keeping
value metadata under the transform that produced the new nodes.

Fixes #141640
Generated by my agent

Test Plan:
- python test/dynamo/test_export.py -k test_export_preserves_metadata_during_normalization
- python test/dynamo/test_export.py -k test_functional_export_transform_preserves_metadata
- python test/dynamo/test_export.py -k test_export_meta
- git diff --check HEAD
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98