### PR TITLE
Add post-op policy and AutoNamingMode for selective activation checkpointing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16540,13 +16540,22 @@ class TestSelectiveActivationCheckpoint(TestCase):
                 "Model.layers.1_my_op.default_2",
             }
 
+            fwd_decisions: list = []
+            fwd_idx = [0]
+
             def policy_fn(ctx, op, *args, **kwargs):
+                if ctx.is_recompute:
+                    decision = fwd_decisions[fwd_idx[0]]
+                    fwd_idx[0] += 1
+                    return decision
                 out = ctx.op_output
+                decision = CheckpointPolicy.PREFER_RECOMPUTE
                 if isinstance(out, torch.Tensor):
                     name = naming.names.get(out)
                     if name in save_names:
-                        return CheckpointPolicy.MUST_SAVE
-                return CheckpointPolicy.PREFER_RECOMPUTE
+                        decision = CheckpointPolicy.MUST_SAVE
+                fwd_decisions.append(decision)
+                return decision
 
             x = torch.randn(4, requires_grad=True)
             context_fn = functools.partial(

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1385,6 +1385,14 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
         out = func(*args, **kwargs)
 
+        # HOPs don't support func._schema
+        # HOPs don't alias -> this is always true today and will be always true for a long time
+        # TODO HOPs don't mutate -> this is always true today but will not be true forever
+        if isinstance(func, torch._ops.HigherOrderOperator):
+            any_ret_has_alias_info = False
+        else:
+            any_ret_has_alias_info = any(ret.alias_info is not None for ret in func._schema.returns)
+
         key = _sac_storage_key(func, args)
         idx = self.func_counter[key]
         self.func_counter[key] += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Authored with Claude.


Pull-Request: https://github.com/pytorch/pytorch/pull/185282