### PR TITLE
[jit][mobile] Bounds-check Function.class_type in flatbuffer loader

### DIFF
--- a/test/mobile/test_flatbuffer_oob_class_type.py
+++ b/test/mobile/test_flatbuffer_oob_class_type.py
@@ -1,0 +1,42 @@
+# Regression test for out-of-bounds read in the mobile flatbuffer loader.
+#
+# A malformed flatbuffer model can set Function.class_type to an index that is
+# out of range for the module's object_types table. Before the fix,
+# FlatbufferLoader::parseModule indexed all_types_ with that value via the
+# unchecked std::vector::operator[] and dereferenced the result, causing a
+# SIGSEGV while loading. The loader must reject such a module with a clean
+# RuntimeError instead of crashing.
+#
+# The buffer below was produced with the flatbuffers runtime (see craft.py in
+# the PR description): one Function ivalue with class_type=100 and an empty
+# object_types table. It passes VerifyModuleBuffer but exercises the bug. It is
+# embedded as base64 so the test has no third-party build/runtime dependency.
+#
+# Suggested location: test/mobile/test_lite_script_module.py (or
+# test/cpp/jit/test_flatbuffer.cpp for a C++ equivalent).
+
+import base64
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+# 176-byte malformed mobile flatbuffer module (class_type index out of range).
+_MALFORMED_MODULE_B64 = (
+    "JAAAAFBUTUYAABoAFAAQAAAAAAAAAAwAAAAAAAgAAAAAAAQAGgAAAP///38MAAAADAAAAAkA"
+    "AAAAAAAAAQAAAAwAAAAIAAoACQAEAAgAAAAcAAAAABAWABwAGAAUABAADAAIAAAAAAAAAAQA"
+    "FgAAAGQAAAAUAAAAFAAAABQAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAX190b3Jj"
+    "aF9fLk0uZm9yd2FyZAA="
+)
+
+
+class TestFlatbufferLoaderRobustness(TestCase):
+    def test_out_of_range_class_type_is_rejected(self):
+        buf = base64.b64decode(_MALFORMED_MODULE_B64)
+        # Must raise (bounds check in getType), not segfault.
+        with self.assertRaises(RuntimeError):
+            torch._C._load_mobile_module_from_bytes(buf)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -323,7 +323,13 @@ mobile::Module FlatbufferLoader::parseModule(
   for (const auto& f : all_functions_) {
     uint32_t class_index =
         ivalues->Get(f.first)->val_as_Function()->class_type();
-    ClassTypePtr class_type = all_types_[class_index];
+    // class_index is parsed from the (untrusted) flatbuffer and is not
+    // range-checked by VerifyModuleBuffer; validate it before indexing.
+    ClassTypePtr class_type = getType(class_index);
+    TORCH_CHECK(
+        class_type != nullptr,
+        "Parsing flatbuffer module: function references uninitialized class type at index ",
+        class_index);
     class_type->addMethod(f.second);
   }
 
@@ -744,7 +750,13 @@ void FlatbufferLoader::extractJitSourceAndConstants(
     if (f.first >= mobile_ivalue_size_) {
       uint32_t class_index =
           ivalues->Get(f.first)->val_as_Function()->class_type();
-      ClassTypePtr class_type = all_types_[class_index];
+      // See note in parseModule: class_index is untrusted and must be
+      // validated before indexing all_types_.
+      ClassTypePtr class_type = getType(class_index);
+      TORCH_CHECK(
+          class_type != nullptr,
+          "Parsing flatbuffer module: function references uninitialized class type at index ",
+          class_index);
       class_type->addMethod(f.second);
     }
   }


### PR DESCRIPTION
# Input-validation hardening: bounds-check `class_type` index in the mobile flatbuffer loader

## Summary

`torch/csrc/jit/mobile/flatbuffer_loader.cpp` parses a `class_type` index out of an
untrusted flatbuffer model and uses it to index `all_types_` via the unchecked
`std::vector::operator[]`, then immediately dereferences the result. The flatbuffer
`Verifier` (`VerifyModuleBuffer`) only checks **structural** integrity of the buffer; it
does **not** range-check this scalar against the size of the `object_types` table it is
meant to reference. A malformed `.ff` / lite model can therefore set `class_type` to an
arbitrary value, producing an out-of-bounds read of `all_types_` followed by a wild /
null pointer dereference while the file is being loaded.

This is the same missing-cross-reference-validation class that has been fixed repeatedly
in this exact file (see precedent below). It is a robustness / untrusted-input gap, not a
logic change for well-formed models.

## Affected code (current `main`, commit `038e929bfa`, 2026-06-06)

File: `torch/csrc/jit/mobile/flatbuffer_loader.cpp`

Site 1 — `FlatbufferLoader::parseModule`, lines 323–328:

```cpp
  // register functions
  for (const auto& f : all_functions_) {
    uint32_t class_index =
        ivalues->Get(f.first)->val_as_Function()->class_type();
    ClassTypePtr class_type = all_types_[class_index];   // <-- unchecked operator[]
    class_type->addMethod(f.second);                     // <-- deref of OOB/garbage ptr
  }
```

Site 2 — `FlatbufferLoader::extractJitSourceAndConstants`, lines 744–749 (same pattern,
reached via the JIT load path `parse_and_initialize_mobile_module_for_jit` →
`torch.jit.load` / `jit_module_from_flatbuffer`):

```cpp
    if (f.first >= mobile_ivalue_size_) {
      uint32_t class_index =
          ivalues->Get(f.first)->val_as_Function()->class_type();
      ClassTypePtr class_type = all_types_[class_index]; // <-- same unchecked access
      class_type->addMethod(f.second);
    }
```

`all_types_` is sized to `module->object_types()->size()` (line 305). `class_index`
originates from the `Function.class_type` field of the mobile_bytecode schema
(`torch/csrc/jit/serialization/mobile_bytecode.fbs`):

```
table Function {
  ...
  class_type:uint; // index into type table
}
```

Nothing between parsing and use constrains `class_type` to `[0, object_types size)`.

## Why the existing guard does not cover it

The file already has a *correct, bounds-checked* accessor for exactly this vector:

```cpp
ClassTypePtr getType(uint32_t pos) {
  TORCH_CHECK(pos < all_types_.size());
  return all_types_[pos];
}
```

`getType()` is used elsewhere (e.g. `getOrCreateClassTypeForObject`, line 607), but the
two function-registration loops above bypass it and index `all_types_` directly. The fix
simply routes both sites through `getType()` and adds an explicit non-null check before
the dereference (covering the in-range-but-never-initialized slot, which is a null
`ClassTypePtr`).

## Reachability

Reachable from the public, documented load APIs on an untrusted model file, before any
user code runs:

- Python: `torch._C._load_mobile_module_from_bytes(...)`,
  `torch._C._load_for_lite_interpreter[_from_buffer](...)`, `torch.jit.load(...)` /
  `torch.jit.jit_module_from_flatbuffer(...)` on a flatbuffer-format model.
- C++: `torch::jit::load`, `parse_and_initialize_mobile_module`,
  `parse_and_initialize_mobile_module_for_jit`.

All of these call `VerifyModuleBuffer` first; the crafted buffer passes verification and
still crashes, because the bug is a semantic cross-reference the verifier does not model.

## Empirical confirmation

Environment: stock CPU wheel `torch==2.7.1+cpu` (aarch64), Python 3.10. No source build.

A 176-byte module was crafted with the `flatbuffers` runtime: a single `Function` ivalue
whose `class_type = 100`, with an **empty** `object_types` table (so `all_types_.size()
== 0`). Result:

```
baseline good module loads OK
verifier/parse-info: PASSED structural verification
RESULT: child killed by signal 11 (SIGSEGV)  <-- out-of-bounds read in parseModule
```

The same crafted bytes are embedded (base64) in the regression test
`test_flatbuffer_oob_class_type.py`. On a build with this patch applied, the loader
instead raises a `c10::Error` / `RuntimeError` ("type index ... out of bounds" from
`getType`'s `TORCH_CHECK`) and the process stays alive. (The patched assertion path was
verified by code inspection — `getType` already exists and is used for the same vector —
since the sandbox cannot rebuild libtorch.)

## Precedent (same file, accepted fixes for the same bug class)

- #127437 "Validate mobile module fields parsed by flatbuffer loader" — added
  `storage_data_size` validation (fixes #127434).
- #110162 "Fix for PyTorch mobile flatbuffer loader out of bounds reads" — clamp
  `mobile_ivalue_size` against `ivalues` size.
- #108439 / #107510 / #104243 / #95221 — out-of-bounds reads / out-of-range pointer /
  corrupted-ivalue / malformed-module segfaults, all from fuzzing the flatbuffer loader.

This change continues that pattern for the one remaining unchecked index in the file.

## Severity

Memory-safety crash (OOB read → wild/null pointer dereference) when loading a malicious
model file. Denial-of-service is reliable; reading arbitrary heap memory as a
`shared_ptr<ClassType>` and dereferencing it is undefined behavior. Consistent with the
threat model behind the prior fixes (untrusted models reaching the C++ binary parsers, as
opposed to the pickle path which is code-execution-by-design).

## Disclosure

This is reported as a defensive hardening change in the same style as the accepted prior
fixes. If maintainers consider the crash sensitive, it should be handled through
PyTorch's private GitHub security advisory process rather than a public PR. The materials
here (writeup, patch, regression test) are provided so the maintainer can decide the
channel.
