### PR TITLE
Make Storage pin_memory / is_pinned device-agnostic

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1714,13 +1714,6 @@ if __name__ == "__main__":
         s = storage.pin_memory()
         self.assertTrue(s.is_pinned())
 
-        t = torch.empty(10, device="xpu")
-        s = t.untyped_storage()
-        s_cpu = s.to(device="cpu", non_blocking=True)
-
-        torch.xpu.synchronize()
-        self.assertTrue(s_cpu.is_pinned())
-
     def test_graph_is_current_stream_capturing(self):
         self.assertFalse(torch.xpu.is_current_stream_capturing())
         s = torch.xpu.Stream()

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1714,6 +1714,13 @@ if __name__ == "__main__":
         s = storage.pin_memory()
         self.assertTrue(s.is_pinned())
 
+        t = torch.empty(10, device="xpu")
+        s = t.untyped_storage()
+        s_cpu = s.to(device="cpu", non_blocking=True)
+
+        torch.xpu.synchronize()
+        self.assertTrue(s_cpu.is_pinned())
+
     def test_graph_is_current_stream_capturing(self):
         self.assertFalse(torch.xpu.is_current_stream_capturing())
         s = torch.xpu.Stream()

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1702,6 +1702,18 @@ if __name__ == "__main__":
         restored_handle = module.get_xpu_work_stream(tensor, api_capsule)
         self.assertEqual(default_handle, restored_handle)
 
+    def test_storage_pin_memory(self):
+        t = torch.empty(10, pin_memory=True)
+        self.assertTrue(t.is_pinned())
+        storage = t.untyped_storage()
+        self.assertTrue(storage.is_pinned())
+
+        t = torch.empty(10)
+        self.assertFalse(t.is_pinned())
+        storage = t.untyped_storage()
+        s = storage.pin_memory()
+        self.assertTrue(s.is_pinned())
+
     def test_graph_is_current_stream_capturing(self):
         self.assertFalse(torch.xpu.is_current_stream_capturing())
         s = torch.xpu.Stream()

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -77,8 +77,6 @@ def _to(self, device, non_blocking=False):
     if device.type == "cpu":
         pin_memory = non_blocking and self.device.type in (
             "cuda",
-            "xpu",
-            "mtia",
             torch._C._get_privateuse1_backend_name(),
         )
         untyped_storage = torch.empty(

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -77,6 +77,8 @@ def _to(self, device, non_blocking=False):
     if device.type == "cpu":
         pin_memory = non_blocking and self.device.type in (
             "cuda",
+            "xpu",
+            "mtia",
             torch._C._get_privateuse1_backend_name(),
         )
         untyped_storage = torch.empty(

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -352,11 +352,11 @@ class _StorageBase:
         """Casts this storage to float8_e4m3fnuz type"""
         return self._to(torch.float8_e4m3fnuz)
 
-    def is_pinned(self, device: str | torch.device = "cuda"):
+    def is_pinned(self, device: DeviceLikeType | None = None):
         r"""Determine whether the CPU storage is already pinned on device.
 
         Args:
-            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+            device (str or torch.device): The device to pin memory on (default: ``None``).
                 This argument is discouraged and subject to deprecated.
 
         Returns:
@@ -368,11 +368,11 @@ class _StorageBase:
             .is_pinned(device)
         )
 
-    def pin_memory(self, device: str | torch.device = "cuda"):
+    def pin_memory(self, device: DeviceLikeType | None = None):
         r"""Copy the CPU storage to pinned memory, if it's not already pinned.
 
         Args:
-            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+            device (str or torch.device): The device to pin memory on (default: ``None``).
                 This argument is discouraged and subject to deprecated.
 
         Returns:
@@ -1164,11 +1164,11 @@ class TypedStorage:
         _warn_typed_storage_removal()
         return self._new_wrapped_storage(self._untyped_storage.cpu())
 
-    def is_pinned(self, device: str | torch.device = "cuda"):
+    def is_pinned(self, device: DeviceLikeType | None = None):
         r"""Determine whether the CPU TypedStorage is already pinned on device.
 
         Args:
-            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+            device (str or torch.device): The device to pin memory on (default: ``None``).
                 This argument is discouraged and subject to deprecated.
 
         Returns:
@@ -1177,11 +1177,11 @@ class TypedStorage:
         _warn_typed_storage_removal()
         return self._untyped_storage.is_pinned(device)
 
-    def pin_memory(self, device: str | torch.device = "cuda"):
+    def pin_memory(self, device: DeviceLikeType | None = None):
         r"""Copy the CPU TypedStorage to pinned memory, if it's not already pinned.
 
         Args:
-            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+            device (str or torch.device): The device to pin memory on (default: ``None``).
                 This argument is discouraged and subject to deprecated.
 
         Returns:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #186224
* __->__ #186223

# Motivation
Currently, Storage `pin_memory` and `is_pinned` accept `cuda` as the default device type. Change it to `None` to make the `pin_memory()` and `is_pinned()` works on other backends.

# Additional Context
fix https://github.com/intel/torch-xpu-ops/issues/3861
