### PR TITLE
[activation_offloading] Add pinned memory pool for ao::offload ops

### DIFF
--- a/test/dynamo/test_activation_offloading.py
+++ b/test/dynamo/test_activation_offloading.py
@@ -469,6 +469,165 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         with torch._functorch.config.patch(activation_offload_cpu_gpu_bw=25.0):
             self.assertAlmostEqual(_estimate_transfer_time_in_ms(size_bytes), 40.0)
 
+    def test_pinned_pool_reuse(self):
+        """Pool returns cached buffers on second call with same size."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pinned_pool,
+            _pool_alloc,
+            _pool_free,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            buf = _pool_alloc(1024, torch.float32)
+            self.assertTrue(buf.is_pinned())
+            self.assertEqual(buf.nelement(), 1024 // 4)  # float32 = 4 bytes
+
+            _pool_free(buf)
+            self.assertEqual(len(_pinned_pool[(1024, torch.float32)]), 1)
+
+            buf2 = _pool_alloc(1024, torch.float32)
+            self.assertIs(buf2, buf)  # same object reused
+            self.assertEqual(len(_pinned_pool.get((1024, torch.float32), [])), 0)
+
+    def test_pinned_pool_dtype_separation(self):
+        """Same nbytes but different dtypes must not share buffers."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pool_alloc,
+            _pool_free,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            # 16 bytes: 4 float32 or 8 float16
+            f32 = _pool_alloc(16, torch.float32)
+            self.assertEqual(f32.dtype, torch.float32)
+            _pool_free(f32)
+
+            f16 = _pool_alloc(16, torch.float16)
+            # Must NOT return the float32 buffer
+            self.assertEqual(f16.dtype, torch.float16)
+            self.assertIsNot(f16, f32)
+
+    def test_pinned_pool_nested_context(self):
+        """Nested pinned_memory_pool() contexts work correctly."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pinned_pool,
+            _pool_alloc,
+            _pool_free,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            buf = _pool_alloc(256, torch.float32)
+            _pool_free(buf)
+
+            with pinned_memory_pool():
+                # Inner context: pool still enabled
+                buf2 = _pool_alloc(512, torch.float32)
+                _pool_free(buf2)
+
+            # After inner exit: pool still enabled (outer still active)
+            buf3 = _pool_alloc(256, torch.float32)
+            self.assertIs(buf3, buf)  # reused from outer context
+            _pool_free(buf3)
+
+        # After outer exit: pool cleared
+        self.assertEqual(len(_pinned_pool), 0)
+
+    def test_pinned_pool_different_sizes(self):
+        """Pool buckets by size — different sizes don't share buffers."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pool_alloc,
+            _pool_free,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            small = _pool_alloc(256, torch.float32)
+            large = _pool_alloc(1024, torch.float32)
+
+            _pool_free(small)
+            _pool_free(large)
+
+            got = _pool_alloc(1024, torch.float32)
+            self.assertIs(got, large)
+
+            got2 = _pool_alloc(256, torch.float32)
+            self.assertIs(got2, small)
+
+    def test_pinned_pool_disabled_outside_context(self):
+        """Without pinned_memory_pool(), alloc/free don't use the pool."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pinned_pool,
+            _pool_alloc,
+            _pool_clear,
+            _pool_free,
+        )
+
+        _pool_clear()
+        buf = _pool_alloc(512, torch.float32)
+        _pool_free(buf)
+        # Pool should be empty — free is a no-op outside context
+        self.assertEqual(len(_pinned_pool), 0)
+
+        buf2 = _pool_alloc(512, torch.float32)
+        self.assertIsNot(buf2, buf)  # fresh allocation, not reused
+        _pool_clear()
+
+    def test_pinned_pool_context_manager(self):
+        """pinned_memory_pool() enables pooling and clears on exit."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pinned_pool,
+            _pool_alloc,
+            _pool_free,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            buf = _pool_alloc(1024, torch.float32)
+            _pool_free(buf)
+            self.assertEqual(len(_pinned_pool[(1024, torch.float32)]), 1)
+
+        # Pool cleared on exit
+        self.assertEqual(len(_pinned_pool), 0)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    def test_pinned_pool_offload_roundtrip(self):
+        """Offload/reload roundtrip reuses pooled buffers on second step."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _pinned_pool,
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            x = torch.randn(64, 64, device=GPU_TYPE)
+            x_ref = x.clone().cpu()
+
+            # Step 1: cold — allocates new pinned buffer
+            cpu = torch.ops.ao.offload.default(x)
+            cpu = torch.ops.ao.wait_tensor.default(cpu, x)
+            gpu = torch.ops.ao.reload.default(cpu, torch.device(GPU_TYPE))
+            gpu = torch.ops.ao.wait_tensor.default(gpu, cpu)
+            torch.testing.assert_close(gpu.cpu(), x_ref)
+
+            # Buffer returned to pool
+            pool_count = sum(len(v) for v in _pinned_pool.values())
+            self.assertEqual(pool_count, 1, "Buffer should be back in pool")
+
+            # Step 2: warm — reuses pooled buffer
+            x2 = torch.randn(64, 64, device=GPU_TYPE)
+            cpu2 = torch.ops.ao.offload.default(x2)
+            pool_count_during = sum(len(v) for v in _pinned_pool.values())
+            self.assertEqual(pool_count_during, 0, "Buffer taken from pool")
+
+            cpu2 = torch.ops.ao.wait_tensor.default(cpu2, x2)
+            gpu2 = torch.ops.ao.reload.default(cpu2, torch.device(GPU_TYPE))
+            gpu2 = torch.ops.ao.wait_tensor.default(gpu2, cpu2)
+
+            pool_count_after = sum(len(v) for v in _pinned_pool.values())
+            self.assertEqual(pool_count_after, 1, "Buffer back in pool")
+
 
 @unittest.skipIf(not HAS_GPU, "requires GPU")
 class DefaultPartitionerActivationOffloadingTests(TestCase):

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -38,6 +38,64 @@ def _get_or_create_transfer_stream(device: torch.device) -> torch.Stream:
     return _transfer_streams[device]
 
 
+# --- Pinned memory pool (avoids per-offload cudaHostAlloc overhead) ---
+# Keyed by (nbytes, dtype) to prevent cross-dtype reuse.
+_pinned_pool: dict[tuple[int, torch.dtype], list[torch.Tensor]] = {}
+_pool_depth: int = 0
+
+
+def _pool_alloc(nbytes: int, dtype: torch.dtype) -> torch.Tensor:
+    """Get a pinned CPU buffer from the pool (if enabled), or allocate fresh."""
+    if _pool_depth > 0:
+        key = (nbytes, dtype)
+        bucket = _pinned_pool.get(key)
+        if bucket:
+            return bucket.pop()
+    numel = nbytes // torch._utils._element_size(dtype)
+    return torch.empty(numel, dtype=dtype, device="cpu", pin_memory=True)
+
+
+def _pool_free(buf: torch.Tensor) -> None:
+    """Return a pinned buffer to the pool for reuse (no-op if pool disabled)."""
+    if _pool_depth <= 0:
+        return
+    nbytes = buf.nelement() * buf.element_size()
+    key = (nbytes, buf.dtype)
+    _pinned_pool.setdefault(key, []).append(buf)
+
+
+def _pool_clear() -> None:
+    """Free all cached pinned buffers."""
+    _pinned_pool.clear()
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def pinned_memory_pool():
+    """Context manager that enables pinned memory pooling for offload ops.
+
+    Without this context manager, ``ao.offload`` allocates a fresh pinned
+    buffer every call and ``ao.wait_tensor`` does not cache freed buffers.
+    Inside the context, buffers are reused across calls, avoiding the
+    ~3 ms per-tensor ``cudaHostAlloc`` overhead.  Nestable::
+
+        with pinned_memory_pool():
+            for step in range(num_steps):
+                train_step()  # ao.offload/reload reuse pooled buffers
+        # pinned buffers freed here
+    """
+    global _pool_depth
+    _pool_depth += 1
+    try:
+        yield
+    finally:
+        _pool_depth -= 1
+        if _pool_depth == 0:
+            _pool_clear()
+
+
 # --- Wait registry: maps data_ptr() -> (completion_event, device) ---
 # Created by ao.offload / ao.reload, consumed (popped) by ao.wait_tensor.
 # Not thread-safe — graph execution is single-threaded Python.
@@ -85,7 +143,8 @@ def offload(tensor: torch.Tensor) -> torch.Tensor:
     transfer_stream.wait_stream(current_stream)
 
     torch.accelerator.set_stream(transfer_stream)
-    result = torch.empty_like(tensor, device="cpu", pin_memory=True)
+    nbytes = tensor.nelement() * tensor.element_size()
+    result = _pool_alloc(nbytes, tensor.dtype).view(tensor.shape)
     completion_event = _register_wait(result, device)
     result.copy_(tensor, non_blocking=True)
     transfer_stream.record_event(completion_event)
@@ -96,7 +155,9 @@ def offload(tensor: torch.Tensor) -> torch.Tensor:
 
 @offload.register_fake
 def _(tensor: torch.Tensor) -> torch.Tensor:
-    return torch.empty_like(tensor, device="cpu")
+    return torch.empty(
+        tensor.shape, dtype=tensor.dtype, device="cpu", pin_memory=False
+    )
 
 
 @custom_op("ao::reload", mutates_args=())
@@ -179,9 +240,13 @@ def _ao_wait_tensor(
 
     current_stream.wait_event(completion_event)
     if keepalive is not None:
-        storage = keepalive.untyped_storage()
-        if storage.size() > 0:
-            storage.resize_(0)
+        if keepalive.is_pinned():
+            # Return CPU pinned buffer to pool for reuse
+            _pool_free(keepalive.view(-1))
+        else:
+            storage = keepalive.untyped_storage()
+            if storage.size() > 0:
+                storage.resize_(0)
     return tensor
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186161

Adds a lazily-populated pinned memory pool that reuses CPU buffers
across training steps, avoiding per-tensor cudaHostAlloc overhead
(~3ms each). The pool is keyed by buffer size and grows on first
use.

Also adds pinned_memory_pool() context manager that clears the pool
on entry and exit, ensuring pinned memory is freed when the caller
is done.

Benchmarks (Llama3 8B, 8xH100, 155 tensors offloaded):
  Without pool: 3,984 TPS (49.6% overhead)
  With pool:    6,163 TPS (22.0% overhead)
  Root cause: cudaHostAlloc ~3ms/tensor × 155 tensors = 465ms/step

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98