### PR TITLE
docs: fix missing article typo in CONTRIBUTING.md ASAN section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1236,7 +1236,7 @@ useful for debugging memory errors in C++. We run it in CI, but here's how to
 get the same thing to run on your local machine.
 
 First, install LLVM 8. The easiest way is to get [prebuilt
-binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to
+binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to a
 folder (later called `$LLVM_ROOT`).
 
 Then set up the appropriate scripts. You can put this in your `.bashrc`:


### PR DESCRIPTION
Fixed a minor typo in the "Building PyTorch with ASAN" section by changing "extract them to folder" to "extract them to a folder".