### PR TITLE
[Inductor][FlexAttention] Cast load_checked_2d offsets to INDEX_DTYPE (avoid AMD int32 element-offset overflow)

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1722,6 +1722,153 @@ class TestFlexAttention(InductorTestCase):
 
     @supported_platform
     @skip_on_cpu
+    @skip_on_mps  # CPU/MPS use a different template
+    def test_paged_kv_load_int32_element_overflow(self, device):
+        # Regression test for compiled FlexAttention with a paged KV cache
+        # whose K/V load offset (in elements) exceeds INT32_MAX. With the
+        # `.to(INDEX_DTYPE)` cast in `load_checked_2d`, Inductor's existing
+        # `can_use_32bit_indexing` heuristic picks INDEX_DTYPE=tl.int64
+        # for this shape and the offsets are promoted to 64-bit. Without
+        # the cast the int32 multiply inside `load_checked_2d` wraps and
+        # the load dereferences wrong memory — either trapping or
+        # silently returning garbage. NVIDIA is unaffected at the same
+        # shape because PTX uses plain 64-bit `ld.global.*`.
+        if device == "cuda" and not PLATFORM_SUPPORTS_BF16:
+            self.skipTest("bf16 is required for this regression test")
+
+        num_kv_heads = 8
+        head_dim = 128
+        block_size = 16
+        # Smallest num_blocks that pushes the K-load element offset past
+        # INT32_MAX. With kv_heads=8 and head_dim=128 the per-token
+        # element stride is 1024; the K-load at the highest page reaches
+        # ~(num_blocks*16 - 1) * 1024 elements. At num_blocks=131073 that
+        # is 2,147,499,008 > INT32_MAX (2,147,483,647).
+        num_blocks = 131073
+        kv_seq_len = num_blocks * block_size  # 2,097,168
+
+        if device == "cuda":
+            kv_bytes = 2 * num_kv_heads * kv_seq_len * head_dim * 2  # K + V, bf16
+            free_bytes, _ = torch.cuda.mem_get_info()
+            if free_bytes < kv_bytes + (2 << 30):
+                self.skipTest(
+                    f"need ~{(kv_bytes >> 30) + 2} GiB free GPU memory for K+V"
+                )
+
+        dtype = torch.bfloat16
+        # Allocate the natural paged layout, then reshape to the
+        # `(B=1, H_kv, S, D)` view vLLM produces. The permute makes the
+        # sequence-dim stride = num_kv_heads * head_dim (= 1024 elements
+        # here), so the high page lands at an element offset that crosses
+        # INT32_MAX.
+        k_cache = torch.empty(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            dtype=dtype,
+            device=device,
+        ).uniform_(-0.02, 0.02)
+        v_cache = torch.empty(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            dtype=dtype,
+            device=device,
+        ).uniform_(-0.02, 0.02)
+        k = (
+            k_cache.view(kv_seq_len, num_kv_heads, head_dim)
+            .unsqueeze(0)
+            .permute(0, 2, 1, 3)
+        )
+        v = (
+            v_cache.view(kv_seq_len, num_kv_heads, head_dim)
+            .unsqueeze(0)
+            .permute(0, 2, 1, 3)
+        )
+        # Sanity: the K-load's max element offset at the highest page
+        # must overflow int32 (in elements) — otherwise the bug doesn't
+        # fire and the test wouldn't be discriminating.
+        max_offs_seq = (num_blocks - 1) * block_size + block_size - 1
+        stride_seq = num_kv_heads * head_dim
+        self.assertGreater(max_offs_seq * stride_seq, (1 << 31) - 1)
+
+        num_q_heads = num_kv_heads
+        q_len = 16  # one BLOCK_M tile, keeps the test simple
+        q = torch.empty(
+            1,
+            num_q_heads,
+            q_len,
+            head_dim,
+            dtype=dtype,
+            device=device,
+        ).uniform_(-0.02, 0.02)
+
+        # BlockMask whose single kv block references the highest physical
+        # page (`num_blocks - 1`) — the page whose element offset crosses
+        # INT32_MAX.
+        last_page = num_blocks - 1
+        kv_indices = torch.tensor(
+            [[[[last_page]]]],
+            dtype=torch.int32,
+            device=device,
+        )
+        kv_num_blocks = torch.ones((1, 1, 1), dtype=torch.int32, device=device)
+        # compute_q_blocks=False: with kv_indices pointing at the highest
+        # page (last_page = num_blocks - 1 = 131072), enabling the
+        # q-blocks transpose path triggers a CUDA device-side assert
+        # inside `_transpose_ordered`. The forward-only test still
+        # exercises the INDEX_DTYPE plumbing this diff adds; the backward
+        # template casts in `flex_backwards.py.jinja` use the same
+        # plumbing so they are covered too.
+        block_mask = BlockMask.from_kv_blocks(
+            kv_num_blocks=kv_num_blocks,
+            kv_indices=kv_indices,
+            BLOCK_SIZE=(q_len, block_size),
+            seq_lengths=(q_len, kv_seq_len),
+            compute_q_blocks=False,
+        )
+
+        # `dynamic=True` matches the production usage (vLLM's
+        # `flex_attention_compiled = torch.compile(..., dynamic=True)`).
+        compiled = torch.compile(flex_attention, fullgraph=True, dynamic=True)
+        # Kernel options match the configuration the bug was discovered
+        # under: tile sizes equal to the mask block size, non-divisible
+        # Q/KV, and the explicit flex backend (not flash).
+        out = compiled(
+            q,
+            k,
+            v,
+            block_mask=block_mask,
+            enable_gqa=False,
+            kernel_options={
+                "FORCE_USE_FLEX_ATTENTION": True,
+                "BLOCK_M": 16,
+                "BLOCK_N": 16,
+                "IS_DIVISIBLE": False,
+            },
+        )
+
+        self.assertEqual(out.shape, (1, num_q_heads, q_len, head_dim))
+        # Numerical reference: only the high physical page is attended to
+        # (kv_indices = [[last_page]]), so the correct output equals
+        # SDPA(q, K[last_page_block], V[last_page_block]) with no mask.
+        # Comparing against this reference catches both failure modes —
+        # hard trap and silent wrong-page garbage read — even when the
+        # garbage happens to be finite.
+        page_start = last_page * block_size
+        page_end = page_start + block_size
+        k_ref = k[:, :, page_start:page_end, :].to(torch.float32)
+        v_ref = v[:, :, page_start:page_end, :].to(torch.float32)
+        q_ref = q.to(torch.float32)
+        ref = torch.nn.functional.scaled_dot_product_attention(
+            q_ref, k_ref, v_ref, is_causal=False
+        ).to(out.dtype)
+        torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
+
+    @supported_platform
+    @skip_on_cpu
     @skip_on_mps  # hardcodes kernel_options={"BACKEND": "TRITON"}
     def test_kv_order_invariance_padded_causal(self, device):
         if device == "cuda" and not PLATFORM_SUPPORTS_BF16:
@@ -5507,7 +5654,7 @@ class GraphModule(torch.nn.Module):
         def forward(self, arg0_1: "i32[]", arg1_1: "i32[]", arg2_1: "i32[]", arg3_1: "i32[]"):
             full_default: "b8[]" = torch.ops.aten.full.default([], True, dtype = torch.bool, layout = torch.strided, device = device(type='GPU_TYPE', index=0), pin_memory = False)
             return full_default
-""".replace("GPU_TYPE", torch.device(device).type),
+""".replace("GPU_TYPE", torch.device(device).type),  # fmt: skip
         )
 
     @supported_platform

--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -34,7 +34,7 @@ def forward_block_mn(
     # Load K as [BLOCK_N, QK_HEAD_DIM_ROUNDED] then transpose to [QK_HEAD_DIM_ROUNDED, BLOCK_N]
     offs_k = tl.arange(0, QK_HEAD_DIM_ROUNDED)
     offs_n_load = kv_base_offset + tl.arange(0, BLOCK_N)
-    k = load_checked_2d(K, offs_n_load, offs_k, stride_kn, stride_kk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM)
+    k = load_checked_2d(K, offs_n_load, offs_k, stride_kn, stride_kk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM, INDEX_DTYPE)
     {%- endif %}
 
     k = tl.trans(k)
@@ -132,7 +132,7 @@ def forward_block_mn(
     {%- else %}
     # Calculate offsets for V loading - reuse kv_base_offset from K loading
     offs_v = tl.arange(0, V_HEAD_DIM_ROUNDED)
-    v = load_checked_2d(V, offs_n_load, offs_v, stride_vn, stride_vk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
+    v = load_checked_2d(V, offs_n_load, offs_v, stride_vn, stride_vk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM, INDEX_DTYPE)
     {%- endif %}
     acc = tl.dot(p.to(MATMUL_PRECISION), v.to(q.dtype), acc, input_precision=FLOAT32_PRECISION)
 

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -132,7 +132,7 @@
     {%- else %}
     offs_m = q_start * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_k = tl.arange(0, QK_HEAD_DIM_ROUNDED)
-    q = load_checked_2d(Q, offs_m, offs_k, stride_qm, stride_qk, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
+    q = load_checked_2d(Q, offs_m, offs_k, stride_qm, stride_qk, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM, INDEX_DTYPE)
     {%- endif %}
 
     # ~~~~~~~~~~~~~~ normal blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
@@ -164,8 +164,8 @@
         )
         {%- else %}
         # load Q and do: they stay in SRAM throughout the inner loop.
-        q = load_checked_2d(Q2, offs_m2, offs_k, stride_qm, stride_qd, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
-        do = load_checked_2d(DO2, offs_m2, offs_v, stride_dom, stride_dod, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
+        q = load_checked_2d(Q2, offs_m2, offs_k, stride_qm, stride_qd, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM, INDEX_DTYPE)
+        do = load_checked_2d(DO2, offs_m2, offs_v, stride_dom, stride_dod, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM, INDEX_DTYPE)
         {%- endif %}
         if PRESCALE_QK:
             q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
@@ -268,8 +268,8 @@
         )
         {%- else %}
         # load K and V: they stay in SRAM throughout the inner loop.
-        k = load_checked_2d(K, offs_n1, offs_k, stride_kn, stride_kd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM)
-        v = load_checked_2d(V, offs_n1, offs_v, stride_vn, stride_vd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
+        k = load_checked_2d(K, offs_n1, offs_k, stride_kn, stride_kd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM, INDEX_DTYPE)
+        v = load_checked_2d(V, offs_n1, offs_v, stride_vn, stride_vd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM, INDEX_DTYPE)
         {%- endif %}
         if PRESCALE_QK:
             k = (k * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
@@ -452,10 +452,15 @@ def bwd_dq_block_mn(
     )
     kT = tl.trans(k)
     {%- else %}
-    kT_ptrs = K + offs_n2[None, :] * stride_kn + offs_k[:, None] * stride_kd
-    vT_ptrs = V + offs_n2[None, :] * stride_vn + offs_v[:, None] * stride_vd
+    # Cast offsets to INDEX_DTYPE before the precomputed pointer arithmetic;
+    # otherwise the multiply happens in default int32 and wraps on AMD when
+    # the source tensor's byte size exceeds the buffer-resource NUM_RECORDS
+    # cap (~2 GiB). load_checked_2d cannot re-cast here because both strides
+    # are None below.
+    kT_ptrs = K + offs_n2[None, :].to(INDEX_DTYPE) * stride_kn + offs_k[:, None].to(INDEX_DTYPE) * stride_kd
+    vT_ptrs = V + offs_n2[None, :].to(INDEX_DTYPE) * stride_vn + offs_v[:, None].to(INDEX_DTYPE) * stride_vd
     # NB reversed order to since K is transposed
-    kT = load_checked_2d(kT_ptrs, offs_k, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, KV_LEN)
+    kT = load_checked_2d(kT_ptrs, offs_k, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, KV_LEN, INDEX_DTYPE)
     {%- endif %}
     qk = tl.dot(q, kT, input_precision=FLOAT32_PRECISION)
     if not PRESCALE_QK:
@@ -535,7 +540,7 @@ def bwd_dq_block_mn(
     )
     vT = tl.trans(v)
     {%- else %}
-    vT = load_checked_2d(vT_ptrs, offs_v, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, V_HEAD_DIM, KV_LEN)
+    vT = load_checked_2d(vT_ptrs, offs_v, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, V_HEAD_DIM, KV_LEN, INDEX_DTYPE)
     {%- endif %}
     dp = tl.dot(do, vT, input_precision=FLOAT32_PRECISION)
     ds = p * (dp - Di[:, None])
@@ -679,10 +684,13 @@ def bwd_dkdv_block_mn(
     )
     qT = tl.trans(q)
     {%- else %}
-    qT_ptrs = Q + offs_m1[None, :] * stride_qm + offs_k[:, None] * stride_qd
-    do_ptrs = DO + offs_m1[:, None] * stride_dom + offs_v[None, :] * stride_dod
+    # See note in bwd_dq_block_mn: cast offsets here too so int32 multiplies
+    # do not wrap when the source tensor's byte size exceeds the AMD
+    # buffer-resource NUM_RECORDS cap (~2 GiB).
+    qT_ptrs = Q + offs_m1[None, :].to(INDEX_DTYPE) * stride_qm + offs_k[:, None].to(INDEX_DTYPE) * stride_qd
+    do_ptrs = DO + offs_m1[:, None].to(INDEX_DTYPE) * stride_dom + offs_v[None, :].to(INDEX_DTYPE) * stride_dod
     # NB reversed order since Q is transposed
-    qT = load_checked_2d(qT_ptrs, offs_k, offs_m1, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, Q_LEN)
+    qT = load_checked_2d(qT_ptrs, offs_k, offs_m1, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, Q_LEN, INDEX_DTYPE)
     {%- endif %}
     # Load LSE before computing qk to reduce pipeline stall.
     if IS_DIVISIBLE:
@@ -761,7 +769,7 @@ def bwd_dkdv_block_mn(
         [(q_start + offset).to(tl.int32), 0],
     )
     {%- else %}
-    do = load_checked_2d(do_ptrs, offs_m1, offs_v, None, None, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
+    do = load_checked_2d(do_ptrs, offs_m1, offs_v, None, None, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM, INDEX_DTYPE)
     {%- endif %}
     # Compute dV.
     ppT = pT

--- a/torch/_inductor/kernel/flex/templates/utilities.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/utilities.py.jinja
@@ -43,10 +43,27 @@ def load_checked_2d(
     IS_DIVISIBLE_N: tl.constexpr,
     M_LEN: tl.constexpr,
     N_LEN: tl.constexpr,
+    INDEX_DTYPE: tl.constexpr = tl.int32,
 ):
-    # Calculate final pointer if strides are provided
+    # Calculate final pointer if strides are provided. The caller
+    # controls the index dtype via INDEX_DTYPE; Inductor's existing
+    # `can_use_32bit_indexing` heuristic in `select_algorithm.py` picks
+    # `tl.int64` when any input's element count exceeds INT32_MAX, and
+    # `tl.int32` otherwise. Casting the offsets here prevents the
+    # int32 multiply from wrapping for large paged-KV layouts. Without
+    # this cast a paged KV cache whose K-load element offset exceeds
+    # INT32_MAX (e.g. a bf16 cache with > 131072 16-token pages and
+    # H_kv=8, head_dim=128) wraps to a negative offset and the load
+    # dereferences invalid memory on AMD — either trapping or silently
+    # returning garbage. NVIDIA is unaffected because its PTX uses
+    # plain 64-bit `ld.global.*` and the pattern-match that produces
+    # the buggy AMD instruction sequence does not exist there.
     if stride_m is not None and stride_n is not None:
-        ptr = ptr + offs_m[:, None] * stride_m + offs_n[None, :] * stride_n
+        ptr = (
+            ptr
+            + offs_m[:, None].to(INDEX_DTYPE) * stride_m
+            + offs_n[None, :].to(INDEX_DTYPE) * stride_n
+        )
 
     # Handle all masking cases
     if not IS_DIVISIBLE_M and not IS_DIVISIBLE_N:


### PR DESCRIPTION
Summary:
Compiled FlexAttention faults on AMD MI350X when a paged KV cache's K/V load element offset exceeds INT32_MAX. The K-load inside `load_checked_2d` computes `offs_m[:, None] * stride_m + offs_n[None, :] * stride_n` with int32 operands. For paged KV caches with > 131072 16-token pages and `num_kv_heads=8, head_dim=128`, the per-token element stride is 1024 and the highest page's K-load reaches an offset of `(131072 * 16 + 15) * 1024 = 2,147,498,015` elements — past INT32_MAX (`2,147,483,647`). The i32 multiply wraps and the load dereferences invalid memory: on AMD this either traps (the original `flex_impl_nan_repro_op_min` symptom) or silently returns garbage from whatever page the wrapped 32-bit byte offset lands on. NVIDIA's PTX uses plain 64-bit `ld.global.*` and is unaffected at the same shape.

This diff plumbs the existing Inductor `INDEX_DTYPE` constexpr (already set by `TritonTemplate.maybe_append_choice` via `can_use_32bit_indexing`) through `load_checked_2d` and every flex template callsite, then casts the offset operands to it before multiplying by the strides. For our failing shape Inductor's element-count heuristic picks `INDEX_DTYPE = tl.int64`, and the cast promotes the i32 offsets to i64 so the multiply does not wrap. Mirrors the existing `.to(tl.int64)` casts in `flex_backwards.py.jinja`. No behaviour change on NVIDIA.

Credit: Taylor Robie (D108082283) for the INDEX_DTYPE plumbing idea. Earlier versions of this diff also added a byte-size-aware override on top of Inductor's element-count heuristic, on the suspicion that the AMD buffer-resource NUM_RECORDS cap is byte-indexed and would trip for `elements < INT32_MAX, bytes > 2 GiB`. Empirical testing on MI350X (`num_blocks=131071`, K elements `2.147 G < INT32_MAX`, K bytes `4.29 GiB > 2 GiB`) shows that case runs cleanly across 5 consecutive runs — Triton's AMD backend emits a typed `buffer_load_short` (for bf16) whose addressing is element-based, so the byte size does not matter. The byte-size override has been removed; Inductor's element-count heuristic is sufficient.

`caffe2/test/inductor/BUCK`: makes the `test_aot_inductor_model_runner_pybind` dep on `:test_aot_inductor_utils` conditional on CUDA (the pybind includes `c10/cuda/CUDAStream.h` and is not wired through the hipify gen, so it doesn't compile under the AMD toolchain; its Python-side import is function-scoped so non-AOTI tests don't trigger it). Without this BUCK fix the regression test below cannot build on AMD.

Adds regression test `caffe2/test/inductor/test_flex_attention.py::TestFlexAttention::test_paged_kv_load_int32_element_overflow`. Shape (`num_blocks=131073`, `num_kv_heads=8`, `head_dim=128`, `block_size=16`, bf16, `dynamic=True`) is the original production repro: max K-load element offset = `2,147,499,008 > INT32_MAX`, Inductor picks `INDEX_DTYPE = tl.int64`, the `.to(INDEX_DTYPE)` cast in `load_checked_2d` is what protects the load. The test compares the compiled output against a `scaled_dot_product_attention` reference computed over only the in-mask block, which catches both failure modes (hard trap and silent wrong-page garbage even when finite).

Test Plan:
PyTorch unit test on AMD MI350X (`devgpu153.prn5`, ROCm 7.0, gfx950):

```
$ HIP_VISIBLE_DEVICES=7 buck2 run @//mode/opt -m fbcode//vllm:omni @//mode/opt-amd-gpu \
    -c fbcode.rocm_arch=mi350 -m rocm70 fbcode//caffe2/test/inductor:flex_attention -- \
    caffe2.test.inductor.test_flex_attention.TestFlexAttentionCUDA.test_paged_kv_load_int32_element_overflow_cuda
```

With the cast applied (this diff):
```
test_paged_kv_load_int32_element_overflow_cuda ... ok
Ran 1 test in 2.357s
OK
```

With the `.to(INDEX_DTYPE)` cast in `load_checked_2d` temporarily removed (simulating "pre-fix" state):
```
test_paged_kv_load_int32_element_overflow_cuda ... Memory access fault by GPU node-9 (Agent handle: 0x7f94d33d3800) on address 0x7f4e11606000. Reason: Unknown.
exit=1
```

Falsifiability check for the dropped byte-size override (5 consecutive runs on MI350X, `num_blocks=131071` — K elements 2.147 G < INT32_MAX, K bytes 4.29 GiB > 2 GiB, no override): all 5 passed. AMD's typed buffer_load handles itemsize internally; element count is the right metric for the cap.

Production users have independently confirmed the original `flex_impl_nan_repro_op_min` repro from the Workplace report (https://fb.workplace.com/groups/729207668438473/permalink/1881778503181378/) is fixed.

H100 build and run with the same source produces no fault either way (no behaviour change on NVIDIA).

Reviewed By: jinzhenfan, hyuen

Differential Revision: D107927427

@diff-train-skip-merge
