### PR TITLE
[Operators] Implement power operator in Dynamo

### DIFF
--- a/test/dynamo/test_nb_power.py
+++ b/test/dynamo/test_nb_power.py
@@ -1,0 +1,254 @@
+# Owner(s): ["module: dynamo"]
+
+import torch
+import torch._dynamo.test_case
+from torch.testing._internal.common_utils import make_dynamo_test
+
+
+@torch._dynamo.config.patch(enable_trace_unittest=True)
+@torch._dynamo.config.patch(enable_trace_load_build_class=True)
+class TestNbPower(torch._dynamo.test_case.TestCase):
+    # --- Integer power ---
+
+    @make_dynamo_test
+    def test_pow_integers(self):
+        self.assertEqual(2**10, 1024)
+        self.assertEqual(3**3, 27)
+        self.assertEqual(1**100, 1)
+        self.assertEqual(0**0, 1)
+
+    @make_dynamo_test
+    def test_pow_negative_exponent(self):
+        self.assertEqual(2**-1, 0.5)
+        self.assertEqual(4**-1, 0.25)
+
+    @make_dynamo_test
+    def test_pow_chained(self):
+        self.assertEqual(2**2**3, 256)
+
+    # --- Floats ---
+
+    @make_dynamo_test
+    def test_pow_floats(self):
+        self.assertEqual(2.0**3.0, 8.0)
+        self.assertEqual(9.0**0.5, 3.0)
+
+    @make_dynamo_test
+    def test_pow_mixed_int_float(self):
+        self.assertEqual(2**3.0, 8.0)
+        self.assertEqual(2.0**3, 8.0)
+
+    # --- Complex ---
+
+    @make_dynamo_test
+    def test_pow_complex(self):
+        self.assertEqual((1 + 1j) ** 2, 2j)
+        self.assertEqual((2 + 0j) ** 3, (8 + 0j))
+
+    # --- Booleans ---
+
+    @make_dynamo_test
+    def test_pow_bools(self):
+        self.assertEqual(True**True, 1)
+        self.assertEqual(False**True, 0)
+        self.assertEqual(True**False, 1)
+
+    # --- Errors ---
+
+    @make_dynamo_test
+    def test_pow_zero_base_negative_exp_raises(self):
+        with self.assertRaises(ZeroDivisionError):
+            0**-1
+
+    @make_dynamo_test
+    def test_pow_str_raises(self):
+        with self.assertRaises(TypeError):
+            2 ** "a"
+        with self.assertRaises(TypeError):
+            "a" ** 2
+
+    # --- Inplace **= ---
+
+    @make_dynamo_test
+    def test_inplace_pow_integers(self):
+        x = 2
+        x **= 8
+        self.assertEqual(x, 256)
+
+    @make_dynamo_test
+    def test_inplace_pow_chained(self):
+        x = 2
+        x **= 3
+        x **= 2
+        self.assertEqual(x, 64)
+
+    # --- User-defined __pow__ ---
+
+    @make_dynamo_test
+    def test_user_defined_pow_basic(self):
+        class C:
+            def __init__(self, v):
+                self.value = v
+
+            def __pow__(self, other):
+                return type(self)(self.value**other.value)
+
+            def __eq__(self, other):
+                return type(other) is type(self) and self.value == other.value
+
+        self.assertEqual(C(2) ** C(10), C(1024))
+
+    @make_dynamo_test
+    def test_user_defined_pow_with_integer(self):
+        class C:
+            def __init__(self, v):
+                self.value = v
+
+            def __pow__(self, other):
+                return type(self)(self.value**other)
+
+            def __eq__(self, other):
+                return type(other) is type(self) and self.value == other.value
+
+        self.assertEqual(C(2) ** 10, C(1024))
+
+    @make_dynamo_test
+    def test_reversed_pow_with_integer(self):
+        class C:
+            def __init__(self, v):
+                self.value = v
+
+            def __rpow__(self, other):
+                return type(self)(other**self.value)
+
+            def __eq__(self, other):
+                return type(other) is type(self) and self.value == other.value
+
+        self.assertEqual(2 ** C(10), C(1024))
+
+    @make_dynamo_test
+    def test_inplace_user_defined_pow(self):
+        class C:
+            def __init__(self, v):
+                self.value = v
+
+            def __ipow__(self, other):
+                self.value **= other.value
+                return self
+
+            def __eq__(self, other):
+                return type(other) is type(self) and self.value == other.value
+
+        x = C(2)
+        x **= C(10)
+        self.assertEqual(x, C(1024))
+
+    # --- Subclass dispatch ---
+
+    @make_dynamo_test
+    def test_subclass_of_int_gets_priority(self):
+        class IntSub(int):
+            def __pow__(self, other, modulo=None):
+                return "IntSub.__pow__"
+
+            def __rpow__(self, other, modulo=None):
+                return "IntSub.__rpow__"
+
+        self.assertEqual(IntSub(2) ** 10, "IntSub.__pow__")
+        self.assertEqual(2 ** IntSub(10), "IntSub.__rpow__")
+
+    @make_dynamo_test
+    def test_subclass_of_object_baseline(self):
+        class Base:
+            def __pow__(self, other):
+                return "Base.__pow__"
+
+            def __rpow__(self, other):
+                return "Base.__rpow__"
+
+        self.assertEqual(Base() ** 1, "Base.__pow__")
+        self.assertEqual(1 ** Base(), "Base.__rpow__")
+
+    # --- NotImplemented handling ---
+
+    @make_dynamo_test
+    def test_pow_not_implemented_returns_type_error(self):
+        class C:
+            def __pow__(self, other):
+                return NotImplemented
+
+            def __rpow__(self, other):
+                return NotImplemented
+
+        a = C()
+        with self.assertRaises(TypeError):
+            a**a
+
+    @make_dynamo_test
+    def test_pow_mixed_not_implemented_fallback(self):
+        class A:
+            def __pow__(self, other):
+                return NotImplemented
+
+        class B:
+            def __rpow__(self, other):
+                return "B.__rpow__ called"
+
+        result = A() ** B()
+        self.assertEqual(result, "B.__rpow__ called")
+
+    # --- 3-arg pow ---
+
+    @make_dynamo_test
+    def test_three_arg_pow_constants(self):
+        self.assertEqual(pow(2, 10, 1000), 24)
+        self.assertEqual(pow(3, 4, 7), 4)
+
+    # --- SymNode power ---
+
+    def test_pow_symnode_and_int(self):
+        def fn(x):
+            s = x.shape[0]
+            return x.new_zeros(s**2)
+
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+
+    def test_pow_symnode_negative_exponent(self):
+        # int ** negative_int produces float; shape expressions hit this
+        def fn(x):
+            s = x.shape[0]
+            return s**-1
+
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0)
+        opt_fn = torch.compile(fn, backend="eager")
+        self.assertEqual(opt_fn(x), fn(x))
+
+    def test_pow_tensor(self):
+        def fn(x, y):
+            return x**y
+
+        x = torch.randn(4).abs() + 1
+        y = torch.randn(4)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x, y), fn(x, y))
+
+    def test_pow_inplace_tensor(self):
+        def fn(x, y):
+            x **= y
+            return x
+
+        x = torch.randn(4).abs() + 1
+        y = torch.randn(4)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        x_clone = x.clone()
+        self.assertEqual(opt_fn(x, y), fn(x_clone, y))
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -931,6 +931,12 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return self.nb_xor_impl(tx, args[0], reverse=True)
         elif name == "__ixor__":
             return self.nb_inplace_xor_impl(tx, args[0])
+        elif name == "__pow__":
+            return self.nb_power_impl(tx, args[0])
+        elif name == "__rpow__":
+            return self.nb_power_impl(tx, args[0], reverse=True)
+        elif name == "__ipow__":
+            return self.nb_inplace_power_impl(tx, args[0])
         elif name == "__hash__" and not args and not kwargs:
             from .object_protocol import generic_hash
 
@@ -1480,6 +1486,27 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_xor slot. Default: returns NotImplemented."""
+        return variables.ConstantVariable(NotImplemented)
+
+    def nb_power_impl(
+        self,
+        tx: Any,
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        """tp_as_number->nb_power slot. Default: returns NotImplemented.
+
+        ``reverse=True`` means self is the right-hand operand (CPython would
+        look up ``__rpow__`` instead of ``__pow__``).
+        """
+        return variables.ConstantVariable(NotImplemented)
+
+    def nb_inplace_power_impl(
+        self,
+        tx: Any,
+        other: VariableTracker,
+    ) -> VariableTracker:
+        """tp_as_number->nb_inplace_power slot. Default: returns NotImplemented."""
         return variables.ConstantVariable(NotImplemented)
 
     def nb_multiply_impl(

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -581,8 +581,6 @@ class BuiltinVariable(BaseBuiltinVariable):
                 operator.ifloordiv,
             ),
             operator.mod: (["__mod__", "__rmod__", "__imod__"], operator.imod),
-            pow: (["__pow__", "__rpow__", "__ipow__"], operator.ipow),
-            operator.pow: (["__pow__", "__rpow__", "__ipow__"], operator.ipow),
             # NB: The follow binary operators are not supported for now, since the
             # corresponding magic methods aren't defined on SymInt / SymFloat:
             # operator.matmul
@@ -2736,6 +2734,26 @@ class BuiltinVariable(BaseBuiltinVariable):
         self, tx: "InstructionTranslatorBase", a: VariableTracker, b: VariableTracker
     ) -> VariableTracker | None:
         return binary_iop(tx, a, b, "nb_inplace_rshift", "nb_rshift", ">>=")
+
+    def call_pow(
+        self,
+        tx: "InstructionTranslatorBase",
+        a: VariableTracker,
+        b: VariableTracker,
+        c: VariableTracker | None = None,
+    ) -> VariableTracker | None:
+        # 3-arg pow(x, y, z) uses the same nb_power slot but passes a modulus
+        # as the third argument. Fall through to constant-fold / graph insertion
+        # for that case; only the binary form maps cleanly to nb_power here.
+        # https://github.com/python/cpython/blob/3.13/Objects/abstract.c#L920
+        if c is not None:
+            return None
+        return binary_op(tx, a, b, "nb_power", "**")
+
+    def call_ipow(
+        self, tx: "InstructionTranslatorBase", a: VariableTracker, b: VariableTracker
+    ) -> VariableTracker | None:
+        return binary_iop(tx, a, b, "nb_inplace_power", "nb_power", "**=")
 
     def call_not_(
         self, tx: "InstructionTranslatorBase", a: VariableTracker

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -35,6 +35,16 @@ if TYPE_CHECKING:
     from .functions import UserFunctionVariable
 
 
+def _pow_op(v: Any, w: Any) -> Any:
+    # CHECK_BINOP: long_pow/float_pow/complex_pow all verify both operands are
+    # numeric before computing, returning NotImplemented for non-numeric types.
+    if not isinstance(v, (int, float, complex)) or not isinstance(
+        w, (int, float, complex)
+    ):
+        return NotImplemented
+    return v**w
+
+
 class ConstantVariable(VariableTracker):
     """
     Variable tracker for Python literals and basic immutable types, with automatic
@@ -529,7 +539,7 @@ class ConstantVariable(VariableTracker):
         v, w = self_.as_python_constant(), other_.as_python_constant()
         try:
             result = op(v, w)
-        except (TypeError, ValueError, OverflowError) as e:
+        except (TypeError, ValueError, ZeroDivisionError, OverflowError) as e:
             raise_observed_exception(type(e), tx, args=list(e.args))
         if result is NotImplemented:
             return ConstantVariable.create(NotImplemented)
@@ -708,6 +718,24 @@ class ConstantVariable(VariableTracker):
 
         return self._nb_binary_impl(
             tx, other, operator.add, type_implements_nb_add, reverse
+        )
+
+    def nb_power_impl(
+        self,
+        tx: Any,
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # CPython: int, float, and complex all define nb_power (bool inherits int's).
+        # All three use CHECK_BINOP, returning NotImplemented when either operand is
+        # not the expected numeric type; _pow_op mirrors this behavior.
+        # https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c (long_pow)
+        # https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c (float_pow)
+        # https://github.com/python/cpython/blob/v3.13.0/Objects/complexobject.c (complex_pow)
+        from .object_protocol import type_implements_nb_power
+
+        return self._nb_binary_impl(
+            tx, other, _pow_op, type_implements_nb_power, reverse
         )
 
     def nb_absolute_impl(

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -852,6 +852,8 @@ NB_SLOT_MAPPING = {
     "nb_inplace_and": PyNumberSlots.NB_INPLACE_AND,
     "nb_xor": PyNumberSlots.NB_XOR,
     "nb_inplace_xor": PyNumberSlots.NB_INPLACE_XOR,
+    "nb_power": PyNumberSlots.NB_POWER,
+    "nb_inplace_power": PyNumberSlots.NB_INPLACE_POWER,
 }
 
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2422,6 +2422,27 @@ class TensorVariable(VariableTracker):
             sym_num=None,
         )
 
+    def nb_power_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # Reaches here only via direct ``tensor.__pow__(x)`` calls — the
+        # ``operator.pow`` path goes through ``_handle_insert_op_in_graph``
+        # in ``BuiltinVariable``.  Build the same FX proxy.
+        if not (isinstance(other, TensorVariable) or _is_sym_arith_operand(other)):
+            return VariableTracker.build(tx, NotImplemented)
+        from .builder import wrap_fx_proxy
+
+        lhs, rhs = (other, self) if reverse else (self, other)
+        return wrap_fx_proxy(
+            tx,
+            tx.output.create_proxy(
+                "call_function", operator.pow, *proxy_args_kwargs([lhs, rhs], {})
+            ),
+        )
+
     def is_python_equal(self, other: object) -> bool:
         if not isinstance(other, VariableTracker):
             return False
@@ -2800,6 +2821,23 @@ class SymNodeVariable(VariableTracker):
         return SymNodeVariable.create(
             tx,
             operator.abs(self.as_proxy()),
+            sym_num=None,
+        )
+
+    def nb_power_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        if not _is_sym_arith_operand(other):
+            return VariableTracker.build(tx, NotImplemented)
+        lhs, rhs = (other, self) if reverse else (self, other)
+        return SymNodeVariable.create(
+            tx,
+            tx.output.create_proxy(
+                "call_function", operator.pow, *proxy_args_kwargs([lhs, rhs], {})
+            ),
             sym_num=None,
         )
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2514,6 +2514,29 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     ) -> VariableTracker:
         return self.call_method(tx, "__imul__", [other], {})
 
+    def nb_power_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L10319-L10322
+        return self.SLOT1BIN(
+            tx,
+            other,
+            "__pow__",
+            "__rpow__",
+            nb_slot=PyNumberSlots.NB_POWER,
+            reverse=reverse,
+        )
+
+    def nb_inplace_power_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+    ) -> VariableTracker:
+        return self.call_method(tx, "__ipow__", [other], {})
+
     def call_method(
         self,
         tx: "InstructionTranslatorBase",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184836
* #184789
* #184788
* __->__ #186250

Add ** and **= support to torch.compile by implementing CPython's
nb_power / nb_inplace_power tp_as_number slots on Dynamo's
VariableTracker hierarchy, following the floordiv/truediv/remainder/divmod
changes.

NB_POWER and NB_INPLACE_POWER already existed in the C extension
(torch/csrc/dynamo/init.cpp), so no C++ rebuild is required.

On the Python side, operator.pow / builtin pow (2-arg) dispatch through
BuiltinVariable.call_pow into the generic binary_op dispatcher. 3-arg
pow(x,y,z) returns None to fall through to constant-fold / graph
insertion. operator.ipow dispatches through call_ipow into binary_iop.
ConstantVariable computes int/float/complex power; the CHECK_BINOP guard
(both operands must be numeric, matching long_pow/float_pow/complex_pow)
is enforced before computing so that NotImplemented is returned when
operand types are incompatible, letting binary_iop use the correct **=
error symbol. TensorVariable and SymNodeVariable build FX proxies via
operator.pow. UserDefinedObjectVariable bridges to __pow__/__rpow__/
__ipow__ via SLOT1BIN.

Removes CPython313-test_descr-ClassPropertiesAndMethods.test_ipow_returns_not_implemented
from dynamo_expected_failures since the test now passes.

Test Plan:

```
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_nb_power.py
PYTORCH_TEST_WITH_DYNAMO=1 pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_binop.py
PYTORCH_TEST_WITH_DYNAMO=1 pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_operator.py
PYTORCH_TEST_WITH_DYNAMO=1 pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_descr.py
```

This PR was authored with the assistance of an AI coding agent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98