### PR TITLE
Advertise Python 3.15 support in wheel metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dynamic = [
     "entry-points",


### PR DESCRIPTION
## Summary

Adds the `Programming Language :: Python :: 3.15` trove classifier to the `torch` package metadata.

`requires-python` is already `>=3.10` with no upper bound, and `setup.py` only enforces a minimum version (`python_min_version = (3, 10, 0)`), so 3.15 builds/installs are already permitted. This change advertises that support in the wheel `METADATA` (and on PyPI).

## Note on Linux-only

Trove classifiers are platform-independent — they go into every wheel built from this source identically. Restricting 3.15 to **Linux-only** wheels cannot be done via this metadata; it is controlled by the release build matrices (which interpreter versions are built per platform) in `pytorch/test-infra` / `.github`.

## Test Plan

Metadata-only change, verified by inspecting the rendered classifier list:

```
grep "Python :: 3.1" pyproject.toml
```

This PR was authored with the assistance of an AI assistant.