### PR TITLE
[distributed] Fix Windows gloo allreduce crash by moving ProcessGroupGlooCuda.cpp to base_sources

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -766,6 +766,7 @@ libtorch_cuda_core_sources = [
 
 # These files are the only ones that are supported on Windows.
 libtorch_cuda_distributed_base_sources = [
+    "torch/csrc/distributed/c10d/gloo/ProcessGroupGlooCuda.cpp",
     "torch/csrc/distributed/c10d/reducer_cuda.cpp",
 ]
 
@@ -774,7 +775,6 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/FlightRecorderCuda.cpp",
     "torch/csrc/distributed/c10d/NCCLUtils.cpp",
     "torch/csrc/distributed/c10d/NanCheck.cu",
-    "torch/csrc/distributed/c10d/gloo/ProcessGroupGlooCuda.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupUCC.cpp",
     "torch/csrc/distributed/c10d/ucc/UCCTracing.cpp",

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -1037,6 +1037,11 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce(
 
   work = GlooAllreduceRegistry()->Create(
       device.type(), context, inputs, opts.reduceOp, tag, seq_, opts.timeout);
+  TORCH_CHECK(
+      work,
+      "ProcessGroupGloo::allreduce: no creator registered for device type ",
+      device.type(),
+      ". If you are on Windows, ensure ProcessGroupGlooCuda.cpp is compiled.");
 
   enqueue(work);
   return work;


### PR DESCRIPTION
Fixes #186535

## What's wrong?
The `dist.all_reduce()` function in a CUDA tensor with the gloo backend on Windows causes the process to fail due to an access violation `0xC0000005`. No Python exception or stack trace is thrown; the process simply stops. Since NCCL is not available on Windows, gloo is the only multi-GPU option available, meaning that multi-GPU training on Windows fails on the first `all_reduce` operation of the gradient.

## Why is it failing?
`all_reduce` is the only collective operation in gloo that uses a typed register (`GlooAllreduceRegistry`) to look up its working class at runtime. All the other CUDA builders (broadcast, reduce, allgather, gather, scatter, alltoall, barrier) construct their CUDA worker object directly in `ProcessGroupGloo.cpp` using `c10::make_intrusive`. The CUDA creator for the allreduce registration resides in `ProcessGroupGlooCuda.cpp`. This file is located in `libtorch_cuda_distributed_extra_sources`, which is protected by `if(NOT WIN32)` in `caffe2/CMakeLists.txt`:
~~~cmake
if(NOT WIN32)
append_filelist("libtorch_cuda_distributed_extra_sources" Caffe2_GPU_SRCS)
~~~
Therefore, in Windows builds, `ProcessGroupGlooCuda.cpp` is never compiled. The kCUDA creator is never registered. `Registry::Create()` returns `nullptr` (line 120 of `c10/util/Registry.h` has an explicit comment: `// Returns nullptr if the key is not registered`), and `enqueue(work)` immediately dereferences it: `work->seq_` on line 785 without a null check. This results in an error.

## The solution
Two changes:
1. **`build_variables.bzl`**: Move `ProcessGroupGlooCuda.cpp` from `extra_sources` to `base_sources` so that it compiles on all platforms, including Windows. The file has no NCCL dependencies; Its only inclusions are `ProcessGroupGloo.hpp`, `ProcessGroupGlooDetail.hpp`, `<utility>`, and `<gloo/cuda_allreduce_ring_chunked.h>`. The entire file is wrapped in `#ifdef USE_C10D_GLOO`, so it has no effect if Gloo is not compiled. `base_sources` already contains `reducer_cuda.cpp` (another CUDA-specific file, not distributed by NCCL), so there is a precedent.

2. **`ProcessGroupGloo.cpp`**: Add a `TORCH_CHECK` after the registry lookup so that if a device type is not registered, a `RuntimeError` with that device type is thrown instead of a segmentation error.

## Test Plan
The original playback requires two GPUs on Windows (confirmed by the issue reporter on an RTX 5090). Continuous integration (CI) should verify that the file compiles on all platforms. The issue reporter can verify the solution.