### PR TITLE
c10/util/intrusive_ptr.h: add [[nodiscard]] to query methods (#186519)

### DIFF
--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <map>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -1777,7 +1778,7 @@ TEST(
     givenInvalidPtr_whenMoveAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
@@ -1823,7 +1824,7 @@ TEST(
     givenWeakOnlyPtr_whenMoveAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
@@ -1842,7 +1843,7 @@ TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
-  obj1.lock().get();
+  std::ignore = obj1.lock().get();
   obj1 = std::move(obj1);
   // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.expired());
@@ -1906,7 +1907,7 @@ TEST(
   IntrusiveAndWeak<SomeChildClass> obj1 =
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
@@ -1939,7 +1940,7 @@ TEST(
   IntrusiveAndWeak<SomeChildClass> obj1 =
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
@@ -2021,7 +2022,7 @@ TEST(
     givenInvalidPtr_whenCopyAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
@@ -2040,7 +2041,7 @@ TEST(
     givenWeakOnlyPtr_whenCopyAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
@@ -2059,7 +2060,7 @@ TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
-  obj1.lock().get();
+  std::ignore = obj1.lock().get();
   // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_TRUE(obj1.expired());
@@ -2101,7 +2102,7 @@ TEST(
   IntrusiveAndWeak<SomeChildClass> obj1 =
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
@@ -2134,7 +2135,7 @@ TEST(
   IntrusiveAndWeak<SomeChildClass> obj1 =
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
-  obj1.weak.lock().get();
+  std::ignore = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -569,7 +569,7 @@ class intrusive_ptr final {
     return *this;
   }
 
-  TTarget* get() const noexcept {
+  [[nodiscard]] TTarget* get() const noexcept {
     return target_;
   }
 
@@ -595,32 +595,32 @@ class intrusive_ptr final {
   }
 
   // We do a lot of null-pointer checks in our code, good to have this be cheap.
-  bool defined() const noexcept {
+  [[nodiscard]] bool defined() const noexcept {
     return target_ != NullType::singleton();
   }
 
-  uint32_t use_count() const noexcept {
+  [[nodiscard]] uint32_t use_count() const noexcept {
     if (target_ == NullType::singleton()) {
       return 0;
     }
     return target_->refcount(std::memory_order_relaxed);
   }
 
-  uint32_t weak_use_count() const noexcept {
+  [[nodiscard]] uint32_t weak_use_count() const noexcept {
     if (target_ == NullType::singleton()) {
       return 0;
     }
     return target_->weakcount(std::memory_order_relaxed);
   }
 
-  bool unique() const noexcept {
+  [[nodiscard]] bool unique() const noexcept {
     return use_count() == 1;
   }
 
   /**
    * Stronger than unique() in that it must not have any weakrefs as well.
    */
-  bool is_uniquely_owned() const noexcept {
+  [[nodiscard]] bool is_uniquely_owned() const noexcept {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(target_ != NullType::singleton());
     return detail::is_uniquely_owned(
         target_->combined_refcount_.load(std::memory_order_acquire));
@@ -1011,7 +1011,7 @@ class weak_intrusive_ptr final {
     return target_;
   }
 
-  uint32_t use_count() const noexcept {
+  [[nodiscard]] uint32_t use_count() const noexcept {
     if (target_ == NullType::singleton()) {
       return 0;
     }
@@ -1019,14 +1019,14 @@ class weak_intrusive_ptr final {
         std::memory_order_relaxed); // refcount, not weakcount!
   }
 
-  uint32_t weak_use_count() const noexcept {
+  [[nodiscard]] uint32_t weak_use_count() const noexcept {
     if (target_ == NullType::singleton()) {
       return 0;
     }
     return target_->weakcount(std::memory_order_relaxed);
   }
 
-  bool expired() const noexcept {
+  [[nodiscard]] bool expired() const noexcept {
     return use_count() == 0;
   }
 


### PR DESCRIPTION
Summary:

Add `[[nodiscard]]` to the pure-query methods on both `intrusive_ptr` and `weak_intrusive_ptr`. Silently discarding the result of `get()`, `defined()`, `use_count()`, `weak_use_count()`, `unique()`, `is_uniquely_owned()`, or `expired()` is always a logic error. The `get()` annotation is particularly important — calling `ptr.get()` and ignoring the return is a common mistake that this makes a compile error.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.

Reviewed By: ezyang

Differential Revision: D107127349
