### PR TITLE
[dynamo] Swap @disable / @allow_in_graph order on invoke_subgraph_wrapper_unboxed

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 
 import torch
 import torch._dynamo.testing
+from torch._dynamo.backends.debugging import invoke_subgraph_inner_compiler
 from torch._dynamo.exc import Unsupported
+from torch._dynamo.trace_rules import is_callable_allowed
 from torch._dynamo.utils import counters
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -45,6 +47,27 @@ class DecoratorTests(PytreeRegisteringTestCase):
         # check for graph break on sub
         self.assertEqual(cnts.frame_count, 2)
         self.assertEqual(cnts.op_count, 4)
+
+    def test_invoke_subgraph_wrapper_is_allow_in_graph(self):
+        # `invoke_subgraph_inner_compiler` returns a boxed wrapper that, when
+        # called, invokes an inner closure decorated with `@disable` and
+        # `@torch._dynamo.allow_in_graph`. The id of that inner closure must
+        # be in the allow_in_graph registry — otherwise dynamo's
+        # `lookup_callable` will fall through to the disable check and graph
+        # break, defeating the point of `allow_in_graph`.
+        def f(x):
+            return x + 1
+
+        gm = torch.fx.symbolic_trace(f)
+        boxed = invoke_subgraph_inner_compiler(gm, [torch.randn(4)])
+
+        # The boxed wrapper closes over `invoke_subgraph_wrapper_unboxed`.
+        self.assertEqual(
+            boxed.__code__.co_freevars, ("invoke_subgraph_wrapper_unboxed",)
+        )
+        unboxed = boxed.__closure__[0].cell_contents
+
+        self.assertTrue(is_callable_allowed(unboxed))
 
     def test_disable_for_custom_op(self):
         import torch.library

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -175,6 +175,10 @@ def invoke_subgraph_inner_compiler(
     # NB: The direct to unboxed path is broken, you MUST DO THIS
 
     def invoke_subgraph_wrapper(args: list[Any]) -> Any:
+        # `allow_in_graph` is untyped and its `list` branch leaks a
+        # `list | fn` union into the inferred return; as the outer decorator
+        # here that makes `invoke_subgraph_wrapper_unboxed` look non-callable.
+        # pyrefly: ignore [not-callable]
         return invoke_subgraph_wrapper_unboxed(*args)
 
     invoke_subgraph_wrapper._boxed_call = True  # type: ignore[attr-defined]

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -166,9 +166,9 @@ def invoke_subgraph_inner_compiler(
     from torch._dynamo import disable
     from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer
 
-    @disable
     # pyrefly: ignore [deprecated]
     @torch._dynamo.allow_in_graph
+    @disable
     def invoke_subgraph_wrapper_unboxed(*operands: Any) -> Any:
         return invoke_subgraph_infer(subgraph, *operands)
 


### PR DESCRIPTION
The wrapper returned by `invoke_subgraph_inner_compiler` was decorated with `@disable @torch._dynamo.allow_in_graph` (disable outermost). In that order:

  1. `allow_in_graph` registers `id(fn0)` (the inner function) into `trace_rules._allowed_callable_ids` and returns `fn0` unchanged.
  2. `disable` calls `innermost_fn`, then creates a NEW wrapper `_fn` with `_fn._torchdynamo_orig_callable = fn0`. The id of `_fn` is different from `id(fn0)`.
  3. The name binds to `_fn`. The boxed `invoke_subgraph_wrapper` closure binds to `_fn`, not `fn0`.

When dynamo encounters a call to `_fn`, `lookup_callable(_fn)` checks `is_callable_allowed(_fn)` — but only `id(fn0)` was registered, so this returns False. Dynamo then falls through to the `_torchdynamo_disable` check and graph-breaks instead of emitting the call as a graph leaf. The `@allow_in_graph` annotation is effectively dead in this order.

Swap to `@allow_in_graph @disable`:
  1. `disable` first wraps `fn0` into `_fn`.
  2. `allow_in_graph` registers `id(_fn)` (the wrapper that's actually called) and returns `_fn`.
  3. `lookup_callable(_fn)` now finds it in `_allowed_callable_ids` and returns `TorchInGraphFunctionVariable` — dynamo emits the call as a graph leaf, matching the docstring intent of "emits an invoke_subgraph HOP instead of inlining".

Runtime behavior is otherwise unchanged: calling `_fn` still goes through disable's `_fn` body which sets the eval frame to None and calls `fn0`. The only difference is at dynamo trace time.

Add a regression test that asserts `is_callable_allowed` is True for the wrapper extracted from the boxed wrapper's closure. The test_make_fx_with_invoke_subgraph_dtensor test passes regardless of ordering because it exercises make_fx-traces-over-dynamo, where the wrapper is called by make_fx (which doesn't consult `_allowed_callable_ids`), so the decorator semantics don't matter for that path.

generated by: Claude Opus 4.7 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98