### PR TITLE
Unify triton-xpu CD nightly build into 'triton' package with version suffix

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -100,10 +100,10 @@ fi
 # Set triton via PYTORCH_EXTRA_INSTALL_REQUIREMENTS for triton xpu package
 if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*xpu.* ]]; then
     TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_xpu_version.txt)
-    TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}"
+    TRITON_REQUIREMENT="triton==${TRITON_VERSION}+xpu"
     if [[ -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_BUILD_VERSION" =~ .*dev.* ]]; then
         TRITON_SHORTHASH=$(cut -c1-8 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-xpu.txt)
-        TRITON_REQUIREMENT="triton-xpu==${TRITON_VERSION}+git${TRITON_SHORTHASH}"
+        TRITON_REQUIREMENT="triton==${TRITON_VERSION}+git${TRITON_SHORTHASH}.xpu"
     fi
     if [[ -z "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" ]]; then
         export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${TRITON_REQUIREMENT}"

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -74,7 +74,7 @@ def build_triton(
         if device == "rocm":
             triton_pkg_name = "triton-rocm"
         elif device == "xpu":
-            triton_pkg_name = "triton-xpu"
+            triton_pkg_name = "triton"
             triton_repo = "https://github.com/intel/intel-xpu-backend-for-triton"
         else:
             triton_pkg_name = "triton"
@@ -100,6 +100,14 @@ def build_triton(
         env["TRITON_EXT_ENABLED"] = "ON"
         if with_clang_ldd:
             env["TRITON_BUILD_WITH_CLANG_LLD"] = "1"
+
+        # For XPU, set version suffix so the wheel version becomes:
+        # Release: version+xpu
+        # Nightly: version+git<hash>.xpu
+        # Triton's setup.py handles +git<hash> via get_git_version_suffix(),
+        # and appends TRITON_WHEEL_VERSION_SUFFIX after that.
+        if device == "xpu":
+            env["TRITON_WHEEL_VERSION_SUFFIX"] = f"+{device}"
 
         patch_init_py(
             triton_pythondir / "triton" / "__init__.py",
@@ -157,11 +165,11 @@ def main() -> None:
     if args.triton_version:
         triton_version = args.triton_version
 
+    commit_hash = args.commit_hash if args.commit_hash else read_triton_pin(args.device)
+
     build_triton(
         device=args.device,
-        commit_hash=(
-            args.commit_hash if args.commit_hash else read_triton_pin(args.device)
-        ),
+        commit_hash=commit_hash,
         version=triton_version,
         py_version=args.py_version,
         release=args.release,


### PR DESCRIPTION
## Summary

- Unifies triton XPU wheel build under the single package name `triton` (previously `triton-xpu`)
- Differentiates XPU backend via PEP 440 local version identifier: `+xpu` suffix
- Uses triton's `TRITON_WHEEL_VERSION_SUFFIX` env var to inject the backend suffix into the wheel version
- CUDA and ROCm builds are unchanged (`triton` and `triton-rocm` respectively)

## Version Scheme

| Backend | Nightly | Release |
|---------|---------|---------|
| CUDA | `triton==3.x.y+git<hash>` (unchanged) | `triton==3.x.y` (unchanged) |
| **XPU** | `triton==3.x.y+git<hash>.xpu` | `triton==3.x.y+xpu` |
| ROCm | `triton-rocm==3.x.y+git<hash>` (unchanged) | `triton-rocm==3.x.y` (unchanged) |

Triton's `setup.py` handles `+git<hash>` via its own `get_git_version_suffix()`, then appends `TRITON_WHEEL_VERSION_SUFFIX` after that.

## Files Changed

- `.github/scripts/build_triton_wheel.py` - XPU package name changed from `triton-xpu` to `triton`, set `TRITON_WHEEL_VERSION_SUFFIX="+xpu"` for XPU builds
- `.ci/pytorch/binary_populate_env.sh` - Updated XPU dependency requirements from `triton-xpu==version` to `triton==version+xpu`

## Test Plan

CI will validate via the `build-triton-wheel` workflow trigger on path changes to the modified files.