### PR TITLE
Fix compiled optimizer scheduler kwargs leak

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -46,6 +46,7 @@ from torch.optim.lr_scheduler import (
     OneCycleLR,
     PolynomialLR,
     ReduceLROnPlateau,
+    SequentialLR,
     StepLR,
 )
 from torch.testing._internal.common_device_type import (
@@ -152,11 +153,9 @@ LR_SCHEDULER_TO_KWARGS = {
     StepLR: {"step_size": 1, "gamma": 100},
     MultiStepLR: {"milestones": [1, 2], "gamma": 100},
     ExponentialLR: {"gamma": 100},
+    SequentialLR: {"schedulers": None, "milestones": [1, 2]},
     CosineAnnealingLR: {"T_max": 7},
-    # These schedulers have memory leaks in eager
-    # https://github.com/pytorch/pytorch/issues/126131
-    # SequentialLR: {"schedulers": None, "milestones": [1, 2]},
-    # ChainedScheduler: {"schedulers": None},
+    ChainedScheduler: {"schedulers": None},
     CyclicLR: {"base_lr": 0.001, "max_lr": 0.02, "cycle_momentum": False},
     CosineAnnealingWarmRestarts: {"T_0": 1},
     OneCycleLR: {
@@ -173,7 +172,7 @@ LR_SCHEDULER_TO_KWARGS = {
 
 
 def create_scheduler(scheduler, optim):
-    kwargs = LR_SCHEDULER_TO_KWARGS[scheduler]
+    kwargs = deepcopy(LR_SCHEDULER_TO_KWARGS[scheduler])
     if "schedulers" in kwargs:
         kwargs["schedulers"] = [
             create_scheduler(torch.optim.lr_scheduler.ConstantLR, optim)
@@ -726,6 +725,16 @@ class CompiledOptimizerTests(TestCase):
         manager = torch._inductor.cudagraph_trees.get_container(0).tree_manager
         self.assertIsNotNone(manager)
         self.assertEqual(manager.new_graph_id().id, 1)
+
+    def test_create_scheduler_does_not_mutate_kwargs(self):
+        for scheduler_cls in (ChainedScheduler, SequentialLR):
+            expected_kwargs = deepcopy(LR_SCHEDULER_TO_KWARGS[scheduler_cls])
+            model = torch.nn.Linear(1, 1)
+            opt = SGD(model.parameters(), lr=0.1)
+
+            create_scheduler(scheduler_cls, opt)
+
+            self.assertEqual(LR_SCHEDULER_TO_KWARGS[scheduler_cls], expected_kwargs)
 
     test_adam_recompile = make_recompile_test(Adam, lr=0.01)
     test_adamw_recompile = make_recompile_test(AdamW, lr=0.01)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

The compiled optimizer scheduler test helper reused the dict entries from
LR_SCHEDULER_TO_KWARGS directly. For SequentialLR and ChainedScheduler, the
helper fills in the "schedulers" entry with constructed child schedulers. That
mutated the global table and kept scheduler instances reachable after the test
body returned. The retained schedulers held the optimizer and model parameters,
which made CUDA memory leak checks report leaked allocations.

Copy the scheduler kwargs before filling nested schedulers so each scheduler
construction owns temporary kwargs. With the helper no longer retaining child
schedulers globally, SequentialLR and ChainedScheduler can be restored to the
compiled optimizer test matrix. Add a focused regression test that checks the
kwargs table is not mutated by create_scheduler.

Fixes #126131
Generated by my agent

Test Plan:
- python reproduction script from notes: pre-fix ChainedScheduler failed with CudaMemoryLeakCheck, post-fix ChainedScheduler and SequentialLR report warnings 0
- python test/inductor/test_compiled_optimizers.py CompiledOptimizerTests.test_create_scheduler_does_not_mutate_kwargs (blocked by unrelated local torchvision mismatch)
- python -m pytest -q test/inductor/test_compiled_optimizers.py::CompiledOptimizerTests::test_create_scheduler_does_not_mutate_kwargs (blocked by unrelated local torchvision mismatch)
- python runpy import-hook command for CompiledOptimizerTests.test_create_scheduler_does_not_mutate_kwargs: OK
- python runpy import-hook command for CompiledOptimizerTests.test_asgd_tensor_lr_weight_decay_maximize_capturable_cuda_chainedscheduler and ..._sequentiallr: OK
- lintrunner -a (failed on unrelated clang-tidy issues in torch/csrc/shim_common.cpp, torch/csrc/stable/accelerator.h, and torch/custom_class.h)
- lintrunner test/inductor/test_compiled_optimizers.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo