### PR TITLE
Fix output mismtach for F.softshrink with bfloat16 and float scalar

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -642,7 +642,7 @@ void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& lambd) {
 void softshrink_kernel(TensorIteratorBase& iter, const Scalar& lambd) {
   if (at::isReducedFloatingType(iter.dtype())) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.common_dtype(), "softshrink_cpu", [&]() {
-    auto lambd_val = lambd.to<float>();
+    auto lambd_val = static_cast<float>(lambd.to<scalar_t>());
     auto lambdVec = Vectorized<float>(lambd_val);
     cpu_kernel_vec(
       iter,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3628,6 +3628,19 @@ class CommonTemplate:
             for a, b in zip(out, ref):
                 self.assertTrue(torch.allclose(a, b))
 
+    def test_softshrink_reduced_float_lambd_type_promotion(self):
+        for dtype in [torch.bfloat16, torch.float16]:
+            x = torch.tensor([-10.0625], dtype=dtype, device=self.device)
+            lambd = 9.99
+
+            def fn(x):
+                return torch.nn.functional.softshrink(x, lambd=lambd)
+
+            self.assertEqual(fn(x), torch.nn.functional.softshrink(x, lambd=lambd))
+            self.assertEqual(
+                torch.compile(fn)(x), torch.nn.functional.softshrink(x, lambd=lambd)
+            )
+
     def test_relu(self):
         def fn(a, b):
             return (torch.relu(a), torch.relu(a + b) / 10)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12970,6 +12970,14 @@ if __name__ == '__main__':
                                         r'lambda must be in range \[0,.*input dtype.*BFloat16.*found 1e\+39'):
                 F.softshrink(x_bf16, lambd=1e39)
 
+    @dtypes(torch.bfloat16, torch.float16)
+    def test_softshrink_lambd_type_promotion(self, device, dtype):
+        x = torch.tensor([-10.0625], dtype=dtype, device=device)
+        lambd = 9.99
+        lambd_in_dtype = torch.tensor(lambd, dtype=dtype).item()
+        expected = torch.tensor([x.item() + lambd_in_dtype], dtype=dtype, device=device)
+        self.assertEqual(F.softshrink(x, lambd), expected)
+
     @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
     def test_fold(self, device):
         def test_dtype(fn, input, dtype):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4143,12 +4143,20 @@ def tensor(data, *, dtype=None, device=None, layout=None, pin_memory=False):
 
     ranges: list[sympy.Expr] = []
 
+    _truncate_fp = dtype in (torch.bfloat16, torch.float16)
+
     if isinstance(data, sympy.Basic):
 
         def inner_fn(index):
-            return ops.index_expr(data, dtype)
+            result = ops.index_expr(data, dtype)
+            if _truncate_fp:
+                result = ops.to_dtype(result, dtype, use_compute_types=False)
+                result = ops.to_dtype(result, dtype)
+            return result
 
     elif isinstance(data, (float, int)):
+        if _truncate_fp and isinstance(data, float):
+            data = torch.tensor(data, dtype=dtype).item()
 
         def inner_fn(index):
             return ops.constant(data, dtype)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -10,7 +10,6 @@ import torch
 import torch._prims as prims
 import torch._prims_common as utils
 import torch._refs as refs
-from torch import SymFloat
 from torch._decomp import register_decomposition
 from torch._prims_common import (
     ELEMENTWISE_TYPE_PROMOTION_KIND,
@@ -548,7 +547,7 @@ def softshrink(a: TensorLikeType, lambd: float = 0.5):
         0 <= lambd <= torch.finfo(a.dtype).max,
         lambda: f"lambda must be in range [0, {torch.finfo(a.dtype).max}] for input dtype {a.dtype}, but found {lambd}",
     )
-    if not isinstance(lambd, SymFloat):
+    if a.dtype in (torch.bfloat16, torch.float16):
         lambd = torch.scalar_tensor(lambd, dtype=a.dtype, device=a.device)  # type: ignore[arg-type]
     # We implement this in one torch.where to generate better code in the backward
     # see https://github.com/pytorch/pytorch/pull/107052#discussion_r1293748211

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -10,6 +10,7 @@ import torch
 import torch._prims as prims
 import torch._prims_common as utils
 import torch._refs as refs
+from torch import SymFloat
 from torch._decomp import register_decomposition
 from torch._prims_common import (
     ELEMENTWISE_TYPE_PROMOTION_KIND,
@@ -547,6 +548,8 @@ def softshrink(a: TensorLikeType, lambd: float = 0.5):
         0 <= lambd <= torch.finfo(a.dtype).max,
         lambda: f"lambda must be in range [0, {torch.finfo(a.dtype).max}] for input dtype {a.dtype}, but found {lambd}",
     )
+    if not isinstance(lambd, SymFloat):
+        lambd = torch.scalar_tensor(lambd, dtype=a.dtype, device=a.device)  # type: ignore[arg-type]
     # We implement this in one torch.where to generate better code in the backward
     # see https://github.com/pytorch/pytorch/pull/107052#discussion_r1293748211
     # We multiply by 0 for dealing with nans


### PR DESCRIPTION
Fixes #185484 

The softshrink decomposition and CPU eager kernel did not cast the scalar lambd to the input tensor's dtype before arithmetic. For reduced floating types like bfloat16, this caused lambd to retain float32 precision, producing results inconsistent with CUDA eager which correctly casts lambd to the tensor dtype per PyTorch's type promotion rules. The fix is to cast lambd to the tensor's reduced floating type before computation.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo