### PR TITLE
Enable FA build for SDPA on Windows+CUDA

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -198,6 +198,12 @@ if [[ "$(uname)" != Darwin ]]; then
 EOL
 fi
 
+if [[ "${OS:-}" == windows && "$DESIRED_CUDA" == cu* ]]; then
+  # FlashAttention TUs are compiled once per arch in TORCH_CUDA_ARCH_LIST and each
+  # nvcc invocation is memory-hungry, so bound this target instead of MAX_JOBS.
+  echo "export FLASH_ATTENTION_MAX_JOBS=\"${FLASH_ATTENTION_MAX_JOBS:-4}\"" >> "$envfile"
+fi
+
 echo 'retry () {' >> "$envfile"
 echo '    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)' >> "$envfile"
 echo '}' >> "$envfile"

--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -167,13 +167,8 @@ if [[ "$(uname)" != Darwin ]]; then
   MEMORY_LIMIT_MAX_JOBS=12
   NUM_CPUS=$(( $(nproc) - 2 ))
 
-  if [[ "$(uname)" == Linux ]]; then
-    # Defaults here for **binary** linux builds so they can be changed in one place
-    export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
-  else
-    # For other builds
-    export MAX_JOBS=${NUM_CPUS}
-  fi
+  # Cap applies to all Linux and Windows binary builds since they both compile FlashAttentionV2
+  export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
 
   cat >>"$envfile" <<EOL
   export MAX_JOBS="${MAX_JOBS}"

--- a/.ci/pytorch/win-build.sh
+++ b/.ci/pytorch/win-build.sh
@@ -15,6 +15,8 @@ source "$SCRIPT_PARENT_DIR/common.sh"
 # shellcheck source=./common-build.sh
 source "$SCRIPT_PARENT_DIR/common-build.sh"
 
+export FLASH_ATTENTION_MAX_JOBS="${FLASH_ATTENTION_MAX_JOBS:-2}"
+
 export TMP_DIR="${PWD}/build/win_tmp"
 TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")
 export TMP_DIR_WIN

--- a/.ci/pytorch/win-build.sh
+++ b/.ci/pytorch/win-build.sh
@@ -15,7 +15,7 @@ source "$SCRIPT_PARENT_DIR/common.sh"
 # shellcheck source=./common-build.sh
 source "$SCRIPT_PARENT_DIR/common-build.sh"
 
-export FLASH_ATTENTION_MAX_JOBS="${FLASH_ATTENTION_MAX_JOBS:-2}"
+export FLASH_ATTENTION_MAX_JOBS="${FLASH_ATTENTION_MAX_JOBS:-4}"
 
 export TMP_DIR="${PWD}/build/win_tmp"
 TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -985,7 +985,7 @@ cmake_dependent_option(
   "Whether to build the flash_attention kernel for scaled dot product attention.\
   Will be disabled if not supported by the platform"
   ON
-  "(USE_CUDA AND NOT MSVC) OR USE_ROCM"
+  "USE_CUDA OR USE_ROCM"
   OFF)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1057,7 +1057,7 @@ cmake_dependent_option(
   "Whether to build the flash_attention kernel for scaled dot product attention.\
   Will be disabled if not supported by the platform"
   ON
-  "(USE_CUDA AND NOT MSVC) OR USE_ROCM"
+  "USE_CUDA OR USE_ROCM"
   OFF)
 
 # Flash Attention needs sm80+; disable it if no resolved arch reaches that.

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -352,6 +352,10 @@ if(USE_CUDA AND (USE_FLASH_ATTENTION OR USE_MEM_EFF_ATTENTION))
     UNFUSE_FMA
   )
 
+  if(MSVC)
+    target_compile_definitions(flash_attention PRIVATE _USE_MATH_DEFINES)
+  endif()
+
   set_target_properties(flash_attention PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
   if(FLASH_ATTENTION_MAX_JOBS)

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -337,6 +337,11 @@ file(GLOB mem_eff_attention_cuda_cpp CONFIGURE_DEPENDS "native/transformers/cuda
 if(USE_CUDA AND (USE_FLASH_ATTENTION OR USE_MEM_EFF_ATTENTION))
   add_library(flash_attention OBJECT EXCLUDE_FROM_ALL ${flash_attention_cuda_kernels_cu} ${flash_attention_cuda_cpp})
 
+  if(WIN32)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS flash_attention_compile=2)
+    set_property(TARGET flash_attention PROPERTY JOB_POOL_COMPILE flash_attention_compile)
+  endif()
+
   target_include_directories(flash_attention SYSTEM PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc
     ${PROJECT_SOURCE_DIR}/third_party/flash-attention/include

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -166,7 +166,7 @@ def evaluate_platform_supports_flash_attention():
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
-        return not IS_WINDOWS and SM80OrLater
+        return SM80OrLater
     if TEST_XPU:
         return True
     return False

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -126,7 +126,7 @@ def evaluate_platform_supports_flash_attention():
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
-        return not IS_WINDOWS and SM80OrLater
+        return SM80OrLater
     if TEST_XPU:
         return True
     return False


### PR DESCRIPTION
## Summary

### Description
Enable building the FlashAttention backend for scaled_dot_product_attention on Windows + CUDA (MSVC). Today, the flag is hard-disabled on MSVC, so every Windows CUDA build ships without the flash SDPA backend and silently falls back to slower, memory-heavy backends. With this PR, the FlashAttention kernels now build cleanly under modern MSVC, which restores the fast path.

### Why this matters
On Windows today, SDPA has no FlashAttention backend. For GQA models, which include most modern LLMs, the memory-efficient backend is not eligible either because it does not support grouped-query attention. As a result, SDPA falls back to the math backend, which materializes the full N×N attention matrix and is much slower and more memory-intensive.

### Changes Made
* Remove the gating for Windows + CUDA for attempting to build FlashAttention2 kernels
* Whitelist Windows as a platform that supports flash_attention

### Validation
With the test gate enabled, the Flash SDPA correctness test now runs successfully on Windows. This validates Flash attention forward and backward results against the math reference implementation.

### Profiling

Benchmarked SDPA forward and backward performance using CUDA events. Forward and backward were measured separately with 5 warm-up runs followed by 100 timed runs.

Benchmark configuration: B=4, 16 Q heads / 8 KV heads, GQA, seq=2048, head_dim=128, causal, bf16.
| Backend | Forward latency | Backward latency |
|---|---:|---:|
| Native Flash SDPA — this PR | **0.494 ± 0.024 ms** | **1.379 ± 0.062 ms** |
| External `flash-attn` package — 2.8.4 | 0.531 ± 0.007 ms | 1.388 ± 0.062 ms |
| Math SDPA — current Windows fallback | 11.482 ± 0.129 ms | 13.194 ± 0.141 ms |

These results show that the native Flash SDPA path introduced in this PR matches the performance of the external `flash-attn` package and is significantly faster than the current default Windows SDPA math fallback.

### Build Specs
* OS: Windows 11
* Compiler: Visual Studio 2022
* CUDA: 13.0
* GPU: NVIDIA RTX 5090
* Architecture: sm_120

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv @drisspg @liangel-02 @howardzhang-cv