### PR TITLE
[autograd] Defer device thread creation when multithreading is disabled

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16356,6 +16356,64 @@ if not threads_after:
             f"Context manager test failed: {result.stderr}",
         )
 
+    def test_reentrant_thread_pool_with_multithreading_disabled(self):
+        # Verify that the reentrant thread pool (thread_pool_shared_) works
+        # correctly when multithreading is disabled.  With the PR changes,
+        # thread_pool_shared_ is initialized in the Engine constructor (not
+        # in start_device_threads()), so deep reentrant backward that
+        # exceeds max_recursion_depth_ (MAX_DEPTH=60) triggers
+        # add_thread_pool_task() which dereferences thread_pool_shared_.
+        # This must not crash and must produce correct gradients.
+        # Uses the same DeepReentrant pattern as test_deep_reentrant.
+        script = """\
+import sys, torch
+from torch.autograd import Function, Variable
+
+class DeepReentrant(Function):
+    @staticmethod
+    def forward(ctx, x):
+        with torch.enable_grad():
+            ctx.x = Variable(x.detach(), requires_grad=True)
+            ctx.x = ctx.x - 1
+        return ctx.x.detach()
+
+    @staticmethod
+    def backward(ctx, x):
+        if ctx.x < 0:
+            return x
+        with torch.enable_grad():
+            DeepReentrant.apply(ctx.x).sum().backward()
+        return x
+
+torch.autograd.set_multithreading_enabled(False)
+
+# Use 100 to exceed MAX_DEPTH=60, triggering the reentrant thread pool
+v = torch.tensor(100.0, requires_grad=True)
+DeepReentrant.apply(v).sum().backward()
+
+if v.grad is None or v.grad.item() != 1.0:
+    print(f"FAIL: incorrect gradient: {v.grad}", file=sys.stderr)
+    sys.exit(1)
+
+# Run again with a different depth to verify thread pool reuse
+v2 = torch.tensor(200.0, requires_grad=True)
+DeepReentrant.apply(v2).sum().backward()
+
+if v2.grad is None or v2.grad.item() != 1.0:
+    print(f"FAIL: incorrect gradient on reuse: {v2.grad}", file=sys.stderr)
+    sys.exit(1)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Reentrant thread pool test failed: {result.stderr}",
+        )
+
 
 class TestNestedCheckpoint(TestCase):
     @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16138,6 +16138,224 @@ class TestMultithreadAutograd(TestCase):
         torch._C._remove_obj_from_tls("test_obj")
         self.assertFalse(torch._C._is_key_in_tls("test_obj"))
 
+    @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_no_device_threads_when_multithreading_disabled(self):
+        # Issue #184783: set_multithreading_enabled(False) should prevent
+        # autograd device threads from being spawned.
+        # We run in a subprocess to ensure a fresh engine state.
+        script = """\
+import os, sys, torch
+
+torch.autograd.set_multithreading_enabled(False)
+x = torch.ones(100, device="cuda", requires_grad=True)
+(x * 2).sum().backward()
+
+threads = []
+for tid in os.listdir("/proc/self/task"):
+    try:
+        with open(f"/proc/self/task/{tid}/comm") as f:
+            name = f.read().strip()
+        if name.startswith("pt_autograd"):
+            threads.append(name)
+    except OSError:
+        pass
+
+if threads:
+    print(f"FAIL: found autograd threads: {threads}", file=sys.stderr)
+    sys.exit(1)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Autograd threads spawned despite multithreading disabled: {result.stderr}",
+        )
+
+    @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_device_threads_created_on_reenable(self):
+        # Verify that disabling multithreading, running backward, then
+        # re-enabling actually creates device threads for subsequent calls.
+        script = """\
+import os, sys, threading, torch
+from torch.autograd import Function
+
+torch.autograd.set_multithreading_enabled(False)
+x = torch.ones(10, device="cuda", requires_grad=True)
+x.mean().backward()
+
+# No threads should exist yet
+threads = []
+for tid in os.listdir("/proc/self/task"):
+    try:
+        with open(f"/proc/self/task/{tid}/comm") as f:
+            name = f.read().strip()
+        if name.startswith("pt_autograd"):
+            threads.append(name)
+    except OSError:
+        pass
+if threads:
+    print(f"FAIL phase1: threads exist while disabled: {threads}", file=sys.stderr)
+    sys.exit(1)
+
+# Re-enable and run backward again
+torch.autograd.set_multithreading_enabled(True)
+
+exec_threads = []
+class RecordThread(Function):
+    @staticmethod
+    def forward(ctx, x):
+        return x.clone()
+    @staticmethod
+    def backward(ctx, grad):
+        exec_threads.append(threading.current_thread().name)
+        return grad
+
+y = torch.ones(10, device="cuda", requires_grad=True)
+RecordThread.apply(y).sum().backward()
+
+# Device threads should now exist
+threads = []
+for tid in os.listdir("/proc/self/task"):
+    try:
+        with open(f"/proc/self/task/{tid}/comm") as f:
+            name = f.read().strip()
+        if name.startswith("pt_autograd"):
+            threads.append(name)
+    except OSError:
+        pass
+if not threads:
+    print("FAIL phase2: no threads after re-enable", file=sys.stderr)
+    sys.exit(1)
+
+# Backward should have run on the device thread, not main
+if exec_threads[0] == threading.current_thread().name:
+    print("FAIL phase2: backward ran on main thread after re-enable", file=sys.stderr)
+    sys.exit(1)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Re-enable test failed: {result.stderr}",
+        )
+
+    @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_device_threads_default_behavior(self):
+        # Regression test: default multithreading (enabled) still creates
+        # device threads and routes CUDA backward work to them.
+        script = """\
+import os, sys, threading, torch
+from torch.autograd import Function
+
+exec_threads = []
+class RecordThread(Function):
+    @staticmethod
+    def forward(ctx, x):
+        return x.clone()
+    @staticmethod
+    def backward(ctx, grad):
+        exec_threads.append(threading.current_thread().name)
+        return grad
+
+x = torch.ones(10, device="cuda", requires_grad=True)
+RecordThread.apply(x).sum().backward()
+
+threads = []
+for tid in os.listdir("/proc/self/task"):
+    try:
+        with open(f"/proc/self/task/{tid}/comm") as f:
+            name = f.read().strip()
+        if name.startswith("pt_autograd"):
+            threads.append(name)
+    except OSError:
+        pass
+if not threads:
+    print("FAIL: no autograd threads with default settings", file=sys.stderr)
+    sys.exit(1)
+
+if exec_threads[0] == threading.current_thread().name:
+    print("FAIL: backward ran on main thread with default settings", file=sys.stderr)
+    sys.exit(1)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Default behavior test failed: {result.stderr}",
+        )
+
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_multithreading_disabled_cuda_correctness(self):
+        # Functional correctness: CUDA backward with multithreading disabled
+        # produces correct gradients.
+        with torch.autograd.set_multithreading_enabled(False):
+            x = torch.randn(4, 4, device="cuda", requires_grad=True)
+            y = (x**2).sum()
+            y.backward()
+            self.assertEqual(x.grad, 2 * x)
+
+    @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_context_manager_deferred_threads(self):
+        # Inside the disabled context manager, no device threads should
+        # be spawned.  After exiting and running backward, threads appear.
+        script = """\
+import os, sys, torch
+
+def autograd_threads():
+    names = []
+    for tid in os.listdir("/proc/self/task"):
+        try:
+            with open(f"/proc/self/task/{tid}/comm") as f:
+                name = f.read().strip()
+            if name.startswith("pt_autograd"):
+                names.append(name)
+        except OSError:
+            pass
+    return names
+
+with torch.autograd.set_multithreading_enabled(False):
+    x = torch.ones(10, device="cuda", requires_grad=True)
+    x.mean().backward()
+    threads_inside = autograd_threads()
+    if threads_inside:
+        print(f"FAIL: threads inside context: {threads_inside}", file=sys.stderr)
+        sys.exit(1)
+
+# After exiting the context manager, multithreading is re-enabled
+y = torch.ones(10, device="cuda", requires_grad=True)
+y.mean().backward()
+threads_after = autograd_threads()
+if not threads_after:
+    print("FAIL: no threads after context exit", file=sys.stderr)
+    sys.exit(1)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Context manager test failed: {result.stderr}",
+        )
+
 
 class TestNestedCheckpoint(TestCase):
     @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -84,6 +84,7 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
     slowTest,
+    TEST_ACCELERATOR,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -15701,6 +15702,23 @@ class TestAutogradStreamSynchronization(TestCase):
 
 
 class TestMultithreadAutograd(TestCase):
+    # Shared preamble for subprocess scripts that need to count autograd
+    # threads via /proc.  Each test concatenates this with its own logic.
+    _AUTOGRAD_THREADS_SCRIPT = """\
+import os
+def autograd_threads():
+    names = []
+    for tid in os.listdir("/proc/self/task"):
+        try:
+            with open(f"/proc/self/task/{tid}/comm") as f:
+                name = f.read().strip()
+            if name.startswith("pt_autograd"):
+                names.append(name)
+        except OSError:
+            pass
+    return names
+"""
+
     def _run_py_multithread_fn(
         self, fn, args=(), num_threads=10, kwargs=None, pass_idx=False
     ):
@@ -16139,32 +16157,27 @@ class TestMultithreadAutograd(TestCase):
         self.assertFalse(torch._C._is_key_in_tls("test_obj"))
 
     @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires accelerator")
     def test_no_device_threads_when_multithreading_disabled(self):
         # Issue #184783: set_multithreading_enabled(False) should prevent
         # autograd device threads from being spawned.
         # We run in a subprocess to ensure a fresh engine state.
-        script = """\
-import os, sys, torch
+        script = (
+            self._AUTOGRAD_THREADS_SCRIPT
+            + """\
+import sys, torch
 
+device = torch.accelerator.current_accelerator().type
 torch.autograd.set_multithreading_enabled(False)
-x = torch.ones(100, device="cuda", requires_grad=True)
+x = torch.ones(100, device=device, requires_grad=True)
 (x * 2).sum().backward()
 
-threads = []
-for tid in os.listdir("/proc/self/task"):
-    try:
-        with open(f"/proc/self/task/{tid}/comm") as f:
-            name = f.read().strip()
-        if name.startswith("pt_autograd"):
-            threads.append(name)
-    except OSError:
-        pass
-
+threads = autograd_threads()
 if threads:
     print(f"FAIL: found autograd threads: {threads}", file=sys.stderr)
     sys.exit(1)
 """
+        )
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
@@ -16177,33 +16190,26 @@ if threads:
         )
 
     @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires accelerator")
     def test_device_threads_created_on_reenable(self):
         # Verify that disabling multithreading, running backward, then
         # re-enabling actually creates device threads for subsequent calls.
-        script = """\
-import os, sys, threading, torch
+        script = (
+            self._AUTOGRAD_THREADS_SCRIPT
+            + """\
+import sys, threading, torch
 from torch.autograd import Function
 
+device = torch.accelerator.current_accelerator().type
 torch.autograd.set_multithreading_enabled(False)
-x = torch.ones(10, device="cuda", requires_grad=True)
+x = torch.ones(10, device=device, requires_grad=True)
 x.mean().backward()
 
-# No threads should exist yet
-threads = []
-for tid in os.listdir("/proc/self/task"):
-    try:
-        with open(f"/proc/self/task/{tid}/comm") as f:
-            name = f.read().strip()
-        if name.startswith("pt_autograd"):
-            threads.append(name)
-    except OSError:
-        pass
+threads = autograd_threads()
 if threads:
     print(f"FAIL phase1: threads exist while disabled: {threads}", file=sys.stderr)
     sys.exit(1)
 
-# Re-enable and run backward again
 torch.autograd.set_multithreading_enabled(True)
 
 exec_threads = []
@@ -16216,28 +16222,19 @@ class RecordThread(Function):
         exec_threads.append(threading.current_thread().name)
         return grad
 
-y = torch.ones(10, device="cuda", requires_grad=True)
+y = torch.ones(10, device=device, requires_grad=True)
 RecordThread.apply(y).sum().backward()
 
-# Device threads should now exist
-threads = []
-for tid in os.listdir("/proc/self/task"):
-    try:
-        with open(f"/proc/self/task/{tid}/comm") as f:
-            name = f.read().strip()
-        if name.startswith("pt_autograd"):
-            threads.append(name)
-    except OSError:
-        pass
+threads = autograd_threads()
 if not threads:
     print("FAIL phase2: no threads after re-enable", file=sys.stderr)
     sys.exit(1)
 
-# Backward should have run on the device thread, not main
 if exec_threads[0] == threading.current_thread().name:
     print("FAIL phase2: backward ran on main thread after re-enable", file=sys.stderr)
     sys.exit(1)
 """
+        )
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
@@ -16250,12 +16247,14 @@ if exec_threads[0] == threading.current_thread().name:
         )
 
     @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires accelerator")
     def test_device_threads_default_behavior(self):
-        # Regression test: default multithreading (enabled) still creates
-        # device threads and routes CUDA backward work to them.
-        script = """\
-import os, sys, threading, torch
+        # Regression guard: default multithreading (enabled) still creates
+        # device threads and routes accelerator backward work to them.
+        script = (
+            self._AUTOGRAD_THREADS_SCRIPT
+            + """\
+import sys, threading, torch
 from torch.autograd import Function
 
 exec_threads = []
@@ -16268,19 +16267,11 @@ class RecordThread(Function):
         exec_threads.append(threading.current_thread().name)
         return grad
 
-x = torch.ones(10, device="cuda", requires_grad=True)
+device = torch.accelerator.current_accelerator().type
+x = torch.ones(10, device=device, requires_grad=True)
 RecordThread.apply(x).sum().backward()
 
-threads = []
-for tid in os.listdir("/proc/self/task"):
-    try:
-        with open(f"/proc/self/task/{tid}/comm") as f:
-            name = f.read().strip()
-        if name.startswith("pt_autograd"):
-            threads.append(name)
-    except OSError:
-        pass
-if not threads:
+if not autograd_threads():
     print("FAIL: no autograd threads with default settings", file=sys.stderr)
     sys.exit(1)
 
@@ -16288,6 +16279,7 @@ if exec_threads[0] == threading.current_thread().name:
     print("FAIL: backward ran on main thread with default settings", file=sys.stderr)
     sys.exit(1)
 """
+        )
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
@@ -16299,52 +16291,49 @@ if exec_threads[0] == threading.current_thread().name:
             f"Default behavior test failed: {result.stderr}",
         )
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
-    def test_multithreading_disabled_cuda_correctness(self):
-        # Functional correctness: CUDA backward with multithreading disabled
-        # produces correct gradients.
+    def test_multithreading_disabled_gradient_correctness(self):
+        # Gradient correctness on CPU with multithreading disabled.
         with torch.autograd.set_multithreading_enabled(False):
-            x = torch.randn(4, 4, device="cuda", requires_grad=True)
+            x = torch.randn(4, 4, requires_grad=True)
+            y = (x**2).sum()
+            y.backward()
+            self.assertEqual(x.grad, 2 * x)
+
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires accelerator")
+    def test_multithreading_disabled_accelerator_correctness(self):
+        # Gradient correctness on accelerator with multithreading disabled.
+        device = torch.accelerator.current_accelerator().type
+        with torch.autograd.set_multithreading_enabled(False):
+            x = torch.randn(4, 4, device=device, requires_grad=True)
             y = (x**2).sum()
             y.backward()
             self.assertEqual(x.grad, 2 * x)
 
     @unittest.skipIf(not IS_LINUX, "requires /proc filesystem")
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires accelerator")
     def test_context_manager_deferred_threads(self):
         # Inside the disabled context manager, no device threads should
         # be spawned.  After exiting and running backward, threads appear.
-        script = """\
-import os, sys, torch
+        script = (
+            self._AUTOGRAD_THREADS_SCRIPT
+            + """\
+import sys, torch
 
-def autograd_threads():
-    names = []
-    for tid in os.listdir("/proc/self/task"):
-        try:
-            with open(f"/proc/self/task/{tid}/comm") as f:
-                name = f.read().strip()
-            if name.startswith("pt_autograd"):
-                names.append(name)
-        except OSError:
-            pass
-    return names
-
+device = torch.accelerator.current_accelerator().type
 with torch.autograd.set_multithreading_enabled(False):
-    x = torch.ones(10, device="cuda", requires_grad=True)
+    x = torch.ones(10, device=device, requires_grad=True)
     x.mean().backward()
-    threads_inside = autograd_threads()
-    if threads_inside:
-        print(f"FAIL: threads inside context: {threads_inside}", file=sys.stderr)
+    if autograd_threads():
+        print(f"FAIL: threads inside context: {autograd_threads()}", file=sys.stderr)
         sys.exit(1)
 
-# After exiting the context manager, multithreading is re-enabled
-y = torch.ones(10, device="cuda", requires_grad=True)
+y = torch.ones(10, device=device, requires_grad=True)
 y.mean().backward()
-threads_after = autograd_threads()
-if not threads_after:
+if not autograd_threads():
     print("FAIL: no threads after context exit", file=sys.stderr)
     sys.exit(1)
 """
+        )
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
@@ -16357,14 +16346,11 @@ if not threads_after:
         )
 
     def test_reentrant_thread_pool_with_multithreading_disabled(self):
-        # Verify that the reentrant thread pool (thread_pool_shared_) works
-        # correctly when multithreading is disabled.  With the PR changes,
-        # thread_pool_shared_ is initialized in the Engine constructor (not
-        # in start_device_threads()), so deep reentrant backward that
-        # exceeds max_recursion_depth_ (MAX_DEPTH=60) triggers
+        # Deep reentrant backward (depth > MAX_DEPTH=60) triggers
         # add_thread_pool_task() which dereferences thread_pool_shared_.
-        # This must not crash and must produce correct gradients.
-        # Uses the same DeepReentrant pattern as test_deep_reentrant.
+        # With the deferred-init change, thread_pool_shared_ is
+        # allocated in the Engine constructor, so this path must work
+        # even when start_device_threads() has been skipped.
         script = """\
 import sys, torch
 from torch.autograd import Function, Variable
@@ -16387,21 +16373,13 @@ class DeepReentrant(Function):
 
 torch.autograd.set_multithreading_enabled(False)
 
-# Use 100 to exceed MAX_DEPTH=60, triggering the reentrant thread pool
 v = torch.tensor(100.0, requires_grad=True)
 DeepReentrant.apply(v).sum().backward()
+assert v.grad is not None and v.grad.item() == 1.0, f"bad gradient: {v.grad}"
 
-if v.grad is None or v.grad.item() != 1.0:
-    print(f"FAIL: incorrect gradient: {v.grad}", file=sys.stderr)
-    sys.exit(1)
-
-# Run again with a different depth to verify thread pool reuse
 v2 = torch.tensor(200.0, requires_grad=True)
 DeepReentrant.apply(v2).sum().backward()
-
-if v2.grad is None or v2.grad.item() != 1.0:
-    print(f"FAIL: incorrect gradient on reuse: {v2.grad}", file=sys.stderr)
-    sys.exit(1)
+assert v2.grad is not None and v2.grad.item() == 1.0, f"bad gradient on reuse: {v2.grad}"
 """
         result = subprocess.run(
             [sys.executable, "-c", script],

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -276,7 +276,9 @@ bool ReadyQueue::empty() const {
   return heap_.empty();
 }
 
-Engine::Engine() : non_reentrant_device_thread_count_(0) {}
+Engine::Engine()
+    : thread_pool_shared_(std::make_shared<ThreadPoolShared>()),
+      non_reentrant_device_thread_count_(0) {}
 
 Engine::~Engine() {
   stop();
@@ -1453,11 +1455,14 @@ void Engine::initialize_device_threads_pool() {
       !in_bad_autograd_fork,
       "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
       "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
-  // Ensures device_ready_queues_ are initialized only once
-  static bool start_device_threads_flag_ [[maybe_unused]] = [this]() {
-    this->start_device_threads();
-    return true;
-  }();
+  // thread_pool_shared_ is initialized in the Engine constructor so it is
+  // always available for re-entrant backward.  Device threads are deferred
+  // until the first backward that actually needs multithreading.
+  if (!c10::AutogradState::get_tls_state().get_multithreading_enabled()) {
+    return;
+  }
+  c10::call_once(
+      device_threads_flag_, [this]() { this->start_device_threads(); });
 }
 
 c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
@@ -1630,10 +1635,9 @@ auto Engine::ready_queue_by_index(
 }
 
 auto Engine::start_device_threads() -> void {
-  // First always initialize the thread pool for re-entrant threads
-  thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
+  // thread_pool_shared_ is now initialized in the Engine constructor.
 
-  // Second, create special threads for each non-CPU device
+  // Create special threads for each non-CPU device
   // See Note [Allocating GPUs to autograd threads]
   c10::DeviceIndex num_devices = 0;
   for (const auto& impl_atomic : c10::impl::device_guard_impl_registry) {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -16,6 +16,8 @@
 #include <torch/csrc/autograd/saved_variable_hooks.h>
 #include <torch/csrc/autograd/utils/warnings.h>
 
+#include <c10/util/CallOnce.h>
+
 #include <exception>
 #include <functional>
 #include <memory>
@@ -285,6 +287,11 @@ struct TORCH_API Engine {
   // Destructor will wait for non-reentrant threads to finish
   std::condition_variable non_reentrant_device_thread_condvar_;
   std::mutex non_reentrant_device_thread_mutex_;
+  // Guards one-time creation of device threads.  Unlike the old function-local
+  // static, this member resets on engine reconstruction (fork + reinitialize)
+  // and allows deferred creation when set_multithreading_enabled(False) is
+  // active on the first backward.
+  c10::once_flag device_threads_flag_;
   // stop() must be called before the destruction path goes down to the base
   // class, in order to avoid a data-race-on-vptr. Use this boolean to guard
   // whether stop() has already been called, so we can call this in every


### PR DESCRIPTION
## Summary

Fixes #184783

**Root cause:** `Engine::initialize_device_threads_pool()` used a function-local `static bool` lambda that unconditionally called `start_device_threads()` on the very first backward — without checking `get_multithreading_enabled()`. Additionally, `start_device_threads()` bundled two unrelated concerns: allocating `thread_pool_shared_` (needed always for re-entrant backward) and spawning per-device worker threads (only needed when multithreading is enabled).

**Fix:**

- Move `thread_pool_shared_` initialization to the `Engine` constructor so it is always available for re-entrant backward regardless of multithreading state
- Early-return from `initialize_device_threads_pool()` when `get_multithreading_enabled()` is false, skipping device thread creation entirely
- Replace the function-local `static bool` with `c10::call_once` / `c10::once_flag` as a member variable for lazy, thread-safe, exception-safe device thread creation on the first backward where multithreading is actually enabled
- As a member variable (not function-local static), `device_threads_flag_` correctly resets on engine reconstruction after fork via `PythonEngine::get_python_engine()`

## Test plan

5 new subprocess-based tests in `TestMultithreadAutograd` (CUDA + Linux):

- `test_no_device_threads_when_multithreading_disabled` — core bug fix verification
- `test_device_threads_created_on_reenable` — lazy creation after re-enabling multithreading
- `test_device_threads_default_behavior` — regression guard for default (enabled) behavior
- `test_multithreading_disabled_cuda_correctness` — gradient numerical correctness
- `test_context_manager_deferred_threads` — context manager lifecycle

```bash
python test/test_autograd.py TestMultithreadAutograd -v                        # 17/17 pass
python test/test_autograd.py TestAutograd -v                                   # 388/388 pass
python test/test_autograd.py TestAutogradDeviceTypeCUDA -v                      # 67/67 pass
python test/test_autograd.py TestAutogradMultipleDispatchCUDA -v                # 12/12 pass
python test/test_autograd.py TestAutogradStreamSynchronizationCUDA -v           # 7/7 pass
```

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93
