### PR TITLE
inductor: validate square mix-order reductions by common reads

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -127,6 +127,53 @@ class MixOrderReductionTest(TestBase):
             metrics.codegen_mix_order_reduction,
         )
 
+    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
+    def test_same_order_reductions_with_non_common_strided_read(self):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x, y):
+            return x.sum(dim=1), (x * y.t()).sum(dim=1)
+
+        M = N = 8192
+        x = torch.randn(M, N, device=GPU_TYPE)
+        y = torch.randn(N, M, device=GPU_TYPE)
+
+        opt_f = torch.compile(f)
+
+        ref = f(x, y)
+        act = opt_f(x, y)
+
+        self.assertTrue(same(ref, act, tol=1e-3), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            0,
+            metrics.codegen_mix_order_reduction,
+            "same-order reductions must not be classified as mix-order",
+        )
+
+    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
+    def test_square_mix_order_reductions_non_strict(self):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x):
+            return x.sum(dim=1), x.sum(dim=0)
+
+        M = N = 8192
+        x = torch.randn(M, N, device=GPU_TYPE)
+
+        opt_f = torch.compile(f)
+
+        ref = f(x)
+        act = opt_f(x)
+
+        self.assertTrue(same(ref, act, tol=1e-3), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            1,
+            metrics.codegen_mix_order_reduction,
+            "square reductions with opposite common-read access should use mix-order",
+        )
+
     def test_xmask(self):
         """
         Make sure xmask is setup properly
@@ -944,7 +991,12 @@ class MixOrderReductionTest(TestBase):
         mock_get_common_read.return_value = "common_read"
         from sympy import Integer
 
-        mock_get_numel_rnumel.return_value = (Integer(1), Integer(1))
+        mock_get_numel_rnumel.side_effect = [
+            (Integer(2), Integer(1)),
+            (Integer(1), Integer(2)),
+            (Integer(2), Integer(1)),
+            (Integer(1), Integer(2)),
+        ]
         mock_is_split_reduction.return_value = False
 
         mock_node_1.read_writes = mock.Mock()

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -120,6 +120,53 @@ class MixOrderReductionTest(TestBase):
             metrics.codegen_mix_order_reduction,
         )
 
+    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
+    def test_same_order_reductions_with_non_common_strided_read(self):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x, y):
+            return x.sum(dim=1), (x * y.t()).sum(dim=1)
+
+        M = N = 8192
+        x = torch.randn(M, N, device=GPU_TYPE)
+        y = torch.randn(N, M, device=GPU_TYPE)
+
+        opt_f = torch.compile(f)
+
+        ref = f(x, y)
+        act = opt_f(x, y)
+
+        self.assertTrue(same(ref, act, tol=1e-3), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            0,
+            metrics.codegen_mix_order_reduction,
+            "same-order reductions must not be classified as mix-order",
+        )
+
+    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
+    def test_square_mix_order_reductions_non_strict(self):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x):
+            return x.sum(dim=1), x.sum(dim=0)
+
+        M = N = 8192
+        x = torch.randn(M, N, device=GPU_TYPE)
+
+        opt_f = torch.compile(f)
+
+        ref = f(x)
+        act = opt_f(x)
+
+        self.assertTrue(same(ref, act, tol=1e-3), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            1,
+            metrics.codegen_mix_order_reduction,
+            "square reductions with opposite common-read access should use mix-order",
+        )
+
     def test_xmask(self):
         """
         Make sure xmask is setup properly
@@ -740,7 +787,12 @@ class MixOrderReductionTest(TestBase):
         mock_get_common_read.return_value = "common_read"
         from sympy import Integer
 
-        mock_get_numel_rnumel.return_value = (Integer(1), Integer(1))
+        mock_get_numel_rnumel.side_effect = [
+            (Integer(2), Integer(1)),
+            (Integer(1), Integer(2)),
+            (Integer(2), Integer(1)),
+            (Integer(1), Integer(2)),
+        ]
         mock_is_split_reduction.return_value = False
 
         mock_node_1.read_writes = mock.Mock()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -259,10 +259,10 @@ class MixOrderReduction:
         g1 = cls.get_numel_rnumel(node1)
         g2 = cls.get_numel_rnumel(node2)
 
-        if len(g1) != 2 or len(g2) != 2 or g1 == g2:
+        if len(g1) != 2 or len(g2) != 2:
             return False
 
-        return tuple(g1) == tuple(reversed(g2))
+        return (g1 == g2 and g1[0] == g1[1]) or tuple(g1) == tuple(reversed(g2))
 
     @classmethod
     def _is_full_access(cls, buf: str, node: BaseSchedulerNode) -> bool:
@@ -283,11 +283,22 @@ class MixOrderReduction:
 
         if not var_ranges:
             if not isinstance(node, FusedSchedulerNode):
-                raise AssertionError(f"{type(node)}")
+                return False
+            # FusedSchedulerNode.read_writes is produced by ReadWrites.merge_list(),
+            # which intentionally drops var_ranges because fused children can have
+            # different loop domains. Preserve the existing best-effort fallback to
+            # the first child, but do not require that child to have ranges either.
             var_ranges = node.snodes[0].read_writes.var_ranges
 
         if not var_ranges:
-            raise AssertionError("expected var_ranges to be non-empty")
+            # Missing ranges are still valid here: scalar or fully unrolled nodes
+            # have no loop variables to record. For example,
+            # test_comprehensive_masked_cumprod_cuda_float32 can produce a fused
+            # node whose first child only has constant-indexed reads. Since this
+            # helper only proves a MixOrderReduction fusion opportunity, decline
+            # the proof instead of turning an optional fusion miss into a
+            # compilation failure.
+            return False
         if not (OrderedSet(var_ranges) - OrderedSet(index.free_symbols)):
             return True
 
@@ -411,6 +422,16 @@ class MixOrderReduction:
                 fallback_value=False,
             ):
                 return False
+
+        # Equal groups can be true square inner+outer reductions, but also
+        # same-order reductions where an unrelated read makes one node look
+        # non-contiguous. Compare only common full reads to prove mixed order.
+        g2 = cls.get_numel_rnumel(other_node)
+        if g1 == g2 and not any(
+            cls.is_contiguous_load(buf, node1) != cls.is_contiguous_load(buf, node2)
+            for buf in common_reads
+        ):
+            return False
 
         # Make sure a persistent reduction will be generated
         if any(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -270,10 +270,10 @@ class MixOrderReduction:
         g1 = cls.get_numel_rnumel(node1)
         g2 = cls.get_numel_rnumel(node2)
 
-        if len(g1) != 2 or len(g2) != 2 or g1 == g2:
+        if len(g1) != 2 or len(g2) != 2:
             return False
 
-        return tuple(g1) == tuple(reversed(g2))
+        return (g1 == g2 and g1[0] == g1[1]) or tuple(g1) == tuple(reversed(g2))
 
     @classmethod
     def _is_full_access(cls, buf: str, node: BaseSchedulerNode) -> bool:
@@ -294,11 +294,22 @@ class MixOrderReduction:
 
         if not var_ranges:
             if not isinstance(node, FusedSchedulerNode):
-                raise AssertionError(f"{type(node)}")
+                return False
+            # FusedSchedulerNode.read_writes is produced by ReadWrites.merge_list(),
+            # which intentionally drops var_ranges because fused children can have
+            # different loop domains. Preserve the existing best-effort fallback to
+            # the first child, but do not require that child to have ranges either.
             var_ranges = node.snodes[0].read_writes.var_ranges
 
         if not var_ranges:
-            raise AssertionError("expected var_ranges to be non-empty")
+            # Missing ranges are still valid here: scalar or fully unrolled nodes
+            # have no loop variables to record. For example,
+            # test_comprehensive_masked_cumprod_cuda_float32 can produce a fused
+            # node whose first child only has constant-indexed reads. Since this
+            # helper only proves a MixOrderReduction fusion opportunity, decline
+            # the proof instead of turning an optional fusion miss into a
+            # compilation failure.
+            return False
         if not (OrderedSet(var_ranges) - OrderedSet(index.free_symbols)):
             return True
 
@@ -420,6 +431,16 @@ class MixOrderReduction:
                 fallback_value=False,
             ):
                 return False
+
+        # Equal groups can be true square inner+outer reductions, but also
+        # same-order reductions where an unrelated read makes one node look
+        # non-contiguous. Compare only common full reads to prove mixed order.
+        g2 = cls.get_numel_rnumel(other_node)
+        if g1 == g2 and not any(
+            cls.is_contiguous_load(buf, node1) != cls.is_contiguous_load(buf, node2)
+            for buf in common_reads
+        ):
+            return False
 
         # Make sure a persistent reduction will be generated
         if any(


### PR DESCRIPTION
Co-authored-by: gpt-5.5
## Issue

Mix-order reduction currently rejects equal `(numel, rnumel)` groups, which blocks square-shape inner+outer reductions in non-strict mode. Simply allowing equal groups can introduce false positives: same-order reductions may look mixed-order if one node has an unrelated strided read.

## Fix

- Allow equal `(numel, rnumel)` groups as mix-order candidates.
- In `can_fuse`, validate equal-group candidates using only common full-read buffers; those common reads must have opposite contiguity across the two reductions.
- Add non-strict square-shape coverage for both the valid inner+outer case and the same-order false-positive case.

## Results

bf16 RMSNorm backward on NVIDIA GB200. Kernel time is the CUDA kernel-time sum from `torch.profiler`.
Runs with **non-strict mode**, 16384 is the largest size to use mix-order reduction based on current heuristics.

| Shape | Before us | Before SOL% | After us | After SOL% | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1024 x 1024 | 8.1 | 9.8 | 8.4 | 9.4 | 0.96x |
| 2048 x 2048 | 11.6 | 27.5 | 17.6 | 18.0 | 0.65x |
| 3072 x 3072 | 24.2 | 29.5 | 26.5 | 27.0 | 0.92x |
| 4096 x 4096 | 37.9 | 33.5 | 27.8 | 45.7 | 1.36x |
| 5120 x 5120 | 72.9 | 27.2 | 66.1 | 30.0 | 1.10x |
| 6144 x 6144 | 82.5 | 34.6 | 66.6 | 42.9 | 1.24x |
| 7168 x 7168 | 108.0 | 36.0 | 77.3 | 50.3 | 1.40x |
| 8192 x 8192 | 168.8 | 30.1 | 79.8 | 63.7 | 2.12x |
| 9216 x 9216 | 186.9 | 34.4 | 142.9 | 45.0 | 1.31x |
| 10240 x 10240 | 193.1 | 41.1 | 186.8 | 42.5 | 1.03x |
| 11264 x 11264 | 224.9 | 42.7 | 219.7 | 43.7 | 1.02x |
| 12288 x 12288 | 264.2 | 43.3 | 250.9 | 45.5 | 1.05x |
| 13312 x 13312 | 300.2 | 44.7 | 285.8 | 46.9 | 1.05x |
| 14336 x 14336 | 371.8 | 41.8 | 301.6 | 51.6 | 1.23x |
| 15360 x 15360 | 393.8 | 45.3 | 393.4 | 45.4 | 1.00x |
| 16384 x 16384 | 458.7 | 44.3 | 523.7 | 38.8 | 0.88x |

Tested:

```bash
python -m pytest test/inductor/test_mix_order_reduction.py -k 'same_order_reductions_with_non_common_strided_read or square_mix_order_reductions_non_strict' -q
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo