### PR TITLE
[CI] Route aarch64 docker-builds jobs to an aarch64 runner

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -75,16 +75,18 @@ jobs:
         include:
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13
             buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
+            runner_label: mt-rel-l-arm64g4-16-62
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13-inductor-benchmarks
             buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
             timeout-minutes: 600
+            runner_label: mt-rel-l-arm64g4-16-62
     # Use the release runner pool: its nodes carry osdc.io/runner-class=release,
     # which exempts them from the cache-enforcer DaemonSet's iptables block on
     # outbound ghcr.io traffic so the "Mirror image to GHCR" step can succeed.
     # The regular mt-l-* pool blocks ghcr.io egress at the host iptables layer.
     runs-on:
       group: release-runners
-      labels: mt-rel-l-x86iavx512-8-64
+      labels: ${{ matrix.runner_label || 'mt-rel-l-x86iavx512-8-64' }}
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:


### PR DESCRIPTION
## Summary

The two aarch64 image builds now run on `mt-rel-l-arm64g4-16-62` (still in the `release-runners` group, so the GHCR mirror step keeps its egress exemption) instead of the x86 runner. amd64 builds are unchanged.

This makes the runner scale set per-arch and 1:1 with its BuildKit arch, so `gha_assigned_jobs` per scale set is a clean signal for autoscaling each BuildKit pool.

## Test plan

- [ ] `ciflow/docker`: confirm the two aarch64 jobs schedule on the arm64 runner and the arm64 images build/push as before.