### PR TITLE
nn/utils: reduce CPU overhead in _get_total_norm for many small tensors

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14518,6 +14518,34 @@ if __name__ == '__main__':
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), "`parameters` is an empty generator, no gradient clipping will occur.")
 
+    # issue #133586: CPU norm optimizations in _get_total_norm
+    @onlyCPU
+    @parametrize_test('norm_type', (1.0, 2.0, 3.0, float('inf')))
+    def test_clip_grad_norm_flat_cat_small_tensors(self, norm_type, device):
+        # flat-cat path: all tensors numel<=512, result must match foreach=True reference
+        tensors = [torch.randn(512, device=device) for _ in range(2000)]
+        result = get_total_norm(tensors, norm_type=norm_type, foreach=None)
+        reference = get_total_norm(tensors, norm_type=norm_type, foreach=True)
+        self.assertEqual(result, reference, atol=1e-5, rtol=1e-5)
+
+    @onlyCPU
+    def test_clip_grad_norm_flat_cat_mixed_numel(self, device):
+        # group with mixed numel: flat-cat must not activate when any tensor exceeds threshold
+        small = [torch.randn(512, device=device) for _ in range(50)]
+        large = [torch.randn(1024, device=device) for _ in range(50)]
+        result = get_total_norm(small + large, norm_type=2.0, foreach=None)
+        reference = get_total_norm(small + large, norm_type=2.0, foreach=True)
+        self.assertEqual(result, reference, atol=1e-5, rtol=1e-5)
+
+    @onlyCPU
+    @parametrize_test('norm_type', (1.0, 2.0, float('inf')))
+    def test_clip_grad_norm_skip_to_single_device(self, norm_type, device):
+        # skip-no-op-.to(): large tensors all on same device should still be correct
+        tensors = [torch.randn(4096, device=device) for _ in range(200)]
+        result = get_total_norm(tensors, norm_type=norm_type, foreach=None)
+        reference = get_total_norm(tensors, norm_type=norm_type, foreach=True)
+        self.assertEqual(result, reference, atol=1e-5, rtol=1e-5)
+
     # reference issue: https://github.com/pytorch/pytorch/issues/111484
     @onlyCUDA
     @largeTensorTest("42GB", "cuda")

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -92,7 +92,20 @@ def _get_total_norm(
         if (foreach is None and _has_foreach_support(device_tensors, device)) or (
             foreach and _device_has_foreach_support(device)
         ):
-            norms.extend(torch._foreach_norm(device_tensors, norm_type))
+            # On CPU with small tensors, cat+norm avoids N scalar allocations from
+            # _foreach_norm (issue #133586). reshape(-1) handles non-contiguous grads.
+            if (
+                foreach is None
+                and device.type == "cpu"
+                and all(t.numel() <= 512 for t in device_tensors)
+            ):
+                norms.append(
+                    torch.linalg.vector_norm(
+                        torch.cat([t.reshape(-1) for t in device_tensors]), norm_type
+                    )
+                )
+            else:
+                norms.extend(torch._foreach_norm(device_tensors, norm_type))
         elif foreach:
             raise RuntimeError(
                 f"foreach=True was passed, but can't use the foreach API on {device.type} tensors"
@@ -102,9 +115,13 @@ def _get_total_norm(
                 [torch.linalg.vector_norm(g, norm_type) for g in device_tensors]
             )
 
-    total_norm = torch.linalg.vector_norm(
-        torch.stack([norm.to(first_device) for norm in norms]), norm_type
-    )
+    # When all tensors share the same device (the typical single-GPU or CPU-only
+    # case), the [norm.to(first_device) for norm in norms] list comprehension is
+    # a no-op but still dispatches N Python calls. Skip it when no cross-device
+    # movement is actually needed (issue #133586).
+    if any(device != first_device for (device, _) in grouped_tensors):
+        norms = [norm.to(first_device) for norm in norms]
+    total_norm = torch.linalg.vector_norm(torch.stack(norms), norm_type)
 
     if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
         raise RuntimeError(


### PR DESCRIPTION
Fixes #133586

> **Note:** This supersedes #184072, which was accidentally closed and could not be reopened due to the original branch being an orphan commit (no common history with main). All feedback from that PR has been incorporated here.

## Summary

Two targeted optimizations for `_get_total_norm` (called by `clip_grad_norm_`) on CPU when training models with many gradient tensors:

**1. Skip no-op `.to(first_device)` calls in the final norm aggregation**

When all gradient tensors are on the same device (the overwhelmingly common case — single GPU or CPU-only training), every `.to(first_device)` call is a no-op. A cheap O(k) check (k = number of unique device/dtype groups, typically 1–3) gates the comprehension and eliminates it for the single-device case.

**2. Single flat-cat norm for very small tensors (numel ≤ 512, CPU, `foreach=None`)**

`_foreach_norm` allocates a separate 0-D scalar output tensor for each input, producing N `aten::empty({})` calls. For N=2000 bias/LayerNorm tensors of 512 elements, concatenating their flattened views with `torch.cat` and computing one `vector_norm` avoids these N allocations. `reshape(-1)` handles non-contiguous gradient tensors safely. The threshold uses `all(t.numel() <= 512 for t in device_tensors)` so groups containing any large tensor fall back to `_foreach_norm` correctly.

## Benchmark

Hardware: Apple M-series CPU. N=2000 tensors, each 512 float32 elements (typical bias/LayerNorm parameter size in large transformers). `torch.utils.benchmark.Timer.blocked_autorange(min_run_time=3.0)`:

| Path | Wall time |
|---|---|
| Before: `_foreach_norm` + `stack(.to())` + `vector_norm` | 7.5 ms |
| After: `cat(reshape(-1))` + `vector_norm` (no `.to()` needed) | 6.0 ms |

**→ ~20% reduction in `_get_total_norm` time for many small CPU tensors**

## Changes from #184072

- `view(-1)` → `reshape(-1)` for non-contiguous gradient tensor safety
- Threshold check uses `all(t.numel() <= 512 for t in device_tensors)` (not `[0].numel()`)
- Tests moved into `TestNNDeviceType` in `test/test_nn.py` (no separate test file)