### PR TITLE
[inductor] Don't fold float x * 0 to 0 in uniform-value constant folding (drops NaN/Inf)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7253,6 +7253,46 @@ class CommonTemplate:
 
         self.assertNotIn(view_node, folder.node_replacements)
 
+    def test_uniform_value_mul_by_zero(self):
+        # x * 0 is uniformly 0 only for non-floating-point dtypes. For float and
+        # complex, nan * 0 == nan and (+/-inf) * 0 == nan, so the uniform-value
+        # peephole must not fold x * 0 -> 0 (it would drop NaN/Inf when x is not
+        # known to be finite). Integer/bool x * 0 is still folded.
+        import torch.fx as fx
+        from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
+
+        for dtype, should_fold in (
+            (torch.float32, False),
+            (torch.float16, False),
+            (torch.bfloat16, False),
+            (torch.complex64, False),
+            (torch.int32, True),
+            (torch.int64, True),
+        ):
+            graph = fx.Graph()
+            x = graph.placeholder("x")
+            x.meta["val"] = torch.empty([4], dtype=dtype, device=self.device)
+            mul_node = graph.call_function(torch.ops.aten.mul.Tensor, args=(x, 0))
+            mul_node.meta["val"] = torch.empty([4], dtype=dtype, device=self.device)
+            graph.output(mul_node)
+            gm = fx.GraphModule(torch.nn.Module(), graph)
+
+            folder = UniformValueConstantFolder(gm)
+            folder.run()
+
+            self.assertEqual(
+                mul_node in folder.node_replacements,
+                should_fold,
+                msg=f"unexpected fold decision for dtype={dtype}",
+            )
+
+    def test_mul_by_zero_extremal(self):
+        # End-to-end: compiled x * 0 must match eager on NaN/Inf inputs.
+        def fn(a):
+            return (a * 0,)
+
+        self.common(fn, [torch.tensor([np.nan, np.inf, -np.inf, 0.0, 1.0, -1.0])])
+
     def test_uniform(self):
         def fn(x):
             return aten.uniform.default(x, 0, 1)

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -317,6 +317,13 @@ class UniformValueConstantFolder(ConstantFolder):
             if not any(is_zero_int(a) for a in op.args):
                 continue
 
+            # x * 0 is only uniformly 0 for integer/bool dtypes. For floating
+            # point (and complex) dtypes nan * 0 == nan and (+/-inf) * 0 == nan,
+            # so folding x * 0 -> 0 would incorrectly drop NaN/Inf when x is not
+            # known to be finite.
+            if tensor_val.dtype.is_floating_point or tensor_val.dtype.is_complex:
+                continue
+
             t = torch.full(
                 [1],  # shape
                 0,  # value


### PR DESCRIPTION
Summary:
`UniformValueConstantFolder._add_peephole_patterns` in `torch/_inductor/fx_passes/joint_graph.py` rewrites `aten.mul(x, 0)` to `aten.full([...], 0)` whenever the multiplier is a literal integer `0`, even when `x` is an unknown (non-constant) input. This is incorrect for floating point and complex dtypes: `nan * 0 == nan` and `(+/-inf) * 0 == nan`, so folding `x * 0 -> 0` silently drops NaN/Inf. As a result `torch.compile`'d code containing `x * 0` (directly or via a decomposition) diverges from eager, which dispatches to the native kernel and preserves NaN/Inf.

Fix: skip the peephole when the output dtype is floating point or complex. Integer/bool `x * 0` is still folded (it is always uniformly 0). Float `x * 0` now stays a real multiply, matching eager and preserving NaN/Inf. No decomposition changes are needed.

Test Plan:
```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:test_inductor -- -r 'test_uniform_value_mul_by_zero|test_mul_by_zero_extremal'
```

@diff-train-skip-merge

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo