### PR TITLE
[MPS] Fix LayerNorm variance clamped to zero for small-variance inputs

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LayerNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/LayerNorm.metal
@@ -80,7 +80,7 @@ kernel void layer_norm_single_row(
     if (simd_lane_id == 0) {
       float mean = sum / float(axis_size);
       float var = sum_sq / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
+      var = var < 1e-9 ? 0.0f : var; // for rsqrt precision
       float inv_std = metal::precise::rsqrt(var + epsilon);
       tg_mean[0] = mean;
       tg_inv_std[0] = inv_std;
@@ -201,7 +201,7 @@ kernel void layer_norm_looped(
     if (simd_lane_id == 0) {
       float mean = s / float(axis_size);
       float var = ss / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
+      var = var < 1e-9 ? 0.0f : var; // for rsqrt precision
       float inv_std = metal::precise::rsqrt(var + epsilon);
       tg_mean[0] = mean;
       tg_inv_std[0] = inv_std;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2474,6 +2474,16 @@ class TestMPS(TestCaseMPS):
         # Regression test for https://github.com/pytorch/pytorch/issues/96113
         torch.nn.LayerNorm((16,), elementwise_affine=True).to("mps")(torch.randn(1, 2, 16).to("mps", dtype=torch.float16))
 
+    # axis_size 8 hits layer_norm_single_row, 8192 hits layer_norm_looped
+    @parametrize("axis_size", [8, 8192])
+    def test_layer_norm_small_variance(self, axis_size):
+        a, eps = 1e-4, 1e-9  # var = a^2 = 1e-8
+        row = torch.tensor([a, -a] * (axis_size // 2), dtype=torch.float32)
+        cpu_x = row.repeat(4, 1)
+        cpu_y = F.layer_norm(cpu_x, (axis_size,), eps=eps)
+        mps_y = F.layer_norm(cpu_x.to('mps'), (axis_size,), eps=eps)
+        self.assertEqual(mps_y, cpu_y)
+
     def test_ifft(self):
         # See: https://github.com/pytorch/pytorch/issues/124096
         device = torch.device("mps")


### PR DESCRIPTION
Doing this on current main:
```
import torch, torch.nn.functional as F
x = torch.tensor([[1.0, 1.0+1e-3, 1.0-1e-3, 1.0]])
y_cpu = F.layer_norm(x, (4,), eps=1e-7)
y_mps = F.layer_norm(x.to('mps'), (4,), eps=1e-7)
print(y_cpu)
print(y_mps)

```
Leads to:
```
tensor([[ 0.0000,  1.2911, -1.2910,  0.0000]])
tensor([[ 0.0000,  3.1624, -3.1622,  0.0000]], device='mps:0')
```

Since it's an easy fix I think it's worth to land this