### PR TITLE
Fix ONNX export of pad_sequence with symbolic split lengths

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -656,6 +656,23 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
             [node.op_type for node in onnx_program.model.graph],
         )
 
+    def test_export_pad_sequence_from_tensor_split_indices(self):
+        class Model(torch.nn.Module):
+            def forward(self, text, batch_lengths):
+                lens = batch_lengths[1:] - batch_lengths[:-1]
+                texts = torch.nn.utils.rnn.pad_sequence(
+                    torch.tensor_split(text, batch_lengths),
+                    batch_first=True,
+                    padding_value=-1,
+                )
+                return texts, lens
+
+        text = torch.randint(1024, (1024,), dtype=torch.int64)
+        batch_lengths = torch.tensor([2, 6, 7, 11, 28, 39], dtype=torch.int64)
+
+        onnx_program = self.export(Model(), (text, batch_lengths))
+        onnx_testing.assert_onnx_program(onnx_program)
+
     def test_export_sym_min(self):
         class Model(torch.nn.Module):
             def forward(self, x):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3282,6 +3282,8 @@ def _index_add(
 @register_decomposition(aten.pad_sequence.default)
 @aten.pad_sequence.default.py_impl(DispatchKey.CompositeImplicitAutograd)
 def pad_sequence(sequences, batch_first=False, padding_value=0.0, padding_side="right"):
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
+
     torch._check(len(sequences) > 0, lambda: "received an empty list of sequences")
     torch._check(
         padding_side == "left" or padding_side == "right",
@@ -3290,7 +3292,15 @@ def pad_sequence(sequences, batch_first=False, padding_value=0.0, padding_side="
     sequences_size = len(sequences)
     max_size = sequences[0].size()
     trailing_dims = max_size[1:]
-    max_len = max(x.size(0) for x in sequences)
+    max_len = max_size[0]
+    for i in range(1, sequences_size):
+        x_len = sequences[i].size(0)
+        if statically_known_true(max_len >= x_len):
+            continue
+        if statically_known_true(x_len >= max_len):
+            max_len = x_len
+            continue
+        max_len = torch.sym_max(max_len, x_len)
     if batch_first:
         out_dims = (sequences_size, max_len)
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186429

The pad_sequence decomposition computed the output length with Python
max() over the input sequence lengths. When the inputs come from
`torch.tensor_split(text, batch_lengths)`, those lengths are unbacked
symbolic values derived from data. Python max() compares them by
truth-testing symbolic inequalities, which forces a data-dependent guard
and makes dynamo ONNX export fail before lowering can complete.

Compute the maximum length incrementally. Keep the existing static fast
path when the ordering is known, and emit `torch.sym_max` only when the
relationship cannot be proven statically. This preserves concrete/static
behavior while keeping the data-dependent case represented symbolically
in the exported graph.

Add a regression test covering ONNX dynamo export for the issue's
`pad_sequence(torch.tensor_split(...))` pattern.

Fixes #127153
Generated by my agent

Benchmark Results:
On a module returning `torch._C._nn.pad_sequence([x, y, z],
batch_first=True)` with input shapes `(16, 32)`, `(12, 32)`, and
`(8, 32)`, running 5 warmup iterations and 50 measured
`torch.export.export` calls:

- main (`90e70db69fa`): 0.344696s total, 0.006894s average
- fixed branch: 0.347944s total, 0.006959s average

Test Plan:
- python test/onnx/exporter/test_small_models_e2e.py -k test_export_pad_sequence_from_tensor_split_indices
- python test/test_meta.py TestMetaKernelRegistrations.test_pad_sequence_decomp_left TestMetaKernelRegistrations.test_pad_sequence_decomp_left_not_batch_first TestMetaKernelRegistrations.test_pad_sequence_decomp_mixed_dtype_padding_value
- python test/export/test_export.py -k test_pad_sequence
- lintrunner -a (fails on unrelated PYREFLY missing-attribute in torch/autograd/graph.py)
- lintrunner --skip PYREFLY torch/_decomp/decompositions.py test/onnx/exporter/test_small_models_e2e.py