### PR TITLE
Fix Windows debug build issues

### DIFF
--- a/tools/autograd/templates/python_functions.cpp
+++ b/tools/autograd/templates/python_functions.cpp
@@ -2,7 +2,7 @@
 
 // ${generated_comment}
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <ATen/ATen.h>
 
 #include <c10/core/SymNodeImpl.h>

--- a/tools/autograd/templates/python_functions.h
+++ b/tools/autograd/templates/python_functions.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 // ${generated_comment}
 

--- a/tools/autograd/templates/python_return_types.cpp
+++ b/tools/autograd/templates/python_return_types.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #include <vector>
 #include <map>

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -7,7 +7,7 @@
 // torch._C._VariableFunctions which is also aliased as Variable._torch
 // and also copied into 'torch' module.
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 // Undefine the copysign macro so that at::copysign works as intended with MSVC
 // https://github.com/python/cpython/blob/c60394c7fc9cc09b16e9675a3eeb5844b6d8523f/PC/pyconfig.h#L196

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -1,7 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 // ${generated_comment}
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 // Undefine the copysign macro so that at::copysign works as intended with MSVC
 // https://github.com/python/cpython/blob/c60394c7fc9cc09b16e9675a3eeb5844b6d8523f/PC/pyconfig.h#L196

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4001,7 +4001,14 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         """
         // Python bindings to call {entry_func}():
         #define PY_SSIZE_T_CLEAN
-        #include <Python.h>
+        #if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
+#  pragma push_macro("_DEBUG")
+#  undef _DEBUG
+#  include <Python.h>
+#  pragma pop_macro("_DEBUG")
+#else
+#  include <Python.h>
+#endif
         #include <sstream>
         #include <cstdlib>
         #include <cerrno>

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4002,13 +4002,7 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         // Python bindings to call {entry_func}():
         #define PY_SSIZE_T_CLEAN
         #if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
-#  pragma push_macro("_DEBUG")
-#  undef _DEBUG
-#  include <Python.h>
-#  pragma pop_macro("_DEBUG")
-#else
-#  include <Python.h>
-#endif
+        #include <torch/csrc/utils/PythonWrapper.h>
         #include <sstream>
         #include <cstdlib>
         #include <cerrno>

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4002,7 +4002,13 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         // Python bindings to call {entry_func}():
         #define PY_SSIZE_T_CLEAN
         #if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
-        #include <torch/csrc/utils/PythonWrapper.h>
+        #  pragma push_macro("_DEBUG")
+        #  undef _DEBUG
+        #  include <Python.h>
+        #  pragma pop_macro("_DEBUG")
+        #else
+        #  include <Python.h>
+        #endif
         #include <sstream>
         #include <cstdlib>
         #include <cerrno>

--- a/torch/csrc/Storage.h
+++ b/torch/csrc/Storage.h
@@ -1,11 +1,12 @@
 #ifndef THP_STORAGE_INC
 #define THP_STORAGE_INC
 
+#include <torch/csrc/utils/PythonWrapper.h>
+
 #include <c10/core/Storage.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/Types.h>
-#include <torch/csrc/utils/PythonWrapper.h>
 
 #define THPStorageStr "torch.UntypedStorage"
 

--- a/torch/csrc/Storage.h
+++ b/torch/csrc/Storage.h
@@ -1,7 +1,7 @@
 #ifndef THP_STORAGE_INC
 #define THP_STORAGE_INC
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <c10/core/Storage.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>

--- a/torch/csrc/Storage.h
+++ b/torch/csrc/Storage.h
@@ -1,11 +1,11 @@
 #ifndef THP_STORAGE_INC
 #define THP_STORAGE_INC
 
-#include <torch/csrc/utils/PythonWrapper.h>
 #include <c10/core/Storage.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/Types.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #define THPStorageStr "torch.UntypedStorage"
 

--- a/torch/csrc/StorageMethods.h
+++ b/torch/csrc/StorageMethods.h
@@ -1,7 +1,7 @@
 #ifndef THP_STORAGE_METHODS_INC
 #define THP_STORAGE_METHODS_INC
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 PyMethodDef* THPStorage_getMethods();
 

--- a/torch/csrc/StorageSharing.h
+++ b/torch/csrc/StorageSharing.h
@@ -1,7 +1,7 @@
 #ifndef THP_STORAGE_SHARING_INC
 #define THP_STORAGE_SHARING_INC
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 PyMethodDef* THPStorage_getSharingMethods();
 

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/utils/PythonWrapper.h>
+
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <frameobject.h>
 
 #include <ATen/core/TensorBase.h>

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <torch/csrc/utils/PythonWrapper.h>
+
 #include <frameobject.h>
 
 #include <ATen/core/TensorBase.h>

--- a/torch/csrc/autograd/python_torch_functions.h
+++ b/torch/csrc/autograd/python_torch_functions.h
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 namespace torch::autograd {
 

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -1,3 +1,5 @@
+#include <torch/csrc/utils/PythonWrapper.h>
+
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
@@ -24,7 +26,6 @@
 #include <ATen/native/Resize.h>
 #include <ATen/ops/from_blob.h>
 
-#include <torch/csrc/utils/PythonWrapper.h>
 #include <fmt/format.h>
 #include <pybind11/pybind11.h>
 #include <utility>

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -24,7 +24,7 @@
 #include <ATen/native/Resize.h>
 #include <ATen/ops/from_blob.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <fmt/format.h>
 #include <pybind11/pybind11.h>
 #include <utility>

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -1,5 +1,3 @@
-#include <torch/csrc/utils/PythonWrapper.h>
-
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
@@ -25,6 +23,8 @@
 #include <ATen/FunctionalTensorWrapper.h>
 #include <ATen/native/Resize.h>
 #include <ATen/ops/from_blob.h>
+
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #include <fmt/format.h>
 #include <pybind11/pybind11.h>

--- a/torch/csrc/dynamo/cache_entry.h
+++ b/torch/csrc/dynamo/cache_entry.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #ifdef __cplusplus
 

--- a/torch/csrc/dynamo/eval_frame_cpp.h
+++ b/torch/csrc/dynamo/eval_frame_cpp.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #include <torch/csrc/dynamo/eval_frame.h>
 #include <torch/csrc/dynamo/extra_state.h>

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #include <torch/csrc/dynamo/framelocals_mapping.h>
 

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -13,7 +13,7 @@
 #include <torch/csrc/dynamo/python_compiled_autograd.h>
 #include <torch/csrc/utils/python_numbers.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 static struct PyModuleDef _module =
     {PyModuleDef_HEAD_INIT, "torch._C._dynamo", "", -1, nullptr};

--- a/torch/csrc/dynamo/init.h
+++ b/torch/csrc/dynamo/init.h
@@ -4,7 +4,7 @@
 #include <pybind11/complex.h>
 #include <torch/csrc/utils/pybind.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 namespace torch::dynamo {
 void initDynamoBindings(PyObject* torch);

--- a/torch/csrc/dynamo/stackref_bridge.c
+++ b/torch/csrc/dynamo/stackref_bridge.c
@@ -11,7 +11,7 @@
 #if IS_PYTHON_3_14_PLUS
 
 #define Py_BUILD_CORE
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <internal/pycore_stackref.h>
 #include <torch/csrc/dynamo/stackref_bridge.h>
 #undef Py_BUILD_CORE

--- a/torch/csrc/dynamo/utils.h
+++ b/torch/csrc/dynamo/utils.h
@@ -4,7 +4,7 @@
 #include <pybind11/complex.h>
 #include <torch/csrc/utils/pybind.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 // The visibility attribute is to avoid a warning about storing a field in the
 // struct that has a different visibility (from pybind) than the struct.
 #ifdef _WIN32

--- a/torch/csrc/functorch/init.h
+++ b/torch/csrc/functorch/init.h
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 namespace torch::functorch::impl {
 

--- a/torch/csrc/inductor/cpp_wrapper/common.h
+++ b/torch/csrc/inductor/cpp_wrapper/common.h
@@ -6,7 +6,7 @@
 #include <optional>
 #include <utility>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #if __has_include(<pybind11/gil_simple.h>)
 #include <pybind11/gil_simple.h>
 #else

--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/lazy/python/python_util.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <frameobject.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/lazy/core/debug_util.h>

--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/lazy/python/python_util.h>
 
 #include <torch/csrc/utils/PythonWrapper.h>
+
 #include <frameobject.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/lazy/core/debug_util.h>

--- a/torch/csrc/profiler/python/init.h
+++ b/torch/csrc/profiler/python/init.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 #include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/python/pybind.h>

--- a/torch/csrc/python_headers.h
+++ b/torch/csrc/python_headers.h
@@ -10,6 +10,7 @@
 #undef _POSIX_C_SOURCE
 
 #include <torch/csrc/utils/PythonWrapper.h>
+
 #include <frameobject.h>
 #include <structseq.h>
 

--- a/torch/csrc/python_headers.h
+++ b/torch/csrc/python_headers.h
@@ -9,7 +9,7 @@
 #undef _XOPEN_SOURCE
 #undef _POSIX_C_SOURCE
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <frameobject.h>
 #include <structseq.h>
 

--- a/torch/csrc/stub.c
+++ b/torch/csrc/stub.c
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 extern PyObject* initModule(void);
 

--- a/torch/csrc/utils/PythonWrapper.h
+++ b/torch/csrc/utils/PythonWrapper.h
@@ -1,0 +1,21 @@
+// Safe Python.h include for MSVC Debug builds.
+//
+// On MSVC with _DEBUG defined (Debug configuration), Python.h emits
+// #pragma comment(lib, "python3XX_d.lib") and exposes debug-only CPython APIs.
+// When building against a release Python (no Py_DEBUG), this causes link errors.
+// This header temporarily undefines _DEBUG around #include <Python.h>,
+// matching the same approach used by pybind11 and pythoncapi_compat.h.
+//
+// Use this header instead of directly including <Python.h> in files that
+// cannot include <torch/csrc/python_headers.h>.
+
+#pragma once
+
+#if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
+#  pragma push_macro("_DEBUG")
+#  undef _DEBUG
+#  include <Python.h>
+#  pragma pop_macro("_DEBUG")
+#else
+#  include <Python.h>
+#endif

--- a/torch/csrc/utils/PythonWrapper.h
+++ b/torch/csrc/utils/PythonWrapper.h
@@ -2,17 +2,17 @@
 //
 // On MSVC with _DEBUG defined (Debug configuration), Python.h emits
 // #pragma comment(lib, "python3XX_d.lib") and exposes debug-only CPython APIs.
-// When building against a release Python (no Py_DEBUG), this causes link errors.
-// This header temporarily undefines _DEBUG around #include <Python.h>,
+// When building against a release Python (no Py_DEBUG), this causes link
+// errors. This header temporarily undefines _DEBUG around #include <Python.h>,
 // matching the same approach used by pybind11.
 
 #pragma once
 
 #if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
-#  pragma push_macro("_DEBUG")
-#  undef _DEBUG
-#  include <Python.h>
-#  pragma pop_macro("_DEBUG")
+#pragma push_macro("_DEBUG")
+#undef _DEBUG
+#include <Python.h>
+#pragma pop_macro("_DEBUG")
 #else
-#  include <Python.h>
+#include <Python.h>
 #endif

--- a/torch/csrc/utils/PythonWrapper.h
+++ b/torch/csrc/utils/PythonWrapper.h
@@ -4,10 +4,7 @@
 // #pragma comment(lib, "python3XX_d.lib") and exposes debug-only CPython APIs.
 // When building against a release Python (no Py_DEBUG), this causes link errors.
 // This header temporarily undefines _DEBUG around #include <Python.h>,
-// matching the same approach used by pybind11 and pythoncapi_compat.h.
-//
-// Use this header instead of directly including <Python.h> in files that
-// cannot include <torch/csrc/python_headers.h>.
+// matching the same approach used by pybind11.
 
 #pragma once
 

--- a/torch/csrc/utils/pycfunction_helpers.h
+++ b/torch/csrc/utils/pycfunction_helpers.h
@@ -3,7 +3,7 @@
 #include <c10/macros/Macros.h>
 #include <torch/csrc/utils/python_compat.h>
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 
 inline PyCFunction castPyCFunctionWithKeywords(PyCFunctionWithKeywords func) {
   C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type")

--- a/torch/csrc/utils/pythoncapi_compat.h
+++ b/torch/csrc/utils/pythoncapi_compat.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#include <Python.h>
+#include <torch/csrc/utils/PythonWrapper.h>
 #include <stddef.h>               // offsetof()
 
 // Python 3.11.0b4 added PyFrame_Back() to Python.h


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/186544

## Summary

Fix Windows Debug build (`CMAKE_BUILD_TYPE=Debug`) failing with linker error `python310_d.lib not found` when using a standard (non-debug) CPython distribution from conda/pip.

## Problem

When building PyTorch with MSVC in Debug mode, the compiler defines `_DEBUG`. This causes CPython's `Python.h` to:
1. Emit `#pragma comment(lib, "python310_d.lib")` — requesting the debug Python library that doesn't exist in standard distributions.
2. Enable debug-only CPython APIs (e.g., `_Py_NegativeRefcount`) which produce unresolved symbol errors at link time.

## Solution

Apply the same well-established workaround used by pybind11: temporarily `#undef _DEBUG` before `#include <Python.h>` on MSVC when `Py_DEBUG` is not defined (i.e., we're not intentionally building against a debug Python).

The guard pattern applied to all 28 files that directly include `Python.h`:

```c
#if defined(_MSC_VER) && defined(_DEBUG) && !defined(Py_DEBUG)
#  pragma push_macro("_DEBUG")
#  undef _DEBUG
#  include <Python.h>
#  pragma pop_macro("_DEBUG")
#else
#  include <Python.h>
#endif
```

`_DEBUG` is restored via `pragma push_macro`/`pop_macro` immediately after the include so it remains available for the rest of the translation unit (STL iterator debug checks, etc.).

## Why not just use `/NODEFAULTLIB`?

`/NODEFAULTLIB:python310_d.lib` suppresses the auto-link pragma but does **not** resolve the actual calls to debug-only CPython functions (`_Py_NegativeRefcount`, `_Py_Dealloc`, etc.) that `Python.h` exposes under `_DEBUG`. The only correct fix is to prevent `Python.h` from seeing `_DEBUG` in the first place.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98