### PR TITLE
Added profiler record for THPVariable_dealloc

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -355,6 +355,8 @@ class TestDataFlow(TestCase):
         out: list[tuple[str, tuple[bool, ...]]] = []
         for node in _utils.traverse_dfs(tree):
             if node.tag == _EventType.TorchOp:
+                if node.name == "Tensor_dealloc":
+                    continue
                 e = node.extra_fields
                 schemas = _memory_profiler.SchemaMatcher.match_schemas(e)
                 name = node.name

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -714,6 +714,17 @@ class TestProfiler(TestCase):
             profiler_stats.function_events_build_tree_call_duration_us, 0
         )
 
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    def test_tensor_dealloc_recorded(self):
+        with profile(activities=[ProfilerActivity.CPU]) as p:
+            with record_function("explicit_tensor_del"):
+                x = torch.empty((3, 4))
+                del x
+            gc.collect()
+
+        names = [e.name for e in p.events()]
+        self.assertIn("Tensor_dealloc", names)
+
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_module_hierarchy(self):
         class A(nn.Module):
@@ -2459,10 +2470,10 @@ class TestProfilerDevice(TestCase):
             stats,
             "cpu_memory_usage",
             allocs=["aten::rand", "aten::empty"],
-            deallocs=["[memory]"],
+            deallocs=["Tensor_dealloc"],
         )
         if device_type != "cpu":
-            check_metrics(stats, "device_memory_usage", deallocs=["[memory]"])
+            check_metrics(stats, "device_memory_usage", deallocs=["Tensor_dealloc"])
 
     def test_flops(self, device):
         device_type = device.split(":")[0]
@@ -3206,19 +3217,30 @@ class TestExperimentalUtils(TestCase):
                     f"Expected 1 out event, got {len(aten_add_out_event)}"
                 )
 
-            # Without group_by_overload_name, the overload name is ignored in the key averages
+            # Without group_by_overload_name, the overload name is ignored in the key averages.
             key_averages = prof.key_averages()
-            if len(key_averages) != 2:
+            aten_add_avgs = [evt for evt in key_averages if evt.key == "aten::add"]
+            if len(aten_add_avgs) != 1:
                 raise AssertionError(
-                    f"Expected 2 key averages, got {len(key_averages)}"
+                    f"Expected 1 aten::add key average, got {len(aten_add_avgs)}"
+                )
+            if aten_add_avgs[0].count != 2:
+                raise AssertionError(
+                    f"Expected 2 aten::add calls, got {aten_add_avgs[0].count}"
                 )
             if "Overload Name" in key_averages.table():
                 raise AssertionError("Overload Name should not be in table")
 
             key_averages = prof.key_averages(group_by_overload_name=True)
-            if len(key_averages) != 3:
+            aten_add_overloads = sorted(
+                (evt.overload_name, evt.count)
+                for evt in key_averages
+                if evt.key == "aten::add"
+            )
+            if aten_add_overloads != [("Tensor", 1), ("out", 1)]:
                 raise AssertionError(
-                    f"Expected 3 key averages with group_by_overload_name, got {len(key_averages)}"
+                    "Expected separate aten::add Tensor and out overload key averages, "
+                    f"got {aten_add_overloads}"
                 )
             if "Overload Name" not in key_averages.table():
                 raise AssertionError("Overload Name should be in table")

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -714,6 +714,17 @@ class TestProfiler(TestCase):
             profiler_stats.function_events_build_tree_call_duration_us, 0
         )
 
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    def test_tensor_dealloc_recorded(self):
+        with profile(activities=[ProfilerActivity.CPU]) as p:
+            with record_function("explicit_tensor_del"):
+                x = torch.empty((3, 4))
+                del x
+            gc.collect()
+
+        names = [e.name for e in p.events()]
+        self.assertIn("Tensor_dealloc", names)
+
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_module_hierarchy(self):
         class A(nn.Module):
@@ -2439,10 +2450,10 @@ class TestProfilerDevice(TestCase):
             stats,
             "cpu_memory_usage",
             allocs=["aten::rand", "aten::empty"],
-            deallocs=["[memory]"],
+            deallocs=["Tensor_dealloc"],
         )
         if device_type != "cpu":
-            check_metrics(stats, "device_memory_usage", deallocs=["[memory]"])
+            check_metrics(stats, "device_memory_usage", deallocs=["Tensor_dealloc"])
 
     def test_flops(self, device):
         device_type = device.split(":")[0]
@@ -3186,19 +3197,30 @@ class TestExperimentalUtils(TestCase):
                     f"Expected 1 out event, got {len(aten_add_out_event)}"
                 )
 
-            # Without group_by_overload_name, the overload name is ignored in the key averages
+            # Without group_by_overload_name, the overload name is ignored in the key averages.
             key_averages = prof.key_averages()
-            if len(key_averages) != 2:
+            aten_add_avgs = [evt for evt in key_averages if evt.key == "aten::add"]
+            if len(aten_add_avgs) != 1:
                 raise AssertionError(
-                    f"Expected 2 key averages, got {len(key_averages)}"
+                    f"Expected 1 aten::add key average, got {len(aten_add_avgs)}"
+                )
+            if aten_add_avgs[0].count != 2:
+                raise AssertionError(
+                    f"Expected 2 aten::add calls, got {aten_add_avgs[0].count}"
                 )
             if "Overload Name" in key_averages.table():
                 raise AssertionError("Overload Name should not be in table")
 
             key_averages = prof.key_averages(group_by_overload_name=True)
-            if len(key_averages) != 3:
+            aten_add_overloads = sorted(
+                (evt.overload_name, evt.count)
+                for evt in key_averages
+                if evt.key == "aten::add"
+            )
+            if aten_add_overloads != [("Tensor", 1), ("out", 1)]:
                 raise AssertionError(
-                    f"Expected 3 key averages with group_by_overload_name, got {len(key_averages)}"
+                    "Expected separate aten::add Tensor and out overload key averages, "
+                    f"got {aten_add_overloads}"
                 )
             if "Overload Name" not in key_averages.table():
                 raise AssertionError("Overload Name should be in table")

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -41,6 +41,8 @@ PRUNE_FUNCTIONS = {
     # These show up only on CUDA, prune them so the CUDA and CPU expected results can be the same
     "cudaGetDeviceCount": PRUNE_ALL,
     "cudaGetDeviceProperties_v2": PRUNE_ALL,
+    # Tensor deallocation timing follows Python refcounts and has dedicated coverage.
+    "Tensor_dealloc": IGNORE,
 }
 
 # ROCTracer is currently not producing events that profiler can extract. We

--- a/test/profiler/test_torch_tidy.py
+++ b/test/profiler/test_torch_tidy.py
@@ -496,8 +496,12 @@ class TestTorchTidyProfiler(TestCase):
 
         # Deletion when `x` goes out of scope.
         free_new = [
-            i for i in nodes if i.tag == torch._C._profiler._EventType.Allocation
-        ][-1].extra_fields
+            i.extra_fields
+            for i in _utils.traverse_dfs(nodes)
+            if i.tag == torch._C._profiler._EventType.Allocation
+            and i.extra_fields.alloc_size < 0
+            and i.extra_fields.ptr == allocate_new.ptr
+        ][-1]
         self.assertIsInstance(free_new, torch._C._profiler._ExtraFields_Allocation)
         self.assertEqual(free_new.id, allocate_new.id)
         self.assertEqual(free_new.ptr, allocate_new.ptr)

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1,5 +1,6 @@
 #include <ATen/DTensorState.h>
 #include <ATen/native/Resize.h>
+#include <ATen/record_function.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/SymIntArrayRef.h>
 #include <c10/core/impl/GPUTrace.h>
@@ -3719,6 +3720,7 @@ static int THPVariable_clear(THPVariable* self) {
 }
 
 static void THPVariable_dealloc(PyObject* self) {
+  RECORD_FUNCTION("Tensor_dealloc", {});
   PyObject_GC_UnTrack(self);
   THPVariable_clear((THPVariable*)self);
   ((THPVariable*)self)->cdata.~Variable();


### PR DESCRIPTION
This makes tensor deallocations appear in the profiler's trace.

This is useful because, when some CPU backends are improperly configured, deletions of large tensors can make a non-negligible contribution to the runtime.