### PR TITLE
Improve AOTI error for Python custom ops

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -8681,6 +8681,53 @@ torch._inductor.aoti_load_package("{model_path}")
                 f"Failed to load package in subprocess: {result.stdout + result.stderr}",
             )
 
+    @unittest.skipIf(
+        IS_FBCODE, "Subprocess spawning doesn't work in fbcode Buck environment"
+    )
+    def test_python_custom_op_load_package_error_in_fresh_subprocess(self):
+        if self.device != "cpu":
+            raise unittest.SkipTest("Only needs one no-Python custom op coverage")
+
+        @torch.library.custom_op("aoti_python_custom_ops::custom_add", mutates_args=())
+        def custom_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x + y
+
+        @custom_add.register_fake
+        def _(x, y):
+            return x + y
+
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.ops.aoti_python_custom_ops.custom_add(x, y)
+
+        example_inputs = (torch.randn(2, 3), torch.randn(2, 3))
+        exported = torch.export.export(Model(), example_inputs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_path = pathlib.Path(tmpdir) / "model.pt2"
+            torch._inductor.aoti_compile_and_package(
+                exported, package_path=str(model_path)
+            )
+
+            script = f"""
+import torch
+
+torch._inductor.aoti_load_package("{model_path}")
+"""
+            result = subprocess.run(
+                [sys.executable, "-c", script], capture_output=True, text=True
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Could not find schema for aoti_python_custom_ops::custom_add. "
+                "Custom operators created via torch.library.custom_op cannot be run "
+                "via AOTI without Python environment. Consider using C++ "
+                "TORCH_LIBRARY APIs. See the Custom Operators Landing Page "
+                "https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html "
+                "for more details.",
+                result.stdout + result.stderr,
+            )
+
     @unittest.skip(
         "Skip this test, only for local test. SIGFPE is produced when viewing "
         "empty tensor with dim=0. See D86125095 for model-side workaround."

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -34,6 +34,7 @@ import sympy
 from sympy import Expr, Integer, Symbol
 
 import torch._export.serde.schema as export_schema
+import torch._library.custom_ops as custom_ops
 import torch._library.utils as library_utils
 import torch._logging
 import torch.fx
@@ -9127,13 +9128,20 @@ class FallbackKernel(ExternKernelAlloc):
             ]
 
         assert self.op_overload is not None
+        metadata = {}
+        if (
+            isinstance(self.op_overload, torch._ops.OpOverload)
+            and custom_ops._maybe_get_opdef(self.op_overload) is not None
+        ):
+            metadata["torch_library_custom_op"] = "1"
+
         node = ExternKernelNode(
             name=self.get_name(),
             node=export_schema.Node(
                 target=self.op_overload.name(),
                 inputs=named_arguments,
                 outputs=output_arguments,
-                metadata={},
+                metadata=metadata,
             ),
         )
 

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -705,9 +705,27 @@ OSSProxyExecutor::OSSProxyExecutor(
           get_call_torch_bind_kernel(serialized_node);
       op_kernels_.emplace_back(std::move(op_kernel));
     } else {
-      c10::OperatorHandle op_handle =
-          c10::Dispatcher::singleton().findSchemaOrThrow(
+      c10::OperatorHandle op_handle = [&]() {
+        try {
+          return c10::Dispatcher::singleton().findSchemaOrThrow(
               opName.c_str(), overloadName.c_str());
+        } catch (const c10::Error&) {
+          if (serialized_node.contains("metadata") &&
+              serialized_node["metadata"].value(
+                  "torch_library_custom_op", "") == "1") {
+            TORCH_CHECK(
+                false,
+                "Could not find schema for ",
+                target,
+                ". Custom operators created via torch.library.custom_op cannot "
+                "be run via AOTI without Python environment. Consider using C++ "
+                "TORCH_LIBRARY APIs. See the Custom Operators Landing Page "
+                "https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html "
+                "for more details.");
+          }
+          throw;
+        }
+      }();
       const c10::FunctionSchema& schema = op_handle.schema();
 
       const auto& schema_args = schema.arguments();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186305

AOTI serializes fallback extern nodes for custom ops into the wrapper JSON
consumed by the OSS proxy executor. Before this change, that serialization only
kept the target operator name. When a packaged model containing a
`torch.library.custom_op` was loaded in a process where the Python custom op had
not been registered, the proxy executor called `findSchemaOrThrow` and could
only report the generic missing-schema error.

Preserve whether a serialized extern node came from `torch.library.custom_op` in
`Node.metadata`, and use that marker when schema lookup fails to explain that
Python custom ops require a Python environment for AOTI. The normal dispatcher
error is still rethrown for every other missing schema, so C++ custom ops and
other fallback operators keep their previous behavior.

Fixes #134581
Generated by my agent

Test Plan:
- Reproduced the original failure with a packaged `mylib::custom_op` loaded in a fresh subprocess: `RuntimeError: Could not find schema for mylib::custom_op.`
- `python - <<'PY' ... compile/package torch.library.custom_op("mylib_meta::custom_op") and inspect the .wrapper.json in the .pt2 zip ... PY`
- `ninja -C build libtorch_cpu.so`
- `ninja -C build libtorch_python.so`
- Manual post-fix fresh-subprocess repro now emits the improved AOTI/Python custom-op error.
- `PYTHONPATH=/tmp/pytorch_issue_134581_torchvision_stub:$PYTHONPATH python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleCpu.test_python_custom_op_load_package_error_in_fresh_subprocess_cpu`
- `lintrunner -a`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo