### PR TITLE
Fix missing article in CONTRIBUTING.md ASAN section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1236,7 +1236,7 @@ useful for debugging memory errors in C++. We run it in CI, but here's how to
 get the same thing to run on your local machine.
 
 First, install LLVM 8. The easiest way is to get [prebuilt
-binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to
+binaries](http://releases.llvm.org/download.html#8.0.0) and extract them to a
 folder (later called `$LLVM_ROOT`).
 
 Then set up the appropriate scripts. You can put this in your `.bashrc`:


### PR DESCRIPTION
The ASAN build instructions read "extract them to folder"; add the missing article so it reads "extract them to a folder".

Fixes #186511

Test Plan: Documentation-only change; verified the corrected sentence reads correctly in CONTRIBUTING.md. No code or tests affected.