### PR TITLE
c10/util/ArrayRef.h: specialize std::ranges::enable_borrowed_range

### DIFF
--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -26,6 +26,7 @@
 #include <initializer_list>
 #include <iterator>
 #include <ostream>
+#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -288,3 +289,12 @@ using IntList [[deprecated(
     ArrayRef<int64_t>;
 
 } // namespace c10
+
+// ArrayRef is a non-owning view; iterators remain valid after the ArrayRef
+// is destroyed (the underlying array outlives it). Opt in to the ranges
+// borrowed-range contract so that algorithms like std::ranges::find return
+// real iterators rather than std::ranges::dangling for temporary ArrayRefs.
+namespace std::ranges {
+template <typename T>
+inline constexpr bool enable_borrowed_range<c10::ArrayRef<T>> = true;
+} // namespace std::ranges

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -26,7 +26,6 @@
 #include <initializer_list>
 #include <iterator>
 #include <ostream>
-#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -290,6 +289,8 @@ using IntList [[deprecated(
 
 } // namespace c10
 
+#if __cplusplus >= 202002L
+#include <ranges>
 // ArrayRef is a non-owning view; iterators remain valid after the ArrayRef
 // is destroyed (the underlying array outlives it). Opt in to the ranges
 // borrowed-range contract so that algorithms like std::ranges::find return
@@ -298,3 +299,4 @@ namespace std::ranges {
 template <typename T>
 inline constexpr bool enable_borrowed_range<c10::ArrayRef<T>> = true;
 } // namespace std::ranges
+#endif

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -266,3 +266,15 @@ namespace torch::headeronly {
 using c10::HeaderOnlyArrayRef;
 using IntHeaderOnlyArrayRef = HeaderOnlyArrayRef<int64_t>;
 } // namespace torch::headeronly
+
+#if __cplusplus >= 202002L
+#include <ranges>
+// HeaderOnlyArrayRef is a non-owning view; iterators remain valid after the
+// HeaderOnlyArrayRef is destroyed. Opt in to the ranges borrowed-range
+// contract so that algorithms like std::ranges::find return real iterators
+// rather than std::ranges::dangling for temporary HeaderOnlyArrayRefs.
+namespace std::ranges {
+template <typename T>
+inline constexpr bool enable_borrowed_range<c10::HeaderOnlyArrayRef<T>> = true;
+} // namespace std::ranges
+#endif


### PR DESCRIPTION
Summary:
`c10::ArrayRef<T>` already satisfies `std::ranges::contiguous_range` structurally — its iterator type is a raw `const T*` (which models `std::contiguous_iterator`), `data()` returns `const T*`, and `size()` returns `size_t`. The one missing piece for full C++20 ranges integration is `std::ranges::enable_borrowed_range`.

Without this specialization, range algorithms that return iterators (e.g. `std::ranges::find`, `std::ranges::lower_bound`) yield `std::ranges::dangling` when passed a temporary `ArrayRef`, even though the iterators are safe — `ArrayRef` is a non-owning view and the underlying array outlives it. Opting in corrects this.

No existing call site is affected; this is purely additive. The specialization is placed in `ArrayRef.h` (not `HeaderOnlyArrayRef.h`) because `<ranges>` is a C++20 header and the ExecuTorch mirror only requires `HeaderOnlyArrayRef.h` to compile as C++17.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.

Differential Revision: D107116913


