### PR TITLE
Repro for Inductor tl.broadcast_to(False) Triton compile crash (#186621)

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4288,7 +4288,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         result_var.mask_vars = indexing.mask_vars  # type: ignore[assignment]
 
         if append_broadcast:
-            line = f"tl.broadcast_to({result_var}, {append_broadcast})"
+            bcast_operand = result_var
+            if dtype == torch.bool and str(result_var) in ("True", "False"):
+                bcast_operand = (
+                    f"tl.full([1], {1 if str(result_var) == 'True' else 0}, tl.int1)"
+                )
+            line = f"tl.broadcast_to({bcast_operand}, {append_broadcast})"
             result_var = self.cse.generate(
                 load_buffer, line, dtype=dtype, shape=indexing.expand_shape
             )


### PR DESCRIPTION
Summary:

We have quite a bit of runtime crashes coming from triton , with biggest coming from  from broadcast issue. 

for broadcast_to in the crash, inductor codegens like this 
```
tl.broadcast_to(False, [XBLOCK])
```
But then first param False doesn't have to_block(). Replace that with tl.full([1] to fix it.

Test Plan:
https://fburl.com/scuba/dynamo_compile/cy8f0txk

Some toy programs to verify crash and fix. 


```
buck2 run fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 fbsource//users/sa/sashko/triton_misc:repro_broadcast_false
buck2 run fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 fbsource//users/sa/sashko/triton_misc:repro_torch_compile
```

Reviewed By: jananisriram

Differential Revision: D107897378




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo