### PR TITLE
Fix #176298: support unsigned add and sub on CPU

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -561,6 +561,7 @@
   ufunc_inner_loop:
     Generic: add (AllAndComplex, BFloat16, Half, ComplexHalf)
     ScalarOnly: add (Bool)
+    CPUScalar: add (UInt16, UInt32, UInt64)
   dispatch:
     SparseCPU, SparseMeta: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -82,6 +82,9 @@ device_type = (
 )
 
 _unsigned_int_types = (torch.uint16, torch.uint32, torch.uint64)
+_unsigned_int_add_sub_ufuncs = tuple(
+    op for op in binary_ufuncs if op.name in ("add", "sub")
+)
 
 
 # TODO: update to use opinfos consistently
@@ -4709,10 +4712,26 @@ def generate_not_implemented_tests(cls):
 
 
 generate_not_implemented_tests(TestBinaryUfuncsDevice)
+
+
+class TestUnsignedIntBinaryUfuncs(TestCase):
+    @ops(_unsigned_int_add_sub_ufuncs, dtypes=_unsigned_int_types)
+    def test_add_sub(self, device, dtype, op):
+        lhs = torch.tensor([10, 20, 30], device=device, dtype=dtype)
+        rhs = torch.tensor([1, 2, 3], device=device, dtype=dtype)
+
+        for alpha in (1, 2):
+            expected = torch.from_numpy(
+                op.ref(lhs.numpy(), rhs.numpy(), alpha=alpha)
+            ).to(dtype)
+            self.assertEqual(op(lhs, rhs, alpha=alpha), expected)
+
+
 instantiate_device_type_tests(
     TestBinaryUfuncsDevice, globals(), allow_xpu=True, except_for="cpu"
 )
 instantiate_device_type_tests(TestBinaryUfuncsCUDA, globals(), only_for="cuda")
+instantiate_device_type_tests(TestUnsignedIntBinaryUfuncs, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -398,6 +398,9 @@ class ScalarType(Enum):
     Float8_e4m3fn = auto()
     Float8_e4m3fnuz = auto()
     Float8_e8m0fnu = auto()
+    UInt16 = auto()
+    UInt32 = auto()
+    UInt64 = auto()
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
Fixes #176298

## Summary

This PR adds CPU support for `torch.add` and `torch.sub` on
`torch.uint16`, `torch.uint32`, and `torch.uint64` tensors.

The generated CPU `add` kernel did not include these unsigned dtypes,
which caused `torch.add` to raise `NotImplementedError`. Since
`torch.sub` delegates to `add_stub`, it failed as well.

The issue also mentioned `mul`, but `mul` already works for these
dtypes on current `main`.

This follows up on #176356, which was closed due to inactivity.

## Test Plan

```bash
.venv/bin/python test/test_binary_ufuncs.py -k TestUnsignedIntBinaryUfuncs -v
.venv/bin/python -m spin quicklint
```

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10