### PR TITLE
reland [fx] Add Graph.materialize_symints + helpers; warn on raw SymInt args (#186665)

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -388,11 +388,10 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         self.assertIs(result, args)
 
     def test_get_compile_args_e2e_symbolic_compile(self):
-        """E2E: compile_fx_inner fails with concrete args but succeeds
-        with _get_compile_args for symbolically-traced graphs.
-
-        This is the minimal repro for the 'NameError: name s48 is not
-        defined' bug in fx_graph_runnable repro scripts.
+        """E2E: _get_compile_args produces args usable by compile_fx_inner
+        for symbolically-traced graphs (regression test for the
+        'NameError: name s48 is not defined' issue in fx_graph_runnable
+        repro scripts).
         """
         from torch._inductor.compile_fx import compile_fx_inner
 
@@ -405,13 +404,10 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         concrete_args = [N, torch.randn(32), torch.randn(32)]
         gm = make_fx(f, tracing_mode="symbolic")(*concrete_args)
 
-        # BUG: concrete args cause NameError on undefined symbolic variable
-        with self.assertRaises(NameError):
-            compiled = compile_fx_inner(gm, concrete_args)
-            self.assertNotIsInstance(compiled, str)
-            compiled(list(concrete_args))
+        compiled = compile_fx_inner(gm, concrete_args)
+        self.assertNotIsInstance(compiled, str)
+        compiled(list(concrete_args))
 
-        # FIX: _get_compile_args extracts symbolic metadata
         symbolic_args = _get_compile_args(gm, concrete_args)
         compiled = compile_fx_inner(gm, symbolic_args)
         self.assertNotIsInstance(compiled, str)

--- a/test/expect/TestFXAPIBackwardCompatibility.test_class_member_back_compat-fx_backcompat_class_members.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_class_member_back_compat-fx_backcompat_class_members.expect
@@ -1,6 +1,6 @@
 torch.fx._symbolic_trace.ProxyableClassMeta []
 torch.fx._symbolic_trace.Tracer ['call_module', 'create_arg', 'create_args_for_root', 'get_fresh_qualname', 'getattr', 'is_leaf_module', 'path_of_module', 'trace']
-torch.fx.graph.Graph ['call_function', 'call_method', 'call_module', 'create_node', 'eliminate_dead_code', 'erase_node', 'find_nodes', 'get_attr', 'graph_copy', 'inserting_after', 'inserting_before', 'lint', 'node_copy', 'nodes', 'on_generate_code', 'output', 'output_node', 'owning_module', 'placeholder', 'print_tabular', 'process_inputs', 'process_outputs', 'python_code', 'set_codegen']
+torch.fx.graph.Graph ['call_function', 'call_method', 'call_module', 'create_node', 'create_size_node', 'create_storage_offset_node', 'create_stride_node', 'eliminate_dead_code', 'erase_node', 'find_nodes', 'get_attr', 'graph_copy', 'inserting_after', 'inserting_before', 'lint', 'materialize_symint', 'materialize_symints', 'node_copy', 'nodes', 'on_generate_code', 'output', 'output_node', 'owning_module', 'placeholder', 'print_tabular', 'process_inputs', 'process_outputs', 'python_code', 'set_codegen']
 torch.fx.graph.PythonCode []
 torch.fx.graph_module.GraphModule ['add_submodule', 'code', 'delete_all_unused_submodules', 'delete_submodule', 'graph', 'print_readable', 'recompile', 'to_folder']
 torch.fx.immutable_collections.immutable_dict ['clear', 'pop', 'popitem', 'setdefault', 'update']

--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -904,6 +904,51 @@ class OptimizeForInferenceTemplate(TestCase):
             out_compiled = func1(x.clone())
             self.assertEqual(out_eager, out_compiled)
 
+    @torch._inductor.config.patch(
+        layout_optimization=True, force_layout_optimization=True
+    )
+    def test_as_strided_input_layout_with_symbolic_strides(self):
+        from torch._inductor.compile_fx import compile_fx, compile_fx_inner
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                y = x.transpose(1, 2)
+                return torch.as_strided(y, y.size(), y.stride())
+
+        graph_modules = []
+
+        def my_inner_compile(gm, example_inputs, *args, **kwargs):
+            graph_modules.append(gm)
+            return compile_fx_inner(gm, example_inputs, *args, **kwargs)
+
+        mod = Model().eval().to(self.device)
+        inp = torch.randn(2, 3, 4, device=self.device)
+        torch._dynamo.mark_dynamic(inp, 1)
+        torch._dynamo.mark_dynamic(inp, 2)
+
+        with torch.no_grad():
+            expected = mod(inp)
+            opt_mod = torch.compile(
+                mod,
+                backend=functools.partial(compile_fx, inner_compile=my_inner_compile),
+                dynamic=True,
+            )
+            actual = opt_mod(inp)
+            self.assertEqual(expected, actual)
+
+        self.assertTrue(graph_modules)
+        gm = graph_modules[0]
+        nodes = list(gm.graph.nodes)
+        force_stride_node = next(
+            n for n in nodes if n.target == prims.inductor_force_stride_order.default
+        )
+        as_strided_node = next(n for n in nodes if n.target == aten.as_strided.default)
+
+        self.assertLess(nodes.index(force_stride_node), nodes.index(as_strided_node))
+        for stride_arg in force_stride_node.args[1]:
+            if isinstance(stride_arg, torch.fx.Node):
+                self.assertLess(nodes.index(stride_arg), nodes.index(force_stride_node))
+
     @tf32_on_and_off(0.001)
     @torch._inductor.config.patch(layout_optimization=True)
     def test_redundant_clone_for_layout_convert(self):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -74,6 +74,7 @@ from torch.testing._internal.common_utils import (
     IS_ARM64,
     IS_LINUX,
     IS_WINDOWS,
+    TEST_WITH_CROSSREF,
     TEST_WITH_ROCM,
     run_tests,
     skipIfTorchDynamo,
@@ -4686,6 +4687,275 @@ event={kernel_event} node=add stack_trace=a = s + self.c"""
             "Deserialized graph should contain triton_kernel_wrapper_functional",
         )
 
+
+    @staticmethod
+    def _capture_gm(fn, *example_inputs):
+        """Compile ``fn`` with dynamic shapes, return the captured GraphModule."""
+        from torch._dynamo.testing import EagerAndRecordGraphs
+
+        backend = EagerAndRecordGraphs()
+        torch.compile(fn, dynamic=True, backend=backend)(*example_inputs)
+        return backend.graphs[-1]
+
+    @staticmethod
+    def _find_placeholder(gm, example_value_type):
+        """Return the first placeholder whose ``meta['example_value']`` is an
+        instance of ``example_value_type``."""
+        return next(
+            n
+            for n in gm.graph.nodes
+            if n.op == "placeholder"
+            and isinstance(n.meta.get("example_value"), example_value_type)
+        )
+
+    def test_create_tensor_metadata_nodes(self):
+        def check(meta_key):
+            graph = torch.fx.Graph()
+            tensor_node = graph.placeholder("x")
+            fake = torch.empty_strided((2, 3), (5, 2), device="meta")
+            tensor_node.meta[meta_key] = fake
+
+            size_node = graph.create_size_node(tensor_node, 1)
+            stride_node = graph.create_stride_node(tensor_node, 0)
+            storage_offset_node = graph.create_storage_offset_node(tensor_node)
+
+            self.assertEqual(size_node.target, torch.ops.aten.sym_size.int)
+            self.assertEqual(size_node.args, (tensor_node, 1))
+            self.assertEqual(size_node.meta[meta_key], fake.size(1))
+
+            self.assertEqual(stride_node.target, torch.ops.aten.sym_stride.int)
+            self.assertEqual(stride_node.args, (tensor_node, 0))
+            self.assertEqual(stride_node.meta[meta_key], fake.stride(0))
+
+            self.assertEqual(
+                storage_offset_node.target, torch.ops.aten.sym_storage_offset.default
+            )
+            self.assertEqual(storage_offset_node.args, (tensor_node,))
+            self.assertEqual(storage_offset_node.meta[meta_key], fake.storage_offset())
+
+        check("val")
+        check("example_value")
+
+    @unittest.skipIf(TEST_WITH_CROSSREF, "expectedInline graph differs under TorchFunctionMode")
+    def test_materialize_symints_basic(self):
+        """``Graph.materialize_symints`` lowers each SymInt input into an FX
+        subgraph rooted at existing symbol producers."""
+        gm = self._capture_gm(lambda x: x + 1, torch.randn(8, 4))
+        # Pick a tensor placeholder so we can derive its symbolic dims.
+        tensor_placeholder = self._find_placeholder(gm, torch.Tensor)
+        h, _ = tensor_placeholder.meta["example_value"].shape  # h is a SymInt
+        self.assertIsInstance(h, torch.SymInt)
+
+        # Realistic usage: scope the materialization to run before the existing
+        # output so the new nodes land in the body (not orphaned after the
+        # return), and wire the result into the output so they're not dead.
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        with gm.graph.inserting_before(output_node):
+            result = gm.graph.materialize_symints(
+                [h - 1, 3 * (h - 1), (h - 1) ** 2, 5]
+            )
+        output_node.args = (output_node.args[0] + tuple(result),)
+
+        # Plain int passes through, the rest are Nodes.
+        self.assertEqual(result[3], 5)
+        for got in result[:3]:
+            self.assertIsInstance(got, torch.fx.Node)
+
+        # Note: ``h - 1`` is hash-consed across the inputs that share it as a
+        # sub-expression -- ``h - 1`` itself and ``(h - 1) ** 2`` both reference
+        # the same ``%add_1`` (``%pow_1`` takes ``%add_1`` as its base). The
+        # ``3 * (h - 1)`` input is *not* sharing here because sympy distributes
+        # it into ``3*h - 3`` (i.e., ``%mul`` + ``%add_2``), so ``h - 1`` is
+        # not a sub-expression of that lowered form.
+        self.assertExpectedInline(
+            str(gm.graph).strip(),
+            """\
+graph():
+    %s77 : torch.SymInt [num_users=2] = placeholder[target=s77]
+    %s27 : torch.SymInt [num_users=0] = placeholder[target=s27]
+    %l_x_ : torch.Tensor [num_users=1] = placeholder[target=L_x_]
+    %add : [num_users=1] = call_function[target=operator.add](args = (%l_x_, 1), kwargs = {})
+    %add_1 : [num_users=2] = call_function[target=operator.add](args = (-1, %s77), kwargs = {})
+    %mul : [num_users=1] = call_function[target=operator.mul](args = (3, %s77), kwargs = {})
+    %add_2 : [num_users=1] = call_function[target=operator.add](args = (-3, %mul), kwargs = {})
+    %pow_1 : [num_users=1] = call_function[target=operator.pow](args = (%add_1, 2), kwargs = {})
+    return (add, add_1, add_2, pow_1, 5)""",
+        )
+
+    def test_materialize_symints_constant_symint(self):
+        """A SymInt whose expression has folded to a constant is unwrapped
+        to a plain ``int`` rather than emitting any FX nodes."""
+        gm = self._capture_gm(lambda x: x + 1, torch.randn(8, 4))
+        tensor_placeholder = self._find_placeholder(gm, torch.Tensor)
+        h = tensor_placeholder.meta["example_value"].shape[0]
+        self.assertIsInstance(h, torch.SymInt)
+
+        const = h - h  # = 0, constant SymInt
+        result = gm.graph.materialize_symints([const])
+        self.assertEqual(result, [0])
+        self.assertIsInstance(result[0], int)
+
+    def test_materialize_symints_missing_symbol_rejects(self):
+        """Materializing a SymInt whose symbol has no producer in the graph
+        raises ``AssertionError`` rather than producing a dangling node."""
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        # Manufacture a SymInt with a non-constant symbol (no graph needed).
+        shape_env = ShapeEnv()
+        h = shape_env.create_unbacked_symint()
+        self.assertIsInstance(h, torch.SymInt)
+
+        # Empty graph has no producer for `h`'s symbol → must reject.
+        empty_graph = torch.fx.Graph()
+        with self.assertRaisesRegex(AssertionError, "no producer for"):
+            empty_graph.materialize_symints([h])
+
+    @unittest.skipIf(TEST_WITH_CROSSREF, "expectedInline graph differs under TorchFunctionMode")
+    def test_materialize_symints_symint_placeholder(self):
+        """When the symbol is produced by a top-level SymInt placeholder, the
+        placeholder itself is used as the symbol's producer — no
+        `sym_size.int` node is emitted."""
+        gm = self._capture_gm(lambda n: torch.zeros(n + 1), 8)
+        sym_placeholder = self._find_placeholder(gm, torch.SymInt)
+        s = sym_placeholder.meta["example_value"]
+        self.assertIsInstance(s, torch.SymInt)
+
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        with gm.graph.inserting_before(output_node):
+            result = gm.graph.materialize_symints([s + 2, s * 3])
+        output_node.args = (output_node.args[0] + tuple(result),)
+
+        self.assertEqual(len(result), 2)
+        for got in result:
+            self.assertIsInstance(got, torch.fx.Node)
+
+        # The new `add_1` and `mul` reference `%l_n_` (the SymInt placeholder)
+        # directly — no `aten.sym_size.int` node was emitted to recover `s`.
+        self.assertExpectedInline(
+            str(gm.graph).strip(),
+            """\
+graph():
+    %l_n_ : torch.SymInt [num_users=3] = placeholder[target=L_n_]
+    %add : [num_users=1] = call_function[target=operator.add](args = (%l_n_, 1), kwargs = {})
+    %zeros : [num_users=1] = call_function[target=torch.zeros](args = (%add,), kwargs = {})
+    %add_1 : [num_users=1] = call_function[target=operator.add](args = (2, %l_n_), kwargs = {})
+    %mul : [num_users=1] = call_function[target=operator.mul](args = (3, %l_n_), kwargs = {})
+    return (zeros, add_1, mul)""",
+        )
+
+    def test_materialize_symints_unbacked_via_unbacked_bindings(self):
+        """When an unbacked SymInt's producer is described by
+        ``node.meta['unbacked_bindings']`` with a non-trivial keypath (e.g.
+        ``nonzero()`` → ``.size(0)``), ``materialize_symints`` follows the
+        keypath to emit the right accessor (``aten.sym_size.int``)."""
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def f(x):
+            return torch.nonzero(x)
+
+        gm = make_fx(f, tracing_mode="symbolic")(torch.randn(10))
+        nonzero_node = next(
+            n
+            for n in gm.graph.nodes
+            if n.target == torch.ops.aten.nonzero.default
+        )
+        bindings = nonzero_node.meta["unbacked_bindings"]
+        self.assertEqual(len(bindings), 1)
+        u = next(iter(bindings))
+        # u is the unbacked SymInt for nonzero's first output dim.
+        u_symint = nonzero_node.meta["val"].shape[0]
+        self.assertIsInstance(u_symint, torch.SymInt)
+        self.assertEqual(u_symint.node._expr, u)
+
+        result = gm.graph.materialize_symints([u_symint + 5])
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], torch.fx.Node)
+
+        # The keypath `(CallMethodKey("size"), SequenceKey(0))` is traversed,
+        # emitting `aten.sym_size.int(%nonzero, 0)` as the producer.
+        sym_size_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.target == torch.ops.aten.sym_size.int
+        ]
+        self.assertEqual(len(sym_size_nodes), 1)
+        self.assertIs(sym_size_nodes[0].args[0], nonzero_node)
+        self.assertEqual(sym_size_nodes[0].args[1], 0)
+
+    def test_materialize_symints_unbacked_via_divide_by_key(self):
+        """When an unbacked-binding keypath ends in ``DivideByKey(s_backed)``,
+        ``materialize_symints`` emits ``producer // s_backed_node`` -- where
+        ``s_backed_node`` is the lowered backed shape symbol, not a raw SymInt.
+        """
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.experimental.symbolic_shapes import DivideByKey
+
+        # Trace a graph that has a tensor placeholder + nonzero producer for
+        # an unbacked symbol. We then synthetically rewrite the binding so
+        # the keypath includes a ``DivideByKey(s_backed)`` component, where
+        # ``s_backed`` is a backed shape symbol of the input tensor.
+        def f(x, y):
+            return torch.nonzero(y)
+
+        gm = make_fx(f, tracing_mode="symbolic")(
+            torch.randn(8, 4), torch.randn(10)
+        )
+        nonzero_node = next(
+            n
+            for n in gm.graph.nodes
+            if n.target == torch.ops.aten.nonzero.default
+        )
+        tensor_ph = next(
+            n
+            for n in gm.graph.nodes
+            if n.op == "placeholder"
+            and isinstance(n.meta.get("val"), torch.Tensor)
+            and n.meta["val"].dim() == 2
+        )
+        s_backed_symint = tensor_ph.meta["val"].shape[0]
+        self.assertIsInstance(s_backed_symint, torch.SymInt)
+
+        # Splice DivideByKey(s_backed) onto the existing keypath. The
+        # synthetic semantic: u = nonzero.size(0) // s_backed.
+        u, keypath = next(iter(nonzero_node.meta["unbacked_bindings"].items()))
+        nonzero_node.meta["unbacked_bindings"] = {
+            u: keypath + (DivideByKey(s_backed_symint),)
+        }
+        u_symint = nonzero_node.meta["val"].shape[0]
+
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        with gm.graph.inserting_before(output_node):
+            result = gm.graph.materialize_symints([u_symint + 1])
+        output_node.args = ((output_node.args[0],) + tuple(result),)
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], torch.fx.Node)
+
+        # A floordiv node was emitted whose divisor is the lowered backed
+        # shape symbol (a ``sym_size.int(%tensor_ph, 0)`` node) -- not a raw
+        # SymInt object.
+        self.assertExpectedInline(
+            str(gm.graph).strip(),
+            """\
+graph():
+    %x_1 : [num_users=1] = placeholder[target=x_1]
+    %y_1 : [num_users=1] = placeholder[target=y_1]
+    %nonzero : [num_users=2] = call_function[target=torch.ops.aten.nonzero.default](args = (%y_1,), kwargs = {})
+    %sym_size_int : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%x_1, 0), kwargs = {})
+    %sym_size_int_1 : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%nonzero, 0), kwargs = {})
+    %floordiv : [num_users=1] = call_function[target=operator.floordiv](args = (%sym_size_int_1, %sym_size_int), kwargs = {})
+    %add : [num_users=1] = call_function[target=operator.add](args = (1, %floordiv), kwargs = {})
+    return (nonzero, add)""",
+        )
+
+        floordiv_nodes = [
+            n for n in gm.graph.nodes if n.target is operator.floordiv
+        ]
+        self.assertEqual(len(floordiv_nodes), 1)
+        divisor_arg = floordiv_nodes[0].args[1]
+        self.assertIsInstance(divisor_arg, torch.fx.Node)
+        self.assertEqual(divisor_arg.target, torch.ops.aten.sym_size.int)
+        self.assertIs(divisor_arg.args[0], tensor_ph)
 
 def run_getitem_target():
     from torch.fx._symbolic_trace import _wrapped_methods_to_patch

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -148,10 +148,8 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(PassBase):
 
                                 def sym_size_cb(node, assert_msg, dim):
                                     with node.graph.inserting_after(node):
-                                        dim_node = module.graph.call_function(
-                                            torch.ops.aten.sym_size.int,
-                                            (node, dim),
-                                            {},
+                                        dim_node = module.graph.create_size_node(  # type: ignore[union-attr]
+                                            node, dim
                                         )
                                     cb(node=dim_node, assert_msg=assert_msg)
 

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -225,10 +225,11 @@ def enforce_output_layout(gm: torch.fx.GraphModule):
             ):
                 continue
 
-            # add a node to enforce eager layout
+            # Use materialize_symints intentionally; see its docstring for why.
             ft = n.meta["val"]
+            stride_args = tuple(gm.graph.materialize_symints(ft.stride()))
             new_node = gm.graph.call_function(
-                prims.inductor_force_stride_order.default, (n, ft.stride())
+                prims.inductor_force_stride_order.default, (n, stride_args)
             )
 
             # can not call
@@ -254,12 +255,13 @@ def enforce_as_strided_input_layout(gm: torch.fx.GraphModule):
     strided_nodes = [n for n in gm.graph.nodes if n.target in as_strided_ops]
     for n in strided_nodes:
         with gm.graph.inserting_before(n):
-            # add a node to enforce eager layout
+            # Use materialize_symints intentionally; see its docstring for why.
             ft = n.args[0].meta["val"]
+            stride_args = tuple(gm.graph.materialize_symints(ft.stride()))
             new_node = gm.graph.call_function(
-                prims.inductor_force_stride_order.default, (n.args[0], ft.stride())
+                prims.inductor_force_stride_order.default, (n.args[0], stride_args)
             )
-            n.replace_input_with(n.args[0], new_node)
+        n.replace_input_with(n.args[0], new_node)
 
     gm.graph.lint()
     gm.recompile()

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -191,10 +191,18 @@ def remove_no_ops(
                 val = n.meta.get("val")
                 if isinstance(val, torch.Tensor) and val.device.type == "meta":
                     with graph.inserting_before(output_node):
+                        # size/stride may be symbolic under dynamic shapes;
+                        # materialize them so we never pass raw SymInts as args.
+                        # Use materialize_symints (roots backed sizes on input
+                        # placeholders) rather than create_size_node(n, d), which
+                        # would query `n` and pin it alive, blocking the
+                        # eliminate_dead_code() that removes this meta tensor.
+                        size = graph.materialize_symints(val.size())
+                        stride = graph.materialize_symints(val.stride())
                         n.replace_all_uses_with(
                             graph.call_function(
                                 torch.ops.aten.empty_strided.default,
-                                args=(val.size(), val.stride()),
+                                args=(size, stride),
                                 kwargs={"dtype": val.dtype, "device": val.device},
                             )
                         )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2922,7 +2922,7 @@ def randn(*args, **kwargs):
 
 @register_lowering(inductor_prims.force_stride_order, type_promotion_kind=None)
 def inductor_force_stride_order(input_tensor, stride):
-    stride_order = ir.get_stride_order(stride)
+    stride_order = ir.get_stride_order(stride, V.graph.sizevars.shape_env)
     return ir.ExternKernel.require_stride_order(input_tensor, stride_order)
 
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -25,6 +25,7 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import _fx_map_arg as map_arg, _NodeIter
 from torch._library.opaque_object import get_opaque_obj_repr, is_opaque_value_type
+from torch.types import py_sym_types
 from torch.utils._dtype_abbrs import dtype_abbrs
 
 from . import _pytree as fx_pytree
@@ -38,7 +39,10 @@ log = logging.getLogger(__name__)
 
 __all__ = ["PythonCode", "CodeGen", "Graph"]
 
+
 if TYPE_CHECKING:
+    import sympy
+
     from ._symbolic_trace import Tracer
     from .graph_module import GraphModule
 
@@ -1538,6 +1542,20 @@ class Graph:
             if not isinstance(kwargs, dict):
                 raise AssertionError(f"kwargs must be a dict, got {type(kwargs)}")
 
+        # TODO: Generalize this invariant to all FX node args once the broader
+        # FX argument contract no longer permits raw symbolic leaves.
+        if op in ("call_function", "call_method", "call_module") and (args or kwargs):
+            for val in pytree.tree_iter((args, kwargs)):
+                if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+                    warnings.warn(
+                        f"Raw {type(val).__name__} value ({val}) passed as argument to "
+                        f"Graph.create_node(op='{op}', target={target}). "
+                        f"Use create_*_node() helpers for tensor metadata queries "
+                        f"or materialize_symints() for general symbolic expressions.",
+                        stacklevel=2,
+                    )
+                    break
+
         candidate = name if name is not None else self._target_to_str(target)
         name = self._graph_namespace.create_name(candidate, None)
         n = Node(self, name, op, target, args, kwargs, type_expr)
@@ -1892,6 +1910,391 @@ class Graph:
         return self.create_node(
             "call_function", the_function, args, kwargs, name=name, type_expr=type_expr
         )
+
+    @staticmethod
+    def _get_tensor_meta_val(tensor_node: Node) -> tuple[Any, str]:
+        """Read the example tensor stored on ``tensor_node`` under either
+        ``meta['val']`` (export / proxy_tensor convention) or
+        ``meta['example_value']`` (dynamo convention).
+
+        Returns ``(value, key)`` where ``key`` is the meta key the value was
+        found under (defaulting to ``"val"`` if no meta is present). Callers
+        that emit a new node should mirror ``key`` so the new node matches
+        the surrounding graph's convention.
+        """
+        if "val" in tensor_node.meta:
+            return tensor_node.meta["val"], "val"
+        if "example_value" in tensor_node.meta:
+            return tensor_node.meta["example_value"], "example_value"
+        return None, "val"
+
+    @compatibility(is_backward_compatible=False)
+    def create_size_node(self, tensor_node: Node, dim: int) -> Node:
+        """Create an FX node for ``tensor_node.size(dim)``."""
+        val, key = self._get_tensor_meta_val(tensor_node)
+        node = self.call_function(torch.ops.aten.sym_size.int, (tensor_node, dim))
+        if val is not None:
+            node.meta[key] = val.size(dim)
+        return node
+
+    @compatibility(is_backward_compatible=False)
+    def create_stride_node(self, tensor_node: Node, dim: int) -> Node:
+        """Create an FX node for ``tensor_node.stride(dim)``."""
+        val, key = self._get_tensor_meta_val(tensor_node)
+        node = self.call_function(torch.ops.aten.sym_stride.int, (tensor_node, dim))
+        if val is not None:
+            node.meta[key] = val.stride(dim)
+        return node
+
+    @compatibility(is_backward_compatible=False)
+    def create_storage_offset_node(self, tensor_node: Node) -> Node:
+        """Create an FX node for ``tensor_node.storage_offset()``."""
+        val, key = self._get_tensor_meta_val(tensor_node)
+        node = self.call_function(
+            torch.ops.aten.sym_storage_offset.default, (tensor_node,)
+        )
+        if val is not None:
+            node.meta[key] = val.storage_offset()
+        return node
+
+    @compatibility(is_backward_compatible=False)
+    def _resolve_unbacked_binding(
+        self,
+        producer: Node,
+        keypath: tuple[object, ...],
+        lower_symint: Callable[[torch.SymInt], Node | int],
+    ) -> Node:
+        """Walk an ``unbacked_bindings`` keypath, emitting FX ops on this
+        graph to recover the bound SymInt from ``producer``'s result.
+
+        ``lower_symint`` is invoked for the only keypath component that may
+        carry a non-literal value: ``DivideByKey`` with a SymInt divisor.
+        Callers must provide one (e.g. a wrapper around their sympy interp
+        cache).
+        """
+        import operator
+
+        from torch.fx.experimental.symbolic_shapes import (
+            CallMethodKey,
+            ConvertIntKey,
+            DivideByKey,
+            InnerTensorKey,
+        )
+
+        node = producer
+        i = 0
+        while i < len(keypath):
+            k = keypath[i]
+            nxt = keypath[i + 1] if i + 1 < len(keypath) else None
+            if isinstance(k, CallMethodKey) and isinstance(nxt, pytree.SequenceKey):
+                idx = nxt.idx
+                if k.name == "size":
+                    node = self.create_size_node(node, idx)
+                elif k.name == "stride":
+                    node = self.create_stride_node(node, idx)
+                else:
+                    node = self.call_method(k.name, (node, idx))
+                i += 2
+            elif isinstance(k, CallMethodKey):
+                if k.name == "storage_offset":
+                    node = self.create_storage_offset_node(node)
+                else:
+                    node = self.call_method(k.name, (node,))
+                i += 1
+            elif isinstance(k, pytree.SequenceKey):
+                node = self.call_function(operator.getitem, (node, k.idx))
+                i += 1
+            elif isinstance(k, ConvertIntKey):
+                node = self.call_function(torch.sym_ite, (node, 1, 0))
+                i += 1
+            elif isinstance(k, DivideByKey):
+                divisor = k.divisor
+                if isinstance(divisor, torch.SymInt):
+                    divisor = lower_symint(divisor)
+                node = self.call_function(operator.floordiv, (node, divisor))
+                i += 1
+            elif isinstance(k, InnerTensorKey):
+                node = self.call_function(getattr, (node, k.inner_name))
+                i += 1
+            else:
+                raise AssertionError(f"unrecognized keypath component {k}")
+        return node
+
+    @compatibility(is_backward_compatible=False)
+    def materialize_symints(
+        self, values: Sequence[torch.SymInt | int]
+    ) -> list[Node | int]:
+        """Materialize a list of ``SymInt``/``int`` values as FX subgraphs rooted
+        at existing nodes in this graph whose meta produces the referenced
+        symbols (typically SymInt placeholders or other sym ops).
+
+        consider a graph with a tensor placeholder
+        ``%x`` of shape ``(s32, s32)`` and we want to record this stride
+        as an FX value to pass to a later op, two ways to do it.
+
+        * ``g.create_stride_node(%x, 0)`` emits ``%t = aten.sym_stride.int(%x, 0)``.
+          The semantics of this op are "ask ``%x`` for its current stride at
+          dim 0". If a later pass (e.g. mkldnn channels-last conversion) mutates
+          ``%x``'s layout, re-running ``FakeTensorProp`` will overwrite
+          ``%t.meta["val"]`` with the NEW stride. This is the right behavior
+          when you want a *live* query on the producer.
+
+        * ``g.materialize_symints([%x.meta["val"].stride(0)])`` walks the sympy
+          expression ``s32`` and emits an FX subgraph that recomputes it from
+          the existing producer of ``s32`` (here the placeholder ``%x`` itself
+          via ``aten.sym_size.int(%x, 0)``, or a SymInt placeholder if one
+          exists). The resulting node's value is "what ``s32`` is at runtime"
+          -- which is determined by the input's shape and is INDEPENDENT of any
+          layout change to ``%x``. This is the right behavior when you want to
+          *freeze* the trace-time stride into the graph.
+
+        Note: like other ``Graph`` node-creation APIs (``call_function``,
+        ``create_size_node``, etc.), nodes are emitted at the graph's current
+        insertion point. The default insertion point (``Graph._root.prepend``)
+        appends new nodes to the end of the graph, which on a graph that
+        already has an ``output`` node means they land *after* ``return``
+        (orphaned). Callers typically scope this in
+        ``with graph.inserting_before(graph.output_node()):`` so the new
+        nodes land in the body.
+
+        Performance: each call performs an O(graph_size) producer-discovery
+        scan and builds a per-call ``expr_to_proxy`` hash-cons cache. Prefer
+        batching every SymInt you need to lift into a single call (or as few
+        calls as possible) over calling it once per value -- this amortises
+        the graph scan and lets symints with shared sub-expressions get
+        hash-consed into a single subgraph.
+        """
+        # Local imports keep sympy off the ``import torch`` path; the helper
+        # is only invoked from passes that already depend on symbolic shapes.
+        import operator
+
+        import sympy
+
+        from torch.utils._sympy.interp import _run_sympy_handler, sympy_interp
+        from torch.utils._sympy.reference import PythonReferenceAnalysis
+
+        # TODO: consider caching `expr_to_proxy` / `sym_size_sources` across
+        # calls.
+        # Read tensor/SymInt metadata with fallback. Edge graphs can have
+        # a mixed convention: lifted parameters carry both ``"val"`` and
+        # ``"example_value"`` (dynamo-style) while real user inputs carry
+        # only ``"val"`` (export-style). Probing the graph for a single
+        # key would lock onto one convention and silently miss symbols on
+        # the others; reading per-node with fallback handles both.
+        def _node_val(n: Node) -> Any:
+            val = n.meta.get("val")
+            if val is not None:
+                return val
+            return n.meta.get("example_value")
+
+        def _set_node_val(n: Node, val: Any) -> None:
+            """Set ``n.meta['val']`` and, if any of ``n``'s input nodes carry
+            ``"example_value"``, mirror it there too so the new node matches
+            the surrounding graph's meta-key convention."""
+            n.meta["val"] = val
+            if any(isinstance(a, Node) and "example_value" in a.meta for a in n.args):
+                n.meta["example_value"] = val
+
+        # Build the symbol -> Proxy map once; shared across all inputs so common
+        # sub-expressions across symints get hash-consed into single subgraphs.
+        tracer = torch.fx.proxy.GraphAppendingTracer(self)
+        expr_to_proxy: dict[sympy.Expr, torch.fx.Proxy] = {}
+
+        # Pass 1: walk the graph to discover producers. All backed symbols
+        # must be found here -- their only safe producer is an input.
+        # Populates:
+        #   - ``expr_to_proxy``: SymInt placeholders -> Proxy (direct).
+        #   - ``sym_size_sources``: tensor placeholder shape symbol
+        #     -> (placeholder, dim, divisor) (lazy, used by Pass 2).
+        #     divisor=1 when the placeholder dim IS the bare ``Symbol``;
+        #     divisor>1 when the dim is ``Symbol * c`` (the ``Dim("h")*N``
+        #     derived-shape pattern). Recovery emits
+        #     ``sym_size.int(ph, dim) // divisor``.
+        #   - ``sym_to_binding``: unbacked symbol -> (producer node, keypath)
+        #     from ``node.meta["unbacked_bindings"]`` (lazy, used by Pass 2).
+        sym_size_sources: dict[sympy.Symbol, tuple[Node, int, int]] = {}
+        sym_to_binding: dict[sympy.Symbol, tuple[Node, tuple[object, ...]]] = {}
+
+        def _record_shape_source(expr: sympy.Expr, node: Node, dim: int) -> None:
+            """Register ``(node, dim)`` as a recoverable source for ``expr``.
+
+            - bare ``Symbol``: divisor = 1.
+            - ``Symbol * c`` (positive integer constant): divisor = c.
+              Recovery is ``sym_size.int(ph, dim) // c``.
+            - anything else: skipped (general inverse needs sympy.solve).
+            """
+            if isinstance(expr, sympy.Symbol):
+                sym_size_sources.setdefault(expr, (node, dim, 1))
+                return
+            if isinstance(expr, sympy.Mul) and len(expr.args) == 2:
+                a, b = expr.args
+                if isinstance(b, sympy.Symbol) and isinstance(a, sympy.Integer):
+                    a, b = b, a  # normalize to (Symbol, Integer) order
+                if (
+                    isinstance(a, sympy.Symbol)
+                    and isinstance(b, sympy.Integer)
+                    and int(b) > 0
+                ):
+                    sym_size_sources.setdefault(a, (node, dim, int(b)))
+
+        for node in self.nodes:
+            if node.op == "placeholder":
+                val = _node_val(node)
+                if isinstance(val, py_sym_types):
+                    expr = val.node.expr
+                    if isinstance(expr, sympy.Symbol) and expr not in expr_to_proxy:
+                        expr_to_proxy[expr] = torch.fx.Proxy(node, tracer=tracer)
+                elif isinstance(val, torch.Tensor):
+                    for dim, s in enumerate(val.shape):
+                        if isinstance(s, torch.SymInt):
+                            _record_shape_source(s.node.expr, node, dim)
+            else:
+                bindings = node.meta.get("unbacked_bindings")
+                if bindings:
+                    for sym, keypath in bindings.items():
+                        sym_to_binding.setdefault(sym, (node, tuple(keypath)))
+
+        from sympy.logic.boolalg import BooleanAtom
+
+        from torch.fx.experimental.symbolic_shapes import (
+            DivideByKey,
+            free_unbacked_symbols,
+        )
+
+        def _arg_meta_val(a: Any) -> Any:
+            if isinstance(a, torch.fx.Node):
+                return _node_val(a)
+            return a
+
+        def _sympy_interp_cached(expr: sympy.Expr) -> Any:
+            # Common expressions cached in expr_to_proxy
+            if expr in expr_to_proxy:
+                return expr_to_proxy[expr]
+            if isinstance(
+                expr, (sympy.Integer, sympy.Number, sympy.Symbol, BooleanAtom)
+            ):
+                # handle leaf terms.
+                return sympy_interp(PythonReferenceAnalysis, expr_to_proxy, expr)
+            # handle composite expressions.
+            result = _run_sympy_handler(
+                PythonReferenceAnalysis,
+                [_sympy_interp_cached(arg) for arg in expr.args],
+                expr,
+            )
+            if not isinstance(result, torch.fx.Proxy):
+                return result
+            expr_to_proxy[expr] = result
+            node = result.node
+            target = node.target
+            if not callable(target):
+                return result
+            try:
+                fake_args = tuple(_arg_meta_val(a) for a in node.args)
+                fake_kwargs = {k: _arg_meta_val(v) for k, v in node.kwargs.items()}
+                _set_node_val(node, target(*fake_args, **fake_kwargs))
+            except (TypeError, ValueError, AttributeError) as e:
+                log.debug(
+                    "materialize_symints: skipping meta annotation for %s: %s",
+                    expr,
+                    e,
+                )
+            return result
+
+        def _lower_symint_divisor(d: torch.SymInt) -> Node | int:
+            r = _sympy_interp_cached(d.node.expr)
+            return r.node if isinstance(r, torch.fx.Proxy) else r
+
+        # Pass 2 (lazy, recursive): materialize a producer for each needed
+        # symbol. Three cases:
+        #   - already in expr_to_proxy: nothing to do.
+        #   - in sym_size_sources: emit sym_size.int for shape symbols
+        #     recoverable from a tensor placeholder shape.
+        #   - in sym_to_binding: fallback for missing unbacked symbols. Use
+        #     the node.meta["unbacked_bindings"] map -- the authoritative
+        #     source for "this node produces these unbacked symbols". The
+        #     keypath tells us how to recover the SymInt from the node's
+        #     result (e.g. .size(i), .stride(i), storage_offset()).
+        def _ensure_produced(sym: sympy.Symbol) -> None:
+            if sym in expr_to_proxy:
+                return
+            if sym in sym_size_sources:
+                ph, dim, divisor = sym_size_sources[sym]
+                sym_node = self.call_function(torch.ops.aten.sym_size.int, (ph, dim))
+                tensor = _node_val(ph)
+                if isinstance(tensor, torch.Tensor):
+                    _set_node_val(sym_node, tensor.shape[dim])
+                if divisor != 1:
+                    # Placeholder dim was ``sym * divisor`` (e.g. from
+                    # ``Dim("h") * N``); recover the underlying symbol as
+                    # ``sym_size.int(ph, dim) // divisor``.
+                    div_node = self.call_function(
+                        operator.floordiv, (sym_node, divisor)
+                    )
+                    if isinstance(tensor, torch.Tensor):
+                        _set_node_val(div_node, tensor.shape[dim] // divisor)
+                    expr_to_proxy[sym] = torch.fx.Proxy(div_node, tracer=tracer)
+                else:
+                    expr_to_proxy[sym] = torch.fx.Proxy(sym_node, tracer=tracer)
+                return
+            if sym in sym_to_binding:
+                if not free_unbacked_symbols(sym):
+                    raise AssertionError(
+                        f"materialize_symints: backed symbol {sym} has no "
+                        f"input producer (backed symbols cannot be recovered "
+                        f"from non-placeholder nodes)"
+                    )
+                producer_node, keypath = sym_to_binding[sym]
+                for k in keypath:
+                    if isinstance(k, DivideByKey) and isinstance(
+                        k.divisor, torch.SymInt
+                    ):
+                        for s2 in k.divisor.node.expr.free_symbols:
+                            _ensure_produced(s2)
+                producer = self._resolve_unbacked_binding(
+                    producer_node, keypath, lower_symint=_lower_symint_divisor
+                )
+                expr_to_proxy[sym] = torch.fx.Proxy(producer, tracer=tracer)
+                return
+            raise AssertionError(f"materialize_symints: no producer for {sym}")
+
+        out: list[Node | int] = []
+        for s in values:
+            if isinstance(s, torch.SymInt):
+                pass
+            elif isinstance(s, int):  # also covers bool (subclass of int)
+                out.append(s)
+                continue
+            else:
+                raise TypeError(
+                    f"materialize_symints: expected SymInt or int, got "
+                    f"{type(s).__name__} ({s!r})"
+                )
+            target_expr = s.node.expr
+            if target_expr.is_number:
+                out.append(int(s))
+                continue
+            for sym in target_expr.free_symbols:
+                _ensure_produced(sym)
+            result = _sympy_interp_cached(target_expr)
+            if not isinstance(result, torch.fx.Proxy):
+                # ``target_expr`` was non-constant per sympy but our interpreter
+                # still folded it to a Python int/bool. Unwrap to that constant.
+                if not isinstance(result, (int, bool)):
+                    raise AssertionError(
+                        f"materialize_symints: non-Proxy result {result!r} for "
+                        f"non-constant target {target_expr!r}"
+                    )
+                out.append(int(result))
+                continue
+            out_node = result.node
+            _set_node_val(out_node, s)
+            out.append(out_node)
+        return out
+
+    @compatibility(is_backward_compatible=False)
+    def materialize_symint(self, value: torch.SymInt | int) -> Node | int:
+        """Single-value convenience wrapper around :meth:`materialize_symints`."""
+        return self.materialize_symints([value])[0]
 
     @compatibility(is_backward_compatible=True)
     def node_copy(

--- a/torch/fx/passes/fake_tensor_prop.py
+++ b/torch/fx/passes/fake_tensor_prop.py
@@ -86,7 +86,7 @@ class FakeTensorProp(torch.fx.Interpreter):
                 # TODO: How is it possible that we get a non fake tensor?  We
                 # should be running under the mode...
                 return snapshot_fake(self._mode.from_tensor(obj, static_shapes=True))
-            elif isinstance(obj, py_sym_types):
+            elif isinstance(obj, (*py_sym_types, int, float, bool)):
                 return obj
             else:
                 return None

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import operator
 import sys
 from collections.abc import Callable
 from typing import Any, Optional, TYPE_CHECKING
@@ -97,11 +96,7 @@ def insert_deferred_runtime_asserts(
     from torch.fx.experimental.symbolic_shapes import (
         _get_placeholder_expr,
         _has_uninterpretable_sympy_function,
-        CallMethodKey,
-        ConvertIntKey,
-        DivideByKey,
         free_symbols,
-        InnerTensorKey,
         resolve_unbacked_bindings,
         RuntimeAssert,
     )
@@ -210,6 +205,8 @@ def insert_deferred_runtime_asserts(
     def _sympy_interp(
         expr_to_proxy: dict[sympy.Expr, fx.Proxy], expr: sympy.Expr
     ) -> fx.Proxy:
+        # Lower a sympy expression into the graph and return the resulting
+        # Proxy (use .node to get the FX node representing ``expr``).
         # sympy_interp() with hash consing
         from sympy import Integer, Number, Symbol
         from sympy.logic.boolalg import BooleanAtom
@@ -342,23 +339,17 @@ def insert_deferred_runtime_asserts(
                     for i, s in enumerate(t.size()):
                         match_symbol(
                             s,
-                            lambda: graph.call_function(
-                                torch.ops.aten.sym_size.int, (node, i)
-                            ),
+                            lambda: graph.create_size_node(node, i),
                         )
                     if not is_sparse_any(t):
                         for i, s in enumerate(t.stride()):
                             match_symbol(
                                 s,
-                                lambda: graph.call_function(
-                                    torch.ops.aten.sym_stride.int, (node, i)
-                                ),
+                                lambda: graph.create_stride_node(node, i),
                             )
                         match_symbol(
                             t.storage_offset(),
-                            lambda: graph.call_function(
-                                torch.ops.aten.sym_storage_offset.default, (node,)
-                            ),
+                            lambda: graph.create_storage_offset_node(node),
                         )
 
             # Handle asserts that aren't associated with any symbol.  This
@@ -484,79 +475,9 @@ def insert_deferred_runtime_asserts(
 
                     # TODO: some CSE when generating these nodes can probably
                     # help reduce graph size and improve compile time
-                    def go(node: fx.Node, keypath: tuple[object, ...]) -> fx.Node:
-                        if keypath == ():
-                            return node
-                        if (
-                            len(keypath) >= 2
-                            and isinstance(keypath[0], CallMethodKey)
-                            and isinstance(keypath[1], pytree.SequenceKey)
-                        ):
-                            if keypath[0].name == "size":
-                                return go(
-                                    graph.call_function(
-                                        torch.ops.aten.sym_size.int,
-                                        (node, keypath[1].idx),
-                                    ),
-                                    keypath[2:],
-                                )
-                            if keypath[0].name == "stride":
-                                return go(
-                                    graph.call_function(
-                                        torch.ops.aten.sym_stride.int,
-                                        (node, keypath[1].idx),
-                                    ),
-                                    keypath[2:],
-                                )
-
-                            return go(
-                                graph.call_method(
-                                    keypath[0].name, (node, keypath[1].idx)
-                                ),
-                                keypath[2:],
-                            )
-                        elif isinstance(keypath[0], CallMethodKey):
-                            if keypath[0].name == "storage_offset":
-                                return go(
-                                    graph.call_function(
-                                        torch.ops.aten.sym_storage_offset.default,
-                                        (node,),
-                                    ),
-                                    keypath[1:],
-                                )
-
-                            return go(
-                                graph.call_method(keypath[0].name, (node,)), keypath[1:]
-                            )
-                        elif isinstance(keypath[0], pytree.SequenceKey):
-                            return go(
-                                graph.call_function(
-                                    operator.getitem, (node, keypath[0].idx)
-                                ),
-                                keypath[1:],
-                            )
-                        elif isinstance(keypath[0], ConvertIntKey):
-                            return go(
-                                graph.call_function(torch.sym_ite, (node, 1, 0)),
-                                keypath[1:],
-                            )
-                        elif isinstance(keypath[0], DivideByKey):
-                            # TODO: need to assert divisibility
-                            return go(
-                                graph.call_function(
-                                    operator.floordiv, (node, keypath[0].divisor)
-                                ),
-                                keypath[1:],
-                            )
-                        elif isinstance(keypath[0], InnerTensorKey):
-                            return go(
-                                graph.call_function(
-                                    getattr, (node, keypath[0].inner_name)
-                                ),
-                                keypath[1:],
-                            )
-                        else:
-                            raise AssertionError(f"unrecognized keypath {keypath}")
+                    def _lower_symint_divisor(d: torch.SymInt) -> fx.Node | int:
+                        p = _sympy_interp(expr_to_proxy, d.node.expr)
+                        return p.node if isinstance(p, fx.Proxy) else p
 
                     if s not in expr_to_proxy:
                         with _set_node_metadata_hook(
@@ -571,7 +492,12 @@ def insert_deferred_runtime_asserts(
                             ),
                         ):
                             expr_to_proxy[s] = fx.Proxy(
-                                go(node, keypath), tracer=tracer
+                                graph._resolve_unbacked_binding(
+                                    node,
+                                    tuple(keypath),
+                                    lower_symint=_lower_symint_divisor,
+                                ),
+                                tracer=tracer,
                             )
                         log.debug("expr_to_proxy[%s] = %s", s, expr_to_proxy[s])
 


### PR DESCRIPTION
Summary:

reland plan for
https://github.com/pytorch/pytorch/pull/186272
due to executorch dependency have to stage changes !! 

Adds Graph.materialize_symints / create_size_node / create_stride_node /
create_storage_offset_node and updates pytorch-internal passes (inductor
freezing/lowering, joint_graph, add_runtime_assertions, runtime_assert,
fake_tensor_prop) to use them.

For now, passing raw SymInt/SymFloat/SymBool values to
Graph.create_node(op=call_function/call_method/call_module) only emits a
warning. A follow-up diff will turn this into RuntimeError once executorch
has migrated.

This is split from the original D107573548 to allow executorch's pytorch
pin to roll forward before the executorch-side migration lands.

Test Plan: test in PR

Differential Revision: D107938876




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98