### PR TITLE
[inductor] Add early exits to can_fusion_increase_peak_memory

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6408,12 +6408,18 @@ class Scheduler:
 
         # Check inputs that can be potentially reused
         lhs_dep_nodes = _find_single_user_inputs(node1)
+        if not lhs_dep_nodes:
+            return False
         rhs_dep_nodes = _find_single_user_inputs(node2)
+        if not rhs_dep_nodes:
+            return False
 
         lhs_reuse_keys = OrderedSet(buffer_reuse_key(buf) for buf in lhs_dep_nodes)
         rhs_reuse_keys = OrderedSet(buffer_reuse_key(buf) for buf in rhs_dep_nodes)
 
         common_reuse_keys = lhs_reuse_keys.intersection(rhs_reuse_keys)
+        if not common_reuse_keys:
+            return False
 
         memory_overhead = 0
         for key in common_reuse_keys:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186093
* #186092

can_fusion_increase_peak_memory computes the intersection of single-user
input buffer reuse keys between two nodes. For vertical (producer-consumer)
fusions, one or both nodes typically have no single-user inputs, making
the intersection empty and the function a no-op.

Add early exits when either node has no single-user inputs, or when the
intersection is empty, skipping the expensive buffer_reuse_key computation
and score_fusion_memory call.

Benchmarks on 20K-node repro (10K params, NVIDIA H100):
| Version                          | fuse_nodes | Sched._init | Total   |
|----------------------------------|-----------|-------------|---------|
| Baseline                         | 39.4s     | 101.4s      | 312.8s  |
| + decide_inplace fix             | 39.1s     | 99.9s       | 272.5s  |
| + tiling cache + skip + group    | 11.6s     | 72.9s       | 250.4s  |
| + this (peak memory early exit)  | 8.9s      | 69.3s       | 243.4s  |

Test Plan:
```
python repro_truncated.py --n-params 10000 --profile
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo