### PR TITLE
Validate num_heads before division in MultiheadAttention

### DIFF
--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -5513,6 +5513,12 @@ TEST_F(ModulesTest, PrettyPrintBCEWithLogitsLoss) {
       "torch::nn::BCEWithLogitsLoss()");
 }
 
+TEST_F(ModulesTest, MultiheadAttentionRejectsZeroNumHeads){
+  EXPECT_THROW(
+    MultiheadAttention(MultiheadAttentionOptions(0,0)),
+    c10::Error);
+}
+
 TEST_F(ModulesTest, PrettyPrintMultiheadAttention) {
   ASSERT_EQ(
       c10::str(MultiheadAttention(20, 10)),

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -5513,10 +5513,8 @@ TEST_F(ModulesTest, PrettyPrintBCEWithLogitsLoss) {
       "torch::nn::BCEWithLogitsLoss()");
 }
 
-TEST_F(ModulesTest, MultiheadAttentionRejectsZeroNumHeads){
-  EXPECT_THROW(
-    MultiheadAttention(MultiheadAttentionOptions(0,0)),
-    c10::Error);
+TEST_F(ModulesTest, MultiheadAttentionRejectsZeroNumHeads) {
+  EXPECT_THROW(MultiheadAttention(MultiheadAttentionOptions(0,0)), c10::Error);
 }
 
 TEST_F(ModulesTest, PrettyPrintMultiheadAttention) {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -5514,7 +5514,7 @@ TEST_F(ModulesTest, PrettyPrintBCEWithLogitsLoss) {
 }
 
 TEST_F(ModulesTest, MultiheadAttentionRejectsZeroNumHeads) {
-  EXPECT_THROW(MultiheadAttention(MultiheadAttentionOptions(0,0)), c10::Error);
+  EXPECT_THROW(MultiheadAttention(MultiheadAttentionOptions(0, 0)), c10::Error);
 }
 
 TEST_F(ModulesTest, PrettyPrintMultiheadAttention) {

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -501,6 +501,9 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
 void MultiheadAttentionImpl::reset() {
   _qkv_same_embed_dim = options.kdim() == options.embed_dim() &&
       options.vdim() == options.embed_dim();
+  TORCH_CHECK(
+    options.num_heads()>0,
+    "num_heads must be greater than 0");
   head_dim = options.embed_dim() / options.num_heads();
   TORCH_CHECK(
       head_dim * options.num_heads() == options.embed_dim(),

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -501,7 +501,7 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
 void MultiheadAttentionImpl::reset() {
   _qkv_same_embed_dim = options.kdim() == options.embed_dim() &&
       options.vdim() == options.embed_dim();
-  TORCH_CHECK(options.num_heads()>0, "num_heads must be greater than 0");
+  TORCH_CHECK(options.num_heads() > 0, "num_heads must be greater than 0");
   head_dim = options.embed_dim() / options.num_heads();
   TORCH_CHECK(
       head_dim * options.num_heads() == options.embed_dim(),

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -501,9 +501,7 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
 void MultiheadAttentionImpl::reset() {
   _qkv_same_embed_dim = options.kdim() == options.embed_dim() &&
       options.vdim() == options.embed_dim();
-  TORCH_CHECK(
-    options.num_heads()>0,
-    "num_heads must be greater than 0");
+  TORCH_CHECK(options.num_heads()>0, "num_heads must be greater than 0");
   head_dim = options.embed_dim() / options.num_heads();
   TORCH_CHECK(
       head_dim * options.num_heads() == options.embed_dim(),


### PR DESCRIPTION
# Fix: Division-by-Zero in `MultiheadAttentionImpl::reset()` When `num_heads == 0`

## Summary
Fixes #186237
Fixed a division-by-zero in `MultiheadAttentionImpl::reset()` triggered when `num_heads` is `0`.

Previously, `head_dim` was computed before any validation of `num_heads`:

```cpp
head_dim = options.embed_dim() / options.num_heads();
```

Constructing `MultiheadAttention` with `num_heads = 0` could invoke undefined behavior (integer division by zero / floating-point exception) before any validation logic was reached.

This PR adds a `TORCH_CHECK` to validate that `num_heads > 0` **before** performing the division, replacing the silent UB with a clear, actionable error message.

## Changes

- Added a `TORCH_CHECK(options.num_heads() > 0, ...)` guard in `MultiheadAttentionImpl::reset()` prior to the `head_dim` computation.

## Test Plan

Added a C++ API test verifying that constructing:

```cpp
MultiheadAttention(MultiheadAttentionOptions(0, 0))
```

throws a `c10::Error`.

**Before this change:** the test triggered a floating-point exception due to division by zero.

**After this change:** the test passes and the invalid configuration is reported via a proper error.