### PR TITLE
[dynamo] Serialize higher-order-op subgraphs in NNModuleToString.convert

### DIFF
--- a/test/inductor/test_minifier_utils.py
+++ b/test/inductor/test_minifier_utils.py
@@ -2,12 +2,14 @@
 from unittest.mock import patch
 
 import torch
+from torch._dynamo.debug_utils import NNModuleToString
 from torch._dynamo.exc import UserError, UserErrorType
 from torch._dynamo.repro.aoti import (
     AOTIMinifierError,
     export_for_aoti_minifier,
     get_module_string,
 )
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -88,17 +90,38 @@ class MinifierUtilsTests(TestCase):
         model = M()
         gm = torch.export.export(model, inputs, strict=False).module(check_guards=False)
 
-        # TODO: make NNModuleToString.convert() generate string for nested submodules.
         model_string = get_module_string(gm)
         self.assertExpectedInline(
             model_string.strip(),
             """\
 # from torch.nn import *
+# class true_graph_0_0(torch.nn.Module):
+#     def __init__(self) -> None:
+#         super().__init__()
+
+
+
+#     def forward(self, x):
+#         clone = torch.ops.aten.clone.default(x);  x = None
+#         return (clone,)
+
+
+# class false_graph_0_1(torch.nn.Module):
+#     def __init__(self) -> None:
+#         super().__init__()
+
+
+
+#     def forward(self, x):
+#         clone = torch.ops.aten.clone.default(x);  x = None
+#         return (clone,)
+
+
 # class Repro(torch.nn.Module):
 #     def __init__(self) -> None:
 #         super().__init__()
-#         self.true_graph_0 = <lambda>()
-#         self.false_graph_0 = <lambda>()
+#         self.true_graph_0 = true_graph_0_0()
+#         self.false_graph_0 = false_graph_0_1()
 
 
 
@@ -112,6 +135,32 @@ class MinifierUtilsTests(TestCase):
 #         getitem = cond[0];  cond = None
 #         return pytree.tree_unflatten((getitem,), self._out_spec)""",
         )
+
+    def test_cond_subgraph_roundtrips(self):
+        # torch.cond attaches its branches as nested GraphModule submodules.
+        # NNModuleToString.convert must serialize them as real nested classes
+        # that reconstruct -- not the invalid, body-less `<lambda>()` placeholder.
+        def fn(pred, x):
+            return torch.cond(pred, lambda x: x.sin(), lambda x: x.cos(), (x,))
+
+        pred = torch.tensor(False)
+        x = torch.randn(4)
+        gm = make_fx(fn, tracing_mode="real")(pred, x)
+
+        result = NNModuleToString.convert(gm)
+
+        # The branch bodies must be present, with no invalid placeholder.
+        self.assertIn("sin", result)
+        self.assertIn("cos", result)
+        self.assertNotIn("<lambda>", result)
+
+        # The generated source must reconstruct a module whose forward matches
+        # the original graph for both branches.
+        ns = {"torch": torch}
+        exec(result, ns)
+        repro = ns["Repro"]()
+        self.assertEqual(repro(torch.tensor(False), x), gm(torch.tensor(False), x))
+        self.assertEqual(repro(torch.tensor(True), x), gm(torch.tensor(True), x))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -216,6 +216,10 @@ class NNModuleToString:
     def can_convert_to_string(gm: torch.fx.GraphModule) -> bool:
         cant_convert = set()
         for _, module in gm.named_children():
+            # Nested GraphModules (e.g. torch.cond / torch.while_loop subgraphs)
+            # are serialized recursively by convert().
+            if isinstance(module, torch.fx.GraphModule):
+                continue
             if NNModuleToString._module_constructor_string(module) is None:
                 cant_convert.add(module)
 
@@ -359,78 +363,95 @@ class NNModuleToString:
 
         tab = " " * 4
 
-        model_str = textwrap.dedent(
-            """
-            from torch.nn import *
-            class Repro(torch.nn.Module):
-                def __init__(self) -> None:
-                    super().__init__()
-            """
-        )
+        # Higher-order ops (torch.cond, torch.while_loop, ...) attach their
+        # subgraphs as nested GraphModule children. These have no
+        # constructor-style repr, so serialize each nested GraphModule as its
+        # own top-level class (defined before Repro so it is in scope) and
+        # instantiate it in __init__. Leaf nn.Modules use the constructor-string
+        # path below.
+        subgraph_classes: dict[int, str] = {}
+        subgraph_defs: list[str] = []
 
-        for module_name, module in gm.named_children():
-            module_str = NNModuleToString._module_constructor_string(
-                module, allow_unsafe_repr=allow_unsafe_repr
+        def register_subgraph(name_hint: str, sub: torch.fx.GraphModule) -> str:
+            # Reserve the name before recursing so nested/shared subgraphs are
+            # deduplicated by identity and cannot recurse infinitely.
+            if id(sub) in subgraph_classes:
+                return subgraph_classes[id(sub)]
+            class_name = f"{name_hint}_{len(subgraph_classes)}"
+            subgraph_classes[id(sub)] = class_name
+            body = emit_module_body(sub)
+            subgraph_defs.append(f"class {class_name}(torch.nn.Module):\n{body}")
+            return class_name
+
+        def emit_module_body(module: torch.nn.Module) -> str:
+            model_str = (
+                f"{tab}def __init__(self) -> None:\n{tab * 2}super().__init__()\n"
             )
-            if module_str is None:
-                raise UnsupportedNNModuleError(
-                    f"Cannot convert module to string: {module!r}"
+
+            for module_name, child in module.named_children():
+                if isinstance(child, torch.fx.GraphModule):
+                    class_name = register_subgraph(module_name, child)
+                    model_str += f"{tab * 2}self.{module_name} = {class_name}()\n"
+                    continue
+                module_str = NNModuleToString._module_constructor_string(
+                    child, allow_unsafe_repr=allow_unsafe_repr
                 )
-            # module should be a core torch.nn.Module, so all parameters
-            # and buffers should be on the same device.
-            example_param = next(module.parameters(), None)
-            example_tensor = (
-                example_param
-                if example_param is not None
-                else next(module.buffers(), None)
-            )
-            if example_tensor is not None and example_tensor.device.type != "cpu":
-                module_str = f'{module_str}.to("{example_tensor.device}")'
-            model_str += f"{tab * 2}self.{module_name} = {module_str}\n"
-
-        for buffer_name, buffer in gm._buffers.items():
-            if buffer is None:
-                continue
-            # Serialize full data for small buffers
-            if buffer.numel() <= MAX_CONSTANT_NUMEL_INLINE:
-                from torch._tensor_str import PRINT_OPTS
-
-                if PRINT_OPTS.threshold < MAX_CONSTANT_NUMEL_INLINE:
-                    raise AssertionError(
-                        f"PRINT_OPTS.threshold ({PRINT_OPTS.threshold}) must be >= "
-                        f"MAX_CONSTANT_NUMEL_INLINE ({MAX_CONSTANT_NUMEL_INLINE})"
+                if module_str is None:
+                    raise UnsupportedNNModuleError(
+                        f"Cannot convert module to string: {child!r}"
                     )
-                tensor_str = repr(buffer)
-            elif torch.is_floating_point(buffer):
-                tensor_str = f"torch.randn({list(buffer.shape)}, dtype={buffer.dtype})"
-            else:
-                tensor_str = (
-                    f"torch.randint(1, size={list(buffer.shape)}, dtype={buffer.dtype})"
+                # module should be a core torch.nn.Module, so all parameters
+                # and buffers should be on the same device.
+                example_param = next(child.parameters(), None)
+                example_tensor = (
+                    example_param
+                    if example_param is not None
+                    else next(child.buffers(), None)
                 )
-            if buffer.device.type != "cpu":
-                tensor_str = f'{tensor_str}.to("{buffer.device}")'
-            model_str += (
-                f"{tab * 2}self.register_buffer('{buffer_name}', {tensor_str})\n"
-            )
+                if example_tensor is not None and example_tensor.device.type != "cpu":
+                    module_str = f'{module_str}.to("{example_tensor.device}")'
+                model_str += f"{tab * 2}self.{module_name} = {module_str}\n"
 
-        for param_name, param in gm._parameters.items():
-            if param is None:
-                continue
-            maybe_device = ""
-            if param.device.type != "cpu":
-                maybe_device = f', device="{param.device}"'
-            tensor_str = f"torch.nn.Parameter(torch.randn({list(param.shape)}, dtype={param.dtype}{maybe_device}))"
-            model_str += f"{tab * 2}self.{param_name} = {tensor_str}\n"
+            for buffer_name, buffer in module._buffers.items():
+                if buffer is None:
+                    continue
+                # Serialize full data for small buffers
+                if buffer.numel() <= MAX_CONSTANT_NUMEL_INLINE:
+                    from torch._tensor_str import PRINT_OPTS
 
-        # TODO - Keep this code for now. But, I don't think we will need this.
-        # attrs = dir(gm)
-        # for attr in attrs:
-        #     if "_tensor_constant" in attr:
-        #         val = getattr(gm, attr)
-        #         model_str += f"    {attr} = {val!r}\n"
+                    if PRINT_OPTS.threshold < MAX_CONSTANT_NUMEL_INLINE:
+                        raise AssertionError(
+                            f"PRINT_OPTS.threshold ({PRINT_OPTS.threshold}) must be >= "
+                            f"MAX_CONSTANT_NUMEL_INLINE ({MAX_CONSTANT_NUMEL_INLINE})"
+                        )
+                    tensor_str = repr(buffer)
+                elif torch.is_floating_point(buffer):
+                    tensor_str = (
+                        f"torch.randn({list(buffer.shape)}, dtype={buffer.dtype})"
+                    )
+                else:
+                    tensor_str = f"torch.randint(1, size={list(buffer.shape)}, dtype={buffer.dtype})"
+                if buffer.device.type != "cpu":
+                    tensor_str = f'{tensor_str}.to("{buffer.device}")'
+                model_str += (
+                    f"{tab * 2}self.register_buffer('{buffer_name}', {tensor_str})\n"
+                )
 
-        model_str += f"{_addindent(gm.code, 4)}\n"
-        return model_str
+            for param_name, param in module._parameters.items():
+                if param is None:
+                    continue
+                maybe_device = ""
+                if param.device.type != "cpu":
+                    maybe_device = f', device="{param.device}"'
+                tensor_str = f"torch.nn.Parameter(torch.randn({list(param.shape)}, dtype={param.dtype}{maybe_device}))"
+                model_str += f"{tab * 2}self.{param_name} = {tensor_str}\n"
+
+            model_str += f"{_addindent(module.code, len(tab))}\n"
+            return model_str
+
+        repro_class = f"class Repro(torch.nn.Module):\n{emit_module_body(gm)}"
+        # Subgraph classes must be defined before Repro instantiates them.
+        return "\nfrom torch.nn import *\n" + "\n".join(subgraph_defs + [repro_class])
 
 
 @functools.cache  # subprocess is expensive


### PR DESCRIPTION
Summary:
fx_graph_runnable repros for graphs with higher-order-op branches (torch.cond, torch.while_loop) failed to import with SyntaxError: invalid syntax due to <lambda>.
Example in P2365350203{F1990933956}
Root cause: NNModuleToString.convert serialized each child module as self.<name> = {child.__repr__()}, which only works for leaf nn.Modules with a constructor-style repr. A cond branch is a nested GraphModule whose repr is <lambda>(), so it emitted self.true_graph_0 = <lambda>() — invalid Python, and the branch body was dropped entirely.

Fix: recurse into GraphModule children, emitting each subgraph as its own top-level class (defined before Repro) and instantiating it in __init__, mirroring GraphModule.print_readable but adding the __init__ wiring so the repro is runnable. Subgraph classes are uniquely named and deduplicated by id(). Output is byte-identical for graphs without subgraphs, so there is no change to the common case.

Test Plan:
buck2 run  mode/opt fbcode//caffe2/test/dynamo:test_debug_utils -- -v

Old Output Format:
```
  from torch.nn import *
  class Repro(torch.nn.Module):
      def __init__(self) -> None:
          super().__init__()
          self.true_graph_0 = <lambda>()      # SyntaxError; branch body lost
          self.false_graph_0 = <lambda>()
          
      def forward(self, arg0_1, arg1_1):
          true_graph_0 = self.true_graph_0
          false_graph_0 = self.false_graph_0
          cond = torch.ops.higher_order.cond(arg0_1, true_graph_0, false_graph_0, (arg1_1,))
          return (cond[0],)
```

New Output Format:
```
  from torch.nn import *
  class true_graph_0_0(torch.nn.Module):
      def __init__(self) -> None:
          super().__init__()
   
      def forward(self, arg0_1):
          sin = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None
          return (sin,)
  class false_graph_0_1(torch.nn.Module):
      def __init__(self) -> None:
          super().__init__()
          
      def forward(self, arg0_1):
          cos = torch.ops.aten.cos.default(arg0_1);  arg0_1 = None
          return (cos,)
  class Repro(torch.nn.Module):
      def __init__(self) -> None:
          super().__init__()
          self.true_graph_0 = true_graph_0_0()
          self.false_graph_0 = false_graph_0_1()
      def forward(self, arg0_1, arg1_1):
          true_graph_0 = self.true_graph_0
          false_graph_0 = self.false_graph_0
          cond = torch.ops.higher_order.cond(arg0_1, true_graph_0, false_graph_0, (arg1_1,))
          return (cond[0],)
```

Differential Revision: D107905856




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98