### PR TITLE
Fix torch.istft _refs length handling under dynamic shapes (symbolic clamp/pad)

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7969,6 +7969,45 @@ SavedForBackwardsAOTOutput(idx=5)""",
         self.assertEqual(actual, expected)
         self.assertEqual(actual.shape, (3, length))
 
+    def test_istft_compile_dynamic_length_clamp(self):
+        # Regression for the sym_min/sym_max clamp in the istft ref. Under
+        # dynamic shapes the (requested length vs signal size) clamp must stay
+        # symbolic: the builtin min would install a guard and recompile when the
+        # relationship flips (or raise GuardOnDataDependentSymNode for unbacked
+        # symints). sym_min/sym_max carry it symbolically, so a single graph
+        # serves both the "length exceeds signal" and "length within signal"
+        # cases.
+        n_fft = 1024
+        hop_length = 512
+        length = 60000
+
+        def fn(spec, window):
+            return torch.istft(
+                spec,
+                n_fft=n_fft,
+                hop_length=hop_length,
+                window=window,
+                length=length,
+            )
+
+        window = torch.hann_window(n_fft)
+        # 50 frames -> signal shorter than length (tail is padded);
+        # 200 frames -> signal longer than length (clamped/sliced).
+        spec_short = torch.view_as_complex(torch.randn(4, n_fft // 2 + 1, 50, 2))
+        spec_long = torch.view_as_complex(torch.randn(4, n_fft // 2 + 1, 200, 2))
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled = torch.compile(fn, backend=cnt, fullgraph=True, dynamic=True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(compiled(spec_short, window), fn(spec_short, window))
+            self.assertEqual(compiled(spec_long, window), fn(spec_long, window))
+
+        # Both shapes share a single graph: the symbolic clamp installs no guard
+        # that would force a recompile when the length/signal relationship flips.
+        self.assertEqual(cnt.frame_count, 1)
+
     @unittest.expectedFailure
     def test_method_dunder_dict_setitem(self):
         # Reproducer for: getattr(obj, method_name).__dict__['key'] = value

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3821,20 +3821,47 @@ def istft(
     else:
         end = expected_output_signal_len
 
-    y = aten.slice.Tensor(y, 1, start, end, 1)
-    window_envelop = aten.slice.Tensor(window_envelop, 1, start, end, 1)
+    # Clamp end to the valid signal range before slicing so that downstream
+    # meta / fake-tensor execution never sees an out-of-bounds access.
+    # The eager C++ path relies on slice's implicit clamping, but the
+    # compile path may convert slice to narrow which does not clamp.
+    # Use sym_min (not the builtin min) so the clamp stays symbolic under
+    # dynamic shapes: builtin min would evaluate ``end < expected_output_signal_len``
+    # to a concrete bool, installing a guard for backed symints (forcing a
+    # recompile when the relationship flips) or raising
+    # GuardOnDataDependentSymNode for unbacked symints.
+    clamped_end = sym_min(end, expected_output_signal_len)
+
+    y = aten.slice.Tensor(y, 1, start, clamped_end, 1)
+    window_envelop = aten.slice.Tensor(window_envelop, 1, start, clamped_end, 1)
 
     y = y / window_envelop
     if original_ndim == 2:
         y = y.squeeze(0)
 
-    if end > expected_output_signal_len:
+    # Pad the tail symbolically so dynamic shapes don't force a guard on the
+    # ``end`` vs ``expected_output_signal_len`` relationship. sym_max keeps the
+    # pad >= 0, so a zero pad is a no-op when the signal already covers the
+    # requested length. The warning needs a concrete decision, so it is gated on
+    # statically_known_true: it fires for the common concrete-int case but
+    # installs no guard when the relationship isn't statically known.
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+    if statically_known_true(end > expected_output_signal_len):
         warnings.warn(
             "The length of signal is shorter than the length parameter. Result is being "
             + "padded with zeros in the tail. Please check your center and hop_length settings",
             stacklevel=2,
         )
-        y = aten.constant_pad_nd(y, (0, end - expected_output_signal_len), 0)
+    # Only emit the pad when the signal may be shorter than the requested
+    # length. Skipping it in the statically-known no-pad case avoids turning the
+    # view returned by eager (e.g. the squeeze) into a copy, which keeps
+    # _refs.istft view-consistent with the aten op. When the relationship is not
+    # statically known (dynamic shapes), pad symbolically with sym_max so a zero
+    # pad is a no-op and no specializing guard is installed.
+    if not statically_known_true(end <= expected_output_signal_len):
+        pad = sym_max(end - expected_output_signal_len, 0)
+        y = aten.constant_pad_nd(y, (0, pad), 0)
     return y
 
 


### PR DESCRIPTION
Summary:
torch.istft trims/pads its output to the requested `length`. The _refs.istft decomposition (used by torch.compile for fake/meta shape propagation) handled the "requested length vs actual signal size" relationship with a non-symbolic slice end and a Python `if end > expected_output_signal_len:` branch.

Problem (dynamic shapes): expected_output_signal_len is derived from input.size(-1), so under dynamic shapes it is a SymInt. The slice with a possibly-out-of-bounds `end` and the `if end > ...` branch force the symbolic comparison to a concrete bool. For backed symints this installs a specializing guard -- recompiling whenever the length-vs-signal relationship flips -- and for unbacked symints it raises GuardOnDataDependentSymNode. This is the length-handling mismatch in fake/meta execution tracked by #179593.

Fix (keep the length handling symbolic and eager-aligned):
- clamped_end = sym_min(end, expected_output_signal_len): clamp the slice end symbolically so it never goes out of bounds, matching eager's clamp instead of relying on slice's implicit clamping (the unclamped slice was the root of the original report).
- pad = sym_max(end - expected_output_signal_len, 0) computed symbolically (a zero pad is a no-op) instead of a guarded `if`, with the best-effort warning gated on statically_known_true so it installs no guard.
- emit the pad only when not statically_known_true(end <= expected_output_signal_len), so in the common static no-pad case the eager view (e.g. the squeeze) is not turned into a copy -- keeping _refs.istft view-consistent with the aten op.

Result: a single compiled graph serves both the "length exceeds signal" and "length within signal" cases with no recompile and no data-dependent guard, and the decomposition matches eager's clamp/pad and view semantics.

Note: the original crash from #179593 (RuntimeError: start + length exceeds dimension size; reported on 2.11/2.12) no longer reproduces on current master -- the exact repro compiles cleanly even with the unfixed decomposition (verified locally with the default/inductor backend). This change therefore targets the remaining dynamic-shapes length-handling mismatch and hardens _refs.istft to clamp/pad like eager, rather than fixing a live crash.

Fixes #179593

Test Plan:
Built and run with Buck (mode/dev-nosan) on the fix commit (devvm + A100 GPU).

Dynamic-shapes regression test (the behavior this change fixes):

buck2 run mode/dev-nosan fbcode//caffe2/test/dynamo:test_dynamo -- caffe2/test/dynamo/test_repros.py -k test_istft_compile_dynamic_length_clamp -v
WITHOUT this change: FAILED -- frame_count == 2 (recompiles when the
length-vs-signal relationship flips; the guarded slice/if specializes).
WITH this change:    PASSED -- single compiled graph (frame_count == 1).
The sym_min clamp is load-bearing: keeping only the symbolic pad (dropping
 sym_min) still FAILS this test (frame_count != 1), confirmed locally.

istft op / meta coverage:

buck2 test mode/dev-nosan fbcode//caffe2/test:test_ops fbcode//caffe2/test:meta fbcode//caffe2/test:test_meta_cuda -- istft
=> Pass 32, Fail 0, Skip 11 (the 11 skips are pre-existing/structural).
The conditional (view-preserving) pad keeps the _refs.istft ref-consistency
  tests green; an earlier unconditional-pad revision regressed them
   (Pass 30, Fail 2: test_python_ref_torch_fallback__refs_istft cpu complex64/128).

Note on the original crash: the #179593 repro no longer reproduces on current master -- the exact nn.Module repro compiles cleanly with the unfixed decomposition (verified locally, default/inductor backend). No static-crash regression test is included because none fails without this change; the dynamic-shapes test above is the effective guard.

Reviewed By: williamwen42

Differential Revision: D106705019




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98