### PR TITLE
Fix cuDNN SDPA varlen backward reading d_qk as max_seqlen

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -217,8 +217,11 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
     }
 
     const bool is_nested = cum_seq_q.defined();
-    const int64_t max_seqlen_batch_q = query.size(2);
-    const int64_t max_seqlen_batch_k = key.size(2);
+    // For the nested/varlen path, query is the flat (total_tokens, h, d) tensor,
+    // so query.size(2) == d_qk, not the max sequence length. Use the max_q/max_k
+    // arguments the caller passed in instead.
+    const int64_t max_seqlen_batch_q = is_nested ? max_q : query.size(2);
+    const int64_t max_seqlen_batch_k = is_nested ? max_k : key.size(2);
 
     if (!is_nested) {
       const int64_t batch_size = query.size(0);


### PR DESCRIPTION
`_cudnn_attention_backward` declared the local `max_seqlen_batch_q` and `max_seqlen_batch_k` from `query.size(2)` and `key.size(2)` for both branches. That is fine on the non-nested (4D BHSD) path where `size(2)` is the sequence-length dimension, but on the nested/varlen path Q/K are passed in as flat 3D `(total_tokens, h, d)` tensors, so `size(2)` is `d_qk`/`d_v`, not the maximum sequence length. The caller already passes the real maxima as the `max_q`/`max_k` arguments; the forward op (`_cudnn_attention_forward`) takes them as parameters, but the backward shadows them with the wrong reads.

The wrong value flows into `run_cudnn_SDP_bprop_nestedtensor` -> `build_graph_backward_nestedtensor` -> cuDNN frontend, which sizes the internal `dQ_accum` BHSD tensor with `s_q = d_qk` (e.g. 128) instead of the real `max_seqlen` (e.g. 32768). The cuDNN backward kernel `cudnn::fusion::convert_dq_to_16bits_ragged` then iterates `s_idx` over the real `actual_seq_len[b]` (read from `cu_seqlens`) and walks past the end of the undersized `dQ_accum` buffer, which manifests as `cudaErrorIllegalAddress` after the backward call.

The fix selects `max_q`/`max_k` on the nested path and keeps `query.size(2)`/`key.size(2)` on the non-nested path (where the two are equal anyway), so callers that already pass correct `max_q`/`max_k` start sizing `dQ_accum` correctly.

Test Plan:

Reproduces an illegal memory access on Blackwell (sm_100) with cuDNN 9.22 and on cuDNN 9.30-dev at `(b=8, h=16, s=32768, d=128, causal=False, dropout=off)` flat varlen input. Sweep showed the IMA needs `d=128`, `batch>=2`, `nheads>=4`, `dropout=off`; `d<=96`, `dropout>0`, smaller `nh`/`b` route to other engines that aren't affected.

```
# Repro on the buggy binary (cuDNN 9.22 bundled by PyTorch nvcr image):
python -m pip install --upgrade --force-reinstall --no-cache-dir \
    "nvidia-cudnn-cu13==9.22.0.*"
python benchmark.py --headdim 128 --seqlen 32k --batch-size 8 \
                    --p-dropout 0 --causal false
# -> [ABORT] CUDA error: an illegal memory access was encountered
```

After the fix the same call returns valid `dQ`/`dK`/`dV` with no sync error. compute-sanitizer's only complaint
(`cudnn::fusion::convert_dq_to_16bits_ragged<true>+0x2670` reading 16 bytes past the dQ_accum allocation) is silenced.