### PR TITLE
[MPS] Fix fast::tanh overflow to nan

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -235,7 +235,9 @@ static inline float gelu_dispatch_tanh(float x) {
   if IF_CONSTEXPR (::metal::is_same_v<T, float>) {
     return ::metal::tanh(x);
   } else {
-    return ::metal::fast::tanh(x);
+    // Clamp to avoid fast::tanh's internals overflowing to NaN,
+    // tanh is already saturated here.
+    return ::metal::fast::tanh(::metal::clamp(x, -10.0f, 10.0f));
   }
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7477,6 +7477,24 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
+    def test_gelu_tanh_large_values(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/186278
+        for dtype in [torch.bfloat16, torch.float16, torch.float32]:
+            cpu_x = torch.arange(8, 16, 0.5, dtype=dtype, device='cpu')
+            x = cpu_x.detach().clone().to('mps').requires_grad_()
+            cpu_xg = cpu_x.detach().clone().requires_grad_()
+
+            mps_out = torch.nn.functional.gelu(x, approximate='tanh')
+            cpu_out = torch.nn.functional.gelu(cpu_xg, approximate='tanh')
+            self.assertFalse(torch.isnan(mps_out).any(), f"NaN in forward for {dtype}")
+            self.assertEqual(mps_out, cpu_out.to('mps'))
+
+            grad = torch.ones_like(mps_out)
+            mps_out.backward(gradient=grad)
+            cpu_out.backward(gradient=torch.ones_like(cpu_out))
+            self.assertFalse(torch.isnan(x.grad).any(), f"NaN in backward for {dtype}")
+            self.assertEqual(x.grad, cpu_xg.grad.to('mps'))
+
     # Test hardtanh
     def test_hardtanh(self):
         def helper(shape, min_val, max_val, inplace=False):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/186278

fast::tanh uses expression `(exp(2x)-1)/(exp(2x)+1)` as the approximation. For gelu the expression for `x` scales cubically and will overflow the internal fp32 when abs(input) > 10.0. At this point the tanh approximation is already very much saturated already so we'll just clamp it to [-10, 10]. Perfwise clamping is cheap.