### PR TITLE
[inductor] Preserve dtype in scatter_upon_const_tensor rewrite (#186481)

### DIFF
--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -149,6 +149,33 @@ class TestScatterOpt(TestCase):
         over_estimate = M * torch.float.itemsize + M * N * torch.float.itemsize
         self.assertEqual(metrics.num_bytes_accessed, expected_num_bytes + over_estimate)
 
+    def test_dtype_preserved(self):
+        """
+        The full+scatter -> pointwise rewrite must preserve the const tensor's
+        dtype. torch.where with Python scalar branches promotes to the default
+        float dtype (float32), so for a low-precision const tensor (e.g. f16)
+        the rewrite previously produced a float32 result. This is exactly the
+        pattern emitted by nll_loss_backward / cross_entropy backward on f16
+        inputs.
+        """
+        M, N = 1024, 2048
+
+        for dtype in (torch.float16, torch.bfloat16):
+            metrics.reset()
+
+            def f(x):
+                y = torch.full([M, N], 3.14, dtype=dtype)
+                y.scatter_(1, x.unsqueeze(1), 2.718)
+                return y
+
+            x = torch.randint(0, N, (M,), dtype=torch.int64)
+            expect = f(x)
+            actual = torch.compile(f)(x)
+            self.assertEqual(expect.dtype, dtype)
+            self.assertEqual(actual.dtype, dtype, f"dtype not preserved for {dtype}")
+            self.assertTrue(same(expect, actual, tol=1e-2), f"{expect=}\n{actual=}\n")
+            self.check_metric()
+
     def test_cross_entropy_loss(self):
         """
         Match full+scatter in CEL and replaces it with a pointwise.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10142,7 +10142,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 (a, b, c),
             )
 
-    @xfail_if_mps  # dtypes mismatch
     def test_nll_loss_backward_1d_input(self):
         # 1D input with 1D target used to crash the decomposition because
         # target.unsqueeze(0) produced a 2D index for a 1D scatter.

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1171,8 +1171,13 @@ def scatter_upon_const_tensor(
         # Create a mask for where to scatter
         mask = selector_expanded == indices_view
 
-        # Use torch.where to implement the scatter pointwise operation
-        return torch.where(mask, val, background_val)
+        # Use torch.where to implement the scatter pointwise operation.
+        # When val and background_val are Python scalars, torch.where promotes
+        # the result to the default floating dtype (float32), which loses the
+        # const tensor's dtype. Cast back to dtype so the rewrite preserves
+        # aten.scatter.value semantics (the result has self's dtype, with the
+        # scalar value cast to it).
+        return torch.where(mask, val, background_val).to(dtype)
 
     # replace the scatter operation with pointwise equivalent
     # pyrefly: ignore [bad-argument-type]


### PR DESCRIPTION
Summary:

The `scatter_upon_const_tensor` joint-graph optimization (`caffe2/torch/_inductor/fx_passes/joint_graph.py`, gated by `config.optimize_scatter_upon_const_tensor`, on by default) rewrites `aten.full` + `aten.scatter.value` into a pointwise `torch.where(mask, val, background_val)`. When `val` and `background_val` are Python scalars, `torch.where` promotes the result to the default floating dtype (`float32`), which silently drops the const tensor's dtype. The `dtype` captured from the matched `aten.full` was a parameter of the rewrite function but was never used in `repl_fn`.

For a low-precision const tensor (f16/bf16) this changed the scatter result dtype from f16 to f32, which then promoted the whole dependent chain (and the op's output buffer) to f32. `aten.scatter.value` semantics require the result to have `self`'s dtype, with the scalar value cast to it, so this rewrite was not dtype-preserving.

This surfaced as a numerical failure of the `nll_loss_backward` opinfo on MTIA (f16): its decomposition emits `full_like(f16)` + `scatter.value(value=-1.0)` + `mul`, and the rewrite produced an f32 output buffer that the runtime read back as the op's declared f16, yielding garbage (each value landed at column `2*target`, the low/high 16 bits of the f32). The fix casts the `torch.where` result back to the captured `dtype`.

All existing tests in `test_scatter_optimization.py` used `dtype=torch.float`, so the where-with-f32-scalars coincidentally matched the f32 const tensor and the bug never surfaced; added `test_dtype_preserved` covering f16 and bf16.

Test Plan:
Unit test:
```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:test_scatter_optimization
```

Reviewed By: nandesuka

Differential Revision: D107587288




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo