### PR TITLE
Preserve guard eval defaulting without callback churn

### DIFF
--- a/test/dynamo/test_frame_init.py
+++ b/test/dynamo/test_frame_init.py
@@ -1,8 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
 import torch
+import torch._dynamo.guards
 import torch._dynamo.test_case
-from torch._C._dynamo.eval_frame import set_eval_frame
+from torch._C._dynamo.eval_frame import get_eval_frame_callback, set_eval_frame
 from torch._dynamo.types import ConvertFrameReturn, GuardedCode, wrap_guarded_code
 from torch._guards import CompileId
 
@@ -78,6 +79,9 @@ def varargs_code2(arg1, /, positional_only_arg, *varargs, **kwargs):
 
 
 class FrameInitTests(torch._dynamo.test_case.TestCase):
+    def _compile_id(self):
+        return CompileId(frame_id=None, frame_compile_id=0, compiled_autograd_id=0)
+
     def test_frame_init(self):
         code_map1 = {
             target_with_varargs.__code__: varargs_code1.__code__,
@@ -97,9 +101,7 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
                     GuardedCode(
                         transformed_code,
                         empty_guard_manager,
-                        CompileId(
-                            frame_id=None, frame_compile_id=0, compiled_autograd_id=0
-                        ),
+                        self._compile_id(),
                     )
                 )
             return ConvertFrameReturn()
@@ -111,9 +113,7 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
                     GuardedCode(
                         transformed_code,
                         empty_guard_manager,
-                        CompileId(
-                            frame_id=None, frame_compile_id=0, compiled_autograd_id=0
-                        ),
+                        self._compile_id(),
                     )
                 )
             return ConvertFrameReturn()
@@ -136,6 +136,121 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(real_varargs_output, expected_varargs_output)
             self.assertEqual(real_kwargs_output, expected_kwargs_output)
             set_eval_frame(original)
+
+    def test_guard_eval_recursion_uses_default_eval_frame(self):
+        guard_calls = []
+        helper_intercepts = []
+
+        def target(x):
+            return x + 1
+
+        def target_code(x):
+            return x + 1
+
+        def helper():
+            guard_calls.append("helper")
+            return True
+
+        def helper_code():
+            return False
+
+        target_guard_manager = torch._dynamo.guards.GuardManagerWrapper()
+        target_guard_manager.root.add_lambda_guard(
+            lambda _f_locals: helper(), ["helper()"], None
+        )
+        empty_guard_manager = torch._dynamo.guards.GuardManagerWrapper()
+
+        def callback(frame, cache_entry, frame_state):
+            if frame.f_code is target.__code__:
+                return wrap_guarded_code(
+                    GuardedCode(
+                        target_code.__code__,
+                        target_guard_manager,
+                        self._compile_id(),
+                    )
+                )
+            if frame.f_code is helper.__code__:
+                helper_intercepts.append(frame.f_code.co_name)
+                return wrap_guarded_code(
+                    GuardedCode(
+                        helper_code.__code__,
+                        empty_guard_manager,
+                        self._compile_id(),
+                    )
+                )
+            return ConvertFrameReturn()
+
+        torch._dynamo.reset()
+        original = set_eval_frame(callback)
+        try:
+            self.assertEqual(target(1), 2)
+            self.assertEqual(target(1), 2)
+        finally:
+            set_eval_frame(original)
+
+        self.assertEqual(guard_calls, ["helper"])
+        self.assertEqual(helper_intercepts, [])
+
+    def test_run_only_guard_eval_uses_default_eval_frame_for_nested_frames(self):
+        guard_callbacks = []
+        helper_calls = []
+
+        def target(x):
+            return x + 1
+
+        def target_code(x):
+            return x + 1
+
+        def helper():
+            helper_calls.append("eager")
+            return True
+
+        def helper_code():
+            helper_calls.append("cached")
+            return False
+
+        target_guard_manager = torch._dynamo.guards.GuardManagerWrapper()
+        target_guard_manager.root.add_lambda_guard(
+            lambda _f_locals: (
+                guard_callbacks.append(get_eval_frame_callback()) or helper()
+            ),
+            ["helper()"],
+            None,
+        )
+        empty_guard_manager = torch._dynamo.guards.GuardManagerWrapper()
+
+        def callback(frame, cache_entry, frame_state):
+            if frame.f_code is target.__code__:
+                return wrap_guarded_code(
+                    GuardedCode(
+                        target_code.__code__,
+                        target_guard_manager,
+                        self._compile_id(),
+                    )
+                )
+            if frame.f_code is helper.__code__:
+                return wrap_guarded_code(
+                    GuardedCode(
+                        helper_code.__code__,
+                        empty_guard_manager,
+                        self._compile_id(),
+                    )
+                )
+            return ConvertFrameReturn()
+
+        torch._dynamo.reset()
+        original = set_eval_frame(callback)
+        try:
+            self.assertFalse(helper())
+            self.assertEqual(target(1), 2)
+            helper_calls.clear()
+        finally:
+            set_eval_frame(original)
+
+        self.assertEqual(torch._dynamo.run(target)(1), 2)
+
+        self.assertEqual(guard_callbacks, [False])
+        self.assertEqual(helper_calls, ["eager"])
 
 
 if __name__ == "__main__":

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -512,6 +512,10 @@ static PyObject* dynamo__custom_eval_frame_shim(
     PyThreadState* tstate,
     THP_EVAL_API_FRAME_OBJECT* frame,
     int throw_flag) {
+  if (unlikely(dynamo_is_guard_eval())) {
+    return dynamo_eval_frame_default(tstate, frame, throw_flag);
+  }
+
   // Shims logic into one of three states. Can probably be refactored into a
   // single func, later:
   //  - None: disables TorchDynamo

--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -25,19 +25,37 @@ extern PyObject* guard_complete_hook;
 namespace {
 PyObject* bytecode_debugger_callback_obj = nullptr;
 std::unordered_set<PyCodeObject*> breakpoint_code_objects;
+thread_local int guard_eval_depth = 0;
+
+struct GuardEvalFrameDefault {
+  GuardEvalFrameDefault() {
+    guard_eval_depth++;
+  }
+
+  ~GuardEvalFrameDefault() {
+    guard_eval_depth--;
+  }
+
+  GuardEvalFrameDefault(const GuardEvalFrameDefault&) = delete;
+  GuardEvalFrameDefault& operator=(const GuardEvalFrameDefault&) = delete;
+  GuardEvalFrameDefault(GuardEvalFrameDefault&&) = delete;
+  GuardEvalFrameDefault& operator=(GuardEvalFrameDefault&&) = delete;
+};
 
 // RAII guard that calls __exit__ on a Python context manager when destroyed.
 struct DebugContextGuard {
   py::object ctx;
 
-  explicit DebugContextGuard(py::object c) : ctx(std::move(c)) {
+  explicit DebugContextGuard(const py::object& c) : ctx(c) {
     ctx.attr("__enter__")();
   }
 
   ~DebugContextGuard() {
     // Save any pending Python exception (e.g. KeyboardInterrupt from the
     // debugger's 'q' command) so calling __exit__ doesn't clobber it.
-    PyObject *exc_type, *exc_value, *exc_tb;
+    PyObject* exc_type = nullptr;
+    PyObject* exc_value = nullptr;
+    PyObject* exc_tb = nullptr;
     PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
     try {
       ctx.attr("__exit__")(py::none(), py::none(), py::none());
@@ -52,11 +70,17 @@ struct DebugContextGuard {
 
   DebugContextGuard(const DebugContextGuard&) = delete;
   DebugContextGuard& operator=(const DebugContextGuard&) = delete;
+  DebugContextGuard(DebugContextGuard&&) = delete;
+  DebugContextGuard& operator=(DebugContextGuard&&) = delete;
 };
 
 } // namespace
 
-void set_bytecode_debugger_callback(py::object callback) {
+extern "C" int dynamo_is_guard_eval(void) {
+  return guard_eval_depth > 0;
+}
+
+void set_bytecode_debugger_callback(const py::object& callback) {
   if (callback.is_none()) {
     Py_XSETREF(bytecode_debugger_callback_obj, nullptr);
   } else {
@@ -72,7 +96,7 @@ py::object get_bytecode_debugger_callback() {
       py::handle(bytecode_debugger_callback_obj));
 }
 
-void register_breakpoint_code(py::object code) {
+void register_breakpoint_code(const py::object& code) {
   breakpoint_code_objects.insert((PyCodeObject*)code.ptr());
 }
 
@@ -328,6 +352,10 @@ struct CRecursionLimitRAII {
   ~CRecursionLimitRAII() {
     this->tstate->c_recursion_remaining = this->old_recursion_remaining;
   }
+  CRecursionLimitRAII(const CRecursionLimitRAII&) = delete;
+  CRecursionLimitRAII& operator=(const CRecursionLimitRAII&) = delete;
+  CRecursionLimitRAII(CRecursionLimitRAII&&) = delete;
+  CRecursionLimitRAII& operator=(CRecursionLimitRAII&&) = delete;
 };
 
 #else
@@ -528,55 +556,60 @@ PyObject* dynamo__custom_eval_frame(
       std::make_unique<FrameLocalsMapping>(frame);
   PyObject* backend = get_backend(callback.ptr()); // borrowed
 
-  // We don't run the current custom_eval_frame behavior for guards.
-  // So we temporarily set the callback to Py_None to drive the correct behavior
-  // in the shim.
-  eval_frame_callback_set(Py_None);
-
   DEBUG_CHECK(PyDict_CheckExact(frame->f_globals));
   DEBUG_CHECK(PyDict_CheckExact(frame->f_builtins));
 
-  _PytorchRecordFunctionState* rf =
-      _pytorch_record_function_enter(cache_lookup_profiler_str);
   PyObject* maybe_cached_code = nullptr;
-  lookup(
-      extra,
-      locals.get(),
-      backend,
-      isolate_recompiles_id,
-      &maybe_cached_code,
-      &trace_annotation,
-      is_skip_guard_eval_unsafe);
-  _pytorch_record_function_exit(rf);
-
   // A callback of Py_False indicates "run only" mode, the cache is checked,
   // but we never compile.
   bool run_only = strategy.cur_action == FrameAction::RUN_ONLY ||
-      callback.is(py::bool_(false));
+      Py_IsFalse(callback.ptr());
+
+  {
+    // We don't run the current custom_eval_frame behavior for guards.
+    // Recursive frames entered while guards or guard hooks run should go
+    // straight to the default evaluator, but mutating the callback object for
+    // every cache lookup is too expensive on run-only hot paths.
+    GuardEvalFrameDefault guard_eval;
+
+    _PytorchRecordFunctionState* rf =
+        _pytorch_record_function_enter(cache_lookup_profiler_str);
+    lookup(
+        extra,
+        locals.get(),
+        backend,
+        isolate_recompiles_id,
+        &maybe_cached_code,
+        &trace_annotation,
+        is_skip_guard_eval_unsafe);
+    _pytorch_record_function_exit(rf);
+
+    if (maybe_cached_code == nullptr) {
+      // guard eval failed, keep propagating
+      fail();
+      return eval_result;
+    }
+
+    // NB: We only do guard collectives when there are compiled code entries
+    // for the current region (or the default region); this reduces
+    // overtriggering and we don't need to do guard collectives the very first
+    // time we've seen a frame in this region.
+    bool has_relevant_entries =
+        extra->cache_entry_map.count(isolate_recompiles_id) > 0 ||
+        extra->cache_entry_map.count(-1) > 0;
+    if (guard_complete_hook != nullptr && has_relevant_entries) {
+      py::handle guard_complete_hook_handle(guard_complete_hook);
+      // False means force compilation (someone cache missed)
+      py::object res =
+          guard_complete_hook_handle(!Py_IsNone(maybe_cached_code));
+      if (!py::cast<bool>(res)) {
+        maybe_cached_code = Py_None; // NB: non-owning
+      }
+    }
+  }
+
   if (run_only) {
     DEBUG_TRACE("In run only mode %s", get_frame_name(frame));
-  }
-
-  if (maybe_cached_code == nullptr) {
-    // guard eval failed, keep propagating
-    fail();
-    return eval_result;
-  }
-
-  // NB: We only do guard collectives when there are compiled code entries
-  // for the current region (or the default region); this reduces
-  // overtriggering and we don't need to do guard collectives the very first
-  // time we've seen a frame in this region.
-  bool has_relevant_entries =
-      extra->cache_entry_map.count(isolate_recompiles_id) > 0 ||
-      extra->cache_entry_map.count(-1) > 0;
-  if (guard_complete_hook != nullptr && has_relevant_entries) {
-    py::handle guard_complete_hook_handle(guard_complete_hook);
-    // False means force compilation (someone cache missed)
-    py::object res = guard_complete_hook_handle(!Py_IsNone(maybe_cached_code));
-    if (!py::cast<bool>(res)) {
-      maybe_cached_code = Py_None; // NB: non-owning
-    }
   }
 
   if (!Py_IsNone(maybe_cached_code)) {
@@ -605,6 +638,7 @@ PyObject* dynamo__custom_eval_frame(
   }
 
   // call callback
+  eval_frame_callback_set(Py_None);
   CacheEntry* cache_entry = extract_cache_entry(extra, isolate_recompiles_id);
   FrameState* frame_state = extract_frame_state(extra);
   py::object callback_result;

--- a/torch/csrc/dynamo/eval_frame_cpp.h
+++ b/torch/csrc/dynamo/eval_frame_cpp.h
@@ -22,6 +22,8 @@ PyObject* dynamo__custom_eval_frame(
 PyObject* dynamo_set_code_exec_strategy(PyObject* dummy, PyObject* obj);
 void dynamo_skip_code_recursive(PyCodeObject* code);
 
+int dynamo_is_guard_eval(void);
+
 void dynamo_set_c_recursion_limit(int32_t limit);
 int32_t dynamo_get_c_recursion_limit();
 
@@ -30,11 +32,11 @@ int32_t dynamo_get_c_recursion_limit();
 } // extern "C"
 
 // Bytecode debugger callback functions
-void set_bytecode_debugger_callback(py::object callback);
+void set_bytecode_debugger_callback(const py::object& callback);
 py::object get_bytecode_debugger_callback();
 
 // Breakpoint code object tracking
-void register_breakpoint_code(py::object code);
+void register_breakpoint_code(const py::object& code);
 
 // NullStackValue - sentinel class for representing NULL values on Python stack
 class NullStackValue {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186118

Commit fe4fa1df moved the eval-frame callback to None before guard lookup so frames entered from guard evaluation would run through the default evaluator instead of recursively hitting Dynamo. That fixed guard-eval reentrancy, but it also made explicit run-only cache hits from torch._dynamo.run() mutate the eval-frame callback on every lookup. The torchbench timing loop exercises that path, so the extra callback churn showed up as a CPU Inductor MAML regression.

Keep guard-eval nested frames on the default evaluator without changing the callback object for every lookup. Guard lookup and guard_complete_hook now run under a thread-local guard-eval depth, and the C shim checks that depth before consulting the callback. Nested frames entered from guards still bypass Dynamo, including explicit callback=False run-only mode, while the run-only cache-hit hot path avoids the repeated callback mutation. The compile callback path still sets the callback to None before invoking Python.

An earlier option was to simply leave callback=False active during run-only guard lookup. That avoided the callback write, but it was unsafe because guard helper frames with cached Dynamo entries could execute cached code during guard evaluation. The depth check preserves the original default-eval invariant instead.

Benchmark Results:
On this newer checkout, the historical full torchbench MAML profile from the issue did not reproduce exactly: the local run captured 131 calls at about 78-81 ms rather than the reported 435 calls at about 98 ms. Focused cache-hit microbenchmarks were used to validate the hot path:

Temporary callback-mutation baseline, direct run-only cache hit:
- median 485.7 ns/call, min 483.3 ns/call

Final guard-depth implementation, direct run-only cache hit:
- median 486.1 ns/call, min 484.3 ns/call

Temporary callback-mutation baseline, torch._dynamo.run() cache hit:
- median 13.148 us/call, min 13.118 us/call

Final guard-depth implementation, torch._dynamo.run() cache hit:
- median 13.051 us/call, min 12.958 us/call

Final torchbench sanity run:
- TORCHINDUCTOR_CPP_WRAPPER=1 python benchmarks/dynamo/torchbench.py --performance --inference --inductor --devices cpu --only maml --float32 --threads 1 -n 20 --print-compilation-time --output /tmp/issue140683_maml_tb766a5e3a_safe_final_n20.csv
- cpu,maml,1,1.039451,81.033986,6.914475,0.753850,82.839962,109.889126,131,10,6,3,0,0,10

Test Plan:
- ninja -C build torch_python
- cp build/lib/libtorch_python.so torch/lib/libtorch_python.so
- python test/dynamo/test_frame_init.py
- python -m py_compile test/dynamo/test_frame_init.py && git diff --check && git diff --cached --check
- lintrunner -a

Fixes #140683
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98