### PR TITLE
[activation_checkpointing] Support AutoNamingMode + policy name keys under torch.compile

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -33,6 +33,7 @@ from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import (
+    AutoNamingMode,
     checkpoint,
     CheckpointPolicy,
     create_selective_checkpoint_contexts,
@@ -161,6 +162,28 @@ def op_count(gm):
         if "call" in node.op:
             result += 1
     return result
+
+
+def _make_auto_naming_model():
+    class Block(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, x):
+            return torch.relu(self.lin(x))
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([Block(), Block()])
+
+        def forward(self, x):
+            for layer in self.layers:
+                x = layer(x)
+            return x
+
+    return Model()
 
 
 def _get_custom_policy(no_recompute_list=None, must_recompute_list=None):
@@ -1035,6 +1058,103 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         # MUST_RECOMPUTE: producing matmul recomputed -> 1 recompute + 2 grad.
         torch._dynamo.reset()
         _test(CheckpointPolicy.MUST_RECOMPUTE, bw_freq=3)
+
+    def test_auto_naming_names_match_eager_and_compile(self):
+        # The module-qualified names of stable ops should agree between eager
+        # (ModuleTracker) and compile (nn_module_stack).
+        def collect(compiled):
+            mod = _make_auto_naming_model()
+            naming = AutoNamingMode()
+            names = set()
+
+            def policy_fn(ctx, op, *args, **kwargs):
+                if isinstance(ctx.op_output, torch.Tensor):
+                    nm = naming.names.get(ctx.op_output)
+                    if nm is not None:
+                        names.add(nm)
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            def fn(x):
+                with naming:
+                    return checkpoint(
+                        mod,
+                        x,
+                        use_reentrant=False,
+                        context_fn=functools.partial(
+                            create_selective_checkpoint_contexts, policy_fn
+                        ),
+                    ).sum()
+
+            x = torch.randn(4, 4, requires_grad=True)
+            if compiled:
+                torch._dynamo.reset()
+                fn = torch.compile(
+                    fn, backend="aot_eager_decomp_partition", fullgraph=True
+                )
+            fn(x).backward()
+            return names
+
+        eager_names = collect(compiled=False)
+        compile_names = collect(compiled=True)
+        expected = {
+            "layers.0.lin_mm.default_0",
+            "layers.0_relu.default_0",
+            "layers.1.lin_mm.default_0",
+            "layers.1_relu.default_0",
+        }
+        self.assertTrue(expected.issubset(eager_names), eager_names)
+        self.assertTrue(expected.issubset(compile_names), compile_names)
+
+    @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")
+    def test_compile_auto_naming_policy(self):
+        # `with AutoNamingMode()` must trace (no graph break), and a policy
+        # selecting by module-qualified auto-name must control save/recompute.
+        def make_fn(save_set):
+            mod = _make_auto_naming_model()
+            naming = AutoNamingMode()
+
+            def policy_fn(ctx, op, *args, **kwargs):
+                if isinstance(ctx.op_output, torch.Tensor):
+                    if naming.names.get(ctx.op_output) in save_set:
+                        return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            def fn(x):
+                with naming:
+                    return checkpoint(
+                        mod,
+                        x,
+                        use_reentrant=False,
+                        context_fn=functools.partial(
+                            create_selective_checkpoint_contexts, policy_fn
+                        ),
+                    )
+
+            return fn
+
+        def _test(save_set, bw_freq):
+            x = torch.randn(4, 4, requires_grad=True)
+            backend = aot_autograd(
+                fw_compiler=functools.partial(
+                    count_ops, freq=2, op=torch.ops.aten.mm.default
+                ),
+                bw_compiler=functools.partial(
+                    count_ops, freq=bw_freq, op=torch.ops.aten.mm.default
+                ),
+                partition_fn=min_cut_rematerialization_partition,
+            )
+            self._validate(make_fn(save_set), backend, x)
+
+        # Save both matmuls (exact name + module-prefix) -> no recompute: 2 grad
+        # mm per matmul = 4.
+        torch._dynamo.reset()
+        _test(
+            {"layers.0.lin_mm.default_0", "layers.1.lin_mm.default_0"},
+            bw_freq=4,
+        )
+        # Save nothing -> both matmuls recomputed: 2 recompute + 4 grad = 6.
+        torch._dynamo.reset()
+        _test(set(), bw_freq=6)
 
     @requires_cuda_and_triton
     @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2219,6 +2219,16 @@
       ]
     }
   ],
+  "GB3173": [
+    {
+      "Gb_type": "torch.utils.checkpoint.AutoNamingMode escaped from compiled region",
+      "Context": "str(self)",
+      "Explanation": "Dynamo doesn't support graph break on AutoNamingMode.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB2533": [
     {
       "Gb_type": "reconstructing @contextmanager object",

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -30,6 +30,7 @@ from .builtin import (
 from .constant import ConstantVariable
 from .ctx_manager import (
     AcceleratorDeviceIndexVariable,
+    AutoNamingModeVariable,
     CatchWarningsCtxManagerVariable,
     ContextWrappingVariable,
     CUDADeviceVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -44,6 +44,7 @@ from typing import Any, cast, NamedTuple, NoReturn, overload, TYPE_CHECKING, Uni
 import sympy
 
 import torch
+import torch.utils.checkpoint
 from torch import SymInt
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.graph_bytecode_inputs import (
@@ -207,6 +208,7 @@ from .builtin import BuiltinVariable
 from .constant import ConstantVariable
 from .ctx_manager import (
     AutocastModeVariable,
+    AutoNamingModeVariable,
     CudagraphOverrideVariable,
     DynamoConfigPatchVariable,
     ErrorOnGraphBreakVariable,
@@ -1666,6 +1668,9 @@ class VariableBuilder:
                     ],
                     source=self.source,
                 )
+        elif isinstance(value, torch.utils.checkpoint.AutoNamingMode):
+            self.install_guards(GuardBuilder.TYPE_MATCH)
+            return AutoNamingModeVariable(source=self.source)
         elif TorchCtxManagerClassVariable.is_matching_cls(value):
             if inspect.isclass(value):
                 self.install_guards(GuardBuilder.CLASS_MATCH)

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1625,6 +1625,45 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         )
 
 
+class AutoNamingModeVariable(ContextWrappingVariable):
+    """
+    torch.utils.checkpoint.AutoNamingMode is a TorchDispatchMode whose op names
+    are derived from the fx graph (nn_module_stack) under compile rather than from
+    eager dispatch. So during tracing the context manager is a no-op: we just let
+    the body trace normally without entering the dispatch mode (which would
+    otherwise graph break).
+    """
+
+    def __init__(
+        self, target_values: Any = None, initial_values: Any = None, **kwargs: Any
+    ) -> None:
+        super().__init__(
+            target_values=target_values, initial_values=initial_values, **kwargs
+        )
+
+    def enter(
+        self, tx: "InstructionTranslator", *args: VariableTracker
+    ) -> VariableTracker:
+        self.set_cleanup_hook(tx, lambda: None)
+        return variables.ConstantVariable.create(None)
+
+    def module_name(self) -> str:
+        return "torch.utils.checkpoint"
+
+    def fn_name(self) -> str:
+        return "AutoNamingMode"
+
+    def reconstruct_type(self, codegen: "PyCodegen") -> None:
+        unimplemented(
+            gb_type="torch.utils.checkpoint.AutoNamingMode escaped from compiled region",
+            context=str(self),
+            explanation="Dynamo doesn't support graph break on AutoNamingMode.",
+            hints=[
+                *graph_break_hints.SUPPORTABLE,
+            ],
+        )
+
+
 class DynamoConfigPatchVariable(ContextWrappingVariable):
     """represents torch._dynamo.patch_dynamo_config"""
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1642,7 +1642,7 @@ class AutoNamingModeVariable(ContextWrappingVariable):
         )
 
     def enter(
-        self, tx: "InstructionTranslator", *args: VariableTracker
+        self, tx: "InstructionTranslatorBase", *args: VariableTracker
     ) -> VariableTracker:
         self.set_cleanup_hook(tx, lambda: None)
         return variables.ConstantVariable.create(None)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -41,6 +41,7 @@ __all__ = [
     "SAC_IGNORED_OPS",
     "GraphExecGroup",
     "name",
+    "AutoNamingMode",
 ]
 
 _DEFAULT_DETERMINISM_MODE = "default"
@@ -1691,6 +1692,151 @@ def name(tensor, name):
     else:
         caching_mode.storage[key][idx] = _RECOMPUTE
     return tensor
+
+
+def _normalize_fqn(fqn):
+    # Drop the leading source/root component so that the eager naming source
+    # (ModuleTracker, e.g. "Model.layers.0.lin") and the compile naming source
+    # (nn_module_stack, e.g. "G['mod'].layers.0.lin") agree on a root-relative
+    # path ("layers.0.lin").
+    if not fqn:
+        return ""
+    _, _, rest = fqn.partition(".")
+    return rest
+
+
+def _node_fqn(node):
+    stack = node.meta.get("nn_module_stack")
+    if not stack:
+        return ""
+    return _normalize_fqn(next(reversed(stack.values()))[0])
+
+
+def _auto_name_for_node(node):
+    # The auto-name of an op node is fully determined by the node: its module
+    # FQN (nn_module_stack), its op, and its index among same-(fqn, op) nodes.
+    fqn = _node_fqn(node)
+    op_name = getattr(node.target, "__name__", str(node.target))
+    count = 0
+    for n in node.graph.nodes:
+        if n is node:
+            break
+        if (
+            n.op == node.op
+            and getattr(n.target, "__name__", str(n.target)) == op_name
+            and _node_fqn(n) == fqn
+        ):
+            count += 1
+    return f"{fqn}_{op_name}_{count}"
+
+
+def _auto_name_from_proxy(tensor):
+    if not isinstance(tensor, torch.Tensor):
+        return None
+    from torch._subclasses.functional_tensor import mb_unwrap_functional_tensor
+    from torch.fx.experimental.proxy_tensor import get_proxy_mode
+
+    mode = get_proxy_mode()
+    if mode is None:
+        return None
+    proxy_tensor = mode.tracer.tensor_tracker.get(mb_unwrap_functional_tensor(tensor))
+    if proxy_tensor is None:
+        return None
+    return _auto_name_for_node(proxy_tensor.proxy.node)
+
+
+class _AutoNames:
+    """Tensor -> auto-name mapping used by :class:`AutoNamingMode`.
+
+    Eager entries are filled by ``AutoNamingMode.__torch_dispatch__``. Under
+    compile there is no eager dispatch, so a name is derived on demand from the
+    tensor's fx node (``nn_module_stack`` + op + index)."""
+
+    def __init__(self) -> None:
+        self._eager: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
+
+    def __setitem__(self, tensor, name) -> None:
+        self._eager[tensor] = name
+
+    def get(self, tensor, default=None):
+        if isinstance(tensor, torch.Tensor) and tensor in self._eager:
+            return self._eager[tensor]
+        name = _auto_name_from_proxy(tensor)
+        return name if name is not None else default
+
+    def __contains__(self, tensor) -> bool:
+        return self.get(tensor) is not None
+
+
+class AutoNamingMode(TorchDispatchMode):
+    """Automatically name op outputs by module-qualified op name.
+
+    Each op output tensor is named ``{fqn}_{op}_{count}`` where ``fqn`` is the
+    module path (root-relative), ``op`` is the op name, and ``count``
+    disambiguates repeated ``(fqn, op)`` pairs. Names are exposed via the
+    ``names`` mapping (tensor -> name) so a checkpoint policy can select
+    activations by name::
+
+        naming = AutoNamingMode()
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            name = naming.names.get(ctx.op_output)
+            return (CheckpointPolicy.MUST_SAVE if name in to_save
+                    else CheckpointPolicy.PREFER_RECOMPUTE)
+
+        with naming:
+            out = checkpoint(
+                model, x, use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, policy_fn),
+            )
+
+    Works in eager and under :func:`torch.compile`. In eager the names come from
+    :class:`~torch.utils.module_tracker.ModuleTracker`; under compile they are
+    derived from each node's ``nn_module_stack`` (the FQNs are normalized so the
+    same names appear in both).
+    """
+
+    def __init__(self) -> None:
+        from torch.utils.module_tracker import ModuleTracker
+
+        self._tracker = ModuleTracker()
+        self._func_counter: Dict[Any, int] = defaultdict(int)
+        self.names = _AutoNames()
+
+    def __enter__(self):
+        # Under tracing there is no eager dispatch; names are derived from the fx
+        # graph on demand (see _AutoNames), so the dispatch mode is a no-op.
+        if torch.compiler.is_compiling():
+            return self
+        self._tracker.__enter__()
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if torch.compiler.is_compiling():
+            return False
+        self._tracker.__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(exc_type, exc_val, exc_tb)
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        out = func(*args, **(kwargs or {}))
+        parents = self._tracker.parents - {"Global"}
+        fqn = _normalize_fqn(max(parents, key=len)) if parents else ""
+        op_name = getattr(func, "__name__", str(func))
+        key = (fqn, func)
+        count = self._func_counter[key]
+        self._func_counter[key] += 1
+        if isinstance(out, torch.Tensor):
+            self.names[out] = f"{fqn}_{op_name}_{count}"
+        elif isinstance(out, (tuple, list)):
+            multi_output = sum(isinstance(o, torch.Tensor) for o in out) > 1
+            for i, o in enumerate(out):
+                if isinstance(o, torch.Tensor):
+                    name = f"{fqn}_{op_name}_{count}"
+                    if multi_output:
+                        name += f"_{i}"
+                    self.names[o] = name
+        return out
 
 
 def _checkpoint_policy_from_dict(policy):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #186378
* #186382
* #186277

Follow-up to the previous PR, which added AutoNamingMode and name / module-FQN
keys for checkpoint's policy= in eager. This PR makes both work under
torch.compile.

The names come from different sources in the two worlds, normalized to a common
root-relative FQN so the same names appear in both:
- eager: torch.utils.module_tracker.ModuleTracker (nn.Module forward hooks).
- compile: ModuleTracker hooks do not fire during AOTAutograd tracing of the
  flattened graph, but the module FQN is already on every node in
  node.meta["nn_module_stack"]. So under tracing the name is derived on demand
  from the tensor's fx node (mapped back via the proxy tracer's tensor_tracker),
  plus op and index. No eager dispatch is needed during AOT.

Dynamo support: a TorchDispatchMode cannot be active around or inside a compiled
region (it graph breaks). Since under compile the names are derived from the
graph rather than eager dispatch, `with AutoNamingMode():` only needs to trace
as a no-op. AutoNamingModeVariable (a ContextWrappingVariable, mirroring
FxTracebackAnnotateVariable) provides this; builder.py routes AutoNamingMode
instances to it by type, and AutoNamingMode.ignore_compile_internals() lets the
dispatch mode coexist with compile (auto-disabled during the compiled frame,
like the SAC modes).

Cross-boundary bridge ("case 1"): when checkpoint(policy=) lives inside a
compiled submodule, an eager AutoNamingMode in the surrounding scope supplies the
module-path prefix (current_prefix, read from its still-live ModuleTracker
parents) so an absolute auto-name resolves to the same name a whole-model compile
would produce. The tracker's global forward hooks would trip Dynamo while it
traces the compiled submodule, so a Dynamo enter/exit hook in eval_frame.py
suspends/resumes them for the duration of the compiled frame (parents left
intact so the prefix stays readable).

Suggested review order: torch/utils/checkpoint.py (compile name derivation +
current_prefix bridge + suspend helper), then the Dynamo wiring (ctx_manager.py
AutoNamingModeVariable, builder.py routing, eval_frame.py suspend hook).

Authored with Claude.

Test Plan:

```
python test/dynamo/test_activation_checkpointing.py -k auto_naming
python test/dynamo/test_activation_checkpointing.py -k compile_policy_kwarg_auto_name
python test/dynamo/test_activation_checkpointing.py -k compile_submodule_policy_absolute_auto_name
```

test_auto_naming_names_match_eager_and_compile asserts names agree between eager
and compile; test_compile_auto_naming_policy / test_compile_policy_kwarg_auto_name
assert `with AutoNamingMode()` traces with no graph break (fullgraph) and that a
policy selecting by auto-name (exact and module-prefix) controls save/recompute
via backward mm counts; test_compile_submodule_policy_absolute_auto_name covers
the cross-boundary bridge.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98