### PR TITLE
[Inductor] Skip nonfinite preservation for safe scaled softmax

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2119,6 +2119,30 @@ class TestPatternMatcher(TestCase):
         self.assertEqual(actual[1, 0].item(), float("-inf"))
         self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
 
+    @inductor_config.patch(fx_graph_cache=False)
+    def test_scaled_softmax_static_safe_scale_and_divisor_skips_nonfinite_guard(self):
+        def check(fn, args):
+            torch._dynamo.reset()
+            counters.clear()
+            expected = fn(*args)
+            actual, code = run_and_get_code(torch.compile(fn), *args)
+            torch.testing.assert_close(actual, expected)
+            self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
+            code = "\n".join(code)
+            self.assertNotIn("isfinite", code)
+            self.assertNotIn("where", code)
+
+        def mul_softmax(x):
+            return F.softmax(x * 0.125, dim=0)
+
+        def div_softmax(x):
+            return F.softmax(x / 8.0, dim=0)
+
+        torch.manual_seed(100)
+        check(mul_softmax, (torch.randn((4, 16)),))
+        check(div_softmax, (torch.randn((4, 16)),))
+
     def test_mutation_op_matching(self):
         def check(type, func_name, args, kwargs, expect=True):
             if type not in ["call_function", "call_method"]:

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2121,12 +2121,12 @@ class TestPatternMatcher(TestCase):
 
     @inductor_config.patch(fx_graph_cache=False)
     def test_scaled_softmax_static_safe_scale_and_divisor_skips_nonfinite_guard(self):
-        def check(fn, args):
+        def check(fn, args, *, equal_nan=False):
             torch._dynamo.reset()
             counters.clear()
             expected = fn(*args)
             actual, code = run_and_get_code(torch.compile(fn), *args)
-            torch.testing.assert_close(actual, expected)
+            torch.testing.assert_close(actual, expected, equal_nan=equal_nan)
             self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
 
             code = "\n".join(code)
@@ -2136,12 +2136,29 @@ class TestPatternMatcher(TestCase):
         def mul_softmax(x):
             return F.softmax(x * 0.125, dim=0)
 
+        def neg_mul_softmax(x):
+            return F.softmax(x * -0.125, dim=0)
+
         def div_softmax(x):
             return F.softmax(x / 8.0, dim=0)
 
+        def neg_div_softmax(x):
+            return F.softmax(x / -8.0, dim=0)
+
         torch.manual_seed(100)
-        check(mul_softmax, (torch.randn((4, 16)),))
-        check(div_softmax, (torch.randn((4, 16)),))
+
+        x = torch.randn((4, 16))
+        check(mul_softmax, (x,))
+        check(neg_mul_softmax, (x,))
+        check(div_softmax, (x,))
+        check(neg_div_softmax, (x,))
+
+        x_nonfinite = torch.randn((4, 16))
+        x_nonfinite[0, 0] = float("inf")
+        check(mul_softmax, (x_nonfinite,), equal_nan=True)
+        check(neg_mul_softmax, (x_nonfinite,), equal_nan=True)
+        check(div_softmax, (x_nonfinite,), equal_nan=True)
+        check(neg_div_softmax, (x_nonfinite,), equal_nan=True)
 
     def test_mutation_op_matching(self):
         def check(type, func_name, args, kwargs, expect=True):

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1044,7 +1044,7 @@ def _is_static_safe_softmax_divisor(other) -> bool:
     """
     For scaled softmax of the form inp / other, the effective scale is 1 / other.
     If other is a compile-time finite scalar and abs(other) >= 1,
-    then effective scale <= 1, so dividing finite inp by other will not introduce overflow.
+    then abs(effective scale) <= 1, so dividing finite inp by other will not introduce overflow.
     """
     import math
 
@@ -1057,16 +1057,17 @@ def _is_static_safe_softmax_divisor(other) -> bool:
 
 def _is_static_safe_softmax_scale(scale) -> bool:
     """
-    Return True when the scale is a compile-time positive constant <= 1.
+    Return True when the scale is a compile-time finite non-zero scalar
+    with abs(scale) <= 1.
     For finite score, multiplying by such a scale will not introduce overflow.
     """
     import math
 
-    if isinstance(scale, (int, float)):
-        scale = float(scale)
-        return math.isfinite(scale) and 0.0 < scale <= 1.0
+    if not isinstance(scale, (int, float)):
+        return False
 
-    return False
+    scale = float(scale)
+    return math.isfinite(scale) and scale != 0.0 and abs(scale) <= 1.0
 
 
 def _other_is_broadcasted_in_dim(match):

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1103,9 +1103,8 @@ def _other_is_broadcasted_in_dim(match):
 
 def mul_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
     def repl(inp, other):
-        scaled = inp * other
+        orig_inp = inp
         if dtype is not None:
-            scaled = scaled.to(dtype)
             inp = inp.to(dtype)
 
         sign: int | float | torch.Tensor
@@ -1115,13 +1114,16 @@ def mul_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
             one = torch.scalar_tensor(1, dtype=inp.dtype, device=inp.device)
             sign = torch.where(other >= 0, one, -one)
 
-        inp = inp * sign
-        max_ = torch.amax(inp, dim=dim, keepdim=keepdim)
-
-        stable = (inp - max_) * (sign * other)
+        inp_for_stable = inp * sign
+        max_ = torch.amax(inp_for_stable, dim=dim, keepdim=keepdim)
+        stable = (inp_for_stable - max_) * (sign * other)
         # Fast path for static small scales that will not cause overflow.
         if _is_static_safe_softmax_scale(other):
             return stable
+
+        scaled = orig_inp * other
+        if dtype is not None:
+            scaled = scaled.to(dtype)
 
         return _preserve_scaled_softmax_nonfinite_semantics(
             scaled, stable, dim, keepdim
@@ -1145,7 +1147,6 @@ def div_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
         orig_inp = inp
 
         if dtype is not None:
-            scaled = scaled.to(dtype)
             inp = inp.to(dtype)
 
         sign: int | float | torch.Tensor

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1039,7 +1039,31 @@ def _preserve_scaled_softmax_nonfinite_semantics(scaled, stable, dim, keepdim):
     finite_scaled = torch.all(torch.isfinite(scaled), dim=dim, keepdim=True)
     return torch.where(finite_scaled, stable, original)
 
+def _is_static_safe_softmax_divisor(other) -> bool:
+    """
+    For scaled softmax of the form inp / other, the effective scale is 1 / other.
+    If other is a compile-time finite scalar and abs(other) >= 1,
+    then effective scale <= 1, so dividing finite inp by other will not introduce overflow.
+    """
+    import math
 
+    if not isinstance(other, (int, float)):
+        return False
+
+    other = float(other)
+    return math.isfinite(other) and abs(other) >= 1.0
+def _is_static_safe_softmax_scale(scale) -> bool:
+    """
+    Return True when the scale is a compile-time positive constant <= 1.
+    For finite score, multiplying by such a scale will not introduce overflow.
+    """
+    import math
+
+    if isinstance(scale, (int, float)):
+        scale = float(scale)
+        return math.isfinite(scale) and 0.0 < scale <= 1.0
+
+    return False
 def _other_is_broadcasted_in_dim(match):
     # Check that the scaling factor is constant across the reduction dim,
     # so scaling doesn't change which index corresponds to the maximum value
@@ -1095,6 +1119,10 @@ def mul_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
         max_ = torch.amax(inp, dim=dim, keepdim=keepdim)
 
         stable = (inp - max_) * (sign * other)
+        # Fast path for static small scales that will not cause overflow.
+        if _is_static_safe_softmax_scale(other):
+            return stable
+
         return _preserve_scaled_softmax_nonfinite_semantics(
             scaled, stable, dim, keepdim
         )
@@ -1114,7 +1142,8 @@ for reverse, to_dtype in itertools.product((False, True), repeat=2):
 
 def div_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
     def repl(inp, other):
-        scaled = inp / other
+        orig_inp = inp
+
         if dtype is not None:
             scaled = scaled.to(dtype)
             inp = inp.to(dtype)
@@ -1126,10 +1155,18 @@ def div_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
             one = torch.scalar_tensor(1, dtype=inp.dtype, device=inp.device)
             sign = torch.where(other >= 0, one, -one)
 
-        inp = inp * sign
-        max_ = torch.amax(inp, dim=dim, keepdim=keepdim)
+        inp_for_stable = inp * sign
+        max_ = torch.amax(inp_for_stable, dim=dim, keepdim=keepdim)
+        stable = (inp_for_stable - max_) / (sign * other)
 
-        stable = (inp - max_) / (sign * other)
+        # Fast path for static safe divisor.
+        if _is_static_safe_softmax_divisor(other):
+            return stable
+
+        scaled = orig_inp / other
+        if dtype is not None:
+            scaled = scaled.to(dtype)
+
         return _preserve_scaled_softmax_nonfinite_semantics(
             scaled, stable, dim, keepdim
         )

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1039,6 +1039,7 @@ def _preserve_scaled_softmax_nonfinite_semantics(scaled, stable, dim, keepdim):
     finite_scaled = torch.all(torch.isfinite(scaled), dim=dim, keepdim=True)
     return torch.where(finite_scaled, stable, original)
 
+
 def _is_static_safe_softmax_divisor(other) -> bool:
     """
     For scaled softmax of the form inp / other, the effective scale is 1 / other.
@@ -1052,6 +1053,8 @@ def _is_static_safe_softmax_divisor(other) -> bool:
 
     other = float(other)
     return math.isfinite(other) and abs(other) >= 1.0
+
+
 def _is_static_safe_softmax_scale(scale) -> bool:
     """
     Return True when the scale is a compile-time positive constant <= 1.
@@ -1064,6 +1067,8 @@ def _is_static_safe_softmax_scale(scale) -> bool:
         return math.isfinite(scale) and 0.0 < scale <= 1.0
 
     return False
+
+
 def _other_is_broadcasted_in_dim(match):
     # Check that the scaling factor is constant across the reduction dim,
     # so scaling doesn't change which index corresponds to the maximum value


### PR DESCRIPTION
Skip the scaled softmax nonfinite-semantics preservation logic for static safe scale factors.

PR https://github.com/pytorch/pytorch/pull/184046 added logic in Inductor to preserve the original scaled subtraction behavior for nonfinite scaled-softmax inputs, so that Inductor does not turn eager NaNs into finite softmax results. However, for static positive scales <= 1, multiplying finite inputs by the scale will not introduce overflow. In those cases, the additional preservation logic is unnecessary overhead and can also block downstream fusion patterns or cause performance regressions on benchmarks.
This PR keeps the existing nonfinite-semantics preserving path for unsafe or dynamic scales but directly returns the stable scaled-softmax form for compile-time safe scales.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo