### PR TITLE
Improve schema errors for symbolic int list mismatches

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11727,6 +11727,44 @@ def ___make_guard_fn():
             f(torch.randn(9, requires_grad=True), torch.tensor([3, 6]))
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_custom_op_int_list_error_reports_symint_elements(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::split_with_sizes_and_clone_int_list_error",
+                "(Tensor input, int[] sizes) -> Tensor[]",
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "mylib::split_with_sizes_and_clone_int_list_error",
+                "cpu",
+                lib=lib,
+            )
+            @torch.library.register_fake(
+                "mylib::split_with_sizes_and_clone_int_list_error", lib=lib
+            )
+            def split_with_sizes_and_clone(input, sizes):
+                return [
+                    t.clone()
+                    for t in torch.ops.aten.split_with_sizes.default(input, sizes)
+                ]
+
+            @torch.compile(backend="eager", fullgraph=True)
+            def f(sz, x):
+                s0, s1 = sz.tolist()
+                _, r1 = torch.ops.mylib.split_with_sizes_and_clone_int_list_error(
+                    x, [s0, s1]
+                )
+                return torch.ops.aten.sort.default(r1)
+
+            with self.assertRaises(torch._dynamo.exc.TorchRuntimeError) as cm:
+                f(torch.tensor([420, 7312 - 420]), torch.randn(7312))
+
+            msg = str(cm.exception)
+            self.assertIn("Expected a value of type 'List[int]'", msg)
+            self.assertIn("instead found type 'immutable_list(SymInt, SymInt)'", msg)
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_dim_order(self):
         @torch.compile(dynamic=False, fullgraph=True, backend="eager")
         def f(x):

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -784,12 +784,38 @@ c10::intrusive_ptr<T> toCustomClass(py::handle obj) {
 
 // Small wrapper around getting the type name string from Python to make
 // types easier to interpret, e.g. give the structural type for a NamedTuple
+inline std::string basicTypeName(py::handle obj) {
+  return py::str(py::type::handle_of(obj).attr("__name__"));
+}
+
+inline std::string sequenceTypeName(py::handle obj) {
+  auto seq = py::reinterpret_borrow<py::sequence>(obj);
+  auto length = py::len(seq);
+  if (length == 0) {
+    return basicTypeName(obj);
+  }
+
+  std::stringstream ss;
+  ss << basicTypeName(obj);
+  ss << "(";
+  bool first = true;
+  for (const auto i : c10::irange(length)) {
+    if (!first) {
+      ss << ", ";
+    }
+    ss << basicTypeName(seq[i]);
+    first = false;
+  }
+  ss << ")";
+  return ss.str();
+}
+
 inline std::string friendlyTypeName(py::handle obj) {
   if (py::isinstance<py::tuple>(obj) && py::hasattr(obj, "_fields")) {
     auto field_names =
         py::cast<std::vector<std::string>>(py::getattr(obj, "_fields"));
     std::stringstream ss;
-    ss << py::str(py::type::handle_of(obj).attr("__name__"));
+    ss << basicTypeName(obj);
     ss << " (aka NamedTuple(";
     bool first = true;
     for (auto& field_name : field_names) {
@@ -801,8 +827,10 @@ inline std::string friendlyTypeName(py::handle obj) {
     }
     ss << "))";
     return ss.str();
+  } else if (py::isinstance<py::list>(obj) || py::isinstance<py::tuple>(obj)) {
+    return sequenceTypeName(obj);
   } else {
-    return py::str(py::type::handle_of(obj).attr("__name__"));
+    return basicTypeName(obj);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186488

When Dynamo routes a Python list through FX, the list can become an
immutable_list. If a custom operator schema expects int[] but receives symbolic
integer elements from capture_scalar_outputs, schema conversion fails before the
user can see that the element type is the real problem. The error only reported
the outer container type, for example immutable_list, which obscured the
int[] versus SymInt mismatch.

Teach the Python schema error formatter to include element type names for
non-empty Python list and tuple values while preserving the existing namedtuple
format. This keeps the message focused on the conversion failure and changes the
issue repro to report immutable_list(SymInt, SymInt).

The other possible direction was to normalize FX immutable containers before
fake execution, but that still would not explain why an int[] schema rejected
the value. Improving the schema formatter fixes the root cause of the obscure
message and benefits the same conversion path more generally.

Fixes #122129
Generated by my agent

Test Plan:
- MAX_JOBS=16 python setup.py develop
- python test/dynamo/test_misc.py MiscTests.test_custom_op_int_list_error_reports_symint_elements
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98