### PR TITLE
Fix broken msl.rl conveyor (#186293)

### DIFF
--- a/torch/headeronly/build.bzl
+++ b/torch/headeronly/build.bzl
@@ -74,7 +74,6 @@ def define_targets(rules):
             exported_headers = {
                 h: h for h in native.glob(["**/*.h"], exclude = ["version.h"])
             } | {
-                "version.h": ":version_h",
                 "core/enum_tag.h": ":enum_tag_h",
             },
             visibility = ["PUBLIC"],


### PR DESCRIPTION
Summary:

Our conveyor has been broken since May. 4, because our TBR wheels cannot depend on caffe2 targets. It seems it's not needed anyway (see D103702391 for analysis).

Test Plan: CI

Reviewed By: suo

Differential Revision: D107590581


