### PR TITLE
[TEST][CUDA] Use a bool -> bool op in `test_bool_dtype_skips_tma`

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1697,12 +1697,12 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
 
     def test_bool_dtype_skips_tma(self):
         """
-        torch.bool maps to Triton tl.int1 which has no CUtensorMapDataType
-        entry, so it should skip TMA.
+        torch.bool buffers map to Triton tl.int1 which has no
+        CUtensorMapDataType entry, so they should skip TMA.
         """
 
         def fn(a):
-            return torch.cumsum(a, -1)
+            return torch.logical_not(a)
 
         inp = torch.zeros(16, dtype=torch.bool, device=GPU_TYPE)
         self._run_and_compare(fn, inp, expected_num_block_pointers=0)


### PR DESCRIPTION
Otherwise the test seems to be unhappy as `cumsum` returns an `Int64` result

authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo