### PR TITLE
[inductor] Fix stale xoffset for TMA in mix-order reduction loop

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -465,6 +465,74 @@ class MixOrderReductionTest(TestBase):
             # TMA descriptors point at the right tile each iteration.
             FileCheck().check("xoffset += XBLOCK").run(bwd_wrapper)
 
+    @unittest.skipUnless(
+        has_triton_tma_device(), "Test requires Triton TMA device support"
+    )
+    @parametrize("allow_multi_stages", (False, True))
+    @parametrize("shape", ((32768, 256), (32768 + 1023, 768)))
+    @inductor_config.patch(
+        {
+            "triton.use_tensor_descriptor": True,
+            "assume_aligned_inputs": True,
+            # Pin the split size so each program runs several loop iterations
+            # (iterations = RSPLIT_SIZE // XBLOCK) regardless of the input size
+            # and SM count. This is what lets a small input surface the
+            # stale-xoffset bug that test_rms_norm_bwd_tma reproduces at 1M rows.
+            "triton.mix_order_reduction_split_size": 64,
+        }
+    )
+    def test_rms_norm_bwd_tma_small(self, allow_multi_stages, shape):
+        """
+        Small, CI-friendly variant of test_rms_norm_bwd_tma (regression test for
+        https://github.com/pytorch/pytorch/issues/186241).
+
+        With the split size pinned, every program advances its TMA descriptor
+        offset across multiple loop iterations, so a stale xoffset still
+        produces wrong results at these sizes. The non-divisible-M shape also
+        exercises the masked tail with TMA descriptors.
+        """
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x, w, eps):
+            orig_dtype = x.dtype
+            x = x.float()
+            rsqrt = torch.rsqrt((x * x).sum(dim=-1) / x.shape[-1] + eps)
+            return (x * rsqrt[:, None] * w).to(dtype=orig_dtype)
+
+        def fwd_bwd(compiled_f):
+            x.grad = None
+            w.grad = None
+            out = compiled_f(x, w, eps)
+            out.backward(dy)
+            return x.grad, w.grad
+
+        torch.manual_seed(1337)
+        M, N = shape
+        x = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True)
+        dy = torch.randn_like(x)
+        eps = 1e-5
+
+        opt_f = torch.compile(
+            f,
+            options={
+                "split_reductions": False,
+                "triton.mix_order_reduction_allow_multi_stages": allow_multi_stages,
+            },
+        )
+
+        ref = fwd_bwd(f)
+        act, (_, bwd_wrapper) = utils.run_and_get_code(fwd_bwd, opt_f)
+
+        self.assertTrue(same(ref, act, tol=1e-2), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            inductor_config.triton.mix_order_reduction,
+            metrics.codegen_mix_order_reduction,
+        )
+        if inductor_config.triton.mix_order_reduction:
+            FileCheck().check("xoffset += XBLOCK").run(bwd_wrapper)
+
     @parametrize(
         "wbdtype",
         [
@@ -1369,7 +1437,7 @@ class MixOrderReductionHeuristicTest(TestBase):
             inductor_meta["tma_min_block_sizes"] = {"XBLOCK": 8}
         configs = persistent_reduction(
             {"x": 4096, "r0_": rnumel},
-            triton_meta={"device": object()},
+            triton_meta={"device": torch.device("cpu")},
             inductor_meta=inductor_meta,
             return_configs=True,
         )
@@ -1401,6 +1469,28 @@ class MixOrderReductionHeuristicTest(TestBase):
         for tma in (False, True):
             stages = self._gen_num_stages(tma=tma, allow_multi_stages=False)
             self.assertEqual(stages, {1}, f"tma={tma}: expected {{1}}, got {stages}")
+
+    def test_tma_caps_num_stages_across_shapes(self):
+        """
+        The NUM_STAGES cap with TMA must hold for every (rsplit_size, rnumel)
+        combination the heuristic can produce, not just the shape from the
+        original issue: the underlying failure (triton-lang/triton#10474) is in
+        Triton's software pipeliner for in-loop tensor descriptors, independent
+        of the tile shape.
+        """
+        for rsplit_size in (16, 64, 128, 256):
+            for rnumel in (256, 1024, 8192, 16384):
+                stages = self._gen_num_stages(
+                    tma=True,
+                    allow_multi_stages=True,
+                    rsplit_size=rsplit_size,
+                    rnumel=rnumel,
+                )
+                self.assertTrue(
+                    all(s <= 2 for s in stages),
+                    f"rsplit_size={rsplit_size}, rnumel={rnumel}: "
+                    f"NUM_STAGES must be capped at 2 with TMA, got {stages}",
+                )
 
 
 @inductor_config.patch(

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
 from unittest import mock
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ import torch.nn.functional as F
 from torch import nn
 from torch._dynamo.utils import same
 from torch._inductor import metrics, utils
+from torch._inductor.runtime.triton_heuristics import persistent_reduction
 from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
@@ -19,6 +21,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils._triton import has_triton_tma_device
 
 
 class TestBase(TestCase):
@@ -389,6 +392,78 @@ class MixOrderReductionTest(TestBase):
             inductor_config.triton.mix_order_reduction,
             metrics.codegen_mix_order_reduction,
         )
+
+    @unittest.skipUnless(
+        has_triton_tma_device(), "Test requires Triton TMA device support"
+    )
+    @parametrize("allow_multi_stages", (False, True))
+    @inductor_config.patch(
+        {
+            "triton.use_tensor_descriptor": True,
+            "assume_aligned_inputs": True,
+        }
+    )
+    # The 1M-row input plus its grads needs a fair amount of device memory.
+    @largeTensorTest("16GB", device=GPU_TYPE, inductor=True)
+    def test_rms_norm_bwd_tma(self, allow_multi_stages):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/186241.
+
+        With TMA enabled, the mix-order reduction loop used to leave the scalar
+        `xoffset` (which TMA descriptors index off) frozen while only advancing
+        the `xindex` tensor, so every loop iteration read/wrote the first tile
+        and produced wrong results. Additionally NUM_STAGES >= 3 with TMA active
+        triggers a misaligned-address crash, so the heuristic caps stages at 2.
+
+        ``allow_multi_stages=True`` exercises the multi-stage path that
+        previously crashed (now capped at NUM_STAGES=2 with TMA); ``False``
+        disables multi-staging entirely as a sanity check.
+        """
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x, w, eps):
+            orig_dtype = x.dtype
+            x = x.float()
+            rsqrt = torch.rsqrt((x * x).sum(dim=-1) / x.shape[-1] + eps)
+            return (x * rsqrt[:, None] * w).to(dtype=orig_dtype)
+
+        def fwd_bwd(compiled_f):
+            x.grad = None
+            w.grad = None
+            out = compiled_f(x, w, eps)
+            out.backward(dy)
+            return x.grad, w.grad
+
+        torch.manual_seed(1337)
+        # Large M so the RSPLIT loop runs many iterations per program: this is
+        # what surfaces the stale-xoffset bug (a single iteration would hide it).
+        M, N = 1000000, 256
+        x = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True)
+        w = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True)
+        dy = torch.randn_like(x)
+        eps = 1e-5
+
+        opt_f = torch.compile(
+            f,
+            options={
+                "split_reductions": False,
+                "triton.mix_order_reduction_allow_multi_stages": allow_multi_stages,
+            },
+        )
+
+        ref = fwd_bwd(f)
+        act, (_, bwd_wrapper) = utils.run_and_get_code(fwd_bwd, opt_f)
+
+        self.assertTrue(same(ref, act, tol=1e-2), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            inductor_config.triton.mix_order_reduction,
+            metrics.codegen_mix_order_reduction,
+        )
+        if inductor_config.triton.mix_order_reduction:
+            # The fix advances the scalar xoffset inside the mix-order loop so
+            # TMA descriptors point at the right tile each iteration.
+            FileCheck().check("xoffset += XBLOCK").run(bwd_wrapper)
 
     @parametrize(
         "wbdtype",
@@ -1270,6 +1345,62 @@ class OverFusionTest(TestBase):
         # max_reads should limit over-fusion, not disable mix_order entirely
         self.assertGreater(metrics.codegen_mix_order_reduction, 0)
         self.assertGreater(metrics.rejected_mix_order_reduction_fusion, 0)
+
+
+class MixOrderReductionHeuristicTest(TestBase):
+    """
+    CPU-runnable unit tests for the mix-order persistent_reduction autotuning
+    heuristic. These exercise the config generation logic directly (via
+    ``return_configs=True``) without needing a GPU.
+    """
+
+    def _gen_num_stages(self, *, tma, allow_multi_stages, rsplit_size=256, rnumel=256):
+        """
+        Drive the mix-order branch of persistent_reduction and return the set of
+        NUM_STAGES values across the generated configs.
+        """
+        inductor_meta = {
+            "RSPLIT_SIZE": rsplit_size,
+            "mix_order_reduction_allow_multi_stages": allow_multi_stages,
+        }
+        if tma:
+            # XBLOCK is not a reduction prefix, so it survives the persistent
+            # reduction filtering and marks TMA as active.
+            inductor_meta["tma_min_block_sizes"] = {"XBLOCK": 8}
+        configs = persistent_reduction(
+            {"x": 4096, "r0_": rnumel},
+            triton_meta={"device": object()},
+            inductor_meta=inductor_meta,
+            return_configs=True,
+        )
+        self.assertTrue(configs, "expected at least one config")
+        return {c.kwargs["NUM_STAGES"] for c in configs}
+
+    def test_tma_caps_num_stages(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/186241
+        (part 2). With TMA active, NUM_STAGES >= 3 triggers a misaligned-address
+        crash, so the heuristic must cap it at 2. Without TMA the same shape is
+        allowed to pick NUM_STAGES=3.
+        """
+        # rnumel <= 8192 and num_iters // 4 >= 3 lets the non-TMA path reach 3.
+        no_tma = self._gen_num_stages(tma=False, allow_multi_stages=True)
+        self.assertIn(3, no_tma, f"expected NUM_STAGES=3 without TMA, got {no_tma}")
+
+        with_tma = self._gen_num_stages(tma=True, allow_multi_stages=True)
+        self.assertTrue(
+            all(s <= 2 for s in with_tma),
+            f"NUM_STAGES must be capped at 2 with TMA, got {with_tma}",
+        )
+
+    def test_num_stages_single_when_multi_stage_disabled(self):
+        """
+        When multi-staging is disabled, NUM_STAGES collapses to 1 regardless of
+        whether TMA is active.
+        """
+        for tma in (False, True):
+            stages = self._gen_num_stages(tma=tma, allow_multi_stages=False)
+            self.assertEqual(stages, {1}, f"tma={tma}: expected {{1}}, got {stages}")
 
 
 @inductor_config.patch(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6328,6 +6328,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self.body.splice(self.stores)
                 self.body.splice(self.post_loop_store)
 
+                if self.tma_min_block_sizes:
+                    self.body.writeline("xoffset += XBLOCK")
+
                 # no need to sum if XBLOCK == 1, or does that matter?
                 for idx, partial_accum in enumerate(self.saved_partial_accumulate):
                     var = partial_accum.value

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -614,6 +614,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
                 MAX_NUM_STAGES = 2 if rnumel_hint > 8192 else 3
             else:
                 MAX_NUM_STAGES = 1
+            # TODO: Remove this guard once triton-lang/triton#10474 is fixed.
+            # TMA descriptor loads with num_stages >= 3 currently trigger
+            # CUDA_ERROR_MISALIGNED_ADDRESS, so cap NUM_STAGES at 2 when TMA is used.
             if inductor_meta.get("tma_min_block_sizes"):
                 MAX_NUM_STAGES = min(MAX_NUM_STAGES, 2)
             c.kwargs["NUM_STAGES"] = min(  # type: ignore[union-attr]

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -614,6 +614,8 @@ class ReductionHeuristic(CodegenConfigHeuristics):
                 MAX_NUM_STAGES = 2 if rnumel_hint > 8192 else 3
             else:
                 MAX_NUM_STAGES = 1
+            if inductor_meta.get("tma_min_block_sizes"):
+                MAX_NUM_STAGES = min(MAX_NUM_STAGES, 2)
             c.kwargs["NUM_STAGES"] = min(  # type: ignore[union-attr]
                 max(num_iters // 4, 1), MAX_NUM_STAGES
             )


### PR DESCRIPTION
Fixes #186241.

## Problem

When TMA is enabled (`triton.use_tensor_descriptor=True`), the mix-order reduction codegen emits TMA descriptor loads/stores that index off the scalar `xoffset`, which is **never advanced** inside the loop. Only the `xindex` tensor is incremented (`xindex += XBLOCK`). As a result every loop iteration reads/writes the *same first tile*, silently producing wrong results.

Non-TMA pointer loads are unaffected because they use `xindex`.

Generated kernel (simplified) before the fix:
```python
for _ in tl.range(0, split_size, XBLOCK, num_stages=NUM_STAGES):
    xmask = xindex < xnumel
    x0 = xindex
    xindex += XBLOCK   # vector index advances
    # BUG: xoffset never advances — TMA always reads the first tile
    tmp0 = tl.make_tensor_descriptor(in_ptr0, ...).load([xoffset, r0_offset])
    ...
    tl.make_tensor_descriptor(out_ptr1, ...).store([xoffset, r0_offset], ...)
    # Missing: xoffset += XBLOCK
```

Additionally, even after advancing `xoffset`, `NUM_STAGES >= 3` with TMA active triggers a CUDA misaligned-address crash (suspected Triton bug, triton-lang/triton#10474).

## Fix

1. **`torch/_inductor/codegen/triton.py`** advance the scalar `xoffset` at the end of the mix-order loop body when TMA is active (gated on `tma_min_block_sizes`), mirroring the existing `xindex += XBLOCK`.

2. **`torch/_inductor/runtime/triton_heuristics.py`** in `persistent_reduction()`, cap `NUM_STAGES` at 2 when TMA descriptors are in use, working around the Triton pipelining crash until triton-lang/triton#10474 is resolved.

## Tests

- `test_rms_norm_bwd_tma` (GPU, sm_90+): runs the issue's RMSNorm-backward reproducer with TMA enabled across `allow_multi_stages` ∈ {False, True}, asserts numerical correctness vs eager, and `FileCheck`s that `xoffset += XBLOCK` is emitted.
- `MixOrderReductionHeuristicTest` (CPU-runnable): drives the `persistent_reduction` heuristic directly via `return_configs=True` and verifies the `NUM_STAGES` cap `test_tma_caps_num_stages` asserts a shape that picks `NUM_STAGES=3` without TMA is capped to `<= 2` with TMA; `test_num_stages_single_when_multi_stage_disabled` checks the disabled path collapses to 1.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo