### PR TITLE
[ROCm][inductor][UT] Adjust MI200 addmm OpInfo tolerance

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1336,8 +1336,9 @@ class TestInductorOpInfo(TestCase):
             # otherwise avoids. reference_in_float=True (the eager FP32
             # reference) is inherited from the ("addmm", f16) cuda entry above.
             # Observed rel diff is ~9 * eps; use ~2e-2 for headroom across
-            # samples and rocBLAS solver versions.
-            overridden_kwargs.update({"rtol": 2e-2})
+            # samples and rocBLAS solver versions. Set atol explicitly since
+            # PyTorch requires rtol/atol overrides to be paired.
+            overridden_kwargs.update({"rtol": 2e-2, "atol": 1e-3})
         func = op.get_op()
 
         def fn(*args, **kwargs):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1327,19 +1327,17 @@ class TestInductorOpInfo(TestCase):
             and dtype is f16
             and isRocmArchAnyOf(MI200_ARCH)
         ):
-            # On AMD Instinct MI200, FP16 matrix instructions may flush denormal
-            # values to zero. PyTorch uses rocBLAS alternate FP16 implementations
-            # during backward to preserve these values. See:
+            # MI200 eager backward routes FP16 GEMMs through the rocBLAS
+            # alt-impl to preserve denormals while inductor's compiled GEMM does
+            # not, so the two diverge at FP16 scale. See:
             # https://docs.pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
-            #
-            # Keep the FP32 eager reference, but allow FP16-scale differences:
-            # tiny is the smallest normal FP16 value, so it covers
-            # subnormal-scale absolute differences; eps is FP16 relative
-            # precision near 1.0. The observed relative difference for this
-            # test on MI200 is about 9 * eps, so use 10 * eps as a
-            # small round-number margin.
-            f16_info = torch.finfo(f16)
-            overridden_kwargs.update({"atol": f16_info.tiny, "rtol": 10 * f16_info.eps})
+            # Checked at runtime, not in inductor_override_kwargs, because the
+            # arch query would force import-time HIP init that this module
+            # otherwise avoids. reference_in_float=True (the eager FP32
+            # reference) is inherited from the ("addmm", f16) cuda entry above.
+            # Observed rel diff is ~9 * eps; use ~2e-2 for headroom across
+            # samples and rocBLAS solver versions.
+            overridden_kwargs.update({"rtol": 2e-2})
         func = op.get_op()
 
         def fn(*args, **kwargs):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -37,8 +37,8 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_WINDOWS,
     IS_X86,
-    MI200_ARCH,
     isRocmArchAnyOf,
+    MI200_ARCH,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -1339,9 +1339,7 @@ class TestInductorOpInfo(TestCase):
             # test on MI200 is about 9 * eps, so use 10 * eps as a
             # small round-number margin.
             f16_info = torch.finfo(f16)
-            overridden_kwargs.update(
-                {"atol": f16_info.tiny, "rtol": 10 * f16_info.eps}
-            )
+            overridden_kwargs.update({"atol": f16_info.tiny, "rtol": 10 * f16_info.eps})
         func = op.get_op()
 
         def fn(*args, **kwargs):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -37,6 +37,8 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_WINDOWS,
     IS_X86,
+    MI200_ARCH,
+    isRocmArchAnyOf,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -1318,6 +1320,28 @@ class TestInductorOpInfo(TestCase):
         overridden_kwargs.update(
             inductor_override_kwargs.get(device_type, {}).get((op_name, dtype), {})
         )
+        if (
+            TEST_WITH_ROCM
+            and device_type == GPU_TYPE
+            and op_name == "addmm"
+            and dtype is f16
+            and isRocmArchAnyOf(MI200_ARCH)
+        ):
+            # On AMD Instinct MI200, FP16 matrix instructions may flush denormal
+            # values to zero. PyTorch uses rocBLAS alternate FP16 implementations
+            # during backward to preserve these values. See:
+            # https://docs.pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
+            #
+            # Keep the FP32 eager reference, but allow FP16-scale differences:
+            # tiny is the smallest normal FP16 value, so it covers
+            # subnormal-scale absolute differences; eps is FP16 relative
+            # precision near 1.0. The observed relative difference for this
+            # test on MI200 is about 9 * eps, so use 10 * eps as a
+            # small round-number margin.
+            f16_info = torch.finfo(f16)
+            overridden_kwargs.update(
+                {"atol": f16_info.tiny, "rtol": 10 * f16_info.eps}
+            )
         func = op.get_op()
 
         def fn(*args, **kwargs):


### PR DESCRIPTION
## Summary
This addresses the UT regression exposed after #183766 routed MI200 FP16 backward GEMMs through rocBLAS to preserve subnormals.

- Add an MI200-only tolerance override for Inductor `addmm` FP16 OpInfo coverage.
- Keep the existing FP32 eager reference while allowing FP16-scale absolute/relative differences.

## Test plan
- `python test/inductor/test_torchinductor_opinfo.py -k test_comprehensive_addmm_cuda_float16`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben