### PR TITLE
[Inductor] Promote index_dtype to int64 when fused address constant overflows int32

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3131,7 +3131,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
     @unittest.skipUnless(HAS_GPU, "requires GPU")
     def test_fused_slice_scatter_int32_const_overflow(self):
         # End-to-end repro for the int32 address-constant overflow guarded
-        # by SIMDKernelFeatures._any_index_expr_const_overflows_int32.
+        # by SIMDKernelFeatures.any_index_expr_const_overflows_int32.
         # On unfixed builds the fused backward kernel raises
         #   ValueError('Scalar -2779057358 is out of range for type int32')
         # because slice_scatter.backward + mm.backward fuse into a kernel

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -53,7 +53,7 @@ from torch.testing._internal.common_utils import (
     TEST_XPU,
     xfailIfROCm,
 )
-from torch.testing._internal.inductor_utils import IS_BIG_GPU
+from torch.testing._internal.inductor_utils import HAS_GPU, IS_BIG_GPU
 
 
 if TEST_WITH_ROCM:
@@ -3127,6 +3127,75 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         compile_decimal = Decimal(compile_out.item())
 
         self.assertEqual(compile_decimal, Decimal(0))
+
+    @unittest.skipUnless(HAS_GPU, "requires GPU")
+    def test_fused_slice_scatter_int32_const_overflow(self):
+        # End-to-end repro for the int32 address-constant overflow guarded
+        # by SIMDKernelFeatures._any_index_expr_const_overflows_int32.
+        # On unfixed builds the fused backward kernel raises
+        #   ValueError('Scalar -2779057358 is out of range for type int32')
+        # because slice_scatter.backward + mm.backward fuse into a kernel
+        # whose simplified index expression contains a constant > 2**31.
+        # Needs ~30 GB free GPU memory (leaves + grads); skipped otherwise.
+        total_rows = 9_500_000
+        slice_begin = 9_472_768
+        slice_end = 9_499_648
+        col_widths = [32, 32, 32, 32, 32, 32, 32, 32, 32, 22]
+        total_cols = sum(col_widths)
+        int32_max = 2**31 - 1
+
+        # Three triggering conditions for the bug.
+        self.assertLess(total_rows * max(col_widths), int32_max)
+        self.assertLess((slice_end - slice_begin) * total_cols, int32_max)
+        self.assertGreater(slice_begin * total_cols, int32_max)
+
+        # ~2x leaf bytes for .grad, plus 1.3x safety margin.
+        leaf_bytes = sum(total_rows * w * 4 for w in col_widths)
+        need_gb = leaf_bytes * 2 / 1024**3 * 1.3
+        free_gb = getattr(torch, device_type).mem_get_info()[0] / 1024**3
+        if free_gb < need_gb:
+            raise unittest.SkipTest(
+                f"requires ~{need_gb:.1f} GB free GPU memory, have {free_gb:.1f} GB"
+            )
+
+        class SliceConcatDense(nn.Module):
+            def __init__(self, widths):
+                super().__init__()
+                self.widths = widths
+                self.linears = nn.ModuleList(
+                    [nn.Linear(w, w, bias=False) for w in widths]
+                )
+
+            def forward(self, inputs):
+                sliced = [t[slice_begin:slice_end, :] for t in inputs]
+                cat = torch.cat(sliced, dim=1)
+                out = cat.new_zeros(())
+                col = 0
+                for w, linear in zip(self.widths, self.linears):
+                    out = out + linear(cat[:, col : col + w]).sum()
+                    col += w
+                return out
+
+        torch._dynamo.reset()
+        torch.manual_seed(0)
+        inputs = [
+            torch.randn(
+                total_rows,
+                w,
+                device=device_type,
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+            for w in col_widths
+        ]
+        model = SliceConcatDense(col_widths).to(device_type)
+        compiled = torch.compile(model, dynamic=False)
+        try:
+            loss = compiled(inputs)
+            loss.backward()
+        finally:
+            del inputs, model, compiled
+            getattr(torch, device_type).empty_cache()
 
     @config.patch(
         {"triton.use_block_ptr": True, "triton.codegen_upcast_to_fp32": False}

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -711,8 +711,8 @@ instantiate_parametrized_tests(ExprPrinterTests)
 
 
 class TestIndexConstOverflowInt32(InductorTestCase):
-    """Sympy-level tests for
-    ``SIMDKernelFeatures._any_index_expr_const_overflows_int32``."""
+    """Tests for
+    ``SIMDKernelFeatures.any_index_expr_const_overflows_int32``."""
 
     def _make_feats(self, indices):
         # name / var_names / size are unused by the checker; any value works.
@@ -726,7 +726,7 @@ class TestIndexConstOverflowInt32(InductorTestCase):
         return feats
 
     def _check(self, indices):
-        return self._make_feats(indices)._any_index_expr_const_overflows_int32()
+        return self._make_feats(indices).any_index_expr_const_overflows_int32()
 
     def test_production_constant_detected(self):
         # Exact form observed on PyTorch 2.8.0+cu126 / Triton 3.4.0:

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -765,6 +765,7 @@ class TestIndexConstOverflowInt32(InductorTestCase):
         bad = sympy.Integer(-(2**31) - 1) + x0
         self.assertTrue(self._check([good, bad]))
 
+
 class TestEvaluateMinMax(InductorTestCase):
     def test_evaluate_min_multiple(self):
         """min(u0, k*u0) resolves via GCD: gcd(u0, k*u0)=u0.

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -714,56 +714,49 @@ class TestIndexConstOverflowInt32(InductorTestCase):
     """Tests for
     ``SIMDKernelFeatures.any_index_expr_const_overflows_int32``."""
 
-    def _make_feats(self, indices):
-        # name / var_names / size are unused by the checker; any value works.
+    def make_feats(self, indices):
+        # Bypass __init__ (needs V.graph) and shadow scheduler_nodes().
         deps = [MemoryDep(f"buf{i}", idx, (), ()) for i, idx in enumerate(indices)]
         node = types.SimpleNamespace(
             read_writes=types.SimpleNamespace(reads=deps, writes=[])
         )
-        # Bypass __init__ (needs V.graph) and shadow scheduler_nodes().
         feats = SIMDKernelFeatures.__new__(SIMDKernelFeatures)
         feats.scheduler_nodes = lambda: [node]
         return feats
 
-    def _check(self, indices):
-        return self._make_feats(indices).any_index_expr_const_overflows_int32()
+    def check(self, indices):
+        return self.make_feats(indices).any_index_expr_const_overflows_int32()
 
     def test_production_constant_detected(self):
-        # Exact form observed on PyTorch 2.8.0+cu126 / Triton 3.4.0:
-        #   tl.load(in_ptr0 + ((-2779057358) + x0 + 310*x1), ...)
         x0, x1 = sympy.symbols("x0 x1", integer=True)
         expr = sympy.Integer(-2_779_057_358) + x0 + 310 * x1
-        self.assertTrue(self._check([expr]))
+        self.assertTrue(self.check([expr]))
 
     def test_small_constant_not_flagged(self):
         x0, x1 = sympy.symbols("x0 x1", integer=True)
         expr = sympy.Integer(-1_000_000) + x0 + 310 * x1
-        self.assertFalse(self._check([expr]))
+        self.assertFalse(self.check([expr]))
 
     def test_boundary_at_int32_limits(self):
-        # int32 range is asymmetric: [-2**31, 2**31 - 1].  Both inclusive
-        # bounds must be treated as legal; in particular ``Abs(-2**31) >
-        # 2**31 - 1`` so a naive Abs-based check would mis-flag this.
+        # int32 range is asymmetric: [-2**31, 2**31 - 1].
         x0 = sympy.Symbol("x0", integer=True)
-        self.assertFalse(self._check([sympy.Integer(2**31 - 1) + x0]))
-        self.assertFalse(self._check([sympy.Integer(-(2**31)) + x0]))
+        self.assertFalse(self.check([sympy.Integer(2**31 - 1) + x0]))
+        self.assertFalse(self.check([sympy.Integer(-(2**31)) + x0]))
 
     def test_boundary_just_outside_int32_limits(self):
         x0 = sympy.Symbol("x0", integer=True)
-        self.assertTrue(self._check([sympy.Integer(2**31) + x0]))
-        self.assertTrue(self._check([sympy.Integer(-(2**31) - 1) + x0]))
+        self.assertTrue(self.check([sympy.Integer(2**31) + x0]))
+        self.assertTrue(self.check([sympy.Integer(-(2**31) - 1) + x0]))
 
     def test_pure_constant_expression(self):
-        # Indices with no free symbols still need range-checking.
-        self.assertTrue(self._check([sympy.Integer(-(2**31) - 10)]))
-        self.assertFalse(self._check([sympy.Integer(0)]))
+        self.assertTrue(self.check([sympy.Integer(-(2**31) - 10)]))
+        self.assertFalse(self.check([sympy.Integer(0)]))
 
     def test_any_offender_triggers_detection(self):
-        # Any single offending dep forces the whole kernel to int64.
         x0 = sympy.Symbol("x0", integer=True)
         good = sympy.Integer(42) + x0
         bad = sympy.Integer(-(2**31) - 1) + x0
-        self.assertTrue(self._check([good, bad]))
+        self.assertTrue(self.check([good, bad]))
 
 
 class TestEvaluateMinMax(InductorTestCase):

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import os
 import sys
+import types
 import unittest
 from types import SimpleNamespace
 
@@ -9,8 +10,10 @@ import sympy
 import torch
 from torch._dynamo.source import ConstantSource
 from torch._inductor.codegen.cpp import cexpr
+from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import texpr
 from torch._inductor.codegen.wrapper import pexpr
+from torch._inductor.dependencies import MemoryDep
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.sizevars import (
     simplify_index_in_vec_range,
@@ -706,6 +709,61 @@ class ExprPrinterTests(InductorTestCase):
 
 instantiate_parametrized_tests(ExprPrinterTests)
 
+
+class TestIndexConstOverflowInt32(InductorTestCase):
+    """Sympy-level tests for
+    ``SIMDKernelFeatures._any_index_expr_const_overflows_int32``."""
+
+    def _make_feats(self, indices):
+        # name / var_names / size are unused by the checker; any value works.
+        deps = [MemoryDep(f"buf{i}", idx, (), ()) for i, idx in enumerate(indices)]
+        node = types.SimpleNamespace(
+            read_writes=types.SimpleNamespace(reads=deps, writes=[])
+        )
+        # Bypass __init__ (needs V.graph) and shadow scheduler_nodes().
+        feats = SIMDKernelFeatures.__new__(SIMDKernelFeatures)
+        feats.scheduler_nodes = lambda: [node]
+        return feats
+
+    def _check(self, indices):
+        return self._make_feats(indices)._any_index_expr_const_overflows_int32()
+
+    def test_production_constant_detected(self):
+        # Exact form observed on PyTorch 2.8.0+cu126 / Triton 3.4.0:
+        #   tl.load(in_ptr0 + ((-2779057358) + x0 + 310*x1), ...)
+        x0, x1 = sympy.symbols("x0 x1", integer=True)
+        expr = sympy.Integer(-2_779_057_358) + x0 + 310 * x1
+        self.assertTrue(self._check([expr]))
+
+    def test_small_constant_not_flagged(self):
+        x0, x1 = sympy.symbols("x0 x1", integer=True)
+        expr = sympy.Integer(-1_000_000) + x0 + 310 * x1
+        self.assertFalse(self._check([expr]))
+
+    def test_boundary_at_int32_limits(self):
+        # int32 range is asymmetric: [-2**31, 2**31 - 1].  Both inclusive
+        # bounds must be treated as legal; in particular ``Abs(-2**31) >
+        # 2**31 - 1`` so a naive Abs-based check would mis-flag this.
+        x0 = sympy.Symbol("x0", integer=True)
+        self.assertFalse(self._check([sympy.Integer(2**31 - 1) + x0]))
+        self.assertFalse(self._check([sympy.Integer(-(2**31)) + x0]))
+
+    def test_boundary_just_outside_int32_limits(self):
+        x0 = sympy.Symbol("x0", integer=True)
+        self.assertTrue(self._check([sympy.Integer(2**31) + x0]))
+        self.assertTrue(self._check([sympy.Integer(-(2**31) - 1) + x0]))
+
+    def test_pure_constant_expression(self):
+        # Indices with no free symbols still need range-checking.
+        self.assertTrue(self._check([sympy.Integer(-(2**31) - 10)]))
+        self.assertFalse(self._check([sympy.Integer(0)]))
+
+    def test_any_offender_triggers_detection(self):
+        # Any single offending dep forces the whole kernel to int64.
+        x0 = sympy.Symbol("x0", integer=True)
+        good = sympy.Integer(42) + x0
+        bad = sympy.Integer(-(2**31) - 1) + x0
+        self.assertTrue(self._check([good, bad]))
 
 class TestEvaluateMinMax(InductorTestCase):
     def test_evaluate_min_multiple(self):

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -146,8 +146,60 @@ class SIMDKernelFeatures:
         from .simd import SIMDScheduling
 
         if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
+            # Extra guard: even if numel and every buffer's storage_size fit
+            # into int32, the *address expression* inside a fused kernel may
+            # contain a precomputed constant (from simplified slice_scatter +
+            # mm backward fusion) that falls outside the int32 range
+            # [-2**31, 2**31 - 1].  Triton will then fail compilation with
+            #   ValueError('Scalar <big const> is out of range for type int32')
+            if self._any_index_expr_const_overflows_int32():
+                return torch.int64
             return torch.int32
         return torch.int64
+
+    @cache_on_self
+    def _any_index_expr_const_overflows_int32(self) -> bool:
+        """
+        Scan every memory dependency's indexing expression and return True iff
+        its constant term (obtained by substituting all free symbols with 0)
+        falls outside the int32 range ``[-2**31, 2**31 - 1]``.
+
+        For an index of the form ``base + x0 + stride * x1`` this extracts
+        ``base`` and checks whether that literal alone already overflows
+        int32.  Note int32's negative bound (-2**31) has a larger absolute
+        value than the positive bound (2**31 - 1), so the upper and lower
+        limits must be checked separately rather than via ``Abs(const_part)``.
+        See the caller at select_index_dtype() for why this extra check is
+        necessary.
+        """
+        int32_max = sympy.Integer(2**31 - 1)
+        int32_min = sympy.Integer(-(2**31))
+        for node in self.scheduler_nodes():
+            for dep in itertools.chain(node.read_writes.reads, node.read_writes.writes):
+                if not isinstance(dep, MemoryDep):
+                    continue
+                index = dep.index
+                if not isinstance(index, sympy.Expr):
+                    continue
+                free = index.free_symbols
+                try:
+                    # Replace every free symbol with 0 to extract the pure
+                    # constant term.  Division-by-zero can happen (e.g.
+                    # expressions containing 1/x); in that case we can't
+                    # cleanly extract a constant and must skip this dep.
+                    if free:
+                        const_part = index.subs({s: sympy.Integer(0) for s in free})
+                    else:
+                        const_part = index
+                    if not isinstance(const_part, sympy.Expr):
+                        continue
+                    if const_part > int32_max or const_part < int32_min:
+                        return True
+                except (ZeroDivisionError, TypeError, ValueError):
+                    # Unable to evaluate: stay safe and keep scanning.
+                    continue
+        return False
+
 
     def get_reduction_hint(
         self, tiling_scores: dict[str, int] | None = None

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -166,13 +166,10 @@ class SIMDKernelFeatures:
                 index = dep.index
                 if not isinstance(index, sympy.Expr):
                     continue
-                free = index.free_symbols
                 try:
-                    # Substitute all symbols with 0 to isolate the constant.
-                    if free:
-                        const_part = index.subs({s: sympy.Integer(0) for s in free})
-                    else:
-                        const_part = index
+                    const_part = index.subs(
+                        {s: sympy.Integer(0) for s in index.free_symbols}
+                    )
                     if not isinstance(const_part, sympy.Expr):
                         continue
                     if const_part > int32_max or const_part < int32_min:

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -200,7 +200,6 @@ class SIMDKernelFeatures:
                     continue
         return False
 
-
     def get_reduction_hint(
         self, tiling_scores: dict[str, int] | None = None
     ) -> ReductionHint:

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -156,8 +156,7 @@ class SIMDKernelFeatures:
     @cache_on_self
     def any_index_expr_const_overflows_int32(self) -> bool:
         """Return True if any MemoryDep index has a constant term outside
-        [-2**31, 2**31 - 1].  Uses asymmetric bounds (not Abs) because
-        -2**31 is a legal int32 value."""
+        [-2**31, 2**31 - 1]."""
         int32_max = sympy.Integer(2**31 - 1)
         int32_min = sympy.Integer(-(2**31))
         for node in self.scheduler_nodes():

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -146,32 +146,18 @@ class SIMDKernelFeatures:
         from .simd import SIMDScheduling
 
         if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
-            # Extra guard: even if numel and every buffer's storage_size fit
-            # into int32, the *address expression* inside a fused kernel may
-            # contain a precomputed constant (from simplified slice_scatter +
-            # mm backward fusion) that falls outside the int32 range
-            # [-2**31, 2**31 - 1].  Triton will then fail compilation with
-            #   ValueError('Scalar <big const> is out of range for type int32')
-            if self._any_index_expr_const_overflows_int32():
+            # Fused address expressions may carry a constant term that
+            # overflows int32 even when numel/storage_size are within range.
+            if self.any_index_expr_const_overflows_int32():
                 return torch.int64
             return torch.int32
         return torch.int64
 
     @cache_on_self
-    def _any_index_expr_const_overflows_int32(self) -> bool:
-        """
-        Scan every memory dependency's indexing expression and return True iff
-        its constant term (obtained by substituting all free symbols with 0)
-        falls outside the int32 range ``[-2**31, 2**31 - 1]``.
-
-        For an index of the form ``base + x0 + stride * x1`` this extracts
-        ``base`` and checks whether that literal alone already overflows
-        int32.  Note int32's negative bound (-2**31) has a larger absolute
-        value than the positive bound (2**31 - 1), so the upper and lower
-        limits must be checked separately rather than via ``Abs(const_part)``.
-        See the caller at select_index_dtype() for why this extra check is
-        necessary.
-        """
+    def any_index_expr_const_overflows_int32(self) -> bool:
+        """Return True if any MemoryDep index has a constant term outside
+        [-2**31, 2**31 - 1].  Uses asymmetric bounds (not Abs) because
+        -2**31 is a legal int32 value."""
         int32_max = sympy.Integer(2**31 - 1)
         int32_min = sympy.Integer(-(2**31))
         for node in self.scheduler_nodes():
@@ -183,10 +169,7 @@ class SIMDKernelFeatures:
                     continue
                 free = index.free_symbols
                 try:
-                    # Replace every free symbol with 0 to extract the pure
-                    # constant term.  Division-by-zero can happen (e.g.
-                    # expressions containing 1/x); in that case we can't
-                    # cleanly extract a constant and must skip this dep.
+                    # Substitute all symbols with 0 to isolate the constant.
                     if free:
                         const_part = index.subs({s: sympy.Integer(0) for s in free})
                     else:
@@ -196,7 +179,6 @@ class SIMDKernelFeatures:
                     if const_part > int32_max or const_part < int32_min:
                         return True
                 except (ZeroDivisionError, TypeError, ValueError):
-                    # Unable to evaluate: stay safe and keep scanning.
                     continue
         return False
 


### PR DESCRIPTION

When can_use_32bit_indexing checks index dtype for fused kernels containing slice_scatter, it ignores the constant offset term in the linear address expression. For tensors with stride*size near 2^31, the fused address computation (e.g. `base + x0 + 310*x1`) overflows int32, producing negative indices and triggering:
  ValueError('Scalar -2779057358 is out of range for type int32')

This patch extends select_index_dtype() with an additional guard that scans every MemoryDep.index, substitutes free symbols with 0 to extract the constant term, and forces int64 when any constant lies outside [-2**31, 2**31 - 1].

Implementation notes:
- Range check uses asymmetric bounds (c > `2**31-1 `or c < `-(2**31)`) rather than Abs, since -2**31 is a legal int32 value.
- Supports both int and sympy.Expr index types (bare-int deps like MemoryDep(index=0) must not be skipped).

Fixes #186057

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo