### PR TITLE
xpu: fix CUTLASS cpp_wrapper compilation with correct code cache

### DIFF
--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -132,9 +132,12 @@ class CUTLASSScheduling(BaseScheduling):
             # gains a descriptive prefix (cutlass_fused_mm_<hash>), so the
             # exported symbol differs and we need a fresh compile.
             if V.graph.cpp_wrapper and not V.graph.aot_mode:
-                from ...codecache import CUDACodeCache
+                from ...codecache import CUDACodeCache, XPUCodeCache
 
-                so_path, _, _ = CUDACodeCache.compile(src_code, "so")
+                codecache_cls = (
+                    XPUCodeCache if V.graph.device_type == "xpu" else CUDACodeCache
+                )
+                so_path, _, _ = codecache_cls.compile(src_code, "so")
                 wrapper.external_kernel_libs.add(so_path)
         return kernel_name
 


### PR DESCRIPTION
Fixes #186781

When compiling CUTLASS kernel `.so` files for the JIT cpp_wrapper path, `scheduling.py` hardcoded `CUDACodeCache` which uses `nvcc` (CUDA compiler). On XPU, CUTLASS kernels are SYCL code that needs `icpx` via `XPUCodeCache`.

**Fix**: Dispatch to the correct code cache class based on device type, matching the existing pattern in `autotune_process.py:972`.

**Change**: `torch/_inductor/codegen/cutlass/scheduling.py:134-138`
```diff
- from ...codecache import CUDACodeCache
- so_path, _, _ = CUDACodeCache.compile(src_code, "so")
+ from ...codecache import CUDACodeCache, XPUCodeCache
+ codecache_cls = (
+     XPUCodeCache if V.graph.device_type == "xpu" else CUDACodeCache
+ )
+ so_path, _, _ = codecache_cls.compile(src_code, "so")
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo