### PR TITLE
[dynamo, 3.15] Update IMPORT_NAME generation

### DIFF
--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1720,7 +1720,15 @@ def fix_vars(
                     instructions[i].arg = varnames[instructions[i].argval]
         elif instructions[i].opcode in HAS_NAME:
             if should_compute_arg():
-                instructions[i].arg = get_name_index(instructions[i].argval)
+                arg = get_name_index(instructions[i].argval)
+                if (
+                    sys.version_info >= (3, 15)
+                    and instructions[i].opname == "IMPORT_NAME"
+                ):
+                    arg <<= 2
+                    # Set the second bit to ensure eager imports, since lazy imports are only valid at module scope
+                    arg |= 0x02
+                instructions[i].arg = arg
         elif instructions[i].opcode in HAS_FREE:
             if should_compute_arg():
                 instructions[i].arg = freenames[instructions[i].argval]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178393
* #179094
* __->__ #186402

In 3.15 the lower 2 bits of the IMPORT_NAME oparg are used to indicate lazy vs eager imports.  We need to shift the
index left (this was causing `SyntaxError: 'lazy import' is only allowed at module level` previously in generated
IMPORT_NAME instructions) and set 2nd lowest bit to indicate eager imports.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98