### PR TITLE
Improve Dynamo observed exception messages

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -473,7 +473,7 @@ Attempted to call function marked as skipped
             ),
             """\
 Observed exception
-  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
+  Explanation: Dynamo observed an exception while tracing your code: ValueError('not enough values to unpack (expected 2, got 1)'). Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function.
   Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`.
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
@@ -500,7 +500,7 @@ from user code:
             ),
             """\
 Observed exception
-  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
+  Explanation: Dynamo observed an exception while tracing your code: TypeError("'int' object is not iterable"). Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function.
   Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`.
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
@@ -523,7 +523,7 @@ from user code:
             lambda: fn(torch.randn(2)),
             """\
 Observed exception
-  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
+  Explanation: Dynamo observed an exception while tracing your code: ValueError('not enough values to unpack (expected at least 1, got 0)'). Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function.
   Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`.
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
@@ -545,7 +545,7 @@ from user code:
             lambda: torch.compile(fn, backend="eager", fullgraph=True)(),
             """\
 Observed exception
-  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
+  Explanation: Dynamo observed an exception while tracing your code: RuntimeError('test'). Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function.
   Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`.
   Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
@@ -556,6 +556,45 @@ Observed exception
 from user code:
    File "test_error_messages.py", line N, in fn
     raise RuntimeError("test")""",
+        )
+
+    def test_export_malformed_positional_args_observed_exception(self):
+        class Decoder(torch.nn.Module):
+            def forward(self, decoder_input_ids=None, decoder_inputs_embeds=None):
+                if decoder_input_ids is None and decoder_inputs_embeds is None:
+                    raise ValueError(
+                        "You have to specify either decoder_input_ids "
+                        "or decoder_inputs_embeds"
+                    )
+                return decoder_input_ids
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = Decoder()
+
+            def forward(self, input_ids=None, attention_mask=None, labels=None):
+                return self.decoder(decoder_input_ids=labels)
+
+        with self.assertRaises(Unsupported) as ctx:
+            torch.export.export(
+                Model(),
+                (torch.ones(2), torch.ones(2)),
+                strict=True,
+            )
+
+        exc_str = str(ctx.exception)
+        self.assertIn(
+            "Dynamo observed an exception while tracing your code: "
+            "ValueError('You have to specify either decoder_input_ids "
+            "or decoder_inputs_embeds')",
+            exc_str,
+        )
+        self.assertIn(
+            "Developer debug context: raised exception "
+            "ValueError('You have to specify either decoder_input_ids "
+            "or decoder_inputs_embeds')",
+            exc_str,
         )
 
     def test_uninitialized_module(self):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1217,6 +1217,14 @@
   "GB0088": [
     {
       "Gb_type": "Observed exception",
+      "Context": "exception_context",
+      "Explanation": "Dynamo observed an exception while tracing your code: {exception_repr}. Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "Observed exception",
       "Context": "raised exception {curr_exc.debug_repr()}",
       "Explanation": "observed_exn_gb_explanation",
       "Hints": [
@@ -1233,6 +1241,14 @@
     }
   ],
   "GB0089": [
+    {
+      "Gb_type": "Observed exception (EXCEPT_HANDLER)",
+      "Context": "exception_context",
+      "Explanation": "Dynamo observed an exception while tracing your code: {exception_context}. Exception will propagate outside the compiled region because Dynamo found no exception handler at the top-level compiled function. This graph break is unexpected.",
+      "Hints": [
+        "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
+    },
     {
       "Gb_type": "Observed exception (EXCEPT_HANDLER)",
       "Context": "str(raised_exception)",

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2710,11 +2710,6 @@ class InstructionTranslatorBase(
         self.call_function(fn, args, {})
 
     def exception_handler(self, raised_exception: ObservedException) -> None:
-        observed_exn_gb_explanation = (
-            "Dynamo found no exception handler at the top-level compiled function "
-            "when encountering an exception. Exception will propagate outside the compiled region."
-        )
-
         def bubble_exception_to_interpreter() -> None:
             # Bubble the exception to the interpreter
             curr_exc = self.exn_vt_stack.get_current_exception()
@@ -2723,10 +2718,17 @@ class InstructionTranslatorBase(
                 raise AssertionError(
                     "expected isinstance(raised_exception, dynamo_exc) to be true"
                 )  # sanity check
+            exception_repr = curr_exc.debug_repr()
+            exception_context = f"raised exception {exception_repr}"
             unimplemented(
                 gb_type="Observed exception",
-                context=f"raised exception {curr_exc.debug_repr()}",
-                explanation=observed_exn_gb_explanation,
+                context=exception_context,
+                explanation=(
+                    "Dynamo observed an exception while tracing your code: "
+                    f"{exception_repr}. Exception will propagate outside "
+                    "the compiled region because Dynamo found no exception handler "
+                    "at the top-level compiled function."
+                ),
                 hints=[
                     *graph_break_hints.USER_ERROR,
                     *graph_break_hints.SUPPORTABLE,
@@ -2783,11 +2785,16 @@ class InstructionTranslatorBase(
                         # instruction translator.
                         self.stack.clear()
                         if type(self) is InstructionTranslator:
+                            exception_context = str(raised_exception)
                             unimplemented(
                                 gb_type="Observed exception (EXCEPT_HANDLER)",
-                                context=str(raised_exception),
-                                explanation=observed_exn_gb_explanation
-                                + " This graph break is unexpected.",
+                                context=exception_context,
+                                explanation=(
+                                    "Dynamo observed an exception while tracing your code: "
+                                    f"{exception_context}. Exception will propagate outside "
+                                    "the compiled region because Dynamo found no exception handler "
+                                    "at the top-level compiled function. This graph break is unexpected."
+                                ),
                                 hints=[*graph_break_hints.DYNAMO_BUG],
                                 from_exc=raised_exception,
                             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186119

Dynamo already kept the original observed exception as an ExceptionVariable
and rendered it with debug_repr(), but exception_handler() only surfaced that
information in the developer debug context. The primary explanation stayed
as the generic "Observed exception", which made strict export failures from
malformed positional arguments hard to diagnose.

Include the concrete exception type and message in the user-facing observed
exception explanation while keeping the existing graph-break type and debug
context stable. Add a strict torch.export regression test that reproduces the
malformed positional-args path without downloading the external model from
the original issue.

Fixes #140607
Generated by my agent

Test Plan:
- python test/dynamo/test_error_messages.py ErrorMessagesTest.test_unpack_sequence_with_wrong_length ErrorMessagesTest.test_unpack_sequence_with_non_iterable ErrorMessagesTest.test_unpack_ex_failure ErrorMessagesTest.test_observed_exception ErrorMessagesTest.test_export_malformed_positional_args_observed_exception
- python test/dynamo/test_exceptions.py -k test_observed_exception_formats_fstring_message
- lintrunner -a torch/_dynamo/symbolic_convert.py test/dynamo/test_error_messages.py torch/_dynamo/graph_break_registry.json
- git diff --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98