### PR TITLE
Fix SymInt vector dispatcher signature detection

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <memory>
 #include <type_traits>
+#include <vector>
 
 namespace c10 {
 
@@ -22,17 +23,80 @@ class KernelFunction;
 class KernelToken;
 class SafeKernelFunction;
 
+namespace detail {
+template <typename T>
+struct is_symint_vector : std::false_type {};
+
+template <>
+struct is_symint_vector<std::vector<c10::SymInt>> : std::true_type {};
+
+template <typename From, typename To>
+struct copy_cv {
+  using type = To;
+};
+
+template <typename From, typename To>
+struct copy_cv<const From, To> {
+  using type = const To;
+};
+
+template <typename From, typename To>
+struct copy_cv<volatile From, To> {
+  using type = volatile To;
+};
+
+template <typename From, typename To>
+struct copy_cv<const volatile From, To> {
+  using type = const volatile To;
+};
+
+template <typename From, typename To>
+using copy_cv_t = typename copy_cv<From, To>::type;
+
+template <typename From, typename To>
+struct copy_cvref {
+ private:
+  using MaybeCVTo = copy_cv_t<std::remove_reference_t<From>, To>;
+
+ public:
+  using type = std::conditional_t<
+      std::is_lvalue_reference_v<From>,
+      std::add_lvalue_reference_t<MaybeCVTo>,
+      std::conditional_t<
+          std::is_rvalue_reference_v<From>,
+          std::add_rvalue_reference_t<MaybeCVTo>,
+          MaybeCVTo>>;
+};
+
+template <typename From, typename To>
+using copy_cvref_t = typename copy_cvref<From, To>::type;
+
+} // namespace detail
+
 template <typename T>
 using has_symint = std::disjunction<
     std::is_same<c10::SymInt, T>,
     std::is_same<c10::SymIntArrayRef, T>,
     std::is_same<at::OptionalSymIntArrayRef, T>,
-    std::is_same<std::optional<c10::SymInt>, T>>;
+    std::is_same<std::optional<c10::SymInt>, T>,
+    detail::is_symint_vector<std::remove_cv_t<std::remove_reference_t<T>>>>;
 
 template <typename T>
 struct remove_symint {
-  using type = T;
+  using type = std::conditional_t<
+      detail::is_symint_vector<
+          std::remove_cv_t<std::remove_reference_t<T>>>::value,
+      detail::copy_cvref_t<T, std::vector<int64_t>>,
+      T>;
 };
+
+namespace detail {
+template <typename T>
+using unpacked_symint_arg_t = std::conditional_t<
+    is_symint_vector<std::remove_cv_t<std::remove_reference_t<T>>>::value,
+    std::vector<int64_t>,
+    typename remove_symint<T>::type>;
+} // namespace detail
 
 template <>
 struct remove_symint<c10::SymInt> {

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -108,8 +108,18 @@ inline Return callUnboxedKernelFunction(
 // NB: keep this in sync with cloneWithRealTypes in function_schema.cpp
 
 template <typename T>
-inline typename remove_symint<T>::type unpackSymInt(T x) {
-  return x;
+inline detail::unpacked_symint_arg_t<T> unpackSymInt(T x) {
+  if constexpr (detail::is_symint_vector<
+                    std::remove_cv_t<std::remove_reference_t<T>>>::value) {
+    std::vector<int64_t> r;
+    r.reserve(x.size());
+    for (const auto& i : x) {
+      r.push_back(i.guard_int(__FILE__, __LINE__));
+    }
+    return r;
+  } else {
+    return x;
+  }
 }
 
 template <>

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -2219,6 +2219,58 @@ TEST(OperatorRegistrationTest, TestSymSymRefCompatibility) {
   }, "doesn't match the expected function schema");
 }
 
+Tensor symint_vector_op(
+    const Tensor& self,
+    const std::vector<c10::SymInt>& lengths) {
+  return self.clone();
+}
+
+static_assert(std::is_same_v<
+              c10::remove_symint<const std::vector<c10::SymInt>&>::type,
+              const std::vector<int64_t>&>);
+
+TEST(OperatorRegistrationTest, TestSymIntVectorSchemaCompatibility) {
+  auto m = MAKE_TORCH_LIBRARY(_test);
+  m.def("_test::symint_vector_op(Tensor self, SymInt[] lengths) -> Tensor");
+  auto m_cpu = MAKE_TORCH_LIBRARY_IMPL(_test, CPU);
+  m_cpu.impl(
+      "symint_vector_op", c10::DispatchKey::CPU, TORCH_FN(symint_vector_op));
+
+  auto opHandle = c10::Dispatcher::singleton().findSchemaOrThrow(
+      "_test::symint_vector_op", "");
+  opHandle
+      .typed<Tensor(const Tensor&, const std::vector<c10::SymInt>&)>()
+      .call(
+          dummyTensor(c10::DispatchKey::CPU),
+          std::vector<c10::SymInt>{c10::SymInt(2), c10::SymInt(3)});
+}
+
+Tensor int_vector_op(
+    const Tensor& self,
+    const std::vector<int64_t>& lengths) {
+  EXPECT_EQ(2, lengths.size());
+  if (lengths.size() == 2) {
+    EXPECT_EQ(2, lengths[0]);
+    EXPECT_EQ(3, lengths[1]);
+  }
+  return self.clone();
+}
+
+TEST(OperatorRegistrationTest, TestSymIntVectorCanCallNonSymIntVectorKernel) {
+  auto m = MAKE_TORCH_LIBRARY(_test);
+  m.def("_test::int_vector_op(Tensor self, int[] lengths) -> Tensor");
+  auto m_cpu = MAKE_TORCH_LIBRARY_IMPL(_test, CPU);
+  m_cpu.impl("int_vector_op", c10::DispatchKey::CPU, TORCH_FN(int_vector_op));
+
+  auto opHandle =
+      c10::Dispatcher::singleton().findSchemaOrThrow("_test::int_vector_op", "");
+  opHandle
+      .typed<Tensor(const Tensor&, const std::vector<c10::SymInt>&)>()
+      .call(
+          dummyTensor(c10::DispatchKey::CPU),
+          std::vector<c10::SymInt>{c10::SymInt(2), c10::SymInt(3)});
+}
+
 }
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186533

Registering a C++ kernel that takes `const std::vector<c10::SymInt>&`
against a `SymInt[]` schema failed schema checking with a confusing
`int[]` vs `SymInt[]` mismatch. The dispatcher only classified a small
set of exact SymInt-related parameter types as SymInt-bearing, so the
vector signature was treated as a non-SymInt kernel even though schema
inference correctly inferred a `SymInt[]` argument.

Teach the SymInt function-signature traits to recognize cv/ref-qualified
`std::vector<c10::SymInt>` arguments. For non-SymInt fallback signatures,
map the vector to the matching `std::vector<int64_t>` while preserving
cv/ref qualifiers, and use a separate owning unpacked argument type so a
converted vector can safely bind to const-reference kernels for the
unboxed call. This fixes the root cause without weakening schema checks.

Add dispatcher registration tests for both the original `SymInt[]` schema
case and the fallback path that calls an `int[]` kernel taking
`const std::vector<int64_t>&` through a SymInt-vector typed handle.

Fixes #106135
Generated by my agent

Test Plan:
- cmake --build build --target op_registration_test -j 8
- build/bin/op_registration_test --gtest_filter=OperatorRegistrationTest.TestSymIntVector*
- build/bin/op_registration_test --gtest_filter=OperatorRegistrationTest.TestSym*
- build/bin/op_registration_test
- git diff --check
- lintrunner -a