### PR TITLE
[Inductor] Stabilize checkpointed reduction autotuning

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1863,7 +1863,7 @@ class ComboKernelMetadataTests(TestCase):
             "test_configs.force_filter_reduction_configs": False,
         }
     )
-    def test_checkpointed_standalone_reduction_filters_configs(self):
+    def test_checkpointed_standalone_reduction_uses_ac_stable_policy(self):
         from torch.utils.checkpoint import checkpoint
 
         def block(a):
@@ -1880,15 +1880,19 @@ class ComboKernelMetadataTests(TestCase):
 
         self.assertNotIn("'combo_grid_meta':", code)
         self.assertIn("'optimize_mem': False", code)
+        self.assertIn("'ac_stable_reduction': True", code)
         self.assertIn("'force_filter_reduction_configs': True", code)
         self.assertIn("'dynamic_scale_rblock': False", code)
+        self.assertIn("'disable_reduction_coordesc': True", code)
         self.assertIn("'has_loadstore_with_contiguous_rdim': True", code)
 
         plain_inp = torch.rand(32, 1024, device=GPU_TYPE)
         _, codes = run_and_get_code(torch.compile(block, fullgraph=True), plain_inp)
         code = " ".join(codes)
+        self.assertNotIn("'ac_stable_reduction': True", code)
         self.assertNotIn("'force_filter_reduction_configs': True", code)
         self.assertNotIn("'dynamic_scale_rblock': False", code)
+        self.assertNotIn("'disable_reduction_coordesc': True", code)
 
     @requires_gpu_and_triton
     @torch._inductor.config.patch(
@@ -1898,7 +1902,7 @@ class ComboKernelMetadataTests(TestCase):
             "test_configs.force_filter_reduction_configs": False,
         }
     )
-    def test_checkpointed_combo_reduction_filters_configs_per_subkernel(self):
+    def test_checkpointed_combo_reduction_uses_ac_stable_policy(self):
         from torch.utils.checkpoint import checkpoint
 
         def block(a, b):
@@ -1918,14 +1922,19 @@ class ComboKernelMetadataTests(TestCase):
 
         self.assertIn("'combo_grid_meta':", code)
         self.assertIn("'optimize_mem': False", code)
+        self.assertIn("'ac_stable_reduction': True", code)
         self.assertIn("'dynamic_scale_rblock': False", code)
+        self.assertIn("'disable_reduction_coordesc': True", code)
+        self.assertIn("'disable_combo_kernel_autotune': True", code)
         for num in range(2):
             meta_start = code.find(f"'inductor_meta_{num}'")
             self.assertNotEqual(meta_start, -1)
             meta_end = code.find(f"'inductor_meta_{num + 1}'", meta_start + 1)
             meta = code[meta_start : meta_end if meta_end != -1 else None]
+            self.assertIn("'ac_stable_reduction': True", meta)
             self.assertIn("'force_filter_reduction_configs': True", meta)
             self.assertIn("'dynamic_scale_rblock': False", meta)
+            self.assertIn("'disable_reduction_coordesc': True", meta)
             self.assertIn("'has_loadstore_with_contiguous_rdim': True", meta)
 
         def plain_fn(a, b):
@@ -1937,13 +1946,21 @@ class ComboKernelMetadataTests(TestCase):
         )
         code = " ".join(codes)
         self.assertIn("'combo_grid_meta':", code)
+        self.assertNotIn("'ac_stable_reduction': True", code)
         self.assertNotIn("'force_filter_reduction_configs': True", code)
         self.assertNotIn("'dynamic_scale_rblock': False", code)
+        self.assertNotIn("'disable_reduction_coordesc': True", code)
 
-    def test_combo_subkernel_fingerprint_includes_reduction_filtering(self):
+    def test_combo_subkernel_fingerprint_includes_ac_stable_policy(self):
         from torch._inductor.runtime.triton_heuristics import _subkernel_fingerprint
 
-        def meta(*, force_filter_reduction_configs=False, dynamic_scale_rblock=True):
+        def meta(
+            *,
+            ac_stable_reduction=False,
+            force_filter_reduction_configs=False,
+            dynamic_scale_rblock=True,
+            disable_reduction_coordesc=False,
+        ):
             return {
                 "heuristic_0": "reduction",
                 "size_hints_0": {"x": 32, "r0_": 1024},
@@ -1953,8 +1970,10 @@ class ComboKernelMetadataTests(TestCase):
                     "num_load": 1,
                     "num_store": 1,
                     "num_reduction": 1,
+                    "ac_stable_reduction": ac_stable_reduction,
                     "force_filter_reduction_configs": force_filter_reduction_configs,
                     "dynamic_scale_rblock": dynamic_scale_rblock,
+                    "disable_reduction_coordesc": disable_reduction_coordesc,
                     "has_loadstore_with_contiguous_rdim": True,
                 },
             }
@@ -1967,6 +1986,14 @@ class ComboKernelMetadataTests(TestCase):
         self.assertNotEqual(
             baseline,
             _subkernel_fingerprint(meta(dynamic_scale_rblock=False), 0),
+        )
+        self.assertNotEqual(
+            baseline,
+            _subkernel_fingerprint(meta(ac_stable_reduction=True), 0),
+        )
+        self.assertNotEqual(
+            baseline,
+            _subkernel_fingerprint(meta(disable_reduction_coordesc=True), 0),
         )
 
     @requires_gpu_and_triton

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import torch
 import torch._inductor
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import fresh_cache, run_and_get_code
+from torch._inductor.utils import fresh_cache, run_and_get_code, run_fw_bw_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM90OrLater
 from torch.testing._internal.common_utils import (
@@ -1853,6 +1853,121 @@ class ComboKernelMetadataTests(TestCase):
                 "'has_loadstore_with_contiguous_rdim'"
             )
         fc.run(code)
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch(
+        {
+            "batch_invariant": False,
+            "combo_kernels": False,
+            "deterministic": False,
+            "test_configs.force_filter_reduction_configs": False,
+        }
+    )
+    def test_checkpointed_standalone_reduction_filters_configs(self):
+        from torch.utils.checkpoint import checkpoint
+
+        def block(a):
+            return a.sum(-1)
+
+        def fn(a):
+            return checkpoint(block, a, use_reentrant=False).sum()
+
+        inp = torch.rand(32, 1024, device=GPU_TYPE, requires_grad=True)
+        _, codes = run_fw_bw_and_get_code(
+            lambda: torch.compile(fn, fullgraph=True)(inp)
+        )
+        code = " ".join(codes)
+
+        self.assertNotIn("'combo_grid_meta':", code)
+        self.assertIn("'optimize_mem': False", code)
+        self.assertIn("'force_filter_reduction_configs': True", code)
+        self.assertIn("'dynamic_scale_rblock': False", code)
+        self.assertIn("'has_loadstore_with_contiguous_rdim': True", code)
+
+        plain_inp = torch.rand(32, 1024, device=GPU_TYPE)
+        _, codes = run_and_get_code(torch.compile(block, fullgraph=True), plain_inp)
+        code = " ".join(codes)
+        self.assertNotIn("'force_filter_reduction_configs': True", code)
+        self.assertNotIn("'dynamic_scale_rblock': False", code)
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch(
+        {
+            "batch_invariant": False,
+            "deterministic": False,
+            "test_configs.force_filter_reduction_configs": False,
+        }
+    )
+    def test_checkpointed_combo_reduction_filters_configs_per_subkernel(self):
+        from torch.utils.checkpoint import checkpoint
+
+        def block(a, b):
+            return a.sum(-1), b.mean(-1)
+
+        def fn(a, b):
+            x, y = checkpoint(block, a, b, use_reentrant=False)
+            return (x + y).sum()
+
+        inps = [
+            torch.rand(32, 1024, device=GPU_TYPE, requires_grad=True) for _ in range(2)
+        ]
+        _, codes = run_fw_bw_and_get_code(
+            lambda: torch.compile(fn, fullgraph=True)(*inps)
+        )
+        code = " ".join(codes)
+
+        self.assertIn("'combo_grid_meta':", code)
+        self.assertIn("'optimize_mem': False", code)
+        self.assertIn("'dynamic_scale_rblock': False", code)
+        for num in range(2):
+            meta_start = code.find(f"'inductor_meta_{num}'")
+            self.assertNotEqual(meta_start, -1)
+            meta_end = code.find(f"'inductor_meta_{num + 1}'", meta_start + 1)
+            meta = code[meta_start : meta_end if meta_end != -1 else None]
+            self.assertIn("'force_filter_reduction_configs': True", meta)
+            self.assertIn("'dynamic_scale_rblock': False", meta)
+            self.assertIn("'has_loadstore_with_contiguous_rdim': True", meta)
+
+        def plain_fn(a, b):
+            return block(a, b)
+
+        plain_inps = [torch.rand(32, 1024, device=GPU_TYPE) for _ in range(2)]
+        _, codes = run_and_get_code(
+            torch.compile(plain_fn, fullgraph=True), *plain_inps
+        )
+        code = " ".join(codes)
+        self.assertIn("'combo_grid_meta':", code)
+        self.assertNotIn("'force_filter_reduction_configs': True", code)
+        self.assertNotIn("'dynamic_scale_rblock': False", code)
+
+    def test_combo_subkernel_fingerprint_includes_reduction_filtering(self):
+        from torch._inductor.runtime.triton_heuristics import _subkernel_fingerprint
+
+        def meta(*, force_filter_reduction_configs=False, dynamic_scale_rblock=True):
+            return {
+                "heuristic_0": "reduction",
+                "size_hints_0": {"x": 32, "r0_": 1024},
+                "reduction_hint_0": "INNER",
+                "tile_hint_0": "DEFAULT",
+                "inductor_meta_0": {
+                    "num_load": 1,
+                    "num_store": 1,
+                    "num_reduction": 1,
+                    "force_filter_reduction_configs": force_filter_reduction_configs,
+                    "dynamic_scale_rblock": dynamic_scale_rblock,
+                    "has_loadstore_with_contiguous_rdim": True,
+                },
+            }
+
+        baseline = _subkernel_fingerprint(meta(), 0)
+        self.assertNotEqual(
+            baseline,
+            _subkernel_fingerprint(meta(force_filter_reduction_configs=True), 0),
+        )
+        self.assertNotEqual(
+            baseline,
+            _subkernel_fingerprint(meta(dynamic_scale_rblock=False), 0),
+        )
 
     @requires_gpu_and_triton
     def test_combo_per_kernel_inductor_meta_matches_standalone(self):

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -135,7 +135,7 @@ class TestOnlineSoftmax(TestCase):
             "test_configs.force_filter_reduction_configs": False,
         }
     )
-    def test_checkpointed_softmax_filters_reduction_configs(self):
+    def test_checkpointed_softmax_uses_ac_stable_reduction_policy(self):
         from torch.utils.checkpoint import (
             checkpoint,
             create_selective_checkpoint_contexts,
@@ -154,14 +154,18 @@ class TestOnlineSoftmax(TestCase):
         for code in codes:
             self.assertIn("softmax", code)
             self.assertIn("'optimize_mem': False", code)
+            self.assertIn("'ac_stable_reduction': True", code)
             self.assertIn("'force_filter_reduction_configs': True", code)
             self.assertIn("'dynamic_scale_rblock': False", code)
+            self.assertIn("'disable_reduction_coordesc': True", code)
 
         _, codes = run_and_get_code(lambda: torch.compile(block, fullgraph=True)(x))
         self.assertEqual(len(codes), 1)
         self.assertIn("softmax", codes[0])
+        self.assertNotIn("'ac_stable_reduction': True", codes[0])
         self.assertNotIn("'force_filter_reduction_configs': True", codes[0])
         self.assertNotIn("'dynamic_scale_rblock': False", codes[0])
+        self.assertNotIn("'disable_reduction_coordesc': True", codes[0])
 
         def save_fn(x):
             return checkpoint(
@@ -180,6 +184,7 @@ class TestOnlineSoftmax(TestCase):
 
         self.assertGreater(len(codes), 0)
         for code in codes:
+            self.assertNotIn("'ac_stable_reduction': True", code)
             self.assertNotIn("'force_filter_reduction_configs': True", code)
 
     @inductor_config.patch("triton.persistent_reductions", False)

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import functools
 import math
 import os
 
@@ -9,7 +10,7 @@ import torch.nn.functional as F
 from torch._dynamo.utils import rmse, same
 from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.utils import run_and_get_code
+from torch._inductor.utils import run_and_get_code, run_fw_bw_and_get_code
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
@@ -20,6 +21,10 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, HAS_TRITON
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 USE_LARGE_INPUT = os.environ.get("USE_LARGE_INPUT") == "1" or DO_PERF_TEST
+
+
+def _must_save_policy(ctx, op, *args, **kwargs):
+    return torch.utils.checkpoint.CheckpointPolicy.MUST_SAVE
 
 
 def _prepare_softmax(x, dim):
@@ -122,6 +127,60 @@ class TestOnlineSoftmax(TestCase):
         """
         wrapper_code = self.get_softmax_wrapper(1024)
         self.assertEqual(wrapper_code.count("for r0_offset in"), 0)
+
+    @inductor_config.patch(
+        {
+            "batch_invariant": False,
+            "deterministic": False,
+            "test_configs.force_filter_reduction_configs": False,
+        }
+    )
+    def test_checkpointed_softmax_filters_reduction_configs(self):
+        from torch.utils.checkpoint import (
+            checkpoint,
+            create_selective_checkpoint_contexts,
+        )
+
+        def block(x):
+            return torch.softmax(x, dim=-1)
+
+        def fn(x):
+            return checkpoint(block, x, use_reentrant=False)
+
+        x = torch.randn(16, 64, device=GPU_TYPE, requires_grad=True)
+        _, codes = run_fw_bw_and_get_code(lambda: torch.compile(fn, fullgraph=True)(x))
+
+        self.assertEqual(len(codes), 2)
+        for code in codes:
+            self.assertIn("softmax", code)
+            self.assertIn("'optimize_mem': False", code)
+            self.assertIn("'force_filter_reduction_configs': True", code)
+            self.assertIn("'dynamic_scale_rblock': False", code)
+
+        _, codes = run_and_get_code(lambda: torch.compile(block, fullgraph=True)(x))
+        self.assertEqual(len(codes), 1)
+        self.assertIn("softmax", codes[0])
+        self.assertNotIn("'force_filter_reduction_configs': True", codes[0])
+        self.assertNotIn("'dynamic_scale_rblock': False", codes[0])
+
+        def save_fn(x):
+            return checkpoint(
+                block,
+                x,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, _must_save_policy
+                ),
+            )
+
+        x = torch.randn(16, 64, device=GPU_TYPE, requires_grad=True)
+        _, codes = run_fw_bw_and_get_code(
+            lambda: torch.compile(save_fn, fullgraph=True)(x)
+        )
+
+        self.assertGreater(len(codes), 0)
+        for code in codes:
+            self.assertNotIn("'force_filter_reduction_configs': True", code)
 
     @inductor_config.patch("triton.persistent_reductions", False)
     def test_sdpa(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3163,15 +3163,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             f"tl.full([{entry.block_size_str()}], True, tl.int1)[{suffix}]"
         )
 
+    def _should_track_contiguous_rdim(self) -> bool:
+        # This analysis is only needed for reduction kernels whose configs may
+        # be filtered. Use inside_reduction instead of num_reduction here
+        # because loads may be emitted before the reduction op increments
+        # num_reduction.
+        return (
+            config.deterministic
+            or config.test_configs.force_filter_reduction_configs
+            or (self.inside_reduction and self._has_activation_checkpoint_origins())
+        )
+
     @staticmethod
     def _has_stride1_on_rdim(index) -> bool:
-        # These analysis is only needed in deterministic mode so far
-        # to filter triton configs. Return false immediately to avoid
-        # increasing compilation time when the mode is off.
-        if not (
-            config.deterministic or config.test_configs.force_filter_reduction_configs
-        ):
-            return False
         support_vars = index.free_symbols
         reduce_vars = [
             var
@@ -4141,8 +4145,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             ),
         )
 
-        if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
-            indexing.index
+        if (
+            isinstance(indexing, IndexingOptions)
+            and self._should_track_contiguous_rdim()
+            and self._has_stride1_on_rdim(indexing.index)
         ):
             self.has_load_with_contiguous_rdim = True
 
@@ -4346,8 +4352,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             mask_constant_index=mode == "atomic_add",
         )
 
-        if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
-            indexing.index
+        if (
+            isinstance(indexing, IndexingOptions)
+            and self._should_track_contiguous_rdim()
+            and self._has_stride1_on_rdim(indexing.index)
         ):
             self.stores_with_contiguous_rdim.append(name)
 
@@ -6229,6 +6237,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self.has_load_with_contiguous_rdim
                 or self.has_store_with_contiguous_rdim
             )
+        if self._needs_activation_checkpoint_reduction_config_filtering():
+            # Combo kernels pass per-sub-kernel metadata through this helper.
+            # Keep checkpointed reductions on the same filtered config path
+            # there as well as in the standalone codegen_kernel() path.
+            out["force_filter_reduction_configs"] = True
+            out["dynamic_scale_rblock"] = False
+            out["has_loadstore_with_contiguous_rdim"] = (
+                self.has_load_with_contiguous_rdim
+                or self.has_store_with_contiguous_rdim
+            )
         if self.tma_min_block_sizes:
             out["tma_min_block_sizes"] = self.tma_min_block_sizes
         if self.tiling_scores:
@@ -6256,6 +6274,26 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 out["kernel_flop"] = flops
         return out
+
+    @cache_on_self
+    def _has_activation_checkpoint_origins(self) -> bool:
+        from torch.utils.checkpoint import CheckpointPolicy
+
+        for scheduler_node in self.features.scheduler_nodes():
+            node = scheduler_node.node
+            if node is None:
+                continue
+            for origin in node.get_origins():
+                meta = getattr(origin, "meta", None)
+                if meta is not None and meta.get("recompute") in (
+                    CheckpointPolicy.MUST_RECOMPUTE,
+                    CheckpointPolicy.PREFER_RECOMPUTE,
+                ):
+                    return True
+        return False
+
+    def _needs_activation_checkpoint_reduction_config_filtering(self) -> bool:
+        return self.num_reduction > 0 and self._has_activation_checkpoint_origins()
 
     @functools.cached_property
     def add_persistent_rblock(self) -> bool:
@@ -6443,6 +6481,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # every new node will increase the peak memory and our greedy approach would
         # introduce a lot of unnecessary cpu copies.
         optimize_mem = V.graph.is_inference or V.graph.is_backward
+        if self._needs_activation_checkpoint_reduction_config_filtering():
+            # Checkpointed forward reductions are compiled once in the training
+            # forward graph and again as recompute inside the backward graph.
+            # Treating the recompute copy like an arbitrary backward kernel can
+            # make it autotune under different mutation-preservation rules than
+            # the original forward. Keep these kernels on the forward-compatible
+            # autotune path so discrete downstream decisions, such as MoE routing,
+            # see the same low bits.
+            optimize_mem = False
 
         inductor_meta = {
             "grid_type": self._get_grid_type().__name__,
@@ -6452,6 +6499,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             **self.inductor_meta_per_kernel(),
             **self.inductor_meta_common(),
         }
+
+        if self._needs_activation_checkpoint_reduction_config_filtering():
+            # AC forward and recompute graphs are compiled independently. Keep
+            # reductions in checkpointed regions on the canonical filtered config
+            # path so downstream discrete decisions see the same low bits.
+            inductor_meta["force_filter_reduction_configs"] = True
+            # Dynamic R-block scaling depends on compiled register pressure. A
+            # recompute graph can legitimately materialize extra backward-needed
+            # outputs, so letting register pressure choose the reduction tree can
+            # make recompute numerics differ from the original forward.
+            inductor_meta["dynamic_scale_rblock"] = False
+            inductor_meta["has_loadstore_with_contiguous_rdim"] = (
+                self.has_load_with_contiguous_rdim
+                or self.has_store_with_contiguous_rdim
+            )
 
         # Triton compiler includes equal_to_1 args into constants even
         # when they are not constexpr. otherwise there may be a segfault

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3171,7 +3171,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return (
             config.deterministic
             or config.test_configs.force_filter_reduction_configs
-            or (self.inside_reduction and self._has_activation_checkpoint_origins())
+            or (self.inside_reduction and self._has_ac_recompute_origins())
         )
 
     @staticmethod
@@ -6237,16 +6237,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self.has_load_with_contiguous_rdim
                 or self.has_store_with_contiguous_rdim
             )
-        if self._needs_activation_checkpoint_reduction_config_filtering():
-            # Combo kernels pass per-sub-kernel metadata through this helper.
-            # Keep checkpointed reductions on the same filtered config path
-            # there as well as in the standalone codegen_kernel() path.
-            out["force_filter_reduction_configs"] = True
-            out["dynamic_scale_rblock"] = False
-            out["has_loadstore_with_contiguous_rdim"] = (
-                self.has_load_with_contiguous_rdim
-                or self.has_store_with_contiguous_rdim
-            )
+        self._apply_ac_stable_reduction_policy(out)
         if self.tma_min_block_sizes:
             out["tma_min_block_sizes"] = self.tma_min_block_sizes
         if self.tiling_scores:
@@ -6276,7 +6267,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return out
 
     @cache_on_self
-    def _has_activation_checkpoint_origins(self) -> bool:
+    def _has_ac_recompute_origins(self) -> bool:
         from torch.utils.checkpoint import CheckpointPolicy
 
         for scheduler_node in self.features.scheduler_nodes():
@@ -6292,8 +6283,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     return True
         return False
 
-    def _needs_activation_checkpoint_reduction_config_filtering(self) -> bool:
-        return self.num_reduction > 0 and self._has_activation_checkpoint_origins()
+    def _needs_ac_stable_reduction_policy(self) -> bool:
+        return self.num_reduction > 0 and self._has_ac_recompute_origins()
+
+    def _apply_ac_stable_reduction_policy(self, out: dict[str, Any]) -> None:
+        if not self._needs_ac_stable_reduction_policy():
+            return
+
+        out["ac_stable_reduction"] = True
+        out["force_filter_reduction_configs"] = True
+        out["dynamic_scale_rblock"] = False
+        out["disable_reduction_coordesc"] = True
+        out["has_loadstore_with_contiguous_rdim"] = (
+            self.has_load_with_contiguous_rdim or self.has_store_with_contiguous_rdim
+        )
 
     @functools.cached_property
     def add_persistent_rblock(self) -> bool:
@@ -6481,14 +6484,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # every new node will increase the peak memory and our greedy approach would
         # introduce a lot of unnecessary cpu copies.
         optimize_mem = V.graph.is_inference or V.graph.is_backward
-        if self._needs_activation_checkpoint_reduction_config_filtering():
-            # Checkpointed forward reductions are compiled once in the training
-            # forward graph and again as recompute inside the backward graph.
-            # Treating the recompute copy like an arbitrary backward kernel can
-            # make it autotune under different mutation-preservation rules than
-            # the original forward. Keep these kernels on the forward-compatible
-            # autotune path so discrete downstream decisions, such as MoE routing,
-            # see the same low bits.
+        if self._needs_ac_stable_reduction_policy():
+            # AC forward and recompute reductions compile independently today.
+            # Keep their autotune input-preservation policy aligned so they do
+            # not choose different numerics-affecting reduction strategies.
             optimize_mem = False
 
         inductor_meta = {
@@ -6499,21 +6498,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             **self.inductor_meta_per_kernel(),
             **self.inductor_meta_common(),
         }
-
-        if self._needs_activation_checkpoint_reduction_config_filtering():
-            # AC forward and recompute graphs are compiled independently. Keep
-            # reductions in checkpointed regions on the canonical filtered config
-            # path so downstream discrete decisions see the same low bits.
-            inductor_meta["force_filter_reduction_configs"] = True
-            # Dynamic R-block scaling depends on compiled register pressure. A
-            # recompute graph can legitimately materialize extra backward-needed
-            # outputs, so letting register pressure choose the reduction tree can
-            # make recompute numerics differ from the original forward.
-            inductor_meta["dynamic_scale_rblock"] = False
-            inductor_meta["has_loadstore_with_contiguous_rdim"] = (
-                self.has_load_with_contiguous_rdim
-                or self.has_store_with_contiguous_rdim
-            )
+        self._apply_ac_stable_reduction_policy(inductor_meta)
 
         # Triton compiler includes equal_to_1 args into constants even
         # when they are not constexpr. otherwise there may be a segfault

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -766,6 +766,17 @@ class ComboKernel(Kernel):
                 default=0,
             )
 
+        # Compute per-sub-kernel metadata before the outer combo metadata so
+        # checkpointed reductions can opt out of backward autotune memory
+        # optimization in the combined launch path as well.
+        sub_metas = [sub.inductor_meta_per_kernel() for sub in self.sub_kernels]
+        optimize_mem = V.graph.is_inference or V.graph.is_backward
+        has_ac_filtered_reduction = any(
+            m.get("force_filter_reduction_configs", False) for m in sub_metas
+        )
+        if has_ac_filtered_reduction:
+            optimize_mem = False
+
         inductor_meta = {
             "grid_type": dispatch.grid_expr.__name__,
             "combo_grid_meta": self.combo_grid_meta(size_hints_list),
@@ -774,14 +785,15 @@ class ComboKernel(Kernel):
             # Matches triton.py:codegen_kernel(): inference/backward graphs skip
             # CPU-copy of mutated args during autotune retries; training-forward
             # graphs must keep it to preserve benchmark inputs across retries.
-            "optimize_mem": V.graph.is_inference or V.graph.is_backward,
+            "optimize_mem": optimize_mem,
             **self.triton_kernel_cls.inductor_meta_common(),
         }
+        if has_ac_filtered_reduction:
+            inductor_meta["dynamic_scale_rblock"] = False
         if max_persistent_rblock > 0:
             inductor_meta["max_persistent_rblock"] = max_persistent_rblock
 
         # Sum per-sub-kernel bandwidth / FLOP estimates for the combo launch.
-        sub_metas = [sub.inductor_meta_per_kernel() for sub in self.sub_kernels]
         self._kernel_num_gb = sum(m.get("kernel_num_gb") or 0 for m in sub_metas)
         if config.benchmark_kernel or config.profile_bandwidth:
             inductor_meta["kernel_num_gb"] = self._kernel_num_gb

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -766,15 +766,14 @@ class ComboKernel(Kernel):
                 default=0,
             )
 
-        # Compute per-sub-kernel metadata before the outer combo metadata so
-        # checkpointed reductions can opt out of backward autotune memory
-        # optimization in the combined launch path as well.
+        # Compute per-sub-kernel metadata before the outer combo metadata so AC
+        # reductions can apply the same stable strategy in the combined launch.
         sub_metas = [sub.inductor_meta_per_kernel() for sub in self.sub_kernels]
         optimize_mem = V.graph.is_inference or V.graph.is_backward
-        has_ac_filtered_reduction = any(
-            m.get("force_filter_reduction_configs", False) for m in sub_metas
+        has_ac_stable_reduction = any(
+            m.get("ac_stable_reduction", False) for m in sub_metas
         )
-        if has_ac_filtered_reduction:
+        if has_ac_stable_reduction:
             optimize_mem = False
 
         inductor_meta = {
@@ -788,8 +787,11 @@ class ComboKernel(Kernel):
             "optimize_mem": optimize_mem,
             **self.triton_kernel_cls.inductor_meta_common(),
         }
-        if has_ac_filtered_reduction:
+        if has_ac_stable_reduction:
+            inductor_meta["ac_stable_reduction"] = True
             inductor_meta["dynamic_scale_rblock"] = False
+            inductor_meta["disable_reduction_coordesc"] = True
+            inductor_meta["disable_combo_kernel_autotune"] = True
         if max_persistent_rblock > 0:
             inductor_meta["max_persistent_rblock"] = max_persistent_rblock
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1897,12 +1897,17 @@ class CachingAutotuner(KernelInterface):
             HeuristicType.FIXED,
         ):
             return False
-        # Deterministic mode forbids tuning RBLOCK / num_warps for reductions
-        # because those knobs shift numerics.
-        if self.deterministic_mode and self.heuristic_type in (
+        reduction_heuristic = self.heuristic_type in (
             HeuristicType.REDUCTION,
             HeuristicType.PERSISTENT_REDUCTION,
             HeuristicType.SPLIT_SCAN,
+        )
+        # These knobs can shift reduction numerics by changing the tree.
+        if self.deterministic_mode and reduction_heuristic:
+            return False
+        if (
+            self.inductor_meta.get("disable_reduction_coordesc", False)
+            and reduction_heuristic
         ):
             return False
         return True
@@ -2129,8 +2134,10 @@ class CachingAutotuner(KernelInterface):
                 if len(self.launchers) > 1:
                     self.autotune_to_one_config(*args, **kwargs)
 
-        if self.inductor_meta.get("combo_tuning_groups") and not getattr(
-            self.launchers[0].config, "found_by_combo_autotune", False
+        if (
+            self.inductor_meta.get("combo_tuning_groups")
+            and not self.inductor_meta.get("disable_combo_kernel_autotune", False)
+            and not getattr(self.launchers[0].config, "found_by_combo_autotune", False)
         ):
             with dynamo_timed(
                 "CachingAutotuner.combo_sequential_autotune",
@@ -3571,8 +3578,10 @@ def _subkernel_fingerprint(combo_meta: dict[str, Any], i: int) -> tuple[Any, ...
         combo_meta.get(f"reduction_hint_{i}"),
         combo_meta.get(f"tile_hint_{i}"),
         sub_meta.get("add_persistent_rblock", False),
+        sub_meta.get("ac_stable_reduction", False),
         sub_meta.get("force_filter_reduction_configs", False),
         sub_meta.get("dynamic_scale_rblock"),
+        sub_meta.get("disable_reduction_coordesc", False),
         sub_meta.get("has_loadstore_with_contiguous_rdim"),
         tuple(sorted(tma.items())),
         tuple(sorted(tiling_scores.items())),

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3571,6 +3571,8 @@ def _subkernel_fingerprint(combo_meta: dict[str, Any], i: int) -> tuple[Any, ...
         combo_meta.get(f"reduction_hint_{i}"),
         combo_meta.get(f"tile_hint_{i}"),
         sub_meta.get("add_persistent_rblock", False),
+        sub_meta.get("force_filter_reduction_configs", False),
+        sub_meta.get("dynamic_scale_rblock"),
         sub_meta.get("has_loadstore_with_contiguous_rdim"),
         tuple(sorted(tma.items())),
         tuple(sorted(tiling_scores.items())),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #186573

Activation checkpointing wants the original forward AC region and its recompute to use the same numerics-affecting compiled strategy. The ideal long-term design is compile-once/reuse for AC subgraphs in AOTAutograd or partitioning, but today those copies are compiled independently.

That independent compilation can change the compiled strategy for reductions. In the failure this fixes, recompute materialized backward-needed outputs, which changed register pressure and let dynamic R-block selection choose a different reduction tree. Low-bit output drift from that difference can then affect downstream discrete decisions such as routing or counts.

This PR keeps the fix Inductor-local and narrower than global deterministic algorithms: use existing AC metadata to put AC-origin reductions on a canonical reduction/autotune policy. The policy uses filtered reduction configs, disables dynamic R-block scaling, disables reduction coordinate-descent and combo retuning choices that can alter the reduction tree, and aligns autotune input-preservation behavior. Unrelated non-AC reductions keep the existing fast path.

The change was authored with assistance from an AI assistant.

Fixes #186572

Test Plan:

```bash
python -m py_compile torch/_inductor/codegen/triton.py torch/_inductor/codegen/triton_combo_kernel.py torch/_inductor/runtime/triton_heuristics.py test/inductor/test_combo_kernels.py test/inductor/test_online_softmax.py
```

```bash
python test/inductor/test_combo_kernels.py ComboKernelMetadataTests.test_checkpointed_standalone_reduction_uses_ac_stable_policy ComboKernelMetadataTests.test_checkpointed_combo_reduction_uses_ac_stable_policy ComboKernelMetadataTests.test_combo_subkernel_fingerprint_includes_ac_stable_policy
```

```bash
python test/inductor/test_online_softmax.py -k test_checkpointed_softmax_uses_ac_stable_reduction_policy
```

```bash
python test/inductor/test_combo_kernels.py -k combo_kernel_coordesc_tunes_largest_subkernel_first
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo