### PR TITLE
Fix Windows AOTI self-mmap size seek

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -172,7 +172,12 @@ int open(char* pathname, int flags) {
   }
 
   if (flags & O_APPEND) {
-    lseek(fd, 0, SEEK_END);
+    if (_lseeki64(fd, 0, SEEK_END) == -1) {
+      int saved_errno = errno;
+      _close(fd);
+      errno = saved_errno;
+      return -1;
+    }
   }
 
   return fd;
@@ -1084,11 +1089,21 @@ class AOTInductorModelBase {
         dladdr(__func__, &dl_info), "Can't find shared library name");
     int fd = open(dl_info.dli_fname, O_RDONLY);
     AOTI_RUNTIME_CHECK(fd >= 0, "Shared library file cannot be opened");
-    auto fsize = lseek(fd, 0, SEEK_END);
+#ifdef _WIN32
+    auto seek_result = _lseeki64(fd, 0, SEEK_END);
+#else
+    auto seek_result = lseek(fd, 0, SEEK_END);
+#endif
+    AOTI_RUNTIME_CHECK(
+        seek_result >= 0, "Failed to seek to end of shared library file");
     auto weights_size =
         reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[0];
     auto magic_number =
         reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[1];
+    uint64_t fsize = static_cast<uint64_t>(seek_result);
+    AOTI_RUNTIME_CHECK(
+        fsize >= weights_size,
+        "Shared library file is smaller than embedded weights size");
     auto weights_offset = fsize - weights_size;
     AOTI_RUNTIME_CHECK(
         (weights_offset & 0x3fff) == 0,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186386

AOTInductor self-mmap loading computes the appended constants offset as the shared library file size minus the serialized weights size. On Windows/MSVC, lseek returns a 32-bit long, so models whose compiled binary plus appended constants exceed 2GB can overflow the file-size query and fail the 16K alignment check even when the appended weights are correctly aligned.

Use _lseeki64 for Windows self-mmap file-size seeks while preserving lseek on POSIX. Validate the signed seek result before converting to uint64_t, check that the file is large enough for the embedded weights, and use the same 64-bit seek in the local Windows O_APPEND shim.

Fixes #186357

Generated by my agent

Test Plan:

- git diff --check

- git diff --cached --check

- python targeted unittest runner for AOTInductorTestABICompatibleCpu.test_large_mmaped_weights_cpu and test_large_mmaped_weights_on_disk_cpu (passed; used in-memory torchvision stub due local torchvision::nms import mismatch)

- static validation script checking _lseeki64 and signed seek-result guards

- lintrunner -a (failed on pre-existing unrelated clang-tidy findings in model_base.h)