### PR TITLE
[Accelerator] Fix missing no-op guards in reset_*_memory_stats

### DIFF
--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -39,8 +39,6 @@ def empty_host_cache() -> None:
     .. note:: This function is a no-op if the memory allocator for the current
         :ref:`accelerator <accelerators>` has not been initialized.
     """
-    if not torch._C._accelerator_isAllocatorInitialized():
-        return
     torch._C._accelerator_emptyHostCache()
 
 
@@ -269,14 +267,10 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
         dict: a dictionary containing memory allocator state information.
     """
     acc = torch.accelerator.current_accelerator()
-    if acc is not None:
-        if acc.type == "xpu":
-            return torch.xpu.memory._snapshot(
-                device, augment_with_fx_traces=augment_with_fx_traces
-            )
-        elif acc.type == "cuda":
-            return torch.cuda.memory._snapshot(
-                device, augment_with_fx_traces=augment_with_fx_traces
-            )
-
-    raise RuntimeError(f"Memory snapshots are not supported on accelerator: {getattr(acc, 'type', 'None')}")
+    if acc is not None and acc.type == "xpu":
+        return torch.xpu.memory._snapshot(
+            device, augment_with_fx_traces=augment_with_fx_traces
+        )
+    return torch.cuda.memory._snapshot(
+        device, augment_with_fx_traces=augment_with_fx_traces
+    )

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -39,6 +39,8 @@ def empty_host_cache() -> None:
     .. note:: This function is a no-op if the memory allocator for the current
         :ref:`accelerator <accelerators>` has not been initialized.
     """
+    if not torch._C._accelerator_isAllocatorInitialized():
+        return
     torch._C._accelerator_emptyHostCache()
 
 
@@ -208,6 +210,8 @@ def reset_accumulated_memory_stats(device_index: _device_t = None, /) -> None:
     .. note:: This function is a no-op if the memory allocator for the current
         :ref:`accelerator <accelerators>` has not been initialized.
     """
+    if not torch._C._accelerator_isAllocatorInitialized():
+        return
     device_index = _get_device_index(device_index, optional=True)
     return torch._C._accelerator_resetAccumulatedStats(device_index)
 
@@ -225,6 +229,8 @@ def reset_peak_memory_stats(device_index: _device_t = None, /) -> None:
     .. note:: This function is a no-op if the memory allocator for the current
         :ref:`accelerator <accelerators>` has not been initialized.
     """
+    if not torch._C._accelerator_isAllocatorInitialized():
+        return
     device_index = _get_device_index(device_index, optional=True)
     return torch._C._accelerator_resetPeakStats(device_index)
 
@@ -263,10 +269,14 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
         dict: a dictionary containing memory allocator state information.
     """
     acc = torch.accelerator.current_accelerator()
-    if acc is not None and acc.type == "xpu":
-        return torch.xpu.memory._snapshot(
-            device, augment_with_fx_traces=augment_with_fx_traces
-        )
-    return torch.cuda.memory._snapshot(
-        device, augment_with_fx_traces=augment_with_fx_traces
-    )
+    if acc is not None:
+        if acc.type == "xpu":
+            return torch.xpu.memory._snapshot(
+                device, augment_with_fx_traces=augment_with_fx_traces
+            )
+        elif acc.type == "cuda":
+            return torch.cuda.memory._snapshot(
+                device, augment_with_fx_traces=augment_with_fx_traces
+            )
+
+    raise RuntimeError(f"Memory snapshots are not supported on accelerator: {getattr(acc, 'type', 'None')}")


### PR DESCRIPTION
### Summary

Fixes two bugs in [`torch/accelerator/memory.py`](https://github.com/pytorch/pytorch/blob/main/torch/accelerator/memory.py) reported in #186265.

---

#### Bug 1 — Missing no-op allocator initialization guard

`empty_host_cache()`, `reset_accumulated_memory_stats()`, and `reset_peak_memory_stats()` all document a **no-op guarantee** when the allocator is uninitialized, but the `torch._C._accelerator_isAllocatorInitialized()` guard was missing. `empty_cache()` and `memory_stats()` in the same file already implement this correctly.

Without the fix, calling these functions before a device is available crashes:
```
RuntimeError: Cannot access accelerator device when none is available.
```

**Fix:** Add the same early-return guard already present in `empty_cache()`.

---

#### Bug 2 — Hardcoded CUDA fallback in `_snapshot()`

`_snapshot()` only explicitly handled `acc.type == "xpu"`, then fell through **unconditionally** to `torch.cuda.memory._snapshot()` for all other cases — including `mps`, `tpu`, and CPU-only builds. This breaks `torch.accelerator`'s device-agnostic contract:

```
AttributeError: module 'torch._C' has no attribute '_cuda_memorySnapshot'
```

**Fix:** Add an explicit `elif acc.type == "cuda"` branch and raise a clean `RuntimeError` for unsupported accelerators.

---

### Files Changed

- `torch/accelerator/memory.py`

---

### Testing

Two-phase reproduction + verification script run on `2.13.0.dev20260603+cpu` (CPU-only, Python 3.14):

- **Phase A** — simulates original buggy code → all 4 crashes confirmed
- **Phase B** — loads patched source with mocked C++ bindings → 8/8 assertions pass:
  - All 3 guards fire correctly, C++ backend never called
  - `_snapshot()` raises clean `RuntimeError` for `mps`, `tpu`, `None`
  - `_snapshot()` still routes correctly for `cuda`

---

### Related

Fixes #186265

cc @wschin @albanD @guangyey @EikanWang