### PR TITLE
Add expected-failure test for ConstantLR factor=0

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2687,6 +2687,26 @@ class TestLRScheduler(TestCase):
     # the underlying behavior is fixed.
 
     @expectedFailure
+    def test_constantlr_factor_zero_rejected(self):
+        # factor=0 should be rejected during validation. Otherwise, ConstantLR
+        # later tries to restore the original learning rate using 1 / factor,
+        # which results in a ZeroDivisionError.
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+
+        try:
+            sched = ConstantLR(optim, factor=0, total_iters=2)
+        except ValueError:
+            return
+
+        optim.step()
+        sched.step()
+
+        optim.step()
+        sched.step()
+        self.fail("ConstantLR accepted factor=0 without rejecting it.")
+
+    @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
         # Note: Saving and restoring both the optimizer and SequentialLR
         # state mid training should reproduce the same LR sequence as a


### PR DESCRIPTION
This PR adds an expected-failure test documenting the current behavior of ConstantLR when `factor=0`.

`ConstantLR` uses `factor` to scale the learning rate during the constant phase and later restores the original learning rate by applying the inverse scaling. When `factor=0` is provided, the scheduler can be constructed successfully, but a later step reaches a code path that computes `1 / factor`, resulting in a raw `ZeroDivisionError`.

While investigating scheduler validation and edge case handling, I noticed that `ConstantLR` implicitly assumes `factor` is non zero, but this assumption is not currently enforced during initialization.

This PR is tests only. It documents the current behavior and makes the failure mode explicit in the test suite. A follow up PR can introduce input validation or define consistent handling for this invalid configuration, such as raising a clearer `ValueError` during scheduler construction.

Related discussion

This test is part of the broader scheduler cleanup work described in:

"RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition" #168044
