### PR TITLE
Normalize device_type in distributed reordering/logger tests

### DIFF
--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -37,7 +37,7 @@ from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils.checkpoint import checkpoint
 
 
-device_type = str(get_devtype())
+device_type = get_devtype().type
 
 DIM = 2000
 

--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -39,7 +39,7 @@ def estimate_aten_runtime(fx_node, override_size=None, compute_multiplier=1.0):
         return None
 
 
-device_type = str(get_devtype())
+device_type = get_devtype().type
 
 
 def apply_reordering_and_get_graph(graph, out_li) -> None:

--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
 
-device_type = str(get_devtype())
+device_type = get_devtype().type
 
 if TEST_WITH_DEV_DBG_ASAN:
     print(

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -36,7 +36,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_GPU
 
 
-device_type = str(get_devtype())
+device_type = get_devtype().type
 
 
 def get_snode_runtime_for_reorder_compute_test(snode):

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -40,7 +40,7 @@ aten = torch.ops.aten
 from torch.testing._internal.common_fsdp import get_devtype
 
 
-device_type = str(get_devtype())
+device_type = get_devtype().type
 
 
 import torch


### PR DESCRIPTION
Use `get_devtype().type` instead of `str(get_devtype())` so HPU no longer leaks its `:0` index into `device_type`, matching `test_fake_pg.py`. Removes the last `str(get_devtype())` in the repo.