### PR TITLE
[Draft][xpu] Add NVFP4 support on Intel GPU

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -111,6 +111,18 @@ bool is_blockwise_128x128_scaling(
       (scale.is_contiguous() || scale.t().is_contiguous()));
 }
 
+// NVFP4 blockwise 1x16 scaling: fp4x2 data with fp8 scales.
+// t is Float4_e2m1fn_x2 (packed, t.size(1) = K/2), scale shape
+// [t.size(0), ceil_div(K_actual, 16)] where K_actual = t.size(1) * 2.
+bool is_blockwise_1x16_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  return (
+      t.scalar_type() == at::ScalarType::Float4_e2m1fn_x2 &&
+      scale.scalar_type() == at::kFloat8_e4m3fn &&
+      scale.dim() == 2 && scale.size(0) == t.size(0) &&
+      scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 16) &&
+      (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -124,6 +136,8 @@ bool is_desired_scaling(
       return is_blockwise_1x128_scaling(t, scale);
     case ScalingType::BlockWise128x128:
       return is_blockwise_128x128_scaling(t, scale);
+    case ScalingType::BlockWise1x16:
+      return is_blockwise_1x16_scaling(t, scale);
     default:
       return false;
   }
@@ -173,6 +187,15 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ", ",
       ceil_div<int64_t>(b.size(1), 128),
       ").\n"
+      "- For NVFP4 BlockWise 1x16 scaling, a and b should be Float4_e2m1fn_x2, scales should be Float8_e4m3fn, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1) * 2, 16),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0) * 2, 16),
+      ", ",
+      b.size(1),
+      ").\n"
       "Got a.dtype()=",
       a.scalar_type(),
       ", scale_a.dtype()=",
@@ -209,8 +232,8 @@ Tensor& _scaled_gemm(
     TORCH_WARN(
         "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
-  // TODO: scale_result and alpha is not defined or used!
-  std::optional<Tensor> scaled_result = std::nullopt;
+  // Pass alpha (e.g. global_scale_a * global_scale_b for NVFP4) as DST scale
+  // to oneDNN's scaled_matmul.
   at::native::onednn::scaled_matmul(
       mat1,
       mat2,
@@ -220,7 +243,7 @@ Tensor& _scaled_gemm(
       scaling_choice_a,
       scaling_choice_b,
       bias,
-      scaled_result,
+      alpha,
       false /* use_fast_accum */);
 
   return out;
@@ -304,6 +327,7 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
           std::make_pair(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
+          std::make_pair(ScalingType::BlockWise1x16, ScalingType::BlockWise1x16),
       },
       mat1,
       mat2,
@@ -339,12 +363,14 @@ Tensor& _scaled_mm_out_xpu(
       !out_dtype || *out_dtype == out.scalar_type(),
       "out_dtype must match output matrix type");
   TORCH_CHECK(
-      at::isFloat8Type(mat1.scalar_type()),
-      "Expected mat1 to be Float8 matrix got ",
+      at::isFloat8Type(mat1.scalar_type()) ||
+          mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat1 to be Float8 or Float4_x2 matrix got ",
       mat1.scalar_type());
   TORCH_CHECK(
-      at::isFloat8Type(mat2.scalar_type()),
-      "Expected mat2 to be Float8 matrix got ",
+      at::isFloat8Type(mat2.scalar_type()) ||
+          mat2.scalar_type() == at::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat2 to be Float8 or Float4_x2 matrix got ",
       mat2.scalar_type());
   // TODO: oneDNN Currently only supports e4m3 with group scales on BMG. Not
   // support 2D scales, only 1D. Needs to add more checks there.
@@ -393,29 +419,11 @@ Tensor& _scaled_mm_out_xpu(
   }
 
   // TODO: Scale_result is not supported by now!!
-  // API shapes match CUDA v1. oneDNN needs row-major contiguous.
-  // scale_a: [M, K//128] or [M//128, K//128]
-  // scale_b: [K//128, N] or [K//128, N//128]
-  // Because the user might passed in the CUDA's stride (col-major because of
-  // swizzling)
-  // call a contiguous() to ensure row-major for oneDNN
-  Tensor scale_a_internal = scale_a;
-  Tensor scale_b_internal = scale_b;
-  if (scaling_choice_a == ScalingType::BlockWise128x128 ||
-      scaling_choice_a == ScalingType::BlockWise1x128) {
-    scale_a_internal = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
-  }
-  if (scaling_choice_b == ScalingType::BlockWise1x128 ||
-      scaling_choice_b == ScalingType::BlockWise128x128) {
-    // CUDA v1 shapes [K//128, N] and [K//128, N//128] already match oneDNN's
-    // expected row-major layout. Just ensure contiguous.
-    scale_b_internal = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
-  }
   return _scaled_gemm(
       mat1,
       mat2,
-      scale_a_internal,
-      scale_b_internal,
+      scale_a,
+      scale_b,
       scaling_choice_a,
       scaling_choice_b,
       bias,
@@ -459,7 +467,7 @@ namespace scaled_blas = at::native::scaled;
 using scaled_blas::convert_int_to_enum;
 using scaled_blas::ScaledGemmImplementation;
 
-std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 5>
+std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 7>
     scale_kernel_dispatch = {{
         {"tensorwise_tensorwise",
          scaled_blas::check_tensorwise_recipe,
@@ -503,6 +511,12 @@ std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 5>
              _5,
              _6),
          ScaledGemmImplementation::BLOCK_1x128_1x128},
+        {"nvfp4_nvfp4",
+         scaled_blas::check_nvfp4_recipe,
+         ScaledGemmImplementation::NVFP4_NVFP4},
+        {"nvfp4_nvfp4_single_scale",
+         scaled_blas::check_nvfp4_recipe_single_scale,
+         ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE},
     }};
 
 Tensor& _scaled_tensorwise_tensorwise(
@@ -806,6 +820,88 @@ Tensor& _scaled_block1x128_block128x128(
   return out;
 }
 
+Tensor& _scaled_nvfp4_nvfp4(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    Tensor& out,
+    const std::optional<Tensor>& global_scale_a = std::nullopt,
+    const std::optional<Tensor>& global_scale_b = std::nullopt) {
+  std::optional<Tensor> alpha = std::nullopt;
+  // If either global scale is provided, both must be present (two-level NVFP4).
+  if (global_scale_a.has_value() || global_scale_b.has_value()) {
+    TORCH_CHECK_VALUE(
+        global_scale_a.has_value(),
+        "For two-level-scaled NVFP4, global_scale_a must have a value");
+    TORCH_CHECK_VALUE(
+        global_scale_b.has_value(),
+        "For two-level-scaled NVFP4, global_scale_b must have a value");
+    alpha = global_scale_a.value().mul(global_scale_b.value());
+  }
+
+  TORCH_CHECK_VALUE(
+      mat_a.scalar_type() == at::kFloat4_e2m1fn_x2 &&
+          mat_b.scalar_type() == at::kFloat4_e2m1fn_x2,
+      "mat_a and mat_b must be fp4 types, got: ",
+      mat_a.scalar_type(),
+      mat_b.scalar_type());
+
+  // fp4x2 packing: each byte packs 2 fp4 values.
+  // mat_a: [M, K/2], mat_b: [K/2, N] (transposed view of [N, K/2])
+  int64_t M = mat_a.size(0);
+  int64_t K_logical = mat_a.size(1) * 2;
+  int64_t N = mat_b.size(1);
+  int64_t scale_k = ceil_div<int64_t>(K_logical, 16);
+
+  TORCH_CHECK_VALUE(
+      scale_a.scalar_type() == at::kFloat8_e4m3fn,
+      "scale_a must be Float8_e4m3fn, got: ",
+      scale_a.scalar_type());
+  TORCH_CHECK_VALUE(
+      scale_b.scalar_type() == at::kFloat8_e4m3fn,
+      "scale_b must be Float8_e4m3fn, got: ",
+      scale_b.scalar_type());
+  TORCH_CHECK_VALUE(
+      scale_a.dim() == 2 && scale_a.size(0) == M &&
+          scale_a.size(1) == scale_k,
+      "scale_a must have shape [",
+      M,
+      ", ",
+      scale_k,
+      "], got ",
+      scale_a.sizes());
+  TORCH_CHECK_VALUE(
+      scale_b.dim() == 2 && scale_b.size(0) == N &&
+          scale_b.size(1) == scale_k,
+      "scale_b must have shape [",
+      N,
+      ", ",
+      scale_k,
+      "], got ",
+      scale_b.sizes());
+  TORCH_CHECK_VALUE(
+      scale_a.is_contiguous() && scale_b.is_contiguous(),
+      "For NVFP4 blockwise scaling both scales should be contiguous");
+
+  auto scaling_choice_a = ScalingType::BlockWise1x16;
+  auto scaling_choice_b = ScalingType::BlockWise1x16;
+
+  return _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      false /* use_fast_accum */,
+      out,
+      alpha);
+}
+
 // V2: Computes matrix multiply + bias while applying scaling to input and
 // output matrices Scales are only applicable when matrices are of Float8 type
 // and assumed to be equal to 1.0 by default. If output matrix type is 16 or
@@ -955,12 +1051,10 @@ Tensor& _scaled_mm_xpu_v2_out(
   auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
   auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
-  // XPU does not support swizzle. Accept empty (not specified) or NO_SWIZZLE.
+  // XPU does not support swizzle for now. So directly return false.
   TORCH_CHECK_VALUE(
-      (swizzle_a_enum.empty() ||
-       swizzle_a_enum[0] == at::blas::SwizzleType::NO_SWIZZLE) &&
-          (swizzle_b_enum.empty() ||
-           swizzle_b_enum[0] == at::blas::SwizzleType::NO_SWIZZLE),
+      swizzle_a_enum[0] == at::blas::SwizzleType::NO_SWIZZLE &&
+          swizzle_b_enum[0] == at::blas::SwizzleType::NO_SWIZZLE,
       "XPU does not support swizzle yet.");
 
   // at this point we can start working out what we want to be doing
@@ -1013,6 +1107,8 @@ Tensor& _scaled_mm_xpu_v2_out(
       ", ",
       ceil_div<int64_t>(mat_b.size(1), 128),
       ").\n"
+      "- For NVFP4 scaling, a and b should be Float4_e2m1fn_x2, blockwise scales should be Float8_e4m3fn. "
+      "Two-level variant requires additional Float32 global scales.\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -1084,6 +1180,26 @@ Tensor& _scaled_mm_xpu_v2_out(
         bias,
         out_dtype_,
         use_fast_accum,
+        out);
+  } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4) {
+    return _scaled_nvfp4_nvfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        out,
+        scale_a[1],
+        scale_b[1]);
+  } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE) {
+    return _scaled_nvfp4_nvfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
         out);
   } else {
     TORCH_CHECK_VALUE(

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -117,8 +117,8 @@ bool is_blockwise_128x128_scaling(
 bool is_blockwise_1x16_scaling(const at::Tensor& t, const at::Tensor& scale) {
   return (
       t.scalar_type() == at::ScalarType::Float4_e2m1fn_x2 &&
-      scale.scalar_type() == at::kFloat8_e4m3fn &&
-      scale.dim() == 2 && scale.size(0) == t.size(0) &&
+      scale.scalar_type() == at::kFloat8_e4m3fn && scale.dim() == 2 &&
+      scale.size(0) == t.size(0) &&
       scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 16) &&
       (scale.is_contiguous() || scale.t().is_contiguous()));
 }
@@ -327,7 +327,8 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
           std::make_pair(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
-          std::make_pair(ScalingType::BlockWise1x16, ScalingType::BlockWise1x16),
+          std::make_pair(
+              ScalingType::BlockWise1x16, ScalingType::BlockWise1x16),
       },
       mat1,
       mat2,
@@ -865,8 +866,7 @@ Tensor& _scaled_nvfp4_nvfp4(
       "scale_b must be Float8_e4m3fn, got: ",
       scale_b.scalar_type());
   TORCH_CHECK_VALUE(
-      scale_a.dim() == 2 && scale_a.size(0) == M &&
-          scale_a.size(1) == scale_k,
+      scale_a.dim() == 2 && scale_a.size(0) == M && scale_a.size(1) == scale_k,
       "scale_a must have shape [",
       M,
       ", ",
@@ -874,8 +874,7 @@ Tensor& _scaled_nvfp4_nvfp4(
       "], got ",
       scale_a.sizes());
   TORCH_CHECK_VALUE(
-      scale_b.dim() == 2 && scale_b.size(0) == N &&
-          scale_b.size(1) == scale_k,
+      scale_b.dim() == 2 && scale_b.size(0) == N && scale_b.size(1) == scale_k,
       "scale_b must have shape [",
       N,
       ", ",
@@ -1194,13 +1193,7 @@ Tensor& _scaled_mm_xpu_v2_out(
         scale_b[1]);
   } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE) {
     return _scaled_nvfp4_nvfp4(
-        mat_a,
-        mat_b,
-        scale_a[0],
-        scale_b[0],
-        bias,
-        out_dtype_,
-        out);
+        mat_a, mat_b, scale_a[0], scale_b[0], bias, out_dtype_, out);
   } else {
     TORCH_CHECK_VALUE(
         false, "Invalid state - found an implementation, but not really");

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -459,12 +459,23 @@ inline ScaleSpec make_scale_spec(
           dnnl::memory::data_type::f32};
     }
 
+    case at::blas::ScalingType::BlockWise1x16: {
+      // NVFP4 blockwise 1x16 scaling
+      // Scale dtype is f8_e4m3 (not f32, unlike other blockwise modes).
+      // For SRC (A): groups = {1, 16}, scale shape [M, ceil_div(K, 16)]
+      // For WEI (B): groups = {16, 1}, scale shape [ceil_div(K, 16), N]
+      return {
+          (1 << 0) | (1 << 1),
+          is_src ? dnnl::memory::dims{1, 16} : dnnl::memory::dims{16, 1},
+          dnnl::memory::data_type::f8_e4m3};
+    }
+
     default:
       TORCH_INTERNAL_ASSERT(
           false,
           "Unsupported scaling_type: ",
           static_cast<int>(scaling_type),
-          ". Currently only support TensorWise, RowWise, BlockWise1x128, and BlockWise128x128");
+          ". Currently only support TensorWise, RowWise, BlockWise1x128, BlockWise128x128, and BlockWise1x16");
   }
 }
 
@@ -487,13 +498,33 @@ sycl::event scaled_matmul(
   // 2. call write_to_dnnl_memory() to actually write memory
   // 3. execute
 
+  // Detect fp4x2 packed inputs.
+  // Float4_e2m1fn_x2 packs 2 fp4 values per byte, so:
+  //   mat1: [M, K_packed] where K_logical = K_packed * 2
+  //   mat2: [K_packed, N] (transposed view of original [N, K_packed])
+  // oneDNN matmul expects A[M,K] @ B[K,N], so we create memory descriptors
+  // with logical dims and transposed strides for B.
+  const bool is_fp4 =
+      mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2;
+
   const int64_t M = mat1.size(0);
-  const int64_t K = mat1.size(1);
+  // For fp4x2, K is the logical (unpacked) dimension
+  const int64_t K = is_fp4 ? mat1.size(1) * 2 : mat1.size(1);
   const int64_t N = mat2.size(1);
 
   // 1.1 Create memory descriptors
+  // get_onednn_md handles fp4x2 internally (expands [M, K/2] -> [M, K])
   dnnl::memory::desc src_md = get_onednn_md(mat1);
-  dnnl::memory::desc weights_md = get_onednn_md(mat2);
+  dnnl::memory::desc weights_md;
+  if (is_fp4) {
+    // B arrives as [K_packed, N] (transposed view of original [N, K_packed])
+    // oneDNN needs [K, N] with f4_e2m1 dtype. The physical data is [N, K_packed]
+    // contiguous, so strides in fp4 element units: {1, K} maps [k, n] -> n*K + k
+    weights_md = {
+        {K, N}, dnnl::memory::data_type::f4_e2m1, {1, K}};
+  } else {
+    weights_md = get_onednn_md(mat2);
+  }
   dnnl::memory::desc dst_md = get_onednn_md(result);
 
   dnnl::memory::desc bias_md;
@@ -587,11 +618,16 @@ sycl::event scaled_matmul(
     args.insert({DNNL_ARG_BIAS, b_usr_m});
   }
 
+  // Scale tensors must be contiguous for the 1D memory descriptor.
+  // Transposed scale tensors (e.g., from NVFP4 weight.t()) may not be.
+  auto scale_a_contig = scale_a.contiguous();
+  auto scale_b_contig = scale_b.contiguous();
+
   auto src_sc_mem = make_scale_mem_from_spec(
-      src_spec, src_spec.expected_numel(M, K, "src"), scale_a);
+      src_spec, src_spec.expected_numel(M, K, "src"), scale_a_contig);
 
   auto wei_sc_mem = make_scale_mem_from_spec(
-      wei_spec, wei_spec.expected_numel(N, K, "wei"), scale_b);
+      wei_spec, wei_spec.expected_numel(N, K, "wei"), scale_b_contig);
 
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, src_sc_mem});
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_sc_mem});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -504,8 +504,7 @@ sycl::event scaled_matmul(
   //   mat2: [K_packed, N] (transposed view of original [N, K_packed])
   // oneDNN matmul expects A[M,K] @ B[K,N], so we create memory descriptors
   // with logical dims and transposed strides for B.
-  const bool is_fp4 =
-      mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2;
+  const bool is_fp4 = mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2;
 
   const int64_t M = mat1.size(0);
   // For fp4x2, K is the logical (unpacked) dimension
@@ -518,10 +517,10 @@ sycl::event scaled_matmul(
   dnnl::memory::desc weights_md;
   if (is_fp4) {
     // B arrives as [K_packed, N] (transposed view of original [N, K_packed])
-    // oneDNN needs [K, N] with f4_e2m1 dtype. The physical data is [N, K_packed]
-    // contiguous, so strides in fp4 element units: {1, K} maps [k, n] -> n*K + k
-    weights_md = {
-        {K, N}, dnnl::memory::data_type::f4_e2m1, {1, K}};
+    // oneDNN needs [K, N] with f4_e2m1 dtype. The physical data is [N,
+    // K_packed] contiguous, so strides in fp4 element units: {1, K} maps [k, n]
+    // -> n*K + k
+    weights_md = {{K, N}, dnnl::memory::data_type::f4_e2m1, {1, K}};
   } else {
     weights_md = get_onednn_md(mat2);
   }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -136,14 +136,10 @@ dnnl::memory::desc get_onednn_md(const at::Tensor& tensor) {
   if (t.scalar_type() == at::ScalarType::Float4_e2m1fn_x2) {
     TORCH_CHECK(t.dim() == 2, "fp4x2 tensor must be 2D, got ", t.dim(), "D");
     TORCH_CHECK(
-        t.is_contiguous(),
-        "fp4x2 tensor must be contiguous for get_onednn_md");
+        t.is_contiguous(), "fp4x2 tensor must be contiguous for get_onednn_md");
     int64_t M = t.size(0);
     int64_t K_logical = t.size(1) * 2;
-    return {
-        {M, K_logical},
-        dnnl::memory::data_type::f4_e2m1,
-        {K_logical, 1}};
+    return {{M, K_logical}, dnnl::memory::data_type::f4_e2m1, {K_logical, 1}};
   }
   return {
       get_onednn_dims(t),

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -89,6 +89,8 @@ dnnl::memory::data_type get_onednn_dtype(
       return dnnl::memory::data_type::f8_e4m3;
     case at::ScalarType::Float8_e5m2:
       return dnnl::memory::data_type::f8_e5m2;
+    case at::ScalarType::Float4_e2m1fn_x2:
+      return dnnl::memory::data_type::f4_e2m1;
     default:
       if (!allow_undef) {
         TORCH_CHECK(
@@ -129,6 +131,20 @@ dnnl::memory::dims get_onednn_strides(const at::Tensor& tensor) {
 
 dnnl::memory::desc get_onednn_md(const at::Tensor& tensor) {
   Tensor t = tensor.sizes().empty() ? tensor.unsqueeze(0) : tensor;
+  // Float4_e2m1fn_x2 packs 2 fp4 values per byte. PyTorch shape [M, K/2]
+  // must be expanded to logical [M, K] with f4_e2m1 data type for oneDNN.
+  if (t.scalar_type() == at::ScalarType::Float4_e2m1fn_x2) {
+    TORCH_CHECK(t.dim() == 2, "fp4x2 tensor must be 2D, got ", t.dim(), "D");
+    TORCH_CHECK(
+        t.is_contiguous(),
+        "fp4x2 tensor must be contiguous for get_onednn_md");
+    int64_t M = t.size(0);
+    int64_t K_logical = t.size(1) * 2;
+    return {
+        {M, K_logical},
+        dnnl::memory::data_type::f4_e2m1,
+        {K_logical, 1}};
+  }
   return {
       get_onednn_dims(t),
       get_onednn_dtype_include_double(t),

--- a/aten/src/ATen/xpu/XPUScaledBlas.h
+++ b/aten/src/ATen/xpu/XPUScaledBlas.h
@@ -61,6 +61,8 @@ enum class ScaledGemmImplementation {
   BLOCK_128x128_1x128 = 3,
   BLOCK_1x128_128x128 = 4,
   BLOCK_1x128_1x128 = 5,
+  NVFP4_NVFP4 = 7,
+  NVFP4_NVFP4_SINGLE_SCALE = 8,
 };
 
 /**

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -76,7 +76,7 @@ if TEST_CUDA:
 
 f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+, XPU and CPU devices"
 f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
-mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
+mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+ or XPU"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
 
 # avoid division by zero when calculating scale
@@ -1838,7 +1838,7 @@ class TestFP8Matmul(TestCase):
         torch.testing.assert_close(lp_data_actual, lp_data_expected, atol=0, rtol=0)
 
     @skipIfRocm
-    @onlyCUDA
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     @parametrize("mkn", [
         # Nice shapes
@@ -1870,7 +1870,7 @@ class TestFP8Matmul(TestCase):
         A, A_scale, A_global_scale = data_to_nvfp4_with_global_scale(A_ref, BLOCK_SIZE)
         B, B_scale, B_global_scale = data_to_nvfp4_with_global_scale(B_ref, BLOCK_SIZE)
 
-        if torch.version.cuda:
+        if "cuda" in device:
             A_scale = to_blocked(A_scale)
             B_scale = to_blocked(B_scale)
             swizzle = [SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE]
@@ -1935,6 +1935,8 @@ class TestFP8Matmul(TestCase):
     def test_blockwise_mxfp8_nvfp4_mxfp4_numerics(self, test_case_name, fast_accum, mkn, recipe, device) -> None:
         if torch.version.hip and recipe == "nvfp4":
             raise unittest.SkipTest("nvfp4 not supported on ROCm, skipping")
+        if "xpu" in device and recipe != "nvfp4":
+            raise unittest.SkipTest(f"{recipe} not supported on XPU, skipping")
         if (recipe == "nvfp4" or recipe == "mxfp4") and fast_accum:
             raise unittest.SkipTest("fast_accum not supported in nvfp4/mxfp4 cublas gemm, skipping")
         if recipe == "mxfp4" and SM120OrLater:
@@ -2134,8 +2136,8 @@ class TestFP8Matmul(TestCase):
 
         C_ref = A_ref @ B_ref.t()
 
-        # convert to swizzled format
-        if not torch.version.hip:
+        # convert to swizzled format (CUDA only)
+        if "cuda" in device:
             A_scale = to_blocked(A_scale)
             B_scale = to_blocked(B_scale)
 
@@ -2281,6 +2283,8 @@ class TestFP8Matmul(TestCase):
     def test_blockwise_mxfp8_nvfp4_error_messages(self, device, recipe) -> None:
         if recipe == "mxfp4" and SM120OrLater:
             raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
+        if "xpu" in device and recipe != "nvfp4":
+            raise unittest.SkipTest(f"{recipe} not supported on XPU, skipping")
         M, K, N = (1024, 512, 2048)
         BLOCK_SIZE_K = 16 if recipe == "nvfp4" else 32
         BLOCK_SIZE_MN = 128
@@ -2298,16 +2302,20 @@ class TestFP8Matmul(TestCase):
             y_lowp = _bfloat16_to_float4_e2m1fn_x2(y.bfloat16()).t()
 
         num_k_blocks = ceil_div(K, BLOCK_SIZE_K)
-        padded_num_k_blocks = ceil_div(num_k_blocks, 4) * 4
-        expected_a_size = BLOCK_SIZE_MN * ceil_div(M, BLOCK_SIZE_MN) * padded_num_k_blocks
-        expected_b_size = BLOCK_SIZE_MN * ceil_div(N, BLOCK_SIZE_MN) * padded_num_k_blocks
+        if "xpu" in device:
+            expected_a_size = M * num_k_blocks
+            expected_b_size = N * num_k_blocks
+        else:
+            padded_num_k_blocks = ceil_div(num_k_blocks, 4) * 4
+            expected_a_size = BLOCK_SIZE_MN * ceil_div(M, BLOCK_SIZE_MN) * padded_num_k_blocks
+            expected_b_size = BLOCK_SIZE_MN * ceil_div(N, BLOCK_SIZE_MN) * padded_num_k_blocks
 
         block = (
             ScalingType.BlockWise1x16
             if recipe == "nvfp4"
             else ScalingType.BlockWise1x32
         )
-        if torch.version.hip:
+        if torch.version.hip or "xpu" in device:
             swizzle = SwizzleType.NO_SWIZZLE
         else:
             swizzle = SwizzleType.SWIZZLE_32_4_4
@@ -2584,7 +2592,6 @@ class TestFP8Matmul(TestCase):
             use_fast_accum=False,
         )
         torch.testing.assert_close(C, C_ref, atol=0, rtol=0)
-
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4890,6 +4890,16 @@ def _infer_scale_swizzle_impl(
 
     # NVFP4: BlockWise1x16 with float8_e4m3fn scales
     if mat_dtype == torch.float4_e2m1fn_x2 and scale_dtype == torch.float8_e4m3fn:
+        # 2D unpadded scales XPU: shape [outer, ceil_div(K*2, block)]
+        if len(scale_size) == 2:
+            if (
+                (eq_fn(scale_size[0], mat_size[0]) and
+                 eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[1], 16))) or
+                (eq_fn(scale_size[0], mat_size[1]) and
+                 eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[0], 16)))
+            ):
+                return ScalingType.BlockWise1x16, SwizzleType.NO_SWIZZLE
+        # 1D padded scales (CUDA/cuBLAS after to_blocked): numel with round_up
         expected_numel_a = _round_up(mat_size[0], 128) * _round_up(
             ceildiv(K_multiplier * mat_size[1], 16), 4
         )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4893,10 +4893,11 @@ def _infer_scale_swizzle_impl(
         # 2D unpadded scales XPU: shape [outer, ceil_div(K*2, block)]
         if len(scale_size) == 2:
             if (
-                (eq_fn(scale_size[0], mat_size[0]) and
-                 eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[1], 16))) or
-                (eq_fn(scale_size[0], mat_size[1]) and
-                 eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[0], 16)))
+                eq_fn(scale_size[0], mat_size[0])
+                and eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[1], 16))
+            ) or (
+                eq_fn(scale_size[0], mat_size[1])
+                and eq_fn(scale_size[1], ceildiv(K_multiplier * mat_size[0], 16))
             ):
                 return ScalingType.BlockWise1x16, SwizzleType.NO_SWIZZLE
         # 1D padded scales (CUDA/cuBLAS after to_blocked): numel with round_up

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -207,6 +207,8 @@ def evaluate_platform_supports_mx_gemm():
                 return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
         else:
             return SM100OrLater
+    if torch.xpu.is_available():
+        return True
     return False
 
 def evaluate_platform_supports_mxfp8_grouped_gemm():


### PR DESCRIPTION
This PR adds NVFP4 (Float4_e2m1fn_x2) scaled_mm support for XPU, following the pattern established by the Float8 blockwise and mirroring the CUDA NVFP4 implementation.




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo