### PR TITLE
Support closed-over data-dependent indexing in scan (forward and autograd)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1659,6 +1659,51 @@ def forward(self, pred_1, x_1):
         exp_out = _fake_scan(combine_fn, init, xs, dim=dim)
         self.assertEqual(out, exp_out)
 
+    @parametrize("compile_mode", ["none", "eager"])
+    def test_scan_closed_over_indexing(self, compile_mode):
+        # The combine_fn closes over a tensor and indexes it with the per-step
+        # integer xs element (a common JAX idiom, e.g. table[:, t] in HMMs and
+        # decoding loops). The xs slice is data-dependent during tracing.
+        scan_fct = compile_mode_helper(scan, compile_mode)
+
+        table = torch.rand(2, 4)
+        transition = torch.rand(2, 2)
+
+        def combine_fn(c, t):
+            y = (c[..., None] * transition).sum(dim=0) * table[:, t]
+            return y, y.clone()
+
+        init = torch.tensor([0.6, 0.4])
+        xs = torch.arange(1, table.shape[1], dtype=torch.int64)
+
+        out = scan_fct(combine_fn, init, xs)
+        exp_out = _fake_scan(combine_fn, init, xs)
+        self.assertEqual(out, exp_out)
+
+    def test_scan_closed_over_indexing_autograd(self):
+        # Differentiate through closed-over indexing. The per-step index value is
+        # an unbacked SymInt; the backward must recompute it (rather than stack
+        # it) and use a data-dependent-friendly select_copy meta.
+        table = torch.rand(2, 4, dtype=torch.float64, requires_grad=True)
+        transition = torch.rand(2, 2, dtype=torch.float64, requires_grad=True)
+        init = torch.tensor([0.6, 0.4], dtype=torch.float64, requires_grad=True)
+        xs = torch.arange(1, table.shape[1], dtype=torch.int64)
+
+        def combine_fn(c, t):
+            y = torch.tanh((c[..., None] * transition).sum(dim=0) + table[:, t])
+            return y, y.clone()
+
+        c, ys = scan(combine_fn, init, xs)
+        c_ref, ys_ref = _fake_scan(combine_fn, init, xs)
+        self.assertEqual(c, c_ref)
+        self.assertEqual(ys, ys_ref)
+
+        loss = (c * 1.3).sum() + (ys**2).sum()
+        loss_ref = (c_ref * 1.3).sum() + (ys_ref**2).sum()
+        grads = torch.autograd.grad(loss, (table, transition, init))
+        grads_ref = torch.autograd.grad(loss_ref, (table, transition, init))
+        self.assertEqual(grads, grads_ref)
+
     # TODO: provide an implementation for all compile modes and re-enable all test
     @skipIfTorchDynamo("don't test compile on compile")
     @requires_cuda

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1659,7 +1659,7 @@ def forward(self, pred_1, x_1):
         exp_out = _fake_scan(combine_fn, init, xs, dim=dim)
         self.assertEqual(out, exp_out)
 
-    @skipIfTorchDynamo("Skip due to graph break when run with dynamo")
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     @parametrize("compile_mode", ["none", "eager"])
     def test_scan_closed_over_indexing(self, compile_mode):
         scan_fct = compile_mode_helper(scan, compile_mode)
@@ -1678,7 +1678,7 @@ def forward(self, pred_1, x_1):
         exp_out = _fake_scan(combine_fn, init, xs)
         self.assertEqual(out, exp_out)
 
-    @skipIfTorchDynamo("Skip due to graph break when run with dynamo")
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_closed_over_indexing_autograd(self):
         table = torch.rand(2, 4, dtype=torch.float64, requires_grad=True)
         transition = torch.rand(2, 2, dtype=torch.float64, requires_grad=True)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1659,6 +1659,7 @@ def forward(self, pred_1, x_1):
         exp_out = _fake_scan(combine_fn, init, xs, dim=dim)
         self.assertEqual(out, exp_out)
 
+    @skipIfTorchDynamo("Skip due to graph break when run with dynamo")
     @parametrize("compile_mode", ["none", "eager"])
     def test_scan_closed_over_indexing(self, compile_mode):
         scan_fct = compile_mode_helper(scan, compile_mode)
@@ -1677,6 +1678,7 @@ def forward(self, pred_1, x_1):
         exp_out = _fake_scan(combine_fn, init, xs)
         self.assertEqual(out, exp_out)
 
+    @skipIfTorchDynamo("Skip due to graph break when run with dynamo")
     def test_scan_closed_over_indexing_autograd(self):
         table = torch.rand(2, 4, dtype=torch.float64, requires_grad=True)
         transition = torch.rand(2, 2, dtype=torch.float64, requires_grad=True)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1661,9 +1661,6 @@ def forward(self, pred_1, x_1):
 
     @parametrize("compile_mode", ["none", "eager"])
     def test_scan_closed_over_indexing(self, compile_mode):
-        # The combine_fn closes over a tensor and indexes it with the per-step
-        # integer xs element (a common JAX idiom, e.g. table[:, t] in HMMs and
-        # decoding loops). The xs slice is data-dependent during tracing.
         scan_fct = compile_mode_helper(scan, compile_mode)
 
         table = torch.rand(2, 4)
@@ -1681,9 +1678,6 @@ def forward(self, pred_1, x_1):
         self.assertEqual(out, exp_out)
 
     def test_scan_closed_over_indexing_autograd(self):
-        # Differentiate through closed-over indexing. The per-step index value is
-        # an unbacked SymInt; the backward must recompute it (rather than stack
-        # it) and use a data-dependent-friendly select_copy meta.
         table = torch.rand(2, 4, dtype=torch.float64, requires_grad=True)
         transition = torch.rand(2, 2, dtype=torch.float64, requires_grad=True)
         init = torch.tensor([0.6, 0.4], dtype=torch.float64, requires_grad=True)

--- a/torch/_higher_order_ops/partitioner.py
+++ b/torch/_higher_order_ops/partitioner.py
@@ -253,12 +253,20 @@ class HopJointGraph:
         By marking the recompute polify for complex nodes as MUST_RECOMPUTE, the partitioning boundary
         no longer contains complex expressions.
 
-        Note that this pass doesn't exclude basic symbols from partitioning boundary
-        and it's up to the downstream to decide whether to return the basic symbol
-        or have a separate graph pass to remove them.
+        We also recompute unbacked basic symbols (e.g. the value produced by a
+        data-dependent ``.item()`` from a per-step xs element used to index a
+        closed-over tensor). Such a symbol varies across iterations, so it cannot
+        be threaded through the boundary as a single value, and it is always
+        recomputable in backward from the (read-only) inputs it was derived from.
+
+        Note that this pass doesn't exclude loop-invariant basic symbols (e.g.
+        backed shape symbols) from the partitioning boundary and it's up to the
+        downstream to decide whether to return the basic symbol or have a
+        separate graph pass to remove them.
         """
 
         from torch._functorch.partitioners import CheckpointPolicy
+        from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
         for n in (
             node for node in self.joint_gm.graph.nodes if node.op == "call_function"
@@ -266,7 +274,9 @@ class HopJointGraph:
             if "val" not in n.meta:
                 continue
             val = n.meta["val"]
-            if isinstance(val, torch.SymInt) and is_complex_expr(val.node.expr):
+            if isinstance(val, torch.SymInt) and (
+                is_complex_expr(val.node.expr) or free_unbacked_symbols(val.node.expr)
+            ):
                 if n.meta.get("recompute", None) is not None:
                     raise AssertionError(
                         f"node {n} with complex SymInt expression should not have recompute policy set"

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import contextlib
 import enum
 import functools
 import itertools
@@ -845,12 +846,22 @@ def scan_proxy_mode(mode, combine_fn, init, xs, additional_inputs):
 def scan_fake_tensor_mode(mode, combine_fn, init, xs, additional_inputs):
     with mode:
         scan_length = xs[0].shape[0]
-        carry, outputs = _extract_carry_and_out(
-            combine_fn(
+        # The body may allocate unbacked symbols (e.g. from data-dependent
+        # indexing) that are internal to a single iteration and never surface in
+        # scan's outputs, whose shapes must be consistent across iterations.
+        ignore_ctx = (
+            mode.shape_env.ignore_fresh_unbacked_symbols()
+            if mode.shape_env is not None
+            else contextlib.nullcontext()
+        )
+        with ignore_ctx:
+            body_out = combine_fn(
                 *init,
                 *[first_slice_copy(inp) for inp in xs],
                 *additional_inputs,
-            ),
+            )
+        carry, outputs = _extract_carry_and_out(
+            body_out,
             len(init),
         )
         out = (

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -697,6 +697,44 @@ def meta_select(
     return self.as_strided(new_size, new_stride, new_storage_offset)
 
 
+@register_op_impl(aten.select_copy.int)
+def meta_select_copy(
+    fake_mode: FakeTensorMode,
+    func: OpOverload,
+    self: FakeTensor,
+    dim: int,
+    index: IntLikeType,
+) -> FakeTensor:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if self.is_sparse:
+        return NotImplemented
+
+    ndim = self.dim()
+    torch._check_index(
+        ndim != 0,
+        lambda: "select() cannot be applied to a 0-dim tensor.",
+    )
+
+    dim = dim if dim >= 0 else dim + ndim
+    size = self.size(dim)
+
+    if guard_or_false(index >= size) or guard_or_false(index < -size):
+        torch._check_index(
+            False,
+            lambda: f"select(): index {index} out of range for tensor of size "
+            f"{list(self.size())} at dimension {dim}",
+        )
+
+    # Unlike select, select_copy returns a contiguous copy, so it has no
+    # data-dependent storage offset to reason about and can index by a
+    # data-dependent (unbacked) index without specializing it.
+    new_size = list(self.size())
+    del new_size[dim]
+    # pyrefly: ignore[bad-return]
+    return self.new_empty(new_size)
+
+
 @register_op_impl(aten.unique_dim.default)
 def unique_dim(
     fake_mode: FakeTensorMode,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186139
* #186138

A scan combine_fn that closes over a tensor and indexes it with the per-step
integer xs element (e.g. table[:, t], a common JAX idiom in HMMs and decoding
loops) previously failed, while jax.lax.scan handles it. This builds on
data-dependent 0-dim tensor indexing (parent commit) and adds the
scan-specific pieces for both forward and autograd.

Forward: scan traces the body with a fake per-step slice whose value is an
unbacked SymInt. Such body-internal symbols never surface in scan's outputs
(whose shapes are consistent across iterations), so the fake-tensor-mode body
run now ignores fresh unbacked symbols (ignore_fresh_unbacked_symbols).

Backward (review these two together):
  - The functionalized select_copy.int had no data-dependent-friendly meta and
    fell through to the hard-guarding C++ impl. meta_select_copy mirrors
    meta_select's bounds but returns a contiguous copy, so it has no
    storage-offset symbol to reason about.
  - The partitioner saved the per-step index value (an unbacked SymInt from
    .item()) as a forward intermediate, which scan stacks across iterations --
    impossible for a SymInt. Unbacked basic symbols are now recomputed in
    backward (they are recomputable from the read-only inputs), alongside the
    existing complex-expr recompute.

Test Plan:
```
python test/functorch/test_control_flow.py TestControlFlow -k test_scan_closed_over_indexing
python test/functorch/test_control_flow.py TestControlFlow -k scan
python test/functorch/test_control_flow.py TestControlFlowTraced -k scan
```

This PR was authored with the assistance of an AI coding assistant (Claude).