### PR TITLE
Profile lazy backward compilation with cProfile

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: dynamo"]
+import os
+import tempfile
 import threading
 from unittest.mock import patch
 
@@ -14,6 +16,49 @@ from torch.testing._internal.common_utils import TemporaryFileName
 
 
 class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
+    def test_cprofile_profiles_lazy_backward_compile(self):
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        class DummyPopen:
+            stdout = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        def compiler(gm, _example_inputs):
+            return make_boxed_func(gm.forward)
+
+        backend = aot_autograd(fw_compiler=compiler, bw_compiler=compiler)
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.object(tempfile, "tempdir", tmpdir),
+            patch("torch._dynamo.profiler.subprocess.Popen", return_value=DummyPopen()),
+            patch("torch._dynamo.profiler.subprocess.check_call"),
+            torch._dynamo.config.patch(cprofile=True),
+        ):
+
+            @torch.compile(backend=backend)
+            def fn(x):
+                return (x.sin() * x).sum()
+
+            y = fn(torch.randn(3, requires_grad=True))
+            profiles_before = set(os.listdir(tmpdir))
+
+            y.backward()
+
+            new_profiles = sorted(
+                name
+                for name in set(os.listdir(tmpdir)) - profiles_before
+                if name.endswith(".profile")
+            )
+            self.assertEqual(len(new_profiles), 1)
+            self.assertTrue(new_profiles[0].startswith("compile_backward_"))
+
     def test_dynamo_timed_profiling_isolated(self):
         # dynamo_timed functions should appear in profile traces.
         def inner_fn(x):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import collections
 import contextlib
-import cProfile
 import dataclasses
 import dis
 import functools
@@ -35,11 +34,8 @@ import inspect
 import itertools
 import logging
 import os
-import pstats
 import random  # noqa: F401 -- eval_frame_cpp.cpp imports random at runtime; torch.package needs this to detect the dependency
-import subprocess
 import sys
-import tempfile
 import threading
 import time
 import traceback
@@ -48,7 +44,6 @@ import typing
 import unittest.mock as mock
 import weakref
 from dataclasses import dataclass
-from pathlib import Path
 from types import CellType, CodeType, FunctionType, ModuleType
 from typing import Any, cast, NoReturn, TypeVar
 from typing_extensions import ParamSpec
@@ -62,11 +57,7 @@ from torch._dynamo.distributed import get_compile_pg
 from torch._dynamo.symbolic_convert import TensorifyState
 from torch._guards import compile_context, CompileContext, CompileId, tracing
 from torch._logging import structured
-from torch._utils_internal import (
-    compile_time_strobelight_meta,
-    maybe_upload_prof_stats_to_manifold,
-    signpost_event,
-)
+from torch._utils_internal import compile_time_strobelight_meta, signpost_event
 from torch.fx._lazy_graph_module import _use_lazy_graph_module
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
@@ -83,7 +74,14 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._traceback import CapturedTraceback, format_traceback_short
 
-from . import config, decorators, exc, graph_break_hints, trace_rules
+from . import (
+    config,
+    decorators,
+    exc,
+    graph_break_hints,
+    profiler as dynamo_profiler,
+    trace_rules,
+)
 from .backends.registry import _is_registered_backend
 from .bytecode_analysis import remove_dead_code, remove_pointless_jumps
 from .bytecode_transformation import (
@@ -200,6 +198,10 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 bytecode_log = torch._logging.getArtifactLogger(__name__, "bytecode")
 graph_break_log = torch._logging.getArtifactLogger(__name__, "graph_breaks")
+
+
+cprofile_wrapper = dynamo_profiler.cprofile_wrapper
+maybe_cprofile = dynamo_profiler.maybe_cprofile
 
 
 compile_lock = threading.RLock()
@@ -485,88 +487,6 @@ def exception_handler(
 
 FRAME_COUNTER = 0
 FRAME_COMPILE_COUNTER: typing.Counter[int | FrameStateSizeEntry] = collections.Counter()
-
-
-def maybe_cprofile(func: Callable[_P, _T]) -> Callable[_P, _T]:
-    if config.cprofile:
-        return cprofile_wrapper(func)
-    return func
-
-
-def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
-    @functools.wraps(func)
-    def profile_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        trace_id = CompileContext.current_trace_id()
-        if not trace_id:
-            raise AssertionError("Trace id is None")
-        profile_path = Path(
-            os.path.join(
-                tempfile.gettempdir(),
-                f"{func.__name__}_{str(trace_id).replace('/', '_')}.profile",
-            )
-        )
-        prof = cProfile.Profile()
-        try:
-            start_ts = time.time()
-            # runcall calls prof.enable() and prof.disable(), so do NOT call
-            # enable outside. This leads to issues like
-            # ValueError: Another profiling tool is already active
-            # pyrefly: ignore [bad-argument-type]
-            retval = prof.runcall(func, *args, **kwargs)
-            profile_latency = time.time() - start_ts
-        except ValueError:
-            log.exception("failed to enable cProfile")
-            profile_latency = 0
-            retval = func(*args, **kwargs)
-        log.warning(
-            "### Cprofile for %s trace id [%s] took %.3f seconds ###",
-            func.__name__,
-            trace_id,
-            profile_latency,
-        )
-        ps = pstats.Stats(prof)
-        try:
-            prof.dump_stats(profile_path)
-        except OSError:
-            log.exception("Cannot write to %s", profile_path)
-        log.warning("Raw profile at %s", profile_path)
-        svg_path = profile_path.with_suffix(".svg")
-        try:
-            with subprocess.Popen(
-                [
-                    "gprof2dot",
-                    "-f",
-                    "pstats",
-                    "--node-label=total-time-percentage",
-                    "--node-label=self-time-percentage",
-                    "--node-label=total-time",
-                    str(profile_path),
-                ],
-                stdout=subprocess.PIPE,
-            ) as gprof2dot_process:
-                subprocess.check_call(
-                    ["dot", "-Tsvg", "-o", str(svg_path)],
-                    stdin=gprof2dot_process.stdout,
-                )
-                log.warning("Generated SVG from profile at %s", svg_path)
-        except FileNotFoundError:
-            log.warning(
-                "Failed to generate SVG from profile -- dumping stats instead."
-                "Try installing gprof2dot and dot for a better visualization"
-            )
-            ps.sort_stats(pstats.SortKey.TIME).print_stats(20)
-            ps.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
-
-        if manifold_link := maybe_upload_prof_stats_to_manifold(
-            str(profile_path)
-        ):  # fb-only
-            torch._logging.trace_structured(
-                "link",
-                lambda: {"name": "cprofile_manifold_url", "url": manifold_link},
-            )
-        return retval
-
-    return profile_wrapper
 
 
 @dataclass

--- a/torch/_dynamo/profiler.py
+++ b/torch/_dynamo/profiler.py
@@ -14,14 +14,125 @@ by tracking both captured and total operations, timing, and graph statistics.
 
 from __future__ import annotations
 
+import cProfile
 import dataclasses
+import functools
+import logging
 import os
-from typing import Any
-from typing_extensions import Self
+import pstats
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, TYPE_CHECKING, TypeVar
+from typing_extensions import ParamSpec, Self
 
 import torch
+from torch._guards import CompileContext
+from torch._utils_internal import maybe_upload_prof_stats_to_manifold
 
+from . import config
 from .utils import print_once
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+log = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+def _callable_name(func: Callable[..., Any]) -> str:
+    if isinstance(func, functools.partial):
+        return _callable_name(func.func)
+    return getattr(func, "__name__", type(func).__name__)
+
+
+def maybe_cprofile(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    if config.cprofile:
+        return cprofile_wrapper(func)
+    return func
+
+
+def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    func_name = _callable_name(func)
+
+    @functools.wraps(func)
+    def profile_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        trace_id = CompileContext.current_trace_id()
+        if not trace_id:
+            raise AssertionError("Trace id is None")
+        profile_path = Path(
+            os.path.join(
+                tempfile.gettempdir(),
+                f"{func_name}_{str(trace_id).replace('/', '_')}.profile",
+            )
+        )
+        prof = cProfile.Profile()
+        try:
+            start_ts = time.time()
+            # runcall calls prof.enable() and prof.disable(), so do NOT call
+            # enable outside. This leads to issues like
+            # ValueError: Another profiling tool is already active
+            # pyrefly: ignore [bad-argument-type]
+            retval = prof.runcall(func, *args, **kwargs)
+            profile_latency = time.time() - start_ts
+        except ValueError:
+            log.exception("failed to enable cProfile")
+            profile_latency = 0
+            retval = func(*args, **kwargs)
+        log.warning(
+            "### Cprofile for %s trace id [%s] took %.3f seconds ###",
+            func_name,
+            trace_id,
+            profile_latency,
+        )
+        ps = pstats.Stats(prof)
+        try:
+            prof.dump_stats(profile_path)
+        except OSError:
+            log.exception("Cannot write to %s", profile_path)
+        log.warning("Raw profile at %s", profile_path)
+        svg_path = profile_path.with_suffix(".svg")
+        try:
+            with subprocess.Popen(
+                [
+                    "gprof2dot",
+                    "-f",
+                    "pstats",
+                    "--node-label=total-time-percentage",
+                    "--node-label=self-time-percentage",
+                    "--node-label=total-time",
+                    str(profile_path),
+                ],
+                stdout=subprocess.PIPE,
+            ) as gprof2dot_process:
+                subprocess.check_call(
+                    ["dot", "-Tsvg", "-o", str(svg_path)],
+                    stdin=gprof2dot_process.stdout,
+                )
+                log.warning("Generated SVG from profile at %s", svg_path)
+        except FileNotFoundError:
+            log.warning(
+                "Failed to generate SVG from profile -- dumping stats instead."
+                "Try installing gprof2dot and dot for a better visualization"
+            )
+            ps.sort_stats(pstats.SortKey.TIME).print_stats(20)
+            ps.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
+
+        if manifold_link := maybe_upload_prof_stats_to_manifold(
+            str(profile_path)
+        ):  # fb-only
+            torch._logging.trace_structured(
+                "link",
+                lambda: {"name": "cprofile_manifold_url", "url": manifold_link},
+            )
+        return retval
+
+    return profile_wrapper
 
 
 @dataclasses.dataclass

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -25,6 +25,7 @@ import torch.fx as fx
 from torch import Tensor
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.callback import callback_handler, CallbackTrigger
+from torch._dynamo.profiler import cprofile_wrapper
 from torch._dynamo.utils import CompileEventLogger, dynamo_timed, get_metrics_context
 from torch._guards import (
     compile_context,
@@ -2850,9 +2851,15 @@ class _AutogradBackwardCompiler:
             # See Note: [Backward graph lazy lowering]
             if self.bw_compiler is None:
                 raise AssertionError("bw_compiler must not be None")
-            self.compiled_bw = self.bw_compiler(
-                copy.deepcopy(bw_module), placeholder_list
-            )
+            bw_compiler = self.bw_compiler
+
+            def compile_backward() -> Callable[..., Any]:
+                return bw_compiler(copy.deepcopy(bw_module), placeholder_list)
+
+            if dynamo_config.cprofile and CompileContext.current_trace_id() is not None:
+                compile_backward = cprofile_wrapper(compile_backward)
+
+            self.compiled_bw = compile_backward()
             # Maybe save cache entry
             if self.try_save_cache_entry is not None:
                 self.try_save_cache_entry(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186214

TORCH_COMPILE_CPROFILE only wrapped Dynamo's forward frame compilation path via _compile_inner. Lazy AOTAutograd backward lowering restores the saved CompileContext when backward() first needs to lower the backward graph, but then called the backward compiler directly. That meant a valid compile trace id was present, yet no cProfile profile was produced for the backward compiler.

Move the shared cProfile wrapper into torch._dynamo.profiler so non-convert_frame compile paths can reuse it, keep convert_frame aliases for existing internal imports, and wrap the lazy backward compiler call while the saved CompileContext is active. The wrapper is only applied when Dynamo cProfile is enabled and a trace id exists.

The alternative was to add a local cProfile implementation in AOTAutograd, but sharing the existing helper keeps forward and backward profile naming, logging, SVG generation, and fb-only upload behavior consistent.

Fixes #137996
Generated by my agent

Test Plan:
- TMPDIR=$(mktemp -d) TORCH_COMPILE_CPROFILE=1 python - <<'PY' ... torch.compile(fn, backend='inductor'); y.backward(); list profile files ... PY
- python test/dynamo/test_profiler.py -k test_cprofile_profiles_lazy_backward_compile
- python test/dynamo/test_profiler.py
- PYTHONDONTWRITEBYTECODE=1 python test/dynamo/test_profiler.py -k test_cprofile_profiles_lazy_backward_compile -v
- git diff --check
- git diff --cached --check
- lintrunner -a

Note: python test/inductor/test_torchinductor.py -k check_stack_no_cycles -v was attempted but blocked during import by a local torchvision::nms registration mismatch.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98