### PR TITLE
[ROCm] Skip cuda graph utils tests on ROCm

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -16,7 +16,7 @@ from torch.cuda._graph_annotations import (
     remap_to_exec_graph,
     resolve_pending_annotations,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
 
 
 TEST_CUDA = torch.cuda.is_available()
@@ -29,6 +29,8 @@ except ImportError:
     TEST_CUDA_BINDINGS = False
 
 
+# cuda.bindings is NVIDIA-only; graph annotation APIs have no ROCm equivalent.
+@skipIfRocm
 @unittest.skipUnless(TEST_CUDA, "CUDA not available")
 @unittest.skipUnless(TEST_CUDA_BINDINGS, "cuda.bindings not available")
 @unittest.skipIf(
@@ -493,6 +495,8 @@ class TestMarkKernels(TestCase):
             self.assertEqual(anns, [{"str": "tagged"}])
 
 
+# cuda.bindings is NVIDIA-only; get_graph_data has no ROCm equivalent.
+@skipIfRocm
 @unittest.skipUnless(TEST_CUDA, "CUDA not available")
 @unittest.skipUnless(TEST_CUDA_BINDINGS, "cuda.bindings not available")
 @unittest.skipIf(


### PR DESCRIPTION
## Summary
- Add `@skipIfRocm` to `TestMarkKernels` and `TestGetGraphData` in `test/test_cuda_graph_utils.py`.
- These tests depend on `cuda.bindings` graph introspection APIs (e.g. `cudaGraphNodeGetToolsId`, `get_graph_data`) which are NVIDIA-only and have no ROCm equivalent.

## Test plan
- [ ] Confirm `test/test_cuda_graph_utils.py` skips on ROCm CI (trunk, rocm-mi300)
- [ ] Confirm tests still run on CUDA with cuda.bindings available

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang