### PR TITLE
Add Inductor profiler timeline provenance

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3855,6 +3855,51 @@ class TestFxGraphCacheHashing(TestCase):
             pickler.dumps(details3),
         )
 
+    def test_hash_provenance_tracking_to_timeline(self):
+        """
+        Test that provenance_tracking_to_timeline affects hashes.
+        """
+        with config.patch(
+            {
+                "trace.provenance_tracking_level": 1,
+                "trace.provenance_tracking_to_timeline": False,
+            }
+        ):
+            details1 = FxGraphHashDetails(None, [], {}, [])
+            details2 = FxGraphHashDetails(None, [], {}, [])
+
+        with config.patch(
+            {
+                "trace.provenance_tracking_level": 1,
+                "trace.provenance_tracking_to_timeline": True,
+            }
+        ):
+            details3 = FxGraphHashDetails(None, [], {}, [])
+
+        with config.patch(
+            {
+                "trace.provenance_tracking_level": 0,
+                "trace.provenance_tracking_to_timeline": True,
+            }
+        ):
+            details4 = FxGraphHashDetails(None, [], {}, [])
+
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        pickler = FxGraphCachePickler(gm)
+
+        self.assertEqual(
+            pickler.dumps(details1),
+            pickler.dumps(details2),
+        )
+        self.assertNotEqual(
+            pickler.dumps(details1),
+            pickler.dumps(details3),
+        )
+        self.assertNotEqual(
+            pickler.dumps(details1),
+            pickler.dumps(details4),
+        )
+
     def test_provenance_tracking_level_causes_cache_miss(self):
         """
         Test that changing provenance_tracking_level causes a cache miss.

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -21,7 +21,9 @@ from torch._inductor.debug import (
     create_kernel_information_json,
     create_mapping_pre_post_grad_nodes,
     create_node_mapping_kernel_to_post_grad,
+    get_kernel_information_jsons,
     reset_inductor_kernel_provenance_debug_handle,
+    reset_provenance_globals,
 )
 from torch._inductor.fx_passes.post_grad import post_grad_passes
 from torch._inductor.test_case import run_tests, TestCase
@@ -850,6 +852,20 @@ class TestProvenanceTracingStackTraces(TestCase):
         result = create_kernel_information_json()
         self.assertIsInstance(result, dict)
         self.assertEqual(len(result), 0)  # Should be empty with no provenance data
+
+    def test_reset_provenance_globals_resets_kernel_information_jsons(self):
+        kernel_information_jsons = get_kernel_information_jsons()
+        previous = dict(kernel_information_jsons)
+        kernel_information_jsons.clear()
+        kernel_information_jsons["outer"] = {}
+        try:
+            with reset_provenance_globals():
+                self.assertEqual(get_kernel_information_jsons(), {})
+                get_kernel_information_jsons()["inner"] = {}
+            self.assertEqual(get_kernel_information_jsons(), {"outer": {}})
+        finally:
+            get_kernel_information_jsons().clear()
+            get_kernel_information_jsons().update(previous)
 
     @unittest.skipIf(
         IS_MACOS,

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -853,16 +853,16 @@ class TestProvenanceTracingStackTraces(TestCase):
         self.assertIsInstance(result, dict)
         self.assertEqual(len(result), 0)  # Should be empty with no provenance data
 
-    def test_reset_provenance_globals_resets_kernel_information_jsons(self):
+    def test_reset_provenance_globals_preserves_kernel_information_jsons(self):
         kernel_information_jsons = get_kernel_information_jsons()
         previous = dict(kernel_information_jsons)
         kernel_information_jsons.clear()
         kernel_information_jsons["outer"] = {}
         try:
             with reset_provenance_globals():
-                self.assertEqual(get_kernel_information_jsons(), {})
+                self.assertEqual(get_kernel_information_jsons(), {"outer": {}})
                 get_kernel_information_jsons()["inner"] = {}
-            self.assertEqual(get_kernel_information_jsons(), {"outer": {}})
+            self.assertEqual(get_kernel_information_jsons(), {"outer": {}, "inner": {}})
         finally:
             get_kernel_information_jsons().clear()
             get_kernel_information_jsons().update(previous)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -171,6 +171,61 @@ class TestProfilerCUDA(TestCase):
             profiler_stats.function_events_build_tree_call_duration_us, 0
         )
 
+    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_compile_timeline_provenance_survives_reset_scope(self):
+        import torch._inductor.config as inductor_config
+        import torch._inductor.debug as inductor_debug
+
+        previous_kernel_information_jsons = copy.deepcopy(
+            inductor_debug.get_kernel_information_jsons()
+        )
+        inductor_debug.get_kernel_information_jsons().clear()
+
+        def fn(x):
+            return torch.sin(x + 1).relu()
+
+        try:
+            with (
+                inductor_config.patch(
+                    {
+                        "force_disable_caches": True,
+                        "trace.provenance_tracking_to_timeline": True,
+                        "triton.unique_kernel_names": True,
+                    }
+                ),
+                TemporaryFileName(mode="w+") as trace_path,
+            ):
+                compiled_fn = torch.compile(fn, backend="inductor")
+                x = torch.randn(64, 64, device="cuda")
+                with profile(
+                    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                ) as prof:
+                    compiled_fn(x)
+                    torch.cuda.synchronize()
+
+                prof.export_chrome_trace(trace_path)
+                with open(trace_path) as f:
+                    trace = json.load(f)
+
+            kernel_stacks = [
+                event.get("args", {}).get("stack")
+                for event in trace["traceEvents"]
+                if event.get("cat") == "kernel"
+                and event.get("name", "").startswith("triton_")
+            ]
+            self.assertTrue(
+                any(stack for stack in kernel_stacks),
+                "Expected a generated Triton kernel in the exported trace to "
+                "carry a stack",
+            )
+            self.assertEqual(inductor_debug.get_kernel_information_jsons(), {})
+        finally:
+            inductor_debug.get_kernel_information_jsons().clear()
+            inductor_debug.get_kernel_information_jsons().update(
+                previous_kernel_information_jsons
+            )
+
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/78457")
     def test_mem_leak(self):
         """Checks that there's no memory leak when using profiler with CUDA"""

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1012,6 +1012,60 @@ class TestProfiler(TestCase):
             [(9, 16, [(0, 0, 4), (5, 8, 8)])],
         )
 
+    def test_build_flow_mapping_supports_sparse_flow_ids(self):
+        flow_id = 1_000_000_000
+        trace = {
+            "traceEvents": [
+                {
+                    "name": "aten::add",
+                    "cat": "cpu_op",
+                    "ph": "X",
+                    "ts": 0,
+                    "dur": 5,
+                    "tid": 1,
+                    "args": {},
+                },
+                {
+                    "name": "ac2g",
+                    "cat": "ac2g",
+                    "ph": "s",
+                    "id": flow_id,
+                    "ts": 5,
+                    "tid": 1,
+                    "args": {},
+                },
+                {
+                    "name": "triton_poi_fused_add_0",
+                    "cat": "kernel",
+                    "ph": "X",
+                    "ts": 10,
+                    "dur": 7,
+                    "tid": 2,
+                    "args": {},
+                },
+                {
+                    "name": "ac2g",
+                    "cat": "ac2g",
+                    "ph": "f",
+                    "id": flow_id,
+                    "ts": 17,
+                    "tid": 2,
+                    "args": {},
+                },
+            ]
+        }
+
+        prof = _profile()
+        prof._assign_uniq_id_to_event(trace)
+
+        src2dst, dst2src = prof._build_flow_mapping(
+            trace,
+            [trace["traceEvents"][1], trace["traceEvents"][3]],
+        )
+
+        self.assertEqual(src2dst, {0: 2})
+        self.assertEqual(dst2src, {2: 0})
+
     def test_add_inductor_kernel_stack_to_chrome_trace(self):
         import torch._inductor.debug as inductor_debug
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -212,12 +212,10 @@ class TestProfilerCUDA(TestCase):
                 event.get("args", {}).get("stack")
                 for event in trace["traceEvents"]
                 if event.get("cat") == "kernel"
-                and event.get("name", "").startswith("triton_")
             ]
             self.assertTrue(
                 any(stack for stack in kernel_stacks),
-                "Expected a generated Triton kernel in the exported trace to "
-                "carry a stack",
+                "Expected a generated kernel in the exported trace to carry a stack",
             )
             self.assertEqual(inductor_debug.get_kernel_information_jsons(), {})
         finally:
@@ -1245,6 +1243,58 @@ class TestProfiler(TestCase):
                     },
                     {
                         "name": kernel_name,
+                        "cat": "kernel",
+                        "ph": "X",
+                        "ts": 20,
+                        "dur": 3,
+                        "tid": 2,
+                        "args": {"External id": 6},
+                    },
+                ]
+            }
+
+            prof = _profile()
+            updated_trace = prof.add_to_chrome_trace(trace)
+
+            self.assertEqual(updated_trace["traceEvents"][2]["args"]["stack"], stack)
+
+    def test_add_inductor_kernel_stack_to_chrome_trace_by_external_id_without_triton_kernel_name(
+        self,
+    ):
+        kernel_name = "triton_poi_fused_add_0"
+        stack = ["model.py:7 in forward"]
+        kernel_information_jsons = {
+            str(("Torch-Compiled Region: 0/0", False)): {
+                kernel_name + ":1": {
+                    "stack_traces": stack,
+                    "post_grad_nodes": ["add"],
+                    "pre_grad_nodes": ["add"],
+                }
+            }
+        }
+        with self._kernel_information_jsons(kernel_information_jsons):
+            trace = {
+                "traceEvents": [
+                    {
+                        "name": "Torch-Compiled Region: 0/0",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "hipLaunchKernel",
+                        "cat": "cuda_runtime",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {"External id": 6},
+                    },
+                    {
+                        "name": "kernel",
                         "cat": "kernel",
                         "ph": "X",
                         "ts": 20,

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1012,6 +1012,134 @@ class TestProfiler(TestCase):
             [(9, 16, [(0, 0, 4), (5, 8, 8)])],
         )
 
+    def test_add_inductor_kernel_stack_to_chrome_trace(self):
+        import torch._inductor.debug as inductor_debug
+
+        kernel_name = "triton_poi_fused_add_0"
+        stack = ["model.py:7 in forward"]
+        prev_kernel_information_jsons = inductor_debug._kernel_information_jsons
+        inductor_debug._kernel_information_jsons = {
+            str(("Torch-Compiled Region: 0/0", False)): {
+                kernel_name: {
+                    "stack_traces": stack,
+                    "post_grad_nodes": ["add"],
+                    "pre_grad_nodes": ["add"],
+                }
+            }
+        }
+        try:
+            trace = {
+                "traceEvents": [
+                    {
+                        "name": "Torch-Compiled Region: 0/0",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "aten::add",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "ac2g",
+                        "cat": "ac2g",
+                        "ph": "s",
+                        "id": 0,
+                        "ts": 15,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": kernel_name,
+                        "cat": "cuda_driver",
+                        "ph": "X",
+                        "ts": 20,
+                        "dur": 7,
+                        "tid": 2,
+                        "args": {},
+                    },
+                    {
+                        "name": "ac2g",
+                        "cat": "ac2g",
+                        "ph": "f",
+                        "id": 0,
+                        "ts": 27,
+                        "tid": 2,
+                        "args": {},
+                    },
+                ]
+            }
+
+            prof = _profile()
+            updated_trace = prof.add_to_chrome_trace(trace)
+
+            self.assertEqual(updated_trace["traceEvents"][3]["args"]["stack"], stack)
+        finally:
+            inductor_debug._kernel_information_jsons = prev_kernel_information_jsons
+
+    def test_add_inductor_kernel_stack_to_chrome_trace_by_external_id(self):
+        import torch._inductor.debug as inductor_debug
+
+        kernel_name = "triton_poi_fused_add_0"
+        stack = ["model.py:7 in forward"]
+        prev_kernel_information_jsons = inductor_debug._kernel_information_jsons
+        inductor_debug._kernel_information_jsons = {
+            str(("Torch-Compiled Region: 0/0", False)): {
+                kernel_name + ":1": {
+                    "stack_traces": stack,
+                    "post_grad_nodes": ["add"],
+                    "pre_grad_nodes": ["add"],
+                }
+            }
+        }
+        try:
+            trace = {
+                "traceEvents": [
+                    {
+                        "name": "Torch-Compiled Region: 0/0",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": kernel_name,
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {"External id": 6},
+                    },
+                    {
+                        "name": kernel_name,
+                        "cat": "kernel",
+                        "ph": "X",
+                        "ts": 20,
+                        "dur": 3,
+                        "tid": 2,
+                        "args": {"External id": 6},
+                    },
+                ]
+            }
+
+            prof = _profile()
+            updated_trace = prof.add_to_chrome_trace(trace)
+
+            self.assertEqual(updated_trace["traceEvents"][2]["args"]["stack"], stack)
+        finally:
+            inductor_debug._kernel_information_jsons = prev_kernel_information_jsons
+
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."
     )

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F841
 
 import collections
+import contextlib
 import copy
 import gc
 import gzip
@@ -773,6 +774,20 @@ class TestProfilerITT(TestCase):
 
 @instantiate_parametrized_tests
 class TestProfiler(TestCase):
+    @contextlib.contextmanager
+    def _kernel_information_jsons(self, kernel_information_jsons):
+        import torch._inductor.debug as inductor_debug
+
+        previous = copy.deepcopy(inductor_debug.get_kernel_information_jsons())
+        current = inductor_debug.get_kernel_information_jsons()
+        current.clear()
+        current.update(kernel_information_jsons)
+        try:
+            yield
+        finally:
+            current.clear()
+            current.update(previous)
+
     @skipIfTorchDynamo("native ctypes/CUPTI probe; nothing to compile")
     @parametrize("version", [1, 2])
     def test_cupti_monitor_buffer_pool_reuse(self, version):
@@ -1066,13 +1081,16 @@ class TestProfiler(TestCase):
         self.assertEqual(src2dst, {0: 2})
         self.assertEqual(dst2src, {2: 0})
 
-    def test_add_inductor_kernel_stack_to_chrome_trace(self):
-        import torch._inductor.debug as inductor_debug
+    def test_maybe_triton_call_uses_inductor_prefix(self):
+        prof = _profile()
 
+        self.assertTrue(prof._maybe_triton_call("triton_poi_fused_add_0"))
+        self.assertFalse(prof._maybe_triton_call("not_triton_related"))
+
+    def test_add_inductor_kernel_stack_to_chrome_trace(self):
         kernel_name = "triton_poi_fused_add_0"
         stack = ["model.py:7 in forward"]
-        prev_kernel_information_jsons = inductor_debug._kernel_information_jsons
-        inductor_debug._kernel_information_jsons = {
+        kernel_information_jsons = {
             str(("Torch-Compiled Region: 0/0", False)): {
                 kernel_name: {
                     "stack_traces": stack,
@@ -1081,7 +1099,7 @@ class TestProfiler(TestCase):
                 }
             }
         }
-        try:
+        with self._kernel_information_jsons(kernel_information_jsons):
             trace = {
                 "traceEvents": [
                     {
@@ -1136,16 +1154,11 @@ class TestProfiler(TestCase):
             updated_trace = prof.add_to_chrome_trace(trace)
 
             self.assertEqual(updated_trace["traceEvents"][3]["args"]["stack"], stack)
-        finally:
-            inductor_debug._kernel_information_jsons = prev_kernel_information_jsons
 
     def test_add_inductor_kernel_stack_to_chrome_trace_by_external_id(self):
-        import torch._inductor.debug as inductor_debug
-
         kernel_name = "triton_poi_fused_add_0"
         stack = ["model.py:7 in forward"]
-        prev_kernel_information_jsons = inductor_debug._kernel_information_jsons
-        inductor_debug._kernel_information_jsons = {
+        kernel_information_jsons = {
             str(("Torch-Compiled Region: 0/0", False)): {
                 kernel_name + ":1": {
                     "stack_traces": stack,
@@ -1154,7 +1167,7 @@ class TestProfiler(TestCase):
                 }
             }
         }
-        try:
+        with self._kernel_information_jsons(kernel_information_jsons):
             trace = {
                 "traceEvents": [
                     {
@@ -1191,8 +1204,159 @@ class TestProfiler(TestCase):
             updated_trace = prof.add_to_chrome_trace(trace)
 
             self.assertEqual(updated_trace["traceEvents"][2]["args"]["stack"], stack)
-        finally:
-            inductor_debug._kernel_information_jsons = prev_kernel_information_jsons
+
+    def test_add_inductor_kernel_stack_to_chrome_trace_skips_missing_stack(self):
+        kernel_name = "triton_poi_fused_add_0"
+        kernel_information_jsons = {
+            str(("Torch-Compiled Region: 0/0", False)): {
+                kernel_name: {
+                    "post_grad_nodes": ["add"],
+                    "pre_grad_nodes": ["add"],
+                }
+            }
+        }
+        with self._kernel_information_jsons(kernel_information_jsons):
+            trace = {
+                "traceEvents": [
+                    {
+                        "name": "Torch-Compiled Region: 0/0",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "aten::add",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "ac2g",
+                        "cat": "ac2g",
+                        "ph": "s",
+                        "id": 0,
+                        "ts": 15,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": kernel_name,
+                        "cat": "kernel",
+                        "ph": "X",
+                        "ts": 20,
+                        "dur": 7,
+                        "tid": 2,
+                        "args": {},
+                    },
+                    {
+                        "name": "ac2g",
+                        "cat": "ac2g",
+                        "ph": "f",
+                        "id": 0,
+                        "ts": 27,
+                        "tid": 2,
+                        "args": {},
+                    },
+                ]
+            }
+
+            prof = _profile()
+            updated_trace = prof.add_to_chrome_trace(trace)
+
+            self.assertNotIn("stack", updated_trace["traceEvents"][3]["args"])
+
+    def test_add_inductor_kernel_stack_to_chrome_trace_backward_quoted_region(self):
+        compile_name = "Torch-Compiled Region: odd', True) name"
+        kernel_name = "triton_poi_fused_mul_0"
+        stack = ["model.py:9 in backward"]
+        kernel_information_jsons = {
+            str((compile_name + "_backward_0", True)): {
+                kernel_name: {
+                    "stack_traces": stack,
+                    "post_grad_nodes": ["mul"],
+                    "pre_grad_nodes": ["mul"],
+                }
+            }
+        }
+        with self._kernel_information_jsons(kernel_information_jsons):
+            trace = {
+                "traceEvents": [
+                    {
+                        "name": compile_name,
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "aten::add",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "fwdbwd",
+                        "cat": "fwdbwd",
+                        "ph": "s",
+                        "id": 0,
+                        "ts": 16,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "CompiledFunctionBackward",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 200,
+                        "dur": 100,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "fwdbwd",
+                        "cat": "fwdbwd",
+                        "ph": "f",
+                        "id": 0,
+                        "ts": 201,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "aten::mul",
+                        "cat": "cpu_op",
+                        "ph": "X",
+                        "ts": 210,
+                        "dur": 5,
+                        "tid": 1,
+                        "args": {"External id": 6},
+                    },
+                    {
+                        "name": kernel_name,
+                        "cat": "kernel",
+                        "ph": "X",
+                        "ts": 220,
+                        "dur": 3,
+                        "tid": 2,
+                        "args": {"External id": 6},
+                    },
+                ]
+            }
+
+            prof = _profile()
+            updated_trace = prof.add_to_chrome_trace(trace)
+
+            self.assertEqual(updated_trace["traceEvents"][6]["args"]["stack"], stack)
 
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1474,7 +1474,10 @@ class FxGraphHashDetails:
         # in the CompiledFxGraph, so it must be part of the cache key.
         # Note: the "trace" prefix is excluded from _cache_config_ignore_prefix,
         # so we add this explicitly.
-        self.provenance_tracking_level = config.trace.provenance_tracking_level
+        self.provenance_tracking_level = config.effective_provenance_tracking_level()
+        self.provenance_tracking_to_timeline = (
+            config.trace.provenance_tracking_to_timeline
+        )
 
         # Factory ops with dtype=None are lowered using the ambient default dtype,
         # so cached code compiled under one default dtype is not valid under another.
@@ -3525,7 +3528,7 @@ end
                 if config.aot_inductor.package:
                     generated_files.append(output_so)
 
-        if config.trace.provenance_tracking_level != 0:
+        if config.effective_provenance_tracking_level() != 0:
             kernel_info = torch._inductor.debug.create_kernel_information_json()
             kernel_info_json = os.path.join(
                 wrapper_path_operator.parent, "kernel_information.json"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -44,7 +44,7 @@ from torch.utils._sympy.functions import Max, Min
 from torch.utils._sympy.singleton_int import SingletonInt
 from torch.utils._sympy.symbol import symbol_is_type, SymT
 
-from .. import async_compile, config, ir
+from .. import async_compile, config, debug as inductor_debug, ir
 from ..codecache import output_code_log
 from ..ir import IRNode, ReinterpretView
 from ..runtime import triton_heuristics
@@ -2037,11 +2037,18 @@ class PythonWrapperCodegen(CodeGen):
             # doesn't know the memory is still needed and might reuse it.
             ending = f".clone(){ending}"
 
+        if config.trace.provenance_tracking_to_timeline:
+            wrapper_name = self.define_extern_kernel_profile_wrapper(
+                kernel_name, self.next_kernel_suffix()
+            )
+        else:
+            wrapper_name = kernel_name
+
         if no_return:
-            self.writeline(f"{self.declare}{kernel_name}({', '.join(args)}){ending}")
+            self.writeline(f"{self.declare}{wrapper_name}({', '.join(args)}){ending}")
         else:
             self.writeline(
-                f"{self.declare}{output_name} = {kernel_name}({', '.join(args)}){ending}"
+                f"{self.declare}{output_name} = {wrapper_name}({', '.join(args)}){ending}"
             )
             if (
                 self.supports_intermediate_hooks
@@ -2072,9 +2079,15 @@ class PythonWrapperCodegen(CodeGen):
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")
-        args.append(f"out={out_view if out_view else out}")
+        args.append(f"out={out_view or out}")
         with debug_printer_manager:
-            self.writeline(f"{kernel}({', '.join(args)})")
+            if config.trace.provenance_tracking_to_timeline:
+                wrapper_name = self.define_extern_kernel_profile_wrapper(
+                    kernel, self.next_kernel_suffix()
+                )
+            else:
+                wrapper_name = kernel
+            self.writeline(f"{wrapper_name}({', '.join(args)})")
 
     def _generate_tma_descriptor_call_experimental(self, desc, apply_size_hints=False):
         dims = desc.dims
@@ -2136,14 +2149,31 @@ class PythonWrapperCodegen(CodeGen):
         kwargs,
         device,
     ):
+        orig_python_kernel_name = python_kernel_name
+        if config.trace.provenance_tracking_to_timeline:
+            python_kernel_name = self.define_extern_kernel_profile_wrapper(
+                python_kernel_name, self.next_kernel_suffix()
+            )
         line = f"{python_kernel_name}({','.join(map(str, inputs))}"
-        if python_kernel_name.startswith("aten.scatter_reduce"):
+        if orig_python_kernel_name.startswith("aten.scatter_reduce"):
             line += ", ".join([""] + kwargs)
         else:
             if reduce:
                 line += f", reduce={repr(reduce)}"
         line += ")"
         self.writeline(line)
+
+    def define_extern_kernel_profile_wrapper(self, kernel_name: str, suffix: str):
+        wrapper_kernel_name = re.sub(
+            r"\W",
+            "_",
+            f"extern_kernels_{kernel_name}_{suffix}",
+        )
+        inductor_debug.alias_kernel_provenance(kernel_name, wrapper_kernel_name)
+        self.header.splice(f"def {wrapper_kernel_name}(*args, **kwargs):")
+        with self.header.indent():
+            self.header.splice(f"return {kernel_name}(*args, **kwargs)")
+        return wrapper_kernel_name
 
     def generate_index_put_fallback(self, node: ir.IndexPutFallback) -> None:
         # Collect index tensors into a list.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2164,6 +2164,7 @@ class PythonWrapperCodegen(CodeGen):
         self.writeline(line)
 
     def define_extern_kernel_profile_wrapper(self, kernel_name: str, suffix: str):
+        """Wrap extern calls so profiler events use names with provenance metadata."""
         wrapper_kernel_name = re.sub(
             r"\W",
             "_",
@@ -2172,6 +2173,9 @@ class PythonWrapperCodegen(CodeGen):
         inductor_debug.alias_kernel_provenance(kernel_name, wrapper_kernel_name)
         self.header.splice(f"def {wrapper_kernel_name}(*args, **kwargs):")
         with self.header.indent():
+            self.header.splice(
+                "# Extra indirection is only enabled for profiler timeline provenance."
+            )
             self.header.splice(f"return {kernel_name}(*args, **kwargs)")
         return wrapper_kernel_name
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -72,7 +72,9 @@ from torch._inductor.cudagraph_utils import (
 )
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.debug import (
+    create_kernel_information_json,
     create_mapping_pre_post_grad_nodes,
+    get_kernel_information_jsons,
     save_args_for_compile_fx_inner,
 )
 from torch._inductor.output_code import (
@@ -838,12 +840,21 @@ def compile_fx_inner(
             "inductor_compile",
             is_backward=kwargs["is_backward"],
         )
-        return wrap_compiler_debug(_compile_fx_inner, compiler_name="inductor")(
+        compiled_graph = wrap_compiler_debug(
+            _compile_fx_inner, compiler_name="inductor"
+        )(
             gm,
             example_inputs,
             compile_region_name=compile_region_name,
             **kwargs,
         )
+        if config.trace.provenance_tracking_to_timeline:
+            compile_id = torch._guards.CompileContext.current_compile_id()
+            kernel_information_jsons = get_kernel_information_jsons()
+            key = str((f"Torch-Compiled Region: {compile_id}", kwargs["is_backward"]))
+            if key not in kernel_information_jsons:
+                kernel_information_jsons[key] = create_kernel_information_json()
+        return compiled_graph
 
 
 @time_and_log(attr="compilation time (in seconds)")

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1455,7 +1455,7 @@ class _InProcessFxCompile(FxCompile):
                     },
                     payload_fn=lambda: inductor_post_grad_graph_str,
                 )
-                if config.trace.provenance_tracking_level != 0:
+                if config.effective_provenance_tracking_level() != 0:
                     provenance_tracking_json = (
                         torch.fx.traceback.get_graph_provenance_json(gm.graph)
                     )
@@ -1665,7 +1665,7 @@ class _InProcessFxCompile(FxCompile):
                     # Dump provenance artifacts for debugging trace
                     inductor_provenance_tracking_node_mappings = None
                     inductor_kernel_stack_trace_str = None
-                    if config.trace.provenance_tracking_level != 0:
+                    if config.effective_provenance_tracking_level() != 0:
                         inductor_provenance_tracking_node_mappings = json.dumps(
                             torch._inductor.debug.dump_inductor_provenance_info()
                         )
@@ -2740,7 +2740,7 @@ def run_pre_grad_passes(
     )
     torch._inductor.debug._pre_grad_graph_id = id(model_.graph)
 
-    if config.trace.provenance_tracking_level == 1:
+    if config.effective_provenance_tracking_level() == 1:
         for node in model_.graph.nodes:
             if node.stack_trace:
                 torch._inductor.debug._inductor_pre_grad_node_stack_trace[node.name] = (
@@ -2993,7 +2993,7 @@ def _compile_fx_main(
         _use_lazy_graph_module(dynamo_config.use_lazy_graph_module),
         enable_python_dispatcher(),
         torch.fx.traceback.preserve_node_meta(
-            config.trace.provenance_tracking_level == 1
+            config.effective_provenance_tracking_level() == 1
         ),
         torch._inductor.debug.reset_provenance_globals(),
     ):
@@ -3417,7 +3417,7 @@ def autograd_cache_key(
         _use_lazy_graph_module(dynamo_config.use_lazy_graph_module),
         enable_python_dispatcher(),
         torch.fx.traceback.preserve_node_meta(
-            config.trace.provenance_tracking_level == 1
+            config.effective_provenance_tracking_level() == 1
         ),
         torch._inductor.debug.reset_provenance_globals(),
         V.set_fake_mode(fake_mode),

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2818,6 +2818,18 @@ class trace:
 
     log_autotuning_results = os.environ.get("LOG_AUTOTUNE_RESULTS", "0") == "1"
 
+    # Add Inductor kernel stack traces back into exported PyTorch profiler timelines.
+    provenance_tracking_to_timeline = (
+        os.environ.get("TORCH_COMPILE_DEBUG_EXTEND", "0") == "1"
+    )
+
+    # Maximum number of trace events to process in profiler timeline post-processing.
+    # If the trace exceeds this limit, provenance tracking will be skipped to avoid OOM.
+    # Set to 0 to disable this protection.
+    provenance_tracking_max_events: int = int(
+        os.environ.get("TORCH_COMPILE_DEBUG_MAX_EVENTS", "500000")
+    )
+
     # Save mapping info from inductor generated kernel to post_grad/pre_grad fx nodes
     # Levels:
     #   0 - disabled (default)
@@ -2831,6 +2843,8 @@ class trace:
             "INDUCTOR_PROVENANCE", os.environ.get("TORCH_COMPILE_DEBUG", "0")
         )
     )
+    if provenance_tracking_to_timeline:
+        provenance_tracking_level = max(provenance_tracking_level, 1)
 
 
 _save_config_ignore: list[str] = [

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2843,8 +2843,6 @@ class trace:
             "INDUCTOR_PROVENANCE", os.environ.get("TORCH_COMPILE_DEBUG", "0")
         )
     )
-    if provenance_tracking_to_timeline:
-        provenance_tracking_level = max(provenance_tracking_level, 1)
 
 
 def effective_provenance_tracking_level() -> int:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2847,6 +2847,12 @@ class trace:
         provenance_tracking_level = max(provenance_tracking_level, 1)
 
 
+def effective_provenance_tracking_level() -> int:
+    if trace.provenance_tracking_to_timeline:
+        return max(trace.provenance_tracking_level, 1)
+    return trace.provenance_tracking_level
+
+
 _save_config_ignore: list[str] = [
     # workaround: "Can't pickle <function ...>"
     "trace.upload_tar",

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -389,6 +389,7 @@ def reset_provenance_globals() -> Iterator[None]:
     global _inductor_triton_kernel_to_post_grad_node_info
     global _inductor_pre_grad_node_stack_trace
     global _inductor_kernel_stack_trace
+    global _kernel_information_jsons
     global _inductor_kernel_provenance_debug_handle
 
     # Store original values
@@ -401,6 +402,7 @@ def reset_provenance_globals() -> Iterator[None]:
         _inductor_pre_grad_node_stack_trace.copy()
     )
     original_inductor_kernel_stack_trace = _inductor_kernel_stack_trace.copy()
+    original_kernel_information_jsons = _kernel_information_jsons.copy()
     original_inductor_kernel_provenance_debug_handle = (
         _inductor_kernel_provenance_debug_handle
     )
@@ -411,6 +413,7 @@ def reset_provenance_globals() -> Iterator[None]:
     _inductor_triton_kernel_to_post_grad_node_info = {}
     _inductor_pre_grad_node_stack_trace = {}
     _inductor_kernel_stack_trace = {}
+    _kernel_information_jsons = {}
     _inductor_kernel_provenance_debug_handle = 0
 
     try:
@@ -423,6 +426,7 @@ def reset_provenance_globals() -> Iterator[None]:
             original_triton_kernel_to_post_grad_node_info
         )
         _inductor_kernel_stack_trace = original_inductor_kernel_stack_trace
+        _kernel_information_jsons = original_kernel_information_jsons
         _inductor_pre_grad_node_stack_trace = (
             original_inductor_pre_grad_node_stack_trace
         )

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -355,7 +355,24 @@ _inductor_triton_kernel_to_post_grad_node_info: dict[str, list[str]] = {}
 _pre_grad_graph_id: int | None = None
 _inductor_pre_grad_node_stack_trace: dict[str, str] = {}
 _inductor_kernel_stack_trace: dict[str, list[str]] = {}
+_kernel_information_jsons: dict[str, dict[str, Any]] = {}
 _inductor_kernel_provenance_debug_handle: int = 0
+
+
+def get_kernel_information_jsons() -> dict[str, dict[str, Any]]:
+    return _kernel_information_jsons
+
+
+def alias_kernel_provenance(original_kernel_name: str, alias_kernel_name: str) -> None:
+    """Expose existing kernel provenance under an additional generated name."""
+    if original_kernel_name in _inductor_kernel_stack_trace:
+        _inductor_kernel_stack_trace[alias_kernel_name] = _inductor_kernel_stack_trace[
+            original_kernel_name
+        ]
+    if original_kernel_name in _inductor_triton_kernel_to_post_grad_node_info:
+        _inductor_triton_kernel_to_post_grad_node_info[alias_kernel_name] = (
+            _inductor_triton_kernel_to_post_grad_node_info[original_kernel_name]
+        )
 
 
 def reset_inductor_kernel_provenance_debug_handle() -> None:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -1176,7 +1176,7 @@ def set_kernel_post_grad_provenance_tracing(
     Returns a unique int debug handler for each call to this function.
     """
 
-    if config.trace.provenance_tracking_level == 0:
+    if config.effective_provenance_tracking_level() == 0:
         return None
 
     try:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -389,7 +389,6 @@ def reset_provenance_globals() -> Iterator[None]:
     global _inductor_triton_kernel_to_post_grad_node_info
     global _inductor_pre_grad_node_stack_trace
     global _inductor_kernel_stack_trace
-    global _kernel_information_jsons
     global _inductor_kernel_provenance_debug_handle
 
     # Store original values
@@ -402,7 +401,6 @@ def reset_provenance_globals() -> Iterator[None]:
         _inductor_pre_grad_node_stack_trace.copy()
     )
     original_inductor_kernel_stack_trace = _inductor_kernel_stack_trace.copy()
-    original_kernel_information_jsons = _kernel_information_jsons.copy()
     original_inductor_kernel_provenance_debug_handle = (
         _inductor_kernel_provenance_debug_handle
     )
@@ -413,7 +411,9 @@ def reset_provenance_globals() -> Iterator[None]:
     _inductor_triton_kernel_to_post_grad_node_info = {}
     _inductor_pre_grad_node_stack_trace = {}
     _inductor_kernel_stack_trace = {}
-    _kernel_information_jsons = {}
+    # Kernel timeline information is populated from compile_fx_inner while this
+    # context is active.  It must outlive the reset scope so the profiler can
+    # consume it during export_chrome_trace, which then clears it.
     _inductor_kernel_provenance_debug_handle = 0
 
     try:
@@ -426,7 +426,6 @@ def reset_provenance_globals() -> Iterator[None]:
             original_triton_kernel_to_post_grad_node_info
         )
         _inductor_kernel_stack_trace = original_inductor_kernel_stack_trace
-        _kernel_information_jsons = original_kernel_information_jsons
         _inductor_pre_grad_node_stack_trace = (
             original_inductor_pre_grad_node_stack_trace
         )

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -160,7 +160,7 @@ def _transfer_meta(
 
     # Transfer metadata after pattern matching occurs.
     # Copies _COPY_META_FIELDS, stack_trace, and (if missing) val/tensor_meta.
-    if config.trace.provenance_tracking_level == 1:
+    if config.effective_provenance_tracking_level() == 1:
         new_from_node = new_meta.get("from_node", []).copy()
         new_from_node.append(NodeSource(old_node, pass_name, NodeSourceAction.REPLACE))
         new_meta.update(

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -609,10 +609,7 @@ class profile:
         if not flow_events:
             return {}, {}
 
-        flow_count = max(int(event["id"]) for event in flow_events)
-        flow_pair: list[list[int | None]] = [
-            [None, None] for _ in range(flow_count + 1)
-        ]
+        flow_pair: dict[int, list[int | None]] = {}
         prev_event = None
         for event in trace["traceEvents"]:
             if (
@@ -624,16 +621,18 @@ class profile:
             if event.get("ph") == "s":
                 if prev_event is None:
                     continue
-                flow_pair[int(event["id"])][0] = prev_event["uid"]
+                pair = flow_pair.setdefault(int(event["id"]), [None, None])
+                pair[0] = prev_event["uid"]
             elif event.get("ph") == "f":
                 if prev_event is None:
                     continue
-                flow_pair[int(event["id"])][1] = prev_event["uid"]
+                pair = flow_pair.setdefault(int(event["id"]), [None, None])
+                pair[1] = prev_event["uid"]
             prev_event = event
 
         src2dst = {}
         dst2src = {}
-        for src, dst in flow_pair:
+        for src, dst in flow_pair.values():
             if src is None or dst is None:
                 continue
             src2dst[src] = dst

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -118,7 +118,7 @@ class _ProfilerStats:
     function_events_build_tree_call_duration_us: int = 0
 
 
-class EventItem:
+class _EventItem:
     def __init__(self, event):
         self.e = event
         self.start, self.end = self._interval_of()
@@ -129,7 +129,7 @@ class EventItem:
         return start, start + duration
 
 
-def find_events_covered_in(
+def _find_events_covered_in(
     events: list[dict[str, Any]],
     top_level_events: list[dict[str, Any]],
 ):
@@ -139,7 +139,7 @@ def find_events_covered_in(
     """
     top_level_by_tid = defaultdict(list)
     for event in top_level_events:
-        top_level_by_tid[event["tid"]].append(EventItem(event))
+        top_level_by_tid[event["tid"]].append(_EventItem(event))
     for tid in top_level_by_tid:
         top_level_by_tid[tid] = sorted(top_level_by_tid[tid], key=lambda x: x.start)
     starts_by_tid = {
@@ -163,7 +163,7 @@ def find_events_covered_in(
         tid = event.get("tid")
         if tid not in top_level_by_tid:
             continue
-        item = EventItem(event)
+        item = _EventItem(event)
         event_items = top_level_by_tid[tid]
         idx = bisect_left(starts_by_tid[tid], item.start) - 1
         if idx < 0 or idx >= len(event_items):
@@ -698,9 +698,9 @@ class profile:
             ):
                 extern_events.append(event)
 
-        compiled_events = sorted(compiled_events, key=lambda x: EventItem(x).start)
-        ops_in_compile_region = find_events_covered_in(real_events, compiled_events)
-        ops_in_extern_region = find_events_covered_in(real_events, extern_events)
+        compiled_events = sorted(compiled_events, key=lambda x: _EventItem(x).start)
+        ops_in_compile_region = _find_events_covered_in(real_events, compiled_events)
+        ops_in_extern_region = _find_events_covered_in(real_events, extern_events)
         src2dst, dst2src = self._build_flow_mapping(trace, flow_events)
         kernel_uids_by_external_id = defaultdict(list)
         for event in real_events:
@@ -712,9 +712,9 @@ class profile:
 
         def _related_compile_region(compile_event):
             src_event = uid_2_events[dst2src[compile_event["uid"]]]
-            src_item = EventItem(src_event)
+            src_item = _EventItem(src_event)
             for event in reversed(compiled_events):
-                region_item = EventItem(event)
+                region_item = _EventItem(event)
                 if (
                     src_item.start > region_item.start
                     and src_item.end < region_item.end

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1,7 +1,10 @@
 # mypy: allow-untyped-defs
 import copy
+import json
 import logging
+import re
 import uuid
+from bisect import bisect_left
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -83,6 +86,11 @@ except ImportError:
 # useful for fast python checks to reduce latency
 _is_profiler_enabled: bool = False
 
+# https://github.com/pytorch/kineto/blob/a054a4be0db117c579a21747debf19c863631f26/libkineto/src/output_json.cpp#L559
+# Kernel and CUDA runtime API events are connected by ac2g; forward and backward
+# ATen ops are connected by fwdbwd.
+_profile_flow_types = {"fwdbwd", "ac2g"}
+
 
 def _set_is_profiler_enabled(enable: bool):
     global _is_profiler_enabled
@@ -108,6 +116,62 @@ class _ProfilerStats:
     profiler_disable_call_duration_us: int = 0
     parse_kineto_call_duration_us: int = 0
     function_events_build_tree_call_duration_us: int = 0
+
+
+class EventItem:
+    def __init__(self, event):
+        self.e = event
+        self.start, self.end = self._interval_of()
+
+    def _interval_of(self):
+        start = self.e["ts"]
+        duration = self.e.get("dur", 0)
+        return start, start + duration
+
+
+def find_events_covered_in(
+    events: list[dict[str, Any]],
+    top_level_events: list[dict[str, Any]],
+):
+    """Find events covered in top level events.
+
+    Returns a dict mapping top-level event uid to covered event uids.
+    """
+    top_level_by_tid = defaultdict(list)
+    for event in top_level_events:
+        top_level_by_tid[event["tid"]].append(EventItem(event))
+    for tid in top_level_by_tid:
+        top_level_by_tid[tid] = sorted(top_level_by_tid[tid], key=lambda x: x.start)
+    starts_by_tid = {
+        tid: [event.start for event in event_items]
+        for tid, event_items in top_level_by_tid.items()
+    }
+    top_level_id_to_events = defaultdict(set)
+
+    for event in events:
+        if event.get("cat") not in {
+            "cuda_runtime",
+            "cuLaunchKernel",
+            "cpu_op",
+            "cuda_driver",
+            "gpu_memset",
+            "python_function",
+        }:
+            continue
+        if "CallFrom" in event.get("args", {}):
+            continue
+        tid = event.get("tid")
+        if tid not in top_level_by_tid:
+            continue
+        item = EventItem(event)
+        event_items = top_level_by_tid[tid]
+        idx = bisect_left(starts_by_tid[tid], item.start) - 1
+        if idx < 0 or idx >= len(event_items):
+            continue
+        top_level_item = event_items[idx]
+        if top_level_item.start <= item.start and item.end <= top_level_item.end:
+            top_level_id_to_events[top_level_item.e["uid"]].add(event["uid"])
+    return top_level_id_to_events
 
 
 class profile:
@@ -530,6 +594,245 @@ class profile:
 
     table.__doc__ = EventList.table.__doc__
 
+    def _assign_uniq_id_to_event(self, trace):
+        if trace.get("uid_assigned"):
+            return {event["uid"]: event for event in trace["traceEvents"]}
+        uid_2_events = {}
+        for uid, event in enumerate(trace["traceEvents"]):
+            event["uid"] = uid
+            uid_2_events[uid] = event
+        trace["uid_assigned"] = True
+        return uid_2_events
+
+    def _build_flow_mapping(self, trace, flow_events):
+        """Build src/dst event mappings from profiler flow events."""
+        if not flow_events:
+            return {}, {}
+
+        flow_count = max(int(event["id"]) for event in flow_events)
+        flow_pair: list[list[int | None]] = [
+            [None, None] for _ in range(flow_count + 1)
+        ]
+        prev_event = None
+        for event in trace["traceEvents"]:
+            if (
+                event.get("name") not in _profile_flow_types
+                and event.get("cat") not in _profile_flow_types
+            ):
+                prev_event = event
+                continue
+            if event.get("ph") == "s":
+                if prev_event is None:
+                    continue
+                flow_pair[int(event["id"])][0] = prev_event["uid"]
+            elif event.get("ph") == "f":
+                if prev_event is None:
+                    continue
+                flow_pair[int(event["id"])][1] = prev_event["uid"]
+            prev_event = event
+
+        src2dst = {}
+        dst2src = {}
+        for src, dst in flow_pair:
+            if src is None or dst is None:
+                continue
+            src2dst[src] = dst
+            dst2src[dst] = src
+        return src2dst, dst2src
+
+    def _maybe_triton_call(self, kernel_name):
+        return "triton_" in kernel_name
+
+    def _has_kernel_info(self, compile_info, graph_key, kernel_name):
+        graph_info = compile_info.get(graph_key, {})
+        if kernel_name in graph_info:
+            return True
+        kernel_prefix = kernel_name + ":"
+        return any(name.startswith(kernel_prefix) for name in graph_info)
+
+    def _maybe_extern_call(self, event, compile_info, fwd_key, bw_keys, need_bw):
+        kernel_name = event["name"]
+        return not self._has_kernel_info(compile_info, fwd_key, kernel_name) and (
+            not need_bw
+            or all(
+                not self._has_kernel_info(compile_info, bw_key, kernel_name)
+                for bw_key in bw_keys
+            )
+        )
+
+    def add_to_chrome_trace(self, origin_trace):
+        """Add Inductor kernel stack information to a Chrome trace."""
+        from torch._inductor.debug import get_kernel_information_jsons
+
+        compile_linenos = get_kernel_information_jsons()
+        if not compile_linenos:
+            return origin_trace
+
+        trace = origin_trace
+        uid_2_events = self._assign_uniq_id_to_event(trace)
+
+        real_events = []
+        flow_events = []
+        compiled_events = []
+        extern_events = []
+        for event in trace["traceEvents"]:
+            name = event.get("name", "")
+            cat = event.get("cat", "")
+            if name in _profile_flow_types or cat in _profile_flow_types:
+                flow_events.append(event)
+                continue
+
+            real_events.append(event)
+            if cat == "cpu_op" and (
+                name == "CompiledFunctionBackward" or "Torch-Compiled Region" in name
+            ):
+                compiled_events.append(event)
+            if (
+                name
+                and "extern_kernels" in name
+                and cat
+                in (
+                    "cpu_op",
+                    "python_function",
+                )
+            ):
+                extern_events.append(event)
+
+        compiled_events = sorted(compiled_events, key=lambda x: EventItem(x).start)
+        ops_in_compile_region = find_events_covered_in(real_events, compiled_events)
+        ops_in_extern_region = find_events_covered_in(real_events, extern_events)
+        src2dst, dst2src = self._build_flow_mapping(trace, flow_events)
+        kernel_uids_by_external_id = defaultdict(list)
+        for event in real_events:
+            if event.get("cat") != "kernel":
+                continue
+            external_id = event.get("args", {}).get("External id")
+            if external_id is not None:
+                kernel_uids_by_external_id[external_id].append(event["uid"])
+
+        def _related_compile_region(compile_event):
+            src_event = uid_2_events[dst2src[compile_event["uid"]]]
+            src_item = EventItem(src_event)
+            for event in reversed(compiled_events):
+                region_item = EventItem(event)
+                if (
+                    src_item.start > region_item.start
+                    and src_item.end < region_item.end
+                ):
+                    return event
+            raise ValueError(f"Cannot find compile region for {compile_event}")
+
+        def _backward_graph_keys(compile_info, compile_name):
+            bw_graph_key = str((compile_name, True))
+            keys = [bw_graph_key]
+            if bw_graph_key in compile_info:
+                return keys
+
+            prefix = compile_name + "_"
+            for key, info in compile_info.items():
+                if not key.endswith(", True)") or not info:
+                    continue
+                graph_name = key.split("', True)", 1)[0].removeprefix("('")
+                if graph_name.startswith(prefix):
+                    keys.append(key)
+            return keys
+
+        def _stack_for_kernel(compile_info, graph_key, kernel_name):
+            graph_info = compile_info.get(graph_key, {})
+            kernel_info = graph_info.get(kernel_name)
+            if kernel_info is None:
+                kernel_prefix = kernel_name + ":"
+                for name, info in graph_info.items():
+                    if name.startswith(kernel_prefix):
+                        kernel_info = info
+                        break
+            if isinstance(kernel_info, dict):
+                return kernel_info.get("stack_traces")
+            return kernel_info
+
+        def _assign_stack(event, compile_info, fwd_key, bw_keys, kernel_name):
+            event.setdefault("args", {})
+            event["args"]["stack"] = None
+            for bw_key in bw_keys:
+                stack = _stack_for_kernel(compile_info, bw_key, kernel_name)
+                if stack is not None:
+                    event["args"]["stack"] = stack
+                    return
+            event["args"]["stack"] = _stack_for_kernel(
+                compile_info, fwd_key, kernel_name
+            )
+
+        def _kernel_events_for_op(op_id):
+            if op_id in src2dst:
+                return [uid_2_events[src2dst[op_id]]]
+            external_id = uid_2_events[op_id].get("args", {}).get("External id")
+            if external_id is None:
+                return []
+            return [
+                uid_2_events[kernel_uid]
+                for kernel_uid in kernel_uids_by_external_id.get(external_id, [])
+            ]
+
+        def _extern_kernel_name(name):
+            match = re.search(r"\b(extern\w+)\s*,", name)
+            return match.group(1) if match else name
+
+        for compile_func_id, scoped_ops in ops_in_compile_region.items():
+            compile_event = uid_2_events[compile_func_id]
+            compile_name = compile_event["name"]
+            need_bw = "Backward" in compile_name
+
+            if need_bw:
+                try:
+                    compile_name = _related_compile_region(compile_event)["name"]
+                except ValueError:
+                    continue
+
+            fw_graph_key = str((compile_name, False))
+            bw_graph_keys = _backward_graph_keys(compile_linenos, compile_name)
+            if fw_graph_key not in compile_linenos and all(
+                bw_graph_key not in compile_linenos for bw_graph_key in bw_graph_keys
+            ):
+                continue
+
+            for op_id in scoped_ops:
+                kernel_events = _kernel_events_for_op(op_id)
+                if not kernel_events:
+                    continue
+                for kernel_event in kernel_events:
+                    if self._maybe_extern_call(
+                        kernel_event,
+                        compile_linenos,
+                        fw_graph_key,
+                        bw_graph_keys,
+                        need_bw,
+                    ):
+                        for extern_call, related_ops in ops_in_extern_region.items():
+                            if op_id in related_ops:
+                                extern_event = uid_2_events[extern_call]
+                                _assign_stack(
+                                    kernel_event,
+                                    compile_linenos,
+                                    fw_graph_key,
+                                    bw_graph_keys,
+                                    _extern_kernel_name(extern_event.get("name", "")),
+                                )
+                    elif not self._maybe_triton_call(kernel_event.get("name", "")):
+                        log.warning(
+                            "Kernel %s cannot be recognized as a custom kernel or triton kernel. "
+                            "Please try profile with stack=True.",
+                            kernel_event.get("name", ""),
+                        )
+                    else:
+                        _assign_stack(
+                            kernel_event,
+                            compile_linenos,
+                            fw_graph_key,
+                            bw_graph_keys,
+                            kernel_event.get("name", ""),
+                        )
+        return trace
+
     def export_chrome_trace(self, path, metadata=None, use_python_export=False):
         """
         Exports the collected trace in Chrome JSON format. If kineto is enabled, only
@@ -546,6 +849,49 @@ class profile:
         else:
             self._ensure_function_events()
             return self._function_events.export_chrome_trace(path)  # type: ignore[union-attr]
+
+        import torch._inductor.config as inductor_config
+
+        if inductor_config.trace.provenance_tracking_to_timeline:
+            with open(path) as f:
+                trace = json.load(f)
+
+            num_events = len(trace.get("traceEvents", []))
+            max_events = inductor_config.trace.provenance_tracking_max_events
+            if max_events > 0 and num_events > max_events:
+                log.warning(
+                    "Skipping provenance tracking: trace has %d events "
+                    "(exceeds limit of %d). Set TORCH_COMPILE_DEBUG_MAX_EVENTS=0 "
+                    "to disable this protection or increase the limit.",
+                    num_events,
+                    max_events,
+                )
+                return
+
+            if not inductor_config.triton.unique_kernel_names:
+                log.warning(
+                    "Profiling trace does not contain Triton kernel stack traces "
+                    "because TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=0."
+                )
+            if inductor_config.cpp_wrapper:
+                log.warning(
+                    "Profiling trace does not contain compiled kernel stack traces "
+                    "because cpp_wrapper is enabled."
+                )
+                return
+            try:
+                log.info("Add stack trace to compiled kernel.")
+                trace = self.add_to_chrome_trace(trace)
+                with open(path, "w") as f:
+                    json.dump(trace, f, indent=1)
+            except MemoryError:
+                log.error(
+                    "MemoryError during add_to_chrome_trace. "
+                    "Try increasing TORCH_COMPILE_DEBUG_MAX_EVENTS or disable provenance tracking."
+                )
+                raise
+            except Exception:
+                log.exception("Failed to add stack trace to compiled kernel")
 
     export_chrome_trace.__doc__ = EventList.export_chrome_trace.__doc__
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import ast
 import copy
 import json
 import logging
@@ -640,7 +641,7 @@ class profile:
         return src2dst, dst2src
 
     def _maybe_triton_call(self, kernel_name):
-        return "triton_" in kernel_name
+        return kernel_name.startswith("triton_")
 
     def _has_kernel_info(self, compile_info, graph_key, kernel_name):
         graph_info = compile_info.get(graph_key, {})
@@ -698,6 +699,8 @@ class profile:
                 extern_events.append(event)
 
         compiled_events = sorted(compiled_events, key=lambda x: _EventItem(x).start)
+        compiled_event_items = [_EventItem(event) for event in compiled_events]
+        compiled_event_starts = [item.start for item in compiled_event_items]
         ops_in_compile_region = _find_events_covered_in(real_events, compiled_events)
         ops_in_extern_region = _find_events_covered_in(real_events, extern_events)
         src2dst, dst2src = self._build_flow_mapping(trace, flow_events)
@@ -712,14 +715,30 @@ class profile:
         def _related_compile_region(compile_event):
             src_event = uid_2_events[dst2src[compile_event["uid"]]]
             src_item = _EventItem(src_event)
-            for event in reversed(compiled_events):
-                region_item = _EventItem(event)
+            idx = bisect_left(compiled_event_starts, src_item.start) - 1
+            while idx >= 0:
+                region_item = compiled_event_items[idx]
                 if (
                     src_item.start > region_item.start
                     and src_item.end < region_item.end
                 ):
-                    return event
+                    return region_item.e
+                idx -= 1
             raise ValueError(f"Cannot find compile region for {compile_event}")
+
+        def _parse_compile_region_key(key):
+            try:
+                parsed_key = ast.literal_eval(key)
+            except (SyntaxError, ValueError):
+                return None
+            if (
+                not isinstance(parsed_key, tuple)
+                or len(parsed_key) != 2
+                or not isinstance(parsed_key[0], str)
+                or not isinstance(parsed_key[1], bool)
+            ):
+                return None
+            return parsed_key
 
         def _backward_graph_keys(compile_info, compile_name):
             bw_graph_key = str((compile_name, True))
@@ -729,10 +748,13 @@ class profile:
 
             prefix = compile_name + "_"
             for key, info in compile_info.items():
-                if not key.endswith(", True)") or not info:
+                if not info:
                     continue
-                graph_name = key.split("', True)", 1)[0].removeprefix("('")
-                if graph_name.startswith(prefix):
+                parsed_key = _parse_compile_region_key(key)
+                if parsed_key is None:
+                    continue
+                graph_name, is_backward = parsed_key
+                if is_backward and graph_name.startswith(prefix):
                     keys.append(key)
             return keys
 
@@ -750,16 +772,14 @@ class profile:
             return kernel_info
 
         def _assign_stack(event, compile_info, fwd_key, bw_keys, kernel_name):
-            event.setdefault("args", {})
-            event["args"]["stack"] = None
             for bw_key in bw_keys:
                 stack = _stack_for_kernel(compile_info, bw_key, kernel_name)
                 if stack is not None:
-                    event["args"]["stack"] = stack
+                    event.setdefault("args", {})["stack"] = stack
                     return
-            event["args"]["stack"] = _stack_for_kernel(
-                compile_info, fwd_key, kernel_name
-            )
+            stack = _stack_for_kernel(compile_info, fwd_key, kernel_name)
+            if stack is not None:
+                event.setdefault("args", {})["stack"] = stack
 
         def _kernel_events_for_op(op_id):
             if op_id in src2dst:
@@ -852,6 +872,9 @@ class profile:
         import torch._inductor.config as inductor_config
 
         if inductor_config.trace.provenance_tracking_to_timeline:
+            # Kineto owns the initial serialization path.  Re-read the exported
+            # trace here so timeline provenance stays decoupled from Kineto's
+            # JSON writer and remains a Python-only post-processing step.
             with open(path) as f:
                 trace = json.load(f)
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -716,6 +716,8 @@ class profile:
             src_event = uid_2_events[dst2src[compile_event["uid"]]]
             src_item = _EventItem(src_event)
             idx = bisect_left(compiled_event_starts, src_item.start) - 1
+            # Compiled regions are expected to be nearly nested around their
+            # source events, so the nearest preceding region usually matches.
             while idx >= 0:
                 region_item = compiled_event_items[idx]
                 if (
@@ -872,48 +874,53 @@ class profile:
         import torch._inductor.config as inductor_config
 
         if inductor_config.trace.provenance_tracking_to_timeline:
-            # Kineto owns the initial serialization path.  Re-read the exported
-            # trace here so timeline provenance stays decoupled from Kineto's
-            # JSON writer and remains a Python-only post-processing step.
-            with open(path) as f:
-                trace = json.load(f)
+            from torch._inductor.debug import get_kernel_information_jsons
 
-            num_events = len(trace.get("traceEvents", []))
-            max_events = inductor_config.trace.provenance_tracking_max_events
-            if max_events > 0 and num_events > max_events:
-                log.warning(
-                    "Skipping provenance tracking: trace has %d events "
-                    "(exceeds limit of %d). Set TORCH_COMPILE_DEBUG_MAX_EVENTS=0 "
-                    "to disable this protection or increase the limit.",
-                    num_events,
-                    max_events,
-                )
-                return
-
-            if not inductor_config.triton.unique_kernel_names:
-                log.warning(
-                    "Profiling trace does not contain Triton kernel stack traces "
-                    "because TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=0."
-                )
-            if inductor_config.cpp_wrapper:
-                log.warning(
-                    "Profiling trace does not contain compiled kernel stack traces "
-                    "because cpp_wrapper is enabled."
-                )
-                return
             try:
-                log.info("Add stack trace to compiled kernel.")
-                trace = self.add_to_chrome_trace(trace)
-                with open(path, "w") as f:
-                    json.dump(trace, f, indent=1)
-            except MemoryError:
-                log.error(
-                    "MemoryError during add_to_chrome_trace. "
-                    "Try increasing TORCH_COMPILE_DEBUG_MAX_EVENTS or disable provenance tracking."
-                )
-                raise
-            except Exception:
-                log.exception("Failed to add stack trace to compiled kernel")
+                # Kineto owns the initial serialization path.  Re-read the exported
+                # trace here so timeline provenance stays decoupled from Kineto's
+                # JSON writer and remains a Python-only post-processing step.
+                with open(path) as f:
+                    trace = json.load(f)
+
+                num_events = len(trace.get("traceEvents", []))
+                max_events = inductor_config.trace.provenance_tracking_max_events
+                if max_events > 0 and num_events > max_events:
+                    log.warning(
+                        "Skipping provenance tracking: trace has %d events "
+                        "(exceeds limit of %d). Set TORCH_COMPILE_DEBUG_MAX_EVENTS=0 "
+                        "to disable this protection or increase the limit.",
+                        num_events,
+                        max_events,
+                    )
+                    return
+
+                if not inductor_config.triton.unique_kernel_names:
+                    log.warning(
+                        "Profiling trace does not contain Triton kernel stack traces "
+                        "because TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=0."
+                    )
+                if inductor_config.cpp_wrapper:
+                    log.warning(
+                        "Profiling trace does not contain compiled kernel stack traces "
+                        "because cpp_wrapper is enabled."
+                    )
+                    return
+                try:
+                    log.info("Add stack trace to compiled kernel.")
+                    trace = self.add_to_chrome_trace(trace)
+                    with open(path, "w") as f:
+                        json.dump(trace, f, indent=1)
+                except MemoryError:
+                    log.error(
+                        "MemoryError during add_to_chrome_trace. "
+                        "Try increasing TORCH_COMPILE_DEBUG_MAX_EVENTS or disable provenance tracking."
+                    )
+                    raise
+                except Exception:
+                    log.exception("Failed to add stack trace to compiled kernel")
+            finally:
+                get_kernel_information_jsons().clear()
 
     export_chrome_trace.__doc__ = EventList.export_chrome_trace.__doc__
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -760,6 +760,11 @@ class profile:
                     keys.append(key)
             return keys
 
+        def _stack_from_kernel_info(kernel_info):
+            if isinstance(kernel_info, dict):
+                return kernel_info.get("stack_traces")
+            return kernel_info
+
         def _stack_for_kernel(compile_info, graph_key, kernel_name):
             graph_info = compile_info.get(graph_key, {})
             kernel_info = graph_info.get(kernel_name)
@@ -769,19 +774,44 @@ class profile:
                     if name.startswith(kernel_prefix):
                         kernel_info = info
                         break
-            if isinstance(kernel_info, dict):
-                return kernel_info.get("stack_traces")
-            return kernel_info
+            return _stack_from_kernel_info(kernel_info)
+
+        def _single_stack_for_graph(compile_info, graph_key):
+            stacks = [
+                stack
+                for stack in (
+                    _stack_from_kernel_info(kernel_info)
+                    for kernel_info in compile_info.get(graph_key, {}).values()
+                )
+                if stack is not None
+            ]
+            if len(stacks) == 1:
+                return stacks[0]
+            return None
 
         def _assign_stack(event, compile_info, fwd_key, bw_keys, kernel_name):
             for bw_key in bw_keys:
                 stack = _stack_for_kernel(compile_info, bw_key, kernel_name)
                 if stack is not None:
                     event.setdefault("args", {})["stack"] = stack
-                    return
+                    return True
             stack = _stack_for_kernel(compile_info, fwd_key, kernel_name)
             if stack is not None:
                 event.setdefault("args", {})["stack"] = stack
+                return True
+            return False
+
+        def _assign_single_stack(event, compile_info, fwd_key, bw_keys):
+            for bw_key in bw_keys:
+                stack = _single_stack_for_graph(compile_info, bw_key)
+                if stack is not None:
+                    event.setdefault("args", {})["stack"] = stack
+                    return True
+            stack = _single_stack_for_graph(compile_info, fwd_key)
+            if stack is not None:
+                event.setdefault("args", {})["stack"] = stack
+                return True
+            return False
 
         def _kernel_events_for_op(op_id):
             if op_id in src2dst:
@@ -821,6 +851,8 @@ class profile:
                 if not kernel_events:
                     continue
                 for kernel_event in kernel_events:
+                    assigned_stack = False
+                    warn_if_unrecognized = False
                     if self._maybe_extern_call(
                         kernel_event,
                         compile_linenos,
@@ -831,25 +863,42 @@ class profile:
                         for extern_call, related_ops in ops_in_extern_region.items():
                             if op_id in related_ops:
                                 extern_event = uid_2_events[extern_call]
-                                _assign_stack(
+                                assigned_stack = _assign_stack(
                                     kernel_event,
                                     compile_linenos,
                                     fw_graph_key,
                                     bw_graph_keys,
                                     _extern_kernel_name(extern_event.get("name", "")),
                                 )
+                                if assigned_stack:
+                                    break
+                        if not assigned_stack:
+                            assigned_stack = _assign_single_stack(
+                                kernel_event,
+                                compile_linenos,
+                                fw_graph_key,
+                                bw_graph_keys,
+                            )
                     elif not self._maybe_triton_call(kernel_event.get("name", "")):
-                        log.warning(
-                            "Kernel %s cannot be recognized as a custom kernel or triton kernel. "
-                            "Please try profile with stack=True.",
-                            kernel_event.get("name", ""),
-                        )
-                    else:
-                        _assign_stack(
+                        warn_if_unrecognized = True
+                        assigned_stack = _assign_single_stack(
                             kernel_event,
                             compile_linenos,
                             fw_graph_key,
                             bw_graph_keys,
+                        )
+                    else:
+                        assigned_stack = _assign_stack(
+                            kernel_event,
+                            compile_linenos,
+                            fw_graph_key,
+                            bw_graph_keys,
+                            kernel_event.get("name", ""),
+                        )
+                    if not assigned_stack and warn_if_unrecognized:
+                        log.warning(
+                            "Kernel %s cannot be recognized as a custom kernel or triton kernel. "
+                            "Please try profile with stack=True.",
                             kernel_event.get("name", ""),
                         )
         return trace

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -204,14 +204,18 @@ struct MetadataBase {
     }
   }
 
-  void addMetadata(const std::string& key, const std::string& value) {
+  void addMetadata(
+      const std::string& key,
+      const std::string& value,
+      bool quote = false) {
     if (kinetoActivity_ && !value.empty() && value != "\"\"") {
       torch::profiler::impl::kineto::addMetadata(
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<torch::profiler::impl::kineto::activity_t*>(
               kinetoActivity_),
           key,
-          value);
+          value,
+          quote);
     }
   }
 
@@ -244,6 +248,12 @@ struct AddTensorboardFields : public MetadataBase {
         parent = parent->parent_.lock();
       }
       this->addMetadata("Python parent id", parent_id.value_or("null"));
+      if (i.caller_.line_no_ > 0) {
+        this->addMetadata(
+            "CallFrom",
+            fmt::format("{}:{}", i.caller_.filename_.str(), i.caller_.line_no_),
+            /*quote=*/true);
+      }
     });
   }
 

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -120,9 +120,14 @@ const DeviceAndResource kineto_ids() {
 void addMetadata(
     activity_t* activity,
     const std::string& key,
-    const std::string& value) {
+    const std::string& value,
+    bool quote) {
 #ifdef USE_KINETO
-  activity->addMetadata(key, value);
+  if (quote) {
+    activity->addMetadataQuoted(key, value);
+  } else {
+    activity->addMetadata(key, value);
+  }
 #endif // USE_KINETO
 }
 

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -62,7 +62,8 @@ struct activity_t;
 void addMetadata(
     activity_t* activity,
     const std::string& key,
-    const std::string& value);
+    const std::string& value,
+    bool quote = false);
 
 // Wraps: libkineto::CpuTraceBuffer
 struct TraceWrapper {

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -3050,7 +3050,7 @@ def make_fx(
         _allow_fake_constant,
         _error_on_data_dependent_ops,
         record_stack_traces=record_stack_traces
-        or config.trace.provenance_tracking_level == 1,
+        or config.effective_provenance_tracking_level() == 1,
         proxy_module_inputs=proxy_module_inputs,
         _disable_torch_fn_metadata_mode=_disable_torch_fn_metadata_mode,
     )

--- a/torch/fx/passes/graph_transform_observer.py
+++ b/torch/fx/passes/graph_transform_observer.py
@@ -45,7 +45,7 @@ class GraphTransformObserver:
 
         self.active = (
             self.log_url is not None
-            or inductor_config.trace.provenance_tracking_level == 1
+            or inductor_config.effective_provenance_tracking_level() == 1
         )
 
         if self.active:


### PR DESCRIPTION
## Summary
- Attach optional Inductor kernel provenance to profiler Chrome traces so generated CUDA/Triton kernels can carry source stack context in timeline args.
- Thread Triton and extern-kernel metadata through Inductor debug/profiling paths and Kineto shim event arguments.
- Add profiler tests covering stack injection and trace post-processing behavior.

## Test Plan
- `spin quicklint -a -- --skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,PYREFLY`
- `git diff --cached --check`
- `/opt/homebrew/bin/python3.10 -m py_compile test/profiler/test_profiler.py torch/_inductor/codegen/wrapper.py torch/_inductor/compile_fx.py torch/_inductor/config.py torch/_inductor/debug.py torch/autograd/profiler.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo