### PR TITLE
[benchmarks/dynamo] Disable fallback_random for DistillGPT2 accuracy/training

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4335,12 +4335,16 @@ def run(runner, args, original_dir=None):
                 "DistillGPT2",
             }
         ):
-            # aten.native_dropout is decomposed in AOT-autograd (see
-            # torch/_decomp/decompositions.py) before inductor's fallback_random
-            # gate fires, so the post-decomposition rand is lowered with a Philox
-            # layout that disagrees with eager. align_random_eager re-aligns it
-            # at codegen time (torch/_inductor/fx_passes/replace_random.py).
-            inductor_config.align_random_eager = True
+            # With the harness-wide fallback_random=True, inductor falls back
+            # to ATen rng for the dropout decomposition. That fallback Philox
+            # path indexes randoms by flat element offset, whereas eager CUDA
+            # rng indexes by (thread_id, intra_thread_iter), so the two produce
+            # different dropout masks for the same seed and trip DistillGPT2's
+            # tight accuracy tolerance (observed on gfx942). Setting
+            # fallback_random=False re-enables inductor's replace_random passes,
+            # which align the masks with eager. This is correct/harmless on
+            # other backends since it only changes how inductor lowers rng.
+            inductor_config.fallback_random = False
 
         # Some models e.g. yolov3 assert batch size on n_gpus
         if "CUDA_VISIBLE_DEVICES" not in os.environ and not args.multiprocess:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4327,6 +4327,21 @@ def run(runner, args, original_dir=None):
             torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
             torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
 
+        if (
+            args.training
+            and args.only is not None
+            and args.only
+            in {
+                "DistillGPT2",
+            }
+        ):
+            # aten.native_dropout is decomposed in AOT-autograd (see
+            # torch/_decomp/decompositions.py) before inductor's fallback_random
+            # gate fires, so the post-decomposition rand is lowered with a Philox
+            # layout that disagrees with eager. align_random_eager re-aligns it
+            # at codegen time (torch/_inductor/fx_passes/replace_random.py).
+            inductor_config.align_random_eager = True
+
         # Some models e.g. yolov3 assert batch size on n_gpus
         if "CUDA_VISIBLE_DEVICES" not in os.environ and not args.multiprocess:
             args.device_index = "0"


### PR DESCRIPTION
 Why:
  The accuracy harness already sets inductor_config.fallback_random = True for every --accuracy run (benchmarks/dynamo/common.py:4317), but that flag does not save DistillGPT2 in --training mode: aten.native_dropout is decomposed in AOT-autograd into rand + compare before inductor lowers the graph. With fallback_random = True, inductor falls back to ATen rng for that decomposed rand, and the fallback Philox path indexes randoms by flat element offset, whereas eager CUDA rng indexes by (thread_id, intra_thread_iter).
  The two layouts produce different dropout masks for the same seed, and DistillGPT2's tight accuracy tolerance catches the mismatch → fail_accuracy.
  
  Fix:
  Set inductor_config.fallback_random = False only when args.training and args.only == "DistillGPT2". This re-enables inductor's replace_random passes (gated behind not fallback_random at torch/_inductor/fx_passes/joint_graph.py:697, early-return at replace_random.py:61), which lower the rng so the masks align with eager. Surgical — does not touch other models or non-training runs, and is harmless on non-GPU backends since it only changes how inductor lowers rng.

  Verified (MI300 / gfx942 — the perf-nightly CI hardware; bug does not repro on MI350X/gfx950):
  DistillGPT2, training + AMP, inductor. Stock harness = fail_accuracy; fix = pass, across all four failing configs (default, cudagraphs, cudagraphs_dynamic, cpp_wrapper), confirmed over two repeated runs each.

  ▎ Note: the earlier align_random_eager = True approach was empirically confirmed to be a no-op — with fallback_random = True still set, its pass never runs, and DistillGPT2 still failed. An A/B test showed fallback_random = False alone fixes all four configs; adding align_random_eager = True on top changed nothing.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98