### PR TITLE
Remove CUDA sync in `torch.combinations` to improve `torch.compile` support

### DIFF
--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -13,6 +13,8 @@
 #include <ATen/ops/full.h>
 #include <ATen/ops/meshgrid.h>
 #include <ATen/ops/stack.h>
+#include <ATen/ops/index_select.h>
+#include <ATen/ops/nonzero_static.h>
 #endif
 
 #include <vector>
@@ -21,12 +23,26 @@ namespace {
 
 using namespace at;
 
+c10::SymInt calculate_num_combinations(c10::SymInt n, int64_t r, bool with_replacement) {
+  // Helper to compute the number of combinations (binomial coefficient)
+  if (with_replacement) {
+    n = n + r - 1;
+  }
+  if (r < 0) return 0;
+  if (r == 0) return 1;
+  c10::SymInt res = 1;
+  for (int64_t i = 1; i <= r; ++i) {
+    res = res * (n - r + i) / i;
+  }
+  return res;
+}
+
 Tensor _triu_mask(c10::SymInt n, int64_t dims, bool diagonal, TensorOptions opt) {
   // get a mask that has value 1 whose indices satisfies i < j < k < ...
   // or i <= j <= k <= ... (depending on diagonal)
   Tensor range = at::arange(std::move(n), opt.dtype(kLong));
   std::vector<Tensor> index_grids = at::meshgrid(std::vector<Tensor>(dims, range), "ij");
-  Tensor mask = at::full(index_grids[0].sizes(), true, opt.dtype(kBool));
+  Tensor mask = at::full_symint(index_grids[0].sym_sizes(), true, opt.dtype(kBool));
   if(diagonal) {
     for(int64_t i = 0; i < dims - 1; i++) {
       mask *= index_grids[i] <= index_grids[i+1];
@@ -64,12 +80,10 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
     return at::empty({0}, self.options());
   }
   c10::SymInt num_elements = self.sym_numel();
-  std::vector<Tensor> grids = at::meshgrid(std::vector<Tensor>(r, self), "ij");
+  c10::SymInt num_combinations = calculate_num_combinations(num_elements, r, with_replacement);
   Tensor mask = _triu_mask(std::move(num_elements), r, with_replacement, self.options());
-  for(Tensor &t : grids) {
-    t = t.masked_select(mask);
-  }
-  return at::stack(grids, 1);
+  Tensor indices = at::nonzero_static_symint(mask, num_combinations);
+  return self.index_select(0, indices.flatten()).view_symint({num_combinations, r});
 }
 
 }  // namespace at::native

--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -86,7 +86,7 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
     Tensor mask = _triu_mask(std::move(num_elements), r, with_replacement, self.options());
     indices = at::nonzero_static_symint(mask, num_combinations);
   }
-  return self.index({indices});
+  return self.index({indices}).contiguous();
 }
 
 }  // namespace at::native

--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -13,7 +13,7 @@
 #include <ATen/ops/full.h>
 #include <ATen/ops/meshgrid.h>
 #include <ATen/ops/stack.h>
-#include <ATen/ops/index_select.h>
+#include <ATen/ops/index.h>
 #include <ATen/ops/nonzero_static.h>
 #endif
 
@@ -86,7 +86,7 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
     Tensor mask = _triu_mask(std::move(num_elements), r, with_replacement, self.options());
     indices = at::nonzero_static_symint(mask, num_combinations);
   }
-  return self.index_select(0, indices.flatten()).view_symint({num_combinations, r});
+  return self.index({indices});
 }
 
 }  // namespace at::native

--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -81,8 +81,11 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
   }
   c10::SymInt num_elements = self.sym_numel();
   c10::SymInt num_combinations = calculate_num_combinations(num_elements, r, with_replacement);
-  Tensor mask = _triu_mask(std::move(num_elements), r, with_replacement, self.options());
-  Tensor indices = at::nonzero_static_symint(mask, num_combinations);
+  Tensor indices;
+  {
+    Tensor mask = _triu_mask(std::move(num_elements), r, with_replacement, self.options());
+    indices = at::nonzero_static_symint(mask, num_combinations);
+  }
   return self.index_select(0, indices.flatten()).view_symint({num_combinations, r});
 }
 

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -771,6 +771,7 @@ ops_unbacked_dtensor_dde = {
     skip("broadcast_to"),
     xfail("bucketize"),
     xfail("cartesian_prod"),
+    xfail("combinations"),
     xfail("constant_pad_nd"),
     xfail("cumprod"),
     xfail("diagonal_scatter"),

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -31,7 +31,6 @@ from torch.utils import _pytree as pytree
 # following are failing with regular torch.export.export
 export_failures = {
     xfail("allclose"),
-    xfail("combinations"),
     xfail("corrcoef"),
     xfail("cov"),
     xfail("equal"),

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1471,6 +1471,18 @@ class TestInductorDynamic(DynamicShapesTestCase):
         # Test backward pass as well - this is where the bug manifested
         out_compiled.sum().backward()
 
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    def test_combinations_dynamic(self):
+        def f(x):
+            return torch.combinations(x, r=2)
+
+        compiled_f = torch.compile(f, fullgraph=True, dynamic=True)
+        for n in [3, 5, 7]:
+            x = torch.randn(n)
+            expected = f(x)
+            actual = compiled_f(x)
+            self.assertEqual(actual, expected)
+
 
 instantiate_device_type_tests(TestInductorDynamic, globals(), allow_xpu=True)
 

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -248,7 +248,6 @@ inductor_expected_failures_single_sample["cpu"] = {
     "resize_": {b8, f16, f32, f64, i32, i64},
     "resize_as_": {b8, f16, f32, f64, i32, i64},
     "histc": {f16},
-    "nonzero_static": {b8, f16, f32, f64, i32, i64},
     ("sparse.mm", "reduce"): {f32, f64, f16},
     "sparse.sampled_addmm": {f32, f64},
     "to_sparse": {

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -665,7 +665,6 @@ meta_function_expected_failures = {
     torch.Tensor.to_sparse : {f64, i32, c128, i64, i16, f16, u8, c64, bf16, b8, i8, f32},
     torch.allclose : {f64, f16, c128, c64, bf16, f32},
     torch.argwhere : {f64, i32, c128, i64, i16, f16, u8, c64, bf16, b8, i8, f32},
-    torch.combinations : {f64, i32, c128, i64, i16, f16, u8, c64, bf16, b8, i8, f32},
     torch.corrcoef : {f64, i32, c128, i64, i16, u8, c64, bf16, f16, i8, f32},
     torch.cov : {f64, i32, c128, i64, i16, u8, c64, bf16, i8, f32, f16},
     torch.functional.istft : {f64, c64, c128, f32},

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2772,7 +2772,6 @@ fake_autocast_device_skips["cuda"] = {"linalg.pinv", "pinverse"}
 dynamic_output_op_tests = (
     "argwhere",
     "bincount",
-    "combinations",
     "linalg.lstsq",
     "masked_select",
     "nonzero",

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2082,6 +2082,7 @@ class TestTorchDeviceType(TestCase):
                           lambda: torch.repeat_interleave(x, 2, output_size=2 * size),
                           lambda: torch.repeat_interleave(x, repeats, output_size=2 * size),
                           lambda: torch.any(y),
+                          lambda: torch.combinations(x, r=2),
                           lambda: torch.normal(x, x))
         expect_sync = (lambda: _ind_put_fn(x, mask, y),
                        lambda: _ind_put_fn(x, ind_cpu, y),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3739,6 +3739,8 @@ make_fallback(aten._fft_r2c)  # needs complex as well
 
 # Data dependent (are these necessary?)
 make_fallback(aten.nonzero.default)
+# Not data-dependent, but still using fallback
+make_fallback(aten.nonzero_static.default)
 # Data-dependent output size; route to ATen eager kernel (CPU/CUDA/XPU all have
 # native implementations)
 make_fallback(aten.bincount.default, warn=False)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22368,7 +22368,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
                DecorateInfo(unittest.expectedFailure, 'TestDTensorOps', 'test_dtensor_op_db'),
-               DecorateInfo(unittest.expectedFailure, 'TestInductorOpInfo', 'test_comprehensive'),
                DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfo', 'test_op_has_batch_rule'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13767,7 +13767,15 @@ op_db: list[OpInfo] = [
            # See https://github.com/pytorch/pytorch/pull/78358
            check_batched_forward_grad=False,
            supports_out=False,
-           sample_inputs_func=sample_inputs_combinations),
+           sample_inputs_func=sample_inputs_combinations,
+           decorators=[
+               DecorateInfo(
+                   toleranceOverride({torch.float16: tol(atol=5e-4, rtol=2e-3)}),
+                   device_type='cuda',
+                   dtypes=(torch.float16,),
+                   active_if=TEST_WITH_ROCM,
+               ),
+           ]),
     OpInfo('cartesian_prod',
            op=torch.cartesian_prod,
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),

--- a/torch/testing/_internal/common_ops_unbacked.py
+++ b/torch/testing/_internal/common_ops_unbacked.py
@@ -24,7 +24,6 @@ ops_dde_xfail = {
     xfail("cdist"),
     xfail("cholesky"),
     xfail("chunk"),
-    xfail("combinations"),
     xfail("corrcoef"),
     xfail("cov"),
     xfail("cross"),


### PR DESCRIPTION
Currently `torch.combinations` causes a CUDA sync due to `masked_select` being data dependent. This PR changes the implementation to statically compute the number of combinations and uses `nonzero_static` to compute the indices with a statically known shape.

I did some quick benchmarks on CPU and GPU with the following script. Performance on CPU and GPU is much better, especially for large inputs. ~~GPU memory usage in eager mode is slightly larger, but significantly lower when compiled since we don't have a graph break anymore.~~fixed below

<details><summary>Full Benchmarking script</summary>
<p>

```python
import torch
import time
import pandas as pd

def run_benchmark(device, n_sizes, r_values, num_runs=5, warmups=2, compiled=False):
    results = []

    def run_comb(x, r):
        return torch.combinations(x, r=r)

    func = torch.compile(run_comb) if compiled else run_comb

    for n in n_sizes:
        for r in r_values:
            x = torch.randn(n, device=device)
            for _ in range(warmups):
                _ = func(x, r=r)

            memory_used = None
            if device.startswith("cuda"):
                torch.cuda.reset_peak_memory_stats(device)
                _ = func(x, r=r)
                torch.cuda.synchronize(device)
                memory_used = torch.cuda.max_memory_allocated(device) / (1024 * 1024)  # convert bytes to MB

            start_time = time.perf_counter()
            for _ in range(num_runs):
                _ = func(x, r=r)
                if device.startswith("cuda"):
                    torch.cuda.synchronize(device)
            end_time = time.perf_counter()
            execution_time = (end_time - start_time) / num_runs * 1000  # ms

            device_str = f"{device.upper()} (compiled)" if compiled else f"{device.upper()} (eager)"
            results.append({
                "Device": device_str,
                "N": n,
                "R": r,
                "Num Combinations": torch.combinations(x, r=r).shape[0],
                "Execution Time (ms)": f"{execution_time:.3f}",
                "Memory Usage (MB)": f"{memory_used:.3f}" if memory_used is not None else "N/A",
            })

    return results

if __name__ == "__main__":
    n_sizes = [100, 200, 300]

    print("Benchmarking on CPU (eager)...")
    cpu_results = run_benchmark("cpu", n_sizes, [2, 3], compiled=False)
    print("Benchmarking on CPU (compiled)...")
    cpu_compiled_results = run_benchmark("cpu", n_sizes, [2, 3], compiled=True)

    cuda_results = []
    cuda_compiled_results = []
    if torch.cuda.is_available():
        print("Benchmarking on CUDA (eager)...")
        cuda_results = run_benchmark("cuda", n_sizes, [2, 3, 4], compiled=False)
        print("Benchmarking on CUDA (compiled)...")
        cuda_compiled_results = run_benchmark("cuda", n_sizes, [2, 3, 4], compiled=True)

    all_results = cpu_results + cpu_compiled_results + cuda_results + cuda_compiled_results
    df = pd.DataFrame(all_results)

    df = df.sort_values(by=["Device", "R", "N"])

    print("\nBenchmark Results:")
    print(df.to_string(index=False))
```

</p>
</details> 

**main:**
```
         Device   N  R  Num Combinations Execution Time (ms) Memory Usage (MB)
 CPU (compiled) 100  2              4950               0.096               N/A
 CPU (compiled) 200  2             19900               0.229               N/A
 CPU (compiled) 300  2             44850               0.384               N/A
 CPU (compiled) 100  3            161700               2.692               N/A
 CPU (compiled) 200  3           1313400             110.978               N/A
 CPU (compiled) 300  3           4455100             392.575               N/A
    CPU (eager) 100  2              4950               0.074               N/A
    CPU (eager) 200  2             19900               0.229               N/A
    CPU (eager) 300  2             44850               0.338               N/A
    CPU (eager) 100  3            161700              13.006               N/A
    CPU (eager) 200  3           1313400             109.279               N/A
    CPU (eager) 300  3           4455100             387.542               N/A
CUDA (compiled) 100  2              4950               0.206             0.162
CUDA (compiled) 200  2             19900               0.199             0.647
CUDA (compiled) 300  2             44850               0.205             1.457
CUDA (compiled) 100  3            161700               0.274             8.358
CUDA (compiled) 200  3           1313400               0.340            67.753
CUDA (compiled) 300  3           4455100               0.835           229.690
CUDA (compiled) 100  4           3921225               2.845           335.668
CUDA (compiled) 200  4          64684950              55.691          5474.059
CUDA (compiled) 300  4         330791175             282.391         27914.657
   CUDA (eager) 100  2              4950               0.180             0.162
   CUDA (eager) 200  2             19900               0.167             0.647
   CUDA (eager) 300  2             44850               0.174             1.457
   CUDA (eager) 100  3            161700               0.244             8.358
   CUDA (eager) 200  3           1313400               0.316            67.753
   CUDA (eager) 300  3           4455100               0.818           229.690
   CUDA (eager) 100  4           3921225               2.821           335.668
   CUDA (eager) 200  4          64684950              55.851          5474.059
   CUDA (eager) 300  4         330791175             283.848         27914.657
```

**This PR:** (see better benchmarks below)
```
         Device   N  R  Num Combinations Execution Time (ms) Memory Usage (MB)
 CPU (compiled) 100  2              4950               0.131               N/A
 CPU (compiled) 200  2             19900               0.276               N/A
 CPU (compiled) 300  2             44850               0.461               N/A
 CPU (compiled) 100  3            161700               1.839               N/A
 CPU (compiled) 200  3           1313400              24.267               N/A
 CPU (compiled) 300  3           4455100              84.516               N/A
    CPU (eager) 100  2              4950               0.073               N/A
    CPU (eager) 200  2             19900               0.216               N/A
    CPU (eager) 300  2             44850               0.412               N/A
    CPU (eager) 100  3            161700               3.078               N/A
    CPU (eager) 200  3           1313400              24.326               N/A
    CPU (eager) 300  3           4455100              87.258               N/A
CUDA (compiled) 100  2              4950               0.105             0.152
CUDA (compiled) 200  2             19900               0.100             0.608
CUDA (compiled) 300  2             44850               0.100             1.371
CUDA (compiled) 100  3            161700               0.109             7.403
CUDA (compiled) 200  3           1313400               0.149            60.124
CUDA (compiled) 300  3           4455100               0.351           203.940
CUDA (compiled) 100  4           3921225               1.510           275.838
CUDA (compiled) 200  4          64684950              24.367          4487.048
CUDA (compiled) 300  4         330791175             138.127         22867.187
   CUDA (eager) 100  2              4950               0.111             0.228
   CUDA (eager) 200  2             19900               0.100             0.912
   CUDA (eager) 300  2             44850               0.121             2.055
   CUDA (eager) 100  3            161700               0.121            11.104
   CUDA (eager) 200  3           1313400               0.137            90.186
   CUDA (eager) 300  3           4455100               0.465           305.910
   CUDA (eager) 100  4           3921225               1.599           359.667
   CUDA (eager) 200  4          64684950              28.038          5922.086
   CUDA (eager) 300  4         330791175             199.538         30284.839
```
/cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @ezyang @ngimel
Fixes #74324