### PR TITLE
Require NCCL >= 2.27 and drop version gates for older NCCL

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -46,12 +46,10 @@ class NCCLTestBase {
     c10::intrusive_ptr<c10d::ProcessGroupNCCL::Options> opts =
         c10::make_intrusive<c10d::ProcessGroupNCCL::Options>();
     opts->timeout = pgTimeout_;
-#ifdef NCCL_HAS_COMM_SPLIT
     if (split_from) {
       opts->split_from = *split_from;
       opts->split_color = ++color_;
     }
-#endif
     pg_ = c10::make_intrusive<::c10d::ProcessGroupNCCL>(
         store_, rank, size, std::move(opts));
   }

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -17,14 +17,6 @@
 #include <type_traits>
 #include <unordered_map>
 
-#if (NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 13))
-#define NCCL_HAS_REMOTE_ERROR 1
-#endif
-
-#if (NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 14))
-#define NCCL_HAS_COMM_NONBLOCKING 1
-#endif
-
 ncclComm_t* to_nccl_comm(torch::cuda::nccl::ncclComm_t* var) {
   return reinterpret_cast<ncclComm_t*>(var);
 }
@@ -51,14 +43,10 @@ ncclResult_t to_nccl_result(torch::cuda::nccl::ncclResult var) {
       return ncclResult_t::ncclInvalidArgument;
     case torch::cuda::nccl::ncclResult::InvalidUsage:
       return ncclResult_t::ncclInvalidUsage;
-#ifdef NCCL_HAS_REMOTE_ERROR
     case torch::cuda::nccl::ncclResult::RemoteError:
       return ncclResult_t::ncclRemoteError;
-#endif
-#ifdef NCCL_HAS_COMM_NONBLOCKING
     case torch::cuda::nccl::ncclResult::InProgress:
       return ncclResult_t::ncclInProgress;
-#endif
     case torch::cuda::nccl::ncclResult::NumResults:
       return ncclResult_t::ncclNumResults;
     default:
@@ -80,14 +68,10 @@ torch::cuda::nccl::ncclResult from_nccl_result(ncclResult_t var) {
       return torch::cuda::nccl::ncclResult::InvalidArgument;
     case ncclInvalidUsage:
       return torch::cuda::nccl::ncclResult::InvalidUsage;
-#ifdef NCCL_HAS_REMOTE_ERROR
     case ncclRemoteError:
       return torch::cuda::nccl::ncclResult::RemoteError;
-#endif
-#ifdef NCCL_HAS_COMM_NONBLOCKING
     case ncclInProgress:
       return torch::cuda::nccl::ncclResult::InProgress;
-#endif
     case ncclNumResults:
       return torch::cuda::nccl::ncclResult::NumResults;
     default:
@@ -182,7 +166,6 @@ static int nccl_nonblocking_timeout() {
 }
 
 static void NCCL_CHECK_TIMEOUT(ncclResult status, ncclComm_t comm) {
-#ifdef NCCL_HAS_COMM_NONBLOCKING
   ncclResult_t result = to_nccl_result(status);
   auto startTimepoint = std::chrono::steady_clock::now();
   while (result == ncclInProgress) {
@@ -199,10 +182,6 @@ static void NCCL_CHECK_TIMEOUT(ncclResult status, ncclComm_t comm) {
   if (result != ncclSuccess) {
     throw_nccl_error(from_nccl_result(result));
   }
-#else
-  TORCH_INTERNAL_ASSERT(
-      false, "NCCL COMM NONBLOCKING USED WITH UNSUPPORTED NCCL VERSION.");
-#endif
 }
 
 static void NCCL_CHECK_TIMEOUT(ncclResult_t result, ncclComm_t comm) {
@@ -212,7 +191,6 @@ static void NCCL_CHECK_TIMEOUT(ncclResult_t result, ncclComm_t comm) {
 static void NCCL_CHECK_TIMEOUT(
     ncclResult status,
     std::vector<ncclComm_t>& comms) {
-#ifdef NCCL_HAS_COMM_NONBLOCKING
   ncclResult_t result = to_nccl_result(status);
   auto startTimepoint = std::chrono::steady_clock::now();
   if (result == ncclInProgress) {
@@ -236,10 +214,6 @@ static void NCCL_CHECK_TIMEOUT(
   if (result != ncclSuccess) {
     throw_nccl_error(from_nccl_result(result));
   }
-#else
-  TORCH_INTERNAL_ASSERT(
-      false, "NCCL COMM NONBLOCKING USED WITH UNSUPPORTED NCCL VERSION.");
-#endif
 }
 
 static void NCCL_CHECK_TIMEOUT(
@@ -419,39 +393,26 @@ void check_inputs(
 } // namespace detail
 
 AutoNcclGroup::AutoNcclGroup() : comm_(nullptr), comm_nonblocking_(false) {
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
-  // nccl < 2.0 cannot be called concurrently with cudaFree
-  (c10::cuda::getFreeMutex())->lock();
-#endif
-
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+#if defined(NCCL_MAJOR)
   detail::NCCL_CHECK(ncclGroupStart());
 #endif
 }
 
 AutoNcclGroup::AutoNcclGroup(ncclComm_t comm, bool comm_nonblocking)
     : comm_(comm), comm_nonblocking_(comm_nonblocking) {
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
-  // nccl < 2.0 cannot be called concurrently with cudaFree
-  (c10::cuda::getFreeMutex())->lock();
-#endif
-
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+#if defined(NCCL_MAJOR)
   detail::NCCL_CHECK(ncclGroupStart());
 #endif
 }
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 AutoNcclGroup::~AutoNcclGroup() noexcept(false) {
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+#if defined(NCCL_MAJOR)
   if (comm_nonblocking_ && comm_ != nullptr) {
     detail::NCCL_CHECK_TIMEOUT(ncclGroupEnd(), comm_);
   } else {
     detail::NCCL_CHECK(ncclGroupEnd());
   }
-#endif
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
-  (c10::cuda::getFreeMutex())->unlock();
 #endif
 }
 
@@ -479,9 +440,6 @@ std::uint64_t version() {
   constexpr std::uint64_t ver = (((uint64_t)NCCL_MAJOR) << 32) |
       (((uint64_t)NCCL_MINOR) << 16) | ((uint64_t)NCCL_PATCH);
   return ver;
-#elif defined(USE_NCCL)
-  // return major version "1"
-  return ((uint64_t)1) << 32;
 #else
   return 0;
 #endif
@@ -555,20 +513,10 @@ constexpr auto count_max =
 // https://github.com/NVIDIA/nccl/issues/696. The issue of skipping send/recv
 // is that it can cause deadlock when a rank send and recv 0 bytes so it's
 // completely skipping the collective, causing mismatch across ranks
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR > 13)))
 template <typename T>
 constexpr bool _nccl_should_send_recv([[maybe_unused]] T _unused_) {
   return true;
 }
-#else
-// old NCCL uses 0 byte message for synchronization
-// Avoid send/recv when message size is zero
-template <typename T>
-inline bool _nccl_should_send_recv(T value) {
-  return value != 0;
-}
-#endif
 } // namespace
 
 size_t get_max_count() {
@@ -788,7 +736,6 @@ void all_gather(
         : streams[i]->stream();
 
     ncclComm_t comm = comms_ref[i];
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
     NCCL_CHECK(ncclAllGather(
         inputs[i].const_data_ptr(),
         outputs[i].mutable_data_ptr(),
@@ -796,15 +743,6 @@ void all_gather(
         data_type,
         to_nccl_comm(comm),
         stream));
-#else
-    NCCL_CHECK(ncclAllGather(
-        inputs[i].const_data_ptr(),
-        count,
-        data_type,
-        outputs[i].mutable_data_ptr(),
-        to_nccl_comm(comm),
-        stream));
-#endif
   }
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
@@ -818,8 +756,6 @@ void all2all_single_equal_split(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto type = to_nccl_data_type(input);
@@ -847,14 +783,7 @@ void all2all_single_equal_split(
           ncclRecv(recvbuff + r * rankdiff, count, type, r, comm, stream));
     }
   }
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclGroupEnd());
-#else
   NCCL_CHECK_TIMEOUT(ncclGroupEnd(), _comm);
-#endif
-#endif
-#else
-  TORCH_CHECK(false, "all2all is only supported for NCCL lib version >= 2.7.0");
 #endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
@@ -873,8 +802,6 @@ void all2all_single_unequal_split(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto type = to_nccl_data_type(_type);
@@ -917,14 +844,7 @@ void all2all_single_unequal_split(
           stream));
     }
   }
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclGroupEnd());
-#else
   NCCL_CHECK_TIMEOUT(ncclGroupEnd(), _comm);
-#endif
-#endif
-#else
-  TORCH_CHECK(false, "all2all is only supported for NCCL lib version >= 2.7.0");
 #endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
@@ -937,8 +857,6 @@ void all2all(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
   auto comm = to_nccl_comm(_comm);
 
@@ -966,14 +884,7 @@ void all2all(
           stream.stream()));
     }
   }
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclGroupEnd());
-#else
   NCCL_CHECK_TIMEOUT(ncclGroupEnd(), _comm);
-#endif
-#else
-  TORCH_CHECK(false, "all2all is only supported for NCCL lib version >= 2.7.0");
-#endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
 #endif
@@ -985,18 +896,7 @@ void send(
     at::cuda::CUDAStream stream,
     int dst) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclSend(
-      input.const_data_ptr(),
-      input.numel(),
-      to_nccl_data_type(input),
-      dst,
-      to_nccl_comm(comm),
-      stream.stream()));
-#else
   NCCL_CHECK_TIMEOUT(
       ncclSend(
           input.const_data_ptr(),
@@ -1006,10 +906,6 @@ void send(
           to_nccl_comm(comm),
           stream.stream()),
       comm);
-#endif
-#else
-  TORCH_CHECK(false, "Send is only supported for NCCL lib version >= 2.7.0");
-#endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
 #endif
@@ -1021,18 +917,7 @@ void recv(
     at::cuda::CUDAStream stream,
     int src) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclRecv(
-      output.mutable_data_ptr(),
-      output.numel(),
-      to_nccl_data_type(output),
-      src,
-      to_nccl_comm(comm),
-      stream.stream()));
-#else
   NCCL_CHECK_TIMEOUT(
       ncclRecv(
           output.mutable_data_ptr(),
@@ -1042,10 +927,6 @@ void recv(
           to_nccl_comm(comm),
           stream.stream()),
       comm);
-#endif
-#else
-  TORCH_CHECK(false, "Recv is only supported for NCCL lib version >= 2.7.0");
-#endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
 #endif
@@ -1058,8 +939,6 @@ void gather(
     at::cuda::CUDAStream& stream,
     int32_t root) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto comm = to_nccl_comm(_comm);
@@ -1086,15 +965,8 @@ void gather(
   } else {
     NCCL_CHECK(ncclSend(sendbuff, count, type, root, comm, stream));
   }
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclGroupEnd());
-#else
   NCCL_CHECK_TIMEOUT(ncclGroupEnd(), _comm);
-#endif
 
-#else
-  TORCH_CHECK(false, "gather is only supported for NCCL lib version >= 2.7.0");
-#endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
 #endif
@@ -1107,19 +979,12 @@ void scatter(
     at::cuda::CUDAStream& stream,
     int32_t root) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto comm = to_nccl_comm(_comm);
   int numranks = 0, cur_rank = 0;
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclCommCount(comm, &numranks));
-  NCCL_CHECK(ncclCommUserRank(comm, &cur_rank));
-#else
   NCCL_CHECK_TIMEOUT(ncclCommCount(comm, &numranks), _comm);
   NCCL_CHECK_TIMEOUT(ncclCommUserRank(comm, &cur_rank), _comm);
-#endif
   NCCL_CHECK(ncclGroupStart());
   if (cur_rank == root) {
     for (const auto r : c10::irange(numranks)) {
@@ -1140,14 +1005,7 @@ void scatter(
     auto* recvbuff = reinterpret_cast<char*>(outputs.mutable_data_ptr());
     NCCL_CHECK(ncclRecv(recvbuff, recv_count, recv_type, root, comm, stream));
   }
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  NCCL_CHECK(ncclGroupEnd());
-#else
   NCCL_CHECK_TIMEOUT(ncclGroupEnd(), _comm);
-#endif
-#else
-  TORCH_CHECK(false, "scatter is only supported for NCCL lib version >= 2.7.0");
-#endif
 #else
   TORCH_CHECK(false, "PyTorch built without NCCL support");
 #endif

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -7,11 +7,10 @@
 #include <optional>
 #include <vector>
 
-// NCCL BFloat16 is enabled only for CUDA 11+ and NCCL versions 2.10+, or for
-// HIP 3.1+
+// NCCL BFloat16 is enabled for CUDA builds where the bf16 type exists and NCCL
+// is present (NCCL is required to be 2.27+), or for HIP 3.1+
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-#define HAS_NCCL_BF16_DATATYPE \
-  ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#define HAS_NCCL_BF16_DATATYPE (NCCL_MAJOR >= 2)
 #elif defined(USE_ROCM) && (TORCH_HIP_VERSION >= 301)
 #define HAS_NCCL_BF16_DATATYPE 1
 #else

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -78,7 +78,6 @@ std::shared_ptr<NCCLComm> NCCLComm::create(
   return comm;
 }
 
-#ifdef NCCL_HAS_CONFIG
 std::shared_ptr<NCCLComm> NCCLComm::create(
     int numRanks,
     int rank,
@@ -103,7 +102,6 @@ std::shared_ptr<NCCLComm> NCCLComm::create(
   comm->initialized_ = !comm->nonBlocking_;
   return comm;
 }
-#ifdef NCCL_HAS_INIT_RANK_SCALABLE
 std::shared_ptr<NCCLComm> NCCLComm::create_scalable(
     int numRanks,
     int rank,
@@ -134,8 +132,6 @@ std::shared_ptr<NCCLComm> NCCLComm::create_scalable(
   comm->initialized_ = !comm->nonBlocking_;
   return comm;
 }
-#endif // NCCL_HAS_INIT_RANK_SCALABLE
-#endif // NCCL_HAS_CONFIG
 
 ncclComm_t NCCLComm::getNcclComm() {
   LockType lock(mutex_);
@@ -218,7 +214,6 @@ std::optional<std::string> NCCLComm::getNcclCommFailureReason() const {
   return commFailureReason_;
 }
 
-#if defined(NCCL_HAS_COMM_SPLIT)
 std::shared_ptr<NCCLComm> NCCLComm::split(
     NCCLComm* source,
     int color_id,
@@ -236,11 +231,6 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
   auto comm = std::make_shared<NCCLComm>();
   // This call will block until the source communicator is initialized
   auto sourceComm = source->getNcclComm();
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  C10D_NCCL_CHECK(
-      ncclCommSplit(sourceComm, color_id, rank, &(comm->ncclComm_), &config),
-      std::nullopt);
-#else
   // After calling ncclCommSplit in non-blocking mode, we should wait for the
   // source communicator to be out of ncclInProgress state.
   // Reason 1:
@@ -267,7 +257,6 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
   }
   // comm->ncclComm_ should have valid ptr by now, but not necessarily
   // initialized. Rely on getNcclComm() to wait for its initialization.
-#endif
   ++source->ncclCommSplitCounter_;
   comm->rank_ = rank;
   // Child comm should be on the same device as parent comm
@@ -280,9 +269,7 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
             << comm->repr() << " with color_id " << color_id;
   return comm;
 }
-#endif
 
-#ifdef NCCL_HAS_COMM_SHRINK
 std::shared_ptr<NCCLComm> NCCLComm::shrink(
     NCCLComm* source,
     std::vector<int>& ranks_to_exclude,
@@ -339,7 +326,6 @@ std::shared_ptr<NCCLComm> NCCLComm::shrink(
 
   return comm;
 }
-#endif
 
 void NCCLComm::finalize() {
   LockType lock(mutex_);
@@ -370,19 +356,16 @@ void NCCLComm::destroy() {
 void NCCLComm::abort(std::optional<std::string> commFailureReason) {
   LockType lock(mutex_);
   at::cuda::OptionalCUDAGuard gpuGuard(deviceIndex_);
-#ifdef ENABLE_NCCL_ERROR_CHECKING
   if (aborted_ && !initialized_) {
     // Should not abort twice.
     return;
   }
 
-#ifdef NCCL_HAS_COMM_REGISTER
   // Deregister all registered segments before aborting.
   for (auto& it : registeredSegmentHandles_) {
     void* handle = it.second.first;
     bool is_window = it.second.second;
     if (is_window) {
-#ifdef NCCL_HAS_COMM_WINDOW_REGISTER
       C10D_NCCL_CHECK(
           ::ncclCommWindowDeregister(ncclComm_, (ncclWindow_t)handle),
           c10::str(
@@ -390,7 +373,6 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
               handle,
               " on ncclComm_ ",
               ncclComm_));
-#endif
     } else {
       C10D_NCCL_CHECK(
           ::ncclCommDeregister(ncclComm_, handle),
@@ -402,7 +384,6 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
     }
   }
   registeredSegmentHandles_.clear();
-#endif
 
   // Set true failure reason if provided by ProcessGroupNCCL (e.g. work
   // timeout)
@@ -410,9 +391,6 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
   LOG(INFO) << "Aborting ncclComm_ " << ncclComm_ << " with reason: "
             << (commFailureReason ? *commFailureReason
                                   : "No abort reason provided.");
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  C10D_NCCL_CHECK(::ncclCommAbort(ncclComm_), commFailureReason_);
-#else
   // Note: We already hold the mutex_ lock here, so the direct call to
   // ncclCommGetAsyncError is safe from concurrent access.
   ncclResult_t result = ::ncclCommAbort(ncclComm_);
@@ -437,7 +415,6 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
         "\n" + getNcclErrorDetailStr(result, commFailureReason_);
     TORCH_CHECK_WITH(DistBackendError, false, err);
   }
-#endif
   aborted_ = true;
   ncclComm_ = nullptr;
 
@@ -445,10 +422,6 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
   if (ncclAsyncErr_ == ncclSuccess) {
     ncclAsyncErr_ = ncclSystemError;
   }
-#else
-  // This is a NOOP, if error checks are disabled.
-  return;
-#endif
 }
 
 bool NCCLComm::isInitialized() const {
@@ -467,17 +440,12 @@ uint64_t NCCLComm::getCommSplitCounter() const {
 
 ncclResult_t NCCLComm::checkForNcclError() {
   LockType lock(mutex_);
-#ifdef ENABLE_NCCL_ERROR_CHECKING
   if (ncclAsyncErr_ != ncclSuccess) {
     return ncclAsyncErr_;
   }
   C10D_NCCL_CHECK(
       ncclCommGetAsyncError(ncclComm_, &ncclAsyncErr_), commFailureReason_);
   return ncclAsyncErr_;
-#else
-  // Always return success, if error checks are disabled.
-  return ncclSuccess;
-#endif
 }
 
 ncclResult_t NCCLComm::getAsyncError(ncclResult_t* asyncError) {
@@ -491,7 +459,6 @@ ncclResult_t NCCLComm::registerSegment(
     bool errorOnRereg, /*=true*/
     bool window /*=false*/) {
   LockType lock(mutex_);
-#ifdef NCCL_HAS_COMM_REGISTER
   // We register only segments from cache allocator
   // which are guaranteed to be with disjoint addr ranges. Thus, a ptr always
   // maps to a unique handle and should not be registered before the current
@@ -510,7 +477,6 @@ ncclResult_t NCCLComm::registerSegment(
   void* handle = nullptr;
   // Use getNcclComm to make sure comm is ready before calling nccl APIs
   auto comm = getNcclComm();
-#ifdef NCCL_HAS_COMM_WINDOW_REGISTER
   if (window) {
     C10D_NCCL_CHECK(
         ncclCommWindowRegister(
@@ -533,27 +499,12 @@ ncclResult_t NCCLComm::registerSegment(
             " on ncclComm_ ",
             comm));
   }
-#else
-  C10D_NCCL_CHECK(
-      ncclCommRegister(comm, ptr, size, &handle),
-      c10::str(
-          "Failed to register segment with ptr ",
-          ptr,
-          ", size ",
-          size,
-          " on ncclComm_ ",
-          comm));
-#endif
   registeredSegmentHandles_[ptr] = {handle, window};
   return ncclSuccess;
-#else
-  return ncclInvalidUsage;
-#endif
 }
 
 ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
   LockType lock(mutex_);
-#ifdef NCCL_HAS_COMM_REGISTER
   TORCH_CHECK(
       registeredSegmentHandles_.count(ptr) == 1,
       "Segment with ptr ",
@@ -564,7 +515,6 @@ ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
   void* handle = registeredSegmentHandles_[ptr].first;
   // Use getNcclComm to make sure comm is ready before calling nccl APIs
   auto comm = getNcclComm();
-#ifdef NCCL_HAS_COMM_WINDOW_REGISTER
   if (window) {
     C10D_NCCL_CHECK(
         ncclCommWindowDeregister(comm, (ncclWindow_t)handle),
@@ -586,22 +536,8 @@ ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
             " on ncclComm_ ",
             comm));
   }
-#else
-  C10D_NCCL_CHECK(
-      ncclCommDeregister(comm, handle),
-      c10::str(
-          "Failed to deregister segment handle ",
-          handle,
-          ", with ptr ",
-          ptr,
-          " on ncclComm_ ",
-          comm));
-#endif
   registeredSegmentHandles_.erase(ptr);
   return ncclSuccess;
-#else
-  return ncclInvalidUsage;
-#endif
 }
 
 std::string NCCLComm::repr() const {
@@ -776,14 +712,12 @@ std::string getNcclErrorDetailStr(
   }
   std::string interpret;
   std::string err;
-#ifdef ENABLE_NCCL_GET_LAST_ERROR
   auto ret = ncclGetLastError(nullptr);
   if (ret) {
     err = "\nLast error:\n" + std::string(ret);
   } else {
     err = "\nLast error: Unknown NCCL Error\n";
   }
-#endif
   switch (error) {
     case ncclUnhandledCudaError:
       interpret = "ncclUnhandledCudaError: Call to CUDA function failed.";
@@ -791,11 +725,6 @@ std::string getNcclErrorDetailStr(
     case ncclSystemError:
       interpret =
           "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. ";
-#ifndef NCCL_REMOTE_ERROR
-      // Before ncclRemoteError was created, unexpected remote disconnect was
-      // categorized as ncclSystemError
-      interpret += "It can be also caused by unexpected exit of a remote peer.";
-#endif
       break;
     case ncclInternalError:
       interpret = "ncclInternalError: Internal check failed.";
@@ -807,12 +736,10 @@ std::string getNcclErrorDetailStr(
       interpret =
           "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
       break;
-#ifdef NCCL_REMOTE_ERROR
     case ncclRemoteError:
       interpret =
           "ncclRemoteError: A call failed possibly due to a network error or a remote process exiting prematurely.";
       break;
-#endif
     default:
       interpret = "Unknown NCCL error!";
   }

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -18,81 +18,9 @@
 
 constexpr int64_t kCommInitBusyWaitMillis = 2;
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 14, 0)
-#define NCCL_HAS_COMM_NONBLOCKING
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 18, 0)
-#define NCCL_HAS_COMM_SPLIT
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 23, 0)
-#define NCCL_HAS_INIT_RANK_SCALABLE
-#endif
-
-// ncclGetLastError() is enabled only for NCCL versions 2.13+
-// ncclRemoteError only exists in NCCL versions 2.13+
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 13, 0)
-#define ENABLE_NCCL_GET_LAST_ERROR
-#define NCCL_REMOTE_ERROR
-#endif
-
 static_assert(
-    NCCL_VERSION_CODE >= NCCL_VERSION(2, 7, 0),
-    "NCCL version must be 2.7 or later");
-// The following macros represent features supported prior to NCCL 2.7,
-// therefore we can define them unconditionally, given the static_assert above.
-// TODO: remove these macros from code.
-#define ENABLE_NCCL_ERROR_CHECKING
-#define ENABLE_NCCL_P2P_SUPPORT
-// End of macros for NCCL 2.7 and below.
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 11, 0)
-#define ENABLE_NCCL_PREMUL_SUM_SUPPORT
-#endif
-
-// Note: the first version that supports ncclConfig_t is 2.14. Here we
-// fast-forward the version requirement to 2.17 where ncclConfig_t has CTA and
-// CGA fields because they have already been pybinded out.
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 17, 0)
-#define NCCL_HAS_CONFIG
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-#define NCCL_HAS_COMM_REGISTER
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-#define NCCL_HAS_COMM_WINDOW_REGISTER
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-#define NCCL_HAS_MEM_ALLOC
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 26, 0)
-#define NCCL_HAS_QOS
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 0)
-#define NCCL_SUPPORTS_FP8
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-#define NCCL_HAS_COLLNET
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-#define NCCL_HAS_CTA_POLICY
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-#define NCCL_HAS_NVLS_CTAS
-#endif
-
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-#define NCCL_HAS_COMM_SHRINK
-#endif
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0),
+    "NCCL version must be 2.27 or later");
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
 #define NCCL_HAS_COMM_OFFLOAD
@@ -231,13 +159,8 @@ static std::map<at::ScalarType, ncclDataType_t> ncclDataType = {
     {at::kLong, ncclInt64},
     {at::kHalf, ncclHalf},
     {at::kBool, ncclUint8},
-#ifdef NCCL_SUPPORTS_FP8
     {at::kFloat8_e5m2, ncclFloat8e5m2},
     {at::kFloat8_e4m3fn, ncclFloat8e4m3},
-#else
-    {at::kFloat8_e5m2, ncclUint8},
-    {at::kFloat8_e4m3fn, ncclUint8},
-#endif
     // NVIDIA GPUs does not support the UZ version standing for "no negative
     // zero".  See https://onnx.ai/onnx/technical/float8.html
     {at::kFloat8_e4m3fnuz, ncclUint8},
@@ -285,38 +208,30 @@ class NCCLComm {
       ncclUniqueId commId,
       at::DeviceIndex deviceIndex);
 
-#ifdef NCCL_HAS_CONFIG
   static std::shared_ptr<NCCLComm> create(
       int numRanks,
       int rank,
       ncclUniqueId commId,
       at::DeviceIndex deviceIndex,
       ncclConfig_t& config);
-#ifdef NCCL_HAS_INIT_RANK_SCALABLE
   static std::shared_ptr<NCCLComm> create_scalable(
       int numRanks,
       int rank,
       std::vector<ncclUniqueId>& commIds,
       at::DeviceIndex deviceIndex,
       ncclConfig_t& config);
-#endif // NCCL_HAS_INIT_RANK_SCALABLE
-#endif // NCCL_HAS_CONFIG
 
-#ifdef NCCL_HAS_COMM_SPLIT
   static std::shared_ptr<NCCLComm> split(
       NCCLComm* source,
       int color_id,
       int rank,
       ncclConfig_t& config);
-#endif // NCCL_HAS_COMM_SPLIT
 
-#ifdef NCCL_HAS_COMM_SHRINK
   static std::shared_ptr<NCCLComm> shrink(
       NCCLComm* source,
       std::vector<int>& ranks_to_exclude,
       ncclConfig_t* config,
       int shrinkFlags = 0);
-#endif // NCCL_HAS_COMM_SHRINK
 
 #if (defined(IS_NCCLX) || defined(USE_ROCM)) && defined(NCCL_COMM_DUMP)
   std::unordered_map<std::string, std::string> ncclCommDump();
@@ -412,11 +327,9 @@ class NCCLComm {
   bool nonBlocking_{true};
   // Device index for which the NCCL comm is created
   at::DeviceIndex deviceIndex_{-1};
-#ifdef NCCL_HAS_COMM_REGISTER
   // Stores handlers for tensors registered by NCCL.
   // Maps ptr -> (handle, is_window_registered).
   std::unordered_map<void*, std::pair<void*, bool>> registeredSegmentHandles_;
-#endif // NCCL_HAS_COMM_REGISTER
 
  private:
   ncclComm_t ncclComm_{nullptr};
@@ -435,13 +348,11 @@ struct ncclRedOpRAII {
     std::swap(tmp.comm_, this->comm_);
     std::swap(tmp.premul_sum_, this->premul_sum_);
   }
-#if defined(ENABLE_NCCL_PREMUL_SUM_SUPPORT)
   ~ncclRedOpRAII() {
     if (premul_sum_) {
       ncclRedOpDestroy(op_, comm_);
     }
   }
-#endif // ENABLE_NCCL_PREMUL_SUM_SUPPORT
   operator ncclRedOp_t() const {
     return op_;
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -45,34 +45,22 @@ using FlightRecorderCUDA = FlightRecorder<at::cuda::CUDAEvent>;
 
 namespace {
 
-#if defined(NCCL_MAJOR) && \
-    ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
-#define NCCL_HAS_AVG 1
-#endif // NCCL version >= 2.10
-
 // NCCL op mapping
 const std::map<ReduceOp::RedOpType, ncclRedOp_t> ncclOp = {
     {ReduceOp::MIN, ncclMin},
     {ReduceOp::MAX, ncclMax},
     {ReduceOp::SUM, ncclSum},
     {ReduceOp::PRODUCT, ncclProd},
-#ifdef NCCL_HAS_AVG
     {ReduceOp::AVG, ncclAvg},
-#endif // NCCL_HAS_AVG
 };
 
 inline bool isUnsupportedFloat8(at::ScalarType t) {
   return (
       t == at::ScalarType::Float8_e5m2fnuz ||
       t == at::ScalarType::Float8_e4m3fnuz ||
-      t == at::ScalarType::Float8_e8m0fnu
-#ifndef NCCL_SUPPORTS_FP8
-      || t == at::ScalarType::Float8_e5m2 || t == at::ScalarType::Float8_e4m3fn
-#endif
-  );
+      t == at::ScalarType::Float8_e8m0fnu);
 }
 
-#ifdef ENABLE_NCCL_PREMUL_SUM_SUPPORT
 template <typename T, ncclDataType_t dataType>
 ncclRedOpRAII unpackPreMulSum(
     const ReduceOp& reduceOp,
@@ -97,7 +85,6 @@ ncclRedOpRAII unpackPreMulSum(
       comm);
   return ncclRedOpRAII(preMulSum, comm);
 }
-#endif // ENABLE_NCCL_PREMUL_SUM_SUPPORT
 
 ncclRedOpRAII getNcclReduceOp(
     const ReduceOp& reduceOp,
@@ -112,15 +99,12 @@ ncclRedOpRAII getNcclReduceOp(
         // represent a bool (see ncclDataType mapping).
         return ncclMax;
       }
-#ifdef NCCL_HAS_AVG
       if (reduceOp == ReduceOp::AVG) {
         C10_THROW_ERROR(
             TypeError, "Cannot use ReduceOp.AVG with boolean inputs");
       }
-#endif // NCCL_HAS_AVG
     }
     if (reduceOp == ReduceOp::PREMUL_SUM) {
-#ifdef ENABLE_NCCL_PREMUL_SUM_SUPPORT
       switch (dataType) {
         case ncclHalf:
           return unpackPreMulSum<at::Half, ncclHalf>(reduceOp, comm);
@@ -135,22 +119,10 @@ ncclRedOpRAII getNcclReduceOp(
               TypeError,
               "PreMulSum Data type must be half, float, bfloat16 or double");
       }
-#else
-      C10_THROW_ERROR(ValueError, "PreMulSum requires NCCL>=2.11.1");
-#endif // ENABLE_NCCL_PREMUL_SUM_SUPPORT
     }
     return ncclOp.at(reduceOp);
   } catch (const std::out_of_range&) {
     switch (reduceOp) {
-      case ReduceOp::AVG:
-        C10_THROW_ERROR(
-            ValueError,
-            c10::str(
-                "AVG requires NCCL 2.10+. The current version is ",
-                NCCL_MAJOR,
-                ".",
-                NCCL_MINOR));
-        break;
       case ReduceOp::BAND:
         C10_THROW_ERROR(ValueError, "Cannot use ReduceOp.BAND with NCCL");
         break;
@@ -298,7 +270,6 @@ inline void errorIfCapturingNonCapturableNCCL(c10::cuda::CaptureStatus status) {
 // When TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK is set, all tensors (no
 // matter how they have been allocated) are registered with all NCCL comms.
 bool shouldAllCommunicatorsRegisterAllTensors() {
-#ifdef NCCL_HAS_COMM_REGISTER
   static const bool flag = [] {
     const bool flag =
         getCvarBool(TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK, false);
@@ -312,9 +283,6 @@ bool shouldAllCommunicatorsRegisterAllTensors() {
     return flag;
   }();
   return flag;
-#else
-  return false;
-#endif // NCCL_HAS_COMM_REGISTER
 }
 
 } // namespace
@@ -995,10 +963,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   debugInfoPipeFile_ = getCvarString({"TORCH_NCCL_DEBUG_INFO_PIPE_FILE"}, "");
   auto desyncDebug = getCvarBool(TORCH_NCCL_DESYNC_DEBUG, false) ||
       (dist_debug_level_ >= DebugLevel::Detail);
-#ifdef ENABLE_NCCL_ERROR_CHECKING
   enableTiming_.store(
       getCvarBool(TORCH_NCCL_ENABLE_TIMING, false) || desyncDebug);
-#endif // ENABLE_NCCL_ERROR_CHECKING
   if (getCvarBool(TORCH_NCCL_AVOID_RECORD_STREAMS, false)) {
     TORCH_WARN_ONCE(
         "TORCH_NCCL_AVOID_RECORD_STREAMS is the default now, this environment variable is thus deprecated.");
@@ -1043,14 +1009,12 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   heartbeatMonitor_ = std::make_unique<HeartbeatMonitor>(this);
   watchdog_ = std::make_unique<Watchdog>(this);
 
-#ifdef ENABLE_NCCL_ERROR_CHECKING
   // in blockingWait mode, we don't need to enable the watchdog thread to check
   // the timeout or nccl error because the main thread would throw an exception
   // and it is the user's responsibility to handle the exception.
   if (!blockingWait_) {
     watchdog_->start();
   }
-#endif // ENABLE_NCCL_ERROR_CHECKING
 
   init();
   const std::string OFF = "OFF";
@@ -1073,10 +1037,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
               << ", TORCH_NCCL_ENABLE_TIMING: " << enableTiming_.load()
               << ", TORCH_NCCL_BLOCKING_WAIT: " << blockingWait_
               << ", TORCH_DISTRIBUTED_DEBUG: " << torch_distributed_debug
-#ifdef NCCL_HAS_COMM_REGISTER
               << ", TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK: "
               << shouldAllCommunicatorsRegisterAllTensors()
-#endif // NCCL_HAS_COMM_REGISTER
               << ", TORCH_NCCL_TRACE_BUFFER_SIZE: " << traceBufferSize_
               << ", TORCH_NCCL_NAN_CHECK: " << enableNanCheck_
               << ", TORCH_NCCL_CUDA_EVENT_CACHE: " << cudaEventCacheEnabled_;
@@ -1106,9 +1068,6 @@ void ProcessGroupNCCL::eagerConnectSingleDevice(at::Device device) {
 }
 
 bool ProcessGroupNCCL::useNonblocking() {
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  return false;
-#endif // NCCL_HAS_COMM_NONBLOCKING
   // Already parsed, return the cached value
   if (useNonblocking_.has_value()) {
     return useNonblocking_.value();
@@ -1145,7 +1104,6 @@ void ProcessGroupNCCL::performNocolorSplit(at::Device device) {
   // If our backend doesn't support splitting, this is a no-op for
   // ranks not in the new subgroup (and ranks that would be in it will
   // just use a new communicator rather than split).
-#ifdef NCCL_HAS_COMM_SPLIT
   const auto key = getKeyFromDevice(device);
   LOG(INFO) << logPrefix() << "Performing nocolor split on backend device "
             << device << ", key " << key << ", i am " << this;
@@ -1157,7 +1115,6 @@ void ProcessGroupNCCL::performNocolorSplit(at::Device device) {
                << "No parent communicator exists for nocolor split";
   }
   NCCLComm::split(comm.get(), NCCL_SPLIT_NOCOLOR, rank_, options_->config);
-#endif // NCCL_HAS_COMM_SPLIT
 }
 
 bool ProcessGroupNCCL::isInitialized() {
@@ -1474,10 +1431,8 @@ void ProcessGroupNCCL::abortCommsFromMap(
   // The process may control multiple devices, loop through the communicators on
   // each device
   // NCCL expects Group abort when there are multiple communicators created in a
-  // device. Group abort requires 2.22.0 release and up.
-  if (getNcclVersionNumber() >= NCCL_VERSION(2, 22, 0)) {
-    groupStart();
-  }
+  // device.
+  groupStart();
   for (auto& it : ncclCommsMap) {
     auto& devName = it.first;
     auto& ncclComm = it.second;
@@ -1498,9 +1453,7 @@ void ProcessGroupNCCL::abortCommsFromMap(
     VLOG(2) << logPrefix() << "ProcessGroupNCCL destroyed "
             << " communicator on CUDA device: " << devName;
   }
-  if (getNcclVersionNumber() >= NCCL_VERSION(2, 22, 0)) {
-    groupEnd();
-  }
+  groupEnd();
 }
 
 // Abort all communicators on this rank
@@ -2882,12 +2835,7 @@ std::exception_ptr ProcessGroupNCCL::checkForNCCLErrorsInternal(
   // When nonblocking mode is enabled by TORCH_NCCL_USE_COMM_NONBLOCKING,
   // ncclInProgress could be returned when there are pending NCCL calls.
   // In this case, no exception should be thrown
-#ifdef NCCL_HAS_COMM_NONBLOCKING
-  // ncclInProgress is defined only if NCCL_HAS_COMM_NONBLOCKING is defined
   if (ncclAsyncErr != ncclSuccess && ncclAsyncErr != ncclInProgress) {
-#else
-  if (ncclAsyncErr != ncclSuccess) {
-#endif // NCCL_HAS_COMM_NONBLOCKING
     return std::make_exception_ptr(C10_BUILD_ERROR(
         DistBackendError,
         "NCCL error: " + ncclGetErrorWithVersion(ncclAsyncErr) + "\n" +
@@ -3173,12 +3121,9 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::initNCCLComm(
       globalRankStride_, // globalRankStride_
       size_); // worldSize
 
-#ifdef NCCL_HAS_COMM_NONBLOCKING
   bool useNb = useNonblocking();
   options_->config.blocking = useNb ? 0 : 1;
-#endif // NCCL_HAS_COMM_NONBLOCKING
 
-#ifdef NCCL_HAS_COMM_SPLIT
   // Use split to create a new communicator only if:
   // 1. The parent comm is known; AND
   // 2. The new comm is not for a point-to-point operation.
@@ -3199,16 +3144,13 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::initNCCLComm(
       }
     }
   }
-#endif // NCCL_HAS_COMM_SPLIT
 
   bool useScalableInit = false;
   // (nranks / nroots) == 128 was the default NCCL recommended
   // according to
   // https://github.com/pytorch/pytorch/pull/136789#discussion_r1779171615.
   auto ranksPerRoot = getCvarInt(TORCH_NCCL_RANKS_PER_ROOT, 128);
-#if defined(NCCL_HAS_INIT_RANK_SCALABLE) && defined(NCCL_HAS_CONFIG)
   useScalableInit = !singleP2POp && (getSize() > ranksPerRoot);
-#endif // NCCL_HAS_INIT_RANK_SCALABLE && NCCL_HAS_CONFIG
 
   if (useScalableInit) {
     auto numRoots = (getSize() + ranksPerRoot - 1) / ranksPerRoot;
@@ -3232,17 +3174,8 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::initNCCLComm(
       LOG(INFO) << logPrefix()
                 << "ProcessGroupNCCL all-gather unique IDs through store took "
                 << timerDeltaMs << " ms";
-#if defined(NCCL_HAS_INIT_RANK_SCALABLE) && defined(NCCL_HAS_CONFIG)
       ncclComm = NCCLComm::create_scalable(
           numRanks, rank, ncclIDs, deviceIndex, options_->config);
-#else
-      C10_THROW_ERROR(
-          DistBackendError,
-          c10::str(
-              logPrefix(),
-              "create_scalable is called when useScalableInit is enabled but ",
-              "neither NCCL_HAS_INIT_RANK_SCALABLE nor NCCL_HAS_CONFIG is not defined, this should not happen "));
-#endif // NCCL_HAS_INIT_RANK_SCALABLE
     }
   } else {
     // To simplify conditional nesting, just create the ncclComms[i]
@@ -3269,12 +3202,8 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::initNCCLComm(
                   << timerDeltaMs << " ms";
       }
 
-#ifdef NCCL_HAS_CONFIG
       ncclComm = NCCLComm::create(
           numRanks, rank, ncclID, deviceIndex, options_->config);
-#else
-      ncclComm = NCCLComm::create(numRanks, rank, ncclID, deviceIndex);
-#endif // NCCL_HAS_CONFIG
     }
   }
 
@@ -3923,23 +3852,17 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   //
   // See [Sync Streams].
 
-// Not all collectives have the same signature, e.g, all-reduce take in a Tensor
-// as the input and output while all-to-all take in a vector of Tensors as input
-// and output. Because we define the signature of the fn to take only single
-// tensor as input and output, we need to do a hack to get the first element in
-// the vector and pass it to fn.
-// TODO: we should clean up this in future (by either entirely removing lambda's
-// or removing input and output from lambda's signature).
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  C10D_NCCL_CHECK(
-      fn(inputs[0], outputs[0], comm, ncclStream),
-      ncclComm->getNcclCommFailureReason());
-#else
+  // Not all collectives have the same signature, e.g, all-reduce take in a
+  // Tensor as the input and output while all-to-all take in a vector of Tensors
+  // as input and output. Because we define the signature of the fn to take only
+  // single tensor as input and output, we need to do a hack to get the first
+  // element in the vector and pass it to fn.
+  // TODO: we should clean up this in future (by either entirely removing
+  // lambda's or removing input and output from lambda's signature).
   C10D_NCCL_CHECK_TIMEOUT(
       fn(inputs[0], outputs[0], comm, ncclStream),
       ncclComm,
       ncclComm->getNcclCommFailureReason());
-#endif // NCCL_HAS_COMM_NONBLOCKING
 
   post(ncclStream, work);
 
@@ -4102,16 +4025,10 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   {
     torch::cuda::nccl::AutoNcclGroup nccl_group_guard(comm, useNonblocking());
     for (const auto i : c10::irange(inputs.size())) {
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-      C10D_NCCL_CHECK(
-          fn(inputs[i], outputs[i], comm, ncclStream),
-          ncclComm->getNcclCommFailureReason());
-#else
       C10D_NCCL_CHECK_TIMEOUT(
           fn(inputs[i], outputs[i], comm, ncclStream),
           ncclComm,
           ncclComm->getNcclCommFailureReason());
-#endif // NCCL_HAS_COMM_NONBLOCKING
     }
   }
 
@@ -4402,11 +4319,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   // This part seems common to both p2p and coalesced-p2p usage?
   ncclComm_t comm_ = ncclComm->getNcclComm();
 
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  C10D_NCCL_CHECK(
-      fn(tensor, comm_, ncclStream, p2pTargetRank),
-      ncclComm->getNcclCommFailureReason());
-#else
   // In non-blocking mode, we need to use ncclGroup semantics to ensure that the
   // kernel is enqueued for single-P2P ops.  Otherwise, the event record below
   // may not capture the kernel, leading to data corruption.
@@ -4415,7 +4327,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
       fn(tensor, comm_, ncclStream, p2pTargetRank), std::nullopt);
   C10D_NCCL_CHECK_TIMEOUT_GROUPEND(
       ncclGroupEnd(), ncclComm, ncclComm->getNcclCommFailureReason());
-#endif // NCCL_HAS_COMM_NONBLOCKING
 
   if (!coalescing_state_) {
     post(ncclStream);
@@ -5710,15 +5621,11 @@ void ProcessGroupNCCL::groupEnd() {
 
 void ProcessGroupNCCL::groupEndNonblocking(
     const std::shared_ptr<NCCLComm>& comm) {
-#ifndef NCCL_HAS_COMM_NONBLOCKING
-  C10D_NCCL_CHECK(ncclGroupEnd(), std::nullopt);
-#else
   if (!useNonblocking()) {
     C10D_NCCL_CHECK(ncclGroupEnd(), std::nullopt);
   } else {
     C10D_NCCL_CHECK_TIMEOUT_GROUPEND(ncclGroupEnd(), comm, std::nullopt);
   }
-#endif // NCCL_HAS_COMM_NONBLOCKING
   --ncclActiveGroupCounter_;
 }
 
@@ -5957,28 +5864,18 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
 
 // Allocate function
 static void* _ncclMemAlloc(size_t size, int device, void* stream) {
-#ifndef NCCL_HAS_MEM_ALLOC
-  TORCH_CHECK(
-      false, "NCCL mem allocator is not supported in this NCCL version");
-#else
   LOG(INFO) << "NCCL mem allocator: allocating " << size << " bytes";
   at::cuda::OptionalCUDAGuard gpuGuard(device);
   void* ptr = nullptr;
   TORCH_CHECK(ncclMemAlloc(&ptr, size) == ncclSuccess, "ncclMemAlloc failed");
   return ptr;
-#endif // NCCL_HAS_MEM_ALLOC
 }
 
 // Free function
 static void _ncclMemFree(void* ptr, size_t size, int device, void* stream) {
-#ifndef NCCL_HAS_MEM_ALLOC
-  TORCH_CHECK(
-      false, "NCCL mem allocator is not supported in this NCCL version");
-#else
   LOG(INFO) << "NCCL mem allocator: freeing " << size << " bytes";
   at::cuda::OptionalCUDAGuard gpuGuard(device);
   TORCH_CHECK(ncclMemFree(ptr) == ncclSuccess, "ncclMemFree failed");
-#endif // NCCL_HAS_MEM_ALLOC
 }
 
 // Create a `CUDAPluggableAllocator` that uses the above functions.
@@ -5997,14 +5894,6 @@ std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
 }
 
 bool ProcessGroupNCCL::supportsTensorAlloc(c10::DeviceIndex deviceIdx) {
-  // Check if NCCL has `ncclMemAlloc` and `ncclMemFree` functions
-  int version = 0;
-  // Rely on link-time versioning
-  ncclGetVersion(&version);
-  if (version < NCCL_VERSION(2, 19, 0)) {
-    return false;
-  }
-
   // We do an extra check to see if CUDA driver supports multicast.  If not, we
   // will return false. Although `ncclMemAlloc` will fall back to regular
   // `cudaMalloc` and hence not error out, we may still want to avoid creating a
@@ -6053,7 +5942,6 @@ at::Tensor ProcessGroupNCCL::allocateTensor(
   return tensor;
 }
 
-#ifdef NCCL_HAS_COMM_SHRINK
 c10::intrusive_ptr<Backend> ProcessGroupNCCL::shrink(
     const std::vector<int64_t>& ranks_to_exclude,
     int shrink_flags,
@@ -6148,21 +6036,6 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::shrink(
 
   return c10::static_intrusive_pointer_cast<Backend>(new_pg);
 }
-
-#else // !NCCL_HAS_COMM_SHRINK
-// Backend interface override: raise consistent error when shrink is
-// unsupported.
-c10::intrusive_ptr<Backend> ProcessGroupNCCL::shrink(
-    const std::vector<int64_t>& /*ranks_to_exclude*/,
-    int /*shrink_flags*/,
-    const c10::intrusive_ptr<Backend::Options>& /*opts_override*/) {
-  TORCH_CHECK(
-      false,
-      "ProcessGroupNCCL::shrink requires NCCL version 2.27.0 or later, "
-      "but PyTorch was built with an older version or without NCCL shrink support.");
-}
-
-#endif // NCCL_HAS_COMM_SHRINK
 
 void ProcessGroupNCCL::initializeDeviceStateForComm(
     const at::Device& device,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -527,10 +527,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
 
-#ifdef NCCL_HAS_CONFIG
     // Configure ranks
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-#endif
 
     // Optional "parent" backend and color to create communicators from
     // via `ncclCommSplit`
@@ -546,14 +544,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // must be within the numerical range of C++ int. Otherwise, Python will
     // raise a RuntimeError saying type is incompatible. See also
     // `_process_group_color` in `distributed_c10d.py`.
-#ifdef NCCL_HAS_COMM_SPLIT
     int split_color{NCCL_SPLIT_NOCOLOR - 1};
-#else
-    // [Note 3]: for older NCCL versions, NCCL_SPLIT_NOCOLOR is not defined. But
-    // `split_color` is pybinded to Python, so we need to define it. So we use
-    // the int value of `NCCL_SPLIT_NOCOLOR` (-1) instead.
-    int split_color{-2};
-#endif
   };
 
   // Helper class related to TORCH_NCCL_DESYNC_DEBUG
@@ -1002,11 +993,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   ErrorType getError() override;
 
   bool supportsShrinking() const override {
-#ifdef NCCL_HAS_COMM_SHRINK
     return true;
-#else
-    return false;
-#endif
   }
 
   // Backend-style shrink override that returns a Backend instance.

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3562,7 +3562,6 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
             return ::c10d::getNcclVersionTuple();
           });
 
-#ifdef NCCL_HAS_CTA_POLICY
   processGroupNCCL.def_property_readonly_static(
       "NCCL_CTA_POLICY_DEFAULT",
       [](const py::object&) { return NCCL_CTA_POLICY_DEFAULT; });
@@ -3574,13 +3573,11 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
       "NCCL_CTA_POLICY_ZERO",
       [](const py::object&) { return NCCL_CTA_POLICY_ZERO; });
 #endif // NCCL_CTA_POLICY_ZERO
-#endif // NCCL_HAS_CTA_POLICY
 
   module.def(
       "_get_intra_node_comm_usage_counter",
       &::c10d::intra_node_comm::getIntraNodeCommUsageCounter);
 
-#ifdef NCCL_HAS_CONFIG
   py::class_<ncclConfig_t>(
       processGroupNCCL,
       "NCCLConfig",
@@ -3597,21 +3594,11 @@ for details.
       .def_readwrite("cga_cluster_size", &ncclConfig_t::cgaClusterSize)
       .def_readwrite("min_ctas", &ncclConfig_t::minCTAs)
       .def_readwrite("max_ctas", &ncclConfig_t::maxCTAs)
-#ifdef NCCL_HAS_COMM_SPLIT
       .def_readwrite("split_share", &ncclConfig_t::splitShare)
-#endif
-#ifdef NCCL_HAS_QOS
       .def_readwrite("traffic_class", &ncclConfig_t::trafficClass)
-#endif
-#ifdef NCCL_HAS_COLLNET
       .def_readwrite("collnet_enable", &ncclConfig_t::collnetEnable)
-#endif
-#ifdef NCCL_HAS_CTA_POLICY
       .def_readwrite("cta_policy", &ncclConfig_t::CTAPolicy)
-#endif
-#ifdef NCCL_HAS_NVLS_CTAS
       .def_readwrite("nvls_ctas", &ncclConfig_t::nvlsCTAs)
-#endif
 #ifdef NCCL_HAS_MAX_P2P_PEERS
       .def_readwrite("max_p2p_peers", &ncclConfig_t::maxP2pPeers)
 #endif
@@ -3638,7 +3625,6 @@ for details.
             return ncclConfig_t(self);
           },
           py::arg("memo"));
-#endif // NCCL_HAS_CONFIG
 
   intrusive_ptr_class_<::c10d::ProcessGroupNCCL::Options>(
       processGroupNCCL,
@@ -3674,9 +3660,7 @@ Example::
     >>> dist.init_process_group("nccl", pg_options=nccl_options)
       )")
       .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
-#ifdef NCCL_HAS_CONFIG
       .def_readwrite("config", &::c10d::ProcessGroupNCCL::Options::config)
-#endif
       .def_readwrite(
           "is_high_priority_stream",
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream)

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -5,9 +5,9 @@
 #include <nccl.h>
 #include <torch/csrc/cuda/nccl.h>
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+// NCCL is required to be 2.27+, so symmetric memory support is always available
+// in NCCL builds.
 #define NCCL_HAS_SYMMEM_SUPPORT
-#endif
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
 #if !defined(USE_ROCM)


### PR DESCRIPTION
## Summary

Raise the compile-time minimum NCCL version to **2.27** and remove the preprocessor and runtime version gates that guarded features introduced in NCCL 2.27 or earlier.

The introduction version of every gated feature was cross-checked against the NCCL release notes before its gate was removed:

| Feature | Introduced |
| --- | --- |
| `ncclAvg` | 2.10 |
| PreMulSum (`ncclRedOpCreatePreMulSum`) | 2.11 |
| `ncclGetLastError` / `ncclRemoteError` | 2.13 |
| non-blocking comms + `ncclConfig_t` | 2.14 |
| `ncclCommSplit` | 2.18 |
| `ncclCommRegister` / `ncclMemAlloc` | 2.19 |
| group abort (`ncclGroupStart/End` for abort) | 2.22 |
| `ncclCommInitRankScalable` | 2.23 |
| FP8 `e5m2`/`e4m3` | 2.24 |
| QoS / `trafficClass` | 2.26 |
| `ncclCommShrink`, `ncclCommWindowRegister`, symmetric memory, `collnetEnable`/`CTAPolicy`/`nvlsCTAs` | 2.27 |

## Suggested review order

1. **`NCCLUtils.hpp`** — the `static_assert` is bumped from 2.7 to 2.27 and the now-unconditional feature macros are deleted. This makes every gate below dead code.
2. **`NCCLUtils.cpp`, `ProcessGroupNCCL.{hpp,cpp}`, `init.cpp`** — dead `#ifdef`/`#ifndef`/`#else` branches are removed and the live branch inlined; the runtime `getNcclVersionNumber() >= 2.22` (group abort) and `version < 2.19` (mem allocator) checks are dropped.
3. **`cuda/nccl.{h,cpp}`** — the local 2.13/2.14 feature macros and the ancient NCCL 1.x / 2.0 / 2.7 / 2.12.10 guards are removed; only NCCL-presence gates (`USE_NCCL`, `defined(NCCL_MAJOR)`) and `>= 2.28` gates remain.
4. **`symm_mem/nccl_dev_cap.hpp`** and the C++ test — `NCCL_HAS_SYMMEM_SUPPORT` is made unconditional within `USE_NCCL`.

## Kept intentionally

Gates for versions newer than 2.27 are untouched (`>= 2.28` `ncclAlltoAll`, `NCCL_HAS_SYMMEM_DEVICE_SUPPORT`, `NCCL_HAS_COMM_OFFLOAD` 2.29.7, `NCCL_HAS_MAX_P2P_PEERS` 2.30, etc.), as is the defensive runtime `version >= 2.27` check inside `ProcessGroupNCCL::shrink()`.

Two macros were not deleted outright because they encode NCCL **availability**, not just a version, and are evaluated in non-NCCL build configs:

- `HAS_NCCL_BF16_DATATYPE` (`nccl.h`) keeps its CUDA-bf16/ROCm structure; only the `NCCL_MINOR >= 10` subexpression is dropped (now `NCCL_MAJOR >= 2`), preserving the "NCCL absent => disabled" behavior its consumers (e.g. `quantization_gpu.cu`) rely on.
- `NCCL_HAS_SYMMEM_SUPPORT` is kept as a macro but defined unconditionally inside `#if USE_NCCL`, since the symmetric-memory source files use it to gate on NCCL presence as well as version.

## Test plan

Build against NCCL 2.29.7 (satisfies the new `static_assert`):

```
uv pip install -e . --no-build-isolation -v
```

Lint the changed files:

```
lintrunner -a <changed files>
```

---
This PR was authored with the assistance of Claude, an AI coding assistant.
