### PR TITLE
Fix segfault and invalid cast in UntypedStorage

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -1,7 +1,12 @@
 #include <c10/core/Allocator.h>
+#include <c10/core/CPUAllocator.h>
 #include <array>
 
 #include <c10/util/ThreadLocalDebugInfo.h>
+
+#ifdef USE_CUDA
+#include <c10/cuda/CUDACachingAllocator.h>
+#endif
 
 #include <cstring>
 
@@ -55,6 +60,33 @@ at::Allocator* GetAllocator(const at::DeviceType& t) {
   auto* alloc = allocator_array[static_cast<int>(t)];
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(alloc, "Allocator for ", t, " is not set.");
   return alloc;
+}
+
+bool isKnownAllocator(Allocator* ptr) {
+  if (ptr == nullptr) {
+    return false;
+  }
+  if (ptr == GetDefaultCPUAllocator()) {
+    return true;
+  }
+  if (auto* cpu_alloc = GetCPUAllocator();
+      cpu_alloc != nullptr && ptr == cpu_alloc) {
+    return true;
+  }
+  for (int i = 0;
+       i < static_cast<int>(at::DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
+       ++i) {
+    auto* alloc = allocator_array[i];
+    if (alloc != nullptr && ptr == alloc) {
+      return true;
+    }
+  }
+#ifdef USE_CUDA
+  if (ptr == c10::cuda::CUDACachingAllocator::get()) {
+    return true;
+  }
+#endif
+  return false;
 }
 
 bool memoryProfilingEnabled() {

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -289,6 +289,10 @@ struct C10_API InefficientStdFunctionContext {
 C10_API void SetAllocator(DeviceType t, Allocator* alloc, uint8_t priority = 0);
 C10_API Allocator* GetAllocator(const DeviceType& t);
 
+// Returns true if ptr is a registered PyTorch allocator (not e.g. a tensor
+// data_ptr).
+C10_API bool isKnownAllocator(Allocator* ptr);
+
 template <DeviceType t>
 struct AllocatorRegisterer {
   explicit AllocatorRegisterer(Allocator* alloc) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7754,6 +7754,37 @@ class TestTorch(TestCase):
                 with self.assertRaisesRegex(RuntimeError, r'cannot set item'):
                     s.fill_(s_other)
 
+    def test_untyped_storage_invalid_allocator_raises(self):
+        t = torch.randint(0, 100, (5,), dtype=torch.int32)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"'allocator' must be a valid c10::Allocator pointer",
+        ):
+            torch.UntypedStorage(
+                t.untyped_storage().nbytes(),
+                allocator=t.untyped_storage().data_ptr(),
+            )
+
+    def test_quantized_storage_dtype_cast_raises(self):
+        quantized_storages = [
+            torch.QInt32Storage,
+            torch.QInt8Storage,
+            torch.QUInt2x4Storage,
+            torch.QUInt4x2Storage,
+            torch.QUInt8Storage,
+        ]
+        for storage_class in quantized_storages:
+            s = storage_class(4)
+            for cast_fn in (
+                s.bfloat16, s.float, s.double, s.complex_double,
+                s.complex_float, s.half, s.long, s.int, s.short,
+                s.char, s.byte, s.bool,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, r"Cannot cast quantized storage"
+                ):
+                    cast_fn()
+
     def test_storage_error_no_attribute(self):
         storage_classes = [
             torch.cuda.ByteStorage,

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -121,10 +121,17 @@ static PyObject* THPStorage_pynew(
   if (allocator_opt.has_value()) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     allocator = reinterpret_cast<c10::Allocator*>(allocator_opt.value());
+    TORCH_CHECK(
+        c10::isKnownAllocator(allocator),
+        THPStorageStr,
+        "(): 'allocator' must be a valid c10::Allocator pointer. ",
+        "Do not pass tensor.data_ptr() or untyped_storage().data_ptr(). ",
+        "Use device= to select device memory, or omit allocator for the default CPU allocator.");
   } else if (device_opt.has_value()) {
     at::Device device = device_opt.value();
     torch::utils::maybe_initialize_device(device);
 
+    // NOLINTBEGIN(bugprone-branch-clone)
     switch (device.type()) {
       case at::kCPU:
         allocator = c10::GetDefaultCPUAllocator();
@@ -427,16 +434,19 @@ typedef PyObject* (*getter)(PyObject*, void*);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)
 static struct PyGetSetDef THPStorage_properties[] = {
+    // NOLINTNEXTLINE(modernize-use-designated-initializers)
     {"device",
      reinterpret_cast<getter>(THPStorage_device),
      nullptr,
      nullptr,
      nullptr},
+    // NOLINTNEXTLINE(modernize-use-designated-initializers)
     {"_cdata",
      reinterpret_cast<getter>(THPStorage_get_cdata),
      nullptr,
      nullptr,
      nullptr},
+    // NOLINTNEXTLINE(modernize-use-designated-initializers)
     {nullptr}};
 
 bool THPStorage_init(PyObject* module) {

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -592,6 +592,31 @@ def _storage_type_to_dtype_map():
     return dtype_map
 
 
+@functools.cache
+def _quantized_storage_dtypes() -> frozenset[torch.dtype]:
+    return frozenset(
+        {
+            torch.qint8,
+            torch.qint32,
+            torch.quint8,
+            torch.quint4x2,
+            torch.quint2x4,
+        }
+    )
+
+
+def _raise_if_quantized_storage_cast(
+    source_dtype: torch.dtype | None, target_dtype: torch.dtype
+) -> None:
+    quantized_dtypes = _quantized_storage_dtypes()
+    if source_dtype in quantized_dtypes or target_dtype in quantized_dtypes:
+        raise RuntimeError(
+            "Cannot cast quantized storage to another dtype directly. "
+            "Quantized values require scale and zero_point; dequantize the "
+            "tensor first, then call .to()."
+        )
+
+
 def _get_storage_from_sequence(sequence, dtype, device):
     if dtype in [
         torch.quint8,
@@ -1316,6 +1341,7 @@ class TypedStorage:
     def _to(self, dtype):
         if not isinstance(dtype, torch.dtype):
             raise TypeError(f"Argument 'dtype' must be torch.dtype, not {type(dtype)}")
+        _raise_if_quantized_storage_cast(self.dtype, dtype)
         storage = (
             torch.tensor([], dtype=self.dtype, device=self.device)
             .set_(self)


### PR DESCRIPTION
## Summary

Fixes two error-checking gaps reported in #169210 where invalid usage of `UntypedStorage` caused a segfault rather than a clear Python error.

**Fix 1 — Segfault on invalid `allocator=` argument (`c10/`, `torch/csrc/`)**

Passing `tensor.data_ptr()` as `allocator=` to `UntypedStorage()` caused a segfault because the integer was blindly cast to `c10::Allocator*` and `allocator->allocate()` was called on it. Adds `c10::isKnownAllocator()` which validates the pointer against PyTorch's registered allocators (CPU default, all device slots via `allocator_array`, CUDA caching allocator) before use. `THPStorage_pynew` now calls `TORCH_CHECK(isKnownAllocator(allocator))` and raises `RuntimeError` with an actionable message instead of crashing.

**Fix 2 — Silent invalid cast on quantized storage (`torch/storage.py`)**

`TypedStorage._to()` silently attempted dtype conversion for quantized storage types (`qint8`, `qint32`, `quint8`, `quint4x2`, `quint2x4`), which is semantically invalid because quantized values require `scale` and `zero_point`
to be meaningful. Adds `_raise_if_quantized_storage_cast()` guard in `TypedStorage._to()` which raises `RuntimeError` directing users to dequantize first.

Also fixes two pre-existing clang-tidy warnings in `Storage.cpp` (unmatched `NOLINTEND` and `PyGetSetDef` designated initializer warnings) that were surfaced when the file was touched.

## Test plan

New tests in `test/test_torch.py`:

- `test_untyped_storage_invalid_allocator_raises` — verifies `RuntimeError` is raised when `data_ptr()` is passed as `allocator=` 
- `test_quantized_storage_dtype_cast_raises` — verifies all 12 dtype cast methods raise `RuntimeError` across all 5 quantized storage types

```bash
python test/test_torch.py TestTorch.test_quantized_storage_dtype_cast_raises
python test/test_torch.py TestTorch.test_untyped_storage_invalid_allocator_raises
```
Co-authored-with: AI assistant (Cursor/Claude Sonnet)

Fixes: #169210