### PR TITLE
Fix size-oblivious guards for mark_dynamic upper bounds

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13653,6 +13653,18 @@ fn
         self.assertEqual(f(torch.randn(0)).shape, (1,))
         self.assertEqual(f(torch.randn(2)).shape, (2,))
 
+    def test_guard_size_oblivious_mark_dynamic_upper_bound(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            if guard_size_oblivious(x.size(1) != 1024):
+                return x + 1
+            return x - 1
+
+        x = torch.randn(2, 7)
+        torch._dynamo.mark_dynamic(x, 1, min=2, max=1024)
+
+        self.assertEqual(f(x), x + 1)
+
     def _test_compile_model_free(self, model_inp_ctr, weakref_watch):
         """
         Args:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4723,10 +4723,16 @@ class ShapeEnv:
                             specialization,
                         )
                     )
+            # StrictMinMaxConstraint documents the same size-oblivious
+            # assumptions for constrained sizes that backed_size_oblivious
+            # enables globally.
             if (
-                config.backed_size_oblivious
-                and isinstance(sym, sympy.Symbol)  # could be static
+                isinstance(sym, sympy.Symbol)  # could be static
                 and symbol_is_type(sym, SymT.SIZE)
+                and (
+                    config.backed_size_oblivious
+                    or isinstance(constraint_dims[i], StrictMinMaxConstraint)
+                )
             ):
                 self.size_like.add(sym)
             size.append(sym)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186451

mark_dynamic(..., max=...) records a StrictMinMaxConstraint for the
selected tensor dimension. That constraint already documents that the
symbol may rely on the same size-oblivious assumptions used for backed
sizes, but the produced backed SIZE symbol was only added to
ShapeEnv.size_like when the global backed_size_oblivious config was
on.

As a result, a guard_size_oblivious check such as size != 1024 was
emitted as a normal guard for a dimension marked dynamic with max=1024.
Guard production then rejected the guard because the user-specified
range includes 1024, causing the ConstraintViolationError reported by
GPT2/TensorRT dynamic-shape compilation.

Fix this by marking symbolic SIZE dimensions with StrictMinMaxConstraint
as size_like when tensor size symbols are produced. This keeps the
behavior tied to explicit constrained-size dimensions instead of enabling
size-oblivious reasoning globally. I considered extending the newer
_check_is_size(max=...) path, but issue 125604 uses mark_dynamic, so the
root cause is the missing size_like classification for StrictMinMaxConstraint.

Fixes #125604
Generated by my agent

Test Plan:
- python test/dynamo/test_misc.py -k test_guard_size_oblivious_mark_dynamic_upper_bound
- python test/dynamo/test_misc.py -k guard_size_oblivious
- python test/test_dynamic_shapes.py -k backed_size_oblivious
- python test/export/test_export.py -k test_export_slice_unbacked_dim1
- lintrunner torch/fx/experimental/symbolic_shapes.py test/dynamo/test_misc.py
- lintrunner -a (failed only on unrelated existing clang-tidy findings outside this change)

Benchmark Results:
- Command: simple torch.compile(backend='eager') loop with mark_dynamic(x, 1, min=2, max=1024), 5 warmup iterations and 20 measured iterations.
- Before: median 0.022022s, mean 0.022265s, min 0.021240s, max 0.024301s.
- After: median 0.021702s, mean 0.021879s, min 0.020765s, max 0.023880s.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98