### PR TITLE
dynamo] [dynamic] torch.combinations throws RuntimeError when (backend=aot_eager, dynamic=True) #163759 - noah

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -211,9 +211,9 @@ class TestSerialize(TestCase):
         buffer = io.BytesIO()
         torch.export.save(ep, buffer)
         buffer.seek(0)
-        
+
         loaded_ep = torch.export.load(buffer, weights_only=True)
-        
+
         exp_out = ep.module()(*inp)
         actual_out = loaded_ep.module()(*inp)
         self.assertEqual(exp_out, actual_out)

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -196,6 +196,28 @@ class TestSerialize(TestCase):
         self.assertEqual(exp_out, actual_out)
         self.assertEqual(exp_out.requires_grad, actual_out.requires_grad)
 
+    def test_export_weights_only(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.ones(4, 4))
+                self.register_buffer("bias", torch.zeros(4))
+
+            def forward(self, x):
+                return x @ self.weight + self.bias
+
+        inp = (torch.ones(4),)
+        ep = export(Foo(), inp, strict=True)
+        buffer = io.BytesIO()
+        torch.export.save(ep, buffer)
+        buffer.seek(0)
+        
+        loaded_ep = torch.export.load(buffer, weights_only=True)
+        
+        exp_out = ep.module()(*inp)
+        actual_out = loaded_ep.module()(*inp)
+        self.assertEqual(exp_out, actual_out)
+
     def test_export_example_inputs_preserved(self):
         class MyModule(torch.nn.Module):
             """A test module with that has multiple args and uses kwargs"""

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2955,7 +2955,9 @@ class GraphModuleDeserializer(metaclass=Final):
                 "Identity": torch.utils._sympy.functions.Identity,
             }
             self.symbol_name_to_symbol: dict[str, sympy.Symbol] = {}
-            self.constants = deserialize_torch_artifact(constants, weights_only=weights_only)
+            self.constants = deserialize_torch_artifact(
+                constants, weights_only=weights_only
+            )
             self.signature = self.deserialize_signature(
                 serialized_graph_module.signature
             )
@@ -2991,7 +2993,9 @@ class GraphModuleDeserializer(metaclass=Final):
                 self.shape_env.unbacked_symint_counter += 1
 
             if example_inputs is not None and len(example_inputs) > 0:
-                self.example_inputs = deserialize_torch_artifact(example_inputs, weights_only=weights_only)
+                self.example_inputs = deserialize_torch_artifact(
+                    example_inputs, weights_only=weights_only
+                )
             else:
                 self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
@@ -3017,7 +3021,9 @@ class GraphModuleDeserializer(metaclass=Final):
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict, weights_only=weights_only),
+                state_dict=deserialize_torch_artifact(
+                    serialized_state_dict, weights_only=weights_only
+                ),
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -426,6 +426,7 @@ def serialize_torch_artifact(
 
 def deserialize_torch_artifact(
     serialized: dict[str, Any] | tuple[Any, ...] | bytes,
+    weights_only: bool = False,
 ):
     if isinstance(serialized, (dict, tuple)):
         return serialized
@@ -434,17 +435,20 @@ def deserialize_torch_artifact(
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
     # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
-    try:
+    if weights_only:
         artifact = torch.load(buffer, weights_only=True)
-    except Exception as e:
-        buffer.seek(0)
-        artifact = torch.load(buffer, weights_only=False)
-        log.warning(
-            "Fallback to weights_only=False succeeded. "
-            "Loaded object of type %s after initial failure: %s",
-            type(artifact),
-            exc_info=e,
-        )
+    else:
+        try:
+            artifact = torch.load(buffer, weights_only=True)
+        except Exception as e:
+            buffer.seek(0)
+            artifact = torch.load(buffer, weights_only=False)
+            log.warning(
+                "Fallback to weights_only=False succeeded. "
+                "Loaded object of type %s after initial failure: %s",
+                type(artifact),
+                exc_info=e,
+            )
     if not isinstance(artifact, (tuple, dict)):
         raise AssertionError(f"expected tuple or dict, got {type(artifact).__name__}")
     return artifact
@@ -2908,6 +2912,7 @@ class GraphModuleDeserializer(metaclass=Final):
         | bytes
         | None = None,
         symbol_name_to_range: dict[str, symbolic_shapes.ValueRanges] | None = None,
+        weights_only: bool = False,
     ) -> Result:
         global _CURRENT_DESERIALIZER
         if _CURRENT_DESERIALIZER is not None:
@@ -2950,7 +2955,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 "Identity": torch.utils._sympy.functions.Identity,
             }
             self.symbol_name_to_symbol: dict[str, sympy.Symbol] = {}
-            self.constants = deserialize_torch_artifact(constants)
+            self.constants = deserialize_torch_artifact(constants, weights_only=weights_only)
             self.signature = self.deserialize_signature(
                 serialized_graph_module.signature
             )
@@ -2986,7 +2991,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 self.shape_env.unbacked_symint_counter += 1
 
             if example_inputs is not None and len(example_inputs) > 0:
-                self.example_inputs = deserialize_torch_artifact(example_inputs)
+                self.example_inputs = deserialize_torch_artifact(example_inputs, weights_only=weights_only)
             else:
                 self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
@@ -3575,6 +3580,7 @@ class ExportedProgramDeserializer(metaclass=Final):
         | None = None,
         *,
         _unsafe_skip_version_check=False,
+        weights_only: bool = False,
     ) -> ep.ExportedProgram:
         if not isinstance(exported_program, ExportedProgram):
             raise AssertionError(
@@ -3605,6 +3611,7 @@ class ExportedProgramDeserializer(metaclass=Final):
             constants,
             example_inputs,
             symbol_name_to_range,
+            weights_only=weights_only,
         )
         range_constraints = self.deserialize_range_constraints(
             symbol_name_to_range,
@@ -3777,6 +3784,7 @@ def deserialize(
     expected_opset_version: dict[str, int] | None = None,
     *,
     _unsafe_skip_version_check=False,
+    weights_only: bool = False,
 ) -> ep.ExportedProgram:
     if not isinstance(artifact.exported_program, bytes):
         raise AssertionError(
@@ -3791,6 +3799,7 @@ def deserialize(
         artifact.constants,
         artifact.example_inputs,
         _unsafe_skip_version_check=_unsafe_skip_version_check,
+        weights_only=weights_only,
     )
 
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -3017,7 +3017,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict),
+                state_dict=deserialize_torch_artifact(serialized_state_dict, weights_only=weights_only),
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -297,7 +297,8 @@ def load(
         :func:`torch.export.load()` uses pickle under the hood to load models. **Never load data from an untrusted source.**
 
     Loads an :class:`ExportedProgram` previously saved with
-    :func:`torch.export.save <torch.export.save>`.
+    :func:`torch.export.save <torch.export.save>`. When ``weights_only=True``,
+    only weights will be loaded and no complex pickled objects.
 
     Args:
         f (str | os.PathLike[str] | IO[bytes]): A file-like object (has to

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -285,6 +285,7 @@ def load(
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    weights_only: bool = False,
 ) -> ExportedProgram:
     """
 
@@ -308,6 +309,10 @@ def load(
 
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        weights_only (bool): If True, only weights will be loaded and no complex
+         pickled objects. Recommended for untrusted sources. See :func:`torch.load`
+         for more details. Default: False.
 
     Returns:
         An :class:`ExportedProgram` object
@@ -343,6 +348,7 @@ def load(
         pt2_contents = load_pt2(
             f,
             expected_opset_version=expected_opset_version,
+            weights_only=weights_only,
         )
     except RuntimeError:
         log.warning("Ran into the following error when deserializing", exc_info=True)

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -435,7 +435,7 @@ def load(
         )
 
         # Deserialize ExportedProgram
-        ep = deserialize(artifact, expected_opset_version)
+        ep = deserialize(artifact, expected_opset_version, weights_only=weights_only)
 
         return ep
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1103,7 +1103,8 @@ def load_pt2(
     weights_only: bool = False,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
-    Loads all the artifacts previously saved with ``package_pt2``.
+    Loads all the artifacts previously saved with ``package_pt2``. When ``weights_only=True``,
+    only weights will be loaded and no complex pickled objects.
 
     Args:
         f (str | os.PathLike[str] | IO[bytes]): A file-like object (has to

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -968,7 +968,9 @@ def _load_constants(
 
             elif path_name.startswith(CUSTOM_OBJ_FILENAME_PREFIX):
                 if weights_only:
-                    raise ValueError(f"Cannot load custom object {path_name} with weights_only=True")
+                    raise ValueError(
+                        f"Cannot load custom object {path_name} with weights_only=True"
+                    )
                 constant_bytes = archive_reader.read_bytes(
                     os.path.join(CONSTANTS_DIR, path_name)
                 )
@@ -976,7 +978,9 @@ def _load_constants(
 
             elif path_name.startswith(OPAQUE_OBJ_FILENAME_PREFIX):
                 if weights_only:
-                    raise ValueError(f"Cannot load opaque object {path_name} with weights_only=True")
+                    raise ValueError(
+                        f"Cannot load opaque object {path_name} with weights_only=True"
+                    )
                 constant_bytes = archive_reader.read_bytes(
                     os.path.join(CONSTANTS_DIR, path_name)
                 )
@@ -1015,8 +1019,12 @@ def _load_exported_programs(
         serialized_exported_program = _bytes_to_dataclass(
             schema.ExportedProgram, exported_program_bytes
         )
-        state_dict = _load_state_dict(archive_reader, model_name, weights_only=weights_only)
-        constants = _load_constants(archive_reader, model_name, weights_only=weights_only)
+        state_dict = _load_state_dict(
+            archive_reader, model_name, weights_only=weights_only
+        )
+        constants = _load_constants(
+            archive_reader, model_name, weights_only=weights_only
+        )
 
         ep = ExportedProgramDeserializer(expected_opset_version).deserialize(
             serialized_exported_program,
@@ -1114,9 +1122,9 @@ def load_pt2(
             to be loaded. By default, `device_index=-1` is used, which corresponds
             to the device `cuda` when using CUDA. Passing `device_index=1` would
             load the package to `cuda:1`, for example.
-            
+
         load_weights_from_disk (bool): Whether to load weights from disk.
-        
+
         weights_only (bool): If True, only weights will be loaded and no complex
             pickled objects. Recommended for untrusted sources. See `torch.load`
             for more details. Default: False.
@@ -1155,7 +1163,10 @@ def load_pt2(
         file_names = archive_reader.get_file_names()
 
         exported_programs = _load_exported_programs(
-            archive_reader, file_names, expected_opset_version, weights_only=weights_only
+            archive_reader,
+            file_names,
+            expected_opset_version,
+            weights_only=weights_only,
         )
         extra_files = _load_extra_files(archive_reader, file_names)
 
@@ -1181,7 +1192,9 @@ def load_pt2(
                     len(WEIGHTS_DIR) :
                 ]  # remove data/weights/ prefix
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes), weights_only=weights_only)
+                loaded_weight = torch.load(
+                    io.BytesIO(weight_bytes), weights_only=weights_only
+                )
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1023,6 +1023,7 @@ def _load_exported_programs(
             state_dict,
             constants,
             serialized_sample_inputs,
+            weights_only=weights_only,
         )
 
         exported_programs[model_name] = ep

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -861,6 +861,7 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
@@ -888,7 +889,7 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=False
+                    io.BytesIO(weight_bytes), weights_only=weights_only
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -917,6 +918,7 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
@@ -946,7 +948,7 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=False
+                        io.BytesIO(constant_bytes), weights_only=weights_only
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -965,12 +967,16 @@ def _load_constants(
                     constants[constant_fqn] = constant_tensor
 
             elif path_name.startswith(CUSTOM_OBJ_FILENAME_PREFIX):
+                if weights_only:
+                    raise ValueError(f"Cannot load custom object {path_name} with weights_only=True")
                 constant_bytes = archive_reader.read_bytes(
                     os.path.join(CONSTANTS_DIR, path_name)
                 )
                 constants[constant_fqn] = torch._C._pickle_load_obj(constant_bytes)
 
             elif path_name.startswith(OPAQUE_OBJ_FILENAME_PREFIX):
+                if weights_only:
+                    raise ValueError(f"Cannot load opaque object {path_name} with weights_only=True")
                 constant_bytes = archive_reader.read_bytes(
                     os.path.join(CONSTANTS_DIR, path_name)
                 )
@@ -986,6 +992,7 @@ def _load_exported_programs(
     archive_reader: PT2ArchiveReader,
     file_names: list[str],
     expected_opset_version: dict[str, int] | None,
+    weights_only: bool = False,
 ) -> dict[str, ExportedProgram]:
     exported_program_files = [
         file for file in file_names if file.startswith(MODELS_DIR)
@@ -1008,8 +1015,8 @@ def _load_exported_programs(
         serialized_exported_program = _bytes_to_dataclass(
             schema.ExportedProgram, exported_program_bytes
         )
-        state_dict = _load_state_dict(archive_reader, model_name)
-        constants = _load_constants(archive_reader, model_name)
+        state_dict = _load_state_dict(archive_reader, model_name, weights_only=weights_only)
+        constants = _load_constants(archive_reader, model_name, weights_only=weights_only)
 
         ep = ExportedProgramDeserializer(expected_opset_version).deserialize(
             serialized_exported_program,
@@ -1084,6 +1091,7 @@ def load_pt2(
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
+    weights_only: bool = False,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.
@@ -1105,6 +1113,12 @@ def load_pt2(
             to be loaded. By default, `device_index=-1` is used, which corresponds
             to the device `cuda` when using CUDA. Passing `device_index=1` would
             load the package to `cuda:1`, for example.
+            
+        load_weights_from_disk (bool): Whether to load weights from disk.
+        
+        weights_only (bool): If True, only weights will be loaded and no complex
+            pickled objects. Recommended for untrusted sources. See `torch.load`
+            for more details. Default: False.
 
     Returns:
         A ``PT2ArchiveContents`` object which contains all the objects in the PT2.
@@ -1140,7 +1154,7 @@ def load_pt2(
         file_names = archive_reader.get_file_names()
 
         exported_programs = _load_exported_programs(
-            archive_reader, file_names, expected_opset_version
+            archive_reader, file_names, expected_opset_version, weights_only=weights_only
         )
         extra_files = _load_extra_files(archive_reader, file_names)
 
@@ -1166,7 +1180,7 @@ def load_pt2(
                     len(WEIGHTS_DIR) :
                 ]  # remove data/weights/ prefix
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes))
+                loaded_weight = torch.load(io.BytesIO(weight_bytes), weights_only=weights_only)
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):


### PR DESCRIPTION
Fixes #163759
Fixes #172787

When compiled by `aot_eager` with `dynamic=True`, `torch.combinations` failed with `RuntimeError: Cannot call numel() on tensor with symbolic sizes/strides` because the C++ implementation used `numel()` instead of `sym_numel()`. 
This PR fixes the issue by updating `numel()` to `sym_numel()` and modifying the internal `_triu_mask` helper to accept `c10::SymInt`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo