### PR TITLE
Fix stale mutated input history in AOTAutograd

### DIFF
--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -101,6 +101,106 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertIn(".detach()", source)
         self.assertIn("torch._C._set_view_replay_enabled(True)", source)
 
+    def test_training_non_grad_buffer_mutation_keeps_buffer_grad_history(self):
+        """
+        A non-grad buffer mutated with a grad-requiring value should keep the
+        eager autograd state on the buffer without making user-output backward
+        traverse the buffer's prior graph on the next invocation.
+        """
+        with capture_codegen_source("runtime_wrapper_orchestration") as captured:
+            w = torch.nn.Parameter(torch.tensor([2.0, 3.0, 4.0, 5.0]))
+            buf = torch.zeros(4)
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                out = x * w
+                buf.add_(out)
+                return out
+
+            x = torch.tensor([0.1, 0.2, 0.3, 0.4])
+            expected_update = x * w.detach()
+
+            out = f(x)
+            self.assertEqual(buf, expected_update)
+            self.assertTrue(buf.requires_grad)
+            self.assertFalse(buf.is_leaf)
+            self.assertEqual(torch.autograd.grad(buf.sum(), w, retain_graph=True)[0], x)
+            out.sum().backward()
+            self.assertEqual(w.grad, x)
+            w.grad = None
+
+            out = f(x)
+            self.assertEqual(buf, expected_update * 2)
+            self.assertTrue(buf.requires_grad)
+            self.assertFalse(buf.is_leaf)
+            out.sum().backward()
+
+        self.assertEqual(w.grad, x)
+        self.assertEqual(len(captured), 2)
+        self.assertIn("updated_inputs", captured[0])
+        self.assertIn(".detach()", captured[1])
+
+    def test_training_mutated_buffer_alias_output_uses_prior_history(self):
+        """
+        If a differentiable user output aliases a mutated input, do not detach
+        the stale input. The alias observes eager's add_ derivative wrt the old
+        buffer, so gradients flow through both updates.
+        """
+        with capture_codegen_source("runtime_wrapper_orchestration") as captured:
+            w = torch.nn.Parameter(torch.tensor([2.0, 3.0, 4.0, 5.0]))
+            buf = torch.zeros(4)
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                out = x * w
+                buf.add_(out)
+                return out, buf.view_as(buf)
+
+            x = torch.tensor([0.1, 0.2, 0.3, 0.4])
+            expected_update = x * w.detach()
+
+            f(x)
+            self.assertEqual(buf, expected_update)
+
+            _, y = f(x)
+            self.assertEqual(buf, expected_update * 2)
+            self.assertEqual(y.data_ptr(), buf.data_ptr())
+            y.sum().backward()
+
+        self.assertEqual(w.grad, x * 2)
+        self.assertEqual(len(captured), 2)
+        self.assertNotIn(".detach()", captured[1])
+
+    def test_training_mutated_buffer_copy_alias_output_overwrites_prior_history(self):
+        """
+        copy_ overwrites eager's old buffer history. A generic history-preserving
+        copy-back would incorrectly include the first update in this gradient.
+        """
+        with capture_codegen_source("runtime_wrapper_orchestration") as captured:
+            w = torch.nn.Parameter(torch.tensor([2.0, 3.0, 4.0, 5.0]))
+            buf = torch.zeros(4)
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                out = x * w
+                buf.copy_(out)
+                return out, buf.view_as(buf)
+
+            x = torch.tensor([0.1, 0.2, 0.3, 0.4])
+            expected_update = x * w.detach()
+
+            f(x)
+            self.assertEqual(buf, expected_update)
+
+            _, y = f(x)
+            self.assertEqual(buf, expected_update)
+            self.assertEqual(y.data_ptr(), buf.data_ptr())
+            y.sum().backward()
+
+        self.assertEqual(w.grad, x)
+        self.assertEqual(len(captured), 2)
+        self.assertNotIn(".detach()", captured[1])
+
     def test_inference_with_mutation(self):
         """
         Inference with input mutation. With keep_inference_input_mutations,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -56,7 +56,12 @@ from .autograd_cache import (
     should_bundle_autograd_cache,
     should_use_remote_autograd_cache,
 )
-from .descriptors import AOTOutput, PlainAOTOutput
+from .descriptors import (
+    AOTOutput,
+    InputMutationAOTOutput,
+    PlainAOTOutput,
+    TangentAOTInput,
+)
 from .graph_capture import aot_dispatch_autograd_graph, aot_dispatch_base_graph
 from .logging_utils import track_graph_compiling
 from .runtime_wrappers import (
@@ -84,6 +89,7 @@ from .schemas import (
     FlatFn,
     FxValue,
     MutationType,
+    OutputType,
     SubclassMeta,
     ViewAndMutationMeta,
 )
@@ -2140,18 +2146,84 @@ def _compute_indices_of_inps_to_detach(
             f"got {len(bw_outs_no_rng_no_tokens)}"
         )
 
+    # Some mutated inputs are differentiable because their mutated value is
+    # copied back to the original input in the runtime epilogue. If no
+    # differentiable user-visible output aliases the mutated input, and the
+    # user-output backward does not use that input, passing a stale non-leaf
+    # input through the compiled autograd.Function can make an unrelated
+    # user-output backward traverse the input's prior freed graph.
+    #
+    # If a differentiable user output does alias the mutated input, its gradient
+    # may depend on eager's mutation-specific semantics for the old input:
+    # copy_ overwrites old history, add_/sub_ preserve it with identity
+    # derivative, and other mutations may have non-identity derivatives or
+    # version-counter constraints. Detaching here would erase information that
+    # the existing alias/mutation path may need.
+    differentiable_outputs_aliasing_inputs = {
+        info.base_idx
+        for info in fw_metadata.output_info
+        if info.output_type in (OutputType.alias_of_input, OutputType.is_input)
+        and isinstance(info.base_idx, int)
+        and info.requires_grad_for_backward
+    }
+
+    tangent_placeholders = [
+        node
+        for node in bw_module.graph.find_nodes(op="placeholder")
+        if node.name.startswith("tangents")
+    ]
+    user_output_tangent_placeholders = set()
+    if len(tangent_placeholders) == len(fw_metadata.traced_tangents_descs):
+        for tangent, tangent_desc in zip(
+            tangent_placeholders, fw_metadata.traced_tangents_descs
+        ):
+            if not (
+                isinstance(tangent_desc, TangentAOTInput)
+                and isinstance(tangent_desc.output, InputMutationAOTOutput)
+            ):
+                user_output_tangent_placeholders.add(tangent)
+
+    def depends_on_user_output_tangent(node: object) -> bool:
+        if not isinstance(node, torch.fx.Node):
+            return False
+
+        seen: set[torch.fx.Node] = set()
+        stack = [node]
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            if cur in user_output_tangent_placeholders:
+                return True
+            stack.extend(cur.all_input_nodes)
+        return False
+
     for i, bw_out in enumerate(bw_outs_no_rng_no_tokens):
+        info = fw_metadata.input_info[i]
         # If our input experiences a metadata mutation inside the graph (e.g. set_()),
         # we *must* not detach, otherwise it will be the detach'd input that gets the metadata mutation
         metadata_mutation_in_graph = (
-            fw_metadata.input_info[i].mutation_type == MutationType.MUTATED_IN_GRAPH
-            and fw_metadata.input_info[i].mutates_storage_metadata
+            info.mutation_type == MutationType.MUTATED_IN_GRAPH
+            and info.mutates_storage_metadata
         )
-        is_non_leaf = (
-            fw_metadata.input_info[i].requires_grad
-            and not fw_metadata.input_info[i].is_leaf
+        is_non_leaf = info.requires_grad and not info.is_leaf
+        user_outputs_need_input = depends_on_user_output_tangent(bw_out)
+        differentiable_user_output_aliases_input = (
+            i in differentiable_outputs_aliasing_inputs
         )
-        if bw_out is None and not metadata_mutation_in_graph and is_non_leaf:
+        only_mutated_outputs_need_input = (
+            bool(user_output_tangent_placeholders)
+            and info.mutation_type == MutationType.MUTATED_OUT_GRAPH
+            and info.mutates_data
+            and not user_outputs_need_input
+            and not differentiable_user_output_aliases_input
+        )
+        if (
+            (bw_out is None or only_mutated_outputs_need_input)
+            and not metadata_mutation_in_graph
+            and is_non_leaf
+        ):
             indices_of_inps_to_detach.append(i)
 
     return indices_of_inps_to_detach


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186111

AOTAutograd can treat a non-grad buffer mutated with parameter-derived data as a differentiable mutated input. On a later invocation, the compiled autograd Function then receives the stale non-leaf buffer from the previous invocation. If the user-output backward does not actually need that stale input and only the hidden mutation output does, backward can try to traverse saved tensors from the previous already-freed graph.

Teach the detach analysis to distinguish user-output tangent dependencies from input-mutation tangent dependencies. We now detach a stale non-leaf mutated input when only mutation-output tangents need it, while preserving the existing path when a differentiable user-visible alias output may need eager mutation semantics for the old input. Add runtime-wrapper regression coverage for the original two-backward failure and for alias outputs that must not be detached.

A broader direct returned-mutated-input alias case remains out of scope because whether detaching is correct depends on which returned output is later differentiated. This change stays scoped to the original no-alias failure and explicit alias-output safety.

Fixes #140707

Generated by my agent

Test Plan:

- python test/functorch/test_codegen_runtime_wrapper.py TestCodegenRuntimeWrapper.test_training_non_grad_buffer_mutation_keeps_buffer_grad_history TestCodegenRuntimeWrapper.test_training_mutated_buffer_alias_output_uses_prior_history TestCodegenRuntimeWrapper.test_training_mutated_buffer_copy_alias_output_overwrites_prior_history TestCodegenRuntimeWrapper.test_training_with_detach_indices

- python test/functorch/test_codegen_runtime_wrapper.py

- lintrunner -a

- Original minimized repro with backend="aot_eager" and default torch.compile