### PR TITLE
[WIP][Test] Add hardware requirement classification for test classes

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1801,6 +1801,26 @@ exclude_patterns = [
     'test/cpython/**',
 ]
 
+# Initial rollout of hardware requirement enforcement. Start with a small
+# set of test files and expand coverage incrementally as existing tests are
+# migrated.
+[[linter]]
+code = 'TEST_HARDWARE_REQUIREMENT'
+command = [
+    'python3',
+    'tools/linter/adapters/test_hardware_requirement_linter.py',
+    '--',
+    '@{{PATHSFILE}}',
+]
+include_patterns = [
+    'test/profiler/test*.py',
+    'test/profiler/*_test.py',
+]
+exclude_patterns = [
+    'test/profiler/test_profiler.py',
+]
+is_formatter = false
+
 # 'header_only_linter' reports on properly testing header-only APIs.
 [[linter]]
 code = 'HEADER_ONLY_LINTER'

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1801,9 +1801,7 @@ exclude_patterns = [
     'test/cpython/**',
 ]
 
-# Initial rollout of hardware requirement enforcement. Start with a small
-# set of test files and expand coverage incrementally as existing tests are
-# migrated.
+# Check that test classes explicitly declare hardware_requirement.
 [[linter]]
 code = 'TEST_HARDWARE_REQUIREMENT'
 command = [
@@ -1813,11 +1811,8 @@ command = [
     '@{{PATHSFILE}}',
 ]
 include_patterns = [
-    'test/profiler/test*.py',
-    'test/profiler/*_test.py',
-]
-exclude_patterns = [
-    'test/profiler/test_profiler.py',
+    'test/**/test_*.py',
+    'test/**/*_test.py',
 ]
 is_formatter = false
 

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -10,7 +10,12 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
     skipXPUIf,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+    TestHardwareRequirement,
+)
 
 
 if is_fbcode():
@@ -76,6 +81,7 @@ class PythonProfilerEventHandler(cpp.ProfilerEventHandler):
 
 
 class CppThreadTest(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
     ThreadCount = 20  # set to 2 for debugging
     EventHandler = None
     TraceObject = None

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_utils import (
     TemporaryFileName,
     TEST_XPU,
     TestCase,
+    TestHardwareRequirement,
 )
 from torch.utils._triton import has_triton
 
@@ -58,6 +59,8 @@ Json = dict[str, Any]
 
 
 class TestExecutionTrace(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
+
     def payload(self, device, use_device=False):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with record_function("## TEST 1 ##", "1, 2, 3"):

--- a/test/profiler/test_kineto.py
+++ b/test/profiler/test_kineto.py
@@ -6,10 +6,16 @@ from unittest.mock import patch
 
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+    TestHardwareRequirement,
+)
 
 
 class SimpleKinetoInitializationTest(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
+
     @patch.dict(os.environ, {"KINETO_USE_DAEMON": "1"})
     def test_kineto_profiler_with_environment_variable(self, device):
         """

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     TestCase,
+    TestHardwareRequirement,
 )
 from torch.utils import _pytree as pytree
 
@@ -53,6 +54,8 @@ def _lookup_tensor_categories(
 
 @skipIfTorchDynamo("TorchDynamo removes profiler altogether.")
 class TestMemoryProfiler(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def test_config_check(self) -> None:
         with torch.profiler.profile() as prof:
             pass
@@ -132,6 +135,8 @@ class RecordInputOutputDispatchMode(torch.utils._python_dispatch.TorchDispatchMo
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestIdentifyGradients(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
+
     def gradient_detected(
         self,
         prof: torch.profiler.profile,
@@ -336,6 +341,8 @@ class TestIdentifyGradients(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo removes profiler altogether.")
 class TestDataFlow(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self.maxDiff = None
@@ -767,6 +774,8 @@ class TestDataFlow(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerE2E(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def _run_and_format_categories(self, fn, indent=12):
         """Generate summary of assigned categories for expecttest."""
 
@@ -1258,6 +1267,8 @@ class TestMemoryProfilerE2E(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerE2EDeviceType(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
+
     def _run_and_check_parameters_and_gradients(
         self, inner_fn, model, grads_none: bool = False
     ):
@@ -1486,6 +1497,8 @@ class TestMemoryProfilerE2EDeviceType(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerTimeline(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_GENERIC
+
     @skipXPUIf(
         True,
         "The XPU Profiler will not cover this case for now. Will support it in next period.",

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -11,10 +11,13 @@ from torch.testing._internal.common_utils import (
     skipIfPythonVersionMismatch,
     TemporaryFileName,
     TestCase,
+    TestHardwareRequirement,
 )
 
 
 class TestPythonTracer(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_method_with_c_function(self):
         class A:

--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -15,7 +15,11 @@ from torch.autograd import (
 )
 from torch.autograd.profiler import profile as _profile
 from torch.profiler import kineto_available, record_function
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+    TestHardwareRequirement,
+)
 
 
 # if tqdm is not shutdown properly, it will leave the monitor thread alive.
@@ -35,6 +39,8 @@ Json = dict[str, Any]
 
 
 class TestRecordFunction(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def _record_function_with_param(self):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with _profile(

--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
+    TestHardwareRequirement,
 )
 
 
@@ -62,6 +63,8 @@ class SimpleNet(nn.Module):
 
 
 class TestTorchTidyProfiler(TestCase):
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def _get_tensor_fields(self, node, index):
         self.assertIsNotNone(node)
         self.assertIsInstance(

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     TestCase,
+    TestHardwareRequirement,
 )
 
 
@@ -146,6 +147,8 @@ def _load_events(trace_path):
 class TestTraceValidatorRules(TestCase):
     """Synthetic tests for rules not exercised by real E2E payloads."""
 
+    hardware_requirement = TestHardwareRequirement.GENERIC
+
     def test_nccl_metadata_pass(self):
         events = [
             {
@@ -182,6 +185,7 @@ class TestTraceValidatorRules(TestCase):
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
 @instantiate_parametrized_tests
 class TestTraceValidatorE2E(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_SPECIFIC
     _trace_dir: str = ""
     _payloads: dict = {}
 

--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -9,13 +9,20 @@ from collections import defaultdict
 
 import torch
 from torch.profiler import DeviceType
-from torch.testing._internal.common_utils import run_tests, TEST_XPU, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_XPU,
+    TestCase,
+    TestHardwareRequirement,
+)
 
 
 Verbose = False
 
 
 class XpuProfilerTest(TestCase):
+    hardware_requirement = TestHardwareRequirement.DEVICE_SPECIFIC
+
     @unittest.skipIf(not TEST_XPU, "test requires XPU")
     def test_profiler(self):
         t = torch.empty(1000, dtype=torch.int, device="xpu")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -28,6 +28,7 @@ import torch.distributed as dist
 from torch.multiprocessing import current_process, get_context
 from torch.testing._internal.common_utils import (
     get_report_path,
+    HardwareRequirementChoices,
     IS_CI,
     IS_MACOS,
     IS_WINDOWS,
@@ -556,6 +557,10 @@ def run_test(
         unittest_args.extend(test_module.get_pytest_args())
         replacement = {"-f": "-x", "-dist=loadfile": "--dist=loadfile"}
         unittest_args = [replacement.get(arg, arg) for arg in unittest_args]
+
+    if options.hardware_requirement:
+        # forward hardware requirement filter to test subprocess
+        unittest_args += ["--hardware-requirement"] + options.hardware_requirement
 
     if options.showlocals:
         if options.pytest:
@@ -1487,6 +1492,14 @@ def parse_args():
         metavar="TESTS",
         help="select a set of tests to include (defaults to ALL tests)."
         " tests must be a part of the TESTS list defined in run_test.py",
+    )
+    parser.add_argument(
+        "--hardware-requirement",
+        nargs="+",
+        choices=HardwareRequirementChoices(),
+        default=None,
+        metavar="REQ",
+        help="filter tests by hardware requirement categories (e.g., GENERIC DEVICE_GENERIC)",
     )
     parser.add_argument(
         "-x",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2650,6 +2650,87 @@ class TestOpInfoSampleFunctions(TestCase):
         samples = op.error_inputs(device)
         self.assertIsInstance(samples, Iterator)
 
+# Tests hardware requirement classification.
+class TestHardwareRequirements(TestCase):
+    def setUp(self):
+        super().setUp()
+        import torch.testing._internal.common_utils as _cu
+
+        self._cu = _cu
+
+    def _suite_test_names(self, suite) -> set[str]:
+        return {test_case.id().split(".")[-1] for test_case in self._cu._iter_test_cases_recursively(suite)}
+
+    def test_filter_suite(self):
+        requirement = self._cu.TestHardwareRequirement
+
+        class GenericTest(TestCase):
+            hardware_requirement = requirement.GENERIC
+
+            def test_generic(self):
+                pass
+
+        class DeviceSpecificTest(TestCase):
+            hardware_requirement = requirement.DEVICE_SPECIFIC
+
+            def test_device_specific(self):
+                pass
+
+        class MultiDeviceGenericTest(TestCase):
+            hardware_requirement = requirement.MULTI_DEVICE_GENERIC
+
+            def test_multi_device_generic(self):
+                pass
+
+        class MissingRequirementTest(TestCase):
+            def test_missing_requirement(self):
+                pass
+
+        suite = unittest.TestSuite(
+            [
+                unittest.defaultTestLoader.loadTestsFromTestCase(GenericTest),
+                unittest.defaultTestLoader.loadTestsFromTestCase(DeviceSpecificTest),
+                unittest.defaultTestLoader.loadTestsFromTestCase(MultiDeviceGenericTest),
+                unittest.defaultTestLoader.loadTestsFromTestCase(MissingRequirementTest),
+            ]
+        )
+
+        with unittest.mock.patch.object(
+            self._cu,
+            "HARDWARE_REQUIREMENT",
+            {self._cu.TestHardwareRequirement.GENERIC,
+             self._cu.TestHardwareRequirement.MULTI_DEVICE_GENERIC},
+        ):
+            filtered_suite = self._cu._filter_suite_by_hardware_requirement(suite)
+
+        self.assertEqual(
+            self._suite_test_names(filtered_suite),
+            {"test_generic", "test_multi_device_generic"},
+        )
+
+    def test_filter_suite_uses_inherited_metadata(self):
+        requirement = self._cu.TestHardwareRequirement
+
+        class DeviceGenericBase(TestCase):
+            hardware_requirement = requirement.DEVICE_GENERIC
+
+        class DeviceGenericChild(DeviceGenericBase):
+            def test_inherited_requirement(self):
+                pass
+
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
+        with unittest.mock.patch.object(
+            self._cu,
+            "HARDWARE_REQUIREMENT",
+            {self._cu.TestHardwareRequirement.DEVICE_GENERIC},
+        ):
+            filtered_suite = self._cu._filter_suite_by_hardware_requirement(suite)
+
+        self.assertEqual(
+            self._suite_test_names(filtered_suite),
+            {"test_inherited_requirement"},
+        )
+
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)

--- a/tools/linter/adapters/test_hardware_requirement_config.json
+++ b/tools/linter/adapters/test_hardware_requirement_config.json
@@ -1,0 +1,10 @@
+{
+    "_description": "Coverage is intentionally incremental and should be expanded as existing tests are updated to declare hardware requirements.",
+    "include_patterns": [
+        "test/profiler/test*.py",
+        "test/profiler/*_test.py"
+    ],
+    "exclude_patterns": [
+        "test/profiler/test_profiler.py"
+    ]
+}

--- a/tools/linter/adapters/test_hardware_requirement_config.json
+++ b/tools/linter/adapters/test_hardware_requirement_config.json
@@ -5,6 +5,7 @@
         "test/profiler/*_test.py"
     ],
     "exclude_patterns": [
-        "test/profiler/test_profiler.py"
+        "test/profiler/test_profiler.py",
+        "test/profiler/test_profiler_tree.py"
     ]
 }

--- a/tools/linter/adapters/test_hardware_requirement_linter.py
+++ b/tools/linter/adapters/test_hardware_requirement_linter.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import multiprocessing as mp
+from enum import Enum
+from pathlib import Path
+from typing import NamedTuple
+
+
+LINTER_CODE = "TEST_HARDWARE_REQUIREMENT"
+
+HARDWARE_REQUIREMENT_ATTR = "hardware_requirement"
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: str | None
+    line: int | None
+    char: int | None
+    code: str
+    severity: LintSeverity
+    name: str
+    original: str | None
+    replacement: str | None
+    description: str | None
+
+
+def is_test_file(path: Path) -> bool:
+    return (
+        path.name == "test.py"
+        or path.name.startswith("test_")
+        or path.name.endswith("_test.py")
+    )
+
+
+def get_base_name(base: ast.expr) -> str | None:
+    # class XXX(TestCase)
+    # class XXX(YYYTestCase)
+    if isinstance(base, ast.Name):
+        return base.id
+    # class XXX(YYY.TestCase)
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    return None
+
+
+def is_test_case_class(node: ast.ClassDef) -> bool:
+    for base in node.bases:
+        base_name = get_base_name(base)
+        if base_name is not None and base_name.endswith("TestCase"):
+            return True
+    return False
+
+
+def has_hardware_requirement(node: ast.ClassDef) -> bool:
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == HARDWARE_REQUIREMENT_ATTR
+                ):
+                    return True
+        if isinstance(stmt, ast.AnnAssign):
+            target = stmt.target
+            if isinstance(target, ast.Name) and target.id == HARDWARE_REQUIREMENT_ATTR:
+                return True
+    return False
+
+
+def check_file(filename: str) -> list[LintMessage]:
+    path = Path(filename)
+    if not is_test_file(path):
+        return []
+
+    with open(path) as f:
+        tree = ast.parse(f.read(), filename=filename)
+
+    lint_messages = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or not is_test_case_class(node):
+            continue
+        if has_hardware_requirement(node):
+            continue
+
+        lint_messages.append(
+            LintMessage(
+                path=filename,
+                line=node.lineno,
+                char=None,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name=f"[{HARDWARE_REQUIREMENT_ATTR}]",
+                original=None,
+                replacement=None,
+                description=(
+                    f"Test class '{node.name}' must define a class-level "
+                    f"{HARDWARE_REQUIREMENT_ATTR} attribute."
+                ),
+            )
+        )
+
+    return lint_messages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ensure selected test suites declare hardware_requirement.",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument("filenames", nargs="+", help="paths to lint")
+    args = parser.parse_args()
+
+    with mp.Pool(8) as pool:
+        lint_messages = pool.map(check_file, args.filenames)
+
+    for lint_message in [item for sublist in lint_messages for item in sublist]:
+        print(json.dumps(lint_message._asdict()), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/linter/adapters/test_hardware_requirement_linter.py
+++ b/tools/linter/adapters/test_hardware_requirement_linter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import fnmatch
 import json
 import multiprocessing as mp
 from enum import Enum
@@ -14,6 +15,39 @@ from typing import NamedTuple
 LINTER_CODE = "TEST_HARDWARE_REQUIREMENT"
 
 HARDWARE_REQUIREMENT_ATTR = "hardware_requirement"
+
+_CONFIG_PATH = Path(__file__).resolve().parent / "test_hardware_requirement_config.json"
+
+
+def _load_config() -> dict:
+    if not _CONFIG_PATH.exists():
+        return {"include_patterns": [], "exclude_patterns": []}
+    with open(_CONFIG_PATH) as f:
+        return json.load(f)
+
+
+_CONFIG = _load_config()
+
+
+def _is_path_included(filepath: Path) -> bool:
+    """Check if filepath matches the rollout config's include/exclude patterns."""
+    s = str(filepath)
+    include = _CONFIG.get("include_patterns", [])
+    exclude = _CONFIG.get("exclude_patterns", [])
+
+    matched = False
+    for pattern in include:
+        if fnmatch.fnmatch(s, pattern):
+            matched = True
+            break
+    if not matched:
+        return False
+
+    for pattern in exclude:
+        if fnmatch.fnmatch(s, pattern):
+            return False
+
+    return True
 
 
 class LintSeverity(str, Enum):
@@ -80,7 +114,7 @@ def has_hardware_requirement(node: ast.ClassDef) -> bool:
 
 def check_file(filename: str) -> list[LintMessage]:
     path = Path(filename)
-    if not is_test_file(path):
+    if not is_test_file(path) or not _is_path_included(path):
         return []
 
     with open(path) as f:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -114,6 +114,14 @@ class ProfilingMode(Enum):
     SIMPLE = 2
     PROFILING = 3
 
+class TestHardwareRequirement(Enum):
+    # Class-level metadata describing the hardware requirements of a test.
+    GENERIC = "generic"
+    DEVICE_GENERIC = "device_generic"
+    DEVICE_SPECIFIC = "device_specific"
+    MULTI_DEVICE_GENERIC = "multi_device_generic"
+    MULTI_DEVICE_SPECIFIC = "multi_device_specific"
+
 # Set by parse_cmd_line_args() if called
 DISABLED_TESTS_FILE = ""
 GRAPH_EXECUTOR : ProfilingMode | None = None
@@ -130,6 +138,50 @@ TEST_IN_SUBPROCESS = False
 TEST_SAVE_XML = ""
 UNITTEST_ARGS : list[str] = []
 USE_PYTEST = False
+HARDWARE_REQUIREMENT : list[TestHardwareRequirement] | None = None
+
+
+def _iter_test_cases_recursively(
+    suite_or_case: unittest.TestSuite | unittest.TestCase,
+) -> Iterator[unittest.TestCase]:
+    if isinstance(suite_or_case, unittest.TestCase):
+        yield suite_or_case
+        return
+
+    for element in suite_or_case:
+        yield from _iter_test_cases_recursively(element)
+
+
+def _get_hardware_requirement(
+    test_case_cls: type[unittest.TestCase],
+) -> TestHardwareRequirement | None:
+    requirement = getattr(test_case_cls, "hardware_requirement", None)
+    if requirement is None:
+        return None
+
+    if not isinstance(requirement, TestHardwareRequirement):
+        raise TypeError(
+            f"{test_case_cls.__module__}.{test_case_cls.__name__}."
+            "hardware_requirement must be a TestHardwareRequirement"
+        )
+
+    return requirement
+
+
+def _filter_suite_by_hardware_requirement(tests: unittest.TestSuite) -> unittest.TestSuite:
+    if HARDWARE_REQUIREMENT is None:
+        return tests
+
+    filtered_suite = unittest.TestSuite()
+
+    for test_case in _iter_test_cases_recursively(tests):
+        requirement = _get_hardware_requirement(test_case.__class__)
+
+        if requirement is not None and requirement in HARDWARE_REQUIREMENT:
+            filtered_suite.addTest(test_case)
+
+    return filtered_suite
+
 
 def is_navi3_arch():
     if torch.cuda.is_available():
@@ -1006,6 +1058,7 @@ def parse_cmd_line_args():
     global TEST_SAVE_XML
     global UNITTEST_ARGS
     global USE_PYTEST
+    global HARDWARE_REQUIREMENT
 
     is_running_via_run_test = "run_test.py" in getattr(__main__, "__file__", "")
     parser = argparse.ArgumentParser(add_help=not is_running_via_run_test, allow_abbrev=False)
@@ -1027,6 +1080,7 @@ def parse_cmd_line_args():
     parser.add_argument('--rerun-disabled-tests', action='store_true')
     parser.add_argument('--pytest-single-test', type=str, nargs=1)
     parser.add_argument('--showlocals', action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument('--hardware-requirement', action='append', type=TestHardwareRequirement, choices=list(TestHardwareRequirement), default=None)
 
 # Only run when -h or --help flag is active to display both unittest and parser help messages.
     def run_unittest_help(argv):
@@ -1062,6 +1116,11 @@ def parse_cmd_line_args():
     TEST_SAVE_XML = args.save_xml
     REPEAT_COUNT = args.repeat
     SHOWLOCALS = args.showlocals
+    HARDWARE_REQUIREMENT = (
+        set(args.hardware_requirement)
+        if args.hardware_requirement is not None
+        else None
+    )
     if not getattr(expecttest, "ACCEPT", False):
         expecttest.ACCEPT = args.accept
     UNITTEST_ARGS = [sys.argv[0]] + remaining
@@ -1268,6 +1327,14 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
     return test_collector_plugin.tests
 
 
+class HardwareRequirementTestLoader(unittest.TestLoader):
+    def loadTestsFromModule(self, module, *args, pattern=None, **kwargs):
+        suite = super().loadTestsFromModule(
+            module, *args, pattern=pattern, **kwargs
+        )
+        return _filter_suite_by_hardware_requirement(suite)
+
+
 def run_tests(argv=None):
     parse_cmd_line_args()
     if argv is None:
@@ -1430,7 +1497,10 @@ def run_tests(argv=None):
             if not unittest.main(exit=False, argv=argv).result.wasSuccessful():
                 sys.exit(-1)
     else:
-        unittest.main(argv=argv)
+        if HARDWARE_REQUIREMENT is not None:
+            unittest.main(argv=argv, testLoader=HardwareRequirementTestLoader())
+        else:
+            unittest.main(argv=argv)
 
 IS_LINUX = sys.platform == "linux"
 IS_WINDOWS = sys.platform == "win32"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -122,6 +122,21 @@ class TestHardwareRequirement(Enum):
     MULTI_DEVICE_GENERIC = "multi_device_generic"
     MULTI_DEVICE_SPECIFIC = "multi_device_specific"
 
+
+class HardwareRequirementChoices(list):
+    """Custom choices list for --hardware-requirement argument.
+
+    Accepts case-insensitive enum names (e.g., 'GENERIC', 'device_specific').
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__([e.name for e in TestHardwareRequirement])
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            item = item.upper()
+        return list.__contains__(self, item)
+
+
 # Set by parse_cmd_line_args() if called
 DISABLED_TESTS_FILE = ""
 GRAPH_EXECUTOR : ProfilingMode | None = None
@@ -138,7 +153,7 @@ TEST_IN_SUBPROCESS = False
 TEST_SAVE_XML = ""
 UNITTEST_ARGS : list[str] = []
 USE_PYTEST = False
-HARDWARE_REQUIREMENT : list[TestHardwareRequirement] | None = None
+HARDWARE_REQUIREMENT : set[TestHardwareRequirement] | None = None
 
 
 def _iter_test_cases_recursively(
@@ -1080,7 +1095,7 @@ def parse_cmd_line_args():
     parser.add_argument('--rerun-disabled-tests', action='store_true')
     parser.add_argument('--pytest-single-test', type=str, nargs=1)
     parser.add_argument('--showlocals', action=argparse.BooleanOptionalAction, default=False)
-    parser.add_argument('--hardware-requirement', action='append', type=TestHardwareRequirement, choices=list(TestHardwareRequirement), default=None)
+    parser.add_argument('--hardware-requirement', nargs='+', choices=HardwareRequirementChoices(), default=None, metavar='REQ')
 
 # Only run when -h or --help flag is active to display both unittest and parser help messages.
     def run_unittest_help(argv):
@@ -1117,7 +1132,7 @@ def parse_cmd_line_args():
     REPEAT_COUNT = args.repeat
     SHOWLOCALS = args.showlocals
     HARDWARE_REQUIREMENT = (
-        set(args.hardware_requirement)
+        {TestHardwareRequirement[name.upper()] for name in args.hardware_requirement}
         if args.hardware_requirement is not None
         else None
     )
@@ -1328,11 +1343,35 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
 
 
 class HardwareRequirementTestLoader(unittest.TestLoader):
+    """Unittest TestLoader that filters loaded tests by hardware_requirement."""
     def loadTestsFromModule(self, module, *args, pattern=None, **kwargs):
         suite = super().loadTestsFromModule(
             module, *args, pattern=pattern, **kwargs
         )
         return _filter_suite_by_hardware_requirement(suite)
+
+
+class HardwareRequirementPytestPlugin:
+    """Pytest plugin to filter collected tests by hardware_requirement."""
+    def __init__(self, requirement: set[TestHardwareRequirement] | None) -> None:
+        self.requirement = requirement
+
+    def pytest_collection_modifyitems(self, items):
+        if self.requirement is None:
+            return
+        filtered = []
+        for item in items:
+            # hardware_requirement is a class-level attribute. Function-based tests
+            # do not have item.cls and are therefore not filtered.
+            cls = getattr(item, "cls", None)
+            if cls is not None:
+                req = _get_hardware_requirement(cls)
+                if req is not None and req in self.requirement:
+                    filtered.append(item)
+            else:
+                filtered.append(item)
+        items[:] = filtered
+
 
 
 def run_tests(argv=None):
@@ -1375,6 +1414,10 @@ def run_tests(argv=None):
             *argv[1:],
         ]
 
+    testLoader = unittest.loader.defaultTestLoader
+    if HARDWARE_REQUIREMENT is not None:
+        testLoader = HardwareRequirementTestLoader()
+
     if TEST_IN_SUBPROCESS:
         other_args = []
         if DISABLED_TESTS_FILE:
@@ -1387,6 +1430,8 @@ def run_tests(argv=None):
             other_args.append("--rerun-disabled-tests")
         if TEST_SAVE_XML:
             other_args += ['--save-xml', TEST_SAVE_XML]
+        if HARDWARE_REQUIREMENT is not None:
+            other_args += ['--hardware-requirement'] + [req.name for req in HARDWARE_REQUIREMENT]
 
         test_cases = (
             get_pytest_test_cases(argv) if USE_PYTEST else
@@ -1432,6 +1477,8 @@ def run_tests(argv=None):
         processes = []
         for i in range(RUN_PARALLEL):
             command = [sys.executable] + argv + [f'--log-suffix=-shard-{i + 1}'] + test_batches[i]
+            if HARDWARE_REQUIREMENT is not None:
+                command += ['--hardware-requirement'] + [req.name for req in HARDWARE_REQUIREMENT]
             processes.append(subprocess.Popen(command, universal_newlines=True))
         failed = False
         for p in processes:
@@ -1450,7 +1497,10 @@ def run_tests(argv=None):
 
         import pytest
         os.environ["NO_COLOR"] = "1"
-        exit_code = pytest.main(args=pytest_args)
+        plugins = None
+        if HARDWARE_REQUIREMENT is not None:
+            plugins = [HardwareRequirementPytestPlugin(HARDWARE_REQUIREMENT)]
+        exit_code = pytest.main(args=pytest_args, plugins=plugins)
         if TEST_SAVE_XML:
             sanitize_pytest_xml(test_report_path)
 
@@ -1491,16 +1541,13 @@ def run_tests(argv=None):
         unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(
             output=test_report_path,
             verbosity=2 if verbose else 1,
-            resultclass=XMLTestResultVerbose))
+            resultclass=XMLTestResultVerbose), testLoader=testLoader)
     elif REPEAT_COUNT > 1:
         for _ in range(REPEAT_COUNT):
-            if not unittest.main(exit=False, argv=argv).result.wasSuccessful():
+            if not unittest.main(exit=False, argv=argv, testLoader=testLoader).result.wasSuccessful():
                 sys.exit(-1)
     else:
-        if HARDWARE_REQUIREMENT is not None:
-            unittest.main(argv=argv, testLoader=HardwareRequirementTestLoader())
-        else:
-            unittest.main(argv=argv)
+        unittest.main(argv=argv, testLoader=testLoader)
 
 IS_LINUX = sys.platform == "linux"
 IS_WINDOWS = sys.platform == "win32"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1402,8 +1402,12 @@ def run_tests(argv=None):
         _print_test_names()
         return
 
+    testLoader = unittest.loader.defaultTestLoader
+    if HARDWARE_REQUIREMENT is not None:
+        testLoader = HardwareRequirementTestLoader()
+
     # Before running the tests, lint to check that every test class extends from TestCase
-    suite = unittest.TestLoader().loadTestsFromModule(__main__)
+    suite = testLoader.loadTestsFromModule(__main__)
     if not lint_test_case_extension(suite):
         sys.exit(1)
 
@@ -1413,10 +1417,6 @@ def run_tests(argv=None):
             *(["--showlocals", "--tb=long", "--color=yes"] if USE_PYTEST else ["--locals"]),
             *argv[1:],
         ]
-
-    testLoader = unittest.loader.defaultTestLoader
-    if HARDWARE_REQUIREMENT is not None:
-        testLoader = HardwareRequirementTestLoader()
 
     if TEST_IN_SUBPROCESS:
         other_args = []
@@ -1477,8 +1477,6 @@ def run_tests(argv=None):
         processes = []
         for i in range(RUN_PARALLEL):
             command = [sys.executable] + argv + [f'--log-suffix=-shard-{i + 1}'] + test_batches[i]
-            if HARDWARE_REQUIREMENT is not None:
-                command += ['--hardware-requirement'] + [req.name for req in HARDWARE_REQUIREMENT]
             processes.append(subprocess.Popen(command, universal_newlines=True))
         failed = False
         for p in processes:


### PR DESCRIPTION
## Summary

This PR introduces hardware requirement classification for PyTorch test classes.

The goal is to make hardware requirements explicit in test code and provide a common foundation for test selection. Users can selectively run tests by hardware requirement through the `--hardware-requirement` command-line option.

To help keep the classification accurate over time, this PR also introduces a lint check that requires test classes within the rollout scope to explicitly declare a `hardware_requirement`. The rollout is incremental and is currently enabled for tests under `test/profiler/`.

When `--hardware-requirement` is not specified, test discovery and execution follow the existing code path and remain unchanged. As an incremental rollout, hardware requirement filtering is currently applied only to the default
`unittest.main` execution path; other launch modes continue to use the existing behavior.



## Changes

- add a class-level `hardware_requirement` attribute backed by a `TestHardwareRequirement` enum:
  - `GENERIC`
  - `DEVICE_GENERIC`
  - `DEVICE_SPECIFIC`
  - `MULTI_DEVICE_GENERIC`
  - `MULTI_DEVICE_SPECIFIC`
- add the `--hardware-requirement` test filtering option and a dedicated test loader that is used only when the filter is specified.
- apply hardware requirement filtering only to the default `unittest.main` execution path for this initial rollout, leaving other launch modes unchanged.
- introduce a `TEST_HARDWARE_REQUIREMENT` lintrunner check
  - enable lint enforcement for tests under `test/profiler/`
- add unit tests covering hardware requirement parsing and suite filtering behavior.
