### PR TITLE
UCC/test: Undo migration to reduce_scatter_single

### DIFF
--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -345,7 +345,7 @@ class ProcessGroupUCCTest(MultiProcessTestCase):
         input = fn(torch.ones(n, n, 10) * (self.rank + 1.0))
         output = fn(torch.zeros(10))
         expected_output = fn(torch.ones(10) * (n + 1) * n / 2)
-        fut = pg.reduce_scatter_single(output, input).get_future()
+        fut = pg._reduce_scatter_base(output, input).get_future()
         fut.wait()
         result = fut.value()
         self.assertEqual(result[0], expected_output)


### PR DESCRIPTION
`_reduce_scatter_base` was changed to `reduce_scatter_single` in #186135. `ProcessGroupUCC` inherits from `c10::Backend` which does not have a `reduce_scatter_single` member function which causes this test to fail. Other `ProcessGroup*` inherit from `c10::Backend` as well but don't show a test failure because all the other tests call the distributed APIs via a `ProcessGroup` object unlike the UCC test which uses the `Backend` object. Confirmed with @d4l3k that reverting is okay for now.

This failure made it into the repo because the CI does not have support for the UCC backend.

Fixes: #186664