### PR TITLE
[c10d] Normalize register_backend devices=str to a single device key

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1886,6 +1886,32 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
                 with self.assertRaises(ValueError):
                     dist.BackendConfig(config_str)
 
+    def test_register_backend_devices_string(self):
+        # `register_backend` advertises `devices: str | list[str]`. A single
+        # device passed as a bare string must register the same device->backend
+        # mapping as the equivalent one-element list, not iterate the string's
+        # characters into `default_device_backend_map`.
+        backend_map = dist.Backend.default_device_backend_map
+        capability = dist.Backend.backend_capability
+        saved_map = dict(backend_map)
+        saved_capability = dict(capability)
+        try:
+            dist.Backend.register_backend(
+                "dummy_str",
+                PythonProcessGroupExtensionTest.create_dummy,
+                devices="privateuseone",
+            )
+            self.assertEqual(backend_map["privateuseone"], "dummy_str")
+            self.assertEqual(capability["dummy_str"], ["privateuseone"])
+            # The characters of the string must not have leaked in as keys.
+            for ch in set("privateuseone"):
+                self.assertNotIn(ch, backend_map)
+        finally:
+            backend_map.clear()
+            backend_map.update(saved_map)
+            capability.clear()
+            capability.update(saved_capability)
+
     def test_parse_backend_string(self):
         from torch.distributed.distributed_c10d import _parse_backend_string
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -375,6 +375,12 @@ class Backend(str):  # noqa: SLOT000
         if name.lower() not in Backend.backend_list:
             Backend.backend_list.append(name.lower())
 
+        # `devices` advertises `str | list[str]`; normalize a single device
+        # string to a list so the device->backend map below registers the whole
+        # name as one key rather than iterating the string's characters.
+        if isinstance(devices, str):
+            devices = [devices]
+
         if devices is not None:
             for device in devices:
                 current = Backend.default_device_backend_map.get(device)
@@ -398,9 +404,6 @@ class Backend(str):  # noqa: SLOT000
             Backend.backend_capability[name.lower()] = (
                 ["cpu", "cuda", "xpu"] if torch.xpu.is_available() else ["cpu", "cuda"]
             )
-        elif isinstance(devices, str):
-            # Single device string specified. Simply convert to list.
-            Backend.backend_capability[name.lower()] = [devices]
         else:
             Backend.backend_capability[name.lower()] = devices
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186660

Backend.register_backend documents devices as `str | list[str]`, but the
two cases were handled inconsistently. A bare string was iterated character
by character when populating default_device_backend_map, so
register_backend(name, func, devices="tpu") registered the keys 't', 'p',
and 'u' instead of "tpu". The backend_capability branch, on the other hand,
did normalize the string, which masked the bug: explicit-backend callers
(init_process_group(backend="tpu_dist")) resolve through backend_capability
and work fine, while device-type -> backend auto-resolution consults the
polluted default_device_backend_map and silently fails to find the backend.

The fix normalizes a single device string to a one-element list once at the
top of register_backend, so both maps see the same value, and removes the
now-redundant string-handling branch in the capability matrix update.

Test Plan:

New test exercises the previously-broken default_device_backend_map path
directly (a bare string device must register one key, not one per char):

```
python test/distributed/test_c10d_common.py \
    PythonProcessGroupExtensionTest.test_register_backend_devices_string
```

Authored with assistance from an AI coding agent (Claude Code).