### PR TITLE
Improved common device test module for xpu

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -5684,7 +5684,7 @@ else:
 if TEST_XPU:
     device_types += ("xpu", )
 
-instantiate_device_type_tests(TestTransformers, globals(), only_for=device_types)
+instantiate_device_type_tests(TestTransformers, globals(), only_for=device_types, allow_xpu=False)
 instantiate_device_type_tests(TestSDPAFailureModes, globals(), only_for=device_types, allow_mps=True)
 instantiate_device_type_tests(TestSDPA, globals(), only_for=device_types, allow_mps=True, allow_xpu=True)
 instantiate_device_type_tests(TestSDPACudaOnly, globals(), only_for=("cuda"))

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1101,7 +1101,7 @@ def instantiate_device_type_tests(
     only_for=None,
     include_lazy=False,
     allow_mps=False,
-    allow_xpu=False,
+    allow_xpu=None,
 ):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
@@ -1109,6 +1109,9 @@ def instantiate_device_type_tests(
 
     generic_members = set(generic_test_class.__dict__.keys())
     generic_tests = [x for x in generic_members if x.startswith("test")]
+    allow_xpu = (
+        allow_xpu if isinstance(allow_xpu, bool) else (only_for and "xpu" in only_for)
+    )
 
     # Creates device-specific test cases
     for base in get_desired_device_type_test_bases(
@@ -1736,7 +1739,7 @@ class expectedFailure:
 
 
 class onlyOn:
-    def __init__(self, device_type: str | list):
+    def __init__(self, device_type: str | Iterable[str]):
         self.device_type = device_type
 
     def __call__(self, fn):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1095,13 +1095,13 @@ def get_desired_device_type_test_bases(
 # See note "Writing Test Templates"
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
 def instantiate_device_type_tests(
-    generic_test_class:Type[TestCase],
-    scope:dict,
-    except_for:Optional[Iterable]=None,
-    only_for:Optional[Iterable]=None,
-    include_lazy:bool=False,
-    allow_mps:Optional[bool]=None,
-    allow_xpu:Optional[bool]=None,
+    generic_test_class: Type[TestCase],
+    scope: dict,
+    except_for: Optional[Iterable] = None,
+    only_for: Optional[Iterable] = None,
+    include_lazy: bool = False,
+    allow_mps: Optional[bool] = None,
+    allow_xpu: Optional[bool] = None,
 ):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, Optional, Type, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -1095,13 +1095,13 @@ def get_desired_device_type_test_bases(
 # See note "Writing Test Templates"
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
 def instantiate_device_type_tests(
-    generic_test_class,
-    scope,
-    except_for=None,
-    only_for=None,
+    generic_test_class:Type[TestCase],
+    scope:dict,
+    except_for:Optional[Iterable]=None,
+    only_for:Optional[Iterable]=None,
     include_lazy=False,
-    allow_mps=False,
-    allow_xpu=None,
+    allow_mps:Optional[bool]=None,
+    allow_xpu:Optional[bool]=None,
 ):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
@@ -1109,6 +1109,9 @@ def instantiate_device_type_tests(
 
     generic_members = set(generic_test_class.__dict__.keys())
     generic_tests = [x for x in generic_members if x.startswith("test")]
+    allow_mps = (
+        allow_mps if isinstance(allow_mps, bool) else (only_for and "mps" in only_for)
+    )
     allow_xpu = (
         allow_xpu if isinstance(allow_xpu, bool) else (only_for and "xpu" in only_for)
     )

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, ClassVar, Optional, Type, TypeVar
+from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -1095,13 +1095,13 @@ def get_desired_device_type_test_bases(
 # See note "Writing Test Templates"
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
 def instantiate_device_type_tests(
-    generic_test_class: Type[TestCase],
+    generic_test_class: type[TestCase],
     scope: dict,
-    except_for: Optional[Iterable] = None,
-    only_for: Optional[Iterable] = None,
+    except_for: Iterable | None = None,
+    only_for: Iterable | None = None,
     include_lazy: bool = False,
-    allow_mps: Optional[bool] = None,
-    allow_xpu: Optional[bool] = None,
+    allow_mps: bool | None = None,
+    allow_xpu: bool | None = None,
 ):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1099,7 +1099,7 @@ def instantiate_device_type_tests(
     scope:dict,
     except_for:Optional[Iterable]=None,
     only_for:Optional[Iterable]=None,
-    include_lazy=False,
+    include_lazy:bool=False,
     allow_mps:Optional[bool]=None,
     allow_xpu:Optional[bool]=None,
 ):


### PR DESCRIPTION
# Description
Current instantiate_device_type_tests method has overlapped parameters to control XPU test. With this PR changes we don't need to set allow_xpu to True when only_for contains "xpu".

# Changes
Automatic set the allow_xpu when only_for xpu contains the key word "xpu"
Update the onlyOn type definition


# Notify
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @ezyang @chenyang78 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @ipiszy @muchulee8 @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey