### PR TITLE
Defer associative_scan pointwise device check to Inductor lowering (#186594)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -4047,6 +4047,42 @@ class AssociativeScanTests(TestCase):
                 inputs=x,
             )
 
+    def test_associative_scan_pointwise_export_cpu(self):
+        # combine_mode='pointwise' only has Inductor codegen on CUDA/XPU, but the
+        # device check must not block tracing/export of the HOP on other devices.
+        # See https://github.com/pytorch/pytorch/issues/186594.
+        def combine_fn(x_ab, y_ab):
+            x, a, b = x_ab
+            y, _, _ = y_ab
+            return x * a + y * b, a.clone(), b.clone()
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.nn.Parameter(torch.rand(6))
+                self.b = torch.nn.Parameter(torch.rand(6))
+
+            def forward(self, xs):
+                a_tiled = self.a.unsqueeze(0).expand(xs.shape[0], -1)
+                b_tiled = self.b.unsqueeze(0).expand(xs.shape[0], -1)
+                out, _, _ = associative_scan(
+                    combine_fn,
+                    (xs, a_tiled, b_tiled),
+                    dim=0,
+                    combine_mode="pointwise",
+                )
+                return out
+
+        ep = torch.export.export(M(), (torch.randn(16, 6),))
+        self.assertTrue(
+            any(
+                node.op == "call_function"
+                and node.target is torch.ops.higher_order.associative_scan
+                for node in ep.graph_module.graph.nodes
+            ),
+            "exported graph should retain the associative_scan HOP",
+        )
+
     @unittest.skipIf(not SM70OrLater, "triton")
     @requires_cuda
     @parametrize("compile_mode", ["none", "eager", "compile", "compile_dynamic_shape"])

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -212,10 +212,12 @@ def associative_scan(
             raise ValueError(
                 f"Combine_mode must either 'pointwise' or 'generic', but got {cm}"
             )
-        if cm == "pointwise" and not all(l.device.type in ("cuda", "xpu") for l in lxs):
-            raise ValueError(
-                "For combine_mode='pointwise', all input tensors need to be on CUDA or XPU"
-            )
+        # NOTE: The CUDA/XPU device requirement for combine_mode='pointwise' is
+        # enforced in the Inductor lowering (torch/_inductor/lowering.py), not
+        # here. pointwise codegen only happens through Inductor, so validating
+        # the device this early would block tracing/export of the
+        # associative_scan HOP on other devices (e.g. CPU). See
+        # https://github.com/pytorch/pytorch/issues/186594.
 
         # Checks for xs
         if len(lxs) == 0:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8775,6 +8775,19 @@ def invoke_quant_tracer(subgraph_fn: ir.Subgraph, *operands, scheme=None):
 def associative_scan(combine_fn: ir.Subgraph, xs, additional_inputs: tuple[Any, ...]):
     from .subgraph_lowering import InputDescriptor, lower_pointwise_subgraph
 
+    # pointwise associative_scan codegen is only supported on CUDA/XPU. This is
+    # enforced here (rather than in the eager wrapper) so that the HOP can still
+    # be traced/exported on other devices. See
+    # https://github.com/pytorch/pytorch/issues/186594.
+    for x in xs:
+        device = x.get_device()
+        if device is not None and device.type not in ("cuda", "xpu"):
+            raise RuntimeError(
+                "associative_scan with combine_mode='pointwise' only supports CUDA "
+                f"or XPU tensors, but got an input on device '{device.type}'. Use "
+                "combine_mode='generic' for other devices."
+            )
+
     num_scan_inputs = 2 * len(xs)
     placeholders = [
         node for node in combine_fn.graph_module.graph.nodes if node.op == "placeholder"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186629

Fixes https://github.com/pytorch/pytorch/issues/186594

The combine_mode="pointwise" CUDA/XPU device check lived in the eager
associative_scan wrapper (_validate_input). That validation runs during
torch.export / Dynamo tracing, so exporting an associative_scan with
combine_mode="pointwise" on CPU raised

    ValueError: For combine_mode='pointwise', all input tensors need to be
    on CUDA or XPU

before any Inductor lowering happened, making it impossible to capture the
torch.ops.higher_order.associative_scan HOP for downstream/third-party
compilers.

pointwise codegen for associative_scan only ever happens through Inductor, so
the device requirement is fundamentally a codegen constraint. The fix moves the
check out of the eager wrapper and into the registered Inductor lowering for
associative_scan_op, where the pointwise kernel is actually generated. Tracing
and export now capture the HOP on any device; torch.compile + Inductor (and
pure-eager execution, which routes through _hop_compile_and_call -> Inductor)
still fail on unsupported devices, now with a clearer message that points at
combine_mode="generic".

An alternative was to keep the eager check but skip it while tracing. That was
rejected: detecting "are we tracing" reliably across Dynamo and make_fx is
brittle, and the codegen boundary is the natural single place to enforce a
codegen-only constraint. The one behavioral trade-off is that a pure-eager CPU
pointwise call now surfaces the error at lowering time rather than at the
wrapper -- slightly later, but with a clearer message and no change in outcome
(there is no CPU pointwise kernel either way).

Test Plan:

New regression test (CPU, no GPU required):

```
python -m pytest test/functorch/test_control_flow.py::AssociativeScanTests::test_associative_scan_pointwise_export_cpu -q
```

Full pointwise/export associative_scan suite on CUDA:

```
python -m pytest test/functorch/test_control_flow.py -k "AssociativeScanTests and (pointwise or export)" -q
# 126 passed, 388 skipped
```

Manual checks: torch.export of pointwise associative_scan on CPU now succeeds
and the exported graph retains torch.ops.higher_order.associative_scan;
torch.compile of the same on CPU raises a clear RuntimeError from the lowering;
torch.compile on CUDA produces output matching torch.cumsum (max diff ~3e-6).

This change was authored with the assistance of an AI coding assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo