### PR TITLE
[AOTI] Avoid serializing full storage for shared-storage constants

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -1075,9 +1075,7 @@ class TestAOTInductorPackage(TestCase):
         blob_bytes = os.path.getsize(blob_paths[0])
 
         # Logical size of all parameters (each counted once).
-        logical_bytes = sum(
-            p.numel() * p.element_size() for p in model.parameters()
-        )
+        logical_bytes = sum(p.numel() * p.element_size() for p in model.parameters())
 
         # Before the fix, every shared-storage view serialized the full flat
         # weight buffer, inflating the blob to several times the logical size.

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -1037,6 +1037,53 @@ class TestAOTInductorPackage(TestCase):
         lambda device, package_cpp_only: package_cpp_only,
         "No support for cpp only",
     )
+    def test_shared_storage_blob_not_bloated(self):
+        # Constants that share one underlying storage (e.g. RNN parameters
+        # after flatten_parameters) must not each serialize the entire shared
+        # storage into the constant blob. See issue #186176.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.rnn = torch.nn.RNN(256, 256, num_layers=2, batch_first=True)
+
+            def forward(self, x):
+                out, _ = self.rnn(x)
+                return out
+
+        model = Model().eval()
+        example_inputs = (torch.randn(1, 10, 256),)
+
+        options = {
+            "aot_inductor.package": True,
+            "aot_inductor.package_cpp_only": self.package_cpp_only,
+            "always_keep_tensor_constants": True,
+            "aot_inductor.package_constants_in_so": False,
+            "aot_inductor.package_constants_on_disk_format": "binary_blob",
+        }
+
+        ep = torch.export.export(model, example_inputs)
+        aoti_files = torch._inductor.aot_compile(
+            ep.module(), example_inputs, options=options
+        )
+
+        blob_paths = [
+            p
+            for p in aoti_files
+            if isinstance(p, str) and p.endswith("_serialized_weights.bin")
+        ]
+        self.assertEqual(len(blob_paths), 1)
+        blob_bytes = os.path.getsize(blob_paths[0])
+
+        # Logical size of all parameters (each counted once).
+        logical_bytes = sum(
+            p.numel() * p.element_size() for p in model.parameters()
+        )
+
+        # Before the fix, every shared-storage view serialized the full flat
+        # weight buffer, inflating the blob to several times the logical size.
+        # Allow generous headroom for alignment/padding but catch gross bloat.
+        self.assertLess(blob_bytes, logical_bytes * 3)
+
     def test_package_shared_weights(self):
         options = {
             "aot_inductor.package": True,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2969,14 +2969,12 @@ end
                 if t.is_mkldnn:
                     return torch.ops.mkldnn._nbytes(t)
                 if t.is_contiguous():
-                    # Serialize only this tensor's logical extent (storage
-                    # offset through its last element) rather than the entire
-                    # underlying storage. The runtime reader recovers the
-                    # tensor via storage_offset within its blob slice, so the
-                    # slice only needs to span up to this tensor's end. This
-                    # avoids N-way bloat when many constants share one storage
-                    # (e.g. RNN flatten_parameters).
-                    return (t.storage_offset() + t.numel()) * t.element_size()
+                    # Serialize only up to the tensor's last element to avoid
+                    # N-way bloat for shared-storage constants (e.g. RNN
+                    # flatten_parameters). The reader recovers the tensor via
+                    # storage_offset within the slice. Must stay in sync with
+                    # data_size in cpp_wrapper_cpu.py.
+                    return int((t.storage_offset() + t.numel()) * t.element_size())
                 return t.untyped_storage().nbytes()
 
             if (

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2968,6 +2968,15 @@ end
                     return 0
                 if t.is_mkldnn:
                     return torch.ops.mkldnn._nbytes(t)
+                if t.is_contiguous():
+                    # Serialize only this tensor's logical extent (storage
+                    # offset through its last element) rather than the entire
+                    # underlying storage. The runtime reader recovers the
+                    # tensor via storage_offset within its blob slice, so the
+                    # slice only needs to span up to this tensor's end. This
+                    # avoids N-way bloat when many constants share one storage
+                    # (e.g. RNN flatten_parameters).
+                    return (t.storage_offset() + t.numel()) * t.element_size()
                 return t.untyped_storage().nbytes()
 
             if (

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1263,11 +1263,23 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 # If constants to serialize contain cpu tensors, we always align data_size it to 64.
                 # When loading the constants, the valid data will depends on the size
                 # not the data_size so there won't be correctness issue.
-                data_size = (
-                    torch.ops.mkldnn._nbytes(tensor)
-                    if tensor.is_mkldnn
-                    else tensor.untyped_storage().nbytes()
-                )
+                # NOTE: This must stay in sync with `_constant_nbytes` in
+                # codecache.py, which determines how many bytes are actually
+                # written into the constant blob. For contiguous tensors we
+                # only account for the tensor's logical extent (storage offset
+                # through its last element) instead of the full underlying
+                # storage, so that constants sharing one storage (e.g. RNN
+                # flatten_parameters) don't each serialize the whole buffer.
+                if tensor.numel() == 0:
+                    data_size = 0
+                elif tensor.is_mkldnn:
+                    data_size = torch.ops.mkldnn._nbytes(tensor)
+                elif tensor.is_contiguous():
+                    data_size = (
+                        tensor.storage_offset() + tensor.numel()
+                    ) * tensor.element_size()
+                else:
+                    data_size = tensor.untyped_storage().nbytes()
                 self.prefix.writeline(
                     f"constants_info_[{idx}].data_size = {data_size if all_cuda else _align(data_size)};"
                 )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1275,11 +1275,13 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 elif tensor.is_mkldnn:
                     data_size = torch.ops.mkldnn._nbytes(tensor)
                 elif tensor.is_contiguous():
-                    data_size = (
-                        tensor.storage_offset() + tensor.numel()
-                    ) * tensor.element_size()
+                    data_size = int(
+                        (tensor.storage_offset() + tensor.numel())
+                        * tensor.element_size()
+                    )
                 else:
                     data_size = tensor.untyped_storage().nbytes()
+                data_size = int(data_size)
                 self.prefix.writeline(
                     f"constants_info_[{idx}].data_size = {data_size if all_cuda else _align(data_size)};"
                 )


### PR DESCRIPTION
Fixes #186176

AOTI's binary-blob constant serialization wrote each constant's entire
`untyped_storage()`. When constants share one storage (e.g. RNN params
after `flatten_parameters()`), every view serialized the whole buffer,
bloating the blob to ~N× for N shared views.

For contiguous constants, this computes the serialized size from the
tensor's logical extent (`(storage_offset + numel) * element_size`)
instead of the full storage, applied consistently in the three places
that must agree: `_constant_nbytes` and the `_worker` copy in
`codecache.py`, and `data_size` in `cpp_wrapper_cpu.py`. The reader
recovers tensors via `storage_offset` within the slice, so `offset` is
unchanged and **no runtime reader changes are needed**. Non-contiguous
and mkldnn constants keep the previous behavior.

This stays within the existing reader contract, so it removes the N×
duplication but isn't maximally compact (a large-offset constant still
includes leading padding). Full per-constant compaction would need a
reader-contract change — separate follow-up.

Added `test_shared_storage_blob_not_bloated` (nn.RNN via `binary_blob`).


> and run the test. Happy to iterate on the bound or approach per CI +
> review.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo