### PR TITLE
Support tensor torch._assert in export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2856,6 +2856,27 @@ graph():
                 foo, bad_example_inp, dynamic_shapes=dynamic_shapes, strict=False
             )
 
+    def test_torch_assert_tensor_condition(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                torch._assert(x.min() >= 0, "x must be positive")
+                return x
+
+        for strict in (False, True):
+            with self.subTest(strict=strict):
+                inp = torch.ones(1, 32, 64)
+                ep = export(Foo(), (inp,), strict=strict)
+                self.assertTrue(
+                    any(
+                        node.target == torch.ops.aten._assert_async.msg
+                        for node in ep.graph.nodes
+                    )
+                )
+                self.assertEqual(ep.module()(inp), inp)
+
+                with self.assertRaisesRegex(RuntimeError, "x must be positive"):
+                    ep.module()(-inp)
+
     def test_symint_item(self):
         class M(torch.nn.Module):
             def forward(self, tensor):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1735,6 +1735,13 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 and condition.evaluate_expr()
             ):
                 return ConstantVariable.create(None)
+            if condition.is_tensor():
+                tx.output.create_proxy(
+                    "call_function",
+                    torch._assert_async,
+                    *proxy_args_kwargs((condition, message), {}),
+                )
+                return ConstantVariable.create(None)
             return None
 
         @register(SDPAParams)

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -1082,6 +1082,22 @@ class _NonStrictTorchFunctionHandler(torch.overrides.TorchFunctionMode):
                 for a in pytree.tree_flatten(args[0])[0]
             ):
                 return torch._refs.tensor, args, kwargs
+        if func is torch._assert:
+            condition = args[0] if args else kwargs.get("condition")
+            if isinstance(condition, torch.Tensor):
+                if len(args) >= 2:
+                    return torch._assert_async, args, kwargs
+                if len(args) == 1 and "message" in kwargs:
+                    return torch._assert_async, (args[0], kwargs["message"]), {}
+                if "condition" in kwargs and "message" in kwargs:
+                    return (
+                        torch._assert_async,
+                        (
+                            kwargs["condition"],
+                            kwargs["message"],
+                        ),
+                        {},
+                    )
         if func.__name__ == "__getitem__" and isinstance(args[0], torch.Tensor):
 
             def rewrite(dim, item):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #186306

`torch._assert` only had special Dynamo handling for statically true Python constants and symbolic expressions. Tensor-valued conditions fell through to the eager Python implementation, whose `if not condition` forced proxy tensors through Python truthiness. During export this produced a data-dependent guard such as `Eq(u0, 1)` instead of preserving the assertion in the exported program.

Lower tensor-valued `torch._assert(condition, message)` to `torch._assert_async(condition, message)` in both strict export and non-strict export. This matches the runtime assertion behavior already used for compiled Python asserts and avoids requiring export to decide a data-dependent tensor predicate on the host. Static true assertions still elide as before.

Fixes #134533

Generated by my agent

Test Plan:
- python test/export/test_export.py -k test_torch_assert_tensor_condition
- python test/dynamo/test_export.py -k test_export_persist_assert
- python test/test_utils.py -k TestAssert
- lintrunner -a

Benchmark Results:
Measured export latency on main at 30326da5970 and on this branch with 3 warmups and 12 measured reps.
- strict_static_torch_assert: main median 0.030381s, fixed median 0.031370s
- non_strict_simple_export: main median 0.005397s, fixed median 0.005496s

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98