### PR TITLE
Validate conv transpose output padding

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -776,6 +776,15 @@ static void check_shape_forward(const at::Tensor& input,
                   "Given padding=", padding[i-2], " at dimension ", i-2, " , expected padding to be at most ",
                   (std::numeric_limits<T>::max() / 2));
     }
+    for (const auto i : c10::irange(params.output_padding.size())) {
+      TORCH_CHECK(
+          params.output_padding[i] < params.stride[i] || params.output_padding[i] < dilation[i],
+          "output padding must be smaller than either stride or dilation, "
+          "but got output_padding=", params.output_padding[i],
+          " stride=", params.stride[i],
+          " dilation=", dilation[i],
+          " at dimension ", i);
+    }
     if constexpr (std::is_same_v<T, c10::SymInt>) {
       TORCH_SYM_CHECK(at::symint::size<T>(input, 1).sym_eq(weight_sizes[0]),
                "Given transposed=", transposed, ", weight of size ", weight_sizes,

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -447,14 +447,10 @@ class CPUReproTests(TestCase):
 
         with torch.no_grad():
             compiled_m = torch.compile(m)
-            # The cpp_wrapper C-shim can't utilize the Python error API, so error
-            # messages are printed to stderr directly, and the intercepted RuntimeError
-            # is significantly less verbose.
-            msg = (
-                r"aoti_torch_cpu_convolution\(.*\) API call failed"
-                if config.cpp_wrapper
-                else "output padding must be smaller than either stride or dilation"
-            )
+            # The shared conv shape check rejects the invalid output_padding at
+            # trace time (via the FakeTensor conv impl), so the error is the
+            # same regardless of cpp_wrapper.
+            msg = "output padding must be smaller than either stride or dilation"
             with self.assertRaisesRegex(RuntimeError, msg):
                 compiled_m(input)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4077,6 +4077,21 @@ def sample_inputs_conv_transpose3d(op_info, device, dtype, requires_grad, **kwar
         ), kwargs=kwargs)
 
 
+def error_inputs_conv_transpose(opinfo, device, *, dim, **kwargs):
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+    error_regex = "output padding must be smaller than either stride or dilation"
+
+    # error inputs for output_padding not smaller than either stride or dilation
+    yield ErrorInput(
+        SampleInput(make_arg((1, 1) + (4,) * dim), args=(make_arg((1, 1) + (3,) * dim),),
+                    kwargs={'stride': 2, 'output_padding': 2}),
+        error_regex=error_regex)
+    yield ErrorInput(
+        SampleInput(make_arg((0, 1) + (4,) * dim), args=(make_arg((1, 1) + (3,) * dim),),
+                    kwargs={'stride': 2, 'output_padding': 2}),
+        error_regex=error_regex)
+
+
 def sample_inputs_conv1d(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -16591,6 +16606,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.chalf,
                                                        torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose1d,
+           error_inputs_func=partial(error_inputs_conv_transpose, dim=1),
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
@@ -16642,6 +16658,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.chalf,
                                                        torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose2d,
+           error_inputs_func=partial(error_inputs_conv_transpose, dim=2),
            # Runs very slowly on slow-gradcheck for complex.
            gradcheck_fast_mode=True,
            supports_forward_ad=True,
@@ -16696,6 +16713,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(
                torch.float16, torch.chalf, torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose3d,
+           error_inputs_func=partial(error_inputs_conv_transpose, dim=3),
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,


### PR DESCRIPTION
Fixes #169236.

## Summary
- Move conv transpose `output_padding` validation into the shared transposed convolution shape check.
- Cover invalid `output_padding` for both non-empty and empty inputs through OpInfo error inputs.
- Update the Inductor repro expectation now that FakeTensor tracing sees the shared error message.

## Test Plan
- `git diff --check`
- `source .venv/bin/activate && python test/test_ops.py -k test_errors_nn_functional_conv_transpose`
- `source .venv/bin/activate && python test/test_mps.py TestErrorInputsMPS -k conv_transpose`
- `source .venv/bin/activate && lintrunner -a`

Manual CPU/MPS canaries covered empty invalid inputs, valid dilation inputs, and `torch.compile` with `cpp_wrapper` on and off.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo