### PR TITLE
Fix timm benchmark dependency installation

### DIFF
--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -12,7 +12,7 @@ function install_timm() {
   local commit
   commit=$(get_pinned_commit timm)
 
-  pip_install "git+https://github.com/huggingface/pytorch-image-models@${commit}"
+  pip_install --no-deps "git+https://github.com/huggingface/pytorch-image-models@${commit}"
 }
 
 function install_torchbench() {

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -1510,7 +1510,8 @@ def cmd_prepare_repro(args):
     if "timm_models" in suites:
         print("# ── Timm ──")
         print(
-            f"pip install git+https://github.com/huggingface/pytorch-image-models@{timm_pin}"
+            "pip install --no-deps "
+            f"git+https://github.com/huggingface/pytorch-image-models@{timm_pin}"
         )
         print()
 

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -1,5 +1,12 @@
+import importlib
+import importlib.util
+import io
 import os
+import sys
+import types
 import unittest
+from contextlib import redirect_stdout
+from unittest import mock
 
 from .common import parse_args, run
 from .torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
@@ -15,6 +22,82 @@ except ImportError:
 
 
 class TestDynamoBenchmark(unittest.TestCase):
+    def test_timm_auto_install_uses_no_deps(self) -> None:
+        module_name = "benchmarks.dynamo._timm_models_install_test"
+        module_path = os.path.join(os.path.dirname(__file__), "timm_models.py")
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None:
+            self.fail("could not load timm_models.py spec")
+        if spec.loader is None:
+            self.fail("could not load timm_models.py loader")
+        module = importlib.util.module_from_spec(spec)
+
+        fake_timm = types.ModuleType("timm")
+        fake_timm.__version__ = "1.0.0"
+        fake_timm_data = types.ModuleType("timm.data")
+        fake_timm_data.resolve_data_config = lambda *args, **kwargs: {}
+        fake_timm_models = types.ModuleType("timm.models")
+        fake_timm_models.create_model = lambda *args, **kwargs: None
+        fake_timm_models.list_models = lambda *args, **kwargs: []
+        fake_timm.data = fake_timm_data
+        fake_timm.models = fake_timm_models
+
+        original_import_module = importlib.import_module
+
+        def import_module(name, package=None):
+            if name == "timm":
+                raise ModuleNotFoundError("No module named 'timm'")
+            return original_import_module(name, package)
+
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "timm": fake_timm,
+                    "timm.data": fake_timm_data,
+                    "timm.models": fake_timm_models,
+                },
+            ),
+            mock.patch("importlib.import_module", side_effect=import_module),
+            mock.patch("subprocess.check_call") as check_call,
+        ):
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                sys.modules.pop(module_name, None)
+
+        check_call.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                "git+https://github.com/rwightman/pytorch-image-models",
+            ]
+        )
+
+    def test_prepare_repro_installs_timm_without_deps(self) -> None:
+        from . import perf_cli
+
+        def read_pin(name):
+            return "abc123" if name == "timm.txt" else "unused"
+
+        output = io.StringIO()
+        args = types.SimpleNamespace(suite="timm", no_repro=True)
+        with (
+            mock.patch.object(perf_cli, "read_pin", side_effect=read_pin),
+            redirect_stdout(output),
+        ):
+            perf_cli.cmd_prepare_repro(args)
+
+        self.assertIn(
+            "pip install --no-deps "
+            "git+https://github.com/huggingface/pytorch-image-models@abc123",
+            output.getvalue(),
+        )
+
     def test_dashboard_performance_uses_warm_peak_memory(self) -> None:
         args = parse_args(
             [

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -24,15 +24,19 @@ if "TORCHINDUCTOR_FX_GRAPH_CACHE" not in os.environ:
     torch._inductor.config.fx_graph_cache = True
 
 
-def pip_install(package):
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+def pip_install(package, *, no_deps=False):
+    command = [sys.executable, "-m", "pip", "install"]
+    if no_deps:
+        command.append("--no-deps")
+    command.append(package)
+    subprocess.check_call(command)
 
 
 try:
     importlib.import_module("timm")
 except ModuleNotFoundError:
     print("Installing PyTorch Image Models...")
-    pip_install("git+https://github.com/rwightman/pytorch-image-models")
+    pip_install("git+https://github.com/rwightman/pytorch-image-models", no_deps=True)
 finally:
     from timm import __version__ as timmversion
     from timm.data import resolve_data_config


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186289

The timm benchmark fallback and CI benchmark dependency setup installed timm with normal pip dependency resolution. When torchvision was missing or broken, pip could resolve timm's torchvision dependency by downloading binary torchvision and torch wheels, which is wrong for source-checkout benchmark environments.

Install timm with --no-deps in the benchmark fallback and Docker benchmark dependency setup, and update the prepare-repro output so local reproduction instructions match CI. This keeps torch/torchvision ownership with the explicit setup steps instead of timm's transitive dependencies.

Fixes #135122

Generated by my agent

Test Plan:

python -m pytest benchmarks/dynamo/test.py -k 'timm_auto_install_uses_no_deps or prepare_repro_installs_timm_without_deps' -q

git diff --check

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98