### PR TITLE
Don't skip linux cpu/cuda binary tests when ROCm/XPU builds fail

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -24,6 +24,11 @@ name: !{{ build_environment }}
 {%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 {%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 
+{#- Standard (non-ROCm/XPU) configs that are built by the manywheel-build matrix
+    rather than an inline unified job (e.g. cpu-s390x). manywheel-test consumes
+    these, so it must wait on manywheel-build only when such configs exist. -#}
+{%- set matrix_standard_configs = matrix_build_configs | rejectattr('gpu_arch_type', 'in', ['rocm', 'xpu']) | list %}
+
 {#- Group unified configs by (gpu_arch_type, desired_cuda). Containers differ
     per CUDA version, so each (arch, cuda) needs its own job; within a group
     only the Python version varies. -#}
@@ -247,11 +252,15 @@ jobs:
 {%- endif %}
 
 {%- if test_standard_configs %}
-
+{# manywheel-test depends only on the builds it actually consumes: the unified
+   cpu/cuda jobs, plus manywheel-build only when that matrix builds a standard
+   (non-ROCm/XPU) config such as cpu-s390x. ROCm/XPU are tested by
+   manywheel-test-rocm / manywheel-test-xpu, so a ROCm/XPU build failure must not
+   skip the cpu/cuda tests. #}
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type{%- if matrix_build_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
+    needs: [get-label-type{%- if matrix_standard_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -639,7 +639,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
+    needs: [get-label-type, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
manywheel-test (cpu/cuda) declared a dependency on the manywheel-build matrix, which builds ROCm and XPU. GitHub Actions skips a job when any of its needs fails, so an XPU (or ROCm) build failure skipped all the x86 cpu/cuda binary tests, even though those tests don't consume the ROCm/XPU artifacts. ROCm/XPU have their own test jobs (manywheel-test-rocm / manywheel-test-xpu).

Depend on manywheel-build only when that matrix builds a standard (non-ROCm/XPU) config the test consumes (e.g. cpu-s390x); otherwise depend only on the unified cpu/cuda build jobs. Regenerated workflows.

See the failure here on today's nightly: https://github.com/pytorch/pytorch/actions/runs/27127327988/job/80130536233

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang