### PR TITLE
Allow HOP speculation through torch autograd.Function skipfiles

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import copy
 import math
+import os
 from dataclasses import dataclass
 
 import torch
@@ -217,6 +218,59 @@ class ContextMarkAndSave(torch.autograd.Function):
         return grad_output
 
 
+def _put_function_in_torch_skipfile(fn):
+    torch_dir = os.path.dirname(torch.__file__)
+    skipfile = os.path.join(
+        torch_dir, "nested", "_internal", "test_skipfile_autograd_function.py"
+    )
+    fn.__code__ = fn.__code__.replace(co_filename=skipfile)
+    return fn
+
+
+class TorchSkipfileAutogradFunction(torch.autograd.Function):
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        return x.sin()
+
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def backward(ctx, grad_output):
+        (x,) = ctx.saved_tensors
+        return grad_output * x.cos()
+
+
+@torch.compiler.disable
+def _disabled_helper(x):
+    return x.sin()
+
+
+class TorchSkipfileAutogradFunctionWithGraphBreak(torch.autograd.Function):
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def forward(ctx, x):
+        torch._dynamo.graph_break()
+        return x.sin()
+
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def backward(ctx, grad_output):
+        return grad_output
+
+
+class TorchSkipfileAutogradFunctionWithDisable(torch.autograd.Function):
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def forward(ctx, x):
+        return _disabled_helper(x)
+
+    @staticmethod
+    @_put_function_in_torch_skipfile
+    def backward(ctx, grad_output):
+        return grad_output
+
+
 class ModuleWithGradFunc(torch.nn.Module):
     def __init__(self, func):
         super().__init__()
@@ -253,6 +307,42 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
                     res = opt_model(x)
                     self.assertTrue(torch.allclose(ref, res))
                 self.assertEqual(cnts.frame_count, 2)
+
+    def test_autograd_function_in_torch_skipfile(self):
+        def fn(x):
+            return TorchSkipfileAutogradFunction.apply(x).cos()
+
+        ref_x = torch.randn(10, requires_grad=True)
+        opt_x = ref_x.detach().clone().requires_grad_()
+
+        ref = fn(ref_x).sum()
+        opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        res = opt_fn(opt_x).sum()
+
+        self.assertEqual(res, ref)
+        ref.backward()
+        res.backward()
+        self.assertEqual(opt_x.grad, ref_x.grad)
+
+    def test_autograd_function_in_torch_skipfile_preserves_explicit_skips(self):
+        def fn_with_graph_break(x):
+            return TorchSkipfileAutogradFunctionWithGraphBreak.apply(x)
+
+        def fn_with_disable(x):
+            return TorchSkipfileAutogradFunctionWithDisable.apply(x)
+
+        x = torch.randn(10, requires_grad=True)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "graph_break",
+        ):
+            torch.compile(fn_with_graph_break, backend="eager", fullgraph=True)(x)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "torch.compiler.disable",
+        ):
+            torch.compile(fn_with_disable, backend="eager", fullgraph=True)(x)
 
     def test_linear_setup_context(self):
         model = ModuleLinear()

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -38,6 +38,7 @@ import typing
 import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterator
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
@@ -3894,6 +3895,42 @@ def _force_inline() -> Iterator[None]:
         _force_inline_flag = old_val
 
 
+_ignore_torch_skipfile_rules_flag: ContextVar[bool] = ContextVar(
+    "_ignore_torch_skipfile_rules_flag", default=False
+)
+
+
+def _is_ignoring_torch_skipfile_rules() -> bool:
+    return _ignore_torch_skipfile_rules_flag.get()
+
+
+def _is_ignorable_torch_skipfile(filename: str | None, reason: str | None) -> bool:
+    if (
+        not _ignore_torch_skipfile_rules_flag.get()
+        or filename is None
+        or reason is None
+    ):
+        return False
+    if not reason.startswith(
+        ("file matches MOD_SKIPLIST", "file is under skip directory")
+    ):
+        return False
+    return is_torch(filename)
+
+
+@contextlib.contextmanager
+def _ignore_torch_skipfile_rules() -> Iterator[None]:
+    """
+    Temporarily ignore torch skipfile decisions while preserving explicit skip
+    rules. Used when Dynamo is speculatively tracing a higher-order op body.
+    """
+    token = _ignore_torch_skipfile_rules_flag.set(True)
+    try:
+        yield
+    finally:
+        _ignore_torch_skipfile_rules_flag.reset(token)
+
+
 def check_verbose(
     obj: Any, is_inlined_call: bool = False, frame: Any | None = None
 ) -> SkipResult:
@@ -4201,6 +4238,14 @@ def _lookup_inner(
         filename = getfile(obj)
 
     skip_result = check_file(filename, is_direct_call)
+    if skip_result.skipped and _is_ignorable_torch_skipfile(
+        filename, skip_result.reason
+    ):
+        if reasons is not None:
+            reasons.add(
+                "Attempted skip but we are ignoring torch skipfiles while tracing a higher-order op"
+            )
+        return UserFunctionVariable
     if reasons is not None and skip_result.reason is not None:
         reasons.add(skip_result.reason)
     if skip_result.skipped:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2361,7 +2361,12 @@ class SkipFunctionVariable(VariableTracker):
                 hints=[*graph_break_hints.SUPPORTABLE],
             )
         else:
-            if config.dont_skip_tracing:
+            from .. import trace_rules
+
+            if (
+                config.dont_skip_tracing
+                or trace_rules._is_ignoring_torch_skipfile_rules()
+            ):
                 from .builder import SourcelessBuilder
 
                 # re-build the function, attempting to not skip

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1497,6 +1497,9 @@ def trace_hop_function(
         if enable_side_effects_with_extra_outputs
         else contextlib.nullcontext()
     )
+    from torch._dynamo import trace_rules
+
+    trace_rules_ctx = trace_rules._ignore_torch_skipfile_rules()
 
     # For handling side effects, we can make an argument that we don't
     # have to do anything here. The side effects infra does a good job
@@ -1526,7 +1529,7 @@ def trace_hop_function(
         else contextlib.nullcontext()
     )
 
-    with autograd_ctx, side_effects_ctx, deferred_ctx:
+    with autograd_ctx, side_effects_ctx, deferred_ctx, trace_rules_ctx:
         output = f.call_function(tx, args, sub_kwargs)
 
     if restore_side_effects:
@@ -1567,8 +1570,11 @@ def trace_hop_function_with_auto_output_flattening(
         if not allow_side_effects
         else contextlib.nullcontext()
     )
+    from torch._dynamo import trace_rules
 
-    with autograd_ctx, side_effects_ctx, deferred_ctx:
+    trace_rules_ctx = trace_rules._ignore_torch_skipfile_rules()
+
+    with autograd_ctx, side_effects_ctx, deferred_ctx, trace_rules_ctx:
         output = f.call_function(tx, args, sub_kwargs)
 
     return output


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186504

Dynamo normally treats most framework files under torch/ as skipfiles. That is correct for ordinary tracing, but it also applied while higher-order operators speculatively trace an autograd.Function forward or backward to prove that the function can be represented as a single graph. When the autograd.Function itself lived under a skipped torch directory, Dynamo rebuilt the forward as a SkipFunctionVariable and graph-broke before the HOP machinery could validate the function body.

Fix this by adding a scoped trace-rules context for HOP body tracing. Inside that context, Dynamo ignores only torch-owned skipfile decisions from module skip lists and skip directories, while preserving explicit skip mechanisms such as torch.compiler.disable, torch._dynamo.graph_break, manual callable skip rules, and non-torch skipfiles. The state is stored in a ContextVar so the relaxed rule is scoped to the active tracing context and restored reliably.

I considered broadening dont_skip_tracing for this path, but that would also bypass more skip decisions than this bug requires. Keeping a dedicated HOP context limits the behavior change to framework autograd.Function bodies that HOP speculation already needs to inspect.

Fixes #118334
Generated by my agent

Benchmark Results:
Repeated 10 one-shot torch.compile(fn, backend="eager", fullgraph=True) runs on a small custom autograd.Function, resetting Dynamo each iteration and running backward.

Before, main eb80dd583a7:
- times_s: 0.367223, 0.030003, 0.028214, 0.028602, 0.028305, 0.027070, 0.026681, 0.027042, 0.026864, 0.027354
- median_s: 0.027784
- mean_s: 0.061736

After, this patch:
- times_s: 0.315379, 0.029453, 0.028966, 0.028853, 0.027919, 0.027959, 0.027638, 0.027453, 0.027285, 0.027213
- median_s: 0.027939
- mean_s: 0.056812

Test Plan:
- python test/dynamo/test_autograd_function.py -k test_autograd_function_in_torch_skipfile
- python test/dynamo/test_autograd_function.py -k autograd_function
- python test/dynamo/test_decorators.py -k test_dont_skip_tracing
- git diff --check
- git diff --cached --check
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98