### PR TITLE
MPS: add SDPA fused backend choice for native prefill attention

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -1,5 +1,6 @@
 #include <string>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/ExpandUtils.h>
 #include <fmt/format.h>
 #include <iostream>
 #include <optional>
@@ -13,6 +14,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_fused_sdp_choice_native.h>
 #include <ATen/ops/_scaled_dot_product_attention_math_for_mps_native.h>
 #include <ATen/ops/empty_native.h>
 #endif
@@ -543,6 +545,224 @@ inline bool prefill_attention_supports_head_dim(int64_t head_dim) {
 
 } // namespace
 
+static bool prefill_attention_disabled() {
+  static const bool disabled = []() {
+    auto val = c10::utils::get_env("PYTORCH_MPS_DISABLE_PREFILL_ATTENTION");
+    return val.has_value() && val != "0";
+  }();
+  return disabled;
+}
+
+static bool mps_prefill_inputs_require_grad(const Tensor& query,
+                                            const Tensor& key,
+                                            const Tensor& value,
+                                            const std::optional<Tensor>& attn_mask) {
+  const bool any_inputs_require_grad =
+      query.requires_grad() || key.requires_grad() || value.requires_grad() ||
+      (attn_mask.has_value() && attn_mask->requires_grad());
+  return any_inputs_require_grad && at::GradMode::is_enabled();
+}
+
+static bool mps_prefill_leading_batch_dims_broadcastable(const Tensor& query, const Tensor& key, const Tensor& value) {
+  auto dims_broadcast_to_query = [](IntArrayRef query_dims, IntArrayRef other_dims) {
+    if (other_dims.size() > query_dims.size()) {
+      return false;
+    }
+    const auto offset = query_dims.size() - other_dims.size();
+    for (const auto i : c10::irange(other_dims.size())) {
+      const auto query_size = query_dims[offset + i];
+      const auto other_size = other_dims[i];
+      if (other_size != 1 && other_size != query_size) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const auto q_batch_dims = query.sizes().slice(0, query.dim() - 3);
+  return dims_broadcast_to_query(q_batch_dims, key.sizes().slice(0, key.dim() - 3)) &&
+      dims_broadcast_to_query(q_batch_dims, value.sizes().slice(0, value.dim() - 3));
+}
+
+static bool mps_leading_batch_dims_broadcastable(const Tensor& query, const Tensor& key, const Tensor& value) {
+  auto dims_broadcastable = [](IntArrayRef a, IntArrayRef b) {
+    const auto ndim = std::max(a.size(), b.size());
+    for (const auto i : c10::irange(ndim)) {
+      const auto a_size = i < a.size() ? a[a.size() - 1 - i] : 1;
+      const auto b_size = i < b.size() ? b[b.size() - 1 - i] : 1;
+      if (a_size != b_size && a_size != 1 && b_size != 1) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const auto q_batch_dims = query.sizes().slice(0, query.dim() - 3);
+  const auto k_batch_dims = key.sizes().slice(0, key.dim() - 3);
+  const auto v_batch_dims = value.sizes().slice(0, value.dim() - 3);
+  return dims_broadcastable(q_batch_dims, k_batch_dims) && dims_broadcastable(q_batch_dims, v_batch_dims) &&
+      dims_broadcastable(k_batch_dims, v_batch_dims);
+}
+
+static Tensor mps_expand_to_leading_batch_shape(const Tensor& tensor, IntArrayRef leading_batch_shape) {
+  std::vector<int64_t> expand_shape(leading_batch_shape.begin(), leading_batch_shape.end());
+  expand_shape.insert(expand_shape.end(), {tensor.size(-3), tensor.size(-2), tensor.size(-1)});
+  if (tensor.sizes().vec() == expand_shape) {
+    return tensor;
+  }
+  auto expanded = tensor.expand(expand_shape);
+  return tensor.dim() > 4 ? expanded.contiguous() : expanded;
+}
+
+static std::tuple<Tensor, Tensor, Tensor> mps_broadcast_leading_batch_dims(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value) {
+  const auto q_batch_dims = query.sizes().slice(0, query.dim() - 3);
+  const auto k_batch_dims = key.sizes().slice(0, key.dim() - 3);
+  const auto v_batch_dims = value.sizes().slice(0, value.dim() - 3);
+  auto leading_batch_shape = at::infer_size(q_batch_dims, k_batch_dims);
+  leading_batch_shape = at::infer_size(IntArrayRef(leading_batch_shape), v_batch_dims);
+  return {
+      mps_expand_to_leading_batch_shape(query, leading_batch_shape),
+      mps_expand_to_leading_batch_shape(key, leading_batch_shape),
+      mps_expand_to_leading_batch_shape(value, leading_batch_shape)};
+}
+
+static bool can_use_mps_prefill_attention(const Tensor& query,
+                                          const Tensor& key,
+                                          const Tensor& value,
+                                          const std::optional<Tensor>& attn_mask,
+                                          double dropout,
+                                          bool is_causal,
+                                          bool enable_gqa) {
+  if (prefill_attention_disabled() || dropout != 0.0 ||
+      mps_prefill_inputs_require_grad(query, key, value, attn_mask)) {
+    return false;
+  }
+
+  if (query.is_nested() || key.is_nested() || value.is_nested()) {
+    return false;
+  }
+
+  if (query.dim() < 3 || key.dim() < 3 || value.dim() < 3) {
+    return false;
+  }
+
+  if (is_causal && attn_mask.has_value()) {
+    return false;
+  }
+
+  if (!mps_prefill_leading_batch_dims_broadcastable(query, key, value)) {
+    return false;
+  }
+
+  if (!(query.scalar_type() == key.scalar_type() && query.scalar_type() == value.scalar_type())) {
+    return false;
+  }
+
+  const auto dtype = query.scalar_type();
+  const bool prefill_supported_dtype = dtype == at::kFloat || dtype == at::kHalf || dtype == at::kBFloat16;
+  if (!prefill_supported_dtype) {
+    return false;
+  }
+
+  auto query_tuple = ensure_4d(query);
+  Tensor q = std::get<0>(query_tuple);
+  Tensor k = std::get<0>(ensure_4d(key));
+  Tensor v = std::get<0>(ensure_4d(value));
+
+  if (q.size(0) != k.size(0) || q.size(0) != v.size(0)) {
+    return false;
+  }
+
+  const auto q_heads = q.size(1);
+  const auto k_heads = k.size(1);
+  const auto v_heads = v.size(1);
+  if (k_heads == 0 || k_heads != v_heads) {
+    return false;
+  }
+  if (enable_gqa) {
+    if (q_heads % k_heads != 0) {
+      return false;
+    }
+  } else if (q_heads != k_heads) {
+    return false;
+  }
+
+  const auto query_head_dim = q.size(3);
+  const auto key_head_dim = k.size(3);
+  const auto value_head_dim = v.size(3);
+  const bool prefill_head_dim_supported =
+      query_head_dim == key_head_dim && query_head_dim == value_head_dim &&
+      prefill_attention_supports_head_dim(query_head_dim);
+  const bool prefill_q_long_enough = q.size(2) > 8;
+  const bool key_seq_nonzero = k.size(2) > 0;
+  if (!prefill_head_dim_supported || !prefill_q_long_enough || !key_seq_nonzero) {
+    return false;
+  }
+
+  if (attn_mask) {
+    auto maskExpandedDims = query.sizes().vec();
+    maskExpandedDims[maskExpandedDims.size() - 1] = k.size(2);
+    Tensor mask = attn_mask->expand(maskExpandedDims);
+    std::tie(mask, std::ignore) = ensure_4d(mask);
+    if (!(mask.scalar_type() == at::kBool || mask.scalar_type() == dtype)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool can_use_mps_prefill_attention(sdp::sdp_params const& params) {
+  return can_use_mps_prefill_attention(
+      params.query,
+      params.key,
+      params.value,
+      params.attn_mask,
+      params.dropout,
+      params.is_causal,
+      params.enable_gqa);
+}
+
+static sdp::SDPBackend select_sdp_backend_mps(sdp::sdp_params const& params) {
+  auto& ctx = at::globalContext();
+  if (!ctx.userEnabledMathSDP() && !ctx.userEnabledFlashSDP()) {
+    return sdp::SDPBackend::error;
+  }
+
+  if (ctx.userEnabledFlashSDP() && can_use_mps_prefill_attention(params)) {
+    // MPS maps its existing native prefill attention route onto the public
+    // Flash backend selector only for supported forward inference cases. The
+    // eligibility gate above rejects dropout and grad-requiring inputs until an
+    // MPS training-capable fused attention path exists.
+    return sdp::SDPBackend::flash_attention;
+  }
+
+  if (ctx.userEnabledMathSDP()) {
+    return sdp::SDPBackend::math;
+  }
+
+  return sdp::SDPBackend::error;
+}
+
+int64_t _fused_sdp_choice_mps(const Tensor& query,
+                              const Tensor& key,
+                              const Tensor& value,
+                              const std::optional<Tensor>& attn_mask,
+                              double dropout_p,
+                              bool is_causal,
+                              std::optional<double> scale,
+                              bool enable_gqa) {
+  sdp::sdp_params params{query, key, value, attn_mask, dropout_p, is_causal, enable_gqa};
+  auto backend = select_sdp_backend_mps(params);
+  if (backend == sdp::SDPBackend::error) {
+    TORCH_CHECK(false,
+                "No viable backend for scaled_dot_product_attention was found. ",
+                "This is likely due to turning off both the math kernel and the fused kernels.");
+  }
+  return static_cast<int64_t>(backend);
+}
+
 static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
                                                    const Tensor& k_,
                                                    const Tensor& v_,
@@ -714,27 +934,39 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
                 "For GQA, the query tensor's head dimension (" + std::to_string(q_heads) +
                     ") must be divisible by the key tensor's head dimension (" + std::to_string(k_heads) + ").");
   }
+  TORCH_CHECK(
+      mps_leading_batch_dims_broadcastable(query, key_, value_),
+      "Expected query, key, and value leading batch dimensions to be broadcastable.");
 
-  auto query_tuple = ensure_4d(query);
+  auto [query_expanded, key_expanded, value_expanded] = mps_broadcast_leading_batch_dims(query, key_, value_);
+
+  auto query_tuple = ensure_4d(query_expanded);
   Tensor q_ = std::get<0>(query_tuple);
   bool unsqueezed = std::get<1>(query_tuple);
 
-  auto key_tuple = ensure_4d(key_);
+  auto key_tuple = ensure_4d(key_expanded);
   Tensor k_ = std::get<0>(key_tuple);
 
-  auto value_tuple = ensure_4d(value_);
+  auto value_tuple = ensure_4d(value_expanded);
   Tensor v_ = std::get<0>(value_tuple);
 
   std::optional<Tensor> mask_;
   if (attn_mask) {
-    auto maskExpandedDims = query.sizes().vec();
+    auto maskExpandedDims = query_expanded.sizes().vec();
     maskExpandedDims[maskExpandedDims.size() - 1] = k_.size(2);
     mask_ = attn_mask->expand(maskExpandedDims);
     std::tie(*mask_, std::ignore) = ensure_4d(*mask_);
   }
 
   int query_head_dim = q_.size(3);
+  int key_head_dim = k_.size(3);
   int value_head_dim = v_.size(3);
+  TORCH_CHECK(
+      query_head_dim == key_head_dim,
+      "Expected query and key to have the same head dimension, but got query.size(-1) = ",
+      query_head_dim,
+      " and key.size(-1) = ",
+      key_head_dim);
 
   // For a vector fast implementation support {64, 96, 128, 256} and for full support {64, 80, 128} head_dims
   bool sdpa_vector_supported_head_dim = (query_head_dim == value_head_dim) &&
@@ -752,31 +984,12 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   // boolean to decide if we can use kernel paths
   bool supports_fast_sdpa = supports_sdpa_vector && !(is_causal && mask_.has_value());
 
-  // Prefill kernel: long-Q path. Requires Q/K/V to share the same
-  // head dim, the head dim to be one of the instantiated shapes, the dtype to
-  // be float/half/bfloat, and any mask to be either bool or matching the
-  // query dtype. Set PYTORCH_MPS_DISABLE_PREFILL_ATTENTION=1 to fall back to
-  // MPSGraph for benchmarking / debugging.
-  static const bool prefill_attention_disabled = []() {
-    auto val = c10::utils::get_env("PYTORCH_MPS_DISABLE_PREFILL_ATTENTION");
-    return val.has_value() && val != "0";
-  }();
-  bool prefill_supported_dtype =
-      q_.scalar_type() == at::kFloat || q_.scalar_type() == at::kHalf || q_.scalar_type() == at::kBFloat16;
-  bool prefill_mask_compatible =
-      !mask_.has_value() || (mask_.value().dtype() == at::kBool || mask_.value().dtype() == q_.dtype());
-  bool prefill_head_dim_supported =
-      (query_head_dim == value_head_dim) && prefill_attention_supports_head_dim(query_head_dim);
-  // For very short Q (qL <= 8) the BQ=16/32 prefill tile is mostly empty and
-  // the existing MPSGraph fallback gives similar throughput with tighter
-  // numerical accuracy at small head counts. Skip prefill there so we don't
-  // regress the existing decode-style tests.
-  bool prefill_q_long_enough = query_seq_len > 8;
-  bool supports_prefill = !prefill_attention_disabled && !supports_fast_sdpa && prefill_supported_dtype &&
-      prefill_mask_compatible && prefill_head_dim_supported && prefill_q_long_enough && (k_.size(2) > 0);
+  bool supports_prefill = !supports_fast_sdpa &&
+      can_use_mps_prefill_attention(query, key_, value_, attn_mask, dropout_p, is_causal, enable_gqa);
 
   if (!supports_fast_sdpa && !supports_prefill) {
-    return sdpa_general_mps(q_, k_, v_, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+    return sdpa_general_mps(
+        q_, k_, v_, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   }
 
   // Kernels load head-dim elements linearly, so stride(-1) == 1 is the only hard requirement
@@ -787,17 +1000,19 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   Tensor v_contig = can_use_kernel_strides(v_) ? v_ : v_.contiguous();
 
   if (supports_prefill) {
-    return sdpa_prefill_mps(q_contig, k_contig, v_contig, mask_, is_causal, scale, query, unsqueezed);
+    return sdpa_prefill_mps(q_contig, k_contig, v_contig, mask_, is_causal, scale, query_expanded, unsqueezed);
   }
 
   // for short sequences, differentiate based on key sequence length
   if ((k_.size(2) >= 1024) || (k_.size(1) < q_.size(1) && k_.size(2) >= 4096)) {
     return sdpa_vector_2pass_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   } else {
     return sdpa_vector_fast_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   }
 }
+
+REGISTER_MPS_DISPATCH(_fused_sdp_choice_stub, &_fused_sdp_choice_mps)
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14788,6 +14788,7 @@
     Meta: _fused_sdp_choice_meta
     CPU, NestedTensorCPU: _fused_sdp_choice_cpp
     CUDA, NestedTensorCUDA: _fused_sdp_choice_cuda
+    MPS: _fused_sdp_choice_mps
     XPU: _fused_sdp_choice_xpu
   tags: nondeterministic_seeded
 

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -744,13 +744,25 @@ Tensor scaled_dot_product_attention(
     auto out = at::zeros_symint(output_shape, query_.options());
     return out + (query_.sum() + key.sum() + value.sum()) * 0;
   }
+  const auto query_device_type = query_.device().type();
   int64_t choice_int = static_cast<int64_t>(sdp::SDPBackend::math);
-  if (_fused_sdp_choice_stub.is_device_supported(query_.device().type())) {
-    choice_int = _fused_sdp_choice_stub(query_.device().type(),
+  const bool has_symbolic_mps_inputs = query_device_type == c10::kMPS &&
+      (query_.unsafeGetTensorImpl()->has_symbolic_sizes_strides() ||
+       key.unsafeGetTensorImpl()->has_symbolic_sizes_strides() ||
+       value.unsafeGetTensorImpl()->has_symbolic_sizes_strides());
+  if (has_symbolic_mps_inputs) {
+    TORCH_CHECK(
+        at::globalContext().userEnabledMathSDP(),
+        "No viable backend for scaled_dot_product_attention was found. ",
+        "This is likely due to turning off both the math kernel and the fused kernels.");
+  } else if (_fused_sdp_choice_stub.is_device_supported(query_device_type)) {
+    choice_int = _fused_sdp_choice_stub(query_device_type,
           query_, key, value, attn_mask_, dropout_p, is_causal, scale, enable_gqa);
   }
-  const auto query_device_type = query_.device().type();
   const auto backend = static_cast<SDPBackend>(choice_int);
+  const bool any_inputs_require_grad =
+      query_.requires_grad() || key.requires_grad() || value.requires_grad() ||
+      (attn_mask_.has_value() && attn_mask_->requires_grad());
   auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
   switch (backend) {
     case SDPBackend::cudnn_attention: {
@@ -760,6 +772,22 @@ Tensor scaled_dot_product_attention(
       return std::get<0>(out_lse_softmax);
     }
     case SDPBackend::flash_attention: {
+      if (query_device_type == c10::kMPS && !(at::GradMode::is_enabled() && any_inputs_require_grad)) {
+        return std::get<0>(at::_scaled_dot_product_attention_math_for_mps(
+            query_,
+            key,
+            value,
+            attn_mask,
+            dropout_p,
+            is_causal,
+            std::nullopt, /*dropout_mask*/
+            scale,
+            enable_gqa));
+      }
+      TORCH_CHECK(
+          query_device_type != c10::kMPS,
+          "MPS flash attention is only available for forward inference inputs; ",
+          "grad-requiring MPS inputs must use the math backend.");
       if(query_device_type == DeviceType::CUDA ||
          query_device_type == DeviceType::XPU) {
         c10::SymInt og_size = query_.sym_size(-1);
@@ -792,7 +820,6 @@ Tensor scaled_dot_product_attention(
       return std::get<0>(out_lse_softmax);
     }
     case SDPBackend::math: {
-      const bool any_inputs_require_grad = query_.requires_grad() || key.requires_grad() || value.requires_grad();
       if (query_device_type == c10::kMPS && !(at::GradMode::is_enabled() && any_inputs_require_grad)) {
         return std::get<0>(at::_scaled_dot_product_attention_math_for_mps(
             query_,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -17,7 +17,13 @@ from unittest.mock import patch, MagicMock, ANY
 import math
 import itertools
 import torch.optim as optim
-from torch.testing._internal.common_device_type import expectedFailureMPS, instantiate_device_type_tests, onlyCUDA, largeTensorTest
+from torch.testing._internal.common_device_type import (
+    expectedFailureMPS,
+    instantiate_device_type_tests,
+    onlyCUDA,
+    onlyMPS,
+    largeTensorTest,
+)
 import torch.utils.cpp_extension
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
@@ -1612,6 +1618,267 @@ class TestSDPAFailureModes(NNTestCase):
             self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
                                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
 
+    @onlyMPS
+    def test_fused_sdp_choice_mps_prefill_flash(self, device):
+        torch.manual_seed(0)
+        dtype = torch.float16
+        size = (1, 2, 16, 64)
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+
+        self.assertEqual(torch._fused_sdp_choice(q, k, v), SDPBackend.FLASH_ATTENTION.value)
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.mps.synchronize()
+        self.assertEqual(out.device.type, "mps")
+        self.assertTrue(torch.isfinite(out).all().item())
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_prefill_flash_matches_math(self, device):
+        torch.manual_seed(0)
+        dtype = torch.float16
+        cases = []
+
+        q = torch.randn((1, 4, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        v = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        cases.append((q, k, v, None, {"is_causal": True, "scale": 0.5, "enable_gqa": True}))
+
+        q = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        v = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        attn_mask = torch.zeros((1, 2, 16, 16), device=device, dtype=dtype)
+        attn_mask[..., 8:] = -3.0
+        cases.append((q, k, v, attn_mask, {"attn_mask": attn_mask, "scale": 0.75}))
+
+        for q, k, v, attn_mask, kwargs in cases:
+            self.assertEqual(torch._fused_sdp_choice(
+                q, k, v, attn_mask, 0.0, kwargs.get("is_causal", False),
+                scale=kwargs.get("scale"), enable_gqa=kwargs.get("enable_gqa", False)),
+                SDPBackend.FLASH_ATTENTION.value)
+            with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+                flash_out = torch.nn.functional.scaled_dot_product_attention(q, k, v, **kwargs)
+            torch.mps.synchronize()
+            cpu_kwargs = dict(kwargs)
+            if attn_mask is not None:
+                cpu_kwargs["attn_mask"] = attn_mask.cpu()
+            cpu_out = torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu(), **cpu_kwargs)
+            torch.testing.assert_close(flash_out.cpu(), cpu_out, atol=2e-2, rtol=2e-2)
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_flash_only_rejects_prefill_ineligible(self, device):
+        dtype = torch.float16
+
+        def make_qkv(size, requires_grad=False):
+            return tuple(torch.randn(size, device=device, dtype=dtype, requires_grad=requires_grad)
+                         for _ in range(3))
+
+        cases = [
+            (*make_qkv((1, 2, 8, 64)), {}),
+            (*make_qkv((1, 2, 16, 23)), {}),
+            (*make_qkv((1, 2, 16, 64)), {"dropout_p": 0.1}),
+            (*make_qkv((1, 2, 16, 64), requires_grad=True), {}),
+        ]
+
+        for q, k, v, kwargs in cases:
+            dropout_p = kwargs.get("dropout_p", 0.0)
+            is_causal = kwargs.get("is_causal", False)
+            self.assertEqual(
+                torch._fused_sdp_choice(q, k, v, kwargs.get("attn_mask"), dropout_p, is_causal),
+                SDPBackend.MATH.value)
+            with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No viable backend for scaled_dot_product_attention was found.",
+                    lambda: torch._fused_sdp_choice(q, k, v, kwargs.get("attn_mask"), dropout_p, is_causal))
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No viable backend for scaled_dot_product_attention was found.",
+                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v, **kwargs))
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_flash_only_rejects_prefill_shape_contract(self, device):
+        dtype = torch.float32
+        cases = [
+            (
+                torch.randn((1, 2, 16, 64), device=device, dtype=dtype),
+                torch.randn((1, 2, 16, 32), device=device, dtype=dtype),
+                torch.randn((1, 2, 16, 64), device=device, dtype=dtype),
+                {},
+            ),
+            (
+                torch.randn((1, 4, 16, 64), device=device, dtype=dtype),
+                torch.randn((1, 2, 16, 64), device=device, dtype=dtype),
+                torch.randn((1, 3, 16, 64), device=device, dtype=dtype),
+                {"enable_gqa": False},
+            ),
+            (
+                torch.randn((2, 2, 16, 64), device=device, dtype=dtype),
+                torch.randn((1, 2, 16, 64), device=device, dtype=dtype),
+                torch.randn((2, 2, 16, 64), device=device, dtype=dtype),
+                {},
+            ),
+        ]
+
+        for q, k, v, kwargs in cases:
+            self.assertEqual(
+                torch._fused_sdp_choice(q, k, v, enable_gqa=kwargs.get("enable_gqa", False)),
+                SDPBackend.MATH.value)
+            with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No viable backend for scaled_dot_product_attention was found.",
+                    lambda: torch._fused_sdp_choice(q, k, v, enable_gqa=kwargs.get("enable_gqa", False)))
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No viable backend for scaled_dot_product_attention was found.",
+                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v, **kwargs))
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_default_rejects_prefill_shape_contract(self, device):
+        dtype = torch.float32
+
+        q = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((1, 2, 16, 32), device=device, dtype=dtype)
+        v = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        self.assertEqual(torch._fused_sdp_choice(q, k, v), SDPBackend.MATH.value)
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu()))
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
+
+        q = torch.randn((2, 2, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        v = torch.randn((2, 2, 16, 64), device=device, dtype=dtype)
+        self.assertEqual(torch._fused_sdp_choice(q, k, v), SDPBackend.MATH.value)
+        mps_out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.mps.synchronize()
+        cpu_out = torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu())
+        torch.testing.assert_close(mps_out.cpu(), cpu_out, atol=2e-4, rtol=2e-4)
+
+        q = torch.randn((1, 2, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((2, 2, 16, 64), device=device, dtype=dtype)
+        v = torch.randn((2, 2, 16, 64), device=device, dtype=dtype)
+        self.assertEqual(torch._fused_sdp_choice(q, k, v), SDPBackend.MATH.value)
+        mps_out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.mps.synchronize()
+        cpu_out = torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu())
+        torch.testing.assert_close(mps_out.cpu(), cpu_out, atol=2e-4, rtol=2e-4)
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_rejects_nonbroadcastable_same_product_batch(self, device):
+        dtype = torch.float32
+        q = torch.randn((2, 3, 2, 16, 64), device=device, dtype=dtype)
+        k = torch.randn((3, 2, 2, 16, 64), device=device, dtype=dtype)
+        v = torch.randn((3, 2, 2, 16, 64), device=device, dtype=dtype)
+
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu()))
+        self.assertEqual(torch._fused_sdp_choice(q, k, v), SDPBackend.MATH.value)
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch._fused_sdp_choice(q, k, v))
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_rank5_singleton_batch_broadcast(self, device):
+        code = """
+import torch
+import torch.nn.functional as F
+torch.manual_seed(0)
+shapes = [
+    ((1, 3, 2, 16, 64), (2, 3, 2, 16, 64), (2, 3, 2, 16, 64)),
+    ((2, 3, 2, 16, 64), (1, 3, 2, 16, 64), (1, 3, 2, 16, 64)),
+]
+for q_shape, k_shape, v_shape in shapes:
+    q = torch.randn(q_shape, device="mps")
+    k = torch.randn(k_shape, device="mps")
+    v = torch.randn(v_shape, device="mps")
+    choice = torch._fused_sdp_choice(q, k, v)
+    assert choice == torch.nn.attention.SDPBackend.MATH.value, choice
+    mps_out = F.scaled_dot_product_attention(q, k, v)
+    torch.mps.synchronize()
+    cpu_out = F.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(mps_out.cpu(), cpu_out, atol=2e-4, rtol=2e-4)
+print("RANK5_OK")
+"""
+        stdout, stderr = self.run_process_no_exception(code)
+        output = (stdout + stderr).decode("utf-8", errors="replace")
+        self.assertIn("RANK5_OK", output)
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_rejects_grad_mask_prefill(self, device):
+        dtype = torch.float32
+        size = (1, 2, 16, 64)
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+        attn_mask = torch.zeros((1, 2, 16, 16), device=device, dtype=dtype, requires_grad=True)
+
+        self.assertEqual(torch._fused_sdp_choice(q, k, v, attn_mask), SDPBackend.MATH.value)
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch._fused_sdp_choice(q, k, v, attn_mask))
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask))
+
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+        self.assertTrue(out.requires_grad)
+        out.sum().backward()
+        torch.mps.synchronize()
+        self.assertIsNotNone(attn_mask.grad)
+        self.assertTrue(torch.isfinite(attn_mask.grad).all().item())
+
+    @onlyMPS
+    def test_fused_sdp_choice_mps_flash_only_rejects_causal_with_explicit_mask(self, device):
+        dtype = torch.float16
+        size = (1, 2, 16, 64)
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+        attn_mask = torch.ones((16, 16), device=device, dtype=torch.bool).tril()
+
+        self.assertEqual(
+            torch._fused_sdp_choice(q, k, v, attn_mask, 0.0, True),
+            SDPBackend.MATH.value)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Explicit attn_mask should not be set when is_causal=True",
+            lambda: torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=True))
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch._fused_sdp_choice(q, k, v, attn_mask, 0.0, True))
+            self.assertRaisesRegex(
+                RuntimeError,
+                "No viable backend for scaled_dot_product_attention was found.",
+                lambda: torch.nn.functional.scaled_dot_product_attention(
+                    q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=True))
+
+    @onlyMPS
+    def test_dispatch_fails_no_backend_with_mps_chooser(self, device):
+        dtype = torch.float16
+        size = (1, 2, 16, 64)
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+
+        with sdpa_kernel(backends=[SDPBackend.ERROR]):
+            self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
+                                   lambda: torch._fused_sdp_choice(q, k, v))
+            self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
+                                   lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
+
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
     @parametrize(
@@ -2361,6 +2628,63 @@ class TestSDPA(NNTestCase):
 
         # Should not crash during export with unbacked symbolic mask batch dim
         torch.export.export(model, args=(x,))
+
+    @onlyMPS
+    def test_sdpa_export_prefill_eligible_mps_public_api(self, device):
+        """Public MPS SDPA export should not run the concrete-size chooser on symbolic inputs."""
+
+        class Model(nn.Module):
+            def forward(self, q, k, v):
+                return F.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=False)
+
+        model = Model().eval().to(device)
+        seq = torch.export.Dim("seq", min=9, max=64)
+        q = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+        k = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+        v = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+
+        ep = torch.export.export(
+            model,
+            args=(q, k, v),
+            dynamic_shapes={"q": {2: seq}, "k": {2: seq}, "v": {2: seq}},
+            strict=True,
+        )
+
+        q2 = torch.randn(1, 4, 24, 64, device=device, dtype=torch.float32)
+        k2 = torch.randn(1, 4, 24, 64, device=device, dtype=torch.float32)
+        v2 = torch.randn(1, 4, 24, 64, device=device, dtype=torch.float32)
+        out = ep.module()(q2, k2, v2)
+        torch.mps.synchronize()
+        self.assertEqual(out.shape, (1, 4, 24, 64))
+        self.assertEqual(out.device.type, "mps")
+        self.assertTrue(torch.isfinite(out).all().item())
+
+    @onlyMPS
+    def test_sdpa_export_forced_error_mps_public_api(self, device):
+        class Model(nn.Module):
+            def forward(self, q, k, v):
+                with sdpa_kernel(backends=[SDPBackend.ERROR]):
+                    return F.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=False)
+
+        model = Model().eval().to(device)
+        seq = torch.export.Dim("seq", min=9, max=64)
+        q = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+        k = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+        v = torch.randn(1, 4, 16, 64, device=device, dtype=torch.float32)
+
+        try:
+            ep = torch.export.export(
+                model,
+                args=(q, k, v),
+                dynamic_shapes={"q": {2: seq}, "k": {2: seq}, "v": {2: seq}},
+                strict=True,
+            )
+        except RuntimeError as exc:
+            self.assertIn("No viable backend for scaled_dot_product_attention was found.", str(exc))
+            return
+
+        with self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found."):
+            ep.module()(q, k, v)
 
 class TestSDPACpuOnly(NNTestCase):
     """ Used to test CPU only functionality of scaled_dot_product_attention """


### PR DESCRIPTION
## Summary

Add an MPS dispatch for `_fused_sdp_choice` so eligible forward-inference MPS SDPA prefill rows are reported through PyTorch's existing fused SDPA backend choice.

This makes MPS SDPA backend control more truthful for the supported native prefill path: eligible rows can be selected as `SDPBackend.FLASH_ATTENTION`, ineligible Flash-only rows fail instead of silently running Math, and forced `SDPBackend.ERROR` fails closed for concrete MPS inputs.

For MPS, `SDPBackend.FLASH_ATTENTION` here means the supported native MPS prefill attention path exposed through PyTorch's existing fused backend enum. This PR does not add a new Metal FlashAttention kernel and does not claim CUDA FlashAttention feature parity, dropout/backward support, or broad training support. Forced `SDPBackend.MATH` continues to use the existing MPS math SDPA entry point, which may internally choose MPS kernels including native prefill for eligible rows.

## Changes

- Add MPS `_fused_sdp_choice` dispatch registration.
- Share a strict MPS native-prefill eligibility predicate between chooser and public MPS SDPA execution.
- Route forced/selected MPS fused attention through the existing native MPS prefill path only for supported forward-inference rows.
- Make forced Flash reject unsupported MPS rows instead of silently falling back to Math.
- Make forced Error fail closed for concrete MPS SDPA inputs.
- Preserve symbolic/export-oriented MPS SDPA behavior while respecting disabled Math / forced Error policy.
- Add regression coverage for forced-backend behavior, unsupported shape/mask/grad cases, symbolic export policy, and rank/broadcast edge cases.

## Verification

Local verification:

- `python test/test_transformers.py TestSDPAMPS.test_sdpa_export_prefill_eligible_mps_public_api_mps TestSDPAMPS.test_sdpa_export_forced_error_mps_public_api_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_prefill_flash_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_prefill_flash_matches_math_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_flash_only_rejects_prefill_ineligible_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_flash_only_rejects_prefill_shape_contract_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_default_rejects_prefill_shape_contract_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_rejects_nonbroadcastable_same_product_batch_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_rank5_singleton_batch_broadcast_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_rejects_grad_mask_prefill_mps TestSDPAFailureModesMPS.test_fused_sdp_choice_mps_flash_only_rejects_causal_with_explicit_mask_mps TestSDPAFailureModesMPS.test_dispatch_fails_no_backend_with_mps_chooser_mps -v` passed: `Ran 12 tests`, `OK`.
- `python test/test_transformers.py TestSDPAFailureModesMPS -v` passed: `Ran 52 tests`, `OK (skipped=33)`.
- `git diff --check` passed.
