### PR TITLE
[BE][Ez]: Use rvalue overload for stringstream str

### DIFF
--- a/android/pytorch_android/generate_test_asset.cpp
+++ b/android/pytorch_android/generate_test_asset.cpp
@@ -15,6 +15,6 @@ int main(int argc, char* argv[]) {
   buffer << ifs.rdbuf();
   torch::jit::Module m("TestModule");
 
-  m.define(buffer.str());
+  m.define(std::move(buffer).str());
   m.save(output_file_path);
 }

--- a/aten/src/ATen/code_template.h
+++ b/aten/src/ATen/code_template.h
@@ -84,7 +84,7 @@ struct TemplateEnv {
   [[noreturn]] void notFound(const std::string& k) const {
     std::stringstream ss;
     ss << "key not found: " << k;
-    throw std::logic_error(ss.str());
+    throw std::logic_error(std::move(ss).str());
   }
 
   std::unordered_map<std::string, std::string> strings_;
@@ -116,7 +116,7 @@ struct CodeTemplate {
         bool comma_before = false;
         bool comma_after = false;
         size_t new_pos = parseKey(pos, kss, comma_before, comma_after);
-        std::string k = kss.str();
+        std::string k = std::move(kss).str();
         bool is_string = env.keyIsString(k);
         if (all_whitespace) {
           if (is_string)
@@ -143,7 +143,7 @@ struct CodeTemplate {
         pos++;
       }
     }
-    return out.str();
+    return std::move(out).str();
   }
 
  private:

--- a/aten/src/ATen/core/class_type.cpp
+++ b/aten/src/ATen/core/class_type.cpp
@@ -65,7 +65,7 @@ static std::string getSchemaInputTypesString(const FunctionSchema& schema) {
   if (forward_args.size() == 1) {
     input_types << "()";
   }
-  return input_types.str();
+  return std::move(input_types).str();
 }
 
 std::string ClassType::getForwardPreHookErrorMessage(size_t pre_hook_idx) const {

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -101,7 +101,7 @@ struct TORCH_API ClassType : public NamedType {
     std::stringstream ss;
     ss << str()
        << " (of Python compilation unit at: " << compilation_unit().get() << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
 
   const std::vector<torch::jit::Function*>& methods() const;

--- a/aten/src/ATen/core/function_schema.cpp
+++ b/aten/src/ATen/core/function_schema.cpp
@@ -254,7 +254,7 @@ std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema) {
   if (returns.size() == 1 && !schema.is_varret()) {
     std::stringstream return_ss;
     return_ss << returns.at(0);
-    auto return_str = return_ss.str();
+    auto return_str = std::move(return_ss).str();
 
     // enclosing the single return item with parenthesis if the return type
     // starts with a left parenthesis.

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -642,7 +642,7 @@ std::ostream& IValue::repr(
       std::stringstream device_stream;
       device_stream << v.toDevice();
       out << "torch.device(";
-      c10::printQuotedString(out, device_stream.str());
+      c10::printQuotedString(out, std::move(device_stream).str());
       return out << ')';
     }
     case IValue::Tag::Generator: {
@@ -758,7 +758,7 @@ IValueComparator getLessThanComparator(const IValue& v) {
     torch::jit::Function* lt_func =
         checkObjectSortSchema(v.type()->expect<ClassType>(), why_not);
     if (!lt_func) {
-      TORCH_CHECK(false, why_not.str());
+      TORCH_CHECK(false, std::move(why_not).str());
     }
 
     return [lt_func](const IValue& a, const IValue& b) {
@@ -1054,7 +1054,7 @@ c10::intrusive_ptr<ivalue::Object> ivalue::Object::deepcopy(
       }
       err << ". Please define serialization methods via def_pickle() for "
             "this class.";
-      TORCH_CHECK(false, err.str());
+      TORCH_CHECK(false, std::move(err).str());
     }
     object->setSlot(i, slots_[i].deepcopy(memo, device));
   }

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -212,7 +212,7 @@ struct TORCH_API OptionalType : public UnionType {
   std::string str() const override {
     std::stringstream ss;
     ss << getElementType()->str() << '?';
-    return ss.str();
+    return std::move(ss).str();
   }
 
   TypePtr createWithContained(
@@ -241,7 +241,7 @@ struct TORCH_API OptionalType : public UnionType {
   std::string annotation_str_impl(const TypePrinter& printer = nullptr) const override {
     std::stringstream ss;
     ss << "Optional[" << getElementType()->annotation_str(printer) << ']';
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 
@@ -873,7 +873,7 @@ struct TORCH_API ListType
   std::string str() const override {
     std::stringstream ss;
     ss << getElementType()->str() << "[]";
-    return ss.str();
+    return std::move(ss).str();
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
@@ -907,7 +907,7 @@ struct TORCH_API ListType
   std::string annotation_str_impl(const TypePrinter& printer = nullptr) const override {
     std::stringstream ss;
     ss << "List[" << getElementType()->annotation_str(printer) << ']';
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 
@@ -947,7 +947,7 @@ struct TORCH_API DictType : public SharedType {
     std::stringstream ss;
     ss << "Dict(" << getKeyType()->str() << ", " << getValueType()->str()
        << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
 
   TypePtr createWithContained(
@@ -1019,7 +1019,7 @@ struct TORCH_API FutureType
   std::string str() const override {
     std::stringstream ss;
     ss << "Future(" << getElementType()->str() << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
@@ -1042,7 +1042,7 @@ struct TORCH_API FutureType
   std::string annotation_str_impl(const TypePrinter& printer = nullptr) const override {
     std::stringstream ss;
     ss << "Future[" << getElementType()->annotation_str(printer) << ']';
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 
@@ -1061,7 +1061,7 @@ struct TORCH_API AwaitType
   std::string str() const override {
     std::stringstream ss;
     ss << "Await(" << getElementType()->str() << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
@@ -1084,7 +1084,7 @@ struct TORCH_API AwaitType
   std::string annotation_str_impl(const TypePrinter& printer = nullptr) const override {
     std::stringstream ss;
     ss << "Await[" << getElementType()->annotation_str(printer) << ']';
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 
@@ -1103,7 +1103,7 @@ struct TORCH_API RRefType
   std::string str() const override {
     std::stringstream ss;
     ss << "RRef(" << getElementType()->str() << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
@@ -1116,7 +1116,7 @@ struct TORCH_API RRefType
   std::string annotation_str_impl(const TypePrinter& printer = nullptr) const override {
     std::stringstream ss;
     ss << "RRef[" << getElementType()->annotation_str(printer) << ']';
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -510,7 +510,7 @@ MatchTypeReturn matchTypeVariables(
     ss << "Type variable '" << vt->name() << "' previously matched to type "
        << it->second->repr_str() << " is matched to type "
        << actual->repr_str();
-    return ss.str();
+    return std::move(ss).str();
   } else if (auto lt_formal = formal->castRaw<ListType>()) {
     if (auto lt_actual = actual->castRaw<ListType>()) {
       auto innerMatch = matchTypeVariables(
@@ -532,7 +532,7 @@ MatchTypeReturn matchTypeVariables(
     std::stringstream ss;
     ss << "Cannot match " << lt_formal->repr_str() << " to "
        << actual->repr_str();
-    return ss.str();
+    return std::move(ss).str();
   } else if (auto tp_formal = formal->castRaw<TupleType>()) {
     if (auto tp_actual = actual->castRaw<TupleType>()) {
       if (tp_formal->elements().size() != tp_actual->elements().size()) {
@@ -549,7 +549,7 @@ MatchTypeReturn matchTypeVariables(
     } else {
       std::stringstream ss;
       ss << "Cannot match a tuple to " << actual->repr_str();
-      return MatchTypeReturn(ss.str());
+      return MatchTypeReturn(std::move(ss).str());
     }
   } else if (auto lt_formal = formal->castRaw<FutureType>()) {
     if (auto lt_actual = actual->castRaw<FutureType>()) {
@@ -562,7 +562,7 @@ MatchTypeReturn matchTypeVariables(
     } else {
       std::stringstream ss;
       ss << "Cannot match a future to " << actual->repr_str();
-      return ss.str();
+      return std::move(ss).str();
     }
   } else if (auto lt_formal = formal->castRaw<AwaitType>()) {
     if (auto lt_actual = actual->castRaw<AwaitType>()) {
@@ -575,7 +575,7 @@ MatchTypeReturn matchTypeVariables(
     } else {
       std::stringstream ss;
       ss << "Cannot match an await to " << actual->repr_str();
-      return ss.str();
+      return std::move(ss).str();
     }
   } else if (auto lt_formal = formal->castRaw<RRefType>()) {
     if (auto lt_actual = actual->castRaw<RRefType>()) {
@@ -588,7 +588,7 @@ MatchTypeReturn matchTypeVariables(
     } else {
       std::stringstream ss;
       ss << "Cannot match a rref to " << actual->repr_str();
-      return ss.str();
+      return std::move(ss).str();
     }
   } else if (auto opt_formal = formal->castRaw<OptionalType>()) {
     if (auto opt_actual = actual->castRaw<OptionalType>()) {
@@ -625,7 +625,7 @@ MatchTypeReturn matchTypeVariables(
     } else {
       std::stringstream ss;
       ss << "Cannot match a dict to " << actual->repr_str();
-      return ss.str();
+      return std::move(ss).str();
     }
   }
 
@@ -913,7 +913,7 @@ std::string TupleType::str() const {
     }
     ss << ')';
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 std::string TupleType::annotation_str_impl(const TypePrinter& printer) const {
   if (schema_ && name()) {

--- a/aten/src/ATen/core/union_type.cpp
+++ b/aten/src/ATen/core/union_type.cpp
@@ -207,7 +207,7 @@ UnionType::UnionType(std::vector<TypePtr> reference, TypeKind kind) : SharedType
     msg << "} has the single type " << types_[0]->repr_str()
          << ". Use the common supertype instead of creating a Union"
          << "type";
-    TORCH_INTERNAL_ASSERT(false, msg.str());
+    TORCH_INTERNAL_ASSERT(false, std::move(msg).str());
   }
 
   can_hold_none_ = false;
@@ -400,7 +400,7 @@ std::string UnionType::unionStr(const TypePrinter& printer, bool is_annotation_s
     }
   }
   ss << close_delimeter;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string UnionType::str() const {

--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -49,7 +49,7 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
   ss << vec_size;
 // DeviceIndex, e.g. int8_t, is not treated as a number by the stream, cast to int as a workaround
   ss << static_cast<int>(dev_idx);
-  const std::string cache_key = ss.str();
+  const std::string cache_key = std::move(ss).str();
 
   static std::mutex _jiterator_mutex;
   static std::unordered_map<std::string, at::cuda::jit::NvrtcFunction> fns;
@@ -150,7 +150,7 @@ static inline void launch_jitted_unrolled_kernel_dynamic(
   ss << static_cast<int>(at::cuda::jit::BinaryFuncVariant::NoScalar);
   ss << extra_args_types;
   ss << dev_idx;
-  const std::string cache_key = ss.str();
+  const std::string cache_key = std::move(ss).str();
 
   static std::mutex _jiterator_mutex;
   static std::unordered_map<std::string, at::cuda::jit::NvrtcFunction> fns;

--- a/aten/src/ATen/mps/MPSProfiler.h
+++ b/aten/src/ATen/mps/MPSProfiler.h
@@ -93,7 +93,7 @@ struct OperationInfo : BaseInfo {
     for (const Tensor& tensor : tensors) {
       kernelStr << ':' << BaseInfo::buildTensorString(tensor, includeBufferId);
     }
-    return kernelStr.str();
+    return std::move(kernelStr).str();
   }
 };
 

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -42,7 +42,7 @@ std::string BaseInfo::buildTensorString(const Tensor& tensor, bool includeBuffer
       tensorStr << "(buf#" << (getIMPSAllocator()->getBufferId(buffer)) << ':' << buffer.retainCount << ')';
     }
     tensorStr << ':' << tensor.scalar_type() << tensor.sizes();
-    return tensorStr.str();
+    return std::move(tensorStr).str();
   } else {
     return "undefined";
   }

--- a/aten/src/ATen/native/CPUFallback.cpp
+++ b/aten/src/ATen/native/CPUFallback.cpp
@@ -297,7 +297,7 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
               op.schema().operator_name(),
               " appears to be a view operator, ",
               "but it has no implementation for the backend \"",
-              dev_str.str(),
+              std::move(dev_str).str(),
               "\". View operators don't support ",
               "since the tensor's storage cannot be shared across devices.");
         } else {
@@ -307,7 +307,7 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
               op.schema().operator_name(),
               " appears to be a view operator, ",
               "but it has no implementation for the backend \"",
-              dev_str.str(),
+              std::move(dev_str).str(),
               "\". View operators don't support falling back to run on the CPU, ",
               "since the tensor's storage cannot be shared across devices.");
         }

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -184,7 +184,7 @@ static void check_args(CheckedFrom c, IntArrayRef args, size_t expected_size, co
     ss << arg_name << " should be greater than zero but got (";
     std::copy(args.begin(), args.end() - 1, std::ostream_iterator<int>(ss,", "));
     ss << args.back() << ')' << " (while checking arguments for " << c << ')';
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 

--- a/aten/src/ATen/native/ScaledBlas.cpp
+++ b/aten/src/ATen/native/ScaledBlas.cpp
@@ -68,7 +68,7 @@ void invalid_scaling_config(
     exception_ss << " and scale_b=None";
   }
 
-  TORCH_CHECK_VALUE(false, exception_ss.str());
+  TORCH_CHECK_VALUE(false, std::move(exception_ss).str());
 }
 
 /*

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -337,7 +337,7 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
        << dim;
     ss << " and source slice shape: " << sourceSlicedSizes
        << " at dimension 0.";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   TORCH_CHECK_INDEX(
       source.dim() == 0 || numIndices == source.size(dim),

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -1076,14 +1076,14 @@ std::string generate_code(
     declare_load_arrays << f_inputs_type << " arg" << std::to_string(i)
                         << '[' << std::to_string(thread_work_size) << "];\n";
   }
-  env.s("declare_load_arrays", declare_load_arrays.str());
+  env.s("declare_load_arrays", std::move(declare_load_arrays).str());
 
   std::stringstream declare_store_arrays;
   for (int i = 0; i < nOutputs; i++) {
     declare_store_arrays << result_type << " out" << std::to_string(i)
                         << '[' << std::to_string(thread_work_size) << "];\n";
   }
-  env.s("declare_store_arrays", declare_store_arrays.str());
+  env.s("declare_store_arrays", std::move(declare_store_arrays).str());
 
   std::stringstream functor_args;
   if (scalar_pos == BinaryFuncVariant::NoScalar) {
@@ -1098,7 +1098,7 @@ std::string generate_code(
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(nInputs == 1);
     functor_args << "arg0[j], scalar_val";
   }
-  env.s("args", functor_args.str());
+  env.s("args", std::move(functor_args).str());
 
   std::string call_functor_template;
   if (return_by_ref) {  // return one or more outputs by reference
@@ -1115,7 +1115,7 @@ std::string generate_code(
       }
       functor_outs << "out" << std::to_string(nOutputs - 1) << "[j]";
     }
-    env.s("functor_outs", functor_outs.str());
+    env.s("functor_outs", std::move(functor_outs).str());
 
     if (need_temp_out) {
       call_functor_template += "${compute_type} ${functor_outs};\n";
@@ -1208,7 +1208,7 @@ std::string generate_code(
                   << "], input_offsets[" << i_string << "], " << i_string
                   << ");\n";
     }
-    env.s("load_inputs", load_inputs.str());
+    env.s("load_inputs", std::move(load_inputs).str());
 
     std::stringstream store_outputs;
     for (int i = 0; i < nOutputs; i++) {
@@ -1218,7 +1218,7 @@ std::string generate_code(
                     << "], output_offsets[" << i_string << "], " << i_string
                     << ");\n";
     }
-    env.s("store_outputs", store_outputs.str());
+    env.s("store_outputs", std::move(store_outputs).str());
 
     static auto cuda_template = at::jit::CodeTemplate(
       jit_preamble + jit_common_types + offset_calc_template + jit_code_template + jit_epilogue);
@@ -1237,7 +1237,7 @@ std::string generate_code(
         " = reinterpret_cast<const scalar_t*>(data[" << i_string << '+' << nOutputs << "])" <<
         " + block_work_size * idx;\n";
   }
-  env.s("vector_inputs", vector_inputs.str());
+  env.s("vector_inputs", std::move(vector_inputs).str());
 
   std::stringstream vector_outputs;
   for (const auto i : c10::irange(nOutputs)){
@@ -1246,7 +1246,7 @@ std::string generate_code(
     " = reinterpret_cast<vec_t_output*>(data[" << i_string << "])" <<
     " + block_work_size / vec_size * idx;\n";
   }
-  env.s("vector_outputs", vector_outputs.str());
+  env.s("vector_outputs", std::move(vector_outputs).str());
 
   std::stringstream load_vectorized_inputs;
   for (const auto i : c10::irange(nInputs)) {
@@ -1258,7 +1258,7 @@ std::string generate_code(
     load_vectorized_inputs << "  arg" << i_string << "[vec_size * i + j] = vec" << i_string << ".val[j];\n";
     load_vectorized_inputs << "}\n";
   }
-  env.s("load_vectorized_inputs", load_vectorized_inputs.str());
+  env.s("load_vectorized_inputs", std::move(load_vectorized_inputs).str());
 
   std::stringstream store_vectorized_outputs;
   for (const auto i : c10::irange(nOutputs)) {
@@ -1269,7 +1269,7 @@ std::string generate_code(
     store_vectorized_outputs << "}\n";
     store_vectorized_outputs << "to_"<< i_string << "[thread_idx] = v;\n";
   }
-  env.s("store_vectorized_outputs", store_vectorized_outputs.str());
+  env.s("store_vectorized_outputs", std::move(store_vectorized_outputs).str());
 
   std::stringstream load_unrolled_inputs;
   for (const auto i: c10::irange(nInputs)){
@@ -1277,7 +1277,7 @@ std::string generate_code(
     load_unrolled_inputs << "arg" << i_string << "[j] = load<" << f_inputs_type
       << ">(data[" << std::to_string(i + nOutputs) << "], linear_idx);\n";
   }
-  env.s("load_unrolled_inputs", load_unrolled_inputs.str());
+  env.s("load_unrolled_inputs", std::move(load_unrolled_inputs).str());
 
   std::stringstream store_unrolled_outputs;
   for (const auto i : c10::irange(nOutputs)) {
@@ -1285,7 +1285,7 @@ std::string generate_code(
     store_unrolled_outputs << "store<" << result_type << ">(out" << i_string
       << "[j], data[" << i_string << "], linear_idx);\n";
   }
-  env.s("store_unrolled_outputs", store_unrolled_outputs.str());
+  env.s("store_unrolled_outputs", std::move(store_unrolled_outputs).str());
 
   static auto cuda_template = at::jit::CodeTemplate(
     jit_preamble + jit_common_types + jit_vectorized_code_template + jit_epilogue);
@@ -1571,7 +1571,7 @@ NvrtcFunction jit_pwise_function(
     ss << (compile_to_sass ? "_sass" : "_ptx");
     ss << '_' << code.length();
     ss << '_' << hash_code;
-    file_path = ss.str();
+    file_path = std::move(ss).str();
 
     std::ifstream read_stream{file_path, std::ios::in | std::ifstream::binary};
     if (read_stream.fail()) {
@@ -1677,7 +1677,7 @@ NvrtcFunction jit_pwise_function(
     const auto pid = getpid();
     std::stringstream tmp_file_path_ss;
     tmp_file_path_ss << file_path << "_tmp_" << pid;
-    const std::string tmp_file_path = tmp_file_path_ss.str();
+    const std::string tmp_file_path = std::move(tmp_file_path_ss).str();
     std::ofstream cubin(tmp_file_path, std::ios::out | std::ofstream::binary);
     if (cubin.fail()) {
       TORCH_WARN_ONCE("Failed to write temporarily kernel cache file!",

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -636,7 +636,7 @@ std::string _format_non_converging_batches(const std::vector<int64_t>& batches) 
     ss << "and other " << batches.size() - too_long << " batches";
   }
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 // This function returns V, not V^H.

--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -89,7 +89,7 @@ C10_ALWAYS_INLINE std::pair<int64_t, int64_t> _check_layer_norm_inputs(
       ss << ", " << size;
     }
     ss << "], but got input of size" << input_shape;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 
   const int axis = input_ndim - normalized_ndim;

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -104,7 +104,7 @@ typedef bool (^Func)(void);
 bool TEST(const std::vector<int64_t>& sizes, std::string name, Func block) {
   std::stringstream ss;
   std::copy(sizes.begin(), sizes.end(), std::ostream_iterator<int>(ss, " "));
-  __block std::string str1 = ss.str();
+  __block std::string str1 = std::move(ss).str();
   c10::InferenceMode guard;
   bool b = block();
   void (^print)(NSString*) = ^(NSString* result) {

--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -427,7 +427,7 @@ std::string Adapter::stringize() const {
   ss << "  ]" << std::endl;
   ss << '}';
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::ostream& operator<<(std::ostream& os, const Adapter& adapter) {

--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -175,7 +175,7 @@ static std::string stringize(const VkExtent3D& extents) {
   std::stringstream ss;
   ss << '{' << extents.width << ", " << extents.height << ", " << extents.depth
      << '}';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string QueryPool::generate_string_report() {
@@ -210,7 +210,7 @@ std::string QueryPool::generate_string_report() {
     ss << std::endl;
   }
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void QueryPool::print_results() {

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -150,7 +150,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
 
   std::stringstream stream;
   stream << layer_prefix << ' ' << message_code << ' ' << message << std::endl;
-  const std::string log = stream.str();
+  const std::string log = std::move(stream).str();
 
   std::cout << log;
 

--- a/aten/src/ATen/native/vulkan/ops/NativeLayerNorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/NativeLayerNorm.cpp
@@ -48,7 +48,7 @@ void _check_layer_norm_inputs(
       ss << ", " << size;
     }
     ss << "], but got input of size" << input_shape;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -248,7 +248,7 @@ void TestToString() {
   std::stringstream s;
   s << b << '\n';
   std::string expect = "1e-07 *";
-  ASSERT_EQ_RESOLVED(s.str().substr(0, expect.size()), expect);
+  ASSERT_EQ_RESOLVED(std::move(s).str().substr(0, expect.size()), expect);
 }
 
 void TestIndexingByScalar() {

--- a/aten/src/ATen/test/half_test.cpp
+++ b/aten/src/ATen/test/half_test.cpp
@@ -62,7 +62,7 @@ TEST(TestHalf, Construction) {
 static std::string to_string(const Half& h) {
   std::stringstream ss;
   ss << h;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 TEST(TestHalf, Half2String) {

--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -292,14 +292,14 @@ TEST(IValueTest, TuplePrint) {
 
     std::stringstream ss;
     ss << tp;
-    ASSERT_EQ(ss.str(), "(3,)");
+    ASSERT_EQ(std::move(ss).str(), "(3,)");
   }
 
   {
     IValue tp = std::make_tuple(3, 3);
     std::stringstream ss;
     ss << tp;
-    ASSERT_EQ(ss.str(), "(3, 3)");
+    ASSERT_EQ(std::move(ss).str(), "(3, 3)");
   }
 }
 
@@ -308,21 +308,21 @@ TEST(IValueTest, ComplexIValuePrint) {
     IValue complex(c10::complex<double>(2, -3));
     std::stringstream ss;
     ss << complex;
-    ASSERT_EQ(ss.str(), "2.-3.j");
+    ASSERT_EQ(std::move(ss).str(), "2.-3.j");
   }
 
   {
     IValue complex(c10::complex<double>(2, 0));
     std::stringstream ss;
     ss << complex;
-    ASSERT_EQ(ss.str(), "2.+0.j");
+    ASSERT_EQ(std::move(ss).str(), "2.+0.j");
   }
 
   {
     IValue complex(c10::complex<double>(0, 3));
     std::stringstream ss;
     ss << complex;
-    ASSERT_EQ(ss.str(), "0.+3.j");
+    ASSERT_EQ(std::move(ss).str(), "0.+3.j");
   }
 }
 

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -863,7 +863,7 @@ public:
         }
         stream << "Expected:\n#\t" << exp << "\nActual:\n#\t" << act;
         stream << "\nFirst mismatch Index: " << index;
-        return stream.str();
+        return std::move(stream).str();
     }
 
     bool check(bool bitwise = false, bool checkWithTolerance = false, ValueType<T> toleranceEps = {}) const

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -159,7 +159,7 @@ bool isIncludedInAlias(DispatchKey k, DispatchKey alias) {
 std::string toString(DispatchKeySet ts) {
   std::stringstream ss;
   ss << ts;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::ostream& operator<<(std::ostream& os, DispatchKeySet ts) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -34,7 +34,6 @@
 #include <c10/util/Exception.h>
 #include <cuda_runtime_api.h>
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstddef>
@@ -43,7 +42,6 @@
 #include <memory>
 #include <mutex>
 #include <new>
-#include <ranges>
 #include <regex>
 #include <set>
 #include <stack>
@@ -144,7 +142,7 @@ namespace Native {
  */
 
 // counter to track order for Mempool Registration
-static std::atomic<int32_t> registration_counter_global{-1};
+std::atomic<int32_t> registration_counter_global{-1};
 
 static char SHAREABLE_HANDLE_VERSION = 3;
 enum ShareableHandleType : char {
@@ -538,10 +536,7 @@ struct ExpandableSegment {
         C10_CUDA_DRIVER_CHECK(status);
 #endif
       }
-      handles_.at(i) = Handle{
-          .handle = handle,
-          .shareable_handle = std::nullopt,
-      };
+      handles_.at(i) = Handle{handle, std::nullopt};
     }
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
@@ -745,10 +740,7 @@ struct ExpandableSegment {
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
         close(static_cast<int>(myfd));
-        segment->handles_.emplace_back(Handle{
-            .handle = handle,
-            .shareable_handle = std::nullopt,
-        });
+        segment->handles_.emplace_back(Handle{handle, std::nullopt});
       }
       close(static_cast<int>(pidfd));
 #endif // !_WIN32
@@ -773,10 +765,7 @@ struct ExpandableSegment {
             get_nvml_fabric_info(device),
             "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
-        segment->handles_.emplace_back(Handle{
-            .handle = handle,
-            .shareable_handle = std::nullopt,
-        });
+        segment->handles_.emplace_back(Handle{handle, std::nullopt});
       }
 #endif
     }
@@ -793,8 +782,8 @@ struct ExpandableSegment {
     return max_handles_ * segment_size_;
   }
 
-  std::optional<cudaStream_t> getStream() const {
-    return stream_;
+  cudaStream_t getStream() {
+    return *stream_;
   }
 
   size_t getMappedSize() const {
@@ -862,13 +851,13 @@ struct ExpandableSegment {
   void setAccess(c10::DeviceIndex device, size_t begin, size_t end) {
 #if defined(USE_ROCM) && (ROCM_VERSION >= 70200)
     constexpr int num_desc = 2;
-    std::array<CUmemAccessDesc, num_desc> desc{};
+    CUmemAccessDesc desc[num_desc];
     desc[1].location.type = CU_MEM_LOCATION_TYPE_HOST;
     desc[1].location.id = 0; // ignored
     desc[1].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
 #else
     constexpr int num_desc = 1;
-    std::array<CUmemAccessDesc, num_desc> desc{};
+    CUmemAccessDesc desc[num_desc];
 #endif
     desc[0].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     // NOLINTNEXTLINE(bugprone-signed-char-misuse)
@@ -878,14 +867,14 @@ struct ExpandableSegment {
     C10_CUDA_CHECK(hipMemSetAccess(
         ptr() + begin * segment_size_,
         (end - begin) * segment_size_,
-        desc.data(),
-        desc.size()));
+        &desc[0],
+        num_desc));
 #else
     C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemSetAccess_(
         ptr_ + begin * segment_size_,
         (end - begin) * segment_size_,
-        desc.data(),
-        desc.size()));
+        &desc[0],
+        num_desc));
 #endif
   }
 
@@ -953,7 +942,7 @@ struct ExpandableSegment {
     trimHandles();
   }
   void trimHandles() {
-    auto it = std::ranges::find_if(
+    auto it = std::find_if(
         handles_.rbegin(),
         handles_.rend(),
         [](const std::optional<Handle>& opt) { return opt.has_value(); });
@@ -1049,8 +1038,8 @@ struct ExpandableSegment {
   size_t size() const {
     return 0;
   }
-  std::optional<cudaStream_t> getStream() const {
-    return std::nullopt;
+  cudaStream_t getStream() {
+    return nullptr;
   }
 
   size_t getMappedSize() const {
@@ -1426,7 +1415,7 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
     }
     ss << " has " << format_size(proc.usedGpuMemory) << " memory in use. ";
   }
-  return std::move(ss).str();
+  return ss.str();
 #else
   return "";
 #endif
@@ -1637,7 +1626,7 @@ class DeviceCachingAllocator {
       TORCH_INTERNAL_ASSERT(b != nullptr);
       TORCH_INTERNAL_ASSERT(b->pool != nullptr);
       if (b->allocated && b->pool->owner_PrivatePool == pool) {
-        if (!expected_live_allocations.contains(b->ptr)) {
+        if (!expected_live_allocations.count(b->ptr)) {
           return false;
         }
 
@@ -2364,11 +2353,12 @@ class DeviceCachingAllocator {
     if (graph_reuse_context.find(info.capture_id) ==
         graph_reuse_context.end()) {
       bool found = false;
-      // Search allocation_scopes_ in LIFO order.
-      for (const auto& [mempool_id, filter] :
-           allocation_scopes_ | std::views::reverse) {
-        if (filter(stream)) {
-          auto graph_pool = graph_pools.find(mempool_id);
+      // Use the reverse iterator to search allocation_scopes_ in LIFO order.
+      for (auto it = allocation_scopes_.rbegin();
+           it != allocation_scopes_.rend();
+           ++it) {
+        if (it->second(stream)) {
+          auto graph_pool = graph_pools.find(it->first);
           TORCH_INTERNAL_ASSERT(
               graph_pool != graph_pools.end(),
               "Could not find graph pool for capture.");
@@ -2420,9 +2410,7 @@ class DeviceCachingAllocator {
     }
   }
 
-  void free_locked(
-      Block* block,
-      const std::shared_ptr<GatheredContext>& context) {
+  void free_locked(Block* block, std::shared_ptr<GatheredContext> context) {
     block->allocated = false;
 
     // following logic might modifying underlying Block, causing the size
@@ -2487,7 +2475,7 @@ class DeviceCachingAllocator {
     std::shared_ptr<GatheredContext> context =
         maybeGatherContext(RecordContext::ALL);
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    free_locked(block, context);
+    free_locked(block, std::move(context));
   }
 
   void* getBaseAllocation(Block* block, size_t* outSize) {
@@ -2532,10 +2520,7 @@ class DeviceCachingAllocator {
           SegmentRange(block->ptr, block->size), ss);
       offset = static_cast<const char*>(block->ptr) - full_range.ptr;
     }
-    return ShareableHandle{
-        .offset = offset,
-        .handle = std::move(ss).str(),
-    };
+    return ShareableHandle{offset, ss.str()};
   }
 
   void recordStream(Block* block, cuda::CUDAStream stream) {
@@ -2580,16 +2565,11 @@ class DeviceCachingAllocator {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     std::vector<StreamSegmentSize> sizes;
     for (auto& segment : expandable_segments_) {
-      auto stream = segment->getStream();
-      if (!stream) {
-        continue;
-      }
-      cudaStream_t raw_stream = *stream;
-      if (!raw_stream) {
+      if (!segment->getStream()) {
         continue;
       }
       sizes.emplace_back(
-          raw_stream,
+          segment->getStream(),
           segment->getSegmentSize() == kSmallBuffer,
           segment->getMappedSize());
     }
@@ -3028,9 +3008,12 @@ class DeviceCachingAllocator {
       total_active += segment_info.active_size;
     }
 
-    std::ranges::sort(result, [](const SegmentInfo& a, const SegmentInfo& b) {
-      return a.address < b.address;
-    });
+    std::sort(
+        result.begin(),
+        result.end(),
+        [](const SegmentInfo& a, const SegmentInfo& b) {
+          return a.address < b.address;
+        });
 
     record_trace(
         TraceEntry::SNAPSHOT, 0, total_active, nullptr, 0, mempool_id, nullptr);
@@ -3263,8 +3246,10 @@ class DeviceCachingAllocator {
 
   void addPeerAccess(c10::DeviceIndex dev_to_access) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    if (std::ranges::find(devices_with_peer_access_, dev_to_access) !=
-        devices_with_peer_access_.end()) {
+    if (std::find(
+            devices_with_peer_access_.begin(),
+            devices_with_peer_access_.end(),
+            dev_to_access) != devices_with_peer_access_.end()) {
       return;
     }
     devices_with_peer_access_.push_back(dev_to_access);
@@ -3662,11 +3647,12 @@ class DeviceCachingAllocator {
     // warmup). When non-empty we route allocations into the matching private
     // pool. It is usually empty, so we can short-circuit on the common path.
     if (C10_UNLIKELY(!allocation_scopes_.empty())) {
-      // Search allocation_scopes_ in LIFO order.
-      for (const auto& [mempool_id, filter] :
-           allocation_scopes_ | std::views::reverse) {
-        if (filter(stream)) {
-          auto it1 = graph_pools.find(mempool_id);
+      // Use the reverse iterator to search allocation_scopes_ in LIFO order.
+      for (auto it = allocation_scopes_.rbegin();
+           it != allocation_scopes_.rend();
+           ++it) {
+        if (it->second(stream)) {
+          auto it1 = graph_pools.find(it->first);
           TORCH_INTERNAL_ASSERT(it1 != graph_pools.end());
           if (size <= kSmallSize) {
             return it1->second->small_blocks;
@@ -3796,13 +3782,9 @@ class DeviceCachingAllocator {
     // Unlike release_cached_blocks(), this does not enforce synchronization and
     // therefore should be of less overheads.
 
-    if (!allowed_memory_maximum.has_value()) {
-      return;
-    }
-    const size_t memory_maximum = *allowed_memory_maximum;
     size_t gc_threshold = static_cast<size_t>(
         AcceleratorAllocatorConfig::garbage_collection_threshold() *
-        static_cast<double>(memory_maximum));
+        static_cast<double>(allowed_memory_maximum.value()));
     // No need to trigger GC yet
     if (total_allocated_memory <= gc_threshold) {
       return;
@@ -3889,25 +3871,21 @@ class DeviceCachingAllocator {
     // configured limit. This prevents fatal HSA/driver aborts by throwing
     // OutOfMemoryError instead.
     if (CUDAAllocatorConfig::throw_on_cudamalloc_oom()) {
-      const size_t device_total = device_prop.totalGlobalMem;
-      const auto memory_fraction =
-          CUDAAllocatorConfig::per_process_memory_fraction();
+      size_t device_total = static_cast<size_t>(device_prop.totalGlobalMem);
       size_t max_allowed = static_cast<size_t>(
-          memory_fraction * static_cast<double>(device_total));
+          CUDAAllocatorConfig::per_process_memory_fraction() *
+          static_cast<double>(device_total));
       if (total_allocated_memory + size > max_allowed) {
         stats.num_oom_rejections++;
         p.oom_rejection_info = {
-            .rejected = true,
-            .alloc_size = size,
-            .total_allocated = total_allocated_memory,
-            .device_total = device_total,
-        };
+            true, size, total_allocated_memory, device_total};
         C10_LOG_EVERY_MS(WARNING, 60000)
             << "Preemptively rejecting allocation: requested "
             << format_size(size) << " but total_allocated_memory ("
             << format_size(total_allocated_memory)
             << ") + requested size would exceed memory limit ("
-            << format_size(max_allowed) << " = " << memory_fraction * 100
+            << format_size(max_allowed) << " = "
+            << CUDAAllocatorConfig::per_process_memory_fraction() * 100
             << "% of " << format_size(device_total)
             << "). Set throw_on_cudamalloc_oom:false to disable.";
         p.err = cudaErrorMemoryAllocation;
@@ -4129,8 +4107,10 @@ class DeviceCachingAllocator {
         block->size == block->expandable_segment_->size(),
         "block disagrees with segment");
     TORCH_INTERNAL_ASSERT(!block->mapped);
-    auto it =
-        std::ranges::find(expandable_segments_, block->expandable_segment_);
+    auto it = std::find(
+        expandable_segments_.begin(),
+        expandable_segments_.end(),
+        block->expandable_segment_);
     TORCH_INTERNAL_ASSERT(it != expandable_segments_.end());
     expandable_segments_.erase(it);
     block->pool->unmapped.erase(block);
@@ -4559,10 +4539,10 @@ class NativeCachingAllocator : public CUDAAllocator {
   std::array<AlignedMutex, kNumMutexShard> mutex;
 
   // allocated blocks by device pointer
-  std::array<ska::flat_hash_map<const void*, Block*>, kNumMutexShard>
+  std::array<ska::flat_hash_map<void*, Block*>, kNumMutexShard>
       allocated_blocks;
 
-  static size_t get_mutex_shard_id(const void* ptr) {
+  static size_t get_mutex_shard_id(void* ptr) {
     return twang_mix64(reinterpret_cast<uintptr_t>(ptr)) % kNumMutexShard;
   }
 
@@ -4581,7 +4561,7 @@ class NativeCachingAllocator : public CUDAAllocator {
  public:
   std::vector<std::unique_ptr<DeviceCachingAllocator>> device_allocator;
 
-  Block* get_allocated_block(const void* ptr, bool remove = false) {
+  Block* get_allocated_block(void* ptr, bool remove = false) {
     const auto mutex_shard_id = get_mutex_shard_id(ptr);
     std::lock_guard<std::mutex> lock(mutex[mutex_shard_id].m);
     auto it = allocated_blocks[mutex_shard_id].find(ptr);
@@ -4790,7 +4770,7 @@ class NativeCachingAllocator : public CUDAAllocator {
 
   std::shared_ptr<GatheredContext> getContextForPointer(
       const void* ptr) override {
-    Block* block = get_allocated_block(ptr);
+    Block* block = get_allocated_block(const_cast<void*>(ptr));
     if (!block) {
       return nullptr;
     }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -142,7 +142,7 @@ namespace Native {
  */
 
 // counter to track order for Mempool Registration
-std::atomic<int32_t> registration_counter_global{-1};
+static std::atomic<int32_t> registration_counter_global{-1};
 
 static char SHAREABLE_HANDLE_VERSION = 3;
 enum ShareableHandleType : char {
@@ -536,7 +536,10 @@ struct ExpandableSegment {
         C10_CUDA_DRIVER_CHECK(status);
 #endif
       }
-      handles_.at(i) = Handle{handle, std::nullopt};
+      handles_.at(i) = Handle{
+          .handle = handle,
+          .shareable_handle = std::nullopt,
+      };
     }
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
@@ -740,7 +743,10 @@ struct ExpandableSegment {
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
         close(static_cast<int>(myfd));
-        segment->handles_.emplace_back(Handle{handle, std::nullopt});
+        segment->handles_.emplace_back(Handle{
+            .handle = handle,
+            .shareable_handle = std::nullopt,
+        });
       }
       close(static_cast<int>(pidfd));
 #endif // !_WIN32
@@ -765,7 +771,10 @@ struct ExpandableSegment {
             get_nvml_fabric_info(device),
             "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
-        segment->handles_.emplace_back(Handle{handle, std::nullopt});
+        segment->handles_.emplace_back(Handle{
+            .handle = handle,
+            .shareable_handle = std::nullopt,
+        });
       }
 #endif
     }
@@ -3246,10 +3255,8 @@ class DeviceCachingAllocator {
 
   void addPeerAccess(c10::DeviceIndex dev_to_access) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    if (std::find(
-            devices_with_peer_access_.begin(),
-            devices_with_peer_access_.end(),
-            dev_to_access) != devices_with_peer_access_.end()) {
+    if (std::ranges::find(devices_with_peer_access_, dev_to_access) !=
+        devices_with_peer_access_.end()) {
       return;
     }
     devices_with_peer_access_.push_back(dev_to_access);
@@ -3871,21 +3878,25 @@ class DeviceCachingAllocator {
     // configured limit. This prevents fatal HSA/driver aborts by throwing
     // OutOfMemoryError instead.
     if (CUDAAllocatorConfig::throw_on_cudamalloc_oom()) {
-      size_t device_total = static_cast<size_t>(device_prop.totalGlobalMem);
+      const size_t device_total = device_prop.totalGlobalMem;
+      const auto memory_fraction =
+          CUDAAllocatorConfig::per_process_memory_fraction();
       size_t max_allowed = static_cast<size_t>(
-          CUDAAllocatorConfig::per_process_memory_fraction() *
-          static_cast<double>(device_total));
+          memory_fraction * static_cast<double>(device_total));
       if (total_allocated_memory + size > max_allowed) {
         stats.num_oom_rejections++;
         p.oom_rejection_info = {
-            true, size, total_allocated_memory, device_total};
+            .rejected = true,
+            .alloc_size = size,
+            .total_allocated = total_allocated_memory,
+            .device_total = device_total,
+        };
         C10_LOG_EVERY_MS(WARNING, 60000)
             << "Preemptively rejecting allocation: requested "
             << format_size(size) << " but total_allocated_memory ("
             << format_size(total_allocated_memory)
             << ") + requested size would exceed memory limit ("
-            << format_size(max_allowed) << " = "
-            << CUDAAllocatorConfig::per_process_memory_fraction() * 100
+            << format_size(max_allowed) << " = " << memory_fraction * 100
             << "% of " << format_size(device_total)
             << "). Set throw_on_cudamalloc_oom:false to disable.";
         p.err = cudaErrorMemoryAllocation;
@@ -4107,10 +4118,8 @@ class DeviceCachingAllocator {
         block->size == block->expandable_segment_->size(),
         "block disagrees with segment");
     TORCH_INTERNAL_ASSERT(!block->mapped);
-    auto it = std::find(
-        expandable_segments_.begin(),
-        expandable_segments_.end(),
-        block->expandable_segment_);
+    auto it =
+        std::ranges::find(expandable_segments_, block->expandable_segment_);
     TORCH_INTERNAL_ASSERT(it != expandable_segments_.end());
     expandable_segments_.erase(it);
     block->pool->unmapped.erase(block);
@@ -4539,10 +4548,10 @@ class NativeCachingAllocator : public CUDAAllocator {
   std::array<AlignedMutex, kNumMutexShard> mutex;
 
   // allocated blocks by device pointer
-  std::array<ska::flat_hash_map<void*, Block*>, kNumMutexShard>
+  std::array<ska::flat_hash_map<const void*, Block*>, kNumMutexShard>
       allocated_blocks;
 
-  static size_t get_mutex_shard_id(void* ptr) {
+  static size_t get_mutex_shard_id(const void* ptr) {
     return twang_mix64(reinterpret_cast<uintptr_t>(ptr)) % kNumMutexShard;
   }
 
@@ -4561,7 +4570,7 @@ class NativeCachingAllocator : public CUDAAllocator {
  public:
   std::vector<std::unique_ptr<DeviceCachingAllocator>> device_allocator;
 
-  Block* get_allocated_block(void* ptr, bool remove = false) {
+  Block* get_allocated_block(const void* ptr, bool remove = false) {
     const auto mutex_shard_id = get_mutex_shard_id(ptr);
     std::lock_guard<std::mutex> lock(mutex[mutex_shard_id].m);
     auto it = allocated_blocks[mutex_shard_id].find(ptr);
@@ -4770,7 +4779,7 @@ class NativeCachingAllocator : public CUDAAllocator {
 
   std::shared_ptr<GatheredContext> getContextForPointer(
       const void* ptr) override {
-    Block* block = get_allocated_block(const_cast<void*>(ptr));
+    Block* block = get_allocated_block(ptr);
     if (!block) {
       return nullptr;
     }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -862,13 +862,13 @@ struct ExpandableSegment {
   void setAccess(c10::DeviceIndex device, size_t begin, size_t end) {
 #if defined(USE_ROCM) && (ROCM_VERSION >= 70200)
     constexpr int num_desc = 2;
-    std::array<CUmemAccessDesc, num_desc> desc;
+    std::array<CUmemAccessDesc, num_desc> desc{};
     desc[1].location.type = CU_MEM_LOCATION_TYPE_HOST;
     desc[1].location.id = 0; // ignored
     desc[1].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
 #else
     constexpr int num_desc = 1;
-    std::array<CUmemAccessDesc, num_desc> desc;
+    std::array<CUmemAccessDesc, num_desc> desc{};
 #endif
     desc[0].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     // NOLINTNEXTLINE(bugprone-signed-char-misuse)
@@ -2420,7 +2420,9 @@ class DeviceCachingAllocator {
     }
   }
 
-  void free_locked(Block* block, std::shared_ptr<GatheredContext> context) {
+  void free_locked(
+      Block* block,
+      const std::shared_ptr<GatheredContext>& context) {
     block->allocated = false;
 
     // following logic might modifying underlying Block, causing the size
@@ -2485,7 +2487,7 @@ class DeviceCachingAllocator {
     std::shared_ptr<GatheredContext> context =
         maybeGatherContext(RecordContext::ALL);
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    free_locked(block, std::move(context));
+    free_locked(block, context);
   }
 
   void* getBaseAllocation(Block* block, size_t* outSize) {
@@ -2530,7 +2532,10 @@ class DeviceCachingAllocator {
           SegmentRange(block->ptr, block->size), ss);
       offset = static_cast<const char*>(block->ptr) - full_range.ptr;
     }
-    return ShareableHandle{offset, ss.str()};
+    return ShareableHandle{
+        .offset = offset,
+        .handle = std::move(ss).str(),
+    };
   }
 
   void recordStream(Block* block, cuda::CUDAStream stream) {
@@ -2579,8 +2584,12 @@ class DeviceCachingAllocator {
       if (!stream) {
         continue;
       }
+      cudaStream_t raw_stream = *stream;
+      if (!raw_stream) {
+        continue;
+      }
       sizes.emplace_back(
-          *stream,
+          raw_stream,
           segment->getSegmentSize() == kSmallBuffer,
           segment->getMappedSize());
     }
@@ -3019,12 +3028,9 @@ class DeviceCachingAllocator {
       total_active += segment_info.active_size;
     }
 
-    std::sort(
-        result.begin(),
-        result.end(),
-        [](const SegmentInfo& a, const SegmentInfo& b) {
-          return a.address < b.address;
-        });
+    std::ranges::sort(result, [](const SegmentInfo& a, const SegmentInfo& b) {
+      return a.address < b.address;
+    });
 
     record_trace(
         TraceEntry::SNAPSHOT, 0, total_active, nullptr, 0, mempool_id, nullptr);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -34,6 +34,7 @@
 #include <c10/util/Exception.h>
 #include <cuda_runtime_api.h>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstddef>
@@ -42,6 +43,7 @@
 #include <memory>
 #include <mutex>
 #include <new>
+#include <ranges>
 #include <regex>
 #include <set>
 #include <stack>
@@ -791,8 +793,8 @@ struct ExpandableSegment {
     return max_handles_ * segment_size_;
   }
 
-  cudaStream_t getStream() {
-    return *stream_;
+  std::optional<cudaStream_t> getStream() const {
+    return stream_;
   }
 
   size_t getMappedSize() const {
@@ -860,13 +862,13 @@ struct ExpandableSegment {
   void setAccess(c10::DeviceIndex device, size_t begin, size_t end) {
 #if defined(USE_ROCM) && (ROCM_VERSION >= 70200)
     constexpr int num_desc = 2;
-    CUmemAccessDesc desc[num_desc];
+    std::array<CUmemAccessDesc, num_desc> desc;
     desc[1].location.type = CU_MEM_LOCATION_TYPE_HOST;
     desc[1].location.id = 0; // ignored
     desc[1].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
 #else
     constexpr int num_desc = 1;
-    CUmemAccessDesc desc[num_desc];
+    std::array<CUmemAccessDesc, num_desc> desc;
 #endif
     desc[0].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     // NOLINTNEXTLINE(bugprone-signed-char-misuse)
@@ -876,14 +878,14 @@ struct ExpandableSegment {
     C10_CUDA_CHECK(hipMemSetAccess(
         ptr() + begin * segment_size_,
         (end - begin) * segment_size_,
-        &desc[0],
-        num_desc));
+        desc.data(),
+        desc.size()));
 #else
     C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemSetAccess_(
         ptr_ + begin * segment_size_,
         (end - begin) * segment_size_,
-        &desc[0],
-        num_desc));
+        desc.data(),
+        desc.size()));
 #endif
   }
 
@@ -951,7 +953,7 @@ struct ExpandableSegment {
     trimHandles();
   }
   void trimHandles() {
-    auto it = std::find_if(
+    auto it = std::ranges::find_if(
         handles_.rbegin(),
         handles_.rend(),
         [](const std::optional<Handle>& opt) { return opt.has_value(); });
@@ -1047,8 +1049,8 @@ struct ExpandableSegment {
   size_t size() const {
     return 0;
   }
-  cudaStream_t getStream() {
-    return nullptr;
+  std::optional<cudaStream_t> getStream() const {
+    return std::nullopt;
   }
 
   size_t getMappedSize() const {
@@ -1635,7 +1637,7 @@ class DeviceCachingAllocator {
       TORCH_INTERNAL_ASSERT(b != nullptr);
       TORCH_INTERNAL_ASSERT(b->pool != nullptr);
       if (b->allocated && b->pool->owner_PrivatePool == pool) {
-        if (!expected_live_allocations.count(b->ptr)) {
+        if (!expected_live_allocations.contains(b->ptr)) {
           return false;
         }
 
@@ -2362,12 +2364,11 @@ class DeviceCachingAllocator {
     if (graph_reuse_context.find(info.capture_id) ==
         graph_reuse_context.end()) {
       bool found = false;
-      // Use the reverse iterator to search allocation_scopes_ in LIFO order.
-      for (auto it = allocation_scopes_.rbegin();
-           it != allocation_scopes_.rend();
-           ++it) {
-        if (it->second(stream)) {
-          auto graph_pool = graph_pools.find(it->first);
+      // Search allocation_scopes_ in LIFO order.
+      for (const auto& [mempool_id, filter] :
+           allocation_scopes_ | std::views::reverse) {
+        if (filter(stream)) {
+          auto graph_pool = graph_pools.find(mempool_id);
           TORCH_INTERNAL_ASSERT(
               graph_pool != graph_pools.end(),
               "Could not find graph pool for capture.");
@@ -2574,11 +2575,12 @@ class DeviceCachingAllocator {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     std::vector<StreamSegmentSize> sizes;
     for (auto& segment : expandable_segments_) {
-      if (!segment->getStream()) {
+      auto stream = segment->getStream();
+      if (!stream) {
         continue;
       }
       sizes.emplace_back(
-          segment->getStream(),
+          *stream,
           segment->getSegmentSize() == kSmallBuffer,
           segment->getMappedSize());
     }
@@ -3654,12 +3656,11 @@ class DeviceCachingAllocator {
     // warmup). When non-empty we route allocations into the matching private
     // pool. It is usually empty, so we can short-circuit on the common path.
     if (C10_UNLIKELY(!allocation_scopes_.empty())) {
-      // Use the reverse iterator to search allocation_scopes_ in LIFO order.
-      for (auto it = allocation_scopes_.rbegin();
-           it != allocation_scopes_.rend();
-           ++it) {
-        if (it->second(stream)) {
-          auto it1 = graph_pools.find(it->first);
+      // Search allocation_scopes_ in LIFO order.
+      for (const auto& [mempool_id, filter] :
+           allocation_scopes_ | std::views::reverse) {
+        if (filter(stream)) {
+          auto it1 = graph_pools.find(mempool_id);
           TORCH_INTERNAL_ASSERT(it1 != graph_pools.end());
           if (size <= kSmallSize) {
             return it1->second->small_blocks;
@@ -3789,9 +3790,13 @@ class DeviceCachingAllocator {
     // Unlike release_cached_blocks(), this does not enforce synchronization and
     // therefore should be of less overheads.
 
+    if (!allowed_memory_maximum.has_value()) {
+      return;
+    }
+    const size_t memory_maximum = *allowed_memory_maximum;
     size_t gc_threshold = static_cast<size_t>(
         AcceleratorAllocatorConfig::garbage_collection_threshold() *
-        static_cast<double>(allowed_memory_maximum.value()));
+        static_cast<double>(memory_maximum));
     // No need to trigger GC yet
     if (total_allocated_memory <= gc_threshold) {
       return;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1415,7 +1415,7 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
     }
     ss << " has " << format_size(proc.usedGpuMemory) << " memory in use. ";
   }
-  return ss.str();
+  return std::move(ss).str();
 #else
   return "";
 #endif

--- a/c10/cuda/CUDADeviceAssertionHost.cpp
+++ b/c10/cuda/CUDADeviceAssertionHost.cpp
@@ -186,7 +186,7 @@ std::string c10_retrieve_device_side_assertion_info() {
       }
     }
   }
-  return oss.str();
+  return std::move(oss).str();
 #else
   return "";
 #endif

--- a/c10/test/util/NetworkFlow_test.cpp
+++ b/c10/test/util/NetworkFlow_test.cpp
@@ -31,7 +31,7 @@ void expect_vector_contains_subset(
         ss << e << ", ";
       }
       ss << "}, but couldn't find " << element;
-      FAIL() << ss.str();
+      FAIL() << std::move(ss).str();
     }
   }
 }

--- a/test/cpp/aoti_abi_check/test_scalartype.cpp
+++ b/test/cpp/aoti_abi_check/test_scalartype.cpp
@@ -76,11 +76,11 @@ TEST(TestScalarType, toString) {
 TEST(TestScalarType, operator_left_shift) {
   using torch::headeronly::ScalarType;
 
-#define DEFINE_CHECK(_, name)   \
-  {                             \
-    std::stringstream ss;       \
-    ss << ScalarType::name;     \
-    EXPECT_EQ(ss.str(), #name); \
+#define DEFINE_CHECK(_, name)              \
+  {                                        \
+    std::stringstream ss;                  \
+    ss << ScalarType::name;                \
+    EXPECT_EQ(std::move(ss).str(), #name); \
   }
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_CHECK);
 #undef DEFINE_CHECK

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -235,7 +235,7 @@ TEST_F(NNUtilsTest, ClipGradNormErrorIfNonfinite) {
        << ", grad_only_one_elem: " << grad_only_one_elem
        << ", prefix_finite_grad_param: " << prefix_finite_grad_param
        << ", is_norm_nonfinite: " << is_norm_nonfinite;
-    std::string msg = ss.str();
+    std::string msg = std::move(ss).str();
 
     auto parameters = gen_parameters(
         scalar, grad_only_one_elem, prefix_finite_grad_param, device_type);

--- a/test/cpp/jit/test_backend_compiler_preprocess.cpp
+++ b/test/cpp/jit/test_backend_compiler_preprocess.cpp
@@ -59,7 +59,7 @@ c10::IValue preprocess(
       }
       ss << ',';
     }
-    std::string blob = ss.str();
+    std::string blob = std::move(ss).str();
     if (!blob.empty()) {
       blob.pop_back();
     }

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -318,7 +318,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
       std::stringstream err;
       err << "Expected " << input_names_.size() << " inputs, but got "
           << inputs.size() << '!';
-      throw std::runtime_error(err.str());
+      throw std::runtime_error(std::move(err).str());
     }
     for (size_t i = 0; i < inputs.size(); ++i) {
       environment[input_names_[i]] = inputs[i];
@@ -341,7 +341,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
         } else {
           std::stringstream err;
           err << "Instruction referenced unknown value " << input_name << '!';
-          throw std::runtime_error(err.str());
+          throw std::runtime_error(std::move(err).str());
         }
       }
 
@@ -361,7 +361,7 @@ struct ElementwiseInterpreter : torch::CustomClassHolder {
       } else {
         std::stringstream err;
         err << "Unknown operator " << op << '!';
-        throw std::runtime_error(err.str());
+        throw std::runtime_error(std::move(err).str());
       }
 
       // Write back result into environment
@@ -607,7 +607,7 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
               }
             }
             ss << ']';
-            return ss.str();
+            return std::move(ss).str();
           });
   // clang-format off
         // The following will fail with a static assert telling you you have to

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -594,7 +594,7 @@ class TorchBindFlatbufferTestStruct : public torch::jit::CustomClassHolder {
     ss << "Hello! Your tensor has ";
     ss << t.numel();
     ss << " elements!";
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/test/cpp/jit/test_graph_iterator.cpp
+++ b/test/cpp/jit/test_graph_iterator.cpp
@@ -47,7 +47,7 @@ std::vector<std::string> traverse_depth_first(
     std::stringstream buffer;
     std::vector<const torch::jit::Node*> vec;
     node->print(buffer, 0, &vec, false, true, true, false);
-    result.push_back(buffer.str());
+    result.push_back(std::move(buffer).str());
     node = graph_it.next();
     ++count;
   }

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -45,7 +45,7 @@ TEST(JitTypeTest, UnifyTypes) {
   ss << (*out)->annotation_str();
   testing::FileCheck()
       .check("Optional[Tuple[Optional[int], Optional[int]]]")
-      ->run(ss.str());
+      ->run(std::move(ss).str());
 
   auto fut_1 = FutureType::create(IntType::get());
   auto fut_2 = FutureType::create(NoneType::get());

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -408,7 +408,7 @@ class TorchBindLiteInterpreterTestStruct
     ss << "Hello! Your tensor has ";
     ss << t.numel();
     ss << " elements!";
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/test/cpp/jit/test_lite_interpreter_direct.cpp
+++ b/test/cpp/jit/test_lite_interpreter_direct.cpp
@@ -311,7 +311,7 @@ class TorchBindLiteInterpreterDirectTestStruct
     ss << "Hello! Your tensor has ";
     ss << t.numel();
     ss << " elements!";
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/test/cpp/jit/test_lite_trainer.cpp
+++ b/test/cpp/jit/test_lite_trainer.cpp
@@ -171,7 +171,7 @@ TEST(MobileTest, SaveParametersDefaultsToZip) {
   EXPECT_EQ(ss_data.str()[0], 'P');
   EXPECT_EQ(ss_data.str()[1], 'K');
   EXPECT_EQ(ss_data.str()[2], '\x03');
-  EXPECT_EQ(ss_data.str()[3], '\x04');
+  EXPECT_EQ(std::move(ss_data).str()[3], '\x04');
 }
 
 TEST(MobileTest, SaveParametersCanUseFlatbuffer) {
@@ -187,7 +187,7 @@ TEST(MobileTest, SaveParametersCanUseFlatbuffer) {
   EXPECT_EQ(ss_data.str()[4], 'P');
   EXPECT_EQ(ss_data.str()[5], 'T');
   EXPECT_EQ(ss_data.str()[6], 'M');
-  EXPECT_EQ(ss_data.str()[7], 'F');
+  EXPECT_EQ(std::move(ss_data).str()[7], 'F');
 }
 
 TEST(MobileTest, SaveLoadParametersUsingFlatbuffers) {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -2304,12 +2304,12 @@ TEST(InlinedCallStackTest, BlockAnnotation) {
   ASSERT_NE(add_ss.str().find("line 4"), std::string::npos);
   ASSERT_NE(
       add_ss.str().find("return self.A0.forward(x, y, z)"), std::string::npos);
-  ASSERT_NE(add_ss.str().find("return x + y"), std::string::npos);
+  ASSERT_NE(std::move(add_ss).str().find("return x + y"), std::string::npos);
   ASSERT_NE(mul_ss.str().find("line 3"), std::string::npos);
   ASSERT_NE(mul_ss.str().find("line 6"), std::string::npos);
   ASSERT_NE(
       mul_ss.str().find("return self.A0.forward(x, y, z)"), std::string::npos);
-  ASSERT_NE(mul_ss.str().find("return x * y"), std::string::npos);
+  ASSERT_NE(std::move(mul_ss).str().find("return x * y"), std::string::npos);
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/test/cpp/lazy/test_backend_device.cpp
+++ b/test/cpp/lazy/test_backend_device.cpp
@@ -96,7 +96,7 @@ TEST(BackendDeviceTest, Ostream) {
   std::stringstream ss;
   ss << device;
 
-  EXPECT_EQ(device.toString(), ss.str());
+  EXPECT_EQ(device.toString(), std::move(ss).str());
 }
 
 TEST(BackendDeviceTest, FromAten) {

--- a/test/cpp/lazy/test_shape.cpp
+++ b/test/cpp/lazy/test_shape.cpp
@@ -77,7 +77,7 @@ TEST(ShapeTest, Ostream) {
   std::stringstream ss;
   ss << shape;
 
-  EXPECT_EQ(shape.to_string(), ss.str());
+  EXPECT_EQ(shape.to_string(), std::move(ss).str());
 }
 
 } // namespace lazy

--- a/test/cpp/nativert/test_itree.cpp
+++ b/test/cpp/nativert/test_itree.cpp
@@ -755,7 +755,7 @@ TEST(ITreeTest, IValueApplyFromArgs) {
 {}
 return(%o1)
 )",
-        ss.str());
+        std::move(ss).str());
 
     auto graph = stringToGraph(source);
     std::vector<const Value*> userInputs(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/profiler/stubs/openreg.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/profiler/stubs/openreg.cpp
@@ -24,7 +24,7 @@ static void openregCheck(orError_t result, const char* file, int line) {
     } else {
       ss << "OpenReg error: " << result;
     }
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 #define TORCH_OPENREG_CHECK(result) openregCheck(result, __FILE__, __LINE__);

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -706,7 +706,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                         ss << "{handle_kind}[{idx}]: unmatched dtype, "
                            << "expected: " << {name}_expected_dtype << "({expected_dtype_name}), "
                            << "but got: " << {name}_dtype << "\\n";
-                        throw std::runtime_error(ss.str());
+                        throw std::runtime_error(std::move(ss).str());
                     }}
                 """
             )
@@ -720,7 +720,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 ss << "{handle_kind}[{idx}]: unmatched dim value at {dim_idx}, "
                                    << "expected: {d}, " << "but got: " << {name}_size[{dim_idx}]
                                    << "\\n";
-                                throw std::runtime_error(ss.str());
+                                throw std::runtime_error(std::move(ss).str());
                             }}
                         """
                     )
@@ -738,7 +738,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                     ss << "{handle_kind}[{idx}]: dim value is too small at {dim_idx}, "
                                        << "expected it to be >= {sym_range.lower}, " << "but got: "
                                        << {name}_size[{dim_idx}] << "\\n";
-                                    throw std::runtime_error(ss.str());
+                                    throw std::runtime_error(std::move(ss).str());
                                 }}
                             """
                         )
@@ -753,7 +753,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                     ss << "{handle_kind}[{idx}]: dim value is too large at {dim_idx}, "
                                        << "expected to be <= {upper_bound}, " << "but got: "
                                        << {name}_size[{dim_idx}] << "\\n";
-                                    throw std::runtime_error(ss.str());
+                                    throw std::runtime_error(std::move(ss).str());
                                 }}
                             """
                         )
@@ -769,7 +769,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                             ss << "{handle_kind}[{idx}]: unmatched stride value at {stride_idx}, "
                                << "expected: {s}, " << "but got: " << {name}_stride[{stride_idx}]
                                << "\\n";
-                            throw std::runtime_error(ss.str());
+                            throw std::runtime_error(std::move(ss).str());
                         }}
                     """
                 )
@@ -793,7 +793,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                     ss << "{handle_kind}[{idx}]: unmatched device type, "
                                     << "expected: " << {name}_expected_device_type << "{expected_device_type}({device_type_str}), "
                                     << "but got: " << {name}_device_type << "\\n";
-                                    throw std::runtime_error(ss.str());
+                                    throw std::runtime_error(std::move(ss).str());
                                 }}
                             """
                         )

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -224,7 +224,7 @@ static PyObject* THPModule_initExtension(
         oss << '#' << idx << ' ' << frame.funcname << " from " << frame.filename
             << ':' << frame.lineno << '\n';
       }
-      return oss.str();
+      return std::move(oss).str();
     });
   }
 #endif

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -959,7 +959,7 @@ void ConcretePyInterpreterVTable::reset_backward_hooks(
 std::string ConcretePyInterpreterVTable::name() const {
   std::stringstream ss;
   ss << getPyInterpreter();
-  return ss.str();
+  return std::move(ss).str();
 }
 
 PyInterpreterHolder self_interpreter;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -923,7 +923,7 @@ static void validate_outputs_impl(
     std::stringstream ss;
     ss << "invalid number of gradients - expected ";
     ss << input_metadata_container.size() << ", but got " << grads.size();
-    TORCH_CHECK(false, format_error(ss.str()));
+    TORCH_CHECK(false, format_error(std::move(ss).str()));
   }
   for (const auto i : c10::irange(grads.size())) {
     if (!has_input_metadata(input_metadata_container[i])) {
@@ -957,7 +957,7 @@ static void validate_outputs_impl(
         std::stringstream ss;
         ss << "invalid gradient at index " << i << " - expected dtype ";
         ss << metadata.grad_dtype().value() << " but got " << grad.dtype();
-        TORCH_CHECK(false, format_error(ss.str()));
+        TORCH_CHECK(false, format_error(std::move(ss).str()));
       }
     }
     if (grad.layout() != metadata.layout()) {
@@ -975,7 +975,7 @@ static void validate_outputs_impl(
         std::stringstream ss;
         ss << "invalid gradient at index " << i << " - expected layout ";
         ss << metadata.layout() << " but got " << grad.layout();
-        TORCH_CHECK(false, format_error(ss.str()));
+        TORCH_CHECK(false, format_error(std::move(ss).str()));
       }
     }
 
@@ -990,7 +990,7 @@ static void validate_outputs_impl(
           std::stringstream ss;
           ss << "invalid gradient at index " << i << " - expected device ";
           ss << metadata.device() << " but got " << grad.device();
-          TORCH_CHECK(false, format_error(ss.str()));
+          TORCH_CHECK(false, format_error(std::move(ss).str()));
         }
       }
     }

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -194,7 +194,7 @@ Variable SavedVariable::unpack(c10::intrusive_ptr<Node> saved_for) const {
                "that failed to compute its gradient. The variable in question "
                "was changed in there or anywhere later. Good luck!";
       }
-      TORCH_CHECK(false, message.str());
+      TORCH_CHECK(false, std::move(message).str());
     }
   }
 

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -333,7 +333,7 @@ void check_inputs(
     std::stringstream err;
     err << "inputs and outputs sequences have to be of the same length, but got input of length "
         << len << " and output of length " << outputs.size();
-    TORCH_CHECK(false, err.str());
+    TORCH_CHECK(false, std::move(err).str());
   }
 
   device_set devices;

--- a/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorderDetail.hpp
@@ -35,7 +35,7 @@ std::string FlightRecorder<EventType>::Entry::getTraceback() {
     #4 main from /home/user/repro.py:34
     #5 <module> from /home/user/repro.py:40
   */
-  return oss.str();
+  return std::move(oss).str();
 }
 
 template <typename EventType>

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -176,7 +176,7 @@ struct CollectiveFingerPrint {
             ss << std::get<1>(diff_result);
           }
 
-          TORCH_CHECK(false, ss.str());
+          TORCH_CHECK(false, std::move(ss).str());
         }
       }
     }
@@ -277,9 +277,9 @@ struct CollectiveFingerPrint {
 
     check("Tensor devices", other_devices, this_devices);
     if (!found_diff) {
-      return std::make_pair(false, ss.str());
+      return std::make_pair(false, std::move(ss).str());
     } else {
-      return std::make_pair(true, ss.str());
+      return std::make_pair(true, std::move(ss).str());
     }
   }
 
@@ -715,7 +715,7 @@ void ProcessGroupWrapper::runCollectiveChecks(
     // Attach collective info to the exception and re-raise.
     std::stringstream ss;
     ss << finger_print;
-    auto collective_info = ss.str();
+    auto collective_info = std::move(ss).str();
     auto err_msg = c10::str(
         "ProcessGroupWrapper: Monitored Barrier encountered error running collective: ",
         collective_info,

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -56,13 +56,13 @@ inline std::string toString(at::IntArrayRef l) {
     ss << l[i];
   }
   ss << ')';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 inline std::string toString(const c10::Layout& layout) {
   std::stringstream ss;
   ss << layout;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 inline void assertSameType(

--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -220,7 +220,7 @@ void Logger::set_construction_data_and_log(
     for (const auto& strItem : ddp_logging_data_->strs_map) {
       ddpLoggingDataInfo << strItem.first << ": " << strItem.second << '\n';
     }
-    LOG(INFO) << initInfo << ddpLoggingDataInfo.str();
+    LOG(INFO) << initInfo << std::move(ddpLoggingDataInfo).str();
   }
 
   at::LogPyTorchDDPUsage(*ddp_logging_data_);

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -169,7 +169,7 @@ void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
         << "GC has deleted them before calling shutdown(): \n"
         << ss.str();
     if (!ignoreRRefLeak) {
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   }
 }

--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -321,7 +321,7 @@ struct CRecursionLimitRAII {
       ss << "new c_recursion limit (" << limit
          << ") is lower than thread's current c_recursion_remaining ("
          << remaining << ").";
-      PyErr_WarnEx(PyExc_RuntimeWarning, ss.str().c_str(), 1);
+      PyErr_WarnEx(PyExc_RuntimeWarning, std::move(ss).str().c_str(), 1);
     }
     remaining = limit;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -253,23 +253,23 @@ std::string TensorCheck::check_verbose(
     fail_reason << "dispatch key set mismatch. expected "
                 << c10::DispatchKeySet(c10::DispatchKeySet::RAW, dispatch_key_)
                 << ", actual " << state.apply(v.key_set());
-    return fail_reason.str();
+    return std::move(fail_reason).str();
   } else if (dtype_ != v.dtype().toScalarType()) {
     // return fmt::format("tensor dtype mismatch. expected {}, actual {}",
     // dtype_, v.dtype().toScalarType());
     fail_reason << "dtype mismatch. expected " << dtype_ << ", actual "
                 << v.dtype().toScalarType();
-    return fail_reason.str();
+    return std::move(fail_reason).str();
   } else if (device_index_ != v.device().index()) {
     fail_reason << "Tensor device index mismatch. Expected device index to be "
                 << device_index_ << ", actual " << v.device().index();
-    return fail_reason.str();
+    return std::move(fail_reason).str();
   } else if (requires_grad_ != v.requires_grad()) {
     // return fmt::format("tensor requires_grad mismatch. expected {}",
     // requires_grad_);
     fail_reason << "requires_grad mismatch. expected requires_grad="
                 << requires_grad_;
-    return fail_reason.str();
+    return std::move(fail_reason).str();
   }
   auto ndim = v.ndimension();
   if (ndim != dim_) {
@@ -277,7 +277,7 @@ std::string TensorCheck::check_verbose(
     // sizes_.size(), ndim);
     fail_reason << "rank mismatch. expected " << sizes_.size() << ", actual "
                 << ndim;
-    return fail_reason.str();
+    return std::move(fail_reason).str();
   }
   const auto& sizes = v.sym_sizes();
   for (auto i : c10::irange(ndim)) {
@@ -285,7 +285,7 @@ std::string TensorCheck::check_verbose(
     if (known_size.has_value() && (known_size.value() != sizes[i])) {
       fail_reason << "size mismatch at index " << i << ". expected "
                   << known_size.value() << ", actual " << sizes[i];
-      return fail_reason.str();
+      return std::move(fail_reason).str();
     }
   }
   const bool supports_stride =
@@ -297,7 +297,7 @@ std::string TensorCheck::check_verbose(
       if (known_stride.has_value() && known_stride.value() != strides[i]) {
         fail_reason << "stride mismatch at index " << i << ". expected "
                     << known_stride.value() << ", actual " << strides[i];
-        return fail_reason.str();
+        return std::move(fail_reason).str();
       }
     }
   }
@@ -546,7 +546,7 @@ PyObject* TensorGuards_check_verbose(
         fail_reason << "' but found " << PyUnicode_AsUTF8(type_str);
         Py_DECREF(type_str);
       }
-      return Py_BuildValue("s", fail_reason.str().c_str());
+      return Py_BuildValue("s", std::move(fail_reason).str().c_str());
     }
 
     auto insertion = unique_tensors.insert({item, nullptr});
@@ -555,7 +555,7 @@ PyObject* TensorGuards_check_verbose(
       fail_reason << "Duplicate tensor found where not expected! ";
       fail_reason << tensor_check_names[i]
                   << "should not alias to anything, but is aliased";
-      return Py_BuildValue("s", fail_reason.str().c_str());
+      return Py_BuildValue("s", std::move(fail_reason).str().c_str());
     }
     std::string fail_reason = checks[i].check_verbose(
         state, THPVariable_Unpack(item), tensor_check_names[i]);
@@ -947,7 +947,7 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
     if (op_name) {
       msg << " for op: " << op_name;
     }
-    PyErr_SetString(PyExc_TypeError, msg.str().c_str());
+    PyErr_SetString(PyExc_TypeError, std::move(msg).str().c_str());
     return nullptr;
   }
   if (!PyTuple_CheckExact(size) || !PyTuple_CheckExact(stride)) {
@@ -956,7 +956,7 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
     if (op_name) {
       msg << " for op: " << op_name;
     }
-    PyErr_SetString(PyExc_TypeError, msg.str().c_str());
+    PyErr_SetString(PyExc_TypeError, std::move(msg).str().c_str());
     return nullptr;
   }
   at::Tensor tensor = THPVariable_Unpack(item);
@@ -967,7 +967,7 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
     if (op_name) {
       msg << " for op: " << op_name;
     }
-    PyErr_SetString(PyExc_AssertionError, msg.str().c_str());
+    PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
     return nullptr;
   }
 
@@ -1002,7 +1002,7 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
     msg << "\nThis error most often comes from a incorrect fake (aka meta) kernel for a custom op.";
     msg << "\nUse torch.library.opcheck to test your custom op.";
     msg << "\nSee https://pytorch.org/docs/stable/library.html#torch.library.opcheck";
-    PyErr_SetString(PyExc_AssertionError, msg.str().c_str());
+    PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
     return nullptr;
   }
 
@@ -1027,7 +1027,7 @@ static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
     if (op_name) {
       msg << " for op: " << op_name;
     }
-    PyErr_SetString(PyExc_TypeError, msg.str().c_str());
+    PyErr_SetString(PyExc_TypeError, std::move(msg).str().c_str());
     return nullptr;
   }
   if (alignment == 0) {
@@ -1036,7 +1036,7 @@ static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
     if (op_name) {
       msg << " in op: " << op_name;
     }
-    PyErr_SetString(PyExc_AssertionError, msg.str().c_str());
+    PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
     return nullptr;
   }
 
@@ -1052,7 +1052,7 @@ static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
     msg << "\nExpect the tensor to be " << alignment
         << " bytes aligned. Fail due to storage_offset=" << storage_offset
         << " itemsize=" << itemsize;
-    PyErr_SetString(PyExc_AssertionError, msg.str().c_str());
+    PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
     return nullptr;
   }
 
@@ -1630,7 +1630,7 @@ class GuardDebugInfo {
        << "verbose_code_parts=" << verbose_code_parts << ",\n"
        << "num_guards_executed=" << num_guards_executed << ",\n"
        << "user_stack=" << user_stack << ")\n";
-    return ss.str();
+    return std::move(ss).str();
   }
 
   // Whether the guard passed or failed.
@@ -5068,7 +5068,7 @@ class TENSOR_MATCH : public LeafGuard {
         fail_reason << "' but found " << PyUnicode_AsUTF8(type_str);
         Py_DECREF(type_str);
       }
-      return GuardDebugInfo(false, fail_reason.str(), 0);
+      return GuardDebugInfo(false, std::move(fail_reason).str(), 0);
     }
 
     std::string fail_reason = _tensor_check->check_verbose(

--- a/torch/csrc/inductor/aoti_runtime/device_utils.h
+++ b/torch/csrc/inductor/aoti_runtime/device_utils.h
@@ -40,7 +40,7 @@ using DeviceStreamType = cudaStream_t;
     if (status != ZE_RESULT_SUCCESS) {                                    \
       std::stringstream ss;                                               \
       ss << "L0 runtime error: " << std::hex << std::uppercase << status; \
-      throw std::runtime_error(ss.str());                                 \
+      throw std::runtime_error(std::move(ss).str());                      \
     }                                                                     \
   } while (0)
 

--- a/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
@@ -13,7 +13,7 @@
     if (status != ZE_RESULT_SUCCESS) {                                    \
       std::stringstream ss;                                               \
       ss << "L0 runtime error: " << std::hex << std::uppercase << status; \
-      throw std::runtime_error(ss.str());                                 \
+      throw std::runtime_error(std::move(ss).str());                      \
     }                                                                     \
   }
 

--- a/torch/csrc/inductor/aoti_runtime/utils.h
+++ b/torch/csrc/inductor/aoti_runtime/utils.h
@@ -519,7 +519,7 @@ inline void assert_size_stride(
   if (num_errors) {
     AOTI_RUNTIME_CHECK(
         false,
-        msg.str() + op_msg +
+        std::move(msg).str() + op_msg +
             "\nThis error most often comes from a incorrect fake (aka meta) "
             "kernel for a custom op."
             "\nUse torch.library.opcheck to test your custom op."

--- a/torch/csrc/inductor/static_launcher/xpu.cpp
+++ b/torch/csrc/inductor/static_launcher/xpu.cpp
@@ -32,7 +32,7 @@
     if (status != ZE_RESULT_SUCCESS) {                                    \
       std::stringstream ss;                                               \
       ss << "L0 runtime error: " << std::hex << std::uppercase << status; \
-      throw std::runtime_error(ss.str());                                 \
+      throw std::runtime_error(std::move(ss).str());                      \
     }                                                                     \
   }
 

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -589,13 +589,13 @@ std::string Module::dump_to_str(
 
   ss << "module " << type()->name()->qualifiedName() << " {" << '\n';
   ss << "  parameters {" << '\n';
-  ss << torch::jit::jit_log_prefix("    ", parameters_ss.str());
+  ss << torch::jit::jit_log_prefix("    ", std::move(parameters_ss).str());
   ss << "  }" << '\n';
   ss << "  attributes {" << '\n';
-  ss << torch::jit::jit_log_prefix("    ", attributes_ss.str());
+  ss << torch::jit::jit_log_prefix("    ", std::move(attributes_ss).str());
   ss << "  }" << '\n';
   ss << "  methods {" << '\n';
-  ss << torch::jit::jit_log_prefix("  ", methods_ss.str());
+  ss << torch::jit::jit_log_prefix("  ", std::move(methods_ss).str());
   ss << "  }" << '\n';
   ss << "  submodules {" << '\n';
   for (const NameModule& s : named_children()) {
@@ -610,7 +610,7 @@ std::string Module::dump_to_str(
   ss << "  }" << '\n';
   ss << '}' << '\n';
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void Module::dump(

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -84,7 +84,7 @@ struct TORCH_API Object {
     std::stringstream err;
     err << _ivalue()->type()->repr_str() << " does not have a field with name '"
         << name.c_str() << '\'';
-    throw ObjectAttributeError(err.str());
+    throw ObjectAttributeError(std::move(err).str());
   }
 
   c10::IValue attr(const std::string& name, c10::IValue or_else) const {

--- a/torch/csrc/jit/backends/backend_detail.cpp
+++ b/torch/csrc/jit/backends/backend_detail.cpp
@@ -310,14 +310,14 @@ Module codegen_backend_module(
         default_value->repr(
             def_ss, [](std::ostream&, const IValue&) -> bool { return false; });
         def_inputs.emplace_back(def_ss.str());
-        fwd_inputs.emplace_back(fwd_ss.str());
+        fwd_inputs.emplace_back(std::move(fwd_ss).str());
       } else {
         // If this is not a kwarg, it should be emitted as is in the
         // signature and the call to backend_execute.
         std::stringstream def_ss;
         // Annotate type of the arg
         def_ss << name << ": " << arg.type()->annotation_str(nullptr);
-        def_inputs.emplace_back(def_ss.str());
+        def_inputs.emplace_back(std::move(def_ss).str());
         fwd_inputs.emplace_back(name);
       }
     }
@@ -349,7 +349,7 @@ Module codegen_backend_module(
       }
     } else {
       type_check_ss << out_ty->annotation_str() << ')';
-      type_checks.emplace_back(type_check_ss.str());
+      type_checks.emplace_back(std::move(type_check_ss).str());
     }
 
     method_te.v("def_inputs", def_inputs);
@@ -367,7 +367,7 @@ Module codegen_backend_module(
       out_ss << ',';
     }
 
-    method_te.s("ret", out_ss.str());
+    method_te.s("ret", std::move(out_ss).str());
 
     loweredModule.define(method_ct.format(method_te), loweredModuleResolver());
   }

--- a/torch/csrc/jit/backends/backend_init.cpp
+++ b/torch/csrc/jit/backends/backend_init.cpp
@@ -61,7 +61,7 @@ static void toBackendSelectiveImpl(
       } else {
         std::stringstream err;
         err << "Attribute named " << atoms[i] << " is not a Module";
-        throw std::runtime_error(err.str());
+        throw std::runtime_error(std::move(err).str());
       }
     }
 

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -90,7 +90,7 @@ static c10::IValue preprocess(
       py::cast<torch::jit::Module>(nnapi_processed[0].attr("_c"));
   std::stringstream ss;
   shape_compute_module._save_for_mobile(ss);
-  dict.insert("shape_compute_module", ss.str());
+  dict.insert("shape_compute_module", std::move(ss).str());
 
   // transform Python lists to C++ c10::List
   c10::List<at::Tensor> weights(

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
@@ -96,7 +96,7 @@ std::string XNNSerializer::finishAndSerialize(
   ss.write(
       reinterpret_cast<char*>(_builder.GetBufferPointer()), _builder.GetSize());
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 } // namespace delegate

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -126,7 +126,8 @@ void XNNGraph::checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph) {
   }
   TORCH_CHECK(
       unsupported_ops.empty(),
-      "the module contains the following unsupported ops:\n" + error.str());
+      "the module contains the following unsupported ops:\n" +
+          std::move(error).str());
 }
 
 std::string XNNGraph::serializedXNNGraph() {

--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -653,12 +653,12 @@ std::string generateKernel(
   // clang-format on
 
   // Instantiates the CUDA or CPU-specific templates
-  env.s("tensorOffsets", tensorOffsets.str());
-  env.s("tensorChecks", tensorChecks.str());
-  env.s("kernelBody", body.str());
-  env.s("kernelBody_vec4", body_vec4.str());
-  env.s("kernelLoad", load.str());
-  env.s("kernelStore", store.str());
+  env.s("tensorOffsets", std::move(tensorOffsets).str());
+  env.s("tensorChecks", std::move(tensorChecks).str());
+  env.s("kernelBody", std::move(body).str());
+  env.s("kernelBody_vec4", std::move(body_vec4).str());
+  env.s("kernelLoad", std::move(load).str());
+  env.s("kernelStore", std::move(store).str());
   env.v("formals", formals);
   env.v("argument_loads", argument_loads);
   std::string code_string;

--- a/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
@@ -158,7 +158,7 @@ static bool programExists(const std::string& program) {
   std::stringstream ss;
   c10::printQuotedString(ss, program);
   at::jit::TemplateEnv env;
-  env.s("program", ss.str());
+  env.s("program", std::move(ss).str());
   std::string cmd = format(check_exists_string, env);
 #ifdef _MSC_VER
   return (run(cmd.c_str()) == 0);

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -84,7 +84,7 @@ static std::string get_stacked_errors(const std::vector<Call>& error_stack) {
       callee->caller_range.highlight(msg);
     }
   }
-  return msg.str();
+  return std::move(msg).str();
 }
 
 std::string ErrorReport::current_call_stack() {
@@ -103,7 +103,7 @@ const char* ErrorReport::what() const noexcept {
 
   msg << get_stacked_errors(error_stack);
 
-  the_message = msg.str();
+  the_message = std::move(msg).str();
   return the_message.c_str();
 }
 

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -416,7 +416,7 @@ struct Environment {
                    "of another type (torch.jit.annotate(List[T, []]) where T "
                    "is the type of elements in the list for Python 2)";
         }
-        error << '\n' << why_not.str();
+        error << '\n' << std::move(why_not).str();
         throw ErrorReport(error);
       }
     }
@@ -1446,7 +1446,7 @@ struct to_ir {
       }
       throw(
           ErrorReport(src) << "Union type annotation `" << type_hint->repr_str()
-                           << "` can hold " << vector_repr.str()
+                           << "` can hold " << std::move(vector_repr).str()
                            << ", but none of "
                            << "those types match the types of the given list "
                            << "elements, which were unified to "
@@ -1499,7 +1499,7 @@ struct to_ir {
       }
       throw(
           ErrorReport(src) << "Union type annotation `" << type_hint->repr_str()
-                           << "` can hold " << vector_repr.str()
+                           << "` can hold " << std::move(vector_repr).str()
                            << ", but none of "
                            << "those dict types can hold the types of the given"
                            << " keys and values, which were unified to Dict["
@@ -1738,11 +1738,11 @@ struct to_ir {
               << "` did not match the "
               << "type of an actual value type `" << v->type()->repr_str()
               << "`\n"
-              << ss.str();
+              << std::move(ss).str();
         }
 
         if (!is_key_subtype || !is_value_subtype) {
-          throw(ErrorReport(dc) << err.str());
+          throw(ErrorReport(dc) << std::move(err).str());
         }
       }
 
@@ -2034,7 +2034,7 @@ struct to_ir {
                  << "The source info is eliminated due to the source file is too large. "
                  << "To get it back, please set PYTORCH_JIT_ENABLE_LARGE_SOURCE_LOCATION=1 "
                  << "as env var";
-              return ss.str();
+              return std::move(ss).str();
             });
           }
         }
@@ -2059,7 +2059,7 @@ struct to_ir {
                  << "The source info is eliminated due to the source file is too large. "
                  << "To get it back, please set PYTORCH_JIT_ENABLE_LARGE_SOURCE_LOCATION=1 "
                  << "as env var";
-              return ss.str();
+              return std::move(ss).str();
             });
           }
         }
@@ -3448,7 +3448,7 @@ struct to_ir {
               ErrorReport(apply.inputs())
               << "expected an expression of type " << type->repr_str()
               << " but found " << expr->type()->repr_str() << '\n'
-              << why_not.str());
+              << std::move(why_not).str());
         }
 
         // None is a subtype of Optional[T], but we want to remember what T is
@@ -3830,11 +3830,11 @@ struct to_ir {
         err << "Generated value type " << value_type->repr_str()
             << " did not match the annotated value type, which was "
             << annotated_v_type->repr_str() << '\n'
-            << ss.str();
+            << std::move(ss).str();
       }
 
       if (!is_key_subtype || !is_value_subtype) {
-        throw(ErrorReport(apply) << err.str());
+        throw(ErrorReport(apply) << std::move(err).str());
       }
     };
 

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -443,14 +443,14 @@ struct Lexer {
     std::stringstream ss;
     ss << what << ":\n";
     t.range.highlight(ss);
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
   [[noreturn]] void expected(const std::string& what, const Token& t) {
     std::stringstream ss;
     ss << "expected " << what << " but found '" << t.kindString()
        << "' here:\n";
     t.range.highlight(ss);
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
   [[noreturn]] void expected(const std::string& what) {
     expected(what, cur());

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -234,7 +234,7 @@ static Value* tryMatchArgument(
         }
       }
 
-      ostream << ss.str();
+      ostream << std::move(ss).str();
     }
 
     return nullptr;
@@ -548,7 +548,7 @@ MatchedSchema matchSchema(
           /*allow_conversions=*/true)) {
     return *result;
   }
-  throw(ErrorReport(loc) << failure_messages.str());
+  throw(ErrorReport(loc) << std::move(failure_messages).str());
 }
 
 static std::string prefixLine(
@@ -562,7 +562,7 @@ static std::string prefixLine(
     ss.put(c);
     was_newline = c == '\n';
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::pair<size_t, MatchedSchema> matchSchemas(
@@ -612,7 +612,7 @@ std::pair<size_t, MatchedSchema> matchSchemas(
                        << "The following variants are available:\n"
                        << prefixLine(failure_messages.str(), "  ")
                        << "\nThe original call is");
-  throw(ErrorReport(loc) << failure_messages.str());
+  throw(ErrorReport(loc) << std::move(failure_messages).str());
 }
 
 // pack outputs of a function following python rules. If there is a single value

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -48,7 +48,7 @@ struct TORCH_API StringCordView {
     for (auto s : pieces_) {
       ss << std::string(s);
     }
-    return ss.str();
+    return std::move(ss).str();
   }
 
   bool operator==(const std::string& rhs) const;
@@ -501,7 +501,7 @@ struct TORCH_API SourceRange {
   std::string str() const {
     std::stringstream ss;
     highlight(ss);
-    return ss.str();
+    return std::move(ss).str();
   }
 
   std::optional<std::tuple<std::string, size_t, size_t>> file_line_col() const {

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -162,7 +162,7 @@ struct TORCH_API SimpleValue : public SugaredValue {
     std::stringstream ss;
     // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     ss << "value of type '" << value_->type()->annotation_str() << '\'';
-    return ss.str();
+    return std::move(ss).str();
   }
   Value* asValue(const SourceRange& range, GraphFunction& m) override {
     return value_;

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -981,7 +981,7 @@ void ensureUniqueIfOutOfPlaced(const char* name, const at::Tensor& tensor) {
        << "that also reference this data will not reflect this change in the trace! "
        << "On the other hand, if all other views use the same memory chunk, but are disjoint (e.g. "
        << "are outputs of torch.split), this might still be safe.";
-    warn(ss.str().c_str());
+    warn(std::move(ss).str().c_str());
   }
 }
 void ensureUniqueIfOutOfPlaced(

--- a/torch/csrc/jit/frontend/tree.h
+++ b/torch/csrc/jit/frontend/tree.h
@@ -97,7 +97,7 @@ struct Tree : c10::intrusive_ptr_target {
          << expected_subtrees << " subtrees, but found only " << trees().size()
          << '\n';
       range().highlight(ss);
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   }
   ~Tree() override = default;
@@ -191,7 +191,7 @@ struct pretty_tree {
         out << ')';
         break;
     }
-    auto it_ = flat_strings.emplace(t, out.str());
+    auto it_ = flat_strings.emplace(t, std::move(out).str());
     return it_.first->second;
   }
   void print(std::ostream& out, const TreeRef& t, int indent) {

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -481,7 +481,7 @@ std::string AliasDb::toString() const {
     ss << '\n';
   }
   ss << '\n';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 bool AliasDb::dumpToGraphvizFile(const char* filename) const {
@@ -550,7 +550,7 @@ std::string AliasDb::toGraphviz() const {
   }
 
   dot << "}\n";
-  return dot.str();
+  return std::move(dot).str();
 }
 
 void AliasDb::analyze(const std::shared_ptr<Graph>& graph) {
@@ -2013,7 +2013,7 @@ void Lint(const AliasDb* db) {
          << "It was defined in " << *v->node();
     }
   }
-  TORCH_INTERNAL_ASSERT(!failed, ss.str());
+  TORCH_INTERNAL_ASSERT(!failed, std::move(ss).str());
 
   // Two checks that we want to add but can't until the mutation API is more
   // fully developed.

--- a/torch/csrc/jit/ir/attributes.h
+++ b/torch/csrc/jit/ir/attributes.h
@@ -168,7 +168,7 @@ struct IRAttributeError : public std::exception {
       ss << "required keyword attribute '" << name.toUnqualString()
          << "' has the wrong type";
     }
-    msg = ss.str();
+    msg = std::move(ss).str();
   }
   const char* what() const noexcept override {
     return msg.c_str();

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -102,7 +102,7 @@ std::optional<Value*> tryInsertConstant(
   } else if (val.isDevice()) {
     std::stringstream ss;
     ss << val.toDevice();
-    n->s_(attr::value, ss.str());
+    n->s_(attr::value, std::move(ss).str());
     n->output()->setType(DeviceObjType::get());
   } else if (val.isGenerator()) {
     auto generator = val.toGenerator();

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -886,7 +886,7 @@ Value* Value::setDebugName(const std::string& name) {
       ss.imbue(c_locale);
 #endif
       ss << name_base << '.' << suffix++;
-      replacement_name = ss.str();
+      replacement_name = std::move(ss).str();
     } while (names.count(replacement_name) > 0);
 
     names_suffixes[name_base] = suffix;

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -84,7 +84,7 @@ std::ostream& get_jit_logging_output_stream() {
 std::string getHeader(const Node* node) {
   std::stringstream ss;
   node->print(ss, 0, {}, false, false, false, false);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void JitLoggingConfig::parse() {
@@ -149,7 +149,7 @@ std::string jit_log_prefix(
     out_ss << prefix << line << '\n';
   }
 
-  return out_ss.str();
+  return std::move(out_ss).str();
 }
 
 std::string jit_log_prefix(
@@ -164,7 +164,7 @@ std::string jit_log_prefix(
   prefix_ss << std::setfill('0') << std::setw(3) << l;
   prefix_ss << "] ";
 
-  return jit_log_prefix(prefix_ss.str(), in_str);
+  return jit_log_prefix(std::move(prefix_ss).str(), in_str);
 }
 
 std::ostream& operator<<(std::ostream& out, JitLoggingLevels level) {

--- a/torch/csrc/jit/mobile/file_format.h
+++ b/torch/csrc/jit/mobile/file_format.h
@@ -122,7 +122,7 @@ static void file_not_found_error() {
   } else {
     message << "error no is: " << errno << '\n';
   }
-  TORCH_CHECK(false, message.str());
+  TORCH_CHECK(false, std::move(message).str());
 }
 
 // NOLINTNEXTLINE(facebook-hte-NamespaceScopedStaticDeclaration)

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -62,7 +62,8 @@ c10::IValue IValueUnpickler::readArchive(
   picklename << archive_name << ".pkl";
   at::DataPtr pickle_ptr;
   size_t pickle_size = 0;
-  std::tie(pickle_ptr, pickle_size) = reader_->getRecord(picklename.str());
+  std::tie(pickle_ptr, pickle_size) =
+      reader_->getRecord(std::move(picklename).str());
 
   size_t bytes_read = 0;
   auto data = reinterpret_cast<const char*>(pickle_ptr.get());
@@ -128,7 +129,7 @@ c10::IValue IValueUnpickler::readArchive(
       for (const auto i : c10::irange(ndict)) {
         std::stringstream name;
         name << it->key();
-        cls->addOrCheckAttribute(name.str(), it->key().type());
+        cls->addOrCheckAttribute(std::move(name).str(), it->key().type());
         obj->setSlot(i, it->value());
         ++it;
       }
@@ -139,7 +140,7 @@ c10::IValue IValueUnpickler::readArchive(
   auto read_record = [&](const std::string& name) {
     std::stringstream ss;
     ss << archive_name << '/' << name;
-    return std::get<0>(reader_->getRecord(ss.str()));
+    return std::get<0>(reader_->getRecord(std::move(ss).str()));
   };
 
   Unpickler unpickler(

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -222,7 +222,8 @@ bool InterpreterState::run(Stack& stack) {
           while (static_cast<int>(userObj->type()->numAttributes()) <= inst.X) {
             std::stringstream ss;
             ss << userObj->type()->numAttributes();
-            userObj->type()->addAttribute(ss.str(), c10::NoneType::get());
+            userObj->type()->addAttribute(
+                std::move(ss).str(), c10::NoneType::get());
           }
           userObj->setSlot(inst.X, std::move(v));
           frame.step();

--- a/torch/csrc/jit/passes/check_strict_fusion.cpp
+++ b/torch/csrc/jit/passes/check_strict_fusion.cpp
@@ -74,7 +74,9 @@ static void checkForUnfusedOps(Node* enter_node) {
     for (Node* n : guarding_ifs) {
       ss << *n << '\n';
     }
-    throw(ErrorReport(enter_node->input()->node()->sourceRange()) << ss.str());
+    throw(
+        ErrorReport(enter_node->input()->node()->sourceRange())
+        << std::move(ss).str());
   }
 
   // autodiff/nnc both insert a number of guards, see
@@ -107,7 +109,9 @@ static void checkForUnfusedOps(Node* enter_node) {
       }
       ss << '\n';
     }
-    throw(ErrorReport(enter_node->input()->node()->sourceRange()) << ss.str());
+    throw(
+        ErrorReport(enter_node->input()->node()->sourceRange())
+        << std::move(ss).str());
   }
 }
 

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -297,7 +297,7 @@ void ConstantValueMap::PrintMaps() {
       }
     }
     ss << " (rank = " << x.second << ')';
-    std::cout << "node " << x.first << ": " << ss.str() << '\n';
+    std::cout << "node " << x.first << ": " << std::move(ss).str() << '\n';
   }
   std::cout << '\n';
   std::cout << "Value Map:" << '\n';

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -252,14 +252,14 @@ void FunctionExtractor::DebugPrintScopeContexts(
       for (const auto& child_scope : it.second->children_) {
         ss << child_scope->name().toDisplayString() << ' ';
       }
-      return ss.str();
+      return std::move(ss).str();
     }());
     GRAPH_UPDATE("Node types: \n", [&]() {
       std::stringstream ss;
       for (auto n : it.second->nlist_) {
         ss << "  " << *n;
       }
-      return ss.str();
+      return std::move(ss).str();
     }());
     GRAPH_UPDATE("Node count: ", it.second->nlist_.size());
   }

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -452,7 +452,7 @@ std::string InplaceConverter::ValueTracker::toString() const {
     ss << " map to " << it.second->debugName() << '\n';
   }
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void InplaceConverter::ValueTracker::recordSetValue(

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -319,7 +319,7 @@ class ShapePropagator : public PropertyPropBase {
     std::stringstream ss;
     ss << "unable to create representative value for: " << type_->str()
        << ". File a bug report";
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
 
   void broadcastBinary(

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -425,7 +425,7 @@ void insertDynamicShapesGuard(
     guarded_node->addInput(pair.second);
     std::stringstream ss;
     ss << "SS_" << -pair.first;
-    subgraph->addInput(ss.str())->setType(IntType::get());
+    subgraph->addInput(std::move(ss).str())->setType(IntType::get());
   }
   guarded_node->is_(
       attr::symbolic_shape_inputs, std::move(symbolic_shape_inputs));

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -611,7 +611,7 @@ static std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
   std::stringstream truncated;
   truncated << s.substr(0, trunc_len);
   truncated << '_' << hash_str;
-  return truncated.str();
+  return std::move(truncated).str();
 }
 
 std::string generateNameForGraph(
@@ -626,7 +626,7 @@ std::string generateNameForGraph(
     }
     graph_name << '_' << node->kind().toUnqualString();
   }
-  return truncateStrWithHash(graph_name.str(), maxlen);
+  return truncateStrWithHash(std::move(graph_name).str(), maxlen);
 }
 
 } // namespace torch::jit::SubgraphUtils

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -2036,20 +2036,20 @@ void initJITBindings(PyObject* module) {
           [](const FunctionSchema& self) {
             std::stringstream ss;
             ss << self;
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(
           "__repr__",
           [](const FunctionSchema& self) {
             std::stringstream ss;
             ss << self;
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(py::pickle(
           [](const FunctionSchema& self) { // __getstate__
             std::stringstream ss;
             ss << self;
-            return py::str(ss.str());
+            return py::str(std::move(ss).str());
           },
           [](const py::str& schema) { // __setstate__, note: no `self` argument
             return parseSchema(schema);

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -493,7 +493,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
             " is not compatible with interface ",
             interfaceType->repr_str(),
             "\n",
-            why_not.str()));
+            std::move(why_not).str()));
       }
       return res;
     }
@@ -850,7 +850,7 @@ std::pair<std::shared_ptr<Operator>, Stack> getOpWithStack(
       for (const auto& err : errors) {
         ss << err.what() << "\n\n";
       }
-      throw std::runtime_error(ss.str());
+      throw std::runtime_error(std::move(ss).str());
     }
 
     return std::make_pair(std::move(found_op), std::move(stack));

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -800,7 +800,7 @@ inline std::string friendlyTypeName(py::handle obj) {
       first = false;
     }
     ss << "))";
-    return ss.str();
+    return std::move(ss).str();
   } else {
     return py::str(py::type::handle_of(obj).attr("__name__"));
   }
@@ -868,7 +868,7 @@ inline py::object getScriptedClassOrError(const c10::NamedTypePtr& classType) {
     err << "Unknown reference to ScriptClass ";
     err << classType->name()->qualifiedName();
     err << ". (Did you forget to import it?)";
-    throw std::runtime_error(err.str());
+    throw std::runtime_error(std::move(err).str());
   }
   return py_class;
 }

--- a/torch/csrc/jit/python/python_dict.cpp
+++ b/torch/csrc/jit/python/python_dict.cpp
@@ -71,7 +71,7 @@ void initScriptDictBindings(PyObject* module) {
             std::stringstream ss;
             ss << "Unable to infer type of dictionary: "
                << inferred_type.reason();
-            throw JITException(ss.str());
+            throw JITException(std::move(ss).str());
           }
 
           type = inferred_type.type();

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -503,7 +503,7 @@ void initPythonIRBindings(PyObject* module_) {
           [](Value& n) {
             std::stringstream ss;
             ss << n.debugName() << " defined in (" << *n.node() << ')';
-            return ss.str();
+            return std::move(ss).str();
           })
       .VS(type)
       .VS(setType)
@@ -594,7 +594,7 @@ void initPythonIRBindings(PyObject* module_) {
           [](Node& n) {
             std::stringstream ss;
             ss << n;
-            return ss.str();
+            return std::move(ss).str();
           })
       .def("sourceRange", [](Node& n) { return n.sourceRange().str(); })
       .def("hasMultipleOutputs", [](Node& n) { return n.outputs().size() > 1; })
@@ -619,7 +619,7 @@ void initPythonIRBindings(PyObject* module_) {
             } else {
               ss << "(no schema)";
             }
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(
           "outputs",

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -70,7 +70,7 @@ void initScriptListBindings(PyObject* module) {
           if (!inferred_type.success()) {
             std::stringstream ss;
             ss << "Unable to infer type of list: " << inferred_type.reason();
-            throw JITException(ss.str());
+            throw JITException(std::move(ss).str());
           }
 
           type = inferred_type.type();
@@ -298,7 +298,7 @@ void initScriptListBindings(PyObject* module) {
                 std::stringstream ss;
                 ss << "Unable to infer type of list: "
                    << inferred_type.reason();
-                throw JITException(ss.str());
+                throw JITException(std::move(ss).str());
               }
 
               type = inferred_type.type();

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<SugaredValue> PythonValue::call(
 std::string PythonValue::kind() const {
   std::stringstream ss;
   ss << "python value of type '" << typeString(self) << '\'';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::vector<std::shared_ptr<SugaredValue>> PythonValue::asTuple(
@@ -170,7 +170,7 @@ std::vector<std::shared_ptr<SugaredValue>> PythonValue::asTuple(
   std::stringstream ss;
   ss << kind() << " cannot be used as a tuple";
   checkForAddToConstantsError(ss);
-  throw(ErrorReport(loc) << ss.str());
+  throw(ErrorReport(loc) << std::move(ss).str());
 }
 
 std::shared_ptr<SugaredValue> PythonValue::attr(
@@ -180,7 +180,7 @@ std::shared_ptr<SugaredValue> PythonValue::attr(
   std::stringstream ss;
   ss << "attribute lookup is not defined on " << kind();
   checkForAddToConstantsError(ss);
-  throw(ErrorReport(loc) << ss.str());
+  throw(ErrorReport(loc) << std::move(ss).str());
 }
 
 py::object PythonValue::getattr(
@@ -283,7 +283,7 @@ bool ModuleValue::areAllSubmodulesSubtypeOf(
         if (why_not) {
           *why_not << "Attribute " << self_type->getAttributeName(i)
                    << " is not of annotated type " << ty->annotation_str()
-                   << ": " << ss.str();
+                   << ": " << std::move(ss).str();
         }
 
         return false;
@@ -304,7 +304,7 @@ SugaredValuePtr ModuleValue::getitem(
       // Check that all submodules comply with the type hint.
       std::stringstream ss;
       if (!areAllSubmodulesSubtypeOf(type_hint, &ss)) {
-        throw(ErrorReport(loc) << ss.str());
+        throw(ErrorReport(loc) << std::move(ss).str());
       }
 
       // Emit a prim::ModuleContainerIndex operator. This is needed because
@@ -351,7 +351,7 @@ SugaredValuePtr ModuleValue::getitem(
       // Check that all submodules comply with the type hint.
       std::stringstream ss;
       if (!areAllSubmodulesSubtypeOf(type_hint, &ss)) {
-        throw(ErrorReport(loc) << ss.str());
+        throw(ErrorReport(loc) << std::move(ss).str());
       }
 
       // Emit a prim::ModuleContainerIndex operator. This is needed because

--- a/torch/csrc/jit/python/python_tracer.cpp
+++ b/torch/csrc/jit/python/python_tracer.cpp
@@ -64,7 +64,7 @@ SourceRange getPythonInterpreterSourceRange() {
     }
   }
 
-  auto stack_trace_text = stack_trace.str();
+  auto stack_trace_text = std::move(stack_trace).str();
   auto source =
       std::make_shared<Source>(stack_trace_text, source_filename, source_line);
   return SourceRange(source, 0, stack_trace_text.size());

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -18,7 +18,7 @@ static std::optional<std::string> maybeConvertToString(const py::object& obj) {
   }
   std::stringstream ss;
   ss << py::str(obj);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 struct SourceRangeFactory {

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1052,7 +1052,7 @@ void initJitScriptBindings(PyObject* module) {
                       err << qualname->qualifiedName() << ' ';
                     }
                     err << "which does not have a __setstate__ method defined!";
-                    throw std::runtime_error(err.str());
+                    throw std::runtime_error(std::move(err).str());
                   }
                 }
 
@@ -1062,7 +1062,7 @@ void initJitScriptBindings(PyObject* module) {
                   err << qualname->qualifiedName() << ' ';
                 }
                 err << "which does not have a __getstate__ method defined!";
-                throw std::runtime_error(err.str());
+                throw std::runtime_error(std::move(err).str());
               })
           .def(py::pickle(
               [](const Object& self)
@@ -1079,7 +1079,7 @@ void initJitScriptBindings(PyObject* module) {
                   err << qualname->qualifiedName() << ' ';
                 }
                 err << "which does not have a __getstate__ method defined!";
-                throw std::runtime_error(err.str());
+                throw std::runtime_error(std::move(err).str());
               },
               [](const std::tuple<py::object, std::string>& state_tup)
                   -> Object {
@@ -1116,7 +1116,7 @@ void initJitScriptBindings(PyObject* module) {
                   err << qualname->qualifiedName() << ' ';
                 }
                 err << "which does not have a __setstate__ method defined!";
-                throw std::runtime_error(err.str());
+                throw std::runtime_error(std::move(err).str());
               }));
 
   py::class_<Object::Property>(m, "ScriptObjectProperty")
@@ -1156,7 +1156,8 @@ void initJitScriptBindings(PyObject* module) {
         if (!method) {
           std::stringstream ss;
           ss << std::hex << static_cast<const void*>(&self);
-          return py::str("<torch.ScriptObject object at " + ss.str() + ">");
+          return py::str(
+              "<torch.ScriptObject object at " + std::move(ss).str() + ">");
         }
         return invokeScriptMethodFromPython(*method, args, kwargs);
       });

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -162,7 +162,8 @@ void sort_op(Stack& stack) {
   if (!g_list.empty()) {
     std::stringstream error_str;
     TORCH_CHECK(
-        isSortableListOfObjectsOrTuples(g_list, error_str), error_str.str());
+        isSortableListOfObjectsOrTuples(g_list, error_str),
+        std::move(error_str).str());
 
     c10::IValueComparator comparator;
     if (reverse) {
@@ -191,7 +192,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         [](Stack& stack) {
           std::stringstream ss;
           ss << pop(stack);
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -776,7 +777,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
           ss << '\n';
           auto* handler = getPrintHandler();
           TORCH_INTERNAL_ASSERT(handler);
-          handler(ss.str());
+          handler(std::move(ss).str());
         },
         aliasAnalysisSpecialCase()),
     // This is an alternative to aten::cat op that takes variable number of
@@ -1009,7 +1010,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
           for (char c : string) {
             ss << static_cast<char>(::tolower(c));
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -1309,7 +1310,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         for (char c : string) {                             \
           ss << static_cast<char>(char_op(c));              \
         }                                                   \
-        push(stack, ss.str());                              \
+        push(stack, std::move(ss).str());                   \
       },                                                    \
       aliasAnalysisFromSchema())
 
@@ -1825,7 +1826,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
               ss << static_cast<char>(::tolower(c));
             }
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -1846,7 +1847,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
               prev_is_nonalpha = true;
             }
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -1879,7 +1880,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
           for (std::string::size_type i = 0; i < r_pad; ++i) {
             ss << fillchar;
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
 
@@ -1991,7 +1992,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
               } while (index % tabsize);
             }
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -2126,7 +2127,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
             (void)i; // Suppress unused variable warning
             ss << fillchar;
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -2148,7 +2149,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
             ss << fillchar;
           }
           ss << string;
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -2165,7 +2166,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
             ss << '0';
           }
           ss << string;
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
@@ -2311,7 +2312,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
               ss << string;
             }
           }
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
 };
@@ -2914,7 +2915,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs2{
           i = -i;                                        \
         }                                                \
         ss << '0' << prefix << char_op << i;             \
-        push(stack, ss.str());                           \
+        push(stack, std::move(ss).str());                \
       },                                                 \
       aliasAnalysisFromSchema())
 
@@ -2936,7 +2937,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs2{
             std::string str = std::bitset<8 * sizeof(i)>(i).to_string();
             str.erase(0, std::min(str.find_first_not_of('0'), str.size() - 1));
             ss << "0b" << str;
-            push(stack, ss.str());
+            push(stack, std::move(ss).str());
           }
         },
         aliasAnalysisFromSchema()),
@@ -2963,7 +2964,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs2{
               i);
           char c = i;
           ss << c;
-          push(stack, ss.str());
+          push(stack, std::move(ss).str());
         },
         aliasAnalysisFromSchema()),
 
@@ -3328,7 +3329,9 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs2{
           std::stringstream ss;
           ss << ind.toInt();
           push(
-              stack, torch::jit::Object(module_dict.toObject()).attr(ss.str()));
+              stack,
+              torch::jit::Object(module_dict.toObject())
+                  .attr(std::move(ss).str()));
         },
         aliasAnalysisFromSchema()),
 

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -628,7 +628,7 @@ IValue convert_scale_factor_to_double(const IValue& int_ivalue) {
     std::stringstream ss;
     ss << "Expecting optional int or int list arg for scale factor, got"
        << int_ivalue;
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
   return scale_factor_double;
 }

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -42,7 +42,7 @@ void checkListInputType(const c10::TypePtr& elem_type, bool empty_list) {
                  "is the type of elements in the list for Python 2)";
       }
     }
-    throw std::runtime_error(error.str());
+    throw std::runtime_error(std::move(error).str());
   }
 }
 

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -1489,7 +1489,7 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
           std::stringstream ss;
           ss << "Cannot input a tensor of type " << tensor.scalar_type()
              << " as an integral argument";
-          throw std::runtime_error(ss.str());
+          throw std::runtime_error(std::move(ss).str());
         }
         pnode->Output(0) = at::native::item(tensor).toInt();
       };

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -67,7 +67,7 @@ void addFormattedArg(
       } else {
         tmp << static_cast<float>(ival.toDouble());
       }
-      ss << tmp.str();
+      ss << std::move(tmp).str();
       break;
     case 'c':
       TORCH_CHECK(
@@ -137,7 +137,7 @@ void format(Stack& stack, size_t num_inputs) {
   }
 
   drop(stack, num_inputs);
-  push(stack, ss.str());
+  push(stack, std::move(ss).str());
 }
 
 void einsum(Stack& stack, size_t num_inputs) {
@@ -199,7 +199,7 @@ void einsum(Stack& stack, size_t num_inputs) {
     parse_sublist(args.back().toIntList(), num_inputs - 1);
   }
 
-  const auto equation = ss.str();
+  const auto equation = std::move(ss).str();
   std::vector<at::Tensor> operands;
 
   // Parse input operands
@@ -257,7 +257,7 @@ void percentFormat(Stack& stack, size_t num_inputs) {
   }
   TORCH_CHECK(used_args == args_size, "Too many arguments for format string");
   drop(stack, num_inputs);
-  push(stack, ss.str());
+  push(stack, std::move(ss).str());
 }
 
 void listUnpack(Stack& stack, size_t num_outputs) {

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -872,7 +872,7 @@ void ExportModule(
     } else {
       message << "Error while opening file: " << errno << '\n';
     }
-    TORCH_CHECK(false, message.str());
+    TORCH_CHECK(false, std::move(message).str());
   }
   ExportModule(
       module,

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -135,7 +135,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     }
     err << ". Please define serialization methods via def_pickle() for "
            "this class.";
-    TORCH_CHECK(false, err.str());
+    TORCH_CHECK(false, std::move(err).str());
   } else if (ivalue.isRRef()) {
 #ifdef USE_RPC
     TORCH_CHECK(

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -386,7 +386,7 @@ struct PythonPrintImpl {
       else
         ss << '_';
     }
-    return ss.str();
+    return std::move(ss).str();
   }
   // if we have to assign 'v' a name, what should it be?
   // use the debugName if it was set, otherwise generate a name.
@@ -835,7 +835,7 @@ struct PythonPrintImpl {
         printBody(graph->block());
         std::stringstream ss;
         ss << "fork(" << name << ')';
-        printOutputDefinition(node, ss.str());
+        printOutputDefinition(node, std::move(ss).str());
       } break;
       case prim::awaitable: {
         // the subgraph gets emitted as another function
@@ -849,7 +849,7 @@ struct PythonPrintImpl {
         printBody(graph->block());
         std::stringstream ss;
         ss << "awaitable(" << name << ')';
-        printOutputDefinition(node, ss.str());
+        printOutputDefinition(node, std::move(ss).str());
       } break;
       case prim::Enter: {
         const auto in = node->inputs().at(0);
@@ -969,7 +969,7 @@ struct PythonPrintImpl {
 
     std::stringstream ss;
     v.repr(ss, customFormatter);
-    stmt << ss.str();
+    stmt << std::move(ss).str();
   }
 
   void printOpName(TaggedStringStream& stmt, Symbol kind) {
@@ -1011,7 +1011,7 @@ struct PythonPrintImpl {
         std::stringstream scalars_stream;
         stmt << '^' << value->name();
         value->writeScalars(scalars_stream);
-        stmt << scalars_stream.str();
+        stmt << std::move(scalars_stream).str();
         printValueList(stmt, node->inputs(), "(", ")");
       } break;
       case prim::Uninitialized: {
@@ -1131,7 +1131,7 @@ struct PythonPrintImpl {
           stmt << "getattr(" << useOf(obj) << ", ";
           std::stringstream field_stream;
           c10::printQuotedString(field_stream, field);
-          stmt << field_stream.str() << ')';
+          stmt << std::move(field_stream).str() << ')';
         }
       } break;
       case prim::CallFunction: {

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -1312,7 +1312,7 @@ void CudaCodeGen::CompileToNVRTC(
     cu << log.data() << '\n';
     cu << "nvrtc compilation failed: " << '\n';
     cu << code << '\n';
-    throw std::runtime_error(cu.str());
+    throw std::runtime_error(std::move(cu).str());
   }
   ResourceGuard holdProgram(
       [&] { AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcDestroyProgram(&program)); });

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -667,7 +667,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     std::stringstream ss;
     ss << "Index out of bounds in check_bounds. Index: " << idx
        << "; bounds: [0, " << bound << ").";
-    throw malformed_input(ss.str(), buf);
+    throw malformed_input(std::move(ss).str(), buf);
   }
 
   void check_bounds(const BufPtr& buf, const std::vector<ExprPtr>& indices) {

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -126,7 +126,7 @@ class TORCH_API HashProvider : public IRVisitor {
     std::stringstream ss;
     IRPrinter printer(ss);
     e->accept(&printer);
-    SimplifierHashType hash = SimplifierHashType(te_hash(ss.str()));
+    SimplifierHashType hash = SimplifierHashType(te_hash(std::move(ss).str()));
     putHash(e, hash);
 
     return hash;
@@ -142,7 +142,7 @@ class TORCH_API HashProvider : public IRVisitor {
     std::stringstream ss;
     IRPrinter printer(ss);
     s->accept(&printer);
-    SimplifierHashType hash = SimplifierHashType(te_hash(ss.str()));
+    SimplifierHashType hash = SimplifierHashType(te_hash(std::move(ss).str()));
     putHash(s, hash);
 
     return hash;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -569,7 +569,7 @@ static bool constZeroDimTensorAsScalarArg(
       std::stringstream ss;
       ss << "Unsupported tensor dtype:" << dtype
          << " for converting constant 0-dim Tensor to scalar" << '\n';
-      throw unsupported_dtype(ss.str());
+      throw unsupported_dtype(std::move(ss).str());
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -135,7 +135,7 @@ std::string sanitizeName(const std::string& input_name) {
       sanitized_name << '_';
     }
   }
-  return sanitized_name.str();
+  return std::move(sanitized_name).str();
 }
 
 class VarNameSanitizer : public IRMutator {

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -87,7 +87,7 @@ void initTensorExprBindings(PyObject* module) {
               [](const ExprHandle& self) {
                 std::stringstream ss;
                 ss << self;
-                return ss.str();
+                return std::move(ss).str();
               })
           .def(py::self + py::self)
           .def(py::self * py::self)
@@ -226,7 +226,7 @@ void initTensorExprBindings(PyObject* module) {
           [](const ExprHandle& self) {
             std::stringstream ss;
             ss << self;
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(py::init<Dtype>())
       .def(py::init<const std::string&, Dtype>());
@@ -398,7 +398,7 @@ void initTensorExprBindings(PyObject* module) {
       .def("__str__", [](Stmt& self) {
         std::stringstream ss;
         ss << self;
-        return ss.str();
+        return std::move(ss).str();
       });
   py::class_<Store, Stmt, std::shared_ptr<Store>>(te, "Store")
       .def_static(
@@ -702,7 +702,7 @@ void initTensorExprBindings(PyObject* module) {
           [](const LoopNest& self) {
             std::stringstream ss;
             ss << *self.root_stmt();
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(
           "root_stmt",

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -105,7 +105,7 @@ size_t assertFind(
     if (extra_msg) {
       extra_msg(ss);
     }
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
   return pos;
 }
@@ -143,7 +143,7 @@ size_t assertFindRegex(
     if (extra_msg) {
       extra_msg(ss);
     }
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
   return pos;
 }
@@ -180,7 +180,7 @@ void assertNotFind(
     ss << " but found it\n";
     found_range.highlight(ss);
     ss << "From " << check << '\n';
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error(std::move(ss).str());
   }
 }
 
@@ -362,7 +362,7 @@ struct FileCheckImpl {
       c10::printQuotedString(ss, check.search_str_);
       ss << "highlighted but it is not." << '\n';
       error_range.highlight(ss);
-      throw std::runtime_error(ss.str());
+      throw std::runtime_error(std::move(ss).str());
     };
 
     size_t search_start_offset = start_offset;
@@ -560,7 +560,7 @@ void FileCheck::run(const std::string& test_file) {
 void FileCheck::run(const Graph& graph) {
   std::stringstream graph_str;
   graph_str << graph;
-  fcImpl->run(graph_str.str());
+  fcImpl->run(std::move(graph_str).str());
 }
 
 void FileCheck::run(
@@ -574,7 +574,7 @@ void FileCheck::run(
     const Graph& graph) {
   std::stringstream graph_str;
   graph_str << graph;
-  fcImpl->run(input_checks_string, graph_str.str());
+  fcImpl->run(input_checks_string, std::move(graph_str).str());
 }
 
 FileCheck* FileCheck::check(const std::string& str) {

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -77,7 +77,7 @@ std::string GetFirstUserFrameInPython() {
     if (loc.file.find("site-packages") == std::string::npos) {
       std::stringstream ss;
       ss << loc.file << ' ' << loc.function << ' ' << loc.line;
-      return ss.str();
+      return std::move(ss).str();
     }
   }
   return empty;
@@ -144,7 +144,7 @@ std::string DebugUtil::GetTensorsGraphInfo(
     LOG(ERROR) << "Invalid graph format: " << format;
   }
   ss << "\n## BEGIN_GRAPH\n" << graph_str << "\n## END_GRAPH\n\n";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void DebugUtil::SaveTensorsGraphInfo(

--- a/torch/csrc/lazy/core/hash.cpp
+++ b/torch/csrc/lazy/core/hash.cpp
@@ -87,7 +87,7 @@ std::string HashToString(const hash_t& a) {
   std::stringstream ss;
   ss << std::hex << c10::Uint128High64(a) << std::setfill('0') << std::setw(16)
      << Uint128Low64(a);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 hash_t Hash(const std::vector<bool>& values) {

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -30,7 +30,7 @@ hash_t Output::shapeHash() const {
 std::string Output::ToString() const {
   std::stringstream ss;
   ss << node->ToString() << ", index=" << index;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 bool Output::operator==(const Value& rhs) const {
@@ -160,7 +160,7 @@ std::string Node::ToString() const {
     ss << ", scope=" << metadata().scope;
   }
   EmitShortFrameInfo(ss, metadata().frame_info);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void Node::AddOperand(const NodePtr& node, size_t index) {

--- a/torch/csrc/lazy/core/ir_dump_util.cpp
+++ b/torch/csrc/lazy/core/ir_dump_util.cpp
@@ -148,7 +148,7 @@ std::string GenerateDotNodeLabel(
   if (opt_root_id) {
     ss << "\\nROOT=" << *opt_root_id;
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string GenerateDotNodeSpec(
@@ -156,7 +156,7 @@ std::string GenerateDotNodeSpec(
     const std::unordered_map<const Node*, size_t>& roots_ids) {
   std::stringstream ss;
   ss << "label=\"" << GenerateDotNodeLabel(node, roots_ids) << '"';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string GenerateTextNodeSpec(const Node* node, const NodeIdMap& id_map) {
@@ -177,7 +177,7 @@ std::string GenerateTextNodeSpec(const Node* node, const NodeIdMap& id_map) {
   for (auto& tag : GetNodeTags(node)) {
     ss << ", " << tag.name << '=' << tag.value;
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 
 } // namespace
@@ -219,7 +219,7 @@ std::string DumpUtil::PostOrderToDot(
     }
   }
   ss << "}\n";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string DumpUtil::ToText(c10::ArrayRef<const Node*> nodes) {
@@ -245,7 +245,7 @@ std::string DumpUtil::PostOrderToText(
     ss << '\n';
   }
   ss << "}\n";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string DumpUtil::ToBackend(

--- a/torch/csrc/lazy/core/metrics.cpp
+++ b/torch/csrc/lazy/core/metrics.cpp
@@ -324,7 +324,7 @@ std::string MetricFnValue(double value) {
   std::stringstream ss;
   ss.precision(2);
   ss << std::fixed << value;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string MetricFnBytes(double value) {
@@ -337,7 +337,7 @@ std::string MetricFnBytes(double value) {
   std::stringstream ss;
   ss.precision(2);
   ss << std::fixed << value << kSizeSuffixes[sfix];
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string MetricFnTime(double value) {
@@ -385,7 +385,7 @@ std::string CreateMetricReport() {
 
   // Append the backend metrics report
   ss << getBackend()->CreateMetricReport();
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string CreateMetricReport(
@@ -418,7 +418,7 @@ std::string CreateMetricReport(
       EmitCounterInfo(name, data, &ss);
     }
   });
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::vector<std::string> GetMetricNames() {

--- a/torch/csrc/lazy/core/trie.cpp
+++ b/torch/csrc/lazy/core/trie.cpp
@@ -76,7 +76,7 @@ void TrieCache::DumpToDotFile(const std::string& file_name) {
   ss << "}\n";
 
   std::ofstream graph_file(file_name);
-  graph_file << ss.str();
+  graph_file << std::move(ss).str();
 }
 
 } // namespace torch::lazy

--- a/torch/csrc/lazy/ts_backend/ops/device_data.cpp
+++ b/torch/csrc/lazy/ts_backend/ops/device_data.cpp
@@ -17,7 +17,7 @@ DeviceData::DeviceData(std::shared_ptr<BackendData> data)
 std::string DeviceData::ToString() const {
   std::stringstream ss;
   ss << TsNode::ToString() << ", device=" << data_->device();
-  return ss.str();
+  return std::move(ss).str();
 }
 
 const DeviceData* DeviceData::Cast(const Node* node) {

--- a/torch/csrc/lazy/ts_backend/ops/to_copy.h
+++ b/torch/csrc/lazy/ts_backend/ops/to_copy.h
@@ -89,7 +89,7 @@ class ToCopy : public torch::lazy::TsNode {
     } else {
       ss << ", memory_format=null";
     }
-    return ss.str();
+    return std::move(ss).str();
   }
 
   torch::lazy::TSOpVector Lower(

--- a/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
@@ -347,7 +347,7 @@ void ts_eager_fallback(
                 op.schema().operator_name(),
                 " appears to be a view operator, ",
                 "but it has no implementation for the backend \"",
-                dev_str.str(),
+                std::move(dev_str).str(),
                 "\". View operators don't support ",
                 "falling back to run on the eager, since the tensor's "
                 "storage cannot be shared across devices.");

--- a/torch/csrc/monitor/counters.h
+++ b/torch/csrc/monitor/counters.h
@@ -228,7 +228,7 @@ class Stat {
       key << name_;
       key << '.';
       key << aggregationName(kv.first);
-      e.data[key.str()] = kv.second;
+      e.data[std::move(key).str()] = kv.second;
     }
 
     logEvent(e);

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -249,7 +249,7 @@ class ExperimentalConfigWrapper {
     LOG(INFO) << "Generated config = " << configss.str();
 
     libkineto::api().activityProfiler().prepareTrace(
-        k_activities, configss.str());
+        k_activities, std::move(configss).str());
 #endif // USE_KINETO
   }
 
@@ -276,7 +276,7 @@ static const std::string setTraceID(const std::string& trace_id) {
   std::stringstream configss;
   configss << "REQUEST_TRACE_ID=" << trace_id << '\n';
   configss << "REQUEST_GROUP_TRACE_ID=" << trace_id << '\n';
-  return configss.str();
+  return std::move(configss).str();
 }
 
 static const std::string appendCustomConfig(
@@ -288,7 +288,7 @@ static const std::string appendCustomConfig(
   std::stringstream configss;
   configss << config;
   configss << "CUSTOM_CONFIG=" << custom_profiler_config << '\n';
-  return configss.str();
+  return std::move(configss).str();
 }
 #endif
 

--- a/torch/csrc/profiler/stubs/cuda.cpp
+++ b/torch/csrc/profiler/stubs/cuda.cpp
@@ -36,7 +36,7 @@ static void cudaCheck(cudaError_t result, const char* file, int line) {
     } else {
       ss << cudaGetErrorString(result);
     }
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 #define TORCH_CUDA_CHECK(result) cudaCheck(result, __FILE__, __LINE__);

--- a/torch/csrc/profiler/unwind/fde.h
+++ b/torch/csrc/profiler/unwind/fde.h
@@ -359,7 +359,7 @@ struct FDE {
             std::stringstream ss;
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
             ss << "unknown op code " << (void*)(uint64_t)lowbits;
-            throw UnwindError(ss.str());
+            throw UnwindError(std::move(ss).str());
           }
         }
       }

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -146,7 +146,7 @@ std::vector<std::string> callstackStr(const std::vector<FileLineFunc>& cs) {
   for (const auto& entry : cs) {
     std::stringstream loc;
     loc << entry.filename << '(' << entry.line << "): " << entry.funcname;
-    cs_str.push_back(loc.str());
+    cs_str.push_back(std::move(loc).str());
   }
   return cs_str;
 }
@@ -316,7 +316,7 @@ std::string ivalueToStr(const c10::IValue& val, bool isString) {
     if (isString) {
       ss << '"';
     }
-    std::string mystr = ss.str();
+    std::string mystr = std::move(ss).str();
 
     // For boolean the values that ivalue gives is "True" and "False" but
     // json only takes "true" and "false" so we convert the string to lower case
@@ -335,6 +335,7 @@ std::string ivalueToStr(const c10::IValue& val, bool isString) {
 
 std::string ivalueListToStr(const std::vector<c10::IValue>& list) {
   std::vector<std::string> concrete_str_inputs;
+  concrete_str_inputs.reserve(list.size());
   std::stringstream ss;
   for (const auto& val : list) {
     if (val.isNone()) {
@@ -342,7 +343,7 @@ std::string ivalueListToStr(const std::vector<c10::IValue>& list) {
     } else {
       ss.str("");
       ss << val;
-      concrete_str_inputs.emplace_back(ss.str());
+      concrete_str_inputs.emplace_back(std::move(ss).str());
     }
   }
   return strListToStr(concrete_str_inputs);
@@ -622,22 +623,23 @@ static std::vector<c10::IntArrayRef> getInputSizes(
     ss << "Failed to save extra arguments for flops computation of op "
        << op_name << ", min size: " << min_size
        << ", actual size: " << inputs.size();
-    TORCH_WARN(ss.str());
+    TORCH_WARN(std::move(ss).str());
     return {};
   }
   std::vector<c10::IntArrayRef> inputSizes = {};
+  inputSizes.reserve(should_be_tensor.size());
   for (auto index : should_be_tensor) {
     if (!inputs[index].isTensor()) {
       ss << "Failed to save extra arguments for flops computation of op "
          << op_name << ", input[" << index << "] must be a tensor.";
-      TORCH_WARN(ss.str());
+      TORCH_WARN(std::move(ss).str());
       return {};
     }
     at::Tensor t = inputs[index].toTensor();
     if (t.is_nested()) {
       ss << "Failed to save extra arguments for flops computation of op "
          << op_name << " with input[" << index << "] as nested tensor.";
-      TORCH_WARN(ss.str());
+      TORCH_WARN(std::move(ss).str());
       return {};
     }
     inputSizes.emplace_back(t.sizes());

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -50,7 +50,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
   std::cerr << '[' << std::put_time(&tm, "%H:%M:%S") << ' ' << file << ':'
             << line << "] Exception across libtorch C API boundary: "
             << torch_exception_get_what();
-  throw std::runtime_error(ss.str());
+  throw std::runtime_error(std::move(ss).str());
 }
 HIDDEN_NAMESPACE_END(torch, stable, detail)
 

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -340,13 +340,13 @@ error:
 std::string int_array_ref_string(at::IntArrayRef sizes) {
   std::stringstream ss;
   ss << sizes;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string dispatch_keyset_string(c10::DispatchKeySet keyset) {
   std::stringstream ss;
   ss << keyset;
-  return ss.str();
+  return std::move(ss).str();
 }
 
 } // namespace torch::gdb

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -686,7 +686,7 @@ auto handle_torch_function_no_python_arg_parser(
          << '\n';
     }
     ss << "\nFor more information, try re-running with TORCH_LOGS=not_implemented";
-    const std::string& tmp = ss.str();
+    const std::string& tmp = std::move(ss).str();
     PyErr_SetString(PyExc_TypeError, tmp.c_str());
     throw python_error();
   }
@@ -1599,7 +1599,7 @@ std::string FunctionSignature::toString() const {
           signature.name,
           num_missing,
           num_missing == 1 ? "s" : "",
-          ss.str()));
+          std::move(ss).str()));
 }
 
 static Py_ssize_t find_param(FunctionSignature& signature, PyObject* name) {

--- a/torch/csrc/utils/structseq.cpp
+++ b/torch/csrc/utils/structseq.cpp
@@ -57,7 +57,7 @@ PyObject* returned_structseq_repr(PyStructSequence* obj) {
   }
   ss << ')';
 
-  return PyUnicode_FromString(ss.str().c_str());
+  return PyUnicode_FromString(std::move(ss).str().c_str());
 }
 
 } // namespace torch::utils

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -361,7 +361,7 @@ class class_ : public ::torch::detail::class_base {
     auto format_getstate_schema = [&getstate_schema]() {
       std::stringstream ss;
       ss << getstate_schema;
-      return ss.str();
+      return std::move(ss).str();
     };
 #endif
     TORCH_CHECK(

--- a/torch/headeronly/util/shim_utils.h
+++ b/torch/headeronly/util/shim_utils.h
@@ -15,7 +15,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, headeronly, detail)
     int64_t line) {
   std::stringstream ss;
   ss << call << " API call failed at " << file << ", line " << line;
-  throw std::runtime_error(ss.str());
+  throw std::runtime_error(std::move(ss).str());
 }
 HIDDEN_NAMESPACE_END(torch, headeronly, detail)
 

--- a/torch/nativert/executor/OpKernel.cpp
+++ b/torch/nativert/executor/OpKernel.cpp
@@ -67,7 +67,7 @@ std::string readableArgs(
     }
     ss << '\n';
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 
 const bool OpKernel::blockingEnabled_ =

--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -476,7 +476,7 @@ std::string Weights::toString() const {
     ss << name << ", ";
   }
   ss << ']';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 void Weights::validateAllWeightsLoaded() {

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -1657,7 +1657,7 @@ std::string graphToString(const Graph& g, bool include_signature) {
     ss << g.signature();
   }
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 } // namespace torch::nativert

--- a/torch/nativert/graph/Graph.h
+++ b/torch/nativert/graph/Graph.h
@@ -315,7 +315,7 @@ class Node : public c10::IntrusiveListHook {
   std::string toString() const {
     std::stringstream ss;
     ss << *this;
-    return ss.str();
+    return std::move(ss).str();
   }
 
   void updateInputName(std::string_view oldName, std::string_view newName) {
@@ -633,7 +633,7 @@ class Graph {
   std::string toString() const {
     std::stringstream ss;
     ss << *this;
-    return ss.str();
+    return std::move(ss).str();
   }
 
   /* Reassigns IDs to every Value in this Graph so that they are contiguous from

--- a/torch/nativert/kernels/KernelFactory.cpp
+++ b/torch/nativert/kernels/KernelFactory.cpp
@@ -221,7 +221,7 @@ ExecutionKernels KernelFactory::initializeNodeKernels(
       ss << op << ": " << count << ", \n";
     }
     LOG(WARNING) << "Following ops are missing static dispatched kernels: \n"
-                 << ss.str();
+                 << std::move(ss).str();
   }
 
   return {

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -319,7 +319,7 @@ class {schema.node_name} : public {self.node_base} {{
     std::stringstream ss;
     ss << {self.node_base}::ToString();
     {members_to_string_str}
-    return ss.str();
+    return std::move(ss).str();
   }}
 
   {self.create_function(schema, reuse_ctor_args)}


### PR DESCRIPTION
CPP20 introduced an rvalue overload to stringstream.str() . Without it, the string is copied out for the str() call every time. Now, we can steal the internal string buffer and return it directly through the rvalue overload. Mechanical find and replace assisted by codex.

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98