### PR TITLE
[ROCm][CI] Add linux.rocm.mi350.docker-cache to docker-cache-rocm

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -61,6 +61,7 @@ self-hosted-runner:
     - linux.rocm.gpu.mi210.1
     - linux.rocm.gpu.mi210.2
     - linux.rocm.mi210.docker-cache
+    - linux.rocm.mi350.docker-cache
     # gfx942 runners
     - linux.rocm.gpu.gfx942.1
     - linux.rocm.gpu.gfx942.4

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -112,6 +112,7 @@ jobs:
           else
             echo "Unexpected branch in ref_name: ${ref_name}" && exit 1
           fi
+          mkdir -p ~/pytorch-data/docker
           docker tag "${GHCR_IMAGE}" "${ECR_IMAGE}"
           # mv is atomic operation, so we use intermediate tar.tmp file to prevent read-write contention
           docker save -o ~/pytorch-data/docker/${docker_image_tag}.tar.tmp "${ECR_IMAGE}"

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -17,9 +17,9 @@ on:
         description: Workflow run id to pull artifacts from
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
+#   cancel-in-progress: true
 
 permissions:
   id-token: write
@@ -56,8 +56,7 @@ jobs:
     needs: download-docker-builds-artifacts
     strategy:
       fail-fast: false
-      matrix:
-        runner: [linux.rocm.mi210.docker-cache, linux.rocm.mi350.docker-cache]
+      matrix:        runner: [linux.rocm.mi350.docker-cache]
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux.rocm.mi210.docker-cache]
+        runner: [linux.rocm.mi210.docker-cache, linux.rocm.mi350.docker-cache]
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -56,7 +56,9 @@ jobs:
     needs: download-docker-builds-artifacts
     strategy:
       fail-fast: false
-      matrix:        runner: [linux.rocm.mi350.docker-cache]
+      matrix:
+        runner: [linux.rocm.mi350.docker-cache]
+
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"


### PR DESCRIPTION
## Summary
- Add `linux.rocm.mi350.docker-cache` to the `docker-cache-rocm` runner matrix alongside MI210.

## Test plan
- [ ] `workflow_dispatch` docker-cache-rocm on this branch with `branch=main` and a recent `docker-builds` run_id

Authored w/ assistance from cursor


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang