### PR TITLE
[PyTorch][AOTI] Optional pinned async H2D copy for constant loading (env-var gated) (#186258)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -403,6 +403,30 @@ class AOTInductorTestsTemplate:
         with config.patch({"always_keep_tensor_constants": True}):
             self.check_model(Model().to(self.device), example_inputs)
 
+    @unittest.skipIf(
+        not HAS_GPU or GPU_TYPE != "cuda" or TEST_WITH_ROCM,
+        "Pinned async constant copy is CUDA-only",
+    )
+    @patch.dict(
+        os.environ,
+        {
+            "AOTI_COPY_USE_PINNED_ASYNC": "1",
+            "AOTI_COPY_STAGE_BUFFER_BYTES": "1024",
+        },
+    )
+    def test_small_constant_pinned_async_copy(self):
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+        with config.patch({"always_keep_tensor_constants": True}):
+            self.check_model(Model().to(self.device), example_inputs)
+
     def test_output_path_1(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -649,6 +649,18 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsFromBlob(
       {container->update_constants_from_blob(weight_blob_ptr); })
     }
 
+AOTIRuntimeError AOTInductorSetUsePinnedAsyncConstantsCopy(bool enabled) {
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    torch::aot_inductor::setUsePinnedAsyncConstantsCopy(enabled);
+  })
+}
+
+AOTIRuntimeError AOTInductorSetPinnedAsyncConstantsCopyStageBufferBytes(
+    size_t bytes) {
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    torch::aot_inductor::setPinnedAsyncConstantsCopyStageBufferBytes(bytes);
+  })
+}
 
 AOTIRuntimeError AOTInductorGetLastError(
     const char** error_msg) {

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -385,6 +385,16 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     const char** in_spec,
     const char** out_spec);
 
+// Enables or disables pinned async H2D copies for constant loading and updates.
+// Call before creating a model/container to affect embedded constant loading.
+AOTI_API AOTIRuntimeError
+AOTInductorSetUsePinnedAsyncConstantsCopy(bool enabled);
+
+// Sets bytes per pinned async staging buffer. Pass 0 to use
+// AOTI_COPY_STAGE_BUFFER_BYTES or the runtime default.
+AOTI_API AOTIRuntimeError
+AOTInductorSetPinnedAsyncConstantsCopyStageBufferBytes(size_t bytes);
+
 // Retrieves the error message from the last failed AOTI runtime call on the
 // current thread. The returned pointer is valid until the next AOTI runtime
 // call on the same thread. Returns an empty string if the last call succeeded.

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -273,11 +273,15 @@ int munmap(void* addr, size_t length) {
 
 #include <fcntl.h>
 
+#include <algorithm>
+#include <atomic>
+#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <optional>
 #include <regex>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -318,11 +322,213 @@ extern uint8_t _binary_constants_bin_end[];
 #define AOTI_CONST_ALIGNMENT 64
 #endif
 
+namespace torch::aot_inductor {
+inline void setUsePinnedAsyncConstantsCopy(bool enabled);
+inline bool usePinnedAsyncConstantsCopy();
+inline void setPinnedAsyncConstantsCopyStageBufferBytes(size_t bytes);
+inline size_t pinnedAsyncConstantsCopyStageBufferBytes();
+} // namespace torch::aot_inductor
+
 namespace {
 
 using RAIIDataPtr = std::unique_ptr<void, std::function<void(void*)>>;
+// PinnedStagingPool (below) owns pinned host blocks via this RAII type from
+// the surrounding torch::aot_inductor namespace. Bring it in by name so the
+// anonymous-namespace class body can use it unqualified.
+using torch::aot_inductor::RAIIAtenTensorHandle;
 
 #ifdef USE_CUDA
+
+// RAII ping-pong pinned staging pool for non-blocking H2D copies of AOTI
+// constants without triggering CUDA/HIP's device-wide implicit sync.
+//
+// Synchronous cudaMemcpy(H2D) from pageable host memory (the .so-embedded
+// constants region, mmap'd by dlopen) performs a device-wide implicit
+// synchronize per the CUDA/HIP spec, stalling concurrent inference streams.
+//
+// We avoid that by staging pageable -> pinned (CPU memcpy) and issuing
+// cudaMemcpyAsync(pinned -> device) on a dedicated non-blocking stream.
+// Two pinned staging buffers ping-pong via cudaEvents so CPU fill of one
+// buffer overlaps GPU H2D from the other.
+//
+// Pinned host buffers are allocated via the stable C ABI
+// aoti_torch_empty_strided_pinned, which routes through ATen's cached
+// pinned host allocator (at::getPinnedMemoryAllocator). That allocator
+// keeps freed blocks in a process-wide pool, so back-to-back model loads
+// reuse buffers instead of paying cudaHostAlloc/cudaFreeHost per call.
+//
+// Total host-locked memory is bounded at 2 * AOTI_COPY_STAGE_BUFFER_BYTES
+// (default 2 * 64 MiB = 128 MiB) independent of model size.
+class PinnedStagingPool {
+ public:
+  static constexpr size_t kDefaultBufferBytes = 64ULL * 1024 * 1024;
+
+  // Returns nullptr on pinned-host alloc / stream / event creation failure
+  // so callers can fall back to the synchronous copy path.
+  static std::unique_ptr<PinnedStagingPool> tryCreate(size_t buffer_bytes) {
+    std::unique_ptr<PinnedStagingPool> pool(new PinnedStagingPool());
+    pool->buffer_bytes_ = buffer_bytes;
+    cudaError_t rc =
+        cudaStreamCreateWithFlags(&pool->stream_, cudaStreamNonBlocking);
+    if (rc != cudaSuccess) {
+      (void)cudaGetLastError();
+      return nullptr;
+    }
+    const int64_t sizes = static_cast<int64_t>(buffer_bytes);
+    const int64_t strides = 1;
+    for (int i = 0; i < 2; ++i) {
+      rc = cudaEventCreateWithFlags(&pool->events_[i], cudaEventDisableTiming);
+      if (rc != cudaSuccess) {
+        (void)cudaGetLastError();
+        return nullptr;
+      }
+      AtenTensorHandle handle = nullptr;
+      AOTITorchError trc = aoti_torch_empty_strided_pinned(
+          /*ndim=*/1,
+          &sizes,
+          &strides,
+          aoti_torch_dtype_uint8(),
+          aoti_torch_device_type_cpu(),
+          /*device_index=*/0,
+          &handle);
+      if (trc != AOTI_TORCH_SUCCESS || handle == nullptr) {
+        return nullptr;
+      }
+      pool->stage_tensors_[i] = RAIIAtenTensorHandle(handle);
+      trc = aoti_torch_get_data_ptr(
+          pool->stage_tensors_[i].get(), &pool->stage_[i]);
+      if (trc != AOTI_TORCH_SUCCESS || pool->stage_[i] == nullptr) {
+        return nullptr;
+      }
+    }
+    return pool;
+  }
+
+  // Chunked copy of a host source range through the ping-pong pinned
+  // buffers. Multiple back-to-back calls keep the H2D stream filled.
+  // Caller-owned dst must remain valid until the destructor synchronizes.
+  void copyH2DViaStage(void* dst, const void* src, size_t total) {
+    const auto* src_bytes = static_cast<const uint8_t*>(src);
+    auto* dst_bytes = static_cast<uint8_t*>(dst);
+    size_t offset = 0;
+    while (offset < total) {
+      const size_t chunk = std::min(buffer_bytes_, total - offset);
+      // Wait for GPU to release this staging buffer.
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventSynchronize(events_[buf_]));
+      memcpy(stage_[buf_], src_bytes + offset, chunk);
+      AOTI_RUNTIME_CUDA_CHECK(cudaMemcpyAsync(
+          dst_bytes + offset,
+          stage_[buf_],
+          chunk,
+          cudaMemcpyHostToDevice,
+          stream_));
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(events_[buf_], stream_));
+      buf_ ^= 1;
+      offset += chunk;
+    }
+  }
+
+  cudaStream_t stream() const {
+    return stream_;
+  }
+
+  // Synchronize the H2D stream and surface any error from a previously issued
+  // async copy (cudaMemcpyAsync failures are reported lazily at the sync).
+  // Call before destroying the pool so a failed load is not silently swallowed
+  // by the no-throw destructor and passed downstream as a populated buffer.
+  void finish() {
+    if (stream_ != nullptr) {
+      AOTI_RUNTIME_CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+  }
+
+  ~PinnedStagingPool() {
+    // Best-effort cleanup: never throw from a destructor.
+    //
+    // Order: sync the stream FIRST so no in-flight async H2D is still
+    // reading from the pinned buffers when their RAIIAtenTensorHandle
+    // members run (which return the blocks to ATen's cached pinned host
+    // allocator pool). Members are destroyed after this body returns, in
+    // reverse declaration order; stage_tensors_ is last-declared so it
+    // runs first among members.
+    if (stream_ != nullptr) {
+      (void)cudaStreamSynchronize(stream_);
+    }
+    for (int i = 0; i < 2; ++i) {
+      if (events_[i] != nullptr) {
+        (void)cudaEventDestroy(events_[i]);
+      }
+    }
+    if (stream_ != nullptr) {
+      (void)cudaStreamDestroy(stream_);
+    }
+    // Clear any error left by best-effort cleanup.
+    (void)cudaGetLastError();
+  }
+
+  PinnedStagingPool(const PinnedStagingPool&) = delete;
+  PinnedStagingPool& operator=(const PinnedStagingPool&) = delete;
+
+ private:
+  PinnedStagingPool() = default;
+
+  cudaStream_t stream_{nullptr};
+  cudaEvent_t events_[2]{nullptr, nullptr};
+  // Cached borrowed pointers into stage_tensors_[i] to avoid a shim call
+  // per chunk in the hot path.
+  void* stage_[2]{nullptr, nullptr};
+  size_t buffer_bytes_{0};
+  int buf_{0};
+  // Owns the pinned host allocations via ATen's cached pinned host
+  // allocator. Declared last so it is destroyed first among members
+  // (after the destructor body has synchronized the stream).
+  RAIIAtenTensorHandle stage_tensors_[2]{};
+};
+
+inline bool envFlagIsEnabled(const char* env) {
+  if (env == nullptr || env[0] == '\0') {
+    return false;
+  }
+  std::string value(env);
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+  return value != "0" && value != "false";
+}
+
+// Returns a PinnedStagingPool when pinned async constant copies are enabled
+// and host pinning succeeds. Returns nullptr otherwise so callers fall back to
+// the synchronous copy path. Per-buffer size comes from
+// AOTI_COPY_STAGE_BUFFER_BYTES (default 64 MiB).
+inline std::unique_ptr<PinnedStagingPool> tryMakeConstantsStagingPool() {
+  if (!torch::aot_inductor::usePinnedAsyncConstantsCopy()) {
+    return nullptr;
+  }
+  const size_t explicit_buffer_bytes =
+      torch::aot_inductor::pinnedAsyncConstantsCopyStageBufferBytes();
+  if (explicit_buffer_bytes > 0) {
+    return PinnedStagingPool::tryCreate(explicit_buffer_bytes);
+  }
+  // Resolve the env var once into a cached value, not the raw getenv pointer.
+  // Per POSIX that pointer may be invalidated by setenv/putenv/unsetenv.
+  static const size_t env_buffer_bytes = [] {
+    const char* env = std::getenv("AOTI_COPY_STAGE_BUFFER_BYTES");
+    size_t bytes = PinnedStagingPool::kDefaultBufferBytes;
+    if (env != nullptr && env[0] != '\0') {
+      try {
+        auto parsed = std::stoull(env);
+        if (parsed > 0) {
+          bytes = static_cast<size_t>(parsed);
+        }
+      } catch (...) {
+        // Ignore parse errors; use default.
+      }
+    }
+    return bytes;
+  }();
+  return PinnedStagingPool::tryCreate(env_buffer_bytes);
+}
 
 // NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
 RAIIDataPtr RAII_gpuMalloc(size_t num_bytes) {
@@ -389,6 +595,50 @@ RAIIDataPtr RAII_cpuMalloc(size_t num_bytes) {
 } // anonymous namespace
 
 namespace torch::aot_inductor {
+
+inline std::atomic<int>& pinnedAsyncConstantsCopySetting() {
+  // -1: use env fallback, 0: disabled, 1: enabled.
+  static std::atomic<int> setting{-1};
+  return setting;
+}
+
+inline void setUsePinnedAsyncConstantsCopy(bool enabled) {
+  pinnedAsyncConstantsCopySetting().store(
+      enabled ? 1 : 0, std::memory_order_relaxed);
+}
+
+inline bool usePinnedAsyncConstantsCopy() {
+  const int setting =
+      pinnedAsyncConstantsCopySetting().load(std::memory_order_relaxed);
+  if (setting != -1) {
+    return setting == 1;
+  }
+#ifdef USE_CUDA
+  static const bool enabled_from_env = [] {
+    const char* env = std::getenv("AOTI_COPY_USE_PINNED_ASYNC");
+    return envFlagIsEnabled(env);
+  }();
+  return enabled_from_env;
+#else
+  return false;
+#endif
+}
+
+inline std::atomic<size_t>& pinnedAsyncConstantsCopyStageBufferBytesSetting() {
+  // 0: use env/default fallback. Nonzero values are bytes per staging buffer.
+  static std::atomic<size_t> bytes{0};
+  return bytes;
+}
+
+inline void setPinnedAsyncConstantsCopyStageBufferBytes(size_t bytes) {
+  pinnedAsyncConstantsCopyStageBufferBytesSetting().store(
+      bytes, std::memory_order_relaxed);
+}
+
+inline size_t pinnedAsyncConstantsCopyStageBufferBytes() {
+  return pinnedAsyncConstantsCopyStageBufferBytesSetting().load(
+      std::memory_order_relaxed);
+}
 
 using ConstantMap =
     std::unordered_map<std::string, MaybeOwningAtenTensorHandle>;
@@ -699,6 +949,14 @@ class AOTInductorModelBase {
     size_t main_blob_idx = 0;
     size_t aux_cpu_blob_idx = 0;
 
+#ifdef USE_CUDA
+    // Opt-in pinned async staging pool for the constant H2D copies below.
+    // nullptr (default / on allocation failure) keeps the throttled
+    // synchronous path.
+    auto staging_pool = tryMakeConstantsStagingPool();
+    PinnedStagingPool* pool_raw = staging_pool.get();
+#endif
+
     for (size_t i = 0; i < num_constants; i++) {
       bool from_folded = this->constant_from_folded(i);
       if (from_folded) {
@@ -730,7 +988,12 @@ class AOTInductorModelBase {
               constants_internal_offset[main_blob_idx],
               bytes_read,
               data_size,
-              /* skip_copy = */ false);
+              /* skip_copy = */ false
+#ifdef USE_CUDA
+              ,
+              pool_raw
+#endif
+          );
         } else {
           auto* aux_cpu_constants_ptr =
               static_cast<uint8_t*>(aux_cpu_constant_blob_.get());
@@ -781,6 +1044,15 @@ class AOTInductorModelBase {
           opaque_metadata_size));
       constants_map_->emplace(std::move(name), tensor_handle);
     }
+#ifdef USE_CUDA
+    // Synchronize the staging stream (surfacing any async copy error) and
+    // release the pinned buffers before the loaded constants are observed by
+    // callers.
+    if (staging_pool != nullptr) {
+      staging_pool->finish();
+    }
+    staging_pool.reset();
+#endif
     if (constants_map_) {
       this->update_constants_array_from_map();
     }
@@ -810,7 +1082,12 @@ class AOTInductorModelBase {
       size_t constant_offset,
       size_t bytes_read,
       size_t data_size,
-      bool skip_copy) {
+      bool skip_copy
+#ifdef USE_CUDA
+      ,
+      PinnedStagingPool* staging_pool = nullptr
+#endif
+  ) {
     auto* constants_ptr = static_cast<uint8_t*>(constant_blob_.get());
     uint8_t* internal_ptr = constants_ptr + constant_offset;
     // TODO: Handle shared storage case.
@@ -822,11 +1099,19 @@ class AOTInductorModelBase {
           ->memcpy(internal_ptr, _get_constants_start() + bytes_read, data_size)
           .wait();
 #elif USE_CUDA
-      aoti_cuda_memcpy_throttled(
-          internal_ptr,
-          _get_constants_start() + bytes_read,
-          data_size,
-          cudaMemcpyHostToDevice);
+      // Prefer the pinned async staging path when the caller supplied a pool
+      // (AOTI_COPY_USE_PINNED_ASYNC). Otherwise fall back to the throttled
+      // synchronous copy (master default).
+      if (staging_pool != nullptr) {
+        staging_pool->copyH2DViaStage(
+            internal_ptr, _get_constants_start() + bytes_read, data_size);
+      } else {
+        aoti_cuda_memcpy_throttled(
+            internal_ptr,
+            _get_constants_start() + bytes_read,
+            data_size,
+            cudaMemcpyHostToDevice);
+      }
 #elif USE_MPS
       aoti_torch_mps_memcpy(
           constants_ptr,

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -587,6 +587,11 @@ class AOTInductorModelContainer {
     // constant as we walk.
     size_t main_blob_idx = 0;
     size_t aux_cpu_blob_idx = 0;
+#ifdef USE_CUDA
+    // Opt-in pinned async staging pool for the delta-update H2D copies below.
+    // nullptr (default / on allocation failure) keeps the throttled path.
+    auto staging_pool = tryMakeConstantsStagingPool();
+#endif
     for (size_t idx = 0; idx < num_constants; idx++) {
       if (models_[0]->constant_from_folded(static_cast<int64_t>(idx))) {
         continue;
@@ -689,11 +694,37 @@ class AOTInductorModelContainer {
         offset = constants_internal_offset_[this_main_idx] /
             aoti_torch_dtype_element_size(dtype);
 #elif USE_CUDA
-        aoti_cuda_memcpy_throttled(
-            internal_constants_ptr,
-            user_constant_ptr,
-            static_cast<size_t>(constant_size),
-            cudaMemcpyDefault);
+        // Pinned-async staging only helps for pageable host sources (which
+        // trigger CUDA/HIP's device-wide implicit sync) and is only safe for
+        // them, since copyH2DViaStage CPU-reads the source. Device / pinned
+        // sources use the synchronous throttled copy, which serializes with
+        // prior device work on the source; the pool's private stream would not.
+        // Detect per constant: a single update may mix pageable-host and
+        // device/pinned sources, so the type cannot be cached across the loop.
+        bool use_staging = false;
+        if (staging_pool != nullptr) {
+          cudaPointerAttributes attrs{};
+          cudaError_t pointer_attrs_result =
+              cudaPointerGetAttributes(&attrs, user_constant_ptr);
+          if (pointer_attrs_result != cudaSuccess) {
+            (void)cudaGetLastError();
+            use_staging = true;
+          } else {
+            use_staging = (attrs.type == cudaMemoryTypeUnregistered);
+          }
+        }
+        if (use_staging) {
+          staging_pool->copyH2DViaStage(
+              internal_constants_ptr,
+              user_constant_ptr,
+              static_cast<size_t>(constant_size));
+        } else {
+          aoti_cuda_memcpy_throttled(
+              internal_constants_ptr,
+              user_constant_ptr,
+              static_cast<size_t>(constant_size),
+              cudaMemcpyDefault);
+        }
 #else
         memcpy(internal_constants_ptr, user_constant_ptr, constant_size);
 #endif
@@ -718,6 +749,15 @@ class AOTInductorModelContainer {
       target.map->insert_or_assign(
           constant_name, RAIIAtenTensorHandle(tensor_handle));
     }
+#ifdef USE_CUDA
+    // Synchronize the staging stream (surfacing any async copy error) and
+    // release the pinned buffers before the updated constants are observed by
+    // callers.
+    if (staging_pool != nullptr) {
+      staging_pool->finish();
+    }
+    staging_pool.reset();
+#endif
     target.update_array(models_[0].get());
   }
 


### PR DESCRIPTION
Summary:

Adds the `AOTI_COPY_USE_PINNED_ASYNC` env var to opt into a pinned async H2D copy path in `AOTInductorModel::load_constants()` and `AOTInductorModelContainer::update_constant_buffer()`.

When enabled, uses two pinned staging buffers (ping-pong) sized by `AOTI_COPY_STAGE_BUFFER_BYTES` (default 64 MiB each) allocated via ATen's cached pinned host allocator through the stable C ABI (`aoti_torch_empty_strided_pinned` + `aoti_torch_get_data_ptr` + `RAIIAtenTensorHandle`). Reuses the process-wide pinned pool across back-to-back model loads instead of paying `cudaHostAlloc`/`cudaFreeHost` per call. CPU memcpy into one buffer overlaps with GPU H2D from the other via `cudaEvent` synchronization on a dedicated `cudaStreamNonBlocking` stream. Bounds host-locked memory regardless of model size.

When unset (default), falls back to the existing synchronous H2D path (`aoti_cuda_memcpy_throttled`), unchanged from master.

Synchronous memcpy from pageable host memory triggers a device-wide implicit synchronization regardless of the stream NonBlocking flag (CUDA and HIP spec). Copying through a pinned staging buffer eliminates this barrier so concurrent inference on other streams continues during the load.

Cached via `getenv()` at first call (process lifetime). Set via predictor TupperwareSpec env. Complements the `AOTI_CUDA_COPY_CHUNK_SIZE` / `AOTI_CUDA_COPY_SLEEP_US` chunking knobs - usable independently or together.

Test Plan:
## Test Results Summary

- **Environment:**  
  - Ran with `AOTI_COPY_USE_PINNED_ASYNC=1` on local devserver (NVIDIA A100, `@//mode/dev-nosan`)

- **Tests Executed:**  
  - `AOTI_COPY_USE_PINNED_ASYNC=1 buck2 test fbcode//caffe2/test/inductor/fb:test_simple_model_fb -- test_model_with_constants`  
    - **Result:** 1 pass, 0 fail
  - `AOTI_COPY_USE_PINNED_ASYNC=1 buck2 test fbcode//caffe2/test/inductor:test_aot_inductor -- test_large_mmaped_weights|test_small_constant|test_constant_folding`  
    - **Result:** 11 pass, 0 fail, 5 skipped (MPS, expected on non-Mac)

---

## Verification Details

- **Activation:**  
  - Verified the new path activates via log line:  
    ```
    [AOTI Loading] PinnedStagingPool: allocated 2x64 MiB pinned staging buffers via cached pinned host allocator
    ```
- **Performance:**  
  - On a 488 MB constants blob with 2 constants:
    - End-to-end load took **139 ms** (~3.5 GiB/s, in the expected range for pinned-staged H2D on PCIe Gen3)
- **Error Check:**  
  - No `cudaHostRegister failed` or `aoti_torch_empty_strided_pinned ... failed` soft-fail lines observed

---

## Test Session

- [View test session details](https://www.internalfb.com/intern/testinfra/testrun/6473924817930023)

Reviewed By: iuliur-meta

Differential Revision: D105915696




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo