### PR TITLE
[CUDA] Add TunableOp support for scaled GEMM

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -12,6 +12,10 @@
 #include <string>
 #include <c10/core/ScalarType.h>
 
+#ifndef USE_ROCM
+#include <optional>
+#endif
+
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <ATen/cuda/tunable/Tunable.h>
 #include <ATen/cuda/CUDABlas.h>
@@ -613,6 +617,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   std::string Signature() const override {
+#ifdef USE_ROCM
     // In Blas.cpp, code defaults to a bias_dtype of Half even when there is no bias vector.
     // Search for this line::
     // params.bias_dtype = bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_;
@@ -622,6 +627,22 @@ struct ScaledGemmParams : OpParams {
       transa, transb, m, n, k, lda, ldb, ldc,
       a_scaling_type == ScalingType::RowWise && b_scaling_type == ScalingType::RowWise,
       bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+#else
+    return fmt::sprintf(
+      "%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_a_%s_b_%s_c_%s_as_%s_bs_%s_"
+      "ast_%d_bst_%d_dscale_%d_fast_%d_bias_%s",
+      transa, transb, m, n, k, lda, ldb, ldc,
+      at::toString(a_dtype),
+      at::toString(b_dtype),
+      at::toString(c_dtype),
+      at::toString(a_scale_dtype),
+      at::toString(b_scale_dtype),
+      static_cast<int>(a_scaling_type),
+      static_cast<int>(b_scaling_type),
+      c_scale_ptr != nullptr,
+      use_fast_accum,
+      bias_ptr == nullptr ? "None" : at::toString(bias_dtype));
+#endif
   }
 
   size_t GetSizeA() const {
@@ -711,6 +732,9 @@ struct ScaledGemmParams : OpParams {
   ScalarType c_dtype{};
   void* amax_ptr{};
   bool use_fast_accum{};
+#ifndef USE_ROCM
+  std::optional<Tensor> alpha{};
+#endif
 private:
   bool duplicate_inputs_{false};
 };

--- a/aten/src/ATen/cuda/tunable/GemmCublaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmCublaslt.h
@@ -126,10 +126,126 @@ at::cuda::blas::GEMMAndBiasActivationEpilogue CublasltActivation(
   return params->activation;
 }
 
+// Shared cuBLASLt problem surface consumed by the templated Callable/TunableOp
+// helpers via static (duck-typed) dispatch. Holds the descriptors, preference,
+// workspace, and resolved data types common to every problem variant. Accessors
+// are non-virtual: helpers always operate on the concrete derived type, so
+// derived classes hide (rather than override) the defaults below where the two
+// variants diverge (D layout aliasing and heuristic descriptor selection).
+class CublasltGemmProblemBase {
+ public:
+  CublasltGemmProblemBase(
+      cublasComputeType_t compute_type,
+      cudaDataType_t scale_type,
+      cudaDataType_t a_type,
+      cudaDataType_t b_type,
+      cudaDataType_t c_type,
+      cudaDataType_t d_type)
+      : compute_desc_(compute_type, scale_type),
+        compute_type_(compute_type),
+        scale_type_(scale_type),
+        a_type_(a_type),
+        b_type_(b_type),
+        c_type_(c_type),
+        d_type_(d_type) {}
+
+  cublasComputeType_t compute_type() const {
+    return compute_type_;
+  }
+
+  cudaDataType_t scale_type() const {
+    return scale_type_;
+  }
+
+  cudaDataType_t a_type() const {
+    return a_type_;
+  }
+
+  cudaDataType_t b_type() const {
+    return b_type_;
+  }
+
+  cudaDataType_t c_type() const {
+    return c_type_;
+  }
+
+  cudaDataType_t d_type() const {
+    return d_type_;
+  }
+
+  cublasLtMatmulDesc_t compute_desc() const {
+    return compute_desc_.descriptor();
+  }
+
+  cublasLtMatrixLayout_t adesc() const {
+    return adesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t bdesc() const {
+    return bdesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t cdesc() const {
+    return cdesc_->descriptor();
+  }
+
+  // Default: D aliases C. Variants with a distinct D layout hide this.
+  cublasLtMatrixLayout_t ddesc() const {
+    return cdesc();
+  }
+
+  // Defaults: heuristic descriptors are the real ones. Variants that feed
+  // cuBLASLt a different shape for heuristic queries hide these.
+  cublasLtMatrixLayout_t heuristic_bdesc() const {
+    return bdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_cdesc() const {
+    return cdesc();
+  }
+
+  cublasLtMatmulPreference_t preference() const {
+    return preference_.descriptor();
+  }
+
+  void* alpha_ptr() const {
+    return alpha_ptr_;
+  }
+
+  void* beta_ptr() const {
+    return beta_ptr_;
+  }
+
+  void* workspace() const {
+    return workspace_.ptr;
+  }
+
+  size_t workspace_size() const {
+    return workspace_.size;
+  }
+
+ protected:
+  at::cuda::blas::detail::CuBlasLtMatmulDescriptor compute_desc_;
+  at::cuda::blas::detail::CuBlasLtMatmulPreference preference_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> adesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> bdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> cdesc_;
+  at::cuda::blas::detail::CublasLtWorkspace workspace_;
+  cublasComputeType_t compute_type_;
+  cudaDataType_t scale_type_;
+  cudaDataType_t a_type_;
+  cudaDataType_t b_type_;
+  cudaDataType_t c_type_;
+  cudaDataType_t d_type_;
+  void* alpha_ptr_ = nullptr;
+  void* beta_ptr_ = nullptr;
+};
+
 template <typename T, typename C_Dtype = T>
-class CublasltStandardGemmProblem {
+class CublasltStandardGemmProblem : public CublasltGemmProblemBase {
  public:
   CublasltStandardGemmProblem(
+      at::cuda::blas::detail::CublasLtTypeInfo<T, C_Dtype> type_info,
       char transa,
       char transb,
       int64_t m,
@@ -150,7 +266,13 @@ class CublasltStandardGemmProblem {
       const void* bias,
       at::cuda::blas::GEMMAndBiasActivationEpilogue activation,
       bool set_epilogue_attribute)
-      : type_info_(at::cuda::blas::detail::getCublasLtTypeInfo<T, C_Dtype>()),
+      : CublasltGemmProblemBase(
+            type_info.compute_type,
+            type_info.scale_type,
+            type_info.ab_type,
+            type_info.ab_type,
+            type_info.c_type,
+            type_info.c_type),
         m_(m),
         n_(n),
         k_(k),
@@ -168,57 +290,12 @@ class CublasltStandardGemmProblem {
         beta_(beta),
         opa_(at::cuda::blas::detail::cublasOpFromChar(transa)),
         opb_(at::cuda::blas::detail::cublasOpFromChar(transb)),
-        compute_desc_(type_info_.compute_type, type_info_.scale_type),
         bias_(bias),
         activation_(activation),
         set_epilogue_attribute_(set_epilogue_attribute) {
     at::cuda::blas::detail::cublasAdjustLdLevel3(
         transa, transb, m_, n_, k_, &lda_, &ldb_, &ldc_);
     initialize();
-  }
-
-  cublasComputeType_t compute_type() const {
-    return type_info_.compute_type;
-  }
-
-  cudaDataType_t scale_type() const {
-    return type_info_.scale_type;
-  }
-
-  cudaDataType_t a_type() const {
-    return type_info_.ab_type;
-  }
-
-  cudaDataType_t b_type() const {
-    return type_info_.ab_type;
-  }
-
-  cudaDataType_t c_type() const {
-    return type_info_.c_type;
-  }
-
-  cudaDataType_t d_type() const {
-    return type_info_.c_type;
-  }
-
-  cublasLtMatmulDesc_t compute_desc() const {
-    return compute_desc_.descriptor();
-  }
-
-  cublasLtMatrixLayout_t adesc() const {
-    return adesc_->descriptor();
-  }
-
-  cublasLtMatrixLayout_t bdesc() const {
-    return bdesc_->descriptor();
-  }
-
-  cublasLtMatrixLayout_t cdesc() const {
-    return cdesc_->descriptor();
-  }
-
-  cublasLtMatrixLayout_t ddesc() const {
-    return cdesc();
   }
 
   cublasLtMatrixLayout_t heuristic_bdesc() const {
@@ -231,18 +308,6 @@ class CublasltStandardGemmProblem {
 
   cublasLtMatrixLayout_t heuristic_ddesc() const {
     return heuristic_cdesc();
-  }
-
-  cublasLtMatmulPreference_t preference() const {
-    return preference_.descriptor();
-  }
-
-  void* alpha_ptr() const {
-    return alpha_ptr_;
-  }
-
-  void* beta_ptr() const {
-    return beta_ptr_;
   }
 
   const T* a() const {
@@ -261,20 +326,12 @@ class CublasltStandardGemmProblem {
     return c_;
   }
 
-  void* workspace() const {
-    return workspace_.ptr;
-  }
-
-  size_t workspace_size() const {
-    return workspace_.size;
-  }
-
  private:
   void initialize() {
     alpha_ptr_ = &alpha_;
     beta_ptr_ = &beta_;
     if constexpr (std::is_same_v<T, at::Half>) {
-      if (type_info_.compute_type == CUBLAS_COMPUTE_16F) {
+      if (compute_type_ == CUBLAS_COMPUTE_16F) {
         halpha_ = alpha_;
         hbeta_ = beta_;
         alpha_ptr_ = &halpha_;
@@ -332,11 +389,11 @@ class CublasltStandardGemmProblem {
     }
 
     adesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
-        type_info_.ab_type, m_, k_, lda_, opa_ != CUBLAS_OP_N);
+        a_type_, m_, k_, lda_, opa_ != CUBLAS_OP_N);
     bdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
-        type_info_.ab_type, k_, n_, ldb_, opb_ != CUBLAS_OP_N);
+        b_type_, k_, n_, ldb_, opb_ != CUBLAS_OP_N);
     cdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
-        type_info_.c_type, m_, n_, ldc_);
+        c_type_, m_, n_, ldc_);
 
     if (batch_count_ > 1) {
       int batch_as_int = static_cast<int>(batch_count_);
@@ -377,10 +434,10 @@ class CublasltStandardGemmProblem {
       const auto fake_ldc = ldc_ == 1 ? 2 : ldc_;
       fake_bdesc_ =
           std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
-              type_info_.ab_type, k_, 2, fake_ldb, opb_ == CUBLAS_OP_T);
+              b_type_, k_, 2, fake_ldb, opb_ == CUBLAS_OP_T);
       fake_cdesc_ =
           std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
-              type_info_.c_type, m_, 2, fake_ldc);
+              c_type_, m_, 2, fake_ldc);
       if (batch_count_ > 1) {
         int batch_as_int = static_cast<int>(batch_count_);
         fake_bdesc_->setAttribute(
@@ -395,7 +452,6 @@ class CublasltStandardGemmProblem {
     }
   }
 
-  at::cuda::blas::detail::CublasLtTypeInfo<T, C_Dtype> type_info_;
   int64_t m_;
   int64_t n_;
   int64_t k_;
@@ -413,29 +469,22 @@ class CublasltStandardGemmProblem {
   at::opmath_type<T> beta_;
   at::Half halpha_;
   at::Half hbeta_;
-  void* alpha_ptr_ = nullptr;
-  void* beta_ptr_ = nullptr;
   uint32_t reduction_mask_ = std::numeric_limits<uint32_t>::max();
   cublasOperation_t opa_;
   cublasOperation_t opb_;
-  at::cuda::blas::detail::CuBlasLtMatmulDescriptor compute_desc_;
-  at::cuda::blas::detail::CuBlasLtMatmulPreference preference_;
   const void* bias_ = nullptr;
   at::cuda::blas::GEMMAndBiasActivationEpilogue activation_;
   bool set_epilogue_attribute_;
   cublasLtEpilogue_t epilogue_ = CUBLASLT_EPILOGUE_DEFAULT;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> adesc_;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> bdesc_;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> cdesc_;
   std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> fake_bdesc_;
   std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> fake_cdesc_;
-  at::cuda::blas::detail::CublasLtWorkspace workspace_;
   bool lie_to_cublaslt_ = false;
 };
 
 template <typename T, typename ParamsT>
 auto MakeCublasltStandardGemmProblem(const ParamsT* params) {
   return CublasltStandardGemmProblem<T>(
+      at::cuda::blas::detail::getCublasLtTypeInfo<T>(),
       params->transa,
       params->transb,
       params->m,
@@ -462,6 +511,7 @@ template <typename T, typename C_Dtype>
 auto MakeCublasltStandardGemmProblem(
     const GemmStridedBatchedParams<T, C_Dtype>* params) {
   return CublasltStandardGemmProblem<T, C_Dtype>(
+      at::cuda::blas::detail::getCublasLtTypeInfo<T, C_Dtype>(),
       params->transa,
       params->transb,
       params->m,
@@ -487,84 +537,27 @@ auto MakeCublasltStandardGemmProblem(
 }
 
 template <typename CT>
-class CublasltScaledGemmProblem {
+class CublasltScaledGemmProblem : public CublasltGemmProblemBase {
  public:
   explicit CublasltScaledGemmProblem(const ScaledGemmParams<CT>* params)
-      : params_(params),
-        a_type_(ScalarTypeToCudaDataType(params->a_dtype)),
-        b_type_(ScalarTypeToCudaDataType(params->b_dtype)),
-        c_type_(ScalarTypeToCudaDataType(params->bias_dtype)),
-        d_type_(ScalarTypeToCudaDataType(params->c_dtype)),
-        compute_desc_(compute_type_, scale_type_) {
+      : CublasltGemmProblemBase(
+            CUBLAS_COMPUTE_32F,
+            CUDA_R_32F,
+            ScalarTypeToCudaDataType(params->a_dtype),
+            ScalarTypeToCudaDataType(params->b_dtype),
+            ScalarTypeToCudaDataType(params->bias_dtype),
+            ScalarTypeToCudaDataType(params->c_dtype)),
+        params_(params) {
     initialize();
   }
 
-  cublasComputeType_t compute_type() const {
-    return compute_type_;
-  }
-
-  cudaDataType_t scale_type() const {
-    return scale_type_;
-  }
-
-  cudaDataType_t a_type() const {
-    return a_type_;
-  }
-
-  cudaDataType_t b_type() const {
-    return b_type_;
-  }
-
-  cudaDataType_t c_type() const {
-    return c_type_;
-  }
-
-  cudaDataType_t d_type() const {
-    return d_type_;
-  }
-
-  cublasLtMatmulDesc_t compute_desc() const {
-    return compute_desc_.descriptor();
-  }
-
-  cublasLtMatrixLayout_t adesc() const {
-    return adesc_->descriptor();
-  }
-
-  cublasLtMatrixLayout_t bdesc() const {
-    return bdesc_->descriptor();
-  }
-
-  cublasLtMatrixLayout_t cdesc() const {
-    return cdesc_->descriptor();
-  }
-
+  // Scaled GEMM has a distinct D layout, so it does not alias C.
   cublasLtMatrixLayout_t ddesc() const {
     return ddesc_->descriptor();
   }
 
-  cublasLtMatrixLayout_t heuristic_bdesc() const {
-    return bdesc();
-  }
-
-  cublasLtMatrixLayout_t heuristic_cdesc() const {
-    return cdesc();
-  }
-
   cublasLtMatrixLayout_t heuristic_ddesc() const {
     return ddesc();
-  }
-
-  cublasLtMatmulPreference_t preference() const {
-    return preference_.descriptor();
-  }
-
-  void* alpha_ptr() const {
-    return alpha_ptr_;
-  }
-
-  void* beta_ptr() const {
-    return beta_ptr_;
   }
 
   const void* a() const {
@@ -584,14 +577,6 @@ class CublasltScaledGemmProblem {
 
   void* d() const {
     return params_->c;
-  }
-
-  void* workspace() const {
-    return workspace_.ptr;
-  }
-
-  size_t workspace_size() const {
-    return workspace_.size;
   }
 
  private:
@@ -678,23 +663,9 @@ class CublasltScaledGemmProblem {
   }
 
   const ScaledGemmParams<CT>* params_;
-  cudaDataType_t a_type_;
-  cudaDataType_t b_type_;
-  cudaDataType_t c_type_;
-  cudaDataType_t d_type_;
-  cublasComputeType_t compute_type_ = CUBLAS_COMPUTE_32F;
-  cudaDataType_t scale_type_ = CUDA_R_32F;
-  at::cuda::blas::detail::CuBlasLtMatmulDescriptor compute_desc_;
-  at::cuda::blas::detail::CuBlasLtMatmulPreference preference_;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> adesc_;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> bdesc_;
-  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> cdesc_;
   std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> ddesc_;
-  at::cuda::blas::detail::CublasLtWorkspace workspace_;
   float alpha_val_ = 1.0f;
   float beta_val_ = 0.0f;
-  void* alpha_ptr_ = nullptr;
-  void* beta_ptr_ = nullptr;
 };
 
 struct CublasltAlgoConfig {

--- a/aten/src/ATen/cuda/tunable/GemmCublaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmCublaslt.h
@@ -3,6 +3,7 @@
 #ifndef USE_ROCM
 
 #include <ATen/cuda/CUDAContextLight.h>
+#include <ATen/cuda/CUDADataType.h>
 #include <ATen/cuda/detail/BLASConstants.h>
 #include <ATen/cuda/detail/CublasLtUtils.h>
 #include <ATen/cuda/Exceptions.h>
@@ -485,6 +486,216 @@ auto MakeCublasltStandardGemmProblem(
       false /* set_epilogue_attribute */);
 }
 
+template <typename CT>
+class CublasltScaledGemmProblem {
+ public:
+  explicit CublasltScaledGemmProblem(const ScaledGemmParams<CT>* params)
+      : params_(params),
+        a_type_(ScalarTypeToCudaDataType(params->a_dtype)),
+        b_type_(ScalarTypeToCudaDataType(params->b_dtype)),
+        c_type_(ScalarTypeToCudaDataType(params->bias_dtype)),
+        d_type_(ScalarTypeToCudaDataType(params->c_dtype)),
+        compute_desc_(compute_type_, scale_type_) {
+    initialize();
+  }
+
+  cublasComputeType_t compute_type() const {
+    return compute_type_;
+  }
+
+  cudaDataType_t scale_type() const {
+    return scale_type_;
+  }
+
+  cudaDataType_t a_type() const {
+    return a_type_;
+  }
+
+  cudaDataType_t b_type() const {
+    return b_type_;
+  }
+
+  cudaDataType_t c_type() const {
+    return c_type_;
+  }
+
+  cudaDataType_t d_type() const {
+    return d_type_;
+  }
+
+  cublasLtMatmulDesc_t compute_desc() const {
+    return compute_desc_.descriptor();
+  }
+
+  cublasLtMatrixLayout_t adesc() const {
+    return adesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t bdesc() const {
+    return bdesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t cdesc() const {
+    return cdesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t ddesc() const {
+    return ddesc_->descriptor();
+  }
+
+  cublasLtMatrixLayout_t heuristic_bdesc() const {
+    return bdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_cdesc() const {
+    return cdesc();
+  }
+
+  cublasLtMatrixLayout_t heuristic_ddesc() const {
+    return ddesc();
+  }
+
+  cublasLtMatmulPreference_t preference() const {
+    return preference_.descriptor();
+  }
+
+  void* alpha_ptr() const {
+    return alpha_ptr_;
+  }
+
+  void* beta_ptr() const {
+    return beta_ptr_;
+  }
+
+  const void* a() const {
+    return params_->a;
+  }
+
+  const void* b() const {
+    return params_->b;
+  }
+
+  // cuBLASLt requires a non-null C pointer even when beta is zero. Match the
+  // non-tunable scaled_gemm path by passing an input pointer; beta = 0 means
+  // C is never read.
+  const void* c() const {
+    return params_->a;
+  }
+
+  void* d() const {
+    return params_->c;
+  }
+
+  void* workspace() const {
+    return workspace_.ptr;
+  }
+
+  size_t workspace_size() const {
+    return workspace_.size;
+  }
+
+ private:
+  void initialize() {
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_TRANSA,
+        at::cuda::blas::detail::cublasOpFromChar(params_->transa));
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_TRANSB,
+        at::cuda::blas::detail::cublasOpFromChar(params_->transb));
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, params_->a_scale_ptr);
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, params_->b_scale_ptr);
+    if (params_->c_scale_ptr != nullptr) {
+      compute_desc_.setAttribute(
+          CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, params_->c_scale_ptr);
+    }
+
+    const int8_t fast_accum = params_->use_fast_accum ? 1 : 0;
+    compute_desc_.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fast_accum);
+
+    if (at::globalContext()._SMCarveout_EXPERIMENTAL().has_value()) {
+      compute_desc_.setAttribute<int32_t>(
+          CUBLASLT_MATMUL_DESC_SM_COUNT_TARGET,
+          at::cuda::getCurrentDeviceProperties()->multiProcessorCount -
+              at::globalContext()._SMCarveout_EXPERIMENTAL().value());
+    }
+
+    if (params_->bias_ptr != nullptr) {
+      compute_desc_.setAttribute(
+          CUBLASLT_MATMUL_DESC_BIAS_POINTER, params_->bias_ptr);
+      compute_desc_.setAttribute(
+          CUBLASLT_MATMUL_DESC_EPILOGUE, CUBLASLT_EPILOGUE_BIAS);
+      compute_desc_.setAttribute(
+          CUBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, c_type_);
+    }
+
+    alpha_ptr_ = &alpha_val_;
+    beta_ptr_ = &beta_val_;
+    if (params_->alpha.has_value()) {
+      const auto& alpha = params_->alpha.value();
+      if (alpha.is_cuda()) {
+        float* user_alpha_ptr = at::cuda::detail::get_user_alpha_ptr();
+        at::Tensor user_alpha = at::from_blob(
+            user_alpha_ptr, {1}, TensorOptions().device(kCUDA).dtype(kFloat));
+        user_alpha.copy_(alpha);
+        auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
+        compute_desc_.setAttribute(
+            CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
+        alpha_ptr_ = user_alpha.data_ptr<float>();
+        beta_ptr_ = at::cuda::detail::get_cublas_device_zero();
+      } else {
+        alpha_val_ = alpha.template item<float>();
+      }
+    }
+
+    int a_scale_mode = at::cuda::blas::detail::cublasLtMatmulScaleMode(
+        params_->a_scaling_type,
+        params_->a_scale_dtype,
+        params_->use_fast_accum);
+    int b_scale_mode = at::cuda::blas::detail::cublasLtMatmulScaleMode(
+        params_->b_scaling_type,
+        params_->b_scale_dtype,
+        params_->use_fast_accum);
+#if CUDA_VERSION >= 12080
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_A_SCALE_MODE, a_scale_mode);
+    compute_desc_.setAttribute(
+        CUBLASLT_MATMUL_DESC_B_SCALE_MODE, b_scale_mode);
+#endif
+
+    adesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        a_type_, params_->m, params_->k, params_->lda, params_->transa == 't');
+    bdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        b_type_, params_->k, params_->n, params_->ldb, params_->transb == 't');
+    cdesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        c_type_, params_->m, params_->n, params_->ldc);
+    ddesc_ = std::make_unique<at::cuda::blas::detail::CuBlasLtMatrixLayout>(
+        d_type_, params_->m, params_->n, params_->ldc);
+
+    preference_.setAttribute(
+        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspace_.size);
+  }
+
+  const ScaledGemmParams<CT>* params_;
+  cudaDataType_t a_type_;
+  cudaDataType_t b_type_;
+  cudaDataType_t c_type_;
+  cudaDataType_t d_type_;
+  cublasComputeType_t compute_type_ = CUBLAS_COMPUTE_32F;
+  cudaDataType_t scale_type_ = CUDA_R_32F;
+  at::cuda::blas::detail::CuBlasLtMatmulDescriptor compute_desc_;
+  at::cuda::blas::detail::CuBlasLtMatmulPreference preference_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> adesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> bdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> cdesc_;
+  std::unique_ptr<at::cuda::blas::detail::CuBlasLtMatrixLayout> ddesc_;
+  at::cuda::blas::detail::CublasLtWorkspace workspace_;
+  float alpha_val_ = 1.0f;
+  float beta_val_ = 0.0f;
+  void* alpha_ptr_ = nullptr;
+  void* beta_ptr_ = nullptr;
+};
 
 struct CublasltAlgoConfig {
   int32_t id = 0;
@@ -672,6 +883,12 @@ struct CublasltStandardGemmProblemFactory {
   }
 };
 
+template <typename CT>
+struct CublasltScaledGemmProblemFactory {
+  auto operator()(const ScaledGemmParams<CT>* params) const {
+    return CublasltScaledGemmProblem<CT>(params);
+  }
+};
 
 template <typename ParamsT, typename ProblemFactory>
 class CublasltMatmulOp : public Callable<ParamsT> {
@@ -835,6 +1052,11 @@ class CublasltGemmTunableOp
           ParamsT,
           CublasltStandardGemmProblemFactory<T>> {};
 
+template <typename AT, typename BT, typename CT, typename ParamsT>
+class CublasltScaledGemmTunableOp
+    : public CublasltMatmulTunableOp<
+          ParamsT,
+          CublasltScaledGemmProblemFactory<CT>> {};
 
 } // namespace at::cuda::tunable
 

--- a/aten/src/ATen/cuda/tunable/GemmCublaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmCublaslt.h
@@ -620,14 +620,10 @@ class CublasltScaledGemmProblem : public CublasltGemmProblemBase {
     if (params_->alpha.has_value()) {
       const auto& alpha = params_->alpha.value();
       if (alpha.is_cuda()) {
-        float* user_alpha_ptr = at::cuda::detail::get_user_alpha_ptr();
-        at::Tensor user_alpha = at::from_blob(
-            user_alpha_ptr, {1}, TensorOptions().device(kCUDA).dtype(kFloat));
-        user_alpha.copy_(alpha);
         auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
         compute_desc_.setAttribute(
             CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
-        alpha_ptr_ = user_alpha.data_ptr<float>();
+        alpha_ptr_ = alpha.const_data_ptr<float>();
         beta_ptr_ = at::cuda::detail::get_cublas_device_zero();
       } else {
         alpha_val_ = alpha.template item<float>();

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -18,6 +18,7 @@
 #endif
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/Float4_e2m1fn_x2.h>
 #include <c10/util/Float8_e4m3fn.h>
 #include <c10/util/Float8_e4m3fnuz.h>
 #include <c10/util/Float8_e5m2.h>
@@ -25,6 +26,7 @@
 #include <c10/util/Float8_e8m0fnu.h>
 #include <c10/util/StringUtil.h>
 #include <fmt/printf.h>
+#include <optional>
 
 namespace at::cuda::tunable {
 
@@ -112,7 +114,11 @@ class DefaultScaledGemmOp : public Callable<ScaledGemmParams<T>> {
           params->ldc,
           params->c_dtype,
           params->use_fast_accum,
+#ifdef USE_ROCM
           std::nullopt /* alpha */);
+#else
+          params->alpha);
+#endif
       return OK;
     }
 };
@@ -169,6 +175,11 @@ inline const char* TypeName(BFloat16 v) {
 template <>
 inline const char* TypeName(Half v) {
   return "Half";
+}
+
+template <>
+inline const char* TypeName(Float4_e2m1fn_x2 v) {
+  return "Float4_e2m1fn_x2";
 }
 
 template <>
@@ -326,7 +337,14 @@ class GemmStridedBatchedTunableOp
 };
 
 template <typename AT, typename BT, typename CT, BlasOp ALayout, BlasOp BLayout>
-class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>> {
+class ScaledGemmTunableOp
+    : public
+#ifdef USE_ROCM
+          TunableOp<ScaledGemmParams<CT>>
+#else
+          CublasltScaledGemmTunableOp<AT, BT, CT, ScaledGemmParams<CT>>
+#endif
+{
  public:
   ScaledGemmTunableOp() {
     this->RegisterOp(std::string("Default"), std::make_unique<DefaultScaledGemmOp<CT>>());

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -171,25 +171,7 @@ class TunableOp {
         op = GetOp(result.GetKey());
       }
       TORCH_CHECK(op != nullptr);
-      auto status = op->Call(params);
-      if (status != OK && result != ResultEntry::Default()) {
-        auto& mgr = ctx->GetTuningResultsManager();
-        auto op_sig = Signature();
-        auto params_sig = params->Signature();
-        TUNABLE_LOG2(
-            "candidate ",
-            result,
-            " failed for ",
-            op_sig,
-            '(',
-            params_sig,
-            "), deleting and using default");
-        mgr.Delete(op_sig, params_sig);
-        auto* default_op = GetOp(ResultEntry::Default().GetKey());
-        TORCH_CHECK(default_op != nullptr);
-        return default_op->Call(params);
-      }
-      return status;
+      return op->Call(params);
     }
 
     virtual std::string Signature() {

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -171,7 +171,25 @@ class TunableOp {
         op = GetOp(result.GetKey());
       }
       TORCH_CHECK(op != nullptr);
-      return op->Call(params);
+      auto status = op->Call(params);
+      if (status != OK && result != ResultEntry::Default()) {
+        auto& mgr = ctx->GetTuningResultsManager();
+        auto op_sig = Signature();
+        auto params_sig = params->Signature();
+        TUNABLE_LOG2(
+            "candidate ",
+            result,
+            " failed for ",
+            op_sig,
+            '(',
+            params_sig,
+            "), deleting and using default");
+        mgr.Delete(op_sig, params_sig);
+        auto* default_op = GetOp(ResultEntry::Default().GetKey());
+        TORCH_CHECK(default_op != nullptr);
+        return default_op->Call(params);
+      }
+      return status;
     }
 
     virtual std::string Signature() {

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -255,7 +255,7 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
 }
 
 Tensor&
-_tunable_scaled_gemm_rocm(
+_tunable_scaled_gemm(
           cublasCommonArgs& args,
           const Tensor& mat1, const Tensor& mat2,
           const Tensor& scale_a, const Tensor& scale_b,
@@ -263,8 +263,10 @@ _tunable_scaled_gemm_rocm(
           const std::optional<Tensor>& bias,
           const bool use_fast_accum,
           const at::ScalarType out_dtype,
-          Tensor& out) {
+          Tensor& out,
+          const std::optional<Tensor>& alpha) {
 #ifdef USE_ROCM
+  (void)alpha;
 #define TUNABLE_DISPATCH(BLASOP_A, BLASOP_B)                            \
       if (mat1.scalar_type() == ScalarType::Float8_e4m3fnuz) {        \
         if (mat2.scalar_type() == ScalarType::Float8_e4m3fnuz) {      \
@@ -322,6 +324,15 @@ _tunable_scaled_gemm_rocm(
           scaledgemm(&params);                                        \
         }                                                             \
       }
+#else
+      // CUDA cuBLASLt dispatches on runtime dtypes in ScaledGemmParams, whose
+      // signature also keys the tuning cache by dtype. AT/BT are placeholders.
+#define TUNABLE_DISPATCH(BLASOP_A, BLASOP_B)                         \
+      static at::cuda::tunable::ScaledGemmTunableOp<                 \
+          at::Float8_e4m3fn, at::Float8_e4m3fn, scalar_t,            \
+          BLASOP_A, BLASOP_B> scaledgemm{};                          \
+      scaledgemm(&params);
+#endif
   AT_DISPATCH_V2(out_dtype, "_tunable_scaled_gemm", AT_WRAP([&] {
     bool transa_ = ((args.transa != 'n') && (args.transa != 'N'));
     bool transb_ = ((args.transb != 'n') && (args.transb != 'N'));
@@ -333,14 +344,12 @@ _tunable_scaled_gemm_rocm(
     params.k = args.k;
     params.a = args.mata->data_ptr();
     params.a_scale_ptr = args.scale_mata_ptr;
-    params.a_scale_dtype = args.scale_mata_dtype.value();
     params.lda = args.lda;
     params.a_dtype = args.mata->scalar_type();
     params.a_scale_dtype = args.scale_mata_dtype.value();
     params.a_scaling_type = args.scaling_mata_type.value();
     params.b = args.matb->data_ptr();
     params.b_scale_ptr = args.scale_matb_ptr;
-    params.b_scale_dtype = args.scale_matb_dtype.value();
     params.ldb = args.ldb;
     params.b_dtype = args.matb->scalar_type();
     params.b_scale_dtype = args.scale_matb_dtype.value();
@@ -352,6 +361,9 @@ _tunable_scaled_gemm_rocm(
     params.ldc = args.result_ld;
     params.c_dtype = out_dtype;
     params.use_fast_accum = use_fast_accum;
+#ifndef USE_ROCM
+    params.alpha = alpha;
+#endif
     if (transa_ && transb_) {
       TUNABLE_DISPATCH(at::cuda::tunable::BlasOp::T, at::cuda::tunable::BlasOp::T)
     }
@@ -368,12 +380,13 @@ _tunable_scaled_gemm_rocm(
       TORCH_CHECK(false, "unreachable");
     }
   }),
+#ifdef USE_ROCM
   kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_FLOATING_TYPES));
+#else
+  kHalf, kBFloat16, kFloat, AT_EXPAND(AT_FLOAT8_TYPES));
+#endif
 #undef TUNABLE_DISPATCH
   return out;
-#else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, "_scaled_gemm_rocm only callable on ROCM devices");
-#endif
 }
 
 Tensor&
@@ -400,17 +413,10 @@ _scaled_gemm(
   if (_scaled_mm_allowed_device(true, false)) {
     TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
   }
-// ROCM enables the TunableOp path only
-// but can fallback to at::cuda::blas::scaled_gemm
-#ifdef USE_ROCM
   auto tuning_ctx = at::cuda::tunable::getTuningContext();
   bool tunable_op_enabled = tuning_ctx->IsTunableOpEnabled();
-#else
-  bool tunable_op_enabled = false;
-#endif
   if (tunable_op_enabled) {
-      // Only available on ROCM
-      return _tunable_scaled_gemm_rocm(
+      return _tunable_scaled_gemm(
           args,
           mat1, mat2,
           scale_a, scale_b,
@@ -418,7 +424,8 @@ _scaled_gemm(
           bias,
           use_fast_accum,
           out_dtype_,
-          out);
+          out,
+          alpha);
   }
   else
   {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -41,7 +41,7 @@ from torch.testing._internal.common_dtype import (
     all_types, all_types_and_complex_and, floating_and_complex_types, integral_types,
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
-from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
+from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, IS_SM90, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
     _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, blas_library_context
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
@@ -9605,10 +9605,12 @@ class TestLinalgCudaOnly(TestCase):
             ok = self._compare_untuned_tuned_entries()
             self.assertTrue(ok)
 
-    @skipCUDAIfNotRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @dtypes(e4m3_type, e5m2_type)
     def test_scaled_gemm_offline_tunableop(self, device, dtype):
+        if not TEST_WITH_ROCM and dtype is e5m2_type:
+            raise unittest.SkipTest("CUDA does not support e5m2 x e5m2 scaled GEMM")
+
         import os
         # This test is the offline version of test_scaled_gemm_tunableop
 
@@ -9684,7 +9686,7 @@ class TestLinalgCudaOnly(TestCase):
 
             # Rowwise case will have an extra solution
             if dtype is e4m3_type:  # rowwise
-                count = 7
+                count = 7 if TEST_WITH_ROCM or IS_SM90 else 6
             else:
                 count = 6
             self.assertEqual(total_num_results, count)
@@ -10356,7 +10358,6 @@ class TestLinalgCudaOnly(TestCase):
             ok = self._compare_untuned_tuned_entries()
             self.assertTrue(ok)
 
-    @skipCUDAIfNotRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @dtypes(e4m3_type, e5m2_type)
     def test_scaled_gemm_tunableop(self, device, dtype):
@@ -10370,6 +10371,8 @@ class TestLinalgCudaOnly(TestCase):
         #
         # Refer to test/test_matmul_cuda for support combinations that are
         # tested by PyTorch
+        if not TEST_WITH_ROCM and dtype is e5m2_type:
+            raise unittest.SkipTest("CUDA does not support e5m2 x e5m2 scaled GEMM")
         with self._tunableop_ctx():
             # set these to single iterations to keep it short but still exercise the code
             torch.cuda.tunable.set_rotating_buffer_size(0)
@@ -10424,7 +10427,7 @@ class TestLinalgCudaOnly(TestCase):
 
             # Rowwise case will have an extra solution
             if dtype is e4m3_type:  # rowwise
-                count = 7
+                count = 7 if TEST_WITH_ROCM or IS_SM90 else 6
             else:
                 count = 6
             self.assertEqual((total_num_results - ref_num_results), count)
@@ -10950,7 +10953,6 @@ class TestLinalgCudaOnly(TestCase):
                                 if l and not l.startswith('Validator')]
                 self.assertGreater(len(result_lines), 0)
 
-    @skipCUDAIfNotRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @dtypes(e4m3_type)
     def test_rowwise_scaled_gemm_numerics_tunableop(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -43,7 +43,6 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, IS_SM90, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
     _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, PLATFORM_SUPPORTS_MX_GEMM, blas_library_context
-from torch.testing._internal.common_quantized import _bfloat16_to_float4_e2m1fn_x2, ceil_div, to_blocked
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
 from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off
@@ -125,6 +124,72 @@ def get_tunableop_untuned_filename():
     untuned_filename_base, _, _ = untuned_filename_env.rpartition('.')
     untuned_filename = f"{untuned_filename_base}{ordinal}.csv"
     return untuned_filename
+
+def parse_tunable_log(log):
+    # Parse the PYTORCH_TUNABLEOP_VERBOSE=3 output into a per-op dict keyed by
+    # (op_signature, param_signature). Each entry records how many candidates
+    # were considered, which ones were tried, their timings, and the winner.
+    tuned = {}
+    current_key = None
+
+    finding_re = re.compile(
+        r"finding fastest for ([^(]+)\(([^)]+)\) out of (\d+) candidates"
+    )
+    tuning_re = re.compile(
+        r"tuning using .* instance id=\d+, ([^(]+)\(([^)]+)\) (.+)$"
+    )
+    timing_re = re.compile(
+        r"found (?:better|slower) instance id=\d+\. ([0-9.e+-]+)ms\. (.+?) min "
+    )
+    fastest_re = re.compile(r"found fastest for ([^(]+)\(([^)]+)\) (.+)$")
+
+    for line in log.splitlines():
+        finding_match = finding_re.search(line)
+        if finding_match:
+            current_key = (finding_match.group(1), finding_match.group(2))
+            tuned[current_key] = {
+                "candidate_count": int(finding_match.group(3)),
+                "tried": set(),
+                "timings": {},
+                "winner": None,
+            }
+            continue
+
+        tuning_match = tuning_re.search(line)
+        if tuning_match:
+            key = (tuning_match.group(1), tuning_match.group(2))
+            tuned.setdefault(
+                key,
+                {
+                    "candidate_count": 0,
+                    "tried": set(),
+                    "timings": {},
+                    "winner": None,
+                },
+            )["tried"].add(tuning_match.group(3))
+            continue
+
+        timing_match = timing_re.search(line)
+        if timing_match and current_key is not None:
+            tuned[current_key]["timings"][timing_match.group(2)] = float(
+                timing_match.group(1)
+            )
+            continue
+
+        fastest_match = fastest_re.search(line)
+        if fastest_match:
+            key = (fastest_match.group(1), fastest_match.group(2))
+            tuned.setdefault(
+                key,
+                {
+                    "candidate_count": 0,
+                    "tried": set(),
+                    "timings": {},
+                    "winner": None,
+                },
+            )["winner"] = fastest_match.group(3)
+
+    return tuned
 
 
 class TestLinalg(TestCase):
@@ -9986,69 +10051,6 @@ class TestLinalgCudaOnly(TestCase):
         if not torch.cuda.is_bf16_supported():
             raise unittest.SkipTest("bfloat16 not supported on this CUDA device")
 
-        def parse_tunable_log(log):
-            tuned = {}
-            current_key = None
-
-            finding_re = re.compile(
-                r"finding fastest for ([^(]+)\(([^)]+)\) out of (\d+) candidates"
-            )
-            tuning_re = re.compile(
-                r"tuning using .* instance id=\d+, ([^(]+)\(([^)]+)\) (.+)$"
-            )
-            timing_re = re.compile(
-                r"found (?:better|slower) instance id=\d+\. ([0-9.e+-]+)ms\. (.+?) min "
-            )
-            fastest_re = re.compile(r"found fastest for ([^(]+)\(([^)]+)\) (.+)$")
-
-            for line in log.splitlines():
-                finding_match = finding_re.search(line)
-                if finding_match:
-                    current_key = (finding_match.group(1), finding_match.group(2))
-                    tuned[current_key] = {
-                        "candidate_count": int(finding_match.group(3)),
-                        "tried": set(),
-                        "timings": {},
-                        "winner": None,
-                    }
-                    continue
-
-                tuning_match = tuning_re.search(line)
-                if tuning_match:
-                    key = (tuning_match.group(1), tuning_match.group(2))
-                    tuned.setdefault(
-                        key,
-                        {
-                            "candidate_count": 0,
-                            "tried": set(),
-                            "timings": {},
-                            "winner": None,
-                        },
-                    )["tried"].add(tuning_match.group(3))
-                    continue
-
-                timing_match = timing_re.search(line)
-                if timing_match and current_key is not None:
-                    tuned[current_key]["timings"][timing_match.group(2)] = float(
-                        timing_match.group(1)
-                    )
-                    continue
-
-                fastest_match = fastest_re.search(line)
-                if fastest_match:
-                    key = (fastest_match.group(1), fastest_match.group(2))
-                    tuned.setdefault(
-                        key,
-                        {
-                            "candidate_count": 0,
-                            "tried": set(),
-                            "timings": {},
-                            "winner": None,
-                        },
-                    )["winner"] = fastest_match.group(3)
-
-            return tuned
-
         import os
         import shutil
         import subprocess
@@ -10434,60 +10436,128 @@ class TestLinalgCudaOnly(TestCase):
                 count = 6
             self.assertEqual((total_num_results - ref_num_results), count)
 
+    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_msg)
     def test_scaled_gemm_blockwise_tunableop(self, device):
         # Exercise the block-scaled scaled GEMM recipes (MXFP8 and NVFP4)
         # through TunableOp. Both recipes dispatch to _scaled_gemm, which
-        # routes to the ScaledGemm TunableOp when tuning is enabled.
-        m, n, k = 128, 64, 128
+        # routes to the ScaledGemm TunableOp when tuning is enabled. We parse
+        # the verbose tuning log to confirm that non-Default candidates are
+        # actually tried and timed, and that the fastest candidate wins.
+        import os
+        import shutil
+        import subprocess
+        import sys
+        import tempfile
+        import textwrap
 
-        def mxfp8_gemm():
-            block = 32
-            matA = torch.ones((m, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
-            matB = torch.ones((n, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
-            scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
-            scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
-            torch.nn.functional.scaled_mm(
-                matA, matB.t(),
-                scale_a=scaleA, scale_recipe_a=torch.nn.functional.ScalingType.BlockWise1x32,
-                scale_b=scaleB, scale_recipe_b=torch.nn.functional.ScalingType.BlockWise1x32,
-                swizzle_a=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
-                output_dtype=torch.bfloat16,
+        # Create the results file in the parent so we can always clean it up,
+        # even if the subprocess is killed before its own teardown runs.
+        results_dir = tempfile.mkdtemp(prefix="tunableop_scaled_gemm_blockwise_")
+        results_filename = os.path.join(results_dir, "results.csv")
+
+        script = textwrap.dedent(
+            """
+            import torch
+            from torch.testing._internal.common_device_type import e4m3_type
+            from torch.testing._internal.common_quantized import (
+                _bfloat16_to_float4_e2m1fn_x2, ceil_div, to_blocked,
             )
 
-        def nvfp4_gemm():
-            block = 16
-            # fp4 packs two elements per byte, so the k dimension is halved on-device.
-            matA = _bfloat16_to_float4_e2m1fn_x2(torch.ones((m, k), dtype=torch.bfloat16, device=device))
-            matB = _bfloat16_to_float4_e2m1fn_x2(torch.ones((n, k), dtype=torch.bfloat16, device=device))
-            scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=e4m3_type, device=device))
-            scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=e4m3_type, device=device))
-            global_scale = torch.ones((), dtype=torch.float32, device=device)
-            swizzle = [torch.nn.functional.SwizzleType.SWIZZLE_32_4_4, torch.nn.functional.SwizzleType.NO_SWIZZLE]
-            recipe = [torch.nn.functional.ScalingType.BlockWise1x16, torch.nn.functional.ScalingType.TensorWise]
-            torch.nn.functional.scaled_mm(
-                matA, matB.t(),
-                scale_a=[scaleA, global_scale], scale_recipe_a=recipe,
-                scale_b=[scaleB, global_scale], scale_recipe_b=recipe,
-                swizzle_a=swizzle, swizzle_b=swizzle,
-                output_dtype=torch.bfloat16,
+            results_filename = {results_filename!r}
+            device = {device!r}
+            m, n, k = 128, 64, 128
+
+            def mxfp8_gemm():
+                block = 32
+                matA = torch.ones((m, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
+                matB = torch.ones((n, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
+                scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
+                scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
+                torch.nn.functional.scaled_mm(
+                    matA, matB.t(),
+                    scale_a=scaleA, scale_recipe_a=torch.nn.functional.ScalingType.BlockWise1x32,
+                    scale_b=scaleB, scale_recipe_b=torch.nn.functional.ScalingType.BlockWise1x32,
+                    swizzle_a=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
+                    swizzle_b=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
+                    output_dtype=torch.bfloat16,
+                )
+
+            def nvfp4_gemm():
+                block = 16
+                # fp4 packs two elements per byte, so the k dimension is halved on-device.
+                matA = _bfloat16_to_float4_e2m1fn_x2(torch.ones((m, k), dtype=torch.bfloat16, device=device))
+                matB = _bfloat16_to_float4_e2m1fn_x2(torch.ones((n, k), dtype=torch.bfloat16, device=device))
+                scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=e4m3_type, device=device))
+                scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=e4m3_type, device=device))
+                global_scale = torch.ones((), dtype=torch.float32, device=device)
+                swizzle = [torch.nn.functional.SwizzleType.SWIZZLE_32_4_4, torch.nn.functional.SwizzleType.NO_SWIZZLE]
+                recipe = [torch.nn.functional.ScalingType.BlockWise1x16, torch.nn.functional.ScalingType.TensorWise]
+                torch.nn.functional.scaled_mm(
+                    matA, matB.t(),
+                    scale_a=[scaleA, global_scale], scale_recipe_a=recipe,
+                    scale_b=[scaleB, global_scale], scale_recipe_b=recipe,
+                    swizzle_a=swizzle, swizzle_b=swizzle,
+                    output_dtype=torch.bfloat16,
+                )
+
+            gemms = [mxfp8_gemm, nvfp4_gemm]
+            try:
+                torch.cuda.tunable.enable(False)
+                torch.cuda.tunable.record_untuned_enable(False)
+                torch.cuda.tunable.tuning_enable(True)
+                torch.cuda.tunable.set_max_tuning_duration(1)
+                torch.cuda.tunable.set_max_tuning_iterations(3)
+                torch.cuda.tunable.set_cublaslt_requested_algo_count(8)
+                torch.cuda.tunable.set_rotating_buffer_size(0)
+                torch.cuda.tunable.set_numerical_check_tolerances(False)
+                torch.cuda.tunable.set_filename(results_filename, False)
+                torch.cuda.tunable.enable(True)
+
+                for gemm in gemms:
+                    gemm()
+            finally:
+                torch.cuda.tunable.enable(False)
+            """
+        ).format(results_filename=results_filename, device=device)
+
+        env = os.environ.copy()
+        env["PYTORCH_TUNABLEOP_VERBOSE"] = "3"
+        env["PYTORCH_TUNABLEOP_VERBOSE_FILENAME"] = "out"
+        try:
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=os.path.dirname(__file__),
+                check=True,
             )
+        finally:
+            shutil.rmtree(results_dir, ignore_errors=True)
 
-        # NVFP4 is not supported on ROCm.
-        gemms = [mxfp8_gemm] if TEST_WITH_ROCM else [mxfp8_gemm, nvfp4_gemm]
+        tuned = parse_tunable_log(result.stdout)
+        self.assertGreater(len(tuned), 0, result.stdout)
+        self.assertTrue(
+            any(key[0].startswith("ScaledGemmTunableOp") for key in tuned), tuned
+        )
+        self.assertTrue(
+            any(
+                info["candidate_count"] > 1
+                and any(c.startswith("Gemm_Cublaslt_") for c in info["tried"])
+                and len(info["timings"]) > 1
+                for info in tuned.values()
+            ),
+            (tuned, result.stdout),
+        )
 
-        with self._tunableop_ctx():
-            torch.cuda.tunable.set_rotating_buffer_size(0)
-            torch.cuda.tunable.set_max_tuning_iterations(1)
-
-            ref_num_results = len(torch.cuda.tunable.get_results())
-            for gemm in gemms:
-                gemm()
-            total_num_results = len(torch.cuda.tunable.get_results())
-
-            # Each recipe has a distinct problem signature, so each adds one result.
-            self.assertEqual((total_num_results - ref_num_results), len(gemms))
+        for key, info in tuned.items():
+            if not info["timings"]:
+                continue
+            self.assertIn(info["winner"], info["timings"], (key, info, result.stdout))
+            winner_time = info["timings"][info["winner"]]
+            fastest_time = min(info["timings"].values())
+            self.assertEqual(winner_time, fastest_time, (key, info))
 
     @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -42,7 +42,8 @@ from torch.testing._internal.common_dtype import (
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
 from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, IS_SM90, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
-    _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, blas_library_context
+    _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, PLATFORM_SUPPORTS_MX_GEMM, blas_library_context
+from torch.testing._internal.common_quantized import _bfloat16_to_float4_e2m1fn_x2, ceil_div, to_blocked
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
 from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off
@@ -56,6 +57,7 @@ from torch.testing._internal.common_utils import (
 )
 
 f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices"
+mx_msg = "MX gemm is only supported on CUDA capability 10.0+ and gfx950/gfx1250"
 
 # Protects against includes accidentally setting the default dtype
 if torch.get_default_dtype() is not torch.float32:
@@ -10431,6 +10433,61 @@ class TestLinalgCudaOnly(TestCase):
             else:
                 count = 6
             self.assertEqual((total_num_results - ref_num_results), count)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_msg)
+    def test_scaled_gemm_blockwise_tunableop(self, device):
+        # Exercise the block-scaled scaled GEMM recipes (MXFP8 and NVFP4)
+        # through TunableOp. Both recipes dispatch to _scaled_gemm, which
+        # routes to the ScaledGemm TunableOp when tuning is enabled.
+        m, n, k = 128, 64, 128
+
+        def mxfp8_gemm():
+            block = 32
+            matA = torch.ones((m, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
+            matB = torch.ones((n, k), dtype=torch.bfloat16, device=device).to(e4m3_type)
+            scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
+            scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=torch.float8_e8m0fnu, device=device))
+            torch.nn.functional.scaled_mm(
+                matA, matB.t(),
+                scale_a=scaleA, scale_recipe_a=torch.nn.functional.ScalingType.BlockWise1x32,
+                scale_b=scaleB, scale_recipe_b=torch.nn.functional.ScalingType.BlockWise1x32,
+                swizzle_a=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
+                swizzle_b=torch.nn.functional.SwizzleType.SWIZZLE_32_4_4,
+                output_dtype=torch.bfloat16,
+            )
+
+        def nvfp4_gemm():
+            block = 16
+            # fp4 packs two elements per byte, so the k dimension is halved on-device.
+            matA = _bfloat16_to_float4_e2m1fn_x2(torch.ones((m, k), dtype=torch.bfloat16, device=device))
+            matB = _bfloat16_to_float4_e2m1fn_x2(torch.ones((n, k), dtype=torch.bfloat16, device=device))
+            scaleA = to_blocked(torch.ones((m, ceil_div(k, block)), dtype=e4m3_type, device=device))
+            scaleB = to_blocked(torch.ones((n, ceil_div(k, block)), dtype=e4m3_type, device=device))
+            global_scale = torch.ones((), dtype=torch.float32, device=device)
+            swizzle = [torch.nn.functional.SwizzleType.SWIZZLE_32_4_4, torch.nn.functional.SwizzleType.NO_SWIZZLE]
+            recipe = [torch.nn.functional.ScalingType.BlockWise1x16, torch.nn.functional.ScalingType.TensorWise]
+            torch.nn.functional.scaled_mm(
+                matA, matB.t(),
+                scale_a=[scaleA, global_scale], scale_recipe_a=recipe,
+                scale_b=[scaleB, global_scale], scale_recipe_b=recipe,
+                swizzle_a=swizzle, swizzle_b=swizzle,
+                output_dtype=torch.bfloat16,
+            )
+
+        # NVFP4 is not supported on ROCm.
+        gemms = [mxfp8_gemm] if TEST_WITH_ROCM else [mxfp8_gemm, nvfp4_gemm]
+
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
+
+            ref_num_results = len(torch.cuda.tunable.get_results())
+            for gemm in gemms:
+                gemm()
+            total_num_results = len(torch.cuda.tunable.get_results())
+
+            # Each recipe has a distinct problem signature, so each adds one result.
+            self.assertEqual((total_num_results - ref_num_results), len(gemms))
 
     @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -194,6 +194,7 @@ import multiprocessing as mp
 import os
 import shutil
 import warnings
+from typing import NamedTuple
 
 import torch
 
@@ -572,6 +573,129 @@ def _create_batch_matrices(
         return matA, matB
 
 
+def _get_dtype_from_string(
+    dtype_string: str, dtype_dict: dict[str, torch.dtype], field_name: str
+) -> torch.dtype:
+    dtype = dtype_dict.get(dtype_string)
+    if dtype is None:
+        raise TypeError(f"{field_name} must be a torch.dtype, but got {dtype_string}")
+    return dtype
+
+
+class _ScaledGemmOptions(NamedTuple):
+    dtypeA: torch.dtype
+    dtypeB: torch.dtype
+    dtypeC: torch.dtype
+    rowwise: bool
+    bias_dtype: torch.dtype | None
+    use_fast_accum: bool
+
+
+def _parse_cuda_scaled_gemm_fields(tokens: list[str]) -> dict[str, str]:
+    labels = ("a", "b", "c", "as", "bs", "ast", "bst", "dscale", "fast", "bias")
+    label_set = set(labels)
+    fields: dict[str, str] = {}
+
+    i = 8
+    for label in labels:
+        if i >= len(tokens) or tokens[i] != label:
+            got = tokens[i] if i < len(tokens) else None
+            raise AssertionError(f"expected {label!r} at index {i}, got {got!r}")
+        i += 1
+
+        value_start = i
+        while i < len(tokens) and tokens[i] not in label_set:
+            i += 1
+        if i == value_start:
+            raise AssertionError(f"expected value for {label!r}")
+        fields[label] = "_".join(tokens[value_start:i])
+
+    if i != len(tokens):
+        raise AssertionError(f"unexpected CUDA scaled GEMM fields: {tokens[i:]}")
+
+    return fields
+
+
+def _parse_rocm_scaled_gemm_options(
+    tokens: list[str],
+    dtype_dict: dict[str, torch.dtype],
+    dtypeA: torch.dtype | None,
+    dtypeB: torch.dtype | None,
+    dtypeC: torch.dtype | None,
+) -> _ScaledGemmOptions:
+    if tokens[8] != "rw":
+        raise AssertionError(f"expected 'rw' at index 8, got {tokens[8]!r}")
+
+    if tokens[10] != "bias":
+        raise AssertionError(f"expected 'bias' at index 10, got {tokens[10]!r}")
+
+    if dtypeA is None or not isinstance(dtypeA, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeA}")
+    if dtypeB is None or not isinstance(dtypeB, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeB}")
+    if dtypeC is None or not isinstance(dtypeC, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeC}")
+
+    bias_dtype = (
+        None
+        if tokens[11] == "None"
+        else _get_dtype_from_string(tokens[11], dtype_dict, "bias_dtype")
+    )
+    return _ScaledGemmOptions(
+        dtypeA, dtypeB, dtypeC, tokens[9] == "1", bias_dtype, False
+    )
+
+
+def _parse_cuda_scaled_gemm_options(
+    tokens: list[str], dtype_dict: dict[str, torch.dtype]
+) -> _ScaledGemmOptions:
+    fields = _parse_cuda_scaled_gemm_fields(tokens)
+
+    if fields["dscale"] != "0":
+        raise AssertionError(
+            "offline tuning for CUDA scaled GEMM with dscale is not supported"
+        )
+
+    if fields["ast"] != fields["bst"]:
+        raise AssertionError(
+            "offline tuning only supports matching CUDA scaled GEMM scaling types"
+        )
+    if fields["ast"] not in ("0", "1"):
+        raise AssertionError(
+            "offline tuning only supports CUDA tensorwise and rowwise scaled GEMM"
+        )
+    if fields["fast"] not in ("0", "1"):
+        raise AssertionError("expected CUDA scaled GEMM fast field to be 0 or 1")
+
+    bias_dtype = (
+        None
+        if fields["bias"] == "None"
+        else _get_dtype_from_string(fields["bias"], dtype_dict, "bias_dtype")
+    )
+    return _ScaledGemmOptions(
+        dtypeA=_get_dtype_from_string(fields["a"], dtype_dict, "dtypeA"),
+        dtypeB=_get_dtype_from_string(fields["b"], dtype_dict, "dtypeB"),
+        dtypeC=_get_dtype_from_string(fields["c"], dtype_dict, "dtypeC"),
+        rowwise=fields["ast"] == "1",
+        bias_dtype=bias_dtype,
+        use_fast_accum=fields["fast"] == "1",
+    )
+
+
+def _parse_scaled_gemm_options(
+    tokens: list[str],
+    dtype_dict: dict[str, torch.dtype],
+    dtypeA: torch.dtype | None,
+    dtypeB: torch.dtype | None,
+    dtypeC: torch.dtype | None,
+) -> _ScaledGemmOptions:
+    if torch.version.hip:
+        return _parse_rocm_scaled_gemm_options(
+            tokens, dtype_dict, dtypeA, dtypeB, dtypeC
+        )
+    return _parse_cuda_scaled_gemm_options(tokens, dtype_dict)
+
+
 def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
     r"""Process a single untuned GEMM."""
 
@@ -730,9 +854,9 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
                 f"transA must be False for ScaledGemmTunableOp, got {transA}"
             )
 
-        # Resolve linter issue
-        if dtypeA is None or not isinstance(dtypeA, torch.dtype):
-            raise TypeError(f"dtype must be a torch.dtype, but got {dtypeA}")
+        scaled_gemm_options = _parse_scaled_gemm_options(
+            untuned_gemm_temp, dtype_dict, dtypeA, dtypeB, dtypeC
+        )
 
         matA, matB = _create_matrices(
             m,
@@ -743,22 +867,14 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             ldc,
             transA,
             transB,
-            dtypeA,
+            scaled_gemm_options.dtypeA,
             deviceid,
-            dtypeB=dtypeB,
+            dtypeB=scaled_gemm_options.dtypeB,
             randn=False,
             subMatrix=subMatrix,
         )
 
-        if untuned_gemm_temp[8] != "rw":
-            raise AssertionError(
-                f"expected 'rw' at index 8, got {untuned_gemm_temp[8]!r}"
-            )
-        if untuned_gemm_temp[9] == "1":
-            rowwise = True
-        else:
-            rowwise = False
-        if rowwise:
+        if scaled_gemm_options.rowwise:
             scaleA = (
                 torch.ones((1, m), device=deviceid)
                 if transA
@@ -773,25 +889,30 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
             scaleA = torch.tensor(0.8, device=deviceid)
             scaleB = torch.tensor(0.9, device=deviceid)
 
-        if untuned_gemm_temp[10] != "bias":
-            raise AssertionError(
-                f"expected 'bias' at index 10, got {untuned_gemm_temp[10]!r}"
-            )
-        if untuned_gemm_temp[11] == "None":  # no bias vector
-            torch._scaled_mm(
-                matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC
-            )
-        else:  # bias vector present
+        kwargs = {
+            "scale_a": scaleA,
+            "scale_b": scaleB,
+            "out_dtype": scaled_gemm_options.dtypeC,
+            "use_fast_accum": scaled_gemm_options.use_fast_accum,
+        }
+        if scaled_gemm_options.bias_dtype is not None:
             fillbias = 0.10
-            bias_dtype = dtype_dict.get(untuned_gemm_temp[11])
-            bias = (
-                torch.full((n,), fillbias, dtype=bias_dtype, device=deviceid)
+            kwargs["bias"] = (
+                torch.full(
+                    (n,),
+                    fillbias,
+                    dtype=scaled_gemm_options.bias_dtype,
+                    device=deviceid,
+                )
                 if transB
-                else torch.full((m,), fillbias, dtype=bias_dtype, device=deviceid)
+                else torch.full(
+                    (m,),
+                    fillbias,
+                    dtype=scaled_gemm_options.bias_dtype,
+                    device=deviceid,
+                )
             )
-            torch._scaled_mm(
-                matA, matB, scale_a=scaleA, scale_b=scaleB, out_dtype=dtypeC, bias=bias
-            )
+        torch._scaled_mm(matA, matB, **kwargs)
 
     elif op_sig == "GemmAndBiasTunableOp":
         # y = x*A^T + b

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -616,36 +616,6 @@ def _parse_cuda_scaled_gemm_fields(tokens: list[str]) -> dict[str, str]:
     return fields
 
 
-def _parse_rocm_scaled_gemm_options(
-    tokens: list[str],
-    dtype_dict: dict[str, torch.dtype],
-    dtypeA: torch.dtype | None,
-    dtypeB: torch.dtype | None,
-    dtypeC: torch.dtype | None,
-) -> _ScaledGemmOptions:
-    if tokens[8] != "rw":
-        raise AssertionError(f"expected 'rw' at index 8, got {tokens[8]!r}")
-
-    if tokens[10] != "bias":
-        raise AssertionError(f"expected 'bias' at index 10, got {tokens[10]!r}")
-
-    if dtypeA is None or not isinstance(dtypeA, torch.dtype):
-        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeA}")
-    if dtypeB is None or not isinstance(dtypeB, torch.dtype):
-        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeB}")
-    if dtypeC is None or not isinstance(dtypeC, torch.dtype):
-        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeC}")
-
-    bias_dtype = (
-        None
-        if tokens[11] == "None"
-        else _get_dtype_from_string(tokens[11], dtype_dict, "bias_dtype")
-    )
-    return _ScaledGemmOptions(
-        dtypeA, dtypeB, dtypeC, tokens[9] == "1", bias_dtype, False
-    )
-
-
 def _parse_cuda_scaled_gemm_options(
     tokens: list[str], dtype_dict: dict[str, torch.dtype]
 ) -> _ScaledGemmOptions:
@@ -682,18 +652,35 @@ def _parse_cuda_scaled_gemm_options(
     )
 
 
-def _parse_scaled_gemm_options(
+def _parse_rocm_scaled_gemm_options(
     tokens: list[str],
     dtype_dict: dict[str, torch.dtype],
     dtypeA: torch.dtype | None,
     dtypeB: torch.dtype | None,
     dtypeC: torch.dtype | None,
 ) -> _ScaledGemmOptions:
-    if torch.version.hip:
-        return _parse_rocm_scaled_gemm_options(
-            tokens, dtype_dict, dtypeA, dtypeB, dtypeC
-        )
-    return _parse_cuda_scaled_gemm_options(tokens, dtype_dict)
+    if tokens[8] != "rw":
+        raise AssertionError(f"expected 'rw' at index 8, got {tokens[8]!r}")
+
+    if tokens[10] != "bias":
+        raise AssertionError(f"expected 'bias' at index 10, got {tokens[10]!r}")
+
+    # Make linter happy
+    if dtypeA is None or not isinstance(dtypeA, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeA}")
+    if dtypeB is None or not isinstance(dtypeB, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeB}")
+    if dtypeC is None or not isinstance(dtypeC, torch.dtype):
+        raise TypeError(f"dtype must be a torch.dtype, but got {dtypeC}")
+
+    bias_dtype = (
+        None
+        if tokens[11] == "None"
+        else _get_dtype_from_string(tokens[11], dtype_dict, "bias_dtype")
+    )
+    return _ScaledGemmOptions(
+        dtypeA, dtypeB, dtypeC, tokens[9] == "1", bias_dtype, False
+    )
 
 
 def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
@@ -854,9 +841,14 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
                 f"transA must be False for ScaledGemmTunableOp, got {transA}"
             )
 
-        scaled_gemm_options = _parse_scaled_gemm_options(
-            untuned_gemm_temp, dtype_dict, dtypeA, dtypeB, dtypeC
-        )
+        if torch.version.hip:
+            scaled_gemm_options = _parse_rocm_scaled_gemm_options(
+                untuned_gemm_temp, dtype_dict, dtypeA, dtypeB, dtypeC
+            )
+        else:
+            scaled_gemm_options = _parse_cuda_scaled_gemm_options(
+                untuned_gemm_temp, dtype_dict
+            )
 
         matA, matB = _create_matrices(
             m,


### PR DESCRIPTION
This PR builds on #186270, extending CUDA TunableOp support to scaled GEMM. Most of this PR is just guarded CUDA-only equivalents for the existing ROCm scaled GEMM TunableOp paths. The biggest additions are a new test for TunableOp with blockwise scaling modes, factoring out CUDA/ROCm parsing logic for offline tuning, and the `CublasltScaledGemmProblem` class- I pulled many of the functions from `CublasltStandardGemmProblem` into a shared base class to reduce redundancy but there's still a fair bit of added boilerplate.

### Benchmarking

On RTX 5090 I benchmarked throughput with and without TunableOp enabled for tensorwise, MXFP8, and NVFP4 scaling modes on square matmuls with valid alignments. Average TunableOp performance does not exceed default performance in eager because of the additional CPU overhead, but there are cases where extra performance can be realized over the top-1 result from the cuBLAS heuristic. Best use cases for this are paired with CUDA Graphs to drop the CPU cost, or for specific cases where the GPU win outweighs the CPU cost.

Square shapes:

<img width="2100" height="750" alt="scaled_mm_square_tensorwise_tunableop" src="https://github.com/user-attachments/assets/c5946ab6-652b-4131-ab4c-30fd4903744d" />

<img width="2100" height="750" alt="scaled_mm_square_mxfp8_tunableop" src="https://github.com/user-attachments/assets/963fd0db-4a7e-499e-9da0-392ad5c4fcc6" />

<img width="2100" height="750" alt="scaled_mm_square_nvfp4_tunableop" src="https://github.com/user-attachments/assets/0a0ad255-7b98-4082-abbe-82a4ee871d81" />

Random shapes (note this is graphing speedup vs index, not TFLOPs vs shape):

<img width="2100" height="750" alt="scaled_mm_random_tensorwise_tunableop" src="https://github.com/user-attachments/assets/8ab637aa-5077-48b5-bcc2-605e7aa355ba" />

<img width="2100" height="750" alt="scaled_mm_random_mxfp8_tunableop" src="https://github.com/user-attachments/assets/9adfd1e1-b257-4c1c-8ace-89d27bbc8b59" />

<img width="2100" height="750" alt="scaled_mm_random_nvfp4_tunableop" src="https://github.com/user-attachments/assets/525f054b-81a3-41ad-9fae-11be37cb066b" />

### Links
[Benchmarking spreadsheet](https://docs.google.com/spreadsheets/d/1t5W1X6sj2cLgQTAhETd4CLJK2OLd38La)
[Benchmarking script](https://gist.github.com/gderossi/b3d47f0aadce18e293cd80367d4567d9)

cc @eqy @drisspg 

Authored with assistance from agents