### PR TITLE
Make topk deterministic under deterministic algorithms

### DIFF
--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ATen/Context.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/NumericUtils.h>
 
@@ -28,6 +29,24 @@ void topk_impl_loop(
     return;
   }
   using elem_t = std::pair<accscalar_t, int64_t>;
+  // See Note [Enabling Deterministic Operations]
+  const bool deterministic = at::globalContext().deterministicAlgorithms();
+  // Keep NumPy-compatible NaN ordering: NaNs sort first for largest=True and
+  // last for largest=False.
+  auto topk_comp = [largest, deterministic](const elem_t& x, const elem_t& y) -> bool {
+    const bool x_nan = _isnan<accscalar_t>(x.first);
+    const bool y_nan = _isnan<accscalar_t>(y.first);
+    if (x_nan || y_nan) {
+      if (x_nan != y_nan) {
+        return largest ? x_nan : !x_nan;
+      }
+      return deterministic ? x.second < y.second : false;
+    }
+    if (x.first == y.first) {
+      return deterministic ? x.second < y.second : false;
+    }
+    return largest ? x.first > y.first : x.first < y.first;
+  };
   std::vector<elem_t> queue(dim_size);
   for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(
@@ -48,42 +67,12 @@ void topk_impl_loop(
       queue[j].second = j;
     }
 
-    // we want nan to be sorted as top for numpy compatibility
     if (use_partial_sort) {
-      if (largest) {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
-      } else {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
-      }
+      std::partial_sort(queue.begin(), queue.begin() + k, queue.end(), topk_comp);
     } else {
-      if (largest) {
-        std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k - 1,
-            [](const elem_t& x, const elem_t& y) -> bool {
-              return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-            });
-        }
-      } else {
-        std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k -1,
-            [](const elem_t& x, const elem_t& y) -> bool {
-              return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-            });
-        }
+      std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(), topk_comp);
+      if (sorted) {
+        std::sort(queue.begin(), queue.begin() + k, topk_comp);
       }
     }
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/cuda/TensorTopK.h>
 
+#include <ATen/Context.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorUtils.h>
@@ -23,9 +24,10 @@ void topk_out_with_sort(
   const Tensor& self,
   int64_t k, int64_t dim, bool largest,
   const Tensor& values,
-  const Tensor& indices
+  const Tensor& indices,
+  bool stable
 ) {
-  auto [sorted_values, sorted_indices] = at::cuda::sort(self, /* stable= */false, dim, largest);
+  auto [sorted_values, sorted_indices] = at::cuda::sort(self, stable, dim, largest);
   values.copy_(sorted_values.narrow(dim, 0, k));
   indices.copy_(sorted_indices.narrow(dim, 0, k));
 }
@@ -83,9 +85,20 @@ TORCH_IMPL_FUNC(topk_out_cuda)
   checkAllSameGPU(__func__, {topK_arg, indices_arg, input_arg});
 
   dim = at::maybe_wrap_dim(dim, self);
+  // See Note [Enabling Deterministic Operations]
+  const bool deterministic = at::globalContext().deterministicAlgorithms();
+
+#if defined(USE_ROCM)
+  if (deterministic) {
+    // The ROCm top-k gather path can reserve tie slots through atomics.
+    // Use stable full sort in deterministic mode to guarantee index tie-breaking.
+    topk_out_with_sort(self, k, dim, largest, values, indices, /*stable=*/true);
+    return;
+  }
+#endif
 
   if (should_use_sort(self, dim)) {
-    topk_out_with_sort(self, k, dim, largest, values, indices);
+    topk_out_with_sort(self, k, dim, largest, values, indices, deterministic);
     return;
   }
 
@@ -103,7 +116,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
       // This avoids any memory allocations and performs all sorting
       // work inplace along the slice
 
-      sortKeyValueInplace(values, indices, dim, largest);
+      sortKeyValueInplace(values, indices, dim, largest, deterministic);
     } else {
       // Depend upon the backup sort that returns indices, which we
       // can use in conjunction with gather to produce the original
@@ -116,7 +129,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
 
       Tensor sortedIndices = at::empty_like(indices);
       Tensor sortedValues = at::empty_like(values);
-      at::cuda::sort_outf(values, /* stable= */ false, dim, largest, sortedValues, sortedIndices);
+      at::cuda::sort_outf(values, deterministic, dim, largest, sortedValues, sortedIndices);
       indices.copy_(indices.gather(dim, sortedIndices));
       values.copy_(sortedValues);
     }

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_dtype import (
     integral_types,
 )
 from torch.testing._internal.common_utils import (
+    DeterministicGuard,
     parametrize,
     run_tests,
     skipIfTorchDynamo,
@@ -513,6 +514,77 @@ class TestSortAndSelect(TestCase):
         # see https://github.com/pytorch/pytorch/issues/116324
         x = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
         x.topk(1)
+
+    def test_topk_deterministic_tie_breaking(self, device):
+        x = torch.tensor(
+            [
+                [3.0, 3.0, 2.0, 3.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0, 2.0],
+            ],
+            device=device,
+        )
+
+        with DeterministicGuard(True):
+            values, indices = torch.topk(x, 3, dim=-1, largest=True, sorted=True)
+            self.assertEqual(
+                values,
+                torch.tensor([[3.0, 3.0, 3.0], [2.0, 1.0, 0.0]], device=device),
+            )
+            self.assertEqual(
+                indices, torch.tensor([[0, 1, 3], [4, 0, 1]], device=device)
+            )
+
+            values, indices = torch.topk(x, 4, dim=-1, largest=False, sorted=True)
+            self.assertEqual(
+                values,
+                torch.tensor(
+                    [[1.0, 2.0, 3.0, 3.0], [0.0, 0.0, 0.0, 1.0]],
+                    device=device,
+                ),
+            )
+            self.assertEqual(
+                indices, torch.tensor([[4, 2, 0, 1], [1, 2, 3, 0]], device=device)
+            )
+
+            _, indices = torch.topk(x, 3, dim=-1, largest=True, sorted=False)
+            self.assertEqual(
+                indices.sort(dim=-1).values,
+                torch.tensor([[0, 1, 3], [0, 1, 4]], device=device),
+            )
+
+            nan_x = torch.tensor(
+                [[float("nan"), float("nan"), 3.0, 3.0, 2.0]],
+                device=device,
+            )
+            values, indices = torch.topk(nan_x, 4, dim=-1, largest=True, sorted=True)
+            self.assertTrue(values[0, :2].isnan().all())
+            self.assertEqual(values[0, 2:], torch.tensor([3.0, 3.0], device=device))
+            self.assertEqual(indices, torch.tensor([[0, 1, 2, 3]], device=device))
+
+            values, indices = torch.topk(nan_x, 4, dim=-1, largest=False, sorted=True)
+            self.assertEqual(
+                values[0, :3], torch.tensor([2.0, 3.0, 3.0], device=device)
+            )
+            self.assertTrue(values[0, 3].isnan().item())
+            self.assertEqual(indices, torch.tensor([[4, 2, 3, 0]], device=device))
+
+    @onlyCUDA
+    def test_topk_deterministic_tie_breaking_cuda_multiblock(self, device):
+        x = torch.ones(2, 20000, device=device)
+
+        with DeterministicGuard(True):
+            for k in (128, 129, 4096):
+                _, indices = torch.topk(x, k, dim=-1, largest=True, sorted=True)
+                self.assertEqual(
+                    indices,
+                    torch.arange(k, device=device).expand_as(indices),
+                )
+
+                _, indices = torch.topk(x, k, dim=-1, largest=False, sorted=True)
+                self.assertEqual(
+                    indices,
+                    torch.arange(k, device=device).expand_as(indices),
+                )
 
     def test_topk_arguments(self, device):
         q = torch.randn(10, 2, 10, device=device)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1424,6 +1424,7 @@ def use_deterministic_algorithms(
         * :func:`torch.Tensor.put_` with ``accumulate=True`` when called on a CPU
           tensor
         * :func:`torch.Tensor.scatter_add_` when called on a CUDA tensor
+        * :func:`torch.topk` when called on a CPU or CUDA tensor
         * :func:`torch.gather` when called on a CUDA tensor that requires grad
         * :func:`torch.index_add` when called on CUDA tensor
         * :func:`torch.index_select` when attempting to differentiate a CUDA tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11559,7 +11559,11 @@ The boolean option :attr:`sorted` if ``True``, will make sure that the returned
 
 .. note::
     When using `torch.topk`, the indices of tied elements are not guaranteed to be stable
-    and may vary across different invocations.
+    and may vary across different invocations unless
+    :func:`torch.use_deterministic_algorithms` is enabled. In deterministic mode,
+    lower indices are selected before higher indices for tied values. If
+    :attr:`sorted` is ``False``, the returned elements are still not guaranteed
+    to appear in sorted order.
 
 Args:
     {input}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #186653

When torch.use_deterministic_algorithms(True) is enabled, make topk resolve tied values with stable index tie-breaking.

CPU topk now compares by value and then index in deterministic mode. CUDA keeps the existing top-k selection path and uses stable sorting for the selected top-k outputs so threshold ties preserve input-index order without falling back to a full sort on NVIDIA. ROCm uses stable sort in deterministic mode because its current top-k gather reserves tie slots through atomics.

This gives deterministic mode a topk behavior analogous to scatter_add: fast default kernels remain available, while deterministic mode uses stable algorithms when requested.

Test Plan:

- Rebuilt PyTorch from source with CUDA enabled.

- python -m py_compile test/test_sort_and_select.py torch/__init__.py torch/_torch_docs.py

- python test/test_sort_and_select.py -k topk_deterministic

- python test/test_sort_and_select.py -k topk

- git diff --check HEAD^

- lintrunner --config=.lintrunner.toml --skip=PYREFLY aten/src/ATen/native/TopKImpl.h aten/src/ATen/native/cuda/TensorTopK.cpp test/test_sort_and_select.py torch/__init__.py torch/_torch_docs.py

cc @manuelcandales @angelayi