### PR TITLE
Warn on unsupported custom op schema types

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import typing
 import unittest
+import warnings
 from functools import partial
 from pathlib import Path
 from typing import *  # noqa: F403
@@ -2126,6 +2127,112 @@ Dynamic shape operator
                 lib.define(f"foo12({type_name} a) -> Tensor")
             finally:
                 torch._C._unregister_opaque_type(type_name)
+
+    def test_define_warns_for_unsupported_schema_types(self):
+        tests = [
+            (
+                "deep_tensor_list_arg(Tensor[][][][] x) -> Tensor",
+                r"argument 'x' with type List\[List\[List\[List\[Tensor\]\]\]\]",
+            ),
+            (
+                "optional_tensor_list_arg(Tensor[]? x) -> Tensor",
+                r"argument 'x' with type Optional\[List\[Tensor\]\]",
+            ),
+            (
+                "deep_tensor_list_return(Tensor x) -> Tensor[][]",
+                r"return 0 with type List\[List\[Tensor\]\]",
+            ),
+            (
+                "dict_arg(Dict(str, Tensor) x) -> Tensor",
+                r"argument 'x' with type Dict\[str, Tensor\]",
+            ),
+        ]
+        for schema, regex in tests:
+            with self.subTest(schema=schema):
+                lib = self.lib()
+                with self.assertWarnsRegex(FutureWarning, regex):
+                    lib.define(schema)
+
+    def test_define_does_not_warn_for_supported_schema_types(self):
+        schemas = [
+            "supported_tensor(Tensor x) -> Tensor",
+            "supported_optional_tensor(Tensor? x) -> Tensor?",
+            "supported_tensor_list(Tensor[] x) -> Tensor[]",
+            "supported_optional_tensor_list(Tensor?[] x) -> Tensor",
+            "supported_scalars(int i, float f, bool b, str s, Scalar n, Device d) -> Tensor",
+            "supported_scalar_lists(int[] i, float[] f, bool[] b, str[] s, Scalar[] n, Device[] d) -> Tensor",
+            "supported_optional_scalars(int? i, float? f, bool? b, str? s, Scalar? n, Device? d) -> Tensor",
+            "supported_enum_lists(ScalarType[] dtypes, Layout[] layouts, MemoryFormat[] formats) -> Tensor",
+        ]
+        lib = self.lib()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            for schema in schemas:
+                lib.define(schema)
+        custom_op_schema_warnings = [
+            w for w in caught if "unsupported schema types" in str(w.message)
+        ]
+        self.assertEqual(custom_op_schema_warnings, [])
+
+    def test_define_wrapper_warns_at_user_stacklevel(self):
+        lib = self.lib()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            torch.library.define(
+                f"{self.test_ns}::wrapper_stacklevel",
+                "(Tensor[][] x) -> Tensor",
+                lib=lib,
+            )
+        custom_op_schema_warnings = [
+            w for w in caught if "unsupported schema types" in str(w.message)
+        ]
+        self.assertEqual(len(custom_op_schema_warnings), 1)
+        self.assertEqual(
+            os.path.abspath(custom_op_schema_warnings[0].filename),
+            os.path.abspath(__file__),
+        )
+
+    def test_legacy_define_wrapper_warns_at_user_stacklevel(self):
+        lib = self.lib()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @torch.library.define(
+                lib, "legacy_wrapper_stacklevel(Tensor[][] x) -> Tensor"
+            )
+            def f(x):
+                return x[0][0]
+
+        custom_op_schema_warnings = [
+            w for w in caught if "unsupported schema types" in str(w.message)
+        ]
+        self.assertEqual(len(custom_op_schema_warnings), 1)
+        self.assertEqual(
+            os.path.abspath(custom_op_schema_warnings[0].filename),
+            os.path.abspath(__file__),
+        )
+
+    def test_custom_op_manual_schema_warns_at_user_stacklevel(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @torch.library.custom_op(
+                f"{self.test_ns}::custom_op_stacklevel",
+                mutates_args=(),
+                schema="(Tensor[][] x) -> Tensor",
+            )
+            def f(x: list[list[Tensor]]) -> Tensor:
+                return x[0][0]
+
+        custom_op_schema_warnings = [
+            w for w in caught if "unsupported schema types" in str(w.message)
+        ]
+        self.assertEqual(len(custom_op_schema_warnings), 1)
+        self.assertEqual(
+            os.path.abspath(custom_op_schema_warnings[0].filename),
+            os.path.abspath(__file__),
+        )
 
     def test_is_tensorlist_like_type(self):
         tensorlists = [

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -232,6 +232,8 @@ def custom_op(
 
     """
 
+    is_direct_call = fn is not None
+
     def inner(fn: Callable[..., object]) -> CustomOpDef:
         import torch
 
@@ -246,7 +248,15 @@ def custom_op(
             schema_str = schema
 
         namespace, opname = name.split("::")
-        result = CustomOpDef(namespace, opname, schema_str, fn, normalized_tags)
+        define_stacklevel = 6 if is_direct_call else 5
+        result = CustomOpDef(
+            namespace,
+            opname,
+            schema_str,
+            fn,
+            normalized_tags,
+            define_stacklevel=define_stacklevel,
+        )
         if schema is not None:
             # Check that schema's alias annotations match those of `mutates_args`.
             expected = set()
@@ -285,12 +295,15 @@ class CustomOpDef:
         schema: str,
         fn: Callable,
         tags: tags_t = None,
+        *,
+        define_stacklevel: int = 5,
     ) -> None:
         # Fields used to interface with the PyTorch dispatcher
         self._namespace = namespace
         self._name = name
         self._schema = schema
         self._tags = _normalize_tags(tags)
+        self._define_stacklevel = define_stacklevel
 
         self._init_fn = fn
 
@@ -765,6 +778,7 @@ class CustomOpDef:
         self._lib.define(
             schema_str,
             tags=_with_pt2_compliant_tag(tags),
+            _stacklevel=self._define_stacklevel,
         )
         self._opoverload = utils.lookup_op(self._qualname)
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -164,6 +164,64 @@ def is_tensor_like_type(typ: Any) -> bool:
     return typ == _C.TensorType.get() or typ == _C.OptionalType(_C.TensorType.get())
 
 
+# Source of truth for tensor-bearing schema types that custom op registration
+# supports without deprecation. Keep this in sync with
+# c10::DispatchKeyExtractor::isDispatchType.
+SUPPORTED_CUSTOM_OP_SCHEMA_TYPES = (
+    "Tensor",
+    "Optional[Tensor]",
+    "List[Tensor]",
+    "List[Optional[Tensor]]",
+)
+
+
+# should be torch._C.JitType but that annotation is busted
+def _is_tensor_schema_type(typ: Any) -> bool:
+    return isinstance(typ, torch.TensorType)
+
+
+# should be torch._C.JitType but that annotation is busted
+def _is_optional_tensor_schema_type(typ: Any) -> bool:
+    return isinstance(typ, torch.OptionalType) and _is_tensor_schema_type(
+        typ.getElementType()
+    )
+
+
+# should be torch._C.JitType but that annotation is busted
+def _custom_op_schema_type_contains_tensor(typ: Any) -> bool:
+    if _is_tensor_schema_type(typ):
+        return True
+    if isinstance(typ, (torch.OptionalType, torch.ListType)):
+        return _custom_op_schema_type_contains_tensor(typ.getElementType())
+    return any(
+        _custom_op_schema_type_contains_tensor(contained_type)
+        for contained_type in typ.containedTypes()
+    )
+
+
+# should be torch._C.JitType but that annotation is busted
+def is_supported_custom_op_schema_type(typ: Any) -> bool:
+    if not _custom_op_schema_type_contains_tensor(typ):
+        return True
+    if _is_tensor_schema_type(typ) or _is_optional_tensor_schema_type(typ):
+        return True
+    if isinstance(typ, torch.ListType):
+        elem = typ.getElementType()
+        return _is_tensor_schema_type(elem) or _is_optional_tensor_schema_type(elem)
+    return False
+
+
+def get_unsupported_custom_op_schema_types(schema: _C.FunctionSchema) -> list[str]:
+    unsupported = []
+    for arg in schema.arguments:
+        if not is_supported_custom_op_schema_type(arg.type):
+            unsupported.append(f"argument '{arg.name}' with type {arg.type}")
+    for idx, ret in enumerate(schema.returns):
+        if not is_supported_custom_op_schema_type(ret.type):
+            unsupported.append(f"return {idx} with type {ret.type}")
+    return unsupported
+
+
 def mutates_and_returns_first_arg(op: OpOverload):
     """Check if an op is an inplace aten op, i.e. it mutates and returns the first arg.
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import re
 import sys
+import warnings
 import weakref
 from collections.abc import Callable, Sequence
 from typing import Any, overload, TYPE_CHECKING, TypeVar, Union
@@ -269,7 +270,7 @@ class Library:
     def __repr__(self):
         return f"Library(kind={self.kind}, ns={self.ns}, dispatch_key={self.dispatch_key})>"
 
-    def define(self, schema, alias_analysis="", *, tags=()):
+    def define(self, schema, alias_analysis="", *, tags=(), _stacklevel=1):
         r"""Defines a new operator and its semantics in the ns namespace.
 
         Args:
@@ -309,6 +310,25 @@ class Library:
             _validate_out_schema(schema)
         if torch.Tag.inplace in tags:
             _validate_inplace_schema(schema)
+
+        parsed_schema = torch._C.parse_schema(schema)
+        unsupported_schema_types = (
+            torch._library.utils.get_unsupported_custom_op_schema_types(parsed_schema)
+        )
+        if unsupported_schema_types:
+            warnings.warn(
+                "Registering custom ops with unsupported schema types is deprecated. "
+                f"Found unsupported schema types: {', '.join(unsupported_schema_types)}. "
+                "PyTorch subsystems may not correctly handle unsupported "
+                "Tensor-bearing types, and the dispatcher may not correctly "
+                "dispatch on unsupported Tensor-bearing input types. Supported "
+                "custom op schema types that contain tensors are: "
+                f"{', '.join(torch._library.utils.SUPPORTED_CUSTOM_OP_SCHEMA_TYPES)}. "
+                "The ability to register custom ops with unsupported schema types "
+                "will be removed in a future PyTorch release.",
+                FutureWarning,
+                stacklevel=_stacklevel + 1,
+            )
 
         result = self.m.define(schema, alias_analysis, tuple(tags))
         name = schema.split("(")[0]
@@ -742,7 +762,7 @@ def define(qualname, schema, *, lib=None, tags=()):
             f'to look like e.g. "(Tensor x) -> Tensor" but '
             f'got "{schema}"'
         )
-    lib.define(name + schema, alias_analysis="", tags=tags)
+    lib.define(name + schema, alias_analysis="", tags=tags, _stacklevel=3)
 
 
 @define.register
@@ -752,7 +772,7 @@ def _(lib: Library, schema, alias_analysis=""):
     """
 
     def wrap(f):
-        name = lib.define(schema, alias_analysis)
+        name = lib.define(schema, alias_analysis, _stacklevel=2)
         lib.impl(name, f)
         return f
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186454

Custom operators could register schemas with tensor-bearing containers that
are accepted by the schema parser but are not considered dispatch inputs by
DispatchKeyExtractor, such as Tensor[][] or Tensor[]?. Those arguments can
silently be ignored when computing the dispatch key, which makes the operator
registration look supported even though core dispatcher behavior is incomplete.

Add a structured parsed-schema check in torch._library.utils for tensor-bearing
schema types that are outside the DispatchKeyExtractor-supported set: Tensor,
Tensor?, Tensor[], and Tensor?[]. Library.define now emits a FutureWarning for
unsupported argument and return types while preserving registration during the
deprecation period. Public wrappers pass adjusted stacklevels so the warning
points at user registration code for Library.define, torch.library.define, and
torch.library.custom_op paths.

The fix keeps the validation in Python registration code rather than changing
C++ dispatch behavior because the issue requests deprecating unsupported custom
op schemas before removal, and warning during registration gives users a direct
migration signal without changing dispatcher semantics immediately.

Fixes #124863
Generated by my agent

Test Plan:
- python test/test_custom_ops.py TestCustomOp.test_incorrect_schema_types TestCustomOp.test_is_tensorlist_like_type TestCustomOp.test_define_warns_for_unsupported_schema_types TestCustomOp.test_define_does_not_warn_for_supported_schema_types TestCustomOp.test_define_wrapper_warns_at_user_stacklevel TestCustomOp.test_legacy_define_wrapper_warns_at_user_stacklevel TestCustomOp.test_custom_op_manual_schema_warns_at_user_stacklevel
- lintrunner torch/_library/custom_ops.py torch/library.py torch/_library/utils.py test/test_custom_ops.py
- git diff --check

Note: lintrunner -a was attempted and failed on unrelated pre-existing C++ clang-tidy findings in torch/csrc/shim_common.cpp, torch/csrc/stable/accelerator.h, and torch/custom_class.h.