### PR TITLE
Remove redundant conditional in _dump_launch_params

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -230,10 +230,7 @@ def _dump_launch_params(args, kwargs, launcher, kernel_name, grid):
         else:
             call_args.append("T")
     for k, v in kwargs.items():
-        if isinstance(arg, (int, bool)):
-            call_kwargs[k] = v
-        else:
-            call_kwargs[k] = v
+        call_kwargs[k] = v
     call_kwargs.update(launcher.config.kwargs)
     call_kwargs["num_warps"] = launcher.config.num_warps
     call_kwargs["num_stages"] = launcher.config.num_stages

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -223,14 +223,12 @@ def autotune_hints_to_configs(
 
 def _dump_launch_params(args, kwargs, launcher, kernel_name, grid):
     call_args = []
-    call_kwargs = {}
+    call_kwargs = dict(kwargs)
     for arg in args:
         if isinstance(arg, (int, bool)):
             call_args.append(str(arg))
         else:
             call_args.append("T")
-    for k, v in kwargs.items():
-        call_kwargs[k] = v
     call_kwargs.update(launcher.config.kwargs)
     call_kwargs["num_warps"] = launcher.config.num_warps
     call_kwargs["num_stages"] = launcher.config.num_stages


### PR DESCRIPTION
## Summary

Remove a redundant conditional in `_dump_launch_params`.

The current implementation contains:

```python
for k, v in kwargs.items():
    if isinstance(arg, (int, bool)):
        call_kwargs[k] = v
    else:
        call_kwargs[k] = v
```

Both branches perform the same assignment, so the conditional has no effect on behavior.

This PR simplifies the code to:

```python
for k, v in kwargs.items():
    call_kwargs[k] = v
```

## Test Plan

No functional change intended.

This change removes a redundant conditional while preserving the existing behavior of `_dump_launch_params`.

Verified that the resulting behavior is unchanged since both branches of the original conditional performed the same assignment.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo