### PR TITLE
[BE][Ez]: Micro-opt char literal ostream overloads

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -183,7 +183,7 @@ static void check_args(CheckedFrom c, IntArrayRef args, size_t expected_size, co
     std::stringstream ss;
     ss << arg_name << " should be greater than zero but got (";
     std::copy(args.begin(), args.end() - 1, std::ostream_iterator<int>(ss,", "));
-    ss << args.back() <<  ")" << " (while checking arguments for " << c << ')';
+    ss << args.back() << ')' << " (while checking arguments for " << c << ')';
     TORCH_CHECK(false, ss.str());
   }
 }

--- a/aten/src/ATen/native/hip/ck_gemm_template.h
+++ b/aten/src/ATen/native/hip/ck_gemm_template.h
@@ -397,8 +397,8 @@ void gemm_impl_wmma(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
   float gb_per_sec = num_btype / 1.E6 / ave_time;
 
   std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops << " TFlops, "
-                          << gb_per_sec << " GB/s, " << N <<" " <<M<<" " << k <<" "
-                          << "stride: "<<StrideA <<" "<<StrideB <<" "<<StrideC <<" "
+                          << gb_per_sec << " GB/s, " << N << ' ' << M << ' ' << k << ' '
+                          << "stride: " << StrideA << ' ' << StrideB << ' ' << StrideC << ' '
                           <<  gemm.GetTypeString()
                           << std::endl;
 #endif

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -226,7 +226,7 @@ inline void printQuotedString(std::ostream& stmt, const std::string_view str) {
           s /= 8;
           // NOLINTNEXTLINE(*narrowing-conversions)
           buf[0] += s;
-          stmt << "\\" << buf;
+          stmt << '\\' << buf;
         }
         break;
     }

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -165,7 +165,7 @@ struct C10_API SourceLocation {
       const char* file = __builtin_FILE(),
       const char* function = __builtin_FUNCTION(),
       const std::uint_least32_t line = __builtin_LINE()) noexcept {
-    return {function, file, line};
+    return {.function = function, .file = file, .line = line};
   }
 };
 

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -424,7 +424,7 @@ size_t PyTorchStreamReader::getRecordMultiReaders(
               recordOff + startPos, (char*)dst + startPos, threadReadSize);
         }
         readSizes[i] = size;
-        LOG(INFO) << "Thread " << i << " read [" << startPos << "-" << endPos
+        LOG(INFO) << "Thread " << i << " read [" << startPos << '-' << endPos
                   << "] " << "from " << name << " of size " << n;
         TORCH_CHECK(
             threadReadSize == size,

--- a/test/cpp/aoti_abi_check/test_vec_half.cpp
+++ b/test/cpp/aoti_abi_check/test_vec_half.cpp
@@ -14,9 +14,9 @@ TEST(TestVecHalf, TestConversion) {
     float x = torch::headeronly::vec::half2float_scalar(u16);
     EXPECT_EQ(
         u16, torch::headeronly::detail::fp16_ieee_from_fp32_value(f32s[i]))
-        << "Test failed for float to uint16 " << f32s[i] << "\n";
+        << "Test failed for float to uint16 " << f32s[i] << '\n';
     EXPECT_EQ(x, torch::headeronly::detail::fp16_ieee_to_fp32_value(u16))
-        << "Test failed for uint16 to float " << u16 << "\n";
+        << "Test failed for uint16 to float " << u16 << '\n';
 #endif
   }
 }

--- a/test/cpp/api/init.cpp
+++ b/test/cpp/api/init.cpp
@@ -36,7 +36,7 @@ void check_exact_values(
 
       if (!tensor.allclose(expectedTensor, /*rtol=*/1e-3, /*atol=*/5e-4)) {
         std::cout << "layer " << i << ": " << tensor << " != " << expectedTensor
-                  << " (parameter " << p << ")" << std::endl;
+                  << " (parameter " << p << ')' << std::endl;
         ASSERT_TRUE(false);
       }
     }

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -1033,7 +1033,7 @@ TEST_F(ModuleTest, PrettyPrint) {
     TestModule(int x, float y) : x_(x), y_(y) {}
 
     void pretty_print(std::ostream& stream) const override {
-      stream << "TestModule(x=" << x_ << ", y=" << y_ << ")";
+      stream << "TestModule(x=" << x_ << ", y=" << y_ << ')';
     }
 
     int x_;

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -143,7 +143,7 @@ static void check_exact_values(
             expected_parameters.at(i / kSampleEvery).at(p).to(torch::kFloat64);
         if (!computed.allclose(expected, /*rtol=*/1e-3, /*atol=*/5e-4)) {
           std::cout << "Iteration " << i << ": " << computed
-                    << " != " << expected << " (parameter " << p << ")" << '\n';
+                    << " != " << expected << " (parameter " << p << ')' << '\n';
           ASSERT_TRUE(false);
         }
       }

--- a/test/cpp/api/printing.cpp
+++ b/test/cpp/api/printing.cpp
@@ -11,7 +11,7 @@ TEST(PrintSciModeTest, ToggleScientificNotation) {
   std::ostringstream oss1;
   oss1 << t;
   auto out1 = oss1.str();
-  std::cout << "With sci_mode=true: '" << out1 << "'" << std::endl;
+  std::cout << "With sci_mode=true: '" << out1 << '\'' << std::endl;
   EXPECT_TRUE(
       out1.find("e-") != std::string::npos ||
       out1.find("e+") != std::string::npos);
@@ -21,7 +21,7 @@ TEST(PrintSciModeTest, ToggleScientificNotation) {
   std::ostringstream oss2;
   oss2 << t;
   auto out2 = oss2.str();
-  std::cout << "With sci_mode=false: '" << out2 << "'" << std::endl;
+  std::cout << "With sci_mode=false: '" << out2 << '\'' << std::endl;
   EXPECT_TRUE(
       out2.find("e-") == std::string::npos &&
       out2.find("e+") == std::string::npos);

--- a/test/cpp/common/support.h
+++ b/test/cpp/common/support.h
@@ -25,7 +25,7 @@ namespace test {
         std::string::npos) {                                            \
       FAIL() << "Error message \"" << assert_throws_with_error_message  \
              << "\" did not contain expected substring \"" << substring \
-             << "\"";                                                   \
+             << '"';                                                    \
     }                                                                   \
   }
 

--- a/test/cpp/jit/test_backend_compiler_preprocess.cpp
+++ b/test/cpp/jit/test_backend_compiler_preprocess.cpp
@@ -35,7 +35,7 @@ c10::IValue preprocess(
     for (const auto& node : graph->nodes()) {
       switch (node->kind()) {
         case prim::Constant:
-          ss << node->kind().toDisplayString() << "#"
+          ss << node->kind().toDisplayString() << '#'
              << toIValue(node->output()).value();
           ss << "<debug_handle>" << node_debug_handles[node];
           break;
@@ -57,7 +57,7 @@ c10::IValue preprocess(
               node->sourceRange().str());
           break;
       }
-      ss << ",";
+      ss << ',';
     }
     std::string blob = ss.str();
     if (!blob.empty()) {

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -317,7 +317,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
     if (inputs.size() != input_names_.size()) {
       std::stringstream err;
       err << "Expected " << input_names_.size() << " inputs, but got "
-          << inputs.size() << "!";
+          << inputs.size() << '!';
       throw std::runtime_error(err.str());
     }
     for (size_t i = 0; i < inputs.size(); ++i) {
@@ -340,7 +340,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
           inputs.push_back(constants_.at(input_name));
         } else {
           std::stringstream err;
-          err << "Instruction referenced unknown value " << input_name << "!";
+          err << "Instruction referenced unknown value " << input_name << '!';
           throw std::runtime_error(err.str());
         }
       }
@@ -360,7 +360,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
         result = inputs[0] * inputs[1];
       } else {
         std::stringstream err;
-        err << "Unknown operator " << op << "!";
+        err << "Unknown operator " << op << '!';
         throw std::runtime_error(err.str());
       }
 
@@ -599,14 +599,14 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
           "__str__",
           [](const c10::intrusive_ptr<MyStackClass<std::string>>& self) {
             std::stringstream ss;
-            ss << "[";
+            ss << '[';
             for (size_t i = 0; i < self->stack_.size(); ++i) {
               ss << self->stack_[i];
               if (i != self->stack_.size() - 1) {
                 ss << ", ";
               }
             }
-            ss << "]";
+            ss << ']';
             return ss.str();
           });
   // clang-format off

--- a/test/cpp/jit/test_graph_iterator.cpp
+++ b/test/cpp/jit/test_graph_iterator.cpp
@@ -60,12 +60,12 @@ void assert_ordering(
     std::initializer_list<std::string> expected_list) {
   auto expected = std::vector<std::string>(expected_list);
   ASSERT_EQ(expected.size(), actual.size())
-      << "Got " << actual.size() << " elements (" << actual << ")"
-      << " expected " << expected.size() << " elements (" << expected << ")";
+      << "Got " << actual.size() << " elements (" << actual << ')'
+      << " expected " << expected.size() << " elements (" << expected << ')';
   for (unsigned i = 0; i < expected.size(); i++) {
     ASSERT_EQ(expected[i], actual[i])
         << "Difference at index " << i << " in " << actual << " (expected "
-        << actual << ")";
+        << actual << ')';
   }
 }
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -92,13 +92,13 @@ inline c10::AliasAnalysisKind aliasAnalysisFromSchema() {
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& list) {
   size_t i = 0;
-  out << "{";
+  out << '{';
   for (auto&& e : list) {
     if (i++ > 0)
       out << ", ";
     out << e;
   }
-  out << "}";
+  out << '}';
   return out;
 }
 

--- a/test/cpp/lazy/test_lazy_ops_util.cpp
+++ b/test/cpp/lazy/test_lazy_ops_util.cpp
@@ -51,8 +51,8 @@ bool EqualValues(at::Tensor tensor1, at::Tensor tensor2) {
   if (tensor1.sizes() != tensor2.sizes() ||
       tensor1.dtype() != tensor2.dtype()) {
     std::cerr << "Different shape:\n"
-              << tensor1.dtype() << " " << tensor1.sizes() << "\n-vs-\n"
-              << tensor2.dtype() << " " << tensor2.sizes() << "\n";
+              << tensor1.dtype() << ' ' << tensor1.sizes() << "\n-vs-\n"
+              << tensor2.dtype() << ' ' << tensor2.sizes() << '\n';
     return false;
   }
   at::ScalarType type1 = tensor1.scalar_type();
@@ -69,8 +69,8 @@ bool EqualValuesNoElementTypeCheck(at::Tensor tensor1, at::Tensor tensor2) {
   tensor2 = ToCpuTensor(tensor2);
   if (tensor1.sizes() != tensor2.sizes()) {
     std::cerr << "Different shape:\n"
-              << tensor1.dtype() << " " << tensor1.sizes() << "\n-vs-\n"
-              << tensor2.dtype() << " " << tensor2.sizes() << "\n";
+              << tensor1.dtype() << ' ' << tensor1.sizes() << "\n-vs-\n"
+              << tensor2.dtype() << ' ' << tensor2.sizes() << '\n';
     return false;
   }
   at::ScalarType type1 = tensor1.scalar_type();
@@ -106,8 +106,8 @@ bool CloseValues(
   if (tensor1.sizes() != tensor2.sizes() ||
       tensor1.dtype() != tensor2.dtype()) {
     std::cerr << "Different shape:\n"
-              << tensor1.dtype() << " " << tensor1.sizes() << "\n-vs-\n"
-              << tensor2.dtype() << " " << tensor2.sizes() << "\n";
+              << tensor1.dtype() << ' ' << tensor1.sizes() << "\n-vs-\n"
+              << tensor2.dtype() << ' ' << tensor2.sizes() << '\n';
     return false;
   }
   bool equal = tensor1.allclose(tensor2, rtol, atol);

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/profiler/stubs/openreg.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/profiler/stubs/openreg.cpp
@@ -18,7 +18,7 @@ namespace {
 static void openregCheck(orError_t result, const char* file, int line) {
   if (result != orSuccess) {
     std::stringstream ss;
-    ss << file << ":" << line << ": ";
+    ss << file << ':' << line << ": ";
     if (result == orErrorNotReady) {
       ss << "OpenReg operation not ready";
     } else {

--- a/test/custom_backend/test_custom_backend.cpp
+++ b/test/custom_backend/test_custom_backend.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char* argv[]) {
   }
   const std::string path_to_exported_script_module = argv[1];
 
-  std::cout << "Testing " << torch::custom_backend::getBackendName() << "\n";
+  std::cout << "Testing " << torch::custom_backend::getBackendName() << '\n';
   load_serialized_lowered_module_and_execute(path_to_exported_script_module);
 
   std::cout << "OK\n";

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1150,9 +1150,9 @@ class NativeOpSchema {
     std::ostringstream ss;
     ss << op_.operator_name().name;
     if (!op_.operator_name().overload_name.empty()) {
-      ss << "." << op_.operator_name().overload_name;
+      ss << '.' << op_.operator_name().overload_name;
     }
-    ss << "(";
+    ss << '(';
     bool first = true;
     for (const auto& item : comparison_key_) {
       if (!first)
@@ -1164,7 +1164,7 @@ class NativeOpSchema {
         ss << item.iv;
       }
     }
-    ss << ")";
+    ss << ')';
     return ss.str();
   }
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -570,7 +570,7 @@ static void validate_nvlink_fabric_support(
       }
       oss << "rank " << r << " (host: " << reqs[r].hostname
           << ", device: " << reqs[r].device_idx
-          << ", clique_id: " << reqs[r].clique_id << ")";
+          << ", clique_id: " << reqs[r].clique_id << ')';
     }
     TORCH_CHECK(false, oss.str());
   }

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -83,7 +83,7 @@ struct TORCH_API Object {
     }
     std::stringstream err;
     err << _ivalue()->type()->repr_str() << " does not have a field with name '"
-        << name.c_str() << "'";
+        << name.c_str() << '\'';
     throw ObjectAttributeError(err.str());
   }
 

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -78,7 +78,7 @@ static std::string get_stacked_errors(const std::vector<Call>& error_stack) {
     for (auto it = error_stack.rbegin(); it != error_stack.rend() - 1; ++it) {
       auto callee = it + 1;
 
-      msg << "'" << it->fn_name
+      msg << '\'' << it->fn_name
           << "' is being compiled since it was called from '" << callee->fn_name
           << "'\n";
       callee->caller_range.highlight(msg);

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -970,7 +970,7 @@ struct to_ir {
       const std::string& stmt_name) {
     if (loop_status_ == LoopStatus::NOT_IN_LOOP) {
       throw(
-          ErrorReport(loc) << "SyntaxError: '" << stmt_name << "'"
+          ErrorReport(loc) << "SyntaxError: '" << stmt_name << '\''
                            << " outside loop");
     } else if (loop_status_ == LoopStatus::IN_UNROLLED_LOOP) {
       throw(
@@ -3681,7 +3681,7 @@ struct to_ir {
             throw(
                 ErrorReport(loc)
                 << "enumerate expected kwarg name 'start', got '"
-                << attributes[0].name().name() << "'");
+                << attributes[0].name().name() << '\'');
           }
           start_index =
               emitSugaredExpr(attributes[0].value(), 1)->asValue(loc, method);

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -336,7 +336,7 @@ TypePtr SchemaTypeParser::parseRefinedTensor() {
         });
         return;
       }
-      throw(ErrorReport(L.cur()) << "Unexpected specifier '" << field << "'");
+      throw(ErrorReport(L.cur()) << "Unexpected specifier '" << field << '\'');
     }
     if (device.has_value() || requires_grad.has_value()) {
       throw(

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -293,7 +293,7 @@ TypePtr ScriptTypeParser::parseTypeFromExprImpl(const Expr& expr) const {
       }
     }
 
-    throw ErrorReport(expr) << "Unknown type name '" << type_name << "'";
+    throw ErrorReport(expr) << "Unknown type name '" << type_name << '\'';
   } else if (auto name = parseBaseTypeName(expr)) {
     auto itr = string_to_type_lut().find(*name);
     if (itr != string_to_type_lut().end()) {
@@ -309,7 +309,7 @@ TypePtr ScriptTypeParser::parseTypeFromExprImpl(const Expr& expr) const {
       return custom_class_type;
     }
 
-    throw ErrorReport(expr) << "Unknown type name '" << *name << "'";
+    throw ErrorReport(expr) << "Unknown type name '" << *name << '\'';
   }
   throw ErrorReport(expr.range())
       << "Expression of type " << kindToString(expr.kind())

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -265,7 +265,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
   }
 
   ErrorReport report(loc);
-  report << "'" << value_->type()->repr_str()
+  report << '\'' << value_->type()->repr_str()
          << "' object has no attribute or method '" << field << "'.";
   if (auto classType = value_->type()->cast<ClassType>()) {
     if (classType->isUnresolvedClassAttribute(field)) {
@@ -357,7 +357,7 @@ void SimpleValue::setAttr(
         throw(
             ErrorReport(loc)
             << "Assignment to attribute '" << field
-            << "' cannot be of a type that contains class " << "'"
+            << "' cannot be of a type that contains class " << '\''
             << classType->repr_str() << "'.\n"
             << "Classes that recursively contain instances of themselves"
             << " are not yet supported");
@@ -460,7 +460,7 @@ Value* SimpleValue::len(const SourceRange& loc, GraphFunction& m) {
     return g.insert(aten::len, {val}, {}, loc);
   } else {
     throw(
-        ErrorReport(loc) << "'" << val_type->repr_str() << "'"
+        ErrorReport(loc) << '\'' << val_type->repr_str() << '\''
                          << " object is not iterable");
   }
 }
@@ -500,7 +500,7 @@ SugaredValuePtr SimpleValue::getitem(
     return attr(loc, m, "__getitem__")->call(loc, m, {idx}, {}, 1);
   } else {
     throw(
-        ErrorReport(loc) << "'" << val_type->repr_str() << "'"
+        ErrorReport(loc) << '\'' << val_type->repr_str() << '\''
                          << " object is not subscriptable");
   }
 }
@@ -527,7 +527,7 @@ SugaredValuePtr SimpleValue::iter(const SourceRange& loc, GraphFunction& m) {
     return std::make_shared<SugaredTupleValue>(tup_sugared);
   } else {
     throw(
-        ErrorReport(loc) << "'" << type->repr_str() << "'"
+        ErrorReport(loc) << '\'' << type->repr_str() << '\''
                          << " object is not iterable");
   }
 }
@@ -798,8 +798,8 @@ std::shared_ptr<SugaredValue> SugaredEnumClass::attr(
       [&field](const at::EnumNameValue& nv) { return nv.first == field; });
   if (it == names_values.end()) {
     throw(
-        ErrorReport(loc) << enum_type_->repr_str() << "'"
-                         << " has no attribute '" << field << "'");
+        ErrorReport(loc) << enum_type_->repr_str() << '\''
+                         << " has no attribute '" << field << '\'');
   }
   auto enum_holder = c10::make_intrusive<at::ivalue::EnumHolder>(
       enum_type_, it->first, it->second);
@@ -861,7 +861,7 @@ std::shared_ptr<SugaredValue> TorchCheckValue::call(
     } else {
       throw(
           ErrorReport(loc) << "torch._check() got unexpected keyword argument '"
-                           << kwarg.name() << "'");
+                           << kwarg.name() << '\'');
     }
   }
 

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -136,7 +136,8 @@ struct TORCH_API SugaredValue
   // Value *
   virtual Value* len(const SourceRange& loc, GraphFunction& m) {
     throw(
-        ErrorReport(loc) << "'" << kind() << "'" << " object is not iterable");
+        ErrorReport(loc) << '\'' << kind() << '\''
+                         << " object is not iterable");
   }
 
   // expression for ith element for iterable value
@@ -146,7 +147,7 @@ struct TORCH_API SugaredValue
       Value* idx,
       TypePtr type_hint = nullptr) {
     throw(
-        ErrorReport(loc) << "'" << kind() << "'"
+        ErrorReport(loc) << '\'' << kind() << '\''
                          << " object is not subscriptable");
   }
 
@@ -160,7 +161,7 @@ struct TORCH_API SimpleValue : public SugaredValue {
   std::string kind() const override {
     std::stringstream ss;
     // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    ss << "value of type '" << value_->type()->annotation_str() << "'";
+    ss << "value of type '" << value_->type()->annotation_str() << '\'';
     return ss.str();
   }
   Value* asValue(const SourceRange& range, GraphFunction& m) override {

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -801,7 +801,7 @@ Value* IRParser::findValueInVMap(const std::string& name) {
   if (!vmap.count(name)) {
     throw(
         ErrorReport(L.cur().range)
-        << "Cannot find a variable with name '" << name << "'");
+        << "Cannot find a variable with name '" << name << '\'');
   }
   return vmap.at(name);
 }

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -159,7 +159,7 @@ std::shared_ptr<SugaredValue> PythonValue::call(
 
 std::string PythonValue::kind() const {
   std::stringstream ss;
-  ss << "python value of type '" << typeString(self) << "'";
+  ss << "python value of type '" << typeString(self) << '\'';
   return ss.str();
 }
 
@@ -856,8 +856,7 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
       ErrorReport(loc)
       << "Module '"
       << concreteType_->getJitType()->expectRef<ClassType>().name()->name()
-      << "'"
-      << " has no attribute '" << field << "' " << hint);
+      << '\'' << " has no attribute '" << field << "' " << hint);
 }
 
 SugaredValuePtr ModuleValue::iter(const SourceRange& loc, GraphFunction& m) {

--- a/torch/csrc/jit/serialization/onnx.cpp
+++ b/torch/csrc/jit/serialization/onnx.cpp
@@ -110,7 +110,7 @@ void dump(
   } else if (attr.has_i()) {
     stream << "int, value: " << attr.i();
   } else if (attr.has_s()) {
-    stream << "string, value: '" << attr.s() << "'";
+    stream << "string, value: '" << attr.s() << '\'';
   } else if (attr.has_g()) {
     stream << "graph, value:\n";
     dump(attr.g(), stream, indent + 1);
@@ -133,7 +133,7 @@ void dump(
   } else if (attr.strings_size()) {
     stream << "strings, values: [";
     for (const auto i : c10::irange(attr.strings_size())) {
-      stream << "'" << attr.strings(i) << "'"
+      stream << '\'' << attr.strings(i) << '\''
              << (i == attr.strings_size() - 1 ? "" : " ");
     }
     stream << ']';

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -43,11 +43,11 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
   std::stringstream ss;
   ss << torch_exception_get_what_without_backtrace();
   ss << " (originally from " << call << " API call failed at " << file
-     << ", line " << line << ")";
+     << ", line " << line << ')';
 
   std::time_t t = std::time(nullptr);
   std::tm tm = *std::localtime(&t);
-  std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
+  std::cerr << '[' << std::put_time(&tm, "%H:%M:%S") << ' ' << file << ':'
             << line << "] Exception across libtorch C API boundary: "
             << torch_exception_get_what();
   throw std::runtime_error(ss.str());

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -389,7 +389,7 @@ static void registerXpuDeviceProperties(PyObject* module) {
 #if SYCL_COMPILER_VERSION >= 20260000
                    << ", is_integrated_gpu=" << prop.is_integrated_gpu
 #endif
-                   << ")";
+                   << ')';
             return stream.str();
           });
 }

--- a/torch/nativert/graph/passes/SubgraphRewriter.h
+++ b/torch/nativert/graph/passes/SubgraphRewriter.h
@@ -30,7 +30,7 @@ inline std::ostream& operator<<(std::ostream& out, const Match& match) {
     const Node* patternNode = kv.first;
     Node* targetNode = kv.second;
     out << "  Pattern Node: " << *patternNode
-        << " -> Target Node: " << *targetNode << "\n";
+        << " -> Target Node: " << *targetNode << '\n';
   }
 
   out << "Value mapping:\n";
@@ -38,7 +38,7 @@ inline std::ostream& operator<<(std::ostream& out, const Match& match) {
     const Value* patternValue = kv.first;
     Value* targetValue = kv.second;
     out << "  Pattern Value: " << *patternValue
-        << " -> Target Value: " << *targetValue << "\n";
+        << " -> Target Value: " << *targetValue << '\n';
   }
 
   return out;

--- a/torch/nativert/graph/passes/pass_manager/PassManager.cpp
+++ b/torch/nativert/graph/passes/pass_manager/PassManager.cpp
@@ -42,7 +42,7 @@ bool GraphPassManager::run_pass(Graph* graph, const GraphPassIdentifier& name) {
               << " nodes (delta: "
               << static_cast<int64_t>(nodesAfter) -
               static_cast<int64_t>(nodesBefore)
-              << ")";
+              << ')';
     } else {
       VLOG(1) << "Pass " << name << ": no change (" << nodesAfter << " nodes)";
     }


### PR DESCRIPTION
A lot of streams append single characters without going through the char level overload. This requires them to calculate and reserve length on it and go through less efficient string and `<<` overloads.