### PR TITLE
Preserve overlap deps without blocking fusion

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -920,14 +920,9 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             compiled = torch.compile(func_c)
             test_out, (code,) = run_and_get_code(compiled, a, b, c, d)
 
-            # Check that right deps are added
-            f = FileCheck()
-            for _ in range(2):
-                f.check("control_deps").check_same("all_gather").check_same(
-                    "subgraph_mm"
-                )
-                f.check("control_deps").check_same("mm").check_same("subgraph_wait")
-            f.run(li[0])
+            # Overlap deps are now carried as Inductor scheduler metadata rather
+            # than opaque FX HOPs, so the ATen graph remains transparent to fusion.
+            FileCheck().check_not("control_deps").run(li[0])
 
             f = FileCheck()
             for _ in range(2):

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1652,7 +1652,10 @@ class TestOverlapSchedulingFixes(InductorTestCase):
         )
 
     def test_graphsafe_rng_state_with_insert_overlap_deps(self):
-        from torch._inductor.fx_passes.control_dependencies import control_deps
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps,
+            CONTROL_DEPS_META_KEY,
+        )
         from torch._inductor.fx_passes.overlap_scheduling import (
             schedule_overlap_bucketing,
         )
@@ -1698,17 +1701,413 @@ class TestOverlapSchedulingFixes(InductorTestCase):
             pre_bucketing_fsdp_collectives=False,
         )
 
+        self.assertFalse(
+            any(
+                n.op == "call_function" and n.target is control_deps
+                for n in traced.graph.nodes
+            )
+        )
+
+        rng_node = next(
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function" and n.target is graphsafe_run_with_rng_state
+        )
+        wait_node = next(
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function"
+            and n.target == torch.ops._c10d_functional.wait_tensor.default
+        )
+        self.assertIn(CONTROL_DEPS_META_KEY, rng_node.meta)
+        self.assertIn(CONTROL_DEPS_META_KEY, wait_node.meta)
+
         rng_placeholder = next(
             n
             for n in traced.graph.nodes
             if n.op == "placeholder" and isinstance(n.meta.get("val"), torch.Generator)
         )
-        user = next(iter(rng_placeholder.users))
-        self.assertIs(user.target, control_deps)
+        self.assertEqual(len(rng_placeholder.users), 1)
+        self.assertIs(
+            next(iter(rng_placeholder.users)).target, graphsafe_run_with_rng_state
+        )
 
         graph = GraphLowering(traced, [a, b, gen])
         with V.set_fake_mode(fake_mode), V.set_graph_handler(graph):
             graph.run(a, b, gen)
+
+    def test_insert_overlap_deps_does_not_wrap_fusible_compute(self):
+        from torch._inductor.debug import DebugContext
+        from torch._inductor.dependencies import WeakDep
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps,
+            CONTROL_DEPS_META_KEY,
+        )
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+        from torch._inductor.graph import GraphLowering
+        from torch._inductor.scheduler import Scheduler, SchedulerNode
+        from torch._inductor.virtualized import V
+
+        def func(a, b):
+            ag = torch.ops._c10d_functional.all_gather_into_tensor(a, 2, "0")
+            x = b + 1
+            x = x * 2
+            wait = torch.ops._c10d_functional.wait_tensor(ag)
+            return wait[:4] + x
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            a = torch.empty(4, 4, device=self.device)
+            b = torch.empty(4, 4, device=self.device)
+            traced = make_fx(func)(a, b)
+
+        def custom_runtime_estimation(
+            node: fx.Node, override_size: int | None
+        ) -> float | None:
+            if node.op != "call_function":
+                return None
+            if node.target == torch.ops._c10d_functional.all_gather_into_tensor.default:
+                return 10.0
+            if node.target in (torch.ops.aten.add.Tensor, torch.ops.aten.mul.Tensor):
+                return 10.0
+            return None
+
+        schedule_overlap_bucketing(
+            traced,
+            insert_overlap_deps=True,
+            collective_bucketing=False,
+            custom_runtime_estimation=custom_runtime_estimation,
+            collective_estimator="analytical",
+            compute_estimator="analytical",
+            pre_bucketing_fsdp_collectives=False,
+        )
+
+        self.assertFalse(
+            any(
+                n.op == "call_function" and n.target is control_deps
+                for n in traced.graph.nodes
+            )
+        )
+        self.assertTrue(
+            any(CONTROL_DEPS_META_KEY in n.meta for n in traced.graph.nodes)
+        )
+
+        graph = GraphLowering(traced, [a, b])
+        with (
+            V.set_fake_mode(fake_mode),
+            V.set_graph_handler(graph),
+            V.set_debug_handler(DebugContext()),
+        ):
+            graph.run(a, b)
+            scheduler = Scheduler(graph.operations)
+
+        weak_dep_ordering = []
+        node_order = {node: idx for idx, node in enumerate(scheduler.nodes)}
+
+        def has_scheduler_node(snode):
+            return any(isinstance(n, SchedulerNode) for n in snode.get_nodes())
+
+        for consumer in scheduler.nodes:
+            for dep in consumer.unmet_dependencies:
+                if not (isinstance(dep, WeakDep) and dep.is_fake):
+                    continue
+                buf = scheduler.name_to_buf.get(dep.name)
+                if buf is None or buf.defining_op is None:
+                    continue
+                producer = scheduler.name_to_fused_node.get(
+                    buf.defining_op.get_name(), buf.defining_op
+                )
+                if not (has_scheduler_node(producer) or has_scheduler_node(consumer)):
+                    continue
+                weak_dep_ordering.append((node_order[producer], node_order[consumer]))
+
+        self.assertTrue(weak_dep_ordering)
+        for producer_idx, consumer_idx in weak_dep_ordering:
+            self.assertLess(producer_idx, consumer_idx)
+
+    def test_insert_overlap_deps_preserves_nonfusible_compute_ordering(self):
+        from torch._inductor.debug import DebugContext
+        from torch._inductor.dependencies import WeakDep
+        from torch._inductor.fx_passes.control_dependencies import CONTROL_DEPS_META_KEY
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+        from torch._inductor.graph import GraphLowering
+        from torch._inductor.scheduler import Scheduler, SchedulerNode
+        from torch._inductor.virtualized import V
+
+        def func(a, b, c):
+            ag = torch.ops._c10d_functional.all_gather_into_tensor(a, 2, "0")
+            x = b.sum(dim=1)
+            y = c.sum(dim=0)
+            wait = torch.ops._c10d_functional.wait_tensor(ag)
+            return wait[:4, :4] + x[:, None] + y[None, :]
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            a = torch.empty(4, 4, device=self.device)
+            b = torch.empty(4, 8, device=self.device)
+            c = torch.empty(8, 4, device=self.device)
+            traced = make_fx(func)(a, b, c)
+
+        sum_nodes = [
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.sum.dim_IntList
+        ]
+        self.assertEqual(len(sum_nodes), 2)
+        first_sum, second_sum = sum_nodes
+
+        def custom_runtime_estimation(
+            node: fx.Node, override_size: int | None
+        ) -> float | None:
+            if node.op != "call_function":
+                return None
+            if node.target == torch.ops._c10d_functional.all_gather_into_tensor.default:
+                return 100.0
+            if node.target == torch.ops.aten.sum.dim_IntList:
+                return 10.0
+            return None
+
+        schedule_overlap_bucketing(
+            traced,
+            insert_overlap_deps=True,
+            collective_bucketing=False,
+            custom_runtime_estimation=custom_runtime_estimation,
+            collective_estimator="analytical",
+            compute_estimator="analytical",
+            pre_bucketing_fsdp_collectives=False,
+        )
+
+        self.assertIn(first_sum, second_sum.meta.get(CONTROL_DEPS_META_KEY, ()))
+
+        graph = GraphLowering(traced, [a, b, c])
+        with (
+            V.set_fake_mode(fake_mode),
+            V.set_graph_handler(graph),
+            V.set_debug_handler(DebugContext()),
+        ):
+            graph.run(a, b, c)
+            scheduler = Scheduler(graph.operations)
+
+        def scheduler_node_for_origin(origin: fx.Node):
+            matches = []
+            for snode in scheduler.nodes:
+                for subnode in snode.get_nodes():
+                    if not isinstance(subnode, SchedulerNode):
+                        continue
+                    if subnode.node is None:
+                        continue
+                    if origin in subnode.node.get_origins():
+                        matches.append(snode)
+            self.assertEqual(len(matches), 1)
+            return matches[0]
+
+        first_snode = scheduler_node_for_origin(first_sum)
+        second_snode = scheduler_node_for_origin(second_sum)
+        self.assertIsNot(first_snode, second_snode)
+
+        producer_buffers = first_snode.get_buffer_names()
+        self.assertTrue(
+            any(
+                isinstance(dep, WeakDep)
+                and dep.is_fake
+                and dep.name in producer_buffers
+                for dep in second_snode.unmet_dependencies
+            )
+        )
+
+        node_order = {node: idx for idx, node in enumerate(scheduler.nodes)}
+        self.assertLess(node_order[first_snode], node_order[second_snode])
+
+    def test_insert_overlap_deps_survive_multi_template_extern_replacement(self):
+        from unittest.mock import patch
+
+        from torch._inductor.dependencies import WeakDep
+        from torch._inductor.scheduler import ExternKernelSchedulerNode, Scheduler
+
+        captured_schedulers = []
+        orig_scheduler_init = Scheduler.__init__
+
+        def capture_scheduler_init(self, nodes):
+            orig_scheduler_init(self, nodes)
+            captured_schedulers.append(self)
+
+        def func(a, b, c, d, e):
+            ar = torch.ops._c10d_functional.all_reduce(a, "sum", "0")
+            mm1 = b @ c
+            mm2 = d @ e
+            wait = torch.ops._c10d_functional.wait_tensor(ar)
+            return wait + mm1 + mm2
+
+        def custom_runtime_estimation(
+            node: fx.Node, override_size: int | None = None
+        ) -> float | None:
+            if node.op != "call_function":
+                return None
+            if node.target == torch.ops._c10d_functional.all_reduce.default:
+                return 100.0
+            if node.target == torch.ops.aten.mm.default:
+                return 10.0
+            return None
+
+        inputs = [
+            torch.randn(16, 16, device=self.device),
+            torch.randn(16, 16, device=self.device),
+            torch.randn(16, 16, device=self.device),
+            torch.randn(16, 16, device=self.device),
+            torch.randn(16, 16, device=self.device),
+        ]
+
+        with (
+            torch._inductor.config.patch(
+                {
+                    "aten_distributed_optimizations.enable_overlap_scheduling": True,
+                    "aten_distributed_optimizations.collective_bucketing": False,
+                    "aten_distributed_optimizations.insert_overlap_deps": True,
+                    "aten_distributed_optimizations.custom_runtime_estimation": custom_runtime_estimation,
+                    "aten_distributed_optimizations.collective_estimator": "analytical",
+                    "aten_distributed_optimizations.compute_estimator": "analytical",
+                    "aten_distributed_optimizations.pre_bucketing_fsdp_collectives": False,
+                    "max_autotune": True,
+                    "max_autotune_gemm": True,
+                    "max_autotune_gemm_backends": "TRITON,ATEN",
+                    "test_configs.force_extern_kernel_in_multi_template": True,
+                    "triton.native_matmul": False,
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                    "force_disable_caches": True,
+                    "compile_threads": 1,
+                }
+            ),
+            patch.object(Scheduler, "__init__", capture_scheduler_init),
+        ):
+            out = torch.compile(func, dynamic=False)(*inputs)
+            torch.cuda.synchronize()
+
+        self.assertEqual(out.shape, inputs[0].shape)
+        self.assertEqual(len(captured_schedulers), 1)
+        scheduler = captured_schedulers[0]
+
+        def has_mm_origin(snode):
+            for subnode in snode.get_nodes():
+                if subnode.node is None:
+                    continue
+                for origin in subnode.node.get_origins():
+                    if (
+                        isinstance(origin, fx.Node)
+                        and origin.op == "call_function"
+                        and origin.target
+                        in (torch.ops.aten.mm.default, torch.ops.aten.addmm.default)
+                    ):
+                        return True
+            return False
+
+        mm_nodes = [n for n in scheduler.nodes if has_mm_origin(n)]
+        self.assertEqual(len(mm_nodes), 2)
+        self.assertTrue(all(isinstance(n, ExternKernelSchedulerNode) for n in mm_nodes))
+
+        node_order = {node: idx for idx, node in enumerate(scheduler.nodes)}
+        weak_mm_edges = []
+        for consumer in mm_nodes:
+            for dep in consumer.unmet_dependencies:
+                if not (isinstance(dep, WeakDep) and dep.is_fake):
+                    continue
+                buf = scheduler.name_to_buf.get(dep.name)
+                if buf is None or buf.defining_op is None:
+                    continue
+                producer = scheduler.name_to_fused_node.get(
+                    buf.defining_op.get_name(), buf.defining_op
+                )
+                if producer in mm_nodes:
+                    weak_mm_edges.append((producer, consumer))
+
+        self.assertEqual(len(weak_mm_edges), 1)
+        producer, consumer = weak_mm_edges[0]
+        self.assertLess(node_order[producer], node_order[consumer])
+
+    def test_insert_overlap_deps_preserves_fusible_kernel_count(self):
+        import torch.distributed._functional_collectives as funcol
+        from torch._inductor import async_compile as ac
+        from torch._inductor.fx_passes import overlap_scheduling as op
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(16, 32, 3, padding=1)
+                self.ln1 = torch.nn.LayerNorm(32)
+                self.ln2 = torch.nn.LayerNorm(32)
+
+            def forward(self, y):
+                h = self.conv(y).permute(0, 2, 3, 1).contiguous()
+                h = self.ln1(h)
+                h = h + h.mean(dim=-1, keepdim=True)
+                a = funcol.all_reduce(
+                    torch.zeros_like(h), "sum", group=dist.group.WORLD
+                )
+                return self.ln2(a + h)
+
+        state = {"kernels": 0, "control_deps": 0}
+        orig_triton = ac.AsyncCompile.triton
+        orig_schedule_overlap_bucketing = op.schedule_overlap_bucketing
+
+        def wrap_triton(self, name, src, device_str="cuda"):
+            state["kernels"] += 1
+            return orig_triton(self, name, src, device_str=device_str)
+
+        def wrap_schedule_overlap_bucketing(gm, *args, **kwargs):
+            ret = orig_schedule_overlap_bucketing(gm, *args, **kwargs)
+            state["control_deps"] += sum(
+                1
+                for n in gm.graph.nodes
+                if "control_deps" in getattr(n.target, "__name__", str(n.target))
+            )
+            return ret
+
+        def run(insert_overlap_deps):
+            state["kernels"] = 0
+            state["control_deps"] = 0
+            torch._dynamo.reset()
+            torch.manual_seed(0)
+
+            with torch._inductor.config.patch(
+                {
+                    "aten_distributed_optimizations.enable_overlap_scheduling": True,
+                    "aten_distributed_optimizations.collective_bucketing": True,
+                    "aten_distributed_optimizations.insert_overlap_deps": insert_overlap_deps,
+                    "aten_distributed_optimizations.collective_estimator": "analytical",
+                    "reorder_for_compute_comm_overlap": False,
+                    "reorder_for_compute_comm_overlap_passes": [],
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                    "force_disable_caches": True,
+                    "compile_threads": 1,
+                }
+            ):
+                model = Model().to(self.device).eval()
+                y = torch.randn(1, 16, 16, 16, device=self.device)
+                with torch.no_grad():
+                    out = torch.compile(model, dynamic=False)(y)
+                torch.cuda.synchronize()
+
+            return out, state["kernels"], state["control_deps"]
+
+        ac.AsyncCompile.triton = wrap_triton
+        op.schedule_overlap_bucketing = wrap_schedule_overlap_bucketing
+        try:
+            out_off, kernels_off, control_deps_off = run(False)
+            out_on, kernels_on, control_deps_on = run(True)
+        finally:
+            ac.AsyncCompile.triton = orig_triton
+            op.schedule_overlap_bucketing = orig_schedule_overlap_bucketing
+            torch._dynamo.reset()
+
+        self.assertEqual(control_deps_off, 0)
+        self.assertEqual(control_deps_on, 0)
+        self.assertEqual(kernels_on, kernels_off)
+        self.assertEqual((out_off - out_on).abs().max().item(), 0.0)
 
 
 class TestForeachGroupsUnit(InductorTestCase):

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -19,6 +19,9 @@ from torch.fx._lazy_graph_module import _LazyGraphModule
 from torch.utils._ordered_set import OrderedSet
 
 
+CONTROL_DEPS_META_KEY = "inductor_control_deps"
+
+
 class ControlDeps(HigherOrderOperator):
     """
     Higher-order operator that enforces ordering by making dependencies explicit.
@@ -206,6 +209,30 @@ def preserve_node_ordering(
 
         # Track the replacement for future dependencies
         replacements[dependent_node] = ordered_node
+
+
+def record_node_ordering_metadata(
+    graph: fx.Graph,
+    additional_deps_map: dict[fx.Node, OrderedSet[fx.Node]],
+) -> None:
+    """
+    Record extra ordering constraints in FX node metadata for Inductor lowering.
+
+    Unlike preserve_node_ordering(), this does not wrap the target operation in a
+    higher-order op. Inductor's scheduler consumes this metadata after lowering
+    and applies weak buffer dependencies between the generated scheduler nodes.
+    That preserves ordering constraints without hiding fusible compute from
+    Inductor's normal fusion machinery.
+    """
+    if not additional_deps_map:
+        return
+
+    for dependent_node, dep_nodes in additional_deps_map.items():
+        assert dependent_node.op == "call_function", dependent_node.op
+        existing = dependent_node.meta.get(CONTROL_DEPS_META_KEY)
+        deps = OrderedSet(existing) if existing is not None else OrderedSet()
+        deps.update(dep_nodes)
+        dependent_node.meta[CONTROL_DEPS_META_KEY] = tuple(deps)
 
 
 def _create_subgraph_for_node(

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -347,17 +347,20 @@ class OverlapPreservingBucketer:
             for node, deps in additional_deps.items():
                 filtered_node_deps: OrderedSet[fx.Node] = OrderedSet()
                 for dep in deps:
-                    if not (is_collective_or_wait(node) and is_collective_or_wait(dep)):
-                        filtered_node_deps.add(dep)
+                    node_is_collective_or_wait = is_collective_or_wait(node)
+                    dep_is_collective_or_wait = is_collective_or_wait(dep)
+                    if node_is_collective_or_wait and dep_is_collective_or_wait:
+                        continue
+                    filtered_node_deps.add(dep)
                 if filtered_node_deps:
                     filtered_deps[node] = filtered_node_deps
 
             if filtered_deps:
                 from torch._inductor.fx_passes.control_dependencies import (
-                    preserve_node_ordering,
+                    record_node_ordering_metadata,
                 )
 
-                preserve_node_ordering(self.graph, filtered_deps)
+                record_node_ordering_metadata(self.graph, filtered_deps)
 
     def bucket_collectives(self) -> None:
         """Run the full bucketing and dep application flow."""

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4151,6 +4151,7 @@ class Scheduler:
 
         self.merge_loops()
         self.finalize_multi_template_buffers()
+        self.apply_control_deps_from_fx_metadata()
         if (
             config.max_autotune_gemm or config.max_autotune
         ) and use_pipelined_autotuning():
@@ -4388,6 +4389,102 @@ class Scheduler:
             return ExternKernelSchedulerNode(self, node)
         else:
             raise NotImplementedError(node)
+
+    def apply_control_deps_from_fx_metadata(self) -> bool:
+        """
+        Apply FX-level ordering constraints after fusion and template finalization.
+
+        Overlap scheduling records extra deps in FX metadata so that regular
+        Inductor lowering and fusion can still see through compute nodes. After
+        fusion and MultiTemplateBuffer replacement, map those FX origins onto the
+        final scheduler nodes and encode the constraints as weak buffer deps.
+        """
+        from torch._inductor.fx_passes.control_dependencies import CONTROL_DEPS_META_KEY
+
+        origin_to_nodes: defaultdict[torch.fx.Node, OrderedSet[BaseSchedulerNode]] = (
+            defaultdict(OrderedSet)
+        )
+        dependent_origins: OrderedSet[torch.fx.Node] = OrderedSet()
+
+        for node in self.nodes:
+            for sub_node in node.get_nodes():
+                assert sub_node.node is not None
+                for origin in sub_node.node.get_origins():
+                    if isinstance(origin, torch.fx.Node):
+                        origin_to_nodes[origin].add(node)
+                        if origin.meta.get(CONTROL_DEPS_META_KEY):
+                            dependent_origins.add(origin)
+
+        if not dependent_origins:
+            return False
+
+        direct_data_deps: dict[BaseSchedulerNode, OrderedSet[BaseSchedulerNode]] = {
+            node: OrderedSet() for node in self.nodes
+        }
+        for node in self.nodes:
+            for dep in node.read_writes.reads:
+                # Existing WeakDeps are ordering-only edges. Use only material
+                # data deps when checking whether a new ordering edge would
+                # point backwards and create a scheduler cycle.
+                if isinstance(dep, WeakDep):
+                    continue
+                buf = self.name_to_buf.get(dep.name)
+                if buf is None or buf.defining_op is None:
+                    continue
+                dep_node = self.name_to_fused_node.get(buf.defining_op.get_name())
+                if dep_node is not None and dep_node is not node:
+                    direct_data_deps[node].add(dep_node)
+
+        @functools.cache
+        def data_ancestors(node: BaseSchedulerNode) -> tuple[BaseSchedulerNode, ...]:
+            ancestors: OrderedSet[BaseSchedulerNode] = OrderedSet()
+            for dep_node in direct_data_deps.get(node, ()):
+                ancestors.add(dep_node)
+                ancestors.update(data_ancestors(dep_node))
+            return tuple(ancestors)
+
+        applied = False
+        for dependent_origin in dependent_origins:
+            dep_origins = dependent_origin.meta.get(CONTROL_DEPS_META_KEY, ())
+            for consumer_node in origin_to_nodes.get(dependent_origin, ()):
+                for dep_origin in dep_origins:
+                    if not isinstance(dep_origin, torch.fx.Node):
+                        continue
+                    for producer_node in origin_to_nodes.get(dep_origin, ()):
+                        if producer_node is consumer_node:
+                            continue
+                        if consumer_node in data_ancestors(producer_node):
+                            continue
+                        for output in producer_node.get_outputs():
+                            dep_name = output.get_name()
+                            weak_dep = WeakDep(
+                                dep_name,
+                                consumer_node.get_name(),
+                                is_fake=True,
+                            )
+                            consumer_node.set_read_writes(
+                                consumer_node.read_writes.with_read(weak_dep)
+                            )
+                            consumer_node.unmet_dependencies.add(weak_dep)
+                            self.name_to_buf[dep_name].users.append(
+                                NodeUser(consumer_node, is_weak=True)
+                            )
+                            self.name_to_buf[dep_name].set_users(
+                                self.name_to_buf[dep_name].users
+                            )
+                            applied = True
+
+        if applied:
+            self.nodes = self.topological_sort_schedule(self.nodes)
+            self.name_to_fused_node = {}
+            for node in self.nodes:
+                self.name_to_fused_node[node.get_name()] = node
+                for name in node.get_operation_names():
+                    self.name_to_fused_node[name] = node
+            self.compute_ancestors()
+            self.compute_input_distances()
+
+        return applied
 
     def create_foreach_nodes(self) -> None:
         removed_node_names: OrderedSet[str] = OrderedSet()
@@ -4916,10 +5013,15 @@ class Scheduler:
         for node in self.nodes:
             ancestors: OrderedSet[str] = OrderedSet()
             for dep in node.unmet_dependencies:
-                dep_node_name = self.name_to_buf[dep.name].defining_op_name()
-                ancestors.add(dep_node_name)
-                ancestors |= name_to_ancestors[dep_node_name]
+                dep_op_name = self.name_to_buf[dep.name].defining_op_name()
+                dep_node = self.name_to_fused_node[dep_op_name]
+                if dep_node is node:
+                    continue
+                ancestors.add(dep_op_name)
+                ancestors |= name_to_ancestors[dep_op_name]
             name_to_ancestors[node.get_name()] = ancestors
+            for op_name in node.get_operation_names():
+                name_to_ancestors[op_name] = ancestors
             node.ancestors = ancestors
 
         for order, node in enumerate(self.nodes):
@@ -4939,20 +5041,30 @@ class Scheduler:
                 min_dist = 0
                 max_dist = 0
             else:
+                dep_node_names = []
+                for dep in node.unmet_dependencies:
+                    dep_op_name = self.name_to_buf[dep.name].defining_op_name()
+                    dep_node = self.name_to_fused_node[dep_op_name]
+                    if dep_node is node:
+                        continue
+                    dep_node_names.append(dep_op_name)
                 dep_min_dists = [
-                    name_to_min_distance[self.name_to_buf[dep.name].defining_op_name()]
-                    + 1
-                    for dep in node.unmet_dependencies
+                    name_to_min_distance[dep_node_name] + 1
+                    for dep_node_name in dep_node_names
                 ]
                 dep_max_dists = [
-                    name_to_max_distance[self.name_to_buf[dep.name].defining_op_name()]
-                    + 1
-                    for dep in node.unmet_dependencies
+                    name_to_max_distance[dep_node_name] + 1
+                    for dep_node_name in dep_node_names
                 ]
-                min_dist = min(dep_min_dists)
-                max_dist = max(dep_max_dists)
-            name_to_min_distance[node.get_name()] = min_dist
-            name_to_max_distance[node.get_name()] = max_dist
+                if not dep_min_dists or not dep_max_dists:
+                    min_dist = 0
+                    max_dist = 0
+                else:
+                    min_dist = min(dep_min_dists)
+                    max_dist = max(dep_max_dists)
+            for name in itertools.chain((node.get_name(),), node.get_operation_names()):
+                name_to_min_distance[name] = min_dist
+                name_to_max_distance[name] = max_dist
             node.min_input_distance = min_dist
             node.max_input_distance = max_dist
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186395

Overlap scheduling used preserve_node_ordering() to encode extra ordering constraints when insert_overlap_deps=True. That rewrote the dependent FX nodes as higher_order.control_deps subgraphs. The HOP is opaque to Inductor fusion and its lowering realizes dependency tensors, so an ordering-only edge could become a materialization barrier around fusible pointwise/reduction compute.

Record those ordering constraints in FX metadata instead. The scheduler now materializes the metadata after loop fusion and MultiTemplateBuffer finalization as fake WeakDeps on the final scheduler nodes. This keeps overlap ordering for collective/wait and independent compute edges, while same-fused-node edges disappear after fusion and do not split fusible compute chains.

Only collective/wait-to-collective/wait deps are filtered before metadata recording, matching the old NCCL-stream-ordering exception. Tests cover transparent FX graphs, preserved scheduler weak deps for non-fusible compute, MultiTemplate extern replacement, graphsafe RNG metadata, and the reported kernel-count regression.

Benchmark Results:

Local fake-PG CUDA reproducer for the issue shape: before fix, insert_overlap_deps=True emitted 5 Triton kernels and 7 control_deps HOPs versus 4 kernels with insert_overlap_deps=False; after fix, insert_overlap_deps=True emits 4 Triton kernels and 0 control_deps HOPs, matching the off case, with max diff 0.0.

Test Plan:

python test/distributed/test_overlap_bucketing_unit.py TestOverlapSchedulingFixes.test_insert_overlap_deps_survive_multi_template_extern_replacement TestOverlapSchedulingFixes.test_insert_overlap_deps_preserves_nonfusible_compute_ordering TestOverlapSchedulingFixes.test_insert_overlap_deps_does_not_wrap_fusible_compute TestOverlapSchedulingFixes.test_insert_overlap_deps_preserves_fusible_kernel_count TestOverlapSchedulingFixes.test_graphsafe_rng_state_with_insert_overlap_deps

python test/distributed/test_aten_comm_compute_reordering.py TestComputeCommReorderingBucketing.test_bucketing_split_for_overlap_blocking_deps_inductor

lintrunner -a torch/_inductor/fx_passes/control_dependencies.py torch/_inductor/fx_passes/overlap_preserving_bucketer.py torch/_inductor/scheduler.py test/distributed/test_overlap_bucketing_unit.py test/distributed/test_aten_comm_compute_reordering.py

Fixes #186084

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo