### PR TITLE
c10/core/DispatchKeySet: promote Full, FullAfter, Raw to enum class

### DIFF
--- a/aten/src/ATen/LegacyBatchingRegistrations.cpp
+++ b/aten/src/ATen/LegacyBatchingRegistrations.cpp
@@ -846,7 +846,7 @@ Tensor _make_dual_batching_rule(
   int64_t level
 ) {
   DispatchKeySet after_batched_keyset =
-      DispatchKeySet(DispatchKeySet::FULL_AFTER, c10::DispatchKey::Batched);
+      DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::Batched);
   return at::redispatch::_make_dual(ks & after_batched_keyset, primal, tangent, level);
 }
 

--- a/aten/src/ATen/ZeroTensorFallback.cpp
+++ b/aten/src/ATen/ZeroTensorFallback.cpp
@@ -66,7 +66,7 @@ namespace at {
       // We assume that view operators automatically handle the ZeroTensor bit
       // correctly by propagating the dispatch key in key_set.
       // This is not necessarily always right, so you should test these cases.
-      op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::ZeroTensor), stack);
+      op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, DispatchKey::ZeroTensor), stack);
       return;
     }
 
@@ -108,7 +108,7 @@ namespace at {
       }
     }
 
-    op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::ZeroTensor), stack);
+    op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, DispatchKey::ZeroTensor), stack);
   }
 
 

--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -23,8 +23,8 @@ c10::impl::LocalDispatchKeySet safe_get_tls_on_entry() {
 }
 
 // All the keys below the Python key
-constexpr c10::DispatchKeySet after_Python_keyset = c10::DispatchKeySet(c10::DispatchKeySet::FULL) ^
-  (c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::Python) |
+constexpr c10::DispatchKeySet after_Python_keyset = c10::DispatchKeySet(c10::DispatchKeySet::Full::FULL) ^
+  (c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::Python) |
    c10::DispatchKeySet(c10::DispatchKey::Python));
 
 
@@ -144,7 +144,7 @@ void pythonTLSSnapshotFallback(const c10::OperatorHandle &op, c10::DispatchKeySe
   // The guard below will properly ignore such calls.
   at::impl::MaybeSetTLSOnEntryGuard guard;
 
-  op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::PythonTLSSnapshot), stack);
+  op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::PythonTLSSnapshot), stack);
 }
 
 // The PreDispatch key gets a no-op fallback that just redispatches.
@@ -154,7 +154,7 @@ void pythonTLSSnapshotFallback(const c10::OperatorHandle &op, c10::DispatchKeySe
 // Alternatively, we could have hardcoded this kernel (in C++) to directly call in TorchProxyDispatchMode.
 // Doing that in C++ is a pain though, so it's done in python using the PythonDispatcher for convenience.
 void preDispatchFallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
-  op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::PreDispatch), stack);
+  op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::PreDispatch), stack);
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/core/boxing/impl/kernel_stackbased_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_stackbased_test.cpp
@@ -38,7 +38,7 @@ bool called_redispatching_kernel = false;
 void redispatchingKernel_with_DispatchKeySet(const OperatorHandle& op, c10::DispatchKeySet ks, Stack* stack) {
   // this kernel is a no-op- it just redispatches to the lower-priority kernel
   called_redispatching_kernel = true;
-  auto updated_ks = ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::TESTING_ONLY_GenericWrapper);
+  auto updated_ks = ks & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::TESTING_ONLY_GenericWrapper);
   op.redispatchBoxed(updated_ks, stack);
 }
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -145,7 +145,8 @@ struct TORCH_API DispatchKeyExtractor final {
 
   C10_ALWAYS_INLINE DispatchKeySet getDispatchKeySetFromRawDispatchKeySet(
       DispatchKeySet ks,
-      DispatchKeySet key_mask = DispatchKeySet(DispatchKeySet::FULL)) const {
+      DispatchKeySet key_mask =
+          DispatchKeySet(DispatchKeySet::Full::FULL)) const {
     // Callers that already collected the raw tensor keyset still need the
     // operator-specific fallthrough and TLS logic below.
     c10::impl::LocalDispatchKeySet tls =
@@ -249,9 +250,10 @@ struct TORCH_API DispatchKeyExtractor final {
 
   explicit DispatchKeyExtractor(c10::utils::bitset dispatch_arg_indices_reverse)
       : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse),
-        nonFallthroughKeys_(DispatchKeySet::FULL) {
+        nonFallthroughKeys_(DispatchKeySet::Full::FULL) {
     for (const auto i : c10::irange(nonFallthroughKeysPerBackend_.size())) {
-      nonFallthroughKeysPerBackend_[i] = DispatchKeySet::FULL;
+      nonFallthroughKeysPerBackend_[i] =
+          DispatchKeySet(DispatchKeySet::Full::FULL);
     }
   }
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -25,7 +25,7 @@ namespace {
 static const std::vector<DispatchKey>& allDispatchKeysInFullSet() {
   static const auto result = []() {
     std::vector<DispatchKey> vec;
-    for (const auto dispatch_key: DispatchKeySet(DispatchKeySet::FULL)) {
+    for (const auto dispatch_key: DispatchKeySet(DispatchKeySet::Full::FULL)) {
       vec.push_back(dispatch_key);
     }
     return vec;

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -1942,7 +1942,7 @@ TEST(NewOperatorRegistrationTest, BackendSelectRedispatchesToCPU) {
   bool cpu_called = false;
   bool backend_generic_called = false;
   auto m = MAKE_TORCH_LIBRARY(test);
-  auto after_backend_select = c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::BackendSelect);
+  auto after_backend_select = c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::BackendSelect);
   m.def("fn(Tensor self) -> Tensor");
   m.impl("fn", c10::kCPU, [&](const Tensor& x) { cpu_called = true; return x; });
   m.impl("fn", c10::DispatchKey::BackendSelect, [&](c10::DispatchKeySet ks, const Tensor& x) {
@@ -2047,7 +2047,7 @@ void cpu_kernel(Tensor) {
 void autograd_kernel_redispatching_with_DispatchKeySet(c10::DispatchKeySet ks, Tensor a) {
   called_kernel_autograd = true;
   auto op = Dispatcher::singleton().findSchema({"test::fn", ""});
-  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::AutogradOther);
+  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::AutogradOther);
   callOpUnboxedWithPrecomputedDispatchKeySet<void, Tensor>(*op, updatedDispatchKeySet, a);
 }
 
@@ -2055,7 +2055,7 @@ void autograd_kernel_redispatching_with_DispatchKeySet(c10::DispatchKeySet ks, T
 void autograd_kernel_redispatching_without_DispatchKeySet(c10::DispatchKeySet ks, Tensor a) {
   called_kernel_autograd = true;
   auto op = Dispatcher::singleton().findSchema({"test::fn", ""});
-  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::AutogradOther);
+  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::AutogradOther);
   callOpUnboxedWithPrecomputedDispatchKeySet<void, Tensor>(*op, updatedDispatchKeySet, a);
 }
 
@@ -2063,7 +2063,7 @@ void autograd_kernel_redispatching_without_DispatchKeySet(c10::DispatchKeySet ks
 void tracing_kernel_redispatching_with_DispatchKeySet(c10::DispatchKeySet ks, Tensor a) {
   called_kernel_tracing = true;
   auto op = Dispatcher::singleton().findSchema({"test::fn", ""});
-  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::Tracer);
+  auto updatedDispatchKeySet = ks & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::Tracer);
   callOpUnboxedWithPrecomputedDispatchKeySet<void, Tensor>(*op, updatedDispatchKeySet, a);
 }
 

--- a/aten/src/ATen/functorch/Interpreter.cpp
+++ b/aten/src/ATen/functorch/Interpreter.cpp
@@ -13,8 +13,8 @@ static DispatchKeySet get_all_dynlayer_keyset() {
 
   // "all dispatch keys between DynamicLayer{Front, Back}Mode, inclusive"
   auto result =
-    DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::FuncTorchDynamicLayerFrontMode) -
-    DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::FuncTorchDynamicLayerBackMode);
+    DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, DispatchKey::FuncTorchDynamicLayerFrontMode) -
+    DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, DispatchKey::FuncTorchDynamicLayerBackMode);
   result = result | DispatchKeySet({DispatchKey::FuncTorchDynamicLayerFrontMode});
 
   // Hack: don't handle the autocast dispatch keys. Their interaction with functorch

--- a/aten/src/ATen/native/MathBitsFallback.h
+++ b/aten/src/ATen/native/MathBitsFallback.h
@@ -81,7 +81,7 @@ struct MathOpFallback {
       // We assume that view operators automatically handle the math bit
       // correctly by propagating the dispatch key in key_set.
       // This is not necessarily always right, so you should test these cases.
-      op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, key), stack);
+      op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, key), stack);
       return;
     }
 
@@ -127,7 +127,7 @@ struct MathOpFallback {
       }
     }
 
-    op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, key), stack);
+    op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, key), stack);
 
     TORCH_INTERNAL_ASSERT(mutable_inputs_with_their_clones.size() <= 1);
 

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -57,7 +57,7 @@ constexpr DispatchKeySet math_dispatch_keyset = backend_dispatch_keyset |
 constexpr DispatchKeySet nested_dispatch_keyset =
     DispatchKeySet(
         {DispatchKey::AutogradNestedTensor, DispatchKey::NestedTensor}) |
-    DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
+    DispatchKeySet(DispatchKeySet::Raw::RAW, full_backend_mask);
 
 constexpr DispatchKeySet functorch_batched_dispatch_keyset =
     DispatchKeySet(DispatchKey::FuncTorchBatched);
@@ -71,7 +71,7 @@ DispatchKeySet getRuntimeDispatchKeySet(DispatchKey t) {
       // getRuntimeDispatchKeySet() expects to return a keyset of runtime
       // dispatch keys, like AutogradCPU, but that requires having backend bits.
       return autograd_dispatch_keyset |
-          DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
+          DispatchKeySet(DispatchKeySet::Raw::RAW, full_backend_mask);
     case DispatchKey::CompositeImplicitAutograd:
       return math_dispatch_keyset;
     case DispatchKey::CompositeImplicitAutogradNestedTensor:
@@ -144,7 +144,7 @@ DispatchKeySet getBackendKeySetFromAutograd(DispatchKey t) {
       return DispatchKeySet(DispatchKey::PrivateUse3);
     case DispatchKey::AutogradNestedTensor:
       return DispatchKeySet(DispatchKey::NestedTensor) |
-          DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
+          DispatchKeySet(DispatchKeySet::Raw::RAW, full_backend_mask);
     case DispatchKey::AutogradOther:
       return autogradother_backends;
     default:

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -166,9 +166,9 @@ C10_ALWAYS_INLINE static const std::
 // An undefined tensor is one with an empty tensor type set.
 class DispatchKeySet final {
  public:
-  enum Full { FULL };
-  enum FullAfter { FULL_AFTER };
-  enum Raw { RAW };
+  enum class Full { FULL };
+  enum class FullAfter { FULL_AFTER };
+  enum class Raw { RAW };
 
   // NB: default constructor representation as zero is MANDATORY as
   // use of DispatchKeySet in TLS requires this.
@@ -397,7 +397,7 @@ class DispatchKeySet final {
   }
 
   static DispatchKeySet from_raw_repr(uint64_t x) {
-    return DispatchKeySet(RAW, x);
+    return DispatchKeySet(Raw::RAW, x);
   }
 
   [[nodiscard]] DispatchKey highestFunctionalityKey() const {
@@ -719,22 +719,25 @@ constexpr DispatchKeySet autogradother_backends =
     // Including the backend bits because this keyset is used during op
     // registration, which requires looping over all runtime autogradother
     // backend keys.
-    | DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
+    | DispatchKeySet(DispatchKeySet::Raw::RAW, full_backend_mask);
 
 // The set of dispatch keys that come after autograd
 // n.b. this relies on the fact that AutogradOther is currently the lowest
 // Autograd key
-constexpr DispatchKeySet after_autograd_keyset =
-    DispatchKeySet(DispatchKeySet::FULL_AFTER, c10::DispatchKey::AutogradOther);
+constexpr DispatchKeySet after_autograd_keyset = DispatchKeySet(
+    DispatchKeySet::FullAfter::FULL_AFTER,
+    c10::DispatchKey::AutogradOther);
 
 // The set of dispatch keys that come after ADInplaceOrView
 constexpr DispatchKeySet after_ADInplaceOrView_keyset = DispatchKeySet(
-    DispatchKeySet::FULL_AFTER,
+    DispatchKeySet::FullAfter::FULL_AFTER,
     c10::DispatchKey::ADInplaceOrView);
 
 // The set of dispatch keys that come after Functionalize
 constexpr DispatchKeySet after_func_keyset =
-    DispatchKeySet(DispatchKeySet::FULL_AFTER, c10::DispatchKey::Functionalize)
+    DispatchKeySet(
+        DispatchKeySet::FullAfter::FULL_AFTER,
+        c10::DispatchKey::Functionalize)
         .remove(
             // NOTE: we also need to remove ADInplaceOrView from the keyset when
             // redispatching after the func kernels. This is because we're not
@@ -750,7 +753,7 @@ constexpr DispatchKeySet after_func_keyset =
             c10::DispatchKey::ADInplaceOrView);
 
 constexpr DispatchKeySet backend_bitset_mask =
-    DispatchKeySet(DispatchKeySet::RAW, (1ULL << num_backends) - 1);
+    DispatchKeySet(DispatchKeySet::Raw::RAW, (1ULL << num_backends) - 1);
 
 constexpr auto inplace_or_view_ks =
     DispatchKeySet(DispatchKey::ADInplaceOrView);
@@ -796,7 +799,7 @@ constexpr DispatchKeySet backend_functionality_keys =
         DispatchKey::Sparse,
         DispatchKey::SparseCsr,
     }) |
-    DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
+    DispatchKeySet(DispatchKeySet::Raw::RAW, full_backend_mask);
 
 struct OpTableOffsetAndMask {
   uint16_t offset;

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -34,11 +34,11 @@ struct C10_API PODLocalDispatchKeySet {
 
   // See Note [TLS Initialization]
   DispatchKeySet included() const {
-    return DispatchKeySet(DispatchKeySet::RAW, included_) ^
+    return DispatchKeySet(DispatchKeySet::Raw::RAW, included_) ^
         c10::default_included_set;
   }
   DispatchKeySet excluded() const {
-    return DispatchKeySet(DispatchKeySet::RAW, excluded_) ^
+    return DispatchKeySet(DispatchKeySet::Raw::RAW, excluded_) ^
         c10::default_excluded_set;
   }
 

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -291,7 +291,7 @@ TEST(DispatchKeySet, DoubletonPerBackend) {
 }
 
 TEST(DispatchKeySet, Full) {
-  DispatchKeySet full(DispatchKeySet::FULL);
+  DispatchKeySet full(DispatchKeySet::Full::FULL);
   for (const auto i : c10::irange(1, num_functionality_keys)) {
     auto tid = static_cast<DispatchKey>(i);
     ASSERT_TRUE(full.has(tid));
@@ -301,7 +301,7 @@ TEST(DispatchKeySet, Full) {
 
 TEST(DispatchKeySet, IteratorBasicOps) {
   DispatchKeySet empty_set;
-  DispatchKeySet full_set(DispatchKeySet::FULL);
+  DispatchKeySet full_set(DispatchKeySet::Full::FULL);
   DispatchKeySet mutated_set = empty_set.add(DispatchKey::CPU);
 
   // Constructor + Comparison
@@ -376,7 +376,7 @@ TEST(DispatchKeySet, IteratorCrossProduct) {
 }
 
 TEST(DispatchKeySet, IteratorFull) {
-  DispatchKeySet full_set(DispatchKeySet::FULL);
+  DispatchKeySet full_set(DispatchKeySet::Full::FULL);
   std::ptrdiff_t count = std::distance(full_set.begin(), full_set.end());
 
   // Total # of runtime entries includes an entry for DispatchKey::Undefined,
@@ -384,7 +384,7 @@ TEST(DispatchKeySet, IteratorFull) {
   ASSERT_EQ(count, std::ptrdiff_t{num_runtime_entries} - 1);
 }
 TEST(DispatchKeySet, FailAtEndIterator) {
-  DispatchKeySet full_set(DispatchKeySet::FULL);
+  DispatchKeySet full_set(DispatchKeySet::Full::FULL);
   uint64_t raw_repr = full_set.raw_repr();
 
   // doesn't throw
@@ -446,9 +446,9 @@ TEST(DispatchKeySet, TestFunctionalityDispatchKeyToString) {
 
 TEST(DispatchKeySet, TestGetRuntimeDispatchKeySet) {
   // Check if getRuntimeDispatchKeySet and runtimeDispatchKeySetHas agree.
-  for (auto dk1 : DispatchKeySet(DispatchKeySet::FULL)) {
+  for (auto dk1 : DispatchKeySet(DispatchKeySet::Full::FULL)) {
     auto dks = getRuntimeDispatchKeySet(dk1);
-    for (auto dk2 : DispatchKeySet(DispatchKeySet::FULL)) {
+    for (auto dk2 : DispatchKeySet(DispatchKeySet::Full::FULL)) {
       ASSERT_EQ(dks.has(dk2), runtimeDispatchKeySetHas(dk1, dk2));
     }
   }

--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -414,7 +414,7 @@ def emit_trace_body(f: NativeFunction) -> list[str]:
 
     # code-generated tracing kernels plumb and recompute dispatch keys directly through the kernel for performance.
     # See Note [Plumbing Keys Through The Dispatcher] for details.
-    dispatch_key_set = "ks & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::Tracer)"
+    dispatch_key_set = "ks & c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::Tracer)"
     redispatch_args = ", ".join([dispatch_key_set] + [a.expr for a in dispatcher_exprs])
 
     assign_return_values = (

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -283,7 +283,8 @@ std::string TensorCheck::check_verbose(
     // return fmt::format("tensor dispatch key mismatch. expected {}, actual
     // {}", dispatch_key_, state.apply(v.key_set()).raw_repr());
     fail_reason << "dispatch key set mismatch. expected "
-                << c10::DispatchKeySet(c10::DispatchKeySet::RAW, dispatch_key_)
+                << c10::DispatchKeySet(
+                       c10::DispatchKeySet::Raw::RAW, dispatch_key_)
                 << ", actual " << state.apply(v.key_set());
     return std::move(fail_reason).str();
   } else if (dtype_ != v.dtype().toScalarType()) {
@@ -7591,11 +7592,11 @@ PyObject* torch_c_dynamo_guards_init() {
             TORCH_CHECK(t.size() == 5, "LocalState expected 5 values");
             LocalState state;
             state.dispatch_modifier.included_ = c10::DispatchKeySet(
-                c10::DispatchKeySet::RAW, t[0].cast<uint64_t>());
+                c10::DispatchKeySet::Raw::RAW, t[0].cast<uint64_t>());
             state.dispatch_modifier.excluded_ = c10::DispatchKeySet(
-                c10::DispatchKeySet::RAW, t[1].cast<uint64_t>());
+                c10::DispatchKeySet::Raw::RAW, t[1].cast<uint64_t>());
             state.override_dispatch_key_set = c10::DispatchKeySet(
-                c10::DispatchKeySet::RAW, t[2].cast<uint64_t>());
+                c10::DispatchKeySet::Raw::RAW, t[2].cast<uint64_t>());
             state.grad_mode_enabled = t[3].cast<bool>();
             state.should_mask_python_keys = t[4].cast<bool>();
             return state;

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -339,7 +339,7 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
     auto dispatch_key_set_raw_repr =
         metadata["dispatch_key_set"].cast<uint64_t>();
     auto dispatch_key_set = c10::DispatchKeySet(
-        c10::DispatchKeySet::RAW, dispatch_key_set_raw_repr);
+        c10::DispatchKeySet::Raw::RAW, dispatch_key_set_raw_repr);
     auto device = c10::Device(device_type);
     device.set_index(device_index);
 

--- a/torch/csrc/utils/disable_torch_function.cpp
+++ b/torch/csrc/utils/disable_torch_function.cpp
@@ -338,9 +338,9 @@ PyObject* THPModule_disable_torch_dispatch(PyObject* self, PyObject* a) {
   // set, but if there are, then we will have to do something else here.
   c10::impl::ExcludeDispatchKeyGuard guard_(
       // TODO: add constructor for this specifically
-      c10::DispatchKeySet(c10::DispatchKeySet::FULL) -
+      c10::DispatchKeySet(c10::DispatchKeySet::Full::FULL) -
       c10::DispatchKeySet(
-          c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::Python)
+          c10::DispatchKeySet::FullAfter::FULL_AFTER, c10::DispatchKey::Python)
       // NB: off by one hazard here, but it works out: python key is not
       // included in AFTER, so it is included in the negation (and that's
       // correct: we want to exclude Python key and everything BEFORE it.)

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -1184,7 +1184,8 @@ void initDispatchBindings(PyObject* module) {
     std::vector<c10::DispatchKey> keys;
     if (c10::isPerBackendFunctionalityKey(key)) {
       auto ks = c10::DispatchKeySet(key) |
-          c10::DispatchKeySet(c10::DispatchKeySet::RAW, c10::full_backend_mask);
+          c10::DispatchKeySet(
+                    c10::DispatchKeySet::Raw::RAW, c10::full_backend_mask);
       for (auto k : ks) {
         keys.push_back(k);
       }
@@ -1299,11 +1300,11 @@ void initDispatchBindings(PyObject* module) {
   });
 
   m.def("_dispatch_keyset_full_after", [](c10::DispatchKey t) {
-    return c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, t);
+    return c10::DispatchKeySet(c10::DispatchKeySet::FullAfter::FULL_AFTER, t);
   });
 
   m.def("_dispatch_keyset_full", []() {
-    return c10::DispatchKeySet(c10::DispatchKeySet::FULL);
+    return c10::DispatchKeySet(c10::DispatchKeySet::Full::FULL);
   });
 
   m.def("_dispatch_is_alias_key", c10::isAliasDispatchKey);

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -1019,7 +1019,7 @@ class ComputeBackendSelect:
                 tensor_args = ", ".join(a.name for a in native_tensor_args)
                 compute_dk = f"""\
 DispatchKeySet _dk_set = c10::DispatchKeySet({dispatch_key}) | c10::detail::multi_dispatch_key_set({tensor_args});
-DispatchKeySet _dk_mask = c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::BackendSelect);
+DispatchKeySet _dk_mask = c10::DispatchKeySet(DispatchKeySet::FullAfter::FULL_AFTER, DispatchKey::BackendSelect);
 DispatchKeySet _dk = c10::impl::computeDispatchKeySet(_dk_set, _dk_mask);"""
             else:
                 if f.func.arguments.has_tensor_arg():


### PR DESCRIPTION
Summary:
Change the three constructor-tag enums inside `c10::DispatchKeySet` from unscoped to scoped:

  enum Full     { FULL      }  →  enum class Full     { FULL      }
  enum FullAfter{ FULL_AFTER}  →  enum class FullAfter{ FULL_AFTER}
  enum Raw      { RAW       }  →  enum class Raw      { RAW       }

With unscoped enums, the enumerators `FULL`, `FULL_AFTER`, and `RAW` were injected directly into the `DispatchKeySet` class scope, making them accessible as `DispatchKeySet::FULL` without qualification. This makes them look like data members or constants rather than type-tag arguments, and allows implicit integer conversion. Scoped enums require `DispatchKeySet::Full::FULL` etc., which makes the tagging intent explicit and removes the implicit-conversion footgun.

All 20 call sites updated across:
- `c10/core/DispatchKeySet.h` (definition + global constants + `from_raw_repr`)
- `c10/core/DispatchKeySet.cpp`
- `c10/core/impl/LocalDispatchKeySet.h`
- `aten/src/ATen/core/dispatch/DispatchKeyExtractor.h`
- `aten/src/ATen/core/dispatch/OperatorEntry.cpp`
- `aten/src/ATen/core/PythonFallbackKernel.cpp`
- `aten/src/ATen/native/MathBitsFallback.h`
- `aten/src/ATen/ZeroTensorFallback.cpp`
- `aten/src/ATen/LegacyBatchingRegistrations.cpp`
- `aten/src/ATen/functorch/Interpreter.cpp`
- `aten/src/ATen/core/boxing/impl/kernel_stackbased_test.cpp`
- `aten/src/ATen/core/op_registration/op_registration_test.cpp`
- `c10/test/core/DispatchKeySet_test.cpp`
- `torch/csrc/utils/disable_torch_function.cpp`
- `torch/csrc/utils/python_dispatch.cpp`
- `torch/csrc/inductor/aoti_eager/kernel_holder.cpp`
- `torch/csrc/dynamo/guards.cpp`
- `torchgen/gen.py` (codegen string literal)
- `tools/autograd/gen_trace_type.py` (codegen string literal)

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.

Differential Revision: D107132608




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98