### PR TITLE
Add skipIfXpu decorator to tests for semi-structured sparsity support

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,
     run_tests,
+    skipIfXpu,
     subtest,
     TEST_WITH_ROCM,
     TestCase,
@@ -182,6 +183,7 @@ def rand_sparse_semi_structured_all_patterns(r, c, dtype, device):
     return dense_inv, dense_val
 
 
+@skipIfXpu(msg="semi-structured sparsity is not supported on XPU")
 class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
     def setUp(self):
         if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) == 0:
@@ -297,6 +299,7 @@ class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
         output.backward(output)
 
 
+@skipIfXpu(msg="semi-structured sparsity is not supported on XPU")
 class TestSparseSemiStructured(TestCase):
     def setUp(self):
         super().setUp()
@@ -645,6 +648,7 @@ def create_random_mask(shape) -> torch.Tensor:
     return mask
 
 
+@skipIfXpu(msg="semi-structured sparsity is not supported on XPU")
 class TestSparseSemiStructuredTraining(TestCase):
     def setUp(self):
         super().setUp()
@@ -1041,6 +1045,7 @@ class TestSparseSemiStructuredTraining(TestCase):
             torch.testing.assert_close(a_s @ b, (a * a_m) @ b, **atol_rtol_kw[a.dtype])
 
 
+@skipIfXpu(msg="semi-structured sparsity is not supported on XPU")
 class TestSparseSemiStructuredCUTLASS(TestCase):
     """
     This contains CUTLASS specific tests for
@@ -1305,6 +1310,7 @@ def to_float8(x, dtype=torch.float8_e4m3fn):
     return x_scl_sat.to(dtype), scale.float().reciprocal()
 
 
+@skipIfXpu(msg="semi-structured sparsity is not supported on XPU")
 class TestSparseSemiStructuredCUSPARSELT(TestCase):
     """
     This contains cuSPARSELt specific tests for


### PR DESCRIPTION
**Add `skipIfXpu` to semi-structured sparsity tests**

Semi-structured sparsity (`SparseSemiStructuredTensor` and its backends) is not yet supported on XPU. Without the `skipIfXpu` decorator, running the test suite on an XPU device causes all semi-structured tests to fail unconditionally rather than being skipped. This PR adds the decorator to the four affected test classes so they are correctly skipped on XPU.

Resolves https://github.com/intel/torch-xpu-ops/issues/2663