### PR TITLE
[inductor] Add tensor std validation to normal decomposition

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3998,6 +3998,15 @@ class CommonTemplate:
                 b = torch.full((8,), b_val, dtype=dtype, device=self.device)
                 self.common(fn, (a, b))
 
+    def test_normal_negative_std(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/185248
+        # compiled torch.normal must reject negative std like eager does.
+        def fn(mean, std):
+            return torch.normal(mean, std)
+
+        mean = torch.zeros(4, device=self.device)
+        std = torch.full((4,), -1.0, device=self.device)
+        self.common(fn, (mean, std))
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6524,6 +6524,11 @@ def normal(
         torch._check(
             std >= 0, lambda: f"normal expects std >= 0.0, but found std {std}"
         )
+    else:
+        torch._check(
+            torch.all(std >= 0),
+            lambda: "normal expects all elements of std >= 0.0",
+        )
 
     if size is None:
         tensors = tuple(t for t in (mean, std) if isinstance(t, TensorLike))


### PR DESCRIPTION
Fixes #185248

The decomposition for `aten.normal` only validated `std >= 0` when std is a Python scalar. When std is a tensor with negative values, the check was skipped, causing `torch.compile` to silently produce values while eager raises `RuntimeError`.

Add the missing tensor check: `torch._check(torch.all(std >= 0), ...)`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo