### PR TITLE
[CUDA graphs] Add resolve_and_remap convenience for kernel annotations

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -14,6 +14,7 @@ from torch.cuda._graph_annotations import (
     mark_kernels,
     mark_stream,
     remap_to_exec_graph,
+    resolve_and_remap,
     resolve_pending_annotations,
 )
 from torch.testing._internal.common_utils import (
@@ -525,6 +526,33 @@ class TestMarkKernels(TestCase):
         # both -- not just the last -- were remapped correctly.
         self.assertEqual(graph_ids_by_name["graph_a"], {exec_a})
         self.assertEqual(graph_ids_by_name["graph_b"], {exec_b})
+
+    def test_resolve_and_remap_sequence(self):
+        """resolve_and_remap called once per graph handles a whole sequence.
+
+        Uses default (keep_graph=False) graphs to show the capture id is
+        recovered from the graph itself, not the (destroyed) graph template.
+        """
+        graphs = [torch.cuda.CUDAGraph() for _ in range(3)]
+        x = torch.randn(8, device="cuda")
+
+        for i, graph in enumerate(graphs):
+            with torch.cuda.graph(graph):
+                with mark_kernels(f"graph_{i}"):
+                    _ = x + i
+
+        # First call resolves all pending scopes; every call remaps its graph.
+        for graph in graphs:
+            resolve_and_remap(graph)
+
+        graph_ids_by_name: dict[str, set] = {}
+        for tools_id, anns in get_kernel_annotations().items():
+            self.assertEqual(len(anns), 1)
+            graph_ids_by_name.setdefault(anns[0]["str"], set()).add(tools_id >> 32)
+
+        for i, graph in enumerate(graphs):
+            exec_id = self._exec_graph_id(graph)
+            self.assertEqual(graph_ids_by_name[f"graph_{i}"], {exec_id})
 
     def test_mark_kernels_skips_preexisting_dependents_on_entry_frontier(self):
         graph = torch.cuda.CUDAGraph()

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -409,6 +409,16 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     _kernel_annotations.update(remapped)
 
 
+def resolve_and_remap(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
+    """Resolve any pending scopes and remap one graph in a single call.
+
+    Shorthand for ``resolve_pending_annotations()`` followed by
+    ``remap_to_exec_graph(graph)``, the pair normally run after a capture.
+    """
+    resolve_pending_annotations()
+    remap_to_exec_graph(torch_cuda_graph)
+
+
 def get_kernel_annotations() -> dict[int, list[Any]]:
     """Return the current kernel annotation map (toolsId -> annotations)."""
     return _kernel_annotations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186627
* #186626

Wrap the common end-of-capture sequence -- resolve_pending_annotations() followed
by remap_to_exec_graph(graph) -- into a single resolve_and_remap(graph) call. When
several graphs are captured in sequence, calling it once per graph after all
captures is enough: the first call drains every pending scope, and each call remaps
the annotations of the graph it is handed. Order-independent, since each graph
carries its own capture id.

Test Plan:
The tests exercise cudaGraphNodeGetToolsId, which requires cuda-bindings >= 13.1
and a CUDA driver >= 13.1 (or a matching cuda-compat userspace driver); they skip
when it is unavailable.

```
python -m pytest test/test_cuda_graph_utils.py -v
```

Authored-with: Claude (Claude Code)