### PR TITLE
[xpu][fix] Fix segfault in _scaled_mm_xpu_v2 due to empty swizzle vector access

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -955,10 +955,12 @@ Tensor& _scaled_mm_xpu_v2_out(
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
   auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
-  // XPU does not support swizzle for now. So directly return false.
+  // XPU does not support swizzle. Accept empty (not specified) or NO_SWIZZLE.
   TORCH_CHECK_VALUE(
-      swizzle_a_enum[0] == at::blas::SwizzleType::NO_SWIZZLE &&
-          swizzle_b_enum[0] == at::blas::SwizzleType::NO_SWIZZLE,
+      (swizzle_a_enum.empty() ||
+       swizzle_a_enum[0] == at::blas::SwizzleType::NO_SWIZZLE) &&
+          (swizzle_b_enum.empty() ||
+           swizzle_b_enum[0] == at::blas::SwizzleType::NO_SWIZZLE),
       "XPU does not support swizzle yet.");
 
   // at this point we can start working out what we want to be doing

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1570,6 +1570,47 @@ class TestFP8Lowering(TestCase):
         torch.testing.assert_close(y_eager, y_compiled, rtol=1e-2, atol=0.07)
 
     @onlyOn(["cuda", "xpu"])
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_scaled_mm_v2_no_swizzle(self, device):
+        """Regression test: _scaled_mm_v2 must not segfault when swizzle is
+        omitted (empty) or explicitly set to NO_SWIZZLE."""
+        from torch.nn.functional import SwizzleType
+
+        m, k, n = 32, 64, 16
+        dtype_float8 = torch.float8_e4m3fn
+        dtype_float8 = _fix_fp8_dtype_for_rocm(dtype_float8, device)
+        a = torch.randn(m, k, device=device, dtype=torch.bfloat16).to(dtype_float8)
+        b = torch.randn(n, k, device=device, dtype=torch.bfloat16).to(dtype_float8).t()
+        scale_a = torch.ones(1, device=device)
+        scale_b = torch.ones(1, device=device)
+
+        # swizzle omitted (None -> empty list in C++)
+        out_no_swizzle = scaled_mm(
+            a,
+            b,
+            scale_a=scale_a,
+            scale_recipe_a=ScalingType.TensorWise,
+            scale_b=scale_b,
+            scale_recipe_b=ScalingType.TensorWise,
+            output_dtype=torch.bfloat16,
+        )
+        self.assertEqual(out_no_swizzle.shape, (m, n))
+
+        # swizzle explicitly NO_SWIZZLE
+        out_explicit = scaled_mm(
+            a,
+            b,
+            scale_a=scale_a,
+            scale_recipe_a=ScalingType.TensorWise,
+            swizzle_a=SwizzleType.NO_SWIZZLE,
+            scale_b=scale_b,
+            scale_recipe_b=ScalingType.TensorWise,
+            swizzle_b=SwizzleType.NO_SWIZZLE,
+            output_dtype=torch.bfloat16,
+        )
+        self.assertEqual(out_no_swizzle, out_explicit)
+
+    @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, "Not supported on non B200")
     def test_mx_fp8_max_autotune(self, device):
         M, K, N = 128, 32, 128


### PR DESCRIPTION
The XPU implementation of _scaled_mm_xpu_v2_out accessed swizzle_a_enum[0] and swizzle_b_enum[0] unconditionally, but these vectors are empty when no swizzle is specified. This out-of-bounds access on std::vector caused a segfault.

**Why formerly not catched by CI?**

The commit [#9eb8bcb2f55 ](https://github.com/pytorch/pytorch/commit/9eb8bcb2f55f6c5c7e65d8a098127cba1be75b5c) changed from `torch._scaled_mm` (v1) version to `torch._scaled_mm_v2`, and this bug only occurs in v2.

**Why CUDA doesn't have but XPU triggered?**
Because XPU does not have the `check_swizzle_lengths()` as CUDA. So for XPU implementation, we need to fix the assert.

**Failed Test:**
```
test/inductor/test_fp8.py::TestFP8LoweringXPU::test_rowwise_scaling_acceptable_input_dims_M_1024_K_1024_N_16_persistent_matmul_False_xpu

Fatal Python error: Segmentation fault
2026-06-03T08:55:58.5152121Z 
2026-06-03T08:55:58.5152385Z Current thread 0x00007fc9b8dab740 (most recent call first):
2026-06-03T08:55:58.5153066Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/nn/functional.py", line 7121 in scaled_mm
2026-06-03T08:55:58.5153810Z   File "/var/lib/jenkins/pytorch/test/inductor/test_fp8.py", line 1466 in linear
2026-06-03T08:55:58.5154589Z   File "/var/lib/jenkins/pytorch/test/inductor/test_fp8.py", line 1479 in test_rowwise_scaling_acceptable_input_dims

```


Co-Author: Github Copilot

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey