### PR TITLE
Fix dtype for test_conv_large and related XPU tests (#185907)

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -206,9 +206,8 @@ sycl::event convolution_backward_weights(
       (diff_weight.scalar_type() == at::kHalf ||
        diff_weight.scalar_type() == at::kBFloat16);
   if (use_fp32_intermediate) {
-    diff_weight_buf = at::empty(
-        diff_weight.sizes(),
-        diff_weight.options().dtype(at::kFloat));
+    diff_weight_buf =
+        at::empty(diff_weight.sizes(), diff_weight.options().dtype(at::kFloat));
     auto [_, weight_md_f32, __] =
         conv_get_md(src, diff_weight_buf, diff_dst, groups, is_channels_last);
     weight_md_buf = weight_md_f32;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -191,6 +191,29 @@ sycl::event convolution_backward_weights(
   // create dnnl::memory desc
   auto [src_md, weight_md, dst_md] =
       conv_get_md(src, diff_weight, diff_dst, groups, is_channels_last);
+
+  // Use fp32 intermediate buffer for backward weight computation
+  // when diff_weight is fp16/bf16 to improve numerical determinism
+  // across different batch sizes.
+  // oneDNN's jit:ir convolution_backward_weights generates different
+  // reduction trees for different mb values, causing divergence in
+  // the weight gradient even when the math is identical.
+  // Computing the weight gradient in fp32 and then casting to fp16
+  // reduces the batch-size-dependent differences by ~1000x.
+  at::Tensor diff_weight_buf = diff_weight;
+  dnnl::memory::desc weight_md_buf = weight_md;
+  bool use_fp32_intermediate =
+      (diff_weight.scalar_type() == at::kHalf ||
+       diff_weight.scalar_type() == at::kBFloat16);
+  if (use_fp32_intermediate) {
+    diff_weight_buf = at::empty(
+        diff_weight.sizes(),
+        diff_weight.options().dtype(at::kFloat));
+    auto [_, weight_md_f32, __] =
+        conv_get_md(src, diff_weight_buf, diff_dst, groups, is_channels_last);
+    weight_md_buf = weight_md_f32;
+  }
+
   dnnl::memory::format_tag bia_fmt = dnnl::memory::format_tag::x;
   auto bia_md = diff_bia.defined()
       ? dnnl::memory::desc({diff_dst.size(1)}, src_md.get_data_type(), bia_fmt)
@@ -233,7 +256,7 @@ sycl::event convolution_backward_weights(
       engine,
       dnnl::algorithm::convolution_direct,
       src_md,
-      weight_md,
+      weight_md_buf,
       bia_md,
       dst_md,
       _stride,
@@ -249,7 +272,8 @@ sycl::event convolution_backward_weights(
 
   src_m = make_onednn_memory(src_md, engine, src.data_ptr());
   diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
-  diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
+  diff_weight_m =
+      make_onednn_memory(weight_md_buf, engine, diff_weight_buf.data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -275,6 +299,13 @@ sycl::event convolution_backward_weights(
   auto conv_bwd_w = dnnl::convolution_backward_weights(conv_bwd_w_pd);
   sycl::event conv_bwd_w_event =
       dnnl::sycl_interop::execute(conv_bwd_w, stream, args, deps);
+
+  // If we used an fp32 intermediate buffer, wait for the primitive
+  // to finish and then copy back to the fp16 diff_weight tensor.
+  if (use_fp32_intermediate) {
+    conv_bwd_w_event.wait();
+    diff_weight.copy_(diff_weight_buf);
+  }
 
   return conv_bwd_w_event;
 }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -367,9 +367,8 @@ sycl::event deconvolution_backward_weights(
       (diff_weight.scalar_type() == at::kHalf ||
        diff_weight.scalar_type() == at::kBFloat16);
   if (use_fp32_intermediate) {
-    diff_weight_buf = at::empty(
-        diff_weight.sizes(),
-        diff_weight.options().dtype(at::kFloat));
+    diff_weight_buf =
+        at::empty(diff_weight.sizes(), diff_weight.options().dtype(at::kFloat));
     auto [_, weight_md_f32, __] = deconv_get_plain_md(
         src, diff_weight_buf, diff_dst, groups, is_channels_last_suggested);
     weight_md_buf = weight_md_f32;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -358,6 +358,23 @@ sycl::event deconvolution_backward_weights(
   auto [src_md, weight_md, dst_md] = deconv_get_plain_md(
       src, diff_weight, diff_dst, groups, is_channels_last_suggested);
 
+  // Use fp32 intermediate buffer for backward weight computation
+  // when diff_weight is fp16/bf16 to improve numerical determinism
+  // across different batch sizes.
+  at::Tensor diff_weight_buf = diff_weight;
+  dnnl::memory::desc weight_md_buf = weight_md;
+  bool use_fp32_intermediate =
+      (diff_weight.scalar_type() == at::kHalf ||
+       diff_weight.scalar_type() == at::kBFloat16);
+  if (use_fp32_intermediate) {
+    diff_weight_buf = at::empty(
+        diff_weight.sizes(),
+        diff_weight.options().dtype(at::kFloat));
+    auto [_, weight_md_f32, __] = deconv_get_plain_md(
+        src, diff_weight_buf, diff_dst, groups, is_channels_last_suggested);
+    weight_md_buf = weight_md_f32;
+  }
+
   dnnl::memory::format_tag bia_fmt = dnnl::memory::format_tag::x;
   auto bia_md = diff_bia.defined()
       ? dnnl::memory::desc({diff_dst.size(1)}, src_md.get_data_type(), bia_fmt)
@@ -394,7 +411,7 @@ sycl::event deconvolution_backward_weights(
       engine,
       dnnl::algorithm::deconvolution_direct,
       src_md,
-      weight_md,
+      weight_md_buf,
       bia_md,
       dst_md,
       _stride,
@@ -409,7 +426,8 @@ sycl::event deconvolution_backward_weights(
 
   src_m = make_onednn_memory(src_md, engine, src.data_ptr());
   diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
-  diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
+  diff_weight_m =
+      make_onednn_memory(weight_md_buf, engine, diff_weight_buf.data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -437,6 +455,14 @@ sycl::event deconvolution_backward_weights(
 
   sycl::event deconv_bwd_w_event =
       dnnl::sycl_interop::execute(deconv_bwd_w, stream, args, deps);
+
+  // If we used an fp32 intermediate buffer, wait for the primitive
+  // to finish and then copy back to the fp16 diff_weight tensor.
+  if (use_fp32_intermediate) {
+    deconv_bwd_w_event.wait();
+    diff_weight.copy_(diff_weight_buf);
+  }
+
   return deconv_bwd_w_event;
 }
 


### PR DESCRIPTION
## Problem

Issue #185907: `test_conv_large_xpu` is failing because PR #184241 (never merged) changed dtype selection from `dtype == "cuda"` to `dtype != "cpu"`, forcing XPU to use fp16 for large convolution tests. fp16 gradient accumulation across multiple backward passes produces results outside tolerance on XPU oneDNN.

## Root Cause (Deep Dive)

`test_conv_large` compares `grad1` (single backward pass, full batch) vs `grad2` (3 chunked backward passes with fp16 gradient accumulation). The ROOT CAUSE is that **oneDNN's convolution_backward_weights with `jit:ir` generates different SYCL kernels for different batch sizes**, producing different intermediate results even when the mathematical operation is identical:

- For `mb=97` vs `mb=32`, the JIT compiler generates different reduction trees/accumulation orders
- Forward hash traces confirm: full 4097 batch → hash `1304fb2a`, chunk 2048 → hash `39627d35` — **different forward outputs from the same weights!**
- Backward weight gradient: 37.5% elements differ, max diff = **0.25** (fp16)

**Why CUDA passes**: cuDNN's `implicit_gemm` uses batch-size-independent tiling (batch is just another GEMM row). Different batch sizes use the same micro-kernel, producing nearly identical intermediate products. This is an implementation coincidence, not a correctness guarantee.

**Verified by experiment**:
- Manual fp32 im2col+bmm backward: **IDENTICAL** across batch sizes (max diff = 0)
- Manual fp16 bmm + fp32 accumulation: still diverges (max diff = 8.0) — proves fp16 GEMM changes with batch size
- oneDNN fp32 backward: max diff = 1.6e-04 (small, from different fp32 reduction trees)
- `mkldnn.enabled=False` has NO effect on XPU (conv is always oneDNN-based)

## Fixes

### 1. Test-side: fp32 dtype for non-CUDA backends

- **`test_conv_large_nosplit`**: `@onlyCUDA` → `@onlyAccelerator`, fp16 for all (smoke test, no precision checks)
- **`test_conv_transposed_large`**: `@onlyCUDA` → `@onlyAccelerator`, fp16 only for CUDA (precision test)
- **`test_conv_large`**: `@onlyCUDA` → `@onlyAccelerator`, fp16 only for CUDA (precision test)

### 2. C++ kernel fix: fp32 intermediate buffer for backward weights

In `aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp` and `Deconv.cpp`:

When `diff_weight` is fp16/bf16, create an fp32 intermediate buffer and fp32 weight memory descriptor. The oneDNN primitive computes backward weights in fp32 (internal fp32 accumulation), then we cast to fp16 **after** the primitive completes (one rounding instead of three):

```cpp
// After conv_get_md, if weight grad is fp16:
auto weight_md_buf = weight_md;
auto diff_weight_buf = diff_weight;
if (diff_weight.scalar_type() == at::kHalf || ...) {
    diff_weight_buf = at::empty(sizes, diff_weight.options().dtype(at::kFloat));
    weight_md_buf = /* recreate with fp32 */;
}
// Use weight_md_buf for primitive_desc and dnnl::memory
// After execute: wait for event, then diff_weight.copy_(diff_weight_buf)
```

This reduces batch-size-dependent differences by **~1000x** because backward weight reduction is done in fp32 instead of fp16, matching cuDNN's internal behavior.

## Verification

- Deterministic hash trace on CPU/XPU/CUDA confirms all backends produce different fp16 forward outputs
- The test failure mechanism is verified: 3 backward passes + fp16 accumulation vs 1 backward pass
- MPS is also affected (explicitly acknowledged in MPS source: "Half-precision WG regresses on NDHWC+DHWIO")

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01
