### PR TITLE
Fix batch_norm abort on inputs with fewer than 2 dims

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -568,6 +568,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
   const Tensor& running_mean = running_mean_opt.value_or(Tensor());
   const Tensor& running_var = running_var_opt.value_or(Tensor());
 
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "batch_norm: expected input to have at least 2 dimensions (N, C, ...), but got input of dimension ",
+      input.dim());
+
   auto num_features = input.sym_sizes()[1];
 
   if (input.sym_numel() == 0) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5183,6 +5183,14 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, running_var, bias=Parameter(torch.rand(size)))
 
+    def test_batchnorm_raises_error_if_input_has_fewer_than_two_dims(self):
+        # at::batch_norm reads the channel dim (index 1) and previously aborted
+        # with an internal assert when the input was 1-D. It should raise a
+        # user-facing error instead.
+        input = torch.randn(1)
+        with self.assertRaisesRegex(RuntimeError, "at least 2 dimensions"):
+            torch.batch_norm(input, None, None, None, None, True, 0.5, 1e-5, True)
+
     def test_batchnorm_raises_error_if_running_var_or_running_mean_have_forward_grad(self):
         args = (
             torch.randn(3, 2, 5),  # input


### PR DESCRIPTION
## Summary

Calling the C++ API `at::batch_norm` (or `torch.batch_norm`) with a fewer-than-2-D input aborted the process with an internal `SmallVector` assertion instead of raising a user-facing error. This adds an input rank check so invalid input is rejected cleanly.

Fixes #186212 

## Root cause

Batch norm requires the channel dimension at index 1, i.e. an input of rank >= 2 `(N, C, ...)`. The public entry point never validated this:
- `_batch_norm_impl_index` reads `input.sym_sizes()[1]`. For a 1-D input this is out of bounds, but `ArrayRef::operator[]` does not bounds-check in release builds, so it silently read garbage. With `weight`/`bias`/ `running_*` left as `nullopt`, the `check_dims_match_num_input_features` validations were skipped and the bad value went unnoticed.
- Execution then reached `batch_norm_cpu`, where `ndim == 1` makes `DimVector reduce_dims(ndim - 1)` zero-length, and `reduce_dims[0] = 0;` indexes element 0 of a size-0 `SmallVector`. `SmallVector::operator[]` asserts `idx < size()`, which calls `abort()`.

The assertion was only a symptom; the defect was the missing rank check at the public entry point.

## Fix

Add `TORCH_CHECK(input.dim() >= 2, ...)` in `_batch_norm_impl_index`, before the `input.sym_sizes()[1]` access. This is the single dispatch choke point used by `at::batch_norm` for all backends (CPU/CUDA/cuDNN/MIOpen), so the check is device-independent and runs before backend selection. It mirrors the existing rank check in `renorm` in the same file.

Invalid input now raises a catchable `c10::Error` / Python `RuntimeError`:
```
batch_norm: expected input to have at least 2 dimensions (N, C, ...), but got input of dimension 1
```

## Tests

Added `test_batchnorm_raises_error_if_input_has_fewer_than_two_dims` in `test/test_nn.py`, alongside the existing `test_batchnorm_raises_error_*` cases. It calls the low-level `torch.batch_norm` op (which maps directly to `at::batch_norm`, the API from the bug report) with a 1-D input and the same all `None` weight/bias/running_* arguments, and asserts that a `RuntimeError` matching "at least 2 dimensions" is raised.