### PR TITLE
Add explicit schema registration for TorchBind methods

### DIFF
--- a/test/cpp/jit/test_custom_class.cpp
+++ b/test/cpp/jit/test_custom_class.cpp
@@ -3,6 +3,7 @@
 #include <test/cpp/jit/test_custom_class_registrations.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/custom_class.h>
+#include <torch/library.h>
 #include <torch/script.h>
 
 #include <iostream>
@@ -66,6 +67,13 @@ class TorchBindTestClass : public torch::jit::CustomClassHolder {
   }
 };
 
+class TorchBindMutatingTensorClass : public torch::jit::CustomClassHolder {
+ public:
+  void fill(at::Tensor x) {
+    x.fill_(3);
+  }
+};
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 constexpr char class_doc_string[] = R"(
   I am docstring for TorchBindTestClass
@@ -88,6 +96,15 @@ static auto reg =
         .def("get", &TorchBindTestClass::get)
         .def("get_with_docstring", &TorchBindTestClass::get, method_doc_string);
 
+static auto mutating_tensor_reg =
+    torch::class_<TorchBindMutatingTensorClass>(
+        "_TorchBindTest",
+        "_TorchBindMutatingTensorClass")
+        .def(
+            torch::schema(
+                "fill(__torch__.torch.classes._TorchBindTest._TorchBindMutatingTensorClass self, Tensor(a!) x) -> None"),
+            &TorchBindMutatingTensorClass::fill);
+
 } // namespace
 
 // Tests DocString is properly propagated when defining CustomClasses.
@@ -101,6 +118,31 @@ TEST(CustomClassTest, TestDocString) {
   AT_ASSERT(
       class_type->getMethod("get_with_docstring").doc_string() ==
       method_doc_string);
+}
+
+TEST(CustomClassTest, ExplicitMethodSchemaWithTensorMutation) {
+  auto class_type = getCustomClass(
+      "__torch__.torch.classes._TorchBindTest._TorchBindMutatingTensorClass");
+  AT_ASSERT(class_type);
+
+  const auto& schema = class_type->getMethod("fill").getSchema();
+  ASSERT_EQ(
+      toString(schema),
+      "fill(__torch__.torch.classes._TorchBindTest._TorchBindMutatingTensorClass self, Tensor(a!) x) -> NoneType");
+  ASSERT_TRUE(schema.is_mutable("x"));
+
+  script::Module m("m");
+  m.define(R"(
+    def forward(self, obj : __torch__.torch.classes._TorchBindTest._TorchBindMutatingTensorClass, x : Tensor):
+      obj.fill(x)
+      return x
+  )");
+
+  auto obj = make_custom_class<TorchBindMutatingTensorClass>();
+  auto x = at::zeros({2});
+  auto out = m.run_method("forward", obj, x).toTensor();
+  ASSERT_TRUE(out.equal(at::full({2}, 3)));
+  ASSERT_TRUE(x.equal(out));
 }
 
 TEST(CustomClassTest, Serialization) {

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -59,6 +59,7 @@ decltype(auto) init(Func&& f) {
 /// a pointer to the Foo class's `myMethod()` method. `lambdaMethod()`
 /// is registered with a C++ lambda expression.
 template <class CurClass>
+// NOLINTBEGIN(performance-unnecessary-value-param)
 class class_ : public ::torch::detail::class_base {
   static_assert(
       std::is_base_of_v<CustomClassHolder, CurClass>,
@@ -162,6 +163,19 @@ class class_ : public ::torch::detail::class_base {
         std::move(wrapped_f),
         std::move(doc_string),
         default_args);
+    return *this;
+  }
+
+  /// Method registration API with an explicitly provided schema. Use this
+  /// overload when the inferred schema cannot express required annotations,
+  /// such as Tensor aliasing or mutation.
+  template <typename Func>
+  class_& def(
+      c10::FunctionSchema schema,
+      Func f,
+      std::string doc_string = "") {
+    auto wrapped_f = detail::wrap_func<CurClass, Func>(std::move(f));
+    defineMethod(std::move(schema), std::move(wrapped_f), std::move(doc_string));
     return *this;
   }
 
@@ -395,6 +409,45 @@ class class_ : public ::torch::detail::class_base {
  private:
   template <typename Func>
   torch::jit::Function* defineMethod(
+      c10::FunctionSchema schema,
+      Func func,
+      std::string doc_string = "") {
+    TORCH_CHECK(
+        !schema.getNamespace().has_value(),
+        "Custom class method schemas must use an unqualified method name, got ",
+        schema.name());
+
+    auto inferred_schema = c10::inferFunctionSchemaSingleReturn<Func>(
+        std::string(schema.name()), std::string(schema.overload_name()));
+    auto schema_diff = c10::findSchemaDifferences(inferred_schema, schema);
+    TORCH_CHECK(
+        !schema_diff.has_value(),
+        "Provided schema for custom class method ",
+        schema.name(),
+        " is incompatible with the inferred schema. ",
+        *schema_diff);
+
+    auto qualMethodName = qualClassName + "." + schema.name();
+    auto wrapped_func =
+        [func = std::move(func)](jit::Stack& stack) mutable -> void {
+      using RetType =
+          typename c10::guts::infer_function_traits_t<Func>::return_type;
+      detail::BoxedProxy<RetType, Func>()(stack, func);
+    };
+    auto method = std::make_unique<jit::BuiltinOpFunction>(
+        qualMethodName,
+        std::move(schema),
+        std::move(wrapped_func),
+        std::move(doc_string));
+
+    auto method_val = method.get();
+    classTypePtr->addMethod(method_val);
+    registerCustomClassMethod(std::move(method));
+    return method_val;
+  }
+
+  template <typename Func>
+  torch::jit::Function* defineMethod(
       std::string name,
       Func func,
       std::string doc_string = "",
@@ -445,6 +498,7 @@ class class_ : public ::torch::detail::class_base {
     return method_val;
   }
 };
+// NOLINTEND(performance-unnecessary-value-param)
 
 /// make_custom_class() is a convenient way to create an instance of a
 /// registered custom class and wrap it in an IValue, for example when you want


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186322

TorchBind custom class methods could only be registered through torch::class_<T>::def(name, fn), which infers the method schema from the C++ callable. Inferred schemas cannot encode Tensor aliasing and mutation annotations, so a method that mutates a tensor argument could not be registered with the required Tensor(a!) schema for PT2/compile analysis.

Add a typed def(c10::FunctionSchema, Func, ...) overload for custom classes. The new path validates the explicit schema's argument and return types against the inferred wrapped method signature, then registers the explicit schema so names, defaults, aliasing, and mutation annotations are preserved. This keeps the existing inferred-schema API unchanged while covering schema annotations that inference cannot represent.

The touched public header triggers clang-tidy performance-unnecessary-value-param checks across existing value-taking torch::class_ APIs. Suppress that check around the class to avoid unrelated public signature churn in this focused fix.

Fixes #133592

Generated by my agent

Test Plan:

- ninja -C build test_jit

- build/bin/test_jit --gtest_filter=CustomClassTest.ExplicitMethodSchemaWithTensorMutation

- build/bin/test_jit --gtest_filter=CustomClassTest.*

- git diff --check

- lintrunner -a