### PR TITLE
[inductor] Add early exits to can_fusion_increase_peak_memory

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6408,12 +6408,18 @@ class Scheduler:
 
         # Check inputs that can be potentially reused
         lhs_dep_nodes = _find_single_user_inputs(node1)
+        if not lhs_dep_nodes:
+            return False
         rhs_dep_nodes = _find_single_user_inputs(node2)
+        if not rhs_dep_nodes:
+            return False
 
         lhs_reuse_keys = OrderedSet(buffer_reuse_key(buf) for buf in lhs_dep_nodes)
         rhs_reuse_keys = OrderedSet(buffer_reuse_key(buf) for buf in rhs_dep_nodes)
 
         common_reuse_keys = lhs_reuse_keys.intersection(rhs_reuse_keys)
+        if not common_reuse_keys:
+            return False
 
         memory_overhead = 0
         for key in common_reuse_keys:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186102
* #186106
* #186101
* __->__ #186097
* #186096
* #186095

Return early when either node has no single-user inputs or when the
reuse-key intersection is empty -- the memory overhead is guaranteed
zero in both cases, so fusion is always allowed. This is the common
case for vertical (producer-consumer) fusions.

Profiled on 20K-node Shampoo optimizer graph (10K params, H100),
applied on top of tiling cache + skip-<=2D:

  fuse_nodes before: 2.8s
  fuse_nodes after:  2.5s

  Total before:      121.2s
  Total after:       118.0s

Test Plan:
```
python repro_truncated.py --n-params 10000
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo