### PR TITLE
[dtensor] add sharding support for scatter op

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -589,6 +589,53 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
                 self.assertEqual(output_dt.placements, [Replicate()])
                 self.assertEqual(output_dt.to_local(), global_output)
 
+        # case 2 shard on a non-scatter dim: input/index/src and output all
+        # sharded on dim 0, scatter performed along dim 1. This must run as a
+        # purely local op with no communication.
+        shard_dim, scatter_dim = 0, 1
+        rows = self.world_size * 2
+        global_input = torch.zeros(rows, 5, dtype=torch.int64)
+        # deterministic index so every spawned rank builds the same tensor
+        global_index = torch.arange(rows * 3).reshape(rows, 3) % 5
+        srcs = [torch.arange(1, rows * 3 + 1).reshape((rows, 3)), 4]
+        for global_src in srcs:
+            global_output = torch.scatter(
+                global_input, scatter_dim, global_index, global_src
+            )
+            input_dt = distribute_tensor(
+                global_input.clone(), device_mesh, [Shard(shard_dim)]
+            )
+            index_dt = distribute_tensor(global_index, device_mesh, [Shard(shard_dim)])
+            if isinstance(global_src, torch.Tensor):
+                src_dt = distribute_tensor(global_src, device_mesh, [Shard(shard_dim)])
+            else:
+                src_dt = global_src
+            with comm_mode:
+                output_dt = torch.scatter(input_dt, scatter_dim, index_dt, src_dt)
+
+            self.assertEqual(comm_mode.get_total_counts(), 0)
+            self.assertEqual(output_dt.placements, [Shard(shard_dim)])
+            self.assertEqual(output_dt.full_tensor(), global_output)
+
+        # case 3 src larger than index on the shard dim: sharding src to match
+        # index would misalign boundaries, so the sharded strategy must not be
+        # offered and the op falls back to replicate. Result must stay correct.
+        global_input = torch.zeros(rows, 5, dtype=torch.int64)
+        global_index = torch.arange(rows * 3).reshape(rows, 3) % 5
+        global_src = torch.arange(1, (rows + 2) * 3 + 1).reshape((rows + 2, 3))
+        global_output = torch.scatter(
+            global_input, scatter_dim, global_index, global_src
+        )
+        input_dt = distribute_tensor(
+            global_input.clone(), device_mesh, [Shard(shard_dim)]
+        )
+        index_dt = distribute_tensor(global_index, device_mesh, [Shard(shard_dim)])
+        src_dt = distribute_tensor(global_src, device_mesh, [Replicate()])
+        output_dt = torch.scatter(input_dt, scatter_dim, index_dt, src_dt)
+        # the sharded strategy is not offered, so the op falls back to replicate
+        self.assertEqual(output_dt.placements, [Replicate()])
+        self.assertEqual(output_dt.full_tensor(), global_output)
+
     def test_gather(self):
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -695,19 +695,89 @@ def replica_only_strategy(op_schema: OpSchema) -> StrategyType:
     schema_info=RuntimeSchemaInfo(1),
 )
 def scatter_strategy(op_schema: OpSchema) -> StrategyType:
+    """Sharding strategy for scatter/scatter_ (``.value`` and ``.src`` overloads).
+
+    scatter writes along the ``dim`` argument, so that tensor axis must stay
+    replicated. Any *other* axis can be sharded, but only if every operand has
+    the same size on it -- then the scatter runs locally with no communication.
+    We always also offer a fully-replicated strategy as the universal fallback
+    (valid for any input layout, at the cost of redistributing to replicate).
+
+    Each strategy is a placement list ``[output, input, index, src]`` (``src``
+    is dropped for the scalar-value overloads, giving a 3-element list). Tensor
+    args below are written as ``name(shape)``; "axis N" is a tensor axis,
+    distinct from the scatter ``dim`` argument. Strategies offered per mesh axis:
+
+    - ``scatter(input(8, 5), dim=1, index(8, 3), src(8, 3))``::
+
+          [Replicate(), Replicate(), Replicate(), Replicate()]  # fallback
+          [Shard(0), Shard(0), Shard(0), Shard(0)]  # local, no comm
+          # axis 1 is the scatter dim -> never sharded
+          # axis 0 sizes all match (8) -> shardable
+
+    - ``scatter(input(8, 5), dim=0, index(8, 3), value=True)`` (scalar, no src)::
+
+          [Replicate(), Replicate(), Replicate()]  # fallback only
+          # axis 0 is the scatter dim -> never sharded
+          # axis 1 sizes differ (input 5 != index 3) -> not shardable
+
+    - ``scatter(input(8, 5), dim=1, index(8, 3), src(10, 3))`` (src larger)::
+
+          [Replicate(), Replicate(), Replicate(), Replicate()]  # fallback only
+          # axis 1 is the scatter dim -> never sharded
+          # axis 0 sizes differ (src 10 != index 8) -> sharding would misalign
+          #   the src/index shards, so it is not offered
+    """
     mesh = op_schema.get_mesh_from_args()
+
+    input_strategy, dim, index_strategy = op_schema.args_schema[:3]
+    if not isinstance(input_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
+    if not isinstance(index_strategy, OpStrategy):
+        raise AssertionError(f"Expected OpStrategy, got {type(index_strategy)}")
+    if not isinstance(dim, int):
+        raise AssertionError(f"Expected int, got {type(dim)}")
+    dim = normalize_dim(dim, input_strategy.ndim)
+    input_shape = input_strategy.shape
+    index_shape = index_strategy.shape
+
+    # Placement lists are [output, input, index, src]. The scalar `.value`
+    # overloads (and `.src` with a python-number src) carry no src tensor,
+    # giving a 3-element list; otherwise capture src's shape for the guard below.
+    if len(op_schema.args_strategy) < 3:
+        num_specs = 3
+        src_shape = None
+    else:
+        num_specs = 4
+        src_strategy = op_schema.args_schema[3]
+        if not isinstance(src_strategy, OpStrategy):
+            raise AssertionError(f"Expected OpStrategy, got {type(src_strategy)}")
+        src_shape = src_strategy.shape
+
     single_mesh_dim_strategies = []
 
-    # placement list stores placements of [output, input, index, src]
-    # first we always have replicate all for inputs and output
-    if len(op_schema.args_strategy) < 3:
-        # scatter_.src/scatter.src with src be float number instead of tensor
-        all_replicate: PlacementList = [Replicate()] * 3
-    else:
-        all_replicate = [Replicate()] * 4
+    # The fully-replicated strategy is always valid; it is the fallback used
+    # when no sharded strategy matches the input placements.
+    all_replicate: PlacementList = [Replicate()] * num_specs
     single_mesh_dim_strategies.append(all_replicate)
 
-    # TODO: see if we can support input sharding pattern
+    # Shard any non-scatter axis on which all operands agree in size: each rank
+    # then scatters its own slice as a purely local op (mirrors scatter_add).
+    #   - the scatter axis (`dim`) stays replicated, since indices address its
+    #     full extent;
+    #   - input/index must match in size so each output row and the writes into
+    #     it co-locate on the same rank;
+    #   - src may legally be larger than index, so only shard where they match
+    #     too, else the src/index shards would misalign.
+    if len(input_shape) == len(index_shape):
+        for d in range(len(input_shape)):
+            if d == dim or input_shape[d] != index_shape[d]:
+                continue
+            if src_shape is not None and src_shape[d] != index_shape[d]:
+                continue
+            sharding: PlacementList = [Shard(d)] * num_specs
+            single_mesh_dim_strategies.append(sharding)
+
     op_strategy = expand_to_full_mesh_op_strategy(
         mesh,
         op_schema,


### PR DESCRIPTION
`scatter_strategy` previously offered only the all-replicate strategy (it had a standing TODO for input sharding), forcing an all-gather to Replicate before any scatter/scatter_ on sharded DTensors. This is costly on hot paths like MoE routing — `zeros_like(scores).scatter_(-1, topk_ids, True)` where `scores/topk_ids` are token-sharded but the scatter writes along the replicated expert dim. This PR mirrors` scatter_add_strategy` to additionally shard any non-scatter axis where all operands agree in size, so each rank scatters its local slice with no communication (the scatter axis stays replicated; src is only sharded where it matches index, since src may legally be larger; all-replicate remains as the fallback). Extends test_scatter with a sharded non-scatter-dim case (asserts zero comm + Shard output) and a src-larger-than-index case (asserts replicate fallback); full `test_tensor_ops.py` passes.