### PR TITLE
Enable CuTeDSL op overrides in CI: accept cutlass-dsl 4.5.2, install tvm-ffi

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -331,7 +331,10 @@ function install_cutlass_dsl() {
   fi
 
   echo "Installing NVIDIA CUTLASS DSL from PyPI..."
-  pip_install nvidia-cutlass-dsl
+  # Pin to a version accepted by torch._native's cutedsl version gate
+  # (_CUTEDSL_REQUIRED_VERSIONS); apache-tvm-ffi is a required runtime dep of
+  # the CuTeDSL op overrides but is not pulled in by nvidia-cutlass-dsl.
+  pip_install nvidia-cutlass-dsl==4.5.2 apache-tvm-ffi==0.1.11
   echo "NVIDIA CUTLASS DSL installation complete."
 }
 

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -30,6 +30,7 @@ _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     #                   but > v26 of packaging.
     Version(f"{4}.{4}.{1}"),
     Version(f"{4}.{4}.{2}"),
+    Version(f"{4}.{5}.{2}"),
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186081

The CuTeDSL overrides only register when nvidia-cutlass-dsl is at a version in
_CUTEDSL_REQUIRED_VERSIONS and apache-tvm-ffi is installed. CI satisfied
neither: install_cutlass_dsl pinned no version (so pip pulled 4.5.2, which the
gate rejected) and never installed apache-tvm-ffi, so the overrides were
silently disabled and their tests ran against aten. Add 4.5.2 to the accepted
set, pin the CI install to it, and install apache-tvm-ffi==0.1.11 alongside (it
is a required runtime dep but not pulled in by nvidia-cutlass-dsl).

Note: _CUTEDSL_REQUIRED_VERSIONS gates registration for every user, not just
CI, so this enables the CuTeDSL overrides on 4.5.2 wherever that wheel is
installed.

Test Plan: on a B200 with nvidia-cutlass-dsl==4.5.2 and apache-tvm-ffi==0.1.11
installed (overrides now register; previously absent):

    pytest test/test_nn.py -k TestFusedRMSNormOverride          # 36 passed
    OPINFO_RESTRICT_TO_DSL=cutedsl pytest test/test_ops.py -k "rms_norm and cutedsl"  # 14 passed, 20 skipped
    pytest test/python_native/test_topk_cutedsl.py              # 52 passed
    pytest test/python_native/test_cutedsl_smoketest.py         # 4 passed
    lintrunner torch/_native/cutedsl_utils.py .ci/pytorch/common_utils.sh

Authored with assistance from Claude (Anthropic AI assistant).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>