### PR TITLE
Add repo google-pytorch/torch_tpu to PyTorch CRCR allowlist.

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -39,6 +39,7 @@ L1:
   - riseproject-dev/pytorch-ci
   - NVIDIA-dev/pytorch-oot-internal
   - NVIDIA/pytorch-windows-ci
+  - google-pytorch/torch_tpu
 
 L2:
   # Canonical test repo for CRCR.


### PR DESCRIPTION
Following [the CRCR Onboarding Guide - Step2](https://github.com/pytorch/crcr-test/blob/main/README.md#step-2-add-your-repository-to-the-allowlist), add our repository [google-pytorch/torch_tpu](https://github.com/google-pytorch/torch_tpu) to the allowlist file, get started from L1 and will incrementally move to higher level(s). 

Currently the repository [google-pytorch/torch_tpu](https://github.com/google-pytorch/torch_tpu) is private. If this PR's approvers or PyTorch's maintainers need access to this repository, please let us know.

