### PR TITLE
[activation_checkpointing] Per-region memory_budget via fx_traceback.annotate (#185672)

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -2675,6 +2675,51 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_memory_budget_annotation_causes_cache_miss(self):
+        """Changing per-region memory_budget set via fx_traceback.annotate
+        invalidates the AOTAutograd cache."""
+        import torch.fx.traceback as fx_traceback
+
+        def make_fn(budget):
+            def fn(x, y):
+                with fx_traceback.annotate({"memory_budget": budget}):
+                    return (torch.mm(x, y) + 1).relu()
+
+            return fn
+
+        with fresh_cache():
+            compiled_fn1 = torch.compile(make_fn(0.3), backend="inductor")
+            x1 = torch.randn(10, 10, requires_grad=True)
+            y1 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn1(x1, y1).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            compiled_fn2 = torch.compile(make_fn(0.8), backend="inductor")
+            x2 = torch.randn(10, 10, requires_grad=True)
+            y2 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn2(x2, y2).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # Same budget as the first compile -> cache hit.
+            compiled_fn3 = torch.compile(make_fn(0.3), backend="inductor")
+            x3 = torch.randn(10, 10, requires_grad=True)
+            y3 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn3(x3, y3).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     @functorch_config.patch({"activation_memory_budget": 0.5})
     def test_different_custom_estimator_uuids_cause_cache_miss(self):
         """Test that different uuid values cause cache miss."""

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -510,6 +510,27 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
 
+        # node.meta["custom"] is populated by fx_traceback.annotate(...) and is
+        # stripped by GraphModule.__reduce__, so per-node memory_budget values
+        # set via annotate({"memory_budget": ...}) would be invisible to the
+        # cache key. Extract them explicitly so that changing per-region budgets
+        # correctly invalidates the cache. Recurse into nested GraphModules
+        # (e.g. invoke_subgraph / SAC HOP bodies) and fold the owning module's
+        # qualified name into the key so per-module node indices stay distinct.
+        self.custom_memory_budget_per_node: list[tuple[str, int, float]] = []
+        for module_name, module in gm.named_modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for i, node in enumerate(module.graph.nodes):
+                custom = node.meta.get("custom")
+                if not isinstance(custom, dict):
+                    continue
+                budget = custom.get("memory_budget")
+                if isinstance(budget, (int, float)):
+                    self.custom_memory_budget_per_node.append(
+                        (module_name, i, float(budget))
+                    )
+
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and
         # activation_memory_budget_solver are excluded from save_config (in

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3791,10 +3791,25 @@ def min_cut_rematerialization_partition(
             for user in node.users:
                 node.dist_from_bw = min(node.dist_from_bw, user.dist_from_bw + 1)
 
+    # Per-region memory_budget override resolution. Two reader paths share the
+    # same precedence rule: first matching node wins, custom overrides legacy.
+    #   - Legacy: node.meta["memory_budget"], populated by the
+    #     `MemoryBudgetMode` / `set_memory_budget` allow_in_graph marker.
+    #   - Custom: node.meta["custom"]["memory_budget"], populated by
+    #     `fx_traceback.annotate({"memory_budget": ...})` and propagated to all
+    #     FX nodes via _COPY_META_FIELDS["custom"]. The annotate path is the
+    #     supported replacement -- its contextmanager `finally:` restores
+    #     `current_meta` on every exit path, so it cannot leak across compiles
+    #     the way the legacy marker did (no-op __exit__ under Dynamo).
     memory_budget = config.activation_memory_budget
     for node in joint_graph.nodes:
         if isinstance(node.meta.get("memory_budget", None), float):
             memory_budget = node.meta["memory_budget"]
+            break
+    for node in joint_graph.nodes:
+        custom_budget = node.meta.get("custom", {}).get("memory_budget", None)
+        if isinstance(custom_budget, float):
+            memory_budget = custom_budget
             break
     saved_values = choose_saved_values_set(
         joint_graph,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:

Adds a per-region activation `memory_budget` override driven by `fx_traceback.annotate`, plus the AOTAutograd cache plumbing to make it cacheable.

Motivation: `config.activation_memory_budget` is a single global knob applied to every recomputation decision in the graph, but models often want different aggressiveness in different regions (e.g. recompute cheap matmul-only blocks aggressively while preserving expensive attention activations). The legacy per-node knob, `node.meta["memory_budget"]` set by the `MemoryBudgetMode` / `set_memory_budget` allow_in_graph marker, has a no-op `__exit__` under Dynamo and could leak across compiles. `fx_traceback.annotate` is the supported replacement: it is a regular `contextmanager`, so its `finally:` restores `current_meta` on every exit path (success, exception, graph break), keeping the annotation scoped to its region.

Usage: wrap a forward region with `with torch.fx.traceback.annotate({"memory_budget": value}):`. Any node carrying the annotation inside the joint graph overrides `config.activation_memory_budget` for the entire partition; first matching node wins.

Partitioner: the AOT min-cut partitioner gains a reader for `node.meta["custom"]["memory_budget"]`, run as a separate loop after the legacy `node.meta["memory_budget"]` reader. Both pick the first matching node and break; custom overrides legacy when both are present. No further plumbing is required because `fx_traceback.annotate` writes into `current_meta["custom"]` and `_COPY_META_FIELDS["custom"]` (already upstream) propagates that onto every FX node produced inside the annotated forward.

Cache key: `AOTAutogradCacheDetails` collects `(node_index, float(budget))` from `node.meta["custom"]["memory_budget"]` into `custom_memory_budget_per_node`. This is required because `GraphModule.__reduce__` strips `node.meta` during pickling, so the annotation would otherwise be invisible to the cache key -- recompiling the same model with a different annotated budget would silently return a stale cached compile.

No-op for graphs that do not set `node.meta["custom"]["memory_budget"]`.

Test Plan:
`buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/dynamo:test_aot_autograd_cache -- test_custom_memory_budget_annotation_causes_cache_miss`

The new test wraps a region with `fx_traceback.annotate({"memory_budget": budget})` and compiles three times inside a single `fresh_cache()`: budget=0.3 -> miss, budget=0.8 -> miss, budget=0.3 (same as first) -> hit. Partitioner reader is covered by CI.

Differential Revision: D106863375

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98