### PR TITLE
Improve draft export report color contrast

### DIFF
--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -9,7 +9,7 @@ import torch
 from torch._dynamo.exc import UserError, UserErrorType
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.export import Dim, draft_export, export
-from torch.export._draft_export import FailureType
+from torch.export._draft_export import DraftExportReport, FailureReport, FailureType
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
@@ -33,6 +33,34 @@ class TestDraftExport(TestCase):
 
     def tearDown(self):
         return
+
+    def test_report_warning_color_is_readable_on_light_background(self):
+        report = DraftExportReport(
+            [
+                FailureReport(
+                    FailureType.MISSING_FAKE_KERNEL,
+                    {"op": "mylib.foo.default"},
+                )
+            ],
+            {},
+            {},
+            {},
+        )
+
+        rendered = str(report)
+        self.assertIn("\033[31m", rendered)
+        self.assertNotIn("\033[93m", rendered)
+        self.assertLess(
+            rendered.index("\033[0m"),
+            rendered.index("1. Missing fake kernel."),
+        )
+
+    def test_report_success_color_is_readable_on_light_background(self):
+        report = DraftExportReport([], {}, {}, {})
+
+        rendered = str(report)
+        self.assertIn("\033[32m", rendered)
+        self.assertNotIn("\033[92m", rendered)
 
     def test_retry_on_constraint_violation_uses_dim_auto(self):
         class M(torch.nn.Module):

--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -29,6 +29,15 @@ from .exported_program import ExportedProgram
 log = logging.getLogger(__name__)
 
 
+_DRAFT_EXPORT_WARNING_COLOR = "\033[31m"
+_DRAFT_EXPORT_SUCCESS_COLOR = "\033[32m"
+_DRAFT_EXPORT_END_COLOR = "\033[0m"
+
+
+def _format_colored(text: str, color: str) -> str:
+    return f"{color}{text}{_DRAFT_EXPORT_END_COLOR}"
+
+
 class FailureType(IntEnum):
     MISSING_FAKE_KERNEL = 1
     DATA_DEPENDENT_ERROR = 2
@@ -178,29 +187,31 @@ class DraftExportReport:
         return f"DraftExportReport({self.failures})"
 
     def __str__(self) -> str:
-        WARNING_COLOR = "\033[93m"
-        GREEN_COLOR = "\033[92m"
-        END_COLOR = "\033[0m"
-
         if self.successful():
-            return f"""{GREEN_COLOR}
+            return _format_colored(
+                """
 ##############################################################################################
 Congratulations: No issues are found during export, and it was able to soundly produce a graph.
 You can now change back to torch.export.export()
 ##############################################################################################
-{END_COLOR}"""
+""",
+                _DRAFT_EXPORT_SUCCESS_COLOR,
+            )
 
-        error = f"""{WARNING_COLOR}
+        error = _format_colored(
+            f"""
 ###################################################################################################
 WARNING: {len(self.failures)} issue(s) found during export, and it was not able to soundly produce a graph.
 Please follow the instructions to fix the errors.
 ###################################################################################################
 
-"""
+""",
+            _DRAFT_EXPORT_WARNING_COLOR,
+        )
+        error += "\n"
 
         for i, failure in enumerate(self.failures):
             error += f"{i + 1}. {failure.print(self.str_to_filename)}\n"
-        error += END_COLOR
         return error
 
     def apply_suggested_fixes(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186070

Draft export reports used bright ANSI yellow for warning output and bright green for success output. Bright yellow has poor contrast on white terminal backgrounds, and the warning path also colored the detailed failure body, making the actionable content hard to read.

Use standard ANSI red for the warning banner and standard ANSI green for the success banner. Keep the detailed failure text uncolored so it inherits the terminal default foreground color. Add focused tests for the warning and success color codes and for resetting before failure details.

Fixes #141242

Generated by my agent

Test Plan:

python -m py_compile torch/export/_draft_export.py

python -m py_compile torch/export/_draft_export.py test/export/test_draft_export.py

python test/export/test_draft_export.py TestDraftExport.test_report_warning_color_is_readable_on_light_background TestDraftExport.test_report_success_color_is_readable_on_light_background

python test/export/test_draft_export.py TestDraftExport.test_missing_meta_kernel_custom_op_basic

lintrunner -a