### PR TITLE
Fix fake deepcopy for custom module mappings

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1284,6 +1284,113 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         # model can be compiled without error
         y = model(x)
 
+    def test_deepcopy_to_fake_tensor_parented_parameters(self):
+        from collections import OrderedDict
+
+        from torch._dynamo.utils import deepcopy_to_fake_tensor
+        from torch._subclasses.fake_tensor import FakeTensorMode, is_fake
+
+        class ZeROOrderedDict(OrderedDict):
+            __slots__ = ("slot_state",)
+
+            def __init__(self, parent_module, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._parent_module = parent_module
+                self.slot_state = "preserved"
+
+            def __getitem__(self, key):
+                raise AssertionError("custom __getitem__ should not be called")
+
+            def items(self):
+                raise AssertionError("custom items should not be called")
+
+        def inject_parameters(module, cls):
+            for m in module.modules():
+                new_param = cls(parent_module=m)
+
+                for key, param in m._parameters.items():
+                    OrderedDict.__setitem__(new_param, key, param)
+                m._parameters = new_param
+
+        model = ParametersModule5()
+        model.register_buffer("buf", torch.ones(1))
+        model._buffers = collections.defaultdict(list, model._buffers)
+        inject_parameters(model, ZeROOrderedDict)
+
+        fake_model = deepcopy_to_fake_tensor(model, FakeTensorMode())
+
+        self.assertIsInstance(fake_model._parameters, ZeROOrderedDict)
+        self.assertIs(fake_model._parameters._parent_module, fake_model)
+        self.assertEqual(fake_model._parameters.slot_state, "preserved")
+        self.assertIsInstance(fake_model.linear1._parameters, ZeROOrderedDict)
+        self.assertIs(fake_model.linear1._parameters._parent_module, fake_model.linear1)
+        self.assertEqual(fake_model.linear1._parameters.slot_state, "preserved")
+        self.assertIs(fake_model._buffers.default_factory, list)
+        self.assertEqual(fake_model._buffers["missing"], [])
+        self.assertTrue(is_fake(fake_model._buffers["buf"]))
+        self.assertTrue(
+            is_fake(OrderedDict.__getitem__(fake_model._parameters, "scale"))
+        )
+        self.assertTrue(
+            is_fake(OrderedDict.__getitem__(fake_model.linear1._parameters, "weight"))
+        )
+        self.assertIs(
+            OrderedDict.__getitem__(fake_model._parameters, "scale"),
+            OrderedDict.__getitem__(fake_model._parameters, "scale_dup"),
+        )
+
+    def test_deepcopy_to_fake_tensor_preserves_custom_copy_protocols(self):
+        from torch._dynamo.utils import deepcopy_to_fake_tensor
+        from torch._subclasses.fake_tensor import FakeTensorMode, is_fake
+
+        class CustomDeepcopyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(2))
+                self.custom_deepcopy_used = False
+
+            def __deepcopy__(self, memo):
+                result = type(self)()
+                memo[id(self)] = result
+                result.weight = copy.deepcopy(self.weight, memo)
+                result.custom_deepcopy_used = True
+                return result
+
+        fake_model = deepcopy_to_fake_tensor(CustomDeepcopyModule(), FakeTensorMode())
+
+        self.assertTrue(fake_model.custom_deepcopy_used)
+        self.assertTrue(is_fake(fake_model.weight))
+
+        class RequiredParentOrderedDict(collections.OrderedDict):
+            def __init__(self, parent_module, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._parent_module = parent_module
+
+        class CustomReduceModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(2))
+                self.reduce_used = False
+                parameters = RequiredParentOrderedDict(self)
+                for key, param in self._parameters.items():
+                    parameters[key] = param
+                self._parameters = parameters
+
+            def __reduce_ex__(self, protocol):
+                weight = collections.OrderedDict.__getitem__(self._parameters, "weight")
+                return (rebuild_custom_reduce_module, (weight,))
+
+        def rebuild_custom_reduce_module(weight):
+            result = CustomReduceModule()
+            result.weight = weight
+            result.reduce_used = True
+            return result
+
+        fake_model = deepcopy_to_fake_tensor(CustomReduceModule(), FakeTensorMode())
+
+        self.assertTrue(fake_model.reduce_used)
+        self.assertTrue(is_fake(fake_model.weight))
+
     def test_module_forward_has_graph_break(self):
         m = ModuleForwardHasGraphBreak()
         x = torch.rand([10, 10])

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3424,7 +3424,184 @@ def deepcopy_to_fake_tensor(
     obj: Any, fake_mode: torch._subclasses.fake_tensor.FakeTensorMode
 ) -> Any:
     with torch._subclasses.fake_tensor.FakeCopyMode(fake_mode):
-        return wrap_fake_exception(lambda: copy.deepcopy(obj))
+        return wrap_fake_exception(lambda: _deepcopy_to_fake_tensor(obj))
+
+
+def _deepcopy_to_fake_tensor(obj: Any, memo: dict[int, Any] | None = None) -> Any:
+    if memo is None:
+        memo = {}
+    if (
+        isinstance(obj, torch.nn.Module)
+        and _has_custom_module_mappings(obj)
+        and not _has_custom_deepcopy_protocol(obj)
+    ):
+        return _deepcopy_nn_module_to_fake_tensor(obj, memo)
+    return copy.deepcopy(obj, memo)
+
+
+def _type_has_custom_attr(cls: type, name: str, ignored: tuple[type, ...]) -> bool:
+    for base in cls.__mro__:
+        if base in ignored:
+            continue
+        if name in base.__dict__:
+            return True
+    return False
+
+
+def _has_custom_deepcopy_protocol(obj: torch.nn.Module) -> bool:
+    return any(
+        _type_has_custom_attr(type(obj), name, ignored=(torch.nn.Module, object))
+        for name in (
+            "__deepcopy__",
+            "__reduce_ex__",
+            "__reduce__",
+            "__getnewargs_ex__",
+            "__getnewargs__",
+            "__getstate__",
+            "__setstate__",
+        )
+    )
+
+
+def _has_custom_module_mappings(
+    obj: torch.nn.Module, seen: set[int] | None = None
+) -> bool:
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return False
+    seen.add(obj_id)
+
+    state = object.__getattribute__(obj, "__dict__")
+    for key in ("_parameters", "_buffers", "_modules"):
+        value = state.get(key)
+        if isinstance(value, dict) and not istype(value, (dict, OrderedDict)):
+            return True
+
+    modules = state.get("_modules")
+    if isinstance(modules, dict):
+        for _, submodule in get_items_from_dict(modules):
+            if isinstance(submodule, torch.nn.Module) and _has_custom_module_mappings(
+                submodule, seen
+            ):
+                return True
+
+    return False
+
+
+def _mapping_state(obj: dict[Any, Any]) -> Any:
+    if _type_has_custom_attr(type(obj), "__getstate__", ignored=(object,)):
+        return obj.__getstate__()
+    return _object_getstate(obj)
+
+
+def _slot_name(cls: type, name: str) -> str:
+    if name.startswith("__") and not name.endswith("__"):
+        return f"_{cls.__name__.lstrip('_')}{name}"
+    return name
+
+
+def _object_getstate(obj: Any) -> Any:
+    object_getstate = getattr(object, "__getstate__", None)
+    if object_getstate is not None:
+        return object_getstate(obj)
+
+    state = getattr(obj, "__dict__", None)
+    if state is not None:
+        state = state.copy()
+
+    slotstate: dict[str, Any] = {}
+    for cls in type(obj).__mro__:
+        slots = cls.__dict__.get("__slots__")
+        if slots is None:
+            continue
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot in slots:
+            if slot in ("__dict__", "__weakref__"):
+                continue
+            slot = _slot_name(cls, slot)
+            try:
+                slotstate[slot] = getattr(obj, slot)
+            except AttributeError:
+                pass
+
+    if slotstate:
+        return state, slotstate
+    return state
+
+
+def _set_mapping_state(obj: dict[Any, Any], state: Any, memo: dict[int, Any]) -> None:
+    if state is None:
+        return
+
+    state = copy.deepcopy(state, memo)
+    if hasattr(obj, "__setstate__"):
+        obj.__setstate__(state)
+        return
+
+    if isinstance(state, tuple) and len(state) == 2:
+        state, slotstate = state
+    else:
+        slotstate = None
+
+    if state is not None:
+        obj.__dict__.update(state)
+    if slotstate is not None:
+        for key, value in slotstate.items():
+            setattr(obj, key, value)
+
+
+def _deepcopy_module_mapping_to_fake_tensor(
+    obj: dict[Any, Any], memo: dict[int, Any]
+) -> dict[Any, Any]:
+    obj_id = id(obj)
+    if obj_id in memo:
+        return memo[obj_id]
+
+    if isinstance(obj, OrderedDict):
+        result = OrderedDict.__new__(type(obj))
+    else:
+        result = dict.__new__(type(obj))
+
+    memo[obj_id] = result
+    if isinstance(obj, collections.defaultdict) and isinstance(
+        result, collections.defaultdict
+    ):
+        result.default_factory = copy.deepcopy(obj.default_factory, memo)
+    _set_mapping_state(result, _mapping_state(obj), memo)
+
+    for key, value in get_items_from_dict(obj):
+        key_copy = copy.deepcopy(key, memo)
+        value_copy = _deepcopy_to_fake_tensor(value, memo)
+        if isinstance(result, OrderedDict):
+            OrderedDict.__setitem__(result, key_copy, value_copy)
+        else:
+            dict.__setitem__(result, key_copy, value_copy)
+    return result
+
+
+def _deepcopy_nn_module_to_fake_tensor(
+    obj: torch.nn.Module, memo: dict[int, Any]
+) -> torch.nn.Module:
+    obj_id = id(obj)
+    if obj_id in memo:
+        return memo[obj_id]
+
+    result = nn_module_new(type(obj))
+    memo[obj_id] = result
+
+    state = obj.__getstate__()
+    result_state = {}
+    for key, value in state.items():
+        if key in ("_parameters", "_buffers", "_modules") and isinstance(value, dict):
+            result_state[key] = _deepcopy_module_mapping_to_fake_tensor(value, memo)
+        else:
+            result_state[key] = copy.deepcopy(value, memo)
+
+    result.__setstate__(result_state)
+    return result
 
 
 def rmse(ref: torch.Tensor, res: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186549

Dynamo fake tensor propagation deepcopies modules before running FX call_module nodes. The previous implementation delegated directly to copy.deepcopy under FakeCopyMode, which reconstructs dict and OrderedDict subclasses through their reduce constructor. DeepSpeed-style ZeRO module mappings can require a parent_module constructor argument, so deepcopying an nn.Module containing those mappings failed before FakeCopyMode could convert parameters to fake tensors.

This changes deepcopy_to_fake_tensor to keep the normal copy.deepcopy path for ordinary modules and for modules with explicit copy or pickle protocols. Only module trees containing non-standard _parameters, _buffers, or _modules mappings use a module-aware copy path. That path reconstructs module state without invoking custom mapping constructors, copies mapping entries through Dynamo's raw dict item helper to avoid overridden accessors, preserves mapping state including slots and defaultdict factories, and keeps shared memoization so parent pointers and parameter aliases are remapped to the copied module tree.

The alternative would be catching TypeError around copy.deepcopy and retrying with custom logic, but that would hide unrelated copy bugs and make behavior depend on exception text. Scoping the custom path to module mapping subclasses fixes the root cause directly while preserving normal deepcopy semantics for the common case.

Fixes #97078

Benchmark Results:
- Command: compared previous helper behavior (`copy.deepcopy` under `FakeCopyMode`) against patched `deepcopy_to_fake_tensor` in the current built tree on an ordinary 8-layer `nn.Sequential` module with standard module mappings, 200 iterations after warmup.
- Previous behavior: mean_s=0.00495367, median_s=0.00494301.
- This change: mean_s=0.00497462, median_s=0.00496407.

Test Plan:
- python test/dynamo/test_modules.py NNModuleTests.test_deepcopy_to_fake_tensor_parented_parameters NNModuleTests.test_deepcopy_to_fake_tensor_preserves_custom_copy_protocols NNModuleTests.test_inject_module_parameters
- lintrunner -a
- git diff --check

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98