### PR TITLE
Skip Dynamo inside non-traceable subclass dispatch hooks

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: dynamo"]
 import abc
 import functools
+import io
 import itertools
+import logging
 import unittest
 from functools import partial
 
@@ -1565,6 +1567,133 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
             ref = opt_f(t)
 
         self.assertEqual(res, ref)
+
+    def test_nontraceable_torch_dispatch_subclass_skips_dispatch_hooks(self):
+        calls = []
+
+        def helper():
+            calls.append("helper")
+            return torch.ones(1) + 2
+
+        class MySubclass(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                calls.append("__torch_function__")
+                return super().__torch_function__(func, types, args, kwargs)
+
+            @classmethod
+            def __torch_dispatch__(cls, *args, **kwargs):
+                calls.append("__torch_dispatch__")
+                helper()
+                return super().__torch_dispatch__(*args, **kwargs)
+
+        def f(t):
+            return t + 1
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        logger = logging.getLogger("torch._dynamo")
+        logger.addHandler(handler)
+        torch._logging.set_logs(trace_source=True)
+        try:
+            cnt = torch._dynamo.testing.CompileCounter()
+            opt_f = torch.compile(f, backend=cnt, fullgraph=False)
+            opt_f(MySubclass([1, 2]))
+        finally:
+            torch._logging.set_logs()
+            logger.removeHandler(handler)
+
+        self.assertEqual(cnt.frame_count, 0)
+        self.assertIn("__torch_dispatch__", calls)
+        self.assertIn("helper", calls)
+        self.assertNotIn("__torch_function__", buf.getvalue())
+        self.assertNotIn("__torch_dispatch__", buf.getvalue())
+        self.assertNotIn("helper", buf.getvalue())
+
+    def test_nontraceable_torch_dispatch_subclass_skips_assigned_hook(self):
+        calls = []
+
+        def helper():
+            calls.append("helper")
+            return torch.ones(1) + 2
+
+        class MySubclass(torch.Tensor):
+            pass
+
+        def dispatch_impl(cls, *args, **kwargs):
+            calls.append("dispatch_impl")
+            helper()
+            return super(MySubclass, cls).__torch_dispatch__(*args, **kwargs)
+
+        self.assertNotEqual(dispatch_impl.__name__, "__torch_dispatch__")
+        MySubclass.__torch_dispatch__ = classmethod(dispatch_impl)
+
+        def f(t):
+            return t + 1
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        logger = logging.getLogger("torch._dynamo")
+        logger.addHandler(handler)
+        torch._logging.set_logs(trace_source=True)
+        try:
+            cnt = torch._dynamo.testing.CompileCounter()
+            opt_f = torch.compile(f, backend=cnt, fullgraph=False)
+            opt_f(MySubclass([1, 2]))
+        finally:
+            torch._logging.set_logs()
+            logger.removeHandler(handler)
+
+        self.assertEqual(cnt.frame_count, 0)
+        self.assertIn("dispatch_impl", calls)
+        self.assertIn("helper", calls)
+        self.assertNotIn("dispatch_impl", buf.getvalue())
+        self.assertNotIn("helper", buf.getvalue())
+
+    def test_nontraceable_torch_dispatch_subclass_skips_skipfile_hook(self):
+        from torch._dynamo import trace_rules
+
+        calls = []
+
+        def helper():
+            calls.append("helper")
+            return torch.ones(1) + 2
+
+        class MySubclass(torch.Tensor):
+            pass
+
+        def dispatch_impl(cls, *args, **kwargs):
+            calls.append("dispatch_impl")
+            helper()
+            return super(MySubclass, cls).__torch_dispatch__(*args, **kwargs)
+
+        dispatch_impl.__code__ = dispatch_impl.__code__.replace(
+            co_filename=torch.__file__
+        )
+        self.assertTrue(trace_rules.check(dispatch_impl.__code__))
+        MySubclass.__torch_dispatch__ = classmethod(dispatch_impl)
+
+        def f(t):
+            return t + 1
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        logger = logging.getLogger("torch._dynamo")
+        logger.addHandler(handler)
+        torch._logging.set_logs(trace_source=True)
+        try:
+            cnt = torch._dynamo.testing.CompileCounter()
+            opt_f = torch.compile(f, backend=cnt, fullgraph=False)
+            opt_f(MySubclass([1, 2]))
+        finally:
+            torch._logging.set_logs()
+            logger.removeHandler(handler)
+
+        self.assertEqual(cnt.frame_count, 0)
+        self.assertIn("dispatch_impl", calls)
+        self.assertIn("helper", calls)
+        self.assertNotIn("dispatch_impl", buf.getvalue())
+        self.assertNotIn("helper", buf.getvalue())
 
     def test_compile_with_fake_tensor_dynamic_dim(self):
         x = torch.randn([3, 4])

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -80,6 +80,7 @@ from torch.utils._python_dispatch import (
     any_torch_dispatch_mode_on_stack,
     is_in_any_mode_without_ignore_compile_internals,
     is_traceable_wrapper_subclass,
+    is_traceable_wrapper_subclass_type,
 )
 from torch.utils._traceback import CapturedTraceback, format_traceback_short
 
@@ -2488,6 +2489,58 @@ def first_real_inst_idx(code: CodeType) -> int:
     raise RuntimeError("RESUME instruction not found in code")
 
 
+def _is_non_traceable_torch_dispatch_subclass_hook_frame(
+    frame: DynamoFrameType,
+) -> bool:
+    def hook_code(hook: object) -> CodeType | None:
+        if isinstance(hook, (classmethod, staticmethod)):
+            hook = hook.__func__
+        elif isinstance(hook, types.MethodType):
+            hook = hook.__func__
+        return getattr(hook, "__code__", None)
+
+    def hook_code_matches(receiver_type: type[torch.Tensor]) -> bool:
+        for hook_name in ("__torch_dispatch__", "__torch_function__"):
+            for hook in (
+                inspect.getattr_static(receiver_type, hook_name, None),
+                getattr(receiver_type, hook_name, None),
+            ):
+                if hook_code(hook) is frame.f_code:
+                    return True
+        return False
+
+    def receiver_type(value: object) -> type[torch.Tensor] | None:
+        typ = value if isinstance(value, type) else type(value)
+        if (
+            isinstance(typ, type)
+            and issubclass(typ, torch.Tensor)
+            and typ is not torch.Tensor
+            and typ.__torch_dispatch__ is not torch.Tensor.__torch_dispatch__
+            and not is_traceable_wrapper_subclass_type(typ)
+        ):
+            return typ
+        return None
+
+    seen: set[type[torch.Tensor]] = set()
+
+    def check_value(value: object) -> bool:
+        typ = receiver_type(value)
+        if typ is None or typ in seen:
+            return False
+        seen.add(typ)
+        return hook_code_matches(typ)
+
+    for value in frame.f_locals.values():
+        if check_value(value):
+            return True
+        if isinstance(value, tuple):
+            for item in value:
+                if check_value(item):
+                    return True
+
+    return False
+
+
 class ConvertFrameProtocol(typing.Protocol):
     def __call__(
         self,
@@ -2544,6 +2597,21 @@ class CatchErrorsWrapper:
         else:
             should_skip_for_dispatch_mode = (
                 is_in_any_mode_without_ignore_compile_internals()
+            )
+
+        if _is_non_traceable_torch_dispatch_subclass_hook_frame(frame):
+            return self._handle_skip(
+                ConvertFrameReturn(
+                    frame_exec_strategy=FrameExecStrategy(
+                        FrameAction.SKIP, FrameAction.SKIP
+                    ),
+                    apply_to_code=False,
+                    skip_reason=(
+                        "dispatch hook of a non-traceable tensor subclass cannot be "
+                        "traced"
+                    ),
+                ),
+                frame,
             )
 
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186425

Dynamo already graph breaks when an operator sees a tensor subclass with a
custom __torch_dispatch__ that has not opted into the traceable wrapper
subclass protocol. The eager fallback still ran with Dynamo's frame callback
active, so the hook body itself could be picked up as a fresh compile target.
That let Dynamo trace through __torch_dispatch__, __torch_function__, and helper
frames called from those hooks.

Fix this by detecting dispatch hook frames for non-traceable tensor subclasses
before the generic skipfile/config/mode skip path. These frames now use a
recursive SKIP/SKIP execution strategy with apply_to_code=False, so the current
hook and helper frames it calls run eagerly without caching a receiver-sensitive
skip decision on the code object. The detector matches the active frame code
against the class hook descriptor rather than relying on the function name, so
hooks assigned as classmethod(dispatch_impl) are handled too.

Tests cover direct hooks, assigned hook functions, nested helper calls, and
hooks whose code object comes from a skiplisted file.

Fixes #128160
Generated by my agent

Benchmark Results:
- Command: repeated 40-iteration torch.compile(..., backend="eager") loop, 7 reps.
- Main baseline times_sec: 1.305118, 0.939794, 1.104977, 0.922713, 0.911296, 0.918623, 1.083244; median 0.939794s, mean 1.026538s.
- Fix branch times_sec: 1.156385, 0.807566, 0.980092, 0.821582, 0.825342, 0.850277, 1.034951; median 0.850277s, mean 0.925171s.

Test Plan:
- python test/dynamo/test_subclasses.py SubclassTests.test_nontraceable_torch_dispatch_subclass_skips_dispatch_hooks SubclassTests.test_nontraceable_torch_dispatch_subclass_skips_assigned_hook SubclassTests.test_nontraceable_torch_dispatch_subclass_skips_skipfile_hook
- python test/dynamo/test_subclasses.py SubclassTests.test_nontraceable_tensor_subclass SubclassTests.test_torch_dispatch_subclass_guard_recompile SubclassTests.test_torch_function_wrapper_class SubclassTests.test_torch_function_subclass_with_mode
- python test/dynamo/test_misc.py MiscTests.test_compile_non_infra_inside_compile MiscTests.test_compile_non_infra_empty
- python -m py_compile torch/_dynamo/convert_frame.py test/dynamo/test_subclasses.py
- git diff --cached --check
- lintrunner -a (fails on unrelated existing Pyrefly error in torch/autograd/graph.py: missing torch._C._remove_obj_from_tls)
- lintrunner torch/_dynamo/convert_frame.py test/dynamo/test_subclasses.py (same unrelated Pyrefly error)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98