### PR TITLE
[CUDA] Add TunableOp support for cublasLt

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -373,8 +373,21 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
   const bool lie_to_cublaslt = false;
 #endif
   if (lie_to_cublaslt) {
-     CuBlasLtMatrixLayout FakeBdesc(abType, k, 2, ldb, opb == CUBLAS_OP_T);
-     CuBlasLtMatrixLayout FakeCdesc(cType, m, 2, ldc);
+     const auto fake_ldb = ldb == 1 ? 2 : ldb;
+     const auto fake_ldc = ldc == 1 ? 2 : ldc;
+     CuBlasLtMatrixLayout FakeBdesc(abType, k, 2, fake_ldb, opb == CUBLAS_OP_T);
+     CuBlasLtMatrixLayout FakeCdesc(cType, m, 2, fake_ldc);
+     if (num_batches > 1) {
+       int num_batches_as_int = static_cast<int>(num_batches);
+       FakeBdesc.setAttribute(
+           CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, num_batches_as_int);
+       FakeCdesc.setAttribute(
+           CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, num_batches_as_int);
+       FakeBdesc.setAttribute(
+           CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, strideb);
+       FakeCdesc.setAttribute(
+           CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stridec);
+     }
 
      TORCH_CUDABLAS_CHECK(cublasLtMatmulAlgoGetHeuristic(
         ltHandle,

--- a/aten/src/ATen/cuda/tunable/GemmCublaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmCublaslt.h
@@ -1,0 +1,841 @@
+#pragma once
+
+#ifndef USE_ROCM
+
+#include <ATen/cuda/CUDAContextLight.h>
+#include <ATen/cuda/detail/BLASConstants.h>
+#include <ATen/cuda/detail/CublasLtUtils.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/cuda/tunable/GemmCommon.h>
+#include <ATen/cuda/tunable/TunableOp.h>
+#include <fmt/printf.h>
+
+#include <cstdio>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace at::cuda::tunable {
+
+namespace {
+
+template <typename T>
+int64_t CublasltBatchCount(const GemmParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T>
+int64_t CublasltBatchCount(const GemmAndBiasParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T, typename C_Dtype>
+int64_t CublasltBatchCount(
+    const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return params->batch;
+}
+
+template <typename T>
+int64_t CublasltStrideA(const GemmParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T>
+int64_t CublasltStrideA(const GemmAndBiasParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T, typename C_Dtype>
+int64_t CublasltStrideA(const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return params->stride_a;
+}
+
+template <typename T>
+int64_t CublasltStrideB(const GemmParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T>
+int64_t CublasltStrideB(const GemmAndBiasParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T, typename C_Dtype>
+int64_t CublasltStrideB(const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return params->stride_b;
+}
+
+template <typename T>
+int64_t CublasltStrideC(const GemmParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T>
+int64_t CublasltStrideC(const GemmAndBiasParams<T>* /*params*/) {
+  return 0;
+}
+
+template <typename T, typename C_Dtype>
+int64_t CublasltStrideC(const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return params->stride_c;
+}
+
+template <typename T>
+at::opmath_type<T> CublasltBeta(const GemmParams<T>* params) {
+  return params->beta;
+}
+
+template <typename T, typename C_Dtype>
+at::opmath_type<T> CublasltBeta(
+    const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return params->beta;
+}
+
+template <typename T>
+at::opmath_type<T> CublasltBeta(const GemmAndBiasParams<T>* params) {
+  return params->bias ? 0 : 1;
+}
+
+template <typename ParamsT>
+const void* CublasltBias(const ParamsT* /*params*/) {
+  return nullptr;
+}
+
+template <typename T>
+const void* CublasltBias(const GemmAndBiasParams<T>* params) {
+  return params->bias;
+}
+
+template <typename ParamsT>
+at::cuda::blas::GEMMAndBiasActivationEpilogue CublasltActivation(
+    const ParamsT* /*params*/) {
+  return at::cuda::blas::GEMMAndBiasActivationEpilogue::None;
+}
+
+template <typename T>
+at::cuda::blas::GEMMAndBiasActivationEpilogue CublasltActivation(
+    const GemmAndBiasParams<T>* params) {
+  return params->activation;
+}
+
+template <typename T, typename C_Dtype = T>
+class CublasltStandardGemmProblem {
+ public:
+  CublasltStandardGemmProblem(
+      char transa,
+      char transb,
+      int64_t m,
+      int64_t n,
+      int64_t k,
+      at::opmath_type<T> alpha,
+      const T* a,
+      int64_t lda,
+      int64_t stride_a,
+      const T* b,
+      int64_t ldb,
+      int64_t stride_b,
+      at::opmath_type<T> beta,
+      C_Dtype* c,
+      int64_t ldc,
+      int64_t stride_c,
+      int64_t batch_count,
+      const void* bias,
+      at::cuda::blas::GEMMAndBiasActivationEpilogue activation,
+      bool set_epilogue_attribute)
+      : type_info_(at::cuda::blas::detail::getCublasLtTypeInfo<T, C_Dtype>()),
+        m_(m),
+        n_(n),
+        k_(k),
+        lda_(lda),
+        ldb_(ldb),
+        ldc_(ldc),
+        stride_a_(stride_a),
+        stride_b_(stride_b),
+        stride_c_(stride_c),
+        batch_count_(batch_count),
+        a_(a),
+        b_(b),
+        c_(c),
+        alpha_(alpha),
+        beta_(beta),
+        opa_(at::cuda::blas::detail::cublasOpFromChar(transa)),
+        opb_(at::cuda::blas::detail::cublasOpFromChar(transb)),
+        compute_desc_(type_info_.compute_type, type_info_.scale_type),
+        bias_(bias),
+        activation_(activation),
+        set_epilogue_attribute_(set_epilogue_attribute) {
+    at::cuda::blas::detail::cublasAdjustLdLevel3(
+        transa, transb, m_, n_, k_, &lda_, &ldb_, &ldc_);
+    initialize();
+  }
+
+  cublasComputeType_t compute_type() const {
+    return type_info_.compute_type;
+  }
+
+  cudaDataType_t scale_type() const {
+    return type_info_.scale_type;
+  }
+
+  cudaDataType_t a_type() const {
+    return type_info_.ab_type;
+  }
+
+  cudaDataType_t b_type() const {
+    return type_info_.ab_type;
+  }
+
+  cudaDataType_t c_type() const {
+    return type_info_.c_type;
+  }
+
+  cudaDataType_t d_type() const {
+    return type_info_.c_type;
+  }
+
+  cublasLtMatmulDesc_t compute_desc() const {
+    return compute_desc_.descriptor();
+  }
+
+  cublasLtMatrixLayout_t adesc() const {
+    return adesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t bdesc() const {
+    return bdesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t cdesc() const {
+    return cdesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t ddesc() const {
+    return cdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_bdesc() const {
+    return lie_to_cublaslt_ ? fake_bdesc_->descriptor() : bdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_cdesc() const {
+    return lie_to_cublaslt_ ? fake_cdesc_->descriptor() : cdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_ddesc() const {
+    return heuristic_cdesc();
+  }
+
+  cublasLtMatmulPreference_t preference() const {
+    return preference_.descriptor();
+  }
+
+  void* alpha_ptr() const {
+    return alpha_ptr_;
+  }
+
+  void* beta_ptr() const {
+    return beta_ptr_;
+  }
+
+  const T* a() const {
+    return a_;
+  }
+
+  const T* b() const {
+    return b_;
+  }
+
+  C_Dtype* c() const {
+    return c_;
+  }
+
+  C_Dtype* d() const {
+    return c_;
+  }
+
+  void* workspace() const {
+    return workspace_.ptr;
+  }
+
+  size_t workspace_size() const {
+    return workspace_.size;
+  }
+
+ private:
+  void initialize() {
+    alpha_ptr_ = &alpha_;
+    beta_ptr_ = &beta_;
+    if constexpr (std::is_same_v<T, at::Half>) {
+      if (type_info_.compute_type == CUBLAS_COMPUTE_16F) {
+        halpha_ = alpha_;
+        hbeta_ = beta_;
+        alpha_ptr_ = &halpha_;
+        beta_ptr_ = &hbeta_;
+      }
+    }
+
+    compute_desc_.setAttribute(CUBLASLT_MATMUL_DESC_TRANSA, opa_);
+    compute_desc_.setAttribute(CUBLASLT_MATMUL_DESC_TRANSB, opb_);
+    if (set_epilogue_attribute_ || bias_ != nullptr ||
+        activation_ != at::cuda::blas::GEMMAndBiasActivationEpilogue::None) {
+      epilogue_ =
+          at::cuda::blas::detail::cublasLtEpilogue(activation_, bias_);
+      compute_desc_.setAttribute(CUBLASLT_MATMUL_DESC_EPILOGUE, epilogue_);
+    }
+    if (bias_ != nullptr) {
+      compute_desc_.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_POINTER, bias_);
+    }
+
+    if (at::globalContext()._SMCarveout_EXPERIMENTAL().has_value()) {
+      compute_desc_.setAttribute<int32_t>(
+          CUBLASLT_MATMUL_DESC_SM_COUNT_TARGET,
+          at::cuda::getCurrentDeviceProperties()->multiProcessorCount -
+              at::globalContext()._SMCarveout_EXPERIMENTAL().value());
+    }
+
+    if constexpr (std::is_same_v<T, at::Half>) {
+      auto fp16_reduction = at::globalContext().allowFP16ReductionCuBLAS();
+      if (fp16_reduction !=
+          at::CuBLASReductionOption::AllowReducedPrecisionWithSplitK) {
+        reduction_mask_ =
+            fp16_reduction ==
+                    at::CuBLASReductionOption::
+                        DisallowReducedPrecisionAllowSplitK
+                ? (CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE |
+                   CUBLASLT_REDUCTION_SCHEME_NONE)
+                : CUBLASLT_REDUCTION_SCHEME_NONE;
+        preference_.setAttribute(
+            CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, reduction_mask_);
+      }
+    } else if constexpr (std::is_same_v<T, at::BFloat16>) {
+      auto bf16_reduction = at::globalContext().allowBF16ReductionCuBLAS();
+      if (bf16_reduction !=
+          at::CuBLASReductionOption::AllowReducedPrecisionWithSplitK) {
+        reduction_mask_ =
+            bf16_reduction ==
+                    at::CuBLASReductionOption::
+                        DisallowReducedPrecisionAllowSplitK
+                ? (CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE |
+                   CUBLASLT_REDUCTION_SCHEME_NONE)
+                : CUBLASLT_REDUCTION_SCHEME_NONE;
+        preference_.setAttribute(
+            CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, reduction_mask_);
+      }
+    }
+
+    adesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        type_info_.ab_type, m_, k_, lda_, opa_ != CUBLAS_OP_N);
+    bdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        type_info_.ab_type, k_, n_, ldb_, opb_ != CUBLAS_OP_N);
+    cdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        type_info_.c_type, m_, n_, ldc_);
+
+    if (batch_count_ > 1) {
+      int batch_as_int = static_cast<int>(batch_count_);
+      adesc_->setAttribute(CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_as_int);
+      bdesc_->setAttribute(CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_as_int);
+      cdesc_->setAttribute(CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_as_int);
+      adesc_->setAttribute(
+          CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride_a_);
+      bdesc_->setAttribute(
+          CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride_b_);
+      cdesc_->setAttribute(
+          CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride_c_);
+    }
+
+    preference_.setAttribute(
+        CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES,
+        at::cuda::blas::detail::getAlignment(reinterpret_cast<uintptr_t>(a_)));
+    preference_.setAttribute(
+        CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES,
+        at::cuda::blas::detail::getAlignment(reinterpret_cast<uintptr_t>(b_)));
+    preference_.setAttribute(
+        CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES,
+        at::cuda::blas::detail::getAlignment(reinterpret_cast<uintptr_t>(c_)));
+    if (bias_ != nullptr) {
+      preference_.setAttribute(
+          CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES,
+          at::cuda::blas::detail::getAlignment(
+              reinterpret_cast<uintptr_t>(bias_)));
+    }
+
+    preference_.setAttribute(
+        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspace_.size);
+
+    lie_to_cublaslt_ = reduction_mask_ == CUBLASLT_REDUCTION_SCHEME_NONE &&
+        n_ == 1 && at::cuda::getCurrentDeviceProperties()->major >= 10;
+    if (lie_to_cublaslt_) {
+      const auto fake_ldb = ldb_ == 1 ? 2 : ldb_;
+      const auto fake_ldc = ldc_ == 1 ? 2 : ldc_;
+      fake_bdesc_ =
+          std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+              type_info_.ab_type, k_, 2, fake_ldb, opb_ == CUBLAS_OP_T);
+      fake_cdesc_ =
+          std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+              type_info_.c_type, m_, 2, fake_ldc);
+      if (batch_count_ > 1) {
+        int batch_as_int = static_cast<int>(batch_count_);
+        fake_bdesc_->setAttribute(
+            CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_as_int);
+        fake_cdesc_->setAttribute(
+            CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_as_int);
+        fake_bdesc_->setAttribute(
+            CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride_b_);
+        fake_cdesc_->setAttribute(
+            CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride_c_);
+      }
+    }
+  }
+
+  at::cuda::blas::detail::CublasLtTypeInfo<T, C_Dtype> type_info_;
+  int64_t m_;
+  int64_t n_;
+  int64_t k_;
+  int64_t lda_;
+  int64_t ldb_;
+  int64_t ldc_;
+  int64_t stride_a_;
+  int64_t stride_b_;
+  int64_t stride_c_;
+  int64_t batch_count_;
+  const T* a_;
+  const T* b_;
+  C_Dtype* c_;
+  at::opmath_type<T> alpha_;
+  at::opmath_type<T> beta_;
+  at::Half halpha_;
+  at::Half hbeta_;
+  void* alpha_ptr_ = nullptr;
+  void* beta_ptr_ = nullptr;
+  uint32_t reduction_mask_ = std::numeric_limits<uint32_t>::max();
+  cublasOperation_t opa_;
+  cublasOperation_t opb_;
+  at::cuda::blas::detail::CuBlasLtMatmulDescriptor compute_desc_;
+  at::cuda::blas::detail::CuBlasLtMatmulPreference preference_;
+  const void* bias_ = nullptr;
+  at::cuda::blas::GEMMAndBiasActivationEpilogue activation_;
+  bool set_epilogue_attribute_;
+  cublasLtEpilogue_t epilogue_ = CUBLASLT_EPILOGUE_DEFAULT;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> adesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> bdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> cdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> fake_bdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> fake_cdesc_;
+  at::cuda::blas::detail::CublasLtWorkspace workspace_;
+  bool lie_to_cublaslt_ = false;
+};
+
+template <typename T, typename ParamsT>
+auto MakeCublasltStandardGemmProblem(const ParamsT* params) {
+  return CublasltStandardGemmProblem<T>(
+      params->transa,
+      params->transb,
+      params->m,
+      params->n,
+      params->k,
+      params->alpha,
+      params->a,
+      params->lda,
+      CublasltStrideA(params),
+      params->b,
+      params->ldb,
+      CublasltStrideB(params),
+      CublasltBeta(params),
+      params->c,
+      params->ldc,
+      CublasltStrideC(params),
+      CublasltBatchCount(params),
+      CublasltBias(params),
+      CublasltActivation(params),
+      true /* set_epilogue_attribute */);
+}
+
+template <typename T, typename C_Dtype>
+auto MakeCublasltStandardGemmProblem(
+    const GemmStridedBatchedParams<T, C_Dtype>* params) {
+  return CublasltStandardGemmProblem<T, C_Dtype>(
+      params->transa,
+      params->transb,
+      params->m,
+      params->n,
+      params->k,
+      params->alpha,
+      params->a,
+      params->lda,
+      params->stride_a,
+      params->b,
+      params->ldb,
+      params->stride_b,
+      params->beta,
+      params->c,
+      params->ldc,
+      params->stride_c,
+      params->batch,
+      nullptr,
+      at::cuda::blas::GEMMAndBiasActivationEpilogue::None,
+      // Keep batched GEMM descriptor behavior aligned with the legacy path;
+      // setting EPILOGUE_DEFAULT changes some cuBLASLt heuristic results.
+      false /* set_epilogue_attribute */);
+}
+
+
+struct CublasltAlgoConfig {
+  int32_t id = 0;
+  uint32_t tile = 0;
+  uint32_t stages = 0;
+  int32_t splitk = 1;
+  uint32_t reduction = 0;
+  uint32_t swizzle = 0;
+  uint32_t custom = 0;
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 12000
+  uint16_t inner_shape = 0;
+  uint16_t cluster_shape = 0;
+#endif
+};
+
+template <typename T>
+bool CublasltGetAlgoConfigAttribute(
+    const cublasLtMatmulAlgo_t* algo,
+    cublasLtMatmulAlgoConfigAttributes_t attr,
+    T* value) {
+  size_t written = 0;
+  return cublasLtMatmulAlgoConfigGetAttribute(
+             algo, attr, value, sizeof(T), &written) == CUBLAS_STATUS_SUCCESS;
+}
+
+inline std::optional<CublasltAlgoConfig> CublasltAlgoConfigFromAlgo(
+    const cublasLtMatmulAlgo_t& algo) {
+  CublasltAlgoConfig config;
+  bool ok =
+      CublasltGetAlgoConfigAttribute(&algo, CUBLASLT_ALGO_CONFIG_ID, &config.id) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &config.tile) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_STAGES_ID, &config.stages) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &config.splitk) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME, &config.reduction) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, &config.swizzle) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, &config.custom);
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 12000
+  ok = ok &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_INNER_SHAPE_ID, &config.inner_shape) &&
+      CublasltGetAlgoConfigAttribute(
+          &algo, CUBLASLT_ALGO_CONFIG_CLUSTER_SHAPE_ID, &config.cluster_shape);
+#endif
+  if (!ok) {
+    return std::nullopt;
+  }
+  return config;
+}
+
+inline std::string CublasltAlgoConfigName(const CublasltAlgoConfig& config) {
+  std::string name = fmt::sprintf(
+      "Gemm_Cublaslt_id_%d_tile_%u_stages_%u_splitk_%d_red_%u_swizzle_%u_custom_%u",
+      config.id,
+      config.tile,
+      config.stages,
+      config.splitk,
+      config.reduction,
+      config.swizzle,
+      config.custom);
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 12000
+  name += fmt::sprintf(
+      "_inner_%hu_cluster_%hu", config.inner_shape, config.cluster_shape);
+#endif
+  return name;
+}
+
+inline std::optional<CublasltAlgoConfig> CublasltAlgoConfigFromName(
+    const std::string& name) {
+  CublasltAlgoConfig config;
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 12000
+  int matched = std::sscanf(
+      name.c_str(),
+      "Gemm_Cublaslt_id_%d_tile_%u_stages_%u_splitk_%d_red_%u_swizzle_%u_custom_%u"
+      "_inner_%hu_cluster_%hu",
+      &config.id,
+      &config.tile,
+      &config.stages,
+      &config.splitk,
+      &config.reduction,
+      &config.swizzle,
+      &config.custom,
+      &config.inner_shape,
+      &config.cluster_shape);
+  if (matched != 9) {
+    return std::nullopt;
+  }
+#else
+  int matched = std::sscanf(
+      name.c_str(),
+      "Gemm_Cublaslt_id_%d_tile_%u_stages_%u_splitk_%d_red_%u_swizzle_%u_custom_%u",
+      &config.id,
+      &config.tile,
+      &config.stages,
+      &config.splitk,
+      &config.reduction,
+      &config.swizzle,
+      &config.custom);
+  if (matched != 7) {
+    return std::nullopt;
+  }
+#endif
+  return config;
+}
+
+template <typename T>
+bool CublasltSetAlgoConfigAttribute(
+    cublasLtMatmulAlgo_t* algo,
+    cublasLtMatmulAlgoConfigAttributes_t attr,
+    const T& value) {
+  return cublasLtMatmulAlgoConfigSetAttribute(
+             algo, attr, &value, sizeof(value)) == CUBLAS_STATUS_SUCCESS;
+}
+
+template <typename ProblemT>
+bool CublasltInitializeAlgo(
+    const ProblemT& problem,
+    const CublasltAlgoConfig& config,
+    cublasLtMatmulAlgo_t* algo) {
+  auto status = cublasLtMatmulAlgoInit(
+      at::cuda::getCurrentCUDABlasLtHandle(),
+      problem.compute_type(),
+      problem.scale_type(),
+      problem.a_type(),
+      problem.b_type(),
+      problem.c_type(),
+      problem.d_type(),
+      config.id,
+      algo);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    return false;
+  }
+
+  bool ok =
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_TILE_ID, config.tile) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_STAGES_ID, config.stages) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, config.splitk) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME, config.reduction) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_CTA_SWIZZLING, config.swizzle) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION, config.custom);
+#if defined(CUBLAS_VERSION) && CUBLAS_VERSION >= 12000
+  ok = ok &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_INNER_SHAPE_ID, config.inner_shape) &&
+      CublasltSetAlgoConfigAttribute(
+          algo, CUBLASLT_ALGO_CONFIG_CLUSTER_SHAPE_ID, config.cluster_shape);
+#endif
+  return ok;
+}
+
+template <typename ProblemT>
+bool CublasltValidateAlgo(
+    const ProblemT& problem,
+    cublasLtMatmulAlgo_t* algo) {
+  cublasLtMatmulHeuristicResult_t check_result = {};
+  auto status = cublasLtMatmulAlgoCheck(
+      at::cuda::getCurrentCUDABlasLtHandle(),
+      problem.compute_desc(),
+      problem.adesc(),
+      problem.bdesc(),
+      problem.cdesc(),
+      problem.ddesc(),
+      algo,
+      &check_result);
+  return status == CUBLAS_STATUS_SUCCESS &&
+      check_result.workspaceSize <= problem.workspace_size();
+}
+
+template <typename T>
+struct CublasltStandardGemmProblemFactory {
+  template <typename ParamsT>
+  auto operator()(const ParamsT* params) const {
+    return MakeCublasltStandardGemmProblem<T>(params);
+  }
+};
+
+
+template <typename ParamsT, typename ProblemFactory>
+class CublasltMatmulOp : public Callable<ParamsT> {
+ public:
+  explicit CublasltMatmulOp(std::string name)
+      : name_(std::move(name)), config_(CublasltAlgoConfigFromName(name_)) {}
+
+  CublasltMatmulOp(std::string name, CublasltAlgoConfig config)
+      : name_(std::move(name)), config_(config) {}
+
+  TuningStatus Call(const ParamsT* params) override {
+    auto problem = problem_factory_(params);
+    if (problem.workspace() == nullptr) {
+      return FAIL;
+    }
+    cublasLtMatmulAlgo_t algo = {};
+    if (!InitializeAlgo(problem, &algo)) {
+      return FAIL;
+    }
+    auto status = cublasLtMatmul(
+        at::cuda::getCurrentCUDABlasLtHandle(),
+        problem.compute_desc(),
+        problem.alpha_ptr(),
+        problem.a(),
+        problem.adesc(),
+        problem.b(),
+        problem.bdesc(),
+        problem.beta_ptr(),
+        problem.c(),
+        problem.cdesc(),
+        problem.d(),
+        problem.ddesc(),
+        &algo,
+        problem.workspace(),
+        problem.workspace_size(),
+        at::cuda::getCurrentCUDAStream());
+    return status == CUBLAS_STATUS_SUCCESS ? OK : FAIL;
+  }
+
+ private:
+  template <typename ProblemT>
+  bool InitializeAlgo(const ProblemT& problem, cublasLtMatmulAlgo_t* algo) {
+    if (!config_.has_value() ||
+        !CublasltInitializeAlgo(problem, config_.value(), algo) ||
+        !CublasltValidateAlgo(problem, algo)) {
+      return false;
+    }
+    return true;
+  }
+
+  ProblemFactory problem_factory_;
+  std::string name_;
+  std::optional<CublasltAlgoConfig> config_;
+};
+
+template <typename ProblemT>
+std::vector<std::pair<std::string, CublasltAlgoConfig>>
+GetCublasltHeuristicCandidates(const ProblemT& problem) {
+  std::vector<std::pair<std::string, CublasltAlgoConfig>> ret;
+  if (problem.workspace() == nullptr) {
+    return ret;
+  }
+
+  std::vector<cublasLtMatmulHeuristicResult_t> heuristic_results(
+      getTuningContext()->GetCublasLtRequestedAlgoCount());
+  int returned_result = 0;
+  auto status = cublasLtMatmulAlgoGetHeuristic(
+      at::cuda::getCurrentCUDABlasLtHandle(),
+      problem.compute_desc(),
+      problem.adesc(),
+      problem.heuristic_bdesc(),
+      problem.heuristic_cdesc(),
+      problem.heuristic_ddesc(),
+      problem.preference(),
+      static_cast<int>(heuristic_results.size()),
+      heuristic_results.data(),
+      &returned_result);
+  if (status != CUBLAS_STATUS_SUCCESS || returned_result == 0) {
+    return ret;
+  }
+
+  for (int i = 0; i < returned_result; ++i) {
+    if (heuristic_results[i].state != CUBLAS_STATUS_SUCCESS) {
+      continue;
+    }
+    auto config = CublasltAlgoConfigFromAlgo(heuristic_results[i].algo);
+    if (!config.has_value()) {
+      continue;
+    }
+    ret.emplace_back(CublasltAlgoConfigName(config.value()), config.value());
+  }
+  return ret;
+}
+
+} // anonymous namespace
+
+template <typename ParamsT, typename ProblemFactory>
+class CublasltMatmulTunableOp : public TunableOp<ParamsT> {
+ public:
+  CublasltMatmulTunableOp() = default;
+
+ protected:
+  void RegisterOpCandidates(const ParamsT* params) override {
+    const auto params_sig = params->Signature();
+    std::scoped_lock l{candidate_lock_};
+    if (candidate_names_by_params_.find(params_sig) !=
+        candidate_names_by_params_.end()) {
+      return;
+    }
+
+    std::vector<std::string> candidate_names{"Default"};
+    auto problem = problem_factory_(params);
+    for (auto&& [name, config] : GetCublasltHeuristicCandidates(problem)) {
+      if (!this->HasOp(name)) {
+        this->RegisterOp(
+            name,
+            std::make_unique<CublasltMatmulOp<ParamsT, ProblemFactory>>(
+                name, config));
+      }
+      candidate_names.emplace_back(std::move(name));
+    }
+    candidate_names_by_params_.emplace(params_sig, std::move(candidate_names));
+  }
+
+  std::vector<std::string> CandidateNames(const ParamsT* params) const override {
+    const auto params_sig = params->Signature();
+    std::scoped_lock l{candidate_lock_};
+    auto it = candidate_names_by_params_.find(params_sig);
+    if (it == candidate_names_by_params_.end()) {
+      return {"Default"};
+    }
+    return it->second;
+  }
+
+  bool RegisterOpForResult(
+      const ResultEntry& result,
+      const ParamsT* /*params*/) override {
+    const auto name = result.GetKey();
+    if (this->HasOp(name)) {
+      return true;
+    }
+    if (!CublasltAlgoConfigFromName(name).has_value()) {
+      return false;
+    }
+    this->RegisterOp(
+        name,
+        std::make_unique<CublasltMatmulOp<ParamsT, ProblemFactory>>(name));
+    return true;
+  }
+
+ private:
+  ProblemFactory problem_factory_;
+  mutable std::mutex candidate_lock_;
+  std::unordered_map<std::string, std::vector<std::string>>
+      candidate_names_by_params_;
+};
+
+template <typename T, typename ParamsT>
+class CublasltGemmTunableOp
+    : public CublasltMatmulTunableOp<
+          ParamsT,
+          CublasltStandardGemmProblemFactory<T>> {};
+
+
+} // namespace at::cuda::tunable
+
+#endif // USE_ROCM

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -150,6 +150,7 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | PYTORCH_TUNABLEOP_HIPBLASLT_ENABLED | Default is 1. Set to 0 to disable hipblaslt being considered during tuning. |
 | PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS | Default is 30. Unit is milliseconds. |
 | PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS | Default is 100. |
+| PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT | Default is 8. CUDA only. Number of cuBLASLt heuristic candidates to request. Values less than 1 are clamped to 1. |
 | PYTORCH_TUNABLEOP_MAX_WARMUP_DURATION_MS | Default is 0, meaning it is not used. Unit is milliseconds. |
 | PYTORCH_TUNABLEOP_MAX_WARMUP_ITERATIONS | Default is 0, meaning it is not used. |
 | PYTORCH_TUNABLEOP_ICACHE_FLUSH_ENABLED | Default is 1. Set to 0 to disable. |
@@ -171,6 +172,8 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | get_max_tuning_duration() -> int | |
 | set_max_tuning_iterations(iterations: int) -> None | |
 | get_max_tuning_iterations() -> int | |
+| set_cublaslt_requested_algo_count(count: int) -> None | CUDA only. Values less than 1 are clamped to 1. |
+| get_cublaslt_requested_algo_count() -> int | CUDA only. |
 | set_filename(filename: str, insert_device_ordinal: bool = False) -> None | |
 | get_filename() -> str | |
 | set_numerical_check_tolerances(enable: bool, atol: float, rtol: float) -> None | Enable or disable numerical checking; atol and rtol default to 1e-5.

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -16,6 +16,14 @@
 #include <torch/version.h>
 
 
+#ifndef USE_ROCM
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#endif
+
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -161,6 +169,11 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
   }
 }
 
+void TuningResultsManager::ClearUntuned() {
+  std::scoped_lock l{lock_};
+  untuned_results_.clear();
+}
+
 void TuningResultsManager::InitRealtimeAppend(const std::string& filename, const std::unordered_map<std::string, std::string>& validators) {
   std::scoped_lock fl{realtime_file_mutex_};
 
@@ -301,7 +314,22 @@ TuningResultsValidator::TuningResultsValidator() {
       "PT_VERSION",
       []() { return GetPyTorchVersion(); },
       [this](auto&& k) { return ValidatePyTorchVersion(std::forward<decltype(k)>(k)); });
-#ifdef USE_ROCM
+#ifndef USE_ROCM
+  auto register_exact_validator = [this](const char* name, auto getter) {
+    RegisterValidator(name, getter, [name, getter](auto&& k) {
+      std::string value = getter();
+      TUNABLE_LOG1(name, " validation: expect ", k, " to match ", value);
+      return value == k ? OK : FAIL;
+    });
+  };
+
+  register_exact_validator(
+      "CUBLASLT_VERSION", []() { return c10::str(cublasLtGetVersion()); });
+  register_exact_validator("CUDA_DEVICE", []() {
+    const auto* prop = at::cuda::getCurrentDeviceProperties();
+    return c10::str(prop->major, ".", prop->minor, ":", prop->name);
+  });
+#else
   // hip
   {
     // HIP version is more accurate than ROCm version.  User's environment could be a stock
@@ -481,6 +509,7 @@ TuningContext::TuningContext() :
     numerics_check_enable_{false},
     max_tuning_duration_ms_{30},
     max_tuning_iterations_{100},
+    cublaslt_requested_algo_count_{8},
     max_warmup_duration_ms_{0},
     max_warmup_iterations_{0},
     icache_flush_{true},
@@ -542,6 +571,7 @@ void TuningContext::EnableRecordUntuned(bool value) {
     TUNABLE_LOG1("Disable Record Untuned for TunableOp");
     TUNABLE_LOG1("Closing Untuned GEMM Results File");
     untuned_file_.close();
+    manager_.ClearUntuned();
   }
 }
 
@@ -654,6 +684,26 @@ int TuningContext::GetMaxTuningIterations() const {
     return val < 0 ? 0 : val;
   }
   return max_tuning_iterations_;
+}
+
+void TuningContext::SetCublasLtRequestedAlgoCount(int count) {
+  cublaslt_requested_algo_count_ = std::max(1, count);
+}
+
+int TuningContext::GetCublasLtRequestedAlgoCount() const {
+  static const auto env = c10::utils::get_env(
+      "PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT");
+  if (env.has_value()) {
+    try {
+      return std::max(1, std::stoi(env.value()));
+    } catch (const std::exception&) {
+      TORCH_WARN_ONCE(
+          "PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT is not a valid "
+          "integer (got `", env.value(), "`). Falling back to the value set "
+          "via torch.cuda.tunable.set_cublaslt_requested_algo_count.");
+    }
+  }
+  return cublaslt_requested_algo_count_;
 }
 
 void TuningContext::SetMaxWarmupDurationMs(int max_duration_ms) {

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -103,6 +103,7 @@ class TORCH_CUDA_CPP_API TuningResultsManager {
 
     void RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature,
       const std::string& params_signature, const std::string& blas_signature);
+    void ClearUntuned();
 
     void InitRealtimeAppend(
         const std::string& filename,
@@ -188,6 +189,9 @@ class TORCH_CUDA_CPP_API TuningContext {
     void SetMaxTuningIterations(int max_iter);
     int GetMaxTuningIterations() const;
 
+    void SetCublasLtRequestedAlgoCount(int count);
+    int GetCublasLtRequestedAlgoCount() const;
+
     void SetMaxWarmupDurationMs(int max_duration_ms);
     int GetMaxWarmupDurationMs() const;
 
@@ -233,6 +237,7 @@ class TORCH_CUDA_CPP_API TuningContext {
     bool numerics_check_enable_;
     int max_tuning_duration_ms_;
     int max_tuning_iterations_;
+    int cublaslt_requested_algo_count_;
     int max_warmup_duration_ms_;
     int max_warmup_iterations_;
     bool icache_flush_;

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -13,6 +13,8 @@
 #ifdef USE_ROCM
 #include <ATen/cuda/tunable/GemmHipblaslt.h>
 #include <ATen/cuda/tunable/GemmRocblas.h>
+#else
+#include <ATen/cuda/tunable/GemmCublaslt.h>
 #endif
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <c10/cuda/CUDACachingAllocator.h>
@@ -205,7 +207,14 @@ inline const char* TypeName(c10::complex<float> v) {
 }
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmTunableOp : public TunableOp<GemmParams<T>> {
+class GemmTunableOp
+    : public
+#ifdef USE_ROCM
+          TunableOp<GemmParams<T>>
+#else
+          CublasltGemmTunableOp<T, GemmParams<T>>
+#endif
+{
  public:
   GemmTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmOp<T>>());
@@ -240,7 +249,14 @@ class GemmTunableOp : public TunableOp<GemmParams<T>> {
 };
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>> {
+class GemmAndBiasTunableOp
+    : public
+#ifdef USE_ROCM
+          TunableOp<GemmAndBiasParams<T>>
+#else
+          CublasltGemmTunableOp<T, GemmAndBiasParams<T>>
+#endif
+{
  public:
   GemmAndBiasTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmAndBiasOp<T>>());
@@ -268,7 +284,14 @@ class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>> {
 };
 
 template <typename T, BlasOp ALayout, BlasOp BLayout>
-class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>> {
+class GemmStridedBatchedTunableOp
+    : public
+#ifdef USE_ROCM
+          TunableOp<GemmStridedBatchedParams<T>>
+#else
+          CublasltGemmTunableOp<T, GemmStridedBatchedParams<T>>
+#endif
+{
  public:
   GemmStridedBatchedTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultGemmStridedBatchedOp<T>>());

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -13,11 +13,17 @@
 #include <ATen/cuda/tunable/StreamTimer.h>
 #include <ATen/cuda/Sleep.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#ifndef USE_ROCM
+#include <c10/cuda/CUDAGraphsC10Utils.h>
+#endif
 
 #ifndef _WIN32
 #include <cxxabi.h>
 #endif
 
+#ifndef USE_ROCM
+#include <mutex>
+#endif
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -122,11 +128,25 @@ class TunableOp {
         result = mgr.Lookup(op_sig, params_sig);
         // If there is not previous tuning result been found, we do the tuning iff tuning is enabled
         if (result == ResultEntry::Null()) {
+          bool should_record_untuned = !ctx->IsTuningEnabled();
           if (ctx->IsTuningEnabled()) {
+#ifndef USE_ROCM
+            bool is_capturing =
+                c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+                c10::cuda::CaptureStatus::None;
+            if (!is_capturing) {
+              RegisterOpCandidates(params);
+              result = FindFastest(params);
+              mgr.Add(op_sig, params_sig, result);
+            } else {
+              should_record_untuned = true;
+            }
+#else
             result = FindFastest(params);
             mgr.Add(op_sig, params_sig, result);
+#endif
           }
-          else if (ctx->IsRecordUntunedEnabled()) {
+          if (should_record_untuned && ctx->IsRecordUntunedEnabled()) {
             // or record the gemm into file
             mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig, blas_sig);
           }
@@ -139,9 +159,19 @@ class TunableOp {
         TUNABLE_LOG2("no result, using default");
         result = ResultEntry::Default();
       }
-      auto iter = ops_.find(result);
-      TORCH_CHECK(iter != ops_.end());
-      return iter->second->Call(params);
+      auto* op = GetOp(result.GetKey());
+#ifndef USE_ROCM
+      if (op == nullptr && RegisterOpForResult(result, params)) {
+        op = GetOp(result.GetKey());
+      }
+#endif
+      if (op == nullptr) {
+        TUNABLE_LOG2("missing candidate ", result, ", using default");
+        result = ResultEntry::Default();
+        op = GetOp(result.GetKey());
+      }
+      TORCH_CHECK(op != nullptr);
+      return op->Call(params);
     }
 
     virtual std::string Signature() {
@@ -156,9 +186,48 @@ class TunableOp {
 
   protected:
     void RegisterOp(const std::string& name, std::unique_ptr<Callable<ParamsT>> op) {
+#ifndef USE_ROCM
+      std::scoped_lock l{ops_lock_};
+#endif
       this->op_names_.emplace_back(name);
       this->ops_.emplace(name, std::move(op));
     }
+
+    bool HasOp(const std::string& name) const {
+#ifndef USE_ROCM
+      std::scoped_lock l{ops_lock_};
+#endif
+      return this->ops_.find(name) != this->ops_.end();
+    }
+
+    Callable<ParamsT>* GetOp(const std::string& name) const {
+#ifndef USE_ROCM
+      std::scoped_lock l{ops_lock_};
+#endif
+      auto it = ops_.find(name);
+      return it == ops_.end() ? nullptr : it->second.get();
+    }
+
+    std::vector<std::string> OpNames() const {
+#ifndef USE_ROCM
+      std::scoped_lock l{ops_lock_};
+#endif
+      return op_names_;
+    }
+
+    virtual void RegisterOpCandidates(const ParamsT* /*params*/) {}
+
+    virtual std::vector<std::string> CandidateNames(const ParamsT* /*params*/) const {
+      return OpNames();
+    }
+
+#ifndef USE_ROCM
+    virtual bool RegisterOpForResult(
+        const ResultEntry& /*result*/,
+        const ParamsT* /*params*/) {
+      return false;
+    }
+#endif
 
   private:
     static void WarmUp(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset) {
@@ -226,7 +295,8 @@ class TunableOp {
       auto op_sig = Signature();
       auto params_sig = params->Signature();
       auto blas_sig = params->BLASSignature();
-      TUNABLE_LOG2("finding fastest for ", op_sig, '(', params_sig, ')', " out of ", op_names_.size(), " candidates");
+      auto candidate_names = CandidateNames(params);
+      TUNABLE_LOG2("finding fastest for ", op_sig, '(', params_sig, ')', " out of ", candidate_names.size(), " candidates");
       auto min_duration_ms = std::numeric_limits<double>::infinity();
       std::string id_name = "Default";
       ParamsT* reference_params = nullptr;
@@ -238,7 +308,9 @@ class TunableOp {
       // calculate a reference answer for numerical check
       if (do_numerics_check) {
         reference_params = params->DeepCopy(false);
-        TORCH_CHECK(ops_[ResultEntry::Default()]->Call(reference_params) == OK);
+        auto* default_op = GetOp(ResultEntry::Default().GetKey());
+        TORCH_CHECK(default_op != nullptr);
+        TORCH_CHECK(default_op->Call(reference_params) == OK);
       }
 
       // need copies of params to reuse
@@ -264,12 +336,13 @@ class TunableOp {
       // for rotating buffer
       size_t offset = 0;
 
-      for (size_t i = 0; i < op_names_.size(); i++) {
-        auto* candidate = ops_[op_names_[i]].get(); // borrow pointer
+      for (size_t i = 0; i < candidate_names.size(); i++) {
+        auto* candidate = GetOp(candidate_names[i]); // borrow pointer
+        TORCH_CHECK(candidate != nullptr);
 
         auto status = candidate->Call(reusable_params[0]);
         if (status != OK) {
-          TUNABLE_LOG3("├──unsupported id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+          TUNABLE_LOG3("├──unsupported id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
           continue;
         }
 
@@ -279,7 +352,7 @@ class TunableOp {
         double approx_duration = s._mean;
         // bail if too slow
         if (approx_duration > 1.5 * min_duration_ms) {
-          TUNABLE_LOG3("├──skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+          TUNABLE_LOG3("├──skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
           continue;
         }
 
@@ -289,7 +362,7 @@ class TunableOp {
         approx_duration = s._mean;
         // bail if too slow
         if (approx_duration > 1.15 * min_duration_ms) {
-          TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+          TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
           continue;
         }
 
@@ -298,13 +371,13 @@ class TunableOp {
           auto status = candidate->Call(numerical_params);
           if (status != OK) {
             numerical_params->Delete();
-            TUNABLE_LOG3("├──unsupported id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+            TUNABLE_LOG3("├──unsupported id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
             continue;
           }
           status = reference_params->NumericalCheck(numerical_params);
           numerical_params->Delete();
           if (status != OK) {
-            TUNABLE_LOG3("├──numerics check failed for id=", i, ", ", op_sig, '(', params_sig, ") ", op_names_[i]);
+            TUNABLE_LOG3("├──numerics check failed for id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
             continue;
           }
         }
@@ -355,7 +428,7 @@ class TunableOp {
         TUNABLE_LOG3("├──tuning using "
             "warmup iters ", warmup_iter, " [", warmup_ms, " ms] "
             "and tuning iters ", tuning_iter, " [", tuning_ms, " ms] ",
-            "instance id=", i, ", ", op_sig, "(", params_sig, ") ", op_names_[i]);
+            "instance id=", i, ", ", op_sig, "(", params_sig, ") ", candidate_names[i]);
         TUNABLE_LOG3("├──offset at ", offset);
         WarmUp(candidate, reusable_params, warmup_iter, offset);
         s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
@@ -364,18 +437,18 @@ class TunableOp {
         // Solution with smallest mean + 2*sigma will be a better solution?
         // if ((s._mean + 2*s_stddev) < (min_duration_ms + 2*min_stddev_ms)) {
         if (s._mean < min_duration_ms) {
-          TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
+          TUNABLE_LOG3("├──found better instance id=", i, ". " , s._mean, "ms. ", candidate_names[i],
                 " min ", s._min,
                 " max ", s._max,
                 " mean ", s._mean,
                 " std ", s_stddev);
           min_duration_ms = s._mean;
-          id_name = op_names_[i];
-          std::string current_soln = std::to_string(s._mean) + " " + op_names_[i];
+          id_name = candidate_names[i];
+          std::string current_soln = std::to_string(s._mean) + " " + candidate_names[i];
           top_solns.push(current_soln);
         }
         else {
-          TUNABLE_LOG3("├──found slower instance id=", i, ". " , s._mean, "ms. ", op_names_[i],
+          TUNABLE_LOG3("├──found slower instance id=", i, ". " , s._mean, "ms. ", candidate_names[i],
                 " min ", s._min,
                 " max ", s._max,
                 " mean ", s._mean,
@@ -418,6 +491,9 @@ class TunableOp {
 
     std::unordered_map<std::string, std::unique_ptr<Callable<ParamsT>>> ops_;
     std::vector<std::string> op_names_;
+#ifndef USE_ROCM
+    mutable std::mutex ops_lock_;
+#endif
 };
 
 struct OpParams {

--- a/docs/source/cuda.tunable.md
+++ b/docs/source/cuda.tunable.md
@@ -53,6 +53,14 @@
 ```
 
 ```{eval-rst}
+.. autofunction:: set_cublaslt_requested_algo_count
+```
+
+```{eval-rst}
+.. autofunction:: get_cublaslt_requested_algo_count
+```
+
+```{eval-rst}
 .. autofunction:: set_filename
 ```
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9294,6 +9294,11 @@ class TestLinalgCudaOnly(TestCase):
         # Initialize and then tear down TunableOp
         import glob
         import os
+        prev_cublaslt_count = (
+            torch.cuda.tunable.get_cublaslt_requested_algo_count()
+            if torch.cuda.is_available()
+            else None
+        )
         self._set_tunableop_defaults()
         torch.cuda.tunable.enable(True)
 
@@ -9302,6 +9307,10 @@ class TestLinalgCudaOnly(TestCase):
         finally:
             # disables TunableOp
             torch.cuda.tunable.enable(False)
+            if prev_cublaslt_count is not None:
+                torch.cuda.tunable.set_cublaslt_requested_algo_count(
+                    prev_cublaslt_count
+                )
 
             # clean up, remove any files that were generated
             results_filename = torch.cuda.tunable.get_filename()
@@ -9339,6 +9348,7 @@ class TestLinalgCudaOnly(TestCase):
         torch.cuda.tunable.tuning_enable(True)
         torch.cuda.tunable.set_max_tuning_duration(30)
         torch.cuda.tunable.set_max_tuning_iterations(100)
+        torch.cuda.tunable.set_cublaslt_requested_algo_count(8)
         torch.cuda.tunable.set_rotating_buffer_size(-1)
         torch.cuda.tunable.set_numerical_check_tolerances(False)
         ordinal = torch.cuda.current_device()
@@ -9368,10 +9378,11 @@ class TestLinalgCudaOnly(TestCase):
                 untuned_csv_entries = {(row[0], row[1]) for row in untuned_reader}
 
                 tuned_reader = csv.reader(file2)
-                for _ in range(5):  # Skip the first 5 lines for the validator
-                    next(tuned_reader, None)
-
-                result_csv_entries = {(row[0], row[1]) for row in tuned_reader}
+                result_csv_entries = {
+                    (row[0], row[1])
+                    for row in tuned_reader
+                    if row and row[0] != "Validator"
+                }
 
                 missing = untuned_csv_entries - result_csv_entries
 
@@ -9425,7 +9436,6 @@ class TestLinalgCudaOnly(TestCase):
             # clean up intermediate files
             self._set_tunableop_defaults()
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.half)
     def test_matmul_offline_tunableop(self, device, dtype):
         import os
@@ -9639,7 +9649,6 @@ class TestLinalgCudaOnly(TestCase):
             self.assertTrue(ok)
 
     @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    @skipCUDAIfNotRocm
     @dtypes(torch.float)
     def test_matmul_offline_mgpu_tunableop(self, device, dtype):
         # Offline tuning with multiple GPUs.
@@ -9721,9 +9730,30 @@ class TestLinalgCudaOnly(TestCase):
         torch.cuda.tunable.set_rotating_buffer_size(-1)
         self.assertEqual(torch.cuda.tunable.get_rotating_buffer_size(), l2_cache_size)
 
-    @skipCUDAIfNotRocm
+    @skipIfRocm
     @dtypes(torch.float)
-    def test_bmm_tunableop_rocm(self, device, dtype):
+    def test_cublaslt_requested_algo_count_tunableop(self, device, dtype):
+        import os
+        env_key = "PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT"
+        prev_env = os.environ.pop(env_key, None)
+        self._set_tunableop_defaults()
+        original = torch.cuda.tunable.get_cublaslt_requested_algo_count()
+        try:
+            torch.cuda.tunable.set_cublaslt_requested_algo_count(7)
+            self.assertEqual(torch.cuda.tunable.get_cublaslt_requested_algo_count(), 7)
+            torch.cuda.tunable.set_cublaslt_requested_algo_count(1)
+            self.assertEqual(torch.cuda.tunable.get_cublaslt_requested_algo_count(), 1)
+            torch.cuda.tunable.set_cublaslt_requested_algo_count(0)
+            self.assertEqual(torch.cuda.tunable.get_cublaslt_requested_algo_count(), 1)
+            torch.cuda.tunable.set_cublaslt_requested_algo_count(-7)
+            self.assertEqual(torch.cuda.tunable.get_cublaslt_requested_algo_count(), 1)
+        finally:
+            torch.cuda.tunable.set_cublaslt_requested_algo_count(original)
+            if prev_env is not None:
+                os.environ[env_key] = prev_env
+
+    @dtypes(torch.float)
+    def test_bmm_tunableop(self, device, dtype):
         # buffer rotation (on by default) with strided batched gemm tunableop was causing a mem fault
         with self._tunableop_ctx():
             torch.cuda.tunable.set_max_tuning_iterations(10)
@@ -9772,11 +9802,10 @@ class TestLinalgCudaOnly(TestCase):
             k_chunks = k.split(64, dim=-2)
             C = torch.matmul(q_chunks[0], k_chunks[0])
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.bfloat16)
-    def test_numeric_check_leak_tunableop_rocm(self, device, dtype):
+    def test_numeric_check_leak_tunableop(self, device, dtype):
         from torch.testing._internal.common_utils import CudaMemoryLeakCheck
-        # run operator first without tuning to ensure all rocm libs are loaded,
+        # run operator first without tuning to ensure all libs are loaded,
         # otherwise false positive mem leak
         B = 5
         N = M = K = 29
@@ -9828,6 +9857,23 @@ class TestLinalgCudaOnly(TestCase):
             self.assertTrue(re.match(r'^\d+[a-z0-9.]+$', validators["ROCBLAS_VERSION"]))
             self.assertTrue("HIPBLASLT_VERSION" in validators)
             self.assertTrue(re.match(r'^\d+-[a-z0-9]+$', validators["HIPBLASLT_VERSION"]))
+
+    @skipIfRocm
+    @dtypes(torch.float)
+    def test_validator_tunableop_cuda(self, device, dtype):
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_max_tuning_iterations(1)
+
+            A = torch.randn(4, 4, device=device, dtype=dtype)
+            B = torch.randn(4, 4, device=device, dtype=dtype)
+            torch.matmul(A, B)
+
+            validators = get_tunableop_validators()
+            for key in ("PT_VERSION", "CUBLASLT_VERSION", "CUDA_DEVICE"):
+                self.assertIn(key, validators)
+
+            self.assertRegex(validators["CUBLASLT_VERSION"], r"^\d+$")
+            self.assertRegex(validators["CUDA_DEVICE"], r"^\d+\.\d+:.+")
 
     @dtypes(torch.half)
     def test_minimum_tuning_iteration_tunableop(self, device, dtype):
@@ -9881,6 +9927,97 @@ class TestLinalgCudaOnly(TestCase):
             # the this test and verify that it agrees with the number of
             # GEMMs.
             self.assertEqual((total_num_results - ref_num_results), count_matmul)
+
+    @skipIfRocm
+    @dtypes(torch.bfloat16)
+    def test_cublaslt_candidate_tunableop(self, device, dtype):
+        if not torch.cuda.is_bf16_supported():
+            raise unittest.SkipTest("bfloat16 not supported on this CUDA device")
+
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.set_max_tuning_duration(1)
+            torch.cuda.tunable.set_max_tuning_iterations(3)
+
+            A = torch.randn(128, 256, device=device, dtype=dtype)
+            B = torch.randn(256, 96, device=device, dtype=dtype)
+            torch.matmul(A, B)
+
+            X = torch.randn(512, 512, device=device, dtype=dtype)
+            W = torch.randn(512, 512, device=device, dtype=dtype)
+            bias = torch.randn(512, device=device, dtype=dtype)
+            torch.nn.functional.linear(X, W, bias)
+
+            for b, m, k, n in (
+                    (8, 128, 256, 192),
+                    (16, 128, 256, 256),
+                    (8, 256, 256, 256),
+                    (2, 512, 512, 512)):
+                batch_A = torch.randn(b, m, k, device=device, dtype=dtype)
+                batch_B = torch.randn(b, k, n, device=device, dtype=dtype)
+                torch.bmm(batch_A, batch_B)
+
+            results = torch.cuda.tunable.get_results()
+            result_strings = [str(row) for row in results]
+            self.assertTrue(
+                any("Gemm_Cublaslt_" in row for row in result_strings), results)
+            self.assertTrue(
+                any("GemmTunableOp" in row for row in result_strings), results)
+            self.assertTrue(
+                any("GemmStridedBatchedTunableOp" in row for row in result_strings),
+                results)
+            self.assertTrue(
+                any("GemmAndBiasTunableOp" in row for row in result_strings),
+                results)
+
+    @skipIfRocm
+    @dtypes(torch.half)
+    def test_invalid_cublaslt_candidate_fallback_tunableop(self, device, dtype):
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.tuning_enable(False)
+
+            results_filename = torch.cuda.tunable.get_filename()
+            validators = torch.cuda.tunable.get_validators()
+            with open(results_filename, "w") as file:
+                for key, value in validators:
+                    file.write(f"Validator,{key},{value}\n")
+                file.write(
+                    "GemmTunableOp_Half_NN,nn_96_128_256_ld_96_256_96,"
+                    "Gemm_Cublaslt_id_999999_tile_999999_stages_999999_"
+                    "splitk_1_red_0_swizzle_0_custom_0_inner_0_cluster_0,0.1\n"
+                )
+
+            A = torch.randn(128, 256, device=device, dtype=dtype)
+            B = torch.randn(256, 96, device=device, dtype=dtype)
+            C = torch.matmul(A, B)
+            self.assertEqual(C.shape, (128, 96))
+
+    @skipIfRocm
+    @dtypes(torch.half)
+    def test_cuda_graph_capture_skips_first_tuning_tunableop(self, device, dtype):
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.set_max_tuning_duration(1)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
+            ref_num_results = len(torch.cuda.tunable.get_results())
+
+            A = torch.randn(64, 64, device=device, dtype=dtype)
+            B = torch.randn(64, 64, device=device, dtype=dtype)
+            C = torch.empty(64, 64, device=device, dtype=dtype)
+
+            torch.cuda.tunable.enable(False)
+            torch.mm(A, B, out=C)
+            torch.cuda.synchronize()
+            torch.cuda.tunable.enable(True)
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                torch.mm(A, B, out=C)
+            graph.replay()
+            torch.cuda.synchronize()
+
+            self.assertEqual(len(torch.cuda.tunable.get_results()), ref_num_results)
 
     @dtypes(torch.float)
     def test_disable_tuning_tunableop(self, device, dtype):
@@ -9990,7 +10127,6 @@ class TestLinalgCudaOnly(TestCase):
             # There must be a new tuning result
             self.assertEqual((total_num_results - ref_num_results), 2)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.bfloat16)
     def test_gemm_bias_offline_tunableop(self, device, dtype):
         import os
@@ -10124,7 +10260,6 @@ class TestLinalgCudaOnly(TestCase):
                 count = 6
             self.assertEqual((total_num_results - ref_num_results), count)
 
-    @skipCUDAIfNotRocm
     @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)
     def test_tf32_tunableop(self, device, dtype):
@@ -10184,7 +10319,6 @@ class TestLinalgCudaOnly(TestCase):
             # Disable TF32
             torch.backends.cuda.matmul.allow_tf32 = False
 
-    @skipCUDAIfNotRocm
     @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)
     def test_tf32_offline_tunableop(self, device, dtype):
@@ -10254,7 +10388,6 @@ class TestLinalgCudaOnly(TestCase):
             # Disable TF32
             torch.backends.cuda.matmul.allow_tf32 = False
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float16)
     def test_blaslog_tunableop(self, device, dtype):
         # Test that PYTORCH_TUNABLEOP_BLAS_LOG=1 gives
@@ -10329,16 +10462,13 @@ class TestLinalgCudaOnly(TestCase):
             # Check that there BLAS PARAMS are in the CSV file
             with open(result_filename) as file:
                 reader = csv.reader(file)
-                for _ in range(5):  # Skip the first 5 lines for the validator
-                    next(reader, None)
+                first_row = next(row for row in reader if row[0] != "Validator")
                 # Check for extra column
-                first_row = next(reader)
                 self.assertGreater(len(first_row), 5)
                 # Check for YAML entry to the right of
                 # BLAS PARAMS
                 self.assertTrue("{ function:" in first_row[4])
 
-    @skipCUDAIfNotRocm
     # Fails with triton 3.7
     @dtypes(torch.float)
     def test_mm_submatrix_offline_tunableop(self, device, dtype):
@@ -10474,7 +10604,7 @@ class TestLinalgCudaOnly(TestCase):
             # With hipBLASLt preferred, the two linear/addmm+bias calls are
             # tracked as GemmAndBias tunables (+2). With rocBLAS preferred,
             # they fall back to regular GEMM signatures and don't add entries.
-            expected_num_results = 10 if preferred_blas == "_BlasBackend.Cublaslt" else 8
+            expected_num_results = 10 if not TEST_WITH_ROCM or preferred_blas == "_BlasBackend.Cublaslt" else 8
             self.assertEqual(total_num_results, expected_num_results)
 
             results_filename = torch.cuda.tunable.get_filename()
@@ -10485,7 +10615,6 @@ class TestLinalgCudaOnly(TestCase):
             ok = self._compare_untuned_tuned_entries()
             self.assertTrue(ok)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float32)
     def test_ops_append_to_existing_file_tunableop(self, device, dtype):
         """If a TunableOp results file already exists (with matching Validator),
@@ -10538,7 +10667,6 @@ class TestLinalgCudaOnly(TestCase):
 
             self.assertGreater(final_count, initial_count)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float32)
     def test_offline_tuning_append_to_existing_file_tunableop(self, device, dtype):
         """If an offline tuning untuned file already exists,
@@ -10588,7 +10716,6 @@ class TestLinalgCudaOnly(TestCase):
             # Verify the seeded entry is still present (proving it wasn't overwritten)
             self.assertIn(seed_lines[0], final_content)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float32)
     def test_matmul_empty_existing_file_tunableop(self, device, dtype):
         """ Test that if an existing results file is empty/corrupted, then the default behaviour should hold """
@@ -10639,7 +10766,6 @@ class TestLinalgCudaOnly(TestCase):
         delta = tuned_default_scaled_mm - ref_scaled_mm
         self.assertTrue(torch.all(delta == 0))
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float)
     def test_call_count_tunableop(self, device, dtype):
         # Test that after tuning a GEMM in TunableOp, we only call the GEMM kernel once
@@ -10678,7 +10804,7 @@ class TestLinalgCudaOnly(TestCase):
             # Check that after tuning, there was only one kernel
             # launched per PyTorch API. The kernels have string
             # that always starts with `Cijk*`
-            mm_key = 'Cijk'
+            mm_key = 'Cijk' if TEST_WITH_ROCM else 'kernel'
             events = prof.events()
             for evt in events:
                 if mm_key in evt.name:
@@ -10688,7 +10814,6 @@ class TestLinalgCudaOnly(TestCase):
             # There must be exactly three kernels only
             self.assertEqual(kernel_count, 3)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float16)
     def test_numerical_check_python_binding_tunableop(self, device, dtype):
         with self._tunableop_ctx():
@@ -10709,7 +10834,6 @@ class TestLinalgCudaOnly(TestCase):
             with self.assertRaisesRegex(RuntimeError, r"positive"):
                 torch.cuda.tunable.set_numerical_check_tolerances(True, -1e-5, -1e5)
 
-    @skipCUDAIfNotRocm
     @dtypes(torch.float16, torch.float32)
     def test_numerical_check_accuracy_tunableop(self, device, dtype):
         shapes = [(127, 193, 61), (251, 317, 73), (89, 149, 41)]
@@ -10727,14 +10851,13 @@ class TestLinalgCudaOnly(TestCase):
                 C_numeric = a @ b
             self.assertTrue(torch.allclose(C_baseline, C_numeric, atol=atol, rtol=rtol))
 
-    @skipCUDAIfNotRocm
     @precisionOverride({torch.double: 1e-8, torch.float: 1e-4, torch.bfloat16: 5e-2,
                         torch.half: 5e-2, torch.cfloat: 1e-4, torch.cdouble: 1e-8})
     @dtypesIfCUDA(*floating_types_and(torch.bfloat16, torch.half))
     @dtypes(*floating_types_and(torch.bfloat16))
     @tf32_on_and_off(0.05)
     @reduced_f32_on_and_off(0.05)
-    def test_addmm_relu_tunableop_rocm(self, device, dtype):
+    def test_addmm_relu_tunableop(self, device, dtype):
         if torch.version.hip and isRocmArchAnyOf(MI350_ARCH) and dtype is torch.double:
             self.skipTest("Currently failing on rocm mi350, hipblaslt mem fault")
         with self._tunableop_ctx():

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -521,9 +521,10 @@ class TestMatmulCuda(InductorTestCase):
     @onlyCUDA
     @skipIfRocm
     @dtypes(torch.half, torch.bfloat16)
+    @parametrize("batched", [False, True])
     @unittest.skipIf(not SM100OrLater, "cuBLAS integration for batch invariance is only on Blackwell")
     @serialTest()
-    def test_cublas_batch_invariance_blackwell(self, device, dtype):
+    def test_cublas_batch_invariance_blackwell(self, device, dtype, batched):
         orig_bf16 = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
         orig_fp16 = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
         torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False, False)
@@ -532,12 +533,21 @@ class TestMatmulCuda(InductorTestCase):
             N = 2048
             K = 6144
             M_max = 32
-            x = torch.randn(M_max, K, device="cuda", dtype=torch.bfloat16)
-            w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16).t()
-            full = x @ w
-            xx = x[:1]
-            out = xx @ w
-            self.assertEqual(full[:1], out, atol=0., rtol=0.)
+            if batched:
+                B = 8
+                x = torch.randn(B, M_max, K, device=device, dtype=dtype)
+                w = torch.randn(B, N, K, device=device, dtype=dtype).transpose(-2, -1)
+                full = x @ w
+                xx = x[:, :1]
+                out = xx @ w
+                self.assertEqual(full[:, :1], out, atol=0.0, rtol=0.0)
+            else:
+                x = torch.randn(M_max, K, device=device, dtype=dtype)
+                w = torch.randn(N, K, device=device, dtype=dtype).t()
+                full = x @ w
+                xx = x[:1]
+                out = xx @ w
+                self.assertEqual(full[:1], out, atol=0.0, rtol=0.0)
         torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = orig_bf16
         torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = orig_fp16
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1851,6 +1851,29 @@ PyObject* THCPModule_cuda_tunableop_get_max_tuning_iterations(
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THCPModule_cuda_tunableop_set_cublaslt_requested_algo_count(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkLong(arg),
+      "cuda_tunableop_set_cublaslt_requested_algo_count expects an int, but got ",
+      THPUtils_typename(arg));
+  auto count = static_cast<int>(THPUtils_unpackLong(arg));
+  at::cuda::tunable::getTuningContext()->SetCublasLtRequestedAlgoCount(count);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THCPModule_cuda_tunableop_get_cublaslt_requested_algo_count(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  return THPUtils_packInt32(
+      at::cuda::tunable::getTuningContext()->GetCublasLtRequestedAlgoCount());
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THCPModule_cuda_tunableop_set_filename(
     PyObject* _unused,
     PyObject* args) {
@@ -2345,6 +2368,14 @@ static struct PyMethodDef _THCPModule_methods[] = {
      nullptr},
     {"_cuda_tunableop_get_max_tuning_iterations",
      THCPModule_cuda_tunableop_get_max_tuning_iterations,
+     METH_NOARGS,
+     nullptr},
+    {"_cuda_tunableop_set_cublaslt_requested_algo_count",
+     THCPModule_cuda_tunableop_set_cublaslt_requested_algo_count,
+     METH_O,
+     nullptr},
+    {"_cuda_tunableop_get_cublaslt_requested_algo_count",
+     THCPModule_cuda_tunableop_get_cublaslt_requested_algo_count,
      METH_NOARGS,
      nullptr},
     {"_cuda_tunableop_set_filename",

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -93,19 +93,28 @@ among all that were successfully profiled will be chosen. A profile might fail
 if the given solution doesn't achieve the same accuracy as the default
 implementation or if the solution returns an error code.
 
+CUDA cuBLASLt support uses the TunableOp result cache and profiling machinery
+to time a configurable number of cuBLASLt heuristic candidates.
+
 Current Tunable Operators
 =========================
 
 TunableGemm for ROCm
 --------------------
 
-Currently only a TunableGemm for ROCm is implemented. Note that CUDA builds of
-PyTorch will function correctly when using TunableOp but the only solution
-available to CUDA builds is the 'Default' implementation i.e. the original
-cuBLAS default, now called through TunableOp. Any call to at::cuda::blas::gemm()
-or ::bgemm() will be routed through TunableOp when enabled. Calling gemm() for a
-given set of input arguments (transa, transb, m, n, k) will attempt to use the
-fastest available implementation across both rocblas and hipblaslt.
+Any call to at::cuda::blas::gemm() or ::bgemm() will be routed through TunableOp
+when enabled. Calling gemm() for a given set of input arguments
+(transa, transb, m, n, k) on ROCm will attempt to use the fastest available
+implementation across both rocblas and hipblaslt. On CUDA, TunableGemm registers
+cuBLASLt heuristic candidates for GEMM paths that already use cuBLASLt.
+
+cuBLASLt Heuristic Tuning for CUDA
+----------------------------------
+
+The number of cuBLASLt heuristic candidates is controlled by
+set_cublaslt_requested_algo_count() or
+PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT, which defaults to 8. If this
+count is 1, only the top cuBLASLt heuristic candidate is available.
 
 Offline Tuning
 ==============
@@ -180,7 +189,6 @@ Use the C++ or Python APIs instead.
 
 """
 
-import concurrent.futures
 import glob
 import multiprocessing as mp
 import os
@@ -201,6 +209,8 @@ __all__ = [
     "get_max_tuning_duration",
     "set_max_tuning_iterations",
     "get_max_tuning_iterations",
+    "set_cublaslt_requested_algo_count",
+    "get_cublaslt_requested_algo_count",
     "set_filename",
     "get_filename",
     "get_results",
@@ -277,6 +287,22 @@ def set_max_tuning_iterations(iterations: int) -> None:
 def get_max_tuning_iterations() -> int:
     r"""Get max iterations to spend tuning a given solution."""
     return torch._C._cuda_tunableop_get_max_tuning_iterations()  # type: ignore[attr-defined]
+
+
+def set_cublaslt_requested_algo_count(count: int) -> None:
+    r"""Set the number of cuBLASLt heuristic algorithms to request on CUDA.
+
+    Values less than 1 are clamped to 1.
+    """
+    torch._C._cuda_tunableop_set_cublaslt_requested_algo_count(count)  # type: ignore[attr-defined]
+
+
+def get_cublaslt_requested_algo_count() -> int:
+    r"""Get the number of cuBLASLt heuristic algorithms requested on CUDA."""
+    get_count = (
+        torch._C._cuda_tunableop_get_cublaslt_requested_algo_count  # type: ignore[attr-defined]
+    )
+    return get_count()
 
 
 def set_filename(filename: str, insert_device_ordinal: bool = False) -> None:
@@ -550,8 +576,10 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     r"""Process a single untuned GEMM."""
 
     deviceid = "cuda:" + str(gpu_id)
+    torch.cuda.set_device(deviceid)
 
     dtype_dict = {
+        "Float": torch.float32,
         "float": torch.float32,
         "tf32": torch.float32,
         "double": torch.float64,
@@ -778,6 +806,13 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         warnings.warn(f"error: unknown op {op_sig}", stacklevel=2)
 
 
+def _process_offline_gemms(untuned_gemm_lines: list[str], gpu_id: int) -> None:
+    r"""Process multiple untuned GEMMs on a single GPU."""
+    _check_tuning_assertions()
+    for line in untuned_gemm_lines:
+        _process_single_offline_gemm(line, gpu_id)
+
+
 def _check_tuning_assertions() -> None:
     r"""Helper function for multi-GPU tuning case. Need to check that TunableOp feature
     is enabled and that tuning is enabled.
@@ -807,27 +842,30 @@ def mgpu_tune_gemm_in_file(filename_pattern: str, num_gpus: int) -> None:
 
     mp_context = mp.get_context("spawn")
 
-    futures = []  # empty list to hold futures
+    gemm_entries_by_gpu: list[list[str]] = [[] for _ in range(num_gpus)]
 
     # GEMM are assigned to GPUs in a round robin manner
-    h = 0
-    with concurrent.futures.ProcessPoolExecutor(
-        max_workers=num_gpus,
-        mp_context=mp_context,
-        initializer=_check_tuning_assertions,
-    ) as executor:
-        # The workers are a separate process. TunableOp will be
-        # enabled in the child processes if PYTORCH_TUNABLEOP_ENABLED=1
-        # In the initializer, we also try to enable TunableOP if th
-        # environment variable was NOT set.
+    for h, line in enumerate(unique_gemm_entries):
+        gemm_entries_by_gpu[h % num_gpus].append(line)
 
-        for line in unique_gemm_entries:
-            future = executor.submit(_process_single_offline_gemm, line, h)
-            futures.append(future)
-            h = (h + 1) % num_gpus
+    processes = []
+    for h, entries in enumerate(gemm_entries_by_gpu):
+        if not entries:
+            continue
+        # TunableOp initializes its output filename once per process, so keep
+        # each spawned process bound to a single GPU.
+        process = mp_context.Process(target=_process_offline_gemms, args=(entries, h))
+        process.start()
+        processes.append((h, process))
 
-        for future in concurrent.futures.as_completed(futures):
-            future.result()
+    failed_processes = []
+    for h, process in processes:
+        process.join()
+        if process.exitcode != 0:
+            failed_processes.append((h, process.exitcode))
+
+    if failed_processes:
+        raise RuntimeError(f"offline tuning processes failed: {failed_processes}")
 
     torch.cuda.synchronize()
 


### PR DESCRIPTION
This PR adds TunableOp support for CUDA. Implementations have been proposed before and even landed briefly (#133896, #153316), and the perf issues surfaced by #181718 highlight the usefulness of landing this now.

This PR represents the main body of work but is intended to be the second in a stack, on top of #186266. Scaled GEMM TunableOp support is added on top of this PR in #186271.

For the most part this implementation just integrates with the existing TunableOp design using compilation guards and leaves the ROCm path untouched, but there are some changes worth calling out explicitly:
- Added some protected functions to the TunableOp class to safely interact with ops, which get registered dynamically on the CUDA path after calls to `cublasLtMatmulAlgoGetHeuristic`. The ROCm path now routes through these too but behavior should be preserved.
- Added `ClearUntuned()`, which runs when enabling untuned recording to clear in in-process untuned results. This is not critical and can be removed- I added it mostly for process cleanup because some offline tuning tests were failing on repeat.
- Replaced the process pool in `mgpu_tune_gemm_in_file` with individual processes per GPU because reuse of worker processes could cause a later GPU to write to an earlier GPU's file instead of its own copy.
- Added a  cublasLt-specific flag to set the number of algorithms requested from the heuristic. The env var is `PYTORCH_TUNABLEOP_CUBLASLT_REQUESTED_ALGO_COUNT`, and the API in Python is `torch.cuda.tunable.set_cublaslt_requested_algo_count(int count)`.

## Results

Benchmarking results on RTX 6000 Ada (SM 8.9) with CUDA Graphs demonstrate that TunableOp is able to select faster kernels and recover performance for the slower cases identified in #181718. It's worth noting that the existing TunableOp design autotunes using events, so performance under CUDA Graphs could probably be improved further by adding profiler-based autotuning for just the kernels.
<img width="1362" height="610" alt="kernel_diff_comparison" src="https://github.com/user-attachments/assets/bde0a40f-ed30-46ca-bf18-0b0684608d5b" />

On H100 in eager mode, where the available algos are better, the average improvement is essentially zero but there are some benefits for specific sizes. Of course, in eager mode, below a size threshold the additional overhead outweighs any perf gains from the kernel.
<img width="1360" height="1267" alt="H100_tunableop_comparison" src="https://github.com/user-attachments/assets/d6b2a6b7-0ccd-4678-9d88-241448cddd19" />
H100 Summary:
- CUDA events around Python call loop:
   - TunableOp faster (>1%): 1071, ties: 2307, slower (>1%): 717
   - Mean speedup: 0.996x
   - Max speedup: 1.57x at N=544
   - Min speedup: 0.66x at N=2

- CUDA Graph replay TunableOp on/off:
  - TunableOp faster (>1%): 1224, ties: 2377, slower (>1%): 494
  - Mean speedup: 1.022x
  - Max speedup: 1.70x at N=622
  - Min speedup: 0.79x at N=233

- Estimated cached TunableOp CPU overhead:
   - Mean: 1.9 us
   - Median: 0.3 us
   - Max: 16.6 us at N=3920

cc @eqy

Authored with Codex and Claude