### PR TITLE
Guard QuACK scaled mm epilogue scales

### DIFF
--- a/test/inductor/test_gemm_epilogue_fusion.py
+++ b/test/inductor/test_gemm_epilogue_fusion.py
@@ -828,6 +828,51 @@ class GemmEpilogueFusionTests(TestCase):
         ).check_not("extern_kernels._scaled_mm").run(code)
 
     @requires_cuda_and_triton
+    def test_cuda_inductor_quack_backend_rejects_scaled_mm_non_mxfp8_scales(self):
+        if not PLATFORM_SUPPORTS_MX_GEMM:
+            self.skipTest("MX GEMM is not supported")
+
+        def fn(a, b, scale_a, scale_b):
+            return gemm_epilogue_fusion(
+                torch.ops.aten._scaled_mm.default,
+                (a, b, scale_a, scale_b),
+                lambda acc: acc.relu(),
+                gemm_kwargs={"out_dtype": torch.bfloat16},
+                kernel_options={"backend": "QUACK"},
+            )
+
+        m, k, n = 128, 32, 128
+        a = torch.eye(m, k, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+        b = (
+            torch.eye(n, k, device="cuda", dtype=torch.bfloat16)
+            .to(torch.float8_e4m3fn)
+            .t()
+        )
+
+        with self.assertRaisesRegex(Exception, "MXFP8-like.*BlockWise1x32"):
+            torch.compile(fn, backend="inductor", fullgraph=True)(
+                a,
+                b,
+                torch.ones((), device="cuda", dtype=torch.float32),
+                torch.ones((), device="cuda", dtype=torch.float32),
+            )
+
+        scale_a = torch.full(
+            (m, ceil_div(k, 32)),
+            1.0,
+            device="cuda",
+            dtype=torch.float8_e8m0fnu,
+        )
+        scale_b = torch.full(
+            (n, ceil_div(k, 32)),
+            1.0,
+            device="cuda",
+            dtype=torch.float8_e8m0fnu,
+        )
+        with self.assertRaisesRegex(Exception, "Invalid blockwise scaling configuration"):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b, scale_a, scale_b)
+
+    @requires_cuda_and_triton
     def test_cuda_inductor_cutlass_backend_uses_cutlass_template_fusion(self):
         from torch._inductor.codegen.cutlass.utils import try_import_cutlass
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -92,6 +92,7 @@ from .utils import (
     decode_device,
     is_dynamic,
     is_gpu,
+    infer_scale_swizzle_ir,
     is_pointwise_use,
     is_view,
     needs_fallback_due_to_atomic_add_limitations,
@@ -8529,17 +8530,41 @@ def gemm_epilogue_fusion_lowering(gemm_op, subgraph, args, gemm_kwargs, kernel_o
             for arg in args
             if isinstance(arg, IRNode) and arg.has_tensor_output()
         )
-        if gemm_op == torch.ops.aten._scaled_mm.default and (
-            len(quack_args) != 4
-            or gemm_kwargs.get("out_dtype") is None
-            or gemm_kwargs.get("bias") is not None
-            or gemm_kwargs.get("scale_result") is not None
-            or gemm_kwargs.get("use_fast_accum", False)
-        ):
-            raise NotImplementedError(
-                "QUACK _scaled_mm epilogue currently supports only "
-                "(A, B, scale_a, scale_b) with explicit out_dtype"
+        if gemm_op == torch.ops.aten._scaled_mm.default:
+            if (
+                len(quack_args) != 4
+                or gemm_kwargs.get("out_dtype") is None
+                or gemm_kwargs.get("bias") is not None
+                or gemm_kwargs.get("scale_result") is not None
+                or gemm_kwargs.get("use_fast_accum", False)
+            ):
+                raise NotImplementedError(
+                    "QUACK _scaled_mm epilogue currently supports only "
+                    "(A, B, scale_a, scale_b) with explicit out_dtype"
+                )
+            from torch.nn.functional import ScalingType, SwizzleType
+
+            scale_a_type, scale_a_swizzle = infer_scale_swizzle_ir(
+                quack_args[0], quack_args[2]
             )
+            scale_b_type, scale_b_swizzle = infer_scale_swizzle_ir(
+                quack_args[1], quack_args[3], transpose=True
+            )
+            expected_swizzle = (
+                SwizzleType.NO_SWIZZLE
+                if torch.version.hip
+                else SwizzleType.SWIZZLE_32_4_4
+            )
+            if (
+                scale_a_type != ScalingType.BlockWise1x32
+                or scale_b_type != ScalingType.BlockWise1x32
+                or scale_a_swizzle != expected_swizzle
+                or scale_b_swizzle != expected_swizzle
+            ):
+                raise NotImplementedError(
+                    "QUACK _scaled_mm epilogue currently supports only MXFP8-like "
+                    "BlockWise1x32 float8_e8m0fnu scales"
+                )
         if gemm_op == torch.ops.aten._grouped_mm.default:
             grouped_mm_supported = (
                 len(quack_args) == 3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo