### PR TITLE
Fix build_with_debinfo.py broken by CONFIGURE_DEPENDS globbing

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -289,8 +289,8 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
   if [[ -f build/compile_commands.json ]] && command -v ninja > /dev/null && grep -q "csrc/Module.cpp" build/compile_commands.json; then
     debinfo_plan="$(python tools/build_with_debinfo.py --dry-run torch/csrc/Module.cpp)"
     echo "${debinfo_plan}"
-    echo "${debinfo_plan}" | grep -qE ' -g( |$)' || { echo "ERROR: build_with_debinfo --dry-run emitted no -g debug compile flag"; exit 1; }
-    echo "${debinfo_plan}" | grep -q 'libtorch_python' || { echo "ERROR: build_with_debinfo --dry-run emitted no libtorch_python link command"; exit 1; }
+    grep -qE ' -g( |$)' <<< "$debinfo_plan" || { echo "ERROR: build_with_debinfo --dry-run emitted no -g debug compile flag"; exit 1; }
+    grep -q 'libtorch_python' <<< "$debinfo_plan" || { echo "ERROR: build_with_debinfo --dry-run emitted no libtorch_python link command"; exit 1; }
   fi
 
   if [[ "$BUILD_ENVIRONMENT" == *full-debug* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -279,6 +279,20 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
     python -m build --wheel --no-isolation
   fi
   pip_install_whl "$(echo dist/*.whl)"
+
+  # Smoke-test tools/build_with_debinfo.py against the real build tree: it must
+  # still emit a debug-rebuild plan with a -g compile and the libtorch_python
+  # relink. This guards against build-system changes (e.g. a new
+  # CONFIGURE_DEPENDS glob scheme) silently breaking the tool, which only works
+  # on a from-source build that test jobs don't have. --dry-run reads the tree
+  # without rebuilding, so it leaves the checkout clean (assert_git_not_dirty).
+  if [[ -f build/compile_commands.json ]] && command -v ninja > /dev/null && grep -q "csrc/Module.cpp" build/compile_commands.json; then
+    debinfo_plan="$(python tools/build_with_debinfo.py --dry-run torch/csrc/Module.cpp)"
+    echo "${debinfo_plan}"
+    echo "${debinfo_plan}" | grep -qE ' -g( |$)' || { echo "ERROR: build_with_debinfo --dry-run emitted no -g debug compile flag"; exit 1; }
+    echo "${debinfo_plan}" | grep -q 'libtorch_python' || { echo "ERROR: build_with_debinfo --dry-run emitted no libtorch_python link command"; exit 1; }
+  fi
+
   if [[ "$BUILD_ENVIRONMENT" == *full-debug* ]]; then
     # Regression test for https://github.com/pytorch/pytorch/issues/164297
     # Torch should be importable and that's about it

--- a/tools/build_with_debinfo.py
+++ b/tools/build_with_debinfo.py
@@ -4,7 +4,7 @@
 # It recompiles each named source with -g (in place of -O2/-O3), reusing the
 # exact compile command CMake recorded for it, then relinks libtorch_python
 # and symlinks the result into torch/lib so an editable `import torch` picks
-# it up.
+# it up. Use --dry-run to print the plan without building.
 #
 # Why not `ninja -n torch_python | sed 's/-O[23]/-g/' | sh` (the old approach):
 # the build uses file(GLOB ... CONFIGURE_DEPENDS), which wires a glob-check
@@ -43,6 +43,11 @@ def parse_args() -> Any:
 
     parser = ArgumentParser(description="Incremental build PyTorch with debinfo")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the rebuild plan (compile + link commands) without building.",
+    )
     parser.add_argument("files", nargs="*")
     return parser.parse_args()
 
@@ -89,14 +94,19 @@ def debugify(cmd: str) -> str:
     return cmd
 
 
-def load_compile_commands() -> dict[str, dict[str, Any]]:
+def index_compile_commands(
+    entries: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     """Map each absolute source path to its compile_commands.json entry."""
-    entries = json.loads(COMPILE_COMMANDS.read_text())
     result: dict[str, dict[str, Any]] = {}
     for entry in entries:
         src = (Path(entry["directory"]) / entry["file"]).resolve()
         result[str(src)] = entry
     return result
+
+
+def load_compile_commands() -> dict[str, dict[str, Any]]:
+    return index_compile_commands(json.loads(COMPILE_COMMANDS.read_text()))
 
 
 def entry_command(entry: dict[str, Any]) -> str:
@@ -106,20 +116,14 @@ def entry_command(entry: dict[str, Any]) -> str:
     return cmd
 
 
-def torch_python_link_command() -> str:
-    """Return the libtorch_python link command via a ninja graph walk.
+def extract_link_command(ninja_commands: str, lib: str) -> str:
+    """Pick the link command producing `lib` from `ninja -t commands` output.
 
-    `ninja -t commands` expands a target's commands without the dry-run
-    staleness logic that CONFIGURE_DEPENDS defeats. The link is the last
-    command that produces libtorch_python; ninja wraps linker rules as
-    `: && <cmd> && :`.
+    The link is the last command mentioning `lib`; ninja wraps linker rules
+    as `: && <cmd> && :`.
     """
-    output = check_output(
-        ["ninja", "-t", "commands", "torch_python"], cwd=str(BUILD_DIR)
-    )
-    lib = f"libtorch_python.{get_lib_extension()}"
     link = None
-    for line in output.split("\n"):
+    for line in ninja_commands.split("\n"):
         if lib not in line:
             continue
         line = line.strip()
@@ -127,22 +131,27 @@ def torch_python_link_command() -> str:
             line = line[4:-4].strip()
         link = line
     if link is None:
-        raise RuntimeError(
-            f"Could not find the {lib} link command in `ninja -t commands torch_python`"
-        )
+        raise RuntimeError(f"Could not find the {lib} link command")
     return link
+
+
+def torch_python_link_command() -> str:
+    """Return the libtorch_python link command via a ninja graph walk.
+
+    `ninja -t commands` expands a target's commands without the dry-run
+    staleness logic that CONFIGURE_DEPENDS defeats.
+    """
+    output = check_output(
+        ["ninja", "-t", "commands", "torch_python"], cwd=str(BUILD_DIR)
+    )
+    return extract_link_command(output, f"libtorch_python.{get_lib_extension()}")
 
 
 def main() -> None:
     if sys.platform == "win32":
         print("Not supported on Windows yet")
         sys.exit(-95)
-    if not is_devel_setup():
-        print(
-            "Not a devel setup of PyTorch, "
-            "please run `python -m pip install --no-build-isolation -v -e .` first"
-        )
-        sys.exit(-1)
+    args = parse_args()
     if not has_build_ninja():
         print("Only ninja build system is supported at the moment")
         sys.exit(-1)
@@ -152,7 +161,16 @@ def main() -> None:
             "CMAKE_EXPORT_COMPILE_COMMANDS=ON (PyTorch's build sets this by default)"
         )
         sys.exit(-1)
-    args = parse_args()
+    # The symlink step rewrites torch/lib, so a real run must target the in-tree
+    # (editable) torch. --dry-run only reads the build tree, so it works against
+    # any build -- e.g. a CI wheel-build job where torch isn't installed -e.
+    if not args.dry_run and not is_devel_setup():
+        print(
+            "Not a devel setup of PyTorch, "
+            "please run `python -m pip install --no-build-isolation -v -e .` first"
+        )
+        sys.exit(-1)
+
     files = [f for f in args.files if f]
     if not files:
         return print("Nothing to do")
@@ -170,13 +188,22 @@ def main() -> None:
             sys.exit(-1)
         plan.append((src, debugify(entry_command(entry)), entry["directory"]))
 
+    link = torch_python_link_command()
+
+    if args.dry_run:
+        for name, cmd, _ in plan:
+            print(f"# debug rebuild: {name}")
+            print(cmd)
+        print("# relink libtorch_python")
+        print(link)
+        return
+
     for idx, (name, cmd, cwd) in enumerate(plan):
         print(f"[{idx + 1} / {len(plan)}] Building {Path(name).name} with debug info")
         if args.verbose:
             print(cmd)
         subprocess.check_call(["sh", "-c", cmd], cwd=cwd)
 
-    link = torch_python_link_command()
     print("Relinking libtorch_python")
     if args.verbose:
         print(link)

--- a/tools/build_with_debinfo.py
+++ b/tools/build_with_debinfo.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
-# Tool quickly rebuild one or two files with debug info
-# Mimics following behavior:
-# - touch file
-# - ninja -j1 -v -n torch_python | sed -e 's/-O[23]/-g/g' -e 's#\[[0-9]\+\/[0-9]\+\] \+##' |sh
-# - Copy libs from build/lib to torch/lib folder
+# Tool to quickly rebuild one or two files with debug info.
+#
+# It recompiles each named source with -g (in place of -O2/-O3), reusing the
+# exact compile command CMake recorded for it, then relinks libtorch_python
+# and symlinks the result into torch/lib so an editable `import torch` picks
+# it up.
+#
+# Why not `ninja -n torch_python | sed 's/-O[23]/-g/' | sh` (the old approach):
+# the build uses file(GLOB ... CONFIGURE_DEPENDS), which wires a glob-check
+# into build.ninja's own regeneration. In dry-run (-n) mode ninja cannot run
+# that check or reload the regenerated graph, so `ninja -n <target>` only ever
+# reports the regeneration step (VerifyGlobs + regenerate-during-build) and
+# never the real compile/link commands. We therefore source the per-file
+# compile command from build/compile_commands.json and the link command from
+# `ninja -t commands` (a graph walk, not a dry run), neither of which is
+# affected by the glob-check.
 
 from __future__ import annotations
 
+import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -18,6 +31,7 @@ TORCH_DIR = PYTORCH_ROOTDIR / "torch"
 TORCH_LIB_DIR = TORCH_DIR / "lib"
 BUILD_DIR = PYTORCH_ROOTDIR / "build"
 BUILD_LIB_DIR = BUILD_DIR / "lib"
+COMPILE_COMMANDS = BUILD_DIR / "compile_commands.json"
 
 
 def check_output(args: list[str], cwd: str | None = None) -> str:
@@ -66,27 +80,57 @@ def is_devel_setup() -> bool:
     return output.strip() == str(TORCH_DIR / "__init__.py")
 
 
-def create_build_plan() -> list[tuple[str, str]]:
+def debugify(cmd: str) -> str:
+    """Swap optimization flags for debug info, leaving everything else intact."""
+    cmd = cmd.replace("-O2", "-g").replace("-O3", "-g")
+    # Build Metal shaders with debug information.
+    if "xcrun metal " in cmd and "-frecord-sources" not in cmd:
+        cmd += " -frecord-sources -gline-tables-only"
+    return cmd
+
+
+def load_compile_commands() -> dict[str, dict[str, Any]]:
+    """Map each absolute source path to its compile_commands.json entry."""
+    entries = json.loads(COMPILE_COMMANDS.read_text())
+    result: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        src = (Path(entry["directory"]) / entry["file"]).resolve()
+        result[str(src)] = entry
+    return result
+
+
+def entry_command(entry: dict[str, Any]) -> str:
+    cmd = entry.get("command")
+    if cmd is None:
+        cmd = " ".join(shlex.quote(arg) for arg in entry["arguments"])
+    return cmd
+
+
+def torch_python_link_command() -> str:
+    """Return the libtorch_python link command via a ninja graph walk.
+
+    `ninja -t commands` expands a target's commands without the dry-run
+    staleness logic that CONFIGURE_DEPENDS defeats. The link is the last
+    command that produces libtorch_python; ninja wraps linker rules as
+    `: && <cmd> && :`.
+    """
     output = check_output(
-        ["ninja", "-j1", "-v", "-n", "torch_python"], cwd=str(BUILD_DIR)
+        ["ninja", "-t", "commands", "torch_python"], cwd=str(BUILD_DIR)
     )
-    rc = []
+    lib = f"libtorch_python.{get_lib_extension()}"
+    link = None
     for line in output.split("\n"):
-        if not line.startswith("["):
+        if lib not in line:
             continue
-        line = line.split("]", 1)[1].strip()
+        line = line.strip()
         if line.startswith(": &&") and line.endswith("&& :"):
-            line = line[4:-4]
-        line = line.replace("-O2", "-g").replace("-O3", "-g")
-        # Build Metal shaders with debug information
-        if "xcrun metal " in line and "-frecord-sources" not in line:
-            line += " -frecord-sources -gline-tables-only"
-        try:
-            name = line.split("-o ", 1)[1].split(" ")[0]
-            rc.append((name, line))
-        except IndexError:
-            print(f"Skipping {line} as it does not specify output file")
-    return rc
+            line = line[4:-4].strip()
+        link = line
+    if link is None:
+        raise RuntimeError(
+            f"Could not find the {lib} link command in `ninja -t commands torch_python`"
+        )
+    return link
 
 
 def main() -> None:
@@ -102,22 +146,42 @@ def main() -> None:
     if not has_build_ninja():
         print("Only ninja build system is supported at the moment")
         sys.exit(-1)
-    args = parse_args()
-    for file in args.files:
-        if file is None:
-            continue
-        Path(file).touch()
-    build_plan = create_build_plan()
-    if len(build_plan) == 0:
-        return print("Nothing to do")
-    if len(build_plan) > 100:
-        print("More than 100 items needs to be rebuild, run `ninja torch_python` first")
+    if not COMPILE_COMMANDS.exists():
+        print(
+            f"{COMPILE_COMMANDS} not found; configure with "
+            "CMAKE_EXPORT_COMPILE_COMMANDS=ON (PyTorch's build sets this by default)"
+        )
         sys.exit(-1)
-    for idx, (name, cmd) in enumerate(build_plan):
-        print(f"[{idx + 1} / {len(build_plan)}] Building {name}")
+    args = parse_args()
+    files = [f for f in args.files if f]
+    if not files:
+        return print("Nothing to do")
+
+    compile_commands = load_compile_commands()
+    plan: list[tuple[str, str, str]] = []
+    for file in files:
+        src = str(Path(file).resolve())
+        entry = compile_commands.get(src)
+        if entry is None:
+            print(
+                f"No compile command for {file}; is it a source compiled into "
+                "the build? (try a path relative to the repo root)"
+            )
+            sys.exit(-1)
+        plan.append((src, debugify(entry_command(entry)), entry["directory"]))
+
+    for idx, (name, cmd, cwd) in enumerate(plan):
+        print(f"[{idx + 1} / {len(plan)}] Building {Path(name).name} with debug info")
         if args.verbose:
             print(cmd)
-        subprocess.check_call(["sh", "-c", cmd], cwd=BUILD_DIR)
+        subprocess.check_call(["sh", "-c", cmd], cwd=cwd)
+
+    link = torch_python_link_command()
+    print("Relinking libtorch_python")
+    if args.verbose:
+        print(link)
+    subprocess.check_call(["sh", "-c", link], cwd=str(BUILD_DIR))
+
     create_symlinks()
 
 

--- a/tools/test/test_build_with_debinfo.py
+++ b/tools/test/test_build_with_debinfo.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import unittest
+
+from tools.build_with_debinfo import (
+    debugify,
+    entry_command,
+    extract_link_command,
+    index_compile_commands,
+)
+
+
+class TestDebugify(unittest.TestCase):
+    def test_swaps_optimization_for_debug(self) -> None:
+        self.assertEqual(debugify("cc -O2 -c a.cpp"), "cc -g -c a.cpp")
+        self.assertEqual(debugify("cc -O3 -c a.cpp"), "cc -g -c a.cpp")
+
+    def test_leaves_other_flags_untouched(self) -> None:
+        cmd = "cc -DNDEBUG -I/x -fPIC -c a.cpp -o a.o"
+        self.assertEqual(debugify(cmd), cmd)
+
+    def test_metal_gets_debug_flags_once(self) -> None:
+        out = debugify("xcrun metal -c a.metal")
+        self.assertIn("-frecord-sources", out)
+        self.assertIn("-gline-tables-only", out)
+        # Idempotent: do not append a second time.
+        self.assertEqual(out, debugify(out))
+
+
+class TestEntryCommand(unittest.TestCase):
+    def test_command_form(self) -> None:
+        self.assertEqual(entry_command({"command": "cc -c a.cpp"}), "cc -c a.cpp")
+
+    def test_arguments_form_is_quoted(self) -> None:
+        entry = {"arguments": ["cc", "-c", "a b.cpp"]}
+        self.assertEqual(entry_command(entry), "cc -c 'a b.cpp'")
+
+
+class TestIndexCompileCommands(unittest.TestCase):
+    def test_maps_resolved_source_paths(self) -> None:
+        entries = [
+            {"directory": "/repo/build", "file": "../torch/csrc/Module.cpp"},
+            {"directory": "/repo/build", "file": "/repo/torch/csrc/Other.cpp"},
+        ]
+        index = index_compile_commands(entries)
+        self.assertIn("/repo/torch/csrc/Module.cpp", index)
+        self.assertIn("/repo/torch/csrc/Other.cpp", index)
+
+
+class TestExtractLinkCommand(unittest.TestCase):
+    def test_strips_ninja_wrapper(self) -> None:
+        out = ": && clang++ -shared -o lib/libtorch_python.so a.o b.o && :"
+        self.assertEqual(
+            extract_link_command(out, "libtorch_python.so"),
+            "clang++ -shared -o lib/libtorch_python.so a.o b.o",
+        )
+
+    def test_picks_link_among_compiles(self) -> None:
+        out = "\n".join(
+            [
+                "clang++ -c torch_python.dir/Module.cpp.o",
+                ": && clang++ -shared -o lib/libtorch_python.so a.o && :",
+            ]
+        )
+        self.assertEqual(
+            extract_link_command(out, "libtorch_python.so"),
+            "clang++ -shared -o lib/libtorch_python.so a.o",
+        )
+
+    def test_raises_when_absent(self) -> None:
+        with self.assertRaises(RuntimeError):
+            extract_link_command("clang++ -c a.o", "libtorch_python.so")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`tools/build_with_debinfo.py` recompiles named source files with `-g` so you
can get debug info for a targeted file without a full (slow, ABI-incompatible)
debug build. It is referenced in `CONTRIBUTING.md`, and it broke on current
`main`: running it just prints `Nothing to do` and rebuilds nothing.

## Root cause

The tool derived its compile/link commands from `ninja -j1 -v -n torch_python`
(a dry run) and rewrote `-O2`/`-O3` to `-g`. The build now uses
`file(GLOB ... CONFIGURE_DEPENDS)`, which wires a glob-verification step into
`build.ninja`'s own regeneration (`CMakeFiles/VerifyGlobs.cmake` +
`regenerate-during-build`). In dry-run (`-n`) mode ninja cannot run that check
or reload the regenerated graph, so `ninja -n <target>` only ever reports the
regeneration step and never the real compile/link commands. The tool parsed an
empty plan and no-op'd.

## Fix

Source the commands from places the glob-check does not gate:

- the per-file compile command from `build/compile_commands.json` (rewrite
  `-O2`/`-O3` -> `-g`);
- the `libtorch_python` link command from `ninja -t commands torch_python`
  (a graph walk, not a dry run; strip ninja's `: && ... && :` wrapper).

Then symlink `build/lib` into `torch/lib` as before. The tool now rebuilds
exactly the files you name plus the relink, rather than touching sources and
relying on ninja's staleness detection. The old `>100 stale items` guard was a
dry-run artifact and is removed; the tool now requires `compile_commands.json`
and an already-built tree.

## Tests

- **Unit tests** (`tools/test/test_build_with_debinfo.py`) for the pure
  plan-derivation helpers: the `-O` -> `-g` rewrite, `compile_commands.json`
  indexing, the command/arguments entry forms, and the `ninja -t commands`
  link extraction.
- **Build-tree smoke check**: a new `--dry-run` mode plus a step in
  `.ci/pytorch/build.sh` that, after the Linux build, asserts the emitted plan
  contains a `-g` compile and the `libtorch_python` relink. This exercises the
  real `compile_commands.json` and `ninja -t commands` and fails loudly if a
  future build-system change breaks those data sources -- the class of bug
  here, which unit tests alone would not catch. `--dry-run` only reads the
  tree, so it does not dirty the checkout.

## Test plan

Validated on a real editable CUDA build of `viable/strict`:

```
python tools/build_with_debinfo.py --verbose torch/csrc/Module.cpp
```
recompiles `Module.cpp.o` with `.debug_info`, relinks `libtorch_python.so`
(which then carries `.debug_info`), symlinks it into `torch/lib`, and
`import torch` still works.

```
python tools/build_with_debinfo.py --dry-run torch/csrc/Module.cpp
```
exits 0, prints the plan, and leaves the git tree clean; the build.sh `-g` and
`libtorch_python` plan assertions both pass against that output.

```
python -m pytest tools/test/test_build_with_debinfo.py
```
-> 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
