### PR TITLE
Update stale pytorch/functorch URLs in vmap error messages

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -180,7 +180,7 @@ static std::tuple<Tensor, std::optional<int64_t>> masked_select_batch_rule(
       "vmap: Attempted to vmap over `mask` in torch.masked_select(self, mask) ",
       "We cannot support this because for each batch this would return a ",
       "differently shaped Tensor. "
-      "Please voice your support in https://github.com/pytorch/functorch/issues/256");
+      "Please file an issue at https://github.com/pytorch/pytorch/issues if you need this feature.");
   auto self_ = moveBatchDimToFront(self, self_bdim);
   const auto batch_size = self_.size(0);
   const auto self_logical_rank = rankWithoutBatchDim(self, self_bdim);
@@ -200,7 +200,7 @@ static std::tuple<Tensor, std::optional<int64_t>> masked_select_backward_batch_r
       "vmap: Attempted to vmap over `mask` in torch.masked_select_backward(grad, self, mask) ",
       "We cannot support this because for each batch this would return a ",
       "differently shaped Tensor. "
-      "Please voice your support in https://github.com/pytorch/functorch/issues/256");
+      "Please file an issue at https://github.com/pytorch/pytorch/issues if you need this feature.");
   auto self_ = moveBatchDimToFront(self, self_bdim);
   auto grad_ = moveBatchDimToFront(grad, grad_bdim);
 

--- a/aten/src/ATen/functorch/BatchRulesDynamic.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDynamic.cpp
@@ -21,7 +21,8 @@ namespace {
 void unsupportedDynamicOp(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
     TORCH_CHECK(false, "vmap: We do not support batching operators that can output dynamic shape. ",
         "Attempted to vmap over ", op.schema().operator_name(), ". ",
-        "Please voice your support in https://github.com/pytorch/functorch/issues/256");
+        "Please file an issue at https://github.com/pytorch/pytorch/issues ",
+        "if you need this feature.");
 }
 #define UNSUPPORTED_DYNAMIC(op) \
     m.impl(#op, torch::CppFunction::makeFromBoxedFunction<&unsupportedDynamicOp>());
@@ -34,9 +35,8 @@ void unsupportedLocalScalarDense(const c10::OperatorHandle& op, torch::jit::Stac
         "(3) encountering this error in PyTorch internals. ",
         "For (1): we don't support vmap over calling .item() on a Tensor, please try to ",
         "rewrite what you're doing with other operations. ",
-        "For (2): If you're doing some ",
-        "control flow instead, we don't support that yet, please shout over at ",
-        "https://github.com/pytorch/functorch/issues/257 . ",
+        "For (2): we don't support data-dependent control flow in vmap yet, ",
+        "please file an issue at https://github.com/pytorch/pytorch/issues . ",
         "For (3): please file an issue.");
 }
 
@@ -52,14 +52,14 @@ void unsupportedIsNonzero(const c10::OperatorHandle& op, torch::jit::Stack* stac
     TORCH_CHECK(false,
         "vmap: It looks like you're attempting to use a Tensor in some ",
         "data-dependent control flow. ",
-        "We don't support that yet, please shout over at ",
-        "https://github.com/pytorch/functorch/issues/257 .");
+        "We don't support that yet, please file an issue at ",
+        "https://github.com/pytorch/pytorch/issues .");
 }
 
 void unsupportedAllclose(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
     TORCH_CHECK(false,
-        "vmap over torch.allclose isn't supported yet. Please voice your ",
-        "support over at github.com/pytorch/functorch/issues/275");
+        "vmap over torch.allclose isn't supported yet. Please file an issue ",
+        "at https://github.com/pytorch/pytorch/issues if you need this feature.");
 }
 }
 


### PR DESCRIPTION
The pytorch/functorch repository has been archived and merged into
pytorch/pytorch. Error messages in BatchRulesDynamic.cpp and
BatchRulesBinaryOps.cpp still pointed users to dead issue URLs on
the old repo (issues #256, #257, #275).

Update all six references to point to https://github.com/pytorch/pytorch/issues
with actionable guidance, so users land on the active issue tracker.

Fixes https://github.com/pytorch/pytorch/issues/186301

Test Plan:
No runtime behavior change -- only error message strings updated.
Verified by grep that no pytorch/functorch URLs remain in the
functorch directory:
`
grep -r 'pytorch/functorch' aten/src/ATen/functorch/
`

Co-authored-by: AI assistant
