### PR TITLE
Use `at::_assert_async` for argument check of `torch.normal` to prevent GPU sync

### DIFF
--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -20,6 +20,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/full.h>
 #include <ATen/ops/view_as_real.h>
+#include <ATen/ops/_assert_async.h>
 #endif
 
 namespace at::native::templates {
@@ -190,9 +191,17 @@ at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, std::optional<in
     TORCH_CHECK( \
       !std.is_complex(), \
       "normal expects standard deviation to be non-complex"); \
-    TORCH_CHECK( \
-      std.numel() == 0 || std.is_meta() || std.min().ge(0).item<bool>(), \
-      "normal expects all elements of std >= 0.0"); \
+    if (std.numel() > 0 && !std.is_meta()) { \
+      if (std.is_cuda()) { \
+        at::_assert_async( \
+          std.min().ge(0), \
+          "normal expects all elements of std >= 0.0"); \
+      } else { \
+        TORCH_CHECK( \
+          std.min().ge(0).item<bool>(), \
+          "normal expects all elements of std >= 0.0"); \
+      } \
+    } \
   } while (0)
 
 #define CHECK_NORMAL_STD(std) \

--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -407,6 +407,7 @@ aten::normal.float_float
 aten::normal.float_float_out
 aten::normal.out
 aten::normal_
+aten::normal_functional
 aten::permute
 aten::permute_copy
 aten::permute_copy.out

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -1044,7 +1044,6 @@ aten::nonzero
 aten::nonzero.out
 aten::nonzero_static
 aten::nonzero_static.out
-aten::normal_functional
 aten::ones.out
 aten::ormqr
 aten::ormqr.out

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3776,7 +3776,8 @@ class AOTInductorTestsTemplate:
             def forward(self, x):
                 return torch.ops.aten.normal_functional.default(x)
 
-        self.check_model(Model(), (torch.empty(4, 1, 4, 4, device=self.device),))
+        with config.patch({"fallback_random": True}):
+            self.check_model(Model(), (torch.empty(4, 1, 4, 4, device=self.device),))
 
     def test_empty_graph(self):
         class Model(torch.nn.Module):

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -221,8 +221,6 @@ CPU_TEST_FAILURES = {
     # minimal arrayref interface only works with CPU; test crashes.
     # https://github.com/pytorch/pytorch/issues/122983
     "test_multi_device": fail_minimal_arrayref_interface(is_skip=True),
-    # TODO: AssertionError: unsupported Optional type in convert_arg_type: Generator
-    "test_normal_functional": fail_stack_allocation(is_skip=True),
     # the test segfaults
     "test_repeat_output": fail_stack_allocation(is_skip=True),
     # segfault

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7024,6 +7024,19 @@ for dtype in (torch.int32, torch.int64):
             (torch.randn([4, 12, 2, 64]),),
         )
 
+    def test_prims_normal_fallback(self):
+        def fn():
+            return torch.ops.prims.normal(
+                [2, 3],
+                mean=0.0,
+                std=1.0,
+                dtype=torch.float32,
+                device=torch.device(self.device),
+                requires_grad=False,
+            )
+
+        self.common(fn, ())
+
     def test_embedding(self):
         m = torch.nn.Sequential(
             torch.nn.Embedding(10, 4, padding_idx=0),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7024,18 +7024,43 @@ for dtype in (torch.int32, torch.int64):
             (torch.randn([4, 12, 2, 64]),),
         )
 
-    def test_prims_normal_fallback(self):
-        def fn():
-            return torch.ops.prims.normal(
-                [2, 3],
-                mean=0.0,
-                std=1.0,
-                dtype=torch.float32,
-                device=torch.device(self.device),
-                requires_grad=False,
-            )
+    @config.patch(fallback_random=True)
+    def test_normal_fallback(self):
+        def fn_scalar():
+            return torch.normal(0.0, 1.0, size=(2, 3), device=self.device)
 
-        self.common(fn, ())
+        mean = torch.ones(10, device=self.device) * 0.1
+        std = torch.ones(10, device=self.device) * 0.5
+
+        self.common(torch.normal, (mean, std))
+        self.common(fn_scalar, ())
+
+    @config.patch(fallback_random=False)
+    def test_normal_no_fallback(self):
+        def fn_scalar():
+            return torch.normal(0.0, 1.0, size=(2, 3), device=self.device)
+
+        mean = torch.ones(10, device=self.device) * 0.1
+        std = torch.ones(10, device=self.device) * 0.5
+
+        compiled = torch.compile(torch.normal, fullgraph=True)
+        res = compiled(mean, std)
+        self.assertEqual(res.shape, (10,))
+        self.assertEqual(res.dtype, torch.float32)
+        self.assertEqual(res.device.type, torch.device(self.device).type)
+
+        compiled_scalar = torch.compile(fn_scalar, fullgraph=True)
+        res_scalar = compiled_scalar()
+        self.assertEqual(res_scalar.shape, (2, 3))
+        self.assertEqual(res_scalar.dtype, torch.float32)
+        self.assertEqual(res_scalar.device.type, torch.device(self.device).type)
+
+        # Confirm non-eager compilation
+        torch.manual_seed(0)
+        eager_out = torch.normal(mean, std)
+        torch.manual_seed(0)
+        compiled_out = compiled(mean, std)
+        self.assertNotEqual(eager_out, compiled_out)
 
     def test_embedding(self):
         m = torch.nn.Sequential(

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -125,6 +125,9 @@ test_failures = {
     "test_as_strided_on_split_view_dynamic_shapes": TestFailure(
         ("cpu", "cuda", "xpu"), is_skip=True
     ),
+    "test_normal_fallback_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu"), is_skip=True
+    ),
     "test_cat_empty_1d_negative_dim_zero_output_dynamic_shapes": TestFailure(
         ("cpu", "cuda", "xpu"), is_skip=True
     ),

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -57,7 +57,7 @@ from torch.testing._internal.inductor_utils import (
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
 from torch.utils._dtype_abbrs import dtype_abbrs
 from torch.utils._python_dispatch import TorchDispatchMode
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import tree_leaves, tree_map
 
 
 try:
@@ -1459,8 +1459,13 @@ class TestInductorOpInfo(TestCase):
 
                         # skip checking gradient on CPU for now
                         if device_type == GPU_TYPE:
+                            # Only check gradients if there are input tensors requiring gradients
+                            has_grad_inputs = any(
+                                getattr(x, "requires_grad", False)
+                                for x in tree_leaves((args, kwargs))
+                            )
                             adjusted_kwargs.update(
-                                check_gradient=requires_grad,
+                                check_gradient=requires_grad and has_grad_inputs,
                                 output_process_fn_grad=sample_input.output_process_fn_grad,
                             )
                         else:

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -249,7 +249,6 @@ inductor_expected_failures_single_sample["cpu"] = {
     "resize_as_": {b8, f16, f32, f64, i32, i64},
     "histc": {f16},
     "nonzero_static": {b8, f16, f32, f64, i32, i64},
-    ("normal", "in_place"): {f16, f32, f64},
     ("sparse.mm", "reduce"): {f32, f64, f16},
     "sparse.sampled_addmm": {f32, f64},
     "to_sparse": {
@@ -262,7 +261,6 @@ inductor_expected_failures_single_sample["cpu"] = {
 
 inductor_expected_failures_single_sample["cuda"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
-    ("normal", "in_place"): {f16, f32, f64},
     "sparse.sampled_addmm": {f32, f64, f16},
     "torch.ops.aten._flash_attention_forward": {f16},
     "torch.ops.aten._efficient_attention_forward": {f16, f32},
@@ -278,7 +276,6 @@ inductor_expected_failures_single_sample["cuda"] = {
 
 inductor_expected_failures_single_sample["xpu"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
-    ("normal", "in_place"): {f16, f32, f64},
     "sparse.sampled_addmm": {f32, f64, f16},
     "tan": {f16},
     "torch.ops.aten._flash_attention_forward": {f16},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -250,8 +250,6 @@ inductor_expected_failures_single_sample["cpu"] = {
     "histc": {f16},
     "nonzero_static": {b8, f16, f32, f64, i32, i64},
     ("normal", "in_place"): {f16, f32, f64},
-    ("normal", "number_mean"): {f16, f32, f64},
-    "normal": {f16, f32, f64},
     ("sparse.mm", "reduce"): {f32, f64, f16},
     "sparse.sampled_addmm": {f32, f64},
     "to_sparse": {
@@ -265,8 +263,6 @@ inductor_expected_failures_single_sample["cpu"] = {
 inductor_expected_failures_single_sample["cuda"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
     ("normal", "in_place"): {f16, f32, f64},
-    ("normal", "number_mean"): {f16, f32, f64},
-    "normal": {f16, f32, f64},
     "sparse.sampled_addmm": {f32, f64, f16},
     "torch.ops.aten._flash_attention_forward": {f16},
     "torch.ops.aten._efficient_attention_forward": {f16, f32},
@@ -283,8 +279,6 @@ inductor_expected_failures_single_sample["cuda"] = {
 inductor_expected_failures_single_sample["xpu"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
     ("normal", "in_place"): {f16, f32, f64},
-    ("normal", "number_mean"): {f16, f32, f64},
-    "normal": {f16, f32, f64},
     "sparse.sampled_addmm": {f32, f64, f16},
     "tan": {f16},
     "torch.ops.aten._flash_attention_forward": {f16},

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3402,9 +3402,7 @@ exit(2)
             # TODO: reenable multinomial tests if/when the implementation is capturable.
             # ("multinomial", (input.clone(), size, True), {}),
             # ("multinomial", (input.clone(), size // 2, False), {}),
-            # TODO: reenable normal test, where std is a device
-            # tensor, when graph test failures are fixed
-            # ("normal", (input.clone() + 1, input.clone()), {}),
+            ("normal", (input.clone() + 1, input.clone()), {}),
             ("normal", (input.clone() + 1, 1.0), {}),
             ("poisson", (input.clone(),), {}),
             ("rand", (size,), {"device": "cuda", "dtype": torch.float}),

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3481,8 +3481,9 @@ class TestRandomTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, r'normal expects std >= 0.0, but found std'):
                 torch.normal(input, -1, (10,))
 
-            with self.assertRaisesRegex(RuntimeError, r'normal expects all elements of std >= 0.0'):
-                torch.normal(input, std)
+            if not std.is_cuda:  # on GPU this error is raised asynchronously
+                with self.assertRaisesRegex(RuntimeError, r'normal expects all elements of std >= 0.0'):
+                    torch.normal(input, std)
 
     # https://github.com/pytorch/pytorch/issues/126834
     @xfailIfTorchDynamo

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2075,7 +2075,8 @@ class TestTorchDeviceType(TestCase):
                           lambda: torch.randperm(20000, device=device),
                           lambda: torch.repeat_interleave(x, 2, output_size=2 * size),
                           lambda: torch.repeat_interleave(x, repeats, output_size=2 * size),
-                          lambda: torch.any(y))
+                          lambda: torch.any(y),
+                          lambda: torch.normal(x, x))
         expect_sync = (lambda: _ind_put_fn(x, mask, y),
                        lambda: _ind_put_fn(x, ind_cpu, y),
                        lambda: _ind_get_fn(x, mask),

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -653,13 +653,21 @@ def normal(
     requires_grad: bool,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
-    normal_samples = torch.randn(
-        shape,
-        generator=generator,
-        dtype=dtype,
-        device=device,
-        requires_grad=requires_grad,
-    )
+    if generator is None:
+        normal_samples = torch.randn(
+            shape,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+        )
+    else:
+        normal_samples = torch.randn(
+            shape,
+            generator=generator,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+        )
     return std * normal_samples + mean
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -642,6 +642,27 @@ def fmax(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
     return torch.where(torch.isnan(other) | (other < self), self, other)
 
 
+@register_decomposition(prims.normal)
+def normal(
+    shape: list[int | torch.SymInt],
+    *,
+    mean: torch.types.Number,
+    std: torch.types.Number,
+    dtype: torch.dtype,
+    device: torch.device,
+    requires_grad: bool,
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    normal_samples = torch.randn(
+        shape,
+        generator=generator,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+    )
+    return std * normal_samples + mean
+
+
 @register_decomposition(aten.amax)
 def amax(
     self: torch.Tensor,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2973,6 +2973,7 @@ make_fallback(aten.randint)
 make_fallback(aten.rand_like, override_decomp=True)
 make_fallback(aten.randn_like, override_decomp=True)
 make_fallback(aten.randint_like, override_decomp=True)
+make_fallback(aten.normal, override_decomp=True)
 make_fallback(aten.rrelu_with_noise_functional)
 
 # TODO: mlazos reevaluate if we want to codegen something different
@@ -3753,7 +3754,6 @@ make_fallback(torch._prims.rng_prims.run_and_save_rng_state)
 make_fallback(torch._prims.rng_prims.run_with_rng_state)
 make_fallback(torch._prims.rng_prims.graphsafe_run_with_rng_state)
 make_fallback(torch._prims.rng_prims.run_dtensor_rng_op)
-make_fallback(prims.normal)
 
 # AMP / GradScaler ops: both the in-place (_amp_update_scale_) and functional
 # (_amp_update_scale) variants need explicit fallbacks.  Inductor uses the

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3753,6 +3753,7 @@ make_fallback(torch._prims.rng_prims.run_and_save_rng_state)
 make_fallback(torch._prims.rng_prims.run_with_rng_state)
 make_fallback(torch._prims.rng_prims.graphsafe_run_with_rng_state)
 make_fallback(torch._prims.rng_prims.run_dtensor_rng_op)
+make_fallback(prims.normal)
 
 # AMP / GradScaler ops: both the in-place (_amp_update_scale_) and functional
 # (_amp_update_scale) variants need explicit fallbacks.  Inductor uses the

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6678,7 +6678,13 @@ def normal_functional(self, mean=0, std=1, *, generator=None):
         device=self.device,
         generator=generator,
     )
-    return res.contiguous(memory_format=utils.suggest_memory_format(self))
+    if self.stride() == res.stride():
+        return res
+    perm, _ = utils.compute_elementwise_output_logical_to_physical_perm(self)
+    perm_shape = utils.apply_perm(self.shape, perm)
+    new_stride = utils.make_contiguous_strides_for(perm_shape)
+    new_stride = utils.apply_perm(new_stride, utils.invert_perm(perm))
+    return res.as_strided(self.shape, new_stride)
 
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6680,10 +6680,7 @@ def normal_functional(self, mean=0, std=1, *, generator=None):
     )
     if self.stride() == res.stride():
         return res
-    perm, _ = utils.compute_elementwise_output_logical_to_physical_perm(self)
-    perm_shape = utils.apply_perm(self.shape, perm)
-    new_stride = utils.make_contiguous_strides_for(perm_shape)
-    new_stride = utils.apply_perm(new_stride, utils.invert_perm(perm))
+    new_stride = utils.compute_elementwise_output_strides(self)
     return res.as_strided(self.shape, new_stride)
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6600,7 +6600,6 @@ def log_normal(self, mean=1, std=2, generator=None):
     return torch.exp(std * torch.randn_like(self) + mean)
 
 
-# TODO: add support for functionalization aten.normal_functional
 # NOTE: the device and dtype will be ignored when shape is None
 @register_decomposition(aten.normal)
 @out_wrapper()
@@ -6667,6 +6666,19 @@ def normal(
 @register_decomposition(aten.normal_)
 def normal_(self, mean=0, std=1, *, generator=None):
     return normal(mean, std, self.shape, out=self, generator=generator)
+
+
+@register_decomposition(aten.normal_functional)
+def normal_functional(self, mean=0, std=1, *, generator=None):
+    res = normal(
+        mean,
+        std,
+        self.shape,
+        dtype=self.dtype,
+        device=self.device,
+        generator=generator,
+    )
+    return res.contiguous(memory_format=utils.suggest_memory_format(self))
 
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)


### PR DESCRIPTION
Partially addresses #108968

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo