### PR TITLE
Fix Dynamo set subclass comparison guards

### DIFF
--- a/test/dynamo/test_tp_richcompare.py
+++ b/test/dynamo/test_tp_richcompare.py
@@ -1776,6 +1776,71 @@ class TpRichcompareTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(s1, s2)
         self.assertEqual(result, expected)
 
+    def test_set_subclass_inherited_cmp_uses_internal_contents(self):
+        class LyingSet(set):
+            def __iter__(self):
+                return iter([99])
+
+            def __len__(self):
+                raise RuntimeError("__len__ should not be called")
+
+            def __contains__(self, item):
+                raise RuntimeError("__contains__ should not be called")
+
+        class LyingFrozenSet(frozenset):
+            def __iter__(self):
+                return iter([99])
+
+            def __len__(self):
+                raise RuntimeError("__len__ should not be called")
+
+            def __contains__(self, item):
+                raise RuntimeError("__contains__ should not be called")
+
+        def fn(x, a, b):
+            offset = 0
+            comparisons = (
+                a == b,
+                b == a,
+                a != b,
+                b != a,
+                a <= b,
+                b <= a,
+                a < b,
+                b < a,
+                a >= b,
+                b >= a,
+                a > b,
+                b > a,
+            )
+            for i, pred in enumerate(comparisons):
+                if pred:
+                    offset += 1 << i
+            return x + offset
+
+        cases = (
+            ({1, 2, 3}, LyingSet({1, 2, 3})),
+            (LyingSet({1, 2, 3}), {1, 2, 3}),
+            (LyingSet({1, 2}), LyingSet({1, 2, 3})),
+            ({1, 2, 3}, LyingFrozenSet({1, 2, 3})),
+        )
+
+        def base_len(obj):
+            if isinstance(obj, set):
+                return set.__len__(obj)
+            return frozenset.__len__(obj)
+
+        for a, b in cases:
+            with self.subTest(a=type(a), b=type(b), sizes=(base_len(a), base_len(b))):
+                x = torch.ones(())
+                expected = fn(x, a, b)
+                cnt = torch._dynamo.testing.CompileCounter()
+                opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+                self.assertEqual(opt_fn(x, a, b), expected)
+                self.assertEqual(opt_fn(x, a, b), expected)
+                self.assertEqual(cnt.frame_count, 1)
+            torch._dynamo.reset()
+
     # =====================================================================
     # Tensor vs non-proxyable types (followups)
     # =====================================================================

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -189,6 +189,7 @@ from .utils import (
     normalize_count_iter,
     normalize_range_iter,
     orig_code_map,
+    set_getitem,
     tuple_iterator_getitem,
     tuple_iterator_len,
     verify_guard_fn_signature,
@@ -225,6 +226,14 @@ recompiles_verbose_log = torch._logging.getArtifactLogger(
     __name__, "recompiles_verbose"
 )
 verbose_guards_log = torch._logging.getArtifactLogger(__name__, "verbose_guards")
+
+
+def _sequence_length(value: Any) -> int:
+    if isinstance(value, set):
+        return set.__len__(value)
+    if isinstance(value, frozenset):
+        return frozenset.__len__(value)
+    return len(value)
 
 
 dunder_attrs_assumed_constants = (
@@ -773,6 +782,7 @@ def _get_closure_vars() -> dict[str, object]:
             "___normalize_count_iter": normalize_count_iter,
             "___normalize_range_iter": normalize_range_iter,
             "___tuple_iterator_getitem": tuple_iterator_getitem,
+            "___set_getitem": set_getitem,
             "___dataclass_fields": dataclass_fields,
             "___namedtuple_fields": lambda x: x._fields,
             "___get_torch_function_mode_stack_at": get_torch_function_mode_stack_at,
@@ -2891,35 +2901,40 @@ class GuardBuilder(GuardBuilderBase):
         return self.id_match_unchecked(guard)
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: len(value),
-        eval_fn=lambda value, metadata: len(value) == metadata,
+        get_metadata_fn=lambda guard, value: _sequence_length(value),
+        eval_fn=lambda value, metadata: _sequence_length(value) == metadata,
     )
     def SEQUENCE_LENGTH(self, guard: Guard) -> None:
         # This guard is used to check length of PySequence objects like list,
         # tuple, collections.deque etc
         ref = self.arg_ref(guard)
         value = self.get(guard)
+        length = _sequence_length(value)
 
         if not isinstance(value, dict):
             # C++ DICT_LENGTH checks for type
             self.TYPE_MATCH(guard)
 
         code = []
-        if len(value) == 0:
+        if isinstance(value, set):
+            code.append(f"set.__len__({ref}) == {length}")
+        elif isinstance(value, frozenset):
+            code.append(f"frozenset.__len__({ref}) == {length}")
+        elif length == 0:
             code.append(f"not {ref}")
         else:
-            code.append(f"len({ref}) == {len(value)}")
+            code.append(f"len({ref}) == {length}")
 
         self._set_guard_export_info(guard, code)
         if isinstance(value, dict):
             self.get_guard_manager(guard).add_dict_length_check_guard(
-                len(value),
+                length,
                 get_verbose_code_parts(code, guard),
                 guard.user_stack,
             )
         else:
             self.get_guard_manager(guard).add_length_check_guard(
-                len(value),
+                length,
                 get_verbose_code_parts(code, guard),
                 guard.user_stack,
             )

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -817,10 +817,24 @@ class NonSerializableSetGetItemSource(ChainedSource):
         codegen.append_output(codegen.create_load_const(self.index))
         codegen.extend_output(create_call_function(2, False))
 
+    def get_value(
+        self,
+        globals: dict[str, Any],
+        locals: dict[str, Any],
+        cache: dict[Source, Any],
+    ) -> Any:
+        if self in cache:
+            return cache[self]
+        value = utils.set_getitem(
+            self.base.get_value(globals, locals, cache), self.index
+        )
+        cache[self] = value
+        return value
+
     @functools.cached_property
     def _name_template(self) -> str:
         # set ordering might not be stable
-        return f"list({{0}})[{_esc_str(self.index, apply_repr=True)}]"
+        return f"___set_getitem({{0}}, {_esc_str(self.index, apply_repr=True)})"
 
     def is_dict_key(self) -> bool:
         return False

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3183,9 +3183,21 @@ def dict_keys_getitem(d: dict[Any, Any], n: int) -> Any:
     return next(itertools.islice(dict.keys(d), n, n + 1))
 
 
+def set_base_iter(s: Iterable[T]) -> Iterator[T]:
+    if isinstance(s, set):
+        return set.__iter__(s)
+    if isinstance(s, frozenset):
+        return frozenset.__iter__(s)
+    return iter(s)
+
+
 def set_getitem(s: set[T], n: int) -> T:
-    # Set ordering might not be stable
-    return list(s)[n]
+    # Set ordering might not be stable. For set/frozenset subclasses, use the
+    # base iterator so guard reconstruction observes the internal set contents.
+    try:
+        return next(itertools.islice(set_base_iter(s), n, n + 1))
+    except StopIteration:
+        raise IndexError("set index out of range") from None
 
 
 def enum_repr(value: Any, local: bool) -> str:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -186,6 +186,7 @@ from ..utils import (
     odict_values,
     proxy_args_kwargs,
     range_iterator,
+    set_base_iter,
     set_example_value,
     tensor_always_has_static_shape,
     tuple_iterator,
@@ -1208,7 +1209,7 @@ class VariableBuilder:
             # on the Python hash and it is not related to object ordering inside
             # the set object. The order being incorrect at runtime will lead to
             # a recompilation.
-            L = list(value)
+            L = list(value) if istype(value, OrderedSet) else list(set_base_iter(value))
             items = [
                 LazyVariableTracker.create(
                     v,
@@ -2068,7 +2069,7 @@ class VariableBuilder:
             self.install_guards(GuardBuilder.TYPE_MATCH)
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
 
-            L = list(dict.fromkeys(value))
+            L = list(set_base_iter(value))
             output = [
                 LazyVariableTracker.create(
                     list.__getitem__(L, i),

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2107,7 +2107,13 @@ class LENGTH_CHECK : public LeafGuard {
   bool check_nopybind(PyObject* value) override { // borrowed ref
     // PySequence_Length returns -1 if the object is not a sequence. So, we
     // don't have to test for PySequence_Check.
-    return PySequence_Length(value) == _length;
+    Py_ssize_t length{
+        PyAnySet_Check(value) ? PySet_Size(value) : PySequence_Length(value)};
+    if (length == -1) {
+      PyErr_Clear();
+      return false;
+    }
+    return length == _length;
   }
 
  private:
@@ -5683,8 +5689,38 @@ class ListGetItemGuardAccessor : public GuardAccessor {
   Py_ssize_t _index{-1};
 };
 
+static PyObject* set_getitem_new_ref(PyObject* obj, Py_ssize_t index) {
+  if (index < 0) {
+    return nullptr;
+  }
+
+  PyObject* iter = nullptr;
+  if (PySet_Check(obj)) {
+    iter = PySet_Type.tp_iter(obj);
+  } else if (PyFrozenSet_Check(obj)) {
+    iter = PyFrozenSet_Type.tp_iter(obj);
+  } else {
+    iter = PyObject_GetIter(obj);
+  }
+  if (iter == nullptr) {
+    return nullptr;
+  }
+
+  PyObject* item = nullptr;
+  for (Py_ssize_t i = 0; i <= index; i++) {
+    Py_XDECREF(item);
+    item = PyIter_Next(iter);
+    if (item == nullptr) {
+      Py_DECREF(iter);
+      return nullptr;
+    }
+  }
+  Py_DECREF(iter);
+  return item;
+}
+
 /**
- * Represents set[index] accessor by converting the set into a list.
+ * Represents set[index] accessor by walking the set iterator.
  */
 class SetGetItemGuardAccessor : public GuardAccessor {
  public:
@@ -5707,29 +5743,28 @@ class SetGetItemGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
 
-    PyObject* lst = PySequence_List(obj);
-    PyObject* x = PyList_GetItem(lst, _index); // borrowed ref
-    Py_XDECREF(lst);
+    PyObject* x = set_getitem_new_ref(obj, _index);
     if (x == nullptr) {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    bool result{_guard_manager->check_nopybind(x)};
+    Py_DECREF(x);
     return result;
   }
 
   GuardDebugInfo check_verbose_nopybind(
       PyObject* obj) override { // borrowed ref
 
-    PyObject* lst = PySequence_List(obj);
-    PyObject* x = PyList_GetItem(lst, _index); // borrowed ref
-    Py_XDECREF(lst);
+    PyObject* x = set_getitem_new_ref(obj, _index);
 
     if (x == nullptr) {
       PyErr_Clear();
       return GuardDebugInfo(false, 0);
     }
-    GuardDebugInfo result = _guard_manager->check_verbose_nopybind(x);
+    GuardDebugInfo result{_guard_manager->check_verbose_nopybind(x)};
+    Py_DECREF(x);
     return result;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186763

Dynamo materialized sourced set and frozenset subclasses through Python-level iteration when building SetVariable contents and set item guard sources. That lets an overridden __iter__ lie about the container contents, while CPython set rich comparison reads the internal set table directly. Sequence length and C++ set item guards had the same mismatch for set subclasses overriding __len__ or __iter__.

Use base set/frozenset iteration and size APIs for sourced set materialization, guard source reconstruction, Python guard metadata, and C++ guard checks. This keeps Dynamo's view of set subclasses aligned with CPython's inherited set operations while preserving the existing OrderedSet path.

Benchmark Results:

Correctness-focused container guard change; no tensor compute benchmark applies. Cached compiled comparison microbenchmark after the fix: eager set comparison min 0.000461s median 0.000463s for 10000 calls; compiled cached comparison min 0.068355s median 0.069182s for 10000 calls.

Test Plan:

ninja -C build lib/libtorch_python.so

LD_PRELOAD="/data/users/jansel/pytorch-issue-fixer/pytorch/build/lib/libtorch_python.so" python - <<'PY' ... issue repro ... PY

LD_PRELOAD="/data/users/jansel/pytorch-issue-fixer/pytorch/build/lib/libtorch_python.so" python test/dynamo/test_tp_richcompare.py -k set_subclass

LD_PRELOAD="/data/users/jansel/pytorch-issue-fixer/pytorch/build/lib/libtorch_python.so" python test/dynamo/test_sets.py

git diff --cached --check

lintrunner -a (fails on pre-existing broad clang-tidy warnings in torch/csrc/dynamo/guards.cpp)

Fixes #186671

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98