### PR TITLE
Resolve nested ACT inputs before AOTAutograd tracing

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -12,6 +12,7 @@ import torch
 import torch._dynamo
 import torch._dynamo.testing
 import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
 import torch.nn as nn
 from torch._C import FileCheck
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
@@ -264,6 +265,111 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
 
         fn(x).backward()
         self.assertEqual(local.grad, torch.full_like(local, 2))
+
+    def test_compile_waits_act_nested_in_dtensor_local_tensor(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180614.
+        # AOTAutograd must resolve AsyncCollectiveTensors (ACTs) nested in
+        # ``DTensor._local_tensor`` (e.g. from ``redistribute(async_op=True)``
+        # or FSDP2's async all-gather) before tracing and again before runtime
+        # execution. Otherwise inductor can read an in-flight collective.
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def fn(x):
+            return x + 1
+
+        def make_dtensor_with_act_local():
+            dt = DTensor.from_local(
+                torch.randn(4, 4, device=self.device_type),
+                mesh,
+                [Replicate()],
+                run_check=False,
+            )
+            dt._local_tensor = AsyncCollectiveTensor(dt._local_tensor.clone())
+            return dt
+
+        wait_calls = []
+        orig_wait_tensor = funcol.wait_tensor
+
+        def counting_wait_tensor(t):
+            wait_calls.append(1)
+            return orig_wait_tensor(t)
+
+        with patch.object(funcol, "wait_tensor", counting_wait_tensor):
+            # Warmup compiles through Python dispatch (which waits); clear the
+            # counter so we measure only the compiled runtime path.
+            fn(make_dtensor_with_act_local())
+            wait_calls.clear()
+
+            dt = make_dtensor_with_act_local()
+            self.assertFalse(dt._local_tensor.completed)
+            fn(dt)
+
+        self.assertGreaterEqual(
+            len(wait_calls),
+            1,
+            "compiled graph must wait the AsyncCollectiveTensor nested in "
+            "DTensor._local_tensor",
+        )
+        self.assertTrue(dt._local_tensor.completed)
+
+    def test_direct_aot_dtensor_local_tensor_act_to_plain_no_crash(self):
+        # Companion to the wait test above: the crash half of
+        # https://github.com/pytorch/pytorch/issues/180614. Direct AOTAutograd
+        # entry points do not have Dynamo guards to recompile when a nested ACT
+        # input is later a plain tensor. The compiled graph must run on the
+        # plain local instead of trying to wait or unwrap it as ACT.
+        from torch._functorch.aot_autograd import aot_function
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        def fw_compiler(gm, example_inputs):
+            return gm
+
+        fn = aot_function(lambda x: x + 1, fw_compiler=fw_compiler)
+
+        # Trace with an ACT-wrapped local so the codegen specializes on it.
+        dt_act = DTensor.from_local(
+            torch.randn(4, 4, device=self.device_type),
+            mesh,
+            [Replicate()],
+            run_check=False,
+        )
+        dt_act._local_tensor = AsyncCollectiveTensor(dt_act._local_tensor.clone())
+        fn(dt_act)
+
+        # Invoke the same compiled graph with a plain-local DTensor.
+        dt_plain = DTensor.from_local(
+            torch.randn(4, 4, device=self.device_type),
+            mesh,
+            [Replicate()],
+            run_check=False,
+        )
+        self.assertNotIsInstance(dt_plain._local_tensor, AsyncCollectiveTensor)
+        out = fn(dt_plain)
+        self.assertEqual(out.to_local(), dt_plain.to_local() + 1)
+
+    def test_compile_dtensor_local_tensor_act_backward_passthrough(self):
+        # Passthrough forwards preserve ACT wrappers. If nested ACTs are
+        # allowed into traced metadata, backward expects an ACT tangent and
+        # rejects the plain-local cotangent autograd supplies.
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def fn(x):
+            return x
+
+        local = torch.randn(4, 4, device=self.device_type, requires_grad=True)
+        dt = DTensor.from_local(local, mesh, [Replicate()], run_check=False)
+        dt._local_tensor = AsyncCollectiveTensor(dt._local_tensor.clone())
+        out = fn(dt)
+        out.to_local().sum().backward()
+        self.assertIsNotNone(local.grad)
 
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW or TEST_XPU,

--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -275,8 +275,9 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("inductor")
 
-        @torch.compile(backend="inductor", fullgraph=True)
+        @torch.compile(backend=cnt, fullgraph=True)
         def fn(x):
             return x + 1
 
@@ -307,6 +308,7 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
             self.assertFalse(dt._local_tensor.completed)
             fn(dt)
 
+        self.assertEqual(cnt.frame_count, 1)
         self.assertGreaterEqual(
             len(wait_calls),
             1,
@@ -325,8 +327,11 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        compile_calls = 0
 
         def fw_compiler(gm, example_inputs):
+            nonlocal compile_calls
+            compile_calls += 1
             return gm
 
         fn = aot_function(lambda x: x + 1, fw_compiler=fw_compiler)
@@ -351,6 +356,7 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         self.assertNotIsInstance(dt_plain._local_tensor, AsyncCollectiveTensor)
         out = fn(dt_plain)
         self.assertEqual(out.to_local(), dt_plain.to_local() + 1)
+        self.assertEqual(compile_calls, 1)
 
     def test_compile_dtensor_local_tensor_act_backward_passthrough(self):
         # Passthrough forwards preserve ACT wrappers. If nested ACTs are

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1610,6 +1610,28 @@ class ACTCompileTest(TestCase):
         r2 = compiled_fn(act2)
         self.assertEqual(r2, elem2 * 2)
 
+    def test_direct_aot_top_level_act_path_accepts_plain_runtime_input(self):
+        """
+        Unlike torch.compile, direct AOTAutograd entry points do not have
+        Dynamo input-type guards to force a recompile when a top-level ACT input
+        is later a plain tensor. The runtime wait path must therefore guard
+        before calling trigger_wait() on the recorded ACT input path.
+        """
+        from torch._functorch.aot_autograd import aot_function
+
+        def fw_compiler(gm, example_inputs):
+            return gm
+
+        compiled_fn = aot_function(lambda x: x * 2, fw_compiler=fw_compiler)
+
+        elem = torch.randn(4, 4)
+        r1 = compiled_fn(AsyncCollectiveTensor(elem))
+        self.assertEqual(r1, elem * 2)
+
+        plain = torch.randn(4, 4)
+        r2 = compiled_fn(plain)
+        self.assertEqual(r2, plain * 2)
+
     def test_act_guard_recompiles(self):
         """
         Dynamo must recompile when an input switches between plain tensor

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -237,9 +237,13 @@ class CacheKeyEquivalenceMixin:
             captured_gt_key = captured_gt_debug_lines = None
             real_cache_key = autograd_cache.autograd_cache_key
 
-            def capturing_cache_key(mod, ei, config, compiler_config_extra=None):
+            def capturing_cache_key(
+                mod, ei, config, compiler_config_extra=None, act_input_paths=()
+            ):
                 nonlocal captured_gt_key, captured_gt_debug_lines
-                result = real_cache_key(mod, ei, config, compiler_config_extra)
+                result = real_cache_key(
+                    mod, ei, config, compiler_config_extra, act_input_paths
+                )
                 captured_gt_key, captured_gt_debug_lines = result
                 return result
 
@@ -3442,7 +3446,7 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         result = g(*args, **kwargs)
         return (result, fx_graph, example_inputs)
 
-    def gen_cache_key(self, f, config, inputs=None):
+    def gen_cache_key(self, f, config, inputs=None, act_input_paths=()):
         if inputs is None:
             inputs = [torch.ones(3)]
         _, fx_g, example_inputs = self._get_dynamo_output(f, *inputs)
@@ -3452,7 +3456,13 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         # Not needed for actual key calculation.
         with torch._guards.tracing(ctx):
             with sanitize_gm_for_cache(fx_g):
-                return autograd_cache_key(fx_g, example_inputs, config, None)
+                return autograd_cache_key(
+                    fx_g,
+                    example_inputs,
+                    config,
+                    None,
+                    act_input_paths=act_input_paths,
+                )
 
     def test_basic_hash_key(self):
         def fn(x):
@@ -3518,6 +3528,20 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
             config_with_backend, precompile_backend_id="backend"
         )
         self.assertNotEqual(base, self.gen_cache_key(fn, config_with_backend))
+
+    def test_different_act_input_paths(self):
+        def fn(x):
+            return x.sin().cos()
+
+        config = self.default_config()
+        base = self.gen_cache_key(fn, config)
+        top_level_act = self.gen_cache_key(fn, config, act_input_paths=[(0, ())])
+        nested_act = self.gen_cache_key(
+            fn, config, act_input_paths=[(0, ("_local_tensor",))]
+        )
+
+        self.assertNotEqual(base, top_level_act)
+        self.assertNotEqual(top_level_act, nested_act)
 
     def test_different_graphs(self):
         def fn(x):
@@ -4500,9 +4524,13 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
 
         real_cache_key = autograd_cache.autograd_cache_key
 
-        def capturing_cache_key(mod, ei, config, compiler_config_extra=None):
+        def capturing_cache_key(
+            mod, ei, config, compiler_config_extra=None, act_input_paths=()
+        ):
             nonlocal captured_key
-            result = real_cache_key(mod, ei, config, compiler_config_extra)
+            result = real_cache_key(
+                mod, ei, config, compiler_config_extra, act_input_paths
+            )
             captured_key = result[0]
             return result
 
@@ -4762,9 +4790,13 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         real_cache_key_fn = autograd_cache.autograd_cache_key
         captured_key = None
 
-        def capturing_cache_key(mod, ei, config, compiler_config_extra=None):
+        def capturing_cache_key(
+            mod, ei, config, compiler_config_extra=None, act_input_paths=()
+        ):
             nonlocal captured_key
-            captured_key, _ = real_cache_key_fn(mod, ei, config, compiler_config_extra)
+            captured_key, _ = real_cache_key_fn(
+                mod, ei, config, compiler_config_extra, act_input_paths
+            )
             return captured_key, _
 
         with outer_context:

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -510,6 +510,28 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
 
     @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch({"fx_graph_cache": True, "compile_threads": 1})
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_act_input_paths_cache_hit(self):
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        def fn(x):
+            return x + 1
+
+        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        elem = torch.randn(4)
+        self.assertEqual(compiled_fn(AsyncCollectiveTensor(elem)), elem + 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+
+        elem = torch.randn(4)
+        self.assertEqual(compiled_fn(AsyncCollectiveTensor(elem)), elem + 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch(
         {"enable_autograd_cache": True, "strict_autograd_cache": True}

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -513,23 +513,40 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch({"fx_graph_cache": True, "compile_threads": 1})
     @functorch_config.patch({"enable_autograd_cache": True})
     def test_act_input_paths_cache_hit(self):
+        import torch.distributed._functional_collectives as funcol
         from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
         def fn(x):
             return x + 1
 
         compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
-        elem = torch.randn(4)
-        self.assertEqual(compiled_fn(AsyncCollectiveTensor(elem)), elem + 1)
-        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
-        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        wait_calls = []
+        orig_wait_tensor = funcol.wait_tensor
 
-        self._clear_dynamo_and_codecache()
+        def counting_wait_tensor(t):
+            wait_calls.append(1)
+            return orig_wait_tensor(t)
 
-        elem = torch.randn(4)
-        self.assertEqual(compiled_fn(AsyncCollectiveTensor(elem)), elem + 1)
-        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
-        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+        with patch.object(funcol, "wait_tensor", counting_wait_tensor):
+            elem = torch.randn(4)
+            act = AsyncCollectiveTensor(elem)
+            self.assertFalse(act.completed)
+            self.assertEqual(compiled_fn(act), elem + 1)
+            self.assertTrue(act.completed)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            wait_calls.clear()
+            self._clear_dynamo_and_codecache()
+
+            elem = torch.randn(4)
+            act = AsyncCollectiveTensor(elem)
+            self.assertFalse(act.completed)
+            self.assertEqual(compiled_fn(act), elem + 1)
+            self.assertTrue(act.completed)
+            self.assertGreaterEqual(len(wait_calls), 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
 
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -512,6 +512,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch({"fx_graph_cache": True, "compile_threads": 1})
     @functorch_config.patch({"enable_autograd_cache": True})
+    @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")
     def test_act_input_paths_cache_hit(self):
         import torch.distributed._functional_collectives as funcol
         from torch.distributed._functional_collectives import AsyncCollectiveTensor

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9380,7 +9380,7 @@ def forward(self, primals_1, tangents_1):
             enable_log=False,
         )
         fake_mode, shape_env = construct_fake_mode(flat_args, aot_config)
-        fake_flat_args, act_input_indices = process_inputs(
+        fake_flat_args, act_input_paths = process_inputs(
             flat_args, aot_config, fake_mode, shape_env
         )
         flat_args_descs = [PlainAOTInput(i) for i in range(len(fake_flat_args))]
@@ -9395,7 +9395,7 @@ def forward(self, primals_1, tangents_1):
                 fake_mode,
                 shape_env,
             )
-            aot_state.fw_metadata.act_input_indices = act_input_indices
+            aot_state.fw_metadata.act_input_paths = act_input_paths
             aot_config_before_stage2 = aot_state.aot_config
             aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
             compiled_fn, _ = aot_stage2_compile(

--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -197,6 +197,9 @@ def inner_fn(args):
     unwrapped_args.extend(args[1:])
     args.clear()
     unwrapped_outs = compiled_fn(unwrapped_args)
+    _out_idx = 0
+    _has_subclass_symint_outputs = len(unwrapped_outs) == 1
+    _out_idx = max(_out_idx, 1)
     return (unwrapped_outs[0],)""",
         )
 
@@ -223,6 +226,9 @@ def inner_fn(args):
     unwrapped_args.extend(args[1:])
     args.clear()
     unwrapped_outs = compiled_fn(unwrapped_args)
+    _out_idx = 0
+    _has_subclass_symint_outputs = len(unwrapped_outs) == 1
+    _out_idx = max(_out_idx, 1)
     return (unwrapped_outs[0],)""",
         )
 

--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -34,6 +34,22 @@ class _TestSubclassMeta:
 
 
 class TestSubclassCodegen(TestCase):
+    def _two_tensor_meta(self) -> _TestSubclassMeta:
+        return _TestSubclassMeta(
+            flat_tensor_start_idx=0,
+            arg_count=2,
+            included_subclass_symints=True,
+            attrs={
+                "a": PlainTensorMeta(unwrapped_idx=0),
+                "b": PlainTensorMeta(unwrapped_idx=1),
+            },
+            outer_size=(4,),
+            outer_stride=(1,),
+            meta=None,
+            original_subclass=None,
+            original_subclass_type=TwoTensor,
+        )
+
     @contextmanager
     def _capture_wrapper_source(self):
         """Capture subclass_wrapper artifacts from the structured trace log."""
@@ -161,37 +177,57 @@ def inner_fn(args):
     return (_out_19,)""",
         )
 
+    def test_act_wait_top_level_codegen(self):
+        """ACT paths on plain inputs emit waits during input unwrapping."""
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            out_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            num_fw_outs_saved_for_bw=None,
+            act_input_paths=[(0, ())],
+        )
+
+        self.assertExpectedInline(
+            source,
+            """\
+def inner_fn(args):
+    unwrapped_args = []
+    unwrapped_args.append(_maybe_wait_act_0(args[0]))
+    unwrapped_args.extend(args[1:])
+    args.clear()
+    unwrapped_outs = compiled_fn(unwrapped_args)
+    return (unwrapped_outs[0],)""",
+        )
+
+    def test_act_wait_nested_codegen(self):
+        """ACT paths inside subclasses emit waits at the matching leaf."""
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[self._two_tensor_meta()],
+            out_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            num_fw_outs_saved_for_bw=None,
+            act_input_paths=[(0, ("a",))],
+        )
+
+        self.assertExpectedInline(
+            source,
+            """\
+def inner_fn(args):
+    unwrapped_args = []
+    _inp_1 = args[0]
+    assert type(_inp_1) is _expected_type_2, f'expected {_expected_type_2}, got {type(_inp_1)}'
+    _resolved_3 = _maybe_wait_act_0(_inp_1.a)
+    unwrapped_args.append(_resolved_3)
+    unwrapped_args.append(_inp_1.b)
+    unwrapped_args.extend(args[1:])
+    args.clear()
+    unwrapped_outs = compiled_fn(unwrapped_args)
+    return (unwrapped_outs[0],)""",
+        )
+
     def test_trailing_args_forwarded(self):
         """Extra trailing args (e.g. rng seed/offset) are forwarded to compiled_fn."""
         # Build SubclassCreationMeta manually to avoid __post_init__ fake tensor check
-        inp_meta = _TestSubclassMeta(
-            flat_tensor_start_idx=0,
-            arg_count=2,
-            included_subclass_symints=True,
-            attrs={
-                "a": PlainTensorMeta(unwrapped_idx=0),
-                "b": PlainTensorMeta(unwrapped_idx=1),
-            },
-            outer_size=(4,),
-            outer_stride=(1,),
-            meta=None,
-            original_subclass=None,
-            original_subclass_type=TwoTensor,
-        )
-        out_meta = _TestSubclassMeta(
-            flat_tensor_start_idx=0,
-            arg_count=2,
-            included_subclass_symints=True,
-            attrs={
-                "a": PlainTensorMeta(unwrapped_idx=0),
-                "b": PlainTensorMeta(unwrapped_idx=1),
-            },
-            outer_size=(4,),
-            outer_stride=(1,),
-            meta=None,
-            original_subclass=None,
-            original_subclass_type=TwoTensor,
-        )
+        inp_meta = self._two_tensor_meta()
+        out_meta = self._two_tensor_meta()
 
         source, globals_dict = _codegen_subclass_wrapper_source(
             inp_metas=[inp_meta],

--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: functorch"]
 
 import logging
+import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -177,6 +178,7 @@ def inner_fn(args):
     return (_out_19,)""",
         )
 
+    @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")
     def test_act_wait_top_level_codegen(self):
         """ACT paths on plain inputs emit waits during input unwrapping."""
         source, _ = _codegen_subclass_wrapper_source(
@@ -198,6 +200,7 @@ def inner_fn(args):
     return (unwrapped_outs[0],)""",
         )
 
+    @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")
     def test_act_wait_nested_codegen(self):
         """ACT paths inside subclasses emit waits at the matching leaf."""
         source, _ = _codegen_subclass_wrapper_source(

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5713,6 +5713,9 @@ skipped_tests.add("test_custom_function_boxed_grads_materialize_grads")
 skipped_tests.add("test_custom_function_boxed_grads_direct_apply")
 skipped_tests.add("test_custom_function_boxed_grads_single_list_arg")
 
+# DTensor backward calls a skipped global-shape helper under compiled autograd.
+skipped_tests.add("test_compile_dtensor_local_tensor_act_backward_passthrough")
+
 test_autograd = load_test_module("test_autograd")
 test_custom_ops = load_test_module("test_custom_ops")
 test_higher_order_ops = load_test_module("dynamo/test_higher_order_ops")

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -85,6 +85,7 @@ from .runtime_wrappers import (
     SubclassMeta,
 )
 from .schemas import (
+    ActInputPaths,
     AOTAutogradCacheInfo,
     AOTConfig,
     CacheableAOTConfig,
@@ -501,7 +502,7 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         example_inputs: Sequence[Any],
         aot_config: AOTConfig,
         fx_config: _CompileFxKwargs,
-        act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
+        act_input_paths: ActInputPaths = (),
     ) -> None:
         # FxGraphHashDetails contains all the keys related to inductor. Also
         # includes some system info.
@@ -866,7 +867,7 @@ def autograd_cache_key(
     example_inputs: Sequence[Any],
     config: AOTConfig,
     compiler_config_extra: CompilerConfigExtra | None = None,
-    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
+    act_input_paths: ActInputPaths = (),
     # TODO: add args and parameters
 ) -> tuple[str, list[str]]:
     """
@@ -1001,7 +1002,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         compiler_config_extra: CompilerConfigExtra | None,
         local: bool,
         remote: bool,
-        act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
+        act_input_paths: ActInputPaths = (),
         compile_region_name: str | None = None,
     ) -> tuple[Callable[..., Any] | None, AOTConfig]:
         """

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -501,10 +501,12 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         example_inputs: Sequence[Any],
         aot_config: AOTConfig,
         fx_config: _CompileFxKwargs,
+        act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
     ) -> None:
         # FxGraphHashDetails contains all the keys related to inductor. Also
         # includes some system info.
         self.aot_config = aot_config
+        self.act_input_paths = tuple(act_input_paths)
         self._record_runtime_state(gm)
         self.saved_tensors_hooks_fx_wrap_cache_hashes = (
             _collect_saved_tensors_hooks_fx_wrap_cache_hashes(gm)
@@ -864,6 +866,7 @@ def autograd_cache_key(
     example_inputs: Sequence[Any],
     config: AOTConfig,
     compiler_config_extra: CompilerConfigExtra | None = None,
+    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
     # TODO: add args and parameters
 ) -> tuple[str, list[str]]:
     """
@@ -876,7 +879,11 @@ def autograd_cache_key(
             check_cacheable(gm)
             _check_triton_cache_version()
             details = AOTAutogradCacheDetails(
-                gm, example_inputs, config, create_fx_config(compiler_config_extra)
+                gm,
+                example_inputs,
+                config,
+                create_fx_config(compiler_config_extra),
+                act_input_paths,
             )
             pickler = AOTAutogradCachePickler(gm)
             # The prefix distinguishes among the other kinds of objects we cache
@@ -994,6 +1001,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         compiler_config_extra: CompilerConfigExtra | None,
         local: bool,
         remote: bool,
+        act_input_paths: Sequence[tuple[int, tuple[str, ...]]] = (),
         compile_region_name: str | None = None,
     ) -> tuple[Callable[..., Any] | None, AOTConfig]:
         """
@@ -1009,7 +1017,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         cache_state = None
         try:
             cache_key, debug_lines = autograd_cache_key(
-                mod, args, aot_config, compiler_config_extra
+                mod, args, aot_config, compiler_config_extra, act_input_paths
             )
             result: tuple[GenericAOTAutogradResult[Any, Any], bytes] | None = (
                 AOTAutogradCache._lookup(

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -16,7 +16,8 @@ from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config
 from .descriptors import BufferAOTInput, DifferentiableAOTInput, ParamAOTInput
-from .schemas import AOTConfig, FakifiedFlatArgs
+from .schemas import ActInputPath, AOTConfig, FakifiedFlatArgs
+from .utils import get_loaded_async_collective_tensor_type
 
 
 if TYPE_CHECKING:
@@ -36,7 +37,7 @@ def process_inputs(
     fake_mode: FakeTensorMode,
     shape_env: ShapeEnv | None,
     ignore_shape_env: bool = False,
-) -> tuple[FakifiedFlatArgs, list[tuple[int, tuple[str, ...]]]]:
+) -> tuple[FakifiedFlatArgs, list[ActInputPath]]:
     """Convert real tensor inputs into fake tensors for AOT autograd tracing.
 
     Called at compile time (not runtime) to produce the fake inputs that AOT
@@ -65,13 +66,10 @@ def process_inputs(
     # SubclassCreationMeta for output tangent metadata. At runtime, autograd
     # produces plain tensor tangents, causing a type mismatch. Unwrapping
     # here prevents ACT from appearing in the traced metadata.
-    try:
-        from torch.distributed._functional_collectives import AsyncCollectiveTensor
-    except ImportError:
-        AsyncCollectiveTensor = None
-
-    act_input_paths: list[tuple[int, tuple[str, ...]]] = []
+    AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
+    act_input_paths: list[ActInputPath] = []
     if AsyncCollectiveTensor is not None:
+        tracing_context = torch._guards.TracingContext.try_get()
         for i, a in enumerate(flat_args):
             resolved_arg = _resolve_input_async_collectives(
                 a, i, (), act_input_paths, AsyncCollectiveTensor
@@ -79,7 +77,7 @@ def process_inputs(
             # Rebuilt wrapper inputs must keep Dynamo's symbolic context so
             # fakeification does not allocate source-less shape symbols.
             if resolved_arg is not a and isinstance(resolved_arg, torch.Tensor):
-                if tracing_context := torch._guards.TracingContext.try_get():
+                if tracing_context is not None:
                     if a in tracing_context.tensor_to_context:
                         tracing_context.tensor_to_context[resolved_arg] = (
                             tracing_context.tensor_to_context[a]
@@ -180,7 +178,7 @@ def _resolve_input_async_collectives(
     x: object,
     idx: int,
     attr_path: tuple[str, ...],
-    act_input_paths: list[tuple[int, tuple[str, ...]]],
+    act_input_paths: list[ActInputPath],
     AsyncCollectiveTensor: type[AsyncCollectiveTensor],
 ) -> object:
     """Wait on ACT inputs, recording each top-level or wrapper-subclass path."""

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -22,6 +22,8 @@ from .schemas import AOTConfig, FakifiedFlatArgs
 if TYPE_CHECKING:
     from collections.abc import Generator, KeysView
 
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
 
 static_inputs_log = torch._logging.getArtifactLogger(
     __name__, "cudagraph_static_inputs"
@@ -34,7 +36,7 @@ def process_inputs(
     fake_mode: FakeTensorMode,
     shape_env: ShapeEnv | None,
     ignore_shape_env: bool = False,
-) -> tuple[FakifiedFlatArgs, list[int]]:
+) -> tuple[FakifiedFlatArgs, list[tuple[int, tuple[str, ...]]]]:
     """Convert real tensor inputs into fake tensors for AOT autograd tracing.
 
     Called at compile time (not runtime) to produce the fake inputs that AOT
@@ -43,20 +45,19 @@ def process_inputs(
     symbolic shape information from the ShapeEnv. Non-tensor inputs (ints,
     SymInts, ScriptObjects) are converted or passed through as appropriate.
 
-    Tensor subclass inputs (DTensor, etc.) are fakified recursively by
-    walking their ``__tensor_flatten__`` attrs. AsyncCollectiveTensors are
-    resolved via ``trigger_wait()`` before fakification so they don't appear
-    in the traced metadata (see below).
+    Tensor subclass inputs (DTensor, etc.) are fakified recursively by walking
+    their ``__tensor_flatten__`` attrs. AsyncCollectiveTensors are resolved via
+    ``trigger_wait()`` before fakification so they don't appear in the traced
+    metadata (see below).
 
     Called from ``aot_function``, ``aot_module_simplified``, and
     ``aot_export_module`` — anywhere AOT autograd needs fake inputs before
     graph capture.
 
     Returns:
-        A tuple of (fakified_args, act_input_indices) where act_input_indices
-        records which positions held AsyncCollectiveTensors. These indices are
-        stored on ViewAndMutationMeta so that the runtime wrapper can emit
-        direct trigger_wait() calls on those positions.
+        A tuple of (fakified_args, act_input_paths) where act_input_paths records
+        which input paths held AsyncCollectiveTensors. The paths are stored on
+        ViewAndMutationMeta so the runtime wrapper can re-wait those positions.
     """
     # Resolve AsyncCollectiveTensors before tracing. ACTs are transient
     # eager-mode wrappers for async collective overlap; if they leak into the
@@ -69,12 +70,21 @@ def process_inputs(
     except ImportError:
         AsyncCollectiveTensor = None
 
-    act_input_indices: list[int] = []
+    act_input_paths: list[tuple[int, tuple[str, ...]]] = []
     if AsyncCollectiveTensor is not None:
         for i, a in enumerate(flat_args):
-            if isinstance(a, AsyncCollectiveTensor):
-                act_input_indices.append(i)
-                flat_args[i] = a.trigger_wait()
+            resolved_arg = _resolve_input_async_collectives(
+                a, i, (), act_input_paths, AsyncCollectiveTensor
+            )
+            # Rebuilt wrapper inputs must keep Dynamo's symbolic context so
+            # fakeification does not allocate source-less shape symbols.
+            if resolved_arg is not a and isinstance(resolved_arg, torch.Tensor):
+                if tracing_context := torch._guards.TracingContext.try_get():
+                    if a in tracing_context.tensor_to_context:
+                        tracing_context.tensor_to_context[resolved_arg] = (
+                            tracing_context.tensor_to_context[a]
+                        )
+            flat_args[i] = resolved_arg
 
     with fake_mode:
 
@@ -163,7 +173,55 @@ def process_inputs(
 
         return FakifiedFlatArgs(
             [convert(idx, x) for idx, x in enumerate(flat_args)]
-        ), act_input_indices
+        ), act_input_paths
+
+
+def _resolve_input_async_collectives(
+    x: object,
+    idx: int,
+    attr_path: tuple[str, ...],
+    act_input_paths: list[tuple[int, tuple[str, ...]]],
+    AsyncCollectiveTensor: type[AsyncCollectiveTensor],
+) -> object:
+    """Wait on ACT inputs, recording each top-level or wrapper-subclass path."""
+    if isinstance(x, AsyncCollectiveTensor):
+        act_input_paths.append((idx, attr_path))
+        return x.trigger_wait()
+
+    if not isinstance(x, torch.Tensor) or not is_traceable_wrapper_subclass(x):
+        return x
+
+    attrs, meta = x.__tensor_flatten__()
+    inner_tensors: dict[str, Any] | None = None
+    for attr in attrs:
+        inner = getattr(x, attr)
+        match inner:
+            case OpaqueBase():
+                continue
+            case torch.Tensor():
+                resolved_inner = _resolve_input_async_collectives(
+                    inner,
+                    idx,
+                    (*attr_path, attr),
+                    act_input_paths,
+                    AsyncCollectiveTensor,
+                )
+            case _:
+                raise AssertionError(
+                    f"expected Tensor or OpaqueBase, got {type(inner)}"
+                )
+
+        if resolved_inner is not inner:
+            if inner_tensors is None:
+                inner_tensors = {a: getattr(x, a) for a in attrs}
+            inner_tensors[attr] = resolved_inner
+
+    if inner_tensors is None:
+        return x
+
+    return type(x).__tensor_unflatten__(  # type: ignore[attr-defined]
+        inner_tensors, meta, x.size(), x.stride()
+    )
 
 
 def construct_fake_mode(

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -188,7 +188,7 @@ def _resolve_input_async_collectives(
         act_input_paths.append((idx, attr_path))
         return x.trigger_wait()
 
-    if not isinstance(x, torch.Tensor) or not is_traceable_wrapper_subclass(x):
+    if not is_traceable_wrapper_subclass(x):
         return x
 
     attrs, meta = x.__tensor_flatten__()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1403,7 +1403,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
         *,
         runtime_metadata: ViewAndMutationMeta,
     ) -> Callable[..., Any]:
-        if self.maybe_subclass_meta is None and not runtime_metadata.act_input_indices:
+        if self.maybe_subclass_meta is None and not runtime_metadata.act_input_paths:
             return compiled_fn
 
         from .subclass_codegen import codegen_subclass_wrapper
@@ -1414,7 +1414,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
             out_metas=runtime_metadata.subclass_fw_graph_out_meta,
             num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
             frozen_inp_indices=self._get_frozen_inp_indices(),
-            act_input_indices=runtime_metadata.act_input_indices,
+            act_input_paths=runtime_metadata.act_input_paths,
         )
         inner_fn._boxed_call = True  # type: ignore[attr-defined]
         return inner_fn

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -515,10 +515,11 @@ class ViewAndMutationMeta:
     # Keeps track of which input indices store parameters (which we will treat as static)
     static_input_indices: list[int] = field(default_factory=list)
 
-    # Input indices that held AsyncCollectiveTensors at compile time.
-    # Used to emit direct trigger_wait() calls at runtime instead of
+    # Input paths that held AsyncCollectiveTensors at compile time. A path is
+    # (input_index, attr_path), where an empty attr_path means the top-level
+    # input. Used to emit direct trigger_wait() calls at runtime instead of
     # scanning every arg on every graph invocation.
-    act_input_indices: list[int] = field(default_factory=list)
+    act_input_paths: list[tuple[int, tuple[str, ...]]] = field(default_factory=list)
 
     # Map of effect type (ex. _EffectType.ORDERED) to token.  If there are
     # side-effectful operators, FunctionalTensorMode will populate this

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import collections
 import functools
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Any, NewType, Protocol, TYPE_CHECKING, TypeVar
+from typing import Any, NewType, Protocol, TYPE_CHECKING, TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -28,7 +29,7 @@ from .utils import strict_zip
 
 if TYPE_CHECKING:
     import contextlib
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable
 
     from torch._guards import Source
     from torch._inductor.output_code import OutputCode
@@ -42,6 +43,9 @@ if TYPE_CHECKING:
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 zip = strict_zip
+
+ActInputPath: TypeAlias = tuple[int, tuple[str, ...]]
+ActInputPaths: TypeAlias = Sequence[ActInputPath]
 
 
 OutputType = Enum(
@@ -519,7 +523,7 @@ class ViewAndMutationMeta:
     # (input_index, attr_path), where an empty attr_path means the top-level
     # input. Used to emit direct trigger_wait() calls at runtime instead of
     # scanning every arg on every graph invocation.
-    act_input_paths: list[tuple[int, tuple[str, ...]]] = field(default_factory=list)
+    act_input_paths: list[ActInputPath] = field(default_factory=list)
 
     # Map of effect type (ex. _EffectType.ORDERED) to token.  If there are
     # side-effectful operators, FunctionalTensorMode will populate this

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -11,13 +11,12 @@ import functools
 import keyword
 import logging
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import cast, TYPE_CHECKING
 from typing_extensions import TypeIs
 
 import torch
 from torch import SymInt
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .schemas import OpaqueMeta, PlainTensorMeta, SubclassCreationMeta
 
@@ -90,59 +89,55 @@ def _maybe_wait_async_collective_tensor(x: object) -> object:
     return x
 
 
-def _resolve_async_collective_tensor_path(
-    x: object, attr_path: tuple[str, ...]
-) -> object:
-    """Follow a wrapper-subclass attr path and wait on the ACT leaf if present."""
-    if not attr_path:
-        return _maybe_wait_async_collective_tensor(x)
-
-    if not isinstance(x, torch.Tensor) or not is_traceable_wrapper_subclass(x):
-        return x
-
-    attrs, meta = x.__tensor_flatten__()
-    attr = attr_path[0]
-    if attr not in attrs:
-        return x
-
-    inner = getattr(x, attr)
-    resolved_inner = _resolve_async_collective_tensor_path(inner, attr_path[1:])
-    if resolved_inner is inner:
-        return x
-
-    inner_tensors = {a: getattr(x, a) for a in attrs}
-    inner_tensors[attr] = resolved_inner
-    return type(x).__tensor_unflatten__(  # type: ignore[attr-defined]
-        inner_tensors, meta, x.size(), x.stride()
-    )
-
-
 def _codegen_unwrap_subclass(
     state: _CodegenState,
     meta: SubclassCreationMeta,
     var: str,
     indent: int = 1,
     include_symints: bool = True,
+    act_input_paths: set[tuple[str, ...]] | None = None,
+    act_wait_fn: str | None = None,
 ) -> None:
     """Emit code to recursively unwrap a single subclass input."""
+    act_input_paths = act_input_paths or set()
     for attr, attr_meta in meta.attrs.items():
+        attr_expr = _safe_attr_access(var, attr)
+        attr_act_input_paths = {
+            path[1:] for path in act_input_paths if path and path[0] == attr
+        }
         match attr_meta:
             case PlainTensorMeta() | OpaqueMeta():
-                state.emit(
-                    f"unwrapped_args.append({_safe_attr_access(var, attr)})",
-                    indent=indent,
-                )
+                if attr_act_input_paths:
+                    if attr_act_input_paths != {()}:
+                        raise AssertionError(
+                            f"ACT path for {attr} continues past a leaf meta"
+                        )
+                    if act_wait_fn is None:
+                        raise AssertionError("missing ACT wait function")
+                    resolved_var = state.fresh_name("_resolved")
+                    state.emit(
+                        f"{resolved_var} = {act_wait_fn}({attr_expr})",
+                        indent=indent,
+                    )
+                    state.emit(f"unwrapped_args.append({resolved_var})", indent=indent)
+                else:
+                    state.emit(
+                        f"unwrapped_args.append({attr_expr})",
+                        indent=indent,
+                    )
             case SubclassCreationMeta():
+                if () in attr_act_input_paths:
+                    raise AssertionError(f"ACT path for {attr} stops at subclass meta")
                 inner_var = state.fresh_name("_inner")
-                state.emit(
-                    f"{inner_var} = {_safe_attr_access(var, attr)}", indent=indent
-                )
+                state.emit(f"{inner_var} = {attr_expr}", indent=indent)
                 _codegen_unwrap_subclass(
                     state,
                     attr_meta,
                     inner_var,
                     indent=indent,
                     include_symints=include_symints,
+                    act_input_paths=attr_act_input_paths,
+                    act_wait_fn=act_wait_fn,
                 )
 
     if include_symints:
@@ -321,18 +316,33 @@ def _emit_input_unwrapping(
     inp_metas: list[PlainTensorMeta | SubclassCreationMeta],
     frozen_inp_indices: frozenset[int] = frozenset(),
     include_symints: bool = True,
+    act_input_paths_by_input: dict[int, set[tuple[str, ...]]] | None = None,
+    act_wait_fn: str | None = None,
 ) -> None:
     """Emit unwrapping code for input metas into unwrapped_args.
 
     Caller must have already emitted ``unwrapped_args = []``.
     """
+    act_input_paths_by_input = act_input_paths_by_input or {}
     for i, meta in enumerate(inp_metas):
+        input_act_paths = act_input_paths_by_input.get(i, set())
         if isinstance(meta, PlainTensorMeta):
-            state.emit(f"unwrapped_args.append(args[{i}])")
+            if input_act_paths:
+                if input_act_paths != {()}:
+                    raise AssertionError(
+                        f"ACT path for input {i} continues past a plain meta"
+                    )
+                if act_wait_fn is None:
+                    raise AssertionError("missing ACT wait function")
+                state.emit(f"unwrapped_args.append({act_wait_fn}(args[{i}]))")
+            else:
+                state.emit(f"unwrapped_args.append(args[{i}])")
         elif i in frozen_inp_indices:
             # Frozen by inductor freezing: constant already baked into graph.
             state.emit("unwrapped_args.append(None)")
         else:
+            if () in input_act_paths:
+                raise AssertionError(f"ACT path for input {i} stops at subclass meta")
             inp_var = state.fresh_name("_inp")
             type_name = state.add_global(
                 state.fresh_name("_expected_type"),
@@ -344,7 +354,13 @@ def _emit_input_unwrapping(
                 f"f'expected {{{type_name}}}, got {{type({inp_var})}}'",
             )
             _codegen_unwrap_subclass(
-                state, meta, inp_var, indent=1, include_symints=include_symints
+                state,
+                meta,
+                inp_var,
+                indent=1,
+                include_symints=include_symints,
+                act_input_paths=input_act_paths,
+                act_wait_fn=act_wait_fn,
             )
 
 
@@ -353,7 +369,7 @@ def _codegen_subclass_wrapper_source(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
+    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] | None = None,
 ) -> tuple[str, dict[str, object]]:
     """Generate source and globals for a subclass wrapper.
 
@@ -364,21 +380,25 @@ def _codegen_subclass_wrapper_source(
 
     state.emit("def inner_fn(args):", indent=0)
 
-    # --- Resolve AsyncCollectiveTensors ---
-    # ACTs are transient eager-mode wrappers for async collective overlap.
-    # Inductor triton kernels bypass __torch_dispatch__, so we must call
-    # trigger_wait() before the compiled graph uses the data.
+    act_input_paths_by_input: dict[int, set[tuple[str, ...]]] = {}
+    act_wait_fn = None
     if act_input_paths:
-        resolve_fn = state.add_global(
-            state.fresh_name("_resolve_act_path"),
-            _resolve_async_collective_tensor_path,
+        act_wait_fn = state.add_global(
+            state.fresh_name("_maybe_wait_act"),
+            _maybe_wait_async_collective_tensor,
         )
         for i, attr_path in act_input_paths:
-            state.emit(f"args[{i}] = {resolve_fn}(args[{i}], {attr_path!r})")
+            act_input_paths_by_input.setdefault(i, set()).add(attr_path)
 
     # --- Input unwrapping ---
     state.emit("unwrapped_args = []")
-    _emit_input_unwrapping(state, inp_metas, frozen_inp_indices=frozen_inp_indices)
+    _emit_input_unwrapping(
+        state,
+        inp_metas,
+        frozen_inp_indices=frozen_inp_indices,
+        act_input_paths_by_input=act_input_paths_by_input,
+        act_wait_fn=act_wait_fn,
+    )
 
     # Pass through any trailing args not covered by inp_metas
     # (e.g. rng seed/offset added by FunctionalizedRngRuntimeWrapper).
@@ -495,7 +515,7 @@ def codegen_subclass_wrapper(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
+    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] | None = None,
 ) -> Callable[..., object]:
     """Generate a specialized wrapper function for subclass unwrap/wrap."""
     source, globals_dict = _codegen_subclass_wrapper_source(

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -70,10 +70,12 @@ class _CodegenState:
         return name
 
 
-def _maybe_wait_async_collective_tensor(x: object) -> object:
+def _maybe_wait_async_collective_tensor(
+    x: object,
+    AsyncCollectiveTensor: type["AsyncCollectiveTensor"],
+) -> object:
     """Wait on ACT values and leave all other runtime inputs unchanged."""
-    AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
-    if AsyncCollectiveTensor is not None and type(x) is AsyncCollectiveTensor:
+    if isinstance(x, AsyncCollectiveTensor):
         return cast("AsyncCollectiveTensor", x).trigger_wait()
     return x
 
@@ -372,9 +374,15 @@ def _codegen_subclass_wrapper_source(
     act_input_paths_by_input: dict[int, set[tuple[str, ...]]] = {}
     act_wait_fn = None
     if act_input_paths:
+        AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
+        if AsyncCollectiveTensor is None:
+            raise AssertionError("ACT input paths require the ACT type to be loaded")
         act_wait_fn = state.add_global(
             state.fresh_name("_maybe_wait_act"),
-            _maybe_wait_async_collective_tensor,
+            functools.partial(
+                _maybe_wait_async_collective_tensor,
+                AsyncCollectiveTensor=AsyncCollectiveTensor,
+            ),
         )
         for i, attr_path in act_input_paths:
             act_input_paths_by_input.setdefault(i, set()).add(attr_path)

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -17,7 +17,7 @@ import torch
 from torch import SymInt
 
 from .schemas import ActInputPaths, OpaqueMeta, PlainTensorMeta, SubclassCreationMeta
-from .utils import get_loaded_async_collective_tensor_type
+from .utils import import_async_collective_tensor_type
 
 
 log = logging.getLogger(__name__)
@@ -374,9 +374,7 @@ def _codegen_subclass_wrapper_source(
     act_input_paths_by_input: dict[int, set[tuple[str, ...]]] = {}
     act_wait_fn = None
     if act_input_paths:
-        AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
-        if AsyncCollectiveTensor is None:
-            raise AssertionError("ACT input paths require the ACT type to be loaded")
+        AsyncCollectiveTensor = import_async_collective_tensor_type()
         act_wait_fn = state.add_global(
             state.fresh_name("_maybe_wait_act"),
             functools.partial(

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -10,15 +10,22 @@ subclass types, symint positions) is baked in at compile time.
 import functools
 import keyword
 import logging
+import sys
 from collections.abc import Callable, Iterable
+from typing import cast, TYPE_CHECKING
+from typing_extensions import TypeIs
 
 import torch
 from torch import SymInt
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .schemas import OpaqueMeta, PlainTensorMeta, SubclassCreationMeta
 
 
 log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
 
 def _is_symint_placeholder(x: None | int | SymInt) -> bool:
@@ -65,6 +72,51 @@ class _CodegenState:
         return name
 
 
+def _is_async_collective_tensor_type(
+    tp: object,
+) -> TypeIs[type["AsyncCollectiveTensor"]]:
+    """Check for the ACT type without importing distributed collectives eagerly."""
+    if "torch.distributed._functional_collectives" not in sys.modules:
+        return False
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+    return tp is AsyncCollectiveTensor
+
+
+def _maybe_wait_async_collective_tensor(x: object) -> object:
+    """Wait on ACT values and leave all other runtime inputs unchanged."""
+    if _is_async_collective_tensor_type(type(x)):
+        return cast("AsyncCollectiveTensor", x).trigger_wait()
+    return x
+
+
+def _resolve_async_collective_tensor_path(
+    x: object, attr_path: tuple[str, ...]
+) -> object:
+    """Follow a wrapper-subclass attr path and wait on the ACT leaf if present."""
+    if not attr_path:
+        return _maybe_wait_async_collective_tensor(x)
+
+    if not isinstance(x, torch.Tensor) or not is_traceable_wrapper_subclass(x):
+        return x
+
+    attrs, meta = x.__tensor_flatten__()
+    attr = attr_path[0]
+    if attr not in attrs:
+        return x
+
+    inner = getattr(x, attr)
+    resolved_inner = _resolve_async_collective_tensor_path(inner, attr_path[1:])
+    if resolved_inner is inner:
+        return x
+
+    inner_tensors = {a: getattr(x, a) for a in attrs}
+    inner_tensors[attr] = resolved_inner
+    return type(x).__tensor_unflatten__(  # type: ignore[attr-defined]
+        inner_tensors, meta, x.size(), x.stride()
+    )
+
+
 def _codegen_unwrap_subclass(
     state: _CodegenState,
     meta: SubclassCreationMeta,
@@ -93,14 +145,10 @@ def _codegen_unwrap_subclass(
                     include_symints=include_symints,
                 )
 
-    # Emit symint extraction
     if include_symints:
         size_placeholders = _compute_placeholders(meta.outer_size)
         stride_placeholders = _compute_placeholders(meta.outer_stride)
-        has_size_symints = any(size_placeholders)
-        has_stride_symints = any(stride_placeholders)
-
-        if has_size_symints or has_stride_symints:
+        if any(size_placeholders) or any(stride_placeholders):
             size_var = state.fresh_name("_size")
             state.emit(f"{size_var} = {var}.size()", indent=indent)
             for i, is_sym in enumerate(size_placeholders):
@@ -305,7 +353,7 @@ def _codegen_subclass_wrapper_source(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_indices: list[int] | None = None,
+    act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
 ) -> tuple[str, dict[str, object]]:
     """Generate source and globals for a subclass wrapper.
 
@@ -320,9 +368,13 @@ def _codegen_subclass_wrapper_source(
     # ACTs are transient eager-mode wrappers for async collective overlap.
     # Inductor triton kernels bypass __torch_dispatch__, so we must call
     # trigger_wait() before the compiled graph uses the data.
-    if act_input_indices:
-        for i in act_input_indices:
-            state.emit(f"args[{i}] = args[{i}].trigger_wait()")
+    if act_input_paths:
+        resolve_fn = state.add_global(
+            state.fresh_name("_resolve_act_path"),
+            _resolve_async_collective_tensor_path,
+        )
+        for i, attr_path in act_input_paths:
+            state.emit(f"args[{i}] = {resolve_fn}(args[{i}], {attr_path!r})")
 
     # --- Input unwrapping ---
     state.emit("unwrapped_args = []")
@@ -443,7 +495,7 @@ def codegen_subclass_wrapper(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_indices: list[int] | None = None,
+    act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
 ) -> Callable[..., object]:
     """Generate a specialized wrapper function for subclass unwrap/wrap."""
     source, globals_dict = _codegen_subclass_wrapper_source(
@@ -451,7 +503,7 @@ def codegen_subclass_wrapper(
         out_metas,
         num_fw_outs_saved_for_bw,
         frozen_inp_indices,
-        act_input_indices=act_input_indices,
+        act_input_paths=act_input_paths,
     )
     globals_dict["compiled_fn"] = compiled_fn
     return _compile_and_exec_source(

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -10,15 +10,14 @@ subclass types, symint positions) is baked in at compile time.
 import functools
 import keyword
 import logging
-import sys
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 from typing import cast, TYPE_CHECKING
-from typing_extensions import TypeIs
 
 import torch
 from torch import SymInt
 
-from .schemas import OpaqueMeta, PlainTensorMeta, SubclassCreationMeta
+from .schemas import ActInputPaths, OpaqueMeta, PlainTensorMeta, SubclassCreationMeta
+from .utils import get_loaded_async_collective_tensor_type
 
 
 log = logging.getLogger(__name__)
@@ -71,20 +70,10 @@ class _CodegenState:
         return name
 
 
-def _is_async_collective_tensor_type(
-    tp: object,
-) -> TypeIs[type["AsyncCollectiveTensor"]]:
-    """Check for the ACT type without importing distributed collectives eagerly."""
-    if "torch.distributed._functional_collectives" not in sys.modules:
-        return False
-    from torch.distributed._functional_collectives import AsyncCollectiveTensor
-
-    return tp is AsyncCollectiveTensor
-
-
 def _maybe_wait_async_collective_tensor(x: object) -> object:
     """Wait on ACT values and leave all other runtime inputs unchanged."""
-    if _is_async_collective_tensor_type(type(x)):
+    AsyncCollectiveTensor = get_loaded_async_collective_tensor_type()
+    if AsyncCollectiveTensor is not None and type(x) is AsyncCollectiveTensor:
         return cast("AsyncCollectiveTensor", x).trigger_wait()
     return x
 
@@ -369,7 +358,7 @@ def _codegen_subclass_wrapper_source(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] | None = None,
+    act_input_paths: ActInputPaths | None = None,
 ) -> tuple[str, dict[str, object]]:
     """Generate source and globals for a subclass wrapper.
 
@@ -515,7 +504,7 @@ def codegen_subclass_wrapper(
     out_metas: list[PlainTensorMeta | SubclassCreationMeta],
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
-    act_input_paths: Sequence[tuple[int, tuple[str, ...]]] | None = None,
+    act_input_paths: ActInputPaths | None = None,
 ) -> Callable[..., object]:
     """Generate a specialized wrapper function for subclass unwrap/wrap."""
     source, globals_dict = _codegen_subclass_wrapper_source(

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -6,6 +6,7 @@ import copy
 import dataclasses
 import logging
 import operator
+import sys
 import warnings
 from collections.abc import Callable, Sequence
 from contextlib import nullcontext
@@ -26,6 +27,8 @@ from torch.fx.experimental.proxy_tensor import py_sym_types
 
 _T = TypeVar("_T")
 if TYPE_CHECKING:
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
     from .schemas import AOTConfig, ViewAndMutationMeta
 
 
@@ -46,6 +49,15 @@ aot_graphs_effects_log = getArtifactLogger(__name__, "aot_graphs_effects")
 annotation_log = getArtifactLogger(__name__, "annotation")
 
 strict_zip = partial(zip, strict=True)
+
+
+def get_loaded_async_collective_tensor_type() -> type["AsyncCollectiveTensor"] | None:
+    """Return the ACT type if distributed collectives are already loaded."""
+    if "torch.distributed._functional_collectives" not in sys.modules:
+        return None
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+    return AsyncCollectiveTensor
 
 
 def partial_flatten_asdict(obj: object) -> Any:

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -60,6 +60,13 @@ def get_loaded_async_collective_tensor_type() -> type["AsyncCollectiveTensor"] |
     return AsyncCollectiveTensor
 
 
+def import_async_collective_tensor_type() -> type["AsyncCollectiveTensor"]:
+    """Import and return the ACT type."""
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+    return AsyncCollectiveTensor
+
+
 def partial_flatten_asdict(obj: object) -> Any:
     if dataclasses.is_dataclass(obj):
         return {

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -797,7 +797,7 @@ def aot_function(
             flat_fn, out_spec = create_tree_flattened_fn(fn, args, kwargs)
             (fake_mode, shape_env) = construct_fake_mode(flat_args, aot_config)
             fake_flat_args: FakifiedFlatArgs
-            fake_flat_args, act_input_indices = process_inputs(
+            fake_flat_args, act_input_paths = process_inputs(
                 flat_args, aot_config, fake_mode, shape_env
             )
             # TODO: We actually could use the pytree path to make better descs.
@@ -815,7 +815,7 @@ def aot_function(
                     fake_mode,
                     shape_env,
                 )
-                aot_state.fw_metadata.act_input_indices = act_input_indices
+                aot_state.fw_metadata.act_input_paths = act_input_paths
                 aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
                 compiled_fn, _ = aot_stage2_compile(
                     aot_state,
@@ -922,12 +922,12 @@ def autograd_cache_key(
     )
 
     fake_mode, shape_env = construct_fake_mode(full_args, aot_config)
-    fake_flat_args, _act_input_indices = process_inputs(
+    fake_flat_args, act_input_paths = process_inputs(
         full_args, aot_config, fake_mode, shape_env, ignore_shape_env
     )
 
     return autograd_cache.autograd_cache_key(
-        graph, fake_flat_args, aot_config, compiler_config_extra
+        graph, fake_flat_args, aot_config, compiler_config_extra, act_input_paths
     )
 
 
@@ -1054,7 +1054,7 @@ def prepare_aot_module_simplified(
     ShapeEnv | None,
     pytree.TreeSpec | None,
     PytreeThunk | None,
-    list[int],
+    list[tuple[int, tuple[str, ...]]],
 ]:
     if not flatten:
         if kwargs is not None:
@@ -1108,7 +1108,7 @@ def prepare_aot_module_simplified(
 
     fake_mode, shape_env = construct_fake_mode(full_args, aot_config)
     # NB: full_args_descs not needed here, fake_flat_args is 1:1 with full_args
-    fake_flat_args, act_input_indices = process_inputs(
+    fake_flat_args, act_input_paths = process_inputs(
         full_args, aot_config, fake_mode, shape_env, ignore_shape_env
     )
 
@@ -1124,7 +1124,7 @@ def prepare_aot_module_simplified(
         shape_env,
         in_spec,
         out_spec,
-        act_input_indices,
+        act_input_paths,
     )
 
 
@@ -1182,7 +1182,7 @@ def aot_module_simplified(
             shape_env,
             _in_spec,
             _out_spec,
-            act_input_indices,
+            act_input_paths,
         ) = prepare_aot_module_simplified(
             mod,
             args,
@@ -1212,6 +1212,7 @@ def aot_module_simplified(
                     compiler_config_extra,
                     local,
                     remote,
+                    act_input_paths,
                     compile_region_name=compile_region_name,
                 )
 
@@ -1233,7 +1234,7 @@ def aot_module_simplified(
                 fake_mode,
                 shape_env,
             )
-            aot_state.fw_metadata.act_input_indices = act_input_indices
+            aot_state.fw_metadata.act_input_paths = act_input_paths
             aot_graph_capture = aot_stage1_graph_capture(aot_state, functional_call)
             compiled_fn, _ = aot_stage2_compile(
                 aot_state,
@@ -1390,7 +1391,7 @@ def aot_export_joint_with_descriptors(
         shape_env,
         in_spec,
         out_spec,
-        act_input_indices,
+        act_input_paths,
     ) = prepare_aot_module_simplified(
         mod,
         args,
@@ -1424,7 +1425,7 @@ def aot_export_joint_with_descriptors(
         fake_mode,
         shape_env,
     )
-    aot_state.fw_metadata.act_input_indices = act_input_indices
+    aot_state.fw_metadata.act_input_paths = act_input_paths
 
     # NB: no cache lookup!
     aot_graph_capture = aot_stage1_graph_capture(aot_state, functional_call)
@@ -1930,7 +1931,7 @@ def _aot_export_function(
         fake_mode, shape_env = construct_fake_mode(flat_args, aot_config)
     else:
         shape_env = fake_mode.shape_env
-    fake_flat_args, act_input_indices = process_inputs(
+    fake_flat_args, act_input_paths = process_inputs(
         flat_args, aot_config, fake_mode, shape_env
     )
     # TODO: Improve the descs here with pytree information
@@ -1948,7 +1949,7 @@ def _aot_export_function(
             fake_mode,
             shape_env,
         )
-        aot_state.fw_metadata.act_input_indices = act_input_indices
+        aot_state.fw_metadata.act_input_paths = act_input_paths
         aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
         fx_g, meta = aot_stage2_export(aot_state, aot_graph_capture)
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -109,6 +109,7 @@ from ._aot_autograd.runtime_wrappers import (  # noqa: F401
     SerializableCompiledFunction,
 )
 from ._aot_autograd.schemas import (  # noqa: F401
+    ActInputPath,
     AOTConfig,
     AOTDispatchCompiler,
     AOTGraphCapture,
@@ -1054,7 +1055,7 @@ def prepare_aot_module_simplified(
     ShapeEnv | None,
     pytree.TreeSpec | None,
     PytreeThunk | None,
-    list[tuple[int, tuple[str, ...]]],
+    list[ActInputPath],
 ]:
     if not flatten:
         if kwargs is not None:


### PR DESCRIPTION
AOTAutograd previously handled AsyncCollectiveTensor inputs only when the ACT was itself a top-level input. Nested ACTs, such as a DTensor whose `_local_tensor` is an ACT from async redistribution or FSDP2 async all-gather, could survive into traced subclass metadata. That created two related problems: forward execution under Inductor could use in-flight data if the ACT was not waited before the compiled graph consumed it, and backward metadata could record an ACT tangent expectation even though autograd later supplies a plain local tensor cotangent.

Fix this by making `process_inputs` recursively resolve ACTs through traceable wrapper subclass attributes. It records each ACT location as an input index plus attribute path, waits at trace time before fakification, and stores those paths on `ViewAndMutationMeta`.

At runtime, the generated subclass wrapper now threads those recorded ACT paths into the existing input unwrapping codegen. Top-level ACT paths emit a guarded wait around the plain input, and nested ACT paths emit the guarded wait at the exact subclass leaf that is appended to the compiled graph's flat inputs. This avoids rebuilding wrapper subclasses at runtime and still tolerates direct AOTAutograd entry points where a path that was ACT during tracing is later a plain tensor.

Because ACT paths affect the generated runtime wrapper, include them in the AOTAutograd cache key. This specializes cached entries by the ACT path set rather than patching loaded metadata after cache lookup.

When nested ACT resolution rebuilds a wrapper input during tracing, preserve Dynamo's symbolic context on the replacement. Without that, fakeification can allocate source-less shape symbols and Inductor can fail while emitting shape guards for the compiled graph.

Fixes #180614

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98