### PR TITLE
[dtensor] fix conv1d output placement and group scaling

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -43,6 +43,21 @@ def _conv_fn(
         module.register_parameter(name, dist_param)
 
 
+def _depthwise_channel_conv_fn(
+    name: str,
+    module: nn.Module,
+    device_mesh: DeviceMesh,
+) -> None:
+    # Shard depthwise-conv params on the out-channel dim: weight is
+    # (out_channels, 1, *kernel) and bias is (out_channels,), both Shard(0).
+    for name, param in module.named_parameters():
+        dist_param = torch.nn.Parameter(
+            distribute_tensor(param, device_mesh, [Shard(0)])
+        )
+        name = "_".join(name.split("."))
+        module.register_parameter(name, dist_param)
+
+
 class DistConvolutionOpsTest(DTensorTestBase):
     @property
     def world_size(self) -> int:
@@ -393,6 +408,49 @@ class DistConvolutionOpsTest(DTensorTestBase):
     @with_tf32_off
     @with_comms
     @skip_if_lt_x_gpu(2)
+    def test_conv1d_channel_shard(self):
+        # Depthwise Conv1d (groups == channels) sharded on the channel dim: each
+        # group is independent, so the forward runs locally with no comm and the
+        # output stays Shard(1). Exercises the depthwise channel rule in
+        # convolution_single_dim_strategy plus the groups scaling in
+        # convolution_handler.
+        device_mesh = self.build_device_mesh()
+
+        channels = 8
+        model = nn.Conv1d(
+            channels, channels, kernel_size=4, padding=0, groups=channels
+        ).to(self.device_type)
+        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = distribute_module(model, device_mesh, _depthwise_channel_conv_fn)
+
+        x = torch.randn(2, channels, 16, device=self.device_type, requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+        x_dt = distribute_tensor(x, device_mesh, [Shard(1)])
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            out_dt = model(x_dt)
+        # Channel-sharded depthwise conv needs no communication in the forward.
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertTrue(out_dt.placements[0].is_shard(1))
+
+        out_ref = model_ref(x_ref)
+        self.assertEqual(out_dt.full_tensor(), out_ref)
+
+        # Backward is also channel-local: grads stay channel-sharded with no comm.
+        grad = torch.randn_like(out_ref)
+        grad_dt = distribute_tensor(grad, device_mesh, [Shard(1)])
+        with comm_mode:
+            out_dt.backward(grad_dt)
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertTrue(x_dt.grad.placements[0].is_shard(1))
+
+        out_ref.backward(grad)
+        self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
+
+    @with_tf32_off
+    @with_comms
+    @skip_if_lt_x_gpu(2)
     def test_conv3d_batch_shard(self):
         device_mesh = self.build_device_mesh()
 
@@ -437,6 +495,7 @@ DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
         "test_conv2d_no_bias_backward",
         "test_conv2d_module_no_bias",
         "test_conv1d_batch_shard",
+        "test_conv1d_channel_shard",
         "test_conv3d_batch_shard",
     ],
 )

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -15,7 +15,12 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
     register_single_dim_strategy,
 )
 from torch.distributed.tensor._ops.utils import register_prop_rule
-from torch.distributed.tensor.placement_types import Partial, Placement, Replicate
+from torch.distributed.tensor.placement_types import (
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
 
 
 aten = torch.ops.aten
@@ -166,7 +171,13 @@ def convolution_single_dim_strategy(
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
+    # Tensor inputs are TensorMetas in single-dim strategies (see
+    # register_single_dim_strategy docs).
+    input_meta = args_schema[0]
+    weight_meta = args_schema[1]
     bias_meta = args_schema[2]
+    groups = args_schema[8]
+
     # [output, input, weight, (bias)]
     rule: list[Placement | _ShardingPlaceholder] = [
         _ShardingPlaceholder(0),  # output
@@ -175,7 +186,29 @@ def convolution_single_dim_strategy(
     ]
     if bias_meta is not None:
         rule.append(Replicate())  # bias
-    return [rule]
+    strategies = [rule]
+
+    # Depthwise conv (groups == in_channels == out_channels): each channel is
+    # an independent group, so input channels, weight out-channels, and output
+    # channels can all be sharded together with no cross-channel communication.
+    # The per-shard ``groups`` value is scaled at runtime in
+    # ``_tp_conv.convolution_handler`` (strategies decide placements only).
+    if (
+        isinstance(groups, int)
+        and groups > 1
+        and groups == input_meta.shape[1]
+        and groups == weight_meta.shape[0]
+    ):
+        channel_rule: list[Placement | _ShardingPlaceholder] = [
+            Shard(1),  # output: channel dim
+            Shard(1),  # input: channel dim
+            Shard(0),  # weight: out-channel dim
+        ]
+        if bias_meta is not None:
+            channel_rule.append(Shard(0))  # bias: per out-channel
+        strategies.append(channel_rule)
+
+    return strategies
 
 
 @register_single_dim_strategy(
@@ -187,7 +220,10 @@ def convolution_backward_single_dim_strategy(
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder | None]]:
+    input_meta = args_schema[1]
+    weight_meta = args_schema[2]
     bias_sizes = args_schema[3]
+    groups = args_schema[9]
     has_bias = bias_sizes is not None
     # outputs: [grad_input, grad_weight, grad_bias]
     # inputs: [grad_output, input, weight]
@@ -199,4 +235,28 @@ def convolution_backward_single_dim_strategy(
         _ShardingPlaceholder(0),  # input
         Replicate(),  # weight
     ]
-    return [rule]
+    strategies = [rule]
+
+    # Depthwise conv (groups == in_channels == out_channels): channels are
+    # independent groups, so a channel-sharded backward computes each shard's
+    # grads locally (mirrors the forward rule in convolution_single_dim_strategy).
+    # grad_weight/grad_bias are Shard(0) per out-channel -- no cross-rank sum, so
+    # they are not Partial. The per-shard ``groups`` is scaled at runtime in
+    # ``_tp_conv.convolution_backward_handler``.
+    if (
+        isinstance(groups, int)
+        and groups > 1
+        and groups == input_meta.shape[1]
+        and groups == weight_meta.shape[0]
+    ):
+        channel_rule: list[Placement | _ShardingPlaceholder | None] = [
+            Shard(1),  # grad_input: channel dim
+            Shard(0),  # grad_weight: out-channel dim
+            Shard(0) if has_bias else None,  # grad_bias: per out-channel
+            Shard(1),  # grad_output: channel dim
+            Shard(1),  # input: channel dim
+            Shard(0),  # weight: out-channel dim
+        ]
+        strategies.append(channel_rule)
+
+    return strategies

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -246,6 +246,42 @@ def tp_convolution_backward(
         return local_results
 
 
+def _scaled_local_conv_groups(
+    weight: object,
+    local_weight: object,
+    groups: object,
+) -> object:
+    """Local ``groups`` for a channel-sharded (depthwise) conv shard.
+
+    The conv sharding strategies (see ``_ops/_conv_ops.py``) shard channels only
+    for depthwise conv (``groups == in_channels == out_channels``); each shard
+    then holds a slice of the out-channels and its local conv must run with a
+    matching ``groups``. Strategies decide placements only, so the local
+    ``groups`` arg is rescaled here. For any other conv the weight stays
+    replicated (local == global out-channels) and ``groups`` is returned
+    unchanged.
+    """
+    if not (
+        isinstance(groups, int) and groups > 1 and isinstance(weight, dtensor.DTensor)
+    ):
+        return groups
+    global_out_channels = cast(dtensor.DTensor, weight).shape[0]
+    local_out_channels = cast(torch.Tensor, local_weight).shape[0]
+    if local_out_channels == global_out_channels:
+        return groups
+    # Even sharding is required so each shard's local groups is an integer.
+    # DTensor's shardability check should guarantee this, so a violation
+    # indicates an internal bug rather than bad user input.
+    scaled_groups = groups * local_out_channels
+    if scaled_groups % global_out_channels != 0:
+        raise AssertionError(
+            "channel-sharded conv groups must divide evenly across shards: "
+            f"groups={groups}, local_out_channels={local_out_channels}, "
+            f"global_out_channels={global_out_channels}."
+        )
+    return scaled_groups // global_out_channels
+
+
 def convolution_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
@@ -263,10 +299,15 @@ def convolution_handler(
     if not isinstance(output_spec, dtensor.DTensorSpec):
         raise AssertionError
 
+    local_args = list(op_info.local_args)
+    # convolution args: [input, weight, bias, ..., groups(8), ...]. Rescale the
+    # local ``groups`` for a channel-sharded depthwise conv (no-op otherwise).
+    local_args[8] = _scaled_local_conv_groups(args[1], local_args[1], local_args[8])
+
     # local propagation
     local_results = tp_convolution(
         op_call,
-        tuple(op_info.local_args),
+        tuple(local_args),
         op_info.local_kwargs,
         output_spec.dim_map,
     )
@@ -301,10 +342,16 @@ def convolution_backward_handler(
     if not isinstance(op_info.flat_args_schema[0], dtensor.DTensorSpec):
         raise AssertionError
 
+    local_args = list(op_info.local_args)
+    # convolution_backward args: [grad_output, input, weight, ..., groups(9), ...].
+    # Rescale the local ``groups`` for a channel-sharded depthwise conv, mirroring
+    # convolution_handler (no-op otherwise). args[2] is the (global) weight DTensor.
+    local_args[9] = _scaled_local_conv_groups(args[2], local_args[2], local_args[9])
+
     # local propagation
     local_results = tp_convolution_backward(
         op_call,
-        tuple(op_info.local_args),
+        tuple(local_args),
         op_info.local_kwargs,
         op_info.flat_args_schema[0].dim_map,
     )


### PR DESCRIPTION
Fixes DTensor dispatch for **depthwise** convolution (`groups == in_channels == out_channels`) when channels are sharded across the mesh — e.g. under FSDP or TP where the weight is `Shard(0)` and the input is `Shard(1)` on the channel dim. This is the layout used by GatedDeltaNet-style depthwise `Conv1d` in hybrid-attention models (Qwen3.5).

Depthwise conv treats each channel as an independent group, so channel-sharding requires no cross-rank communication — each rank computes its own channels locally. DTensor previously couldn't express or execute this, failing in both forward and backward.

## The bugs

1. **Wrong forward output placement.** `convolution_single_dim_strategy` only enumerated batch-dim sharding with a replicated weight. Channel-sharded input + out-channel-sharded weight matched no rule, so the propagator fell back to all-`Replicate`. The handler then ran on the still-sharded local tensors but labeled the result `Replicate` — so a 64-channel local output was tagged as the full 128-channel tensor. Downstream ops (e.g. `full_tensor()`) trusted the label and silently returned wrong data.

2. **Crash on `groups` (forward and backward).** `groups` is a plain int that isn't sharded. With a channel-sharded weight (128 → 64 local channels per rank), the local conv was still called with `groups=128`:

   ```
   RuntimeError: Given groups=128, expected weight to be at least 128 at dimension 0, but got weight of size [64, 1, 4]
   ```

   The backward path had the identical defect and crashed the same way; it had gone unnoticed because earlier validation only exercised the forward/inference path.

## The fix

Split across the two layers that own each concern, symmetric for forward and backward:

- **`_ops/_conv_ops.py` (sharding strategies)** — add a depthwise channel-sharding rule to both strategies, gated on `groups == in_channels == out_channels`:
  - forward: `[output=Shard(1), input=Shard(1), weight=Shard(0), (bias=Shard(0))]`
  - backward: `[grad_input=Shard(1), grad_weight=Shard(0), grad_bias=Shard(0), grad_output=Shard(1), input=Shard(1), weight=Shard(0)]`

  `grad_weight` / `grad_bias` are `Shard(0)` (per out-channel, no cross-rank sum), **not** `Partial`, because the groups are independent. The propagator now returns the correct `Shard(1)` / `Shard(0)` placements with no redistribution.

- **`_tp_conv.py` (local arg adjustment)** — strategies decide placements only; the local op still needs `groups` rescaled to the local weight shard (`groups * local_out_channels // global_out_channels`). This is factored into a shared `_scaled_local_conv_groups` helper, with a divisibility assertion guarding the even-sharding invariant, and is called from both `convolution_handler` and `convolution_backward_handler`.

Only depthwise conv is handled; regular (`groups=1`) and general grouped conv are untouched and fall through unchanged.

## Test

`test/distributed/tensor/test_convolution_ops.py::test_conv1d_channel_shard` — depthwise `Conv1d`, input `Shard(1)` + weight `Shard(0)`, asserts for **both forward and backward**:

- zero communication (`CommDebugMode`),
- correct `Shard(1)` output / gradient placement,
- `full_tensor()` bit-identical (max_diff 0.0) to a single-device reference.

Regression tests (`test_conv1d`, `test_conv1d_batch_shard`, `test_depthwise_convolution`) still pass. Validated across FSDP, TP, and FSDP+EP configs, and end-to-end on a hybrid-attention model (Qwen3.5) whose GatedDeltaNet layers use depthwise `Conv1d`.
