### PR TITLE
[inductor] Cache per-node tiling in fusion candidate evaluation

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1974,6 +1974,30 @@ class SIMDScheduling(BaseScheduling):
     def group_fn(self, sizes):
         return tuple(V.graph.sizevars.simplify(sympy_product(s)) for s in sizes)
 
+    _tiling_cache: dict[int, dict[str, Any]] | None = None
+    _group_tiling_cache: dict[tuple[Any, ...], dict[str, Any]] | None = None
+
+    def _get_node_tiling(self, node, numel, rnumel):
+        """Cached select_tiling per node. Unfused nodes with the same
+        group share a single tiling computation."""
+        if self._tiling_cache is None:
+            self._tiling_cache = {}
+        key = id(node)
+        if key not in self._tiling_cache:
+            nodes_list = node.get_nodes()
+            if len(nodes_list) == 1:
+                if self._group_tiling_cache is None:
+                    self._group_tiling_cache = {}
+                gk = (node.group, numel, rnumel)
+                if gk not in self._group_tiling_cache:
+                    self._group_tiling_cache[gk] = self.select_tiling(
+                        nodes_list, numel, rnumel
+                    )
+                self._tiling_cache[key] = self._group_tiling_cache[gk]
+            else:
+                self._tiling_cache[key] = self.select_tiling(nodes_list, numel, rnumel)
+        return self._tiling_cache[key]
+
     def can_fuse(self, node1, node2):
         """
         Hook called by Scheduler to determine if the Triton backend
@@ -2092,8 +2116,8 @@ class SIMDScheduling(BaseScheduling):
                     return True
 
             # check for a bad combined tiling
-            tiling1 = self.select_tiling(node1.get_nodes(), numel1, rnumel1)
-            tiling2 = self.select_tiling(node2.get_nodes(), numel1, rnumel1)
+            tiling1 = self._get_node_tiling(node1, numel1, rnumel1)
+            tiling2 = self._get_node_tiling(node2, numel1, rnumel1)
             tiling3 = self.select_tiling(
                 node1.get_nodes() + node2.get_nodes(), numel1, rnumel1
             )

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1971,32 +1971,40 @@ class SIMDScheduling(BaseScheduling):
 
     kernel_type: type[Any] = SIMDKernel  # override in subclass
 
+    def __init__(self, scheduler: Any) -> None:
+        super().__init__(scheduler)
+        self.clear_tiling_caches()
+
     def group_fn(self, sizes):
         return tuple(V.graph.sizevars.simplify(sympy_product(s)) for s in sizes)
 
-    _tiling_cache: dict[int, dict[str, Any]] | None = None
-    _group_tiling_cache: dict[tuple[Any, ...], dict[str, Any]] | None = None
-
     def _get_node_tiling(self, node, numel, rnumel):
         """Cached select_tiling per node. Unfused nodes with the same
-        group share a single tiling computation."""
-        if self._tiling_cache is None:
-            self._tiling_cache = {}
+        group share a single tiling computation.
+
+        Cleared together with candidate_tilings via
+        clear_tiling_caches().
+        """
+        tc = self._tiling_cache
         key = id(node)
-        if key not in self._tiling_cache:
+        if key not in tc:
             nodes_list = node.get_nodes()
             if len(nodes_list) == 1:
-                if self._group_tiling_cache is None:
-                    self._group_tiling_cache = {}
+                gtc = self._group_tiling_cache
                 gk = (node.group, numel, rnumel)
-                if gk not in self._group_tiling_cache:
-                    self._group_tiling_cache[gk] = self.select_tiling(
-                        nodes_list, numel, rnumel
-                    )
-                self._tiling_cache[key] = self._group_tiling_cache[gk]
+                if gk not in gtc:
+                    gtc[gk] = self.select_tiling(nodes_list, numel, rnumel)
+                tc[key] = gtc[gk]
             else:
-                self._tiling_cache[key] = self.select_tiling(nodes_list, numel, rnumel)
-        return self._tiling_cache[key]
+                tc[key] = self.select_tiling(nodes_list, numel, rnumel)
+        return tc[key]
+
+    def clear_tiling_caches(self) -> None:
+        """Clear all tiling caches. Called from
+        SchedulerNode.clear_loop_body_dependent_caches when loop
+        order changes invalidate tiling decisions."""
+        self._tiling_cache = {}
+        self._group_tiling_cache = {}
 
     def can_fuse(self, node1, node2):
         """

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2269,6 +2269,9 @@ class SchedulerNode(BaseSchedulerNode):
             # entry by using a customized cache implementation rather than
             # lru_cache.
             SIMDScheduling.candidate_tilings.cache_clear()
+            backend = self.scheduler.get_backend(self.get_device())
+            if isinstance(backend, SIMDScheduling):
+                backend.clear_tiling_caches()
 
     def snapshot_loop_state(self) -> tuple[Any, ...]:
         """Snapshot mutable state modified by loop transformations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186102
* #186106
* #186101
* #186097
* #186096
* __->__ #186095

select_tiling is called for each node in every fusion pair. With N
pairs, this means O(N) redundant calls for the same node. Cache
results per node id, and share across unfused nodes with the same
group (device + iteration domain), collapsing thousands of calls
to a handful of unique computations.

Profiled on 20K-node Shampoo optimizer graph (10K params, H100):

  Baseline fuse_nodes: 39.4s
  After:               9.4s   (4.2x)

  Baseline total:      312.8s
  After:               129.6s (2.4x)

Test Plan:
```
python repro_truncated.py --n-params 10000
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo