### PR TITLE
[inductor] Avoid O(n) set union in decide_inplace_update

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1472,11 +1472,15 @@ class BaseSchedulerNode:
             return
 
         # NOTE remove V.graph.removed_operations once deps issue is fixed
-        inconsequential_nodes = (
-            self.ancestors
-            | V.graph.removed_operations
-            | self.scheduler.completed_operations
-        )
+        # Check membership against each set separately instead of
+        # creating a union -- the union is O(n) per call and this
+        # function is called for every node during codegen.
+        _ancestors = self.ancestors
+        _removed_ops = V.graph.removed_operations
+        _completed_ops = self.scheduler.completed_operations
+
+        def _is_inconsequential(name: str) -> bool:
+            return name in _ancestors or name in _removed_ops or name in _completed_ops
 
         def single_index_in_fused_node(buf_to_be_inplaced: SchedulerBuffer) -> bool:
             # Inside of NodeUser, we track that the read and write are equivalent
@@ -1542,7 +1546,7 @@ class BaseSchedulerNode:
                     remaining_uses = [
                         x
                         for x in input_buf.users
-                        if x.node.get_name() not in inconsequential_nodes
+                        if not _is_inconsequential(x.node.get_name())
                     ]
                     has_cross_stream_hazard = self.scheduler.has_cross_stream_hazard(
                         read.name, self


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186102
* #186106
* __->__ #186101
* #186097
* #186096
* #186095

decide_inplace_update creates a union of three OrderedSets on every
call during codegen. Since OrderedSet union uses dict.fromkeys which
is O(n), the total cost is O(n^2) for large graphs.

Replace the set union with three separate membership checks.

Profiled on 20K-node graph (10K params, H100):

  Total before: 124.4s
  Total after:  108.1s (1.15x)

Test Plan:
```
python repro_truncated.py --n-params 10000
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo