### PR TITLE
Fix SDPA backend detection for autograd cache

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3294,6 +3294,62 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 0)
             self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
 
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @inductor_config.patch("fx_graph_cache", True)
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    def test_cache_distinguishes_sdpa_backend(self):
+        """
+        Ensure AOTAutograd cache key distinguishes between different
+        scaled_dot_product_attention backends.
+        """
+
+        class Attention(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.scaled_dot_product_attention(
+                    x[0], x[1], x[2]
+                )
+
+        with fresh_cache():
+            from torch.nn.attention import sdpa_kernel, SDPBackend
+
+            model = Attention().eval()
+            x = torch.randn(3, 1, 2, 8, 64)
+
+            # Run 1: compile with the FLASH_ATTENTION backend
+            torch._dynamo.reset()
+            compiled1 = torch.compile(model, backend="inductor")
+            with torch.no_grad(), sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                compiled1(x)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            # Run 2: compile with the MATH backend
+            counters.clear()
+            torch._dynamo.reset()
+            compiled2 = torch.compile(model, backend="inductor")
+            with torch.no_grad(), sdpa_kernel(SDPBackend.MATH):
+                compiled2(x)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            # Run 3: repeat with FLASH_ATTENTION again
+            counters.clear()
+            torch._dynamo.reset()
+            compiled3 = torch.compile(model, backend="inductor")
+            with torch.no_grad(), sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                compiled3(x)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 0)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+            # Run 4: repeat with MATH
+            counters.clear()
+            torch._dynamo.reset()
+            compiled4 = torch.compile(model, backend="inductor")
+            with torch.no_grad(), sdpa_kernel(SDPBackend.MATH):
+                compiled4(x)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 0)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -542,6 +542,16 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
                 self.autocast_state[device_type] = torch.get_autocast_dtype(device_type)
         self.deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
         self.autograd_config = config.save_config()
+        self.sdpa_state = (
+            f"{torch._C._get_flash_sdp_enabled()=}",
+            f"{torch._C._get_fa3_sdp_enabled()=}",
+            f"{torch._C._get_mem_efficient_sdp_enabled()=}",
+            f"{torch._C._get_math_sdp_enabled()=}",
+            f"{torch._C._get_math_sdp_allow_fp16_bf16_reduction()=}",
+            f"{torch._C._get_overrideable_sdp_enabled()=}",
+            f"{torch._C._get_sdp_priority_order()=}",
+            f"{torch._C._get_cudnn_sdp_enabled()=}",
+        )
         if has_triton_package():
             self.triton_kernel_source_codes = self.get_triton_source_codes_from_gm(gm)
 


### PR DESCRIPTION
The choice of backend for `scaled_dot_product_attention` is currently ignored by the Autograd compile cache. This means that after compiling once and then switching backends (e.g. `FLASH_ATTENTION` to `MATH`), torch will continue to use the originally selected kernel until the on-disk cache is cleared.

This PR adds the various `sdp` flags to the `AotAutogradCacheDetails` object so the cache key distinguishes backends.

Questions:

- Originally, the test compared the results of the different compiled kernels against each other, asserting the two flash and two math repeats were very close, and the math vs flash results differed. This test proved the wrong kernel *was* being used (and that this cache key issue wasn't benign), but it relied on pretty tight tolerances and might be inconsistent across backends, so I removed it. Happy to re-add if desired.
- For this PR, I pulled all `get*sdp*enabled` flags from `torch/_C/__init__.py` into `_runtime_state`. Alternatively, we could use `torch.nn.attention._cur_sdpa_kernel_backends(with_priority=True)`, but that doesn't capture    `_get_fa3_sdp_enabled()` and `_get_math_sdp_allow_fp16_bf16_reduction()`. What's the preferred choice here?
- I didn't create an issue for this PR. Can create one if needed.


This PR was inspired by #181564 - I ran into the same issue, saw the fix, and found some more state that wasn't captured in the cache key.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98