### PR TITLE
Update torch cuda compatibility check

### DIFF
--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -30,7 +30,7 @@ class TestCodeCompatibleWithDevice(TestCase):
             torch.cuda._code_compatible_with_device(device_cc=75, code_cc=80)
         )
 
-    def test_igpu_cases(self):
+    def test_igpu_cases_pre_132(self):
         self.assertFalse(
             torch.cuda._code_compatible_with_device(device_cc=53, code_cc=50)
         )
@@ -40,6 +40,15 @@ class TestCodeCompatibleWithDevice(TestCase):
         self.assertTrue(
             torch.cuda._code_compatible_with_device(device_cc=53, code_cc=53)
         )
+
+    def test_igpu_cases_post_132(self):
+        with patch("torch.version.cuda", "13.2"):
+            self.assertTrue(
+                torch.cuda._code_compatible_with_device(device_cc=87, code_cc=80)
+            )
+            self.assertTrue(
+                torch.cuda._code_compatible_with_device(device_cc=53, code_cc=53)
+            )
 
     def test_special_case_sm101_on_sm110(self):
         self.assertTrue(
@@ -156,6 +165,27 @@ class TestCheckCapability(TestCase):
             self.assertNotIn("pip install torch==", msg)
             self.assertIn("No published PyTorch CUDA builds for release", msg)
             self.assertIn("https://pytorch.org/get-started/locally/", msg)
+
+    @patch("torch.cuda.get_arch_list", return_value=["sm_80"])
+    @patch("torch.cuda.get_device_capability", return_value=(8, 7))
+    def test_sbsa_runs_on_jetson_post_cuda132(self, *args):
+        with (
+            patch("torch.version.cuda", "13.2"),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("error")
+            torch.cuda._check_capability()
+
+    @patch("torch.cuda.get_arch_list", return_value=["sm_87"])
+    @patch("torch.cuda.get_device_capability", return_value=(8, 9))
+    def test_jetson_doesnt_run_on_sbsa_post_cuda132(self, *args):
+        with (
+            patch("torch.version.cuda", "13.2"),
+            self.assertWarnsRegex(
+                UserWarning, r"Found GPU0.*which is of compute capability.*8\.9"
+            ),
+        ):
+            torch.cuda._check_capability()
 
 
 if __name__ == "__main__":

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -8,6 +8,7 @@ import torch.cuda
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
+@patch("torch.version.cuda", "12.6")
 class TestCodeCompatibleWithDevice(TestCase):
     def test_compatible_cases(self):
         self.assertTrue(

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -312,13 +312,23 @@ DEVICE_REQUIREMENT: dict[int, _CompatSet | _CompatInterval] = {
     89: _CompatInterval(start=89),
     90: _CompatInterval(start=90),
     100: _CompatInterval(start=100, exclude={101}),
-    101: _CompatSet({101, 110}),
+    101: _CompatSet({101, 110}),  # 101 was renamed to 110
     103: _CompatInterval(start=103),
-    110: _CompatInterval(start=110),
+    110: _CompatSet({101, 110}),  # 101 was renamed to 110
     120: _CompatInterval(start=120),
     121: _CompatInterval(start=121),
 }
 
+# CUDA 13.2 allows SBSA binaries to run on Jetson devices.
+# This dict can be combined with DEVICE_REQUIREMENT once
+# the minimum supported CUDA version is 13.2.
+DEVICE_REQUIREMENT_POST_JETSON_SBSA_UNIFICATION: dict[
+    int, _CompatSet | _CompatInterval
+] = DEVICE_REQUIREMENT | {
+    70: _CompatInterval(start=70),
+    80: _CompatInterval(start=80),
+    86: _CompatInterval(start=86),
+}
 
 # TORCH_CUDA_ARCH_LIST for PyTorch releases, keyed by host arch.
 # Kept in sync with .ci/manywheel/build_cuda.sh by the validator in
@@ -339,20 +349,32 @@ PYTORCH_RELEASES_CODE_CC: dict[str, dict[str, set[int]]] = {
 }
 
 
+def _device_requirement(code_cc):
+    if torch.version.cuda is None:
+        return None
+    requirement = (
+        DEVICE_REQUIREMENT_POST_JETSON_SBSA_UNIFICATION
+        if tuple(int(x) for x in torch.version.cuda.split(".")) >= (13, 2)
+        else DEVICE_REQUIREMENT
+    )
+    return requirement.get(code_cc, None)
+
+
 def _host_arch_key() -> str:
     machine = platform.machine().lower()
     return "aarch64" if machine == "aarch64" else "x86_64"
 
 
 def _code_compatible_with_device(device_cc: int, code_cc: int):
-    if code_cc not in DEVICE_REQUIREMENT:
+    compatible_devices = _device_requirement(code_cc)
+    if compatible_devices is None:
         warnings.warn(
             f"PyTorch was compiled with an unknown compute capability {code_cc // 10}.{code_cc % 10}. "
             + " Please create an issue on Github if this is a valid compute capability.",
             stacklevel=2,
         )
         return device_cc in _CompatInterval(start=code_cc)
-    return device_cc in DEVICE_REQUIREMENT[code_cc]
+    return device_cc in compatible_devices
 
 
 def _warn_unsupported_code(device_index: int, device_cc: int, code_ccs: list[int]):
@@ -369,7 +391,7 @@ def _warn_unsupported_code(device_index: int, device_cc: int, code_ccs: list[int
         f"Found GPU{device_index} {name} which is of compute capability (CC) {device_cc // 10}.{device_cc % 10}.",
         "The following list shows the CCs this version of PyTorch was built for and the hardware CCs it supports:",
     ] + [
-        f"- {cc // 10}.{cc % 10} which supports hardware CC {DEVICE_REQUIREMENT[cc]}"
+        f"- {cc // 10}.{cc % 10} which supports hardware CC {_device_requirement(cc)}"
         for cc in code_ccs
     ]
 


### PR DESCRIPTION
CUDA>=13.2 allows Jetson devices to use SBSA binaries