### PR TITLE
Use indexed storage for SAC forward/backward matching

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16540,22 +16540,13 @@ class TestSelectiveActivationCheckpoint(TestCase):
                 "Model.layers.1_my_op.default_2",
             }
 
-            fwd_decisions: list = []
-            fwd_idx = [0]
-
             def policy_fn(ctx, op, *args, **kwargs):
-                if ctx.is_recompute:
-                    decision = fwd_decisions[fwd_idx[0]]
-                    fwd_idx[0] += 1
-                    return decision
                 out = ctx.op_output
-                decision = CheckpointPolicy.PREFER_RECOMPUTE
                 if isinstance(out, torch.Tensor):
                     name = naming.names.get(out)
                     if name in save_names:
-                        decision = CheckpointPolicy.MUST_SAVE
-                fwd_decisions.append(decision)
-                return decision
+                        return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
 
             x = torch.randn(4, requires_grad=True)
             context_fn = functools.partial(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Switches SAC storage from List with append/pop(0) to Dict[int, Any]
keyed by per-op invocation counter. This allows the backward to find
cached values by index rather than relying on the backward policy to
reproduce the forward's save decisions, which is necessary when the
forward policy uses per-tensor information (like names) that isn't
available during backward.

Authored with Claude.


Pull-Request: https://github.com/pytorch/pytorch/pull/185283