### PR TITLE
[MPS] fix attention compilation on nightly

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -561,7 +561,7 @@ static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
   const int64_t num_kv_heads = k_.size(1);
   const int gqa_factor = static_cast<int>(num_heads / num_kv_heads);
 
-  auto out = at::empty_like(q_);
+  auto out = at::empty(q_.sizes(), q_.options());
 
   // Strides for [B, H, L, D] layout. Last-dim stride must be 1.
   TORCH_CHECK(q_.stride(-1) == 1, "sdpa prefill:query last-dim must be contiguous");

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -257,6 +257,23 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (q, k, v), atol=1e-4, rtol=1e-4, check_lowp=False)
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_sdpa_prefill_strided(self, dtype):
+        torch.manual_seed(0)
+        B, H, S, D = 1, 16, 1179, 128
+
+        def fn(q, k, v, mask):
+            q, k, v = (t.transpose(1, 2) for t in (q, k, v))
+            return torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask
+            )
+
+        q, k, v = (
+            torch.randn(B, S, H, D, device=self.device, dtype=dtype) for _ in range(3)
+        )
+        mask = torch.zeros(B, 1, S, S, device=self.device, dtype=dtype)
+        self.assertEqual(torch.compile(fn)(q, k, v, mask), fn(q, k, v, mask))
+
     def test_nested_masked_cat(self):
         # Regression test for YOLOv3 compilation failure on MPS.
         # See https://github.com/pytorch/pytorch/actions/runs/23477894502


### PR DESCRIPTION
Fix attention compilation on nightly:
```
import torch
from torch.nn.functional import scaled_dot_product_attention as sdpa

q, k, v = (torch.randn(1, 1179, 16, 128, device="mps", dtype=torch.bfloat16).transpose(1, 2) for _ in range(3))
torch.compile(sdpa)(q, k, v)
```
This fails on main, works on 2.12

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo