### PR TITLE
xpu: make oneDNN matmul deterministic by default; fix determinism version gate

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -188,10 +188,14 @@ sycl::event matmul(
   dnnl::primitive_attr pattr;
   pattr.set_post_ops(po);
 
+  // mm/addmm/linear are deterministic ops in PyTorch: they carry no
+  // nondeterministic alert or reproducibility note, and on CUDA cuBLAS GEMM is
+  // deterministic regardless of use_deterministic_algorithms(). Request a
+  // deterministic oneDNN implementation unconditionally so XPU matmul is
+  // reproducible by default and consistent with CUDA. See
+  // intel/torch-xpu-ops#3216.
 #if ONEDNN_SUPPORT_DETERMINISTIC
-  if (at::globalContext().deterministicAlgorithms() ||
-      at::globalContext().deterministicMkldnn())
-    pattr.set_deterministic(true);
+  pattr.set_deterministic(true);
 #endif
 
   // scratchpad

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -515,10 +515,11 @@ sycl::event scaled_matmul(
 
   dnnl::primitive_attr op_attr = dnnl::primitive_attr();
 
+  // Scaled matmul is part of the matmul family and is deterministic by
+  // default, matching CUDA. See the rationale in Matmul.cpp and
+  // intel/torch-xpu-ops#3216.
 #if ONEDNN_SUPPORT_DETERMINISTIC
-  if (at::globalContext().deterministicAlgorithms() ||
-      at::globalContext().deterministicMkldnn())
-    op_attr.set_deterministic(true);
+  op_attr.set_deterministic(true);
 #endif
 
   std::vector<int64_t> default_groups;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -15,8 +15,14 @@
 
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 
+// oneDNN exposes primitive_attr::set_deterministic() since v3.4. Compare the
+// full version so this stays correct across major bumps: a raw
+// "DNNL_VERSION_MINOR >= 4" check wrongly evaluates to false on oneDNN >= 4.0
+// (the minor number resets on a major bump) and would silently drop
+// deterministic support.
 #define ONEDNN_SUPPORT_DETERMINISTIC \
-  (DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)
+  ((DNNL_VERSION_MAJOR > 3) ||       \
+   (DNNL_VERSION_MAJOR == 3 && DNNL_VERSION_MINOR >= 4))
 
 namespace at::native::onednn {
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
@@ -121,11 +121,11 @@ void woq_matmul_int4_impl(
 
   dnnl::primitive_attr pattr;
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+  // Weight-only-quantized matmul is part of the matmul family and is
+  // deterministic by default, matching CUDA. See the rationale in Matmul.cpp
+  // and intel/torch-xpu-ops#3216.
 #if ONEDNN_SUPPORT_DETERMINISTIC
-  if (at::globalContext().deterministicAlgorithms() ||
-      at::globalContext().deterministicMkldnn()) {
-    pattr.set_deterministic(true);
-  }
+  pattr.set_deterministic(true);
 #endif
 
   // Set scales with multiple scales along K dimension and with groups along  K.
@@ -230,11 +230,10 @@ void woq_matmul_int4_impl_cache(
 
     set_quant_primitive_attr(pattr, scale, zp, group_size);
 
+    // Weight-only-quantized matmul is deterministic by default, matching CUDA.
+    // See the rationale in Matmul.cpp and intel/torch-xpu-ops#3216.
 #if ONEDNN_SUPPORT_DETERMINISTIC
-    if (at::globalContext().deterministicAlgorithms() ||
-        at::globalContext().deterministicMkldnn()) {
-      pattr.set_deterministic(true);
-    }
+    pattr.set_deterministic(true);
 #endif
   };
 

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_dtype import floating_types_and
 from torch.testing._internal.common_nn import _test_module_empty_input, NNTestCase
 from torch.testing._internal.common_utils import (
+    DeterministicGuard,
     dtype2prec_DONTUSE,
     gradcheck,
     gradgradcheck,
@@ -1400,6 +1401,20 @@ class TestConvolutionNNDeviceType(NNTestCase):
             enabled=None, deterministic=None, allow_tf32=True
         ):
             self.assertTrue(torch.backends.mkldnn.allow_tf32)
+
+    @onlyXPU
+    @dtypes(torch.float32, torch.bfloat16)
+    def test_conv2d_deterministic_mode(self, device, dtype):
+        # intel/torch-xpu-ops#3216: convolution stays flag-gated (matching
+        # CUDA cuDNN), but when deterministic algorithms are requested the
+        # oneDNN convolution primitive must engage a deterministic
+        # implementation and produce reproducible results run-to-run.
+        with DeterministicGuard(True):
+            x = torch.randn(2, 4, 16, 16, device=device, dtype=dtype)
+            w = torch.randn(8, 4, 3, 3, device=device, dtype=dtype)
+            first = F.conv2d(x, w, padding=1)
+            for _ in range(10):
+                self.assertEqual(first, F.conv2d(x, w, padding=1), atol=0.0, rtol=0.0)
 
 
 instantiate_device_type_tests(

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -880,6 +880,28 @@ class TestBasicGEMM(TestCase):
             for _ in range(10):
                 self.assertEqual(first, torch.matmul(inp, inp), atol=0.0, rtol=0.0)
 
+    @dtypes(torch.float32, torch.bfloat16)
+    def test_matmul_deterministic_by_default(self, device, dtype):
+        # intel/torch-xpu-ops#3216: mm/addmm/linear must produce identical
+        # results regardless of use_deterministic_algorithms(), matching CUDA
+        # where cuBLAS GEMM is deterministic by default. The XPU oneDNN backend
+        # requests a deterministic implementation unconditionally for the
+        # matmul family, so toggling the flag must not change the output.
+        a = torch.randn(13, 512, device=device, dtype=dtype)
+        b = torch.randn(512, 64, device=device, dtype=dtype)
+        c = torch.randn(13, 64, device=device, dtype=dtype)
+        w = torch.randn(128, 512, device=device, dtype=dtype)
+        for op, args in (
+            (torch.mm, (a, b)),
+            (torch.addmm, (c, a, b)),
+            (torch.nn.functional.linear, (a, w)),
+        ):
+            with DeterministicGuard(False):
+                out_nondet = op(*args)
+            with DeterministicGuard(True):
+                out_det = op(*args)
+            self.assertEqual(out_det, out_nondet, atol=0.0, rtol=0.0)
+
     @dtypes(
         torch.int16,
         torch.int32,


### PR DESCRIPTION
## Summary

Fixes intel/torch-xpu-ops#3216 (`mm`, `addmm`, `linear`, `convolution` on XPU produce different results with `use_deterministic_algorithms(True)` vs `(False)`, unlike CUDA).

This PR resolves the issue per-operation, based on **PyTorch's own determinism classification** and the **actual CUDA code paths**, rather than on the incidental observation that CUDA happened to produce bitwise-equal results for the shapes in the issue.

## Why the per-op split (addressing the previous review)

A prior attempt (#184565) made `set_deterministic(true)` unconditional for *every* XPU oneDNN primitive, justified by "CUDA produced equal results". That was rejected as not solid: it matched a CUDA *observation* without showing that CUDA *forces* determinism. It does not — CUDA's behavior differs by op:

**matmul family (`mm` / `addmm` / `linear`, and the quantized variants)**
- PyTorch does **not** classify these as nondeterministic: they have no `alertNotDeterministic` call and no reproducibility note.
- On CUDA they are deterministic by default: `aten/src/ATen/native/cuda/Blas.cpp` (cuBLAS / cuBLASLt / tunable GEMM) never consults `deterministicAlgorithms()` — the flag does not change GEMM.
- Therefore the matmul family should be deterministic by default on XPU too. This PR drops the runtime flag check and calls `set_deterministic(true)` unconditionally (still inside the oneDNN-version guard) in `Matmul.cpp`, `QMatmul.cpp`, and `WoQMatmul.cpp`.

**convolution / deconvolution**
- PyTorch explicitly documents conv as possibly nondeterministic and flag-gated: `conv1d/2d/3d` carry `cudnn_reproducibility_note` ("CuDNN may select a nondeterministic algorithm... set `torch.backends.cudnn.deterministic = True`").
- On CUDA it is flag-gated: `aten/src/ATen/native/Convolution.cpp` sets `deterministic = ctx.deterministicCuDNN() || ctx.deterministicAlgorithms()`, and `cudnn/Conv_v8.cpp::filterEngineConfigs` only removes `CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC` engines when `deterministic == true`.
- So XPU conv/deconv **correctly remain flag-gated** (`Conv.cpp`, `Deconv.cpp` unchanged). The CUDA conv result being bitwise-equal in the issue is incidental to those shapes, not a contract — forcing XPU conv unconditionally would make XPU *stricter* than CUDA.

## Latent bug also fixed

`ONEDNN_SUPPORT_DETERMINISTIC` was `(DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)`, which is **false on oneDNN >= 4.0** (the minor number resets on a major bump). On such builds the entire `set_deterministic` block was compiled out, so even an explicit `use_deterministic_algorithms(True)` / `torch.backends.mkldnn.deterministic = True` was silently ignored for XPU. The guard now compares the full version and stays correct across major bumps.

## Tests

- `test/xpu/test_gemm.py::TestBasicGEMM::test_matmul_deterministic_by_default` — `mm`/`addmm`/`linear` give identical output for `det=False` vs `det=True` (the issue's invariant for the matmul family).
- `test/xpu/test_conv.py::TestConvolutionNNDeviceType::test_conv2d_deterministic_mode` — under `DeterministicGuard(True)`, conv2d is reproducible run-to-run (exercises the flag path the version-gate bug used to disable).

## Validation performed here

- `python -m compileall test/xpu/test_gemm.py test/xpu/test_conv.py`
- `git diff --check`

Runtime XPU execution was not run in this workspace (no in-tree build); the XPU CI lane should exercise the new tests.

Fixes: intel/torch-xpu-ops#3216


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01