### PR TITLE
[B200] Fix IMA in `conv2d_bwd_weight` triton template

### DIFF
--- a/torch/_inductor/kernel/templates/triton_conv2d_bwd_weight.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_conv2d_bwd_weight.py.jinja
@@ -15,32 +15,38 @@
         xh = yh[:, None] * STRIDE_H - PADDING_H + i[None, :] * DILATION_H
         xw = yw[:, None] * STRIDE_W - PADDING_W + j[None, :] * DILATION_W
 
-        x_ptrs = X_base \
-            + n[:,    None]  * stride_xn \
-            + ic[None,    :] * stride_xc \
-            + xh             * stride_xh \
-            + xw             * stride_xw
-
         mask_x = (
             (n[:,    None]  < BATCH) &
             (ic[None,    :] < GROUP_IN_C) &
             (xh >= 0) & (xh < IN_H) &
             (xw >= 0) & (xw < IN_W)
         )
+        # Masked lanes can address out of bounds; pipelined (cp.async) loads still
+        # translate the source address even when masked, so clamp masked lanes to 0.
+        x_ptrs = X_base + tl.where(
+            mask_x,
+            n[:, None] * stride_xn
+            + ic[None, :] * stride_xc
+            + xh * stride_xh
+            + xw * stride_xw,
+            0,
+        )
         matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
         matrix_x = tl.trans(matrix_x)
-
-        dy_ptrs = dY_base \
-            + n[:,    None]  * stride_dyn \
-            + oc[None,    :] * stride_dyc \
-            + yh[:,   None]  * stride_dyh \
-            + yw[:,   None]  * stride_dyw
 
         mask_dy = (
             (n[:,    None]  < BATCH) &
             (oc[None,    :] < GROUP_OUT_C) &
             (yh[:,   None]  < OUT_H) &
             (yw[:,   None]  < OUT_W)
+        )
+        dy_ptrs = dY_base + tl.where(
+            mask_dy,
+            n[:, None] * stride_dyn
+            + oc[None, :] * stride_dyc
+            + yh[:, None] * stride_dyh
+            + yw[:, None] * stride_dyw,
+            0,
         )
         matrix_dy = tl.load(dy_ptrs, mask=mask_dy, other=0.0)
 


### PR DESCRIPTION
Fixes the B200 smoke failure : https://github.com/pytorch/pytorch/actions/runs/26837270317/job/79139348523

The IMA is caused because triton doesn't predicate masked loads under the pipelined path. For the non-pipelined version, triton predicates `ld.global` avoiding masked values loads while the pipelined path uses un-predicated `cp.async.ca.shared.global` causing the IMA.

Fixed by substituting the masked indices with 0 to workaround the bug in triton.

The ideal fix would be to make triton generate predicated cp.async loads.

Before:

```
PTX: no instruction guard; address unconditional, mask is just the byte-count %r17

cp.async.ca.shared.global [ %r38 ], [ %rd7 ], 0x4, %r17 ;
mad.wide.u32 %rd20, %r13, 4, %rd3 ; # index widened UNSIGNED -> neg index -> ~2^32

SASS: the source operand carries the masked boundary lane's negative offset (16 such loads)

LDGSTS.E [R33], desc[UR6][R8.64+-0x44], !PT ;   # source = base + (-0x44); with u32 widening -> ~16 GiB OOB

The LDGSTS issues unconditionally, forms base + (-0x44) ≈ base + 16 GiB, the MMU walks it → illegal access.
```

After:

```
PTX: selp zeroes the masked-lane offset before it's scaled into the address

selp.b32     %r36, %r34, 0, %p1 ;     # tl.where: masked lane offset -> 0
mad.wide.u32 %rd8, %r36, 4, %rd5 ;     # masked lane: 0*4 + base = base

SASS: the source is now the clean base register, no negative offset (0 such loads, down from 16)

LDGSTS.E [R2], desc[UR8][R4.64], !PT ;          # source = base; in bounds -> no fault
```

cc @eqy @nWEIdia @ptrblck @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo