### PR TITLE
Error on unsupported batch norm third derivatives

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5666,6 +5666,8 @@ skipped_tests.add("test_checkpoint_error_suggests_mark_dynamic")
 skipped_tests.add("test_checkpoint_automatic_dynamic_graph_shadowing")
 skipped_tests.add("test_checkpoint_automatic_dynamic_mark_dynamic_workaround")
 skipped_tests.add("test_checkpoint_automatic_dynamic_lru_disabled_workaround")
+# Compiled autograd does not support the higher-order gradients this test needs.
+skipped_tests.add("test_batch_norm_errors_on_third_order_grad")
 
 # Dynamo support for the curried checkpoint API is added in a later commit
 skipped_tests.add(

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12164,6 +12164,16 @@ get_out().sum().backward()
                     self.assertEqual(future.result()(), tensor.grad)
                 self.assertIsNotNone(tensor.grad)
 
+    def test_batch_norm_errors_on_third_order_grad(self):
+        x = torch.randn(8, 3, requires_grad=True)
+        y = torch.nn.functional.batch_norm(x, None, None, training=True)
+        (g,) = torch.autograd.grad(y.sum(), x, create_graph=True)
+        (g2,) = torch.autograd.grad(g.sum(), x, create_graph=True)
+        with self.assertRaisesRegex(
+            RuntimeError, "batch_norm does not support 3rd\\+ order derivatives"
+        ):
+            torch.autograd.grad(g2.sum(), x)
+
 
 def index_perm_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5079,17 +5079,28 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   for (auto s : input.sizes().slice(2)) {
     M *= s;
   }
+  Tensor mean;
+  Tensor invstd;
+  if (training) {
+    mean = toNonOptTensor(save_mean).to(input.scalar_type());
+    invstd = toNonOptTensor(save_invstd).to(input.scalar_type());
+    if (at::GradMode::is_enabled() && input.requires_grad()) {
+      auto node = c10::make_intrusive<DelayedError>(
+          "batch_norm does not support 3rd+ order derivatives.",
+          /* num inputs */ 3);
+      auto result = node->apply({mean, invstd, input});
+      mean = std::move(result[0]);
+      invstd = std::move(result[1]);
+    }
+  } else {
+    mean = toNonOptTensor(running_mean);
+    invstd = toNonOptTensor(running_var).add(Scalar(eps)).pow_(-0.5);
+  }
   // for half inputs, save_mean, save_invstd are float (ideally, we would cast
   // everything else, but not now)
-  auto mu = unsqueeze_dim1(
-      training ? toNonOptTensor(save_mean).to(input.scalar_type())
-               : toNonOptTensor(running_mean),
-      input);
+  auto mu = unsqueeze_dim1(mean, input);
   auto input_sub_mu = input - mu;
-  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(
-      training ? toNonOptTensor(save_invstd).to(input.scalar_type())
-               : toNonOptTensor(running_var).add(Scalar(eps)).pow(-0.5),
-      input);
+  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(invstd, input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);
   auto sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3);
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5088,6 +5088,10 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
       auto node = c10::make_intrusive<DelayedError>(
           "batch_norm does not support 3rd+ order derivatives.",
           /* num inputs */ 3);
+      // input is passed so the node is executable: save_mean/save_invstd do
+      // not require grad, so without a grad-requiring input wrap_outputs would
+      // mark the node non-executable and never install the Error grad_fn. Its
+      // wrapped output (result[2]) is unused.
       auto result = node->apply({mean, invstd, input});
       mean = std::move(result[0]);
       invstd = std::move(result[1]);


### PR DESCRIPTION
Fixes #186256.

`batchnorm_double_backward` analytically accounts for the dependence of the saved training statistics on the input, so second-order gradients are correct. Those saved tensors do not carry autograd history, though, and differentiating through the manual double backward silently treats them as constants.

This change attaches a delayed error to the training statistics when a further derivative is requested. Evaluation mode is unchanged because its running statistics are constants. The regression test is skipped in compiled autograd, which does not support the higher-order gradient sequence required by the test; this avoids the CI failure mode that reverted the analogous layer-norm guard in #176234.

## Validation

- Reproduced the current behavior with installed `torch==2.12.0+cpu`: a third-order batch-norm gradient is silently computed.
- `python -m py_compile test/test_autograd.py test/inductor/test_compiled_autograd.py`
- `git diff --check`

## To verify

- Source build and focused `test_autograd.py -k batch_norm_errors_on_third_order_grad`
- Compiled-autograd test collection confirms the focused test is skipped
- Full PyTorch CI

Local source-build and `lintrunner -a` validation were not available in this Windows worktree: it has no generated `torch.version`, and `spin` / `lintrunner` are not installed.

AI assistance was used to inspect the existing layer-norm precedent and prepare the patch; the duplicate search, implementation, and validation boundaries were reviewed against current main.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo