### PR TITLE
[CUDA] Change nvmlDeviceGetGpuFabricInfoV assertion to warning

### DIFF
--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -188,10 +188,15 @@ bool get_fabric_access(c10::DeviceIndex dev) {
       fabricCliqueId_[dev] = kCliqueIdUnsupported;
       return false;
     }
-    TORCH_CHECK(
-        NVML_SUCCESS ==
-        DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(
-            nvml_device, &fabricInfo));
+    auto nvml_fabric_result = DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(
+        nvml_device, &fabricInfo);
+    if (nvml_fabric_result != NVML_SUCCESS) {
+      TORCH_WARN_ONCE(
+          "nvmlDeviceGetGpuFabricInfoV failed. This function is only supported on sm90+");
+      cache = 0;
+      fabricCliqueId_[dev] = kCliqueIdUnsupported;
+      return false;
+    }
     auto state = fabricInfo.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
     if (state) {
       fabricCliqueId_[dev] = static_cast<int>(fabricInfo.cliqueId);


### PR DESCRIPTION
`nvmlDeviceGetGpuFabricInfoV` is only supported on Hopper and above, but `get_fabric_access` wraps it in an assertion, causing a crash on Orin and other pre-Hopper devices instead of falling back gracefully. Similar to #185946, this PR replaces the assertion with a warning and allows control flow to continue.

Fixes #186374 

cc @eqy