### PR TITLE
Add contains() to ska::flat_hash_map/set

### DIFF
--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -537,6 +537,9 @@ class sherwood_v3_table : private EntryAlloc,
   uint64_t count(const FindKey& key) const {
     return find(key) == end() ? 0 : 1;
   }
+  bool contains(const FindKey& key) const {
+    return find(key) != end();
+  }
   std::pair<iterator, iterator> equal_range(const FindKey& key) {
     iterator found = find(key);
     if (found == end())


### PR DESCRIPTION
We need ``contains`` to eliminate clang-tidy warnings.