### PR TITLE
[pyrefly] enable-fallback-search-path on megarepos (fbcode)

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -131,6 +131,7 @@ errors.deprecated = false # re-enable after we've fix import formatting
 permissive-ignores = true
 replace-imports-with-any = ["!sympy.printing.*", "sympy.*", "onnxscript.onnx_opset.*", "networkx.*"]
 search-path = ["tools/experimental"]
+enable-fallback-search-path = true
 
 # Dynamo sub-config - note, we experiment with stricter typing here
 [[sub-config]]


### PR DESCRIPTION
Summary:
enable-fallback-search-path was added in D106950378. however, it didn't cover every case as discovered by a contributor on discord.

In anticipation for a stack fixing these, this commit turns it on in megarepos in order to not regress type check and IDE functionality. The end goal is to have a system in which build-system-configured projects do not upwards-search unless this flag is set.

This commit covers fbcode/ only. Follow-ups will cover other top-level directories.

Test Plan: CI

Reviewed By: connernilsen

Differential Revision: D107401578


