### PR TITLE
[BE] [MPS] Route multinomial through the shared stub frontend

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -17,13 +17,10 @@
 #include <ATen/ops/_sample_dirichlet_native.h>
 #include <ATen/ops/_standard_gamma_grad_native.h>
 #include <ATen/ops/_standard_gamma_native.h>
-#include <ATen/ops/argmax.h>
 #include <ATen/ops/argsort.h>
 #include <ATen/ops/bernoulli_native.h>
 #include <ATen/ops/clamp.h>
 #include <ATen/ops/cumsum.h>
-#include <ATen/ops/div.h>
-#include <ATen/ops/multinomial_native.h>
 #include <ATen/ops/rand.h>
 #include <ATen/ops/randperm.h>
 #include <ATen/ops/randperm_native.h>
@@ -597,10 +594,13 @@ Tensor& randperm_out_mps(int64_t n, std::optional<Generator> generator, Tensor& 
   return result;
 }
 
-static Tensor& multinomial_with_replacement_mps_kernel(const Tensor& self,
-                                                       const int64_t n_sample,
-                                                       std::optional<Generator> generator,
-                                                       Tensor& result) {
+// MPS kernel for the with-replacement, multi-sample case. The shared frontend
+// in Distributions.cpp handles validation and the no-replacement / single-sample
+// fast path (the latter relies on `_assert_async`, now implemented for MPS).
+static void multinomial_with_replacement_mps_kernel(Tensor& result,
+                                                    const Tensor& self,
+                                                    int64_t n_sample,
+                                                    std::optional<Generator> generator) {
   auto numCategories = self.size(-1);
   // CDF accumulated in float32 since bfloat16/float16 lose precision summing many small probabilities.
   // Sample u from U[0, total) and search the unnormalized CDF,
@@ -609,92 +609,9 @@ static Tensor& multinomial_with_replacement_mps_kernel(const Tensor& self,
   auto uniform = at::rand(result.sizes(), generator, self.options().dtype(kFloat))
                      .mul_(cdf.select(-1, numCategories - 1).unsqueeze(-1));
   at::searchsorted_out(result, cdf, uniform);
-  return result.clamp_(0, numCategories - 1);
+  result.clamp_(0, numCategories - 1);
 }
 
-/* The largest consecutive integer representable in float32 (2^24) */
-constexpr int64_t FLOAT32_MAX_CONSECUTIVE_INT = 1 << (FLT_MANT_DIG);
-
-Tensor& multinomial_out_mps(const Tensor& self,
-                            int64_t n_sample,
-                            bool with_replacement,
-                            std::optional<Generator> gen,
-                            Tensor& result) {
-  TORCH_CHECK(result.device() == self.device(), "multinomial arguments must have the same device");
-  TORCH_CHECK(self.dim() > 0 && self.dim() <= 2, "prob_dist must be 1 or 2 dim");
-  TORCH_CHECK(at::isFloatingType(self.scalar_type()),
-              "multinomial only supports floating-point dtypes for input, got: ",
-              self.scalar_type());
-  TORCH_CHECK(
-      result.scalar_type() == ScalarType::Long, "multinomial expects Long tensor out, got: ", result.scalar_type());
-  TORCH_CHECK(n_sample > 0, "cannot sample n_sample <= 0 samples");
-  int64_t n_categories = self.size(-1);
-  TORCH_CHECK(with_replacement || (n_sample <= n_categories),
-              "cannot sample n_sample > prob_dist.size(-1) samples without replacement");
-  // Since the index tensor is float, numCategories cannot exceed max
-  // float integer precision
-  TORCH_CHECK(n_categories <= FLOAT32_MAX_CONSECUTIVE_INT, "number of categories cannot exceed 2^24");
-
-  if (self.dim() == 1) {
-    result.resize_({n_sample});
-  } else {
-    const int64_t n_dist = self.size(0);
-    result.resize_({n_dist, n_sample});
-  }
-  if (result.numel() == 0) {
-    return result;
-  }
-
-  // Fast-path for no replacement (or if only one sample draw).
-  // Reference:
-  // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
-  if (!with_replacement || n_sample == 1) {
-    // Sanity checks on `self`.
-    auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
-    TORCH_CHECK(is_valid.to<bool>(), "probability tensor contains either `inf`, `nan` or element < 0");
-    bool zero_prob_condition = false;
-    if (self.dim() == 1) {
-      zero_prob_condition = (self.sum() == 0).item().to<bool>();
-    } else {
-      zero_prob_condition = (self.sum(1) == 0).sum().item().to<bool>();
-    }
-    TORCH_CHECK(!zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
-
-    // The algorithm is from gumbel softmax.
-    // s = argmax( logp - log(-log(eps)) ) where eps ~ U(0, 1)
-    // Here we can apply exp to the formula which will not affect result of
-    // argmax or topk. Then we have
-    // s = argmax( p / (-log(eps)) ) where eps ~ U(0, 1).
-    // We can also simplify the formula above by
-    // s = argmax( p / q ) where q ~ Exp(1)
-    // If needed, create `q` as contiguous tensor to ensure memory layout supports inplace operations
-    const auto has_strided_api = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-    auto q = at::empty_like(self, {}, has_strided_api ? std::nullopt : std::optional(MemoryFormat::Contiguous));
-    q.exponential_(1, gen);
-    // In theory the probability to generate 0 from exponential distribution is
-    // 0. However, on CUDA side there is a protection to avoid 0s, but on CPU
-    // side, there is a very low probability to generate 0 from
-    // exponential<double>. The probability is about 2^(-DBL_MANT_DIG). We just
-    // ignore it here, but there may be some risk to get invalid output on CPU.
-    at::div_out(q, self, q);
-    if (n_sample == 1) {
-      at::argmax_out(result, q, /*dim=*/-1, /*keepdim=*/true);
-    } else {
-      Tensor vals = at::empty(result.sizes(), self.options());
-      at::topk_out(vals, result, q, n_sample);
-    }
-    return result;
-  }
-
-  result = multinomial_with_replacement_mps_kernel(const_cast<Tensor&>(self), n_sample, gen, result);
-
-  return result;
-}
-
-Tensor multinomial_mps(const Tensor& self, int64_t n_sample, bool with_replacement, std::optional<Generator> gen) {
-  Tensor result = at::empty({0}, self.options().dtype(kLong));
-  multinomial_out_mps(self, n_sample, with_replacement, gen, result);
-  return result;
-}
+REGISTER_MPS_DISPATCH(multinomial_with_replacement_stub, &multinomial_with_replacement_mps_kernel)
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9398,14 +9398,12 @@
 - func: multinomial.out(Tensor self, SymInt num_samples, bool replacement=False, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
   tags: nondeterministic_seeded
   dispatch:
-    CPU, CUDA: multinomial_out
-    MPS: multinomial_out_mps
+    CPU, CUDA, MPS: multinomial_out
 
 - func: multinomial(Tensor self, SymInt num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
   variants: method, function
   dispatch:
-    CPU, CUDA: multinomial
-    MPS: multinomial_mps
+    CPU, CUDA, MPS: multinomial
   tags: nondeterministic_seeded
 
 - func: lgamma.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #186563
* #186562
* #186558

Multinomial_mps/multinomial_out_mps duplicated the entire shared frontend (validation, resize, and the no-replacement/single-sample Gumbel fast path). Now that _assert_async is implemented for MPS, register multinomial_with_replacement_stub for MPS and native::multinomial/multinomial_out, like every other distribution op.

Authored with the assistance of Claude (claude-opus-4-8).