### PR TITLE
Include epilogue guards in Dynamo code_parts

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -739,6 +739,26 @@ user_stack=None)
             guard_str,
         )
 
+    def test_code_parts_include_epilogue_lambda_guards(self):
+        def fn(x):
+            if x.numel() >= 1024:
+                return x + 5
+            return x * 2
+
+        opt_fn = torch.compile(fn, backend="eager")
+        x = torch.ones(2)
+        torch._dynamo.mark_dynamic(x, 0)
+        opt_fn(x)
+
+        cache_entries = _debug_get_cache_entry_list(fn.__code__)
+        self.assertEqual(len(cache_entries), 1)
+        guard_manager = cache_entries[0].guard_manager
+        self.assertIn("L['x'].size()[0]", str(guard_manager))
+        self.assertTrue(
+            any("L['x'].size()[0]" in part for part in guard_manager.code_parts),
+            guard_manager.code_parts,
+        )
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -715,20 +715,25 @@ class GuardManagerWrapper:
                 code_parts.append(code_part)
             return code_parts
 
-        def visit(mgr: GuardManager) -> None:
+        def add_code_parts(guard: LeafGuard) -> None:
             nonlocal relational_guards_seen
-            for guard in mgr.get_leaf_guards():
-                if isinstance(guard, RelationalGuard):
-                    if guard not in relational_guards_seen:
-                        self.code_parts.extend(get_code_parts(guard))
-                        relational_guards_seen.add(guard)
-                else:
+            if isinstance(guard, RelationalGuard):
+                if guard not in relational_guards_seen:
                     self.code_parts.extend(get_code_parts(guard))
+                    relational_guards_seen.add(guard)
+            else:
+                self.code_parts.extend(get_code_parts(guard))
+
+        def visit(mgr: GuardManager) -> None:
+            for guard in mgr.get_leaf_guards():
+                add_code_parts(guard)
 
             for child_mgr in mgr.get_child_managers():
                 visit(child_mgr)
 
         visit(self.root)
+        for guard in self.root.get_epilogue_lambda_guards():
+            add_code_parts(guard)
 
 
 def from_numpy(a: Any) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #186222

GuardManagerWrapper.populate_code_parts_for_debugging() built its debug code_parts by walking normal leaf guards under the root manager and child managers. Shape guards installed as root epilogue lambda guards are stored separately, so the guard tree could show a LAMBDA_GUARD while guard_manager.code_parts omitted the same expression.

Collect leaf guard code parts through a shared helper and also visit root epilogue lambda guards. This keeps code_parts aligned with the guard tree without changing guard execution semantics. I chose to extend the existing debug population traversal rather than changing epilogue guard storage because the latter would affect guard ordering and runtime behavior.

Fixes #137388

Generated by my agent

Benchmark Results:

Command compared 5 repeats of 30 torch.compile calls for the issue's dynamic-shape repro on main and on this branch. Raw timings include first-run warmup.

main samples: [0.34694441698957235, 0.02792649803450331, 0.02704737603198737, 0.02789245598251, 0.027513677021488547]
main median: 0.02789245598251 seconds

fix samples: [0.972765775048174, 0.02747954602818936, 0.027007015014532954, 0.02609432302415371, 0.025623075023759156]
fix median: 0.027007015014532954 seconds

The median shows no compile-time regression for this repro-scale workload.

Test Plan:

python test/dynamo/test_guard_manager.py GuardManagerTests.test_code_parts_include_epilogue_lambda_guards

python - <<'PY' ... issue reproduction script ... PY

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98