### PR TITLE
Fix PythonMod axiom reuse after size refinement

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13556,6 +13556,20 @@ fn
 
         fn(torch.tensor([3, 3]))
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_python_mod_guard_reused_after_size_refinement(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            u0, u1 = x.tolist()
+            torch._check(u0 % u1 == 0)
+            torch._check_is_size(u0)
+            torch._check_is_size(u1)
+            if u0 % u1 == 0:
+                return torch.tensor(True)
+            return torch.tensor(False)
+
+        self.assertEqual(fn(torch.tensor([6, 3])), torch.tensor(True))
+
     @torch._dynamo.config.patch(assume_static_by_default=True)
     def test_mark_unbacked_strict(self):
         @torch.compile(backend="eager")

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4066,6 +4066,7 @@ class ShapeEnv:
         self.ignorable_fresh_unbacked_symbols: list[sympy.Symbol] = []
 
         # Version counter used to invalidate cached values
+        self._range_refinement_counter = 0
         self._prev_cache_key = self._get_key()
         self._version_counter = 0
         # Separate counter tracking only replacement changes, used by
@@ -4074,6 +4075,8 @@ class ShapeEnv:
 
         # Each time divisible is changed this should be set to True, this is set in _update_version_counter.
         self._resimplify_floor_div_axioms = True
+        # Each time ranges are refined, PythonMod may become equivalent to Mod.
+        self._resimplify_python_mod_axioms = True
 
         # Cache for FX nodes.
         # Maps an already built node a tuple of:
@@ -4264,12 +4267,14 @@ class ShapeEnv:
             "source_name_to_debug_name",
             "_prev_cache_key",
             "_version_counter",
+            "_range_refinement_counter",
             "dim_constraints",
             # source locations are OK to diverge
             "var_to_range_sloc",
             "replacements_slocs",
             "_replacements_version_counter",
             "_resimplify_floor_div_axioms",
+            "_resimplify_python_mod_axioms",
             "_expr_sym_node_id",
             "specialization_stacks",
             # Cached state for optimization_hint unbacked canonicalization
@@ -4641,7 +4646,7 @@ class ShapeEnv:
             self.frozen = old_frozen
             self._error_on_new_guards = old_error
 
-    def _get_key(self) -> tuple[int, int, int, int]:
+    def _get_key(self) -> tuple[int, int, int, int, int]:
         """
         Defines the current "state" of the guards we've accumulated in this ShapeEnv.
         Determines when we need to invalidate our cache
@@ -4651,6 +4656,7 @@ class ShapeEnv:
             len(self.divisible),
             self.num_deferred_runtime_asserts,
             len(self.real_tensor_prop_unbacked_vals),
+            self._range_refinement_counter,
         )
 
     def _update_version_counter(self) -> None:
@@ -7115,10 +7121,19 @@ class ShapeEnv:
 
         expr = canonicalize_bool_expr(expr)
 
-        def resimplify_floor_div(axioms: dict[sympy.Expr, sympy.Expr]) -> None:
-            if not self._resimplify_floor_div_axioms:
+        def resimplify_axioms(
+            axioms: dict[sympy.Expr, sympy.Expr], *, persistent: bool
+        ) -> None:
+            if (
+                not self._resimplify_floor_div_axioms
+                and not self._resimplify_python_mod_axioms
+            ):
                 return
-            self._resimplify_floor_div_axioms = False
+            resimplify_floor_div_axioms = self._resimplify_floor_div_axioms
+            resimplify_python_mod_axioms = self._resimplify_python_mod_axioms
+            if persistent:
+                self._resimplify_floor_div_axioms = False
+                self._resimplify_python_mod_axioms = False
             new_items = {}
             for k, v in list(axioms.items()):
                 # A FloorDiv in implications could have became CleanDiv at this point, due to new facts
@@ -7126,13 +7141,15 @@ class ShapeEnv:
                 # simplification that depends on the global state of shape env.
                 # TODO try to get rid of CleanDiv since it breaks the invariant that's simplifications of sympy
                 # expressions only depend on the expression itself.
-                if k.has(FloorDiv):
+                if (resimplify_floor_div_axioms and k.has(FloorDiv)) or (
+                    resimplify_python_mod_axioms and k.has(PythonMod)
+                ):
                     new_items.update({self.simplify(k): v})
             axioms.update(new_items)
 
         # Pattern matching
         if axioms is None:
-            resimplify_floor_div(self.axioms)
+            resimplify_axioms(self.axioms, persistent=True)
             subst = self.axioms
         else:
             subst = {}
@@ -7140,7 +7157,7 @@ class ShapeEnv:
                 if e.free_symbols.issubset(expr.free_symbols):
                     subst.update(dict(self.get_implications(self.simplify(e))))
 
-            resimplify_floor_div(subst)
+            resimplify_axioms(subst, persistent=False)
 
         expr = expr.xreplace(subst)
         # TODO: compute hint might have gotten broken here
@@ -7285,6 +7302,17 @@ class ShapeEnv:
                 # divisions simplified away
                 if new_pows.issubset(pows) and new_rationals.issubset(rationals):
                     expr = new_expr
+        if expr.has(PythonMod):
+            mod_replacements: dict[sympy.Basic, sympy.Basic] = {}
+            for atom in expr.atoms(PythonMod):
+                base, divisor = atom.args
+                if (
+                    self.bound_sympy(base).lower >= 0
+                    and self.bound_sympy(divisor).lower >= 0
+                ):
+                    mod_replacements[atom] = Mod(base, divisor)
+            if mod_replacements:
+                expr = expr.xreplace(mod_replacements)
         return expr
 
     # TODO: overload for allow_none literal
@@ -7467,6 +7495,9 @@ class ShapeEnv:
                 sloc = self._get_sloc()
                 vr_sloc = ValueRangesSLoc(sloc, sloc)
             self.var_to_range_sloc[symbol] = vr_sloc
+            self._range_refinement_counter += 1
+            self._resimplify_python_mod_axioms = True
+            self._update_version_counter()
         else:
             old = self.var_to_range[symbol]
             new = old & vr
@@ -7480,6 +7511,9 @@ class ShapeEnv:
                     self.var_to_range_sloc[symbol].upper = vr_sloc.upper
                 self.var_to_range[symbol] = new
                 self.log.debug("_update_var_to_range %s = %s (update)", symbol, new)
+                self._range_refinement_counter += 1
+                self._resimplify_python_mod_axioms = True
+                self._update_version_counter()
 
         if (v := self.backed_var_to_val.get(symbol)) is not None:
             r = self.var_to_range[symbol]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186321

When a scalar modulo expression is checked before its operands are known
size-like, ShapeEnv records the assertion with PythonMod semantics. Later
_check_is_size calls refine the same symbols to non-negative ranges, so a
new Python `%` expression can simplify to SymPy Mod. The old PythonMod axiom
was left in its original form, which meant the later Eq(Mod(...), 0) guard
could not use the earlier Eq(PythonMod(...), 0) runtime assertion.

Make ShapeEnv simplification range-aware for PythonMod: when current ranges
prove both operands non-negative, simplify PythonMod to Mod. Range refinements
now invalidate the simplify cache and trigger axiom resimplification, matching
the existing pattern used for FloorDiv axioms whose meaning improves as ShapeEnv
learns more facts. This fixes the root cause instead of special-casing the
reported guard.

Benchmark Results:
Focused compile-time benchmark that resets Dynamo and compiles/runs a small
backend="eager", fullgraph=True function with eight _check_is_size scalar
refinements, reporting 10 runs and excluding the first run for trimmed numbers.

Baseline main 30326da5970ec9410d43f6d87deba0a0c8615a40:
- times_sec=0.545473,0.034132,0.034132,0.033887,0.034147,0.031780,0.032300,0.032082,0.033455,0.032150
- trimmed_mean_sec=0.033118
- trimmed_median_sec=0.033455

Patched fix-133655:
- times_sec=0.481684,0.033515,0.031766,0.031681,0.030413,0.030941,0.032383,0.031803,0.031407,0.030724
- trimmed_mean_sec=0.031626
- trimmed_median_sec=0.031681

Fixes #133655
Generated by my agent

Test Plan:
- Reproduced original data-dependent guard failure before the fix.
- Repro with torch.tensor([6, 3]) now returns tensor(True).
- Repro with torch.tensor([3, 5]) now reaches the expected runtime assertion instead of a Dynamo guard error.
- python test/dynamo/test_misc.py -k test_python_mod_guard_reused_after_size_refinement
- python test/dynamo/test_misc.py -k test_check_simplification
- git diff --check
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98