### PR TITLE
Use larger small-tensor multiplier for functorch_dp_cifar10 accuracy

### DIFF
--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -85,6 +85,10 @@ tolerance:
     sam_fast: 5
 
 require_larger_multiplier_for_smaller_tensor:
+  # Small (128-elem) BatchNorm bias gradient under AMP training; borderline RMSE
+  # after inductor PR #186379 stopped folding float x*0 -> 0. Noise dominates the
+  # error metric on this small tensor, so use the larger small-tensor multiplier.
+  - functorch_dp_cifar10
   - yolov3
 
 # These benchmarks took >600s on an i9-11900K CPU


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186613
* #186612

functorch_dp_cifar10 started failing accuracy in inductor-periodic training
(dynamic_inductor_torchbench, --training --amp) at trunk 7168b60c0d. Root
cause is inductor PR #186379 ('Don't fold float x*0 to 0 in uniform-value
constant folding'), an intended correctness fix that turns float x*0 back
into a real multiply and shifts float32 rounding in batchnorm backward.

The divergence is on a small 128-element tensor (layer2.0.bn2.bias gradient):
  RMSE(res-fp64)=0.00608 vs multiplier(3.0)*RMSE(ref-fp64)=0.00435 -> fail.
This is exactly the 'noise dominates the error metric for smaller tensors'
case the larger-multiplier mechanism exists for. Adding the model raises the
small-tensor multiplier to 8.0 (threshold 0.0117), which it passes with ~2x
margin, while keeping it expected-pass rather than masking it as fail_accuracy.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98