### PR TITLE
[ROCm] remove redundant @skipIfRocm from test_cudnn_attention_broken_166211

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3813,7 +3813,6 @@ class TestSDPACudaOnly(NNTestCase):
         with self.assertRaisesRegex(AssertionError, "AssertionError not raised"):
             self.assertNotEqual(out1, out2)
 
-    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_broken_166211(self):
         # https://github.com/pytorch/pytorch/issues/166211#issue-3551350377


### PR DESCRIPTION
### Investigative summary

FIXES #168871
FIXES #168872

### Test environment
```
-- PyTorch version: 2.13.0a0+gitf6f4e17
-- Hip version: 7.2.53211
-- GPU 0 name: AMD Instinct MI300X
```
### Command to reproduce
`$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_transformers.py -k "test_cudnn_attention_broken_166211" -v`

### Default behaviour
`test/test_transformers.py::TestSDPACudaOnlyCUDA::test_cudnn_attention_broken_166211_cuda SKIPPED [0.0003s] (cudnn Attention is not supported on this system)       [100%]`

### After removing @skipIfRocm
`test/test_transformers.py::TestSDPACudaOnlyCUDA::test_cudnn_attention_broken_166211_cuda SKIPPED [0.0004s] (cudnn Attention is not supported on this system)       [100%]`

### Conclusion & proposed fix
Remove @skipIfRocm, as it is redundant here with the other decorator: 
`@unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")`. 

`PLATFORM_SUPPORTS_CUDNN_ATTENTION` will always evaluate to false on ROCm.

Further, this test test_cudnn_attention_broken_166211 is designed for a specific cuDNN bug: #166211, no evidence this bug applies to ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang