### PR TITLE
[Inductor] Bind fallback output unbacked symbols

### DIFF
--- a/test/higher_order_ops/test_utils.py
+++ b/test/higher_order_ops/test_utils.py
@@ -1,0 +1,29 @@
+# Owner(s): ["module: higher order operators"]
+
+import torch
+from torch._higher_order_ops.utils import _has_potential_branch_input_mutation
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestHigherOrderOpUtils(TestCase):
+    def test_alias_mutation_query_ignores_discarded_unbacked_symbols(self):
+        def branch(x):
+            torch.nonzero(x)
+            return x + 1
+
+        self.assertFalse(_has_potential_branch_input_mutation(branch, [torch.ones(4)]))
+
+    def test_alias_mutation_query_uses_existing_fake_mode(self):
+        def branch(x):
+            torch.nonzero(x)
+            return x + 1
+
+        with FakeTensorMode(shape_env=ShapeEnv()):
+            x = torch.ones(4)
+            self.assertFalse(_has_potential_branch_input_mutation(branch, [x]))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -1,12 +1,17 @@
 # Owner(s): ["module: inductor"]
 import functools
 import unittest
+from unittest import mock
+
+import sympy
 
 import torch
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.exc import InternalTorchDynamoError
-from torch._inductor import config as inductor_config
+from torch._inductor import config as inductor_config, ir
+from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.virtualized import V
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import (
@@ -1007,6 +1012,41 @@ class TestUnbackedSymints(InductorTestCase):
         compiled_fn = torch.compile(fn, backend=fx_pass_backend, fullgraph=True)
         result = compiled_fn(t)
         self.assertEqual(result, 8)
+
+    def test_stride_order_uses_unbacked_optimization_hint(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint()
+        torch._dynamo.override_optimization_hint(seq, 16)
+
+        stride_order = ir.get_stride_order(
+            [256 * sympy.Max(1, seq.node.expr // 2), 256, 1],
+            shape_env,
+        )
+        self.assertEqual(stride_order, [2, 1, 0])
+
+    def test_stride_ordered_rejects_unhinted_unbacked_layout(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint().node.expr
+        sizevars = SizeVarAllocator(shape_env)
+        graph = mock.Mock(sizevars=sizevars)
+
+        layout = ir.FixedLayout(
+            torch.device(device),
+            torch.float32,
+            size=[seq, 2],
+            stride=[seq, 1],
+        )
+        with V.set_graph_handler(graph):
+            with mock.patch.object(
+                sizevars,
+                "optimization_hint",
+                side_effect=AssertionError("unexpected optimization hint"),
+            ):
+                self.assertFalse(layout.is_stride_ordered([1, 0]))
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -861,6 +861,41 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipIfXpu(msg="standalone_compile coverage is CUDA-only")
+    @skipCPUIf(True, "requires gpu and triton")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    def test_standalone_compile_binds_ignored_fallback_unbacked_output(self, device):
+        from torch._inductor import standalone_compile
+        from torch._subclasses.fake_tensor import FakeTensor
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(counts, x):
+            idx = torch.repeat_interleave(counts)
+            return x[idx].sin()
+
+        counts = torch.tensor([1, 2, 1, 0], device=device, dtype=torch.int64)
+        x = torch.randn(4, 8, device=device)
+        torch._dynamo.mark_dynamic(counts, 0, min=1, max=8)
+        gm = make_fx(fn, tracing_mode="symbolic")(counts, x)
+        fake_mode = next(
+            node.meta["val"].fake_mode
+            for node in gm.graph.nodes
+            if isinstance(node.meta.get("val"), FakeTensor)
+        )
+
+        with (
+            torch._guards.tracing(torch._guards.TracingContext(fake_mode)),
+            fake_mode.shape_env.ignore_fresh_unbacked_symbols(),
+        ):
+            compiled = standalone_compile(
+                gm,
+                [counts, x],
+                dynamic_shapes="from_tracing_context",
+                options={},
+            )
+
+        torch.testing.assert_close(compiled(counts, x), fn(counts, x))
+
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_override_optimization_hint_eager(self, device):
         """Test that override_optimization_hint updates var_to_hint_override eagerly."""

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -34,6 +34,7 @@ from torch.fx.experimental.symbolic_shapes import (
     GuardOnDataDependentSymNode,
     has_free_symbols,
     is_symbolic,
+    rebind_unbacked,
     ShapeEnv,
     StatelessSymbolicContext,
     statically_known_false,
@@ -3730,6 +3731,27 @@ def custom_pass(graph: torch.fx.Graph) -> torch.fx.Graph:
 
 
 class TestUnbacked(TestCase):
+    def test_rebind_unbacked_to_symbolic_expression(self):
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        graph = torch.fx.Graph()
+        node = graph.call_function(operator.add, args=(1, 1))
+
+        with fake_mode:
+            old = shape_env.create_unbacked_symint()
+            base = shape_env.create_unbacked_symint()
+            result = (base + 1) // 2
+
+        old_expr = old.node.expr
+        result_expr = result.node.expr
+        node.meta["unbacked_bindings"] = {old_expr: ()}
+
+        rebind_unbacked(shape_env, node, result)
+
+        self.assertEqual(shape_env.replacements[old_expr], result_expr)
+
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/156135")
     @torch._dynamo.config.patch("capture_scalar_outputs", True)
     @parametrize("backend", ["inductor", "eager"])
@@ -4013,6 +4035,27 @@ class TestUnbacked(TestCase):
                 Exception, "Pending unbacked symbols.*not in returned outputs"
             ):
                 func_negative(x)
+
+    def test_ignore_fresh_unbacked_symbols_preserves_existing_pending(self):
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            pending = shape_env.create_unbacked_symint().node.expr
+
+            with shape_env.ignore_fresh_unbacked_symbols():
+                ignored = shape_env.create_unbacked_symint().node.expr
+                example_value = torch.empty(2)
+            with self.assertRaisesRegex(
+                Exception, f"Pending unbacked symbols {{{pending}}}"
+            ):
+                torch.fx.experimental.symbolic_shapes.compute_unbacked_bindings(
+                    shape_env,
+                    example_value,
+                )
+
+        self.assertNotIn(ignored, shape_env.pending_fresh_unbacked_symbols)
 
     def test_meta_copy(self):
         """

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1365,6 +1365,17 @@ class FakeTensorTest(TestCase):
         self.assertEqual(out.shape, (4 * 2 * (seq // 2), 256))
         self.assertTrue(free_unbacked_symbols(out.shape[0]))
 
+    def test_meta_storage_trace_uses_hint_for_symbolic_size(self):
+        from torch._subclasses.meta_utils import MetaStorageDesc, MetaStorageId
+
+        shape_env = ShapeEnv()
+        size = shape_env.create_unbacked_symint()
+        torch._dynamo.override_optimization_hint(size, 16)
+
+        metadata = MetaStorageDesc(MetaStorageId(0), 3 * size, None).as_json(1)
+        self.assertEqual(metadata["size"], "3*u0")
+        self.assertEqual(metadata["size_hint"], 48)
+
     def test_matmul_rank4_unbacked_batch_dim(self):
         fake_mode, (q, k) = self.fake_with_unbacked_batch(
             torch.randn(4, 2, 8, 16),

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -15,7 +15,7 @@ from torch._higher_order_ops.schema import HopSchema
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_opaque_type
 from torch._ops import HigherOrderOperator, OperatorBase, OpOverload
-from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensor, maybe_get_fake_mode
 from torch._subclasses.functional_tensor import (
     disable_functional_mode,
     FunctionalTensor,
@@ -331,13 +331,23 @@ def _set_compilation_env():
 
 
 # The invariant here is that we always trace the branch with fake tensor
-def _maybe_fake_tracing(fn, inputs: list[Any], pre_dispatch):
+def _detect_fake_mode_from_inputs(inputs: list[Any]):
     fake_mode_det = None
     for inp in pytree.tree_leaves(inputs):
-        if isinstance(inp, FakeTensor):
-            fake_mode_det = inp.fake_mode
-            break
+        fake_mode = maybe_get_fake_mode(inp)
+        if fake_mode is None:
+            continue
+        if fake_mode_det is None:
+            fake_mode_det = fake_mode
+        elif fake_mode_det is not fake_mode:
+            raise AssertionError(
+                f"Expected all fake inputs to use the same fake mode, got {fake_mode_det} and {fake_mode}"
+            )
+    return fake_mode_det
 
+
+def _maybe_fake_tracing(fn, inputs: list[Any], pre_dispatch):
+    fake_mode_det = _detect_fake_mode_from_inputs(inputs)
     fake_mode: AbstractContextManager = nullcontext()
     tracing_mode = "fake"
     if fake_mode_det is not None:
@@ -348,12 +358,20 @@ def _maybe_fake_tracing(fn, inputs: list[Any], pre_dispatch):
     # code that happens in make_fx e.g. we now call as_strided when wrapping tensor
     # as fake tensor.
     with fake_mode, disable_proxy_modes_tracing():
-        gm = make_fx(
-            fn,
-            tracing_mode=tracing_mode,
-            pre_dispatch=pre_dispatch,
-            _error_on_data_dependent_ops=False,
-        )(*inputs)
+        from torch.fx.experimental.symbolic_shapes import (
+            _ignore_fresh_unbacked_symbols_tls_context,
+        )
+
+        # This graph is used only to answer alias/mutation questions. Fresh
+        # unbacked symbols created during the trace are therefore discarded with
+        # the graph and should not require bindings in the surrounding graph.
+        with _ignore_fresh_unbacked_symbols_tls_context():
+            gm = make_fx(
+                fn,
+                tracing_mode=tracing_mode,
+                pre_dispatch=pre_dispatch,
+                _error_on_data_dependent_ops=False,
+            )(*inputs)
         if not isinstance(fake_mode, nullcontext) and fake_mode.shape_env is not None:  # type: ignore[attr-defined]
             insert_deferred_runtime_asserts(
                 gm,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -55,6 +55,7 @@ from torch._prims_common import (
     StrideType,
 )
 from torch.fx.experimental.symbolic_shapes import (
+    _free_unbacked_symbols_with_path,
     _remove_effect_token_unbacked_bindings,
     compute_unbacked_bindings,
     free_symbols,
@@ -6959,6 +6960,19 @@ class ExternKernel(InputsKernel):
             unbacked_bindings = compute_unbacked_bindings(
                 shape_env, example_output, node_meta_val
             )
+            if unbacked_bindings is None:
+                pending = cast(
+                    Any,
+                    OrderedSet([*free_unbacked_symbols(example_output)]),
+                )
+                if pending:
+                    unbacked_bindings = _free_unbacked_symbols_with_path(
+                        example_output,
+                        (),
+                        shape_env=shape_env,
+                        pending=pending,
+                        simplify=False,
+                    )
 
         example_out_li = (
             [example_output]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4364,7 +4364,7 @@ class Layout(OutputSpec):
         non_1_indices = [
             i
             for i, dim in enumerate(self.size)
-            if V.graph.sizevars.optimization_hint(dim, fallback=2) != 1
+            if not V.graph.sizevars.statically_known_equals(dim, 1)
         ]
 
         stride = [self.stride[i] for i in non_1_indices]
@@ -4384,11 +4384,15 @@ class Layout(OutputSpec):
         # check if it is in ascending order
         for i in range(len(order) - 1):
             expr = stride_ordered[i] > stride_ordered[i + 1]
-            if not isinstance(expr, bool):
-                expr = V.graph._shape_env.evaluate_expr(
-                    stride_ordered[i] > stride_ordered[i + 1], size_oblivious=True
-                )
-            if expr:
+            if isinstance(expr, bool):
+                if expr:
+                    return False
+                continue
+            if V.graph.sizevars.guard_or_false(expr):
+                return False
+            if not V.graph.sizevars.guard_or_false(
+                stride_ordered[i] <= stride_ordered[i + 1]
+            ):
                 return False
         return True
 
@@ -7125,9 +7129,15 @@ class ExternKernel(InputsKernel):
                     # the current size and stride already satisfies this order.
                     # However by freezing it to the required order, the layout will be changed to:
                     # size=[s0, 1, 28, 28], stride=[784, 1, 28, 1]), which is not actually necessary.
-                    use_current_stride_order = is_stride_order_storage_and_layout(
-                        x, order
-                    ) and not free_unbacked_symbols(x.get_layout().stride)
+                    layout = x.get_layout()
+                    has_unbacked_layout = bool(
+                        free_unbacked_symbols(layout.size)
+                        or free_unbacked_symbols(layout.stride)
+                    )
+                    use_current_stride_order = (
+                        not has_unbacked_layout
+                        and is_stride_order_storage_and_layout(x, order)
+                    )
                     # fix flexiblelayout to be FixedLayout with stride_order
                     as_storage_and_layout(
                         x,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -73,6 +73,7 @@ from torch.fx.experimental._size_hinting import _sympy_subs
 from torch.fx.experimental.symbolic_shapes import (
     free_symbols,
     free_unbacked_symbols,
+    GuardOnDataDependentSymNode,
     IterateExprs,
     ShapeEnv,
 )
@@ -1509,18 +1510,37 @@ def argsort_sym(
     *,
     reverse: bool = False,
 ) -> list[int]:
+    """
+    Return a symbolic sort order for optimization-only layout heuristics.
+
+    Data-dependent comparisons can fall back to non-guarding optimization hints,
+    so callers must not use this order to make correctness decisions.
+    """
+
     def cmp(a: tuple[int, sympy.Expr], b: tuple[int, sympy.Expr]) -> int:
         a_idx, a_val = a
         b_idx, b_val = b
 
-        def evaluate(expr: bool | torch.SymInt | sympy.Expr) -> bool:
+        def evaluate(
+            expr: bool | torch.SymInt | sympy.Expr,
+            fallback: Callable[[], bool],
+        ) -> bool:
             if isinstance(expr, bool):
                 return expr
-            return shape_env.evaluate_expr(expr, size_oblivious=True)
+            try:
+                return shape_env.evaluate_expr(expr)
+            except GuardOnDataDependentSymNode:
+                return fallback()
 
-        if evaluate(a_val < b_val):
+        def hint_lt(lhs: sympy.Expr, rhs: sympy.Expr) -> bool:
+            # Stride sorting is an optimization-only ordering decision.  Keep
+            # semantic reasoning symbolic first, then fall back to explicit
+            # optimization hints when unbacked comparisons are data-dependent.
+            return shape_env.optimization_hint(lhs) < shape_env.optimization_hint(rhs)
+
+        if evaluate(a_val < b_val, lambda: hint_lt(a_val, b_val)):
             return -1
-        if evaluate(a_val > b_val):
+        if evaluate(a_val > b_val, lambda: hint_lt(b_val, a_val)):
             return 1
         # If strides are the same, prefer the original order.
         # (this matches argsort's algorithm).

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -528,11 +528,19 @@ class MetaStorageDesc:
     data: torch.UntypedStorage | None
 
     def as_json(self, describer_id: _DescriberId) -> dict[str, object]:
-        return {
+        metadata: dict[str, object] = {
             "id": self.id,
             "describer_id": describer_id,
             "size": self.size if isinstance(self.size, int) else repr(self.size),
         }
+        if isinstance(self.size, torch.SymInt):
+            node = self.size.node
+            free_symbols = node.expr.free_symbols
+            if free_symbols and all(
+                symbol in node.shape_env.var_to_hint_override for symbol in free_symbols
+            ):
+                metadata["size_hint"] = node.shape_env.optimization_hint(node.expr)
+        return metadata
 
 
 @dataclass(frozen=True)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -721,7 +721,7 @@ def rebind_unbacked(
 
             if not isinstance(raw_u1, sympy.Symbol):
                 if raw_u1.free_symbols:
-                    raise AssertionError(f"should have been constant, but got {raw_u1}")
+                    shape_env._eliminate_unbacked(raw_u0, raw_u1)
                 continue
 
             # The old and new could be the same if you improperly hit the memo


### PR DESCRIPTION
Stacked PRs:
 * #183838
 * __->__#186255
 * #183839
 * #183840
 * #183837


--- --- ---

### [Inductor] Bind fallback output unbacked symbols


Fallback kernels can produce outputs whose shapes contain fresh unbacked symbols. When those symbols were created under ignore_fresh_unbacked_symbols(), compute_unbacked_bindings() may return no pending bindings, but the generated wrapper can still use the fallback output symbol in size assertions or downstream allocations.

If fallback binding discovery returns no bindings, derive bindings directly from the fallback output structure when it still contains free unbacked symbols. This keeps the fallback output extent bound from the runtime output tensor before later wrapper code references it.

Fixes https://github.com/pytorch/pytorch/issues/185341

Test Plan: python test/inductor/test_unbacked_symints.py -k standalone_compile_binds_ignored_fallback_unbacked_output -v

Test Plan: lintrunner --config=.lintrunner.toml torch/_inductor/ir.py test/inductor/test_unbacked_symints.py
