### PR TITLE
Remove stale Dynamo skip for max_pool1d pooling test

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -44,7 +44,6 @@ from torch.testing._internal.common_utils import (
     parametrize as parametrize_test,
     run_tests,
     set_default_dtype,
-    skipIfTorchDynamo,
     slowTest,
     subtest,
     TEST_WITH_UBSAN,
@@ -1276,7 +1275,6 @@ torch.cuda.synchronize()
 
     @onlyCPU
     @dtypes(torch.float, torch.double)
-    @skipIfTorchDynamo("OOMs https://github.com/pytorch/pytorch/issues/111320")
     def test_max_pool1d(self, device, dtype):
         # FIXME For now compare against max_pool1d with indices
         def check(x, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186531

The skip on test_max_pool1d was added when running the CPU pooling
suite under Dynamo reliably hit an LLVM out-of-memory failure. On the
current tree, the max_pool1d Dynamo cases and the broader CPU pooling
class no longer reproduce the OOM, but the decorator still prevents the
regression coverage from running.

Remove the stale skip so Dynamo once again exercises the existing
max_pool1d coverage. Also remove the now-unused skipIfTorchDynamo import.
This keeps the fix scoped to the remaining issue: the test was still
being skipped after the underlying OOM stopped reproducing.

Fixes #111320
Generated by my agent

Test Plan:
- PYTORCH_TEST_WITH_DYNAMO=1 python test/nn/test_pooling.py TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float32
  - Before the fix, this passed only by skipping the test.
- timeout 180s env PYTORCH_TEST_WITH_DYNAMO=1 python test/nn/test_pooling.py TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float32
  - Passed with the decorator temporarily removed; no LLVM OOM.
- timeout 300s env PYTORCH_TEST_WITH_DYNAMO=1 python test/nn/test_pooling.py TestPoolingNNDeviceTypeCPU
  - Passed 101 tests; no LLVM OOM.
- PYTORCH_TEST_WITH_DYNAMO=1 python test/nn/test_pooling.py TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float32 TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float64
  - Passed.
- python test/nn/test_pooling.py TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float32 TestPoolingNNDeviceTypeCPU.test_max_pool1d_cpu_float64
  - Passed.
- timeout 300s lintrunner -a
  - Passed.