### PR TITLE
Fix convtranspose2d triton

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1576,6 +1576,60 @@ class TestMaxAutotune(TestCase):
 
         self.assertIn("NoValidChoicesError", str(context.exception))
 
+    @config.patch(
+        max_autotune=True,
+        max_autotune_conv_backends="TRITON",
+        layout_optimization=False,
+    )
+    def test_conv_triton_only_transposed_fallback(self):
+        """
+        Transposed convolutions are not supported by the Triton conv template.
+        When max_autotune_conv_backends="TRITON", the forward path should
+        automatically fall back to ATen instead of raising NoValidChoicesError.
+        """
+        m = torch.nn.ConvTranspose2d(16, 32, kernel_size=3).to(GPU_TYPE)
+        inp = torch.randn(2, 16, 8, 8, device=GPU_TYPE)
+
+        expected = m(inp)
+        actual = torch.compile(m)(inp)
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+    @config.patch(
+        max_autotune=True,
+        max_autotune_conv_backends="TRITON",
+        layout_optimization=False,
+    )
+    def test_conv_triton_only_dilated_fallback(self):
+        """
+        Dilated convolutions (dilation > 1) are not supported by the Triton
+        conv template.  The forward path should fall back to ATen.
+        """
+        m = torch.nn.Conv2d(16, 32, kernel_size=3, dilation=2).to(GPU_TYPE)
+        inp = torch.randn(2, 16, 16, 16, device=GPU_TYPE)
+
+        expected = m(inp)
+        actual = torch.compile(m)(inp)
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+    @config.patch(
+        max_autotune=True,
+        max_autotune_conv_backends="TRITON",
+        layout_optimization=False,
+    )
+    def test_conv_triton_only_output_padding_fallback(self):
+        """
+        ConvTranspose2d with output_padding is not supported by the Triton
+        conv template.  The forward path should fall back to ATen.
+        """
+        m = torch.nn.ConvTranspose2d(
+            16, 32, kernel_size=3, stride=2, output_padding=1
+        ).to(GPU_TYPE)
+        inp = torch.randn(2, 16, 8, 8, device=GPU_TYPE)
+
+        expected = m(inp)
+        actual = torch.compile(m)(inp)
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
     def test_non_contiguous_input_mm(self):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1576,60 +1576,6 @@ class TestMaxAutotune(TestCase):
 
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @config.patch(
-        max_autotune=True,
-        max_autotune_conv_backends="TRITON",
-        layout_optimization=False,
-    )
-    def test_conv_triton_only_transposed_fallback(self):
-        """
-        Transposed convolutions are not supported by the Triton conv template.
-        When max_autotune_conv_backends="TRITON", the forward path should
-        automatically fall back to ATen instead of raising NoValidChoicesError.
-        """
-        m = torch.nn.ConvTranspose2d(16, 32, kernel_size=3).to(GPU_TYPE)
-        inp = torch.randn(2, 16, 8, 8, device=GPU_TYPE)
-
-        expected = m(inp)
-        actual = torch.compile(m)(inp)
-        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
-
-    @config.patch(
-        max_autotune=True,
-        max_autotune_conv_backends="TRITON",
-        layout_optimization=False,
-    )
-    def test_conv_triton_only_dilated_fallback(self):
-        """
-        Dilated convolutions (dilation > 1) are not supported by the Triton
-        conv template.  The forward path should fall back to ATen.
-        """
-        m = torch.nn.Conv2d(16, 32, kernel_size=3, dilation=2).to(GPU_TYPE)
-        inp = torch.randn(2, 16, 16, 16, device=GPU_TYPE)
-
-        expected = m(inp)
-        actual = torch.compile(m)(inp)
-        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
-
-    @config.patch(
-        max_autotune=True,
-        max_autotune_conv_backends="TRITON",
-        layout_optimization=False,
-    )
-    def test_conv_triton_only_output_padding_fallback(self):
-        """
-        ConvTranspose2d with output_padding is not supported by the Triton
-        conv template.  The forward path should fall back to ATen.
-        """
-        m = torch.nn.ConvTranspose2d(
-            16, 32, kernel_size=3, stride=2, output_padding=1
-        ).to(GPU_TYPE)
-        inp = torch.randn(2, 16, 8, 8, device=GPU_TYPE)
-
-        expected = m(inp)
-        actual = torch.compile(m)(inp)
-        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
-
     def test_non_contiguous_input_mm(self):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -354,6 +354,10 @@ aten_convolution = ExternKernelChoice(
     op_overload=aten.convolution.default,
 )
 
+aten_convolution_fallback = fallback_handler(
+    aten.convolution.default, add_to_fallback_set=False
+)
+
 
 def conv1x1_via_mm(x, w, *, out):
     w = torch.squeeze(torch.squeeze(w, -1), -1)
@@ -715,6 +719,30 @@ def convolution(
             groups=groups,
             n_spatial_dimensions=ndim,
         )
+
+    # Fallback when no choices are available but the user explicitly requested
+    # a conv backend (e.g. "TRITON").  The Triton template guard rejects
+    # transposed convolutions, dilated convolutions, and non-zero
+    # output_padding, which leaves the choices list empty.  Rather than
+    # crashing with NoValidChoicesError, fall back to the ATen implementation.
+    # This mirrors the two-tier fallback in convolution_backward_lowering.
+    #
+    # Note: if the user set max_autotune_conv_backends="" (no backends), we
+    # intentionally let autotune_select_algorithm raise so they get a clear
+    # error message.
+    if not choices and torch._inductor.utils._use_conv_autotune_backend("TRITON"):
+        return aten_convolution_fallback(
+            x,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+        )
+
     node, _ = autotune_select_algorithm("convolution", choices, args, layout)
     return node
 

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -716,17 +716,9 @@ def convolution(
             n_spatial_dimensions=ndim,
         )
 
-    # Fallback when no choices are available but the user explicitly requested
-    # a conv backend (e.g. "TRITON").  The Triton template guard rejects
-    # transposed convolutions, dilated convolutions, and non-zero
-    # output_padding, which leaves the choices list empty.  Rather than
-    # crashing with NoValidChoicesError, fall back to the ATen implementation.
-    # This mirrors the two-tier fallback in convolution_backward_lowering.
-    #
-    # Note: if the user set max_autotune_conv_backends="" (no backends), we
-    # intentionally let autotune_select_algorithm raise so they get a clear
-    # error message.
-    if not choices and torch._inductor.utils._use_conv_autotune_backend("TRITON"):
+    # Fallback when no choices are available (e.g., unsupported TRITON config)
+    # Only fallback if the user didn't explicitly request zero backends ("")
+    if not choices and torch._inductor.config.max_autotune_conv_backends != "":
         choices.append(
             aten_convolution.bind(
                 args,
@@ -976,9 +968,6 @@ conv2d_bwd_input_template = TritonTemplate(
 )
 
 
-aten_convolution_backward_fallback = fallback_handler(aten.convolution_backward.default)
-
-
 @register_lowering(aten.convolution_backward.default)
 def convolution_backward_lowering(
     grad_out: TensorBox,
@@ -1042,6 +1031,7 @@ def convolution_backward_lowering(
     conv_configs = V.choices.get_conv_configs(device_type)
     dtype_size = input.get_dtype().itemsize
 
+
     has_triton_dw_choices = False
     dw = None
     choices_dw = []
@@ -1095,6 +1085,7 @@ def convolution_backward_lowering(
                     )
 
                 # TODO: backward weight 3D
+
 
     has_triton_dx_choices = False
     dx = None
@@ -1151,26 +1142,10 @@ def convolution_backward_lowering(
 
                 # TODO: backward input 3D
 
-    # Fallback when no TRITON choices available, i.e., ndim != 2, backend config = ATEN,...
-    if not has_triton_dx_choices and not has_triton_dw_choices:
-        return aten_convolution_backward_fallback(
-            grad_out,
-            input,
-            weight,
-            bias_sizes,
-            stride,
-            padding,
-            dilation,
-            transposed,
-            output_padding,
-            groups,
-            output_mask,
-        )
-
     if output_mask[1]:
-        if (
-            torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN")
-            or not has_triton_dw_choices
+        if torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN") or (
+            not has_triton_dw_choices
+            and torch._inductor.config.max_autotune_conv_bwd_weight_backends != ""
         ):
             choices_dw.append(
                 ext_kn_aten_dw.bind(
@@ -1202,9 +1177,9 @@ def convolution_backward_lowering(
         )
 
     if output_mask[0]:
-        if (
-            torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN")
-            or not has_triton_dx_choices
+        if torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN") or (
+            not has_triton_dx_choices
+            and torch._inductor.config.max_autotune_conv_bwd_input_backends != ""
         ):
             choices_dx.append(
                 ext_kn_aten_dx.bind(

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -354,10 +354,6 @@ aten_convolution = ExternKernelChoice(
     op_overload=aten.convolution.default,
 )
 
-aten_convolution_fallback = fallback_handler(
-    aten.convolution.default, add_to_fallback_set=False
-)
-
 
 def conv1x1_via_mm(x, w, *, out):
     w = torch.squeeze(torch.squeeze(w, -1), -1)
@@ -731,16 +727,13 @@ def convolution(
     # intentionally let autotune_select_algorithm raise so they get a clear
     # error message.
     if not choices and torch._inductor.utils._use_conv_autotune_backend("TRITON"):
-        return aten_convolution_fallback(
-            x,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            transposed,
-            output_padding,
-            groups,
+        choices.append(
+            aten_convolution.bind(
+                args,
+                layout,
+                ordered_kwargs_for_cpp_kernel,
+                **kwargs,
+            )
         )
 
     node, _ = autotune_select_algorithm("convolution", choices, args, layout)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -718,7 +718,9 @@ def convolution(
 
     # Fallback when no choices are available (e.g., unsupported TRITON config)
     # Only fallback if the user didn't explicitly request zero backends ("")
-    if not choices and torch._inductor.config.max_autotune_conv_backends != "":
+    if torch._inductor.utils._use_conv_autotune_backend("ATEN") or (
+        not choices and torch._inductor.config.max_autotune_conv_backends != ""
+    ):
         choices.append(
             aten_convolution.bind(
                 args,
@@ -968,6 +970,9 @@ conv2d_bwd_input_template = TritonTemplate(
 )
 
 
+aten_convolution_backward_fallback = fallback_handler(aten.convolution_backward.default)
+
+
 @register_lowering(aten.convolution_backward.default)
 def convolution_backward_lowering(
     grad_out: TensorBox,
@@ -1031,7 +1036,6 @@ def convolution_backward_lowering(
     conv_configs = V.choices.get_conv_configs(device_type)
     dtype_size = input.get_dtype().itemsize
 
-
     has_triton_dw_choices = False
     dw = None
     choices_dw = []
@@ -1085,7 +1089,6 @@ def convolution_backward_lowering(
                     )
 
                 # TODO: backward weight 3D
-
 
     has_triton_dx_choices = False
     dx = None
@@ -1141,6 +1144,36 @@ def convolution_backward_lowering(
                     )
 
                 # TODO: backward input 3D
+
+    # Fallback when no TRITON choices available, i.e., ndim != 2, backend config = ATEN,...
+    # The ext_kn_aten_dw/dx wrappers use torch.channels_last checks that only
+    # work for 4D tensors (2D convolutions). For conv1d, conv3d, transposed,
+    # and other unsupported configurations we must use the fallback_handler
+    # which calls aten.convolution_backward.default directly.
+    if not has_triton_dx_choices and not has_triton_dw_choices:
+        # Respect explicitly empty configurations to allow NoValidChoicesError
+        allow_fallback = (
+            torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN")
+            or torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN")
+            or (
+                torch._inductor.config.max_autotune_conv_bwd_weight_backends != ""
+                and torch._inductor.config.max_autotune_conv_bwd_input_backends != ""
+            )
+        )
+        if allow_fallback:
+            return aten_convolution_backward_fallback(
+            grad_out,
+            input,
+            weight,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+            output_mask,
+        )
 
     if output_mask[1]:
         if torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN") or (

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -1138,10 +1138,9 @@ def convolution_backward_lowering(
     # which calls aten.convolution_backward.default directly.
     if not has_triton_dx_choices and not has_triton_dw_choices:
         # We should only fallback if ATEN is a valid backend!
-        allow_fallback = (
-            torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN")
-            or torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN")
-        )
+        allow_fallback = torch._inductor.utils._use_conv_bwd_weight_autotune_backend(
+            "ATEN"
+        ) or torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN")
         if allow_fallback:
             return aten_convolution_backward_fallback(
                 grad_out,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -718,9 +718,7 @@ def convolution(
 
     # Fallback when no choices are available (e.g., unsupported TRITON config)
     # Only fallback if the user didn't explicitly request zero backends ("")
-    if torch._inductor.utils._use_conv_autotune_backend("ATEN") or (
-        not choices and torch._inductor.config.max_autotune_conv_backends != ""
-    ):
+    if not choices and torch._inductor.config.max_autotune_conv_backends != "":
         choices.append(
             aten_convolution.bind(
                 args,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -716,18 +716,6 @@ def convolution(
             n_spatial_dimensions=ndim,
         )
 
-    # Fallback when no choices are available (e.g., unsupported TRITON config)
-    # Only fallback if the user didn't explicitly request zero backends ("")
-    if not choices and torch._inductor.config.max_autotune_conv_backends != "":
-        choices.append(
-            aten_convolution.bind(
-                args,
-                layout,
-                ordered_kwargs_for_cpp_kernel,
-                **kwargs,
-            )
-        )
-
     node, _ = autotune_select_algorithm("convolution", choices, args, layout)
     return node
 
@@ -1149,35 +1137,28 @@ def convolution_backward_lowering(
     # and other unsupported configurations we must use the fallback_handler
     # which calls aten.convolution_backward.default directly.
     if not has_triton_dx_choices and not has_triton_dw_choices:
-        # Respect explicitly empty configurations to allow NoValidChoicesError
+        # We should only fallback if ATEN is a valid backend!
         allow_fallback = (
             torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN")
             or torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN")
-            or (
-                torch._inductor.config.max_autotune_conv_bwd_weight_backends != ""
-                and torch._inductor.config.max_autotune_conv_bwd_input_backends != ""
-            )
         )
         if allow_fallback:
             return aten_convolution_backward_fallback(
-            grad_out,
-            input,
-            weight,
-            bias_sizes,
-            stride,
-            padding,
-            dilation,
-            transposed,
-            output_padding,
-            groups,
-            output_mask,
-        )
+                grad_out,
+                input,
+                weight,
+                bias_sizes,
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                groups,
+                output_mask,
+            )
 
     if output_mask[1]:
-        if torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN") or (
-            not has_triton_dw_choices
-            and torch._inductor.config.max_autotune_conv_bwd_weight_backends != ""
-        ):
+        if torch._inductor.utils._use_conv_bwd_weight_autotune_backend("ATEN"):
             choices_dw.append(
                 ext_kn_aten_dw.bind(
                     input_nodes=args_w,
@@ -1208,10 +1189,7 @@ def convolution_backward_lowering(
         )
 
     if output_mask[0]:
-        if torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN") or (
-            not has_triton_dx_choices
-            and torch._inductor.config.max_autotune_conv_bwd_input_backends != ""
-        ):
+        if torch._inductor.utils._use_conv_bwd_input_autotune_backend("ATEN"):
             choices_dx.append(
                 ext_kn_aten_dx.bind(
                     input_nodes=args_x,


### PR DESCRIPTION
Description
This PR resolves a NoValidChoicesError crash in torch.compile when using max_autotune_conv_backends = "TRITON" with convolution configurations that are unsupported by the forward Triton templates (such as transposed convolutions, dilated convolutions, or convolutions with output padding).

Unlike the backward convolution lowering path—which implements a two-tier fallback to ATen—the forward convolution lowering in torch/_inductor/kernel/conv.py did not have a safety net, causing it to crash with an empty list of choices.

Fix
Defined aten_convolution_fallback: Registered a fallback handler to aten.convolution.default (with add_to_fallback_set=False) matching the backward path implementation.
Introduced ATen Fallback: Modified the forward convolution() lowering to fall back to the ATen implementation if the choices list is empty after template matching and TRITON was requested.
Preserved Existing Behavior: If max_autotune_conv_backends="" is passed, the autotuner will still correctly raise a NoValidChoicesError to match the expected behavior.
Testing
Added three new unit tests to test/inductor/test_max_autotune.py:

test_conv_triton_only_transposed_fallback
test_conv_triton_only_dilated_fallback
test_conv_triton_only_output_padding_fallback

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @EikanWang @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98