### PR TITLE
[CI] Use a shared registry build cache for docker-builds

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -309,11 +309,9 @@ esac
 
 tmp_tag=$(basename "$(mktemp -u)" | tr '[:upper:]' '[:lower:]')
 
-no_cache_flag=""
 progress_flag=""
-# Do not use cache and progress=plain when in CI
+# Plain (non-TTY) progress output in CI for complete, readable build logs.
 if [[ -n "${CI:-}" ]]; then
-  no_cache_flag="--no-cache"
   progress_flag="--progress=plain"
 fi
 
@@ -321,14 +319,23 @@ fi
 # `--load`, so push directly to the registry instead. The caller is expected
 # to have logged in to the target registry already (e.g. via ecr-login).
 output_flag="--load -t ${tmp_tag}"
+cache_flag=""
 if [[ -n "${REMOTE_BUILDKIT:-}" ]]; then
   output_flag="--push"
+  # Remote BuildKit pods are ephemeral with pod-private caches, so share a cache
+  # via a per-image (hence per-arch) tag in the same registry. mode=max caches
+  # intermediate stages; image-manifest/oci-mediatypes keep it ECR-compatible.
+  if [[ -n "${DOCKER_IMAGE:-}" ]]; then
+    cache_ref="${DOCKER_IMAGE%:*}:${image}-buildcache"
+    cache_flag="--cache-from type=registry,ref=${cache_ref}"
+    cache_flag="${cache_flag} --cache-to type=registry,ref=${cache_ref},mode=max,image-manifest=true,oci-mediatypes=true"
+  fi
 fi
 
 # Build image
 docker buildx build \
-       ${no_cache_flag} \
        ${progress_flag} \
+       ${cache_flag} \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
        --build-arg "LLVMDEV=${LLVMDEV:-}" \
        --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}" \


### PR DESCRIPTION
## Summary

`docker-builds` builds on the remote BuildKit fleet (OSDC) and passed `--no-cache`, so every image rebuilt all layers each run — and the ephemeral pods can't share their pod-private caches anyway. This replaces it (remote path only) with a registry cache: `--cache-from/--cache-to type=registry` to a per-image (hence per-arch) `<image>-buildcache` tag in the same ECR repo, `mode=max`, `image-manifest=true,oci-mediatypes=true` for ECR. Unchanged stages are reused, cutting build time and load on the shared fleet.

https://github.com/meta-pytorch/pytorch-gha-infra/pull/1198 to set up the rule to delete the cache after 7 days

## Test plan

- [ ] `ciflow/docker`: first run populates `*-buildcache`; confirm a second run hits cache and the pushed images are unchanged.

## Note

Confirm the ECR lifecycle policy on `pytorch/ci-image` won't expire the `*-buildcache` tags.