### PR TITLE
[BE] Fix Metal compilation warnings

### DIFF
--- a/aten/src/ATen/native/mps/kernels/GroupNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/GroupNorm.metal
@@ -13,7 +13,7 @@ inline float load_affine_scale(constant T* ptr, uint idx) {
 }
 
 template <>
-inline float load_affine_scale(constant void* ptr, uint idx) {
+inline float load_affine_scale(constant void*, uint) {
   return 1;
 }
 
@@ -23,7 +23,7 @@ inline float load_affine_bias(constant T* ptr, uint idx) {
 }
 
 template <>
-inline float load_affine_bias(constant void* ptr, uint idx) {
+inline float load_affine_bias(constant void*, uint) {
   return 0;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186279
* __->__ #186267
* #186264

By removing paramter names if template specialization does not use it
```
Compiling /Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/GroupNorm.metal to GroupNorm_31.air
aten/src/ATen/native/mps/kernels/GroupNorm.metal:16:47: warning: unused parameter 'ptr' [-Wunused-parameter]
inline float load_affine_scale(constant void* ptr, uint idx) {
                                              ^
aten/src/ATen/native/mps/kernels/GroupNorm.metal:16:57: warning: unused parameter 'idx' [-Wunused-parameter]
inline float load_affine_scale(constant void* ptr, uint idx) {
                                                        ^
aten/src/ATen/native/mps/kernels/GroupNorm.metal:26:46: warning: unused parameter 'ptr' [-Wunused-parameter]
inline float load_affine_bias(constant void* ptr, uint idx) {
                                             ^
aten/src/ATen/native/mps/kernels/GroupNorm.metal:26:56: warning: unused parameter 'idx' [-Wunused-parameter]
inline float load_affine_bias(constant void* ptr, uint idx) {
                                                       ^
4 warnings generated.
```