### PR TITLE
Fixing torch.pow crash with integral dtypes on CUDA by gating reciprocal/sqrt/rsqrt shortcuts

### DIFF
--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -168,8 +168,8 @@ void pow_tensor_scalar_kernel_impl(TensorIteratorBase& iter,
 }
 
 void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar) {
-  // Dispatch to fast specialization for sqrt, rsqrt and reciprocal
-  if (!exp_scalar.isComplex()) {
+  // Dispatch to fast specialization for sqrt, rsqrt and reciprocal (float/complex only)
+  if (!exp_scalar.isComplex() && !isIntegralType(iter.common_dtype(), /*includeBool=*/true)) {
     if (exp_scalar.equal(.5)) {
       return sqrt_kernel_cuda(iter);
     } else if (exp_scalar.equal(-0.5)) {

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1441,6 +1441,15 @@ class TestBinaryUfuncs(TestCase):
             res2[i] = pow(3, m1[i][4])
         self.assertEqual(res1, res2)
 
+    @onlyCUDA
+    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_pow_integral_negative_exponent_tensor(self, device, dtype):
+        base = torch.tensor([1, 2, 3, 4], device=device, dtype=dtype)
+        exp = torch.tensor(-1, dtype=dtype)
+        result = torch.pow(base, exp)
+        expected = torch.tensor([1, 0, 0, 0], device=device, dtype=dtype)
+        self.assertEqual(result, expected)
+
     # TODO: refactor all these tests using opinfos properly
     def _test_pow(self, base, exponent, np_exponent=None):
         if np_exponent is None:


### PR DESCRIPTION
Gated the reciprocal/sqrt/rsqrt fast-path shortcuts in pow_tensor_scalar_kernel on !isIntegralType() so integral dtypes skip the shortcuts and fall through to powi(), matching CPU behavior. (Fixes #137440). Added a corresponding test for int8/int16/int32/int64 on CUDA.