### PR TITLE
fix library finalizer for uncached torch ops

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -455,6 +455,46 @@ class TestPythonRegistration(TestCase):
 
         _collect_all_valid_cia_ops_for_namespace(namespace)
 
+    def test_finalizer_no_getattr_into_cpp(self):
+        # Regression test: _clear_torch_ops_cache must not call __getattr__ on
+        # _OpNamespace (which invokes _jit_get_operation in C++). During
+        # interpreter shutdown the C++ runtime may be torn down, causing
+        # UnicodeDecodeError or segfaults when the finalizer fires.
+        lib = Library(self.test_ns, "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define("uncached_op() -> None")
+
+        @impl(lib, "uncached_op", "")
+        def uncached_op():
+            pass
+
+        # Do NOT call torch.ops._test_python_registration.uncached_op() here,
+        # so the OpOverloadPacket is never cached on the namespace object.
+        # This simulates what happens when a library (e.g. vLLM) registers ops
+        # but some are never looked up before shutdown.
+        namespace = torch.ops._test_python_registration
+
+        # Patch __getattr__ to detect if it gets called during cache clearing.
+        original_getattr = type(namespace).__getattr__
+        getattr_called_with = []
+
+        def tracking_getattr(self, name):
+            getattr_called_with.append(name)
+            return original_getattr(self, name)
+
+        type(namespace).__getattr__ = tracking_getattr
+        try:
+            del lib
+            gc.collect()
+        finally:
+            type(namespace).__getattr__ = original_getattr
+
+        self.assertNotIn(
+            "uncached_op",
+            getattr_called_with,
+            "_clear_torch_ops_cache must not trigger __getattr__ (which calls "
+            "into C++) for ops that were never cached on the namespace",
+        )
+
     def test_register_check_mem_op_survives_gc(self):
         # Regression guard for the autorevert of #181785: inductor's
         # `register_check_mem_op` is an lru_cache-decorated registration whose

--- a/torch/library.py
+++ b/torch/library.py
@@ -625,7 +625,11 @@ def _clear_torch_ops_cache(op_defs):
         if not hasattr(torch.ops, ns):
             continue
         namespace = getattr(torch.ops, ns)
-        if not hasattr(namespace, name):
+        # Use vars() to check the instance dict directly, avoiding
+        # __getattr__ which calls into C++ via _jit_get_operation.
+        # During interpreter shutdown the C++ runtime may already be
+        # torn down, causing UnicodeDecodeError or segfaults.
+        if name not in vars(namespace):
             continue
         delattr(namespace, name)
         if name in namespace._dir:


### PR DESCRIPTION
Found the following error when vLLM engine exist when upgrade torch after 20260501 nightly version. Introduced via #181785

```
Traceback (most recent call last):
  File "/usr/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/library.py", line 628, in _del_library
    _clear_torch_ops_cache(op_defs)
  File "/opt/venv/lib/python3.12/site-packages/torch/library.py", line 593, in _clear_torch_ops_cache
    if not hasattr(namespace, name):
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1383, in __getattr__
    op, overload_names = _get_packet(qualified_op_name, module_name)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1408, in _get_packet
    op, overload_names = torch._C._jit_get_operation(qualname)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 275: invalid continuation byte
```

The issue is that `hasattr(namespace, name)` is not safe to call inside a weakref finalizer during interpreter shutdown when name is not already cached on the namespace object. If the op was already cached (via a prior getattr that set it as an attribute), hasattr would find it directly without calling into C++. But if it wasn't cached, it falls through to `__getattr__` which calls into the C++ layer that may already be torn down.