### PR TITLE
[PyTorch] Add missing meta kernel for aten::_sample_dirichlet

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4099,6 +4099,15 @@ class GraphModule(torch.nn.Module):
         compiled_result = compiled_fn(t, scale, zero_point)
         self.assertEqual(compiled_result, result)
 
+    def test_sample_dirichlet(self):
+        def fn(concentration):
+            return torch._sample_dirichlet(concentration)
+
+        concentration = torch.tensor([0.5, 1.0, 2.0])
+        compiled_fn = torch.compile(fn, fullgraph=True)
+        result = compiled_fn(concentration)
+        self.assertEqual(result.shape, concentration.shape)
+
     def test_map_return(self):
         def fn(a, b):
             return map(lambda x: x + 1, [a, b])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -196,6 +196,12 @@ def meta__standard_gamma(self, generator=None):
     return torch.empty_like(self)
 
 
+@register_meta([aten._sample_dirichlet.default, aten._sample_dirichlet.out])
+@out_wrapper()
+def meta__sample_dirichlet(self, generator=None):
+    return torch.empty_like(self)
+
+
 @register_meta(
     [
         aten._transformer_encoder_layer_fwd.default,


### PR DESCRIPTION
Summary:
Fixes torch.compile(fullgraph=True) for models that use
torch.distributions.Dirichlet (e.g. OBA). The op previously had no
meta kernel, causing graph breaks under Dynamo.

The implementation mirrors _standard_gamma — output shape equals
input shape.

Differential Revision: D107307274




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98