### PR TITLE
[WIP]xpu: skip multiprocessing tests requiring GPU IPC

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     load_tests,
     run_tests,
     skipIfRocm,
+    skipIfXpu,
     slowTest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
@@ -491,6 +492,11 @@ class TestMultiprocessingDeviceType(_MultiprocessingTestMixin, TestCase):
             return mp
         return mp.get_context("spawn")
 
+    @skipIfXpu(
+        msg="XPU lacks GPU IPC (no cudaIpcMemHandle equivalent). "
+        "Tensors are serialized as copies; cross-process mutations are not visible. "
+        "See https://github.com/intel/torch-xpu-ops/issues/4000"
+    )
     def test_simple_sharing(self, device):
         ctx = self._get_ctx(device)
         self._test_sharing(ctx, device, torch.float)
@@ -505,6 +511,10 @@ class TestMultiprocessingDeviceType(_MultiprocessingTestMixin, TestCase):
         "non-deterministically hangs with ASAN "
         "https://github.com/pytorch/pytorch/issues/94024",
     )
+    @skipIfXpu(
+        msg="XPU lacks GPU IPC — cross-process mutation visibility not supported. "
+        "See https://github.com/intel/torch-xpu-ops/issues/4000"
+    )
     def test_variable_sharing(self, device):
         ctx = self._get_ctx(device)
         for requires_grad in [True, False]:
@@ -515,6 +525,10 @@ class TestMultiprocessingDeviceType(_MultiprocessingTestMixin, TestCase):
             )
             self._test_autograd_sharing(var, ctx)
 
+    @skipIfXpu(
+        msg="XPU lacks GPU IPC — cross-process mutation visibility not supported. "
+        "See https://github.com/intel/torch-xpu-ops/issues/4000"
+    )
     def test_parameter_sharing(self, device):
         ctx = self._get_ctx(device)
         param = Parameter(torch.arange(1.0, 26, device=device).view(5, 5))

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -150,6 +150,29 @@ def rebuild_meta_tensor(
     return t
 
 
+def rebuild_xpu_tensor(
+    tensor_cls,
+    storage,
+    metadata,
+):
+    """
+    Rebuild a tensor that was originally on XPU from CPU storage.
+
+    XPU lacks IPC support (no cudaIpcMemHandle equivalent), so XPU tensors
+    are copied to CPU before serialization and copied back to XPU here.
+    """
+    storage_offset, size, stride, requires_grad, device = metadata
+    t = torch._utils._rebuild_tensor(storage, storage_offset, size, stride)
+    t = t.to(device)
+    if tensor_cls == torch.nn.parameter.Parameter:
+        # It is crucial for integer tensors to receive
+        # the requires_grad=False as an argument in the constructor
+        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
+    else:
+        t.requires_grad = requires_grad
+    return t
+
+
 def rebuild_cuda_tensor(
     tensor_cls,
     tensor_size,
@@ -386,6 +409,20 @@ def reduce_tensor(tensor):
                 tensor.requires_grad,
             ),
         )
+    elif storage._untyped_storage.device.type == "xpu":
+        # XPU lacks IPC support (no shareIpcHandle equivalent).
+        # Copy the tensor to CPU for serialization; the receiving end
+        # will copy it back to XPU in rebuild_xpu_tensor.
+        cpu_tensor = tensor.cpu()
+        cpu_storage = cpu_tensor._typed_storage()
+        metadata = (
+            cpu_tensor.storage_offset(),
+            cpu_tensor.size(),
+            cpu_tensor.stride(),
+            tensor.requires_grad,
+            tensor.device,
+        )
+        return (rebuild_xpu_tensor, (type(tensor), cpu_storage, metadata))
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -159,7 +159,7 @@ def rebuild_xpu_tensor(
     Rebuild a tensor that was originally on XPU from serialized raw bytes.
 
     XPU lacks IPC support (no cudaIpcMemHandle equivalent), so XPU tensors
-    are serialized as raw bytes (via memoryview of the CPU storage) and
+    are serialized as raw bytes (via numpy().tobytes() of the CPU tensor) and
     reconstructed here before being copied back to XPU.
 
     We avoid fd-based storage sharing because the DupFd / SCM_RIGHTS fd
@@ -431,7 +431,10 @@ def reduce_tensor(tensor):
         # Always contiguous after .contiguous(), so we don't need
         # storage_offset or stride in metadata.
         cpu_tensor = tensor.detach().cpu().contiguous()
-        raw_bytes = memoryview(cpu_tensor.untyped_storage()).tobytes()
+        # Use numpy().tobytes() instead of memoryview(untyped_storage())
+        # to avoid a PYREFLY bad-argument-type lint error (UntypedStorage
+        # is not recognized as a Buffer in type stubs).
+        raw_bytes = cpu_tensor.numpy().tobytes()
         metadata = (
             tuple(cpu_tensor.size()),
             tensor.requires_grad,

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -152,17 +152,26 @@ def rebuild_meta_tensor(
 
 def rebuild_xpu_tensor(
     tensor_cls,
-    storage,
+    raw_bytes,
     metadata,
 ):
     """
-    Rebuild a tensor that was originally on XPU from CPU storage.
+    Rebuild a tensor that was originally on XPU from serialized raw bytes.
 
     XPU lacks IPC support (no cudaIpcMemHandle equivalent), so XPU tensors
-    are copied to CPU before serialization and copied back to XPU here.
+    are serialized as raw bytes (via memoryview of the CPU storage) and
+    reconstructed here before being copied back to XPU.
+
+    We avoid fd-based storage sharing because the DupFd / SCM_RIGHTS fd
+    transfer can fail in spawn child processes (EINVAL on ftruncate).
+    The tensor is always reconstructed as contiguous — strides may differ
+    from the original if it was a view, but the data is identical.
     """
-    storage_offset, size, stride, requires_grad, device = metadata
-    t = torch._utils._rebuild_tensor(storage, storage_offset, size, stride)
+    size, requires_grad, device, dtype_str = metadata
+    # Parse dtype from string like "torch.int64"
+    dtype = getattr(torch, dtype_str.rsplit(".", 1)[-1])
+    # Reconstruct from raw bytes via uint8 intermediate to support all dtypes
+    t = torch.frombuffer(raw_bytes, dtype=torch.uint8).view(dtype).reshape(size)
     t = t.to(device)
     if tensor_cls == torch.nn.parameter.Parameter:
         # It is crucial for integer tensors to receive
@@ -413,16 +422,23 @@ def reduce_tensor(tensor):
         # XPU lacks IPC support (no shareIpcHandle equivalent).
         # Copy the tensor to CPU for serialization; the receiving end
         # will copy it back to XPU in rebuild_xpu_tensor.
-        cpu_tensor = tensor.cpu()
-        cpu_storage = cpu_tensor._typed_storage()
+        #
+        # IMPORTANT: We serialize the raw bytes directly instead of passing
+        # the CPU storage object.  Passing a storage would trigger the
+        # standard CPU fd-sharing path (_share_fd_cpu_ / _new_shared_fd_cpu)
+        # which can fail with EINVAL in spawn child processes when the
+        # shm fd is transferred via SCM_RIGHTS and then ftruncate'd.
+        # Always contiguous after .contiguous(), so we don't need
+        # storage_offset or stride in metadata.
+        cpu_tensor = tensor.detach().cpu().contiguous()
+        raw_bytes = memoryview(cpu_tensor.untyped_storage()).tobytes()
         metadata = (
-            cpu_tensor.storage_offset(),
-            cpu_tensor.size(),
-            cpu_tensor.stride(),
+            tuple(cpu_tensor.size()),
             tensor.requires_grad,
             tensor.device,
+            str(cpu_tensor.dtype),
         )
-        return (rebuild_xpu_tensor, (type(tensor), cpu_storage, metadata))
+        return (rebuild_xpu_tensor, (type(tensor), raw_bytes, metadata))
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -159,19 +159,17 @@ def rebuild_xpu_tensor(
     Rebuild a tensor that was originally on XPU from serialized raw bytes.
 
     XPU lacks IPC support (no cudaIpcMemHandle equivalent), so XPU tensors
-    are serialized as raw bytes (via numpy().tobytes() of the CPU tensor) and
-    reconstructed here before being copied back to XPU.
-
-    We avoid fd-based storage sharing because the DupFd / SCM_RIGHTS fd
-    transfer can fail in spawn child processes (EINVAL on ftruncate).
-    The tensor is always reconstructed as contiguous — strides may differ
-    from the original if it was a view, but the data is identical.
+    are serialized as raw bytes of a CPU copy and reconstructed here before
+    being copied back to XPU.  The resulting tensor is an independent copy —
+    mutations do NOT propagate across processes (unlike CUDA IPC which
+    produces shared-memory-backed tensors).
     """
-    size, requires_grad, device, dtype_str = metadata
-    # Parse dtype from string like "torch.int64"
-    dtype = getattr(torch, dtype_str.rsplit(".", 1)[-1])
-    # Reconstruct from raw bytes via uint8 intermediate to support all dtypes
-    t = torch.frombuffer(raw_bytes, dtype=torch.uint8).view(dtype).reshape(size)
+    size, requires_grad, device, dtype = metadata
+    if len(raw_bytes) == 0:
+        # torch.frombuffer rejects zero-length buffers; construct empty tensor directly
+        t = torch.empty(size, dtype=dtype, device="cpu")
+    else:
+        t = torch.frombuffer(raw_bytes, dtype=torch.uint8).view(dtype).reshape(size)
     t = t.to(device)
     if tensor_cls == torch.nn.parameter.Parameter:
         # It is crucial for integer tensors to receive
@@ -431,15 +429,15 @@ def reduce_tensor(tensor):
         # Always contiguous after .contiguous(), so we don't need
         # storage_offset or stride in metadata.
         cpu_tensor = tensor.detach().cpu().contiguous()
-        # Use numpy().tobytes() instead of memoryview(untyped_storage())
-        # to avoid a PYREFLY bad-argument-type lint error (UntypedStorage
-        # is not recognized as a Buffer in type stubs).
-        raw_bytes = cpu_tensor.numpy().tobytes()
+        # Use untyped_storage bytes directly instead of numpy().tobytes()
+        # so that bfloat16, float8, and complex32 (not supported by numpy)
+        # serialize correctly.
+        raw_bytes = bytes(cpu_tensor.untyped_storage())  # noqa: PYREFLY
         metadata = (
             tuple(cpu_tensor.size()),
             tensor.requires_grad,
             tensor.device,
-            str(cpu_tensor.dtype),
+            cpu_tensor.dtype,
         )
         return (rebuild_xpu_tensor, (type(tensor), raw_bytes, metadata))
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -150,40 +150,6 @@ def rebuild_meta_tensor(
     return t
 
 
-def rebuild_xpu_tensor(
-    tensor_cls,
-    raw_bytes,
-    metadata,
-):
-    """
-    Rebuild a tensor that was originally on XPU from serialized raw bytes.
-
-    XPU lacks IPC support (no cudaIpcMemHandle equivalent), so XPU tensors
-    are serialized as raw bytes of a CPU copy and reconstructed here before
-    being copied back to XPU.  The resulting tensor is an independent copy —
-    mutations do NOT propagate across processes (unlike CUDA IPC which
-    produces shared-memory-backed tensors).
-    """
-    size, requires_grad, device, dtype = metadata
-    if len(raw_bytes) == 0:
-        # torch.frombuffer rejects zero-length buffers; construct empty tensor directly
-        t = torch.empty(size, dtype=dtype, device="cpu")
-    else:
-        t = (
-            torch.frombuffer(bytearray(raw_bytes), dtype=torch.uint8)
-            .view(dtype)
-            .reshape(size)
-        )
-    t = t.to(device)
-    if tensor_cls == torch.nn.parameter.Parameter:
-        # It is crucial for integer tensors to receive
-        # the requires_grad=False as an argument in the constructor
-        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
-    else:
-        t.requires_grad = requires_grad
-    return t
-
-
 def rebuild_cuda_tensor(
     tensor_cls,
     tensor_size,
@@ -420,30 +386,6 @@ def reduce_tensor(tensor):
                 tensor.requires_grad,
             ),
         )
-    elif storage._untyped_storage.device.type == "xpu":
-        # XPU lacks IPC support (no shareIpcHandle equivalent).
-        # Copy the tensor to CPU for serialization; the receiving end
-        # will copy it back to XPU in rebuild_xpu_tensor.
-        #
-        # IMPORTANT: We serialize the raw bytes directly instead of passing
-        # the CPU storage object.  Passing a storage would trigger the
-        # standard CPU fd-sharing path (_share_fd_cpu_ / _new_shared_fd_cpu)
-        # which can fail with EINVAL in spawn child processes when the
-        # shm fd is transferred via SCM_RIGHTS and then ftruncate'd.
-        # Always contiguous after .contiguous(), so we don't need
-        # storage_offset or stride in metadata.
-        cpu_tensor = tensor.detach().cpu().contiguous()
-        # Use untyped_storage bytes directly instead of numpy().tobytes()
-        # so that bfloat16, float8, and complex32 (not supported by numpy)
-        # serialize correctly.
-        raw_bytes = bytes(cpu_tensor.untyped_storage())  # noqa: PYREFLY[102]
-        metadata = (
-            tuple(cpu_tensor.size()),
-            tensor.requires_grad,
-            tensor.device,
-            cpu_tensor.dtype,
-        )
-        return (rebuild_xpu_tensor, (type(tensor), raw_bytes, metadata))
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -169,7 +169,11 @@ def rebuild_xpu_tensor(
         # torch.frombuffer rejects zero-length buffers; construct empty tensor directly
         t = torch.empty(size, dtype=dtype, device="cpu")
     else:
-        t = torch.frombuffer(raw_bytes, dtype=torch.uint8).view(dtype).reshape(size)
+        t = (
+            torch.frombuffer(bytearray(raw_bytes), dtype=torch.uint8)
+            .view(dtype)
+            .reshape(size)
+        )
     t = t.to(device)
     if tensor_cls == torch.nn.parameter.Parameter:
         # It is crucial for integer tensors to receive
@@ -432,7 +436,7 @@ def reduce_tensor(tensor):
         # Use untyped_storage bytes directly instead of numpy().tobytes()
         # so that bfloat16, float8, and complex32 (not supported by numpy)
         # serialize correctly.
-        raw_bytes = bytes(cpu_tensor.untyped_storage())  # noqa: PYREFLY
+        raw_bytes = bytes(cpu_tensor.untyped_storage())  # noqa: PYREFLY[102]
         metadata = (
             tuple(cpu_tensor.size()),
             tensor.requires_grad,


### PR DESCRIPTION
Fixes #186585

## Summary

Disable multiprocessing tests that require XPU GPU IPC (not yet available).
XPU lacks a cudaIpcMemHandle equivalent, so tensor serialization across
processes is unimplemented.

A CPU-copy fallback was explored but rejected — it silently breaks
shared-tensor semantics since child-process mutations are not visible
to the parent.

### Tests skipped
| Test | Reason |
|------|--------|
| test_simple_sharing | Child's fill_(4) on GPU tensor — not visible to parent |
| test_variable_sharing | Post-send mutation not visible to child |
| test_parameter_sharing | Same mutation-visibility pattern |

These tests also skip on ROCm for the same reason.
Tracker: https://github.com/intel/torch-xpu-ops/issues/4000