### PR TITLE
Wait for Docker images before starting builds

### DIFF
--- a/.github/workflows/_wait-for-docker-image.yml
+++ b/.github/workflows/_wait-for-docker-image.yml
@@ -1,0 +1,101 @@
+name: Wait for CI docker image to be available in ECR
+
+on:
+  workflow_call:
+    inputs:
+      docker-image-name:
+        required: true
+        type: string
+        description: |
+          Short image name, e.g. "ci-image:pytorch-linux-jammy-py3.10-clang18".
+          Same value passed to _linux-build.yml's docker-image-name input.
+      ci-docker-hash:
+        required: true
+        type: string
+        description: Git tree hash of .ci/docker, from _runner-determinator.
+      timeout-minutes:
+        required: false
+        type: number
+        default: 120
+      poll-interval-seconds:
+        required: false
+        type: number
+        default: 60
+
+    outputs:
+      docker-image:
+        description: Fully qualified ECR image reference, ready to pull.
+        value: ${{ jobs.wait.outputs.docker-image }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  wait:
+    if: github.repository_owner == 'pytorch'
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    outputs:
+      docker-image: ${{ steps.compose.outputs.docker-image }}
+    env:
+      DOCKER_REGISTRY: 308535385114.dkr.ecr.us-east-1.amazonaws.com
+      REPO_NAME: pytorch
+    steps:
+      - name: Compose full image reference
+        id: compose
+        shell: bash
+        env:
+          NAME: ${{ inputs.docker-image-name }}
+          HASH: ${{ inputs.ci-docker-hash }}
+        run: |
+          if [[ "${NAME}" == *:* ]]; then
+            base=${NAME%%:*}
+            prefix=${NAME#*:}
+            tag="${prefix}-${HASH}"
+          else
+            base=${NAME}
+            tag=${HASH}
+          fi
+          image="${DOCKER_REGISTRY}/${REPO_NAME}/${base}:${tag}"
+          echo "docker-image=${image}" >> "$GITHUB_OUTPUT"
+          echo "Resolved image: ${image}"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-session-name: gha-wait-for-docker-image
+          role-skip-session-tagging: true
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: 308535385114
+          aws-region: us-east-1
+
+      - name: Poll for image manifest
+        shell: bash
+        env:
+          DOCKER_IMAGE: ${{ steps.compose.outputs.docker-image }}
+          POLL_INTERVAL: ${{ inputs.poll-interval-seconds }}
+        run: |
+          set -u
+          attempt=0
+          while true; do
+            attempt=$((attempt + 1))
+            err=$(docker manifest inspect "${DOCKER_IMAGE}" 2>&1 >/dev/null) && rc=0 || rc=$?
+            if [[ "${rc}" -eq 0 ]]; then
+              echo "Image available after ${attempt} attempt(s): ${DOCKER_IMAGE}"
+              exit 0
+            fi
+            # Surface stderr every 5th attempt so silent auth/permission failures
+            # (vs. "image not yet built") are visible in the log.
+            if (( attempt % 5 == 1 )); then
+              echo "Attempt ${attempt}: not available (rc=${rc}); docker stderr: ${err}"
+            else
+              echo "Attempt ${attempt}: image not yet available; sleeping ${POLL_INTERVAL}s"
+            fi
+            sleep "${POLL_INTERVAL}"
+          done

--- a/.github/workflows/_wait-for-docker-image.yml
+++ b/.github/workflows/_wait-for-docker-image.yml
@@ -16,7 +16,7 @@ on:
       timeout-minutes:
         required: false
         type: number
-        default: 120
+        default: 360
       poll-interval-seconds:
         required: false
         type: number

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -62,13 +62,62 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: arc,lf
 
+  wait-for-image-jammy-cuda13-py3-gcc11:
+    name: wait-for-docker-image (jammy-cuda13.0-py3-gcc11)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
+  wait-for-image-jammy-rocm-py3:
+    name: wait-for-docker-image (jammy-rocm-py3)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
+  wait-for-image-jammy-cuda13-py3-gcc11-inductor-benchmarks:
+    name: wait-for-docker-image (jammy-cuda13.0-py3-gcc11-inductor-benchmarks)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-inductor-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
+  wait-for-image-jammy-py3-gcc11-inductor-benchmarks:
+    name: wait-for-docker-image (jammy-py3-gcc11-inductor-benchmarks)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-py3-gcc11-inductor-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
+  wait-for-image-jammy-py3_10-clang18:
+    name: wait-for-docker-image (jammy-py3.10-clang18)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
+  wait-for-image-jammy-aarch64-py3_10-gcc13:
+    name: wait-for-docker-image (jammy-aarch64-py3.10-gcc13)
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+    needs: get-label-type
+    with:
+      docker-image-name: ci-image:pytorch-linux-jammy-aarch64-py3.10-gcc13
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+
   libtorch-linux-jammy-cuda13_0-py3_10-gcc11-debug-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' libtorch-linux-jammy-cuda13.0-py3.10-gcc11-debug ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' libtorch-linux-jammy-cuda13.0-py3.10-gcc11-debug ')) }}
     name: libtorch-linux-jammy-cuda13.0-py3.10-gcc11-debug
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-cuda13-py3-gcc11
     with:
       build-environment: libtorch-linux-jammy-cuda13.0-py3.10-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
@@ -87,12 +136,13 @@ jobs:
     secrets: inherit
 
   linux-jammy-cuda13_0-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test-cuda13 ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test-cuda13 ')) }}
     name: linux-jammy-cuda13.0-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-cuda13-py3-gcc11
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
@@ -167,12 +217,13 @@ jobs:
 
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
   linux-jammy-cuda13_0-py3_10-gcc11-no-ops-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11-no-ops ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.0-py3.10-gcc11-no-ops ')) }}
     name: linux-jammy-cuda13.0-py3.10-gcc11-no-ops
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-cuda13-py3-gcc11
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-no-ops
@@ -282,11 +333,13 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-build:
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' }}
     name: linux-jammy-rocm-py3.10-mi355
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-rocm-py3
     with:
       # Only set the prefix when use-arc is set to true, they go together
       runner_prefix: ""
@@ -331,12 +384,13 @@ jobs:
     secrets: inherit
 
   inductor-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' inductor-build ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' inductor-build ')) }}
     name: inductor-build
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-cuda13-py3-gcc11-inductor-benchmarks
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm80
@@ -350,12 +404,13 @@ jobs:
     secrets: inherit
 
   verify-cachebench-cpu-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' verify-cachebench-cpu-build ') || contains(needs.job-filter.outputs.jobs, ' verify-cachebench-cpu-test ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' verify-cachebench-cpu-build ') || contains(needs.job-filter.outputs.jobs, ' verify-cachebench-cpu-test ')) }}
     name: verify-cachebench-cpu-build
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-py3-gcc11-inductor-benchmarks
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py3.10-gcc11
@@ -424,12 +479,13 @@ jobs:
     secrets: inherit
 
   linux-jammy-py3_10-gcc11-full-debug-build-only:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11-full-debug-build-only ') }}
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11-full-debug-build-only ')) }}
     name: linux-jammy-py3.10-gcc11-full-debug-build-only
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
+      - wait-for-image-jammy-py3_10-clang18
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: linux.r7i.2xlarge
@@ -442,9 +498,12 @@ jobs:
     secrets: inherit
 
   linux-jammy-aarch64-py3_10-gcc13-build:
+    if: ${{ !cancelled() && needs.get-label-type.result == 'success' }}
     name: linux-jammy-aarch64-py3.10
     uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
+    needs:
+      - get-label-type
+      - wait-for-image-jammy-aarch64-py3_10-gcc13
     with:
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
       build-environment: linux-jammy-aarch64-py3.10


### PR DESCRIPTION
- Add reusable _wait-for-docker-image.yml workflow that polls ECR for a container image manifest, with configurable timeout and poll interval
- Add wait-for-image-* jobs in trunk.yml for each distinct Docker image used by Linux build jobs (CUDA, ROCm, inductor, clang18, aarch64)
- Wire build jobs to depend on their corresponding wait-for-image job so builds don't start until the image is available
- Guard build jobs with !cancelled() && needs.get-label-type.result == 'success' so a slow image build doesn't cascade-skip downstream jobs

When .ci/docker/ changes trigger a Docker image rebuild, build jobs that start before the new image is pushed to ECR fail because the image reference doesn't exist yet. The wait jobs poll with docker manifest inspect (default: every 60s, up to 2h) and gate the build on image availability, eliminating these race-condition failures.

See how it was done in the past:
https://github.com/pytorch/pytorch/blob/main/.github/workflows/_linux-test.yml#L174
https://github.com/pytorch/test-infra/blob/main/.github/actions/calculate-docker-image/action.yml#L147