### PR TITLE
Fix the symbol lookup issue with symmetric memory __init__

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -27,6 +27,10 @@ from torch.distributed._symmetric_memory import (
     restride_A_for_fused_matmul_reduce_scatter,
     restride_A_shard_for_fused_all_gather_matmul,
 )
+from torch.distributed._symmetric_memory._nccl import (
+    NcclCommRegistration,
+    register_external_nccl_comm,
+)
 from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
 from torch.testing._internal.common_cuda import (
     SM100OrLater,
@@ -2000,8 +2004,9 @@ class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
 @skipIf(not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch")
 class ExternalNcclCommRegistrationTest(TestCase):
     """Tests for the external NCCL comm registration API
-    (``symm_mem._register_external_nccl_comm`` and the ``_NcclCommRegistration``
-    handle), exercised against a *real* ``ncclComm_t``.
+    (``register_external_nccl_comm`` and the ``NcclCommRegistration`` handle
+    from ``torch.distributed._symmetric_memory._nccl``), exercised against a
+    *real* ``ncclComm_t``.
 
     The comm is created in-process via NCCL's ``ncclCommInitAll`` (single
     rank, single GPU) through ctypes, so no live multi-rank job is needed.
@@ -2050,10 +2055,8 @@ class ExternalNcclCommRegistrationTest(TestCase):
 
     def test_register_unregister_real_comm(self) -> None:
         comm_ptr = self._make_real_comm()
-        reg = symm_mem._register_external_nccl_comm(
-            "ext_nccl_reg_basic", comm_ptr, "cuda:0"
-        )
-        self.assertIsInstance(reg, symm_mem._NcclCommRegistration)
+        reg = register_external_nccl_comm("ext_nccl_reg_basic", comm_ptr, "cuda:0")
+        self.assertIsInstance(reg, NcclCommRegistration)
         self.assertTrue(reg._active)
         self.assertEqual(reg._group_name, "ext_nccl_reg_basic")
         self.assertEqual(reg._device, torch.device("cuda:0"))
@@ -2068,7 +2071,7 @@ class ExternalNcclCommRegistrationTest(TestCase):
         # and releases it on unregister.
         comm_ptr = self._make_real_comm()
         sentinel = object()
-        reg = symm_mem._register_external_nccl_comm(
+        reg = register_external_nccl_comm(
             "ext_nccl_reg_ref", comm_ptr, "cuda:0", comm=sentinel
         )
         self.assertIs(reg._comm, sentinel)
@@ -2077,9 +2080,7 @@ class ExternalNcclCommRegistrationTest(TestCase):
 
     def test_context_manager_real_comm(self) -> None:
         comm_ptr = self._make_real_comm()
-        reg = symm_mem._register_external_nccl_comm(
-            "ext_nccl_reg_cm", comm_ptr, "cuda:0"
-        )
+        reg = register_external_nccl_comm("ext_nccl_reg_cm", comm_ptr, "cuda:0")
         with reg as entered:
             self.assertIs(entered, reg)
             self.assertTrue(reg._active)
@@ -2096,7 +2097,7 @@ class ExternalNcclCommRegistrationTest(TestCase):
         except ImportError:
             self.skipTest("PyTorch built without NCCL symmetric-memory device support")
         with self.assertRaises(RuntimeError):
-            symm_mem._register_external_nccl_comm("ext_nccl_reg_null", 0, "cuda:0")
+            register_external_nccl_comm("ext_nccl_reg_null", 0, "cuda:0")
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from enum import Enum
 from functools import partial
 from typing import Any, Literal
-from typing_extensions import deprecated, Self
+from typing_extensions import deprecated
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -2034,104 +2034,6 @@ def set_backend(name: Literal["NVSHMEM", "CUDA", "NCCL"]) -> None:
             only `"NVSHMEM"`, `"CUDA"`, `"NCCL"` are supported.
     """
     _SymmetricMemory.set_backend(name)
-
-
-class _NcclCommRegistration:
-    r"""
-    Handle returned by :func:`_register_external_nccl_comm`.
-
-    Keeps an externally-owned NCCL communicator published in PyTorch's
-    symmetric memory registry for as long as this object is alive. Dropping it
-    (via ``del``, exiting its ``with`` block, or calling :meth:`unregister`)
-    removes the entry so a successor producer can register cleanly under the
-    same ``group_name``.
-
-    The comm's lifetime is *not* owned by this object; the registration only
-    publishes a borrowed pointer. Optionally a strong reference to the source
-    comm object is held so a stray ``del comm`` cannot dangle the registered
-    pointer for the lifetime of the registration.
-    """
-
-    def __init__(
-        self,
-        group_name: str,
-        device: torch.device,
-        comm: object | None = None,
-    ) -> None:
-        self._group_name = group_name
-        self._device = device
-        self._comm = comm
-        self._active = True
-
-    def unregister(self) -> None:
-        """Remove the registration. Idempotent."""
-        if not self._active:
-            return
-        # Imported lazily: only present in NCCL builds with symmetric-memory
-        # device support.
-        from torch._C._distributed_c10d import _unregister_external_nccl_comm
-
-        _unregister_external_nccl_comm(self._group_name, self._device)
-        self._active = False
-        self._comm = None
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        self.unregister()
-
-    def __del__(self) -> None:
-        try:
-            self.unregister()
-        except Exception:
-            # Best-effort cleanup; never raise from __del__ (e.g. during
-            # interpreter teardown the C extension may already be gone).
-            pass
-
-
-def _register_external_nccl_comm(
-    group_name: str,
-    comm_ptr: int,
-    device: _device,
-    comm: object | None = None,
-) -> _NcclCommRegistration:
-    r"""
-    Publish an externally-owned ``ncclComm_t`` into PyTorch's symmetric memory
-    registry under ``group_name``.
-
-    This lets producers that are not a ``ProcessGroupNCCL`` (e.g. torchcomms
-    backends) supply the host NCCL communicator that
-    :func:`rendezvous` needs, without symmetric memory having to
-    ``dynamic_cast`` to a specific process-group implementation. After this
-    call, ``rendezvous(tensor, group=group_name)`` on a tensor in a process
-    group registered under ``group_name`` will find this comm.
-
-    Args:
-        group_name (str): the process-group name to register the comm under.
-        comm_ptr (int): the host ``ncclComm_t`` as an opaque integer pointer
-            (e.g. from ``torchcomms`` ``get_nccl_comm_ptr()``).
-        device (`torch.device` or str): the CUDA device the comm belongs to.
-        comm (object, optional): the source comm object. When provided, a
-            strong reference is held by the returned registration so the comm
-            cannot be garbage-collected while still registered.
-
-    Returns:
-        _NcclCommRegistration: keep this alive for as long as symmetric memory
-        should use this comm; drop it (or call ``unregister()``) to remove the
-        registration.
-
-    .. note::
-        This is only available in NCCL builds with symmetric-memory device
-        support; otherwise it raises :class:`ImportError`.
-    """
-    from torch._C._distributed_c10d import (
-        _register_external_nccl_comm as _register_external_nccl_comm_impl,
-    )
-
-    device = torch.device(device)
-    _register_external_nccl_comm_impl(group_name, comm_ptr, device)
-    return _NcclCommRegistration(group_name, device, comm)
 
 
 def get_backend(device: _device) -> str | None:

--- a/torch/distributed/_symmetric_memory/_nccl.py
+++ b/torch/distributed/_symmetric_memory/_nccl.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import Self
+
+import torch
+
+
+if TYPE_CHECKING:
+    from torch.types import _device
+
+
+__all__ = ["NcclCommRegistration", "register_external_nccl_comm"]
+
+
+class NcclCommRegistration:
+    r"""
+    Handle returned by :func:`register_external_nccl_comm`.
+
+    Keeps an externally-owned NCCL communicator published in PyTorch's
+    symmetric memory registry for as long as this object is alive. Dropping it
+    (via ``del``, exiting its ``with`` block, or calling :meth:`unregister`)
+    removes the entry so a successor producer can register cleanly under the
+    same ``group_name``.
+
+    The comm's lifetime is *not* owned by this object; the registration only
+    publishes a borrowed pointer. Optionally a strong reference to the source
+    comm object is held so a stray ``del comm`` cannot dangle the registered
+    pointer for the lifetime of the registration.
+    """
+
+    def __init__(
+        self,
+        group_name: str,
+        device: torch.device,
+        comm: object | None = None,
+    ) -> None:
+        self._group_name = group_name
+        self._device = device
+        self._comm = comm
+        self._active = True
+
+    def unregister(self) -> None:
+        """Remove the registration. Idempotent."""
+        if not self._active:
+            return
+        # Imported lazily: only present in NCCL builds with symmetric-memory
+        # device support.
+        from torch._C._distributed_c10d import _unregister_external_nccl_comm
+
+        _unregister_external_nccl_comm(self._group_name, self._device)
+        self._active = False
+        self._comm = None
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.unregister()
+
+    def __del__(self) -> None:
+        try:
+            self.unregister()
+        except Exception:
+            # Best-effort cleanup; never raise from __del__ (e.g. during
+            # interpreter teardown the C extension may already be gone).
+            pass
+
+
+def register_external_nccl_comm(
+    group_name: str,
+    comm_ptr: int,
+    device: _device,
+    comm: object | None = None,
+) -> NcclCommRegistration:
+    r"""
+    Publish an externally-owned ``ncclComm_t`` into PyTorch's symmetric memory
+    registry under ``group_name``.
+
+    This lets producers that are not a ``ProcessGroupNCCL`` (e.g. torchcomms
+    backends) supply the host NCCL communicator that
+    :func:`rendezvous` needs, without symmetric memory having to
+    ``dynamic_cast`` to a specific process-group implementation. After this
+    call, ``rendezvous(tensor, group=group_name)`` on a tensor in a process
+    group registered under ``group_name`` will find this comm.
+
+    Args:
+        group_name (str): the process-group name to register the comm under.
+        comm_ptr (int): the host ``ncclComm_t`` as an opaque integer pointer
+            (e.g. from ``torchcomms`` ``get_nccl_comm_ptr()``).
+        device (`torch.device` or str): the CUDA device the comm belongs to.
+        comm (object, optional): the source comm object. When provided, a
+            strong reference is held by the returned registration so the comm
+            cannot be garbage-collected while still registered.
+
+    Returns:
+        NcclCommRegistration: keep this alive for as long as symmetric memory
+        should use this comm; drop it (or call ``unregister()``) to remove the
+        registration.
+
+    .. note::
+        This is only available in NCCL builds with symmetric-memory device
+        support; otherwise it raises :class:`ImportError`.
+    """
+    from torch._C._distributed_c10d import (
+        _register_external_nccl_comm as _register_external_nccl_comm_impl,
+    )
+
+    device = torch.device(device)
+    _register_external_nccl_comm_impl(group_name, comm_ptr, device)
+    return NcclCommRegistration(group_name, device, comm)


### PR DESCRIPTION
PR #184260 missed adding _register_external_nccl_comm and the _NcclCommRegistration handle to torch/distributed/_symmetric_memory/__init__.py so non-ProcessGroupNCCL producers (e.g. torchcomms) can back symm_mem.rendezvous with an externally-owned ncclComm_t. 

Both were underscore-prefixed and missing from __all__, so they weren't discoverable as public API.

This moves them into a new _nccl.py submodule, renames them to register_external_nccl_comm and NcclCommRegistration, re-exports them from the package, and adds them to __all__. No behavior change.