### PR TITLE
[dynamo] Avoid instantiating autograd Function for FunctionCtx

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -2,6 +2,7 @@
 import copy
 import math
 from dataclasses import dataclass
+from unittest import mock
 
 import torch
 import torch._dynamo.test_case
@@ -228,6 +229,31 @@ class ModuleWithGradFunc(torch.nn.Module):
 
 class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
     # Sound behaviors, tested for working capture
+    def test_function_ctx_does_not_instantiate_function(self):
+        class Foo(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.scale = 3
+                return x.sin()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output * ctx.scale
+
+        def fn(x):
+            return Foo.apply(x)
+
+        x = torch.randn(3, requires_grad=True)
+        ref = fn(x)
+        with mock.patch.object(
+            torch.autograd.Function,
+            "__init__",
+            side_effect=AssertionError("deprecated Function instantiated"),
+        ):
+            res = torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+        self.assertEqual(res, ref)
+
     def test_autograd_function_equivalence(self):
         for grad in [True, False]:
             for i in range(1, 5):

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -27,7 +27,6 @@ import inspect
 import logging
 import textwrap
 import traceback
-import warnings
 import weakref
 from collections.abc import Generator, MutableMapping
 from types import CellType
@@ -646,11 +645,7 @@ class SideEffects:
         variable_cls: Any,
         options: dict[str, Any],
     ) -> VariableTracker:
-        if user_cls is torch.autograd.function.FunctionCtx:
-            with warnings.catch_warnings(record=True):
-                obj = torch.autograd.Function()
-        else:
-            obj = object_new(user_cls)
+        obj = object_new(user_cls)
         variable = variable_cls(
             obj,
             mutation_type=AttributeMutationNew(cls_source),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186421

Dynamo creates a placeholder object when tracking newly constructed user objects for side effects. The autograd.Function context path only needs a FunctionCtx-shaped object because the traced ctx state is held in AutogradFunctionContextVariable, but the old special case created torch.autograd.Function() and suppressed its deprecation warning.

Replace that special case with the regular object_new(user_cls) path so FunctionCtx placeholders are created without invoking the deprecated Function constructor. Add a regression test that patches Function.__init__ to fail if Dynamo reaches the old path while compiling a custom autograd.Function.

The alternative would be to keep suppressing the warning or instantiate FunctionCtx() directly. Suppression preserves the deprecated behavior, and using object_new matches the existing object tracking path without invoking arbitrary constructors.

Fixes #128439

Generated by my agent

Test Plan:

- python test/dynamo/test_autograd_function.py AutogradFunctionTests.test_function_ctx_does_not_instantiate_function AutogradFunctionTests.test_apply_kwargs_all_kwargs AutogradFunctionTests.test_apply_kwargs_inference

- python - <<'PY' ... run test/dynamo/test_autograd_function.py with a local shim for stale torch._C._remove_obj_from_tls ... PY

- git diff --check --cached

- lintrunner -a torch/_dynamo/side_effects.py test/dynamo/test_autograd_function.py (fails on unrelated existing PYREFLY error in torch/autograd/graph.py:989)

- lintrunner -a --skip PYREFLY torch/_dynamo/side_effects.py test/dynamo/test_autograd_function.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98