### PR TITLE
[testing] Add PrintHashTrace utility for cross-backend fp16 hash comparison in UTs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -74,6 +74,9 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 # enable debug asserts in serialization
 export TORCH_SERIALIZATION_DEBUG=1
 
+# enable hash trace for cross-backend fp16 comparison in UTs
+export PYTORCH_TEST_HASH_TRACE=1
+
 # Bound Inductor compile-worker futures on ROCm so a stuck Triton compile
 # fails fast with a clear RuntimeError naming the kernel, instead of blocking
 # until the outer test timeout kills the shard and loses all context. Scoped

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     xfailIf,
 )
+from torch.testing._internal.hash_trace_utils import hash_trace_wrapper
 
 
 AMPERE_OR_ROCM = TEST_WITH_ROCM or torch.cuda.is_tf32_supported()
@@ -3416,7 +3417,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
         conv = nn.ConvTranspose2d(1, 1, 1, 1, bias=False).to(device).to(dtype)
         input_large = torch.randn(4096, 1, 512, 1024, dtype=dtype, device=device)
         # forward
-        ret = conv(input_large)
+        with hash_trace_wrapper():
+            ret = conv(input_large)
         maxdiff0 = (
             (ret.narrow(0, 0, 1024) - conv(input_large.narrow(0, 0, 1024)))
             .abs_()
@@ -3461,7 +3463,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
         conv = nn.Conv2d(2, 2, 8, 8, bias=False).to(device).to(dtype)
         input_large = torch.randn(4097, 2, 512, 512, dtype=dtype, device=device)
         # forward
-        ret = conv(input_large)
+        with hash_trace_wrapper():
+            ret = conv(input_large)
         self.assertEqual(ret[:2048], conv(input_large[:2048]))
         self.assertEqual(ret[2048:4096], conv(input_large[2048:4096]))
         self.assertEqual(ret[4096:], conv(input_large[4096:]))
@@ -3475,9 +3478,10 @@ class TestConvolutionNNDeviceType(NNTestCase):
         del ret
         grad1 = conv.weight.grad.detach().clone()
         conv.zero_grad()
-        conv(input_large[:2048]).view(2048, -1).max(dim=1).values.sum().backward()
-        conv(input_large[2048:4096]).view(2048, -1).max(dim=1).values.sum().backward()
-        conv(input_large[4096:]).view(1, -1).max(dim=1).values.sum().backward()
+        with hash_trace_wrapper():
+            conv(input_large[:2048]).view(2048, -1).max(dim=1).values.sum().backward()
+            conv(input_large[2048:4096]).view(2048, -1).max(dim=1).values.sum().backward()
+            conv(input_large[4096:]).view(1, -1).max(dim=1).values.sum().backward()
         grad2 = conv.weight.grad.detach().clone()
         # gradients are at the order of hundreds, we need to scale it to
         # the order of one so that we can compare
@@ -4416,7 +4420,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
             2, 2, kernel_size=3, stride=1, padding=1, groups=2, dtype=torch.half
         ).to(memory_format=torch.channels_last)
         yref = c(x)
-        y = c.to(device=device)(x.to(device=device))
+        with hash_trace_wrapper():
+            y = c.to(device=device)(x.to(device=device))
         self.assertEqual(yref, y, atol=5e-3, rtol=1e-4)
         del y, yref
 
@@ -4424,7 +4429,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
         x = x.reshape(100, 2, 3280, 3280)
         x = x.contiguous(memory_format=torch.channels_last)
         yref = c.cpu()(x)
-        y = c.to(device=device)(x.to(device=device))
+        with hash_trace_wrapper():
+            y = c.to(device=device)(x.to(device=device))
         self.assertEqual(yref, y, atol=5e-3, rtol=1e-4)
 
 

--- a/torch/testing/_internal/hash_trace_utils.py
+++ b/torch/testing/_internal/hash_trace_utils.py
@@ -24,6 +24,7 @@ Output is grep-friendly: grep 'HASH_TRACE' test.log to extract trace.
 """
 
 import hashlib
+import os
 import sys
 from typing import Any
 
@@ -107,12 +108,17 @@ def hash_trace_wrapper(max_ops: int = 200):
     """
     Context manager: prints tensor hashes for every ATen op within the block.
 
-    Always active when called — the caller controls scope by placing it
-    around specific test blocks.
+    Controlled by env var PYTORCH_TEST_HASH_TRACE:
+        - Set to "1" to enable (default in CI via test.sh)
+        - Unset → no-op (clean local test output)
 
     Usage:
         with hash_trace_wrapper():
             # ... computation to trace ...
     """
-    print("[HASH_TRACE] === Trace start ===", flush=True)
-    return PrintHashTrace(max_ops=max_ops)
+    from contextlib import nullcontext
+
+    if os.environ.get("PYTORCH_TEST_HASH_TRACE") == "1":
+        print("[HASH_TRACE] === Trace start ===", flush=True)
+        return PrintHashTrace(max_ops=max_ops)
+    return nullcontext()

--- a/torch/testing/_internal/hash_trace_utils.py
+++ b/torch/testing/_internal/hash_trace_utils.py
@@ -1,0 +1,118 @@
+"""
+PrintHashTrace: A lightweight TorchDispatchMode for cross-backend hash comparison.
+
+When wrapped around test computation blocks, prints the hash of every tensor
+input/output via print() (printf-style). This allows comparing CI logs across
+CUDA, XPU, MPS, and CPU to identify where numerical divergence begins.
+
+Always active when hash_trace_wrapper() context manager is entered.
+The caller controls scope by placing it around specific test blocks.
+
+Usage in a test:
+    from torch.testing._internal.hash_trace_utils import hash_trace_wrapper
+
+    def test_conv_large(self, device):
+        with hash_trace_wrapper():
+            # ... computation to trace ...
+
+Each traced op prints (to stdout):
+    [HASH_TRACE] op_name
+    [HASH_TRACE]   arg0: shape=... dtype=... hash=...
+    [HASH_TRACE]   -> result: shape=... dtype=... hash=...
+
+Output is grep-friendly: grep 'HASH_TRACE' test.log to extract trace.
+"""
+
+import hashlib
+import sys
+from typing import Any
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+def _hash_tensor(t: torch.Tensor) -> str:
+    """Compute MD5 hash of tensor content (converted to fp32 if low-precision)."""
+    is_low = t.dtype in (torch.float16, torch.bfloat16)
+    t_cpu = t.detach().cpu()
+    if is_low:
+        t_cpu = t_cpu.float()
+    return hashlib.md5(t_cpu.numpy().tobytes()).hexdigest()
+
+
+class PrintHashTrace(TorchDispatchMode):
+    """
+    TorchDispatchMode that prints input/output tensor hashes for every ATen op.
+
+    All output goes through print() (not files), using the [HASH_TRACE] prefix
+    for easy grep extraction from CI logs.
+    """
+
+    def __init__(self, max_ops: int = 200):
+        super().__init__()
+        self._op_count = 0
+        self._max_ops = max_ops
+        self._active = True
+
+    def _print(self, msg: str) -> None:
+        if self._active and self._op_count <= self._max_ops:
+            print(f"[HASH_TRACE] {msg}", flush=True)
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        self._op_count += 1
+
+        if self._op_count > self._max_ops:
+            return func(*args, **kwargs)
+
+        func_name = getattr(func, "__name__", str(func))
+        self._print(f"[{self._op_count:03d}] {func_name}")
+
+        # Hash inputs
+        for i, arg in enumerate(args):
+            if isinstance(arg, torch.Tensor):
+                h = _hash_tensor(arg)
+                self._print(
+                    f"  arg{i}: shape={tuple(arg.shape)} dtype={arg.dtype} "
+                    f"hash={h} device={arg.device}"
+                )
+            elif isinstance(arg, (int, float, bool, str)):
+                self._print(f"  arg{i}: {arg}")
+            elif arg is None:
+                self._print(f"  arg{i}: None")
+
+        # Execute
+        result = func(*args, **kwargs)
+
+        # Hash outputs
+        if isinstance(result, torch.Tensor):
+            h = _hash_tensor(result)
+            self._print(
+                f"  -> result: shape={tuple(result.shape)} dtype={result.dtype} "
+                f"hash={h} device={result.device}"
+            )
+        elif isinstance(result, (tuple, list)):
+            for j, r in enumerate(result):
+                if isinstance(r, torch.Tensor):
+                    h = _hash_tensor(r)
+                    self._print(
+                        f"  -> result[{j}]: shape={tuple(r.shape)} dtype={r.dtype} "
+                        f"hash={h} device={r.device}"
+                    )
+
+        return result
+
+
+def hash_trace_wrapper(max_ops: int = 200):
+    """
+    Context manager: prints tensor hashes for every ATen op within the block.
+
+    Always active when called — the caller controls scope by placing it
+    around specific test blocks.
+
+    Usage:
+        with hash_trace_wrapper():
+            # ... computation to trace ...
+    """
+    print("[HASH_TRACE] === Trace start ===", flush=True)
+    return PrintHashTrace(max_ops=max_ops)


### PR DESCRIPTION
## Summary

Add a lightweight `PrintHashTrace` TorchDispatchMode that prints tensor hashes via **`print()`** (printf-style) when enabled via env var `PYTORCH_TEST_HASH_TRACE=1`.

**Default-ON in CI**: `PYTORCH_TEST_HASH_TRACE=1` is exported in `.ci/pytorch/test.sh`, so all CI runs produce `[HASH_TRACE]` output for instrumented tests. Local runs stay clean (no hash trace unless env var is set).

Integrated into `test_conv_large`, `test_conv_transposed_large`, and `test_depthwise_conv_64bit_indexing` to enable cross-backend (CUDA/XPU/MPS/CPU) fp16 numerical comparison from CI logs.

## Motivation

Currently diagnosing fp16 precision issues across backends requires manual SSH + copy-paste workflows (see PR #186325 deep dive). This PR makes it easy to compare CI logs:

```bash
# On any CI backend (PYTORCH_TEST_HASH_TRACE=1 is default in CI):
python test/nn/test_convolution.py -k test_conv_large 2>&1 | grep HASH_TRACE

# Or locally:
PYTORCH_TEST_HASH_TRACE=1 python test/nn/test_convolution.py -k test_conv_large 2>&1 | grep HASH_TRACE

# Example output:
[HASH_TRACE] === Trace start ===
[HASH_TRACE] [001] aten::convolution
[HASH_TRACE]   arg0: shape=(4097, 2, 512, 512) dtype=torch.float16 hash=c30937a0... device=xpu:0
[HASH_TRACE]   arg1: shape=(2, 2, 8, 8) dtype=torch.float16 hash=cad559c6... device=xpu:0
[HASH_TRACE]   -> result: shape=(4097, 2, 505, 505) dtype=torch.float16 hash=1304fb2a... device=xpu:0
```

## Design

- **`PrintHashTrace`** (in `torch/testing/_internal/hash_trace_utils.py`): Minimal TorchDispatchMode
- **`print()` output with `[HASH_TRACE]` prefix**: grep-friendly for CI log extraction
- **Env var gating**: `PYTORCH_TEST_HASH_TRACE=1` enables; unset → no-op (clean local output)
- **Default-ON in CI**: exported in `.ci/pytorch/test.sh`
- **No file I/O**: all output goes to stdout, making it CI-compatible
- **Reuses existing `hash_accuracy_trace.py` patterns**: same tensor hashing (MD5, fp16→fp32 normalization)
- **`max_ops=200` cap**: prevents log flooding on large models

## Tests instrumented

| Test | What is traced |
|------|---------------|
| `test_conv_large` | Forward (full batch) + chunked backward (3 chunks) |
| `test_conv_transposed_large` | Forward (full batch) |
| `test_depthwise_conv_64bit_indexing` | Forward on device (2 batch sizes) |

## Related

- PyTorch issue: #185907 (`test_conv_large_xpu` fp16 failure)
- PR #186325: Fix `test_conv_large` dtype + fp32 intermediate buffer for XPU backward weights
- PR #186326: Fix `test_depthwise_conv_64bit_indexing` dtype
- Dev tool: https://github.com/xuhancn/debug_pytorch_accuracy/tree/main/03_hash_accuracy_trace

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
