### PR TITLE
c10/util/intrusive_ptr.h: replace hand-written comparison operators with operator<=>

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -4,6 +4,7 @@
 #include <c10/util/MaybeOwned.h>
 #include <atomic>
 #include <climits>
+#include <compare>
 #include <memory>
 #include <type_traits>
 
@@ -765,13 +766,16 @@ inline void swap(
   lhs.swap(rhs);
 }
 
-// To allow intrusive_ptr inside std::map or std::set, we need operator<
+// Pointer ordering and equality for intrusive_ptr.
+// operator<=> gives us <, >, <=, >=; operator== gives us !=.
+// clang-format off
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator<(
+[[nodiscard]] inline std::strong_ordering operator<=>(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return lhs.get() < rhs.get();
+  return lhs.get() <=> rhs.get();
 }
+// clang-format on
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
 [[nodiscard]] inline bool operator==(
@@ -785,34 +789,6 @@ template <class TTarget1, class NullType1>
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     std::nullptr_t) noexcept {
   return lhs.get() == nullptr;
-}
-
-template <class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator==(
-    std::nullptr_t,
-    const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return nullptr == rhs.get();
-}
-
-template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator!=(
-    const intrusive_ptr<TTarget1, NullType1>& lhs,
-    const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return !operator==(lhs, rhs);
-}
-
-template <class TTarget1, class NullType1>
-[[nodiscard]] inline bool operator!=(
-    const intrusive_ptr<TTarget1, NullType1>& lhs,
-    std::nullptr_t) noexcept {
-  return !operator==(lhs, nullptr);
-}
-
-template <class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator!=(
-    std::nullptr_t,
-    const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return !operator==(nullptr, rhs);
 }
 template <typename T>
 struct MaybeOwnedTraits<c10::intrusive_ptr<T>> {
@@ -1120,10 +1096,12 @@ class weak_intrusive_ptr final {
     return ret;
   }
 
+  // clang-format off
   template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-  friend bool operator<(
+  friend std::strong_ordering operator<=>(
       const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
       const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept;
+  // clang-format on
   template <class TTarget1, class NullType1, class TTarget2, class NullType2>
   friend bool operator==(
       const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
@@ -1137,26 +1115,21 @@ inline void swap(
   lhs.swap(rhs);
 }
 
-// To allow weak_intrusive_ptr inside std::map or std::set, we need operator<
+// Pointer ordering and equality for weak_intrusive_ptr.
+// clang-format off
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator<(
+[[nodiscard]] inline std::strong_ordering operator<=>(
     const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
     const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return lhs.target_ < rhs.target_;
+  return lhs.target_ <=> rhs.target_;
 }
+// clang-format on
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
 [[nodiscard]] inline bool operator==(
     const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
     const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return lhs.target_ == rhs.target_;
-}
-
-template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-[[nodiscard]] inline bool operator!=(
-    const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
-    const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
-  return !operator==(lhs, rhs);
 }
 
 // Alias for documentary purposes, to more easily distinguish


### PR DESCRIPTION
Summary: Replace the 9 hand-written free-function comparison operators for `intrusive_ptr` and `weak_intrusive_ptr` (operator<, operator==, operator!=, and the nullptr overloads) with C++20 `operator<=>` + `operator==`. The spaceship operator synthesizes <, >, <=, >= automatically, and the retained `operator==` synthesizes !=. Net change: -9 functions, +2 per type. The nullptr overloads for `operator==` are retained since heterogeneous comparison against `std::nullptr_t` is not synthesized. Adds `#include <compare>` for `std::strong_ordering`.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.



