### PR TITLE
Skip NVFP4 in NVGEMM scaled GEMM

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -87,6 +87,12 @@ def _nvgemm_config(**overrides):
     return cfg
 
 
+def _expected_failure_nvgemm_packed_fp4(fn):
+    # PyTorch stores two FP4 values per byte, but cutlass_api only sees a scalar
+    # FP4 dtype here and cannot represent the packed tensor layout.
+    return unittest.expectedFailure(fn)
+
+
 # TODO(nikhilap): Remove Blackwell restriction once cutlass_api includes H100 kernels
 @unittest.skipIf(
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
@@ -312,6 +318,7 @@ class TestNVUniversalGemm(TestCase):
             (64, 64, 512),
         ),
     )
+    @_expected_failure_nvgemm_packed_fp4
     def test_scaled_gemm_nvf4_padded_scales(self, m, n, k):
         """Test NVF4 with padded scales (M or N < 128).
 
@@ -370,6 +377,7 @@ class TestNVUniversalGemm(TestCase):
             (512, 256, 1024),
         ),
     )
+    @_expected_failure_nvgemm_packed_fp4
     def test_scaled_gemm_nvf4(self, out_dtype, layout_a, m, n, k):
         """Test NVF4 (Float4 + Float8E4M3FN scales, block_size=16) with NVGEMM backend."""
         packed_k = k // 2

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: inductor"]
 
-import importlib.util
 import unittest
 from collections.abc import Callable, Iterator
 
@@ -340,25 +339,6 @@ class TestRuntimeEstimation(TestCase):
 
 class TestFP4Support(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
-
-    @unittest.skipIf(
-        not torch.cuda.is_available()
-        or importlib.util.find_spec("cutlass_api") is None,
-        "requires CUDA and cutlass_api",
-    )
-    def test_ensure_fp4_dtype_registered(self):
-        """_ensure_fp4_dtype_registered should patch cutlass_api for FP4."""
-        from torch._inductor.utils import _ensure_fp4_dtype_registered
-
-        _ensure_fp4_dtype_registered()
-        import cutlass
-        import cutlass_api.utils
-
-        result = cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
-        self.assertEqual(result, cutlass.Float4E2M1FN)
-
-        result_fp32 = cutlass_api.utils.cutlass_type_from_torch_type(torch.float32)
-        self.assertEqual(result_fp32, cutlass.Float32)
 
     def test_rand_strided_fp4(self):
         """rand_strided should produce valid FP4 tensors."""

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -115,10 +115,6 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         """Create a function to run the NVIDIA Universal GEMM kernel."""
         import cutlass_api
 
-        from torch._inductor.utils import _ensure_fp4_dtype_registered
-
-        _ensure_fp4_dtype_registered()
-
         args = self._create_gemm_arguments(cutlass_api, input_tensors, out)
 
         if self._compiled_artifact is None:
@@ -348,10 +344,6 @@ def _add_nv_gemm_choices_impl(
     """
     import cutlass_api
 
-    from torch._inductor.utils import _ensure_fp4_dtype_registered
-
-    _ensure_fp4_dtype_registered()
-
     from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
         get_compatible_kernels,
     )
@@ -549,6 +541,15 @@ def add_nv_universal_scaled_gemm_choices(
         return
 
     mat_a, mat_b, scale_a, scale_b = input_nodes[:4]
+    if (
+        mat_a.get_dtype() == torch.float4_e2m1fn_x2
+        or mat_b.get_dtype() == torch.float4_e2m1fn_x2
+    ):
+        log.debug(
+            "cutlass_api cannot represent PyTorch's packed FP4 tensor layout; "
+            "skipping NVIDIA Universal Scaled GEMM choices"
+        )
+        return
 
     scale_type_a, swizzle_type_a = infer_scale_swizzle_ir(mat_a, scale_a)
     scale_type_b, swizzle_type_b = infer_scale_swizzle_ir(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2303,33 +2303,7 @@ def ensure_nv_universal_gemm_available() -> bool:
         available = importlib.util.find_spec("cutlass_api") is not None
     except ImportError:
         return False
-    if available:
-        _ensure_fp4_dtype_registered()
     return available
-
-
-def _ensure_fp4_dtype_registered():
-    """Patch cutlass_api to handle torch.float4_e2m1fn_x2 -> cutlass.Float4E2M1FN.
-
-    NOTE: cutlass_api doesn't natively map this dtype. We patch the lookup function
-    in-place so all callers (including TensorWrapper) pick up the change.
-    Remove once cutlass_api adds native FP4 support.
-    """
-    import cutlass_api.utils
-
-    try:
-        cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
-    except (KeyError, AttributeError):
-        import cutlass
-
-        _orig = cutlass_api.utils.cutlass_type_from_torch_type
-
-        def _patched(dtype):
-            if dtype == torch.float4_e2m1fn_x2:
-                return cutlass.Float4E2M1FN
-            return _orig(dtype)
-
-        cutlass_api.utils.cutlass_type_from_torch_type = _patched
 
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
`cutlass_api` models FP4 as a scalar dtype at this boundary, while PyTorch represents `torch.float4_e2m1fn_x2` as two FP4 values packed into one byte. 
Registering the packed PyTorch dtype as CUTLASS FP4 made NVGEMM see an invalid dtype/layout pairing.

Make `ensure_nv_universal_gemm_available` side-effect-free, skip NVGEMM scaled-GEMM choices for packed FP4 operands, and keep the NVF4 coverage as expected failures until cutlass_api can represent the packed layout.

Authored with GPT-5.5 xhigh.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo