### PR TITLE
Remove references to torch_tpu.api

### DIFF
--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -209,4 +209,4 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${TORCH_LIB_PATH}"
 echo "Updated LD_LIBRARY_PATH to include: ${TORCH_LIB_PATH}"
 
 # Verify installation
-python -c "import torch; from torch_tpu import api; print(f'Success! Device: {api.tpu_device()}')"
+python -c "import torch; print(f'Success! Device: {torch.device(\"tpu\")}')"

--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -2643,9 +2643,6 @@ if test_torchinductor.RUN_GPU and has_cuda_pallas():
     # make_pallas(test_torchinductor.GPUTests)
 
 if test_torchinductor.RUN_TPU and has_tpu_pallas():
-    from torch_tpu import api as tpu_api  # type: ignore[import-not-found]
-
-    tpu_api.tpu_device()  # initialize TPU runtime
 
     class PallasTestsTPU(PallasTestsMixin, TestCase):
         DEVICE = "tpu"

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -18164,9 +18164,6 @@ if RUN_GPU or HAS_MPS:
     copy_tests(CommonTemplate, GPUTests, GPU_TYPE)
 
 if RUN_TPU:
-    from torch_tpu import api as tpu_api  # type: ignore[import-not-found]
-
-    tpu_api.tpu_device()  # initialize TPU runtime
 
     class SweepInputsTpuTest(SweepInputs2, TestCase):
         gen = InputGen(10, "tpu")

--- a/torch/utils/_pallas.py
+++ b/torch/utils/_pallas.py
@@ -84,14 +84,9 @@ def has_jax_tpu_backend() -> bool:
 @functools.cache
 def has_torch_tpu() -> bool:
     """Check if torch_tpu is installed and available."""
-    try:
-        import torch_tpu.api  # type: ignore[import]
-
-        # Verify hardware/runtime access
-        torch_tpu.api.tpu_device()
-        return True
-    except (ImportError, RuntimeError):
-        return False
+    # The TPU module is an autoloaded out-of-tree backend.
+    tpu_module = getattr(torch, "tpu", None)
+    return tpu_module is not None
 
 
 @functools.cache


### PR DESCRIPTION
The `torch_tpu.api` module was deprecated and scheduled for removal some time ago. `torch_tpu` is now an autoloaded out-of-tree backend and it is not necessary to call `tpu_device()` to initialize it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo