### PR TITLE
[Inductor][Triton] Add host-side TMA support for B200 GEMM templates

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -777,7 +777,7 @@ class TestMaxAutotune(TestCase):
         torch._dynamo.maybe_mark_dynamic(a, 0)
 
         choice_name_regex = (
-            "blackwell_ws_persistent_device_tma"
+            "blackwell_ws_persistent_tma"
             if has_datacenter_blackwell_tma_device()
             else "mm_persistent_tma"
         )
@@ -1044,7 +1044,7 @@ class TestMaxAutotune(TestCase):
         torch._dynamo.maybe_mark_dynamic(a, 0)
 
         choice_name_regex = (
-            "blackwell_ws_persistent_device_tma"
+            "blackwell_ws_persistent_tma"
             if has_datacenter_blackwell_tma_device()
             else "mm_persistent_tma"
         )

--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -45,6 +45,7 @@ class TestMaxAutotuneBlackwell(TestCase):
     @parametrize("dynamic", (False, True))
     @parametrize("tma_store", (False, True))
     @parametrize("epilogue_subtile", (1, 2, 4))
+    @parametrize("host_side_tma", (False, True))
     def test_blackwell_max_autotune_regular_mm_persistent_tma(
         self,
         a_transposed: bool,
@@ -52,6 +53,7 @@ class TestMaxAutotuneBlackwell(TestCase):
         dynamic: bool,
         tma_store: bool,
         epilogue_subtile: int,
+        host_side_tma: bool,
     ):
         def mm(a, b):
             # TMA requires 16-byte alignment: here we repeat the dims
@@ -84,7 +86,8 @@ class TestMaxAutotuneBlackwell(TestCase):
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "triton.enable_host_side_tma": host_side_tma,
+                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 "test_configs.autotune_choice_desc_regex": epilogue_subtile_regex,
             }
         ):
@@ -99,9 +102,53 @@ class TestMaxAutotuneBlackwell(TestCase):
             write_api = "tma_descriptor0.store"
         else:
             write_api = "tl.store"
-        FileCheck().check("triton_tem_fused_mm").check(
-            "triton.language.make_tensor_descriptor"
-        ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
+        fc = FileCheck().check("triton_tem_fused_mm")
+        if host_side_tma:
+            fc.check_not("tl.make_tensor_descriptor")
+            fc.check_not("tl.load_tensor_descriptor")
+        else:
+            fc.check("tl.make_tensor_descriptor")
+            fc.check("tl.load_tensor_descriptor")
+        fc.check(write_api).run(code[0])
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("op", ("mm", "addmm"))
+    def test_blackwell_host_side_tma_transposed_b(self, op: str):
+        # Regression test for host-side TMA with a column-major / transposed B
+        # operand (B_ROW_MAJOR=False, the nn.Linear `x @ W.t()` case).
+        # Previously the host launcher re-permuted the runtime tensor's own
+        # dims -- which are in base layout for a transposed operand -- producing
+        # an incorrect result. Also covers addmm host-side TMA, previously
+        # untested.
+        M, N, K = 512, 256, 512
+        a = torch.randn(M, K).to(torch.float16).to(GPU_TYPE)
+        # b is [N, K]; b.t() is the [K, N] column-major operand.
+        b = torch.randn(N, K).to(torch.float16).to(GPU_TYPE)
+        bias = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+
+        def fn(a, b, bias):
+            if op == "addmm":
+                return torch.addmm(bias, a, b.t())
+            return torch.mm(a, b.t())
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "triton.enable_persistent_tma_matmul": True,
+                "triton.enable_host_side_tma": True,
+                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
+            }
+        ):
+            c_actual, code = run_and_get_code(torch.compile(fn), a, b, bias)
+        c_expected = fn(a, b, bias)
+        torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
+        # host-side TMA: descriptors come from the launcher, none built in-kernel
+        FileCheck().check("triton_tem_fused").check_not(
+            "tl.make_tensor_descriptor"
+        ).run(code[0])
 
     # NOTE: the current Inductor template verifies that the scaling mode is either per-tensor or per-row
     # TODO: support additional scaling modes for Blackwell
@@ -143,7 +190,7 @@ class TestMaxAutotuneBlackwell(TestCase):
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
             }
         ):
             c_actual, code = run_and_get_code(
@@ -209,7 +256,7 @@ class TestMaxAutotuneBlackwell(TestCase):
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
             }
         ):
             c_actual, code = run_and_get_code(
@@ -280,16 +327,16 @@ class TestMaxAutotuneBlackwell(TestCase):
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 "test_configs.autotune_choice_desc_regex": epilogue_subtile_regex,
                 # If we dynamically disable pipelining,
-                # triton_blackwell_ws_persistent_device_tma template will
+                # triton_blackwell_ws_persistent_tma template will
                 # be picked and then cause mis-aligned memory access.
                 # If we don't dynamically disable pipelining,
                 # this template is skipped and triton_tem_fused_addmm_repeat_3
                 # is used.
                 #
-                # Fundamentally we should fix the triton_blackwell_ws_persistent_device_tma template
+                # Fundamentally we should fix the triton_blackwell_ws_persistent_tma template
                 # The flag below work around the problem.
                 #
                 # This only happens in fbcode https://www.internalfb.com/diff/D101855575.
@@ -367,8 +414,8 @@ class TestBlackwellTMAStoreFusion(TestCase):
         from torch._inductor.template_heuristics.registry import get_template_heuristic
 
         _cache_keys = [
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "addmm"),
         ]
         orig_configs_by_key = {}
         for key in _cache_keys:
@@ -381,7 +428,7 @@ class TestBlackwellTMAStoreFusion(TestCase):
                     "max_autotune": True,
                     "triton.enable_persistent_tma_matmul": True,
                     "triton.enable_template_tma_store": True,
-                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 }
             ):
                 actual, code = run_and_get_code(torch.compile(fn), x, W)
@@ -424,8 +471,8 @@ class TestBlackwellTMAStoreFusion(TestCase):
         from torch._inductor.template_heuristics.registry import get_template_heuristic
 
         _cache_keys = [
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "addmm"),
         ]
         orig_configs_by_key = {}
         for key in _cache_keys:
@@ -438,7 +485,7 @@ class TestBlackwellTMAStoreFusion(TestCase):
                     "max_autotune": True,
                     "triton.enable_persistent_tma_matmul": True,
                     "triton.enable_template_tma_store": True,
-                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 }
             ):
                 actual, code = run_and_get_code(torch.compile(fn), x, W, bias)
@@ -497,8 +544,8 @@ class TestBlackwellTMALoadFusion(TestCase):
         from torch._inductor.template_heuristics.registry import get_template_heuristic
 
         _cache_keys = [
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "addmm"),
         ]
         orig_configs_by_key = {}
         for key in _cache_keys:
@@ -511,7 +558,7 @@ class TestBlackwellTMALoadFusion(TestCase):
                     "max_autotune": True,
                     "triton.enable_persistent_tma_matmul": True,
                     "triton.enable_tma_load_for_template_epilogue": True,
-                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 }
             ):
                 actual, code = run_and_get_code(torch.compile(fn), x, W)
@@ -553,8 +600,8 @@ class TestBlackwellTMALoadFusion(TestCase):
         from torch._inductor.template_heuristics.registry import get_template_heuristic
 
         _cache_keys = [
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "addmm"),
         ]
         orig_configs_by_key = {}
         for key in _cache_keys:
@@ -567,7 +614,7 @@ class TestBlackwellTMALoadFusion(TestCase):
                     "max_autotune": True,
                     "triton.enable_persistent_tma_matmul": True,
                     "triton.enable_tma_load_for_template_epilogue": True,
-                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 }
             ):
                 actual, code = run_and_get_code(torch.compile(fn), x, W, scale, bias)
@@ -608,8 +655,8 @@ class TestBlackwellTMALoadFusion(TestCase):
         from torch._inductor.template_heuristics.registry import get_template_heuristic
 
         _cache_keys = [
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
-            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_tma", "cuda", "addmm"),
         ]
         orig_configs_by_key = {}
         for key in _cache_keys:
@@ -622,7 +669,7 @@ class TestBlackwellTMALoadFusion(TestCase):
                     "max_autotune": True,
                     "triton.enable_persistent_tma_matmul": True,
                     "triton.enable_tma_load_for_template_epilogue": True,
-                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_tma",
                 }
             ):
                 actual, code = run_and_get_code(torch.compile(fn), bias, x, W)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3189,9 +3189,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # before kernel launch instead of every CTA calling
         # tl.make_tensor_descriptor() (fixes issue #185819).
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
-        # Buffers that have any non-TMA access (pointer arithmetic, non-zero
-        # offset) and cannot be replaced with host-side TMA descriptors.
-        self._host_tma_ineligible: OrderedSet[str] = OrderedSet()
+        # Vars whose access the host launcher cannot materialize a
+        # TensorDescriptor for (indirect/ModularIndexing indexing, non-zero
+        # offset, misalignment, complex block shape, or >1 read). This is NOT
+        # a TMA eligibility check -- such accesses may still be device-TMA
+        # eligible; eligibility is decided by TMACompatibilityChecker.
+        self._host_tma_non_materializable: OrderedSet[str] = OrderedSet()
+        # True once any access in this kernel is emitted as a device-side TMA
+        # descriptor (tl.make_tensor_descriptor). Used after codegen to decide
+        # whether tma_min_block_sizes constraints are still relevant.
+        self._emitted_device_tma = False
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3276,15 +3283,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return any(stride == 1 for stride in stride_vars)
 
     @staticmethod
-    def _is_host_tma_eligible(
+    def _is_host_tma_materializable(
         indexing: TensorDescriptorOptions,
         dtype: torch.dtype | None = None,
     ) -> bool:
-        """Check if an access pattern is eligible for host-side TMA.
+        """Whether the host launcher can materialize a TensorDescriptor for
+        this access. This is NOT a TMA eligibility (possibility) check --
+        eligibility is decided by TMACompatibilityChecker.
 
-        Rejects:
-        - Complex block shape expressions (floor division, etc.)
-        - Sub-byte dtypes (i1/bool) that TMA can't handle
+        Returns False when:
+        - the block_shape contains non-trivial expressions (e.g. the nested
+          min/max clamps produced by a transpose/reshape) that can't be
+          resolved to concrete host-side dims, or
+        - the dtype is sub-byte i1/bool (no CUtensorMap mapping).
         """
         if dtype is not None and dtype == torch.bool:
             return False
@@ -3296,15 +3307,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return False
         return True
 
-    def _prescan_host_tma_eligibility(self) -> None:
-        """Pre-scan all buffer reads to identify those with non-block-ptr access.
+    def _prescan_host_tma_materializability(self) -> None:
+        """Pre-scan all buffer reads to find those the host launcher cannot
+        materialize a TMA descriptor for.
 
-        Populates _host_tma_ineligible_buffers (buffer names) with buffers
-        that have any read which can't be expressed as a block pointer.
-        During codegen, load() maps these names to var names and adds them
-        to _host_tma_ineligible.
+        Populates _host_tma_non_materializable_buffers (buffer names) with
+        buffers whose reads can't be expressed as a single host-side block
+        descriptor: indirect (TMP) indexing, FloorDiv/ModularIndexing access,
+        or (conservatively) more than one read. During codegen, load() maps
+        these names to var names and adds them to _host_tma_non_materializable.
+
+        Non-materializable means "the host can't build the descriptor", not
+        "TMA is impossible" -- such accesses may still be device-TMA eligible.
         """
-        self._host_tma_ineligible_buffers = set()
+        self._host_tma_non_materializable_buffers = set()
         if not (config.triton.enable_host_side_tma or config.triton.use_tensor_descriptor):
             return
         if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
@@ -3327,31 +3343,31 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for dep in node.read_writes.reads:
                 if not hasattr(dep, "var_names"):
                     if hasattr(dep, "name"):
-                        self._host_tma_ineligible_buffers.add(dep.name)
+                        self._host_tma_non_materializable_buffers.add(dep.name)
                     continue
                 buffer_read_indices[dep.name].append((dep.index, dep.var_names))
 
         for buf_name, reads in buffer_read_indices.items():
-            if buf_name in self._host_tma_ineligible_buffers:
+            if buf_name in self._host_tma_non_materializable_buffers:
                 continue
 
             for index, var_names in reads:
                 dep_vars = set(var_names)
 
                 if any(symbol_is_type(s, SymT.TMP) for s in index.free_symbols):
-                    self._host_tma_ineligible_buffers.add(buf_name)
+                    self._host_tma_non_materializable_buffers.add(buf_name)
                     break
 
                 for expr_node in sympy.preorder_traversal(index):
                     if isinstance(expr_node, (FloorDiv, ModularIndexing)):
                         if expr_node.free_symbols & dep_vars:
-                            self._host_tma_ineligible_buffers.add(buf_name)
+                            self._host_tma_non_materializable_buffers.add(buf_name)
                             break
                 else:
                     continue
                 break
 
-            if buf_name in self._host_tma_ineligible_buffers:
+            if buf_name in self._host_tma_non_materializable_buffers:
                 continue
 
             # Multiple reads from the same buffer may have different access
@@ -3359,7 +3375,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             # compatibility until codegen runs, conservatively mark buffers
             # with >1 read as ineligible.
             if len(reads) > 1:
-                self._host_tma_ineligible_buffers.add(buf_name)
+                self._host_tma_non_materializable_buffers.add(buf_name)
 
     def _check_buffer_alignment(self, name: str, var: str, dtype: torch.dtype) -> bool:
         """Check if a buffer has a misaligned layout offset that prevents TMA use.
@@ -3380,7 +3396,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if layout_offset != 0:
                     offset_bytes = int(layout_offset) * dtype.itemsize
                     if offset_bytes % 16 != 0:
-                        self._host_tma_ineligible.add(var)
+                        self._host_tma_non_materializable.add(var)
                         self.host_tma_descriptor_args.pop(var, None)
                         return True
         except (TypeError, ValueError):
@@ -4053,8 +4069,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 and use_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
-                and var not in self._host_tma_ineligible
-                and self._is_host_tma_eligible(indexing, V.graph.get_dtype(name))
+                and var not in self._host_tma_non_materializable
+                and self._is_host_tma_materializable(
+                    indexing, V.graph.get_dtype(name)
+                )
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
@@ -4066,11 +4084,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 and indexing.constant_offset != 0
             ):
                 # Non-zero offset access — this buffer can't be host-side TMA
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 if var in self.host_tma_descriptor_args:
                     del self.host_tma_descriptor_args[var]
             # ── end host-side TMA fast path ──────────────────────────────
 
+            # Reaching here with a TensorDescriptorOptions means the host fast
+            # path did not claim this access (host-non-materializable), so it
+            # is emitted as a device-side TMA descriptor below.
+            self._emitted_device_tma = True
 
         else:
             if not check:
@@ -4379,16 +4401,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
 
         # Apply pre-scan results: if the buffer was identified as having
-        # non-block-ptr reads, mark the var as ineligible for host-side TMA.
-        if not hasattr(self, "_host_tma_ineligible_buffers"):
-            self._prescan_host_tma_eligibility()
-        prescan_ineligible = name in self._host_tma_ineligible_buffers
-        if prescan_ineligible:
-            self._host_tma_ineligible.add(var)
+        # reads the host launcher can't materialize a descriptor for, mark
+        # the var as non-materializable for host-side TMA.
+        if not hasattr(self, "_host_tma_non_materializable_buffers"):
+            self._prescan_host_tma_materializability()
+        prescan_non_materializable = (
+            name in self._host_tma_non_materializable_buffers
+        )
+        if prescan_non_materializable:
+            self._host_tma_non_materializable.add(var)
 
         buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
 
-        skip_tma = buffer_misaligned or prescan_ineligible
+        skip_tma = buffer_misaligned or prescan_non_materializable
         tma_checker = (
             None if skip_tma
             else self.tma_compatibility_checker_cls(
@@ -4512,13 +4537,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     for_store=False,
                 )
             elif is_sympy_integer_like(original_index):
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({indexing.index_str}), {indexing.mask_str}{ep}{other}{cachemod})"
 
@@ -4626,7 +4651,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             isinstance(indexing, TensorDescriptorOptions)
             and config.triton.enable_host_side_tma
             and not config.triton.use_tensor_descriptor
-            and not self._is_host_tma_eligible(indexing, dtype)
+            and not self._is_host_tma_materializable(indexing, dtype)
         ):
             indexing = self.indexing(
                 index,
@@ -4676,7 +4701,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 ):
                     value_shape = ", ".join(map(str, value.shape))
                     indexing_str += f".broadcast_to({value_shape})"
-            self._host_tma_ineligible.add(var)
+            self._host_tma_non_materializable.add(var)
             self.host_tma_descriptor_args.pop(var, None)
             line = f"tl.store({var} + ({indexing_str}), {value}, {indexing.mask_str})"
         elif mode == "atomic_add":
@@ -6867,7 +6892,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.inductor_meta = inductor_meta
 
         self.codegen_prologue(self.body)
-        self._prescan_host_tma_eligibility()
+        self._prescan_host_tma_materializability()
         self.codegen_body()
 
         # After codegen_body, host_tma_descriptor_args may have been pruned
@@ -6887,12 +6912,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         elif "host_tma_descriptor_args" in self.inductor_meta:
             del self.inductor_meta["host_tma_descriptor_args"]
 
-        # If no buffers use host-side TMA and device-side TMA is off,
-        # clear tma_min_block_sizes to avoid overly aggressive config filtering.
+        # Clear tma_min_block_sizes when this kernel emitted no TMA descriptor
+        # (neither host- nor device-side). The constraint is set during TMA
+        # compatibility probing (are_block_parameters_compatible), which fires
+        # even when the access ultimately falls back to a plain tl.load (e.g.
+        # looping reductions). A stale constraint over-filters the autotune
+        # config space and can severely regress otherwise non-TMA kernels.
         if (
-            config.triton.enable_host_side_tma
-            and not config.triton.use_tensor_descriptor
-            and not self.inductor_meta.get("host_tma_descriptor_args")
+            not self.inductor_meta.get("host_tma_descriptor_args")
+            and not self._emitted_device_tma
         ):
             self.inductor_meta.pop("tma_min_block_sizes", None)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3183,12 +3183,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
-        # Maps inner kernel-arg name (e.g. "in_ptr0") to the
-        # TensorDescriptorOptions for host-side TMA descriptor creation.
-        # The per-config launcher calls TensorDescriptor.from_tensor()
+        # Maps inner kernel-arg name (e.g. "in_ptr0") to its host-side TMA
+        # descriptor info. The per-config launcher creates the TensorDescriptor
         # before kernel launch instead of every CTA calling
-        # tl.make_tensor_descriptor() (fixes issue #185819).
-        self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
+        # tl.make_tensor_descriptor() (fixes issue #185819). Values are a
+        # TensorDescriptorOptions for pointwise/reduction kernels, or a resolved
+        # {block_shape, shape, strides} dict for template kernels (set via
+        # TritonTemplateKernel.tma_descriptor).
+        self.host_tma_descriptor_args: dict[
+            str, "TensorDescriptorOptions | dict[str, Any]"
+        ] = {}
         # Vars whose access the host launcher cannot materialize a
         # TensorDescriptor for (indirect/ModularIndexing indexing, non-zero
         # offset, misalignment, complex block shape, or >1 read). This is NOT
@@ -6629,15 +6633,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             # We need to distinguish autotuned symbols (kernel function args
             # whose values vary per-config) from fixed symbols (defined in
             # the kernel body with concrete values).
-            # Build a mapping of fixed block sizes from the range trees.
             _, _, signature, _ = self.args.python_argdefs()
             sig_arg_names = OrderedSet(
                 arg.name for arg in signature if hasattr(arg, "name")
             )
-            # Map non-argument block size symbols to concrete values.
-            # For persistent reductions, R0_BLOCK is defined in the kernel
-            # body (not a function arg) with a concrete value computed from
-            # the reduction dimension numel.
             fixed_blocks: dict[str, int] = {}
             if self.persistent_reduction:
                 for rt in self.range_trees:
@@ -6665,8 +6664,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             resolved = {}
             for inner, opts in self.host_tma_descriptor_args.items():
+                if isinstance(opts, dict):
+                    resolved[inner] = opts
+                    continue
                 dims = [_resolve_block_dim(s) for s in opts.block_shape]
-                # Skip buffers with degenerate block shapes (any dim <= 0)
                 if any(isinstance(d, int) and d <= 0 for d in dims):
                     continue
                 shape_dims = [_resolve_block_dim(s) for s in opts.shape]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -96,6 +96,7 @@ from .common import (
     ArgName,
     BackendFeature,
     ConstexprArg,
+    TMADescriptorArg,
     CSE,
     CSEVariable,
     DeferredLine,
@@ -3181,6 +3182,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
+        # Maps inner kernel-arg name (e.g. "in_ptr0") to the
+        # TensorDescriptorOptions for host-side TMA descriptor creation.
+        # The per-config launcher calls TensorDescriptor.from_tensor()
+        # before kernel launch instead of every CTA calling
+        # tl.make_tensor_descriptor() (fixes issue #185819).
+        self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3914,6 +3921,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if other != ", other=0.0":
                     raise AssertionError(f"expected ', other=0.0', got {other!r}")
                 other = ""
+
+            # ── Host-side TMA fast path (issue #185819) ─────────────────
+            # When the stable Triton TMA API is available and this buffer
+            # has no constant offset, skip kernel-side descriptor creation.
+            # The kernel receives a pre-built TensorDescriptor from the
+            # host launcher, eliminating per-CTA construction overhead that
+            # causes a 1.4-1.6x slowdown for simple pointwise ops.
+            #
+            # Template-forced paths (can_lift=True) manage their own
+            # host-side descriptors via ir.TMADescriptor; skip them.
+            if (
+                has_triton_stable_tma_api()
+                and config.triton.use_tensor_descriptor
+                and not indexing.can_lift
+                and indexing.constant_offset == 0
+            ):
+                if var not in self.host_tma_descriptor_args:
+                    self.host_tma_descriptor_args[var] = indexing
+                return var, other  # arg IS the pre-created descriptor
+            # ── end host-side TMA fast path ──────────────────────────────
+
         else:
             if not check:
                 # workaround https://github.com/triton-lang/triton/issues/2813
@@ -6403,6 +6431,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             flops = self.estimate_flops()
             if flops is not None:
                 out["kernel_flop"] = flops
+        if self.host_tma_descriptor_args:
+            # Pass {inner_arg: [block_dim_str, ...]} to the per-config
+            # launcher so it can call TensorDescriptor.from_tensor() with
+            # the actual autotuned XBLOCK / YBLOCK values (issue #185819).
+            out["host_tma_descriptor_args"] = {
+                inner: [str(s) for s in opts.block_shape]
+                for inner, opts in self.host_tma_descriptor_args.items()
+            }
         return out
 
     @functools.cached_property
@@ -6495,6 +6531,23 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if symbol in V.graph.sizevars.inv_precomputed_replacements:
                     signature[i] = SizeArg(
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
+                    )
+
+        # Upgrade TensorArg -> TMADescriptorArg for host-side TMA buffers
+        # so Triton compiles the kernel with tensordesc<dtype[B0, B1]>
+        # argument types instead of raw pointers (issue #185819).
+        if self.host_tma_descriptor_args:
+            for i, (argname, arg) in enumerate(zip(argdefs, signature)):
+                if (
+                    isinstance(arg, TensorArg)
+                    and argname.name in self.host_tma_descriptor_args
+                ):
+                    tma_opts = self.host_tma_descriptor_args[argname.name]
+                    signature[i] = TMADescriptorArg(
+                        name=argname.name,
+                        api_type="stable",
+                        block_shape=list(tma_opts.block_shape),
+                        dtype=V.graph.get_dtype(arg.buffer),
                     )
 
         mutated_args: OrderedSet[str] = OrderedSet()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -96,7 +96,6 @@ from .common import (
     ArgName,
     BackendFeature,
     ConstexprArg,
-    TMADescriptorArg,
     CSE,
     CSEVariable,
     DeferredLine,
@@ -2849,16 +2848,18 @@ class TMACompatibilityChecker:
     ) -> bool:
         if self.force:
             return True
+        use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
+        assume_aligned = config.assume_aligned_inputs or config.triton.enable_host_side_tma
         if not (
             (
                 (
                     V.graph.get_current_device_or_throw().type == "cuda"
                     and torch.cuda.get_device_capability()[0] >= 9
-                    and config.assume_aligned_inputs
+                    and assume_aligned
                 )
                 or V.graph.get_current_device_or_throw().type == "xpu"
             )
-            and config.triton.use_tensor_descriptor
+            and use_tma
             and has_triton_stable_tma_api()
             # For CUDA The base ptr needs to be aligned
         ):
@@ -3188,6 +3189,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # before kernel launch instead of every CTA calling
         # tl.make_tensor_descriptor() (fixes issue #185819).
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
+        # Buffers that have any non-TMA access (pointer arithmetic, non-zero
+        # offset) and cannot be replaced with host-side TMA descriptors.
+        self._host_tma_ineligible: OrderedSet[str] = OrderedSet()
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3270,6 +3274,118 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return False
 
         return any(stride == 1 for stride in stride_vars)
+
+    @staticmethod
+    def _is_host_tma_eligible(
+        indexing: TensorDescriptorOptions,
+        dtype: torch.dtype | None = None,
+    ) -> bool:
+        """Check if an access pattern is eligible for host-side TMA.
+
+        Rejects:
+        - Complex block shape expressions (floor division, etc.)
+        - Sub-byte dtypes (i1/bool) that TMA can't handle
+        """
+        if dtype is not None and dtype == torch.bool:
+            return False
+        for dim in indexing.block_shape:
+            if isinstance(dim, (int, sympy.Integer)):
+                continue
+            if isinstance(dim, sympy.Symbol):
+                continue
+            return False
+        return True
+
+    def _prescan_host_tma_eligibility(self) -> None:
+        """Pre-scan all buffer reads to identify those with non-block-ptr access.
+
+        Populates _host_tma_ineligible_buffers (buffer names) with buffers
+        that have any read which can't be expressed as a block pointer.
+        During codegen, load() maps these names to var names and adds them
+        to _host_tma_ineligible.
+        """
+        self._host_tma_ineligible_buffers = set()
+        if not (config.triton.enable_host_side_tma or config.triton.use_tensor_descriptor):
+            return
+        if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
+            return
+
+        from .simd_kernel_features import NodeScheduleMarker
+
+        range_tree_symbols = OrderedSet(
+            tree.symbol() for tree in self.range_trees
+        )
+        if not range_tree_symbols:
+            return
+
+        from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+
+        buffer_read_indices: dict[str, list[tuple[sympy.Expr, tuple[sympy.Symbol, ...]]]] = (
+            collections.defaultdict(list)
+        )
+        for node in NodeScheduleMarker.only_nodes(self.features.node_schedule):
+            for dep in node.read_writes.reads:
+                if not hasattr(dep, "var_names"):
+                    if hasattr(dep, "name"):
+                        self._host_tma_ineligible_buffers.add(dep.name)
+                    continue
+                buffer_read_indices[dep.name].append((dep.index, dep.var_names))
+
+        for buf_name, reads in buffer_read_indices.items():
+            if buf_name in self._host_tma_ineligible_buffers:
+                continue
+
+            for index, var_names in reads:
+                dep_vars = set(var_names)
+
+                if any(symbol_is_type(s, SymT.TMP) for s in index.free_symbols):
+                    self._host_tma_ineligible_buffers.add(buf_name)
+                    break
+
+                for expr_node in sympy.preorder_traversal(index):
+                    if isinstance(expr_node, (FloorDiv, ModularIndexing)):
+                        if expr_node.free_symbols & dep_vars:
+                            self._host_tma_ineligible_buffers.add(buf_name)
+                            break
+                else:
+                    continue
+                break
+
+            if buf_name in self._host_tma_ineligible_buffers:
+                continue
+
+            # Multiple reads from the same buffer may have different access
+            # patterns (different strides, offsets). Since we can't verify
+            # compatibility until codegen runs, conservatively mark buffers
+            # with >1 read as ineligible.
+            if len(reads) > 1:
+                self._host_tma_ineligible_buffers.add(buf_name)
+
+    def _check_buffer_alignment(self, name: str, var: str, dtype: torch.dtype) -> bool:
+        """Check if a buffer has a misaligned layout offset that prevents TMA use.
+
+        Returns True if the buffer is misaligned (TMA should be skipped).
+        """
+        if not (config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma):
+            return False
+        try:
+            buf = V.graph.try_get_buffer(name)
+            if buf is None and hasattr(V.graph, "scheduler") and V.graph.scheduler:
+                real_name = V.graph.scheduler.mutation_real_name.get(name, name)
+                if real_name != name:
+                    buf = V.graph.try_get_buffer(real_name)
+            if buf is not None:
+                layout = buf.get_layout()
+                layout_offset = getattr(layout, "offset", 0)
+                if layout_offset != 0:
+                    offset_bytes = int(layout_offset) * dtype.itemsize
+                    if offset_bytes % 16 != 0:
+                        self._host_tma_ineligible.add(var)
+                        self.host_tma_descriptor_args.pop(var, None)
+                        return True
+        except (TypeError, ValueError):
+            pass
+        return False
 
     @property
     def has_store_with_contiguous_rdim(self) -> bool:
@@ -3931,16 +4047,30 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             #
             # Template-forced paths (can_lift=True) manage their own
             # host-side descriptors via ir.TMADescriptor; skip them.
+            use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
             if (
                 has_triton_stable_tma_api()
-                and config.triton.use_tensor_descriptor
+                and use_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
+                and var not in self._host_tma_ineligible
+                and self._is_host_tma_eligible(indexing, V.graph.get_dtype(name))
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
                 return var, other  # arg IS the pre-created descriptor
+            elif (
+                has_triton_stable_tma_api()
+                and use_tma
+                and not indexing.can_lift
+                and indexing.constant_offset != 0
+            ):
+                # Non-zero offset access — this buffer can't be host-side TMA
+                self._host_tma_ineligible.add(var)
+                if var in self.host_tma_descriptor_args:
+                    del self.host_tma_descriptor_args[var]
             # ── end host-side TMA fast path ──────────────────────────────
+
 
         else:
             if not check:
@@ -4247,16 +4377,32 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         original_index = index
         dtype = V.graph.get_dtype(name)
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
-        indexing = self.indexing(
-            index,
-            block_ptr=True,
-            tma_compatibility_checker=self.tma_compatibility_checker_cls(
+
+        # Apply pre-scan results: if the buffer was identified as having
+        # non-block-ptr reads, mark the var as ineligible for host-side TMA.
+        if not hasattr(self, "_host_tma_ineligible_buffers"):
+            self._prescan_host_tma_eligibility()
+        prescan_ineligible = name in self._host_tma_ineligible_buffers
+        if prescan_ineligible:
+            self._host_tma_ineligible.add(var)
+
+        buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
+
+        skip_tma = buffer_misaligned or prescan_ineligible
+        tma_checker = (
+            None if skip_tma
+            else self.tma_compatibility_checker_cls(
                 self,
                 dtype,
                 for_store=False,
                 force=getattr(self, "tma_load_for_template_epilogue", False),
                 buffer_name=name,
-            ),
+            )
+        )
+        indexing = self.indexing(
+            index,
+            block_ptr=True,
+            tma_compatibility_checker=tma_checker,
         )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
@@ -4366,10 +4512,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     for_store=False,
                 )
             elif is_sympy_integer_like(original_index):
+                self._host_tma_ineligible.add(var)
+                self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:
+                self._host_tma_ineligible.add(var)
+                self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({indexing.index_str}), {indexing.mask_str}{ep}{other}{cachemod})"
 
                 # The block shape of tl.load depends on the indexing expression.
@@ -4452,8 +4602,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         original_index = index
         dtype = V.graph.get_dtype(name)
 
+        buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
+
         tma_compatibility_checker = None
-        if mode is None or mode == "tma":
+        if not buffer_misaligned and (mode is None or mode == "tma"):
             force = mode == "tma" or getattr(self, "tma_store", False)
             tma_compatibility_checker = self.tma_compatibility_checker_cls(
                 self,
@@ -4469,6 +4621,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mode == "atomic_add",
         )
+
+        if (
+            isinstance(indexing, TensorDescriptorOptions)
+            and config.triton.enable_host_side_tma
+            and not config.triton.use_tensor_descriptor
+            and not self._is_host_tma_eligible(indexing, dtype)
+        ):
+            indexing = self.indexing(
+                index,
+                dense_indexing=True,
+                block_ptr=mode is None,
+                tma_compatibility_checker=None,
+                mask_constant_index=mode == "atomic_add",
+            )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
             indexing.index
@@ -4510,6 +4676,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 ):
                     value_shape = ", ".join(map(str, value.shape))
                     indexing_str += f".broadcast_to({value_shape})"
+            self._host_tma_ineligible.add(var)
+            self.host_tma_descriptor_args.pop(var, None)
             line = f"tl.store({var} + ({indexing_str}), {value}, {indexing.mask_str})"
         elif mode == "atomic_add":
             self.atomic_add_found = True
@@ -6432,13 +6600,58 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 out["kernel_flop"] = flops
         if self.host_tma_descriptor_args:
-            # Pass {inner_arg: [block_dim_str, ...]} to the per-config
-            # launcher so it can call TensorDescriptor.from_tensor() with
-            # the actual autotuned XBLOCK / YBLOCK values (issue #185819).
-            out["host_tma_descriptor_args"] = {
-                inner: [str(s) for s in opts.block_shape]
-                for inner, opts in self.host_tma_descriptor_args.items()
-            }
+            # Block shapes contain sympy expressions (XBLOCK, R0_BLOCK, etc).
+            # We need to distinguish autotuned symbols (kernel function args
+            # whose values vary per-config) from fixed symbols (defined in
+            # the kernel body with concrete values).
+            # Build a mapping of fixed block sizes from the range trees.
+            _, _, signature, _ = self.args.python_argdefs()
+            sig_arg_names = OrderedSet(
+                arg.name for arg in signature if hasattr(arg, "name")
+            )
+            # Map non-argument block size symbols to concrete values.
+            # For persistent reductions, R0_BLOCK is defined in the kernel
+            # body (not a function arg) with a concrete value computed from
+            # the reduction dimension numel.
+            fixed_blocks: dict[str, int] = {}
+            if self.persistent_reduction:
+                for rt in self.range_trees:
+                    if rt.is_reduction:
+                        block_name = f"{rt.prefix.upper()}BLOCK"
+                        if block_name not in sig_arg_names:
+                            try:
+                                val = self._get_persistent_RBLOCK(rt.numel)
+                                if self.is_native_matmul:
+                                    val = max(val, 16)
+                                fixed_blocks[block_name] = val
+                            except (TypeError, ValueError):
+                                pass
+
+            def _resolve_block_dim(s):
+                s_str = str(s)
+                if s_str in sig_arg_names:
+                    return s_str
+                if s_str in fixed_blocks:
+                    return fixed_blocks[s_str]
+                try:
+                    return int(s)
+                except (TypeError, ValueError):
+                    return s_str
+
+            resolved = {}
+            for inner, opts in self.host_tma_descriptor_args.items():
+                dims = [_resolve_block_dim(s) for s in opts.block_shape]
+                # Skip buffers with degenerate block shapes (any dim <= 0)
+                if any(isinstance(d, int) and d <= 0 for d in dims):
+                    continue
+                shape_dims = [_resolve_block_dim(s) for s in opts.shape]
+                stride_dims = [_resolve_block_dim(s) for s in opts.strides]
+                resolved[inner] = {
+                    "block_shape": dims,
+                    "shape": shape_dims,
+                    "strides": stride_dims,
+                }
+            out["host_tma_descriptor_args"] = resolved
         return out
 
     @functools.cached_property
@@ -6533,22 +6746,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
                     )
 
-        # Upgrade TensorArg -> TMADescriptorArg for host-side TMA buffers
-        # so Triton compiles the kernel with tensordesc<dtype[B0, B1]>
-        # argument types instead of raw pointers (issue #185819).
-        if self.host_tma_descriptor_args:
-            for i, (argname, arg) in enumerate(zip(argdefs, signature)):
-                if (
-                    isinstance(arg, TensorArg)
-                    and argname.name in self.host_tma_descriptor_args
-                ):
-                    tma_opts = self.host_tma_descriptor_args[argname.name]
-                    signature[i] = TMADescriptorArg(
-                        name=argname.name,
-                        api_type="stable",
-                        block_shape=list(tma_opts.block_shape),
-                        dtype=V.graph.get_dtype(arg.buffer),
-                    )
+        # NOTE: host-side TMA signature upgrade (TensorArg -> tensordesc<>)
+        # is deferred to _precompile_config() where concrete block sizes are
+        # available. The triton_meta signature keeps pointer types here.
 
         mutated_args: OrderedSet[str] = OrderedSet()
         for mutation in self.mutations:
@@ -6667,7 +6867,35 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.inductor_meta = inductor_meta
 
         self.codegen_prologue(self.body)
+        self._prescan_host_tma_eligibility()
         self.codegen_body()
+
+        # After codegen_body, host_tma_descriptor_args may have been pruned
+        # (buffers with mixed TMA/pointer accesses are removed). Update
+        # inductor_meta with the final set.
+        if self.host_tma_descriptor_args:
+            self.inductor_meta["host_tma_descriptor_args"] = (
+                self.inductor_meta.get("host_tma_descriptor_args", {})
+            )
+            # Re-filter: only keep buffers still in host_tma_descriptor_args
+            kept = {
+                k: v
+                for k, v in self.inductor_meta["host_tma_descriptor_args"].items()
+                if k in self.host_tma_descriptor_args
+            }
+            self.inductor_meta["host_tma_descriptor_args"] = kept
+        elif "host_tma_descriptor_args" in self.inductor_meta:
+            del self.inductor_meta["host_tma_descriptor_args"]
+
+        # If no buffers use host-side TMA and device-side TMA is off,
+        # clear tma_min_block_sizes to avoid overly aggressive config filtering.
+        if (
+            config.triton.enable_host_side_tma
+            and not config.triton.use_tensor_descriptor
+            and not self.inductor_meta.get("host_tma_descriptor_args")
+        ):
+            self.inductor_meta.pop("tma_min_block_sizes", None)
+
         self._filter_pdl(self.body)
 
         # Compute configs after codegen_body() so we know if the kernel
@@ -6839,9 +7067,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         val = max(val, 16)
 
                 code.writeline(f"{tree.prefix.upper()}BLOCK: tl.constexpr = {val}")
+                # Store resolved block size for host-side TMA descriptor args
+                if not hasattr(self, "_resolved_block_sizes"):
+                    self._resolved_block_sizes = {}
+                self._resolved_block_sizes[f"{tree.prefix.upper()}BLOCK"] = val
 
             if tree.prefix == "x" and self.no_x_dim:
                 code.writeline("XBLOCK: tl.constexpr = 1")
+                if not hasattr(self, "_resolved_block_sizes"):
+                    self._resolved_block_sizes = {}
+                self._resolved_block_sizes["XBLOCK"] = 1
 
     def _get_grid_type(self) -> type[triton_heuristics.GridExpr]:
         n = sum([int(not tree.is_reduction) for tree in self.range_trees])

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2069,7 +2069,7 @@ class triton:
     #   assume_aligned_inputs to also be enabled
     # TMA descriptors are only going to be generated if the above conditions
     # can be satisfied, along with any existing requirements for index expressions
-    use_tensor_descriptor = False
+    use_tensor_descriptor = True
 
     # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2097,6 +2097,11 @@ class triton:
     enable_tma_load_for_template_epilogue = (
         os.environ.get("ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE", "0") == "1"
     )
+    # Host-side TMA: create TensorDescriptors on CPU and pass as kernel args
+    # instead of creating them device-side inside the kernel. Enables
+    # use_tensor_descriptor and assume_aligned_inputs automatically.
+    enable_host_side_tma = os.environ.get("ENABLE_HOST_SIDE_TMA", "0") == "1"
+
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -124,10 +124,10 @@ scaled_mm_device_tma_main_loop_scaling_template = TritonTemplate(
     source=load_kernel_template("triton_main_loop_scaled_mm"),
 )
 
-blackwell_ws_persistent_device_tma_mm_template = TritonTemplate(
-    name="blackwell_ws_persistent_device_tma",
+blackwell_ws_persistent_tma_mm_template = TritonTemplate(
+    name="blackwell_ws_persistent_tma",
     grid=persistent_mm_grid,
-    source=load_kernel_template("triton_blackwell_ws_persistent_device_tma_mm"),
+    source=load_kernel_template("triton_blackwell_ws_persistent_tma_mm"),
 )
 
 
@@ -431,7 +431,7 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             if use_triton_blackwell_tma_template(
                 mat1, mat2, output_layout=layout, add_guards=True
             ):
-                templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
+                templates_to_use.append(blackwell_ws_persistent_tma_mm_template)
             elif use_triton_tma_template(
                 mat1, mat2, output_layout=layout, add_guards=True
             ):
@@ -691,7 +691,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         if use_triton_blackwell_tma_template(
             mat1, mat2, output_layout=layout, add_guards=True
         ):
-            templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
+            templates_to_use.append(blackwell_ws_persistent_tma_mm_template)
         elif use_triton_tma_template(mat1, mat2, output_layout=layout, add_guards=True):
             if torch.version.hip is None:
                 templates_to_use.append(persistent_tma_mm_template)
@@ -1251,10 +1251,8 @@ def tuned_scaled_mm(
             )
             and not bias
         ):
-            templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
-            kwarg_overrides[blackwell_ws_persistent_device_tma_mm_template.uid] = (
-                overriders
-            )
+            templates_to_use.append(blackwell_ws_persistent_tma_mm_template)
+            kwarg_overrides[blackwell_ws_persistent_tma_mm_template.uid] = overriders
 
         if use_triton_scaling_template(
             scale_option_a, scale_option_b, epilogue_scaling_types

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_tma_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_tma_mm.py.jinja
@@ -11,24 +11,15 @@
     k_tiles = tl.cdiv(K, BLOCK_K)
     num_tiles = grid_m * grid_n
 
-    # Note: We require TMA_EXPERIMENTAL_API == False, which
-    # we will check before invoking this template.
-    stride_am = {{stride("A", 0)}}
-    stride_ak = {{stride("A", 1)}}
-    stride_bk = {{stride("B", 0)}}
-    stride_bn = {{stride("B", 1)}}
-    a_desc = triton.language.make_tensor_descriptor(
-        base=A,
-        shape=[M, K] if A_ROW_MAJOR else [K, M],
-        strides=[stride_am, 1] if A_ROW_MAJOR else [stride_ak, 1],
-        block_shape=[BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
-    )
-    b_desc = triton.language.make_tensor_descriptor(
-        base=B,
-        shape=[K, N] if B_ROW_MAJOR else [N, K],
-        strides=[stride_bk, 1] if B_ROW_MAJOR else [stride_bn, 1],
-        block_shape=[BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
-    )
+    {{tma_descriptor("a_desc", "A",
+        [BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
+        [0, 1] if A_ROW_MAJOR else [1, 0]
+    )}}
+    {{tma_descriptor("b_desc", "B",
+        [BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
+        [0, 1] if B_ROW_MAJOR else [1, 0]
+    )}}
+
     # tile_id_c is used in the epilogue to break the dependency between
     # the prologue and the epilogue
     tile_id_c = start_pid - NUM_SMS
@@ -49,6 +40,18 @@
         for ki in range(k_tiles):
             offs_k = ki * BLOCK_K
             offs_k_desc = offs_k.to(tl.int32)
+            {%- if HOST_SIDE_TMA %}
+            a = a_desc.load(
+                [offs_am_desc, offs_k_desc]
+                if A_ROW_MAJOR
+                else [offs_k_desc, offs_am_desc],
+            )
+            b = b_desc.load(
+                [offs_k_desc, offs_bn_desc]
+                if B_ROW_MAJOR
+                else [offs_bn_desc, offs_k_desc],
+            )
+            {%- else %}
             a = tl.load_tensor_descriptor(
                 a_desc,
                 [offs_am_desc, offs_k_desc]
@@ -61,6 +64,7 @@
                 if B_ROW_MAJOR
                 else [offs_bn_desc, offs_k_desc],
             )
+            {%- endif %}
             accumulator += tl.dot(
                 a if A_ROW_MAJOR else a.T,
                 b if B_ROW_MAJOR else b.T,

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -199,8 +199,8 @@ class StaticallyLaunchedTritonKernel:
         """
         if ty[0] == "*":
             return "O"
-        elif ty == "nvTmaDesc":
-            raise NotImplementedError("nvTmaDesc kernels are not yet supported")
+        elif ty == "nvTmaDesc" or ty.startswith("tensordesc<"):
+            raise NotImplementedError("TMA descriptor kernels are not yet supported")
         return StaticallyLaunchedTritonKernel.type_mappings()[ty]
 
     def arg_ty_from_signature(self, src: ASTSource) -> str:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2956,8 +2956,12 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                     continue
                 if isinstance(desc_info, dict):
                     block_shape_vals = [_eval_dim(s) for s in desc_info["block_shape"]]
-                    shape_vals = [_eval_dim(s) for s in desc_info["shape"]]
-                    stride_vals = [_eval_dim(s) for s in desc_info["strides"]]
+                    shape_vals = desc_info.get("shape")
+                    stride_vals = desc_info.get("strides")
+                    if shape_vals:
+                        shape_vals = [_eval_dim(s) for s in shape_vals]
+                    if stride_vals:
+                        stride_vals = [_eval_dim(s) for s in stride_vals]
                 else:
                     block_shape_vals = [cfg_kwargs.get(s, s) for s in desc_info]
                     shape_vals = None

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -686,15 +686,42 @@ class CachingAutotuner(KernelInterface):
 
         compile_results = []
         exc = None
+        saved_configs = list(self.configs)
         for c in self.configs:
             try:
                 compile_results.append(self._precompile_config(c))
-            except (OutOfResources, PTXASError, IntelGPUError) as e:
+            except (
+                OutOfResources,
+                PTXASError,
+                IntelGPUError,
+            ) as e:
+                exc = e
+            except Exception as e:
                 exc = e
         if len(compile_results) == 0:
-            raise NoTritonConfigsError(
-                f"No valid triton configs. {type(exc).__name__}: {exc}"
-            )
+            # If host-side TMA is enabled, retry without TMA signature upgrade.
+            # The kernel source may have .load() calls that only work with
+            # tensordesc args, but without the upgrade they'll get raw pointers
+            # and fail. This retry only helps for configs where the TMA upgrade
+            # was the ONLY issue (e.g., degenerate block shapes).
+            host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+            if host_tma_args:
+                log.debug(
+                    "All TMA configs failed, retrying without host-side TMA"
+                )
+                saved_tma = self.inductor_meta.pop("host_tma_descriptor_args")
+                try:
+                    for c in saved_configs:
+                        try:
+                            compile_results.append(self._precompile_config(c))
+                        except Exception:
+                            pass
+                finally:
+                    self.inductor_meta["host_tma_descriptor_args"] = saved_tma
+            if len(compile_results) == 0:
+                raise NoTritonConfigsError(
+                    f"No valid triton configs. {type(exc).__name__}: {exc}"
+                )
         self.compile_results = compile_results
         self.configs = None
 
@@ -1050,15 +1077,53 @@ class CachingAutotuner(KernelInterface):
 
         for i in get_constexprs(self.fn):
             arg_name = self.fn.arg_names[i]
-            if arg_name not in compile_meta["constants"] and (
-                arg_name == "num_warps" or arg_name == "num_stages"
-            ):
-                compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
+            if arg_name not in compile_meta["constants"]:
+                if arg_name == "num_warps" or arg_name == "num_stages":
+                    compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
         if HAS_WARP_SPEC:
             compile_meta["num_consumer_groups"] = getattr(cfg, "num_consumer_groups", 0)
             compile_meta["num_buffers_warp_spec"] = getattr(
                 cfg, "num_buffers_warp_spec", 0
             )
+
+        # Upgrade pointer args to tensordesc for host-side TMA buffers.
+        # The triton_meta signature keeps the original pointer types (*bf16);
+        # here we upgrade to tensordesc<bf16[block_shape]> per-config with
+        # concrete block sizes resolved from cfg_kwargs and constants.
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        if host_tma_args:
+            all_constants = compile_meta["constants"]
+            for key, ty in compile_meta["signature"].items():
+                if key in host_tma_args:
+                    block_shape_strs = host_tma_args[key]
+                    if isinstance(block_shape_strs, dict):
+                        block_shape_strs = block_shape_strs.get("block_shape", block_shape_strs)
+                    block_shape_vals = []
+                    for s in block_shape_strs:
+                        if isinstance(s, int):
+                            block_shape_vals.append(s)
+                        elif s in all_constants:
+                            block_shape_vals.append(int(all_constants[s]))
+                        elif s in cfg_kwargs:
+                            block_shape_vals.append(int(cfg_kwargs[s]))
+                        else:
+                            eval_ns = {
+                                "__builtins__": {},
+                                "Min": min, "Max": max,
+                                **cfg_kwargs, **all_constants,
+                            }
+                            block_shape_vals.append(int(eval(s, eval_ns)))
+                    if any(v <= 0 for v in block_shape_vals):
+                        continue
+                    if isinstance(ty, str) and ty.startswith("*"):
+                        dtype_str = ty[1:]
+                    elif isinstance(ty, str) and "tensordesc<" in ty:
+                        dtype_str = ty.split("<")[1].split("[")[0]
+                    else:
+                        continue
+                    compile_meta["signature"][key] = (
+                        f"tensordesc<{dtype_str}{list(block_shape_vals)}>"
+                    )
 
         compile_meta["debug"] = self.inductor_meta.get("assert_indirect_indexing", True)
 
@@ -2870,17 +2935,50 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
         pre_runner_lines: list[str] = []
         if host_tma_args:
             cfg_kwargs = cfg.kwargs
-            for inner_name, block_shape_strs in host_tma_args.items():
+            all_constants = compile_meta["constants"]
+
+            def _eval_dim(s):
+                if isinstance(s, int):
+                    return s
+                if s in cfg_kwargs:
+                    return int(cfg_kwargs[s])
+                if s in all_constants:
+                    return int(all_constants[s])
+                eval_ns = {
+                    "__builtins__": {},
+                    "Min": min, "Max": max,
+                    **cfg_kwargs, **all_constants,
+                }
+                return int(eval(s, eval_ns))
+
+            for inner_name, desc_info in host_tma_args.items():
                 if inner_name not in call_args:
                     continue
-                block_shape_vals = [
-                    cfg_kwargs.get(s, s) for s in block_shape_strs
-                ]
+                if isinstance(desc_info, dict):
+                    block_shape_vals = [_eval_dim(s) for s in desc_info["block_shape"]]
+                    shape_vals = [_eval_dim(s) for s in desc_info["shape"]]
+                    stride_vals = [_eval_dim(s) for s in desc_info["strides"]]
+                else:
+                    block_shape_vals = [cfg_kwargs.get(s, s) for s in desc_info]
+                    shape_vals = None
+                    stride_vals = None
                 desc_var = f"{inner_name}_host_tma_desc"
+                aligned_var = f"{inner_name}_aligned"
                 pre_runner_lines.append(
-                    f"{desc_var} = triton.tools.tensor_descriptor"
-                    f".TensorDescriptor.from_tensor({inner_name}, {block_shape_vals})"
+                    f"{aligned_var} = {inner_name} if {inner_name}.data_ptr() % 16 == 0"
+                    f" else {inner_name}.clone()"
                 )
+                if shape_vals is not None and stride_vals is not None:
+                    pre_runner_lines.append(
+                        f"{desc_var} = triton.tools.tensor_descriptor"
+                        f".TensorDescriptor({aligned_var}, {shape_vals},"
+                        f" {stride_vals}, {block_shape_vals})"
+                    )
+                else:
+                    pre_runner_lines.append(
+                        f"{desc_var} = triton.tools.tensor_descriptor"
+                        f".TensorDescriptor.from_tensor({aligned_var}, {block_shape_vals})"
+                    )
                 runner_args = [
                     desc_var if a == inner_name else a for a in runner_args
                 ]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2393,7 +2393,9 @@ class CompileResult(Generic[_T]):
 
     def make_launcher(self) -> LauncherType: ...
 
-    def _gen_launcher_code(self, scope, def_args, runner_args) -> LauncherType:
+    def _gen_launcher_code(
+        self, scope, def_args, runner_args, pre_runner_lines=None
+    ) -> LauncherType:
         grid = GridExpr.from_meta(self.inductor_meta, self.config)
         # grid.prefix is usually empty, grid.x_grid is something like `-(xnumel//-1024)`
         lines = [
@@ -2402,6 +2404,7 @@ class CompileResult(Generic[_T]):
             f"    grid_0 = {grid.x_grid}",
             f"    grid_1 = {grid.y_grid}",
             f"    grid_2 = {grid.z_grid}",
+            *(f"    {l}" for l in (pre_runner_lines or [])),
             f"    runner({', '.join(runner_args)})",
         ]
         launcher_code = "\n".join(lines)
@@ -2857,7 +2860,35 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 *call_args,
             ]
 
-        launcher = self._gen_launcher_code(scope, def_args, runner_args)
+        # ── Host-side TMA descriptors (issue #185819) ───────────────────
+        # For each buffer in host_tma_descriptor_args the compiled Triton
+        # kernel expects a TensorDescriptor argument rather than a raw
+        # pointer.  Create those descriptors here — once per launcher
+        # invocation using this config's concrete block sizes — eliminating
+        # the per-CTA tl.make_tensor_descriptor() overhead.
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        pre_runner_lines: list[str] = []
+        if host_tma_args:
+            cfg_kwargs = cfg.kwargs
+            for inner_name, block_shape_strs in host_tma_args.items():
+                if inner_name not in call_args:
+                    continue
+                block_shape_vals = [
+                    cfg_kwargs.get(s, s) for s in block_shape_strs
+                ]
+                desc_var = f"{inner_name}_host_tma_desc"
+                pre_runner_lines.append(
+                    f"{desc_var} = triton.tools.tensor_descriptor"
+                    f".TensorDescriptor.from_tensor({inner_name}, {block_shape_vals})"
+                )
+                runner_args = [
+                    desc_var if a == inner_name else a for a in runner_args
+                ]
+        # ── end host-side TMA ─────────────────────────────────────────────
+
+        launcher = self._gen_launcher_code(
+            scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
+        )
 
         launcher = scope["launcher"]
         launcher.config = cfg

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -919,11 +919,32 @@ class TritonTemplateKernel(TritonKernel):
         else:
             self.triton_meta.update(triton_meta)
 
+        # Upgrade signature for host-side TMA: pointer args that the launcher
+        # will replace with TensorDescriptors need tensordesc<> types so Triton
+        # compiles the kernel with the correct arg types.
+        if self.host_tma_descriptor_args:
+            from .codegen.triton_utils import _type_of
+
+            sig = self.triton_meta["signature"]
+            for argname, arg in zip(argdefs, signature):
+                if hasattr(arg, "name") and arg.name in self.host_tma_descriptor_args:
+                    info = self.host_tma_descriptor_args[arg.name]
+                    block_shape = (
+                        info["block_shape"] if isinstance(info, dict) else info
+                    )
+                    dtype = V.graph.get_dtype(arg.buffer)
+                    inner = _type_of(dtype)[1:]  # strip "*": *bf16 -> bf16
+                    sig[argname.name] = f"tensordesc<{inner}{list(block_shape)}>"
+
         inductor_meta = {
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
             **self.inductor_meta_common(),
             **FixedGrid.setup_grid_as_args(),
         }
+        if self.host_tma_descriptor_args:
+            inductor_meta["host_tma_descriptor_args"] = {
+                inner: info for inner, info in self.host_tma_descriptor_args.items()
+            }
         if config.profile_bandwidth or config.benchmark_kernel:
             num_gb = self.estimate_kernel_num_bytes() / 1e9
             inductor_meta["kernel_num_gb"] = num_gb
@@ -1086,6 +1107,57 @@ class TritonTemplateKernel(TritonKernel):
         if isinstance(index, int):
             return texpr(self.rename_indexing(val[index]))
         return ", ".join([texpr(self.rename_indexing(i)) for i in val])
+
+    def tma_descriptor(
+        self,
+        desc_name: str,
+        input_name: str | None,
+        block_shape: list[int],
+        dim_order: list[int] | None = None,
+    ) -> str:
+        """
+        Hook called from template code to declare a TMA descriptor.
+
+        When HOST_SIDE_TMA is True: registers the input's pointer arg in
+        host_tma_descriptor_args so the launcher replaces it with a
+        TensorDescriptor. Emits an alias so the template can use desc_name.
+
+        When HOST_SIDE_TMA is False: emits device-side descriptor creation
+        using tl.make_tensor_descriptor().
+
+        dim_order: permutation of dimensions for TMA layout. e.g. [1, 0]
+            transposes a 2D tensor so the contiguous dim is last. If None,
+            uses natural order [0, 1, ...].
+        """
+        if input_name is not None:
+            node = self.named_input_nodes[input_name]
+        else:
+            node = self.output_node
+
+        size = node.get_size()
+        ndim = len(size)
+        if dim_order is None:
+            dim_order = list(range(ndim))
+
+        if self.meta.get("HOST_SIDE_TMA", False):
+            arg_name = self.args.input_buffers.get(node.get_name(), input_name)
+            # Resolve dim_order to concrete shape/strides from the IR node at
+            # codegen time (same as the device-side path below); the launcher
+            # builds the descriptor over absolute dims and never re-derives
+            # layout from the runtime tensor. dim_order is not serialized.
+            desc: dict[str, Any] = {
+                "block_shape": [int(b) for b in block_shape],
+                "shape": [self.size(input_name, d) for d in dim_order],
+                "strides": [self.stride(input_name, d) for d in dim_order],
+            }
+            self.host_tma_descriptor_args[arg_name] = desc
+            return f"{desc_name} = {input_name}"
+
+        base_name = input_name if input_name is not None else "output"
+        stride_exprs = ", ".join(self.stride(input_name, d) for d in dim_order)
+        size_exprs = ", ".join(self.size(input_name, d) for d in dim_order)
+        block_str = ", ".join(str(b) for b in block_shape)
+        return f"{desc_name} = tl.make_tensor_descriptor(base={base_name}, shape=[{size_exprs}], strides=[{stride_exprs}], block_shape=[{block_str}])"
 
     def _get_subgraph(self, subgraph_number: int):
         if not isinstance(subgraph_number, int):
@@ -1745,6 +1817,7 @@ class TritonTemplateKernel(TritonKernel):
                 self.modification,
                 self.gen_argdefs,
                 self.gen_defines,
+                self.tma_descriptor,
                 *self.extra_template_env_fns,
             ]
         }
@@ -3815,7 +3888,7 @@ def _classify_kernel_operation(
                     "grouped_mm",
                     "scaled_grouped_mm",
                     "mm_plus_mm",
-                    "blackwell_ws_persistent_device_tma",
+                    "blackwell_ws_persistent_tma",
                     "scaled_mm_device_tma_main_loop_scaling",
                 ):
                     return "mm"

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -20,7 +20,7 @@ from torch.utils._triton import has_triton_stable_tma_api
 from .. import config
 from ..kernel.bmm import bmm_template
 from ..kernel.mm import (
-    blackwell_ws_persistent_device_tma_mm_template,
+    blackwell_ws_persistent_tma_mm_template,
     get_scaling_options,
     get_tile_size,
     mm_template,
@@ -2609,6 +2609,7 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 "NUM_SMS": get_num_sms(),
                 "WARP_SPECIALIZE": ws,
                 "FLATTEN": flatten,
+                "HOST_SIDE_TMA": config.triton.enable_host_side_tma,
             }
 
     @staticmethod
@@ -2952,7 +2953,7 @@ class PersistentMMTemplateConfigHeuristic(
 
 
 @register_template_heuristic(
-    blackwell_ws_persistent_device_tma_mm_template.uid,
+    blackwell_ws_persistent_tma_mm_template.uid,
     "cuda",
     register=torch.version.hip is None,
 )
@@ -2980,7 +2981,7 @@ class CUDAAddmmPersistentTMATemplateConfigHeuristic(
 
 
 @register_template_heuristic(
-    blackwell_ws_persistent_device_tma_mm_template.uid,
+    blackwell_ws_persistent_tma_mm_template.uid,
     "cuda",
     register=torch.version.hip is None,
     op_name="addmm",
@@ -3103,7 +3104,7 @@ class CUDAScaledTMAMainLoopScalingTemplateConfigHeuristic(
 
 @register_template_heuristic(
     # regular Blackwell MM template + scaling epilogue from ScaledMMConfigMixin
-    blackwell_ws_persistent_device_tma_mm_template.uid,
+    blackwell_ws_persistent_tma_mm_template.uid,
     "cuda",
     register=torch.version.hip is None,
     op_name="scaled_mm",


### PR DESCRIPTION
Adds host-side TMA support for the B200 GEMM template in Inductor, building off https://github.com/pytorch/pytorch/pull/185825 (issue tracked in https://github.com/pytorch/pytorch/issues/185819), turned on with `ENABLE_HOST_SIDE_TMA=1`.

This PR uses a new `{{tma_descriptor()}}` Jinja hook to create TMA descriptors, either on the host (via registers in `host_tma_descriptor_args`) or on device (by emitting `tl.make_tensor_descriptor` within the Triton kernel). The host-side TMA descriptors are passed into the kernel with the `tensordesc<>` signature.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo