### PR TITLE
[pytorch] Fix Inductor missing wait on AsyncCollectiveTensor nested inside DTensor

### DIFF
--- a/test/functorch/repro_nested_act.py
+++ b/test/functorch/repro_nested_act.py
@@ -1,0 +1,79 @@
+# Owner(s): ["module: functorch"]
+"""End-to-end test for pytorch/pytorch#180614 (fix option 2: reconstruct).
+
+Inductor must wait an AsyncCollectiveTensor nested inside DTensor._local_tensor.
+A correct fix must (a) call wait_tensor at runtime AND (b) not crash Dynamo
+guard construction.
+"""
+
+import os
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@unittest.skipIf(not torch.distributed.is_available(), "torch.distributed required")
+class TestNestedActEndToEnd(TestCase):
+    def test_inductor_waits_nested_act_in_dtensor(self):
+        import torch.distributed as dist
+        import torch.distributed._functional_collectives as fc
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor, Replicate
+
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ.setdefault("MASTER_PORT", "29552")
+        dist.init_process_group("gloo", rank=0, world_size=1)
+        try:
+            wait_tensor_calls: list[str] = []
+            orig_wait_tensor = fc.wait_tensor
+
+            def counting_wait_tensor(t):
+                wait_tensor_calls.append("wait_tensor")
+                return orig_wait_tensor(t)
+
+            fc.wait_tensor = counting_wait_tensor
+
+            mesh = init_device_mesh("cpu", (1,))
+
+            @torch.compile(backend="inductor", fullgraph=True)
+            def fn(x):
+                return x + 1
+
+            # Compile + warmup, then isolate runtime.
+            dt = DTensor.from_local(torch.randn(4, 4), mesh, [Replicate()])
+            dt._local_tensor = AsyncCollectiveTensor(dt._local_tensor.clone())
+            fn(dt)
+
+            wait_tensor_calls.clear()
+
+            dt2 = DTensor.from_local(torch.randn(4, 4), mesh, [Replicate()])
+            dt2._local_tensor = AsyncCollectiveTensor(dt2._local_tensor.clone())
+            self.assertIsInstance(dt2._local_tensor, AsyncCollectiveTensor)
+            self.assertFalse(dt2._local_tensor.completed)
+
+            out = fn(dt2)
+
+            print(f"\nruntime wait_tensor calls: {len(wait_tensor_calls)}")
+            # After a correct run the runtime wrapper resolves the nested ACT,
+            # so _local_tensor is now a plain (waited) tensor.
+            resolved = not isinstance(dt2._local_tensor, AsyncCollectiveTensor)
+            print(f"nested ACT resolved to plain tensor: {resolved}")
+
+            self.assertGreaterEqual(
+                len(wait_tensor_calls),
+                1,
+                "BUG #180614: Inductor ran the compiled kernel without calling "
+                "wait_tensor on the nested AsyncCollectiveTensor.",
+            )
+            self.assertTrue(torch.isfinite(out.to_local()).all())
+        finally:
+            fc.wait_tensor = orig_wait_tensor
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: functorch"]
 
 import logging
+import unittest
 from contextlib import contextmanager
 
 import torch
@@ -206,6 +207,184 @@ def inner_fn(args):
         self.assertEqual(received_args[1], b)
         self.assertIs(received_args[2], seed)
         self.assertIs(received_args[3], offset)
+
+
+    def test_nested_act_codegen(self):
+        """Nested ACT paths emit trigger_wait() calls in generated source."""
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+        from torch._functorch._aot_autograd.subclass_codegen import (
+            _codegen_subclass_wrapper_source,
+        )
+
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            out_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            num_fw_outs_saved_for_bw=None,
+            nested_act_input_paths=[(0, ("_local_tensor",))],
+        )
+        self.assertIn(
+            "args[0]._local_tensor = args[0]._local_tensor.trigger_wait()", source
+        )
+
+    def test_nested_act_codegen_deep_path(self):
+        """Deeply nested ACT paths emit correct chained attr access."""
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+        from torch._functorch._aot_autograd.subclass_codegen import (
+            _codegen_subclass_wrapper_source,
+        )
+
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            out_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            num_fw_outs_saved_for_bw=None,
+            nested_act_input_paths=[(0, ("a", "_local_tensor"))],
+        )
+        self.assertIn(
+            "args[0].a._local_tensor = args[0].a._local_tensor.trigger_wait()",
+            source,
+        )
+
+    def test_nested_act_codegen_combined_with_top_level(self):
+        """Both top-level and nested ACT indices produce trigger_wait() calls."""
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+        from torch._functorch._aot_autograd.subclass_codegen import (
+            _codegen_subclass_wrapper_source,
+        )
+
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[
+                PlainTensorMeta(unwrapped_idx=0),
+                PlainTensorMeta(unwrapped_idx=1),
+            ],
+            out_metas=[
+                PlainTensorMeta(unwrapped_idx=0),
+                PlainTensorMeta(unwrapped_idx=1),
+            ],
+            num_fw_outs_saved_for_bw=None,
+            act_input_indices=[0],
+            nested_act_input_paths=[(1, ("_local_tensor",))],
+        )
+        self.assertIn("args[0] = args[0].trigger_wait()", source)
+        self.assertIn(
+            "args[1]._local_tensor = args[1]._local_tensor.trigger_wait()", source
+        )
+
+    def test_nested_act_codegen_empty_paths(self):
+        """Empty nested_act_input_paths produces no extra codegen."""
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+        from torch._functorch._aot_autograd.subclass_codegen import (
+            _codegen_subclass_wrapper_source,
+        )
+
+        source, _ = _codegen_subclass_wrapper_source(
+            inp_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            out_metas=[PlainTensorMeta(unwrapped_idx=0)],
+            num_fw_outs_saved_for_bw=None,
+            nested_act_input_paths=[],
+        )
+        self.assertNotIn("trigger_wait", source)
+
+
+@unittest.skipIf(
+    not torch.distributed.is_available(), "torch.distributed is required"
+)
+class TestResolveNestedActs(TestCase):
+    """Tests for the reconstruct contract of _resolve_nested_acts.
+
+    The helper must NOT mutate the input in place (Dynamo's
+    TENSOR_SUBCLASS_METADATA_MATCH guard still reads the original inner
+    tensors after this runs). Instead it returns a reconstructed wrapper
+    subclass with the nested ACTs resolved, leaving the original untouched,
+    and records the attribute paths for the runtime codegen.
+    """
+
+    def test_resolve_nested_act_in_wrapper_subclass(self):
+        """ACT nested in a TwoTensor is resolved on the returned object."""
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        from torch._functorch._aot_autograd.frontend_utils import _resolve_nested_acts
+
+        inner_a = torch.randn(4)
+        inner_b = torch.randn(4)
+        tt = TwoTensor(AsyncCollectiveTensor(inner_a), inner_b)
+
+        nested_paths: list[tuple[int, tuple[str, ...]]] = []
+        resolved = _resolve_nested_acts(tt, 0, nested_paths, AsyncCollectiveTensor)
+
+        # Path recorded for runtime codegen.
+        self.assertEqual(nested_paths, [(0, ("a",))])
+        # Returned object is a fresh subclass with the ACT resolved.
+        self.assertIsNot(resolved, tt)
+        self.assertNotIsInstance(resolved.a, AsyncCollectiveTensor)
+        self.assertEqual(resolved.a, inner_a)
+        # Original is left untouched (still holds the ACT).
+        self.assertIsInstance(tt.a, AsyncCollectiveTensor)
+
+    def test_resolve_multiple_nested_acts(self):
+        """Multiple ACTs in different attrs are all recorded and resolved."""
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        from torch._functorch._aot_autograd.frontend_utils import _resolve_nested_acts
+
+        inner_a = torch.randn(4)
+        inner_b = torch.randn(4)
+        tt = TwoTensor(AsyncCollectiveTensor(inner_a), AsyncCollectiveTensor(inner_b))
+
+        nested_paths: list[tuple[int, tuple[str, ...]]] = []
+        resolved = _resolve_nested_acts(tt, 0, nested_paths, AsyncCollectiveTensor)
+
+        self.assertEqual(nested_paths, [(0, ("a",)), (0, ("b",))])
+        self.assertNotIsInstance(resolved.a, AsyncCollectiveTensor)
+        self.assertNotIsInstance(resolved.b, AsyncCollectiveTensor)
+        self.assertIsInstance(tt.a, AsyncCollectiveTensor)
+        self.assertIsInstance(tt.b, AsyncCollectiveTensor)
+
+    def test_resolve_no_act_is_noop(self):
+        """No ACTs: nothing recorded and the same object is returned."""
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        from torch._functorch._aot_autograd.frontend_utils import _resolve_nested_acts
+
+        tt = TwoTensor(torch.randn(4), torch.randn(4))
+        nested_paths: list[tuple[int, tuple[str, ...]]] = []
+        resolved = _resolve_nested_acts(tt, 0, nested_paths, AsyncCollectiveTensor)
+
+        self.assertEqual(len(nested_paths), 0)
+        self.assertIs(resolved, tt)
+
+    def test_resolve_plain_tensor_is_noop(self):
+        """Non-wrapper-subclass tensors are returned unchanged."""
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        from torch._functorch._aot_autograd.frontend_utils import _resolve_nested_acts
+
+        t = torch.randn(4)
+        nested_paths: list[tuple[int, tuple[str, ...]]] = []
+        resolved = _resolve_nested_acts(t, 0, nested_paths, AsyncCollectiveTensor)
+
+        self.assertEqual(len(nested_paths), 0)
+        self.assertIs(resolved, t)
+
+    def test_resolve_deeply_nested_act(self):
+        """ACTs nested multiple levels deep are resolved without mutation."""
+        from torch.distributed._functional_collectives import AsyncCollectiveTensor
+
+        from torch._functorch._aot_autograd.frontend_utils import _resolve_nested_acts
+
+        inner_tensor = torch.randn(4)
+        inner_tt = TwoTensor(AsyncCollectiveTensor(inner_tensor), torch.randn(4))
+        outer_tt = TwoTensor(inner_tt, torch.randn(4))
+
+        nested_paths: list[tuple[int, tuple[str, ...]]] = []
+        resolved = _resolve_nested_acts(
+            outer_tt, 0, nested_paths, AsyncCollectiveTensor
+        )
+
+        self.assertEqual(nested_paths, [(0, ("a", "a"))])
+        self.assertIsNot(resolved, outer_tt)
+        self.assertNotIsInstance(resolved.a.a, AsyncCollectiveTensor)
+        # Original nested subclass is untouched.
+        self.assertIsInstance(outer_tt.a.a, AsyncCollectiveTensor)
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -28,13 +28,71 @@ static_inputs_log = torch._logging.getArtifactLogger(
 )
 
 
+def _resolve_nested_acts(
+    arg: Any,
+    arg_idx: int,
+    nested_paths: list[tuple[int, tuple[str, ...]]],
+    AsyncCollectiveTensor: type,
+    path: tuple[str, ...] = (),
+) -> Any:
+    """Resolve AsyncCollectiveTensors nested inside a wrapper subclass input.
+
+    When a DTensor (or other traceable wrapper subclass) carries an
+    AsyncCollectiveTensor in one of its inner tensor slots (e.g.
+    ``DTensor._local_tensor`` after ``redistribute(async_op=True)``), the
+    top-level ACT scan in ``process_inputs`` misses it.
+
+    This helper walks ``__tensor_flatten__`` attrs recursively and, for any
+    nested ACT, records the attribute path (so the runtime codegen can emit a
+    matching ``trigger_wait()``) and resolves it.
+
+    IMPORTANT: it does NOT mutate ``arg`` in place. The same input object is
+    still referenced by Dynamo's ``TENSOR_SUBCLASS_METADATA_MATCH`` guard,
+    which calls ``__tensor_flatten__()`` on the inner tensor while building
+    guards *after* this runs; mutating ``_local_tensor`` to a plain tensor
+    there raises ``AttributeError: 'Tensor' object has no attribute
+    '__tensor_flatten__'``. Instead we reconstruct a fresh wrapper subclass
+    (via ``__tensor_unflatten__``) with the resolved inner tensors and return
+    it for the caller to swap into ``flat_args``; the original guarded object
+    is left untouched.
+
+    Returns the resolved object (a new wrapper subclass when an ACT was found
+    somewhere inside it, otherwise ``arg`` unchanged).
+    """
+    if not is_traceable_wrapper_subclass(arg):
+        return arg
+    attrs, ctx = arg.__tensor_flatten__()
+    new_inner: dict[str, Any] = {}
+    changed = False
+    for attr in attrs:
+        inner = getattr(arg, attr)
+        current_path = path + (attr,)
+        if isinstance(inner, AsyncCollectiveTensor):
+            nested_paths.append((arg_idx, current_path))
+            new_inner[attr] = inner.trigger_wait()
+            changed = True
+        elif is_traceable_wrapper_subclass(inner):
+            resolved = _resolve_nested_acts(
+                inner, arg_idx, nested_paths, AsyncCollectiveTensor, current_path
+            )
+            new_inner[attr] = resolved
+            changed = changed or (resolved is not inner)
+        else:
+            new_inner[attr] = inner
+    if not changed:
+        return arg
+    return type(arg).__tensor_unflatten__(
+        new_inner, ctx, arg.size(), arg.stride()
+    )
+
+
 def process_inputs(
     flat_args: list[Any],
     aot_config: AOTConfig,
     fake_mode: FakeTensorMode,
     shape_env: ShapeEnv | None,
     ignore_shape_env: bool = False,
-) -> tuple[FakifiedFlatArgs, list[int]]:
+) -> tuple[FakifiedFlatArgs, list[int], list[tuple[int, tuple[str, ...]]]]:
     """Convert real tensor inputs into fake tensors for AOT autograd tracing.
 
     Called at compile time (not runtime) to produce the fake inputs that AOT
@@ -53,10 +111,13 @@ def process_inputs(
     graph capture.
 
     Returns:
-        A tuple of (fakified_args, act_input_indices) where act_input_indices
-        records which positions held AsyncCollectiveTensors. These indices are
-        stored on ViewAndMutationMeta so that the runtime wrapper can emit
-        direct trigger_wait() calls on those positions.
+        A tuple of (fakified_args, act_input_indices, nested_act_input_paths)
+        where act_input_indices records which positions held top-level
+        AsyncCollectiveTensors, and nested_act_input_paths records
+        (arg_index, attr_path) tuples for ACTs found nested inside wrapper
+        subclass inputs (e.g. DTensor._local_tensor). These are stored on
+        ViewAndMutationMeta so that the runtime wrapper can emit direct
+        trigger_wait() calls.
     """
     # Resolve AsyncCollectiveTensors before tracing. ACTs are transient
     # eager-mode wrappers for async collective overlap; if they leak into the
@@ -70,11 +131,21 @@ def process_inputs(
         AsyncCollectiveTensor = None
 
     act_input_indices: list[int] = []
+    nested_act_input_paths: list[tuple[int, tuple[str, ...]]] = []
     if AsyncCollectiveTensor is not None:
         for i, a in enumerate(flat_args):
             if isinstance(a, AsyncCollectiveTensor):
                 act_input_indices.append(i)
                 flat_args[i] = a.trigger_wait()
+            else:
+                # Resolve ACTs nested inside wrapper subclass inputs without
+                # mutating the original (Dynamo still guards on it); swap the
+                # reconstructed, resolved object into flat_args for tracing.
+                resolved = _resolve_nested_acts(
+                    a, i, nested_act_input_paths, AsyncCollectiveTensor
+                )
+                if resolved is not a:
+                    flat_args[i] = resolved
 
     with fake_mode:
 
@@ -161,9 +232,13 @@ def process_inputs(
             )
             return result
 
-        return FakifiedFlatArgs(
-            [convert(idx, x) for idx, x in enumerate(flat_args)]
-        ), act_input_indices
+        return (
+            FakifiedFlatArgs(
+                [convert(idx, x) for idx, x in enumerate(flat_args)]
+            ),
+            act_input_indices,
+            nested_act_input_paths,
+        )
 
 
 def construct_fake_mode(

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1403,7 +1403,11 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
         *,
         runtime_metadata: ViewAndMutationMeta,
     ) -> Callable[..., Any]:
-        if self.maybe_subclass_meta is None and not runtime_metadata.act_input_indices:
+        if (
+            self.maybe_subclass_meta is None
+            and not runtime_metadata.act_input_indices
+            and not runtime_metadata.nested_act_input_paths
+        ):
             return compiled_fn
 
         from .subclass_codegen import codegen_subclass_wrapper
@@ -1415,6 +1419,7 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
             num_fw_outs_saved_for_bw=self.num_fw_outs_saved_for_bw,
             frozen_inp_indices=self._get_frozen_inp_indices(),
             act_input_indices=runtime_metadata.act_input_indices,
+            nested_act_input_paths=runtime_metadata.nested_act_input_paths,
         )
         inner_fn._boxed_call = True  # type: ignore[attr-defined]
         return inner_fn

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -508,6 +508,15 @@ class ViewAndMutationMeta:
     # scanning every arg on every graph invocation.
     act_input_indices: list[int] = field(default_factory=list)
 
+    # Nested ACT paths: list of (arg_index, (attr1, attr2, ...)) for ACTs
+    # found inside wrapper subclass inputs (e.g., DTensor._local_tensor).
+    # At runtime, the codegen emits trigger_wait() calls that walk the
+    # attribute path to resolve the nested ACT before the compiled graph
+    # uses the data.
+    nested_act_input_paths: list[tuple[int, tuple[str, ...]]] = field(
+        default_factory=list
+    )
+
     # Map of effect type (ex. _EffectType.ORDERED) to token.  If there are
     # side-effectful operators, FunctionalTensorMode will populate this
     # dictionary telling us how many tokens we will need during tracing.

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -252,6 +252,7 @@ def _codegen_subclass_wrapper_source(
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
     act_input_indices: list[int] | None = None,
+    nested_act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
 ) -> tuple[str, dict[str, object]]:
     """Generate source and globals for a subclass wrapper.
 
@@ -269,6 +270,16 @@ def _codegen_subclass_wrapper_source(
     if act_input_indices:
         for i in act_input_indices:
             state.emit(f"args[{i}] = args[{i}].trigger_wait()")
+
+    # --- Resolve nested AsyncCollectiveTensors ---
+    # ACTs can also be nested inside wrapper subclass inputs (e.g.
+    # DTensor._local_tensor after redistribute(async_op=True)).
+    if nested_act_input_paths:
+        for idx, path in nested_act_input_paths:
+            accessor = f"args[{idx}]"
+            for attr in path:
+                accessor = _safe_attr_access(accessor, attr)
+            state.emit(f"{accessor} = {accessor}.trigger_wait()")
 
     # --- Input unwrapping ---
     state.emit("unwrapped_args = []")
@@ -387,6 +398,7 @@ def codegen_subclass_wrapper(
     num_fw_outs_saved_for_bw: int | None,
     frozen_inp_indices: frozenset[int] = frozenset(),
     act_input_indices: list[int] | None = None,
+    nested_act_input_paths: list[tuple[int, tuple[str, ...]]] | None = None,
 ) -> Callable[..., object]:
     """Generate a specialized wrapper function for subclass unwrap/wrap."""
     source, globals_dict = _codegen_subclass_wrapper_source(
@@ -395,6 +407,7 @@ def codegen_subclass_wrapper(
         num_fw_outs_saved_for_bw,
         frozen_inp_indices,
         act_input_indices=act_input_indices,
+        nested_act_input_paths=nested_act_input_paths,
     )
     globals_dict["compiled_fn"] = compiled_fn
     return _compile_and_exec_source(

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -797,8 +797,8 @@ def aot_function(
             flat_fn, out_spec = create_tree_flattened_fn(fn, args, kwargs)
             (fake_mode, shape_env) = construct_fake_mode(flat_args, aot_config)
             fake_flat_args: FakifiedFlatArgs
-            fake_flat_args, act_input_indices = process_inputs(
-                flat_args, aot_config, fake_mode, shape_env
+            fake_flat_args, act_input_indices, nested_act_input_paths = (
+                process_inputs(flat_args, aot_config, fake_mode, shape_env)
             )
             # TODO: We actually could use the pytree path to make better descs.
             # Also, the descs here are bad if you do aot_module.
@@ -816,6 +816,9 @@ def aot_function(
                     shape_env,
                 )
                 aot_state.fw_metadata.act_input_indices = act_input_indices
+                aot_state.fw_metadata.nested_act_input_paths = (
+                    nested_act_input_paths
+                )
                 aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
                 compiled_fn, _ = aot_stage2_compile(
                     aot_state,
@@ -922,7 +925,7 @@ def autograd_cache_key(
     )
 
     fake_mode, shape_env = construct_fake_mode(full_args, aot_config)
-    fake_flat_args, _act_input_indices = process_inputs(
+    fake_flat_args, _act_input_indices, _nested_act_input_paths = process_inputs(
         full_args, aot_config, fake_mode, shape_env, ignore_shape_env
     )
 
@@ -1055,6 +1058,7 @@ def prepare_aot_module_simplified(
     pytree.TreeSpec | None,
     PytreeThunk | None,
     list[int],
+    list[tuple[int, tuple[str, ...]]],
 ]:
     if not flatten:
         if kwargs is not None:
@@ -1108,7 +1112,7 @@ def prepare_aot_module_simplified(
 
     fake_mode, shape_env = construct_fake_mode(full_args, aot_config)
     # NB: full_args_descs not needed here, fake_flat_args is 1:1 with full_args
-    fake_flat_args, act_input_indices = process_inputs(
+    fake_flat_args, act_input_indices, nested_act_input_paths = process_inputs(
         full_args, aot_config, fake_mode, shape_env, ignore_shape_env
     )
 
@@ -1125,6 +1129,7 @@ def prepare_aot_module_simplified(
         in_spec,
         out_spec,
         act_input_indices,
+        nested_act_input_paths,
     )
 
 
@@ -1183,6 +1188,7 @@ def aot_module_simplified(
             _in_spec,
             _out_spec,
             act_input_indices,
+            nested_act_input_paths,
         ) = prepare_aot_module_simplified(
             mod,
             args,
@@ -1234,6 +1240,9 @@ def aot_module_simplified(
                 shape_env,
             )
             aot_state.fw_metadata.act_input_indices = act_input_indices
+            aot_state.fw_metadata.nested_act_input_paths = (
+                nested_act_input_paths
+            )
             aot_graph_capture = aot_stage1_graph_capture(aot_state, functional_call)
             compiled_fn, _ = aot_stage2_compile(
                 aot_state,
@@ -1391,6 +1400,7 @@ def aot_export_joint_with_descriptors(
         in_spec,
         out_spec,
         act_input_indices,
+        nested_act_input_paths,
     ) = prepare_aot_module_simplified(
         mod,
         args,
@@ -1425,6 +1435,7 @@ def aot_export_joint_with_descriptors(
         shape_env,
     )
     aot_state.fw_metadata.act_input_indices = act_input_indices
+    aot_state.fw_metadata.nested_act_input_paths = nested_act_input_paths
 
     # NB: no cache lookup!
     aot_graph_capture = aot_stage1_graph_capture(aot_state, functional_call)
@@ -1930,7 +1941,7 @@ def _aot_export_function(
         fake_mode, shape_env = construct_fake_mode(flat_args, aot_config)
     else:
         shape_env = fake_mode.shape_env
-    fake_flat_args, act_input_indices = process_inputs(
+    fake_flat_args, act_input_indices, nested_act_input_paths = process_inputs(
         flat_args, aot_config, fake_mode, shape_env
     )
     # TODO: Improve the descs here with pytree information
@@ -1949,6 +1960,7 @@ def _aot_export_function(
             shape_env,
         )
         aot_state.fw_metadata.act_input_indices = act_input_indices
+        aot_state.fw_metadata.nested_act_input_paths = nested_act_input_paths
         aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
         fx_g, meta = aot_stage2_export(aot_state, aot_graph_capture)
 


### PR DESCRIPTION
Summary:
AOT autograd's `process_inputs` scans `flat_args` for top-level `AsyncCollectiveTensor` (ACT) and records `act_input_indices` so the compiled graph's `inner_fn` can emit `args[i].trigger_wait()` before the kernel runs (introduced for the top-level case in #179849). That scan is non-recursive. When a DTensor carries an ACT in its `_local_tensor` slot — e.g. after `DTensor.redistribute(async_op=True)` or from FSDP2's async all-gather — the ACT is invisible to `process_inputs`, no `trigger_wait()` is emitted, and the Inductor kernel executes on memory whose underlying collective may not have completed. With `backend="eager"` the bug is masked because ACT's `__torch_dispatch__` waits inline on every op; Inductor triton kernels bypass dispatch, so the race is silent data corruption.

This diff resolves ACTs nested inside wrapper-subclass inputs, at both compile time and runtime.

- Adds `_resolve_nested_acts()` in `frontend_utils.py`. It recursively walks a wrapper subclass's `__tensor_flatten__` attrs, records each nested ACT's attribute path (e.g. `(arg_idx, ("_local_tensor",))`), and resolves it via `trigger_wait()`. Crucially it does NOT mutate the input in place: the same input object is still read by Dynamo's `TENSOR_SUBCLASS_METADATA_MATCH` guard, which calls `__tensor_flatten__()` on the inner tensor while building guards after `process_inputs` runs; setting `_local_tensor` to a plain tensor there raises `AttributeError: 'Tensor' object has no attribute '__tensor_flatten__'` and crashes compilation. Instead the helper reconstructs a fresh wrapper subclass via `__tensor_unflatten__` with the resolved inner tensors and returns it; `process_inputs` swaps the reconstructed object into `flat_args` for tracing and leaves the guarded original untouched.
- Extends `process_inputs` to return `nested_act_input_paths` alongside `act_input_indices`, and threads it through every `process_inputs` call site in `aot_autograd.py` onto `ViewAndMutationMeta`.
- Adds the `nested_act_input_paths` field to `ViewAndMutationMeta` (`schemas.py`).
- `subclass_codegen.py` emits a `trigger_wait()` for each recorded path before subclass unwrapping (e.g. `args[0]._local_tensor = args[0]._local_tensor.trigger_wait()`).
- `runtime_wrappers.py` includes `nested_act_input_paths` in the guard that decides whether to generate the subclass wrapper, and passes it through.
- Tests: codegen-string tests for the emitted waits; `TestResolveNestedActs` unit tests asserting the reconstruct contract (returned object resolved, original left untouched, paths recorded); and `repro_nested_act.py`, an end-to-end test that compiles with `backend="inductor"` over a DTensor whose `_local_tensor` is an ACT and asserts `wait_tensor` is called at runtime without crashing Dynamo guard construction.

Fixes https://github.com/pytorch/pytorch/issues/180614

Test Plan:
buck2 test fbcode//caffe2/test/functorch:test_subclass_codegen fbcode//caffe2/test/functorch:repro_nested_act

```
Tests finished: Pass 13. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

End-to-end repro (the #180614 scenario), runtime-only counters after warmup:

```
runtime wait_tensor calls: 1
nested ACT resolved to plain tensor: True
Ran 1 test in 52.585s
OK
```

Behavior matrix on the same repro (single process, gloo CPU):

| Variant | Result |
| Baseline (no fix) | 0 runtime wait_tensor calls — kernel runs on un-waited data (bug) |
| In-place mutate (rejected approach) | InternalTorchDynamoError: 'Tensor' object has no attribute '__tensor_flatten__' |
| This diff (reconstruct) | 1 wait_tensor call, ACT resolved, no crash |

arc lint: ok No lint issues.

Differential Revision: D106243899


