### PR TITLE
Fix serialization errors in SubTest calls

### DIFF
--- a/test/nn/test_pruning.py
+++ b/test/nn/test_pruning.py
@@ -102,7 +102,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     original_tensor = getattr(m, name)
 
                     prune.random_unstructured(m, name=name, amount=0.1)
@@ -129,7 +129,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     # tensor prior to pruning
                     original_tensor = getattr(m, name)
                     prune.random_unstructured(m, name=name, amount=0.1)
@@ -146,7 +146,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     # tensor prior to pruning
                     original_tensor = getattr(m, name)
                     prune.random_unstructured(m, name=name, amount=0.1)
@@ -328,7 +328,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     prune.random_unstructured(m, name=name, amount=0.1)
                     m_new = pickle.loads(pickle.dumps(m))
                     self.assertIsInstance(m_new, type(m))
@@ -600,7 +600,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     # first prune
                     prune.random_unstructured(m, name, amount=0.5)
                     self.assertIn(name + "_orig", dict(m.named_parameters()))
@@ -625,7 +625,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     # check that the module isn't pruned
                     self.assertFalse(prune.is_pruned(m))
                     # since it isn't pruned, pruning can't be removed from it
@@ -740,7 +740,7 @@ class TestPruningNN(NNTestCase):
 
         for m in modules:
             for name in names:
-                with self.subTest(m=m, name=name):
+                with self.subTest(m=type(m).__name__, name=name):
                     with mock.patch(
                         "torch.nn.utils.prune.L1Unstructured.compute_mask"
                     ) as compute_mask:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12964,7 +12964,7 @@ class TestAutogradDeviceType(TestCase):
     def test_min_max_aminmax_median_backprops_to_all_values(self, device):
         # 1) Test min/max/median/nanmedian on both a non NaN and all NaN tensor
         for f in [torch.min, torch.max, torch.median, torch.nanmedian]:
-            with self.subTest(f=f):
+            with self.subTest(f=f.__name__):
                 x1 = torch.tensor(
                     [1.0, 0.0, 1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True
                 )
@@ -12987,7 +12987,7 @@ class TestAutogradDeviceType(TestCase):
             return torch.aminmax(x)[1]
 
         for f in [torch.amin, torch.amax, amax2, amin2]:
-            with self.subTest(f=f):
+            with self.subTest(f=f.__name__):
                 x1 = torch.tensor(
                     [1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
                     device=device,


### PR DESCRIPTION
Change subTest method of passing functions in `test_prunning.py` and `test_autograd.py` to not cause serialization errors when running with xdist. This aligns with methods used in the rest of the repo. Surfaced in: https://github.com/intel/torch-xpu-ops/issues/3793, https://github.com/intel/torch-xpu-ops/issues/3797