### PR TITLE
Avoid full simplify in vector-range index analysis

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -72,6 +72,31 @@ class TestIndexingSimplification(InductorTestCase):
         result2 = stride_at_vec_range(index, i, 16)
         self.assertIsNotNone(result2)
 
+    def test_simplify_index_in_vec_range_skips_full_simplify(self):
+        """Regression test for https://github.com/pytorch/pytorch/issues/133734"""
+        i = sympy.Symbol("i", integer=True, nonnegative=True)
+        s0 = sympy.Symbol("s0", integer=True, positive=True)
+        s1 = sympy.Symbol("s1", integer=True, positive=True)
+        base = 2 * s0 + 3 * s1
+        deep_expr = base
+        for k in range(1, 5):
+            deep_expr = FloorDiv((k + 3) * deep_expr * (base + k), k + 5)
+
+        index = deep_expr + ModularIndexing(i, 1, 16)
+        expected = deep_expr + i + sympy.Symbol("i_mod_c0")
+        original_simplify = sympy.simplify
+
+        def fail_simplify(expr):
+            raise AssertionError(f"unexpected sympy.simplify({expr})")
+
+        simplify_index_in_vec_range.cache_clear()
+        try:
+            sympy.simplify = fail_simplify
+            self.assertEqual(simplify_index_in_vec_range(index, i, 16), expected)
+        finally:
+            sympy.simplify = original_simplify
+            simplify_index_in_vec_range.cache_clear()
+
     def test_analyze_lane_contiguity(self):
         sizevars = SizeVarAllocator()
         i = sympy.Symbol("i", integer=True, nonnegative=True)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -186,8 +186,10 @@ def simplify_index_in_vec_range(index: sympy.Expr, var: sympy.Expr, vec_length: 
     if index.has(ModularIndexing):
         index = index.replace(ModularIndexing(var, div, mod), visit_modular_indexing)
 
-    if not index.has(sympy.Rel):
-        index = sympy.simplify(index)
+    # Avoid full-expression sympy.simplify here.  This helper only needs to
+    # expose lane-uniform FloorDiv/ModularIndexing terms for later stride
+    # analysis, and sympy's general simplifier can be superlinear on the large
+    # dynamic-shape index expressions produced by real models.
     if index != original_index:
         return simplify_index_in_vec_range(index, var, vec_length)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #186319

The C++ vector stride helper first rewrites lane-uniform FloorDiv and
ModularIndexing terms into temporary symbols. It then ran full
sympy.simplify over the entire index expression before computing the stride.
On dynamic-shape models such as RetinaNet, those index expressions can be
large while the lane-varying part is small, so general SymPy simplification
can dominate compile time.

This helper only needs the targeted lane substitutions to expose vector
contiguity for later stride analysis. Skip the full-expression simplify pass
and leave the resulting expression in targeted-rewrite form. This preserves
the direct FloorDiv/ModularIndexing cases while avoiding the expensive global
canonicalization.

The alternative would be a bounded or opaque simplifier, but that still pays
for general simplification on the large arithmetic subexpressions that caused
this regression. A narrower rewrite matches the helper's actual contract.

Fixes #133734
Generated by my agent

Benchmark Results:
Inline old-vs-new synthetic benchmark around simplify_index_in_vec_range:
- n=2 old_s=1.236804 new_s=0.000773 equal=True ops=33
- n=4 old_s=7.057595 new_s=0.001206 equal=True ops=53

Test Plan:
- python test/inductor/test_indexing.py TestIndexingSimplification.test_simplify_index_in_vec_range_skips_full_simplify
- python test/inductor/test_indexing.py TestIndexingSimplification
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo