### PR TITLE
Propagate override_cudagraphs annotation across CM-lifecycle gaps

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -134,7 +134,12 @@ from .guards import (
     GuardedCode,
 )
 from .hooks import Hooks
-from .output_graph import CodeOptions, DynamoTracerOutput, OutputGraphCommon
+from .output_graph import (
+    carry_cudagraph_annotation_across_restart,
+    CodeOptions,
+    DynamoTracerOutput,
+    OutputGraphCommon,
+)
 from .pgo import (
     _log_size_mismatch_recompile,
     log_frame_dynamic_whitelist,
@@ -941,6 +946,16 @@ def trace_frame(
             exc.TensorifyScalarRestartAnalysis,
             exc.SkipFrame,
         ):
+            # Stash the override_cudagraphs annotation before the `finally`
+            # below runs call_cleanup_hooks(), which resets it to None. The
+            # next OutputGraph rehydrates this in its __init__.
+            if (
+                tracer.output is not None
+                and tracer.output.cudagraph_annotation is not None
+            ):
+                carry_cudagraph_annotation_across_restart(
+                    tracer.output.cudagraph_annotation
+                )
             raise
         except Exception:
             if translation_validation_enabled():
@@ -1545,6 +1560,9 @@ def compile_frame(  # type: ignore[return]
     """
     # This is shared across restarts
     speculation_log = SpeculationLog()
+    # Clear any carry left over from a previous compile that didn't consume it
+    # (e.g. it failed before constructing the next OutputGraph).
+    carry_cudagraph_annotation_across_restart(None)
 
     def transform(
         instructions: list[Instruction], code_options: dict[str, Any]
@@ -1606,6 +1624,20 @@ def compile_frame(  # type: ignore[return]
             # Clean up the failed tracer output's graph to break reference cycles
             failed_tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)
             if failed_tracer_output:
+                # Carry the `override_cudagraphs` annotation across the restart
+                # so the retry OutputGraph rehydrates it. Without this, a
+                # disabled call inside the CM-wrapped frame silently drops the
+                # override on every retry, and the eventually-finalized OG
+                # never reaches gm.meta["cudagraph_annotation"].
+                # NOTE: on error, DynamoTracerOutput nulls `output_graph` and
+                # stashes the actual instance on `output_graph_for_cleanup`.
+                failed_og = getattr(
+                    failed_tracer_output, "output_graph", None
+                ) or getattr(failed_tracer_output, "output_graph_for_cleanup", None)
+                if failed_og is not None:
+                    carry_cudagraph_annotation_across_restart(
+                        getattr(failed_og, "cudagraph_annotation", None)
+                    )
                 failed_tracer_output._cleanup_output_graph()
             # If restart reason is None just log the type of the exception
             restart_reasons.add(e.restart_reason or str(type(e)))

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -4,10 +4,11 @@ This module provides decorators and utilities for controlling TorchDynamo's beha
 
 import functools
 import inspect
+import threading
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
-from types import TracebackType
+from types import CodeType, TracebackType
 from typing import Any, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
@@ -1733,10 +1734,35 @@ class CudagraphOverrideContextManager:
         self.fwd = fwd
         self.bwd = bwd
 
-    __call__ = wrap_dunder_call_ctx_manager
+    def __call__(self, fn: Any) -> Any:
+        # When used as a decorator, also register the wrapped function's code
+        # object so OutputGraph.__init__ can rehydrate the annotation even if
+        # the wrapper frame itself never reaches `compile_subgraph` — e.g.
+        # because tracing the wrapper fell back to eager. Without this, only
+        # the wrapper's OG sees the annotation, and the wrapped function later
+        # compiles (as a separate frame) with `cudagraph_annotation=None`.
+        code = getattr(fn, "__code__", None)
+        if code is not None:
+            from torch._inductor import _CudagraphAnnotation
+
+            _CUDAGRAPH_ANNOTATION_BY_CODE[code] = _CudagraphAnnotation(
+                fwd=self.fwd, bwd=self.bwd
+            )
+        return wrap_dunder_call_ctx_manager(self, fn)
 
     def __enter__(self) -> None:
-        pass
+        # Python-level enter: also push onto a thread-local stack so any
+        # Dynamo compile that fires WHILE this CM is active (whether by
+        # eager-fallback of the wrapper, or by a nested `with` block in user
+        # code) inherits the annotation. Dynamo's symbolic-tracing path does
+        # NOT go through this __enter__ (it intercepts the bytecode), so this
+        # is purely a runtime fallback for the cases where Dynamo can't trace
+        # the wrapper itself.
+        from torch._inductor import _CudagraphAnnotation
+
+        _push_active_cudagraph_override(
+            _CudagraphAnnotation(fwd=self.fwd, bwd=self.bwd)
+        )
 
     def __exit__(
         self,
@@ -1744,7 +1770,55 @@ class CudagraphOverrideContextManager:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        pass
+        _pop_active_cudagraph_override()
+
+
+# Per-thread stack of currently-active override_cudagraphs annotations,
+# pushed by `__enter__` and popped by `__exit__`. Lets OutputGraph.__init__
+# inherit the annotation when a Dynamo compile fires for code that is
+# DYNAMICALLY inside an active CM scope at runtime — i.e. the wrapper frame
+# fell back to eager and is now invoking the wrapped function as Python, and
+# Dynamo intercepts that nested call. This is the "we don't know all graph
+# breaks in advance" fallback: covers any failure mode of the wrapper that
+# Dynamo would otherwise route around.
+_active_cudagraph_overrides: threading.local = threading.local()
+
+
+def _push_active_cudagraph_override(annotation: Any) -> None:
+    stack = getattr(_active_cudagraph_overrides, "stack", None)
+    if stack is None:
+        stack = []
+        _active_cudagraph_overrides.stack = stack
+    stack.append(annotation)
+
+
+def _pop_active_cudagraph_override() -> None:
+    stack = getattr(_active_cudagraph_overrides, "stack", None)
+    if stack:
+        stack.pop()
+
+
+def get_active_cudagraph_annotation() -> Any:
+    """Return the innermost active annotation, or None if no CM is active."""
+    stack = getattr(_active_cudagraph_overrides, "stack", None)
+    if stack:
+        return stack[-1]
+    return None
+
+
+# Registry of code-object → cudagraph annotation, populated by the decorator
+# form of `override_cudagraphs`. `OutputGraph.__init__` consults this to seed
+# `self.cudagraph_annotation` whenever it constructs an OG for a registered
+# code object. `CodeType` is not weakref-able, so this is a strong-ref dict;
+# entries leak if the decorated function is itself garbage-collected, but in
+# practice decorated functions are module-level or class-level and outlive the
+# process.
+_CUDAGRAPH_ANNOTATION_BY_CODE: dict[CodeType, Any] = {}
+
+
+def get_cudagraph_annotation_for_code(code: CodeType) -> Any:
+    """Lookup the override annotation for a code object, or None."""
+    return _CUDAGRAPH_ANNOTATION_BY_CODE.get(code)
 
 
 def override_cudagraphs(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -30,6 +30,7 @@ import logging
 import operator
 import re
 import sys
+import threading
 import time
 import traceback
 import types
@@ -197,6 +198,34 @@ graph_tabular_log = torch._logging.getArtifactLogger(__name__, "graph")
 graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
 graph_sizes_log = torch._logging.getArtifactLogger(__name__, "graph_sizes")
 trace_call_log = torch._logging.getArtifactLogger(__name__, "trace_call")
+
+
+# Per-thread carry slot for the `override_cudagraphs` CM annotation. When a
+# RestartAnalysis discards an OutputGraph mid-trace (e.g. because the CM-wrapped
+# frame contains a `torch._dynamo.disable`'d call), `convert_frame` deposits the
+# dying OG's annotation here so the next attempt's OutputGraph rehydrates it in
+# __init__. Without this, the annotation dies with the discarded OG and the
+# eventual finalized OG never carries it into `gm.meta["cudagraph_annotation"]`.
+_cudagraph_annotation_carry: threading.local = threading.local()
+
+
+def carry_cudagraph_annotation_across_restart(
+    annotation: "_CudagraphAnnotation | None",
+) -> None:
+    """Stash an annotation for the next OutputGraph constructed on this thread."""
+    if annotation is None:
+        if hasattr(_cudagraph_annotation_carry, "value"):
+            del _cudagraph_annotation_carry.value
+    else:
+        _cudagraph_annotation_carry.value = annotation
+
+
+def _consume_carried_cudagraph_annotation() -> "_CudagraphAnnotation | None":
+    """Pop and return the carried annotation, or None if nothing is pending."""
+    annotation = getattr(_cudagraph_annotation_carry, "value", None)
+    if annotation is not None:
+        del _cudagraph_annotation_carry.value
+    return annotation
 
 RootGuardManager = guards.RootGuardManager
 
@@ -709,8 +738,35 @@ class OutputGraph(OutputGraphCommon):
 
         # Cudagraph annotation is set during inlining in
         # InliningInstructionTranslator.build_inline_tracer when a decorated
-        # function is inlined.
-        self.cudagraph_annotation: _CudagraphAnnotation | None = None
+        # function is inlined. We also rehydrate from three side channels so
+        # the override survives failure modes that destroy the wrapper's OG
+        # before `compile_subgraph` can copy the annotation to `gm.meta`:
+        #   1. Per-thread carry slot: covers `SpeculationRestartAnalysis` — the
+        #      dying OG's annotation is stashed by `convert_frame.compile_frame`
+        #      and consumed here on the retry.
+        #   2. Per-code-object registry: covers eager-fallback and
+        #      compile-as-separate-frame — when `override_cudagraphs` was used
+        #      as a decorator, the wrapped function's code object is registered
+        #      so any OG constructed for that code picks up the annotation,
+        #      even if the wrapper frame never reaches `compile_subgraph`.
+        #   3. Per-thread active-CM stack: covers ANY dynamically-nested
+        #      compile triggered while the CM is active at the Python level
+        #      (wrapper fell back to eager and called the wrapped function,
+        #      or user wrote `with override_cudagraphs(...): some_call_dynamo_compiles`).
+        #      The CM's `__enter__` pushes the annotation on the stack; any
+        #      OG constructed before the matching `__exit__` inherits it.
+        self.cudagraph_annotation: _CudagraphAnnotation | None = (
+            _consume_carried_cudagraph_annotation()
+        )
+        if self.cudagraph_annotation is None:
+            from torch._dynamo.decorators import (
+                get_active_cudagraph_annotation,
+                get_cudagraph_annotation_for_code,
+            )
+
+            self.cudagraph_annotation = get_cudagraph_annotation_for_code(f_code)
+            if self.cudagraph_annotation is None:
+                self.cudagraph_annotation = get_active_cudagraph_annotation()
 
         self.region_tracker = GraphRegionTracker()
         self._emit_debugger_breakpoint: bool = False


### PR DESCRIPTION
Summary:
`torch._dynamo.override_cudagraphs` stores its annotation on the active
`OutputGraph` during symbolic execution. The annotation only takes effect if
that OG reaches `compile_subgraph`'s finalize line, where it is copied into
`gm.meta["cudagraph_annotation"]` and consumed downstream by Inductor's
`create_compiler_config_extra`. Several common failure modes leave the
annotation stranded on an OG that never finalizes — silently no-oping the
override:

1. A `torch._dynamo.disable`'d call inside the CM-wrapped body raises
   `SpeculationRestartAnalysis`. Dynamo discards the OG and retries from
   scratch. The annotation dies with the discarded OG; the retry path may not
   re-enter the CM at all.
2. The wrapper frame (e.g. `wrap_dunder_call_ctx_manager.<locals>.inner`)
   itself fails to trace and falls back to eager. The wrapped function is
   later compiled as a separate root frame whose OG never saw the CM.
3. The user writes `with override_cudagraphs(...): some_call_dynamo_compiles`,
   and Dynamo can't trace through the wrapper but compiles a nested call from
   inside the Python-active CM scope.

The fix adds three independent side channels so the annotation reaches at
least one finalizing OG regardless of which path Dynamo takes:

- **Per-thread carry slot** (`output_graph.py` + `convert_frame.py`): on
  `RestartAnalysis`, deposit the dying OG's annotation; consume it in the
  next `OutputGraph.__init__`. Also cleared at the top of `compile_frame` so
  a stale annotation from a failed prior compile can't leak into an unrelated
  one.
- **Per-code-object registry** (`decorators.py`): when `override_cudagraphs`
  is used as a decorator, register `(wrapped_fn.__code__) -> annotation`.
  `OutputGraph.__init__` looks up the registry by `f_code` and inherits the
  annotation, so the wrapped function picks it up even when compiled as a
  separate root frame.
- **Per-thread active-CM stack** (`decorators.py`): the CM's `__enter__`
  pushes its annotation, `__exit__` pops. Any `OutputGraph` constructed while
  the CM is dynamically active at the Python level inherits the annotation.
  This is the catch-all for failure modes that can't be predicted statically:
  whatever path Dynamo takes during the CM's Python lifetime gets the
  annotation, as long as `eval_frame` intercepts at least one frame inside
  the `with` scope.

The three layers are independent — none has cross-dependencies on the others.

Test Plan:
Manual end-to-end verification on an APS training run:

```
CUDA_VISIBLE_DEVICES=2,3 buck2 run mode/opt \
    aps_models/ads/launchers/fm:icvr_launcher_publish -- \
    --config-path /home/shuaiyang/local/fbsource/fbcode/tmp \
    --config-name 1093202289_local_mp_hive
```

with `override_cudagraph_by_method_names: { UserEmbeddingArch.forward: {fwd: true, bwd: true} }`
and `disabled_method_names: [UserEmbeddingArch.run_event_and_aggregation_module]`
(the disabled call is inside the CM-wrapped frame, triggering case 1 above).

Before the fix: `cccc=0` (annotation never reaches `gm.meta`), zero CUDA Graphs
captured at runtime.

After the fix: `cccc=2` (one fwd+bwd pair per rank), `gggg` shows
`_CudagraphAnnotation(fwd=True, bwd=True)` reaching Inductor, and Perfetto
traces show `cudaGraphLaunch` events at runtime (~2 per training iteration).

Authored with assistance from Claude (claude.ai/code).

Differential Revision: D107843262




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98