### PR TITLE
[dynamo] Respect mark_dynamic on Parameter inputs

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9933,6 +9933,30 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         with self.assertRaises(ConstraintViolationError):
             torch.compile(my_dyn_fn, backend="eager")(y)
 
+    def test_mark_dynamic_with_open_ended_ranges(self):
+        def my_dyn_fn(x):
+            return x.sin() + 1
+
+        opt = torch.compile(my_dyn_fn, backend="eager", fullgraph=True, dynamic=True)
+
+        for shape in [(2, 2), (1, 1)]:
+            y = torch.randn(shape)
+            for dim in range(y.dim()):
+                torch._dynamo.mark_dynamic(y, dim, min=0, max=65536)
+            self.assertEqual(opt(y), my_dyn_fn(y))
+
+    def test_mark_dynamic_with_zero_min(self):
+        def my_dyn_fn(x):
+            return x.sin() + 1
+
+        opt = torch.compile(my_dyn_fn, backend="eager", fullgraph=True, dynamic=True)
+
+        for shape in [(2, 2), (1, 1)]:
+            y = torch.randn(shape)
+            for dim in range(y.dim()):
+                torch._dynamo.mark_dynamic(y, dim, min=0)
+            self.assertEqual(opt(y), my_dyn_fn(y))
+
     def test_mark_static(self):
         counter = CompileCounter()
 

--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -321,6 +321,92 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(dynamic_comp_dynamic_param.frame_count, 2)
         self.assertEqual(dynamic_comp_dynamic_param.op_count, 2)
 
+    @patch.object(torch._dynamo.config, "force_parameter_static_shapes", True)
+    def test_mark_dynamic_overrides_parameter_static_shapes(self):
+        def foo(x):
+            return x.sin() + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(foo, backend=cnt, fullgraph=True, dynamic=True)
+
+        for shape in [(2, 2), (3, 3)]:
+            x = torch.nn.Parameter(torch.ones(shape), requires_grad=False)
+            for dim in range(x.dim()):
+                torch._dynamo.mark_dynamic(x, dim)
+            opt(x)
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 2)
+
+    def test_tensor_and_parameter_inputs_share_tensor_guards(self):
+        def foo(x):
+            return x.sin() + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(foo, backend=cnt, fullgraph=True)
+
+        x = torch.ones((2, 2), requires_grad=False)
+        p = torch.nn.Parameter(torch.ones((2, 2)), requires_grad=False)
+
+        opt(x)
+        opt(p)
+        opt(x)
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 2)
+
+    def test_tensor_and_tensor_subclass_inputs_do_not_share_tensor_guards(self):
+        class MyTensor(torch.Tensor):
+            pass
+
+        def foo(x):
+            return x.sin() + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(foo, backend=cnt, fullgraph=True)
+
+        x = torch.ones((2, 2))
+        y = torch.ones((2, 2)).as_subclass(MyTensor)
+
+        opt(x)
+        opt(y)
+
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.op_count, 4)
+
+    def test_tensor_and_parameter_inputs_share_tensor_guards_with_requires_grad(self):
+        def foo(x):
+            return x.sin() + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(foo, backend=cnt, fullgraph=True)
+
+        x = torch.ones((2, 2), requires_grad=True)
+        p = torch.nn.Parameter(torch.ones((2, 2)), requires_grad=True)
+
+        opt(x)
+        opt(p)
+        opt(x)
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 2)
+
+    def test_tensor_and_parameter_inputs_recompile_on_requires_grad_mismatch(self):
+        def foo(x):
+            return x.sin() + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(foo, backend=cnt, fullgraph=True)
+
+        x = torch.ones((2, 2), requires_grad=False)
+        p = torch.nn.Parameter(torch.ones((2, 2)), requires_grad=True)
+
+        opt(x)
+        opt(p)
+
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.op_count, 4)
+
     def test_simple_module_recompile(self):
         class SimpleDropout(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3523,6 +3523,9 @@ class GuardBuilder(GuardBuilderBase):
             if not isinstance(value, torch.Tensor):
                 raise AssertionError(f"Expected torch.Tensor, got {type(value)}")
 
+            if pytype is torch.nn.Parameter:
+                pytype = torch.Tensor
+
             if config.log_compilation_metrics and isinstance(value, torch.nn.Parameter):
                 metrics_context = get_metrics_context()
                 if metrics_context.in_progress():

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4496,7 +4496,11 @@ def tensor_always_has_static_shape(
         return True, TensorStaticReason.NN_MODULE_PROPERTY
 
     if (
-        type(tensor) is torch.nn.Parameter
+        (
+            type(tensor) is torch.nn.Parameter
+            and not hasattr(tensor, "_dynamo_dynamic_indices")
+            and not hasattr(tensor, "_dynamo_unbacked_indices")
+        )
         or is_from_unspecialized_param_buffer_source(tensor_source)
     ) and config.force_parameter_static_shapes:
         return True, TensorStaticReason.PARAMETER

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -111,6 +111,7 @@ from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
     is_traceable_wrapper_subclass_type,
 )
+from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.value_ranges import ValueRanges
 from torch.utils.weak import TensorWeakRef
 
@@ -2813,7 +2814,11 @@ class VariableBuilder:
             not _has_spec
             and not is_static_input
             and (
-                isinstance(value, torch.nn.Parameter)
+                (
+                    isinstance(value, torch.nn.Parameter)
+                    and not hasattr(value, "_dynamo_dynamic_indices")
+                    and not hasattr(value, "_dynamo_unbacked_indices")
+                )
                 # mark tensor attributes of nn modules static
                 or (source and source.guard_source.is_unspecialized_nn_module())
             )
@@ -4556,7 +4561,12 @@ def _automatic_dynamic(
     constraint_sizes = []
     constraint_strides = []
     specialize_on = []
-
+    do_not_specialize_zero_one = []
+    excluded_sizes = (
+        list(frame_state_entry.excluded_sizes)
+        if frame_state_entry.excluded_sizes is not None
+        else None
+    )
     for i in range(e.dim()):
         # NB: mark dynamic has precedence over static
         marked_strict_unbacked = i in getattr(e, "_dynamo_strict_unbacked_indices", ())
@@ -4569,7 +4579,15 @@ def _automatic_dynamic(
         ) or i in getattr(e, "_dynamo_propagated_dynamic_indices", ())
         marked_static = i in getattr(e, "_dynamo_static_indices", ())
 
+        if excluded_sizes is not None and marked_dynamic:
+            excluded_sizes[i] = None
+
         specialize_on.append(getattr(e, "_specialize_on", {}).get(i, []))
+        do_not_specialize_zero_one.append(
+            marked_dynamic
+            and not tx.output.export
+            and not isinstance(source, AttrSource)
+        )
 
         # Reflect the user directive in the frame_state
         # For dynamic, apply None always
@@ -4647,8 +4665,10 @@ def _automatic_dynamic(
                             StrictMinMaxConstraint,
                         )
 
+                        lower = 0 if dim_range.min is None else dim_range.min
+                        upper = int_oo if dim_range.max is None else dim_range.max
                         constraint_size = StrictMinMaxConstraint(
-                            vr=ValueRanges(lower=dim_range.min, upper=dim_range.max),
+                            vr=ValueRanges(lower=lower, upper=upper),
                             warn_only=False,
                         )
                 else:
@@ -4715,12 +4735,13 @@ def _automatic_dynamic(
         # pyrefly: ignore [bad-argument-type]
         constraint_strides=constraint_strides,
         specialize_on=specialize_on,
+        do_not_specialize_zero_one=do_not_specialize_zero_one,
         view_base_context=view_base_context,
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         shape_ids=getattr(e, "_dynamo_shape_ids", None),
         unbacked_bounds=getattr(e, "_dynamo_unbacked_bounds", None),
-        excluded_sizes=frame_state_entry.excluded_sizes,
+        excluded_sizes=None if excluded_sizes is None else tuple(excluded_sizes),
     )
 
 

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -617,7 +617,10 @@ def compute_elementwise_output_logical_to_physical_perm(
                 return True
             elif guard_or_false(a == 0):
                 return False
-            return guard_or_false(a >= b) or guard_or_false(a % b == 0)
+            try:
+                return guard_or_false(a >= b) or guard_or_false(a % b == 0)
+            except ZeroDivisionError:
+                return False
 
         for tensor in tensors:
             stride_a = tensor.stride()[idx_a]

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/inductor/inductor_ops.h>
@@ -306,6 +307,20 @@ std::string TensorCheck::check_verbose(
 
 namespace {
 
+bool is_parameter(py::handle tensor) {
+  py::object parameter = py::module::import("torch.nn").attr("Parameter");
+  return py::isinstance(tensor, parameter);
+}
+
+static bool tensor_pytype_matches(PyObject* value, PyTypeObject* expected) {
+  if (Py_TYPE(value) == expected) {
+    return true;
+  }
+  return THPVariableClass &&
+      reinterpret_cast<PyObject*>(expected) == THPVariableClass &&
+      is_parameter(py::handle(value));
+}
+
 typedef std::vector<TensorCheck> ChecksList;
 
 typedef struct {
@@ -466,7 +481,7 @@ PyObject* TensorGuards_check(
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
 
-    if (Py_TYPE(item) != checks[i].pytype) {
+    if (!tensor_pytype_matches(item, checks[i].pytype)) {
       Py_RETURN_FALSE;
     }
     auto insertion = unique_tensors.insert({item, nullptr});
@@ -534,7 +549,7 @@ PyObject* TensorGuards_check_verbose(
   ska::flat_hash_map<PyObject*, std::nullptr_t> unique_tensors;
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
-    if (Py_TYPE(item) != checks[i].pytype) {
+    if (!tensor_pytype_matches(item, checks[i].pytype)) {
       std::stringstream fail_reason;
       PyObject* type_str =
           PyObject_Str(reinterpret_cast<PyObject*>(Py_TYPE(item)));
@@ -1281,11 +1296,6 @@ bool is_immutable_object(py::handle example_value) {
       PyCode_Check(example_value.ptr()) ||
       (Py_TYPE(example_value.ptr()) == &PyCFunction_Type) ||
       (is_tensor_immutable && THPVariable_Check(example_value.ptr()));
-}
-
-bool is_parameter(py::handle tensor) {
-  py::object parameter = py::module::import("torch.nn").attr("Parameter");
-  return py::isinstance(tensor, parameter);
 }
 
 /**
@@ -5046,7 +5056,7 @@ class TENSOR_MATCH : public LeafGuard {
   }
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    if (!tensor_pytype_matches(value, _tensor_check->pytype)) {
       return false;
     }
     return _tensor_check->check(
@@ -5056,7 +5066,7 @@ class TENSOR_MATCH : public LeafGuard {
   GuardDebugInfo check_verbose_nopybind(
       PyObject* value) override { // borrowed ref
 
-    if (Py_TYPE(value) != _tensor_check->pytype) {
+    if (!tensor_pytype_matches(value, _tensor_check->pytype)) {
       std::stringstream fail_reason;
       PyObject* type_str =
           PyObject_Str(reinterpret_cast<PyObject*>(Py_TYPE(value)));

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1564,6 +1564,43 @@ def _guard_or(a: BoolLikeType, default: bool) -> bool:
     sym_node = a.node
     if sym_node.shape_env is None:
         raise AssertionError("shape_env should not be None")
+
+    expr = sym_node.expr
+    has_do_not_specialize_zero_one_symbol = bool(
+        expr.free_symbols & shape_env.do_not_specialize_zero_one_symbols
+    )
+
+    def equality_specializes_zero_one(
+        lhs: sympy.Expr, rhs: sympy.Expr
+    ) -> sympy.Expr | None:
+        diff = sympy.expand(lhs - rhs)
+        for symbol in expr.free_symbols & shape_env.do_not_specialize_zero_one_symbols:
+            coeff = diff.coeff(symbol)
+            if coeff == 0 or not coeff.is_number:
+                continue
+            remainder = diff - coeff * symbol
+            if remainder.has(symbol):
+                continue
+            value = sympy.simplify(-remainder / coeff)
+            if value in (0, 1):
+                return value
+        return None
+
+    if expr.func in (sympy.Eq, sympy.Ne):
+        lhs, rhs = expr.args
+        specialized_value = equality_specializes_zero_one(lhs, rhs)
+        if has_do_not_specialize_zero_one_symbol and (
+            specialized_value == 1 or (specialized_value == 0 and default is True)
+        ):
+            return default
+    elif (
+        default is False
+        and has_do_not_specialize_zero_one_symbol
+        and expr.is_Relational
+        and any(arg in (0, 1, 2) for arg in expr.args)
+    ):
+        return default
+
     r = sym_node.shape_env.evaluate_sym_node(
         sym_node, size_oblivious=False, fallback_value=default
     )
@@ -2283,6 +2320,7 @@ class StatelessSymbolicContext(SymbolicContext, Generic[_P1, _T1]):
     shape_ids: dict[int, str | None] | None = None
     # Maps dimension index to (min, max) bounds for unbacked dimensions.
     unbacked_bounds: dict[int, tuple[int | None, int | None]] | None = None
+    do_not_specialize_zero_one: DimList[bool] = None  # type: ignore[assignment]
     # TODO: add storage offset and stride symbolic_context
 
     def __post_init__(self) -> None:
@@ -2305,6 +2343,10 @@ class StatelessSymbolicContext(SymbolicContext, Generic[_P1, _T1]):
         if self.constraint_strides is None:
             object.__setattr__(
                 self, "constraint_strides", [None] * len(self.dynamic_sizes)
+            )
+        if self.do_not_specialize_zero_one is None:
+            object.__setattr__(
+                self, "do_not_specialize_zero_one", [False] * len(self.dynamic_sizes)
             )
         if not all(
             stride in (DimDynamic.INFER_STRIDE, DimDynamic.DYNAMIC, DimDynamic.DUCK)
@@ -4056,6 +4098,10 @@ class ShapeEnv:
         # transitioned static → dynamic. All pairs are combined into a single
         # Or(Ne(...), ...) guard in produce_guards_verbose.
         self.exclusion_constraints: list[tuple[sympy.Symbol, int]] = []
+        # Symbols created from an explicit context that asked us not to
+        # specialize on 0/1.  This lets guard production distinguish those
+        # symbols from export-created symbols whose ranges also include 0/1.
+        self.do_not_specialize_zero_one_symbols: set[sympy.Symbol] = set()
         # Set that holds "size-like" symbols.  When we perform
         # "size-oblivious" tests, these can be assumed to be >= 2.
         self.size_like: set[sympy.Symbol] = set()
@@ -4778,7 +4824,10 @@ class ShapeEnv:
                 TensorPropertySource(source, TensorProperty.SIZE, i),
                 dynamic_dims[i],
                 constraint_dims[i],
-                do_not_specialize_zero_one=config.backed_size_oblivious,
+                do_not_specialize_zero_one=(
+                    config.backed_size_oblivious
+                    or symbolic_context.do_not_specialize_zero_one[i]  # type: ignore[attr-defined]
+                ),
                 symbolic_context=symbolic_context,
             )
             if (
@@ -4808,6 +4857,9 @@ class ShapeEnv:
         # not-all check in produce_guards_verbose to emit a guard that
         # immediately fails.
         excluded_sizes = getattr(symbolic_context, "excluded_sizes", None)
+        do_not_specialize_zero_one = getattr(
+            symbolic_context, "do_not_specialize_zero_one", None
+        )
         dim = len(tensor_size)
         if (
             excluded_sizes
@@ -4820,6 +4872,11 @@ class ShapeEnv:
                     ev is not None
                     and isinstance(size[i], sympy.Symbol)
                     and i not in (hint_overrides or {})
+                    and not (
+                        do_not_specialize_zero_one
+                        and len(do_not_specialize_zero_one) == dim
+                        and do_not_specialize_zero_one[i]
+                    )
                 ):
                     self._record_exclusion_constraint(size[i], ev)
         return size
@@ -5798,6 +5855,14 @@ class ShapeEnv:
                     SymT.FLOAT, symbol_id, positive=positive, real=True
                 )
             self.source_to_var[source_name] = sympy_expr
+            if do_not_specialize_zero_one and type(val) is int:
+                from torch._dynamo.source import TensorProperty, TensorPropertySource
+
+                if (
+                    isinstance(source, TensorPropertySource)
+                    and source.prop is TensorProperty.SIZE
+                ):
+                    self.do_not_specialize_zero_one_symbols.add(sympy_expr)
             # We always associate vars to vals
             if isinstance(val, int):
                 self.backed_var_to_val[sympy_expr] = sympy.Integer(val)
@@ -5823,8 +5888,11 @@ class ShapeEnv:
 
             if isinstance(val, int):
                 if positive:
-                    # Add assertions for the newly created symbols
-                    self._add_assertion(sympy_expr > 1)
+                    if do_not_specialize_zero_one:
+                        self._add_assertion(sympy_expr >= 0)
+                    else:
+                        # Add assertions for the newly created symbols
+                        self._add_assertion(sympy_expr > 1)
 
                     # Apply default range, which assumes not zero-one
                     self.var_to_range[sympy_expr] = self._default_value_range(
@@ -6620,8 +6688,21 @@ class ShapeEnv:
         #    like s0 == s1*2 because trivial due to simplification)
         issued = set()
 
+        def guard_excludes_valid_zero_one(expr: sympy.Expr) -> bool:
+            if expr.func is not sympy.Ne:
+                return False
+            lhs, rhs = expr.args
+            if isinstance(rhs, sympy.Symbol):
+                lhs, rhs = rhs, lhs
+            if not isinstance(lhs, sympy.Symbol) or rhs not in (0, 1):
+                return False
+            return lhs in self.do_not_specialize_zero_one_symbols
+
         def issue_guard(guard: ShapeGuard) -> None:
             expr = self.simplify(guard.expr)
+
+            if guard_excludes_valid_zero_one(expr):
+                return
 
             # Avoid re-issuing the same guard.
             if expr in issued:


### PR DESCRIPTION
Fixes #135011

This PR fixes Dynamo recompilation behavior for explicitly dynamic
`torch.nn.Parameter` inputs.

Previously, `Parameter` inputs could still be treated as statically shaped
even after `torch._dynamo.mark_dynamic`, which caused unnecessary recompiles
and prevented Tensor and Parameter inputs from sharing guards when their
metadata matched.

The fix:
- honors explicit `mark_dynamic` annotations on `Parameter` inputs
- normalizes Tensor/Parameter type guarding where appropriate
- avoids singleton-size specialization for the affected dynamic shape paths
- handles `mark_dynamic(..., min=0)` and open-ended dynamic ranges correctly
- keeps recompilation when metadata genuinely differs, such as
  `requires_grad` mismatch

Test Plan:

```bash
/usr/bin/python3.10 test/dynamo/test_recompiles.py -v RecompileTests.test_mark_dynamic_overrides_parameter_static_shapes
/usr/bin/python3.10 test/dynamo/test_recompiles.py -v RecompileTests.test_tensor_and_parameter_inputs_share_tensor_guards
/usr/bin/python3.10 test/dynamo/test_recompiles.py -v RecompileTests.test_tensor_and_parameter_inputs_recompile_on_requires_grad_mismatch
/usr/bin/python3.10 test/dynamo/test_misc.py -v MiscTests.test_mark_dynamic_with_zero_min
/usr/bin/python3.10 test/dynamo/test_misc.py -v MiscTests.test_mark_dynamic_with_open_ended_ranges
```
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @anijain2305 @bdhirsh for Dynamo/dynamic-shapes review.