### PR TITLE
[Test] Fix race condition in ddp_under_dist_autograd_test

### DIFF
--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -344,14 +344,18 @@ class DdpUnderDistAutogradTest(RpcAgentTestFixture):
         # The name has to be consistent with that in 'dist_init' decorator.
         return f"worker{rank}"
 
-    def _remote_worker_process(self, ddp_mode):
-        gLogger.info("The remote worker is running.")
+    def _init_process_group(self):
         dist.init_process_group(
             backend="gloo",
             init_method=INIT_METHOD_TEMPLATE.format(file_name=self.file_name),
             world_size=self.world_size,
             rank=self.rank,
         )
+        dist.barrier()
+
+    def _remote_worker_process(self, ddp_mode):
+        gLogger.info("The remote worker is running.")
+        self._init_process_group()
 
         if ddp_mode in (DdpMode.INSIDE, DdpMode.OUTSIDE):
             # new_group needs to be called on ranks.
@@ -370,12 +374,7 @@ class DdpUnderDistAutogradTest(RpcAgentTestFixture):
             rank,
             TRAINER_RANKS,
         )
-        dist.init_process_group(
-            backend="gloo",
-            init_method=INIT_METHOD_TEMPLATE.format(file_name=self.file_name),
-            world_size=self.world_size,
-            rank=self.rank,
-        )
+        self._init_process_group()
 
         gLogger.info("Waiting for shutdown signal on trainer #%s...", rank)
 
@@ -387,12 +386,7 @@ class DdpUnderDistAutogradTest(RpcAgentTestFixture):
 
     def _master_process(self, ddp_mode: DdpMode, simulate_uneven_inputs: bool):
         gLogger.info("Running the master process...")
-        dist.init_process_group(
-            backend="gloo",
-            init_method=INIT_METHOD_TEMPLATE.format(file_name=self.file_name),
-            world_size=self.world_size,
-            rank=self.rank,
-        )
+        self._init_process_group()
 
         remote_em_rref = rpc.remote(
             self.remote_worker_name(), RemoteEM, args=(NUM_EM_ROW, D_SPARSE)


### PR DESCRIPTION
The test `python test/distributed/rpc/test_tensorpipe_agent.py TensorPipeDdpUnderDistAutogradTest.test_backward_ddp_inside` is disabled here but enabled and failing flakily on internal NVIDIA CI. This PR adds a barrier during test initialization to prevent the race condition causing the failure.

Trace on GB200:
```bash
======================================================================
ERROR: test_backward_ddp_inside (__main__.TensorPipeDdpUnderDistAutogradTest.test_backward_ddp_inside)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/pytorch/torch/testing/_internal/common_distributed.py", line 903, in wrapper
    self._join_processes(fn)
  File "/workspace/pytorch/torch/testing/_internal/common_distributed.py", line 1173, in _join_processes
    self._check_return_codes(fn, elapsed_time)
  File "/workspace/pytorch/torch/testing/_internal/common_distributed.py", line 1213, in _check_return_codes
    raise RuntimeError(error)
RuntimeError: Process 5 exited with error code 10 and exception:
Traceback (most recent call last):
  File "/workspace/pytorch/torch/testing/_internal/common_distributed.py", line 1058, in run_test
    getattr(self, test_name)()
  File "/workspace/pytorch/torch/testing/_internal/common_distributed.py", line 905, in wrapper
    fn()
  File "/workspace/pytorch/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/workspace/pytorch/torch/testing/_internal/dist_utils.py", line 80, in new_test_method
    return_value = old_test_method(self, *arg, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 513, in test_backward_ddp_inside
    self._do_test(DdpMode.INSIDE)
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 487, in _do_test
    self._master_process(ddp_mode, simulate_uneven_inputs)
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 404, in _master_process
    self.do_test_on_master(
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 455, in do_test_on_master
    ddp_grads, non_ddp_grads = future.wait()
                               ^^^^^^^^^^^^^
ValueError: ValueError: On WorkerInfo(id=0, name=worker0):
ValueError('On WorkerInfo(id=0, name=worker0):
ValueError('Default process group has not been initialized, please make sure to call init_process_group.')
Traceback (most recent call last):
  File "/workspace/pytorch/torch/distributed/rpc/internal.py", line 209, in _run_function
    result = python_udf.func(*python_udf.args, **python_udf.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 190, in __init__
    dist.new_group(TRAINER_RANKS)
  File "/workspace/pytorch/torch/distributed/c10d_logger.py", line 97, in wrapper
    func_return = func(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 5848, in new_group
    return _new_group_with_tag(
           ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 5947, in _new_group_with_tag
    default_pg = _get_default_group()
                 ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 1423, in _get_default_group
    raise ValueError(
ValueError: Default process group has not been initialized, please make sure to call init_process_group.
')
Traceback (most recent call last):
  File "/workspace/pytorch/torch/distributed/rpc/internal.py", line 209, in _run_function
    result = python_udf.func(*python_udf.args, **python_udf.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 79, in _call_method
    return method(rref.local_value(), *args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/rpc/internal.py", line 236, in _handle_exception
    raise exc
ValueError: On WorkerInfo(id=0, name=worker0):
ValueError('Default process group has not been initialized, please make sure to call init_process_group.')
Traceback (most recent call last):
  File "/workspace/pytorch/torch/distributed/rpc/internal.py", line 209, in _run_function
    result = python_udf.func(*python_udf.args, **python_udf.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py", line 190, in __init__
    dist.new_group(TRAINER_RANKS)
  File "/workspace/pytorch/torch/distributed/c10d_logger.py", line 97, in wrapper
    func_return = func(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 5848, in new_group
    return _new_group_with_tag(
           ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 5947, in _new_group_with_tag
    default_pg = _get_default_group()
                 ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/distributed/distributed_c10d.py", line 1423, in _get_default_group
    raise ValueError(
ValueError: Default process group has not been initialized, please make sure to call init_process_group.



At:
  /workspace/pytorch/torch/distributed/rpc/internal.py(236): _handle_exception


To execute this test, run the following from the base repo dir:
    python test/distributed/rpc/test_tensorpipe_agent.py TensorPipeDdpUnderDistAutogradTest.test_backward_ddp_inside

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0



----------------------------------------------------------------------
Ran 1 test in 5.315s

FAILED (errors=1)
```

Fixes #104328 

cc @eqy

Authored with Codex