### PR TITLE
[dynamo] Enable enable_trace_unittest by default

### DIFF
--- a/test/dynamo/test_contains_protocol.py
+++ b/test/dynamo/test_contains_protocol.py
@@ -222,15 +222,6 @@ class _ContainsBase:
     has_iter = True  # Override in subclass if type doesn't implement __iter__
     has_getitem = True  # Override in subclass if type doesn't implement __getitem__
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     def init(self, thetype, data):
         return thetype(data)
 
@@ -461,15 +452,6 @@ class RangeContainsTest(_ContainsBase, torch._dynamo.test_case.TestCase):
 class ContainsNonBoolReturnTest(torch._dynamo.test_case.TestCase):
     """Test __contains__ that returns non-bool truthy/falsy values."""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_contains_truthy(self):
         seq = ContainsReturnsTruthy()
@@ -490,15 +472,6 @@ class ContainsNonBoolReturnTest(torch._dynamo.test_case.TestCase):
 class NoIterNoContainsTest(torch._dynamo.test_case.TestCase):
     """Tests for objects with neither __iter__ nor __contains__"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_no_iter_no_contains_raises_typeerror(self):
         # Should raise TypeError when neither __iter__ nor __contains__ exists
@@ -516,15 +489,6 @@ class NoIterNoContainsTest(torch._dynamo.test_case.TestCase):
 
 class RaisesDuringIterTest(torch._dynamo.test_case.TestCase):
     """Tests for iterators that raise exceptions during iteration"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_raises_during_iter_found_before_error(self):
@@ -545,15 +509,6 @@ class RaisesDuringIterTest(torch._dynamo.test_case.TestCase):
 class ContainsRaisesTypeErrorTest(torch._dynamo.test_case.TestCase):
     """Tests for __contains__ that raises TypeError"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_contains_raises_typeerror(self):
         # __contains__ raises TypeError
@@ -573,15 +528,6 @@ class ContainsRaisesTypeErrorTest(torch._dynamo.test_case.TestCase):
 
 class RangeContainsMiscTest(torch._dynamo.test_case.TestCase):
     """Specific tests for range __contains__ protocol"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_range_basic(self):
@@ -659,15 +605,6 @@ class SetInSetTest(torch._dynamo.test_case.TestCase):
     retries, so `{1, 2} in {frozenset({1, 2})}` returns True even though set is
     not hashable.  Ref: Objects/setobject.c::set_contains.
     """
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_set_in_frozenset_set_found(self):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -3154,14 +3154,11 @@ class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.enable_trace_contextlib
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_contextlib = True
-        torch._dynamo.config.enable_trace_unittest = True
 
     def tearDown(self):
         super().tearDown()
         torch._dynamo.config.enable_trace_contextlib = self._prev
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
 
     def test_ctx_basic0(self):
         @contextlib.contextmanager

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2223,15 +2223,6 @@ class DictMethodsTests(torch._dynamo.test_case.TestCase):
     # BinOps:
     # ==, !=, |
 
-    def setUp(self):
-        self._prev_trace_unittest = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self._prev_trace_unittest
-        return super().tearDown()
-
     def assertEqual(self, x, y):
         self.assertTrue(x == y, f"Expected {x} to be equal to {y}")
 
@@ -2784,15 +2775,6 @@ class OrderedDictMethodsTests(DictMethodsTests):
 
 
 class OrderedDictSubclassOverload(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        self._prev_trace_unittest = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self._prev_trace_unittest
-        return super().tearDown()
-
     def assertEqual(self, x, y):
         self.assertTrue(x == y, f"Expected {x} to be equal to {y}")
 

--- a/test/dynamo/test_exitstack.py
+++ b/test/dynamo/test_exitstack.py
@@ -18,14 +18,6 @@ def set_default_dtype(dtype):
 
 
 class TestExitStack(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self._prev
-
     def test_exitstack(self):
         @torch.compile(backend="eager", fullgraph=True)
         def fn(t):

--- a/test/dynamo/test_generator.py
+++ b/test/dynamo/test_generator.py
@@ -22,13 +22,10 @@ class GeneratorTestsBase(torch._dynamo.test_case.TestCase):
         super().setUp()
         self._old = torch._dynamo.config.enable_faithful_generator_behavior
         torch._dynamo.config.enable_faithful_generator_behavior = True
-        self._unittest_old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
 
     def tearDown(self):
         super().tearDown()
         torch._dynamo.config.enable_faithful_generator_behavior = self._old
-        torch._dynamo.config.enable_trace_unittest = self._unittest_old
 
     def _compile_check(self, fn, args=None, fullgraph=True):
         eager = EagerAndRecordGraphs()

--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -118,15 +118,6 @@ class NotReversibleNone:
 class TestIterators(torch._dynamo.test_case.TestCase):
     """Test iterator support in Dynamo"""
 
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     @make_dynamo_test
     def test_list_iteration(self):
         """Test iteration over list"""
@@ -926,15 +917,6 @@ class GeneratorIterIterable:
 class TestCustomIteratorMethods(torch._dynamo.test_case.TestCase):
     """Test custom __iter__ implementations on user-defined subclasses"""
 
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     @make_dynamo_test
     def test_custom_object_with_custom_iter(self):
         obj = CustomListWithReverseIter()
@@ -989,15 +971,6 @@ class TestIteratorMutationSemantics(torch._dynamo.test_case.TestCase):
     These tests explore whether Dynamo preserves CPython's iterator semantics
     when the underlying container is modified.
     """
-
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
 
     @make_dynamo_test
     def test_dict_mutation_during_iteration(self):
@@ -1115,15 +1088,6 @@ class Priority(enum.IntEnum):
 class TestEnumIteration(torch._dynamo.test_case.TestCase):
     """Test iteration over enum classes"""
 
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     @make_dynamo_test
     def test_enum_iter(self):
         result = list(iter(Color))
@@ -1166,15 +1130,6 @@ class TestEnumIteration(torch._dynamo.test_case.TestCase):
 
 class TestIterWithBuiltins(torch._dynamo.test_case.TestCase):
     """Test iter() with builtin iterators like zip, map, filter, reversed"""
-
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
 
     @make_dynamo_test
     def test_iter_of_zip(self):
@@ -1399,15 +1354,6 @@ class BlockedLen:
 
 class TestIterErrors(torch._dynamo.test_case.TestCase):
     """Test that iter() raises the correct exceptions"""
-
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
 
     @make_dynamo_test
     def test_iter_non_iterable_raises_type_error(self):

--- a/test/dynamo/test_len_protocol.py
+++ b/test/dynamo/test_len_protocol.py
@@ -29,13 +29,7 @@ class _BaseSequenceLen:
     def setUp(self):
         if self.thetype is None:
             self.skipTest("Base class - not meant to be run directly")
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
         super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_basic(self):
@@ -99,15 +93,6 @@ class _BaseMappingLen:
     def get_mapping(self, items):
         """Override in subclass to return appropriate mapping type"""
         return dict(items)
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_basic(self):
@@ -184,15 +169,6 @@ class _BaseSetLen:
         """Override in subclass to return appropriate set type"""
         return set(items)
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_basic(self):
         s = self.get_set([1, 2, 3])
@@ -248,15 +224,6 @@ class TestFrozenSetLen(_BaseSetLen, torch._dynamo.test_case.TestCase):
 class TestRangeLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on range objects"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_basic(self):
         r = range(5)
@@ -296,15 +263,6 @@ class TestRangeLen(torch._dynamo.test_case.TestCase):
 class TestStringLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on string objects"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_empty(self):
         s = ""
@@ -336,15 +294,6 @@ class TestStringLen(torch._dynamo.test_case.TestCase):
 
 class TestTensorLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on torch.Tensor objects"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_1d(self):
@@ -393,8 +342,6 @@ class TestNNModuleLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on torch.nn module containers"""
 
     def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
         super().setUp()
 
         # Pre-construct nn.Module instances outside compiled regions
@@ -413,10 +360,6 @@ class TestNNModuleLen(torch._dynamo.test_case.TestCase):
         self.seq_5layers = torch.nn.Sequential(
             *[torch.nn.Linear(10, 10) for _ in range(5)]
         )
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_sequential(self):
@@ -463,15 +406,6 @@ class TestNNModuleLen(torch._dynamo.test_case.TestCase):
 
 class TestDictViewLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on dict view objects (keys, values, items)"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_dict_keys_view(self):
@@ -688,15 +622,6 @@ class SetSubclassCustomLen(set):
 class TestUserDefinedLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on user-defined classes with __len__"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_simple_custom_class(self):
         obj = CustomList([1, 2, 3])
@@ -735,15 +660,6 @@ class TestUserDefinedLen(torch._dynamo.test_case.TestCase):
 
 class TestSubclassOverloadedLen(torch._dynamo.test_case.TestCase):
     """Tests for custom classes that inherit from builtins and overload __len__"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_list_subclass_custom_len(self):
@@ -828,15 +744,6 @@ class CustomDescriptorLenClass:
 class TestUserDefinedMappingLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on user-defined mapping (dict-like) classes"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_custom_mapping_basic(self):
         """Test len() on a basic custom mapping class"""
@@ -907,15 +814,6 @@ class TestUserDefinedMappingLen(torch._dynamo.test_case.TestCase):
 class TestDescriptorLenImpl(torch._dynamo.test_case.TestCase):
     """Test that len_impl handles descriptor-based __len__ correctly"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_regular_instance_len(self):
         """Test regular instance method __len__"""
@@ -976,15 +874,6 @@ class TestDescriptorLenImpl(torch._dynamo.test_case.TestCase):
 class TestRaisesTypeError(torch._dynamo.test_case.TestCase):
     """Tests for types that don't support len() - should raise TypeError like Python"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_slice_raises_type_error(self):
         """slice objects do not support len() - should raise TypeError"""
@@ -1039,15 +928,6 @@ class TestRaisesTypeError(torch._dynamo.test_case.TestCase):
 class TestDequeLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on collections.deque objects"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_basic(self):
         d = collections.deque([1, 2, 3])
@@ -1087,15 +967,6 @@ class TestDequeLen(torch._dynamo.test_case.TestCase):
 
 class TestMappingProxyLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on types.MappingProxyType objects"""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_basic(self):
@@ -1164,15 +1035,6 @@ class SimpleMetaclassClass(metaclass=MetaclassWithLen):
 class TestMetaclassLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on metaclasses, classmethods, staticmethods, and properties"""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_metaclass_len_basic(self):
         """Test len() on a class with __len__ defined in metaclass"""
@@ -1231,15 +1093,6 @@ class FrozenData:
 class TestMutableMappingLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on mutable mapping types."""
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     @make_dynamo_test
     def test_len_custom_mutable_mapping(self):
         """Test len() on custom mutable mapping."""
@@ -1256,15 +1109,6 @@ class TestMutableMappingLen(torch._dynamo.test_case.TestCase):
 
 class TestFrozenDataclassLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on frozen dataclasses."""
-
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
 
     @make_dynamo_test
     def test_len_frozen_dataclass_with_len(self):

--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -34,15 +34,6 @@ class TupleTests(torch._dynamo.test_case.TestCase):
 
     thetype = tuple
 
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     def assertEqual(self, a, b):
         return self.assertTrue(a == b, f"{a} != {b}")
 

--- a/test/dynamo/test_mapping_ops.py
+++ b/test/dynamo/test_mapping_ops.py
@@ -76,14 +76,11 @@ class TestMpAssSubscript(torch._dynamo.test_case.TestCase):
 
     def setUp(self):
         super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         self._b_prev = torch._dynamo.config.enable_trace_load_build_class
-        torch._dynamo.config.enable_trace_unittest = True
         torch._dynamo.config.enable_trace_load_build_class = True
 
     def tearDown(self):
         super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
         torch._dynamo.config.enable_trace_load_build_class = self._b_prev
 
     # -- parameterized over mapping container type --

--- a/test/dynamo/test_nb_and.py
+++ b/test/dynamo/test_nb_and.py
@@ -14,14 +14,11 @@ from torch.utils._ordered_set import OrderedSet
 class TestNbAnd(torch._dynamo.test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         self._b_prev = torch._dynamo.config.enable_trace_load_build_class
-        torch._dynamo.config.enable_trace_unittest = True
         torch._dynamo.config.enable_trace_load_build_class = True
 
     def tearDown(self):
         super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
         torch._dynamo.config.enable_trace_load_build_class = self._b_prev
 
     # --- Integer and ---

--- a/test/dynamo/test_nb_multiply.py
+++ b/test/dynamo/test_nb_multiply.py
@@ -98,7 +98,6 @@ class _InheritedSub(_BaseWithMul):
     pass
 
 
-@torch._dynamo.config.patch(enable_trace_unittest=True)
 class TestNbMultiply(torch._dynamo.test_case.TestCase):
     # --- Integer multiply ---
 

--- a/test/dynamo/test_nb_operators.py
+++ b/test/dynamo/test_nb_operators.py
@@ -169,15 +169,6 @@ _INPLACE_COMBOS = {
 
 
 class TestNbOr(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     # --- Logical or ---
 
     @make_dynamo_test
@@ -869,15 +860,6 @@ class _RSubReturnsMarker:
 
 
 class TestNbSub(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     # --- Arithmetic sub ---
 
     @make_dynamo_test
@@ -1348,15 +1330,6 @@ class _InheritedSubAdd(_BaseWithAdd):
 
 
 class TestNbAdd(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     # --- Arithmetic add ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_shift.py
+++ b/test/dynamo/test_nb_shift.py
@@ -5,7 +5,6 @@ import torch._dynamo.test_case
 from torch.testing._internal.common_utils import make_dynamo_test
 
 
-@torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbLshift(torch._dynamo.test_case.TestCase):
     # --- Integer lshift ---
@@ -237,7 +236,6 @@ class TestNbLshift(torch._dynamo.test_case.TestCase):
         self.assertEqual(opt_fn(x), fn(x))
 
 
-@torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbRshift(torch._dynamo.test_case.TestCase):
     # --- Integer rshift ---

--- a/test/dynamo/test_nb_xor.py
+++ b/test/dynamo/test_nb_xor.py
@@ -14,14 +14,11 @@ from torch.utils._ordered_set import OrderedSet
 class TestNbXor(torch._dynamo.test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         self._b_prev = torch._dynamo.config.enable_trace_load_build_class
-        torch._dynamo.config.enable_trace_unittest = True
         torch._dynamo.config.enable_trace_load_build_class = True
 
     def tearDown(self):
         super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
         torch._dynamo.config.enable_trace_load_build_class = self._b_prev
 
     # --- Integer xor ---

--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -60,15 +60,6 @@ class UserDefinedSequence:
 class TestSqConcat(torch._dynamo.test_case.TestCase):
     """Tests for sq_concat (+) and sq_inplace_concat (+=) operators for sequences."""
 
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     # --- List concatenation ---
 
     @parametrize(
@@ -387,14 +378,11 @@ class TestSqAssItem(torch._dynamo.test_case.TestCase):
 
     def setUp(self):
         super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         self._b_prev = torch._dynamo.config.enable_trace_load_build_class
-        torch._dynamo.config.enable_trace_unittest = True
         torch._dynamo.config.enable_trace_load_build_class = True
 
     def tearDown(self):
         super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
         torch._dynamo.config.enable_trace_load_build_class = self._b_prev
 
     # -- parameterized over sequence container type --

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -23,15 +23,6 @@ class FrozenstSubclass(frozenset):
 
 
 class _BaseSetTests(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        self.old = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-        super().setUp()
-
-    def tearDown(self):
-        torch._dynamo.config.enable_trace_unittest = self.old
-        return super().tearDown()
-
     def assertEqual(self, a, b):
         return self.assertTrue(a == b, f"{a} != {b}")
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -3484,7 +3484,6 @@ class _IssubclassRegisteredViaABC:
 _IssubclassMyABC.register(_IssubclassRegisteredViaABC)
 
 
-@torch._dynamo.config.patch(enable_trace_unittest=True)
 class TestIssubclass(torch._dynamo.test_case.TestCase):
     # --- Built-in types ---
 

--- a/test/dynamo/test_unittest.py
+++ b/test/dynamo/test_unittest.py
@@ -7,15 +7,6 @@ from torch.testing._internal.common_utils import make_dynamo_test
 
 
 class TestUnittest(torch._dynamo.test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._prev
-
     @make_dynamo_test
     def test_SkipTest(self):
         z = 0

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -493,15 +493,6 @@ class WithGetattribute:
 class TestSlotsFromCPython(TestCase):
     """Slot tests extracted from CPython's test_descr.py::test_slots."""
 
-    def setUp(self):
-        super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
-        torch._dynamo.config.enable_trace_unittest = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
-
     def test_slots_empty(self):
         class C:
             __slots__ = []
@@ -918,14 +909,11 @@ class TestUserDefinedSetitem(TestCase):
 
     def setUp(self):
         super().setUp()
-        self._u_prev = torch._dynamo.config.enable_trace_unittest
         self._b_prev = torch._dynamo.config.enable_trace_load_build_class
-        torch._dynamo.config.enable_trace_unittest = True
         torch._dynamo.config.enable_trace_load_build_class = True
 
     def tearDown(self):
         super().tearDown()
-        torch._dynamo.config.enable_trace_unittest = self._u_prev
         torch._dynamo.config.enable_trace_load_build_class = self._b_prev
 
     # -- instance __setitem__ --

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -560,7 +560,7 @@ enable_cpp_symbolic_shape_guards = False
 enable_trace_contextlib = True
 
 # Enable tracing through unittest
-enable_trace_unittest = False
+enable_trace_unittest = True
 
 # Enable tracing LOAD_BUILD_CLASS bytecode
 enable_trace_load_build_class = False

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -242,7 +242,6 @@ class CPythonTestCase(TestCase):
         cls._stack = contextlib.ExitStack()  # type: ignore[attr-defined]
         cls._stack.enter_context(  # type: ignore[attr-defined]
             config.patch(
-                enable_trace_unittest=True,
                 enable_trace_load_build_class=True,
             ),
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186755

Flip torch._dynamo.config.enable_trace_unittest to True so Dynamo
inlines through the unittest module by default instead of skipping it.
This makes torch.compile trace unittest assertion helpers (assertEqual,
assertTrue, etc.) out of the box, matching what the Dynamo test suite
already relied on by patching the flag on per test.

Since the flag now defaults on, the per-test toggles are redundant and
are removed: the setUpClass patch in torch/_dynamo/test_case.py and the
setUp/tearDown save/set/restore blocks (and standalone config.patch
decorators) across the dynamo test files. Where a setUp/tearDown only
existed to toggle the flag, the whole method is dropped; where it also
managed another flag or had a skipTest guard, only the flag lines are
removed.

The runtime gate in trace_rules.py / builtin.py is intentionally kept so
the flag can still be turned off if needed.

Test Plan:

```
pixi run -w pytorch -e pytorch313-cp python test/dynamo/test_unittest.py
pixi run -w pytorch -e pytorch313-cp python test/dynamo/test_sets.py
pixi run -w pytorch -e pytorch313-cp python test/dynamo/test_len_protocol.py
```

Authored with assistance from an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98