### PR TITLE
xpu: fix oneDNN deterministic version gating

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -13,10 +13,11 @@
 #include <oneapi/dnnl/dnnl_sycl.hpp>
 #include <oneapi/dnnl/dnnl_version.h>
 
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 
-#define ONEDNN_SUPPORT_DETERMINISTIC \
-  (DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)
+// Use the shared packed-version helper so oneDNN 4.x+ still satisfies >= 3.4.
+#define ONEDNN_SUPPORT_DETERMINISTIC DNNL_PREREQ(3, 4, 0)
 
 namespace at::native::onednn {
 

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -880,6 +880,26 @@ class TestBasicGEMM(TestCase):
             for _ in range(10):
                 self.assertEqual(first, torch.matmul(inp, inp), atol=0.0, rtol=0.0)
 
+    @dtypes(torch.float)
+    def test_matmul_mkldnn_deterministic_flag(self, device, dtype):
+        original_mkldnn_deterministic = torch.backends.mkldnn.deterministic
+
+        with DeterministicGuard(False):
+            self.assertFalse(torch.are_deterministic_algorithms_enabled())
+
+            with torch.backends.mkldnn.flags(
+                enabled=None, deterministic=True, allow_tf32=False
+            ):
+                self.assertTrue(torch.backends.mkldnn.deterministic)
+                inp = torch.randn(513, 513, device=device, dtype=dtype)
+                first = torch.matmul(inp, inp)
+                for _ in range(10):
+                    self.assertEqual(first, torch.matmul(inp, inp), atol=0.0, rtol=0.0)
+
+            self.assertEqual(
+                torch.backends.mkldnn.deterministic, original_mkldnn_deterministic
+            )
+
     @dtypes(
         torch.int16,
         torch.int32,


### PR DESCRIPTION
## What this fixes

`ONEDNN_SUPPORT_DETERMINISTIC` in `aten/src/ATen/native/mkldnn/xpu/detail/Utils.h` gated the deterministic primitive attribute behind:

```cpp
(DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)
```

That predicate is wrong for oneDNN >= 4.0: `DNNL_VERSION_MINOR` resets to 0 on a major bump, so 4.0–4.3 (and any >= 5.x with minor < 4) evaluate the guard to **false** and the entire `set_deterministic(true)` block is compiled out. On those oneDNN builds, `torch.use_deterministic_algorithms(True)` / `torch.backends.mkldnn.deterministic = True` are **silently ignored** for XPU matmul and convolution.

The fix reuses the existing packed-version helper `DNNL_PREREQ(3, 4, 0)` (already used across `aten/src/ATen/native/mkldnn/`), which compares major/minor/patch as a single packed integer and is correct across major-version bumps.

## Why this is the CUDA-aligned behavior (re: the prior review)

The runtime gate is intentionally kept:

```cpp
if (at::globalContext().deterministicAlgorithms() ||
    at::globalContext().deterministicMkldnn())
  pattr.set_deterministic(true);
```

This mirrors how CUDA actually implements determinism — it is **flag-gated, not unconditional**:

- `aten/src/ATen/native/Convolution.cpp`:
  `bool deterministic = ctx.deterministicCuDNN() || ctx.deterministicAlgorithms();`
- `aten/src/ATen/native/cudnn/Conv_v8.cpp` (`filterEngineConfigs`): cuDNN only filters out `CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC` engine configs **when `deterministic == true`**.

So on CUDA, convolution is free to choose non-deterministic kernels by default and restricts to deterministic algorithms only when the flag is set. After this fix, XPU oneDNN follows the same contract.

The previous attempt removed the gate and called `set_deterministic(true)` unconditionally, justified by the observation that CUDA produced bitwise-equal results for the specific shapes in intel/torch-xpu-ops#3216. That observation is incidental (cuDNN happened to pick a deterministic plan for those sizes); CUDA does **not** force determinism unconditionally, so the unconditional change did not match CUDA's actual mechanism. Fixing the version gate while keeping the flag check is the behavior that is actually backed by the CUDA code paths above.

## Tests

- `test/xpu/test_gemm.py::TestBasicGEMM::test_matmul_mkldnn_deterministic_flag` — exercises `torch.backends.mkldnn.deterministic` and asserts run-to-run reproducibility, independent of the global deterministic-algorithms flag.
- `test/xpu/test_conv.py::TestConvolutionNNDeviceType::test_conv2d_deterministic_mode` — asserts conv2d is reproducible run-to-run under `DeterministicGuard(True)`.

## Validation run here

- `python -m compileall test/xpu/test_gemm.py test/xpu/test_conv.py`
- `git diff --check`

Runtime XPU execution was not run in this workspace (no in-tree build present); the XPU CI lane should exercise the new tests.

Addresses intel/torch-xpu-ops#3216.
