### PR TITLE
remove torch/_inductor S101 ruff ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,9 +349,6 @@ select = [
     "LOG015" # please fix
 ]
 
-# torch/ folders still needing S101 migration
-"torch/_inductor/**" = ["S101"]
-
 [tool.codespell]
 ignore-words = "tools/linter/dictionary.txt"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186393
* #186392
* #186391
* #186390
* #182698
* #182436

All plain assert statements under torch/_inductor have been converted to
explicit raise AssertionError, so the S101 (assert-used) ignore is no
longer needed.