### PR TITLE
Fix Halide inplace mutation fusion with aliased reads

### DIFF
--- a/test/inductor/test_halide.py
+++ b/test/inductor/test_halide.py
@@ -275,6 +275,21 @@ class HalideTests(TestCase):
             )
             self.assertIn("@hl.generator", code)
 
+    def test_inplace_add_broadcast_input_alias(self):
+        @torch.compile(backend="inductor", options={"cpu_backend": "halide"})
+        def fn(x, y):
+            return x.add_(y)
+
+        x = torch.ones([2, 12, 13, 17]).transpose(1, 2)
+        y = torch.ones([2, 13, 1, 17])
+        expected = x.clone()
+        expected.add_(y)
+
+        result = fn(x, y)
+
+        self.assertEqual(result, expected)
+        self.assertEqual(x, expected)
+
 
 if test_torchinductor.HAS_CPU and HAS_HALIDE:
     make_halide(test_torchinductor.SweepInputsCpuTest)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1611,11 +1611,6 @@ class CommonTemplate:
         self.common(fn, (torch.randn(32),))
 
     def test_add_inplace_permuted(self):
-        if config.cpu_backend == "halide":
-            raise unittest.SkipTest(
-                "Halide cpu backend does not work for this test case: https://github.com/pytorch/pytorch/issues/140344"
-            )
-
         def fn(x, y):
             return x.add_(y)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7779,6 +7779,15 @@ class Scheduler:
             ]
             if not relevant_reads:
                 continue
+            device = node2.get_device()
+            if device is not None and (
+                (device.type == "cpu" and config.cpu_backend == "halide")
+                or (device.type == "cuda" and config.cuda_backend == "halide")
+            ):
+                # Halide autoschedules may overcompute output tiles via
+                # TailStrategy::ShiftInwards.  That is only semantics-preserving
+                # if the output is not also an input read by the fused producer.
+                return False
             num_concurrent_reads += 1
             if not all(
                 isinstance(read, MemoryDep)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186121

Halide autoscheduling can overcompute output tiles with TailStrategy::ShiftInwards. That is valid when the output is independent, but it is not valid when a vertically fused producer reads the same real buffer that the mutation kernel writes. In that case a shifted tail store can reread values that were already updated by the fused mutation, producing incorrect results for cases such as a transposed destination with a broadcast add input.

Prevent weak-dependency fusion for this aliased mutation pattern when the selected backend is Halide. This materializes the producer before the mutation copy, preserving the in-place semantics instead of relying on Halide to avoid overlapping tail stores. I chose this scheduler-level guard over special-casing add because the root cause is the unsafe aliasing/fusion contract, not the add operation itself.

Remove the stale Halide skip for the original permuted inplace add test and add a focused Halide regression test for the broadcast-input alias case.

Fixes #140344
Generated by my agent

Test Plan:
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 python - <<'PY' ... issue reproducer ... PY
  - Before fix on main: reproduced, `5304 10680.0`.
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_140344_after_patch python - <<'PY' ... issue reproducer ... PY
  - After fix: passed, `5304 10608.0`.
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_140344_unit python - <<'PY' ... load test_halide.py with local torchvision stub and run HalideTests("test_inplace_add_broadcast_input_alias") ... PY
  - Passed, `Ran 1 test in 6.435s`, `OK`.
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_140344_add_permuted_unit python - <<'PY' ... load test_halide.py with local torchvision stub and run HalideCpuTests("test_add_inplace_permuted_cpu_halide") ... PY
  - Passed, `Ran 1 test in 7.914s`, `OK`.
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_140344_test python test/inductor/test_halide.py -k test_inplace_add_broadcast_input_alias
  - Blocked by unrelated local torchvision/PyTorch mismatch: `RuntimeError: operator torchvision::nms does not exist`.
- PYTHONPATH=/tmp/pytorch_issue_140344_halide_21 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_140344_add_permuted_standard python test/inductor/test_halide.py -k test_add_inplace_permuted
  - Blocked by the same unrelated local torchvision/PyTorch mismatch.
- lintrunner -a
  - Passed, `ok No lint issues. Successfully applied all patches.`

Benchmark Results:
- Baseline main, same microbenchmark as the issue reproducer after compile warmup, 30 iterations with fresh inputs: incorrect `sum=10680.0`, median 107.257 us, mean 167.078 us, min 61.663 us, max 852.712 us.
- Fixed branch, same command and iteration count: correct `sum=10608.0`, median 208.894 us, mean 258.325 us, min 155.013 us, max 1698.765 us.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo