### PR TITLE
[TEST][CUDA] Clean environment for `test_allocator_backend`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5798,11 +5798,9 @@ class TestCudaAllocator(TestCase):
 
     def test_allocator_backend(self):
         def check_output(script: str) -> str:
-            return (
-                subprocess.check_output([sys.executable, "-c", script])
-                .decode("ascii")
-                .strip()
-            )
+            return subprocess.check_output(
+                [sys.executable, "-c", script], env={}, text=True
+            ).strip()
 
         test_script = """\
 import os


### PR DESCRIPTION
This PR cleans the environment for `test_allocator_backend`. It is required in the scenarios, when `PYTORCH_CUDA_ALLOC_CONF` is pre-existing like:
```bash
export PYTORCH_CUDA_ALLOC_CONF="per_process_memory_fraction:0.5"
pytest test_cuda.py::TestCudaAllocator::test_allocator_backend
```
Due to `subprocess` being unable to override the environment variable in the `test_script`:
https://github.com/pytorch/pytorch/blob/5c0086d5e784d63f28824413c9f280831c5e2e19/test/test_cuda.py#L5807-L5815