### PR TITLE
docs: fix wording in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1236,7 +1236,7 @@ useful for debugging memory errors in C++. We run it in CI, but here's how to
 get the same thing to run on your local machine.
 
 First, install LLVM 8. The easiest way is to get [prebuilt
-binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to
+binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to a
 folder (later called `$LLVM_ROOT`).
 
 Then set up the appropriate scripts. You can put this in your `.bashrc`:


### PR DESCRIPTION
### Description

Fixed a minor typo in `CONTRIBUTING.md` under the 'Building PyTorch with ASAN' section. 

* **Current:** "extract them to folder"
* **Fixed:** "extract them to a folder"

Fixes #186511

### Context
CC @svekars @sekyondaMeta @AlannaBurke