### PR TITLE
Fix ldexp gradient for negative exponents

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -124,6 +124,19 @@ class TestAutograd(TestCase):
         torch.autograd._force_original_view_tracking(False)
         super(TestCase, self).tearDown()
 
+    def test_ldexp_backward_negative_exponents(self):
+        x = torch.zeros(6, dtype=torch.double, requires_grad=True)
+        e = torch.tensor([-3, -2, -1, 0, 1, 2], dtype=torch.int32)
+
+        y = torch.ldexp(x, e)
+        grad_out = torch.ones_like(x)
+
+        (grad,) = torch.autograd.grad(y, x, grad_out)
+        expected = torch.ldexp(torch.ones_like(x), e)
+
+        self.assertEqual(grad, expected)
+
+
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -929,9 +929,9 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2, other).conj()
+  self: at::ldexp(grad, other)
   other: grad * result.conj() * M_LN2
-  result: self_t * at::pow(2, other_p) + other_t * result * M_LN2
+  result: at::ldexp(self_t, other_p) + other_t * result * M_LN2
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)


### PR DESCRIPTION
Fixes #186556.

`ldexp(self, other)` scales `self` by `2 ** other`, so the derivative
with respect to `self` should scale `grad` the same way

The previous derivative formula used `at::pow(2, other)`, which can produce
integer-style results for negative integer exponents, causing gradients like
`2 ** -1` to become `0` instead of `0.5`.

This PR changes the backward formula to use `at::ldexp(grad, other)` directly
and updates the forward AD formula similarly. It also adds a regression test
for negative exponents