### PR TITLE
Avoid `cudaStreamSync` in `index_put_` when assigning scalar CPU value

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -987,7 +987,8 @@ Tensor& _index_put_impl_(
   auto value_ = value;
   if (value.device() != self.device() && value.numel() == 1 &&
       value.dim() == 0) {
-    value_ = value.to(self.device());
+    bool non_blocking = value.is_cpu() && self.device().is_cuda();
+    value_ = value.to(self.device(), non_blocking);
   }
   at::assert_no_overlap(self, value);
   // NOLINTNEXTLINE(performance-implicit-conversion-in-loop)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2066,6 +2066,7 @@ class TestTorchDeviceType(TestCase):
         mask_cpu = mask.cpu()
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
+                          lambda: _ind_put_fn(x, ind, 1.),
                           lambda: _ind_put_fn(x, ind, y),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),


### PR DESCRIPTION
This PR removes a H2D sync when assigning a scalar CPU value.