### PR TITLE
[FakeTensor] Propagate backend metadata through fake tensor conversion

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -224,6 +224,13 @@ struct C10_API BackendMeta : intrusive_ptr_target {
       const intrusive_ptr<BackendMeta>& ptr) const {
     return ptr;
   }
+  // Clone this metadata for a FakeTensor. Defaults to nullptr (dropped) so
+  // existing backends are unaffected; a backend opts in by overriding this and
+  // should strip data that is only valid on a real tensor.
+  virtual intrusive_ptr<BackendMeta> clone_for_fake(
+      const intrusive_ptr<BackendMeta>& ptr [[maybe_unused]]) const {
+    return nullptr;
+  }
 };
 
 // same as Python's FakeTensorMode

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.cpp
@@ -5,8 +5,20 @@ struct OpenRegBackendMeta : public c10::BackendMeta {
   OpenRegBackendMeta(int version_number, int format_number)
       : version_number_(version_number), format_number_(format_number) {}
 
+  // Carry OpenReg metadata onto FakeTensors, tagging the copy so tests can tell
+  // it went through clone_for_fake() rather than a raw clone().
+  c10::intrusive_ptr<c10::BackendMeta> clone_for_fake(
+      const c10::intrusive_ptr<c10::BackendMeta>& ptr
+      [[maybe_unused]]) const override {
+    auto cloned = c10::make_intrusive<OpenRegBackendMeta>(
+        version_number_, format_number_);
+    cloned->fake_clone_ = true;
+    return cloned;
+  }
+
   int version_number_{-1};
   int format_number_{-1};
+  bool fake_clone_{false};
 };
 
 void for_serialization(
@@ -21,6 +33,10 @@ void for_serialization(
     }
     if (o_meta_ptr->format_number_ == 29) {
       m["format_number"] = true;
+    }
+    // Set by clone_for_fake(); lets tests confirm the fakeification path.
+    if (o_meta_ptr->fake_clone_) {
+      m["fake_clone"] = true;
     }
   }
 }

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -59,6 +59,28 @@ class TestFakeTensor(TestCase):
                 if isinstance(fake, torch.Tensor):
                     self.assertEqual(fake.device.type, "openreg")
 
+    def test_backend_metadata_propagation(self):
+        captured = []
+
+        def capture_backend(gm, example_inputs):
+            for node in gm.graph.nodes:
+                if node.op == "placeholder":
+                    fake = node.meta.get("example_value")
+                    if isinstance(fake, torch.Tensor):
+                        captured.append(torch._utils.get_tensor_metadata(fake))
+            return gm.forward
+
+        @torch.compile(backend=capture_backend, fullgraph=True)
+        def fn(x):
+            return x + 1
+
+        x = torch.empty(3, 3, device="openreg")
+        metadata = {"version_number": True, "format_number": True}
+        torch._utils.set_tensor_metadata(x, metadata)
+        fn(x)
+
+        self.assertEqual(captured, [metadata])
+
     def test_fake_tensor_mode(self):
         with torch._subclasses.fake_tensor.FakeTensorMode():
             x = torch.empty(3, 3, device="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -79,7 +79,9 @@ class TestFakeTensor(TestCase):
         torch._utils.set_tensor_metadata(x, metadata)
         fn(x)
 
-        self.assertEqual(captured, [metadata])
+        # fake_clone is added by clone_for_fake(), confirming the layout metadata
+        # reached the compiler backend through the fakeification path.
+        self.assertEqual(captured, [{**metadata, "fake_clone": True}])
 
     def test_fake_tensor_mode(self):
         with torch._subclasses.fake_tensor.FakeTensorMode():

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -196,6 +196,19 @@ class TestSerialization(TestCase):
             loaded_tensor = torch.load(path)
             self.assertEqual(torch._utils.get_tensor_metadata(loaded_tensor), metadata)
 
+    def test_fake_tensor_metadata_preservation(self):
+        """Test that backend metadata is propagated to a FakeTensor"""
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+        tensor = torch.empty(3, 3, device="openreg")
+        metadata = {"version_number": True, "format_number": True}
+        torch._utils.set_tensor_metadata(tensor, metadata)
+
+        with FakeTensorMode() as mode:
+            fake_tensor = mode.from_tensor(tensor)
+        self.assertIsInstance(fake_tensor, FakeTensor)
+        self.assertEqual(torch._utils.get_tensor_metadata(fake_tensor), metadata)
+
     def test_serialization_map_location_cpu(self):
         """Test serialization with map_location to CPU"""
         tensor = torch.randn(3, 3, device="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -65,6 +65,19 @@ class TestSerialization(TestCase):
             self.assertFalse(tensor_cpu.is_openreg)
             self.assertEqual(torch._utils.get_tensor_metadata(tensor_cpu), {})
 
+    def test_copy_backend_meta(self):
+        """Test copying backend metadata from one tensor to another"""
+        src = torch.empty(3, 3, device="openreg")
+        self.assertEqual(torch._utils.get_tensor_metadata(src), {})
+        metadata = {"version_number": True, "format_number": True}
+        torch._utils.set_tensor_metadata(src, metadata)
+        self.assertEqual(torch._utils.get_tensor_metadata(src), metadata)
+
+        dst = torch.empty(3, 3, device="openreg")
+        self.assertEqual(torch._utils.get_tensor_metadata(dst), {})
+        torch._C._copy_backend_meta(src, dst)
+        self.assertEqual(torch._utils.get_tensor_metadata(dst), metadata)
+
     @skipIfTorchDynamo()
     @unittest.skipIf(
         numpy.__version__ < "1.25",

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -209,6 +209,32 @@ class TestSerialization(TestCase):
         self.assertIsInstance(fake_tensor, FakeTensor)
         self.assertEqual(torch._utils.get_tensor_metadata(fake_tensor), metadata)
 
+    def test_fake_tensor_metadata_preservation_functional(self):
+        """Test backend metadata propagation when fakeifying a FunctionalTensor.
+
+        Exercises the inner_t unwrap in from_real_tensor: the FunctionalTensor
+        wrapper carries no backend metadata, only the inner tensor does, so
+        reading from the wrapper would propagate nothing.
+        """
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+        from torch._subclasses.functional_tensor import (
+            FunctionalTensor,
+            FunctionalTensorMode,
+        )
+
+        tensor = torch.empty(3, 3, device="openreg")
+        metadata = {"version_number": True, "format_number": True}
+        torch._utils.set_tensor_metadata(tensor, metadata)
+
+        with FunctionalTensorMode():
+            functional_tensor = FunctionalTensor.to_functional(tensor)
+            # The wrapper carries no backend metadata; only the inner does.
+            self.assertEqual(torch._utils.get_tensor_metadata(functional_tensor), {})
+            with FakeTensorMode() as mode:
+                fake_tensor = mode.from_tensor(functional_tensor)
+        self.assertIsInstance(fake_tensor, FakeTensor)
+        self.assertEqual(torch._utils.get_tensor_metadata(fake_tensor), metadata)
+
     def test_serialization_map_location_cpu(self):
         """Test serialization with map_location to CPU"""
         tensor = torch.randn(3, 3, device="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -73,10 +73,20 @@ class TestSerialization(TestCase):
         torch._utils.set_tensor_metadata(src, metadata)
         self.assertEqual(torch._utils.get_tensor_metadata(src), metadata)
 
+        # Default (for_fake=False) uses BackendMeta::clone(): a faithful copy.
         dst = torch.empty(3, 3, device="openreg")
         self.assertEqual(torch._utils.get_tensor_metadata(dst), {})
         torch._C._copy_backend_meta(src, dst)
         self.assertEqual(torch._utils.get_tensor_metadata(dst), metadata)
+
+        # for_fake=True uses BackendMeta::clone_for_fake(), which OpenReg tags
+        # with fake_clone so the fake-copy path is distinguishable from clone().
+        dst_fake = torch.empty(3, 3, device="openreg")
+        torch._C._copy_backend_meta(src, dst_fake, for_fake=True)
+        self.assertEqual(
+            torch._utils.get_tensor_metadata(dst_fake),
+            {**metadata, "fake_clone": True},
+        )
 
     @skipIfTorchDynamo()
     @unittest.skipIf(
@@ -207,7 +217,11 @@ class TestSerialization(TestCase):
         with FakeTensorMode() as mode:
             fake_tensor = mode.from_tensor(tensor)
         self.assertIsInstance(fake_tensor, FakeTensor)
-        self.assertEqual(torch._utils.get_tensor_metadata(fake_tensor), metadata)
+        # fake_clone confirms the metadata arrived via clone_for_fake(), not clone().
+        self.assertEqual(
+            torch._utils.get_tensor_metadata(fake_tensor),
+            {**metadata, "fake_clone": True},
+        )
 
     def test_fake_tensor_metadata_preservation_functional(self):
         """Test backend metadata propagation when fakeifying a FunctionalTensor.
@@ -233,7 +247,10 @@ class TestSerialization(TestCase):
             with FakeTensorMode() as mode:
                 fake_tensor = mode.from_tensor(functional_tensor)
         self.assertIsInstance(fake_tensor, FakeTensor)
-        self.assertEqual(torch._utils.get_tensor_metadata(fake_tensor), metadata)
+        self.assertEqual(
+            torch._utils.get_tensor_metadata(fake_tensor),
+            {**metadata, "fake_clone": True},
+        )
 
     def test_serialization_map_location_cpu(self):
         """Test serialization with map_location to CPU"""

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -557,6 +557,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch._C._construct_CUDA_Tensor_From_Storage_And_Metadata",
         "torch._C._construct_storage_from_data_pointer",
         "torch._C._conv_determine_backend_memory_format",
+        "torch._C._copy_backend_meta",
         "torch._C._cpu._init_amx",
         "torch._C._cpu._get_cpu_capability",
         "torch._C._crash_if_aten_asan",

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -565,6 +565,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch._C._construct_CUDA_Tensor_From_Storage_And_Metadata",
         "torch._C._construct_storage_from_data_pointer",
         "torch._C._conv_determine_backend_memory_format",
+        "torch._C._copy_backend_meta",
         "torch._C._cpu._init_amx",
         "torch._C._cpu._get_cpu_capability",
         "torch._C._crash_if_aten_asan",

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -569,6 +569,11 @@ class FakeTensorConverter:
         ):
             out.grad_dtype = inner_t.grad_dtype
 
+        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta) from
+        # the (unwrapped) real tensor onto the fake tensor; a no-op when there is
+        # none.
+        torch._utils.copy_backend_meta(inner_t, out)
+
         from torch._dynamo.source import RandomValueSource
 
         value = None
@@ -662,10 +667,6 @@ class FakeTensorConverter:
                         )
         if make_constant:
             self.add_constant_storage_mapping(out)
-        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta)
-        # from the real tensor onto the fake tensor. No-op when the real tensor
-        # has no backend metadata.
-        torch._utils.copy_backend_meta(t, out)
         # NB: meta_converter set the memo
         return out
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -662,6 +662,10 @@ class FakeTensorConverter:
                         )
         if make_constant:
             self.add_constant_storage_mapping(out)
+        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta)
+        # from the real tensor onto the fake tensor. No-op when the real tensor
+        # has no backend metadata.
+        torch._utils.copy_backend_meta(t, out)
         # NB: meta_converter set the memo
         return out
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -570,9 +570,9 @@ class FakeTensorConverter:
             out.grad_dtype = inner_t.grad_dtype
 
         # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta) from
-        # the (unwrapped) real tensor onto the fake tensor; a no-op when there is
-        # none.
-        torch._utils.copy_backend_meta(inner_t, out)
+        # the (unwrapped) real tensor onto the fake tensor. for_fake lets the
+        # backend drop data that is invalid on a fake; a no-op when there is none.
+        torch._utils.copy_backend_meta(inner_t, out, for_fake=True)
 
         from torch._dynamo.source import RandomValueSource
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -582,9 +582,9 @@ class FakeTensorConverter:
             out.grad_dtype = inner_t.grad_dtype
 
         # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta) from
-        # the (unwrapped) real tensor onto the fake tensor; a no-op when there is
-        # none.
-        torch._utils.copy_backend_meta(inner_t, out)
+        # the (unwrapped) real tensor onto the fake tensor. for_fake lets the
+        # backend drop data that is invalid on a fake; a no-op when there is none.
+        torch._utils.copy_backend_meta(inner_t, out, for_fake=True)
 
         from torch._dynamo.source import RandomValueSource
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -581,6 +581,11 @@ class FakeTensorConverter:
         ):
             out.grad_dtype = inner_t.grad_dtype
 
+        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta) from
+        # the (unwrapped) real tensor onto the fake tensor; a no-op when there is
+        # none.
+        torch._utils.copy_backend_meta(inner_t, out)
+
         from torch._dynamo.source import RandomValueSource
 
         value = None
@@ -674,10 +679,6 @@ class FakeTensorConverter:
                         )
         if make_constant:
             self.add_constant_storage_mapping(out)
-        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta)
-        # from the real tensor onto the fake tensor. No-op when the real tensor
-        # has no backend metadata.
-        torch._utils.copy_backend_meta(t, out)
         # NB: meta_converter set the memo
         return out
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -674,6 +674,10 @@ class FakeTensorConverter:
                         )
         if make_constant:
             self.add_constant_storage_mapping(out)
+        # Propagate backend-specific metadata (e.g. PrivateUse1 BackendMeta)
+        # from the real tensor onto the fake tensor. No-op when the real tensor
+        # has no backend metadata.
+        torch._utils.copy_backend_meta(t, out)
         # NB: meta_converter set the memo
         return out
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -216,6 +216,16 @@ def set_tensor_metadata(tensor, metadata):
     torch._C._set_tensor_metadata(tensor, metadata)  # type: ignore[attr-defined]
 
 
+def copy_backend_meta(src, dst):
+    # Copy the backend-specific metadata (``c10::BackendMeta``) from ``src`` to
+    # ``dst``. See `get_tensor_metadata` / `set_tensor_metadata` above.
+    if not isinstance(src, torch.Tensor):
+        raise AssertionError(f"expected torch.Tensor, got {type(src).__name__}")
+    if not isinstance(dst, torch.Tensor):
+        raise AssertionError(f"expected torch.Tensor, got {type(dst).__name__}")
+    torch._C._copy_backend_meta(src, dst)  # type: ignore[attr-defined]
+
+
 def _restore_device_fake_mode(tensor):
     if torch._guards.detect_fake_mode(None) is not None:
         if tensor.untyped_storage()._fake_device is not None:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -216,14 +216,16 @@ def set_tensor_metadata(tensor, metadata):
     torch._C._set_tensor_metadata(tensor, metadata)  # type: ignore[attr-defined]
 
 
-def copy_backend_meta(src, dst):
+def copy_backend_meta(src, dst, for_fake=False):
     # Copy the backend-specific metadata (``c10::BackendMeta``) from ``src`` to
-    # ``dst``. See `get_tensor_metadata` / `set_tensor_metadata` above.
+    # ``dst``. When ``for_fake`` is set (copying onto a FakeTensor) the backend
+    # may drop or strip data that is not valid on a fake. See
+    # `get_tensor_metadata` / `set_tensor_metadata` above.
     if not isinstance(src, torch.Tensor):
         raise AssertionError(f"expected torch.Tensor, got {type(src).__name__}")
     if not isinstance(dst, torch.Tensor):
         raise AssertionError(f"expected torch.Tensor, got {type(dst).__name__}")
-    torch._C._copy_backend_meta(src, dst)  # type: ignore[attr-defined]
+    torch._C._copy_backend_meta(src, dst, for_fake)  # type: ignore[attr-defined]
 
 
 def _restore_device_fake_mode(tensor):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -217,14 +217,16 @@ def set_tensor_metadata(tensor, metadata):
     torch._C._set_tensor_metadata(tensor, metadata)  # type: ignore[attr-defined]
 
 
-def copy_backend_meta(src, dst):
+def copy_backend_meta(src, dst, for_fake=False):
     # Copy the backend-specific metadata (``c10::BackendMeta``) from ``src`` to
-    # ``dst``. See `get_tensor_metadata` / `set_tensor_metadata` above.
+    # ``dst``. When ``for_fake`` is set (copying onto a FakeTensor) the backend
+    # may drop or strip data that is not valid on a fake. See
+    # `get_tensor_metadata` / `set_tensor_metadata` above.
     if not isinstance(src, torch.Tensor):
         raise AssertionError(f"expected torch.Tensor, got {type(src).__name__}")
     if not isinstance(dst, torch.Tensor):
         raise AssertionError(f"expected torch.Tensor, got {type(dst).__name__}")
-    torch._C._copy_backend_meta(src, dst)  # type: ignore[attr-defined]
+    torch._C._copy_backend_meta(src, dst, for_fake)  # type: ignore[attr-defined]
 
 
 def _restore_device_fake_mode(tensor):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -217,6 +217,16 @@ def set_tensor_metadata(tensor, metadata):
     torch._C._set_tensor_metadata(tensor, metadata)  # type: ignore[attr-defined]
 
 
+def copy_backend_meta(src, dst):
+    # Copy the backend-specific metadata (``c10::BackendMeta``) from ``src`` to
+    # ``dst``. See `get_tensor_metadata` / `set_tensor_metadata` above.
+    if not isinstance(src, torch.Tensor):
+        raise AssertionError(f"expected torch.Tensor, got {type(src).__name__}")
+    if not isinstance(dst, torch.Tensor):
+        raise AssertionError(f"expected torch.Tensor, got {type(dst).__name__}")
+    torch._C._copy_backend_meta(src, dst)  # type: ignore[attr-defined]
+
+
 def _restore_device_fake_mode(tensor):
     if torch._guards.detect_fake_mode(None) is not None:
         if tensor.untyped_storage()._fake_device is not None:

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3229,7 +3229,12 @@ Call this whenever a new thread is created in order to propagate values from
       static_cast<void (*)(
           const at::Tensor&, std::unordered_map<std::string, bool>)>(
           torch::jit::setTensorMetadata));
-  py_module.def("_copy_backend_meta", &torch::jit::copyBackendMeta);
+  py_module.def(
+      "_copy_backend_meta",
+      &torch::jit::copyBackendMeta,
+      py::arg("src"),
+      py::arg("dst"),
+      py::arg("for_fake") = false);
   py_module.def("_dispatch_key_set", [](const at::Tensor& x) {
     return toString(x.key_set());
   });

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3229,6 +3229,7 @@ Call this whenever a new thread is created in order to propagate values from
       static_cast<void (*)(
           const at::Tensor&, std::unordered_map<std::string, bool>)>(
           torch::jit::setTensorMetadata));
+  py_module.def("_copy_backend_meta", &torch::jit::copyBackendMeta);
   py_module.def("_dispatch_key_set", [](const at::Tensor& x) {
     return toString(x.key_set());
   });

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3343,7 +3343,12 @@ Call this whenever a new thread is created in order to propagate values from
       static_cast<void (*)(
           const at::Tensor&, std::unordered_map<std::string, bool>)>(
           torch::jit::setTensorMetadata));
-  py_module.def("_copy_backend_meta", &torch::jit::copyBackendMeta);
+  py_module.def(
+      "_copy_backend_meta",
+      &torch::jit::copyBackendMeta,
+      py::arg("src"),
+      py::arg("dst"),
+      py::arg("for_fake") = false);
   py_module.def("_dispatch_key_set", [](const at::Tensor& x) {
     return toString(x.key_set());
   });

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -3343,6 +3343,7 @@ Call this whenever a new thread is created in order to propagate values from
       static_cast<void (*)(
           const at::Tensor&, std::unordered_map<std::string, bool>)>(
           torch::jit::setTensorMetadata));
+  py_module.def("_copy_backend_meta", &torch::jit::copyBackendMeta);
   py_module.def("_dispatch_key_set", [](const at::Tensor& x) {
     return toString(x.key_set());
   });

--- a/torch/csrc/jit/serialization/pickler_helper.h
+++ b/torch/csrc/jit/serialization/pickler_helper.h
@@ -203,6 +203,14 @@ inline void setTensorMetadata(
   setTensorMetadata(t, std::move(metadata));
 }
 
+// Copy backend metadata (c10::BackendMeta) from src tensor to dst tensor.
+// Other tensor metadata on dst is left untouched. No-op when src has none.
+inline void copyBackendMeta(const at::Tensor& src, const at::Tensor& dst) {
+  if (auto meta = src.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr()) {
+    dst.unsafeGetTensorImpl()->set_backend_meta(meta->clone(meta));
+  }
+}
+
 // Register function pointer of Tensor BackendMetadata for serialization.
 inline void TensorBackendMetaRegistry(
     c10::DeviceType t,

--- a/torch/csrc/jit/serialization/pickler_helper.h
+++ b/torch/csrc/jit/serialization/pickler_helper.h
@@ -203,11 +203,19 @@ inline void setTensorMetadata(
   setTensorMetadata(t, std::move(metadata));
 }
 
-// Copy backend metadata (c10::BackendMeta) from src tensor to dst tensor.
-// Other tensor metadata on dst is left untouched. No-op when src has none.
-inline void copyBackendMeta(const at::Tensor& src, const at::Tensor& dst) {
+// Copy backend metadata (c10::BackendMeta) from src to dst: via
+// BackendMeta::clone_for_fake() when for_fake (copying onto a FakeTensor), else
+// BackendMeta::clone(). A no-op when src has none or the backend declines the
+// fake copy; other tensor metadata on dst is left untouched.
+inline void copyBackendMeta(
+    const at::Tensor& src,
+    const at::Tensor& dst,
+    bool for_fake = false) {
   if (auto meta = src.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr()) {
-    dst.unsafeGetTensorImpl()->set_backend_meta(meta->clone(meta));
+    auto copied = for_fake ? meta->clone_for_fake(meta) : meta->clone(meta);
+    if (copied) {
+      dst.unsafeGetTensorImpl()->set_backend_meta(copied);
+    }
   }
 }
 


### PR DESCRIPTION
Backends that attach `c10::BackendMeta` to a tensor (via the PrivateUse1
backend-metadata mechanism, the same one used for `torch.save` / `torch.load`)
currently lose that metadata when the tensor is converted to a `FakeTensor`.
`FakeTensorConverter.from_real_tensor` builds the fake tensor from a fresh meta
tensor and never copies `backend_meta_`, so any backend relying on it (e.g.
PrivateUse1) sees it dropped under `torch.compile` / fake tensor propagation.

This adds `torch._C._copy_backend_meta(src, dst)`, a small helper in
`pickler_helper.h` alongside `get`/`setTensorMetadata`, that clones the source
tensor's `c10::BackendMeta` onto the destination via `BackendMeta::clone()` and
leaves all other tensor metadata untouched (it is a no-op when the source has no
backend metadata). `from_real_tensor` then calls it so the fake tensor retains
the real tensor's backend metadata.

Unlike routing through `get`/`setTensorMetadata`, the clone-based copy moves the
full `BackendMeta` object rather than a `Dict[str, bool]` projection, and does
not depend on the tensor's reported device — so it is correct regardless of
`FakeTensorMode.in_kernel_invocation`.

Test Plan:

```bash
python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py -k test_copy_backend_meta
python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py -k test_fake_tensor_metadata_preservation
python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py -k test_backend_metadata_propagation
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98