### PR TITLE
[EZ] Chcek dtype in cuda quantized_linear

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/Linear.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Linear.cpp
@@ -94,6 +94,13 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   if (quantized_output.numel() == 0) {
     return;
   }
+
+  TORCH_CHECK(input.scalar_type() == c10::kQInt8,
+                "Expected input data type ",
+                toString(c10::kQInt8),
+                " on CUDA, but got ",
+                toString(input.scalar_type()));
+
   auto act_scale = input.q_scale();
   auto weight_scale = orig_weight.q_scale();
   auto requantize_multiplier = act_scale * weight_scale / output_scale;


### PR DESCRIPTION
The impl only supports int8 symmetric. check the type before we hit the vague error message thrown by `input.data_ptr<int8_t>`