### PR TITLE
[c10d] don't call split_group for fake backend

### DIFF
--- a/test/distributed/test_fake_backend_new_group.py
+++ b/test/distributed/test_fake_backend_new_group.py
@@ -1,0 +1,75 @@
+# Owner(s): ["oncall: distributed"]
+
+"""
+Regression tests for: new_group() must not route a 'fake' subgroup through the
+TorchComms split_group delegation.
+
+split_group can only split the parent's existing communicator, so it cannot
+produce a child whose backend differs from the parent's. A "fake" subgroup of a
+real parent is exactly that case -- which is how DeviceMesh creates disabled /
+unflattened mesh dimensions (with use_local_synchronization=True for hashed PG
+names). Before the fix that delegation raised NotImplementedError. The fix routes
+a fake subgroup of a non-fake parent through the normal path, which builds a
+FakeProcessGroup directly and still produces a hashed name.
+
+These tests use a real (gloo) parent on a single CPU process: no GPU needed.
+"""
+
+import os
+
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class FakeBackendNewGroupTest(TestCase):
+    def setUp(self):
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29517")
+        # Real (non-fake) parent so a fake child differs from the parent backend.
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _check_fake_subgroup(self):
+        g = dist.new_group(ranks=[0], backend="fake", use_local_synchronization=True)
+        self.assertIsNotNone(g)
+        self.assertEqual(dist.get_backend(g), "fake")
+        # Hashed-name path preserved: sha1 hexdigest (40 chars), not a counter int.
+        name = g.group_name
+        self.assertFalse(name.isdigit(), f"expected hashed name, got int {name!r}")
+        self.assertEqual(len(name), 40, f"expected 40-char sha1 hash, got {name!r}")
+
+    def test_fake_subgroup_of_real_parent_builds_fake_pg(self):
+        """With TorchComms 'enabled', new_group(backend='fake',
+        use_local_synchronization=True) on a real parent builds a
+        FakeProcessGroup (no NotImplementedError) and keeps the hashed name."""
+        # Simulate TorchComms enabled for just the new_group call, so the test
+        # needs neither the torchcomms package nor a GPU.
+        orig = c10d._use_torchcomms_enabled
+        c10d._use_torchcomms_enabled = lambda: True
+        try:
+            self._check_fake_subgroup()
+        finally:
+            c10d._use_torchcomms_enabled = orig
+
+    def test_fake_subgroup_real_torchcomms_flag(self):
+        """Same as above but driving the real dist_config.use_torchcomms flag."""
+        import torch.distributed.config as dist_config
+
+        prev = dist_config.use_torchcomms
+        dist_config.use_torchcomms = True
+        try:
+            # With the flag set, _use_torchcomms_enabled() reduces to whether the
+            # torchcomms package is available; skip when it isn't.
+            if not c10d._use_torchcomms_enabled():
+                self.skipTest("torchcomms not available")
+            self._check_fake_subgroup()
+        finally:
+            dist_config.use_torchcomms = prev
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5834,16 +5834,31 @@ def new_group(
     default group's bound device).
     """
     if _use_torchcomms_enabled():
-        return _new_group_via_split_group(
-            ranks=ranks,
-            timeout=timeout,
-            backend=backend,
-            pg_options=pg_options,
-            use_local_synchronization=use_local_synchronization,
-            group_desc=group_desc,
-            device_id=device_id,
-            sort_ranks=sort_ranks,
+        # split_group can only split the parent's existing communicator, so it
+        # cannot produce a child whose backend differs from the parent's. A
+        # "fake" subgroup of a real parent -- how DeviceMesh creates disabled /
+        # unflattened dims, with use_local_synchronization for hashed names -- is
+        # exactly that case: route it through the normal path, which builds the
+        # FakeProcessGroup directly (see ``_new_group_with_tag``). When the
+        # requested backend matches the parent (including a fake parent), split
+        # delegation is fine.
+        parent_backend, _ = _world.pg_map[_get_default_group()]
+        is_fake_subgroup = (
+            backend is not None
+            and str(backend).lower() == "fake"
+            and str(backend).lower() != str(parent_backend).lower()
         )
+        if not is_fake_subgroup:
+            return _new_group_via_split_group(
+                ranks=ranks,
+                timeout=timeout,
+                backend=backend,
+                pg_options=pg_options,
+                use_local_synchronization=use_local_synchronization,
+                group_desc=group_desc,
+                device_id=device_id,
+                sort_ranks=sort_ranks,
+            )
 
     return _new_group_with_tag(
         ranks,


### PR DESCRIPTION

Summary:
DeviceMesh creates disabled mesh dimensions with a
"fake" backend via new_group(..., use_local_synchronization=True). A fake backend
has no underlying TorchComm to split, so
fall through to the normal new_group path.

Test Plan:
`test_fake_backend_new_group.py`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/186172).
* #186173
* __->__ #186172