### PR TITLE
Fix incorrect LR curves in Chained/Sequential scheduler doc images

### DIFF
--- a/docs/source/scripts/build_lr_scheduler_images.py
+++ b/docs/source/scripts/build_lr_scheduler_images.py
@@ -32,12 +32,14 @@ if not LR_SCHEDULER_IMAGE_PATH.exists():
     LR_SCHEDULER_IMAGE_PATH.mkdir()
 
 model = torch.nn.Linear(10, 1)
-optimizer = optim.SGD(model.parameters(), lr=0.05)
 
 num_epochs = 100
 
-scheduler1 = ConstantLR(optimizer, factor=0.1, total_iters=num_epochs // 5)
-scheduler2 = ExponentialLR(optimizer, gamma=0.9)
+def constant_exponential_schedulers(opt):
+    return [
+        ConstantLR(opt, factor=0.1, total_iters=num_epochs // 5),
+        ExponentialLR(opt, gamma=0.9),
+    ]
 
 schedulers = [
     (lambda opt: LambdaLR(opt, lr_lambda=lambda epoch: epoch // 30)),
@@ -53,20 +55,19 @@ schedulers = [
     (lambda opt: CyclicLR(opt, base_lr=0.01, max_lr=0.1, step_size_up=10)),
     (lambda opt: OneCycleLR(opt, max_lr=0.01, epochs=10, steps_per_epoch=10)),
     (lambda opt: ReduceLROnPlateau(opt, mode="min")),
-    (lambda opt: ChainedScheduler([scheduler1, scheduler2])),
+    (lambda opt: ChainedScheduler(constant_exponential_schedulers(opt))),
     (
         lambda opt: SequentialLR(
-            opt, schedulers=[scheduler1, scheduler2], milestones=[num_epochs // 5]
+            opt, constant_exponential_schedulers(opt), milestones=[num_epochs // 5]
         )
     ),
 ]
-
 
 def plot_function(scheduler):
     plt.clf()
     plt.grid(color="k", alpha=0.2, linestyle="--")
     lrs = []
-    optimizer.param_groups[0]["lr"] = 0.05
+    optimizer = optim.SGD(model.parameters(), lr=0.05)
     scheduler = scheduler(optimizer)
 
     plot_path = LR_SCHEDULER_IMAGE_PATH / f"{scheduler.__class__.__name__}.png"

--- a/docs/source/scripts/build_lr_scheduler_images.py
+++ b/docs/source/scripts/build_lr_scheduler_images.py
@@ -35,11 +35,13 @@ model = torch.nn.Linear(10, 1)
 
 num_epochs = 100
 
+
 def constant_exponential_schedulers(opt):
     return [
         ConstantLR(opt, factor=0.1, total_iters=num_epochs // 5),
         ExponentialLR(opt, gamma=0.9),
     ]
+
 
 schedulers = [
     (lambda opt: LambdaLR(opt, lr_lambda=lambda epoch: epoch // 30)),
@@ -62,6 +64,7 @@ schedulers = [
         )
     ),
 ]
+
 
 def plot_function(scheduler):
     plt.clf()

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1488,13 +1488,13 @@ class ChainedScheduler(LRScheduler):
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 0.05 for all groups
-        >>> # lr = 0.05      if epoch == 0
-        >>> # lr = 0.0450    if epoch == 1
-        >>> # lr = 0.0405    if epoch == 2
+        >>> # lr = 0.005      if epoch == 0
+        >>> # lr = 0.00450    if epoch == 1
+        >>> # lr = 0.00405    if epoch == 2
         >>> # ...
-        >>> # lr = 0.00675   if epoch == 19
-        >>> # lr = 0.06078   if epoch == 20
-        >>> # lr = 0.05470   if epoch == 21
+        >>> # lr = 0.000675   if epoch == 19
+        >>> # lr = 0.006078   if epoch == 20
+        >>> # lr = 0.005470   if epoch == 21
         >>> scheduler1 = ConstantLR(optimizer, factor=0.1, total_iters=20)
         >>> scheduler2 = ExponentialLR(optimizer, gamma=0.9)
         >>> scheduler = ChainedScheduler([scheduler1, scheduler2], optimizer=optimizer)


### PR DESCRIPTION
## Summary
---
The example learning-rate curve plots for the [`ChainedScheduler`](https://docs.pytorch.org/docs/2.12/generated/torch.optim.lr_scheduler.ChainedScheduler.html) and [`SequentialLR`](https://docs.pytorch.org/docs/2.12/generated/torch.optim.lr_scheduler.SequentialLR.html) schedulers in the documentation are inconsistent with the examples. As a result, the lr values listed in the `ChainedScheduler` docstring example were also wrong (this is not the case for `SequentialLR`).

The cause is in `docs/source/scripts/build_lr_scheduler_images.py`, which shares a single optimizer instance across all schedulers. Two issues result:
 
1. The optimizer's `lr` is reset to `0.05` *after* the `ConstantLR` and `ExponentialLR` (used by `SequentialLR`/`ChainedScheduler`) are constructed. Since `ConstantLR` applies its factor to the optimizer at construction time, this reset discards the correct starting lr.
2. `OneCycleLR`, which precedes `SequentialLR` in the loop, writes an `"initial_lr"` to the shared optimizer's param groups. `SequentialLR` then picks up those values during instantiation, corrupting the starting lr.

### Change

Use a scheduler factory for the `ConstantLR` and `ExponentialLR` used in `SequentialLR` and `ChainedScheduler`, so that all schedulers are instantiated within the loop.
```python
def constant_exponential_schedulers(opt):
    return [
        ConstantLR(opt, factor=0.1, total_iters=num_epochs // 5),
        ExponentialLR(opt, gamma=0.9),
    ]
```

Instantiate a new optimizer at each iteration to avoid state leakage between schedulers.
```python
def plot_function(scheduler):
    plt.clf()
    plt.grid(color="k", alpha=0.2, linestyle="--")
    lrs = []
    optimizer = optim.SGD(model.parameters(), lr=0.05)
    scheduler = scheduler(optimizer)
```