### PR TITLE
[Inductor][NVGEMM] Enable Epilogue Fusions

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -2,11 +2,16 @@
 
 
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import torch
 from torch._inductor import config
 from torch._inductor.codegen.cuda.cuda_env import is_datacenter_blackwell_arch
+from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_scheduling import (
+    EPILOGUE_FN_NAME,
+)
+from torch._inductor.scheduler import Scheduler
 from torch._inductor.template_heuristics.nv_universal_gemm import (
     HeuristicConfig,
     NVUniversalGemmHeuristics,
@@ -717,6 +722,183 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
                 else:
                     result = compiled_fn(a, b)
                     torch.testing.assert_close(result, a @ b)
+
+
+@unittest.skipIf(
+    not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
+    "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
+)
+@instantiate_parametrized_tests
+class TestNVUniversalGemmEpilogueFusion(TestCase):
+    """Test cases for NVIDIA Universal GEMM epilogue fusion.
+
+    Tests verify both correctness and that fusion actually occurs by examining
+    generated code for epilogue markers. Benchmarks are mocked to ensure
+    deterministic fusion decisions independent of GPU noise.
+    """
+
+    M, N, K = 512, 512, 512
+
+    def _compile_and_check(self, fn, *args):
+        torch._dynamo.reset()
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "NVGEMM",
+                    "nvgemm_max_profiling_configs": 2,
+                    "force_disable_caches": True,
+                }
+            ),
+            mock.patch.object(
+                Scheduler,
+                "benchmark_fused_nodes",
+                return_value=(1.0, ""),
+            ),
+            mock.patch.object(
+                Scheduler,
+                "benchmark_codegened_module",
+                return_value=(0.5, ""),
+            ),
+        ):
+            result, code_list = run_and_get_code(torch.compile(fn), *args)
+        code = "\n".join(code_list)
+        epilogue_fused = EPILOGUE_FN_NAME in code and "EpilogueArguments" in code
+        return result, code, epilogue_fused
+
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_matmul_pointwise_epilogue_fusion(self, dtype):
+        """Pointwise op (relu) is fused into the GEMM epilogue."""
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            return torch.relu(a @ b)
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "pointwise op was NOT fused into epilogue")
+
+    def test_matmul_add_relu_chained(self):
+        """Multi-op pointwise chain (a@b + bias → relu) collapses to one
+        ComputedBuffer and is fused as a single epilogue."""
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+        bias = torch.randn(self.M, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b, bias):
+            return torch.relu((a @ b) + bias)
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b, bias)
+        torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "bias+relu chain was NOT fused into epilogue")
+
+    def test_matmul_cast_dtype(self):
+        """Output-dtype cast in the epilogue."""
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            return (a @ b).to(torch.float32)
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
+        self.assertTrue(epilogue_fused, "dtype cast was NOT fused into epilogue")
+
+    def test_plain_matmul_no_epilogue(self):
+        """Test that plain matmul does NOT produce epilogue fusion markers."""
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            return a @ b
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
+        self.assertFalse(
+            epilogue_fused, "plain matmul should NOT have epilogue fusion markers"
+        )
+
+    def test_reduction_not_fused(self):
+        """Test that reductions after GEMM are NOT fused into the epilogue."""
+        dtype = torch.bfloat16
+        a = torch.randn(self.M, self.K, device="cuda", dtype=dtype)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=dtype)
+
+        def fn(a, b):
+            return (a @ b).sum(dim=-1)
+
+        result, code, epilogue_fused = self._compile_and_check(fn, a, b)
+        expected = fn(a, b)
+        torch.testing.assert_close(
+            result.float(), expected.float(), atol=5e-2, rtol=5e-2
+        )
+        self.assertFalse(
+            epilogue_fused,
+            "reduction after GEMM should NOT be fused into NVGEMM epilogue",
+        )
+
+    def test_workspace_runtime_integration(self):
+        """End-to-end: mock the chosen kernel's workspace_size to non-zero and
+        actually let benchmark_codegened_module run, exercising the runtime
+        path that consumes the generated get_args()/call() helpers.
+
+        Without the workspace fix, the rendered call would TypeError on the
+        missing positional arg, _benchmark_nvgemm_module's broad except would
+        return inf, autotune would silently fall back to a non-EFC choice,
+        and a naive `assert_close` against eager would still pass. To actually
+        catch the regression we intercept _benchmark_nvgemm_module to record
+        every (ms, path) it returns and assert at least one finite-ms result —
+        i.e., at least one EFC choice with workspace did get benchmarked."""
+        import cutlass_api
+
+        from torch._inductor.codegen.cuda_combined_scheduling import (
+            CUDACombinedScheduling,
+        )
+
+        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
+
+        def fn(a, b):
+            return torch.relu(a @ b)
+
+        bench_results: list[tuple[float, str]] = []
+        orig_bench = CUDACombinedScheduling._benchmark_nvgemm_module
+
+        def capturing_bench(self, module):
+            ms, path = orig_bench(self, module)
+            bench_results.append((ms, path))
+            return ms, path
+
+        torch._dynamo.reset()
+        with (
+            patch.object(
+                cutlass_api.Kernel, "get_workspace_size", lambda self, args: 4096
+            ),
+            mock.patch.object(
+                CUDACombinedScheduling, "_benchmark_nvgemm_module", capturing_bench
+            ),
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "NVGEMM",
+                    "nvgemm_max_profiling_configs": 2,
+                    "force_disable_caches": True,
+                }
+            ),
+        ):
+            result = torch.compile(fn)(a, b)
+        torch.testing.assert_close(result, fn(a, b), atol=1e-2, rtol=1e-2)
+        self.assertTrue(bench_results, "_benchmark_nvgemm_module never invoked")
+        finite = [(ms, p) for ms, p in bench_results if ms != float("inf")]
+        self.assertTrue(
+            finite,
+            f"All NVGEMM benchmarks returned inf — workspace handling likely "
+            f"broken. Results: {bench_results}",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -1,8 +1,12 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import logging
 from typing import Any, TYPE_CHECKING
 
+import torch
+
+from ..ir import MultiTemplateBuffer
 from ..scheduler import (
     BaseSchedulerNode,
     BaseScheduling,
@@ -17,13 +21,15 @@ from .rocm.rocm_cpp_scheduling import ROCmCPPScheduling
 from .triton import TritonScheduling
 
 
+log = logging.getLogger(__name__)
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import TypeAlias
 
     from sympy import Expr
 
-    import torch
     from torch.utils._ordered_set import OrderedSet
 
     from .common import BackendFeature
@@ -61,6 +67,8 @@ class CUDACombinedScheduling(BaseScheduling):
             return self._cutedsl_scheduling
         if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node):
             return self._nv_universal_gemm_scheduling
+        if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(node):
+            return self._nv_universal_gemm_scheduling
         return self._triton_scheduling
 
     def can_fuse_vertical(
@@ -77,11 +85,27 @@ class CUDACombinedScheduling(BaseScheduling):
             node1
         ) or self._cutedsl_scheduling.is_cutedsl_template(node2):
             return False
-        # NVIDIA Universal GEMM doesn't support vertical fusion currently
-        elif self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(
-            node1
-        ) or self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node2):
+        # Only intercept when node1 is the NVGEMM template (epilogue direction).
+        # Prologue direction (node1=pointwise, node2=template) must fall through to
+        # Triton, or NVGEMM-winning MTBs silently lose Triton prologue fusion.
+        # For MTBs, if NVGEMM can't fuse, fall through to Triton scheduling so
+        # Triton choices in the same MTB can still attempt epilogue fusion.
+        elif self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node1):
+            if self._nv_universal_gemm_scheduling.can_fuse_vertical(node1, node2):
+                return True
+            if isinstance(node1, SchedulerNode) and isinstance(
+                node1.node, MultiTemplateBuffer
+            ):
+                return self._triton_scheduling.can_fuse_vertical(node1, node2)
             return False
+        elif self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(
+            node1
+        ):
+            if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(
+                node2
+            ):
+                return False
+            return self._nv_universal_gemm_scheduling.can_fuse_vertical(node1, node2)
         return self._triton_scheduling.can_fuse_vertical(node1, node2)
 
     def can_fuse_horizontal(
@@ -96,7 +120,11 @@ class CUDACombinedScheduling(BaseScheduling):
                 return self._cutedsl_scheduling.can_fuse_horizontal(
                     node1, node2
                 )  # always False at the moment
-            if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node):
+            if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(
+                node
+            ) or self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(
+                node
+            ):
                 return self._nv_universal_gemm_scheduling.can_fuse_horizontal(
                     node1, node2
                 )  # always False at the moment
@@ -134,9 +162,9 @@ class CUDACombinedScheduling(BaseScheduling):
         elif self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(
             template_node
         ):
-            # NVIDIA Universal GEMM doesn't support epilogue/prologue fusion yet
-            assert not epilogue_nodes
-            assert not prologue_nodes
+            assert not prologue_nodes, (
+                "NVIDIA Universal GEMM doesn't support prologue fusion yet"
+            )
             return self._nv_universal_gemm_scheduling.codegen_template(
                 template_node, epilogue_nodes, prologue_nodes
             )
@@ -169,7 +197,67 @@ class CUDACombinedScheduling(BaseScheduling):
         return self._triton_scheduling.benchmark_fused_nodes(nodes)
 
     def benchmark_codegened_module(self, module):
+        if getattr(module, "is_nvgemm", False):
+            return self._benchmark_nvgemm_module(module)
         return self._triton_scheduling.benchmark_codegened_module(module)
+
+    def _benchmark_nvgemm_module(self, module) -> tuple[float, str]:
+        from torch._dynamo.utils import preserve_rng_state
+        from torch._inductor.runtime.benchmarking import benchmarker
+        from torch._inductor.utils import (
+            clone_preserve_strides,
+            get_interface_for_device,
+        )
+        from torch._inductor.virtualized import V
+
+        device_interface = get_interface_for_device(V.graph.device_type)
+
+        def clone_args(args: list[Any]) -> list[Any]:
+            return [
+                clone_preserve_strides(a) if torch.is_tensor(a) else a for a in args
+            ]
+
+        with (
+            preserve_rng_state(),
+            device_interface.device(V.graph.get_current_device_or_throw()),
+        ):
+            args = module.get_args()
+            call = module.call
+
+            try:
+                call(clone_args(args))
+            except Exception as e:
+                log.debug(
+                    "Exception (%s) in compiling NVGEMM fused kernel",
+                    e,
+                )
+                return float("inf"), module.__file__ or ""
+
+            device = V.graph.get_current_device_or_throw()
+            try:
+                ms = benchmarker.benchmark(
+                    lambda: call(clone_args(args)),
+                    device=device,
+                )
+            except Exception as e:
+                log.debug(
+                    "Exception (%s) while benchmarking NVGEMM fused kernel",
+                    e,
+                )
+                return float("inf"), module.__file__ or ""
+
+            return ms, module.__file__ or ""
+
+    def _is_nvgemm_node(self, node) -> bool:
+        """Check if a template node is currently configured for NVGEMM codegen."""
+        from torch._inductor.ir import MultiTemplateBuffer, NVUniversalGemmBuffer
+
+        template_node = node.get_template_node()
+        if isinstance(template_node, NVUniversalGemmBuffer):
+            return True
+        if isinstance(template_node, MultiTemplateBuffer):
+            return template_node._render_kind == "nvgemm"
+        return False
 
     def generate_kernel_code_from_nodes(
         self,
@@ -177,6 +265,16 @@ class CUDACombinedScheduling(BaseScheduling):
         benchmark_kernel: bool = False,
         hint_override: int | None = None,
     ) -> str:
+        for node in nodes:
+            if not (hasattr(node, "is_template") and node.is_template()):
+                continue
+            if self._is_nvgemm_node(node):
+                return (
+                    self._nv_universal_gemm_scheduling.generate_kernel_code_from_nodes(
+                        nodes, benchmark_kernel, hint_override=hint_override
+                    )
+                )
+            break
         return self._triton_scheduling.generate_kernel_code_from_nodes(
             nodes, benchmark_kernel, hint_override=hint_override
         )

--- a/torch/_inductor/codegen/cutlass/python_evt.py
+++ b/torch/_inductor/codegen/cutlass/python_evt.py
@@ -187,6 +187,8 @@ class CutlassEVTCodegen(CutlassEVTOpsMixIn):
         cutlass_template_node_name: str,
         epilogue_nodes: list[BaseSchedulerNode],
         removed_buffers: OrderedSet[str],
+        fn_name: str = "fn",
+        as_standalone_function: bool = False,
     ) -> tuple[list[str], list[str], dict[str, Any], str]:
         codegen = CutlassEVTCodegen(cutlass_template_node_name, removed_buffers)
         handler = _AssignmentFormatter(codegen)
@@ -205,15 +207,25 @@ class CutlassEVTCodegen(CutlassEVTOpsMixIn):
             codegen.get_reads(),
             codegen.get_writes(),
             codegen.get_renames(),
-            codegen.get_value(),
+            codegen.get_value(
+                fn_name=fn_name,
+                as_standalone_function=as_standalone_function,
+            ),
         )
 
-    def get_value(self) -> str:
+    def get_value(
+        self,
+        fn_name: str = "fn",
+        as_standalone_function: bool = False,
+    ) -> str:
+        ret = self._render_return_statement()
+        if as_standalone_function:
+            ret = "    " + ret
         return linesep.join(
             [
-                self._render_input_signature(),
+                self._render_input_signature(fn_name),
                 self.body.getvalue(),
-                self._render_return_statement(),
+                ret,
             ]
         )
 
@@ -309,12 +321,12 @@ class CutlassEVTCodegen(CutlassEVTOpsMixIn):
             for l, r in (zip(left, right))
         )
 
-    def _render_input_signature(self) -> str:
+    def _render_input_signature(self, fn_name: str = "fn") -> str:
         arguments = ", ".join(
             [_ACCUMULATOR_ARG_NAME]
             + [name for name in self.reads if name != self.accumulator_node_name]
         )
-        return f"def fn({arguments}):"
+        return f"def {fn_name}({arguments}):"
 
     def _render_return_statement(self) -> str:
         return_vars = OrderedSet(

--- a/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
@@ -11,11 +11,43 @@ dict for O(1) lookup (~0.1 μs).
 """
 
 import logging
+import threading
 from collections.abc import Callable
 from typing import Any
 
+import torch
+
 
 log = logging.getLogger(__name__)
+
+
+def _epilogue_args_signature(epilogue_args: Any) -> tuple:
+    """Extract a hashable signature of epilogue args for cache keying.
+
+    Two callers with the same `(efc_kernel_name, epilogue_source)` but
+    different aux-tensor specs (dtype, shape, stride) would otherwise share
+    a kernel object whose internal JIT state is mutated by each call to
+    `kernel.compile(args)` — a silent miscompile, since the compiled
+    artifact's launch closure reads the kernel's CURRENT JIT at launch time
+    rather than the one from when the artifact was built.
+    """
+    if epilogue_args is None:
+        return ()
+    tensors = getattr(epilogue_args, "tensors", None)
+    if not tensors:
+        return ()
+    sig: list[tuple] = []
+    for name, val in tensors.items():
+        if torch.is_tensor(val):
+            sig.append(
+                (name, "tensor", val.dtype, tuple(val.shape), tuple(val.stride()))
+            )
+        else:
+            sig.append((name, type(val).__name__))
+    return tuple(sig)
+
+
+_cache_lock = threading.Lock()
 
 # Global cache: kernel_name -> kernel object
 _kernel_by_name_cache: dict[str, Any] | None = None
@@ -40,19 +72,29 @@ def _build_kernel_cache() -> dict[str, Any]:
     return cache
 
 
+def _get_kernel_cache() -> dict[str, Any]:
+    """Return the kernel cache, initializing lazily if needed.
+
+    Snapshot to local frame: a concurrent clear_cache() rebinding the global to
+    None cannot turn the caller's subsequent read into AttributeError.
+    """
+    global _kernel_by_name_cache
+    if _kernel_by_name_cache is None:
+        with _cache_lock:
+            if _kernel_by_name_cache is None:
+                _kernel_by_name_cache = _build_kernel_cache()
+    return _kernel_by_name_cache
+
+
 def get_compatible_kernels(
     args: Any,
     cc: int,
     metadata_filter: Callable[[Any], bool] | None = None,
 ) -> list[Any]:
     """Get kernels compatible with the given arguments from the cache."""
-    global _kernel_by_name_cache
-
-    if _kernel_by_name_cache is None:
-        _kernel_by_name_cache = _build_kernel_cache()
-
+    cache = _get_kernel_cache()
     compatible = []
-    for kernel in _kernel_by_name_cache.values():
+    for kernel in cache.values():
         if kernel.metadata.min_cc > cc:
             continue
 
@@ -67,30 +109,92 @@ def get_compatible_kernels(
     log.debug(
         "Found %d compatible kernels from cache of %d total",
         len(compatible),
-        len(_kernel_by_name_cache),
+        len(cache),
     )
     return compatible
 
 
 def get_kernel_by_name(kernel_name: str) -> Any:
     """Get a cutlass_api kernel by name using the global cache."""
-    global _kernel_by_name_cache
-
-    if _kernel_by_name_cache is None:
-        _kernel_by_name_cache = _build_kernel_cache()
-
-    return _kernel_by_name_cache.get(kernel_name)
+    return _get_kernel_cache().get(kernel_name)
 
 
 def ensure_cache_initialized() -> None:
     """Ensure the kernel cache is initialized."""
-    global _kernel_by_name_cache
+    _get_kernel_cache()
 
-    if _kernel_by_name_cache is None:
-        _kernel_by_name_cache = _build_kernel_cache()
+
+_efc_epilogue_cache: dict[tuple[str, str, tuple], Any] = {}
 
 
 def clear_cache() -> None:
-    """Clear the kernel cache."""
-    global _kernel_by_name_cache
-    _kernel_by_name_cache = None
+    """Clear all kernel caches."""
+    global _kernel_by_name_cache, _efc_epilogue_cache
+    with _cache_lock:
+        _kernel_by_name_cache = None
+        _efc_epilogue_cache = {}
+
+
+class _NVGEMMCacheWrapper:
+    def cache_clear(self) -> None:
+        clear_cache()
+
+
+from torch._inductor.utils import clear_on_fresh_cache
+
+
+clear_on_fresh_cache(_NVGEMMCacheWrapper())
+
+
+def get_efc_kernel_with_epilogue(
+    efc_kernel_name: str,
+    epilogue_args: Any,
+    epilogue_source: str = "",
+) -> Any:
+    """Get (or create and cache) an EFC kernel bound to a specific epilogue.
+
+    epilogue_source is preferred over inspect.getsource — generated functions
+    produce unstable source strings that can't be hashed reliably.
+    """
+    if not epilogue_source:
+        epilogue_source = str(epilogue_args) if epilogue_args is not None else ""
+
+    cache_key = (
+        efc_kernel_name,
+        epilogue_source,
+        _epilogue_args_signature(epilogue_args),
+    )
+
+    base_cache = _get_kernel_cache()
+
+    with _cache_lock:
+        if cache_key in _efc_epilogue_cache:
+            log.debug("EFC kernel with epilogue found in cache: %s", efc_kernel_name)
+            return _efc_epilogue_cache[cache_key]
+
+        base_kernel = base_cache.get(efc_kernel_name)
+        if base_kernel is None:
+            log.debug("Base EFC kernel not found: %s", efc_kernel_name)
+            return None
+
+        from cutlass_api.metadata import EpilogueMetadata, KernelMetadata
+
+        epilogue_metadata = EpilogueMetadata.from_args(epilogue_args)
+
+        base_metadata = base_kernel.metadata
+        new_metadata = KernelMetadata(
+            operands=base_metadata.operands,
+            design=base_metadata.design,
+            kernel_name=base_metadata.kernel_name,
+            kernel_class=base_metadata.kernel_class,
+            min_cc=base_metadata.min_cc,
+            epilogue=epilogue_metadata,
+        )
+
+        kernel_class = base_metadata.kernel_class
+        new_kernel = kernel_class(new_metadata)
+
+        _efc_epilogue_cache[cache_key] = new_kernel
+        log.debug("Created and cached EFC kernel with epilogue: %s", efc_kernel_name)
+
+        return new_kernel

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -7,6 +7,7 @@ high-performance GEMM kernels for NVIDIA GPUs.
 """
 
 import itertools
+import re
 from enum import auto, Enum
 from typing import Any
 
@@ -102,14 +103,23 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         fewer tensors than expected. By always creating from input_tensor_meta,
         we ensure each input gets its own tensor with the correct size/stride/offset
         from the view's layout.
+
         """
-        # Always create tensors from input_tensor_meta, ignoring passed-in tensors
+        from torch._inductor.runtime.benchmarking import benchmarker
+
         input_tensors = tuple(x.to_tensor() for x in self.input_tensor_meta)
         if out is None:
             out = self.output_tensor_meta.to_tensor()
 
         fn = self.make_run_fn(*input_tensors, out=out)
-        return self.do_bench(fn, *input_tensors, out=out)
+        try:
+            if self.benchmark_with_cudagraphs:
+                res = benchmarker.benchmark_gpu_with_cuda_graph(fn)
+            else:
+                res = self.do_bench(fn, *input_tensors, out=out)
+        finally:
+            self.cleanup_run_fn()
+        return res
 
     def make_run_fn(self, *input_tensors: torch.Tensor, out: torch.Tensor):
         """Create a function to run the NVIDIA Universal GEMM kernel."""
@@ -213,6 +223,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
         scale_type_b: Any | None = None,
         swizzle_type_a: Any | None = None,
         swizzle_type_b: Any | None = None,
+        supports_epilogue_fusion: bool = False,
     ) -> None:
         super().__init__(
             name=name,
@@ -228,6 +239,8 @@ class NVUniversalGemmCaller(ChoiceCaller):
         self.scale_type_b = scale_type_b
         self.swizzle_type_a = swizzle_type_a
         self.swizzle_type_b = swizzle_type_b
+        self.supports_epilogue_fusion = supports_epilogue_fusion
+        self._cached_output_node: TensorBox | None = None
 
         output_buffer = Buffer(name=f"{variant.op_name}_out", layout=layout)
 
@@ -249,10 +262,17 @@ class NVUniversalGemmCaller(ChoiceCaller):
         return f"NVUniversalGemmCaller({self.kernel.metadata.kernel_name})"
 
     def benchmark(self, *args, out) -> float:
+        self.bmreq.benchmark_with_cudagraphs = self._benchmark_with_cudagraphs
         return self.bmreq.benchmark(*args, out=out)
 
     def output_node(self) -> TensorBox:
         from torch._inductor.ir import NVUniversalGemmBuffer
+
+        # Without memoization, each call registers a new buffer (via
+        # TemplateBuffer.__init__ → V.graph.register_buffer), leaking orphan
+        # buffers into the graph's name tables during EFC benchmarking.
+        if self._cached_output_node is not None:
+            return self._cached_output_node
 
         buffer = NVUniversalGemmBuffer(
             layout=self.layout,
@@ -265,11 +285,12 @@ class NVUniversalGemmCaller(ChoiceCaller):
             scale_type_b=self.scale_type_b,
             swizzle_type_a=self.swizzle_type_a,
             swizzle_type_b=self.swizzle_type_b,
+            supports_epilogue_fusion=self.supports_epilogue_fusion,
         )
-        # Pass KTC annotation to the buffer for encoding
         if "ktc" in self.annotations:
             buffer.annotations["ktc"] = self.annotations["ktc"]
-        return TensorBox.create(buffer)
+        self._cached_output_node = TensorBox.create(buffer)
+        return self._cached_output_node
 
     def call_name(self) -> str:
         return self.name
@@ -278,7 +299,22 @@ class NVUniversalGemmCaller(ChoiceCaller):
         return self.bmreq.make_run_fn
 
     def hash_key(self) -> str:
-        return f"{self.variant.op_name}_{self.kernel.metadata.kernel_name}"
+        # `select_algorithm` uses this as a precompile dedup key. Two callers
+        # wrapping the same physical kernel name but with different accumulator/
+        # scale/swizzle types produce distinct compiled artifacts; collapsing
+        # them here would silently drop the second from autotuning.
+        return "_".join(
+            str(x)
+            for x in (
+                self.variant.op_name,
+                self.kernel.metadata.kernel_name,
+                self.accumulator_type,
+                self.scale_type_a,
+                self.scale_type_b,
+                self.swizzle_type_a,
+                self.swizzle_type_b,
+            )
+        )
 
     def info_dict(self) -> dict[str, Any]:
         return {
@@ -286,6 +322,71 @@ class NVUniversalGemmCaller(ChoiceCaller):
             "backend": self.variant.op_name,
             "kernel_name": self.kernel.metadata.kernel_name,
         }
+
+    def get_make_kernel_render(self):
+        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
+            NVUniversalGemmKernel,
+        )
+        from torch._inductor.utils import Placeholder
+
+        kernel_metadata = {
+            "kernel_name": self.kernel.metadata.kernel_name,
+            "min_cc": self.kernel.metadata.min_cc,
+        }
+        accumulator_type = self.accumulator_type
+        workspace_size = self.workspace_size
+        variant = self.variant
+        scale_type_a = self.scale_type_a
+        scale_type_b = self.scale_type_b
+        swizzle_type_a = self.swizzle_type_a
+        swizzle_type_b = self.swizzle_type_b
+        input_nodes = self.input_nodes
+
+        def make_kernel_render(
+            out_node,
+            hint_override=None,
+            epilogue_fn_code=None,
+            epilogue_reads=None,
+            epilogue_writes=None,
+            epilogue_var_renames=None,
+        ):
+            from torch._inductor.ir import StorageBox, TensorBox
+
+            processed_inputs = []
+            for inp in input_nodes:
+                if isinstance(inp, TensorBox):
+                    inp = inp.data
+                if isinstance(inp, StorageBox):
+                    inp = inp.data
+                processed_inputs.append(inp)
+
+            kernel_name = str(Placeholder.KERNEL_NAME)
+
+            render_kernel = NVUniversalGemmKernel(
+                kernel_name=kernel_name,
+                # pyrefly: ignore [bad-argument-type]
+                input_nodes=processed_inputs,
+                output_node=out_node,
+                kernel_metadata=kernel_metadata,
+                accumulator_type=accumulator_type,
+                workspace_size=workspace_size,
+                variant=variant,
+                scale_type_a=scale_type_a,
+                scale_type_b=scale_type_b,
+                swizzle_type_a=swizzle_type_a,
+                swizzle_type_b=swizzle_type_b,
+                epilogue_fn_code=epilogue_fn_code,
+                epilogue_reads=epilogue_reads,
+                epilogue_writes=epilogue_writes,
+                epilogue_var_renames=epilogue_var_renames,
+            )
+
+            def render():
+                return render_kernel.render()
+
+            return render_kernel, render
+
+        return make_kernel_render
 
 
 def _create_dummy_tensor_from_layout(
@@ -304,18 +405,43 @@ def _create_dummy_tensor_from_layout(
             result = result.view(dtype_override)
         return result
     except Exception:
+        # Broad: layout.get_example()/torch.empty_strided under fake mode can
+        # raise a variety of unexpected errors (TypeError, AssertionError, etc.)
+        # depending on stride/symint state. Failing to materialize a dummy
+        # should never abort autotune — just skip this candidate.
         return None
 
 
-def _exclude_efc_kernels(metadata) -> bool:
-    """
-    Filter out EFC kernels.
+_TILE_RE = re.compile(r"tile(\d+)x\d+x\d+")
 
-    EFC kernels support custom epilogue operations but have additional overhead.
-    Since NVGEMM doesn't support epilogue fusion yet (see nv_universal_gemm_scheduling.py),
-    we use non-EFC kernels which are equivalent for identity epilogue (out = acc).
-    TODO(nikhilap): Remove this filter once NVGEMM supports epilogue fusion.
+
+def _include_efc_kernels_only(metadata) -> bool:
+    """Filter to include only EFC (Epilogue Fusion Compatible) kernels.
+
+    Excludes tile_M=64 EFC kernels: cutlass_api has a broadcast bug in the
+    epilogue thread operation for aux-tensor inputs with tile_M=64, and we
+    don't yet know at autotune time whether fusion will consume aux tensors.
+    Non-EFC kernels still cover tile_M=64, so plain GEMM autotune is unaffected.
+
+    Strictly requires the kernel name to encode tile dims; if cutlass_api ever
+    changes the naming scheme, this raises rather than silently letting the
+    broken tile_M=64 kernels through.
     """
+    if "EFC" not in metadata.kernel_class.__name__:
+        return False
+    match = _TILE_RE.search(metadata.kernel_name)
+    if match is None:
+        raise RuntimeError(
+            f"NVGEMM EFC kernel name does not match expected tile pattern "
+            f"'tileMxNxK': {metadata.kernel_name}. The tile_M=64 broadcast "
+            f"workaround in _include_efc_kernels_only depends on this naming "
+            f"convention; update the regex or move to metadata-based filtering."
+        )
+    return int(match.group(1)) >= 128
+
+
+def _exclude_efc_kernels(metadata) -> bool:
+    """Filter to exclude EFC kernels (for non-epilogue cases)."""
     return "EFC" not in metadata.kernel_class.__name__
 
 
@@ -426,25 +552,39 @@ def _add_nv_gemm_choices_impl(
         return
     cc_int = int(cc)
 
-    kernels = get_compatible_kernels(args, cc_int, metadata_filter=_exclude_efc_kernels)
-    if not kernels:
+    non_efc_kernels = get_compatible_kernels(
+        args, cc_int, metadata_filter=_exclude_efc_kernels
+    )
+    efc_kernels = get_compatible_kernels(
+        args, cc_int, metadata_filter=_include_efc_kernels_only
+    )
+    if not non_efc_kernels and not efc_kernels:
         log.debug("No compatible %s kernels found", variant.op_name)
         return
 
-    max_configs = config.nvgemm_max_profiling_configs or len(kernels)
+    max_configs = config.nvgemm_max_profiling_configs or max(
+        len(non_efc_kernels), len(efc_kernels)
+    )
     if variant in (GemmVariant.GEMM, GemmVariant.SCALED_GEMM) and mm_inputs is not None:
         heuristics = get_nvgemm_heuristics()
-        kernels = heuristics.filter_kernels(
-            kernels, mm_inputs, max_configs, accumulator_type
+        non_efc_kernels = heuristics.filter_kernels(
+            non_efc_kernels, mm_inputs, max_configs, accumulator_type
+        )
+        efc_kernels = heuristics.filter_kernels(
+            efc_kernels, mm_inputs, max_configs, accumulator_type
         )
     else:
         # TODO(nikhilap): Enable heuristics for grouped GEMM
         # when nvMatmulHeuristics adds support
-        kernels = kernels[:max_configs]
+        non_efc_kernels = non_efc_kernels[:max_configs]
+        efc_kernels = efc_kernels[:max_configs]
 
-    # Add callers for each kernel
+    all_kernels = [(kernel, False) for kernel in non_efc_kernels] + [
+        (kernel, True) for kernel in efc_kernels
+    ]
+
     num_added = 0
-    for kernel in kernels:
+    for kernel, supports_epilogue_fusion in all_kernels:
         name = f"{variant.op_name}_{next(NVUniversalGemmCaller.index_counter)}"
         workspace_size = kernel.get_workspace_size(args)
         try:
@@ -460,10 +600,14 @@ def _add_nv_gemm_choices_impl(
                 scale_type_b=scale_type_b,
                 swizzle_type_a=swizzle_type_a,
                 swizzle_type_b=swizzle_type_b,
+                supports_epilogue_fusion=supports_epilogue_fusion,
             )
             choices.append(caller)
             num_added += 1
         except Exception:
+            # Broad: caller construction touches cutlass_api / fake-mode tensors
+            # which can raise types other than RuntimeError/ValueError. A single
+            # bad choice should never abort the rest of autotune choice population.
             log.debug("Failed to create %s choice", variant.op_name, exc_info=True)
 
     log.debug("Added %d %s choices", num_added, variant.op_name)

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -7,12 +7,18 @@ This module generates Python code that calls cutlass_api to execute GEMM operati
 
 from __future__ import annotations
 
-import functools
+import hashlib
 import logging
 from typing import Any, TYPE_CHECKING
 
-from torch._inductor.codegen.common import Kernel, WorkspaceArg, WorkspaceZeroMode
+from torch._inductor.codegen.common import (
+    IndentedBuffer,
+    Kernel,
+    WorkspaceArg,
+    WorkspaceZeroMode,
+)
 from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import CuteDSLOpOverrides
+from torch._inductor.codegen.cutlass.python_evt import _ACCUMULATOR_ARG_NAME
 from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
     to_cutlass_scale_mode,
 )
@@ -23,7 +29,6 @@ from torch._inductor.ir import (
     MutableBox,
     ReinterpretView,
 )
-from torch._inductor.kernel.mm_common import load_kernel_template
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
@@ -51,8 +56,9 @@ class NVUniversalGemmKernel(Kernel):
     """
     Kernel implementation for NVIDIA Universal GEMM.
 
-    Generates Python code that calls cutlass_api to execute GEMM operations
-    using a Jinja template (nv_universal_gemm.py.jinja).
+    Generates Python code that calls cutlass_api to execute GEMM operations.
+    Unlike CuteDSL which uses Jinja templates, this generates simpler direct
+    Python code.
     """
 
     def __init__(
@@ -68,6 +74,10 @@ class NVUniversalGemmKernel(Kernel):
         scale_type_b: Any | None = None,
         swizzle_type_a: Any | None = None,
         swizzle_type_b: Any | None = None,
+        epilogue_fn_code: str | None = None,
+        epilogue_reads: list[str] | None = None,
+        epilogue_writes: list[str] | None = None,
+        epilogue_var_renames: dict[str, Any] | None = None,
     ) -> None:
         super().__init__()
         self.kernel_name = kernel_name
@@ -81,6 +91,10 @@ class NVUniversalGemmKernel(Kernel):
         self.scale_type_b = scale_type_b
         self.swizzle_type_a = swizzle_type_a
         self.swizzle_type_b = swizzle_type_b
+        self.epilogue_fn_code = epilogue_fn_code
+        self.epilogue_reads = epilogue_reads or []
+        self.epilogue_writes = epilogue_writes or []
+        self.epilogue_var_renames = epilogue_var_renames or {}
 
         self._template_input_args: list[tuple[str, Buffer]] = []
         self._seen_input_args: OrderedSet[str] = OrderedSet()
@@ -90,35 +104,20 @@ class NVUniversalGemmKernel(Kernel):
             self._template_input_args.append((param_name, input_node))
             self._seen_input_args.add(param_name)
 
-    @staticmethod
-    @functools.lru_cache(maxsize=1)
-    def _get_template():
-        from torch._inductor.codegen.common import jinja2_env
-
-        env = jinja2_env()
-        assert env is not None, (
-            "jinja2 is required for NV Universal GEMM code generation"
-        )
-        source = load_kernel_template("nv_universal_gemm")
-        return env.from_string(source)
-
     def render(self) -> str:
-        """
-        Render the NVIDIA Universal GEMM kernel code as a Python source string.
-
-        Uses a Jinja template to generate Python code that:
-        1. Looks up the cutlass_api kernel by name from the manifest
-        2. Creates GemmArguments with the input/output tensors and accumulator type
-        3. Compiles the kernel for the specific tensor shapes/dtypes (cached in memory
-           and on disk to avoid recompilation)
-        4. Runs the kernel with the compiled artifact and CUDA stream
-        """
+        """Render the Python source for the NVGEMM kernel wrapper."""
         from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm import (
             GemmVariant,
         )
 
         is_grouped = self.variant == GemmVariant.GROUPED_GEMM
         is_scaled = self.variant == GemmVariant.SCALED_GEMM
+        has_epilogue = bool(self.epilogue_fn_code)
+
+        if has_epilogue and (is_grouped or is_scaled):
+            raise NotImplementedError(
+                "Epilogue fusion is not yet supported for grouped or scaled GEMM variants"
+            )
 
         acc_dtype_str = CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(
             self.accumulator_type, "cutlass.Float32"
@@ -126,39 +125,154 @@ class NVUniversalGemmKernel(Kernel):
 
         input_params = [f"in_ptr{i}" for i, _ in enumerate(self.input_nodes)]
         input_params.append("out_ptr0")
+        input_params.extend(self.epilogue_reads)
         if self.workspace_size > 0:
             input_params.append("workspace")
         input_params.append("stream=None")
 
-        template_args: dict[str, Any] = {
-            "kernel_name": self.kernel_name,
-            "kernel_name_str": self.kernel_metadata["kernel_name"],
-            "is_grouped": is_grouped,
-            "is_scaled": is_scaled,
-            "acc_dtype": acc_dtype_str,
-            "params_str": ", ".join(input_params),
-            "workspace_arg": "workspace" if self.workspace_size > 0 else "None",
-            "input_ptrs": [f"in_ptr{i}" for i, _ in enumerate(self.input_nodes)],
-        }
+        params_str = ", ".join(input_params)
+        kernel_name_str = self.kernel_metadata["kernel_name"]
+        workspace_arg = "workspace" if self.workspace_size > 0 else "None"
+        var_prefix = self.variant.op_name.upper()
+        cache_var = f"_{var_prefix}_compiled_cache"
+        kernel_name_var = f"_{var_prefix}_KERNEL_NAME"
 
-        if is_scaled:
+        extra_imports = ""
+        if is_grouped:
+            cache_key = "(in_ptr0.shape, in_ptr0.dtype, in_ptr1.shape, in_ptr1.dtype, in_ptr2.shape)"
+            create_args = f"""    args = cutlass_api.arguments.GroupedGemmArguments(
+        in_ptr0, in_ptr1, out_ptr0,
+        accumulator_type={acc_dtype_str},
+        offsets=in_ptr2,
+    )"""
+        elif is_scaled:
             scale_mode_a, swizzle_mode_a = to_cutlass_scale_mode(
                 self.scale_type_a, self.swizzle_type_a
             )
             scale_mode_b, swizzle_mode_b = to_cutlass_scale_mode(
                 self.scale_type_b, self.swizzle_type_b
             )
-            template_args["scale_mode_a"] = scale_mode_a.name if scale_mode_a else ""
-            template_args["swizzle_mode_a"] = (
-                swizzle_mode_a.name if swizzle_mode_a else ""
+            extra_imports = (
+                "from cutlass_api.arguments import ScaledTensor\n"
+                "from cutlass_api.library import ScaleMode, ScaleSwizzleMode"
             )
-            template_args["scale_mode_b"] = scale_mode_b.name if scale_mode_b else ""
-            template_args["swizzle_mode_b"] = (
-                swizzle_mode_b.name if swizzle_mode_b else ""
+            cache_key = "(in_ptr0.shape, in_ptr0.dtype, in_ptr1.shape, in_ptr1.dtype, in_ptr2.shape, in_ptr3.shape)"
+            sma = scale_mode_a.name if scale_mode_a else ""
+            smb = scale_mode_b.name if scale_mode_b else ""
+            swa = swizzle_mode_a.name if swizzle_mode_a else ""
+            swb = swizzle_mode_b.name if swizzle_mode_b else ""
+            create_args = f"""    scaled_a = ScaledTensor(in_ptr0, in_ptr2, ScaleMode.{sma}, ScaleSwizzleMode.{swa})
+    scaled_b = ScaledTensor(in_ptr1, in_ptr3, ScaleMode.{smb}, ScaleSwizzleMode.{swb})
+    args = cutlass_api.arguments.GemmArguments(
+        scaled_a, scaled_b, out_ptr0,
+        accumulator_type={acc_dtype_str},
+    )"""
+        else:
+            cache_key = "(in_ptr0.shape, in_ptr0.dtype, in_ptr1.shape, in_ptr1.dtype)"
+            create_args = f"""    args = cutlass_api.arguments.GemmArguments(
+        in_ptr0, in_ptr1, out_ptr0,
+        accumulator_type={acc_dtype_str},
+    )"""
+
+        if has_epilogue:
+            assert self.epilogue_fn_code is not None  # narrowed by has_epilogue
+            epilogue_kwargs = self._render_epilogue_kwargs()
+            source_hash = hashlib.sha256(self.epilogue_fn_code.encode()).hexdigest()
+
+            kernel_cache_import = "from torch._inductor.codegen.nv_universal_gemm.kernel_cache import get_efc_kernel_with_epilogue"
+            epilogue_import = "from cutlass_api.arguments import EpilogueArguments"
+            epilogue_fn_def = (
+                self.epilogue_fn_code + f'\n_EPILOGUE_FN_SOURCE = "{source_hash}"'
             )
 
-        template = self._get_template()
-        return template.render(**template_args)
+            epilogue_setup = f"""
+    epi_args = EpilogueArguments(epilogue_fn=_epilogue_fn, {epilogue_kwargs})
+"""
+            kernel_lookup = f"""    kernel = get_efc_kernel_with_epilogue({kernel_name_str!r}, epi_args, epilogue_source=_EPILOGUE_FN_SOURCE)
+    if kernel is None:
+        raise RuntimeError(f"Could not find EFC kernel: {{{kernel_name_var}}}")"""
+
+            create_args = f"""    args = cutlass_api.arguments.GemmArguments(
+        in_ptr0, in_ptr1, out_ptr0,
+        accumulator_type={acc_dtype_str},
+        epilogue=epi_args,
+    )"""
+            # Aux tensors from the epilogue change the kernel's compiled
+            # artifact (cutlass_api dispatches on their dtype/shape) but the
+            # base cache_key only fingerprints A/B. Without folding aux
+            # tensor metadata in, a wrapper invoked with the same A/B but a
+            # differently-shaped aux input (e.g. dynamic-shape bias) would
+            # silently reuse a stale artifact.
+            aux_sig = ", ".join(
+                f"{name}.shape, {name}.dtype" for name in self.epilogue_reads
+            )
+            if aux_sig:
+                cache_key = f'({cache_key}, "epilogue", {aux_sig})'
+            else:
+                cache_key = f'({cache_key}, "epilogue")'
+        else:
+            kernel_cache_import = "from torch._inductor.codegen.nv_universal_gemm.kernel_cache import get_kernel_by_name"
+            epilogue_import = ""
+            epilogue_fn_def = ""
+            epilogue_setup = ""
+            kernel_lookup = f"""    kernel = get_kernel_by_name({kernel_name_var})
+    if kernel is None:
+        raise RuntimeError(f"Could not find kernel: {{{kernel_name_var}}}")"""
+
+        code = IndentedBuffer()
+        code.splice(
+            f"""
+import cutlass
+import cutlass_api
+{kernel_cache_import}
+{epilogue_import}
+{extra_imports}
+
+{epilogue_fn_def}
+
+{kernel_name_var} = {kernel_name_str!r}
+{cache_var} = {{}}
+
+def {self.kernel_name}_main({params_str}):
+    global {cache_var}
+{epilogue_setup}
+{create_args}
+
+{kernel_lookup}
+
+    cache_key = {cache_key}
+    artifact = {cache_var}.get(cache_key)
+    if artifact is None:
+        artifact = kernel.compile(args)
+        {cache_var}[cache_key] = artifact
+
+    kernel.run(args, artifact, stream=stream, workspace={workspace_arg}, assume_supported_args=True)
+            """
+        )
+
+        return code.getvalue()
+
+    def _render_epilogue_kwargs(self) -> str:
+        """Render kwargs for EpilogueArguments constructor.
+
+        Skips intermediate stores (write_buffer entries from CutlassEVTCodegen.store()
+        in a multi-node epilogue chain) — those names are not kernel parameters and
+        would produce NameError at runtime.
+        """
+        kwargs_parts = []
+        write_buffer_names = OrderedSet(self.epilogue_writes)
+
+        for var_name, buffer_name in self.epilogue_var_renames.items():
+            if var_name == "D":
+                kwargs_parts.append("D=out_ptr0")
+            elif var_name == _ACCUMULATOR_ARG_NAME:
+                continue
+            elif buffer_name in write_buffer_names:
+                continue
+            else:
+                kwargs_parts.append(f"{var_name}={buffer_name}")
+
+        return ", ".join(kwargs_parts)
 
     def _get_reinterpret_view(self, node) -> ReinterpretView | None:
         """Extract or convert to ReinterpretView from a node, handling all views."""
@@ -173,14 +287,16 @@ class NVUniversalGemmKernel(Kernel):
         Generate the kernel call in the wrapper code.
 
         Similar to CuteDSLTemplateKernel.call_kernel but simplified for NVIDIA Universal GEMM.
+        Includes epilogue input tensors when epilogue fusion is enabled.
         """
         wrapper = V.graph.wrapper_code
 
         call_args: list[str] = []
         arg_types: list[Any] = []
         raw_args: list[Buffer | ReinterpretView | None] = []
+        raw_keys: list[str | None] = []
 
-        for _, input_node in self._template_input_args:
+        for param_name, input_node in self._template_input_args:
             reinterpret_view = self._get_reinterpret_view(input_node)
             if reinterpret_view is not None:
                 call_args.append(reinterpret_view.codegen_reference())
@@ -191,11 +307,28 @@ class NVUniversalGemmKernel(Kernel):
                 call_args.append(input_node.get_name())
                 raw_args.append(input_node)
             arg_types.append(V.graph.get_dtype(input_node.get_name()))
+            raw_keys.append(param_name)
 
-        output_name = self.output_node.get_name()
+        # The kernel writes to the epilogue's final output, not the GEMM buffer
+        # (which is removed via removed_buffers aliasing).
+        if self.epilogue_writes:
+            output_name = self.epilogue_writes[-1]
+        else:
+            output_name = self.output_node.get_name()
         call_args.append(output_name)
         arg_types.append(V.graph.get_dtype(output_name))
         raw_args.append(None)  # Output buffer is findable by name
+        raw_keys.append("out_ptr0")
+
+        for read_name in self.epilogue_reads:
+            call_args.append(read_name)
+            arg_types.append(V.graph.get_dtype(read_name))
+            buf = V.graph.get_buffer(read_name)
+            if buf is None:
+                buf = V.graph.graph_inputs.get(read_name)
+            # pyrefly: ignore [bad-argument-type]
+            raw_args.append(buf)
+            raw_keys.append(read_name)
 
         # Allocate workspace if needed
         ws: WorkspaceArg | None = None
@@ -210,17 +343,15 @@ class NVUniversalGemmKernel(Kernel):
             call_args.append(ws.outer_name)
             arg_types.append(ws.dtype)
             raw_args.append(None)
+            raw_keys.append(None)
 
-        # Generate the kernel call using triton=True for Python-based kernels
-        # Pass raw_keys as None list to match raw_args length
-        # TODO(nikhilap)  We don't use autotune_args like the Triton path
         wrapper.generate_kernel_call(
             name,
             call_args,
             triton=True,
             arg_types=arg_types,
             raw_args=raw_args,
-            raw_keys=[None] * len(raw_args),
+            raw_keys=raw_keys,
         )
 
         # Deallocate workspace after kernel call

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -6,7 +6,7 @@ NVIDIA Universal GEMM scheduling for PyTorch Inductor.
 import hashlib
 import logging
 from collections.abc import Sequence
-from typing import cast
+from typing import Any, cast
 
 from torch._inductor.utils import (
     get_fused_kernel_name,
@@ -17,7 +17,14 @@ from torch.utils._ordered_set import OrderedSet
 
 from ... import config
 from ...codecache import code_hash, get_path
-from ...ir import NVUniversalGemmBuffer
+from ...ir import (
+    Buffer,
+    ComputedBuffer,
+    Layout,
+    MultiTemplateBuffer,
+    NVUniversalGemmBuffer,
+    Pointwise,
+)
 from ...scheduler import (
     BaseSchedulerNode,
     BaseScheduling,
@@ -26,11 +33,15 @@ from ...scheduler import (
 )
 from ...virtualized import V
 from ..common import BackendFeature, IndentedBuffer
+from ..cutlass.python_evt import CutlassEVTCodegen
+from .nv_universal_gemm import NVUniversalGemmCaller
 
 
 log = logging.getLogger(__name__)
 
 MAIN_SUFFIX = "main"
+_BENCHMARK_KERNEL_PREFIX = "nv_gemm_"
+EPILOGUE_FN_NAME = "_epilogue_fn"
 
 
 class NVUniversalGemmScheduling(BaseScheduling):
@@ -46,23 +57,286 @@ class NVUniversalGemmScheduling(BaseScheduling):
         return OrderedSet()
 
     @staticmethod
+    def _is_nvgemm_ir_buffer(ir_node: Any) -> bool:
+        """Return True if `ir_node` is an NVGEMM buffer or an MTB resolving to one.
+
+        Honors finalize_as_*_caller's swap (a MultiTemplateBuffer whose render
+        kind is "triton" is no longer NVGEMM, even if the autotune winner was).
+        Falls back to the autotune winner only when no swap has happened.
+        """
+        if isinstance(ir_node, NVUniversalGemmBuffer):
+            return True
+        if not isinstance(ir_node, MultiTemplateBuffer):
+            return False
+        if ir_node._render_kind == "triton":
+            return False
+        if ir_node._render_kind == "nvgemm":
+            return True
+        # Fast path: avoid forcing autotune just to answer this query.
+        if not any(isinstance(c, NVUniversalGemmCaller) for c in ir_node._choices):
+            return False
+        try:
+            min_choice, _ = ir_node.get_min_choice()
+            return isinstance(min_choice, NVUniversalGemmCaller)
+        except (RuntimeError, ValueError):
+            return False
+
+    @staticmethod
     def is_nv_universal_gemm_template(node: BaseSchedulerNode) -> bool:
-        """Check if a node is a NVIDIA Universal GEMM template."""
-        return isinstance(node, SchedulerNode) and isinstance(
-            node.node, NVUniversalGemmBuffer
+        """Check if a node is an NVGEMM template SchedulerNode."""
+        if not isinstance(node, SchedulerNode):
+            return False
+        return NVUniversalGemmScheduling._is_nvgemm_ir_buffer(node.node)
+
+    @staticmethod
+    def get_nv_gemm_buffer_from_node(
+        node: BaseSchedulerNode, require_epilogue_fusion: bool = False
+    ) -> NVUniversalGemmBuffer:
+        """Extract NVUniversalGemmBuffer from node (direct or via MultiTemplateBuffer)."""
+        assert isinstance(node, SchedulerNode)
+        ir_node = node.node
+
+        if isinstance(ir_node, NVUniversalGemmBuffer):
+            return ir_node
+        elif isinstance(ir_node, MultiTemplateBuffer):
+            # Honor an explicit swap/finalize — the fusion benchmark loop swaps
+            # in each EFC choice one at a time and must not re-select from timings.
+            if isinstance(ir_node._render_caller, NVUniversalGemmCaller) and (
+                not require_epilogue_fusion
+                or ir_node._render_caller.supports_epilogue_fusion
+            ):
+                selected_choice = ir_node._render_caller
+            elif require_epilogue_fusion:
+                # `best is None or timing < best_time` so a choice with timing=inf
+                # (benchmark failed) can still win when it's the only EFC option.
+                choice_timings = ir_node.choice_timings()
+                best_efc_choice = None
+                best_efc_time = float("inf")
+                for choice, timing in choice_timings.items():
+                    if (
+                        isinstance(choice, NVUniversalGemmCaller)
+                        and choice.supports_epilogue_fusion
+                    ):
+                        if best_efc_choice is None or timing < best_efc_time:
+                            best_efc_time = timing
+                            best_efc_choice = choice
+                if best_efc_choice is None:
+                    raise RuntimeError("No EFC kernel found for epilogue fusion")
+                selected_choice = best_efc_choice
+            else:
+                min_choice, _ = ir_node.get_min_choice()
+                if isinstance(min_choice, NVUniversalGemmCaller):
+                    selected_choice = min_choice
+                else:
+                    choice_timings = ir_node.choice_timings()
+                    best_nvgemm = None
+                    best_time = float("inf")
+                    for choice, timing in choice_timings.items():
+                        if isinstance(choice, NVUniversalGemmCaller) and (
+                            best_nvgemm is None or timing < best_time
+                        ):
+                            best_time = timing
+                            best_nvgemm = choice
+                    if best_nvgemm is None:
+                        raise RuntimeError("No NVUniversalGemmCaller found in choices")
+                    selected_choice = best_nvgemm
+            tensor_box = selected_choice.output_node()
+            # pyrefly: ignore [missing-attribute]
+            return cast(NVUniversalGemmBuffer, tensor_box.data.data)
+
+        raise TypeError(
+            f"Expected NVUniversalGemmBuffer or MultiTemplateBuffer, got {type(ir_node).__name__}"
         )
 
-    def is_nv_universal_gemm_fused_template(self, node: BaseSchedulerNode) -> bool:
+    @staticmethod
+    def is_nv_universal_gemm_fused_template(node: BaseSchedulerNode) -> bool:
         """Check if a node is a fused NVIDIA Universal GEMM template."""
-        return isinstance(
-            node, FusedSchedulerNode
-        ) and self.is_nv_universal_gemm_template(node)
+        if not isinstance(node, FusedSchedulerNode):
+            return False
+        return NVUniversalGemmScheduling._is_nvgemm_ir_buffer(node.get_template_node())
 
     def can_fuse_vertical(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
-        # NVIDIA Universal GEMM templates don't support vertical fusion yet
+        if self.is_nv_universal_gemm_template(node1):
+            return self._can_fuse_epilogue_impl(
+                cast(SchedulerNode, node1),
+                [],
+                node2,
+            )
+        elif self.is_nv_universal_gemm_fused_template(node1):
+            fnode1 = cast(FusedSchedulerNode, node1)
+            template_snode = next(
+                (n for n in fnode1.snodes if self.is_nv_universal_gemm_template(n)),
+                None,
+            )
+            if template_snode is None:
+                return False
+            return self._can_fuse_epilogue_impl(
+                cast(SchedulerNode, template_snode),
+                self._unwrap_epilogue_nodes(fnode1),
+                node2,
+            )
         return False
+
+    def _unwrap_epilogue_nodes(
+        self, fused_node: FusedSchedulerNode
+    ) -> list[BaseSchedulerNode]:
+        """Extract epilogue nodes from a fused node."""
+        epilogue_nodes = []
+        for node in fused_node.snodes:
+            if not self.is_nv_universal_gemm_template(node):
+                epilogue_nodes.append(node)
+        return epilogue_nodes
+
+    def _can_fuse_epilogue_impl(
+        self,
+        gemm_template_node: SchedulerNode,
+        existing_epilogue_nodes: list[BaseSchedulerNode],
+        node_to_fuse: BaseSchedulerNode,
+    ) -> bool:
+        from .nv_universal_gemm import GemmVariant
+
+        if not config.epilogue_fusion:
+            return False
+
+        ir_node = gemm_template_node.node
+        if not isinstance(ir_node, (NVUniversalGemmBuffer, MultiTemplateBuffer)):
+            return False
+
+        if isinstance(ir_node, NVUniversalGemmBuffer):
+            if ir_node.variant != GemmVariant.GEMM:
+                log.debug(
+                    "NVGEMM epilogue fusion: not supported for %s variant",
+                    ir_node.variant.op_name,
+                )
+                return False
+            if not ir_node.supports_epilogue_fusion:
+                log.debug(
+                    "NVGEMM epilogue fusion: kernel %s does not support epilogue fusion",
+                    ir_node.kernel_metadata.get("kernel_name", "unknown"),
+                )
+                return False
+        elif isinstance(ir_node, MultiTemplateBuffer):
+            # Use _choices, not choice_timings() — the latter forces autotune sync.
+            has_efc_choice = False
+            for choice in ir_node._choices:
+                if not (
+                    isinstance(choice, NVUniversalGemmCaller)
+                    and choice.supports_epilogue_fusion
+                ):
+                    continue
+                has_efc_choice = True
+                if choice.variant != GemmVariant.GEMM:
+                    log.debug(
+                        "NVGEMM epilogue fusion: MultiTemplateBuffer has non-GEMM EFC choices"
+                    )
+                    return False
+            if not has_efc_choice:
+                log.debug("NVGEMM epilogue fusion: no EFC kernel available in choices")
+                return False
+
+        scheduler_nodes_to_fuse = node_to_fuse.get_nodes()
+
+        for s_node in scheduler_nodes_to_fuse:
+            node = s_node.node
+            if not isinstance(node, ComputedBuffer):
+                log.debug("NVGEMM epilogue fusion: %s is not a ComputedBuffer", node)
+                return False
+            if not isinstance(node.data, Pointwise):
+                log.debug("NVGEMM epilogue fusion: %s is not a Pointwise op", node)
+                return False
+
+            if not V.graph.sizevars.statically_known_list_equals(
+                node.get_size(), ir_node.get_size()
+            ):
+                log.debug(
+                    "NVGEMM epilogue fusion: size mismatch %s vs %s",
+                    node.get_size(),
+                    ir_node.get_size(),
+                )
+                return False
+
+        # EFC kernels don't support broadcast. Reject conservatively when a read
+        # can't be resolved — folded constants (weights/biases) aren't in
+        # name_to_buf, and silently skipping them would let a stride-0 bias through.
+        gemm_size = ir_node.get_size()
+        name_to_buf = V.graph.name_to_buffer | V.graph.graph_inputs
+        for s_node in scheduler_nodes_to_fuse:
+            for rd in s_node.read_writes.reads:
+                if rd.name == ir_node.get_name():
+                    continue
+                read_buf = name_to_buf.get(rd.name)
+                if read_buf is None:
+                    log.debug(
+                        "NVGEMM epilogue fusion: read %s not in name_to_buffer/graph_inputs, refusing to fuse",
+                        rd.name,
+                    )
+                    return False
+                read_size = read_buf.get_size()
+                if not V.graph.sizevars.statically_known_list_equals(
+                    read_size, gemm_size
+                ):
+                    log.debug(
+                        "NVGEMM epilogue fusion: read buffer %s size %s != GEMM size %s (broadcast not supported)",
+                        rd.name,
+                        read_size,
+                        gemm_size,
+                    )
+                    return False
+                if hasattr(read_buf, "get_stride"):
+                    for s in read_buf.get_stride():
+                        if s == 0:
+                            log.debug(
+                                "NVGEMM epilogue fusion: read buffer %s has zero stride (broadcast not supported)",
+                                rd.name,
+                            )
+                            return False
+
+        if not existing_epilogue_nodes:
+            reads = OrderedSet(rd.name for rd in node_to_fuse.read_writes.reads)
+            if ir_node.get_name() not in reads:
+                log.debug(
+                    "NVGEMM epilogue fusion: first epilogue node doesn't read from GEMM output"
+                )
+                return False
+
+        if node_to_fuse.has_aliasing_or_mutation():
+            log.debug("NVGEMM epilogue fusion: node has aliasing or mutation")
+            return False
+        elif node_to_fuse.is_reduction():
+            log.debug("NVGEMM epilogue fusion: reductions not supported")
+            return False
+
+        all_epilogue_nodes = list(existing_epilogue_nodes) + list(
+            node_to_fuse.get_nodes()
+        )
+
+        # Multi-store chains (>1 node) not yet supported: _render_epilogue_kwargs
+        # skips intermediate stores, so EpilogueArguments construction would fail.
+        # Normally pre-fusion collapses chains, but reject explicitly to avoid
+        # silent miscompile if that changes.
+        if len(all_epilogue_nodes) > 1:
+            log.debug(
+                "NVGEMM epilogue fusion: multi-stage chains (%d nodes) not yet supported",
+                len(all_epilogue_nodes),
+            )
+            return False
+
+        trial_removed_buffers = V.graph.removed_buffers | OrderedSet(
+            [ir_node.get_name()]
+        )
+        try:
+            CutlassEVTCodegen.ir_to_evt_python_code(
+                ir_node.get_name(),
+                all_epilogue_nodes,
+                trial_removed_buffers,
+            )
+        except (NotImplementedError, AssertionError) as e:
+            log.debug("NVGEMM epilogue fusion: trial EVT codegen failed: %s", e)
+            return False
+
+        return True
 
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
@@ -126,34 +400,125 @@ class NVUniversalGemmScheduling(BaseScheduling):
         template_node: BaseSchedulerNode,
         epilogue_nodes: Sequence[BaseSchedulerNode],
         prologue_nodes: Sequence[BaseSchedulerNode],
-    ):
+        *,
+        only_gen_src_code: bool = False,
+    ) -> str | None:
         """
-        Codegen a NVIDIA Universal GEMM template. Currently doesn't support fusion.
+        Codegen a NVIDIA Universal GEMM template with optional epilogue fusion.
+
+        If `only_gen_src_code=True` the src code will be returned instead of being
+        codegenned into the wrapper (used for benchmarking).
         """
+        log.debug(
+            "NVGEMM codegen_template: template_node=%s, epilogue_nodes=%s, prologue_nodes=%s",
+            template_node,
+            [n.get_name() for n in epilogue_nodes] if epilogue_nodes else [],
+            [n.get_name() for n in prologue_nodes] if prologue_nodes else [],
+        )
         assert self.is_nv_universal_gemm_template(template_node), (
             "Template node passed to NVUniversalGemmScheduling.codegen_template must be a "
-            "SchedulerNode that wraps a NVUniversalGemmBuffer"
-        )
-        # TODO: add support for fusion when needed
-        assert not epilogue_nodes, (
-            "NVIDIA Universal GEMM doesn't support epilogue fusion yet"
+            "SchedulerNode that wraps a NVUniversalGemmBuffer or MultiTemplateBuffer with NVGEMM choice"
         )
         assert not prologue_nodes, (
             "NVIDIA Universal GEMM doesn't support prologue fusion yet"
         )
 
         template_node = cast(SchedulerNode, template_node)
-        ctb: NVUniversalGemmBuffer = cast(NVUniversalGemmBuffer, template_node.node)
+
+        original_ir_node = template_node.node
+        assert isinstance(original_ir_node, Buffer)
+        original_buffer_name = original_ir_node.get_name()
+
+        ctb: NVUniversalGemmBuffer = self.get_nv_gemm_buffer_from_node(
+            template_node, require_epilogue_fusion=bool(epilogue_nodes)
+        )
+
+        epilogue_fn_code: str | None = None
+        epilogue_reads: list[str] = []
+        epilogue_writes: list[str] = []
+        epilogue_var_renames: dict[str, Any] = {}
+
+        if epilogue_nodes:
+            try:
+                removed_buffers_with_gemm = V.graph.removed_buffers | OrderedSet(
+                    [original_buffer_name]
+                )
+
+                reads, writes, var_renames, evt_code = (
+                    CutlassEVTCodegen.ir_to_evt_python_code(
+                        original_buffer_name,
+                        list(epilogue_nodes),
+                        removed_buffers_with_gemm,
+                        fn_name=EPILOGUE_FN_NAME,
+                        as_standalone_function=True,
+                    )
+                )
+                epilogue_fn_code = evt_code
+                epilogue_reads = reads
+                epilogue_writes = writes
+                epilogue_var_renames = var_renames
+
+                if not only_gen_src_code:
+                    fused_buffer_names: OrderedSet[str] = OrderedSet(
+                        n.get_name() for n in epilogue_nodes
+                    )
+                    fused_buffer_names.add(original_buffer_name)
+                    scheduler = V.graph.scheduler
+                    # Must add to removed_buffers BEFORE mark_run: mark_run emits
+                    # AllocateLine eagerly, and codegen_allocation only skips it
+                    # when the name is already in removed_buffers.
+                    for node in epilogue_nodes:
+                        node_name = node.get_name()
+                        if epilogue_writes and node_name == epilogue_writes[-1]:
+                            continue
+                        if scheduler.can_buffer_be_removed_through_fusion(
+                            node_name, fused_buffer_names
+                        ):
+                            V.graph.removed_buffers.add(node_name)
+                    if (
+                        epilogue_writes
+                        and original_buffer_name != epilogue_writes[-1]
+                        and scheduler.can_buffer_be_removed_through_fusion(
+                            original_buffer_name, fused_buffer_names
+                        )
+                    ):
+                        V.graph.removed_buffers.add(original_buffer_name)
+                    for node in epilogue_nodes:
+                        node.mark_run()
+
+                log.debug(
+                    "NVGEMM epilogue fusion: %d nodes, reads=%s, writes=%s",
+                    len(epilogue_nodes),
+                    epilogue_reads,
+                    epilogue_writes,
+                )
+            except (NotImplementedError, AssertionError) as e:
+                log.warning("NVGEMM epilogue codegen failed unexpectedly: %s", e)
+                raise
 
         assert ctb.make_kernel_render is not None
-        kernel, render = ctb.make_kernel_render(ctb)
-        template_node.mark_run()
+        kernel, render = ctb.make_kernel_render(
+            ctb,
+            epilogue_fn_code=epilogue_fn_code,
+            epilogue_reads=epilogue_reads,
+            epilogue_writes=epilogue_writes,
+            epilogue_var_renames=epilogue_var_renames,
+        )
+
+        if not only_gen_src_code:
+            template_node.mark_run()
+
         src_code = render()
+
+        if only_gen_src_code:
+            return src_code
 
         precompile_metadata = self._build_precompile_metadata(kernel, ctb)
 
         with V.set_kernel_handler(kernel):
-            node_schedule = [template_node]
+            node_schedule: list[BaseSchedulerNode] = [template_node]
+            if epilogue_fn_code and epilogue_nodes:
+                node_schedule.extend(epilogue_nodes)
             kernel_name = self.define_kernel(
                 src_code, node_schedule, precompile_metadata
             )
@@ -161,7 +526,9 @@ class NVUniversalGemmScheduling(BaseScheduling):
         self.codegen_comment(node_schedule, kernel_name)
         kernel.call_kernel(kernel_name, ctb)
         V.graph.removed_buffers |= kernel.removed_buffers
+        V.graph.inplaced_to_remove |= kernel.inplaced_to_remove
         self.free_buffers_in_scheduler()
+        return None
 
     def _build_precompile_metadata(self, kernel, ctb):
         """Extract shapes and dtypes from kernel inputs/output for subprocess precompilation.
@@ -207,10 +574,164 @@ class NVUniversalGemmScheduling(BaseScheduling):
         if torch.cuda.is_available():
             device_capability = torch.cuda.get_device_capability(device_index)
 
+        max_active_clusters = None
+        kernel_name = ctb.kernel_metadata.get("kernel_name")
+        if kernel_name and torch.cuda.is_available():
+            try:
+                from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
+                    get_kernel_by_name,
+                )
+
+                k = get_kernel_by_name(kernel_name)
+                if k is not None and hasattr(k, "impl"):
+                    from cutlass_api.providers.cutedsl.utils import (
+                        get_max_active_clusters,
+                    )
+
+                    max_active_clusters = get_max_active_clusters(
+                        k.impl.cluster_shape_mn
+                    )
+            except Exception:
+                log.debug("Could not extract max_active_clusters for precompile")
+
         return {
             "precompile_shapes": precompile_shapes,
             "precompile_strides": precompile_strides,
             "precompile_dtypes": precompile_dtypes,
             "device_index": device_index,
             "device_capability": device_capability,
+            "max_active_clusters": max_active_clusters,
         }
+
+    def generate_kernel_code_from_nodes(
+        self,
+        nodes: Sequence[BaseSchedulerNode],
+        benchmark_kernel: bool = False,
+        hint_override: int | None = None,
+    ) -> str:
+        prologue, template, epilogue = nodes[0].get_prologue_template_epilogue(
+            list(nodes)
+        )
+
+        epilogue_reads: list[str] = []
+        if epilogue:
+            template_sn = cast(SchedulerNode, template)
+            assert isinstance(template_sn.node, Buffer)
+            original_buffer_name = template_sn.node.get_name()
+            removed_buffers_with_gemm = V.graph.removed_buffers | OrderedSet(
+                [original_buffer_name]
+            )
+            try:
+                reads, _, _, _ = CutlassEVTCodegen.ir_to_evt_python_code(
+                    original_buffer_name,
+                    list(epilogue),
+                    removed_buffers_with_gemm,
+                )
+                epilogue_reads = reads
+            except (NotImplementedError, AssertionError) as e:
+                log.warning("NVGEMM benchmark epilogue codegen failed: %s", e)
+
+        with config.patch("benchmark_kernel", benchmark_kernel):
+            src_code = self.codegen_template(
+                template,
+                epilogue,
+                prologue,
+                only_gen_src_code=True,
+            )
+
+        assert src_code is not None
+        src_code = src_code.replace(
+            str(Placeholder.KERNEL_NAME), _BENCHMARK_KERNEL_PREFIX
+        )
+
+        if benchmark_kernel:
+            src_code = self._add_benchmark_helpers(
+                src_code, template, epilogue, epilogue_reads
+            )
+
+        return src_code
+
+    def _add_benchmark_helpers(
+        self,
+        src_code: str,
+        template_node: BaseSchedulerNode,
+        epilogue_nodes: Sequence[BaseSchedulerNode],
+        epilogue_reads: list[str],
+    ) -> str:
+        template_node = cast(SchedulerNode, template_node)
+        ctb: NVUniversalGemmBuffer = self.get_nv_gemm_buffer_from_node(
+            template_node, require_epilogue_fusion=bool(epilogue_nodes)
+        )
+
+        input_nodes = cast(list[Buffer], ctb.inputs)
+        if epilogue_nodes:
+            final_node = cast(SchedulerNode, epilogue_nodes[-1])
+            output_layout = cast(Layout, final_node.node.get_layout())
+        else:
+            output_layout = cast(Layout, ctb.layout)
+
+        args_code = IndentedBuffer()
+        args_code.writeline("")
+        args_code.writeline("is_nvgemm = True")
+        args_code.writeline("")
+        args_code.writeline("def get_args():")
+        with args_code.indent():
+            args_code.writeline("import torch")
+            args_code.writeline("from torch._dynamo.testing import rand_strided")
+            args_code.writeline("args = []")
+
+            for inp in input_nodes:
+                size = V.graph.sizevars.optimization_hints(inp.get_size())
+                stride = V.graph.sizevars.optimization_hints(inp.get_stride())
+                dtype = inp.get_dtype()
+                device = inp.get_device()
+                args_code.writeline(
+                    f"args.append(rand_strided({size}, {stride}, device='{device}', dtype={dtype}))"
+                )
+
+            out_size = V.graph.sizevars.optimization_hints(output_layout.size)
+            out_stride = V.graph.sizevars.optimization_hints(output_layout.stride)
+            out_dtype = output_layout.dtype
+            out_device = output_layout.device
+            args_code.writeline(
+                f"args.append(rand_strided({out_size}, {out_stride}, device='{out_device}', dtype={out_dtype}))"
+            )
+
+            for read_name in epilogue_reads:
+                buf = V.graph.get_buffer(read_name)
+                size = V.graph.sizevars.optimization_hints(buf.get_size())
+                stride = V.graph.sizevars.optimization_hints(buf.get_stride())
+                dtype = buf.get_dtype()
+                device = buf.get_device()
+                args_code.writeline(
+                    f"args.append(rand_strided({size}, {stride}, device='{device}', dtype={dtype}))"
+                )
+
+            if ctb.workspace_size > 0:
+                args_code.writeline(
+                    f"args.append(torch.empty({ctb.workspace_size}, "
+                    f"device='{out_device}', dtype=torch.int8))"
+                )
+
+            args_code.writeline("return args")
+
+        args_code.writeline("")
+        args_code.writeline("def call(args):")
+        with args_code.indent():
+            args_code.writeline("import torch")
+            num_inputs = len(input_nodes)
+            param_list = [f"args[{i}]" for i in range(num_inputs)]
+            param_list.append(f"args[{num_inputs}]")
+
+            for j in range(len(epilogue_reads)):
+                param_list.append(f"args[{num_inputs + 1 + j}]")
+
+            if ctb.workspace_size > 0:
+                param_list.append(f"args[{num_inputs + 1 + len(epilogue_reads)}]")
+
+            params_str = ", ".join(param_list)
+            args_code.writeline("stream = torch.cuda.current_stream().cuda_stream")
+            bench_fn_name = f"{_BENCHMARK_KERNEL_PREFIX}_{MAIN_SUFFIX}"
+            args_code.writeline(f"{bench_fn_name}({params_str}, stream=stream)")
+
+        return src_code + args_code.getvalue()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5981,6 +5981,21 @@ class TritonTemplateCallerBase(ChoiceCaller):
         raise NotImplementedError
 
 
+_NVUniversalGemmCallerClass: type | None = None
+
+
+def _is_output_plannable_nvgemm_choice(choice: ChoiceCaller) -> bool:
+    global _NVUniversalGemmCallerClass
+    if _NVUniversalGemmCallerClass is None:
+        try:
+            from torch._inductor.codegen.nv_universal_gemm import NVUniversalGemmCaller
+
+            _NVUniversalGemmCallerClass = NVUniversalGemmCaller
+        except ImportError:
+            return False
+    return isinstance(choice, _NVUniversalGemmCallerClass)
+
+
 class MultiTemplateBuffer(TritonTemplateBuffer):
     """
     Represents a Buffer with multiple backing implementation choices.
@@ -6010,6 +6025,7 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         self.original_inputs = inputs
         self._output_plannable = all(
             isinstance(choice, TritonTemplateCallerBase)
+            or _is_output_plannable_nvgemm_choice(choice)
             or (
                 isinstance(choice, torch._inductor.select_algorithm.ExternKernelCaller)
                 and choice.has_out_variant
@@ -6017,12 +6033,14 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
             for choice in unfiltered_choices
         )
         self._make_kernel_renders: dict[int | None, Any] = {}
+        self._render_kind: str | None = None
+        # Tracks the bound caller so the fusion-benchmark loop's per-iteration
+        # swap is not silently overridden by re-selection from choice_timings().
+        self._render_caller: ChoiceCaller | None = None
 
     @property
     def output_plannable(self) -> bool:
-        """
-        Are all possible choices TritonTemplates or Extern Kernels with out variants
-        """
+        """True when all choices are TritonTemplates, NVUniversalGemmCallers, or Extern Kernels with out variants."""
         return self._output_plannable
 
     @property
@@ -6044,11 +6062,17 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         assert self.layout == caller.layout
 
         render = self.make_kernel_render
+        prev_kind = self._render_kind
+        prev_caller = self._render_caller
         self.make_kernel_render = caller.get_make_kernel_render()
+        self._render_kind = "triton"
+        self._render_caller = caller
         try:
             yield
         finally:
             self.make_kernel_render = render
+            self._render_kind = prev_kind
+            self._render_caller = prev_caller
 
     def finalize_as_triton_caller(self, caller: TritonTemplateCallerBase) -> None:
         assert isinstance(
@@ -6057,6 +6081,38 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
         assert self.get_size() == caller.layout.size
         assert self.get_stride() == caller.layout.stride
         self.make_kernel_render = caller.get_make_kernel_render()
+        self._render_kind = "triton"
+        self._render_caller = caller
+
+    @contextlib.contextmanager
+    def swap_as_nvgemm_caller(self, caller: ChoiceCaller) -> Iterator[None]:
+        from torch._inductor.codegen.nv_universal_gemm import NVUniversalGemmCaller
+
+        assert isinstance(caller, NVUniversalGemmCaller), type(caller)
+        assert self.layout == caller.layout
+
+        render = self.make_kernel_render
+        prev_kind = self._render_kind
+        prev_caller = self._render_caller
+        self.make_kernel_render = caller.get_make_kernel_render()
+        self._render_kind = "nvgemm"
+        self._render_caller = caller
+        try:
+            yield
+        finally:
+            self.make_kernel_render = render
+            self._render_kind = prev_kind
+            self._render_caller = prev_caller
+
+    def finalize_as_nvgemm_caller(self, caller: ChoiceCaller) -> None:
+        from torch._inductor.codegen.nv_universal_gemm import NVUniversalGemmCaller
+
+        assert isinstance(caller, NVUniversalGemmCaller), type(caller)
+        assert self.get_size() == caller.layout.size
+        assert self.get_stride() == caller.layout.stride
+        self.make_kernel_render = caller.get_make_kernel_render()
+        self._render_kind = "nvgemm"
+        self._render_caller = caller
 
     def get_min_choice(
         self, hint_override: int | None = None
@@ -6074,6 +6130,8 @@ class MultiTemplateBuffer(TritonTemplateBuffer):
 
         # Set the default to be the one without hint override
         self.make_kernel_render = self._make_kernel_renders[None]
+        self._render_kind = "triton"
+        self._render_caller = callers[None]
 
 
 class CUTLASSTemplateBuffer(TemplateBuffer):
@@ -6178,6 +6236,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         scale_type_b: Any | None = None,
         swizzle_type_a: Any | None = None,
         swizzle_type_b: Any | None = None,
+        supports_epilogue_fusion: bool = False,
     ) -> None:
         # We pass None initially, then override with our method below
         super().__init__(layout, inputs, make_kernel_render=None)
@@ -6190,6 +6249,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         self.scale_type_b = scale_type_b
         self.swizzle_type_a = swizzle_type_a
         self.swizzle_type_b = swizzle_type_b
+        self.supports_epilogue_fusion = supports_epilogue_fusion
         # Store kernel metadata for code generation since kernels aren't serializeable yet
         self.kernel_metadata = {
             "kernel_name": kernel.metadata.kernel_name,
@@ -6207,7 +6267,13 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         return self.outputs
 
     def _make_kernel_render(
-        self, out_node: Any, hint_override: int | None = None
+        self,
+        out_node: Any,
+        hint_override: int | None = None,
+        epilogue_fn_code: str | None = None,
+        epilogue_reads: list[str] | None = None,
+        epilogue_writes: list[str] | None = None,
+        epilogue_var_renames: dict[str, Any] | None = None,
     ) -> tuple[Any, Any]:
         """
         Create a kernel renderer for code generation.
@@ -6216,6 +6282,11 @@ class NVUniversalGemmBuffer(TemplateBuffer):
         - kernel: NVUniversalGemmKernel object with call_kernel() method
         - render: function that returns source code string
         """
+        if epilogue_fn_code is not None:
+            assert epilogue_var_renames is not None, (
+                "epilogue_fn_code requires epilogue_var_renames"
+            )
+
         from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
             NVUniversalGemmKernel,
         )
@@ -6243,6 +6314,10 @@ class NVUniversalGemmBuffer(TemplateBuffer):
             scale_type_b=self.scale_type_b,
             swizzle_type_a=self.swizzle_type_a,
             swizzle_type_b=self.swizzle_type_b,
+            epilogue_fn_code=epilogue_fn_code,
+            epilogue_reads=epilogue_reads,
+            epilogue_writes=epilogue_writes,
+            epilogue_var_renames=epilogue_var_renames,
         )
 
         def render():

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5248,6 +5248,10 @@ class Scheduler:
             nodes, benchmark_kernel=True, hint_override=hint_override
         )
         mod = PyCodeCache.load(src_code)
+
+        if not hasattr(mod, "triton_"):
+            return (None, mod)
+
         async_compile = torch._inductor.async_compile.AsyncCompile()
         if not async_compile.use_process_pool():
             fut = None
@@ -5285,7 +5289,6 @@ class Scheduler:
             or node1.is_foreach()
             or node2.is_foreach()
         ):
-            # TODO support benchmarking epilogue fusion
             return FusionResult.fuse(True)
 
         node_list_1 = node1.get_nodes()
@@ -5317,7 +5320,13 @@ class Scheduler:
 
         def log_fusion(ms_fused: float, ms1: float, ms2: float) -> None:
             if fusion_log.isEnabledFor(logging.DEBUG):
-                if ms_fused < ms1 + ms2:
+                if ms_fused == 0.0:
+                    fusion_log.debug(
+                        "can fuse (assumed): fusing %s with %s (benchmarking skipped)",
+                        node1.get_buffer_names(),
+                        node2.get_buffer_names(),
+                    )
+                elif ms_fused < ms1 + ms2:
                     fusion_log.debug(
                         "can fuse (benchmark): fusing %s with %s cause %sx speedup",
                         node1.get_buffer_names(),
@@ -5346,12 +5355,12 @@ class Scheduler:
             if self._has_layout_conflict_for_template(multi_node):
                 return FusionResult.fuse(False)
 
-            hint_override_best_fusion_choice: dict[
-                int | None, TritonTemplateCallerBase
-            ] = {}
+            hint_override_best_fusion_choice: dict[int | None, ir.ChoiceCaller] = {}
             if not has_atomic_add:
-                future_choices: list[tuple[Any, LambdaFuture | None, ModuleType]] = []
                 for hint_override in config.multi_kernel_hints:
+                    future_choices: list[
+                        tuple[Any, LambdaFuture | None, ModuleType]
+                    ] = []
                     choice_timings = multi_node.choice_timings(hint_override)
                     for choice, _ in sorted(choice_timings.items(), key=lambda x: x[1]):
                         if not isinstance(
@@ -5394,26 +5403,32 @@ class Scheduler:
                                 min_ms_fused = ms_fused
                                 ms_fused_choice = choice
                     multi_node._choice_timings[hint_override] = new_timings
-                    assert isinstance(ms_fused_choice, TritonTemplateCallerBase)
-                    hint_override_best_fusion_choice[hint_override] = ms_fused_choice
+                    if ms_fused_choice is not None:
+                        assert isinstance(ms_fused_choice, TritonTemplateCallerBase)
+                        hint_override_best_fusion_choice[hint_override] = (
+                            ms_fused_choice
+                        )
+
+            from torch._inductor.codegen.nv_universal_gemm import NVUniversalGemmCaller
 
             bench_epilogue = config.benchmark_epilogue_fusion
-            num_triton_callers = sum(
-                isinstance(c, TritonTemplateCallerBase) for c in multi_node.choices
+            num_fusible_callers = sum(
+                isinstance(c, (TritonTemplateCallerBase, NVUniversalGemmCaller))
+                for c in multi_node.choices
             )
             # Track if the choice timings can be retrieved async after compilation
             get_choice_timings_async = (
                 use_pipelined_autotuning()
                 and not bench_epilogue
-                and num_triton_callers <= config.max_epilogue_benchmarked_choices
+                and num_fusible_callers <= config.max_epilogue_benchmarked_choices
             )
 
             ms1, ms2 = float("inf"), float("inf")
             min_choice: ir.ChoiceCaller | None = None
             if not get_choice_timings_async:
-                # Eagerly compile and benchmark non-template nodes
                 choice_timings = multi_node.choice_timings()
                 min_choice, ms1 = multi_node.get_min_choice()
+
                 choice_timings_iter = sorted(
                     choice_timings.items(), key=operator.itemgetter(1)
                 )
@@ -5511,30 +5526,62 @@ class Scheduler:
                 ms2 = node2._get_estimated_runtime()
                 ms2_fused = _estimate_fused_epilogue_runtime(node1, node2, ms2)
 
-            # Start compiling choices in parallel
             future_choices: list[tuple[Any, LambdaFuture | None, ModuleType]] = []
-            triton_choices = 0
+            template_choices = 0
             for choice, unfused_time in choice_timings_iter:
-                if not choice_supports_fusion(choice):
+                is_triton = isinstance(
+                    choice, torch._inductor.ir.TritonTemplateCallerBase
+                )
+                is_nvgemm = isinstance(choice, NVUniversalGemmCaller)
+
+                if not is_triton and not is_nvgemm:
                     continue
-                choice = typing.cast(TritonTemplateCallerBase, choice)
+
+                # pyrefly: ignore [missing-attribute]
+                if is_nvgemm and not choice.supports_epilogue_fusion:
+                    continue
+
+                # NVGEMM doesn't support prologue fusion. Skip NVGEMM choices in
+                # the prologue direction (epilogue_fusion is False when node1 is
+                # the pointwise prologue, node2 is the template).
+                if is_nvgemm and not epilogue_fusion:
+                    continue
+
+                # For prologue fusion we check if the underlying template of the choice
+                # supports all allowed prologue inputs. If not, we skip this choice in
+                # the fusion benchmark.
+                # TODO: Remove this check after all Triton templates support prologue fusion.
+                # Currently, persistent+TMA Triton template does not due to the TMA-based loads.
+                if (
+                    is_triton
+                    and not epilogue_fusion
+                    and hasattr(choice, "allowed_prologue_inps")
+                    and choice.allowed_prologue_inps != multi_node.allowed_prologue_inps
+                ):
+                    continue
 
                 if bench_epilogue and unfused_time >= ms1 + ms2:
                     break
 
-                triton_choices += 1
-                if triton_choices > config.max_epilogue_benchmarked_choices:
+                template_choices += 1
+                if template_choices > config.max_epilogue_benchmarked_choices:
                     break
 
-                with multi_node.swap_as_triton_caller(choice):
-                    try:
-                        future_choices.append(
-                            (choice, *self.compile_kernel(node_list_fused))
-                        )
-                    except CantSplit:
-                        # Epilogue node ranges may be incompatible with the
-                        # template kernel's tiling groups — skip this choice.
-                        continue
+                try:
+                    if is_triton:
+                        # pyrefly: ignore [bad-argument-type]
+                        with multi_node.swap_as_triton_caller(choice):
+                            future_choices.append(
+                                (choice, *self.compile_kernel(node_list_fused))
+                            )
+                    elif is_nvgemm:
+                        # pyrefly: ignore [missing-attribute]
+                        with multi_node.swap_as_nvgemm_caller(choice):
+                            future_choices.append(
+                                (choice, *self.compile_kernel(node_list_fused))
+                            )
+                except CantSplit:
+                    continue
 
             if len(future_choices) == 0:
                 return FusionResult.fuse(False)
@@ -5567,8 +5614,11 @@ class Scheduler:
                         if future is not None:
                             res = future.result()
                         elif not bench_epilogue:
-                            res = mod_fused.triton_
-                            res.precompile()
+                            if hasattr(mod_fused, "triton_"):
+                                res = mod_fused.triton_
+                                res.precompile()
+                            else:
+                                res = None
                         else:
                             res = None
 
@@ -5584,8 +5634,15 @@ class Scheduler:
                         continue
 
                     if bench_epilogue:
-                        # pyrefly: ignore [missing-attribute]
-                        with multi_node.swap_as_triton_caller(choice):
+                        is_nvgemm_choice = isinstance(choice, NVUniversalGemmCaller)
+                        swap_ctx = (
+                            # pyrefly: ignore [missing-attribute]
+                            multi_node.swap_as_nvgemm_caller(choice)
+                            if is_nvgemm_choice
+                            # pyrefly: ignore [missing-attribute, bad-argument-type]
+                            else multi_node.swap_as_triton_caller(choice)
+                        )
+                        with swap_ctx:
                             ms_fused, path = self.benchmark_codegened_module(
                                 mod_fused,
                                 # pyrefly: ignore [bad-argument-type]
@@ -5601,7 +5658,13 @@ class Scheduler:
                             or ms2 + ms1 > choice_timings[choice] + ms2_fused
                         )
 
-                        if res and fusible_choice:
+                        is_nvgemm_choice = isinstance(choice, NVUniversalGemmCaller)
+                        if is_nvgemm_choice and fusible_choice:
+                            # NVGEMM register allocations are fixed by cutlass_api;
+                            # Triton's n_regs/n_spills heuristic doesn't apply.
+                            ms_fused_choice = choice
+                            break
+                        elif res and fusible_choice:
                             choice.precompile()
                             # pyrefly: ignore [missing-attribute]
                             assert res.launchers and choice.n_regs
@@ -5632,13 +5695,21 @@ class Scheduler:
                 ) and ms_fused_choice is not None:
                     if config.multi_kernel_hints:
                         hint_override_best_fusion_choice[None] = ms_fused_choice
-                        # pyrefly: ignore [missing-attribute]
-                        multi_node.finalize_as_triton_callers(
-                            hint_override_best_fusion_choice
-                        )
+                        if isinstance(ms_fused_choice, NVUniversalGemmCaller):
+                            # pyrefly: ignore [missing-attribute]
+                            multi_node.finalize_as_nvgemm_caller(ms_fused_choice)
+                        else:
+                            # pyrefly: ignore [missing-attribute]
+                            multi_node.finalize_as_triton_callers(
+                                hint_override_best_fusion_choice
+                            )
                     else:
-                        # pyrefly: ignore [missing-attribute]
-                        multi_node.finalize_as_triton_caller(ms_fused_choice)
+                        if isinstance(ms_fused_choice, NVUniversalGemmCaller):
+                            # pyrefly: ignore [missing-attribute]
+                            multi_node.finalize_as_nvgemm_caller(ms_fused_choice)
+                        else:
+                            # pyrefly: ignore [missing-attribute]
+                            multi_node.finalize_as_triton_caller(ms_fused_choice)
 
                     if bench_epilogue:
                         # pyrefly: ignore [missing-attribute]
@@ -5647,9 +5718,13 @@ class Scheduler:
                 else:
                     return False
 
-            return FusionResult.from_callable(
-                benchmark_when_ready, future_choices[0][1]
+            # Use a non-None future when available: handing None to from_callable
+            # causes benchmark_when_ready to run synchronously, blocking any
+            # remaining Triton async-compile overlap.
+            deferred_future = next(
+                (fut for _, fut, _ in future_choices if fut is not None), None
             )
+            return FusionResult.from_callable(benchmark_when_ready, deferred_future)
 
         else:
             # Start parallel compilation for all three kernels


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Adds epilogue fusion (relu, sigmoid, tanh, exp, add, sub, mul, div,
dtype cast) to the NVGEMM backend via cutlass_api EpilogueArguments.

The scheduler's fusion loop recognizes NVUniversalGemmCaller, benchmarks
fused vs unfused EFC kernels, and selects the winner.
MultiTemplateBuffer gains swap/finalize_as_nvgemm_caller for the
benchmark swap. When NVGEMM can't fuse, MTBs fall through to Triton
scheduling so Triton choices can still attempt epilogue fusion.

Authored with the help of an AI assistant (Claude).

Test Plan:
```
python test/inductor/test_nv_universal_gemm.py -v -k Epilogue
python test/inductor/test_max_autotune.py -v -k epilogue_fusion
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo