### PR TITLE
Split foreach bool inplace error samples

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -265,6 +265,37 @@ class TestForeach(TestCase):
                 expected = ref([ref_input, *sample.ref_args], **ref_kwargs)
                 self.assertEqual(expected, actual)
 
+    @onlyOn(["cpu"])
+    @ops(
+        [op for op in foreach_binary_op_db if op.error_inputs_func is not None],
+        dtypes=(torch.bool,),
+    )
+    def test_inplace_expected_errors(self, device, dtype, op):
+        _, _, func, ref = self._get_funcs(op)
+        seen_error_input = False
+
+        for error_input in op.error_inputs(device, dtype=dtype):
+            seen_error_input = True
+            sample = error_input.sample_input
+            foreach_input = [t.detach().clone() for t in sample.input]
+            ref_input = [t.detach().clone() for t in sample.input]
+
+            with self.assertRaisesRegex(
+                error_input.error_type, error_input.error_regex
+            ) as cm:
+                func(
+                    [foreach_input, *sample.args],
+                    self.is_cuda,
+                    expect_fastpath=False,
+                    **sample.kwargs,
+                )
+
+            error_regex = re.escape(str(cm.exception).splitlines()[0])
+            with self.assertRaisesRegex(error_input.error_type, error_regex):
+                ref([ref_input, *sample.ref_args], **sample.kwargs)
+
+        self.assertTrue(seen_error_input)
+
     def _binary_test(
         self,
         dtype,

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -79,6 +79,11 @@ foreach_op_db = (
     foreach_other_op_db
 )
 
+_FOREACH_INPLACE_ERROR_INPUT_OPS = {
+    "_foreach_add",
+    "_foreach_mul",
+}
+
 
 class TestMetaConverter(TestCase):
     def assertSameVersionCounter(self, m1, m2):
@@ -1245,7 +1250,11 @@ class TestMeta(TestCase):
         if inplace:
             func = self._get_safe_inplace(func)
 
-        samples = op.sample_inputs(device, dtype, requires_grad=False)
+        sample_kwargs = {}
+        # These foreach ops expose their known invalid inplace samples as ErrorInputs.
+        if inplace and not symbolic_meta and op.name in _FOREACH_INPLACE_ERROR_INPUT_OPS:
+            sample_kwargs["exclude_inplace_error_inputs"] = True
+        samples = op.sample_inputs(device, dtype, requires_grad=False, **sample_kwargs)
         for sample_input in samples:
             if inplace and sample_input.broadcasts_input:
                 continue

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10027,6 +10027,49 @@ class ForeachSampleInput(SampleInput):
         self.disable_fastpath = disable_fastpath
 
 
+def _foreach_inplace_type_promotion_error(opinfo, dtype, sample):
+    if opinfo.name not in ("_foreach_add", "_foreach_mul") or dtype is not torch.bool:
+        return None
+    if len(sample.args) != 1:
+        return None
+
+    rhs = sample.args[0]
+    if isinstance(rhs, list):
+        if not rhs or any(isinstance(arg, torch.Tensor) for arg in rhs):
+            return None
+        scalar_args = rhs
+    elif isinstance(rhs, (bool, int, float, complex)):
+        scalar_args = [rhs]
+    else:
+        return None
+
+    if all(isinstance(arg, bool) for arg in scalar_args):
+        return None
+
+    if any(isinstance(arg, complex) for arg in scalar_args):
+        result_type = "ComplexFloat"
+    elif any(isinstance(arg, float) for arg in scalar_args):
+        result_type = "Float"
+    else:
+        result_type = "Long"
+
+    return ErrorInput(
+        sample,
+        error_type=RuntimeError,
+        error_regex=fr"result type {result_type} can't be cast to the desired output type Bool",
+    )
+
+
+def error_inputs_foreach_inplace(opinfo, device, **kwargs):
+    dtype = kwargs.pop("dtype", None)
+    if dtype is None:
+        return
+    for sample in opinfo.sample_inputs(device, dtype, requires_grad=False, **kwargs):
+        error_input = _foreach_inplace_type_promotion_error(opinfo, dtype, sample)
+        if error_input is not None:
+            yield error_input
+
+
 class foreach_inputs_sample_func:
     def __init__(
         self,
@@ -10226,6 +10269,7 @@ class foreach_inputs_sample_func:
         _foreach_inputs_kwargs["requires_grad"] = requires_grad
         _foreach_inputs_kwargs["zero_size"] = False
         allow_higher_dtype_scalars = kwargs.pop("allow_higher_dtype_scalars", False)
+        exclude_inplace_error_inputs = kwargs.pop("exclude_inplace_error_inputs", False)
 
         # add empty tensor interspersion to test fully fixing #100701
         for num_tensors, rightmost_arg_type, intersperse_empty_tensors in itertools.product(
@@ -10253,6 +10297,12 @@ class foreach_inputs_sample_func:
                     if rightmost_arg_type in (ForeachRightmostArgType.Scalar, ForeachRightmostArgType.Tensor):
                         ref_args = args[:-1] + [[args[-1] for _ in range(num_tensors)]]
                     sample = ForeachSampleInput(input, *args, ref_args=ref_args, **kwargs)
+                    if (
+                        exclude_inplace_error_inputs
+                        and _foreach_inplace_type_promotion_error(opinfo, dtype, sample)
+                    ):
+                        args.pop()
+                        continue
                     yield sample
                     args.pop()
             else:
@@ -11662,6 +11712,7 @@ foreach_binary_op_db: list[OpInfo] = [
     ForeachFuncInfo(
         "add",
         sample_inputs_func=foreach_inputs_sample_func(2, True, True, True),
+        error_inputs_func=error_inputs_foreach_inplace,
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.float16, torch.int32),
         supports_alpha_param=True,
         supports_autograd=True,
@@ -11673,8 +11724,6 @@ foreach_binary_op_db: list[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_inplace",
                          dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16)),
             # Samples have complex types and inplace only works if the dtype is complex.
-            DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_meta_inplace",
-                         dtypes=(torch.bool,)),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_symbolic_meta_inplace",
                          dtypes=(torch.bool,)),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_symbolic_meta_inplace_all_strides",
@@ -11706,14 +11755,13 @@ foreach_binary_op_db: list[OpInfo] = [
     ForeachFuncInfo(
         "mul",
         sample_inputs_func=foreach_inputs_sample_func(2, True, True, True),
+        error_inputs_func=error_inputs_foreach_inplace,
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
         supports_autograd=True,
         supports_inplace_autograd=True,
         supports_forward_ad=True,
         decorators=(
             # Samples have complex types and inplace only works if the dtype is complex.
-            DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_meta_inplace",
-                         dtypes=(torch.bool,)),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_symbolic_meta_inplace",
                          dtypes=(torch.bool,)),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_inplace", dtypes=(torch.bool,)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186463

Foreach OpInfo sample generation mixed valid bool inplace samples with scalar and scalar-list samples that correctly fail dtype promotion. test_dispatch_meta_inplace treated those real-op errors as broken OpInfo samples, so _foreach_add and _foreach_mul had to expected-fail the whole bool dtype and lost meta coverage for valid samples.

Classify the known bool inplace promotion failures as ErrorInputs, let the meta dispatch test request valid-only foreach samples for the affected non-symbolic inplace cases, and add foreach coverage that asserts the ErrorInputs fail with the same error as the Tensor reference path.

Fixes #123663

Generated by my agent

Test Plan:

python test/test_meta.py TestMetaCPU.test_dispatch_meta_inplace__foreach_add_cpu_bool TestMetaCPU.test_dispatch_meta_inplace__foreach_mul_cpu_bool TestMetaCPU.test_dispatch_meta_inplace__foreach_div_cpu_bool TestMetaCPU.test_dispatch_meta_inplace__foreach_addcmul_cpu_bool TestMetaCPU.test_dispatch_meta_inplace__foreach_addcdiv_cpu_bool

python test/test_foreach.py TestForeachCPU.test_inplace_expected_errors__foreach_add_cpu_bool TestForeachCPU.test_inplace_expected_errors__foreach_mul_cpu_bool TestForeachCPU.test_parity__foreach_add_fastpath_inplace_cpu_bool TestForeachCPU.test_parity__foreach_add_slowpath_inplace_cpu_bool

lintrunner -a