### PR TITLE
Ship nccl-ep JIT kernel headers in the wheel

### DIFF
--- a/cmake/External/nccl_ep.cmake
+++ b/cmake/External/nccl_ep.cmake
@@ -10,4 +10,19 @@ if(NOT __NCCL_EP_INCLUDED)
   if(TARGET CUDA::cuda_driver)
     target_link_libraries(__caffe2_nccl_ep INTERFACE CUDA::cuda_driver)
   endif()
+
+  # nccl_ep JIT-compiles its CUDA kernels at runtime from .cuh/.h sources on
+  # disk. NCCL is statically linked here (USE_NCCL_EP implies NOT
+  # USE_SYSTEM_NCCL), so the NCCL pip wheel is absent at runtime and in any case
+  # ships neither the device-header tree nor a version-matched copy. Bundle the
+  # whole version-matched include tree (nccl_ep/ + nccl_device/ + nccl.h +
+  # ep_enums.h, ~1.2MB) into the wheel under torch/include/nccl_ep_jit; the
+  # existing include/**/*.{h,hpp,cuh} package_data globs pick it up, and
+  # token_switch.py points NCCL_EP_JIT_SOURCE_DIR / _BUILD_INCLUDE_DIR here.
+  install(DIRECTORY "${NCCL_EP_INCLUDE_DIRS}/"
+          DESTINATION "include/nccl_ep_jit"
+          FILES_MATCHING
+            PATTERN "*.h"
+            PATTERN "*.hpp"
+            PATTERN "*.cuh")
 endif()

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -2,11 +2,27 @@
 from __future__ import annotations
 
 import abc
+import os
 from dataclasses import dataclass
 from typing import Any
 
 import torch
 from torch.distributed.distributed_c10d import ProcessGroup  # noqa: TC001
+
+
+def _set_nccl_ep_jit_paths() -> None:
+    # nccl-ep JIT-compiles its CUDA kernels at runtime and needs its source
+    # headers on disk. A USE_NCCL_EP build bundles them under
+    # torch/include/nccl_ep_jit (NCCL is statically linked, so the NCCL wheel is
+    # absent at runtime and ships neither the device headers nor a
+    # version-matched copy). Point the JIT at the bundled tree, unless the user
+    # already pinned the location via NCCL_EP_JIT_SOURCE_DIR or NCCL_HOME.
+    if "NCCL_EP_JIT_SOURCE_DIR" in os.environ or "NCCL_HOME" in os.environ:
+        return
+    inc = os.path.join(os.path.dirname(torch.__file__), "include", "nccl_ep_jit")
+    if os.path.isdir(inc):
+        os.environ["NCCL_EP_JIT_SOURCE_DIR"] = os.path.join(inc, "nccl_ep")
+        os.environ["NCCL_EP_JIT_BUILD_INCLUDE_DIR"] = inc
 
 
 @dataclass(frozen=True)
@@ -198,6 +214,7 @@ class TokenSwitchNCCL(TokenSwitch):
             raise RuntimeError(
                 "TokenSwitchNCCL requires a build with NCCL EP (USE_NCCL_EP)."
             )
+        _set_nccl_ep_jit_paths()
         self._max_recv_tokens_per_rank = max_recv_tokens_per_rank
         self._group = c10d._NcclEpGroup.create(
             process_group,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #186555
* #181314
* #178712
* #178711
* #177437

nccl-ep JIT-compiles its CUDA kernels at runtime from .cuh/.h sources on
disk. In-tree those resolve to the ExternalProject build dir baked into
libnccl_ep.a, but that path doesn't exist in an installed wheel, and the
sources aren't otherwise packaged — so JIT compilation would fail for a
released PyTorch.

USE_NCCL_EP statically links NCCL from source (it requires
NOT USE_SYSTEM_NCCL), so the NCCL pip wheel is absent at runtime and in any
case ships neither the nccl_device device-header tree nor a version-matched
copy. So bundle the whole version-matched include tree (nccl_ep/ +
nccl_device/ + nccl.h + ep_enums.h, ~1.2MB) into the wheel under
torch/include/nccl_ep_jit via an install() rule; the existing
include/**/*.{h,hpp,cuh} package_data globs ship it.

At runtime TokenSwitchNCCL points NCCL_EP_JIT_SOURCE_DIR and
NCCL_EP_JIT_BUILD_INCLUDE_DIR at the bundled tree unless the user already set
them (or NCCL_HOME). CUDA headers still come from the user's CUDA_HOME, which
the JIT already resolves.