### PR TITLE
Use normalized name spmd-types in wheel Requires-Dist

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -113,7 +113,7 @@ if [[ "$PACKAGE_TYPE" =~ .*wheel.* && -n "$PYTORCH_BUILD_VERSION" && "$PYTORCH_B
 fi
 
 if [[ "$PACKAGE_TYPE" =~ .*wheel.* ]]; then
-  SPMD_TYPES_REQUIREMENT="spmd_types==0.2.0"
+  SPMD_TYPES_REQUIREMENT="spmd-types==0.2.0"
   if [[ -z "${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}" ]]; then
     export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${SPMD_TYPES_REQUIREMENT}"
   else


### PR DESCRIPTION
## Summary

`PYTORCH_EXTRA_INSTALL_REQUIREMENTS` becomes the torch wheel's `Requires-Dist`, so `SPMD_TYPES_REQUIREMENT="spmd_types==0.2.0"` (added in #180880) emitted `Requires-Dist: spmd_types==0.2.0`.

`download.pytorch.org` serves the dependency under its PEP 503-normalized name (`spmd-types/`), so when installing with `--index-url https://download.pytorch.org/whl/nightly/<arch>` pip looks up the normalized path. Emit the normalized requirement `spmd-types==0.2.0` so the metadata matches the index path.

PyPI treats `spmd_types` and `spmd-types` as equivalent, so default-index installs are unaffected.

## Companion change

The matching mirror/index fixes on `download.pytorch.org` are in pytorch/test-infra#8157.

## Note

Changing `PYTORCH_EXTRA_INSTALL_REQUIREMENTS` requires triggering `ciflow/binaries` to validate the binary builds.
