### PR TITLE
fix runtime for non_overlapping_and_dense

### DIFF
--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -468,6 +468,32 @@ def is_channels_last_contiguous_or_false(a: Tensor) -> bool:
     ) or is_channels_last_contiguous_or_false_3d(a)
 
 
+# Defined at module scope so the class is built once, not rebuilt on every call.
+class K(NamedTuple):
+    size: int
+    stride: int
+
+    def __lt__(self, other):
+        from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+
+        # for backed symbols, this is practically a < operation
+        # for unbacked, we return True if < is statically known,
+        # then try to answer this symbolically, with stride ordering semantics
+        # (e.g. u0 < u0 is False, u0 < u1 is False with no axioms, u0 < 2 * u0 is True)
+        return (
+            guard_or_false(
+                self.stride < other.stride
+            )  # checks statically known inequality
+            or (
+                (
+                    guard_or_false(self.stride == 0)
+                    or guard_or_false(other.stride % self.stride == 0)
+                )
+                and guard_or_true(self.stride != other.stride)
+            )  # checks symbolic inequality (e.g. u0 < 2048 * u0)
+        )
+
+
 def _is_non_overlapping_and_dense_or_false(sizes, strides) -> bool:
     """
     Helper function for is_non_overlapping_and_dense.
@@ -478,7 +504,7 @@ def _is_non_overlapping_and_dense_or_false(sizes, strides) -> bool:
     this may be non-overlapping & dense at runtime, for values {u0: 4, u1: 4, u2: 4, u3: 1},
     but isn't true for all values.
     """
-    from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
     from torch.utils._sympy.functions import Max
 
     # Short-circuits for 0/1-element tensors
@@ -496,28 +522,6 @@ def _is_non_overlapping_and_dense_or_false(sizes, strides) -> bool:
     # This sort is done in a size-oblivious way, which helps if we do a
     # comparison like 2048*u0 > u0; we just want this to return True
     # (and not worry about what if u0 is zero).
-    class K(NamedTuple):
-        size: int
-        stride: int
-
-        def __lt__(self, other):
-            # for backed symbols, this is practically a < operation
-            # for unbacked, we return True if < is statically known,
-            # then try to answer this symbolically, with stride ordering semantics
-            # (e.g. u0 < u0 is False, u0 < u1 is False with no axioms, u0 < 2 * u0 is True)
-            return (
-                guard_or_false(
-                    self.stride < other.stride
-                )  # checks statically known inequality
-                or (
-                    (
-                        guard_or_false(self.stride == 0)
-                        or guard_or_false(other.stride % self.stride == 0)
-                    )
-                    and guard_or_true(self.stride != other.stride)
-                )  # checks symbolic inequality (e.g. u0 < 2048 * u0)
-            )
-
     lengths_and_strides = sorted(map(K, sizes, strides))
 
     # verify actual strides match the expected (composed sizes)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186785

_is_non_overlapping_and_dense_or_false builds a NamedTuple subclass to customize stride ordering. The class was defined inside the helper, so every call paid for NamedTuple class construction before doing the actual size/stride check. That overhead dominates the concrete/meta tensor fast path and shows up in Python prim/ref paths that query non-overlapping-and-dense layouts.

Hoist the existing sort key class to module scope so it is constructed once. The symbolic stride ordering behavior is unchanged; __lt__ keeps the guard imports local so torch._prims_common does not import symbolic_shapes during module initialization.

Benchmark:

case | old us/call | new us/call | speedup
--- | ---: | ---: | ---:
public check, 4D meta tensor | 53.57 | 8.01 | 6.69x
compute_elementwise_output_strides, 4D meta tensor | 56.96 | 11.13 | 5.12x
prims.convert_element_type, 2D transposed meta tensor | 80.72 | 15.47 | 5.22x
refs.index_fill, 2D transposed meta tensor | 160.34 | 60.80 | 2.64x

```
python test/test_dynamic_shapes.py -k test_prims_is_non_overlapping_and_dense_or_false
```


Authored with assistance from an AI coding agent.