### PR TITLE
[dynamo] Route OptimizedModule delegated methods through compiled call

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6362,6 +6362,157 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         mod.eval()
         self.assertFalse(opt_mod.training)
 
+    def test_optimized_module_delegated_methods_use_compiled_call(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2)
+
+            @property
+            def linear_property(self):
+                return self.linear
+
+            @property
+            def method_property(self):
+                return self.helper
+
+            @classmethod
+            def class_method(cls):
+                return cls
+
+            @staticmethod
+            def static_method():
+                return "static"
+
+            def helper(self, x):
+                return self.linear(x)
+
+            def forward(self, x):
+                return self.helper(x)
+
+            def generate_call(self, x):
+                return self(x)
+
+            def generate_forward(self, x):
+                return self.forward(x)
+
+        mod = MyModule()
+        opt_mod = torch.compile(mod, backend=CompileCounter())
+
+        self.assertIs(opt_mod.generate_call.__self__, mod)
+        self.assertIs(opt_mod.linear_property, mod.linear)
+        self.assertIs(opt_mod.method_property.__self__, mod)
+        self.assertIs(opt_mod.class_method(), MyModule)
+        self.assertEqual(opt_mod.static_method(), "static")
+
+        for method_name in ("generate_call", "generate_forward"):
+            cnt = CompileCounter()
+            mod = MyModule()
+            opt_mod = torch.compile(mod, backend=cnt)
+
+            x = torch.randn(2)
+            ref = mod(x)
+            res = getattr(opt_mod, method_name)(x)
+
+            self.assertEqual(ref, res)
+            self.assertEqual(cnt.frame_count, 1)
+            self.assertNotIn("_compiled_call_impl", mod.__dict__)
+            self.assertNotIn("forward", mod.__dict__)
+
+    def test_optimized_module_delegated_method_preserves_self_semantics(self):
+        class ParentModule(torch.nn.Module):
+            def generate(self, x):
+                return self(x)
+
+        class MyModule(ParentModule):
+            def __init__(self):
+                super().__init__()
+                self.type_checks = None
+
+            def forward(self, x):
+                return x + 1
+
+            def generate(self, x):
+                self.type_checks = (
+                    isinstance(self, MyModule),
+                    type(self) is MyModule,
+                    self.__class__ is MyModule,
+                )
+                return super().generate(x)
+
+        cnt = CompileCounter()
+        mod = MyModule()
+        opt_mod = torch.compile(mod, backend=cnt)
+
+        self.assertIs(opt_mod.generate.__self__, mod)
+        self.assertEqual(opt_mod.generate(torch.ones(2)), torch.ones(2) + 1)
+        self.assertEqual(mod.type_checks, (True, True, True))
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_optimized_module_delegated_method_preserves_forward_mutation(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+            def generate(self, x):
+                self.forward = lambda y: y + 2
+                return self(x)
+
+        cnt = CompileCounter()
+        mod = MyModule()
+        opt_mod = torch.compile(mod, backend=cnt)
+
+        self.assertEqual(opt_mod.generate(torch.ones(2)), torch.ones(2) + 2)
+        self.assertEqual(mod.forward(torch.ones(2)), torch.ones(2) + 2)
+        self.assertEqual(cnt.frame_count, 0)
+
+    def test_optimized_module_delegated_method_concurrent_calls(self):
+        import threading
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+            def generate(self, x):
+                return self(x)
+
+        backend_runs = 0
+
+        def backend(gm, example_inputs):
+            compiled = gm.forward
+
+            def run(*args):
+                nonlocal backend_runs
+                backend_runs += 1
+                return compiled(*args)
+
+            return run
+
+        mod = MyModule()
+        opt_mod = torch.compile(mod, backend=backend)
+        barrier = threading.Barrier(2)
+        errors = []
+        results = []
+
+        def worker():
+            try:
+                barrier.wait()
+                results.append(opt_mod.generate(torch.ones(2)))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertEqual(result, torch.ones(2) + 1)
+        self.assertEqual(backend_runs, 2)
+
     def test_optimized_module_patched_init(self):
         # A regression test for #138157, and the pattern acame from deepspeed.
         class MyModule(torch.nn.Module):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -447,6 +447,7 @@ class OptimizedModule(torch.nn.Module):
         "__dict__",
         "named_children_walk",
         "_super_module_initialized",
+        "_orig_mod_call_lock",
     }
 
     def __init__(self, mod: torch.nn.Module, dynamo_ctx: _TorchDynamoContext) -> None:
@@ -464,6 +465,7 @@ class OptimizedModule(torch.nn.Module):
         # Installs the params/buffer
         self._orig_mod = mod  # `super().__setattr__` will register this module
         self.dynamo_ctx = dynamo_ctx
+        self._orig_mod_call_lock = threading.RLock()
         self._initialize()
         self.training = self._orig_mod.training
 
@@ -597,7 +599,95 @@ class OptimizedModule(torch.nn.Module):
     def __getattr__(self, name: str) -> Any:
         if name == "_orig_mod":
             return self._modules["_orig_mod"]
-        return getattr(self._orig_mod, name)
+        attr = getattr(self._orig_mod, name)
+        if isinstance(attr, types.MethodType) and attr.__self__ is self._orig_mod:
+            try:
+                static_attr = inspect.getattr_static(self._orig_mod, name)
+            except AttributeError:
+                static_attr = None
+            if isinstance(static_attr, (types.FunctionType, types.MethodType)):
+                return self._wrap_mod_method(attr)
+        return attr
+
+    def _wrap_mod_method(self, method: types.MethodType) -> types.MethodType:
+        @functools.wraps(method.__func__)
+        def wrapped(_orig_mod: torch.nn.Module, *args: Any, **kwargs: Any) -> Any:
+            with self._orig_mod_call_lock:
+                with self._optimize_orig_mod_call():
+                    return method.__func__(_orig_mod, *args, **kwargs)
+
+        return types.MethodType(wrapped, self._orig_mod)
+
+    @contextlib.contextmanager
+    def _optimize_orig_mod_call(self) -> Generator[None, None, None]:
+        orig_mod = self._orig_mod
+        current_compiled_call_impl = orig_mod.__dict__.get("_compiled_call_impl")
+        if (
+            getattr(current_compiled_call_impl, "_torchdynamo_optimized_module", None)
+            is self
+        ):
+            yield
+            return
+
+        sentinel = object()
+        old_compiled_call_impl = orig_mod.__dict__.get("_compiled_call_impl", sentinel)
+        old_forward = orig_mod.__dict__.get("forward", sentinel)
+        active = True
+
+        def has_original_state() -> bool:
+            return (
+                orig_mod.__dict__.get("_compiled_call_impl", sentinel)
+                is old_compiled_call_impl
+                and orig_mod.__dict__.get("forward", sentinel) is old_forward
+            )
+
+        def restore() -> None:
+            if (
+                orig_mod.__dict__.get("_compiled_call_impl", sentinel)
+                is compiled_call_impl
+            ):
+                if old_compiled_call_impl is sentinel:
+                    orig_mod.__dict__.pop("_compiled_call_impl", None)
+                else:
+                    object.__setattr__(
+                        orig_mod, "_compiled_call_impl", old_compiled_call_impl
+                    )
+
+            if orig_mod.__dict__.get("forward", sentinel) is compiled_call_impl:
+                if old_forward is sentinel:
+                    orig_mod.__dict__.pop("forward", None)
+                else:
+                    object.__setattr__(orig_mod, "forward", old_forward)
+
+        def install() -> None:
+            object.__setattr__(orig_mod, "_compiled_call_impl", compiled_call_impl)
+            object.__setattr__(orig_mod, "forward", compiled_call_impl)
+
+        def install_if_unmodified() -> None:
+            if has_original_state():
+                install()
+
+        @functools.wraps(self.forward)
+        def compiled_call_impl(*args: Any, **kwargs: Any) -> Any:
+            forward_was_mutated = (
+                orig_mod.__dict__.get("forward", sentinel) is not compiled_call_impl
+            )
+            restore()
+            try:
+                if forward_was_mutated:
+                    return orig_mod(*args, **kwargs)
+                return self.forward(*args, **kwargs)
+            finally:
+                if active:
+                    install_if_unmodified()
+
+        compiled_call_impl._torchdynamo_optimized_module = self  # type: ignore[attr-defined]
+        install()
+        try:
+            yield
+        finally:
+            active = False
+            restore()
 
     def __setattr__(self, name: str, value: Any) -> None:
         # Allow patching over class attributes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186063

`torch.compile(module)` wraps the original module in `OptimizedModule` and
compiles the wrapper's forward path.  Attributes that are not owned by the
wrapper are delegated to the original module.  For Python instance methods such
as HuggingFace-style `generate`, that delegation returned a method still bound
to the original module, so `self(...)` and `self.forward(...)` inside the
method called eager original-module code and never reached the compiled wrapper.

Keep delegated methods bound to the original module so normal method semantics
continue to work, including zero-argument `super()` and class/type checks.  When
running such a delegated method, temporarily install a per-instance call shim on
the original module so calls through `self(...)` and `self.forward(...)` route
through the optimized wrapper.  The shim restores the original module state
before invoking the compiled path to avoid recursion, preserves in-method
`forward` mutations, and serializes delegated method calls through the same
compiled wrapper while the temporary patch is active.

Add regression coverage for delegated `self(...)` and `self.forward(...)`,
descriptor behavior, `super()` and class identity, in-method `forward` mutation,
concurrent delegated calls, and the previous patched-init robustness case.

Fixes #141473
Generated by my agent

Benchmark Results:
- Delegated method lookup microbenchmark, 1,000,000 iterations:
  - old equivalent `getattr(mod, "generate")`: 0.050 us/lookup
  - new `getattr(opt_mod, "generate")`: 2.895 us/lookup
- This adds overhead only when retrieving delegated Python methods from an
  `OptimizedModule`; regular compiled forward execution is unchanged.

Test Plan:
- python test/dynamo/test_repros.py ReproTests.test_optimized_module_delegated_methods_use_compiled_call ReproTests.test_optimized_module_delegated_method_preserves_self_semantics ReproTests.test_optimized_module_delegated_method_preserves_forward_mutation ReproTests.test_optimized_module_delegated_method_concurrent_calls ReproTests.test_optimized_module_patched_init
- Standalone issue repro: `torch.compile(MyModule(), backend=CompileCounter()).generate(...)` reports `frame_count 2`, `op_count 6` instead of `frame_count 0`.
- git diff --check
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98