### PR TITLE
[pipelining] Optional per-direction P2P communicators for PipelineStage

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -1763,11 +1763,17 @@ class TestBatchP2P(TestCase):
     """Tests that _batch_p2p dispatches homogeneous ops individually to avoid
     head-of-line blocking, while still batching mixed ops for deadlock avoidance."""
 
-    def _make_p2p_op(self, op, group_peer=0):
+    def _make_p2p_op(self, op, group_peer=0, group=None):
         p = MagicMock()
         p.op = op
         p.tensor = torch.zeros(1)
-        p.group = MagicMock()
+        # Ops in a single _batch_p2p call normally share one group; tests pass an
+        # explicit shared group. _batch_p2p splits a list spanning multiple groups
+        # into one batch per group (per-direction PP comms), covered separately.
+        p.group = group if group is not None else MagicMock()
+        # _batch_p2p groups/orders ops by group_name, so give each group a stable
+        # string name (identity-derived) rather than a MagicMock attribute.
+        p.group.group_name = f"pg_{id(p.group)}"
         p.tag = 0
         p.group_peer = group_peer
         return p
@@ -1779,7 +1785,10 @@ class TestBatchP2P(TestCase):
     @patch("torch.distributed.pipelining.schedules.dist.isend")
     def test_all_isend_dispatched_individually(self, mock_isend, mock_batch):
         mock_isend.return_value = MagicMock()
-        ops = [self._make_p2p_op(mock_isend, group_peer=i) for i in range(3)]
+        group = MagicMock()
+        ops = [
+            self._make_p2p_op(mock_isend, group_peer=i, group=group) for i in range(3)
+        ]
 
         result = _batch_p2p(ops)
 
@@ -1795,7 +1804,10 @@ class TestBatchP2P(TestCase):
     @patch("torch.distributed.pipelining.schedules.dist.irecv")
     def test_all_irecv_dispatched_individually(self, mock_irecv, mock_batch):
         mock_irecv.return_value = MagicMock()
-        ops = [self._make_p2p_op(mock_irecv, group_peer=i) for i in range(3)]
+        group = MagicMock()
+        ops = [
+            self._make_p2p_op(mock_irecv, group_peer=i, group=group) for i in range(3)
+        ]
 
         result = _batch_p2p(ops)
 
@@ -1812,9 +1824,10 @@ class TestBatchP2P(TestCase):
     @patch("torch.distributed.pipelining.schedules.dist.isend")
     def test_mixed_ops_use_batch(self, mock_isend, mock_irecv, mock_batch):
         mock_batch.return_value = [MagicMock(), MagicMock()]
+        group = MagicMock()
         ops = [
-            self._make_p2p_op(mock_isend, group_peer=0),
-            self._make_p2p_op(mock_irecv, group_peer=1),
+            self._make_p2p_op(mock_isend, group_peer=0, group=group),
+            self._make_p2p_op(mock_irecv, group_peer=1, group=group),
         ]
 
         result = _batch_p2p(ops)
@@ -1823,6 +1836,31 @@ class TestBatchP2P(TestCase):
         mock_isend.assert_not_called()
         mock_irecv.assert_not_called()
         self.assertEqual(len(result), 2)
+
+    @patch("torch.distributed.pipelining.schedules.dist.batch_isend_irecv")
+    @patch("torch.distributed.pipelining.schedules.dist.irecv")
+    @patch("torch.distributed.pipelining.schedules.dist.isend")
+    def test_mixed_ops_split_per_group(self, mock_isend, mock_irecv, mock_batch):
+        """A mixed op list spanning multiple groups (per-direction PP comms) is
+        issued as one batch_isend_irecv per group, so each direction runs on its
+        own communicator instead of sharing one FIFO."""
+        mock_batch.side_effect = lambda ops: [MagicMock() for _ in ops]
+        g_fwd, g_bwd = MagicMock(), MagicMock()
+        ops = [
+            self._make_p2p_op(mock_isend, group_peer=1, group=g_fwd),
+            self._make_p2p_op(mock_irecv, group_peer=1, group=g_fwd),
+            self._make_p2p_op(mock_isend, group_peer=2, group=g_bwd),
+            self._make_p2p_op(mock_irecv, group_peer=2, group=g_bwd),
+        ]
+
+        result = _batch_p2p(ops)
+
+        self.assertEqual(mock_batch.call_count, 2)
+        mock_batch.assert_any_call([ops[0], ops[1]])
+        mock_batch.assert_any_call([ops[2], ops[3]])
+        mock_isend.assert_not_called()
+        mock_irecv.assert_not_called()
+        self.assertEqual(len(result), 4)
 
 
 if __name__ == "__main__":

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -2,6 +2,7 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 import logging
+import os
 from dataclasses import dataclass
 
 from model_registry import (
@@ -20,6 +21,7 @@ from schedule_registry import (
 
 import torch
 import torch.distributed as dist
+import torch.distributed.config as dist_config
 from torch.distributed.pipelining import (
     _ScheduleForwardOnly,
     pipeline,
@@ -1368,6 +1370,133 @@ class CustomSchedulesTest(MultiProcContinuousTest):
 
 
 instantiate_parametrized_tests(CustomSchedulesTest)
+
+
+class PerDirectionScheduleTest(MultiProcContinuousTest):
+    """Per-direction PP communicators (``config.pipeline_per_direction_p2p``).
+
+    A single PP communicator serializes all send/recv in one FIFO; splitting
+    downstream (r -> r+1 activations) and upstream (r -> r-1 gradients) onto two
+    communicators removes the cross-batch deadlock hazard. PipelineStage builds
+    the two subgroups with ``split_group``, which requires a device-bound default
+    PG -- so this class binds ``device_id`` in ``_init_pg`` (see below) rather
+    than relying on the shared MultiProcContinuousTest path.
+    """
+
+    world_size = 4
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        # Bind device_id so PipelineStage can split the default PG into
+        # downstream/upstream subgroups. We override here instead of changing
+        # MultiProcContinuousTest._init_pg, which also serves CPU/Gloo callers
+        # where device_id would alter PG initialization semantics.
+        if rdvz_file is None:
+            raise AssertionError("Expected rdvz_file to not be None")
+        os.environ["LOCAL_RANK"] = str(rank)
+        store = dist.FileStore(rdvz_file, world_size)
+        # _init_pg runs at class spawn, before the per-test skip_if_lt_x_gpu(4).
+        # Only bind device_id when every rank maps to a real accelerator;
+        # otherwise the tests are skipped anyway and an out-of-range device_id
+        # would make init_process_group raise instead of skip.
+        device_id = None
+        if torch.accelerator.device_count() >= world_size:
+            device_id = torch.device(cls.device_type(), rank)
+        dist.init_process_group(
+            backend=cls.backend_str(),
+            world_size=world_size,
+            rank=rank,
+            store=store,
+            pg_options=cls.opts(),
+            timeout=cls.timeout,
+            device_id=device_id,
+        )
+        cls.pg = dist.distributed_c10d._get_default_group()
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    @property
+    def config(self) -> PipelineTestConfig:
+        return PipelineTestConfig(
+            world_size=self.world_size, device=self.device, rank=self.rank
+        )
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_creates_distinct_direction_groups(self):
+        """PipelineStage builds two distinct, non-WORLD direction groups when the
+        config flag is set (no constructor arg)."""
+        with dist_config.patch(pipeline_per_direction_p2p=True):
+            mod, _, x, _, _ = setup_models_and_data(self.config)
+            chunks = 2 * self.world_size
+            stage, _, _ = create_single_stage_pipeline(
+                self.config, mod, x, chunks, use_tracer=False
+            )
+            self.assertTrue(stage.p2p_per_direction)
+            self.assertIsNot(stage._downstream_group, dist.group.WORLD)
+            self.assertIsNot(stage._upstream_group, dist.group.WORLD)
+            self.assertIsNot(stage._downstream_group, stage._upstream_group)
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
+    @skip_if_lt_x_gpu(4)
+    def test_grad_with_manual_per_direction(self, ScheduleClass):
+        """Per-direction P2P only changes which communicator carries the bytes,
+        not the math: gradients/outputs must still match the reference model."""
+        with dist_config.patch(pipeline_per_direction_p2p=True):
+            mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
+
+            # Run reference
+            ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+            # Create manual pipeline stage; the per-direction groups are built
+            # inside PipelineStage from the config flag set above.
+            chunks = 2 * self.world_size
+            stage, stage_module, _ = create_single_stage_pipeline(
+                self.config, mod, x, chunks, use_tracer=False
+            )
+            self.assertTrue(stage.p2p_per_direction)
+            self.assertIsNot(stage._downstream_group, stage._upstream_group)
+
+            schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
+
+            # Run pipeline
+            out = None
+            losses = []
+            for _ in range(2):
+                zero_gradients(stage_module)
+                if self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    out = schedule.step(target=target, losses=losses)
+                else:
+                    schedule.step()
+
+            dist.barrier(device_ids=[self.rank])
+
+            # Last rank checks result
+            if self.rank == self.world_size - 1:
+                torch.testing.assert_close(out, ref_out)
+                pipe_loss = sum(losses)
+                torch.testing.assert_close(pipe_loss, ref_loss)
+
+            # Check gradients using helper method
+            check_gradients(self.config, stage_module, ref_mod)
+
+
+instantiate_parametrized_tests(PerDirectionScheduleTest)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/config.py
+++ b/torch/distributed/config.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from torch.utils._config_module import Config, install_config_module
 
 
-__all__ = ["compile_on_one_rank", "use_torchcomms"]
+__all__ = ["compile_on_one_rank", "use_torchcomms", "pipeline_per_direction_p2p"]
 
 # When enabled, coordinates are computed at runtime via a custom op rather
 # than being baked in at compile time. This allows compiling on one rank
@@ -25,6 +25,23 @@ compile_on_one_rank: bool = bool(
 use_torchcomms: bool = Config(
     default=False,
     env_name_default="TORCH_DISTRIBUTED_USE_TORCHCOMMS",
+)
+
+# When enabled, pipeline stages carry downstream (r -> r+1, forward activations)
+# and upstream (r -> r-1, backward gradients) P2P on two separate communicators
+# instead of sharing one. A single PP communicator serializes all send/recv in one
+# FIFO: coalescing makes a single mixed batch deadlock-free, but across batches
+# (pipeline skew, looped / V schedules, skip connections) the shared FIFO can
+# still form a dependency cycle and deadlock. Splitting by direction removes that
+# hazard and restores full-duplex bandwidth. Requires a device-bound default
+# process group.
+#
+# This flag force-enables the behavior; it is auto-enabled when TorchComms is in
+# use regardless of this flag (see PipelineStage), so it mainly matters for the
+# non-TorchComms backends.
+pipeline_per_direction_p2p: bool = Config(
+    default=False,
+    env_name_default="TORCH_DISTRIBUTED_PIPELINE_PER_DIRECTION_P2P",
 )
 
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -633,6 +633,25 @@ def _batch_p2p(p2p_ops: list[dist.P2POp], desc: str | None = None) -> list[dist.
     desc_str = f"{desc}, " if desc else ""
     logger.debug("batch_p2p %s%s", desc_str, p2p_ops)
 
+    # Per-direction P2P (config.pipeline_per_direction_p2p) tags forward and
+    # backward ops with different communicators. A fused batch (e.g. 1F1B's
+    # fwd_sends + bwd_recvs) then spans >1 group; issue each group's ops as their
+    # own batch so they run on separate comms/streams instead of one FIFO. When
+    # all ops share a group (the default), this is a no-op fast path.
+    ops_by_group: dict[str, list[dist.P2POp]] = {}
+    for p in p2p_ops:
+        ops_by_group.setdefault(p.group.group_name, []).append(p)
+    if len(ops_by_group) > 1:
+        works: list[dist.Work] = []
+        # Issue the groups in a deterministic, rank-independent order (by group
+        # name -- identical on every rank for a given group). The same fused
+        # batch is built in opposite list order on neighboring ranks (e.g.
+        # ``fwd_sends + bwd_recvs`` vs ``bwd_sends + fwd_recvs``); sorting keeps
+        # every rank issuing the two communicators in the same order.
+        for _, group_ops in sorted(ops_by_group.items()):
+            works += _batch_p2p(group_ops, desc=desc)
+        return works
+
     op_types = {p.op for p in p2p_ops}
     if op_types == {dist.isend}:
         return [

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -3,12 +3,14 @@
 import logging
 import operator
 import warnings
+import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, cast
 
 import torch
 import torch.distributed as dist
+import torch.distributed.config as dist_config
 import torch.fx as fx
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensor
@@ -126,6 +128,61 @@ class _RecvInfo:
         return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={buffer_shape}, meta={meta_type})"
 
 
+# Cache of per-direction P2P communicators, keyed (weakly) by the PP process
+# group they are derived from. Looped/V schedules construct several stage chunks
+# per rank that share one PP group; they must share the same forward/backward
+# comms (and issue the split_group collective only once) so creation stays
+# consistent and cheap across all ranks. Stage chunks are constructed serially
+# within a rank, so the first miss performs the split and the rest hit the cache.
+# The key is a weakref, so entries are
+# dropped automatically once the parent group is destroyed (e.g. via
+# destroy_process_group / reinitialization), avoiding stale dead communicators.
+_PP_DIRECTION_GROUP_CACHE: "weakref.WeakKeyDictionary[dist.ProcessGroup, tuple[dist.ProcessGroup, dist.ProcessGroup]]" = weakref.WeakKeyDictionary()
+
+
+def _build_p2p_direction_groups(
+    group: dist.ProcessGroup | None,
+) -> tuple[dist.ProcessGroup, dist.ProcessGroup]:
+    """Create two communicators over the same ranks as ``group``, one per data-flow
+    direction: ``downstream`` carries traffic flowing ``r -> r+1`` (forward
+    activations) and ``upstream`` carries ``r -> r-1`` (backward gradients).
+
+    Pipeline P2P normally shares a single communicator for both directions, which
+    serializes every send/recv in one FIFO. Coalescing makes a single mixed
+    send+recv batch deadlock-free, but across *separate* batches (pipeline skew,
+    looped / V schedules, skip connections) the shared FIFO can still form a
+    dependency cycle and deadlock. Routing the two directions onto separate
+    communicators / streams removes that cross-batch coupling and restores
+    full-duplex bandwidth.
+
+    Uses ``split_group``, which is collective over ``group``'s own ranks (not the
+    whole world), so it composes with PP as a sub-axis of a larger device mesh.
+    Requires the default process group to be device-bound (e.g.
+    ``init_process_group(..., device_id=...)``), which ``split_group`` needs for
+    NCCL; torchcomms binds the device automatically.
+    """
+    parent = group if group is not None else dist.distributed_c10d._get_default_group()
+    cached = _PP_DIRECTION_GROUP_CACHE.get(parent)
+    if cached is not None:
+        return cached
+
+    split_ranks = [list(range(dist.get_world_size(parent)))]
+    # split_group splits the parent's communicator, so the default process group
+    # must be device-bound (NCCL) -- torchcomms binds the device automatically. If
+    # it is not, split_group raises its own device error.
+    downstream = dist.split_group(
+        parent_pg=group, split_ranks=split_ranks, group_desc="pp_p2p_downstream"
+    )
+    upstream = dist.split_group(
+        parent_pg=group, split_ranks=split_ranks, group_desc="pp_p2p_upstream"
+    )
+    # All parent ranks are members of the single split, so neither is None.
+    assert downstream is not None and upstream is not None  # noqa: S101
+    logger.info("Pipeline P2P: using per-direction (downstream/upstream) communicators")
+    _PP_DIRECTION_GROUP_CACHE[parent] = (downstream, upstream)
+    return downstream, upstream
+
+
 class _PipelineStageBase(ABC):
     """Base class for pipeline stages.
 
@@ -166,6 +223,28 @@ class _PipelineStageBase(ABC):
         self.num_stages = num_stages
         self.device = device
         self.group = group
+
+        # Downstream (data flowing r -> r+1: forward activations) and upstream
+        # (r -> r-1: backward gradients) P2P communicators. Auto-enabled when
+        # TorchComms is in use (its split path is always available and the
+        # single-comm FIFO deadlock is most acute there); the config flag
+        # torch.distributed.config.pipeline_per_direction_p2p (env
+        # TORCH_DISTRIBUTED_PIPELINE_PER_DIRECTION_P2P) force-enables it on other
+        # backends. When disabled both alias ``self.group`` so behavior is
+        # byte-for-byte unchanged.
+        self.p2p_per_direction = (
+            dist_config.pipeline_per_direction_p2p
+            or dist.distributed_c10d._use_torchcomms_enabled()
+        )
+        self._downstream_group: dist.ProcessGroup | None
+        self._upstream_group: dist.ProcessGroup | None
+        if self.p2p_per_direction:
+            self._downstream_group, self._upstream_group = _build_p2p_direction_groups(
+                group
+            )
+        else:
+            self._downstream_group = group
+            self._upstream_group = group
 
         self.dw_builder = dw_builder
 
@@ -349,10 +428,13 @@ class _PipelineStageBase(ABC):
     def _get_recv_ops(
         self,
         recv_infos: tuple[_RecvInfo, ...],
+        group: dist.ProcessGroup | None,
     ) -> list[dist.P2POp]:
         """
         Helper function shared by `get_fwd_recv_ops` and `get_bwd_recv_ops`.
-        Returns a list of ops that correspond to the recv infos.
+        Returns a list of ops that correspond to the recv infos. ``group`` is the
+        direction-specific communicator (downstream vs upstream); it equals
+        ``self.group`` unless per-direction P2P is enabled.
         """
         ops: list[dist.P2POp] = []
         for info in recv_infos:
@@ -366,9 +448,7 @@ class _PipelineStageBase(ABC):
             # At this point, source and buffer are guaranteed non-None
             assert info.source is not None  # noqa: S101
             peer_global_rank = self._resolve_peer_global_rank(info.source)
-            ops.append(
-                dist.P2POp(dist.irecv, info.buffer, peer_global_rank, self.group)
-            )
+            ops.append(dist.P2POp(dist.irecv, info.buffer, peer_global_rank, group))
 
         return ops
 
@@ -467,7 +547,7 @@ class _PipelineStageBase(ABC):
         """
         recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[fwd_chunk_id]
 
-        return self._get_recv_ops(recv_infos)
+        return self._get_recv_ops(recv_infos, self._downstream_group)
 
     def get_bwd_recv_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
         """
@@ -478,7 +558,7 @@ class _PipelineStageBase(ABC):
             return []
 
         recv_infos = self.grad_recv_info[bwd_chunk_id]
-        return self._get_recv_ops(recv_infos)
+        return self._get_recv_ops(recv_infos, self._upstream_group)
 
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
@@ -504,7 +584,12 @@ class _PipelineStageBase(ABC):
                 )
                 peer_global_rank = self._resolve_peer_global_rank(dst)
                 ops.append(
-                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                    dist.P2POp(
+                        dist.isend,
+                        send_tensor,
+                        peer_global_rank,
+                        self._downstream_group,
+                    )
                 )
 
         return ops
@@ -584,7 +669,9 @@ class _PipelineStageBase(ABC):
                 )
                 peer_global_rank = self._resolve_peer_global_rank(grad_recv_stage)
                 ops.append(
-                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                    dist.P2POp(
+                        dist.isend, send_tensor, peer_global_rank, self._upstream_group
+                    )
                 )
             elif grad is None:
                 zero_grad = _make_tensor_from_meta(grad_meta, self.device).zero_()
@@ -1115,18 +1202,23 @@ class _PipelineStageBase(ABC):
         next_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index + 1)
         prev_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index - 1)
 
-        recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        # Separate recv buffers per direction: with per-direction P2P the
+        # downstream and upstream recvs run concurrently on different
+        # communicators/streams, so they must not share a buffer (concurrent
+        # writes = data race). The send buffer is only read, so it can be shared.
+        downstream_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        upstream_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
         send_tensor = torch.tensor(
             self.stage_index, device=self.device, dtype=torch.float32
         )
-        # forward
+        # downstream traffic (r -> r+1: forward activations) -> downstream comm
         if not self.is_first:
             ops.append(
                 dist.P2POp(
                     dist.irecv,
-                    recv_tensor,
+                    downstream_recv_tensor,
                     group_peer=prev_stage_peer_rank,
-                    group=self.group,
+                    group=self._downstream_group,
                 )
             )
         if not self.is_last:
@@ -1135,27 +1227,27 @@ class _PipelineStageBase(ABC):
                     dist.isend,
                     send_tensor,
                     group_peer=next_stage_peer_rank,
-                    group=self.group,
+                    group=self._downstream_group,
                 )
             )
 
-        # backward
+        # upstream traffic (r -> r-1: backward gradients) -> upstream comm
         if not self.is_first:
             ops.append(
                 dist.P2POp(
                     dist.isend,
                     send_tensor,
                     group_peer=prev_stage_peer_rank,
-                    group=self.group,
+                    group=self._upstream_group,
                 )
             )
         if not self.is_last:
             ops.append(
                 dist.P2POp(
                     dist.irecv,
-                    recv_tensor,
+                    upstream_recv_tensor,
                     group_peer=next_stage_peer_rank,
-                    group=self.group,
+                    group=self._upstream_group,
                 )
             )
 


### PR DESCRIPTION

Summary:
Pipeline parallelism issues all send/recv on a single communicator.

NCCL-group coalescing (batch_isend_irecv -> one ncclGroupStart/End) makes a single mixed
send+recv batch deadlock-free, but it does not remove ordering hazards across
separate batches.

This adds per-direction PP communicators. When enabled, forward (
r->r+1) and backward (r->r-1) P2P are carried on two separate
communicators derived from the stage's group via split_group.

Test Plan:
- `test_pp_per_direction_pipeline_stage.py`
- `test_pp_torchcomms_p2p_deadlock.py`
