### PR TITLE
Fix FakeTensor conversion for subclass grads

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -51,6 +51,7 @@ from torch.fx.experimental.symbolic_shapes import (
     free_unbacked_symbols,
     ShapeEnv,
     ShapeEnvSettings,
+    StatefulSymbolicContext,
     StatelessSymbolicContext,
     statically_known_true,
 )
@@ -438,6 +439,24 @@ class FakeTensorTest(TestCase):
         t = torch.rand([4], requires_grad=True)
         fake_t = mode.from_tensor(t)
         self.assertEqual(fake_t.requires_grad, t.requires_grad)
+
+    @expectedFailurePropagateRealTensors
+    def test_non_parameter_grad_tensor_subclass_stateful_context(self):
+        mode = FakeTensorMode(shape_env=ShapeEnv())
+        t = torch.ones(2, requires_grad=True)
+        t.grad = TwoTensor(torch.ones(2), torch.ones(2))
+        source = LocalSource("t", is_input=True)
+        symbolic_context = StatefulSymbolicContext(
+            dynamic_sizes=[DimDynamic.STATIC] * t.dim(),
+            constraint_sizes=[None] * t.dim(),
+            tensor_source=source,
+        )
+
+        fake_t = mode.from_tensor(t, source=source, symbolic_context=symbolic_context)
+
+        self.assertIsInstance(fake_t.grad, TwoTensor)
+        self.assertIsInstance(fake_t.grad.a, FakeTensor)
+        self.assertIsInstance(fake_t.grad.b, FakeTensor)
 
     @unittest.skipIf(
         TEST_WITH_TORCHDYNAMO, "isinstance check for FakeTensor won't work with compile"

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -848,6 +848,11 @@ def _grad_context_compatible(
     if not _view_base_compatible(symbolic_context, grad_desc):
         return False
 
+    if grad_desc.is_traceable_wrapper_subclass and not isinstance(
+        symbolic_context, SubclassSymbolicContext
+    ):
+        return False
+
     # Check inner (subclass) level
     if isinstance(symbolic_context, SubclassSymbolicContext):
         if grad_desc.attrs is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186427

FakeTensor meta conversion reuses a tensor's symbolic context when it
recursively converts the tensor's grad. That is only valid when the grad has a
compatible wrapper structure. If the tensor is tracked with a
StatefulSymbolicContext but its grad is a traceable wrapper subclass, the
subclass allocation path receives the stateful context and asserts because it
needs a SubclassSymbolicContext for the grad's inner tensors.

Treat that pairing as an incompatible grad context, so grad conversion builds a
fresh all-dynamic context from the grad itself. This keeps the existing
compatible-context reuse for normal grads while giving tensor-subclass grads the
subclass-aware inner contexts required by meta conversion.

Fixes #127470
Generated by my agent

Test Plan:
- python test/test_fake_tensor.py -k test_non_parameter_grad_tensor_subclass_stateful_context
- git diff --cached --check
- lintrunner -a (fails on pre-existing torch/autograd/graph.py:989 PYREFLY missing-attribute for torch._C._remove_obj_from_tls; no findings in changed files)