### PR TITLE
Support non-blocking D2H pinned copy for XPU/MTIA

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1714,6 +1714,13 @@ if __name__ == "__main__":
         s = storage.pin_memory()
         self.assertTrue(s.is_pinned())
 
+        t = torch.empty(10, device="xpu")
+        s = t.untyped_storage()
+        s_cpu = s.to(device="cpu", non_blocking=True)
+
+        torch.xpu.synchronize()
+        self.assertTrue(s_cpu.is_pinned())
+
     def test_graph_is_current_stream_capturing(self):
         self.assertFalse(torch.xpu.is_current_stream_capturing())
         s = torch.xpu.Stream()

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -77,6 +77,8 @@ def _to(self, device, non_blocking=False):
     if device.type == "cpu":
         pin_memory = non_blocking and self.device.type in (
             "cuda",
+            "xpu",
+            "mtia",
             torch._C._get_privateuse1_backend_name(),
         )
         untyped_storage = torch.empty(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #186224
* #186223

# Motivation
Fix https://github.com/intel/torch-xpu-ops/issues/3861
The original test case comes from https://github.com/pytorch/pytorch/blob/9680b3aaf628b22b9162507ec972cabd1c8725bf/test/test_torch.py#L4917-L4929
