### PR TITLE
[inductor] Skip combined tiling computation for <=2D pointwise fusion

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2118,26 +2118,30 @@ class SIMDScheduling(BaseScheduling):
             # check for a bad combined tiling
             tiling1 = self._get_node_tiling(node1, numel1, rnumel1)
             tiling2 = self._get_node_tiling(node2, numel1, rnumel1)
-            tiling3 = self.select_tiling(
-                node1.get_nodes() + node2.get_nodes(), numel1, rnumel1
-            )
             if config.triton.tiling_prevents_pointwise_fusion:
-                cond = True
-                if len(tiling1) > 2:
-                    if len(tiling2) > 2:
-                        cond = tiling1 == tiling2 == tiling3
-                    else:
-                        cond = tiling1 == tiling3
-                elif len(tiling2) > 2:
-                    cond = tiling2 == tiling3
-                if not cond:
-                    why(
-                        "tiling mismatch (%s, %s, %s)",
-                        tiling1,
-                        tiling2,
-                        tiling3,
+                # tiling3 is only consulted when at least one tiling
+                # has >2 dims; for <=2D the check always passes.
+                if len(tiling1) > 2 or len(tiling2) > 2:
+                    tiling3 = self.select_tiling(
+                        node1.get_nodes() + node2.get_nodes(), numel1, rnumel1
                     )
-                    return False
+                    cond = True
+                    if len(tiling1) > 2:
+                        cond = (
+                            tiling1 == tiling2 == tiling3
+                            if len(tiling2) > 2
+                            else tiling1 == tiling3
+                        )
+                    else:
+                        cond = tiling2 == tiling3
+                    if not cond:
+                        why(
+                            "tiling mismatch (%s, %s, %s)",
+                            tiling1,
+                            tiling2,
+                            tiling3,
+                        )
+                        return False
 
             return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186102
* #186106
* #186101
* #186097
* __->__ #186096
* #186095

The tiling compatibility check (tiling_prevents_pointwise_fusion) only
rejects fusion when at least one node has >2D tiling. For <=2D nodes
the check unconditionally passes and tiling3 is never consulted.
Skip the expensive combined select_tiling call in that common case.

Profiled on 20K-node Shampoo optimizer graph (10K params, H100),
applied on top of tiling cache:

  fuse_nodes before: 9.4s
  fuse_nodes after:  2.8s   (3.4x)

  Total before:      129.6s
  Total after:       121.2s

Test Plan:
```
python repro_truncated.py --n-params 10000
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo