### PR TITLE
[Inductor] Fix fake dtype inference for weighted torch.bincount

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -119,34 +119,34 @@ if HAS_CPU:
         common = check_model
         device = "cpu"
 
-    copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
+        def test_bincount_weighted_count_nonzero_dtype(self):
+            def fn(x, weights):
+                counts = torch.bincount(x, weights=weights, minlength=6)
+                return counts, counts.count_nonzero()
 
-    def test_bincount_weighted_count_nonzero_dtype(self):
-        def fn(x, weights):
-            counts = torch.bincount(x, weights=weights, minlength=6)
-            return counts.count_nonzero()
-
-        x = torch.tensor(
-            [0, 2, 2, 3, 1, 0, 3, 3],
-            dtype=torch.int64,
-        )
-        weights = torch.tensor(
-            [1.0, -2.0, 3.0, 0.0, 4.0, -5.0, 6.0, 7.0],
-            dtype=torch.float32,
-        )
-
-        expected = fn(x, weights)
-        for dynamic in [False, True]:
-            torch._dynamo.reset()
-            compiled_fn = torch.compile(
-                fn,
-                backend="indcutor",
-                fullgraph=True,
-                dynamic=dynamic,
+            x = torch.tensor(
+                [0, 2, 2, 3, 1, 0, 3, 3],
+                dtype=torch.int64,
             )
-            actual = compiled_fn(x, weights)
-            self.assertEqual(actual[0], expected[0])
-            self.assertEqual(actual[1], expected[1])
+            weights = torch.tensor(
+                [1.0, -2.0, 3.0, 0.0, 4.0, -5.0, 6.0, 7.0],
+                dtype=torch.float32,
+            )
+
+            expected = fn(x, weights)
+            for dynamic in [False, True]:
+                torch._dynamo.reset()
+                compiled_fn = torch.compile(
+                    fn,
+                    backend="inductor",
+                    fullgraph=True,
+                    dynamic=dynamic,
+                )
+                actual = compiled_fn(x, weights)
+                self.assertEqual(actual[0], expected[0])
+                self.assertEqual(actual[1], expected[1])
+
+    copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
 
 
 if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -121,6 +121,33 @@ if HAS_CPU:
 
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
 
+    def test_bincount_weighted_count_nonzero_dtype(self):
+        def fn(x, weights):
+            counts = torch.bincount(x, weights=weights, minlength=6)
+            return counts.count_nonzero()
+
+        x = torch.tensor(
+            [0, 2, 2, 3, 1, 0, 3, 3],
+            dtype=torch.int64,
+        )
+        weights = torch.tensor(
+            [1.0, -2.0, 3.0, 0.0, 4.0, -5.0, 6.0, 7.0],
+            dtype=torch.float32,
+        )
+
+        expected = fn(x, weights)
+        for dynamic in [False, True]:
+            torch._dynamo.reset()
+            compiled_fn = torch.compile(
+                fn,
+                backend="indcutor",
+                fullgraph=True,
+                dynamic=dynamic,
+            )
+            actual = compiled_fn(x, weights)
+            self.assertEqual(actual[0], expected[0])
+            self.assertEqual(actual[1], expected[1])
+
 
 if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1800,11 +1800,11 @@ def bincount(
     torch._check(new_size >= minlength)
 
     if weights is None:
-        return inputs.new_empty(new_size, dtype=torch.long)
+        return inputs.new_empty(new_size, dtype=torch.long)  # type: ignore[return]
     elif weights.dtype == torch.float32:
-        return inputs.new_empty(new_size, dtype=torch.float32)
+        return inputs.new_empty(new_size, dtype=torch.float32)  # type: ignore[return]
     else:
-        return inputs.new_empty(new_size, dtype=torch.float64)
+        return inputs.new_empty(new_size, dtype=torch.float64)  # type: ignore[return]
 
 
 @register_op_impl(torch.ops.aten._pack_padded_sequence.default)

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1798,7 +1798,13 @@ def bincount(
 
     _constrain_range_for_size(new_size)
     torch._check(new_size >= minlength)
-    return inputs.new_empty(new_size)  # type: ignore[return]
+
+    if weights is None:
+        return inputs.new_empty(new_size, dtype=torch.long)
+    elif weights.dtype == torch.float32:
+        return inputs.new_empty(new_size, dtype=torch.float32)
+    else:
+        return inputs.new_empty(new_size, dtype=torch.float64)
 
 
 @register_op_impl(torch.ops.aten._pack_padded_sequence.default)


### PR DESCRIPTION
The implementation of `torch.bincount` in `fake_impls.py` used the input tensor to construct the fake output, making the resulting type of the weighted bincount to inherit the dtype of the input tensor instead of the weight tensor.

This could make torch.compile/Inductor to treat a bincount output of float32 as int64 and generate incorrect code for downstream users such as `count_nonzero`.

Fixes #186029

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo