### PR TITLE
[inductor] Fix truncdiv off-by-one on CUDA with _div_rn

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4129,6 +4129,24 @@ for dtype in (torch.int32, torch.int64):
         b = torch.tensor([0.0], dtype=torch.bfloat16, device=self.device)
         self.common(fn, (a, b))
 
+    def test_truncdiv_float_accuracy(self):
+        # Same root cause as test_floordiv_float_accuracy: Triton's approximate
+        # fp32 division can be off by one for trunc(a / b) when the quotient is
+        # near an integer.  Verify trunc(_div_rn(a, b)) fixes it.
+        # See https://github.com/pytorch/pytorch/issues/184408
+        def fn(a, b):
+            return torch.div(a, b, rounding_mode="trunc")
+
+        # Near-integer quotients: off by +1 without _div_rn
+        a = torch.tensor([14.999999, 26.999999, 13.999999], device=self.device)
+        b = torch.tensor([3.0, 3.0, 7.0], device=self.device)
+        self.common(fn, (a, b))
+
+        # Exact integer quotients: off by -1 without _div_rn
+        a = torch.tensor([148.0, 1073.0, 2112.0], device=self.device)
+        b = torch.tensor([37.0, 37.0, 33.0], device=self.device)
+        self.common(fn, (a, b))
+
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7560,7 +7560,7 @@ def div_mode(a, b, rounding_mode=None):
             raise AssertionError(
                 "truncdiv operands can not be boolean at the same time"
             )
-        return truncdiv(a, b) if both_integer else trunc(div(a, b))
+        return truncdiv(a, b) if both_integer else trunc(_div_rn(a, b))
     return div(a, b)
 
 


### PR DESCRIPTION
Fixes #184408

Triton's approximate fp32 division can produce results slightly below the true quotient, causing `trunc(a / b)` to be off by one when the quotient is near an integer. Use `_div_rn` (IEEE round-to-nearest) instead of plain `div`, matching the existing fix for the `floor` path.

**Change**: `trunc(div(a, b))` -> `trunc(_div_rn(a, b))` in `div_mode` lowering.

**Test**: Added `test_truncdiv_float_accuracy` with the exact reproducer values from the issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo