### PR TITLE
Remove test_transformers from windows blocklist

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -803,9 +803,10 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
     // For mem-eff attention this will cause the expand call to error
     // For now I am going to turn of that path not have to deal with all the annoying
     // Mask type shape grossness
+    // backend falls through to legacy bmm -> softmax path. Produces Nans for large inputs. Use SDPA for math
     if (!mask.has_value() && no_seq_len_1_nested &&
         (backend == sdp::SDPBackend::flash_attention || backend == sdp::SDPBackend::efficient_attention ||
-         backend == sdp::SDPBackend::cudnn_attention)) {
+         backend == sdp::SDPBackend::cudnn_attention || backend == sdp::SDPBackend::math)) {
       auto x = at::linear(query, qkv_weight, qkv_bias);
       auto chunks = x.chunk(3, -1);
       auto x_size_0 = x.size(0);
@@ -823,7 +824,6 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
       return std::make_tuple(
           at::linear(past_sdp, proj_weight, proj_bias), Tensor());
     }
-    // Returned math or error lets not use it
   }
 
   // shape: [B, T, 3 x D]

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1835,7 +1835,6 @@ def get_selected_tests(options) -> list[str]:
                     "test_testing",
                     # Features not supported on Windows ( e.g. rowwise scaling)
                     "test_decomp",
-                    "test_transformers",
                     "test_ops",
                     # Output mismatch errors and long running tests
                     "test_linalg",

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -830,6 +830,7 @@ class TestTransformers(NNTestCase):
                 src_key_padding_mask=padding_mask,
             )
 
+    @xfailIfNoAcceleratorTriton
     def test_transformer_encoder_layer_fwd_fake(self, device):
         model = torch.nn.TransformerEncoder(
             torch.nn.TransformerEncoderLayer(
@@ -3249,6 +3250,10 @@ class TestSDPACudaOnly(NNTestCase):
         self.assertEqual(q.grad, q_cpu.grad.cuda().half(), atol=7e-3, rtol=5e-3)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Flash attention is required as the cudnn fallback when seq_len=1 with dropout",
+    )
     def test_cudnn_attention_seqlen1_dropout_heuristic(self):
         q = torch.randn(2, 8, 1, 128, dtype=torch.half, device='cuda', requires_grad=True)
         grad = torch.randn_like(q)


### PR DESCRIPTION
Allow math SDPA in CUDA MHA fastpath and enable transformers tests on Windows

The native MHA fastpath previously skipped fused SDPA and fell through to legacy bmm/softmax, which can produce NaNs in fp16. Accept SDPBackend::math in the fastpath so SDPA runs instead.

Add xfailIfNoAcceleratorTriton on test_transformer_encoder_layer_fwd_fake and skip test_cudnn_attention_seqlen1_dropout_heuristic when Flash is not built, since that test only enables cuDNN and Flash backends.