### PR TITLE
Deduplicate symbolic cond inputs after export passes

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3000,6 +3000,44 @@ class GraphModule(torch.nn.Module):
             )
         self.assertEqual(m(*args), ep.module()(*args))
 
+    def test_cond_dedup_symint_inputs(self):
+        class M(torch.nn.Module):
+            def forward(self, x, y, z):
+                a = y.shape[0]
+                b = z.shape[0]
+
+                def true_fn(x):
+                    return x + a
+
+                def false_fn(x):
+                    return x + b
+
+                return torch.cond(x.shape[0] > 5, true_fn, false_fn, (x,))
+
+        inp = (torch.ones(3, 3), torch.ones(3, 3), torch.ones(3, 3))
+        ep = export(
+            M(),
+            inp,
+            dynamic_shapes={
+                "x": {0: Dim("d")},
+                "y": {0: Dim("d")},
+                "z": {0: Dim("d")},
+            },
+        )
+
+        cond_node = next(
+            node
+            for node in ep.graph_module.graph.nodes
+            if node.target == torch.ops.higher_order.cond
+        )
+        self.assertEqual(len(cond_node.args[3]), 2)
+        for subgraph_name in ("true_graph_0", "false_graph_0"):
+            subgraph = getattr(ep.graph_module, subgraph_name)
+            placeholders = [n for n in subgraph.graph.nodes if n.op == "placeholder"]
+            self.assertEqual(len(placeholders), 2)
+
+        self.assertEqual(M()(*inp), ep.module()(*inp))
+
     def test_cond_branches_return_same_int(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -21,6 +21,7 @@ from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.proxy_tensor import PreDispatchTorchFunctionMode
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
+from torch.types import py_sym_types
 
 
 if TYPE_CHECKING:
@@ -734,6 +735,91 @@ def _insert_aten_to_metadata_assert_pass(gm: torch.fx.GraphModule) -> None:
                     )
 
 
+def _dedupe_hoo_subgraph_inputs(gm: torch.fx.GraphModule) -> None:
+    def sym_input_key(node: torch.fx.Node) -> tuple[type, Any] | None:
+        val = node.meta.get("val")
+        if isinstance(val, py_sym_types):
+            return (type(val), val.node.expr)
+        return None
+
+    def dedupe_placeholders(
+        subgraph: torch.fx.GraphModule,
+        duplicate_inputs: dict[int, int],
+        num_args: int,
+    ) -> None:
+        placeholders = [n for n in subgraph.graph.nodes if n.op == "placeholder"]
+        if len(placeholders) < num_args:
+            raise AssertionError(
+                "Expected HOO subgraph to have at least as many placeholders as inputs"
+            )
+
+        for duplicate_i, canonical_i in duplicate_inputs.items():
+            duplicate_ph = placeholders[duplicate_i]
+            canonical_ph = placeholders[canonical_i]
+            duplicate_ph.replace_all_uses_with(canonical_ph)
+
+        for duplicate_i in sorted(duplicate_inputs, reverse=True):
+            subgraph.graph.erase_node(placeholders[duplicate_i])
+        subgraph.graph.lint()
+        subgraph.recompile()
+
+    def dedupe_args(args, subgraphs: list[torch.fx.GraphModule]):
+        if not isinstance(args, (list, tuple)):
+            return args
+
+        seen_inputs: dict[tuple[type, Any], int] = {}
+        duplicate_inputs: dict[int, int] = {}
+        for i, arg in enumerate(args):
+            if not isinstance(arg, torch.fx.Node):
+                continue
+            key = sym_input_key(arg)
+            if key is None:
+                continue
+            if key in seen_inputs:
+                duplicate_inputs[i] = seen_inputs[key]
+            else:
+                seen_inputs[key] = i
+
+        if not duplicate_inputs:
+            return args
+
+        for subgraph in subgraphs:
+            dedupe_placeholders(subgraph, duplicate_inputs, len(args))
+
+        return type(args)(
+            arg for i, arg in enumerate(args) if i not in duplicate_inputs
+        )
+
+    for node in gm.graph.nodes:
+        if not (
+            node.op == "call_function"
+            and isinstance(node.target, torch._ops.HigherOrderOperator)
+            and node.target._name == "cond"
+        ):
+            continue
+
+        pred, true_graph, false_graph, cond_args = node.args
+        if not isinstance(true_graph, torch.fx.Node) or not isinstance(
+            false_graph, torch.fx.Node
+        ):
+            continue
+        if not isinstance(true_graph.target, str) or not isinstance(
+            false_graph.target, str
+        ):
+            continue
+        true_subgraph = getattr(gm, true_graph.target)
+        false_subgraph = getattr(gm, false_graph.target)
+        if not isinstance(true_subgraph, torch.fx.GraphModule) or not isinstance(
+            false_subgraph, torch.fx.GraphModule
+        ):
+            continue
+        cond_args = dedupe_args(cond_args, [true_subgraph, false_subgraph])
+        node.args = (pred, true_graph, false_graph, cond_args)
+
+        _dedupe_hoo_subgraph_inputs(true_subgraph)
+        _dedupe_hoo_subgraph_inputs(false_subgraph)
+
+
 def apply_runtime_assertion_pass(gm: torch.fx.GraphModule, graph_signature):
     from torch._export.passes._node_metadata_hook import (
         _node_metadata_hook,
@@ -763,6 +849,10 @@ def apply_runtime_assertion_pass(gm: torch.fx.GraphModule, graph_signature):
 
         # insert runtime assertions for aten.to nodes
         _insert_aten_to_metadata_assert_pass(gm)
+
+    # Runtime assertion insertion can CSE symbolic scalar HOO inputs.
+    # Keep the operand list and subgraph signatures in sync after that rewrite.
+    _dedupe_hoo_subgraph_inputs(gm)
 
     # update output specs
     gm.recompile()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186201

Fixes #138229
Generated by my agent

AOT/export runtime assertion insertion can CSE symbolic size nodes that
represent the same symbolic dimension. In the failing torch.cond export,
the top-level cond operand tuple was rewritten to contain the same SymInt
node twice while the true and false branch GraphModules still had
placeholders for the old longer operand list. The later placeholder naming
pass propagated the duplicated top-level name into both branch signatures,
which generated invalid Python with duplicate argument names.

Fix this by normalizing higher-order cond subgraph inputs after runtime
assertion insertion mutates the graph. Duplicate symbolic scalar operands
are identified by symbolic type and expression, duplicate branch
placeholders are rewritten to the canonical placeholder, and the cond
operand tuple is shortened to match the updated branch signatures. The
pass recurses into nested cond subgraphs so nested signatures stay in sync
as well.

I kept this in export cleanup after the mutating runtime assertion pass
rather than changing cond tracing because the duplication is introduced by
that later graph rewrite; updating the graph and subgraph signatures at
that boundary keeps the fix local to the stale-signature problem.

Test Plan:
- Reproduced the original minimal export script before the fix; it failed
  in placeholder_naming_pass with SyntaxError: duplicate argument
  'sym_size_int_4'.
- Re-ran the original minimal export script after the fix; it passed, the
  exported cond had operands (x, sym_size_int_4), branch graphs had two
  placeholders, and ep.module() returned the expected tensor.
- python test/export/test_export.py -k test_cond_dedup_symint_inputs
- python test/export/test_export.py -k test_cond_branches_return_same_int
- lintrunner -a

Benchmark Results:
- Command: Python time.perf_counter micro-benchmark exporting a small
  torch.cond module with three independent dynamic dimensions for 2 warmup
  exports and 10 measured exports, run on main and fix-138229.
- Before: median=0.073477s mean=0.086682s runs=0.072262,0.073323,
  0.073809,0.072373,0.208752,0.071724,0.073541,0.073412,0.073925,0.073700
- After: median=0.072977s mean=0.084355s runs=0.072440,0.071716,
  0.189725,0.071895,0.073860,0.071598,0.072847,0.073107,0.073139,0.073219