### PR TITLE
[MPS] faster norms

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -95,6 +95,12 @@ kernel void norm(
     } else if (p == 0) {
       output_val += (input_abs == 0) ? 0 : 1;
 
+    } else if (p == 1) {
+      output_val += input_abs;
+
+    } else if (p == 2) {
+      output_val += input_abs * input_abs;
+
     } else {
       output_val += static_cast<TA>(::precise::pow(input_abs, p));
     }
@@ -149,7 +155,9 @@ kernel void norm(
       }
     }
 
-    if (p != 0 && p != 1 && p != INFINITY && p != -INFINITY) {
+    if (p == 2) {
+      output_val = static_cast<TA>(::precise::sqrt(output_val));
+    } else if (p != 0 && p != 1 && p != INFINITY && p != -INFINITY) {
       output_val = static_cast<TA>(::precise::pow(output_val, 1 / p));
     }
     output[output_offset] = static_cast<TO>(output_val);
@@ -178,12 +186,18 @@ REGISTER_NORM(half2, half);
 #include <c10/metal/reduction_utils.h>
 
 // Load modes for sum_reduction: identity (sum), nan-to-zero (nansum),
-// or nonzero-as-one (count_nonzero).
+// nonzero-as-one (count_nonzero), abs (L1 norm), or square (L2 norm).
 enum LoadMode : uint {
   LOAD_IDENTITY = 0,
   LOAD_NAN_TO_ZERO = 1,
-  LOAD_NONZERO = 2
+  LOAD_NONZERO = 2,
+  LOAD_ABS = 3,
+  LOAD_SQUARE = 4
 };
+
+// Finalize op applied to the accumulator (in opmath_t) before the output cast.
+// FINAL_SQRT turns a sum-of-squares reduction into an L2 norm.
+enum FinalizeOp : uint { FINAL_NONE = 0, FINAL_SQRT = 1 };
 
 template <typename T, ::metal::enable_if_t<!is_complex_v<T>, bool> = true>
 inline bool load_is_nonzero(T v) {
@@ -228,6 +242,29 @@ template <
     ::metal::enable_if_t<MODE == LOAD_NONZERO, bool> = true>
 inline uint load_val(TI v) {
   return load_is_nonzero(v) ? 1u : 0u;
+}
+
+template <
+    LoadMode MODE,
+    typename TI,
+    ::metal::enable_if_t<MODE == LOAD_ABS, bool> = true>
+inline opmath_t<TI> load_val(TI v) {
+  return static_cast<opmath_t<TI>>(
+      ::precise::abs(static_cast<opmath_t<TI>>(v)));
+}
+
+template <
+    LoadMode MODE,
+    typename TI,
+    ::metal::enable_if_t<MODE == LOAD_SQUARE, bool> = true>
+inline opmath_t<TI> load_val(TI v) {
+  auto r = static_cast<opmath_t<TI>>(v);
+  return r * r;
+}
+
+template <FinalizeOp FINAL, typename T>
+inline T finalize_val(T v) {
+  return FINAL == FINAL_SQRT ? static_cast<T>(::precise::sqrt(v)) : v;
 }
 
 // Sum reduction kernel with multiple independent accumulation chains (ILP).
@@ -512,7 +549,8 @@ template <
     typename TI,
     typename TO,
     uint NCHAINS = SUM_NCHAINS,
-    LoadMode MODE = LOAD_IDENTITY>
+    LoadMode MODE = LOAD_IDENTITY,
+    FinalizeOp FINAL = FINAL_NONE>
 kernel void sum_reduction_inner(
     constant TI* input [[buffer(0)]],
     device TO* output [[buffer(1)]],
@@ -563,28 +601,31 @@ kernel void sum_reduction_inner(
     if (divisor > 0) {
       sum /= static_cast<TA>(divisor);
     }
-    output[row] = static_cast<TO>(sum);
+    output[row] = static_cast<TO>(finalize_val<FINAL>(sum));
   }
 }
 
-#define REGISTER_SUM_INNER_IMPL(TI, TO, PREFIX, MODE)           \
-  template [[host_name(PREFIX "reduction_inner_" #TI "_" #TO)]] \
-  kernel void sum_reduction_inner<TI, TO, SUM_NCHAINS, MODE>(   \
-      constant TI * input [[buffer(0)]],                        \
-      device TO * output [[buffer(1)]],                         \
-      constant uint2 & sizes [[buffer(2)]],                     \
-      constant float& divisor [[buffer(3)]],                    \
-      uint tptg [[threads_per_threadgroup]],                    \
-      uint tgid [[threadgroup_position_in_grid]],               \
-      uint simd_lane_id [[thread_index_in_simdgroup]],          \
+#define REGISTER_SUM_INNER_IMPL(TI, TO, PREFIX, MODE, FINAL)         \
+  template [[host_name(PREFIX "reduction_inner_" #TI "_" #TO)]]      \
+  kernel void sum_reduction_inner<TI, TO, SUM_NCHAINS, MODE, FINAL>( \
+      constant TI * input [[buffer(0)]],                             \
+      device TO * output [[buffer(1)]],                              \
+      constant uint2 & sizes [[buffer(2)]],                          \
+      constant float& divisor [[buffer(3)]],                         \
+      uint tptg [[threads_per_threadgroup]],                         \
+      uint tgid [[threadgroup_position_in_grid]],                    \
+      uint simd_lane_id [[thread_index_in_simdgroup]],               \
       uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
 
 #define REGISTER_SUM_INNER(TI, TO) \
-  REGISTER_SUM_INNER_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
+  REGISTER_SUM_INNER_IMPL(TI, TO, "sum_", LOAD_IDENTITY, FINAL_NONE)
 #define REGISTER_NANSUM_INNER(TI, TO) \
-  REGISTER_SUM_INNER_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
+  REGISTER_SUM_INNER_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO, FINAL_NONE)
 #define REGISTER_COUNT_NONZERO_INNER(TI) \
-  REGISTER_SUM_INNER_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
+  REGISTER_SUM_INNER_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO, FINAL_NONE)
+#define REGISTER_NORM_INNER(TI, TO)                                 \
+  REGISTER_SUM_INNER_IMPL(TI, TO, "norm_l1_", LOAD_ABS, FINAL_NONE) \
+  REGISTER_SUM_INNER_IMPL(TI, TO, "norm_l2_", LOAD_SQUARE, FINAL_SQRT)
 
 REGISTER_SUM_INNER(float, float);
 REGISTER_SUM_INNER(half, half);
@@ -604,6 +645,10 @@ REGISTER_SUM_INNER(bool, long);
 REGISTER_SUM_INNER(bool, int);
 REGISTER_SUM_INNER(float2, float2);
 REGISTER_SUM_INNER(half2, half2);
+
+REGISTER_NORM_INNER(float, float);
+REGISTER_NORM_INNER(half, half);
+REGISTER_NORM_INNER(bfloat, bfloat);
 
 #define REGISTER_SUM_IMPL(TI, TO, PREFIX, MODE)             \
   template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]   \

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -155,10 +155,10 @@ kernel void norm(
       }
     }
 
-    if (p == 2) {
-      output_val = static_cast<TA>(::precise::sqrt(output_val));
-    } else if (p != 0 && p != 1 && p != INFINITY && p != -INFINITY) {
-      output_val = static_cast<TA>(::precise::pow(output_val, 1 / p));
+    if (p != 0 && p != 1 && p != INFINITY && p != -INFINITY) {
+      output_val = (p == 2)
+          ? static_cast<TA>(::precise::sqrt(output_val))
+          : static_cast<TA>(::precise::pow(output_val, 1 / p));
     }
     output[output_offset] = static_cast<TO>(output_val);
   }
@@ -262,9 +262,20 @@ inline opmath_t<TI> load_val(TI v) {
   return r * r;
 }
 
-template <FinalizeOp FINAL, typename T>
+template <
+    FinalizeOp FINAL,
+    typename T,
+    ::metal::enable_if_t<FINAL == FINAL_NONE, bool> = true>
 inline T finalize_val(T v) {
-  return FINAL == FINAL_SQRT ? static_cast<T>(::precise::sqrt(v)) : v;
+  return v;
+}
+
+template <
+    FinalizeOp FINAL,
+    typename T,
+    ::metal::enable_if_t<FINAL == FINAL_SQRT, bool> = true>
+inline T finalize_val(T v) {
+  return static_cast<T>(::precise::sqrt(v));
 }
 
 // Sum reduction kernel with multiple independent accumulation chains (ILP).

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -277,6 +277,46 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
 
   TORCH_INTERNAL_ASSERT(output.dim() == input.dim());
 
+  // Fast path: L1/L2 norm over the innermost contiguous dim reuses the sum
+  // inner kernel (abs/square load + sqrt)
+  if ((p == 1.0 || p == 2.0) && output.numel() > 1 && input.is_contiguous() && output.is_contiguous() &&
+      input.scalar_type() == output.scalar_type() &&
+      (input.scalar_type() == kFloat || input.scalar_type() == kHalf || input.scalar_type() == kBFloat16)) {
+    int num_reduced = 0;
+    int reduced_dim = -1;
+    for (const auto d : c10::irange(input.dim())) {
+      if (input.size(d) != output.size(d)) {
+        num_reduced++;
+        reduced_dim = d;
+      }
+    }
+    if (num_reduced == 1 && reduced_dim == input.dim() - 1) {
+      uint32_t N = input.size(input.dim() - 1);
+      uint32_t M = input.numel() / N;
+      auto kernel_name = fmt::format("norm_{}_reduction_inner_{}_{}",
+                                     p == 2.0 ? "l2" : "l1",
+                                     scalarToMetalTypeString(input),
+                                     scalarToMetalTypeString(output));
+      constexpr uint32_t TG_SIZE = 256;
+      constexpr uint32_t rows_per_tg = TG_SIZE / 32;
+      const auto num_tgs = c10::metal::ceil_div(M, rows_per_tg);
+      MPSStream* stream = getCurrentMPSStream();
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        @autoreleasepool {
+          id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+          auto ps = lib.getPipelineStateForFunc(kernel_name);
+          getMPSProfiler().beginProfileKernel(ps, "norm_reduction_inner", {input});
+          const float divisor = 0.0f;
+          [ce setComputePipelineState:ps];
+          mtl_setArgs(ce, input, output, std::array<uint32_t, 2>{M, N}, divisor);
+          [ce dispatchThreads:MTLSizeMake(num_tgs * TG_SIZE, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG_SIZE, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps);
+        }
+      });
+      return;
+    }
+  }
+
   NormParams params;
 
   params.ndim = input.dim();

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -301,19 +301,17 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
       constexpr uint32_t rows_per_tg = TG_SIZE / 32;
       const auto num_tgs = c10::metal::ceil_div(M, rows_per_tg);
       MPSStream* stream = getCurrentMPSStream();
-      dispatch_sync_with_rethrow(stream->queue(), ^() {
+      return dispatch_sync_with_rethrow(stream->queue(), ^() {
         @autoreleasepool {
           id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
           auto ps = lib.getPipelineStateForFunc(kernel_name);
           getMPSProfiler().beginProfileKernel(ps, "norm_reduction_inner", {input});
-          const float divisor = 0.0f;
           [ce setComputePipelineState:ps];
-          mtl_setArgs(ce, input, output, std::array<uint32_t, 2>{M, N}, divisor);
+          mtl_setArgs(ce, input, output, std::array<uint32_t, 2>{M, N}, 0.0f);
           [ce dispatchThreads:MTLSizeMake(num_tgs * TG_SIZE, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG_SIZE, 1, 1)];
           getMPSProfiler().endProfileKernel(ps);
         }
       });
-      return;
     }
   }
 


### PR DESCRIPTION
Routes `norm(1/2, dim=-1)` through the efficient `sum_reduction_inner` kernel via abs/square load + sqrt finalize, instead of the slow per-output-threadgroup norm kernel with per-element `pow`. 
Example:

```
import torch
import torch.nn.functional as F

x = torch.randn(4096, 4096, device="mps", dtype=torch.bfloat16)

x.norm(2, dim=-1)          # L2 -> norm_l2_reduction_inner kernel
x.norm(1, dim=-1)          # L1 -> norm_l1_reduction_inner kernel
F.normalize(x, dim=-1)
```

Perf:

### fp32
| shape | old (µs) | new (µs) | speedup |
|---|--:|--:|--:|
| (32,768) | 6.9 | 3.8 | **1.8x** |
| (128,1024) | 17.1 | 4.2 | **4.1x** |
| (512,4096) | 171.9 | 20.9 | **8.2x** |
| (2048,4096) | 676.8 | 114.5 | **5.9x** |
| (4096,4096) | 1348.2 | 238.4 | **5.7x** |
| (16384,1024) | 1601.8 | 236.2 | **6.8x** |
| (1024,8192) | 666.3 | 112.0 | **5.9x** |
| (65536,256) | 1707.3 | 229.9 | **7.4x** |
| (8,32,768) | 27.5 | 4.2 | **6.6x** |
| (32,128,128) | 73.1 | 7.4 | **9.9x** |

### bf16
| shape | old (µs) | new (µs) | speedup |
|---|--:|--:|--:|
| (32,768) | 6.9 | 3.6 | **1.9x** |
| (128,1024) | 17.0 | 3.7 | **4.6x** |
| (512,4096) | 177.5 | 10.3 | **17.2x** |
| (2048,4096) | 715.7 | 40.0 | **17.9x** |
| (4096,4096) | 1402.8 | 117.6 | **11.9x** |
| (16384,1024) | 1650.8 | 112.5 | **14.7x** |
| (1024,8192) | 678.0 | 42.4 | **16.0x** |
| (65536,256) | 1790.2 | 113.2 | **15.8x** |
| (8,32,768) | 27.4 | 3.9 | **7.0x** |
| (32,128,128) | 74.5 | 7.5 | **10.0x** |

### fp16
| shape | old (µs) | new (µs) | speedup |
|---|--:|--:|--:|
| (32,768) | 6.8 | 3.8 | **1.8x** |
| (128,1024) | 17.0 | 3.9 | **4.3x** |
| (512,4096) | 172.6 | 10.2 | **16.9x** |
| (2048,4096) | 678.6 | 40.4 | **16.8x** |
| (4096,4096) | 1352.9 | 112.8 | **12.0x** |
| (16384,1024) | 1604.2 | 107.6 | **14.9x** |
| (1024,8192) | 670.2 | 42.5 | **15.8x** |
| (65536,256) | 1711.6 | 108.1 | **15.8x** |
| (8,32,768) | 27.5 | 4.0 | **6.8x** |
| (32,128,128) | 73.2 | 7.7 | **9.5x** |
