### PR TITLE
Fix persistent Welford layer norm numerics

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3155,6 +3155,51 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         self.common(fn, [x])
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_layer_norm_with_reciprocal_like_epilogue(self):
+        torch.manual_seed(0)
+        direct_x = torch.randn(64, 128, device=device_type)
+        torch.manual_seed(0)
+        x = torch.randn(68, 4, 14, 9, device=device_type)
+
+        def check(fn, arg):
+            torch._dynamo.reset()
+            expected = fn(arg)
+            actual = torch.compile(fn, backend="inductor", fullgraph=True)(arg)
+            self.assertEqual(actual, expected, atol=1e-3, rtol=1e-3)
+
+        def direct_reciprocal_fn(x):
+            t = F.layer_norm(x, [128])
+            return torch.reciprocal(torch.abs(t) + 1e-6)
+
+        def direct_rsqrt_fn(x):
+            t = F.layer_norm(x, [128])
+            return torch.rsqrt(torch.abs(t) + 1e-6)
+
+        def reciprocal_fn(x):
+            t = torch.cummax(x, dim=-1)[0]
+            t = F.layer_norm(t, [9])
+            return torch.reciprocal(torch.abs(t) + 1e-6)
+
+        def rsqrt_fn(x):
+            t = torch.cummax(x, dim=-1)[0]
+            t = F.layer_norm(t, [9])
+            return torch.rsqrt(torch.abs(t) + 1e-6)
+
+        def manual_div_fn(x):
+            t = torch.cummax(x, dim=-1)[0]
+            t = F.layer_norm(t, [9])
+            return 1.0 / torch.sqrt(torch.abs(t) + 1e-6)
+
+        for fn, arg in (
+            (direct_reciprocal_fn, direct_x),
+            (direct_rsqrt_fn, direct_x),
+            (reciprocal_fn, x),
+            (rsqrt_fn, x),
+            (manual_div_fn, x),
+        ):
+            check(fn, arg)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     @skipIfRocm(msg="PTX atan codegen is CUDA-specific")
     @skipIfXpu(msg="PTX atan codegen is CUDA-specific")
     def test_atan_special_psi_eager_parity(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4841,16 +4841,35 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     argreduce_result_kind(),
                 )
             elif reduction_type == "welford_reduce":
-                if self.cooperative_reduction:
-                    # cooperative reductions require full welford for correctness
-                    result_var = self.welford_reduce(
-                        result_var, reduction_type, value, where_cond, acc_type, dtype
+                assert isinstance(masked_value, CSEVariable)
+                zero = self.cse.generate(
+                    self.compute,
+                    f"tl.zeros({masked_value}.shape, {acc_type})",
+                    dtype=torch_acc_type,
+                    shape=masked_value.shape,
+                )
+                one = self.cse.generate(
+                    self.compute,
+                    f"tl.full({masked_value}.shape, 1, {acc_type})",
+                    dtype=torch_acc_type,
+                    shape=masked_value.shape,
+                )
+                weight = (
+                    self.cse.generate(
+                        self.compute,
+                        where_cond(one, zero),
+                        dtype=torch_acc_type,
+                        shape=masked_value.shape,
                     )
-                else:
-                    # For persistent reductions, don't bother with
-                    # welford's algorithm since it uses more registers, and
-                    # taking two reductions doesn't increase memory usage.
-                    result_var = self.welford_reduce_fallback(dtype, value)
+                    if cond
+                    else one
+                )
+                result_var = tuple(
+                    self.cse.generate(self.compute, value, dtype=dtype, shape=shape)
+                    for value, shape in self._welford(
+                        self.compute, masked_value, zero, weight, dim, dtype
+                    )
+                )
             elif reduction_type == "welford_combine":
                 assert isinstance(masked_value, Sequence)
                 (mean, m2, weight) = masked_value


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186582

Inductor lowers native layer norm through var_mean. For Triton persistent reductions, welford_reduce was taking the welford_reduce_fallback path, which computes mean and variance with a two-pass formula instead of preserving the Welford accumulation order. The resulting small layer norm differences can be amplified heavily by reciprocal- and rsqrt-like epilogues near zero, producing silent wrong results.

Keep persistent welford_reduce on the Welford lowering path and use masked lane weights to exclude inactive elements. This fixes the root reduction-order mismatch instead of adding a graph-level fusion barrier. Add CUDA regressions for direct layer_norm followed by reciprocal/rsqrt and for the cummax-amplified reciprocal/rsqrt/manual 1/sqrt cases from the issue.

Test Plan:

- python - <<'PY' ... original direct repro with force_disable_caches=True; aot_eager assert_close PASS; inductor assert_close PASS; eager vs inductor max_abs 0.08984375 max_rel 2.673832386790309e-05

- python - <<'PY' ... cummax reciprocal/rsqrt/manual_div repros with force_disable_caches=True; all assert_close PASS; rsqrt max_abs 0.000293731689453125; reciprocal max_abs 0.015625; manual_div max_abs 0.000293731689453125

- python - <<'PY' ... direct unittest shim for CudaReproTests.test_layer_norm_with_reciprocal_like_epilogue; Ran 1 test in 7.883s, OK

- python test/run_test.py --include inductor/test_cuda_repro -- -k test_layer_norm_with_reciprocal_like_epilogue (blocked: Missing pip dependency pytest-rerunfailures)

- lintrunner -a torch/_inductor/codegen/triton.py test/inductor/test_cuda_repro.py (ok No lint issues)

Benchmark Results:

- NVIDIA B200, CUDA event timing, 100 iterations after warmup, force_disable_caches=True

- direct_reciprocal_64x128: before median 0.041136 ms, after median 0.041888 ms

- cummax_rsqrt_68x4x14x9: before median 0.041456 ms, after median 0.041424 ms

Fixes #186577

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo