### PR TITLE
[ROCm][inductor][UT] Enable 3layer split reduction test

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -16,7 +16,6 @@ from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    skipIfRocm,
     skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -210,7 +209,6 @@ class MixOrderReductionTest(TestBase):
         self.check_numeric(f, (x,))
         self.assertEqual(metrics.codegen_mix_order_reduction, 1)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/167324")
     @inductor_config.patch(unroll_reductions_threshold=1)
     def test_3layer_split_reduction(self):
         """


### PR DESCRIPTION
## Summary
- Remove the ROCm skip from `MixOrderReductionTest.test_3layer_split_reduction` now that it passes locally.

## Test plan
- `python /home/niromero/docker_workspace/pytorch/test/inductor/test_mix_order_reduction.py MixOrderReductionTest.test_3layer_split_reduction -v`
- Re-ran the same test 3 additional times locally; all passed.


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben