### PR TITLE
[MPS] Support captured buffers in flex attention

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7,6 +7,7 @@ import os
 import random
 import string
 import tempfile
+import types
 import unittest
 import warnings
 from collections import namedtuple
@@ -539,6 +540,42 @@ def query_key_value_clones(
     return query_ref, key_ref, value_ref
 
 
+def _relocate_captures(mod, device):
+    """Copy a score_mod / mask_mod with its captured tensors moved to `device`.
+
+    A score_mod / mask_mod can reference a tensor from the surrounding scope:
+
+        bias = torch.randn(S, S, device="mps")
+        score_mod = lambda s, b, h, q, kv: s + bias[q, kv]   # captures `bias`
+
+    The MPS tests check the compiled output against a reference run on CPU in
+    float64 (MPS has no float64). That reference calls `score_mod` with CPU
+    inputs, but `bias` is still on MPS, so `cpu_score + bias[q, kv]` mixes a CPU
+    and an MPS tensor and raises a device-mismatch error.
+
+    This returns a copy of `mod` with every captured tensor moved to `device`
+    (and a captured BlockMask too, recursing into its mask_mod's captures). It
+    builds a new function instead of editing `mod` in place, because the
+    original is still used for the on-device run. A mod that captures nothing is
+    returned unchanged.
+    """
+    cells = getattr(mod, "__closure__", None)
+    if not cells:
+        return mod
+    relocated = []
+    for cell in cells:
+        val = cell.cell_contents
+        if isinstance(val, BlockMask):
+            val = val.to(device)
+            val.mask_mod = _relocate_captures(val.mask_mod, device)
+        elif isinstance(val, torch.Tensor):
+            val = val.to(device)
+        relocated.append(types.CellType(val))
+    return types.FunctionType(
+        mod.__code__, mod.__globals__, mod.__name__, mod.__defaults__, tuple(relocated)
+    )
+
+
 def batch_reserve(paged_attention: PagedAttention, target_seq_len: Tensor):
     (B,) = target_seq_len.shape
     for b in range(B):
@@ -703,7 +740,9 @@ class TestFlexAttention(InductorTestCase):
         sdpa_partial = create_attention(score_mod, block_mask, enable_gqa=(Q_H != KV_H))
         if _is_mps_device(device):
             sdpa_partial_gold = create_attention(
-                score_mod, block_mask.to("cpu"), enable_gqa=(Q_H != KV_H)
+                _relocate_captures(score_mod, "cpu"),
+                block_mask.to("cpu"),
+                enable_gqa=(Q_H != KV_H),
             )
         else:
             sdpa_partial_gold = sdpa_partial
@@ -1009,19 +1048,26 @@ class TestFlexAttention(InductorTestCase):
         q_gold, k_gold, v_gold = query_key_value_clones(q, k, v, torch.float64)
         compiled_sdpa = torch.compile(sdpa_call)
         compiled_out = compiled_sdpa(q, k, v)
-        # On MPS the gold path runs on CPU at fp64, if sdpa_call is a partial
-        # with a block_mask captured on MPS, build a CPU twin so devices match.
+        # On MPS the gold path runs on CPU at fp64; relocate any device-resident
+        # captures (block_mask, score_mod buffers, or a closed-over BlockMask) to
+        # CPU so the reference stays single-device.
         sdpa_call_gold = sdpa_call
-        if (
-            _is_mps_device(device)
-            and isinstance(sdpa_call, functools.partial)
-            and "block_mask" in sdpa_call.keywords
-        ):
-            cpu_kwargs = dict(sdpa_call.keywords)
-            cpu_kwargs["block_mask"] = cpu_kwargs["block_mask"].to("cpu")
-            sdpa_call_gold = functools.partial(
-                sdpa_call.func, *sdpa_call.args, **cpu_kwargs
-            )
+        if _is_mps_device(device):
+            if isinstance(sdpa_call, functools.partial):
+                cpu_kwargs = dict(sdpa_call.keywords)
+                if cpu_kwargs.get("block_mask") is not None:
+                    bm = cpu_kwargs["block_mask"].to("cpu")
+                    bm.mask_mod = _relocate_captures(bm.mask_mod, "cpu")
+                    cpu_kwargs["block_mask"] = bm
+                if cpu_kwargs.get("score_mod") is not None:
+                    cpu_kwargs["score_mod"] = _relocate_captures(
+                        cpu_kwargs["score_mod"], "cpu"
+                    )
+                sdpa_call_gold = functools.partial(
+                    sdpa_call.func, *sdpa_call.args, **cpu_kwargs
+                )
+            else:
+                sdpa_call_gold = _relocate_captures(sdpa_call, "cpu")
         golden_out = sdpa_call_gold(q_gold, k_gold, v_gold)
         ref_out = sdpa_call(q_ref, k_ref, v_ref)
         if not requires_grad:
@@ -1479,8 +1525,8 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods_dynamic(
         self, device, dtype: torch.dtype, score_mask_mod: tuple[Callable, Callable]
     ):
-        # Closures (even over ints) get lifted to "other buffers" by Dynamo,
-        # which the MPS captured-buffers guard rejects for now.
+        # Closures (even over ints) get lifted to "other buffers" by Dynamo as
+        # SymInts, which the MPS path does not support yet.
         captures = _is_mps_device(device) and bool(score_mask_mod[0].__closure__)
         with expect_not_implemented_if(captures):
             self.run_dynamic_test(score_mask_mod, dtype, S=1024, device=device)
@@ -2322,7 +2368,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_padded_dense_causal(self, device, dtype):
         seq_len = torch.arange(B, device=device, dtype=torch.int32) + 1
 
@@ -2862,7 +2907,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps
+    @expected_not_implemented_on_mps  # SymInt captures (dynamic-shape closures)
     def test_mask_mod_handles_symint_addition(self, device):
         dtype = torch.float16
 
@@ -2908,7 +2953,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps  # captured buffers in score_mod/mask_mod unsupported
+    @expected_not_implemented_on_mps  # SymInt captures (dynamic-shape closures)
     def test_mask_mod_handles_derived_symint_closure(self, device):
         dtype = torch.float16
 
@@ -3661,7 +3706,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_new_empty_mask_mod(self, device):
         S = 128
         q, k, v = (torch.randn(4, 1, S, 64, device=device) for _ in range(3))
@@ -4579,7 +4623,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             )
 
     @supported_platform
-    @expected_not_implemented_on_mps  # no captured buffers yet
     def test_block_mask_non_divisible(self, device):
         seq = torch.arange(1023, device=device) // 128
 
@@ -4608,7 +4651,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps
     def test_modular_indexing(self, device):
         B, H, N, D = 100, 12, 128, 64
         dtype = torch.bfloat16
@@ -5032,7 +5074,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps  # no captured buffer syet
     def test_non_divisible_with_captured_buffer(self, device):
         Q_S = S + 3
         KV_S = S + 3
@@ -5737,7 +5778,6 @@ class GraphModule(torch.nn.Module):
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps  # no captured buffers yet
     def test_custom_score_mod_layout_freeze(self, device):
         torch.manual_seed(0)
 
@@ -6853,7 +6893,6 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
         self.assertEqual(block_mask_custom.BLOCK_SIZE, custom_block_size)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_upcast_appropriately(self, device):
         q = torch.randn((1, 1, 128, 16), dtype=torch.float16, device=device)
         k = torch.randn((1, 1, 128, 16), dtype=torch.float16, device=device)
@@ -7436,7 +7475,6 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps  # no captured buffers yet
     def test_broadcasted_head_block_mask(self, device):
         torch.manual_seed(42)
 

--- a/torch/_inductor/codegen/metal_flex_attention_template.py
+++ b/torch/_inductor/codegen/metal_flex_attention_template.py
@@ -2,9 +2,12 @@
 """Metal shader template for flex attention on MPS"""
 
 import itertools
+from collections import namedtuple
+from collections.abc import Sequence
 from typing import Any
 
 import torch
+from torch.utils._ordered_set import OrderedSet
 
 from .. import ir
 
@@ -14,6 +17,25 @@ METAL_DTYPE_MAP = {
     torch.float16: "half",
     torch.bfloat16: "bfloat",
 }
+
+# Captured score_mod/mask_mod buffers may hold more types than q/k/v; elements
+# are always loaded and cast to float for use in the (float-typed) op table.
+# Integer captures (e.g. document ids) are therefore exact only below 2**24,
+# which covers realistic id/index ranges.
+CAPTURE_DTYPE_MAP = {
+    torch.float32: "float",
+    torch.float16: "half",
+    torch.bfloat16: "bfloat",
+    torch.int64: "long",
+    torch.int32: "int",
+    torch.int16: "short",
+    torch.int8: "char",
+    torch.uint8: "uchar",
+    torch.bool: "bool",
+}
+
+# A captured buffer bound as a Metal kernel argument, with its static shape.
+_CapturedBuf = namedtuple("_CapturedBuf", ["name", "sizes", "strides", "dtype"])
 
 
 # FX aten target -> (output C type, Metal format string with positional {} placeholders).
@@ -81,23 +103,43 @@ del aten, prims
 def _fx_graph_to_metal(
     graph_module: torch.fx.GraphModule,
     fixed_inputs: dict[str, str],
+    captured_views: dict[str, _CapturedBuf],
     output_var: str,
     var_prefix: str,
 ) -> str:
     """Compile an FX GraphModule to inline Metal code.
 
-    `fixed_inputs` maps placeholder names to Metal variables; the graph's
-    output is assigned to `output_var`; `var_prefix` namespaces fresh temps.
+    `fixed_inputs` maps scalar placeholder names (score/b/h/q/kv) to Metal
+    variables. `captured_views` maps captured-buffer placeholder names to a
+    `_CapturedBuf`; these are indexed by `aten.index.Tensor` down to a scalar
+    element load. The output is assigned to `output_var`; `var_prefix`
+    namespaces fresh temps.
     """
     var_map: dict[str, str] = {}
+    views: dict[str, tuple] = {}
     code_lines: list[str] = []
     tmp_counter = itertools.count()
+
+    # Only emit nodes the output depends on; this drops dead constant captures
+    output_node = next(n for n in graph_module.graph.nodes if n.op == "output")
+    needed: OrderedSet[str] = OrderedSet()
+    stack = list(output_node.all_input_nodes)
+    while stack:
+        nd = stack.pop()
+        if nd.name not in needed:
+            needed.add(nd.name)
+            stack.extend(nd.all_input_nodes)
 
     def _tmp() -> str:
         return f"{var_prefix}{next(tmp_counter)}"
 
     def _val(node) -> str:
         if isinstance(node, torch.fx.Node):
+            if node.name in views:
+                raise NotImplementedError(
+                    "flex_attention on MPS: captured buffer used without being "
+                    "fully indexed to a scalar"
+                )
             return var_map[node.name]
         if isinstance(node, bool):
             return "true" if node else "false"
@@ -115,54 +157,103 @@ def _fx_graph_to_metal(
 
     for node in graph_module.graph.nodes:
         if node.op == "placeholder":
-            var_map[node.name] = fixed_inputs.get(
-                node.name, f"/* unknown placeholder {node.name} */"
-            )
-
-        elif node.op == "call_function":
-            t = _tmp()
-            target = node.target
-            args = node.args
-
-            if target in _OP_TABLE:
-                out_type, fmt = _OP_TABLE[target]
-                code_lines.append(
-                    f"{out_type} {t} = {fmt.format(*(_val(a) for a in args))};"
-                )
-            elif target == torch.ops.aten.clamp.default:
-                v = _val(args[0])
-                lo = _val(args[1]) if len(args) > 1 and args[1] is not None else None
-                hi = _val(args[2]) if len(args) > 2 and args[2] is not None else None
-                if lo is not None and hi is not None:
-                    code_lines.append(f"float {t} = metal::clamp({v}, {lo}, {hi});")
-                elif lo is not None:
-                    code_lines.append(f"float {t} = metal::max({v}, {lo});")
-                elif hi is not None:
-                    code_lines.append(f"float {t} = metal::min({v}, {hi});")
+            if node.name in fixed_inputs:
+                var_map[node.name] = fixed_inputs[node.name]
+            elif node.name in captured_views:
+                cap = captured_views[node.name]
+                if len(cap.sizes) == 0:
+                    var_map[node.name] = f"(float){cap.name}[0]"
                 else:
-                    code_lines.append(f"float {t} = {v};")
-            elif target in (
-                torch.ops.aten.full_like.default,
-                torch.ops.aten.full.default,
-            ):
-                fill = args[1] if len(args) > 1 else node.kwargs.get("fill_value", 0)
-                code_lines.append(f"float {t} = {_val(fill)};")
+                    views[node.name] = (
+                        cap.name,
+                        "0",
+                        list(cap.sizes),
+                        list(cap.strides),
+                    )
             else:
-                raise NotImplementedError(
-                    f"flex_attention on MPS does not support op {target} in "
-                    f"score_mod/mask_mod yet"
-                )
+                var_map[node.name] = f"/* unknown placeholder {node.name} */"
+            continue
 
-            var_map[node.name] = t
-
-        elif node.op == "get_attr":
-            var_map[node.name] = f"/* get_attr {node.target} */"
-
-        elif node.op == "output":
+        if node.op == "output":
             out_node = node.args[0]
             if isinstance(out_node, (tuple, list)):
                 out_node = out_node[0]
             code_lines.append(f"{output_var} = {_val(out_node)};")
+            continue
+
+        if node.name not in needed:
+            continue
+
+        if node.op == "get_attr":
+            raise NotImplementedError(
+                "flex_attention on MPS does not support constant tensor captures "
+                "in score_mod/mask_mod yet"
+            )
+
+        if node.op != "call_function":
+            continue
+
+        target = node.target
+        args = node.args
+
+        # Index a captured buffer: accumulate a flat offset over the leading
+        # dims, peeling them off; emit a scalar load when fully indexed.
+        if target == torch.ops.aten.index.Tensor:
+            base_node, idx_list = args[0], args[1]
+            if not (isinstance(base_node, torch.fx.Node) and base_node.name in views):
+                raise NotImplementedError(
+                    "flex_attention on MPS only supports indexing captured buffers"
+                )
+            base, offset, sizes, strides = views[base_node.name]
+            if any(ix is None for ix in idx_list) or len(idx_list) > len(sizes):
+                raise NotImplementedError(
+                    "flex_attention on MPS does not support this captured-buffer "
+                    "indexing pattern"
+                )
+            for j, ix in enumerate(idx_list):
+                term = f"(long)({_val(ix)}) * {strides[j]}"
+                offset = term if offset == "0" else f"{offset} + {term}"
+            k = len(idx_list)
+            rem_sizes, rem_strides = sizes[k:], strides[k:]
+            if rem_sizes:
+                views[node.name] = (base, offset, rem_sizes, rem_strides)
+            else:
+                t = _tmp()
+                code_lines.append(f"float {t} = (float){base}[{offset}];")
+                var_map[node.name] = t
+            continue
+
+        t = _tmp()
+        if target in _OP_TABLE:
+            out_type, fmt = _OP_TABLE[target]
+            code_lines.append(
+                f"{out_type} {t} = {fmt.format(*(_val(a) for a in args))};"
+            )
+        elif target == torch.ops.aten.clamp.default:
+            v = _val(args[0])
+            lo = _val(args[1]) if len(args) > 1 and args[1] is not None else None
+            hi = _val(args[2]) if len(args) > 2 and args[2] is not None else None
+            if lo is not None and hi is not None:
+                code_lines.append(f"float {t} = metal::clamp({v}, {lo}, {hi});")
+            elif lo is not None:
+                code_lines.append(f"float {t} = metal::max({v}, {lo});")
+            elif hi is not None:
+                code_lines.append(f"float {t} = metal::min({v}, {hi});")
+            else:
+                code_lines.append(f"float {t} = {v};")
+        elif target in (
+            torch.ops.aten.full_like.default,
+            torch.ops.aten.full.default,
+        ):
+            fill = args[1] if len(args) > 1 else node.kwargs.get("fill_value", 0)
+            code_lines.append(f"float {t} = {_val(fill)};")
+        else:
+            raise NotImplementedError(
+                f"flex_attention on MPS does not support op {target} in "
+                f"score_mod/mask_mod yet"
+            )
+
+        var_map[node.name] = t
 
     return "\n".join(code_lines)
 
@@ -170,6 +261,7 @@ def _fx_graph_to_metal(
 def _compile_subgraph_to_metal(
     graph_module: torch.fx.GraphModule,
     placeholder_metal_names: list[str],
+    captured_meta: list[_CapturedBuf],
     output_var: str,
     var_prefix: str,
 ) -> str:
@@ -177,15 +269,22 @@ def _compile_subgraph_to_metal(
     Bind placeholders by position to Metal variable names and emit parts of Metal .
 
     score_mod placeholders are [score, b, h, q_idx, kv_idx, *captured];
-    mask_mod's are [b, h, q_idx, kv_idx, *captured].
+    mask_mod's are [b, h, q_idx, kv_idx, *captured]. The captured placeholders
+    map positionally to `captured_meta`.
     """
     fixed: dict[str, str] = {}
+    captured_views: dict[str, _CapturedBuf] = {}
+    n_fixed = len(placeholder_metal_names)
     for i, node in enumerate(
         n for n in graph_module.graph.nodes if n.op == "placeholder"
     ):
-        if i < len(placeholder_metal_names):
+        if i < n_fixed:
             fixed[node.name] = placeholder_metal_names[i]
-    return _fx_graph_to_metal(graph_module, fixed, output_var, var_prefix)
+        else:
+            captured_views[node.name] = captured_meta[i - n_fixed]
+    return _fx_graph_to_metal(
+        graph_module, fixed, captured_views, output_var, var_prefix
+    )
 
 
 def _generate_mma_shader(
@@ -196,6 +295,7 @@ def _generate_mma_shader(
     block_m,
     block_n,
     full_kv_params,
+    captured_params,
     scalar_params_str,
     unpack_code,
     score_code,
@@ -314,7 +414,7 @@ kernel void flex_attn_fwd(
     constant {metal_dtype}* V [[buffer(3)]],
     constant int* kv_num_blocks [[buffer(4)]],
     constant int* kv_indices [[buffer(5)]],
-{full_kv_params}{scalar_params_str},
+{full_kv_params}{captured_params}{scalar_params_str},
     uint3 tgpos [[threadgroup_position_in_grid]],
     uint tid [[thread_index_in_threadgroup]]
 ) {{
@@ -405,8 +505,14 @@ def _generate_metal_shader(
     has_full_blocks: bool,
     block_m: int,
     scale: float,
+    score_captured: Sequence[tuple] = (),
+    mask_captured: Sequence[tuple] = (),
 ) -> str:
-    """Generate the complete Metal shader source for flex attention."""
+    """Generate the complete Metal shader source for flex attention.
+
+    `score_captured` / `mask_captured` are the buffers captured by score_mod /
+    mask_mod, as (sizes, strides, dtype) tuples in placeholder order.
+    """
     metal_dtype = METAL_DTYPE_MAP[dtype]
 
     bytes_per_elem = 4 if dtype == torch.float32 else 2
@@ -441,6 +547,27 @@ def _generate_metal_shader(
         buf_idx += 1
     else:
         full_kv_params = ""
+
+    # Captured tensors follow the (full) kv buffers as extra Metal arguments, in
+    # the order built in lower_mps: score captures first, then mask captures.
+    captured_decls: list[str] = []
+    score_meta: list[_CapturedBuf] = []
+    mask_meta: list[_CapturedBuf] = []
+    for meta_list, caps in ((score_meta, score_captured), (mask_meta, mask_captured)):
+        for sizes, strides, cap_dtype in caps:
+            mtype = CAPTURE_DTYPE_MAP.get(cap_dtype)
+            if mtype is None:
+                raise NotImplementedError(
+                    f"flex_attention on MPS does not support captured buffer "
+                    f"dtype {cap_dtype}"
+                )
+            name = f"capbuf{len(captured_decls)}"
+            captured_decls.append(
+                f"    constant {mtype}* {name} [[buffer({buf_idx})]],"
+            )
+            meta_list.append(_CapturedBuf(name, list(sizes), list(strides), cap_dtype))
+            buf_idx += 1
+    captured_params = "".join(d + "\n" for d in captured_decls)
 
     # Pack scalars into one buffer to stay under Metal's 31-buffer limit.
     scalar_names = [
@@ -493,12 +620,14 @@ def _generate_metal_shader(
     score_code = _compile_subgraph_to_metal(
         graph_module=score_mod_graph,
         placeholder_metal_names=["score_val", "b_idx", "h_idx", "m_idx", "n_idx"],
+        captured_meta=score_meta,
         output_var="score_val",
         var_prefix="_sm",
     )
     mask_code = _compile_subgraph_to_metal(
         graph_module=mask_mod_graph,
         placeholder_metal_names=["b_idx", "h_idx", "m_idx", "n_idx"],
+        captured_meta=mask_meta,
         output_var="mask_result",
         var_prefix="_mm",
     )
@@ -516,6 +645,7 @@ def _generate_metal_shader(
             block_m,
             block_n,
             full_kv_params,
+            captured_params,
             scalar_params_str,
             unpack_code,
             score_code,
@@ -611,7 +741,7 @@ kernel void flex_attn_fwd(
     constant {metal_dtype}* V [[buffer(3)]],
     constant int* kv_num_blocks [[buffer(4)]],
     constant int* kv_indices [[buffer(5)]],
-{full_kv_params}{scalar_params_str},
+{full_kv_params}{captured_params}{scalar_params_str},
     uint3 tgpos [[threadgroup_position_in_grid]],
     uint tid [[thread_index_in_threadgroup]]
 ) {{

--- a/torch/_inductor/kernel/flex/flex_mps.py
+++ b/torch/_inductor/kernel/flex/flex_mps.py
@@ -7,6 +7,7 @@ import torch
 from torch._inductor.virtualized import V
 
 from ...ir import FixedLayout, TensorBox
+from ...lowering import empty_strided
 from ...select_algorithm import realize_inputs
 from .common import infer_dense_strides, maybe_realize
 
@@ -30,12 +31,6 @@ def lower_mps(
         _generate_metal_shader,
         MetalFlexAttentionNode,
     )
-
-    if score_mod_other_buffers or mask_mod_other_buffers:
-        raise NotImplementedError(
-            "flex_attention on MPS does not yet support score_mod / mask_mod "
-            "with captured buffers"
-        )
 
     (
         _,  # q_length
@@ -146,6 +141,30 @@ def lower_mps(
 
     scale_val = float(scale)
 
+    # Captured tensors become extra Metal buffers; their sizes/strides are baked
+    # into the index offset math. maybe_realize passes SymInts through untouched;
+    # SymInt captures (from dynamic-shape closures) are not supported yet.
+    def _capture_meta(items):
+        metas, tensors = [], []
+        for cap in maybe_realize(list(items)):
+            if isinstance(cap, sympy.Expr):
+                raise NotImplementedError(
+                    "flex_attention on MPS does not yet support SymInt captures "
+                    "in score_mod/mask_mod (dynamic-shape closures)"
+                )
+            metas.append(
+                (
+                    [sizevars.guard_int(s) for s in cap.get_size()],
+                    [sizevars.guard_int(s) for s in cap.get_stride()],
+                    cap.get_dtype(),
+                )
+            )
+            tensors.append(cap)
+        return metas, tensors
+
+    score_meta, score_tensors = _capture_meta(score_mod_other_buffers)
+    mask_meta, mask_tensors = _capture_meta(mask_mod_other_buffers)
+
     shader_source = _generate_metal_shader(
         dtype=dtype,
         d_qk=d_qk,
@@ -155,6 +174,8 @@ def lower_mps(
         has_full_blocks=has_full_blocks,
         block_m=BLOCK_M,
         scale=scale_val,
+        score_captured=score_meta,
+        mask_captured=mask_meta,
     )
 
     out_size = [B, Hq, seq_len_q, v_head_dim]
@@ -172,10 +193,12 @@ def lower_mps(
     full_kv_idx_strides = _get_strides(full_kv_indices) if has_full_blocks else []
 
     # Buffer order: 0=Out, 1=Q, 2=K, 3=V, 4=kv_num_blocks, 5=kv_indices,
-    # 6=(full_kv_num_blocks), 7=(full_kv_indices), then packed scalar buffer.
+    # 6=(full_kv_num_blocks), 7=(full_kv_indices), then score/mask captured
+    # buffers, then the packed scalar buffer.
     input_nodes = [query, key, value, kv_num_blocks, kv_indices]
     if has_full_blocks:
         input_nodes += [full_kv_num_blocks, full_kv_indices]
+    input_nodes += [*score_tensors, *mask_tensors]
 
     realized_inputs = realize_inputs(*input_nodes)
 
@@ -227,7 +250,15 @@ def lower_mps(
         block_m=BLOCK_M,
     )
 
-    return (TensorBox.create(node),)
+    lse_shape = [B, Hq, seq_len_q]
+    logsumexp = empty_strided(
+        lse_shape, None, dtype=torch.float32, device=query.get_device()
+    )
+    max_scores = empty_strided(
+        lse_shape, None, dtype=torch.float32, device=query.get_device()
+    )
+
+    return (TensorBox.create(node), logsumexp, max_scores)
 
 
 def _get_strides(node):


### PR DESCRIPTION
Support captured buffers in flex attention mps. Before this wasn't possible:
```
import torch
from torch.nn.attention.flex_attention import flex_attention

q, k, v = (torch.randn(1, 4, 256, 64, device="mps") for _ in range(3))
bias = torch.randn(256, 256, device="mps")

out = torch.compile(flex_attention)(q, k, v, score_mod=lambda s, b, h, i, j: s + bias[i, j])
print(out.shape)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo