### PR TITLE
Fix AOTAutograd backward context re-entry

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -9385,6 +9385,28 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
 class CUDAReproTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @torch._dynamo.config.patch(capture_scalar_outputs=False)
+    def test_aot_backward_context_reentry_after_graph_break(self):
+        def fn(x, y, scalar):
+            cpu = x.cpu()
+            other_cpu = x.cpu()
+            before_break = cpu.view_as(other_cpu)
+            scalar.item()
+            after_break = y.cos()
+            return before_break, after_break
+
+        x = torch.randn(8, device="cuda", requires_grad=True)
+        y = torch.randn(8, device="cuda", requires_grad=True)
+        scalar = torch.randn((), device="cuda")
+
+        before_break, after_break = torch.compile(fn, backend="aot_eager")(x, y, scalar)
+        loss = before_break.sum().to("cuda") + after_break.sum()
+        loss.backward()
+
+        self.assertEqual(x.grad, torch.ones_like(x))
+        self.assertEqual(y.grad, -y.detach().sin())
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_sync(self):
         def fn(x):
             y = x + 1

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3247,7 +3247,7 @@ def _codegen_compiled_backward(
     lines.append(
         "            and (_cc := torch._C._get_obj_in_tls('context')) is not None):"
     )
-    lines.append("        impl_fn = functools.partial(_cc.run, impl_fn)")
+    lines.append("        impl_fn = functools.partial(_cc.copy().run, impl_fn)")
 
     if inputs_require_grad:
         lines.append("    if torch.is_grad_enabled():")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186659

AOTAutograd's generated compiled backward wrapper reused the exact contextvars.Context object stashed by autograd in C++ TLS. When backward execution re-entered another compiled backward while that context was still active, Python rejected the nested entry with 'cannot enter context ... is already entered'.

Copy the stashed context before running the compiled backward implementation. The copy preserves the captured ContextVar values for cross-thread/device-thread propagation while ensuring each invocation enters a fresh, unentered Context object.

The alternative would be to skip context propagation in this path, but that would drop compiler/autograd context state in backward. Copying keeps the existing propagation contract and narrows the change to the generated wrapper.

Fixes #185372

Generated by my agent

Benchmark Results:

Direct contextvars microbenchmark, 1,000,000 calls over 7 samples:

ctx.run(fn): median 0.108426s (108.4 ns/call); samples=[0.105933, 0.108421, 0.108501, 0.108442, 0.108426, 0.114369, 0.105557]

ctx.copy().run(fn): median 0.122044s (122.0 ns/call); samples=[0.119809, 0.122249, 0.123108, 0.122044, 0.122263, 0.119801, 0.119654]

Added overhead: about 13.6 ns per compiled backward invocation in this microbenchmark.

Test Plan:

python ../state/185372/repro_185372.py

python -c "import sys, torch; sys.path.append('../state/185372'); import repro_185372 as r; r.run(r.target); torch._dynamo.reset(); r.run(torch.compile(r.target, backend='aot_eager'))"

python test/dynamo/test_repros.py -k test_aot_backward_context_reentry_after_graph_break

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98