### PR TITLE
[jit][mobile] Bounds-check Function.class_type in flatbuffer loader

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -323,7 +323,13 @@ mobile::Module FlatbufferLoader::parseModule(
   for (const auto& f : all_functions_) {
     uint32_t class_index =
         ivalues->Get(f.first)->val_as_Function()->class_type();
-    ClassTypePtr class_type = all_types_[class_index];
+    // class_index is parsed from the (untrusted) flatbuffer and is not
+    // range-checked by VerifyModuleBuffer; validate it before indexing.
+    ClassTypePtr class_type = getType(class_index);
+    TORCH_CHECK(
+        class_type != nullptr,
+        "Parsing flatbuffer module: function references uninitialized class type at index ",
+        class_index);
     class_type->addMethod(f.second);
   }
 
@@ -744,7 +750,13 @@ void FlatbufferLoader::extractJitSourceAndConstants(
     if (f.first >= mobile_ivalue_size_) {
       uint32_t class_index =
           ivalues->Get(f.first)->val_as_Function()->class_type();
-      ClassTypePtr class_type = all_types_[class_index];
+      // See note in parseModule: class_index is untrusted and must be
+      // validated before indexing all_types_.
+      ClassTypePtr class_type = getType(class_index);
+      TORCH_CHECK(
+          class_type != nullptr,
+          "Parsing flatbuffer module: function references uninitialized class type at index ",
+          class_index);
       class_type->addMethod(f.second);
     }
   }

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -323,8 +323,9 @@ mobile::Module FlatbufferLoader::parseModule(
   for (const auto& f : all_functions_) {
     uint32_t class_index =
         ivalues->Get(f.first)->val_as_Function()->class_type();
-    // class_index is parsed from the (untrusted) flatbuffer and is not
-    // range-checked by VerifyModuleBuffer; validate it before indexing.
+    // class_index comes from the flatbuffer but is not range-checked by
+    // VerifyModuleBuffer; validate it before indexing so a malformed module
+    // fails with a clear error instead of crashing.
     ClassTypePtr class_type = getType(class_index);
     TORCH_CHECK(
         class_type != nullptr,
@@ -750,8 +751,8 @@ void FlatbufferLoader::extractJitSourceAndConstants(
     if (f.first >= mobile_ivalue_size_) {
       uint32_t class_index =
           ivalues->Get(f.first)->val_as_Function()->class_type();
-      // See note in parseModule: class_index is untrusted and must be
-      // validated before indexing all_types_.
+      // See note in parseModule: class_index is not range-checked by
+      // VerifyModuleBuffer, so validate it before indexing all_types_.
       ClassTypePtr class_type = getType(class_index);
       TORCH_CHECK(
           class_type != nullptr,


### PR DESCRIPTION
Fixes #<issue-number>

[jit][mobile] Bounds-check Function.class_type in flatbuffer loader

Summary:
The mobile flatbuffer loader reads `Function.class_type` from an untrusted
model and uses it to index `all_types_` via the unchecked `operator[]`, then
dereferences the result (`class_type->addMethod(...)`). `VerifyModuleBuffer`
only validates buffer structure, not this scalar's range against the
`object_types` table, so a malformed module can drive an out-of-bounds read of
`all_types_` followed by a wild/null pointer dereference (SIGSEGV) while
loading.

This routes both function-registration sites
(`FlatbufferLoader::parseModule` and
`FlatbufferLoader::extractJitSourceAndConstants`) through the existing
bounds-checked `getType()` accessor and adds an explicit non-null check before
dereferencing, so an out-of-range or uninitialized class index is rejected with
a clear error instead of crashing.

This continues the same input-validation hardening as prior fixes to this file
(#127437, #110162, #108439, #107510, #104243, #95221).

Test plan:
- Added a regression test that loads a crafted 176-byte flatbuffer module whose
  `class_type` index (100) is out of range for an empty `object_types` table.
  The buffer passes `VerifyModuleBuffer`. Before this change it SIGSEGVs in
  `parseModule`; after it, `torch._C._load_mobile_module_from_bytes` raises a
  `RuntimeError` and the process stays alive.
- Crash reproduced on `torch==2.7.1+cpu` and confirmed present on `main`
  (038e929bfa). Well-formed models load unchanged.

Signed-off-by: Hem Parekh <hemparekh1596@gmail.com>