### PR TITLE
Remove XNNPACK availability check from binary smoke test

### DIFF
--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -12,10 +12,9 @@ set -eux -o pipefail
 #    this is currently not true)
 # 4. Standard Python imports work
 # 5. MKL is available everywhere except for MacOS wheels
-# 6. XNNPACK is available everywhere except for MacOS wheels
-# 7. CUDA is setup correctly and does not hang
-# 8. Magma is available for CUDA builds
-# 9. CuDNN is available for CUDA builds
+# 6. CUDA is setup correctly and does not hang
+# 7. Magma is available for CUDA builds
+# 8. CuDNN is available for CUDA builds
 #
 # This script needs the env variables DESIRED_PYTHON, DESIRED_CUDA,
 # DESIRED_DEVTOOLSET and PACKAGE_TYPE
@@ -204,22 +203,6 @@ elif [[ "$(uname -m)" != "arm64" && "$(uname -m)" != "s390x" ]]; then
       python -c 'import torch; exit(0 if torch.backends.mkl.is_available() else 1)'
       popd
     fi
-  fi
-fi
-
-###############################################################################
-# Check for XNNPACK
-###############################################################################
-
-if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
-  echo "Checking that XNNPACK is available"
-  build_and_run_example_cpp check-torch-xnnpack
-else
-  if [[ "$(uname)" != 'Darwin' || "$PACKAGE_TYPE" != *wheel ]] && [[ "$(uname -m)" != "s390x"  ]]; then
-    echo "Checking that XNNPACK is available"
-    pushd /tmp
-    python -c 'import torch.backends.xnnpack; exit(0 if torch.backends.xnnpack.enabled else 1)'
-    popd
   fi
 fi
 


### PR DESCRIPTION
## Summary

`USE_XNNPACK` now defaults to `OFF` in CMake after #185297 ("Disable XNNPACK by default in CMake"), since XNNPACK is primarily used for the deprecated PyTorch Mobile and ExecuTorch is the recommended replacement. No binary build script re-enables it, so wheels and libtorch artifacts now ship without XNNPACK and `torch.backends.xnnpack.enabled` is `False`.

The binary smoke test in `check_binary.sh` still asserted that XNNPACK was available, which breaks all binary "Test PyTorch binary" jobs (e.g. aarch64 CPU/CUDA manywheel). This removes the now-invalid XNNPACK check to match the new default.

### Example failure
https://github.com/pytorch/pytorch/actions/runs/27127327956/job/80184244661
```
+ python -c 'import torch.backends.xnnpack; exit(0 if torch.backends.xnnpack.enabled else 1)'
##[error]Process completed with exit code 1.
```

## Changes
- Remove the wheel XNNPACK check (`torch.backends.xnnpack.enabled`)
- Remove the libtorch XNNPACK check (`build_and_run_example_cpp check-torch-xnnpack`)
- Renumber the header comment list

cc @malfet
