### PR TITLE
Raise a clear error for malformed allocator config instead of INTERNAL_ASSERT

### DIFF
--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -33,7 +33,7 @@ constexpr size_t kRoundLarge = 2097152;
 // Whitespace is ignored.
 class ConfigTokenizer {
  public:
-  explicit ConfigTokenizer(const std::string& env) {
+  explicit ConfigTokenizer(const std::string& env) : debug_config_str_(env) {
     std::string buffer;
     for (char ch : env) {
       if (ch == ',' || ch == ':' || ch == '[' || ch == ']') {
@@ -52,8 +52,7 @@ class ConfigTokenizer {
   }
 
   const std::string& operator[](size_t i) const {
-    TORCH_INTERNAL_ASSERT(
-        i < config_.size(), "Index out of bounds in ConfigTokenizer");
+    checkIndex(i);
     return config_[i];
   }
 
@@ -112,20 +111,34 @@ class ConfigTokenizer {
     while (++i < config_.size() && config_[i] != "]") {
     }
 
-    TORCH_INTERNAL_ASSERT(
+    TORCH_CHECK_VALUE(
         i < config_.size(),
-        "Expected closing bracket ']' in ConfigTokenizer but reached end of config");
+        "Error parsing the allocator config: expected a closing ']' for a "
+        "list value but reached the end of the configuration string. "
+        "It is set via PYTORCH_ALLOC_CONF (or PYTORCH_CUDA_ALLOC_CONF / "
+        "PYTORCH_HIP_ALLOC_CONF). The configuration string was '",
+        debug_config_str_,
+        "'.");
 
     return i; // Return the index of the closing ']'
   }
 
  private:
   void checkIndex(size_t i) const {
-    TORCH_INTERNAL_ASSERT(
-        i < config_.size(), "Index out of bounds in ConfigTokenizer");
+    TORCH_CHECK_VALUE(
+        i < config_.size(),
+        "Error parsing the allocator config: reached the end of the "
+        "configuration string while more tokens were expected. The "
+        "config is malformed, for example a key with no value or a "
+        "trailing ':' or ','. It is set via PYTORCH_ALLOC_CONF (or "
+        "PYTORCH_CUDA_ALLOC_CONF / PYTORCH_HIP_ALLOC_CONF). The "
+        "configuration string was '",
+        debug_config_str_,
+        "'.");
   }
 
   std::vector<std::string> config_;
+  std::string debug_config_str_;
 };
 
 /**

--- a/c10/test/core/AllocatorConfig_test.cpp
+++ b/c10/test/core/AllocatorConfig_test.cpp
@@ -135,3 +135,40 @@ TEST(AllocatorConfigTest, allocator_config_test) {
   env = "foo:123,bar:456";
   ASSERT_THROW(c10::CachingAllocator::setAllocatorSettings(env), c10::Error);
 }
+
+TEST(AllocatorConfigTest, malformed_config_raises_value_error) {
+  // gh-186453: a malformed allocator config (supplied via PYTORCH_ALLOC_CONF /
+  // PYTORCH_CUDA_ALLOC_CONF / PYTORCH_HIP_ALLOC_CONF) must raise a clean
+  // c10::ValueError, not a TORCH_INTERNAL_ASSERT that asks the user to report a
+  // bug to PyTorch.
+  const std::vector<std::string> malformed = {
+      "max_split_size_mb", // key with no value (checkIndex)
+      "max_split_size_mb:", // trailing colon, no value (checkIndex)
+      "roundup_power2_divisions:[64:8", // unterminated list (operator[])
+  };
+  for (const auto& env : malformed) {
+    EXPECT_THROW(
+        c10::CachingAllocator::setAllocatorSettings(env), c10::ValueError)
+        << "config: " << env;
+  }
+
+  // skipKey's closing-bracket guard: an unterminated list value for a key that
+  // is skipped (rather than parsed) reaches the end of the config.
+  EXPECT_THROW(
+      ConfigTokenizer("large_segment_size_mb:[1").skipKey(0), c10::ValueError);
+
+  // The message must be user-facing: no internal-assert text, and it should
+  // point the user at the allocator config env var.
+  try {
+    c10::CachingAllocator::setAllocatorSettings(
+        "garbage_collection_threshold:");
+    ADD_FAILURE() << "expected a c10::ValueError";
+  } catch (const c10::ValueError& e) {
+    const std::string msg = e.what_without_backtrace();
+    EXPECT_EQ(msg.find("INTERNAL ASSERT"), std::string::npos) << msg;
+    EXPECT_NE(msg.find("PYTORCH_ALLOC_CONF"), std::string::npos) << msg;
+    // gh-186453: the error must echo the offending config string.
+    EXPECT_NE(msg.find("garbage_collection_threshold"), std::string::npos)
+        << msg;
+  }
+}


### PR DESCRIPTION
Fixes #186453

## Summary

`import torch` crashes with `INTERNAL ASSERT FAILED ... Index out of bounds in ConfigTokenizer ... please report a bug to PyTorch` when a malformed allocator config is set, for example `PYTORCH_CUDA_ALLOC_CONF=expandable_segments` (a key with no value, which the reporter in #186453 hit).

`ConfigTokenizer`'s bounds checks (`operator[]`, `checkIndex`, and the closing-bracket guard in `skipKey`) used `TORCH_INTERNAL_ASSERT`, which is meant for PyTorch-internal invariants. The string they validate comes from a user environment variable (`PYTORCH_ALLOC_CONF`, `PYTORCH_CUDA_ALLOC_CONF`, or `PYTORCH_HIP_ALLOC_CONF`), so a malformed value is user error rather than an internal bug.

This converts those checks to `TORCH_CHECK_VALUE`, so a malformed config raises a clear `ValueError` instead of an internal assert. Following the discussion on the issue, the message also echoes the offending config string so it is obvious which value was wrong.

After, for `PYTORCH_CUDA_ALLOC_CONF=expandable_segments`:

```
ValueError: Error parsing the allocator config: reached the end of the configuration string while more tokens were expected. The config is malformed, for example a key with no value or a trailing ':' or ','. It is set via PYTORCH_ALLOC_CONF (or PYTORCH_CUDA_ALLOC_CONF / PYTORCH_HIP_ALLOC_CONF). The configuration string was 'expandable_segments'.
```

## Test plan

Adds `AllocatorConfigTest.malformed_config_raises_value_error` covering a key with no value, a trailing colon, an unterminated list (the `operator[]` and `skipKey` paths), asserting a `c10::ValueError` that names the env var and echoes the offending config string instead of an internal assert. Built from source and ran `c10_AllocatorConfig_test` (both tests pass).

_Prepared with AI assistance (Claude Code, OpenAI Codex). I reviewed and verified the change and ran the tests locally, and take responsibility for it._
