### PR TITLE
Cleaning up the 32/64bit offset checks for im2col/col2im

### DIFF
--- a/aten/src/ATen/native/im2col_shape_check.h
+++ b/aten/src/ATen/native/im2col_shape_check.h
@@ -6,6 +6,18 @@
 
 namespace at::native {
 
+// Number of sliding-window positions along one spatial dimension (floor division, int64_t).
+inline int64_t sliding_window_count(
+    int64_t input_size,
+    int64_t pad,
+    int64_t dilation,
+    int64_t kernel,
+    int64_t stride) {
+  return div_rtn<int64_t>(
+             input_size + 2 * pad - (dilation * (kernel - 1) + 1), stride) +
+      1;
+}
+
 inline void col2im_shape_check(
     const Tensor& input,
     const Tensor& grad_output,
@@ -77,17 +89,10 @@ inline void col2im_shape_check(
   }
 
   int64_t input_length = input.size(batch_dim + 2);
-  int64_t n_blocks_height =
-      div_rtn<int64_t>(
-          output_height + 2 * pad_height -
-              dilation_height * (kernel_height - 1) - 1,
-          stride_height) +
-      1;
-  int64_t n_blocks_width = div_rtn<int64_t>(
-                                   output_width + 2 * pad_width -
-                                       dilation_width * (kernel_width - 1) - 1,
-                                   stride_width) +
-      1;
+  int64_t n_blocks_height = sliding_window_count(
+      output_height, pad_height, dilation_height, kernel_height, stride_height);
+  int64_t n_blocks_width = sliding_window_count(
+      output_width, pad_width, dilation_width, kernel_width, stride_width);
 
   if (input_length != (n_blocks_height * n_blocks_width)) {
     TORCH_CHECK(false,
@@ -201,16 +206,10 @@ inline void im2col_shape_check(
 
   int64_t input_height = input.size(dim_batch + 2);
   int64_t input_width = input.size(dim_batch + 3);
-  int64_t output_height = div_rtn<int64_t>(
-                              input_height + 2 * pad_height -
-                                  (dilation_height * (kernel_height - 1) + 1),
-                              stride_height) +
-      1;
-  int64_t output_width = div_rtn<int64_t>(
-                             input_width + 2 * pad_width -
-                                 (dilation_width * (kernel_width - 1) + 1),
-                             stride_width) +
-      1;
+  int64_t output_height = sliding_window_count(
+      input_height, pad_height, dilation_height, kernel_height, stride_height);
+  int64_t output_width = sliding_window_count(
+      input_width, pad_width, dilation_width, kernel_width, stride_width);
 
   if (output_height < 1 || output_width < 1) {
     TORCH_CHECK(false,

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -9,11 +9,14 @@
 #include <ATen/Utils.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/mps/MPSStream.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #include <ATen/native/mps/TensorFactory.h>
 #include <c10/core/ScalarType.h>
 #include <fmt/format.h>
 #include <torch/library.h>
+#include <limits>
+#include <type_traits>
 #include <unordered_map>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -75,6 +78,27 @@ static inline std::string scalarToMetalTypeString(const TensorBase& t) {
 }
 static inline std::string scalarToMetalTypeString(const std::optional<Tensor>& t) {
   return t.has_value() ? scalarToMetalTypeString(t.value()) : "void";
+}
+
+// True iff every tensor's max element offset fits in Offset32 (signed -> 2^31, unsigned -> 2^32).
+template <typename Offset32, typename... Tensors>
+inline bool offsetsFitIn(const Tensors&... tensors) {
+  constexpr int64_t kMaxOffset = std::numeric_limits<Offset32>::max();
+  return (... && at::native::canUse32BitIndexMath(tensors, kMaxOffset));
+}
+
+inline const char* mtlIdxSuffix(bool use32) {
+  return use32 ? "_u32" : "_u64";
+}
+
+// Lower the runtime use32 bool to a compile-time offset type and pass it to fn as a std::type_identity tag.
+template <typename Offset32, typename Offset64, typename Fn>
+inline void mtlDispatchByIndexWidth(bool use32, Fn&& fn) {
+  if (use32) {
+    fn(std::type_identity<Offset32>{});
+  } else {
+    fn(std::type_identity<Offset64>{});
+  }
 }
 NSArray<NSNumber*>* getTensorAxes(const TensorBase& t);
 NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -87,7 +87,7 @@ inline bool offsetsFitIn(const Tensors&... tensors) {
   return (... && at::native::canUse32BitIndexMath(tensors, kMaxOffset));
 }
 
-inline const char* mtlIdxSuffix(bool use32) {
+inline std::string_view mtlIdxSuffix(bool use32) {
   return use32 ? "_u32" : "_u64";
 }
 

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -100,6 +100,7 @@ inline void mtlDispatchByIndexWidth(bool use32, Fn&& fn) {
     fn(std::type_identity<Offset64>{});
   }
 }
+
 NSArray<NSNumber*>* getTensorAxes(const TensorBase& t);
 NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);
 std::string getMPSShapeString(MPSShape* shape);

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -1,5 +1,4 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/im2col_shape_check.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -69,15 +68,15 @@ static void col2im_out_mps_template(const Tensor& input,
   output.resize_({batch_size, n_output_plane, output_height, output_width});
   auto output_batch_stride = output.stride(0);
 
-  auto height_col = (output_height + 2 * pad_height - (dilation_height * (kernel_height - 1) + 1)) / stride_height + 1;
-  auto width_col = (output_width + 2 * pad_width - (dilation_width * (kernel_width - 1) + 1)) / stride_width + 1;
+  auto height_col = sliding_window_count(output_height, pad_height, dilation_height, kernel_height, stride_height);
+  auto width_col = sliding_window_count(output_width, pad_width, dilation_width, kernel_width, stride_width);
 
   auto stream = getCurrentMPSStream();
-  const bool use_u32 = canUse32BitIndexMath(col_tensor) && canUse32BitIndexMath(output);
-  const std::string idx_suffix = use_u32 ? "_u32" : "_u64";
+  const bool use_u32 = offsetsFitIn<uint32_t>(col_tensor, output);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      auto col2imPSO = lib.getPipelineStateForFunc("col2im_kernel_" + mps::scalarToMetalTypeString(input) + idx_suffix);
+      auto col2imPSO =
+          lib.getPipelineStateForFunc("col2im_kernel_" + mps::scalarToMetalTypeString(input) + mtlIdxSuffix(use_u32));
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:col2imPSO];
       const uint32_t gridWidth = static_cast<uint32_t>(output_width);
@@ -89,12 +88,13 @@ static void col2im_out_mps_template(const Tensor& input,
       uint32_t tgWidth = std::min(gridWidth, threadExecutionWidth);
       uint32_t tgHeight = std::min(gridHeight, maxThreadsPerGroup / tgWidth);
       MTLSize threadgroupSize = MTLSizeMake(tgWidth, tgHeight, 1);
-      auto dispatch_args = [&](auto in_stride, auto out_stride, auto inner_strides) {
+      mtlDispatchByIndexWidth<uint32_t, uint64_t>(use_u32, [&](auto idx_tag) {
+        using idx_t = typename decltype(idx_tag)::type;
         mtl_setArgs(
             computeEncoder,
             col_tensor,
             output,
-            in_stride,
+            idx_t(input_batch_stride),
             n_output_plane,
             std::array<uint32_t, 2>{static_cast<uint32_t>(output_height), static_cast<uint32_t>(output_width)}, // im_hw
             std::array<uint32_t, 2>{static_cast<uint32_t>(kernel_height),
@@ -105,20 +105,9 @@ static void col2im_out_mps_template(const Tensor& input,
             std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
                                     static_cast<uint32_t>(dilation_width)}, // dilation_hw
             std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
-            out_stride,
-            inner_strides);
-      };
-      if (use_u32) {
-        dispatch_args(static_cast<uint32_t>(input_batch_stride),
-                      static_cast<uint32_t>(output_batch_stride),
-                      std::array<uint32_t, 2>{static_cast<uint32_t>(input_channel_stride),
-                                              static_cast<uint32_t>(input_spatial_stride)});
-      } else {
-        dispatch_args(static_cast<uint64_t>(input_batch_stride),
-                      static_cast<uint64_t>(output_batch_stride),
-                      std::array<uint64_t, 2>{static_cast<uint64_t>(input_channel_stride),
-                                              static_cast<uint64_t>(input_spatial_stride)});
-      }
+            idx_t(output_batch_stride),
+            std::array<idx_t, 2>{idx_t(input_channel_stride), idx_t(input_spatial_stride)});
+      });
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
     }
   });

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -75,8 +75,8 @@ static void col2im_out_mps_template(const Tensor& input,
   const bool use_u32 = offsetsFitIn<uint32_t>(col_tensor, output);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      auto col2imPSO =
-          lib.getPipelineStateForFunc("col2im_kernel_" + mps::scalarToMetalTypeString(input) + mtlIdxSuffix(use_u32));
+      auto col2imPSO = lib.getPipelineStateForFunc(
+          fmt::format("col2im_kernel_{}{}", scalarToMetalTypeString(input), mtlIdxSuffix(use_u32)));
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:col2imPSO];
       const uint32_t gridWidth = static_cast<uint32_t>(output_width);

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -78,7 +78,8 @@ static void im2col_out_mps_template(Tensor& output,
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
   const bool use_u32 = offsetsFitIn<int32_t>(input, output);
-  auto im2colPSO = lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input) + mtlIdxSuffix(use_u32));
+  auto im2colPSO =
+      lib.getPipelineStateForFunc(fmt::format("im2col_{}{}", scalarToMetalTypeString(input), mtlIdxSuffix(use_u32)));
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       std::array<int32_t, 4> kernel_dilation = {static_cast<int32_t>(kernel_width),

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -1,6 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/im2col_shape_check.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -70,18 +69,16 @@ static void im2col_out_mps_template(Tensor& output,
   int64_t input_height = input.size(2);
   int64_t input_width = input.size(3);
 
-  int64_t output_height =
-      (input_height + 2 * pad_height - (dilation_height * (kernel_height - 1) + 1)) / stride_height + 1;
-  int64_t output_width = (input_width + 2 * pad_width - (dilation_width * (kernel_width - 1) + 1)) / stride_width + 1;
+  int64_t output_height = sliding_window_count(input_height, pad_height, dilation_height, kernel_height, stride_height);
+  int64_t output_width = sliding_window_count(input_width, pad_width, dilation_width, kernel_width, stride_width);
   int64_t n_output_plane = n_input_plane * kernel_width * kernel_height;
   int64_t output_length = output_height * output_width;
 
   output.resize_({batch_size, n_output_plane, output_length});
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
-  const bool use_u32 = canUse32BitIndexMath(input) && canUse32BitIndexMath(output);
-  auto im2colPSO =
-      lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input) + (use_u32 ? "_u32" : "_u64"));
+  const bool use_u32 = offsetsFitIn<int32_t>(input, output);
+  auto im2colPSO = lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input) + mtlIdxSuffix(use_u32));
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       std::array<int32_t, 4> kernel_dilation = {static_cast<int32_t>(kernel_width),
@@ -95,28 +92,17 @@ static void im2col_out_mps_template(Tensor& output,
       getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input, output});
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:im2colPSO];
-      auto encode = [&](auto input_strides, auto output_strides, auto input_sizes) {
+      mtlDispatchByIndexWidth<int32_t, int64_t>(use_u32, [&](auto idx_tag) {
+        using idx_t = typename decltype(idx_tag)::type;
+        std::array<idx_t, 4> input_strides{
+            idx_t(input.stride(3)), idx_t(input.stride(2)), idx_t(input.stride(1)), idx_t(input.stride(0))};
+        std::array<idx_t, 4> output_strides{
+            idx_t(output.stride(2)), idx_t(output.stride(1)), idx_t(output.stride(0)), idx_t(output_width)};
+        std::array<idx_t, 4> input_sizes{
+            idx_t(input_width), idx_t(input_height), idx_t(n_input_plane), idx_t(batch_size)};
         mtl_setArgs(
             computeEncoder, input, output, kernel_dilation, padding_stride, input_strides, output_strides, input_sizes);
-      };
-      if (use_u32) {
-        encode(std::array<int32_t, 4>{static_cast<int32_t>(input.stride(3)),
-                                      static_cast<int32_t>(input.stride(2)),
-                                      static_cast<int32_t>(input.stride(1)),
-                                      static_cast<int32_t>(input.stride(0))},
-               std::array<int32_t, 4>{static_cast<int32_t>(output.stride(2)),
-                                      static_cast<int32_t>(output.stride(1)),
-                                      static_cast<int32_t>(output.stride(0)),
-                                      static_cast<int32_t>(output_width)},
-               std::array<int32_t, 4>{static_cast<int32_t>(input_width),
-                                      static_cast<int32_t>(input_height),
-                                      static_cast<int32_t>(n_input_plane),
-                                      static_cast<int32_t>(batch_size)});
-      } else {
-        encode(std::array<int64_t, 4>{input.stride(3), input.stride(2), input.stride(1), input.stride(0)},
-               std::array<int64_t, 4>{output.stride(2), output.stride(1), output.stride(0), output_width},
-               std::array<int64_t, 4>{input_width, input_height, n_input_plane, batch_size});
-      }
+      });
       [computeEncoder dispatchThreads:MTLSizeMake(output_length, n_input_plane, batch_size)
                 threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
       getMPSProfiler().endProfileKernel(im2colPSO);


### PR DESCRIPTION
These ops each pick between 32- and 64-bit index kernels and pack their stride/size args in the chosen width. This factors the shared machinery into OperationUtils.h. A duplicated geometry formula for window position computation in im2col/col2im is moved to im2col_shape_check.h.

This PR is a follow-up to discussion in https://github.com/pytorch/pytorch/pull/185860