### PR TITLE
[inductor] Fix FakeTensorUpdater for flex attention backward

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -11,14 +11,21 @@ import torch._dynamo.test_case
 import torch.distributed._functional_collectives as _functional_collectives
 import torch.fx as fx
 from torch._C import FileCheck
-from torch._dynamo.utils import counters, same
+from torch._dynamo.utils import counters, detect_fake_mode, same
+from torch._functorch._aot_autograd.utils import make_boxed_func
+from torch._inductor import compile_fx
+from torch._inductor.compile_fx import _recursive_post_grad_passes
+from torch._inductor.fx_utils import get_fake
 from torch._inductor.utils import run_and_get_code, run_and_get_triton_code
+from torch._inductor.virtualized import V
+from torch.nn.attention.flex_attention import flex_attention
 from torch.testing._internal.common_distributed import (
     _dynamo_dist_per_rank_init,
     at_least_x_gpu,
     DynamoDistributedMultiProcTestCase,
     requires_accelerator_dist_backend,
 )
+from torch.utils import _pytree as pytree
 
 
 aten = torch.ops.aten
@@ -450,6 +457,78 @@ graph():
                 correct = func(inputs)
                 self.assertTrue(same(out, correct))
                 self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 0)
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_overlap_scheduling_flex_attention_backward(self):
+        def func(q, k, v, bias):
+            ar = _functional_collectives.all_reduce(bias, "sum", "0")
+
+            def score_mod(score, b, h, q_idx, kv_idx):
+                return score + ar[q_idx, kv_idx]
+
+            return flex_attention(q, k, v, score_mod=score_mod).sum()
+
+        patches = {
+            **get_patches(),
+            "aten_distributed_optimizations.enable_overlap_scheduling": True,
+            "aten_distributed_optimizations.insert_overlap_deps": True,
+            "aten_distributed_optimizations.pre_bucketing_fsdp_collectives": False,
+        }
+        compiled_graphs = []
+
+        def materialize_output(gm):
+            output = gm.graph.output_node().args[0]
+            fake_output = pytree.tree_map(lambda x: get_fake(x, gm), output)
+
+            def materialize(x):
+                if isinstance(x, torch.Tensor):
+                    return torch.zeros(tuple(x.shape), device=x.device, dtype=x.dtype)
+                return x
+
+            return pytree.tree_map(materialize, fake_output)
+
+        def compile_fx_inner(gm, example_inputs, *args, **kwargs):
+            fake_mode = detect_fake_mode(example_inputs)
+            if fake_mode is None:
+                raise AssertionError("expected fake mode from example inputs")
+            with V.set_fake_mode(fake_mode):
+                _recursive_post_grad_passes(
+                    gm, is_inference=kwargs.get("is_inference", False)
+                )
+            compiled_graphs.append(gm)
+            output = materialize_output(gm)
+            return make_boxed_func(lambda *args: output)
+
+        backend = functools.partial(
+            compile_fx.compile_fx, inner_compile=compile_fx_inner
+        )
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            q = torch.randn(1, 1, 128, 16, device=device_type, requires_grad=True)
+            k = torch.randn(1, 1, 128, 16, device=device_type, requires_grad=True)
+            v = torch.randn(1, 1, 128, 16, device=device_type, requires_grad=True)
+            bias = torch.randn(128, 128, device=device_type, requires_grad=True)
+
+            with torch._inductor.config.patch(patches):
+                loss = torch.compile(func, backend=backend, fullgraph=True)(
+                    q, k, v, bias
+                )
+                loss.backward()
+
+            self.assertEqual(len(compiled_graphs), 2)
+            self.assertTrue(
+                any("flex_attention_backward" in gm.code for gm in compiled_graphs)
+            )
+            self.assertTrue(any("control_deps" in gm.code for gm in compiled_graphs))
+            self.assertIsNotNone(q.grad)
+            self.assertIsNotNone(k.grad)
+            self.assertIsNotNone(v.grad)
+            self.assertIsNotNone(bias.grad)
 
     @torch._inductor.config.patch(get_patches())
     def test_custom_estimator_for_non_compute_nodes(self):

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -19,6 +19,7 @@ from torch._inductor.fx_utils import (
 )
 from torch._inductor.utils import get_device_tflops, sympy_str, sympy_subs
 from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.ops import aten
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -550,6 +551,114 @@ class TestFakeTensorUpdater(TestCase):
         b = torch.randint(0, (1 << 16), (8, 4, 2, 1), dtype=torch.int32)
         graph = self._get_graph(fn, a, b)
         self._add_delete_nodes_test(graph)
+
+    def test_flex_attention_backward_updates_subgraph_inputs(self):
+        with torch._subclasses.FakeTensorMode() as mode:
+            query = mode.from_tensor(torch.randn(2, 2, 4, 8))
+            logsumexp = mode.from_tensor(torch.randn(2, 2, 4))
+            score = query.new_zeros(())
+            index = query.new_zeros((), dtype=torch.int)
+            grad = query.new_zeros(())
+            score_buffer = mode.from_tensor(torch.randn(2, 3, 4, 5).contiguous())
+            restrided_score_buffer = mode.from_tensor(
+                torch.randn(2, 3, 5, 4).permute(0, 1, 3, 2)
+            )
+            mask_buffer = mode.from_tensor(torch.randn(2, 3, 4, 5))
+            restrided_mask_buffer = mode.from_tensor(
+                torch.randn(2, 3, 5, 4).permute(0, 1, 3, 2)
+            )
+
+            def fw(score, b, h, q_idx, kv_idx, score_buffer):
+                return score + score_buffer[0, 0, 0, 0]
+
+            def joint(score, b, h, q_idx, kv_idx, grad, score_buffer):
+                return grad, None, None, None, None, score_buffer
+
+            def mask(b, h, q_idx, kv_idx, mask_buffer):
+                return mask_buffer[0, 0, 0, 0] > 0
+
+            fw_subgraph = make_fx(fw, tracing_mode="fake")(
+                score, index, index, index, index, score_buffer
+            )
+            joint_subgraph = make_fx(joint, tracing_mode="fake")(
+                score, index, index, index, index, grad, score_buffer
+            )
+            mask_subgraph = make_fx(mask, tracing_mode="fake")(
+                index, index, index, index, mask_buffer
+            )
+
+            def flex_backward(
+                query,
+                logsumexp,
+                score_buffer,
+                restrided_score_buffer,
+                mask_buffer,
+                restrided_mask_buffer,
+            ):
+                return torch.ops.higher_order.flex_attention_backward(
+                    query,
+                    query,
+                    query,
+                    query,
+                    logsumexp,
+                    query,
+                    None,
+                    fw_subgraph,
+                    joint_subgraph,
+                    (mask_subgraph,),
+                    1.0,
+                    {},
+                    (score_buffer,),
+                    (mask_buffer,),
+                )
+
+            gm = make_fx(flex_backward, tracing_mode="fake")(
+                query,
+                logsumexp,
+                score_buffer,
+                restrided_score_buffer,
+                mask_buffer,
+                restrided_mask_buffer,
+            )
+            flex_backward_node = next(
+                node
+                for node in gm.graph.nodes
+                if node.target is torch.ops.higher_order.flex_attention_backward
+            )
+            placeholders = {
+                node.target: node for node in gm.graph.find_nodes(op="placeholder")
+            }
+            score_buffer_node = placeholders["score_buffer_1"]
+            restrided_score_buffer_node = placeholders["restrided_score_buffer_1"]
+            mask_buffer_node = placeholders["mask_buffer_1"]
+            restrided_mask_buffer_node = placeholders["restrided_mask_buffer_1"]
+            fw_subgraph = get_fake(flex_backward_node.args[7], gm)
+            joint_subgraph = get_fake(flex_backward_node.args[8], gm)
+            mask_subgraph = get_fake(flex_backward_node.args[9][-1], gm)
+            fw_placeholders = list(fw_subgraph.graph.find_nodes(op="placeholder"))
+            joint_placeholders = list(joint_subgraph.graph.find_nodes(op="placeholder"))
+            mask_placeholders = list(mask_subgraph.graph.find_nodes(op="placeholder"))
+
+            updater = FakeTensorUpdater(gm)
+            flex_backward_args = list(flex_backward_node.args)
+            self.assertEqual(flex_backward_args[12], (score_buffer_node,))
+            self.assertEqual(flex_backward_args[13], (mask_buffer_node,))
+            flex_backward_args[12] = (restrided_score_buffer_node,)
+            flex_backward_args[13] = (restrided_mask_buffer_node,)
+            flex_backward_node.args = tuple(flex_backward_args)
+
+            with V.set_fake_mode(mode):
+                updater.incremental_update()
+
+        self.assertIs(
+            fw_placeholders[-1].meta["val"], restrided_score_buffer_node.meta["val"]
+        )
+        self.assertIs(
+            joint_placeholders[-1].meta["val"], restrided_score_buffer_node.meta["val"]
+        )
+        self.assertIs(
+            mask_placeholders[-1].meta["val"], restrided_mask_buffer_node.meta["val"]
+        )
 
     def test_reorder_nodes(self):
         def fn(*args: torch.Tensor) -> torch.Tensor:

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -8,6 +8,7 @@ operations (e.g., collective_start -> mm -> wait), this pass wraps operations
 with control_deps to make dependencies explicit.
 """
 
+from operator import attrgetter
 from typing import Any
 
 import torch.fx as fx
@@ -242,6 +243,8 @@ def _create_subgraph_for_node(
         placeholder = subgraph.placeholder(f"arg_{idx}")
         if "val" in orig_node.meta:
             placeholder.meta.update(orig_node.meta)
+        elif orig_node.op == "get_attr" and isinstance(orig_node.target, str):
+            placeholder.meta["val"] = attrgetter(orig_node.target)(owning_module)
         node_to_placeholder[orig_node] = placeholder
 
     # Replace fx.Node instances with their placeholders

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -236,6 +236,17 @@ def _extract_subgraphs_and_args(
 
     If the second yielded value is None, this function was unable to determine what args
     to pass to the subgraph."""
+
+    def get_subgraph_args(
+        subgraph: torch.fx.GraphModule,
+    ) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            get_fake(n, subgraph) for n in subgraph.graph.find_nodes(op="placeholder")
+        )
+
+    def is_integer(d: torch.dtype) -> bool:
+        return not d.is_floating_point and not d.is_complex
+
     if node.target is torch.ops.higher_order.associative_scan:
         # Associative scan operates on slices of xs (see: scan), but multiple slices.
         # Use the same slice twice to account for cases where only a single slice is
@@ -254,17 +265,6 @@ def _extract_subgraphs_and_args(
         # assume this format here (adding some defensive assertions), which means that
         # the only inputs we may need to update are the optional additional tensors. See
         # torch._higher_order_ops.flex_attention._math_attention_inner for more details.
-
-        def get_subgraph_args(
-            subgraph: torch.fx.GraphModule,
-        ) -> tuple[torch.Tensor, ...]:
-            return tuple(
-                get_fake(n, subgraph)
-                for n in subgraph.graph.find_nodes(op="placeholder")
-            )
-
-        def is_integer(d: torch.dtype) -> bool:
-            return not d.is_floating_point and not d.is_complex
 
         score_subgraph: torch.fx.GraphModule = args[3]
         score_subgraph_args = get_subgraph_args(score_subgraph)
@@ -286,6 +286,43 @@ def _extract_subgraphs_and_args(
 
         yield score_subgraph, (*score_subgraph_args[:5], *args[7])
         yield args[4][-1], (*mask_subgraph_args[:4], *args[8])
+    elif node.target is torch.ops.higher_order.flex_attention_backward:
+        fw_subgraph = args[7]
+        fw_subgraph_args = get_subgraph_args(fw_subgraph)
+        joint_subgraph = args[8]
+        joint_subgraph_args = get_subgraph_args(joint_subgraph)
+        mask_subgraph = args[9][-1]
+        mask_subgraph_args = get_subgraph_args(mask_subgraph)
+
+        integer_arg_dtypes = OrderedSet[torch.dtype](
+            a.dtype
+            for a in chain(
+                fw_subgraph_args[1:5],
+                joint_subgraph_args[1:5],
+                mask_subgraph_args[:4],
+            )
+        )
+        assert (
+            fw_subgraph_args[0].dtype == args[0].dtype
+            and joint_subgraph_args[0].dtype == args[0].dtype
+            and len(integer_arg_dtypes) == 1
+            and is_integer(integer_arg_dtypes.pop())
+            and all(
+                len(a.size()) == 0
+                for a in chain(
+                    fw_subgraph_args[:5],
+                    joint_subgraph_args[:6],
+                    mask_subgraph_args[:4],
+                )
+            )
+        ), "flex_attention_backward subgraph arg format has changed!"
+
+        if fw_subgraph in valid_subgraphs:
+            yield fw_subgraph, (*fw_subgraph_args[:5], *args[12])
+        if joint_subgraph in valid_subgraphs:
+            yield joint_subgraph, (*joint_subgraph_args[:6], *args[12])
+        if mask_subgraph in valid_subgraphs:
+            yield mask_subgraph, (*mask_subgraph_args[:4], *args[13])
     elif node.target in (
         torch.ops.higher_order.foreach_map,
         torch.ops.higher_order.invoke_quant_packed,
@@ -313,7 +350,42 @@ def _extract_subgraphs_and_args(
             "Subgraph arguments can be renamed, so we cannot consistently "
             "handle kwargs at this point in the stack."
         )
-        yield args[1], tuple(args[2:])
+        control_deps_subgraph = args[1]
+        control_deps_args = tuple(args[2:])
+        if control_deps_subgraph in valid_subgraphs:
+            yield control_deps_subgraph, control_deps_args
+        if isinstance(
+            control_deps_subgraph, torch.fx.GraphModule
+        ) and pytree.tree_any_only(
+            torch.fx.GraphModule,
+            lambda subgraph: subgraph in valid_subgraphs,
+            control_deps_args,
+        ):
+            placeholder_to_arg = dict(
+                zip(
+                    control_deps_subgraph.graph.find_nodes(op="placeholder"),
+                    control_deps_args,
+                    strict=True,
+                )
+            )
+            wrapped_nodes = [
+                n for n in control_deps_subgraph.graph.nodes if n.op == "call_function"
+            ]
+            assert len(wrapped_nodes) == 1
+            wrapped_node = wrapped_nodes[0]
+
+            def replace_placeholder(item: Any) -> Any:
+                if isinstance(item, torch.fx.Node):
+                    return placeholder_to_arg.get(item, item)
+                return item
+
+            wrapped_args, wrapped_kwargs = pytree.tree_map(
+                replace_placeholder,
+                (wrapped_node.args, wrapped_node.kwargs),
+            )
+            yield from _extract_subgraphs_and_args(
+                wrapped_node, valid_subgraphs, *wrapped_args, **wrapped_kwargs
+            )
     else:
         warnings.warn(
             f"Please add support for subgraph args to function {node.target}!"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186410

Overlap scheduling can wrap flex_attention_backward in control_deps after FakeTensorUpdater has already captured the set of subgraph GraphModules it owns. The wrapper is a new one-node subgraph, while the real flex backward fw, joint, and mask subgraphs are passed through that wrapper as operands. The previous control_deps handling only described the wrapper subgraph itself, so the updater could miss the tracked nested flex subgraphs and leave their placeholder metadata unchanged.

The backward flex HOP also has a different subgraph signature from forward flex attention. Forward has score and mask subgraphs with separate optional buffer lists. Backward has fw and joint subgraphs that consume score-mod buffers from args[12], and a mask subgraph that consumes mask buffers from args[13]. FakeTensorUpdater depends on _extract_subgraphs_and_args to translate HOP operands back into the placeholder values used for each subgraph; without this mapping, a re-strided buffer operand can update the outer node while the inner subgraph still sees stale fake tensor metadata.

The fix keeps that reasoning in _extract_subgraphs_and_args, where other HOP-specific argument layouts are already handled. It adds the flex_attention_backward mapping, then teaches control_deps to look through its wrapper when the wrapper operands contain tracked subgraphs. The unwrapping maps wrapper placeholders back to the actual control_deps operands and reuses the wrapped node's existing HOP extraction logic, avoiding a second flex-specific implementation in the control-deps pass or in the updater loop.

control_deps creates wrapper placeholders for original FX operands. When one of those operands is a get_attr node for a GraphModule, the placeholder does not naturally carry fake metadata. Preserving the resolved get_attr value lets fake propagation materialize GraphModule operands inside the wrapper, which is what makes the recursive subgraph update path see the same values that the original graph call would use.

The regression test traces the flex backward FX graph with make_fx, then mutates only the buffer operands that FakeTensorUpdater is expected to repair. The distributed test exercises the end-to-end overlap_scheduling plus insert_overlap_deps path that produces the control_deps wrapper around flex_attention_backward.

Test Plan

```bash
python test/distributed/test_aten_comm_compute_reordering.py TestComputeCommReorderingMultiProc.test_overlap_scheduling_flex_attention_backward
```

Authored with assistance from an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo