### PR TITLE
Preserve SymInt bindings in dynamic-shape minifier repros

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -16,12 +16,17 @@ from torch._dynamo.repro.after_aot import (
     _get_compile_args,
     InputReader,
     InputWriter,
+    repro_common,
     repro_minify,
     repro_run,
     save_graph_repro,
 )
 from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.symbolic_shapes import (
+    find_symbol_binding_fx_nodes,
+    free_symbols,
+)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
 from torch.utils._traceback import report_compile_source_on_error
@@ -500,6 +505,29 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         derived_expr = reader.symint_exprs.get(1)
         self.assertIsNotNone(derived_expr)
         self.assertIn("//", derived_expr)
+
+    def test_save_graph_repro_uses_symbolic_placeholder_metadata(self):
+        def f(n, x):
+            return (x + 1,)
+
+        inp = torch.randn(2)
+        gm = make_fx(f, tracing_mode="symbolic")(2, inp)
+
+        buf = io.StringIO()
+        save_graph_repro(buf, gm, [2, inp], "inductor", command="get_args")
+        repro_src = buf.getvalue()
+
+        self.assertIn("reader.symint(2, expr=", repro_src)
+        self.assertIn("tracing_mode='symbolic'", repro_src)
+
+        ns = {"__name__": "not_main", "__compile_source__": repro_src}
+        exec(compile(repro_src, "<test>", "exec"), ns)
+        options = SimpleNamespace(save_dir=None, tracing_mode="symbolic")
+        repro_gm, _ = repro_common(options, ns["mod"], ns["load_args"])
+        placeholders = [n for n in repro_gm.graph.nodes if n.op == "placeholder"]
+        bindings = find_symbol_binding_fx_nodes(repro_gm.graph)
+        tensor_symbols = free_symbols(placeholders[1].meta["val"])
+        self.assertTrue(set(tensor_symbols).issubset(bindings.keys()))
 
     @unittest.skipIf(IS_FBCODE, "Subprocess spawning doesn't work in fbcode")
     def test_symint_expr_e2e_repro(self):

--- a/test/functorch/test_minifier.py
+++ b/test/functorch/test_minifier.py
@@ -4,6 +4,10 @@ import torch
 from functorch import make_fx
 from functorch.compile import minifier
 from torch._functorch.compile_utils import get_outputs, get_placeholders
+from torch.fx.experimental.symbolic_shapes import (
+    find_symbol_binding_fx_nodes,
+    free_symbols,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -67,6 +71,27 @@ class TestMinifier(TestCase):
         min_f, inps = minifier(failing_f, inps, inputs_returned)
         self.assertEqual(len(min_f.graph.nodes), 2)
         self.assertEqual(len(inps), 1)
+
+    def test_unused_symint_binding_input_preserved(self):
+        def f(n, x):
+            return x + 1
+
+        inp = torch.randn(2)
+        failing_f = make_fx(f, tracing_mode="symbolic")(2, inp)
+
+        def has_add(fx_g, inps):
+            return torch.ops.aten.add.Tensor in (i.target for i in fx_g.graph.nodes)
+
+        min_f, inps = minifier(
+            failing_f, [2, inp], has_add, dump_state=lambda fx_g, inps: None
+        )
+
+        self.assertEqual(len(inps), 2)
+        placeholders = list(get_placeholders(min_f.graph))
+        self.assertEqual(len(placeholders), 2)
+        bindings = find_symbol_binding_fx_nodes(min_f.graph)
+        tensor_symbols = free_symbols(placeholders[1].meta["val"])
+        self.assertTrue(set(tensor_symbols).issubset(bindings.keys()))
 
     def test_tup_use(self):
         def f(a, b):

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -689,10 +689,21 @@ if "__compile_source__" in globals():
     used_syms = {}
 
     # Extract from graph placeholders and their corresponding arguments
+    placeholder_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
     placeholder_targets = fx_placeholder_targets(gm)
-    for placeholder, arg in zip(placeholder_targets, args):
+    for placeholder_node, placeholder, arg in zip(
+        placeholder_nodes, placeholder_targets, args
+    ):
         if isinstance(arg, (int, torch.SymInt)):
-            writer.symint(placeholder, arg)
+            placeholder_val = placeholder_node.meta.get("val")
+            if (
+                isinstance(arg, int)
+                and isinstance(placeholder_val, torch.SymInt)
+                and placeholder_val.node.hint == arg
+            ):
+                writer.symint(placeholder, placeholder_val)
+            else:
+                writer.symint(placeholder, arg)
         elif isinstance(arg, torch.Tensor):
             # TODO: improve these names with FQN
             writer.tensor(placeholder, arg)
@@ -830,6 +841,10 @@ def save_graph_repro(
         tracing_mode = "real"
         if any(
             has_free_symbols(a) for a in args if not isinstance(a, FakeScriptObject)
+        ) or any(
+            has_free_symbols(node.meta.get(meta_name))
+            for node in gm.graph.nodes
+            for meta_name in ("val", "example_value")
         ):
             tracing_mode = "symbolic"
     fd.write("if __name__ == '__main__':\n")

--- a/torch/_functorch/fx_minifier.py
+++ b/torch/_functorch/fx_minifier.py
@@ -10,6 +10,10 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.fx as fx
+from torch.fx.experimental.symbolic_shapes import (
+    free_symbols,
+    is_symbol_binding_fx_node,
+)
 from torch.hub import tqdm
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._content_store import ContentStoreWriter
@@ -388,10 +392,36 @@ def minifier(
                 f"len(ph_nodes)={len(ph_nodes)} != len(cur_inps)={len(cur_inps)}"
             )
 
-        new_inps: list[torch.Tensor] = []
+        unused_symbol_bindings = {
+            node
+            for node in ph_nodes
+            if len(node.users) == 0 and is_symbol_binding_fx_node(node) is not None
+        }
+        needed_symbols = set()
+        for node in cur_graph.nodes:
+            if node in unused_symbol_bindings:
+                continue
+            for meta_name in ("val", "example_value"):
+                if meta_name in node.meta:
+                    needed_symbols |= set(free_symbols(node.meta[meta_name]))
+
+        bound_symbols = {
+            symbol
+            for node in ph_nodes
+            if node not in unused_symbol_bindings
+            if (symbol := is_symbol_binding_fx_node(node)) is not None
+        }
+
+        new_inps: list[Any] = []
         for idx in range(len(ph_nodes)):
-            if len(ph_nodes[idx].users) == 0:
-                cur_graph.erase_node(ph_nodes[idx])
+            ph_node = ph_nodes[idx]
+            if len(ph_node.users) == 0:
+                symbol = is_symbol_binding_fx_node(ph_node)
+                if symbol in needed_symbols and symbol not in bound_symbols:
+                    bound_symbols.add(symbol)
+                    new_inps.append(cur_inps[idx])
+                else:
+                    cur_graph.erase_node(ph_node)
             else:
                 new_inps.append(cur_inps[idx])
         if len(new_inps) < len(cur_inps):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186520

Dynamic-shape FX graphs can have SymInt placeholders whose only purpose is
to bind a symbol used by FakeTensor metadata. The minifier's unused-input
cleanup only looked at graph users, so it could erase one of these otherwise
unused SymInt placeholders while leaving tensor metadata that still referenced
the symbol. That produced invalid minified graphs with free symbols and no
binding node.

Fix this by treating symbol-binding placeholders as live when remaining node
metadata still references their symbol and no other remaining node binds it.
This keeps the minifier's graph/input invariant intact without preserving
unrelated unused inputs.

The generated after-aot repro path had the same class of metadata loss: when
called with concrete integer args for a graph whose placeholder metadata was
symbolic, it serialized the SymInt as a plain int and selected real tracing.
Use matching symbolic placeholder metadata for concrete int args, and select
symbolic tracing when graph metadata contains free symbols.

An existing local PR candidate, #185473, was checked and skipped as a duplicate:
it fixes AOTAutograd partitioner / Inductor backward SymInt binding propagation,
not fx_minifier input pruning or after_aot repro serialization.

Fixes #114296
Generated by my agent

Test Plan:
- python test/functorch/test_minifier.py -v
- python test/dynamo/test_after_aot.py -k test_save_graph_repro_uses_symbolic_placeholder_metadata -v
- python test/dynamo/test_after_aot.py -k test_symint_expr_serialized -v
- python test/dynamo/test_after_aot.py -k test_get_compile_args_e2e_symbolic_compile -v
- python test/functorch/test_minifier.py -k test_unused_symint_binding_input_preserved -v
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98