### PR TITLE
Avoid `cudaStreamSync` in single-item GPU tensor assignment

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -417,6 +417,10 @@ inline SymIntArrayRef slicePrefix1sSize(const SymIntArrayRef& sizes) {
 }
 
 inline void copy_to(const Tensor& dst, const Tensor& src) {
+  if (src.dim() == 0 && src.device().type() == at::kCPU) {
+    dst.fill_(src);
+    return;
+  }
   // Use TORCH_GUARD_OR_FALSE with sym_eq to avoid data-dependent-expression
   // errors with unbacked symbolic sizes.  When we can't prove equality,
   // we fall through to the broadcast/expand path.
@@ -437,9 +441,6 @@ inline void copy_to(const Tensor& dst, const Tensor& src) {
     // constants will still appear. Users can workaround that case by
     // dst[index..] = src.reshape(..)
     dst.copy_(src);
-    return;
-  } else if (src.dim() == 0 && src.device().type() == at::kCPU) {
-    dst.fill_(src);
     return;
   }
   auto src_view = src.view_symint(slicePrefix1sSize(src.sym_sizes()));

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2067,6 +2067,8 @@ class TestTorchDeviceType(TestCase):
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
+                          lambda: _ind_put_fn(x, 0, 5.),
+                          lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),
                           lambda: torch.nn.functional.one_hot(ind, num_classes=size),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2064,7 +2064,7 @@ class TestTorchDeviceType(TestCase):
         repeats = torch.full((1,), 2, device=device)
         mask = torch.randint(2, (size,), device=device, dtype=bool)
         mask_cpu = mask.cpu()
-        scalar_cpu = torch.tensor(5.)
+        scalar_cpu = torch.tensor(5., device="cpu")
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2064,10 +2064,12 @@ class TestTorchDeviceType(TestCase):
         repeats = torch.full((1,), 2, device=device)
         mask = torch.randint(2, (size,), device=device, dtype=bool)
         mask_cpu = mask.cpu()
+        scalar_cpu = torch.tensor(5.)
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
                           lambda: _ind_put_fn(x, 0, 5.),
+                          lambda: _ind_put_fn(x, 0, scalar_cpu),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),


### PR DESCRIPTION
Currently, assigning a scalar tensor or Python value to a single element of a GPU tensor (e.g., `gpu_tensor[0] = 5`) causes a host-device synchronization. In contrast, assigning to a slice (e.g., `gpu_tensor[:1] = 5`) is asynchronous.

This PR resolves the synchronization by checking if the source is a scalar CPU tensor at the beginning of `copy_to`. If true, it directly invokes `dst.fill_(src)`, allowing single-element CUDA assignments to execute asynchronously via CUDA fill kernels rather than using the blocking `dst.copy_(src)` path.