### PR TITLE
[CUDA] Fix SDPA incorrect result with manual mask on long sequences

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -163,12 +163,12 @@ struct AttentionKernel {
 
     uint8_t custom_mask_type = NoCustomMask;
 
-    int32_t q_strideM = 0;
-    int32_t k_strideM = 0;
-    int32_t v_strideM = 0;
-    int32_t bias_strideM = 0;
+    int64_t q_strideM = 0;
+    int64_t k_strideM = 0;
+    int64_t v_strideM = 0;
+    int64_t bias_strideM = 0;
 
-    int32_t o_strideM = 0;
+    int64_t o_strideM = 0;
 
     // Everything below is only used in `advance_to_block`
     // and shouldn't use registers

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2150,6 +2150,70 @@ class TestSDPAFailureModes(NNTestCase):
             # for all ones grad_output, each value position receives grad of 1 (because sum of all softmax weights per row is 1)
             self.assertTrue(torch.allclose(value.grad, torch.ones_like(value)))
 
+    @largeTensorTest("10GB", "cuda")
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support Efficient Attention")
+    def test_mem_eff_attention_large_seq_len_manual_causal_mask(self):
+        device = torch.device("cuda")
+        dtype = torch.float16
+
+        # Smallest multiple of 8 whose final query block overflows uint32.
+        seq_len = 65544
+        num_heads = 1
+        head_dim = 8
+
+        torch.manual_seed(0)
+
+        query = torch.randn(
+            1,
+            num_heads,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        key = torch.randn(
+            1,
+            num_heads,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        value = torch.randn(
+            1,
+            num_heads,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+        mask = torch.empty((seq_len, seq_len), dtype=dtype, device=device)
+        mask.fill_(float("-inf")).triu_(1)
+        overflowing_query_start = 65536
+        self.assertLess(overflowing_query_start, seq_len)
+        self.assertGreater(
+            overflowing_query_start * mask.stride(-2), 2**32 - 1
+        )
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            out_mask = torch.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=mask,
+            )
+
+            out_causal = torch.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                is_causal=True,
+            )
+
+        self.assertEqual(out_mask, out_causal, atol=1e-2, rtol=1e-2)
+
 
 def _get_block_size_n(device, head_dim, is_dropout, is_causal):
     # This should match the block sizes in the CUDA kernel


### PR DESCRIPTION
The mem_eff attention forward kernel uses int32_t for *_strideM fields in its Params struct.  The bias pointer is computed as

    attn_bias_ptr + query_start * bias_strideM + iter_key_start

where query_start is uint32_t.  For a square causal mask with side N, bias_strideM equals N.  When N > 65536 the product overflows uint32 (65536 * 65536 = 2^32), wrapping the pointer offset and reading wrong mask data.  is_causal=True is unaffected because it uses block-level comparison instead of the bias pointer.

Widen all *_strideM from int32_t to int64_t, matching the backward kernel fix in #155397.

Test Plan:

```
CUDA_VISIBLE_DEVICES=0 python3 -c "
import torch, torch.nn.functional as F
device = 'cuda:0'; D = 128
for seq_len in [65000, 65536, 65537, 66000, 68000]:
    torch.manual_seed(42)
    q = torch.randn(1,1,seq_len,D, dtype=torch.float32, device=device)
    k = torch.randn(1,1,seq_len,D, dtype=torch.float32, device=device)
    v = torch.randn(1,1,seq_len,D, dtype=torch.float32, device=device)
    i = torch.arange(seq_len, device=device).unsqueeze(1)
    j = torch.arange(seq_len, device=device).unsqueeze(0)
    mask = i >= j; del i, j
    out_mask = F.scaled_dot_product_attention(q,k,v, attn_mask=mask)
    out_causal = F.scaled_dot_product_attention(q,k,v, is_causal=True)
    diff = (out_mask - out_causal).abs().max().item()
    print(f'seq={seq_len:>6d}: diff={diff:.6e} {\"BUG\" if diff>0.01 else \"OK\"}')
    del q,k,v,mask,out_mask,out_causal; torch.cuda.empty_cache()
"
```
Related issue: https://github.com/pytorch/pytorch/issues/162588

cc @drisspg @liangel-02 @howardzhang-cv