### PR TITLE
[inductor] allow reorder_for_locality on training graphs (opt-in)

### DIFF
--- a/test/inductor/test_reorder_for_locality_in_training.py
+++ b/test/inductor/test_reorder_for_locality_in_training.py
@@ -1,0 +1,133 @@
+# Owner(s): ["module: inductor"]
+"""Tests for ``torch._inductor.config.reorder_for_locality_in_training``.
+
+The flag reads ``TORCHINDUCTOR_REORDER_LOCALITY_TRAINING`` at module
+import time, so we test the runtime gating in
+``torch._inductor.fx_passes.post_grad`` by patching the flag directly
+(``torch._inductor.config.patch``). We also exercise the env path with
+a subprocess.
+"""
+
+import os
+import subprocess
+import sys
+from unittest.mock import patch as mock_patch
+
+import torch
+import torch._inductor.config as inductor_config
+import torch.fx as fx
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestReorderForLocalityInTraining(TestCase):
+    def test_default_off(self):
+        # The default-off statement is what we ship: importing config with
+        # the env unset should leave the flag False.
+        env = os.environ.copy()
+        env.pop("TORCHINDUCTOR_REORDER_LOCALITY_TRAINING", None)
+        out = (
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-c",
+                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
+                ],
+                env=env,
+            )
+            .decode()
+            .strip()
+        )
+        self.assertEqual(out, "0")
+
+    def test_env_one_turns_on(self):
+        env = os.environ.copy()
+        env["TORCHINDUCTOR_REORDER_LOCALITY_TRAINING"] = "1"
+        out = (
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-c",
+                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
+                ],
+                env=env,
+            )
+            .decode()
+            .strip()
+        )
+        self.assertEqual(out, "1")
+
+    def test_env_zero_keeps_off(self):
+        env = os.environ.copy()
+        env["TORCHINDUCTOR_REORDER_LOCALITY_TRAINING"] = "0"
+        out = (
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-c",
+                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
+                ],
+                env=env,
+            )
+            .decode()
+            .strip()
+        )
+        self.assertEqual(out, "0")
+
+    def _make_tiny_gm(self):
+        g = fx.Graph()
+        x = g.placeholder("x")
+        y = g.call_function(torch.relu, args=(x,))
+        g.output(y)
+        return fx.GraphModule(torch.nn.Module(), g)
+
+    def test_pass_does_not_run_on_training_when_flag_off(self):
+        from torch._inductor.fx_passes import post_grad
+
+        called = {"reorder": False}
+        orig = post_grad.reorder_for_locality
+
+        def _spy(graph):
+            called["reorder"] = True
+            return orig(graph)
+
+        with inductor_config.patch({"reorder_for_locality_in_training": False}):
+            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
+                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=False)
+        self.assertFalse(called["reorder"])
+
+    def test_pass_runs_on_training_when_flag_on(self):
+        from torch._inductor.fx_passes import post_grad
+
+        called = {"reorder": False}
+        orig = post_grad.reorder_for_locality
+
+        def _spy(graph):
+            called["reorder"] = True
+            return orig(graph)
+
+        with inductor_config.patch({"reorder_for_locality_in_training": True}):
+            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
+                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=False)
+        self.assertTrue(called["reorder"])
+
+    def test_inference_path_unchanged(self):
+        # The pass should still run on inference graphs regardless of the
+        # new flag's value (preserves the existing default-on inference
+        # behaviour).
+        from torch._inductor.fx_passes import post_grad
+
+        called = {"reorder": False}
+        orig = post_grad.reorder_for_locality
+
+        def _spy(graph):
+            called["reorder"] = True
+            return orig(graph)
+
+        with inductor_config.patch({"reorder_for_locality_in_training": False}):
+            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
+                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=True)
+        self.assertTrue(called["reorder"])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_reorder_for_locality_in_training.py
+++ b/test/inductor/test_reorder_for_locality_in_training.py
@@ -1,12 +1,7 @@
 # Owner(s): ["module: inductor"]
-"""Tests for ``torch._inductor.config.reorder_for_locality_in_training``.
-
-The flag reads ``TORCHINDUCTOR_REORDER_LOCALITY_TRAINING`` at module
-import time, so we test the runtime gating in
-``torch._inductor.fx_passes.post_grad`` by patching the flag directly
-(``torch._inductor.config.patch``). We also exercise the env path with
-a subprocess.
-"""
+"""Tests for the reorder_for_locality_in_training flag: env parsing, and that on
+a real fwd+bwd training graph the flag reorders a node without changing
+grads/params."""
 
 import os
 import subprocess
@@ -14,119 +9,135 @@ import sys
 from unittest.mock import patch as mock_patch
 
 import torch
+import torch._dynamo
 import torch._inductor.config as inductor_config
-import torch.fx as fx
+from torch._inductor.fx_passes import post_grad
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-class TestReorderForLocalityInTraining(TestCase):
-    def test_default_off(self):
-        # The default-off statement is what we ship: importing config with
-        # the env unset should leave the flag False.
-        env = os.environ.copy()
+def _flag_in_subprocess(env_value):
+    # Parse-only: a fresh interpreter imports just the config module and prints
+    # the resolved flag. env_value=None means the var is unset (ship default).
+    env = os.environ.copy()
+    if env_value is None:
         env.pop("TORCHINDUCTOR_REORDER_LOCALITY_TRAINING", None)
-        out = (
-            subprocess.check_output(
-                [
-                    sys.executable,
-                    "-c",
-                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
-                ],
-                env=env,
-            )
-            .decode()
-            .strip()
-        )
-        self.assertEqual(out, "0")
+    else:
+        env["TORCHINDUCTOR_REORDER_LOCALITY_TRAINING"] = env_value
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            "import torch._inductor.config as c;"
+            "print(int(c.reorder_for_locality_in_training))",
+        ],
+        env=env,
+    )
+    return out.decode().strip()
+
+
+class _Recorder:
+    """Wraps ``reorder_for_locality`` and records, per call, whether the pass
+    changed the graph node order. ``orig`` is captured before patching so the
+    real pass still runs."""
+
+    def __init__(self):
+        self.orig = post_grad.reorder_for_locality
+        self.calls = 0
+        self.moved = False
+
+    def __call__(self, graph):
+        before = [n.name for n in graph.nodes]
+        self.orig(graph)
+        after = [n.name for n in graph.nodes]
+        self.calls += 1
+        if before != after:
+            self.moved = True
+
+
+class _TwoBranch(torch.nn.Module):
+    # Two independent matmul branches that only meet at the end. After
+    # functionalization the branch producers land far from their sole
+    # consumers, so reorder_for_locality has real moves to make.
+    def __init__(self):
+        super().__init__()
+        self.w1 = torch.nn.Parameter(torch.randn(16, 16))
+        self.w2 = torch.nn.Parameter(torch.randn(16, 16))
+
+    def forward(self, x):
+        a = torch.tanh(x @ self.w1)
+        b = torch.sigmoid(x @ self.w2)
+        return (a * b + torch.sin(a) * torch.cos(b)).sum(dim=1)
+
+
+def _train_once(flag_on):
+    rec = _Recorder()
+    torch._dynamo.reset()
+    torch.manual_seed(1234)
+    model = _TwoBranch()
+    x = torch.randn(8, 16)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    with inductor_config.patch(
+        {
+            "reorder_for_locality_in_training": flag_on,
+            "fx_graph_cache": False,
+            "force_disable_caches": True,
+        }
+    ):
+        with mock_patch.object(post_grad, "reorder_for_locality", rec):
+            compiled = torch.compile(model, backend="inductor", fullgraph=True)
+            compiled(x).sum().backward()
+    grads = {n: p.grad.detach().clone() for n, p in model.named_parameters()}
+    opt.step()
+    params = {n: p.detach().clone() for n, p in model.named_parameters()}
+    return params, grads, rec
+
+
+class TestReorderForLocalityInTrainingEnv(TestCase):
+    def test_default_off(self):
+        self.assertEqual(_flag_in_subprocess(None), "0")
 
     def test_env_one_turns_on(self):
-        env = os.environ.copy()
-        env["TORCHINDUCTOR_REORDER_LOCALITY_TRAINING"] = "1"
-        out = (
-            subprocess.check_output(
-                [
-                    sys.executable,
-                    "-c",
-                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
-                ],
-                env=env,
-            )
-            .decode()
-            .strip()
-        )
-        self.assertEqual(out, "1")
+        self.assertEqual(_flag_in_subprocess("1"), "1")
 
     def test_env_zero_keeps_off(self):
-        env = os.environ.copy()
-        env["TORCHINDUCTOR_REORDER_LOCALITY_TRAINING"] = "0"
-        out = (
-            subprocess.check_output(
-                [
-                    sys.executable,
-                    "-c",
-                    "import torch._inductor.config as c; print(int(c.reorder_for_locality_in_training))",
-                ],
-                env=env,
-            )
-            .decode()
-            .strip()
+        self.assertEqual(_flag_in_subprocess("0"), "0")
+
+
+class TestReorderForLocalityInTraining(TestCase):
+    def test_training_flag_reorders_and_preserves_semantics(self):
+        p_off, g_off, rec_off = _train_once(flag_on=False)
+        p_on, g_on, rec_on = _train_once(flag_on=True)
+
+        # (a) semantics preserved: same seed/init/input, so grads and the
+        # post-step params must match exactly between flag-off and flag-on.
+        self.assertEqual(set(g_off), set(g_on))
+        for k in g_off:
+            self.assertEqual(g_on[k], g_off[k], atol=0, rtol=0)
+            self.assertEqual(p_on[k], p_off[k], atol=0, rtol=0)
+
+        # (b) the flag actually exercised the pass: with it on the reorder ran
+        # and moved at least one node on a training graph; with it off the pass
+        # never ran on training. The moved check is what gives this teeth, a
+        # no-op graph would leave moved False and fail here.
+        self.assertEqual(rec_off.calls, 0)
+        self.assertGreater(rec_on.calls, 0)
+        self.assertTrue(
+            rec_on.moved,
+            "flag on must reorder at least one node on the training graph",
         )
-        self.assertEqual(out, "0")
 
-    def _make_tiny_gm(self):
-        g = fx.Graph()
-        x = g.placeholder("x")
-        y = g.call_function(torch.relu, args=(x,))
-        g.output(y)
-        return fx.GraphModule(torch.nn.Module(), g)
-
-    def test_pass_does_not_run_on_training_when_flag_off(self):
-        from torch._inductor.fx_passes import post_grad
-
-        called = {"reorder": False}
-        orig = post_grad.reorder_for_locality
-
-        def _spy(graph):
-            called["reorder"] = True
-            return orig(graph)
-
+    def test_inference_gate_unchanged(self):
+        # Gate-only check (invocation, not a feature exercise): inference graphs
+        # must still run the pass regardless of the training flag.
+        rec = _Recorder()
         with inductor_config.patch({"reorder_for_locality_in_training": False}):
-            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
-                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=False)
-        self.assertFalse(called["reorder"])
-
-    def test_pass_runs_on_training_when_flag_on(self):
-        from torch._inductor.fx_passes import post_grad
-
-        called = {"reorder": False}
-        orig = post_grad.reorder_for_locality
-
-        def _spy(graph):
-            called["reorder"] = True
-            return orig(graph)
-
-        with inductor_config.patch({"reorder_for_locality_in_training": True}):
-            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
-                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=False)
-        self.assertTrue(called["reorder"])
-
-    def test_inference_path_unchanged(self):
-        # The pass should still run on inference graphs regardless of the
-        # new flag's value (preserves the existing default-on inference
-        # behaviour).
-        from torch._inductor.fx_passes import post_grad
-
-        called = {"reorder": False}
-        orig = post_grad.reorder_for_locality
-
-        def _spy(graph):
-            called["reorder"] = True
-            return orig(graph)
-
-        with inductor_config.patch({"reorder_for_locality_in_training": False}):
-            with mock_patch.object(post_grad, "reorder_for_locality", _spy):
-                post_grad.post_grad_passes(self._make_tiny_gm(), is_inference=True)
-        self.assertTrue(called["reorder"])
+            with mock_patch.object(post_grad, "reorder_for_locality", rec):
+                g = torch.fx.Graph()
+                xn = g.placeholder("x")
+                g.output(g.call_function(torch.relu, args=(xn,)))
+                gm = torch.fx.GraphModule(torch.nn.Module(), g)
+                post_grad.post_grad_passes(gm, is_inference=True)
+        self.assertGreater(rec.calls, 0)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_reorder_for_locality_in_training.py
+++ b/test/inductor/test_reorder_for_locality_in_training.py
@@ -12,6 +12,7 @@ import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.fx_passes import post_grad
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -69,15 +70,16 @@ class _TwoBranch(torch.nn.Module):
         return (a * b + torch.sin(a) * torch.cos(b)).sum(dim=1)
 
 
-def _train_once(flag_on):
+def _train_once(device, flag_on, reorder_on=True):
     rec = _Recorder()
     torch._dynamo.reset()
     torch.manual_seed(1234)
-    model = _TwoBranch()
-    x = torch.randn(8, 16)
+    model = _TwoBranch().to(device)
+    x = torch.randn(8, 16, device=device)
     opt = torch.optim.SGD(model.parameters(), lr=0.1)
     with inductor_config.patch(
         {
+            "reorder_for_locality": reorder_on,
             "reorder_for_locality_in_training": flag_on,
             "fx_graph_cache": False,
             "force_disable_caches": True,
@@ -102,18 +104,34 @@ class TestReorderForLocalityInTrainingEnv(TestCase):
     def test_env_zero_keeps_off(self):
         self.assertEqual(_flag_in_subprocess("0"), "0")
 
+    def test_inference_gate_unchanged(self):
+        # Gate-only check (invocation, not a feature exercise): inference graphs
+        # must still run the pass regardless of the training flag. Pure FX, no
+        # device execution, so it stays out of the device-generic class below.
+        rec = _Recorder()
+        with inductor_config.patch({"reorder_for_locality_in_training": False}):
+            with mock_patch.object(post_grad, "reorder_for_locality", rec):
+                g = torch.fx.Graph()
+                xn = g.placeholder("x")
+                g.output(g.call_function(torch.relu, args=(xn,)))
+                gm = torch.fx.GraphModule(torch.nn.Module(), g)
+                post_grad.post_grad_passes(gm, is_inference=True)
+        self.assertGreater(rec.calls, 0)
+
 
 class TestReorderForLocalityInTraining(TestCase):
-    def test_training_flag_reorders_and_preserves_semantics(self):
-        p_off, g_off, rec_off = _train_once(flag_on=False)
-        p_on, g_on, rec_on = _train_once(flag_on=True)
+    def test_training_flag_reorders_and_preserves_semantics(self, device):
+        p_off, g_off, rec_off = _train_once(device, flag_on=False)
+        p_on, g_on, rec_on = _train_once(device, flag_on=True)
 
-        # (a) semantics preserved: same seed/init/input, so grads and the
-        # post-step params must match exactly between flag-off and flag-on.
+        # (a) semantics preserved: same seed/init/input, so grads and post-step
+        # params match between flag-off and flag-on. reorder_for_locality is a
+        # mathematical (not bitwise) equivalence -- it can change fusion grouping
+        # and thus low-bit FP accumulation -- so use default tolerances.
         self.assertEqual(set(g_off), set(g_on))
         for k in g_off:
-            self.assertEqual(g_on[k], g_off[k], atol=0, rtol=0)
-            self.assertEqual(p_on[k], p_off[k], atol=0, rtol=0)
+            self.assertEqual(g_on[k], g_off[k])
+            self.assertEqual(p_on[k], p_off[k])
 
         # (b) the flag actually exercised the pass: with it on the reorder ran
         # and moved at least one node on a training graph; with it off the pass
@@ -126,18 +144,14 @@ class TestReorderForLocalityInTraining(TestCase):
             "flag on must reorder at least one node on the training graph",
         )
 
-    def test_inference_gate_unchanged(self):
-        # Gate-only check (invocation, not a feature exercise): inference graphs
-        # must still run the pass regardless of the training flag.
-        rec = _Recorder()
-        with inductor_config.patch({"reorder_for_locality_in_training": False}):
-            with mock_patch.object(post_grad, "reorder_for_locality", rec):
-                g = torch.fx.Graph()
-                xn = g.placeholder("x")
-                g.output(g.call_function(torch.relu, args=(xn,)))
-                gm = torch.fx.GraphModule(torch.nn.Module(), g)
-                post_grad.post_grad_passes(gm, is_inference=True)
-        self.assertGreater(rec.calls, 0)
+    def test_training_flag_noop_when_reorder_off(self, device):
+        # The training flag is gated by reorder_for_locality: enabling it while
+        # reorder_for_locality is off must not run the pass on a training graph.
+        _, _, rec = _train_once(device, flag_on=True, reorder_on=False)
+        self.assertEqual(rec.calls, 0)
+
+
+instantiate_device_type_tests(TestReorderForLocalityInTraining, globals())
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -374,10 +374,14 @@ post_grad_fusion_options: dict[str, dict[str, Any]] = {}
 reorder_for_locality = True
 
 # Also run reorder_for_locality on training (non-inference) graphs.
-# The pass itself is a bitwise-equivalent FX reorder (it walks the graph
-# in reverse and pulls each producer next to its sole consumer) so
-# enabling it cannot change operator semantics. Default off to keep
-# upstream behaviour unchanged on training paths.
+# reorder_for_locality is a semantics-preserving reorder: it walks the graph in
+# reverse and pulls each producer next to its sole consumer. The reorder is only
+# conditionally safe, so the pass guards the order-sensitive cases (RNG-state
+# consumers, collective wait nodes, nodes across a mutation-region boundary, the
+# copy_ mutation epilogue) and skips them. Default off to keep upstream training
+# behaviour unchanged.
+# This depends on reorder_for_locality above being on: setting this True while
+# reorder_for_locality is False does nothing (the master flag gates the pass).
 reorder_for_locality_in_training = (
     os.environ.get("TORCHINDUCTOR_REORDER_LOCALITY_TRAINING", "0") == "1"
 )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -373,6 +373,15 @@ post_grad_fusion_options: dict[str, dict[str, Any]] = {}
 # enable reordering pass for improving memory locality
 reorder_for_locality = True
 
+# Also run reorder_for_locality on training (non-inference) graphs.
+# The pass itself is a bitwise-equivalent FX reorder (it walks the graph
+# in reverse and pulls each producer next to its sole consumer) so
+# enabling it cannot change operator semantics. Default off to keep
+# upstream behaviour unchanged on training paths.
+reorder_for_locality_in_training = (
+    os.environ.get("TORCHINDUCTOR_REORDER_LOCALITY_TRAINING", "0") == "1"
+)
+
 # Scale down Rn_BLOCK for better occupancy
 dynamic_scale_rblock = os.environ.get("TORCHINDUCTOR_DYNAMIC_SCALE_RBLOCK", "1") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -373,15 +373,10 @@ post_grad_fusion_options: dict[str, dict[str, Any]] = {}
 # enable reordering pass for improving memory locality
 reorder_for_locality = True
 
-# Also run reorder_for_locality on training (non-inference) graphs.
-# reorder_for_locality is a semantics-preserving reorder: it walks the graph in
-# reverse and pulls each producer next to its sole consumer. The reorder is only
-# conditionally safe, so the pass guards the order-sensitive cases (RNG-state
-# consumers, collective wait nodes, nodes across a mutation-region boundary, the
-# copy_ mutation epilogue) and skips them. Default off to keep upstream training
-# behaviour unchanged.
-# This depends on reorder_for_locality above being on: setting this True while
-# reorder_for_locality is False does nothing (the master flag gates the pass).
+# Also run reorder_for_locality (a semantics-preserving pass; see
+# reorder_for_locality in fx_passes/post_grad.py for the cases it guards) on
+# training graphs, not just inference. Default off. Gated by reorder_for_locality
+# above: enabling this while that is False does nothing.
 reorder_for_locality_in_training = (
     os.environ.get("TORCHINDUCTOR_REORDER_LOCALITY_TRAINING", "0") == "1"
 )

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -178,7 +178,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         # has some issues with mutation in inference mode
         gm.graph.eliminate_dead_code()
 
-    if is_inference and config.reorder_for_locality:
+    if config.reorder_for_locality and (
+        is_inference or config.reorder_for_locality_in_training
+    ):
         GraphTransformObserver(gm, "reorder_for_locality").apply_graph_pass(
             reorder_for_locality
         )


### PR DESCRIPTION
`reorder_for_locality` is a post-grad FX reorder that walks the graph in reverse and pulls each producer next to its sole consumer for better L2 locality. It's gated on `is_inference`, so training graphs never get it. This adds an opt-in `config.reorder_for_locality_in_training` (env `TORCHINDUCTOR_REORDER_LOCALITY_TRAINING=1`) to run the same pass on training graphs. Default off, so when the env is unset the gate is identical to today; it's an opt-in tuning knob.

The reorder is only conditionally safe, which is why the pass already guards the order-sensitive cases (RNG-state consumers, collective wait nodes, mutation-region boundaries, the `copy_` epilogue) and skips them. The new flag also depends on `reorder_for_locality` itself being on: setting it while `reorder_for_locality` is `False` does nothing, since `reorder_for_locality` gates the pass.

Test plan:
- env parse (unset / `=1` / `=0`) in a fresh interpreter that imports only `torch._inductor.config`.
- a real compiled training step (fwd + bwd, `is_inference=False`) with the flag off vs on, run device-generically on CPU and GPU: grads and post-step params match within default tolerances, and with the flag on the reorder actually moves a node on the training graph. A recorder snapshots node order before/after each pass call, so "moved" means real movement, not just that the pass ran.
- with `reorder_for_locality` off, turning the training flag on is a no-op (the pass never runs).
- the inference path still runs the pass regardless of the flag.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
