### PR TITLE
Detect aliased subclass inputs after desugaring

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2601,6 +2601,31 @@ def forward(self, primals_1, primals_2):
                 make_inputs_subclasses=True,
             )
 
+    @skipIfDynamoInput("Dynamo removes runtime error")
+    def test_subclass_inputs_expose_inner_aliased_mutation(self):
+        def f(a, b):
+            a.mul_(2)
+            return a + b
+
+        compiled_fns = {
+            "aot_function": aot_function(f, nop),
+            "torch.compile(dynamic=True)": torch.compile(
+                f,
+                backend="aot_eager",
+                dynamic=True,
+                fullgraph=True,
+            ),
+        }
+
+        for name, compiled_f in compiled_fns.items():
+            with self.subTest(compiler=name):
+                x = torch.ones(2)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Encountered aliased inputs that are mutated in the graph, but",
+                ):
+                    compiled_f(WrapperSubclass(x), WrapperSubclass(x))
+
     # https://github.com/pytorch/pytorch/issues/106456
     def test_input_mutation_noncontiguous(self):
         def f(a):

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -240,6 +240,7 @@ def _prepare_graph_capture_tracing(
         fn_to_trace,
         updated_flat_args,
         updated_flat_args_descs,
+        aot_config=aot_config,
         is_joint_structure=trace_joint,
         meta=fw_metadata,
         fw_only=flat_fn,

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -14,7 +14,7 @@ import typing
 import warnings
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager, ExitStack, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, TypeVar
 from unittest.mock import patch
 
@@ -58,6 +58,9 @@ from .descriptors import (
     PhiloxForwardSeedAOTInput,
     PhiloxUpdatedBackwardOffsetAOTOutput,
     PhiloxUpdatedForwardOffsetAOTOutput,
+    SubclassGetAttrAOTInput,
+    SubclassSizeAOTInput,
+    SubclassStrideAOTInput,
 )
 from .functional_utils import (
     _check_if_mutation_can_be_in_graph,
@@ -71,6 +74,7 @@ from .functional_utils import (
     to_fun,
     was_inductor_storage_resized,
 )
+from .input_output_analysis import has_aliased_input_mutation
 from .logging_utils import setup_stacktrace_preservation_hooks
 from .schemas import (
     AOTConfig,
@@ -1304,11 +1308,65 @@ def handle_effect_tokens_fn(
 # - fw_only: this is *always* the forward-only function.
 #   Why do we need this? We need to collect updated ViewAndMutationMeta on our new dense -> dense functions.
 #   In particular, we need this to tell the partitioner how many dense forward outputs there are.
+def _get_outer_subclass_input_desc(desc: AOTInput) -> AOTInput:
+    while isinstance(
+        desc,
+        (SubclassGetAttrAOTInput, SubclassSizeAOTInput, SubclassStrideAOTInput),
+    ):
+        desc = desc.base
+    return desc
+
+
+def _remap_unwrapped_subclass_input_sources(
+    aot_config: AOTConfig,
+    outer_input_descs: list[AOTInput],
+    unwrapped_input_descs: list[AOTInput],
+) -> list[Any] | None:
+    if aot_config.aot_autograd_arg_pos_to_source is None:
+        return None
+
+    if len(outer_input_descs) != len(aot_config.aot_autograd_arg_pos_to_source):
+        raise AssertionError(
+            "expected outer input descriptors and aot_autograd sources to match, "
+            f"got {len(outer_input_descs)} and "
+            f"{len(aot_config.aot_autograd_arg_pos_to_source)}"
+        )
+
+    outer_desc_to_source: dict[AOTInput, Any] = {}
+    for outer_desc, source in zip(
+        outer_input_descs, aot_config.aot_autograd_arg_pos_to_source, strict=True
+    ):
+        if outer_desc in outer_desc_to_source:
+            raise AssertionError(f"duplicate outer input descriptor: {outer_desc}")
+        outer_desc_to_source[outer_desc] = source
+
+    remapped_sources: list[Any] = []
+    for desc in unwrapped_input_descs:
+        outer_desc = _get_outer_subclass_input_desc(desc)
+        if outer_desc not in outer_desc_to_source:
+            raise AssertionError(
+                f"expected {outer_desc} to be present in outer input descriptors"
+            )
+        remapped_sources.append(outer_desc_to_source[outer_desc])
+
+    return remapped_sources
+
+
+def _raise_subclass_aliased_input_mutation_error() -> None:
+    raise RuntimeError(
+        """\
+Encountered aliased inputs that are mutated in the graph, but at least one input/output
+to the graph is a tensor subclass. This is not supported today. You can try to
+remove the aliasing yourself as a workaround, or otherwise file an issue on github."""
+    )
+
+
 def aot_dispatch_subclass(
     flat_fn_maybe_joint: JointTraceFn | TraceFn,
     args: list[FxValue] | tuple[list[FxValue], list[FxValue]],
     args_descs: list[AOTInput] | tuple[list[AOTInput], list[AOTInput]],
     *,
+    aot_config: AOTConfig,
     is_joint_structure: bool,
     meta: ViewAndMutationMeta,
     fw_only: Callable[..., Any],
@@ -1400,10 +1458,9 @@ def aot_dispatch_subclass(
         return inner_fn(inner_fw_only, primals, use_trace_joint=False)
 
     if is_joint_structure:
-        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args[0])
-        primals_wrapped_descs: list[AOTInput] = typing.cast(
-            list[AOTInput], args_descs[0]
-        )
+        primals_wrapped = typing.cast(list[FxValue], args[0])
+        primals_wrapped_descs = typing.cast(list[AOTInput], args_descs[0])
+        outer_primal_descs = typing.cast(list[AOTInput], args_descs[0])
         tangents_wrapped: list[FxValue] = typing.cast(list[FxValue], args[1])
         tangents_wrapped_descs: list[AOTInput] = typing.cast(
             list[AOTInput], args_descs[1]
@@ -1430,12 +1487,13 @@ def aot_dispatch_subclass(
             meta.static_input_indices,  # type: ignore[arg-type]
         )
 
-        primals_unwrapped = args_unwrapped[0]  # type: ignore[assignment]
-        primals_unwrapped_descs = args_descs_unwrapped[0]  # type: ignore[assignment]
+        primals_unwrapped = typing.cast(list[Any], args_unwrapped[0])
+        primals_unwrapped_descs = typing.cast(list[AOTInput], args_descs_unwrapped[0])
         fn_to_trace = joint_fn  # type: ignore[assignment]
     else:
-        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args)
-        primals_wrapped_descs: list[AOTInput] = typing.cast(list[AOTInput], args_descs)
+        primals_wrapped = typing.cast(list[FxValue], args)
+        primals_wrapped_descs = typing.cast(list[AOTInput], args_descs)
+        outer_primal_descs = typing.cast(list[AOTInput], args_descs)
 
         args_unwrapped, args_descs_unwrapped = unwrap_tensor_subclasses(  # type: ignore[assignment]
             primals_wrapped,
@@ -1447,9 +1505,21 @@ def aot_dispatch_subclass(
             meta.static_input_indices,  # type: ignore[arg-type]
         )
 
-        primals_unwrapped = args_unwrapped  # type: ignore[assignment]
-        primals_unwrapped_descs = args_descs_unwrapped  # type: ignore[assignment]
+        primals_unwrapped = typing.cast(list[Any], args_unwrapped)
+        primals_unwrapped_descs = typing.cast(list[AOTInput], args_descs_unwrapped)
         fn_to_trace = fw_fn  # type: ignore[assignment]
+
+    primals_unwrapped_aot_config = aot_config
+    primals_unwrapped_sources = _remap_unwrapped_subclass_input_sources(
+        aot_config,
+        outer_primal_descs,
+        primals_unwrapped_descs,
+    )
+    if primals_unwrapped_sources is not None:
+        primals_unwrapped_aot_config = replace(
+            aot_config,
+            aot_autograd_arg_pos_to_source=primals_unwrapped_sources,
+        )
 
     # Note: [Partitioner handling for Subclasses, Part 1]
     # The way the partitioner works is that:
@@ -1476,6 +1546,14 @@ def aot_dispatch_subclass(
         keep_input_mutations=meta.keep_input_mutations,
         # pyrefly: ignore [not-iterable]
     )(*primals_unwrapped)
+
+    # The top-level duplicate/synthetic-base wrappers run before wrapper
+    # subclasses are flattened. Distinct subclass inputs can therefore expose
+    # aliased dense tensors only after desugaring, which we must reject.
+    if has_aliased_input_mutation(
+        primals_unwrapped_aot_config, primals_unwrapped, meta_updated.input_info
+    ):
+        _raise_subclass_aliased_input_mutation_error()
 
     subclass_meta.fw_metadata = meta_updated
 

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -9,6 +9,7 @@ In particular, the following analyses are provided:
 2. We also analyze the function signature for export graphs.
 """
 
+import collections
 import contextlib
 import itertools
 from typing import Any
@@ -21,6 +22,7 @@ from torch._functorch._aot_autograd.schemas import PlainTensorMeta
 from torch._guards import StorageOverlap
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx.experimental.symbolic_shapes import is_concrete_int
+from torch.multiprocessing.reductions import StorageWeakRef
 
 from .collect_metadata_analysis import coerce_tangent_and_suggest_memory_format
 from .descriptors import AOTInput, InputMutationAOTOutput, TangentAOTInput
@@ -111,6 +113,46 @@ def remove_dupe_metadata(
         subclass_fw_graph_out_meta=[],
         subclass_tangent_meta=subclass_tangent_meta,
     )
+
+
+def has_aliased_input_mutation(
+    aot_config: AOTConfig,
+    fwd_inputs: list[Any],
+    input_info: list[InputAliasInfo],
+) -> bool:
+    """
+    Returns whether any tensor input that mutates data aliases another tensor
+    input. This is used after subclass desugaring, where distinct wrapper
+    subclass inputs can expose aliased dense tensor inputs.
+    """
+    if len(fwd_inputs) != len(input_info):
+        raise AssertionError(
+            f"expected len(fwd_inputs) == len(input_info), "
+            f"got {len(fwd_inputs)} != {len(input_info)}"
+        )
+
+    if not any(info.mutates_data for info in input_info):
+        return False
+
+    storage_ref_to_idx: dict[StorageWeakRef, list[int]] = collections.defaultdict(list)
+    for i, inpt in enumerate(fwd_inputs):
+        if isinstance(inpt, Tensor):
+            storage_ref = StorageWeakRef(inpt.untyped_storage())
+            storage_ref_to_idx[storage_ref].append(i)
+
+    for aliased_input_indices in storage_ref_to_idx.values():
+        if len(aliased_input_indices) <= 1 or not any(
+            input_info[inpt_idx].mutates_data for inpt_idx in aliased_input_indices
+        ):
+            continue
+
+        aliased_input_indices_no_false_sharing = compute_overlapping_inputs(
+            aot_config, fwd_inputs, aliased_input_indices
+        )
+        if len(aliased_input_indices_no_false_sharing) > 1:
+            return True
+
+    return False
 
 
 # Given our ViewAndMutation metadata, this fn constructs a new set of metadata,

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1377,6 +1377,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
                 flat_fn,
                 flat_args,
                 flat_args_descs,
+                aot_config=aot_config,
                 is_joint_structure=self.trace_joint,
                 meta=fw_metadata,
                 fw_only=self.fw_only,  # type: ignore[arg-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186517

AOTAutograd detects duplicate and aliased input mutations before tensor
subclasses are unwrapped. That misses a case where two distinct wrapper
subclass inputs do not alias at the outer level but desugar to dense tensor
inputs that share storage. If one of those inner tensors is mutated, the
compiled graph can silently use the stale value from the other input and return
wrong results.

Fix this by re-running the aliased-mutated-input check after subclass
desugaring, when the dense inner tensors and their updated mutation metadata are
available. The check reuses the existing storage-overlap analysis so false
sharing is handled the same way as the top-level input path. Since AOTAutograd
still does not synthesize bases for aliasing that only becomes visible below
subclasses, the safe behavior is to fail fast with the existing unsupported
subclass aliasing error instead of compiling incorrect semantics. The unwrapped
subclass descriptors are also remapped back to the original input sources before
running overlap checks, preserving the guard/source information expected by the
alias analysis.

An alternative would be to support this case by regenerating the hidden aliasing
relationship after subclass desugaring, but that would require extending the
synthetic-base handling through the subclass wrapper path. This patch keeps the
behavior conservative and matches the issue request to at least detect and
raise.

Fixes #114415
Generated by my agent

Test Plan:
- Reproduced the original issue before the fix with a minimized
  `torch.compile(backend="aot_eager", fullgraph=True)` wrapper-subclass repro;
  it returned `tensor([3., 3.])` instead of `tensor([4., 4.])`.
- Re-ran the same repro after the fix and confirmed it fails fast with the
  aliased-mutated-input subclass error instead of returning the wrong result.
- Verified both `aot_function(f, nop)` and
  `torch.compile(dynamic=True, backend="aot_eager", fullgraph=True)` raise an
  error containing `Encountered aliased inputs that are mutated in the graph,
  but` for two wrapper subclass inputs that share an inner tensor.
- `python test/functorch/test_aotdispatch.py TestAOTAutograd.test_subclass_inputs_expose_inner_aliased_mutation`
  was blocked by an unrelated local `torchvision::nms` import failure.
- Ran the new unittest through `runpy` with `sys.modules["torchvision"]` stubbed:
  `Ran 1 test in 0.483s OK`.
- Ran nearby existing test
  `TestAOTAutograd.test_input_data_and_metadata_mutation_aliases_other_input`
  through the same `torchvision` stub: `Ran 1 test in 0.167s OK`.
- `lintrunner -a test/functorch/test_aotdispatch.py torch/_functorch/_aot_autograd/graph_capture.py torch/_functorch/_aot_autograd/graph_capture_wrappers.py torch/_functorch/_aot_autograd/input_output_analysis.py torch/_functorch/_aot_autograd/runtime_wrappers.py`
  passed with `ok No lint issues. Successfully applied all patches.`
- `git diff --cached --check` passed.

Benchmark Results:
- Benchmarked repeated first-call tracing of `aot_function(f, nop)` for a small
  mutating wrapper-subclass function with two non-aliased inner tensors. Each
  measurement constructs `aot_function(f, nop)`, calls it with two fresh
  `SubclassTensor(torch.ones(8))` inputs, and resets Dynamo. The script warmed
  up 5 iterations, disabled GC, and timed 50 iterations.
- Before patch: mean 0.008956896699965s, median 0.008903818961698562s.
- After patch: mean 0.008679539300501346s, median 0.008659996965434402s.