### PR TITLE
change most HOPs to use @register_fake instad of py_impl(FakeTensorMode)

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1397,7 +1397,7 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(exp_out, out)
         self.assertEqual(x_clone, x)
 
-    def test_input_mutation_mutiple_times_fake_tensor_cahche_hit(self):
+    def test_input_mutation_mutiple_times_fake_tensor_cache_hit(self):
         @nested_compile_region
         def gn(x, y):
             x.add_(1)
@@ -1424,7 +1424,7 @@ class GraphModule(torch.nn.Module):
             return (operands[0].clone(),)
 
         with (
-            mock.patch(
+            mock.patch.dict(
                 "torch._higher_order_ops.utils.registered_hop_fake_fns",
                 {torch.ops.higher_order.invoke_subgraph: _mock_invoke_subgraph},
             ),

--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -13,9 +13,8 @@ from torch._higher_order_ops.flat_apply import (
     to_graphable,
 )
 from torch._higher_order_ops.strict_mode import strict_mode
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     PreDispatchTorchFunctionMode,
     ProxyTorchDispatchMode,
@@ -46,10 +45,9 @@ def export_tracepoint_dispatch_mode(mode, *args, **kwargs):
     return track_tensor_tree(args, proxy, constant=None, tracer=mode.tracer)
 
 
-@_export_tracepoint.py_impl(FakeTensorMode)
-def export_tracepoint_fake_tensor_mode(mode, *args, **kwargs):
-    with mode:
-        return args
+@register_fake(_export_tracepoint)
+def export_tracepoint_fake_tensor_mode(*args, **kwargs):
+    return args
 
 
 @_export_tracepoint.py_functionalize_impl

--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -45,7 +45,7 @@ def export_tracepoint_dispatch_mode(mode, *args, **kwargs):
     return track_tensor_tree(args, proxy, constant=None, tracer=mode.tracer)
 
 
-@register_fake(_export_tracepoint)
+@register_fake(_export_tracepoint, skip_cache=True)
 def export_tracepoint_fake_tensor_mode(*args, **kwargs):
     return args
 

--- a/torch/_higher_order_ops/aoti_call_delegate.py
+++ b/torch/_higher_order_ops/aoti_call_delegate.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import torch
 import torch.utils._pytree as pytree
+from torch._higher_order_ops.utils import register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -129,16 +130,14 @@ def call_delegate_proxy_torch_dispatch_mode(
     return res
 
 
-@aoti_call_delegate.py_impl(FakeTensorMode)
+@register_fake(aoti_call_delegate)
 def call_delegate_fake_tensor_mode(
-    mode: FakeTensorMode,
     lowered_module: AOTI_LOWERED_MODULE,  # type: ignore[valid-type]
     original_gm: torch.fx.GraphModule,
     weight_args: list[torch.Tensor],
     input_args: list[torch.Tensor],
 ) -> list[torch.Tensor]:
-    with mode:
-        return call_delegate_cpu(lowered_module, original_gm, weight_args, input_args)
+    return call_delegate_cpu(lowered_module, original_gm, weight_args, input_args)
 
 
 @aoti_call_delegate.py_functionalize_impl

--- a/torch/_higher_order_ops/aoti_call_delegate.py
+++ b/torch/_higher_order_ops/aoti_call_delegate.py
@@ -130,7 +130,7 @@ def call_delegate_proxy_torch_dispatch_mode(
     return res
 
 
-@register_fake(aoti_call_delegate)
+@register_fake(aoti_call_delegate, skip_cache=True)
 def call_delegate_fake_tensor_mode(
     lowered_module: AOTI_LOWERED_MODULE,  # type: ignore[valid-type]
     original_gm: torch.fx.GraphModule,

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -18,6 +18,7 @@ from torch._higher_order_ops.utils import (
     first_slice_copy_with_grad,
     materialize_as_graph,
     reenter_make_fx,
+    register_fake,
     save_values_for_backward,
     saved_values,
     split_into_chunks,
@@ -25,7 +26,6 @@ from torch._higher_order_ops.utils import (
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -858,10 +858,9 @@ def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
     )
 
 
-@associative_scan_op.py_impl(FakeTensorMode)
-def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
-    with mode:
-        return tuple(x.clone() for x in xs)
+@register_fake(associative_scan_op)
+def assoiciative_scan_fake_tensor_mode(combine_fn, xs, additional_inputs):
+    return tuple(x.clone() for x in xs)
 
 
 @associative_scan_op.py_functionalize_impl

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -858,7 +858,7 @@ def associative_scan_proxy_mode(mode, combine_fn, xs, additional_inputs):
     )
 
 
-@register_fake(associative_scan_op)
+@register_fake(associative_scan_op, skip_cache=True)
 def assoiciative_scan_fake_tensor_mode(combine_fn, xs, additional_inputs):
     return tuple(x.clone() for x in xs)
 

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -16,11 +16,11 @@ from torch._higher_order_ops.utils import (
     HopInstance,
     HopSchema,
     materialize_callable_in_args,
+    register_fake,
     unique_graph_id,
 )
 from torch._ops import HigherOrderOperator, OperatorBase, OpOverload
 from torch._prims_common import clone_preserve_strides
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -981,17 +981,15 @@ def auto_functionalized_dense(
         return (out, *result)  # type: ignore[return-value]
 
 
-@auto_functionalized.py_impl(FakeTensorMode)
+@register_fake(auto_functionalized, skip_cache=True)
 def auto_functionalized_fake(
-    mode,
     _mutable_op: OpOverload,
     **kwargs: Any,
 ) -> tuple[Any, tuple[Tensor, ...]]:
-    with mode:
-        result = auto_functionalized_dense(
-            _mutable_op, _only_clone_these_tensors=None, **kwargs
-        )
-        return result
+    result = auto_functionalized_dense(
+        _mutable_op, _only_clone_these_tensors=None, **kwargs
+    )
+    return result
 
 
 @auto_functionalized.py_impl(ProxyTorchDispatchMode)
@@ -1131,17 +1129,15 @@ def _generate_new_op_kwargs_from_bases(
     return new_kwargs, all_bases_new
 
 
-@auto_functionalized_v2.py_impl(FakeTensorMode)
+@register_fake(auto_functionalized_v2, skip_cache=True)
 def auto_functionalized_v2_fake(
-    mode,
     _mutable_op: _MutableOpType,
     **kwargs: dict[str, Any],
 ) -> tuple[Any, tuple[Tensor, ...]]:
-    with mode:
-        result = auto_functionalized_v2_dense(
-            _mutable_op, _only_clone_these_bases=None, **kwargs
-        )
-        return result
+    result = auto_functionalized_v2_dense(
+        _mutable_op, _only_clone_these_bases=None, **kwargs
+    )
+    return result
 
 
 @auto_functionalized_v2.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -65,7 +65,7 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         self.py_autograd_impl(self._call_Autograd)
         self.py_functionalize_impl(self._call_Functionalize)
         self.py_impl(ProxyTorchDispatchMode)(self._call_ProxyTorchDispatchMode)
-        register_fake(self, self._fake_impl)
+        register_fake(self, self._fake_impl, skip_cache=True)
         self.py_impl(DispatchKey.CompositeExplicitAutograd)(
             self._call_CompositeExplicitAutograd
         )

--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -12,9 +12,9 @@ from torch._higher_order_ops.utils import (
     HopInstance,
     materialize_as_graph,
     reenter_make_fx,
+    register_fake,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -65,7 +65,7 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         self.py_autograd_impl(self._call_Autograd)
         self.py_functionalize_impl(self._call_Functionalize)
         self.py_impl(ProxyTorchDispatchMode)(self._call_ProxyTorchDispatchMode)
-        self.py_impl(FakeTensorMode)(self._call_FakeTensorMode)
+        register_fake(self, self._fake_impl)
         self.py_impl(DispatchKey.CompositeExplicitAutograd)(
             self._call_CompositeExplicitAutograd
         )
@@ -127,10 +127,8 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
             tracer=proxy_mode.tracer,  # type: ignore[arg-type]
         )
 
-    def _call_FakeTensorMode(self, mode, subgraph, *operands, **kwargs):
-        # TODO: this should probably route through FakeTensorMode to reuse caching
-        with mode:
-            return subgraph(*operands)
+    def _fake_impl(self, subgraph, *operands, **kwargs):
+        return subgraph(*operands)
 
     # NOTE [Support input mutation of hops]
     # To support input mutation, hop's subgraph must be functionalized because many inductor passes are

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -8,11 +8,11 @@ from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch._higher_order_ops.print import print as hop_print
 from torch._higher_order_ops.schema import HopSchema
 from torch._higher_order_ops.torchbind import call_torchbind
+from torch._higher_order_ops.utils import register_fake
 from torch._library.custom_ops import CustomOpDef
 from torch._library.effects import EffectType
 from torch._library.utils import RegistrationHandle
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -155,17 +155,15 @@ def with_effects_dense(
     return (new_token, out)
 
 
-@with_effects.py_impl(FakeTensorMode)
+@register_fake(with_effects)
 def with_effects_fake(
-    mode,
     token: torch.Tensor,
     op: torch._ops.OpOverload,
     *args: tuple[Any, ...],
     **kwargs: dict[str, Any],
 ) -> tuple[torch.Tensor, ...]:
-    with mode:
-        result = with_effects_dense(token, op, *args, **kwargs)
-        return result
+    result = with_effects_dense(token, op, *args, **kwargs)
+    return result
 
 
 @with_effects.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -155,7 +155,7 @@ def with_effects_dense(
     return (new_token, out)
 
 
-@register_fake(with_effects)
+@register_fake(with_effects, skip_cache=True)
 def with_effects_fake(
     token: torch.Tensor,
     op: torch._ops.OpOverload,

--- a/torch/_higher_order_ops/executorch_call_delegate.py
+++ b/torch/_higher_order_ops/executorch_call_delegate.py
@@ -14,8 +14,8 @@ from typing import Any, cast
 
 import torch
 import torch.utils._pytree as pytree
+from torch._higher_order_ops.utils import register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     get_proxy_slot,
@@ -130,11 +130,10 @@ def call_delegate_proxy_torch_dispatch_mode(mode, lowered_module, *args):
     return res
 
 
-@executorch_call_delegate.py_impl(FakeTensorMode)
+@register_fake(executorch_call_delegate)
 # pyre-ignore
-def call_delegate_fake_tensor_mode(mode, lowered_module, *args):
-    with mode:
-        return call_delegate_cpu(lowered_module, *args)
+def call_delegate_fake_tensor_mode(lowered_module, *args):
+    return call_delegate_cpu(lowered_module, *args)
 
 
 @executorch_call_delegate.py_functionalize_impl

--- a/torch/_higher_order_ops/executorch_call_delegate.py
+++ b/torch/_higher_order_ops/executorch_call_delegate.py
@@ -130,7 +130,7 @@ def call_delegate_proxy_torch_dispatch_mode(mode, lowered_module, *args):
     return res
 
 
-@register_fake(executorch_call_delegate)
+@register_fake(executorch_call_delegate, skip_cache=True)
 # pyre-ignore
 def call_delegate_fake_tensor_mode(lowered_module, *args):
     return call_delegate_cpu(lowered_module, *args)

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -79,7 +79,7 @@ hints_wrapper.py_autograd_impl(
 )
 
 
-@register_fake(hints_wrapper)
+@register_fake(hints_wrapper, skip_cache=True)
 def hints_wrapper_fake_tensor_mode(body_func, args, kwargs, hints):
     flat_args = pytree.tree_leaves(args)
     return body_func(*flat_args, **kwargs)

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -5,10 +5,10 @@ from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
     autograd_not_implemented,
     reenter_make_fx,
+    register_fake,
     unique_graph_id,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 
 
@@ -79,11 +79,10 @@ hints_wrapper.py_autograd_impl(
 )
 
 
-@hints_wrapper.py_impl(FakeTensorMode)
-def hints_wrapper_fake_tensor_mode(mode, body_func, args, kwargs, hints):
+@register_fake(hints_wrapper)
+def hints_wrapper_fake_tensor_mode(body_func, args, kwargs, hints):
     flat_args = pytree.tree_leaves(args)
-    with mode:
-        return body_func(*flat_args, **kwargs)
+    return body_func(*flat_args, **kwargs)
 
 
 @hints_wrapper.py_functionalize_impl

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -5,9 +5,8 @@ import re
 import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 
 
@@ -249,10 +248,9 @@ def _elementwise_output_like(*inputs, dtype):
     )
 
 
-@inline_asm_elementwise.py_impl(FakeTensorMode)
-def _(mode, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
-    with mode:
-        return _elementwise_output_like(*inputs, dtype=dtype)
+@register_fake(inline_asm_elementwise)
+def _(*inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    return _elementwise_output_like(*inputs, dtype=dtype)
 
 
 @inline_asm_elementwise.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -248,7 +248,7 @@ def _elementwise_output_like(*inputs, dtype):
     )
 
 
-@register_fake(inline_asm_elementwise)
+@register_fake(inline_asm_elementwise, skip_cache=True)
 def _(*inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
     return _elementwise_output_like(*inputs, dtype=dtype)
 

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -17,11 +17,12 @@ from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
     clone_outputs_aliasing_inputs,
     redirect_to_mode,
+    register_fake,
     save_values_for_backward,
     saved_values,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensor
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx import GraphModule
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
@@ -556,39 +557,37 @@ def functional_mode_key(
         return ctx.wrap_tensors(out)
 
 
-@local_map_hop.py_impl(FakeTensorMode)
+@register_fake(local_map_hop)
 def fake_mode_key(
-    mode: FakeTensorMode,
     gm: GraphModule,
     *args: Any,
     **kwargs: Any,
 ) -> GraphArg:
-    with mode:
-        if not _DEFER_INLINING:
-            return gm(*args, **kwargs)
+    if not _DEFER_INLINING:
+        return gm(*args, **kwargs)
 
-        # otherwise, we need to convert to local shapes for AP
-        is_backward = gm.meta["is_backward"]
-        redistribute_inputs = (
-            redistribute_bw_inputs if is_backward else redistribute_fw_inputs
-        )
-        local_args = redistribute_inputs(
-            args,
-            gm.meta["local_map_kwargs"]["in_placements"],
-            gm.meta["local_map_kwargs"]["device_mesh"],
-            gm.meta["num_activations"],
-        )
-        local_outs = gm(*local_args)
-        redistribute_outputs = (
-            redistribute_bw_outputs if is_backward else redistribute_fw_outputs
-        )
-        global_outs = redistribute_outputs(
-            local_outs,
-            gm.meta["local_map_kwargs"]["out_placements"],
-            gm.meta["local_map_kwargs"]["device_mesh"],
-            gm.meta["num_activations"],
-        )
-        return global_outs
+    # otherwise, we need to convert to local shapes for AP
+    is_backward = gm.meta["is_backward"]
+    redistribute_inputs = (
+        redistribute_bw_inputs if is_backward else redistribute_fw_inputs
+    )
+    local_args = redistribute_inputs(
+        args,
+        gm.meta["local_map_kwargs"]["in_placements"],
+        gm.meta["local_map_kwargs"]["device_mesh"],
+        gm.meta["num_activations"],
+    )
+    local_outs = gm(*local_args)
+    redistribute_outputs = (
+        redistribute_bw_outputs if is_backward else redistribute_fw_outputs
+    )
+    global_outs = redistribute_outputs(
+        local_outs,
+        gm.meta["local_map_kwargs"]["out_placements"],
+        gm.meta["local_map_kwargs"]["device_mesh"],
+        gm.meta["num_activations"],
+    )
+    return global_outs
 
 
 def proxy_mode_key_common(

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -557,7 +557,7 @@ def functional_mode_key(
         return ctx.wrap_tensors(out)
 
 
-@register_fake(local_map_hop)
+@register_fake(local_map_hop, skip_cache=True)
 def fake_mode_key(
     gm: GraphModule,
     *args: Any,

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -7,9 +7,12 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
-from torch._higher_order_ops.utils import _maybe_run_with_interpreter, reenter_make_fx
+from torch._higher_order_ops.utils import (
+    _maybe_run_with_interpreter,
+    reenter_make_fx,
+    register_fake,
+)
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -343,20 +346,19 @@ def map_proxy_torch_dispatch_mode(mode, f, xs, args):
     return trace_map(mode, map_impl, f, xs, args)
 
 
-@map_impl.py_impl(FakeTensorMode)
-def map_fake_tensor_mode(mode, f, xs, args):
+@register_fake(map_impl)
+def map_fake_tensor_mode(f, xs, args):
     from torch._higher_order_ops.utils import first_slice_copy
 
-    with mode:
-        # Use first_slice_copy instead of _unstack_pytree to avoid
-        # iterating over batch dim, which would guard on symbolic sizes.
-        first_row = pytree.tree_map(first_slice_copy, xs)
-        example_output = f(*first_row, *args)
+    # Use first_slice_copy instead of _unstack_pytree to avoid
+    # iterating over batch dim, which would guard on symbolic sizes.
+    first_row = pytree.tree_map(first_slice_copy, xs)
+    example_output = f(*first_row, *args)
 
-        flat_xs, _ = pytree.tree_flatten(xs)
-        batch_size = flat_xs[0].shape[0]
+    flat_xs, _ = pytree.tree_flatten(xs)
+    batch_size = flat_xs[0].shape[0]
 
-        return _broadcast_to_batch(example_output, batch_size)
+    return _broadcast_to_batch(example_output, batch_size)
 
 
 @map_impl.py_functionalize_impl

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -346,7 +346,7 @@ def map_proxy_torch_dispatch_mode(mode, f, xs, args):
     return trace_map(mode, map_impl, f, xs, args)
 
 
-@register_fake(map_impl)
+@register_fake(map_impl, skip_cache=True)
 def map_fake_tensor_mode(f, xs, args):
     from torch._higher_order_ops.utils import first_slice_copy
 

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -143,7 +143,7 @@ def out_dtype_proxy(
     return trace_out_dtype(mode, out_dtype, op, output_dtype, *args)
 
 
-@register_fake(out_dtype)
+@register_fake(out_dtype, skip_cache=True)
 def out_dtype_fake_tensor_mode(
     op: torch._ops.OpOverload,
     output_dtype: torch.dtype,

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -3,10 +3,9 @@
 import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
 from torch._prims_common import elementwise_dtypes, ELEMENTWISE_TYPE_PROMOTION_KIND
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     maybe_handle_decomp,
@@ -144,15 +143,13 @@ def out_dtype_proxy(
     return trace_out_dtype(mode, out_dtype, op, output_dtype, *args)
 
 
-@out_dtype.py_impl(FakeTensorMode)
+@register_fake(out_dtype)
 def out_dtype_fake_tensor_mode(
-    mode: FakeTensorMode,
     op: torch._ops.OpOverload,
     output_dtype: torch.dtype,
     *args,
 ):
-    with mode:
-        return out_dtype_dense(op, output_dtype, *args)
+    return out_dtype_dense(op, output_dtype, *args)
 
 
 @out_dtype.py_functionalize_impl

--- a/torch/_higher_order_ops/print.py
+++ b/torch/_higher_order_ops/print.py
@@ -85,7 +85,7 @@ def print_proxy_torch_dispatch_mode(
     )
 
 
-@register_fake(print)
+@register_fake(print, skip_cache=True)
 # pyre-ignore
 def print_fake_tensor_mode(format_str: str, *args: object, **kwargs: object):
     return None

--- a/torch/_higher_order_ops/print.py
+++ b/torch/_higher_order_ops/print.py
@@ -2,8 +2,8 @@ import builtins
 
 import torch
 import torch.utils._pytree as pytree
+from torch._higher_order_ops.utils import register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode
 
 
@@ -85,9 +85,9 @@ def print_proxy_torch_dispatch_mode(
     )
 
 
-@print.py_impl(FakeTensorMode)
+@register_fake(print)
 # pyre-ignore
-def print_fake_tensor_mode(mode, format_str: str, *args: object, **kwargs: object):
+def print_fake_tensor_mode(format_str: str, *args: object, **kwargs: object):
     return None
 
 

--- a/torch/_higher_order_ops/run_const_graph.py
+++ b/torch/_higher_order_ops/run_const_graph.py
@@ -61,7 +61,7 @@ run_const_graph.py_autograd_impl(
 )
 
 
-@register_fake(run_const_graph)
+@register_fake(run_const_graph, skip_cache=True)
 def run_const_graph_fake_tensor_mode(
     graph: torch.fx.GraphModule, args: tuple[object, ...]
 ) -> object:

--- a/torch/_higher_order_ops/run_const_graph.py
+++ b/torch/_higher_order_ops/run_const_graph.py
@@ -2,9 +2,8 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 from torch._C import DispatchKey
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 
 
 if TYPE_CHECKING:
@@ -62,16 +61,15 @@ run_const_graph.py_autograd_impl(
 )
 
 
-@run_const_graph.py_impl(FakeTensorMode)
+@register_fake(run_const_graph)
 def run_const_graph_fake_tensor_mode(
-    mode: FakeTensorMode, graph: torch.fx.GraphModule, args: tuple[object, ...]
+    graph: torch.fx.GraphModule, args: tuple[object, ...]
 ) -> object:
     if not isinstance(graph, torch.fx.GraphModule):
         raise AssertionError(
             f"expected graph to be torch.fx.GraphModule, got {type(graph)}"
         )
-    with mode:
-        return graph(*args)
+    return graph(*args)
 
 
 @run_const_graph.py_impl(DispatchKey.CPU)

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -879,7 +879,7 @@ def scan_proxy_mode(mode, combine_fn, init, xs, additional_inputs):
     return trace_scan(mode, scan_op, combine_fn, init, xs, additional_inputs)
 
 
-@register_fake(scan_op)
+@register_fake(scan_op, skip_cache=True)
 def scan_fake_tensor_mode(combine_fn, init, xs, additional_inputs):
     scan_length = xs[0].shape[0]
     carry, outputs = _extract_carry_and_out(

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -26,12 +26,12 @@ from torch._higher_order_ops.utils import (
     mask_list,
     materialize_as_graph,
     reenter_make_fx,
+    register_fake,
     split_into_chunks,
     unique_graph_id,
     validate_subgraph_args_types,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -879,23 +879,22 @@ def scan_proxy_mode(mode, combine_fn, init, xs, additional_inputs):
     return trace_scan(mode, scan_op, combine_fn, init, xs, additional_inputs)
 
 
-@scan_op.py_impl(FakeTensorMode)
-def scan_fake_tensor_mode(mode, combine_fn, init, xs, additional_inputs):
-    with mode:
-        scan_length = xs[0].shape[0]
-        carry, outputs = _extract_carry_and_out(
-            combine_fn(
-                *init,
-                *[first_slice_copy(inp) for inp in xs],
-                *additional_inputs,
-            ),
-            len(init),
-        )
-        out = (
-            *carry,
-            *(stack_y(t, scan_length) for t in outputs),
-        )
-        return out
+@register_fake(scan_op)
+def scan_fake_tensor_mode(combine_fn, init, xs, additional_inputs):
+    scan_length = xs[0].shape[0]
+    carry, outputs = _extract_carry_and_out(
+        combine_fn(
+            *init,
+            *[first_slice_copy(inp) for inp in xs],
+            *additional_inputs,
+        ),
+        len(init),
+    )
+    out = (
+        *carry,
+        *(stack_y(t, scan_length) for t in outputs),
+    )
+    return out
 
 
 @scan_op.py_functionalize_impl

--- a/torch/_higher_order_ops/strict_mode.py
+++ b/torch/_higher_order_ops/strict_mode.py
@@ -77,7 +77,7 @@ def trace_strict_mode(mode, strict_mode_op, callable, operands):
     return track_tensor_tree(out, out_proxy, constant=None, tracer=mode.tracer)
 
 
-@register_fake(strict_mode_op)
+@register_fake(strict_mode_op, skip_cache=True)
 def strict_mode_fake_tensor_mode(callable, operands):
     return callable(*operands)
 

--- a/torch/_higher_order_ops/strict_mode.py
+++ b/torch/_higher_order_ops/strict_mode.py
@@ -5,9 +5,8 @@ import torch._subclasses.functional_tensor
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._functorch.utils import exposed_in
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     make_fx,
@@ -78,11 +77,9 @@ def trace_strict_mode(mode, strict_mode_op, callable, operands):
     return track_tensor_tree(out, out_proxy, constant=None, tracer=mode.tracer)
 
 
-@strict_mode_op.py_impl(FakeTensorMode)
-def strict_mode_fake_tensor_mode(mode, callable, operands):
-    with mode:
-        true_outs = callable(*operands)
-    return true_outs
+@register_fake(strict_mode_op)
+def strict_mode_fake_tensor_mode(callable, operands):
+    return callable(*operands)
 
 
 @strict_mode_op.py_functionalize_impl

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -20,10 +20,9 @@ import torch.fx as fx
 import torch.utils._pytree as pytree
 from torch import SymInt, Tensor
 from torch._C import _dispatch_keys, DispatchKey
-from torch._higher_order_ops.utils import redirect_to_mode
+from torch._higher_order_ops.utils import redirect_to_mode, register_fake
 from torch._ops import HigherOrderOperator
 from torch._prims_common import clone_preserve_strides
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -1407,9 +1406,8 @@ def triton_kernel_wrapper_mutation_dense(
     kernel[grid_fn](*args, **kwargs, **constant_args)
 
 
-@triton_kernel_wrapper_mutation.py_impl(FakeTensorMode)
+@register_fake(triton_kernel_wrapper_mutation)
 def triton_kernel_wrapper_mutation_fake_tensor_mode(
-    mode: FakeTensorMode,
     *,
     kernel_idx: int,
     constant_args_idx: int,
@@ -1417,8 +1415,7 @@ def triton_kernel_wrapper_mutation_fake_tensor_mode(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
 ) -> None:
-    with mode:
-        return None
+    return None
 
 
 @triton_kernel_wrapper_mutation.py_impl(DispatchKey.Meta)
@@ -1578,9 +1575,8 @@ def triton_kernel_wrapper_functional_dense(
     return {key: val for key, val in kwargs.items() if key in tensors_to_clone}
 
 
-@triton_kernel_wrapper_functional.py_impl(FakeTensorMode)
+@register_fake(triton_kernel_wrapper_functional)
 def triton_kernel_wrapper_functional_fake_tensor_mode(
-    mode: FakeTensorMode,
     *,
     kernel_idx: int,
     constant_args_idx: int,
@@ -1593,12 +1589,11 @@ def triton_kernel_wrapper_functional_fake_tensor_mode(
     # `clone_preserve_strides` calls are never executed at runtime
     # (inductor should always optimize them away).
     # Requires https://github.com/pytorch/pytorch/issues/109240
-    with mode:
-        return {
-            key: clone_preserve_strides(val)
-            for key, val in kwargs.items()
-            if key in tensors_to_clone
-        }
+    return {
+        key: clone_preserve_strides(val)
+        for key, val in kwargs.items()
+        if key in tensors_to_clone
+    }
 
 
 @triton_kernel_wrapper_functional.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1406,7 +1406,7 @@ def triton_kernel_wrapper_mutation_dense(
     kernel[grid_fn](*args, **kwargs, **constant_args)
 
 
-@register_fake(triton_kernel_wrapper_mutation)
+@register_fake(triton_kernel_wrapper_mutation, skip_cache=True)
 def triton_kernel_wrapper_mutation_fake_tensor_mode(
     *,
     kernel_idx: int,
@@ -1575,7 +1575,7 @@ def triton_kernel_wrapper_functional_dense(
     return {key: val for key, val in kwargs.items() if key in tensors_to_clone}
 
 
-@register_fake(triton_kernel_wrapper_functional)
+@register_fake(triton_kernel_wrapper_functional, skip_cache=True)
 def triton_kernel_wrapper_functional_fake_tensor_mode(
     *,
     kernel_idx: int,

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1132,23 +1132,30 @@ def check_input_alias_and_mutation_return_outputs(
 
 registered_hop_fake_fns: dict[torch._ops.OpOverload, Callable] = {}
 
+output_alias_hops: set[torch._ops.OpOverload] = set()
+
 
 F = TypeVar("F", bound=Callable)
 
 
 @overload
-def register_fake(hop, fn: None = None) -> Callable[[F], F]: ...
+def register_fake(
+    hop, fn: None = None, *, skip_cache: bool = ...
+) -> Callable[[F], F]: ...
 
 
 @overload
-def register_fake(hop, fn: F) -> F: ...
+def register_fake(hop, fn: F, *, skip_cache: bool = ...) -> F: ...
 
 
-def register_fake(hop, fn=None):
+def register_fake(hop, fn=None, *, skip_cache=False):
     """
     Register a fake function for a HOP. This is conceptually equivalent of the
     register_fake utility for the custom ops. The registered function is called
     inside the fake_tensor _dispatch_impl.
+
+    Set skip_cache=True for HOPs whose fake output aliases itself or tensors
+    nested in container args (identity the cache cannot reconstruct)
     """
     if hop in registered_hop_fake_fns:
         raise AssertionError(f"hop {hop} already registered in registered_hop_fake_fns")
@@ -1159,6 +1166,8 @@ def register_fake(hop, fn=None):
         redirect_to_mode(hop, FakeTensorMode)
 
         registered_hop_fake_fns[hop] = func
+        if skip_cache:
+            output_alias_hops.add(hop)
         return func
 
     if fn is None:

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1132,7 +1132,10 @@ def check_input_alias_and_mutation_return_outputs(
 
 registered_hop_fake_fns: dict[torch._ops.OpOverload, Callable] = {}
 
-output_alias_hops: set[torch._ops.OpOverload] = set()
+# Set skip_cache=True for HOPs that should not be cached in FakeTensorMode
+# (previously these ops were registered with .py_impl(FakeTensorMode)) and
+# were never cached so we are just preserving original behaviour
+hops_that_skip_faketensor_cache: set[torch._ops.OpOverload] = set()
 
 
 F = TypeVar("F", bound=Callable)
@@ -1154,8 +1157,10 @@ def register_fake(hop, fn=None, *, skip_cache=False):
     register_fake utility for the custom ops. The registered function is called
     inside the fake_tensor _dispatch_impl.
 
-    Set skip_cache=True for HOPs whose fake output aliases itself or tensors
-    nested in container args (identity the cache cannot reconstruct)
+    Set skip_cache=True to keep a HOP's fake output out of the FakeTensorMode
+    cache -- either to preserve the historical uncached behavior of
+    py_impl(FakeTensorMode), or because its outputs alias in ways the cache
+    cannot reconstruct (e.g. auto_functionalized).
     """
     if hop in registered_hop_fake_fns:
         raise AssertionError(f"hop {hop} already registered in registered_hop_fake_fns")
@@ -1167,7 +1172,7 @@ def register_fake(hop, fn=None, *, skip_cache=False):
 
         registered_hop_fake_fns[hop] = func
         if skip_cache:
-            output_alias_hops.add(hop)
+            hops_that_skip_faketensor_cache.add(hop)
         return func
 
     if fn is None:

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -5,10 +5,9 @@ import torch
 import torch.utils._pytree as pytree
 from torch import _prims
 from torch._C import DispatchKey
-from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._higher_order_ops.utils import autograd_not_implemented, register_fake
 from torch._ops import HigherOrderOperator
 from torch._prims_common import CUDARngStateHelper, make_contiguous_strides_for
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -193,11 +192,10 @@ def register_run_and_save_rng_state_op():
         impl = impl_map[device]
         return impl(op, *args, **kwargs)
 
-    @run_and_save_rng_state.py_impl(FakeTensorMode)
-    def impl_fake_tensor_mode(mode, op, *args, **kwargs):
+    @register_fake(run_and_save_rng_state)
+    def impl_fake_tensor_mode(op, *args, **kwargs):
         # Check device to call the right impl
-        with mode:
-            return impl_backend_select(op, *args, **kwargs)
+        return impl_backend_select(op, *args, **kwargs)
 
     @run_and_save_rng_state.py_impl(ProxyTorchDispatchMode)
     def impl_proxy_dispatch_mode(mode, op, *args, **kwargs):
@@ -288,12 +286,11 @@ def register_run_with_rng_state_op():
         impl = impl_map[device]
         return impl(rng_state, op, *args, **kwargs)
 
-    @run_with_rng_state.py_impl(FakeTensorMode)
-    def impl_fake_tensor_mode(mode, rng_state, op, *args, **kwargs):
+    @register_fake(run_with_rng_state)
+    def impl_fake_tensor_mode(rng_state, op, *args, **kwargs):
         # Skip setting the set_rng_state as it does not work well with fake tensors.
         # And it does not matter for the fake tensor mode.
-        with mode:
-            return op(*args, **kwargs)
+        return op(*args, **kwargs)
 
     @run_with_rng_state.py_functionalize_impl
     def impl_functional(ctx, rng_state, op, *args, **kwargs):
@@ -360,10 +357,9 @@ def register_graphsafe_run_with_rng_state_op():
             )
         return _impl_graphsafe_rng(op, *args, rng_state=rng_state, **kwargs)
 
-    @graphsafe_run_with_rng_state.py_impl(FakeTensorMode)
-    def impl_fake_tensor_mode(mode, op, *args, rng_state=None, **kwargs):
-        with mode:
-            return op(*args, **kwargs)
+    @register_fake(graphsafe_run_with_rng_state)
+    def impl_fake_tensor_mode(op, *args, rng_state=None, **kwargs):
+        return op(*args, **kwargs)
 
     @graphsafe_run_with_rng_state.py_impl(ProxyTorchDispatchMode)
     def impl_proxy_dispatch_mode(mode, op, *args, rng_state=None, **kwargs):
@@ -492,12 +488,9 @@ def register_run_dtensor_rng_op():
             )
         return impl_cuda(start_offset_incr, end_offset_incr, op, *args, **kwargs)
 
-    @run_dtensor_rng_op.py_impl(FakeTensorMode)
-    def impl_fake_tensor_mode(
-        mode, start_offset_incr, end_offset_incr, op, *args, **kwargs
-    ):
-        with mode:
-            return op(*args, **kwargs)
+    @register_fake(run_dtensor_rng_op)
+    def impl_fake_tensor_mode(start_offset_incr, end_offset_incr, op, *args, **kwargs):
+        return op(*args, **kwargs)
 
     @run_dtensor_rng_op.py_impl(ProxyTorchDispatchMode)
     def impl_proxy_dispatch_mode(

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -192,7 +192,7 @@ def register_run_and_save_rng_state_op():
         impl = impl_map[device]
         return impl(op, *args, **kwargs)
 
-    @register_fake(run_and_save_rng_state)
+    @register_fake(run_and_save_rng_state, skip_cache=True)
     def impl_fake_tensor_mode(op, *args, **kwargs):
         # Check device to call the right impl
         return impl_backend_select(op, *args, **kwargs)
@@ -286,7 +286,7 @@ def register_run_with_rng_state_op():
         impl = impl_map[device]
         return impl(rng_state, op, *args, **kwargs)
 
-    @register_fake(run_with_rng_state)
+    @register_fake(run_with_rng_state, skip_cache=True)
     def impl_fake_tensor_mode(rng_state, op, *args, **kwargs):
         # Skip setting the set_rng_state as it does not work well with fake tensors.
         # And it does not matter for the fake tensor mode.
@@ -357,7 +357,7 @@ def register_graphsafe_run_with_rng_state_op():
             )
         return _impl_graphsafe_rng(op, *args, rng_state=rng_state, **kwargs)
 
-    @register_fake(graphsafe_run_with_rng_state)
+    @register_fake(graphsafe_run_with_rng_state, skip_cache=True)
     def impl_fake_tensor_mode(op, *args, rng_state=None, **kwargs):
         return op(*args, **kwargs)
 
@@ -488,7 +488,7 @@ def register_run_dtensor_rng_op():
             )
         return impl_cuda(start_offset_incr, end_offset_incr, op, *args, **kwargs)
 
-    @register_fake(run_dtensor_rng_op)
+    @register_fake(run_dtensor_rng_op, skip_cache=True)
     def impl_fake_tensor_mode(start_offset_incr, end_offset_incr, op, *args, **kwargs):
         return op(*args, **kwargs)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2017,7 +2017,10 @@ class FakeTensorMode(TorchDispatchMode):
         _BypassDispatchCache if the output tensor has characteristics that
         prevent caching it.
         """
-        from torch._higher_order_ops.utils import registered_hop_fake_fns
+        from torch._higher_order_ops.utils import (
+            output_alias_hops,
+            registered_hop_fake_fns,
+        )
         from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 
         self._validate_cache_key(func, args, kwargs)
@@ -2027,22 +2030,25 @@ class FakeTensorMode(TorchDispatchMode):
         # caching.
         # NB: Note that the HOPs that sta alive till FakeTensor are functional,
         # once they support mutations, we will have to revisit this logic.
+        # We cannot cache HOPs that do output aliasing because cache does not store
+        # the alias relationship so on a cache hit, you'll get two different tensors
         if (
             isinstance(func, torch._ops.HigherOrderOperator)
             and func in registered_hop_fake_fns
         ):
-            if not isinstance(output, tuple) and output is not None:
-                raise AssertionError(
-                    f"Expected tuple output for HOP {func}, got {type(output)}"
-                )
-            if output is not None:
-                non_cacheable = any(
+            outs = output if isinstance(output, tuple) else (output,)
+            non_cacheable = (
+                any(
                     isinstance(o, (torch.Tensor, torch.SymInt))
                     and has_free_unbacked_symbols(o)
-                    for o in output  # pyrefly: ignore[not-iterable]
+                    for o in outs
                 )
-                if non_cacheable:
-                    raise _BypassDispatchCache(f"unbacked symbol in HOP {func} output")
+                or func in output_alias_hops
+            )
+            if non_cacheable:
+                raise _BypassDispatchCache(
+                    f"non_cacheable, unbacked symbol in HOP {func} output or HOP {func} does output aliasing"
+                )
 
         if isinstance(output, (int, torch.SymInt, type(None))):
             output_info = _DispatchCacheEntryOutputInfo(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2018,7 +2018,7 @@ class FakeTensorMode(TorchDispatchMode):
         prevent caching it.
         """
         from torch._higher_order_ops.utils import (
-            output_alias_hops,
+            hops_that_skip_faketensor_cache,
             registered_hop_fake_fns,
         )
         from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
@@ -2030,8 +2030,8 @@ class FakeTensorMode(TorchDispatchMode):
         # caching.
         # NB: Note that the HOPs that sta alive till FakeTensor are functional,
         # once they support mutations, we will have to revisit this logic.
-        # We cannot cache HOPs that do output aliasing because cache does not store
-        # the alias relationship so on a cache hit, you'll get two different tensors
+        # Skipping caching for HOPs that used to be registered with @py.impl(FakeTensorMode)
+        # to preserve original behaviour
         if (
             isinstance(func, torch._ops.HigherOrderOperator)
             and func in registered_hop_fake_fns
@@ -2043,11 +2043,12 @@ class FakeTensorMode(TorchDispatchMode):
                     and has_free_unbacked_symbols(o)
                     for o in outs
                 )
-                or func in output_alias_hops
+                or func in hops_that_skip_faketensor_cache
             )
             if non_cacheable:
                 raise _BypassDispatchCache(
-                    f"non_cacheable, unbacked symbol in HOP {func} output or HOP {func} does output aliasing"
+                    f"unbacked symbol in HOP {func} output \
+                    or {func} in hops_that_skip_faketensor_cache"
                 )
 
         if isinstance(output, (int, torch.SymInt, type(None))):


### PR DESCRIPTION
to prepare moving FakeTensor to C++, first changing all trivial HOPs to use `@register_fake` instead of `.py_impl(FakeTensorMode)`

previously these ops were never cached, so adding `skip_cache = True` for all HOPs that are being migrated to preserve original behaviour

in #183776 i change register_fake to also register w/ DispatchKey.Fake