### PR TITLE
[ROCM][inductor][UT] Enable Inductor-Triton debug asserts on ROCm

### DIFF
--- a/test/inductor/test_minifier_isolate.py
+++ b/test/inductor/test_minifier_isolate.py
@@ -6,9 +6,9 @@ from torch._dynamo.test_minifier_common import MinifierTestBase
 from torch.testing._internal.common_utils import (
     IS_JETSON,
     IS_MACOS,
-    skipIfRocm,
     skipIfWindows,
     TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE
 from torch.testing._internal.triton_utils import requires_gpu
@@ -38,12 +38,15 @@ inner(torch.randn(2, 2).to("{device}"))
     def test_after_aot_cpu_runtime_error(self):
         self._test_after_aot_runtime_error("cpu", "")
 
-    @skipIfRocm
     @requires_gpu
     @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "runtime_error")
     def test_after_aot_gpu_runtime_error(self):
+        # CUDA's __assertfail surfaces through PyTorch as "device-side assert";
+        # ROCm's Triton AMD lowering prints the injected assertion text before trapping.
         expected_error = (
-            "injected assert fail" if GPU_TYPE == "xpu" else "device-side assert"
+            "injected assert fail"
+            if GPU_TYPE == "xpu" or TEST_WITH_ROCM
+            else "device-side assert"
         )
         self._test_after_aot_runtime_error(GPU_TYPE, expected_error)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1044,7 +1044,7 @@ class CachingAutotuner(KernelInterface):
 
         compile_meta["debug"] = self.inductor_meta.get(
             "assert_indirect_indexing", True
-        ) and not self.inductor_meta.get("is_hip", False)
+        )
 
         # device type will be "hip" rather than "cuda" here
         compile_meta["device_type"] = self.device_props.type

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1042,9 +1042,7 @@ class CachingAutotuner(KernelInterface):
                 cfg, "num_buffers_warp_spec", 0
             )
 
-        compile_meta["debug"] = self.inductor_meta.get(
-            "assert_indirect_indexing", True
-        )
+        compile_meta["debug"] = self.inductor_meta.get("assert_indirect_indexing", True)
 
         # device type will be "hip" rather than "cuda" here
         compile_meta["device_type"] = self.device_props.type


### PR DESCRIPTION
## Summary
- Enable Triton debug/assert metadata for HIP Inductor kernels instead of dropping it on ROCm.
- Remove the ROCm skip from `MinifierIsolateTests.test_after_aot_gpu_runtime_error` and make the test validate the ROCm assertion text.

## Context
- The HIP debug guard was introduced in https://github.com/pytorch/pytorch/pull/99756 because ROCm Triton did not support `tl.device_assert` at the time.
- ROCm Triton now supports device-side asserts when Triton debug is enabled.
- Inductor already enables Triton debug from `assert_indirect_indexing` on CUDA; this makes HIP follow that same path.
- Locally, the injected runtime assert now fires and the AOT minifier runtime-error test completes successfully on ROCm.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben