### PR TITLE
Reject dtype conversion of quantized TypedStorage with a clear error

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7851,6 +7851,31 @@ class TestTorch(TestCase):
         self.assertEqual(complexdouble_storage.type(), 'torch.ComplexDoubleStorage')
         self.assertIs(complexdouble_storage.dtype, torch.complex128)
 
+    def test_storage_cast_quantized_raises(self):
+        # Quantized storage is not self-contained: it has no scale or
+        # zero_point, so dtype conversion cannot produce meaningful results
+        # and previously could segfault. Verify it raises a clear error
+        # instead. See #169210.
+        quantized_storage_classes = [
+            torch.QInt32Storage,
+            torch.QInt8Storage,
+            torch.QUInt8Storage,
+            torch.QUInt4x2Storage,
+            torch.QUInt2x4Storage,
+        ]
+        target_methods = [
+            "bfloat16", "float", "double", "complex_double", "complex_float",
+            "half", "long", "int", "short", "char", "byte", "bool",
+        ]
+        for storage_class in quantized_storage_classes:
+            storage = storage_class(5)
+            for method in target_methods:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    r"Cannot cast quantized storage",
+                ):
+                    getattr(storage, method)()
+
     def test_storage_byteswap(self):
         input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         swapped_8bytes = [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8]

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -1316,6 +1316,19 @@ class TypedStorage:
     def _to(self, dtype):
         if not isinstance(dtype, torch.dtype):
             raise TypeError(f"Argument 'dtype' must be torch.dtype, not {type(dtype)}")
+        if self.dtype in (
+            torch.quint8,
+            torch.quint4x2,
+            torch.quint2x4,
+            torch.qint32,
+            torch.qint8,
+        ):
+            raise RuntimeError(
+                f"Cannot cast quantized storage (dtype={self.dtype}) to a "
+                f"non-quantized dtype ({dtype}). Quantized storage is not "
+                f"self-contained and requires a scale and zero_point to be "
+                f"interpreted, so direct dtype conversion is not supported."
+            )
         storage = (
             torch.tensor([], dtype=self.dtype, device=self.device)
             .set_(self)


### PR DESCRIPTION
Fixes #169210.

The dtype-conversion methods on `TypedStorage` (`bfloat16`, `float`, `double`, `half`, `int`, ...) call into the C++ storage-cast path with a quantized dtype. The cast has no well-defined meaning — a quantized dtype is not self-contained and needs the tensor's `scale` and `zero_point` to be interpreted — and previously could segfault instead of failing cleanly.

This adds an early check in `TypedStorage._to` that raises `RuntimeError` for the five quantized dtypes (`qint8`, `qint32`, `quint8`, `quint4x2`, `quint2x4`), so users get a clear message rather than a crash. The original repro in the issue uses `UntypedStorage` wrapping a now-freed int32 buffer, which is a use-after-free in user code; this fix does not address that specific repro but does close the related segfault class for typed quantized storages.

Test Plan:
```bash
python -m pytest test/test_torch.py::TestTorch::test_storage_cast_quantized_raises -x
```