### PR TITLE
Fix torch.kron crash on non-contiguous inputs

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3491,8 +3491,8 @@ struct KronImpl final {
         b_reshape[2 * i + 1] = (i >= pad_other ? other.sizes()[i - pad_other] : 1);
         result_reshape[i] = a_reshape[2 * i] * b_reshape[2 * i + 1];
       }
-      self_view = at::_unsafe_view(self, a_reshape);
-      other_view = at::_unsafe_view(other, b_reshape);
+      self_view = self.reshape(a_reshape);
+      other_view = other.reshape(b_reshape);
     }
 
     Tensor& kron_out(Tensor& result) const {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1230,6 +1230,35 @@ class TestLinalg(TestCase):
         shapes = [(4,), (2, 2), (1, 2, 3), (1, 2, 3, 3)]
         for a_shape, b_shape in itertools.product(shapes, reversed(shapes)):
             run_test_case(a_shape, b_shape)
+    @dtypes(*floating_and_complex_types())
+    def test_kron_non_contiguous(self, device, dtype):
+        a = torch.rand(3, 4, dtype=dtype, device=device)
+        b = torch.rand(4, 3, dtype=dtype, device=device)
+
+        # transposed (non-contiguous) inputs
+        result = torch.kron(a, b.t())
+        expected = torch.kron(a, b.t().contiguous())
+        self.assertEqual(result, expected)
+
+        result = torch.kron(a.t(), b)
+        expected = torch.kron(a.t().contiguous(), b)
+        self.assertEqual(result, expected)
+
+        # both non-contiguous
+        result = torch.kron(a.t(), b.t())
+        expected = torch.kron(a.t().contiguous(), b.t().contiguous())
+        self.assertEqual(result, expected)
+
+        # sliced (non-contiguous) inputs
+        c = torch.rand(6, 4, dtype=dtype, device=device)
+        result = torch.kron(c[::2], b)
+        expected = torch.kron(c[::2].contiguous(), b)
+        self.assertEqual(result, expected)
+
+        # out= variant with non-contiguous inputs
+        out = torch.empty_like(expected)
+        torch.kron(c[::2], b, out=out)
+        self.assertEqual(out, expected)
 
     @dtypes(*floating_and_complex_types())
     def test_kron_empty(self, device, dtype):


### PR DESCRIPTION
This commit fixes a RuntimeError where `torch.kron` crashes on non-contiguous inputs with "view size is not compatible with input tensor's size and stride".

Root Cause:
The implementation was using `at::_unsafe_view` which requires the tensor to be contiguous or viewable without copying. When passed a non-contiguous tensor (e.g. transposed or sliced), `_unsafe_view` fails because it cannot reshape the tensor in-place without copy.

Fix:
Replaced `at::_unsafe_view` with `.reshape()`, which returns a view when possible and a copy (new contiguous tensor) when necessary. This resolves the crash and correctly computes the Kronecker product for non-contiguous inputs.

Test Plan:
Run the newly added tests targeting non-contiguous inputs:
```bash
python test/test_linalg.py -k test_kron_non_contiguous
```

Disclosed: This PR was authored with an AI assistant.
