### PR TITLE
[Accelerator] Replace hardcoded CUDA fallback in _snapshot with explicit dispatch

### DIFF
--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -263,10 +263,17 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
         dict: a dictionary containing memory allocator state information.
     """
     acc = torch.accelerator.current_accelerator()
-    if acc is not None and acc.type == "xpu":
-        return torch.xpu.memory._snapshot(
-            device, augment_with_fx_traces=augment_with_fx_traces
-        )
-    return torch.cuda.memory._snapshot(
-        device, augment_with_fx_traces=augment_with_fx_traces
+    if acc is not None:
+        if acc.type == "xpu":
+            return torch.xpu.memory._snapshot(
+                device, augment_with_fx_traces=augment_with_fx_traces
+            )
+        elif acc.type == "cuda":
+            return torch.cuda.memory._snapshot(
+                device, augment_with_fx_traces=augment_with_fx_traces
+            )
+
+    raise RuntimeError(
+        f"Memory snapshots are not supported on accelerator: "
+        f"{getattr(acc, 'type', 'None')}"
     )


### PR DESCRIPTION
### Summary
`torch.accelerator.memory._snapshot()` currently handles `acc.type == "xpu"`, but unconditionally falls through to `torch.cuda.memory._snapshot()` for all other cases. 

This causes an `AttributeError` on non-CUDA, non-XPU backends (like `mps` or CPU-only builds) instead of failing gracefully, breaking the device-agnostic contract of `torch.accelerator`.

**Fix:** Add an explicit `elif acc.type == "cuda"` branch and raise a clean, informative `RuntimeError` for unsupported accelerators.

*(Split from #186269 as requested by @guangyey)*

---

### Files Changed

- `torch/accelerator/memory.py`

---

### Related

Ref #186265

cc @guangyey