### PR TITLE
Restore Any return type for Module.__getattr__ to fix typing false positives

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1948,10 +1948,18 @@ class Module:
         if "_backward_pre_hooks" not in self.__dict__:
             self._backward_pre_hooks = OrderedDict()
 
-    # It is crucial that the return type is not annotated as `Any`, otherwise type checking
-    # on `torch.nn.Module` and all its subclasses is largely disabled as a result. See:
-    # https://github.com/pytorch/pytorch/pull/115074
-    def __getattr__(self, name: str) -> Union[Tensor, "Module"]:
+    # On the return type:
+    # We choose to return `Any` in the `__getattr__` type signature instead of a
+    # more strict `Union[Tensor, Module]`. This is done for better interop with
+    # various type checkers for the end users. Having a stricter return type
+    # doesn't play nicely with `register_buffer()` and forces people to
+    # excessively use type-ignores, asserts, casts, etc. See full discussion on
+    # the problems with returning `Union` here:
+    # https://github.com/microsoft/pyright/issues/4213
+    #
+    # See https://github.com/pytorch/pytorch/issues/185023 for the user-reported
+    # false positives caused by the stricter `Union[Tensor, Module]` return type.
+    def __getattr__(self, name: str) -> Any:
         if "_parameters" in self.__dict__:
             _parameters = self.__dict__["_parameters"]
             if name in _parameters:


### PR DESCRIPTION
Fixes #185023.

## Problem

`Module.__getattr__` is annotated as `Union[Tensor, "Module"]`. This produces false-positive type errors on common, well-typed code:

```python
class MyModel(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.register_buffer('running_mean', torch.zeros(4))
        self.weight = nn.Parameter(torch.randn(4, 4))

    def update(self, x: torch.Tensor) -> None:
        self.running_mean.add_(x.mean(dim=0))   # ty: call-non-callable

    def reset(self) -> None:
        self.weight.data.fill_(0)               # ty: call-non-callable
```

In a `Union[A, B]`, methods must exist on *both* variants for a call to type-check. `add_` is on `Tensor` but not on `Module`, so the union fails.

## Fix

Revert the return type to `Any`, matching the design that predated #115074. The original justification (preserved here) is the same one the user is now running into: the `Union[Tensor, Module]` return type plays poorly with `register_buffer()`-registered attributes and forces users to add type-ignores, asserts, or casts to satisfy the type checker.

This is a type-annotation-only change. Runtime behavior is identical.

## Test Plan

- Verified the diff applies cleanly and the file parses.
- `python3 tools/linter/adapters/flake8_linter.py torch/nn/modules/module.py` reports no new issues.

Reproduction (with the new `Any` annotation):

```python
class M(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.register_buffer('running_mean', torch.zeros(4))
        self.weight = nn.Parameter(torch.randn(4, 4))

    def update(self, x: torch.Tensor) -> None:
        self.running_mean.add_(x.mean(dim=0))   # OK

    def reset(self) -> None:
        self.weight.data.fill_(0)               # OK
```