### PR TITLE
[dynamo] return [] for _get_current_dispatch_mode_stack instead of graph break

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -138,6 +138,23 @@ class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(eager_res, compiled_res)
         self.assertEqual(cnt.frame_count, 0)
 
+    def test_get_current_dispatch_mode_stack_no_graph_break(self):
+        from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(x):
+            stack = _get_current_dispatch_mode_stack()
+            return x + len(stack)
+
+        x = torch.ones(2, 2)
+        result = fn(x)
+        # Stack is empty during tracing, so len([]) == 0 and result == ones(2,2)
+        self.assertEqual(result, torch.ones(2, 2))
+        # fullgraph=True would have raised if a graph break occurred
+        self.assertEqual(cnt.frame_count, 1)
+
 
 class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
     @classmethod

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -421,6 +421,9 @@ manual_torch_name_rule_map: dict[
     f"torch/testing/_internal/common_distributed.py#{TORCH_DYNAMO_RESUME_IN_PREFIX}": UserFunctionVariable,
     "torch.utils._pytree._get_node_type": PyTreeGetNodeTypeFunctionVariable,
     "torch.utils._pytree.tree_is_leaf": PyTreeTreeIsLeafFunctionVariable,
+    # torch.utils._python_dispatch is in MOD_INLINELIST; override so the handler
+    # in variables/torch.py fires instead of graph-breaking on _len_torch_dispatch_stack.
+    "torch.utils._python_dispatch._get_current_dispatch_mode_stack": TorchInGraphFunctionVariable,
     "torch._utils_internal.justknobs_check": UserFunctionVariable,
     "inspect.signature": InspectSignatureVariable,
 }

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2248,6 +2248,24 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
             return tx.symbolic_torch_function_state.mode_stack[ind]
 
+
+        @register(torch.utils._python_dispatch._get_current_dispatch_mode_stack)
+        def handle_get_current_dispatch_mode_stack(
+            self,
+            tx: "InstructionTranslatorBase",
+            *args: VariableTracker,
+            **kwargs: VariableTracker,
+        ) -> VariableTracker:
+            if args or kwargs:
+                raise_type_error(
+                    tx,
+                    "_get_current_dispatch_mode_stack() takes no arguments",
+                )
+            # During tracing, Dynamo runs with dispatch modes removed, so
+            # the stack is always empty. Return [] as a constant instead
+            # of graph-breaking.
+            return VariableTracker.build(tx, [])
+
         @register(torch.get_device_module.__wrapped__)
         def handle_get_device_module(
             self,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2248,7 +2248,6 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
             return tx.symbolic_torch_function_state.mode_stack[ind]
 
-
         @register(torch.utils._python_dispatch._get_current_dispatch_mode_stack)
         def handle_get_current_dispatch_mode_stack(
             self,


### PR DESCRIPTION
Fixes #125694.

## Summary

When `_get_current_dispatch_mode_stack()` from `torch/utils/_python_dispatch.py` is called inside a `torch.compile` region, Dynamo currently graph-breaks with:

```
Unsupported: 'skip function _get_current_dispatch_mode_stack in file torch/utils/_python_dispatch.py'
```

During tracing, Dynamo removes user-visible `TorchDispatchMode`s (they either set `ignore_compile_internals()=True` or `_should_skip_dynamo()=True`), so the dispatch stack is always empty at trace time. This PR registers a handler in `TorchInGraphFunctionVariable._get_handlers()` that returns `[]` as a compile-time constant, eliminating the graph break.

The fix mirrors the existing pattern for `_get_function_stack_at` and friends in the same file, which handle the `TorchFunction`-mode stack equivalently.

## Test plan

New test in `test/dynamo/test_modes.py::TorchDispatchModeTests`:

```
python test/dynamo/test_modes.py TorchDispatchModeTests.test_get_current_dispatch_mode_stack_no_graph_break
```

Uses `fullgraph=True` to assert no graph break occurs, and checks the return value is correct (`len([]) == 0`).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @gchanan @zou3519 @anijain2305 @bdhirsh