### PR TITLE
Add expected-failure test for ConstantLR factor=0

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2679,6 +2679,72 @@ class TestLRScheduler(TestCase):
         )
 
 
+    def test_sequentiallr_resume_reproducibility(self):
+        # SequentialLR switches between multiple schedulers at milestone
+        # boundaries. If we save and restore both the optimizer and the
+        # scheduler state partway through training, continuing from that
+        # checkpoint should produce exactly the same LR sequence as if the
+        # training had never been interrupted.
+        #
+        # This test makes that expectation explicit by comparing a continuous
+        # run against a resumed run starting from an intermediate step.
+
+        base_lr = 0.1
+        milestone = 5
+        total_steps = 8
+        resume_step = 3
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    ExponentialLR(optim, gamma=0.5),
+                ],
+                milestones=[milestone],
+            )
+
+        # run the full schedule and record the LR.
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        reference_lrs = []
+        for _ in range(total_steps):
+            optim.step()
+            sched.step()
+            reference_lrs.append(sched.get_last_lr()[0])
+
+        # run a fresh optimizer/scheduler pair up to an intermediate step
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
+        sched2 = make_scheduler(optim2)
+
+        for _ in range(resume_step):
+            optim2.step()
+            sched2.step()
+
+        # save state to simulate checkpointing.
+        optim_state = optim2.state_dict()
+        sched_state = sched2.state_dict()
+
+        # restore into a new optimizer/scheduler pair
+        model3 = torch.nn.Linear(1, 1)
+        optim3 = torch.optim.SGD(model3.parameters(), lr=base_lr)
+        optim3.load_state_dict(optim_state)
+
+        sched3 = make_scheduler(optim3)
+        sched3.load_state_dict(sched_state)
+
+        # Continue stepping and check LR with reference 
+        for i in range(resume_step, total_steps):
+            optim3.step()
+            sched3.step()
+            self.assertEqual(
+                sched3.get_last_lr()[0],
+                reference_lrs[i],
+            )
+
 instantiate_parametrized_tests(TestLRScheduler)
 
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2687,6 +2687,27 @@ class TestLRScheduler(TestCase):
 
 
     @expectedFailure
+    def test_constantlr_factor_zero_rejected(self):
+        # factor=0 should be rejected during validation. Otherwise, ConstantLR
+        # later tries to restore the original learning rate using 1 / factor,
+        # which results in a ZeroDivisionError.
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+
+        try:
+            sched = ConstantLR(optim, factor=0, total_iters=2)
+        except ValueError:
+            return
+
+        optim.step()
+        sched.step()
+
+        optim.step()
+        sched.step()
+        self.fail("ConstantLR accepted factor=0 without rejecting it.")
+
+
+    @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
         # Note: Saving and restoring both the optimizer and SequentialLR
         # state mid training should reproduce the same LR sequence as a

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -7,6 +7,7 @@ import tempfile
 import types
 import warnings
 from functools import partial
+from unittest import expectedFailure
 
 import torch
 import torch.nn.functional as F
@@ -2678,16 +2679,13 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
-
+    @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
         # SequentialLR switches between multiple schedulers at milestone
         # boundaries. If we save and restore both the optimizer and the
         # scheduler state partway through training, continuing from that
         # checkpoint should produce exactly the same LR sequence as if the
         # training had never been interrupted.
-        #
-        # This test makes that expectation explicit by comparing a continuous
-        # run against a resumed run starting from an intermediate step.
 
         base_lr = 0.1
         milestone = 5

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2694,6 +2694,21 @@ class TestLRScheduler(TestCase):
         #
         # This currently fails around scheduler transition boundaries after
         # restoring from checkpoint state.
+        #
+        # The problematic state transition comes from SequentialLR's restore
+        # model:
+        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
+        #    lr back to initial_lr, calls recursive_undo(), and then replays
+        #    _schedulers[0]._initial_step().
+        # 2. At this resume point, that constructor path leaves the optimizer
+        #    lr at 0.05 even though the saved scheduler state corresponds to
+        #    an effective lr of 0.08.
+        # 3. SequentialLR.load_state_dict() restores scheduler fields like
+        #    last_epoch and _last_lr, but it does not re-synchronize the
+        #    optimizer param-group lr with that loaded scheduler state.
+        # 4. LinearLR.get_lr() is recursive: it multiplies the current
+        #    optimizer lr, so the next resumed step advances
+        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
 
         base_lr = 0.1
         milestone = 5
@@ -2742,88 +2757,18 @@ class TestLRScheduler(TestCase):
         sched3 = make_scheduler(optim3)
         sched3.load_state_dict(sched_state)
 
+        loaded_optimizer_lr = optim3.param_groups[0]["lr"]
+        loaded_scheduler_lr = sched3.get_last_lr()[0]
+
         resumed_lrs = []
         for _ in range(resume_step, total_steps):
             optim3.step()
             sched3.step()
             resumed_lrs.append(sched3.get_last_lr()[0])
 
+        self.assertEqual(loaded_optimizer_lr, loaded_scheduler_lr)
+        self.assertEqual(resumed_lrs[0], reference_lrs[resume_step])
         self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
-
-    @expectedFailure
-    def test_sequentiallr_resume_restores_optimizer_lr(self):
-        # Note: This is the mechanism level companion to the behavior level
-        # reproducibility test above.
-        #
-        # The problematic state transition comes from SequentialLR's restore
-        # model:
-        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
-        #    lr back to initial_lr, calls recursive_undo(), and then replays
-        #    _schedulers[0]._initial_step().
-        # 2. At this resume point, that constructor path leaves the optimizer
-        #    lr at 0.05 even though the saved scheduler state corresponds to
-        #    an effective lr of 0.08.
-        # 3. SequentialLR.load_state_dict() restores scheduler fields like
-        #    last_epoch and _last_lr, but it does not re-synchronize the
-        #    optimizer param-group lr with that loaded scheduler state.
-        # 4. LinearLR.get_lr() is recursive: it multiplies the current
-        #    optimizer lr, so the next resumed step advances
-        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
-
-        base_lr = 0.1
-        milestone = 5
-        resume_step = 3
-
-        def make_scheduler(optim):
-            return SequentialLR(
-                optim,
-                [
-                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
-                    ExponentialLR(optim, gamma=0.5),
-                ],
-                milestones=[milestone],
-            )
-
-        model = torch.nn.Linear(1, 1)
-        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
-        sched = make_scheduler(optim)
-
-        for _ in range(resume_step):
-            optim.step()
-            sched.step()
-
-        optim_state = optim.state_dict()
-        sched_state = sched.state_dict()
-
-        model2 = torch.nn.Linear(1, 1)
-        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
-        optim2.load_state_dict(optim_state)
-
-        sched2 = make_scheduler(optim2)
-        sched2.load_state_dict(sched_state)
-
-        loaded_optimizer_lr = optim2.param_groups[0]["lr"]
-        loaded_scheduler_lr = sched2.get_last_lr()[0]
-
-        optim2.step()
-        sched2.step()
-        resumed_next_lr = sched2.get_last_lr()[0]
-
-        problems = []
-        if loaded_optimizer_lr != loaded_scheduler_lr:
-            problems.append(
-                "optimizer LR is out of sync with restored scheduler state: "
-                f"optimizer LR = {loaded_optimizer_lr}, "
-                f"scheduler LR = {loaded_scheduler_lr}"
-            )
-
-        if resumed_next_lr != 0.09:
-            problems.append(
-                "first resumed step produced an incorrect LR transition: "
-                f"got {resumed_next_lr}, expected 0.09"
-            )
-
-        self.assertEqual([], problems, "\n".join(problems))
 
 instantiate_parametrized_tests(TestLRScheduler)
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2679,13 +2679,21 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+
+    # NOTE: Expected-failure tests for known scheduler issues.
+    #
+    # These tests should be converted to normal regression tests once
+    # the underlying behavior is fixed.
+
+
     @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
-        # SequentialLR switches between multiple schedulers at milestone
-        # boundaries. If we save and restore both the optimizer and the
-        # scheduler state partway through training, continuing from that
-        # checkpoint should produce exactly the same LR sequence as if the
-        # training had never been interrupted.
+        # Note: Saving and restoring both the optimizer and SequentialLR
+        # state mid training should reproduce the same LR sequence as a
+        # continuous uninterrupted run.
+        #
+        # This currently fails around scheduler transition boundaries after
+        # restoring from checkpoint state.
 
         base_lr = 0.1
         milestone = 5
@@ -2734,14 +2742,88 @@ class TestLRScheduler(TestCase):
         sched3 = make_scheduler(optim3)
         sched3.load_state_dict(sched_state)
 
-        # Continue stepping and check LR with reference 
-        for i in range(resume_step, total_steps):
+        resumed_lrs = []
+        for _ in range(resume_step, total_steps):
             optim3.step()
             sched3.step()
-            self.assertEqual(
-                sched3.get_last_lr()[0],
-                reference_lrs[i],
+            resumed_lrs.append(sched3.get_last_lr()[0])
+
+        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
+
+    @expectedFailure
+    def test_sequentiallr_resume_restores_optimizer_lr(self):
+        # Note: This is the mechanism level companion to the behavior level
+        # reproducibility test above.
+        #
+        # The problematic state transition comes from SequentialLR's restore
+        # model:
+        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
+        #    lr back to initial_lr, calls recursive_undo(), and then replays
+        #    _schedulers[0]._initial_step().
+        # 2. At this resume point, that constructor path leaves the optimizer
+        #    lr at 0.05 even though the saved scheduler state corresponds to
+        #    an effective lr of 0.08.
+        # 3. SequentialLR.load_state_dict() restores scheduler fields like
+        #    last_epoch and _last_lr, but it does not re-synchronize the
+        #    optimizer param-group lr with that loaded scheduler state.
+        # 4. LinearLR.get_lr() is recursive: it multiplies the current
+        #    optimizer lr, so the next resumed step advances
+        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
+
+        base_lr = 0.1
+        milestone = 5
+        resume_step = 3
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    ExponentialLR(optim, gamma=0.5),
+                ],
+                milestones=[milestone],
             )
+
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        for _ in range(resume_step):
+            optim.step()
+            sched.step()
+
+        optim_state = optim.state_dict()
+        sched_state = sched.state_dict()
+
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
+        optim2.load_state_dict(optim_state)
+
+        sched2 = make_scheduler(optim2)
+        sched2.load_state_dict(sched_state)
+
+        loaded_optimizer_lr = optim2.param_groups[0]["lr"]
+        loaded_scheduler_lr = sched2.get_last_lr()[0]
+
+        optim2.step()
+        sched2.step()
+        resumed_next_lr = sched2.get_last_lr()[0]
+
+        problems = []
+        if loaded_optimizer_lr != loaded_scheduler_lr:
+            problems.append(
+                "optimizer LR is out of sync with restored scheduler state: "
+                f"optimizer LR = {loaded_optimizer_lr}, "
+                f"scheduler LR = {loaded_scheduler_lr}"
+            )
+
+        if resumed_next_lr != 0.09:
+            problems.append(
+                "first resumed step produced an incorrect LR transition: "
+                f"got {resumed_next_lr}, expected 0.09"
+            )
+
+        self.assertEqual([], problems, "\n".join(problems))
 
 instantiate_parametrized_tests(TestLRScheduler)
 


### PR DESCRIPTION
This PR adds an expected-failure test documenting the current behavior of ConstantLR when `factor=0`.

`ConstantLR` uses `factor` to scale the learning rate during the constant phase and later restores the original learning rate by applying the inverse scaling. When `factor=0` is provided, the scheduler can be constructed successfully, but a later step reaches a code path that computes `1 / factor`, resulting in a raw `ZeroDivisionError`.

While investigating scheduler validation and edge case handling, I noticed that `ConstantLR` implicitly assumes `factor` is non zero, but this assumption is not currently enforced during initialization.

This PR is tests only. It documents the current behavior and makes the failure mode explicit in the test suite. A follow up PR can introduce input validation or define consistent handling for this invalid configuration, such as raising a clearer `ValueError` during scheduler construction.

Related discussion

This test is part of the broader scheduler cleanup work described in:

"RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition" #168044
