### PR TITLE
Add test cases for 0-sized tensor padding

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8008,6 +8008,17 @@ class TestConstantPadNd(TestCase):
         ])
         self.assertEqual(res, expected)
 
+    def test_constant_pad_nd_zero_sized(self):
+        a = torch.ones((0, 1))
+        res = F.pad(a, [1, 1, 0, 0])
+        self.assertEqual(res.shape, (0, 3))
+        self.assertEqual(res, torch.zeros((0, 3), dtype=a.dtype))
+
+        a = torch.ones(())
+        res = F.pad(a, [])
+        self.assertEqual(res.shape, ())
+        self.assertEqual(res, a.clone())
+
     def test_preserves_memory_format(self):
         nchw_tensor = torch.rand((1, 2, 5, 3))
         nchw_padded = torch.constant_pad_nd(nchw_tensor, [1, 2], 0.5)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6111,6 +6111,8 @@ def sample_inputs_nn_pad(op_info, device, dtype, requires_grad, mode, **kwargs):
         )
     elif mode == 'constant':
         cases = (
+            ((), ()),
+            ((0, 1), (1, 1, 0, 0)),
             ((1, 3), (1, 2)),
             ((1, 3), (0, 1)),
             ((1, 3), (0, 2, 0, 1)),


### PR DESCRIPTION
## Summary

Closes #152750.

PR #153037 corrected the C++ check in `constant_pad_nd` from `new_dim > 0` to `new_dim >= 0`, but went stale before the matching regression tests landed, leaving the fix in C++ but uncovered. This PR adds the missing coverage by extending the constant-mode cases in `sample_inputs_nn_pad` (which flow into the opinfo / python_refs test suites) and adding a focused test in test_nn.py. The new cases are: a 0-dim tensor with empty pad returns a clone, and a tensor of shape `(0, 1)` padded with `[1, 1, 0, 0]` returns shape `(0, 3)` — the exact scenario from the issue.

This PR was authored with assistance from Claude.

## Test Plan

Standalone test of the same logic against the installed wheel (which already has the C++ fix) confirms the new cases pass:

```bash
python -c "
import torch, torch.nn.functional as F
from torch.testing._internal.common_utils import TestCase

class T(TestCase):
    def runTest(self):
        a = torch.ones((0, 1))
        res = F.pad(a, [1, 1, 0, 0])
        self.assertEqual(res.shape, (0, 3))
        self.assertEqual(res, torch.zeros((0, 3), dtype=a.dtype))

        a = torch.ones(())
        res = F.pad(a, [])
        self.assertEqual(res.shape, ())
        self.assertEqual(res, a.clone())

T('runTest').runTest()
print('PASS')
"
```

Against a source build, the new test cases are exercised by:

```bash
pytest test/test_nn.py::TestConstantPadNd::test_constant_pad_nd_zero_sized
pytest test/test_ops.py -k constant_pad_nd
```