### PR TITLE
fix(profiler): map PRIVATEUSE1_DRIVER to DeviceType::PrivateUse1

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -513,9 +513,10 @@ c10::DeviceType deviceTypeFromActivity(libkineto::ActivityType activity_type) {
     case libkineto::ActivityType::PYTHON_FUNCTION:
     case libkineto::ActivityType::CUDA_DRIVER:
     case libkineto::ActivityType::PRIVATEUSE1_RUNTIME:
-    case libkineto::ActivityType::PRIVATEUSE1_DRIVER:
     case libkineto::ActivityType::OVERHEAD:
       return c10::DeviceType::CPU;
+    case libkineto::ActivityType::PRIVATEUSE1_DRIVER:
+      return c10::DeviceType::PrivateUse1;
     default: {
       TORCH_WARN(
           "Unknown activity type (",


### PR DESCRIPTION
PRIVATEUSE1_DRIVER activities represent device-side kernel execution for PrivateUse1 backends. They were incorrectly mapped to DeviceType::CPU in deviceTypeFromActivity(), which prevented key_averages() from showing device time columns for PrivateUse1 backends.

The existing Python correlation code in _parse_kineto_results (profiler.py:722-736) already handles DeviceType.PrivateUse1 events via append_kernel(), but these events never matched because they arrived as CPU-typed.

With this fix, backends that emit PRIVATEUSE1_DRIVER activities via IActivityProfiler (as documented in pytorch/pytorch#177978) will have their device execution time appear natively in key_averages() table output — equivalent to cuda_time_total for CUDA backends.

PRIVATEUSE1_RUNTIME remains mapped to CPU as it represents host-side dispatch (analogous to CUDA_RUNTIME).

Fixes: https://github.com/pytorch/pytorch/issues/166205