### PR TITLE
[CUDA graphs] Annotate kernels across graphs captured in sequence

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -16,7 +16,13 @@ from torch.cuda._graph_annotations import (
     remap_to_exec_graph,
     resolve_pending_annotations,
 )
-from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    skipIfRocm,
+    TestCase,
+)
 
 
 TEST_CUDA = torch.cuda.is_available()
@@ -30,6 +36,7 @@ except ImportError:
 
 
 # cuda.bindings is NVIDIA-only; graph annotation APIs have no ROCm equivalent.
+@instantiate_parametrized_tests
 @skipIfRocm
 @unittest.skipUnless(TEST_CUDA, "CUDA not available")
 @unittest.skipUnless(TEST_CUDA_BINDINGS, "cuda.bindings not available")
@@ -463,6 +470,61 @@ class TestMarkKernels(TestCase):
             ann = anns[0]
             self.assertEqual(ann["name"], "aux_branch")
             self.assertEqual(ann["stream"], expected_stream_id)
+
+    def _exec_graph_id(self, graph):
+        from cuda.bindings import runtime as cuda_runtime
+
+        handle = cuda_runtime.cudaGraphExec_t(init_value=graph.raw_cuda_graph_exec())
+        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(handle)
+        return exec_graph_id
+
+    @parametrize("keep_graph", [True, False])
+    def test_multiple_graphs_in_sequence_each_remapped(self, keep_graph):
+        """Several graphs captured in sequence, then resolved once and
+        remapped each, must all be annotated -- not just the last one.
+
+        Covers both keep_graph modes: with keep_graph=True the template
+        survives capture, with keep_graph=False it is destroyed -- the capture
+        id is recovered from the graph object either way.
+        """
+        graph_a = torch.cuda.CUDAGraph(keep_graph=keep_graph)
+        graph_b = torch.cuda.CUDAGraph(keep_graph=keep_graph)
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph_a):
+            with mark_kernels("graph_a"):
+                _ = x + 1
+
+        # Break in between, then capture a second graph with its own marks.
+        with torch.cuda.graph(graph_b):
+            with mark_kernels("graph_b"):
+                _ = x * 2
+
+        if keep_graph:
+            # keep_graph=False auto-instantiates at capture_end.
+            graph_a.instantiate()
+            graph_b.instantiate()
+
+        # Resolve the whole sequence once, then remap each graph.
+        resolve_pending_annotations()
+        remap_to_exec_graph(graph_a)
+        remap_to_exec_graph(graph_b)
+
+        exec_a = self._exec_graph_id(graph_a)
+        exec_b = self._exec_graph_id(graph_b)
+        self.assertNotEqual(exec_a, exec_b)
+
+        graph_ids_by_name: dict[str, set] = {}
+        for tools_id, anns in get_kernel_annotations().items():
+            self.assertEqual(len(anns), 1)
+            graph_ids_by_name.setdefault(anns[0]["str"], set()).add(tools_id >> 32)
+
+        self.assertIn("graph_a", graph_ids_by_name)
+        self.assertIn("graph_b", graph_ids_by_name)
+        # Each graph's annotations land under that graph's exec id, proving
+        # both -- not just the last -- were remapped correctly.
+        self.assertEqual(graph_ids_by_name["graph_a"], {exec_a})
+        self.assertEqual(graph_ids_by_name["graph_b"], {exec_b})
 
     def test_mark_kernels_skips_preexisting_dependents_on_entry_frontier(self):
         graph = torch.cuda.CUDAGraph()

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -44,7 +44,7 @@ import importlib.metadata
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import getLogger
-from typing import Any, TypeAlias
+from typing import Any, cast, TypeAlias
 
 import torch
 from torch.cuda._utils import _check_cuda_bindings, _HAS_CUDA_BINDINGS
@@ -238,9 +238,6 @@ def _get_annotatable_types() -> set[Any]:
 # Pending scopes: (annotation, toolsIds discovered for the scope).
 _pending_scopes: list[tuple[Any, list[int]]] = []
 
-# Capture graph ID saved by resolve_pending_annotations for remap_to_exec_graph.
-_last_capture_graph_id: int | None = None
-
 
 @contextmanager  # type: ignore[arg-type]
 def mark_kernels(annotation: str | dict[str, Any]):
@@ -325,6 +322,14 @@ def mark_kernels(annotation: str | dict[str, Any]):
         )
 
     if tools_ids:
+        # Stamp the capturing graph with its capture id (toolsId high bits) so
+        # remap can later match these annotations to this graph's exec id
+        # without relying on keep_graph or call ordering.
+        capturing = cast(
+            torch.cuda.CUDAGraph,
+            torch.cuda.CUDAGraph.get_currently_capturing_graph(),
+        )
+        capturing._capture_graph_id = tools_ids[0] >> 32
         _pending_scopes.append((annotation, tools_ids))
 
 
@@ -338,10 +343,6 @@ def resolve_pending_annotations() -> None:
         for annotation, tools_ids in _pending_scopes:
             for tools_id in tools_ids:
                 per_tools_id[tools_id].append(annotation)
-
-        global _last_capture_graph_id
-        if per_tools_id:
-            _last_capture_graph_id = next(iter(per_tools_id)) >> 32
 
         for tools_id, annotations in per_tools_id.items():
             if len(annotations) == 1:
@@ -369,9 +370,16 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     32 bits. After instantiation, the profiler uses the exec graph's ID.
     This function rewrites the keys so annotations match the trace.
 
+    The graph's capture id is read from the ``_capture_graph_id`` stamped on it
+    by ``mark_kernels`` during capture, so only the annotations belonging to
+    this graph are rekeyed. This is order-independent and correct when several
+    graphs are captured in sequence: call once per graph. Graphs that recorded
+    no annotations have no capture id and are skipped.
+
     Must be called after the ``torch.cuda.graph()`` context exits.
     """
-    if not _kernel_annotations:
+    capture_graph_id = torch_cuda_graph._capture_graph_id
+    if not _kernel_annotations or capture_graph_id is None:
         return
 
     exec_handle = _cuda_runtime.cudaGraphExec_t(  # pyrefly: ignore[missing-attribute]
@@ -383,15 +391,11 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
         )
     )
 
-    # Only remap annotations from the most recent capture graph.
-    # Previously remapped annotations (from earlier captures) keep their
-    # correct exec graph IDs.
-    capture_graph_id = _last_capture_graph_id
+    # Rekey only this graph's annotations. Entries from other graphs (already
+    # remapped to their own exec ids, or pending their own remap) are kept.
     remapped: dict[int, list[Any]] = {}
     for tools_id, ann_list in _kernel_annotations.items():
-        graph_id = tools_id >> 32
-        if capture_graph_id is not None and graph_id != capture_graph_id:
-            # Belongs to a different graph — keep as-is.
+        if tools_id >> 32 != capture_graph_id:
             remapped[tools_id] = ann_list
             continue
         node_id = tools_id & 0xFFFFFFFF

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -103,10 +103,14 @@ class CUDAGraph(_CUDAGraph):
     """
 
     _tracker: _CUDAGraphInputLivenessTracker | None
+    # Stays None unless mark_kernels stamps it during capture (requires
+    # annotations enabled and cudaGraphNodeGetToolsId available).
+    _capture_graph_id: int | None
 
     def __new__(cls, keep_graph: bool = False) -> Self:
         instance = super().__new__(cls, keep_graph)
         instance._tracker = None
+        instance._capture_graph_id = None
         return instance
 
     def __del__(self) -> None:
@@ -190,6 +194,7 @@ class CUDAGraph(_CUDAGraph):
         if self._tracker is not None:
             self._tracker.stop()
             self._tracker = None
+        self._capture_graph_id = None
         super().reset()
 
     def pool(self) -> _POOL_HANDLE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186627
* __->__ #186626

mark_kernels records kernel annotations during CUDA graph capture, keyed by the
capture graph's id (the high 32 bits of each node's toolsId). remap_to_exec_graph
later rewrites those keys to the instantiated exec graph's id so they match
profiler traces.

Previously the capture graph id lived in a single module global,
_last_capture_graph_id, which resolve_pending_annotations overwrote with the most
recently resolved capture. When several graphs were captured in sequence, only the
last graph's annotations were remapped; the rest kept their capture-time ids and
never matched the trace.

Store the capture id on the CUDAGraph object instead. mark_kernels stamps
_capture_graph_id during capture (reading it off the live capture, so it does not
depend on keep_graph), and remap_to_exec_graph reads it back to rekey exactly that
graph's annotations. Remap becomes order-independent and correct for any number of
graphs, and graphs that never annotate keep _capture_graph_id == None and skip
remap entirely.

Test Plan:
The tests exercise cudaGraphNodeGetToolsId, which requires cuda-bindings >= 13.1
and a CUDA driver >= 13.1 (or a matching cuda-compat userspace driver); they skip
when it is unavailable.

```
python -m pytest test/test_cuda_graph_utils.py -v
```

Authored-with: Claude (Claude Code)