### PR TITLE
[MPS] Add lcm Metal kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -458,7 +458,7 @@ struct lcm_functor {
     // so the abs matches the CPU/CUDA kernels: abs is taken before narrowing
     // back to T on return. Divide before multiplying to limit overflow.
     auto r = a / g * b;
-    return r < 0 ? -r : r;
+    return ::metal::abs(r);
   }
 };
 

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -447,6 +447,21 @@ struct gcd_functor {
   }
 };
 
+struct lcm_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    T g = gcd_functor{}(a, b);
+    if (g == 0) {
+      return 0;
+    }
+    // `auto` keeps the C++ integer-promoted type (sub-int types widen to int),
+    // so the abs matches the CPU/CUDA kernels: abs is taken before narrowing
+    // back to T on return. Divide before multiplying to limit overflow.
+    auto r = a / g * b;
+    return r < 0 ? -r : r;
+  }
+};
+
 // eq/ne are defined manually (rather than via DEFINE_BINARY_COMPARISON_FUNCTOR)
 // so they can carry complex overloads: `float2 == float2` returns `bool2` in
 // Metal, which doesn't implicitly convert to bool. The reduction `all(...)` /
@@ -599,6 +614,7 @@ REGISTER_INTEGER_BINARY_OP(fmod);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igamma);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igammac);
 REGISTER_INTEGER_BINARY_OP(gcd);
+REGISTER_INTEGER_BINARY_OP(lcm);
 REGISTER_INTEGER_BINARY_OP(bitwise_and);
 REGISTER_INTEGER_BINARY_OP(bitwise_or);
 REGISTER_INTEGER_BINARY_OP(bitwise_xor);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -294,6 +294,12 @@ static void gcd_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "gcd");
 }
 
+static void lcm_mps_kernel(TensorIteratorBase& iter) {
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      c10::isIntegralType(iter.common_dtype(), false), "lcm_mps not implemented for ", iter.common_dtype());
+  lib.exec_binary_kernel(iter, "lcm");
+}
+
 static void bitwise_and_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "bitwise_and");
 }
@@ -379,6 +385,7 @@ REGISTER_DISPATCH(igamma_stub, &igamma_mps_kernel)
 REGISTER_DISPATCH(igammac_stub, &igammac_mps_kernel)
 REGISTER_DISPATCH(hypot_stub, &hypot_mps_kernel)
 REGISTER_DISPATCH(gcd_stub, &gcd_mps_kernel)
+REGISTER_DISPATCH(lcm_stub, &lcm_mps_kernel)
 REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_mps_kernel)
 REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_mps_kernel)
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_mps_kernel)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2887,7 +2887,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: lcm_out
+    CPU, CUDA, MPS: lcm_out
   tags: pointwise
 
 - func: lcm(Tensor self, Tensor other) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14365,11 +14365,11 @@ class TestFallbackWarning(TestCase):
         self.assertEqual(out, "")
 
     def _get_not_implemented_op(self):
-        # This can be changed once we actually implement 'lcm'
-        # Should return fn, args, kwargs, string_version
-        return (torch.lcm,
-                [torch.tensor([1], device='mps'), torch.tensor([2], device='mps')], {},
-                "torch.lcm(torch.tensor([1], device='mps'), torch.tensor([2], device='mps'))")
+        # Should return fn, args, kwargs, string_version. Uses an op with no MPS
+        # kernel; change it if 'special.airy_ai' ever gets one.
+        return (torch.special.airy_ai,
+                [torch.tensor([1.0], device='mps')], {},
+                "torch.special.airy_ai(torch.tensor([1.0], device='mps'))")
 
     def test_error_on_not_implemented(self):
         fn, args, kwargs, _ = self._get_not_implemented_op()

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15744,13 +15744,6 @@ op_db: list[OpInfo] = [
                     ref=np.lcm,
                     dtypes=integral_types_and(),
                     supports_autograd=False,
-                    skips=(
-                        # The operator 'aten::lcm.out' is not currently implemented for the MPS device.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                    ),
                     supports_rhs_python_scalar=False),
     BinaryUfuncInfo('gcd',
                     ref=np.gcd,
@@ -26102,11 +26095,6 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.lcm",
         torch_opinfo_name="lcm",
-        skips=(
-            # The operator 'aten::lcm.out' is not currently implemented for the MPS device.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='mps'),
-        ),
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.le",

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -353,7 +353,6 @@ if torch.backends.mps.is_available():
             "hash_tensor": None,
             "heaviside": None,
             # "kthvalue": None,
-            "lcm": None,
             "linalg.cond": None,
             "linalg.eigh": None,
             "linalg.eigvalsh": None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #186279

Similar to #185932, but it tried to do too much, and rewrod GCD along with introducing LCD, which was buggy.

This change is intentionally minimal: it leaves the existing Euclidean gcd_functor untouched and only adds lcm on top of it. It does not try to fix any gcd bugs, in particular the pre-existing abs(INT_MIN) sign issue that MPS shares with the CPU/CUDA kernels; that is a separate, orthogonal fix.