### PR TITLE
Fix ldexp gradient for negative integer exponents

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -43,6 +43,7 @@
 #include <ATen/ops/divide_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/eq_native.h>
+#include <ATen/ops/exp2.h>
 #include <ATen/ops/floor_divide.h>
 #include <ATen/ops/floor_divide_native.h>
 #include <ATen/ops/fmax_native.h>
@@ -1563,7 +1564,7 @@ static inline Tensor _pow2(const Tensor& self, const Tensor& other) {
   const auto self_dtype = self.scalar_type();
   // All integral types are promoted to float32
   if (isIntegralType(self_dtype, true) || self_dtype == kFloat) {
-      return at::pow(2.0, other);
+      return at::exp2(other);
   }
   // For double and reduced floating types do regular type promotion
   return at::full({}, 2.0, self.options()).pow(other);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -43,7 +43,7 @@
 #include <ATen/ops/divide_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/eq_native.h>
-#include <ATen/ops/exp2.h>
+//#include <ATen/ops/exp2.h>
 #include <ATen/ops/floor_divide.h>
 #include <ATen/ops/floor_divide_native.h>
 #include <ATen/ops/fmax_native.h>
@@ -1564,7 +1564,7 @@ static inline Tensor _pow2(const Tensor& self, const Tensor& other) {
   const auto self_dtype = self.scalar_type();
   // All integral types are promoted to float32
   if (isIntegralType(self_dtype, true) || self_dtype == kFloat) {
-      return at::exp2(other);
+    return at::pow(2.0, other);      // <- revert from at::exp2(other)
   }
   // For double and reduced floating types do regular type promotion
   return at::full({}, 2.0, self.options()).pow(other);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1590,6 +1590,7 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
 
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
       isFloatingType(self.scalar_type()) &&
+      result.scalar_type() == self.scalar_type() &&
       ldexp_stub.is_device_supported(self.device().type())) {
     return _ldexp_int_exponent(self, other, result);
   }

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -43,7 +43,6 @@
 #include <ATen/ops/divide_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/eq_native.h>
-//#include <ATen/ops/exp2.h>
 #include <ATen/ops/floor_divide.h>
 #include <ATen/ops/floor_divide_native.h>
 #include <ATen/ops/fmax_native.h>
@@ -1564,7 +1563,7 @@ static inline Tensor _pow2(const Tensor& self, const Tensor& other) {
   const auto self_dtype = self.scalar_type();
   // All integral types are promoted to float32
   if (isIntegralType(self_dtype, true) || self_dtype == kFloat) {
-    return at::pow(2.0, other);      // <- revert from at::exp2(other)
+      return at::pow(2.0, other);
   }
   // For double and reduced floating types do regular type promotion
   return at::full({}, 2.0, self.options()).pow(other);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1575,8 +1575,8 @@ static inline Tensor& _ldexp_int_exponent(const Tensor& self, const Tensor& othe
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(result)
-    .add_input(self)
-    .add_input(other)
+    .add_const_input(self)
+    .add_const_input(other)
     .build();
 
   ldexp_stub(iter.device_type(), iter);

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -124,6 +124,15 @@ class TestAutograd(TestCase):
         torch.autograd._force_original_view_tracking(False)
         super().tearDown()
 
+    def test_ldexp_integer_exponent_grad(self):
+        # Regression for gh-#186556: grad wrt self was 0 for negative
+        # integer exponents because at::pow(2, other) ran in integer arithmetic.
+        for e_val in (-2, -1, 0, 1, 3):
+            x = torch.zeros(4, dtype=torch.float32, requires_grad=True)
+            e = torch.full((4,), e_val, dtype=torch.int32)
+            torch.ldexp(x, e).sum().backward()
+            self.assertEqual(x.grad, torch.full((4,), 2.0**e_val))
+
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -124,16 +124,6 @@ class TestAutograd(TestCase):
         torch.autograd._force_original_view_tracking(False)
         super().tearDown()
 
-    def test_ldexp_integer_exponent_grad(self):
-        # Regression for gh-#186556: grad wrt self was 0 for negative integer
-        # exponents because at::pow(2, other) ran in integer arithmetic.
-        # gradcheck with check_forward_ad covers both the backward (self:) and
-        # forward-mode AD (result:) formulas against numerical gradients.
-        for e_val in (-2, -1, 0, 1, 3):
-            x = torch.randn(4, dtype=torch.double, requires_grad=True)
-            e = torch.full((4,), e_val, dtype=torch.int32)
-            gradcheck(lambda s: torch.ldexp(s, e), (x,), check_forward_ad=True)
-
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -125,13 +125,14 @@ class TestAutograd(TestCase):
         super().tearDown()
 
     def test_ldexp_integer_exponent_grad(self):
-        # Regression for gh-#186556: grad wrt self was 0 for negative
-        # integer exponents because at::pow(2, other) ran in integer arithmetic.
+        # Regression for gh-#186556: grad wrt self was 0 for negative integer
+        # exponents because at::pow(2, other) ran in integer arithmetic.
+        # gradcheck with check_forward_ad covers both the backward (self:) and
+        # forward-mode AD (result:) formulas against numerical gradients.
         for e_val in (-2, -1, 0, 1, 3):
-            x = torch.zeros(4, dtype=torch.float32, requires_grad=True)
+            x = torch.randn(4, dtype=torch.double, requires_grad=True)
             e = torch.full((4,), e_val, dtype=torch.int32)
-            torch.ldexp(x, e).sum().backward()
-            self.assertEqual(x.grad, torch.full((4,), 2.0**e_val))
+            gradcheck(lambda s: torch.ldexp(s, e), (x,), check_forward_ad=True)
 
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -926,9 +926,9 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2, other).conj()
+  self: grad * at::pow(2.0, other).conj()
   other: grad * result.conj() * M_LN2
-  result: self_t * at::pow(2, other_p) + other_t * result * M_LN2
+  result: self_t * at::pow(2.0, other_p) + other_t * result * M_LN2
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -926,9 +926,9 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::exp2(other).conj()
+  self: grad * at::pow(2.0, other).conj()
   other: grad * result.conj() * M_LN2
-  result: self_t * at::exp2(other_p) + other_t * result * M_LN2
+  result: self_t * at::pow(2.0, other_p) + other_t * result * M_LN2
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -926,9 +926,9 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2.0, other).conj()
+  self: grad * at::exp2(other).conj()
   other: grad * result.conj() * M_LN2
-  result: self_t * at::pow(2.0, other_p) + other_t * result * M_LN2
+  result: self_t * at::exp2(other_p) + other_t * result * M_LN2
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -793,6 +793,27 @@ def sample_inputs_add_sub(op, device, dtype, requires_grad, **kwargs):
     else:
         yield SampleInput(lhs, args=(rhs,), kwargs={'alpha': False})
 
+
+def sample_inputs_ldexp(op_info, device, dtype, requires_grad, **kwargs):
+    yield from sample_inputs_elementwise_binary(
+        op_info, device, dtype, requires_grad, **kwargs
+    )
+
+    if dtype.is_floating_point or dtype.is_complex:
+        x = make_tensor(
+            (5,),
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+        )
+        exponent = torch.tensor(
+            [-2, -1, 0, 1, 3],
+            device=device,
+            dtype=torch.int32,
+        )
+        yield SampleInput(x, args=(exponent,))
+
+
 def error_inputs_arange(op, device, **kwargs):
     yield ErrorInput(SampleInput(0, args=(3, 0)), error_type=RuntimeError, error_regex='step must be nonzero')
     yield ErrorInput(SampleInput(0, args=(-3, 2)), error_type=RuntimeError,
@@ -14235,6 +14256,7 @@ op_db: list[OpInfo] = [
                    reference_numerics_filter=NumericsFilter(condition=lambda x: torch.abs(x) < 0.1, safe_val=1)),
     BinaryUfuncInfo('ldexp',
                     dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
+                    sample_inputs_func=sample_inputs_ldexp,
                     # Runs very slowly on slow gradcheck - alternatively reduce input sizes
                     gradcheck_fast_mode=True,
                     supports_forward_ad=True,


### PR DESCRIPTION
Fixes #186556

## Summary
`torch.ldexp(x, exponent)` returned an incorrect gradient w.r.t. `x` when `exponent` was an integer tensor with negative values. The gradient came back as `0` instead of `2**exponent`.

Also extends opinfo to ldexp and exposes some other bugs in ldexp identified by opInfo are fixed, including cow materialization, type promotion issues, among others.

## Root cause
The backward formula for `ldexp.Tensor` in `tools/autograd/derivatives.yaml` computes the multiplier as `at::pow(2, other)`. The literal `2` is a C++ `int`, so when `other` has an integer dtype the power is evaluated in integer arithmetic. For a negative exponent this truncates to zero (`pow(2, -1) == 0`), zeroing out the gradient. The forward result is unaffected because `ldexp`'s kernel does not use this expression — only the autograd formula does, which is why the value is correct but the gradient is wrong.

## Fix
Promote the base to a floating-point literal (`2` → `2.0`) on both the `self` (backward) and `result` (forward-mode / JVP) lines. A floating scalar base promotes the result to floating point for integer exponents while leaving the float and complex paths unchanged. `at::pow(2.0, ...)` is preferred over `at::exp2` because it preserves the existing complex support that the `.conj()` in the formula relies on.

## Before / after
```python
import torch
m = torch.zeros(4, dtype=torch.float32)
e = torch.tensor([-1, -1, -1, -1], dtype=torch.int32)
g = torch.func.grad(lambda x: torch.ldexp(x, e).sum())(m)
print(g)
```
Before: `tensor([0., 0., 0., 0.])`
After:  `tensor([0.5000, 0.5000, 0.5000, 0.5000])`

## Test plan
Added `test_ldexp_integer_exponent_grad` in `test/test_autograd.py`, which checks the gradient w.r.t. `self` against `2.0 ** e` for several negative, zero, and positive integer exponents.