### PR TITLE
c10/core/impl/SizesAndStrides.h: add [[nodiscard]] to size() and isInline()

### DIFF
--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -128,7 +128,7 @@ class C10_API SizesAndStrides {
     return *this;
   }
 
-  size_t size() const noexcept {
+  [[nodiscard]] size_t size() const noexcept {
     return size_;
   }
 
@@ -285,7 +285,7 @@ class C10_API SizesAndStrides {
   void resizeSlowPath(size_t newSize, size_t oldSize);
 
  private:
-  bool isInline() const noexcept {
+  [[nodiscard]] bool isInline() const noexcept {
     return size_ <= C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE;
   }
 


### PR DESCRIPTION
Summary:
Add `[[nodiscard]]` to two methods in `c10::impl::SizesAndStrides`:
- `size()` — the public dimensionality accessor; discarding it is always a logic error
- `isInline()` — private helper that gates the entire inline vs. out-of-line storage path; discarding it silently would corrupt subsequent pointer arithmetic

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.

Differential Revision: D107115819


