### PR TITLE
Ensure trunk test results are properly uploaded to test_run_s3

### DIFF
--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -199,12 +199,18 @@ def backfill_test_jsons_while_running(
             )
 
         for unzipped_dir in unzipped_xml_dirs:
+            reports_root = unzipped_dir / "test" / "test-reports"
             for xml in unzipped_dir.glob("**/*.xml"):
-                corresponding_json = str(
-                    xml.with_suffix(".json").relative_to(
-                        unzipped_dir / "test" / "test-reports"
-                    )
-                )
+                # Most jobs lay reports out under <unzipped_dir>/test/test-reports,
+                # but some (e.g. ROCm gfx950) put them directly under
+                # <unzipped_dir>/test-reports. Those can't be keyed relative to
+                # reports_root, so skip them instead of aborting the whole upload.
+                try:
+                    relative_json = xml.with_suffix(".json").relative_to(reports_root)
+                except ValueError:
+                    print(f"Skipping test json with unexpected layout: {xml}")
+                    continue
+                corresponding_json = str(relative_json)
                 if corresponding_json in all_existing_jsons:
                     print(f"Skipping upload for existing test json for {xml}")
                     continue
@@ -217,12 +223,7 @@ def backfill_test_jsons_while_running(
                     workflow_run_attempt,
                     job_id,
                 )
-                json_file = xml.with_suffix(".json")
-                s3_key = (
-                    json_file.relative_to(unzipped_dir / "test" / "test-reports")
-                    .as_posix()
-                    .replace("/", "_")
-                )
+                s3_key = relative_json.as_posix().replace("/", "_")
                 s3_key = f"test_jsons_while_running/{workflow_run_id}/{job_id}/{s3_key}"
                 upload_to_s3("gha-artifacts", s3_key, remove_nan_inf(test_cases))
 
@@ -340,8 +341,6 @@ if __name__ == "__main__":
         remove_nan_inf(failed_tests_cases),
     )
 
-    backfill_test_jsons_while_running(args.workflow_run_id, args.workflow_run_attempt)
-
     # Upload full test_run only for trusted refs (main or trunk/{sha} tags)
     if should_upload_full_test_run(args.head_branch, args.head_repository):
         # For jobs on main branch, upload everything.
@@ -351,5 +350,8 @@ if __name__ == "__main__":
             "test_run",
             remove_nan_inf(test_cases),
         )
+
+    # Best-effort backfill; run after the authoritative stats uploads.
+    backfill_test_jsons_while_running(args.workflow_run_id, args.workflow_run_attempt)
 
     upload_additional_info(args.workflow_run_id, args.workflow_run_attempt)

--- a/tools/test/test_upload_test_stats.py
+++ b/tools/test/test_upload_test_stats.py
@@ -1,10 +1,21 @@
 import os
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
-from tools.stats.upload_test_stats import get_tests, summarize_test_cases
+from tools.stats.upload_test_stats import (
+    backfill_test_jsons_while_running,
+    get_tests,
+    summarize_test_cases,
+)
 
 
 IN_CI = os.environ.get("CI")
+
+_MINIMAL_JUNIT_XML = (
+    '<testsuite><testcase classname="C" name="t" time="0"/></testsuite>'
+)
 
 
 class TestUploadTestStats(unittest.TestCase):
@@ -18,6 +29,57 @@ class TestUploadTestStats(unittest.TestCase):
         self.assertEqual(len(test_cases), 609873)
         summary = summarize_test_cases(test_cases)
         self.assertEqual(len(summary), 5068)
+
+    def test_backfill_skips_unexpected_report_layout(self) -> None:
+        """ROCm gfx950 jobs store reports under <dir>/test-reports instead of the
+        usual <dir>/test/test-reports. Backfill must skip those rather than
+        raising ValueError, while still uploading reports in the expected layout.
+        """
+        # backfill chdir's into a TemporaryDirectory; restore cwd afterwards.
+        self.addCleanup(os.chdir, os.getcwd())
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+
+            normal_dir = root / "normal"
+            normal_xml = (
+                normal_dir / "test" / "test-reports" / "python-pytest" / "foo-1.xml"
+            )
+            normal_xml.parent.mkdir(parents=True)
+            normal_xml.write_text(_MINIMAL_JUNIT_XML)
+
+            rocm_dir = root / "rocm"
+            rocm_xml = rocm_dir / "test-reports" / "python-pytest" / "bar-1.xml"
+            rocm_xml.parent.mkdir(parents=True)
+            rocm_xml.write_text(_MINIMAL_JUNIT_XML)
+
+            def fake_download(prefix: str, *_a: object, **_k: object) -> list[str]:
+                # No pre-existing test-jsons; two test-report artifacts.
+                return ["normal.zip", "rocm.zip"] if prefix == "test-report" else []
+
+            unzip_map = {"normal.zip": normal_dir, "rocm.zip": rocm_dir}
+
+            with (
+                mock.patch(
+                    "tools.stats.upload_test_stats.download_s3_artifacts",
+                    side_effect=fake_download,
+                ),
+                mock.patch(
+                    "tools.stats.upload_test_stats.unzip",
+                    side_effect=lambda path: unzip_map[path],
+                ),
+                mock.patch(
+                    "tools.stats.upload_test_stats.get_job_id", return_value=123
+                ),
+                mock.patch("tools.stats.upload_test_stats.upload_to_s3") as mock_upload,
+            ):
+                # Must not raise on the ROCm layout.
+                backfill_test_jsons_while_running(1, 1)
+
+            uploaded_keys = [call.args[1] for call in mock_upload.call_args_list]
+            self.assertEqual(len(uploaded_keys), 1)
+            self.assertIn("foo-1", uploaded_keys[0])
+            self.assertFalse(any("bar-1" in key for key in uploaded_keys))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When examining the *test_run_s3* table, `pull` workflow test data is all present, but `trunk` is almost completely absent (within the ttl of the table). This is NOT the case for the *test_run_summary* table.

Based on Claude analysis, upload-test-stats fails on ~99% of trunk main-push runs, silently dropping trunk's full per-test data. The trunk-triggered upload job uploads test_run_summary and failed_test_runs (early steps) but then crashes before the full test_run upload, so trunk shows up in test_run_summary while being almost entirely absent from test_run_s3 (only ~3 of ~440 main-push runs over a 7-day window landed there; pull/slow/inductor land ~100%).

This can also be observed in the [workflow run history here](https://github.com/pytorch/pytorch/actions/workflows/upload-test-stats.yml?query=actor%3Apytorchmergebot). runs fail frequently, and [this was one such message](https://github.com/pytorch/pytorch/actions/runs/27185684496/job/80253997271):
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/pytorch/pytorch/tools/stats/upload_test_stats.py", line 343, in <module>
    backfill_test_jsons_while_running(args.workflow_run_id, args.workflow_run_attempt)
  File "/home/runner/work/pytorch/pytorch/tools/stats/upload_test_stats.py", line 204, in backfill_test_jsons_while_running
    xml.with_suffix(".json").relative_to(
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/pathlib.py", line 730, in relative_to
    raise ValueError("{!r} is not in the subpath of {!r}"
ValueError: 'unzipped-test-reports-test-default-1-10-linux.rocm.gpu.gfx950.1_80242332713/test-reports/python-pytest/dynamo.test_minifier/dynamo.test_minifier-3fbaef0713662393.json' is not in the subpath of 'unzipped-test-reports-test-default-1-10-linux.rocm.gpu.gfx950.1_80242332713/test/test-reports' OR one path is relative and the other is absolute.
```
Makes the following changes for workflow resiliency:
1. Wraps backfill block in try-catch and skip  on failure 
2. Moves upload to S3 step earlier

Authored by Claude.