### PR TITLE
Fix inconsistent stride for max_unpool2d in compiled v eager

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_max_unpool2d_channels_last_stride_cpu_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_max_unpool2d_channels_last_stride_cpu_cpu
@@ -1,0 +1,3 @@
+# see https://github.com/pytorch/pytorch/issues/187963
+FAIL
+AssertionError: Tensor-likes are not close!

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5584,6 +5584,19 @@ for dtype in (torch.int32, torch.int64):
         x3d = torch.randn(1, 1, 1, 1, 1, device=self.device)
         self.common(Unpool3d().to(self.device), (x3d, x3d.long()))
 
+    def test_max_unpool2d_channels_last_stride_cpu(self):
+        if self.device != "cpu":
+            raise unittest.SkipTest("CPU max_unpool2d preserves channels-last layout")
+
+        def fn(x, indices):
+            return F.max_unpool2d(x, indices, kernel_size=2, stride=2)
+
+        x = torch.randn(2, 3, 4, 4, device=self.device).contiguous(
+            memory_format=torch.channels_last
+        )
+        pooled, indices = F.max_pool2d(x, kernel_size=2, stride=2, return_indices=True)
+        self.common(fn, (pooled, indices), exact_stride=True)
+
     def test_to_dtype(self):
         new_dtype = torch.float64 if self.device != "mps" else torch.bfloat16
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3202,9 +3202,20 @@ def _max_unpoolnd(
     ).reshape(-1)
 
     output = self.new_zeros(output_shape)
-    return aten._unsafe_index_put(
+    result = aten._unsafe_index_put(
         output.reshape(-1), [indices_flat], self.reshape(-1), accumulate=False
     ).view(output.shape)
+
+    # Match the CPU max_unpool2d layout behavior: the native 4D path resizes
+    # the output with self.suggest_memory_format(), preserving channels-last.
+    # The 3D path uses the default contiguous layout.
+    # For compile, FakeTensor preserves the real device here.
+    # The only edge-case we see is direct meta calls, which follow meta strides
+    # and may differ from CPU eager layout.
+    if dim == 2 and self.ndim == 4 and self.device.type == "cpu":
+        result = result.contiguous(memory_format=utils.suggest_memory_format(self))
+
+    return result
 
 
 @register_decomposition(aten.max_unpool2d)


### PR DESCRIPTION
This fixes an inconsistency between `_max_unpoolnd` and the eager version of `max_unpooling2d_forward_out_cpu`, see [MaxUnpooling.cpp](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/MaxUnpooling.cpp); in current version [this code block](https://github.com/pytorch/pytorch/blob/9d12814e74bea2317c097218cca8c01b9cc16fe2/aten/src/ATen/native/MaxUnpooling.cpp#L64) in particular.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo