### PR TITLE
Hide pytest captured output in CI logs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1278,6 +1278,11 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         "-vv",
         "-rfEX",
     ]
+    if not _has_custom_pytest_show_capture_arg(options.additional_args):
+        # Pytest prints captured stdout/stderr between the traceback and short
+        # summary. In CI this can be very large, especially after reruns, and it
+        # makes the actionable failure hard to find in the terminal log.
+        pytest_args.append("--show-capture=no")
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
         # We have a custom pytest shard that conflicts with the normal plugin
@@ -1298,6 +1303,13 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
 
     pytest_args.extend(rerun_options)
     return pytest_args
+
+
+def _has_custom_pytest_show_capture_arg(additional_args: Sequence[str]) -> bool:
+    return any(
+        arg == "--show-capture" or arg.startswith("--show-capture=")
+        for arg in additional_args
+    )
 
 
 def run_ci_sanity_check(test: ShardedTest, test_directory, options):

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -1,6 +1,12 @@
 # Owner(s): ["module: ci"]
 
 import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
 
 import run_test
 
@@ -128,6 +134,60 @@ class DeterminationTest(TestCase):
     def test_new_test_script(self):
         """New test script triggers nothing (since it's not in run_tests.py)"""
         self.assertEqual(self.determined_tests(["test/test_new_test_script.py"]), [])
+
+
+class PytestArgsTest(TestCase):
+    def test_pytest_args_hide_captured_output_by_default(self):
+        options = SimpleNamespace(additional_args=[], pytest_k_expr="")
+
+        self.assertIn("--show-capture=no", run_test.get_pytest_args(options))
+
+    def test_pytest_args_respect_explicit_show_capture(self):
+        options = SimpleNamespace(
+            additional_args=["--show-capture=all"], pytest_k_expr=""
+        )
+
+        self.assertNotIn("--show-capture=no", run_test.get_pytest_args(options))
+
+    def test_pytest_output_keeps_summary_next_to_traceback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test_capture_output.py"
+            test_file.write_text(
+                textwrap.dedent(
+                    """
+                    import sys
+
+
+                    def test_capture_output():
+                        print("stdout marker")
+                        print("stderr marker", file=sys.stderr)
+                        assert False, "needle failure"
+                    """
+                )
+            )
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-vv",
+                    "-rfEX",
+                    "-x",
+                    "--show-capture=no",
+                    str(test_file),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+        self.assertEqual(proc.returncode, 1, proc.stdout)
+        self.assertIn("AssertionError: needle failure", proc.stdout)
+        self.assertIn("short test summary info", proc.stdout)
+        self.assertNotIn("Captured stdout call", proc.stdout)
+        self.assertNotIn("Captured stderr call", proc.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186071

Pytest prints captured stdout and stderr sections after the traceback and before the short test summary. In PyTorch CI, reruns can repeat those captured sections and push the actionable traceback and assertion message far away from the summary line that humans and log classification find first.

Use pytest's built-in --show-capture=no default for run_test.py pytest invocations so the traceback stays adjacent to the summary, while preserving explicit user overrides through additional pytest args.

Fixes #141204

Generated by my agent

Test Plan:

python test/test_determination.py PytestArgsTest

python -m pytest -q test/test_determination.py::PytestArgsTest

lintrunner -a