### PR TITLE
Fix division by zero in range when step becomes zero after conversion

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -157,6 +157,10 @@ Tensor& range_out(const Scalar& start, const Scalar& end, const Scalar& step, Te
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
+    TORCH_CHECK(
+      xstep != 0,
+      "step must be nonzero and representable in the target dtype");
+
     arange_check_bounds(start, end, step);
 
     int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -223,6 +223,10 @@ Tensor& range_cuda_out(const Scalar& start, const Scalar& end, const Scalar& ste
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
+    TORCH_CHECK(
+      xstep != 0,
+      "step must be nonzero and representable in the target dtype");
+
     arange_check_bounds(start, end, step);
 
     int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
@@ -254,6 +258,10 @@ Tensor& arange_cuda_out(const Scalar& start, const Scalar& end, const Scalar& st
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
+
+    TORCH_CHECK(
+      xstep != 0,
+      "step must be nonzero and representable in the target dtype");
 
     arange_check_bounds(start, end, step);
 

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -59,9 +59,10 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
+    TORCH_CHECK(xstep != 0, "step must be nonzero and representable in the target dtype");
+
     double size_d;
     if constexpr (std::is_same_v<scalar_t, int64_t>) {
-      TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
       size_d = std::ceil(static_cast<double>(end.to<accscalar_t>() - start.to<accscalar_t>()) / step.to<accscalar_t>());
     } else {
       size_d = std::ceil(static_cast<double>(end.to<double>() - start.to<double>()) / step.to<double>());
@@ -133,6 +134,8 @@ Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
+
+    TORCH_CHECK(xstep != 0, "step must be nonzero and representable in the target dtype");
 
     // double size_d = ((xend - xstart) / xstep) + 1;
     double size_d;

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -59,7 +59,7 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
-    TORCH_CHECK(xstep != 0, "step must be nonzero and representable in the target dtype");
+    TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
 
     double size_d;
     if constexpr (std::is_same_v<scalar_t, int64_t>) {
@@ -135,7 +135,7 @@ Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
-    TORCH_CHECK(xstep != 0, "step must be nonzero and representable in the target dtype");
+    TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
 
     // double size_d = ((xend - xstart) / xstep) + 1;
     double size_d;

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2431,6 +2431,11 @@ class TestTensorCreation(TestCase):
         torch.range(1, 1, 1, device=device, dtype=dtype, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)
 
+        self.assertRaisesRegex(
+            RuntimeError, "step",
+            lambda: torch.range(0, 20, 1e-6, device=device, dtype=torch.int8)
+        )
+
     # TODO: this test should be updated
     def test_range_warning(self, device):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
# Fix division-by-zero in `torch.range` when step underflows to zero after dtype conversion

Fixes #186233

## Summary

Fixes a division-by-zero crash in `torch.range` when a nonzero floating-point step becomes `0` after conversion to the computation dtype.

**Example that previously crashed:**

```python
torch.range(
    0,
    20,
    1e-6,
    dtype=torch.int8,
    device="meta",
)
```

## Root Cause

The existing validation in `arange_check_bounds()` checks that the original step is nonzero by converting it to `double`. However, the range kernel later converts the step to `accscalar_t` before computing the output size.

For integral dtypes, small floating-point values such as `1e-6` underflow to `0` after this conversion. This leads to a division by zero in the size computation:

```cpp
((xend - xstart) / xstep)
```

## Fix

Adds a validation check on the converted step value before it is used in the size calculation. If the converted step is zero (due to underflow), a descriptive error is raised instead of crashing.

## Test Plan

Added a regression test covering the case where a small floating-point step is used with an integral output dtype.