### PR TITLE
Add opt-in cross-stream segment reclaim to CUDA allocator

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -89,6 +89,9 @@ void CUDAAllocatorConfig::parseArgs(const std::string& env) {
     } else if (key == "graph_capture_record_stream_reuse") {
       i = parseGraphCaptureRecordStreamReuse(tokenizer, i);
       used_native_specific_option = true;
+    } else if (key == "cross_stream_reclaim") {
+      i = parseCrossStreamReclaim(tokenizer, i);
+      used_native_specific_option = true;
     } else if (key == "per_process_memory_fraction") {
       i = parsePerProcessMemoryFraction(tokenizer, i);
       used_native_specific_option = true;
@@ -135,6 +138,14 @@ size_t CUDAAllocatorConfig::parseGraphCaptureRecordStreamReuse(
     size_t i) {
   tokenizer.checkToken(++i, ":");
   m_graph_capture_record_stream_reuse = tokenizer.toBool(++i);
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parseCrossStreamReclaim(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  m_cross_stream_reclaim = tokenizer.toBool(++i);
   return i;
 }
 

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -62,6 +62,12 @@ class C10_CUDA_API CUDAAllocatorConfig {
     return instance().m_graph_capture_record_stream_reuse;
   }
 
+  // Allow malloc to reclaim an idle whole segment from another stream's cache
+  // (with a cross-stream ordering dependency) before cudaMalloc.
+  static bool cross_stream_reclaim() {
+    return instance().m_cross_stream_reclaim;
+  }
+
   static double per_process_memory_fraction() {
     return instance().m_per_process_memory_fraction;
   }
@@ -167,6 +173,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
         "release_lock_on_hipmalloc",
         "pinned_use_hip_host_register",
         "graph_capture_record_stream_reuse",
+        "cross_stream_reclaim",
         "pinned_reserve_segment_size_mb",
         "pinned_num_register_threads",
         "per_process_memory_fraction",
@@ -196,6 +203,9 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parseGraphCaptureRecordStreamReuse(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
+  size_t parseCrossStreamReclaim(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
   size_t parsePerProcessMemoryFraction(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
@@ -217,6 +227,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
   std::atomic<bool> m_release_lock_on_cudamalloc{false};
   std::atomic<bool> m_pinned_use_cuda_host_register{false};
   std::atomic<bool> m_graph_capture_record_stream_reuse{false};
+  std::atomic<bool> m_cross_stream_reclaim{false};
   std::atomic<double> m_per_process_memory_fraction{1.0};
   std::atomic<bool> m_pinned_free_catch_all{false};
   // When true, throw OOM error before calling cudaMalloc if allocation would

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1754,7 +1754,12 @@ class DeviceCachingAllocator {
         // Search pool
         get_free_block(params)
         // Trigger callbacks and retry search
-        || (trigger_free_memory_callbacks(params) && get_free_block(params));
+        || (trigger_free_memory_callbacks(params) && get_free_block(params))
+        // Reclaim an idle segment from another stream before cudaMalloc; skip
+        // under expandable_segments, where no block is reclaimable.
+        ||
+        (CUDAAllocatorConfig::cross_stream_reclaim() &&
+         !is_expandable_segments_active && get_free_block_cross_stream(params));
 
     // Can't reuse an existing block; try to get a new one.
     if (!block_found) {
@@ -3704,6 +3709,17 @@ class DeviceCachingAllocator {
     }
   }
 
+  // Reject oversized reuse: no >=max_split_size block for a smaller request,
+  // and bounded rounding for large ones.
+  static bool acceptable_block_size(size_t request_size, size_t block_size) {
+    const auto max_split = AcceleratorAllocatorConfig::max_split_size();
+    if (request_size < max_split) {
+      return block_size < max_split;
+    }
+    return block_size < request_size +
+        AcceleratorAllocatorConfig::max_non_split_rounding_size();
+  }
+
   bool get_free_block(AllocParams& p) {
     BlockPool& pool = *p.pool;
 
@@ -3750,17 +3766,45 @@ class DeviceCachingAllocator {
       }
     }
 
-    // Do not return an oversized block for a large request
-    if ((p.size() < AcceleratorAllocatorConfig::max_split_size()) &&
-        ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()))
-      return false;
-    // Allow oversized block size to be rounded up but within a limit
-    if ((p.size() >= AcceleratorAllocatorConfig::max_split_size()) &&
-        ((*it)->size >=
-         p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
+    if (!acceptable_block_size(p.size(), (*it)->size))
       return false;
     p.block = *it;
     pool.erase_from_blocks(p.block);
+    return true;
+  }
+
+  // Reclaim a whole idle segment from another stream, order the new stream
+  // after the donor's prior work, and re-key it. Only whole, non-expandable
+  // segments are eligible, so each segment stays single-stream.
+  bool get_free_block_cross_stream(AllocParams& p) {
+    BlockPool& pool = *p.pool;
+    // Graph pools and capture have their own per-stream assumptions.
+    if (pool.owner_PrivatePool || is_capture_context()) {
+      return false;
+    }
+
+    const size_t size = p.size();
+    Block* best = nullptr;
+    // No cross-stream sorted lookup; linear best-fit scan (slow path only).
+    // Skip splittable fits so a small request can't migrate a large segment.
+    for (Block* b : pool.blocks) {
+      if (b->stream == p.stream() || b->expandable_segment_ || b->is_split() ||
+          b->size < size || !acceptable_block_size(size, b->size) ||
+          should_split(b, size, p.is_expandable_segments_active)) {
+        continue;
+      }
+      if (!best || b->size < best->size) {
+        best = b;
+      }
+    }
+    if (!best) {
+      return false;
+    }
+
+    insert_cross_stream_dependency(best->stream, p.stream(), best->device);
+    pool.erase_from_blocks(best);
+    best->stream = p.stream();
+    p.block = best;
     return true;
   }
 
@@ -4279,6 +4323,19 @@ class DeviceCachingAllocator {
     // Leak the event pool to avoid shutdown issues.
     static auto* event_pool = new EventPool();
     return event_pool->get(idx);
+  }
+
+  // Make `consumer` wait for `producer`'s currently-queued work, so memory
+  // freed on `producer` is safe to reuse on `consumer`. The event can be
+  // recycled at once: cudaStreamWaitEvent snapshots its state now.
+  void insert_cross_stream_dependency(
+      cudaStream_t producer,
+      cudaStream_t consumer,
+      c10::DeviceIndex device) {
+    c10::cuda::CUDAGuard device_guard(device);
+    EventPool::Event event = create_event_internal(device);
+    C10_CUDA_CHECK(cudaEventRecord(*event, producer));
+    C10_CUDA_CHECK(cudaStreamWaitEvent(consumer, *event));
   }
 
   void synchronize_and_free_events(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5667,6 +5667,41 @@ class TestCudaAllocator(TestCase):
                 f"expandable_segments:{EXPANDABLE_SEGMENTS}"
             )
 
+    @serialTest()
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "cross_stream_reclaim is native-allocator only"
+    )
+    def test_cross_stream_reclaim(self):
+        # With the flag on, a malloc on stream B reclaims a whole idle segment
+        # freed on stream A, ordered safely behind A's pending work.
+        try:
+            torch.cuda.empty_cache()
+            torch.cuda.memory._set_allocator_settings(
+                "expandable_segments:False,cross_stream_reclaim:True"
+            )
+            n = 8 * 1024 * 1024  # whole, exact-size-class segment
+
+            s_a = torch.cuda.Stream()
+            with torch.cuda.stream(s_a):
+                a = torch.empty(n, dtype=torch.int8, device="cuda")
+                a.fill_(1)
+                torch.cuda._sleep(int(50 * get_cycles_per_ms()))  # delay A's write
+                ptr_a = a.data_ptr()
+            del a
+
+            s_b = torch.cuda.Stream()
+            with torch.cuda.stream(s_b):
+                b = torch.empty(n, dtype=torch.int8, device="cuda")
+                b.fill_(2)
+            torch.cuda.synchronize()
+
+            self.assertEqual(b.data_ptr(), ptr_a)  # reclaimed, not cudaMalloc'd
+            self.assertTrue((b == 2).all().item())  # A's delayed write didn't race B
+        finally:
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS},cross_stream_reclaim:False"
+            )
+
     def test_allocator_settings(self):
         def power2_div(size, div_factor):
             pow2 = 1


### PR DESCRIPTION
This PR allows the allocator to reclaim a whole idle segment cached under another stream, cutting `cudaMalloc`/OOM in multi-stream workloads.