### PR TITLE
[inductor] Fast paths in sizevars for concrete integer comparisons

### DIFF
--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -525,6 +525,13 @@ class SizeVarAllocator:
         """
         Returns a bool indicating if it is sound to optimize as if left and right are equal.
         """
+        if left is right:
+            return True
+        # Fast path for concrete integers -- avoids creating sympy.Eq object
+        if isinstance(left, (int, sympy.Integer)) and isinstance(
+            right, (int, sympy.Integer)
+        ):
+            return int(left) == int(right)
         return self.statically_known_true(sympy.Eq(left, right))  # type: ignore[arg-type]
 
     def statically_known_list_equals(
@@ -848,6 +855,12 @@ class SizeVarAllocator:
         return sympy_subs(left, self.inv_precomputed_replacements)
 
     def check_leq(self, left: Expr, right: Expr) -> None:
+        # Fast path: concrete integers don't need sympy guards
+        if isinstance(left, (int, sympy.Integer)) and isinstance(
+            right, (int, sympy.Integer)
+        ):
+            assert int(left) <= int(right)
+            return
         self.check(sympy.Le(left, right))
 
     def check_lt(self, left: Expr, right: Expr) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186102
* __->__ #186106
* #186101
* #186097
* #186096
* #186095

statically_known_equals and check_leq create sympy.Eq/sympy.Le objects
on every call. For concrete integers, use direct Python comparisons.

Profiled on 20K-node graph (10K params, H100), on top of previous fix:

  Total before: 108.1s
  Total after:  100.4s (1.08x)

Test Plan:
```
python repro_truncated.py --n-params 10000
```

Authored with AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo