### PR TITLE
[BE][MPS] Drop dead non-unified-memory handling, error out instead

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -24,10 +24,7 @@ static const size_t kMinLargeAlloc = MB(10); // allocations between 1 and 10 MiB
 static const size_t kRoundLarge = MB(2); // round up large allocations to 2 MiB
 static const size_t kSmallHeap = MB(8); // "small" allocations are packed in 8 MiB heaps
 static const size_t kLargeHeap = MB(32); // "large" allocations may be packed in 32 MiB heaps
-static const size_t kXLargeHeapD =
-    MB(128); // "extra large" allocations on Discrete devices may be packed in 128 MiB heaps
-static const size_t kXLargeHeapU =
-    MB(1024); // "extra large" allocations on Unified devices may be packed in 1 GiB heaps
+static const size_t kXLargeHeap = MB(1024); // "extra large" allocations may be packed in 1 GiB heaps
 static const size_t kMaxScalarAlloc = (sizeof(int64_t)); // largest "scalar" allocation
 
 // buffer pools could be customized with a combination of usage flags
@@ -100,8 +97,6 @@ struct AllocParams {
   // true if we exceed the low watermark limit. In this case
   // we apply strategies to relieve the pressure before allocation.
   bool has_memory_pressure = false;
-  // true if we're allocating on a unified memory device
-  bool has_unified_memory = true;
 };
 
 struct HeapBlock {
@@ -147,7 +142,6 @@ struct HeapBlock {
     const size_t size = params.size();
     MTLHeapDescriptor* d = [MTLHeapDescriptor new];
     if (d) {
-      const size_t kXLargeHeap = params.has_unified_memory ? kXLargeHeapU : kXLargeHeapD;
       if (size <= kMaxSmallAlloc) {
         d.size = kSmallHeap;
       } else if (size < kMinLargeAlloc) {
@@ -361,8 +355,7 @@ class MPSHeapAllocatorImpl {
   constexpr static double default_high_watermark_upper_bound = 2.0;
   // (see m_low_watermark_ratio for description)
   // on unified memory, we could allocate beyond the recommendedMaxWorkingSetSize
-  constexpr static double default_low_watermark_ratio_unified = 1.4;
-  constexpr static double default_low_watermark_ratio_discrete = 1.0;
+  constexpr static double default_low_watermark_ratio = 1.4;
 
   const id<MTLDevice> m_device;
   std::recursive_mutex m_mutex;

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -5,10 +5,10 @@
 #include <ATen/mps/MPSAllocator.h>
 #include <c10/core/Allocator.h>
 #include <c10/core/Storage.h>
+#include <c10/util/Logging.h>
 #include <c10/util/env.h>
 
 #include <atomic>
-#include <iostream>
 
 namespace at::mps {
 
@@ -25,6 +25,7 @@ uint64_t HeapBlock::heap_counter = 0;
 static std::atomic<bool> s_mps_allocator_initialized{false};
 
 void MPSHeapAllocatorImpl::init_allocator() {
+  TORCH_CHECK(m_device.hasUnifiedMemory, "MPS backend is only supported on devices with unified memory");
   init_buffer_pools();
 
   // debug verbosity flags (see DebugVerbosity enum)
@@ -36,16 +37,13 @@ void MPSHeapAllocatorImpl::init_allocator() {
       high_watermark_ratio_str ? strtod(high_watermark_ratio_str->c_str(), nullptr) : default_high_watermark_ratio;
   setHighWatermarkRatio(high_watermark_ratio);
 
-  const double default_low_watermark_ratio =
-      m_device.hasUnifiedMemory ? default_low_watermark_ratio_unified : default_low_watermark_ratio_discrete;
   static const auto low_watermark_ratio_str = c10::utils::get_env("PYTORCH_MPS_LOW_WATERMARK_RATIO");
   const double low_watermark_ratio =
       low_watermark_ratio_str ? strtod(low_watermark_ratio_str->c_str(), nullptr) : default_low_watermark_ratio;
   setLowWatermarkRatio(low_watermark_ratio);
 
   if (m_debug_verbosity & DebugVerbosity::PROFILING) {
-    std::cerr << "Initializing heap allocator on " << (m_device.hasUnifiedMemory ? "unified" : "discrete")
-              << " device memory of size " << format_size(max_device_size()) << "\n";
+    LOG(INFO) << "Initializing heap allocator on unified device memory of size " << format_size(max_device_size());
   }
 
   s_mps_allocator_initialized.store(true);
@@ -89,8 +87,8 @@ void MPSHeapAllocatorImpl::setHighWatermarkRatio(double ratio) {
   m_max_total_allowed_size =
       (ratio == 0.0) ? std::numeric_limits<size_t>::max() : static_cast<size_t>(ratio * (double)max_device_size());
   if (m_debug_verbosity & DebugVerbosity::PROFILING) {
-    std::cerr << "\nHigh watermark memory allocation limit: "
-              << (ratio == 0.0 ? "unlimited" : format_size(m_max_total_allowed_size)) << "\n";
+    LOG(INFO) << "High watermark memory allocation limit: "
+              << (ratio == 0.0 ? "unlimited" : format_size(m_max_total_allowed_size));
   }
   m_high_watermark_ratio = ratio;
 }
@@ -104,8 +102,8 @@ void MPSHeapAllocatorImpl::setLowWatermarkRatio(double ratio) {
   m_low_watermark_limit =
       (ratio == 0.0) ? std::numeric_limits<size_t>::max() : static_cast<size_t>(ratio * (double)max_device_size());
   if (m_debug_verbosity & DebugVerbosity::PROFILING) {
-    std::cerr << "Low watermark memory allocation limit: "
-              << (ratio == 0.0 ? "unlimited" : format_size(m_low_watermark_limit)) << "\n";
+    LOG(INFO) << "Low watermark memory allocation limit: "
+              << (ratio == 0.0 ? "unlimited" : format_size(m_low_watermark_limit));
   }
   m_low_watermark_ratio = ratio;
 }
@@ -121,10 +119,10 @@ HeapBlock* MPSHeapAllocatorImpl::get_free_heap(AllocParams& params) {
     if (heap_block) {
       m_total_allocated_memory.increase(heap_block->size.total);
       if (m_debug_verbosity & DebugVerbosity::ALLOCATIONS) {
-        std::cerr << "\nAllocated " << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private") << " heap #"
+        LOG(INFO) << "Allocated " << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private") << " heap #"
                   << heap_block->heap_id << " of size " << format_size(heap_block->size.total)
                   << " (#heaps: " << (pool.heaps.size() + 1)
-                  << ", current allocated: " << format_size(current_allocated_size()) << ")\n";
+                  << ", current allocated: " << format_size(current_allocated_size()) << ")";
       }
     }
   } else {
@@ -159,13 +157,13 @@ bool MPSHeapAllocatorImpl::alloc_buffer(AllocParams& params) {
 
   if ((m_debug_verbosity & DebugVerbosity::ALLOCATIONS) &&
       (!(m_debug_verbosity & DebugVerbosity::LARGE_ONLY) || !(pool.usage & UsageFlags::SMALL))) {
-    std::cerr << "Allocated " << ((params.pool->usage & UsageFlags::SHARED) ? "shared" : "private")
+    LOG(INFO) << "Allocated " << ((params.pool->usage & UsageFlags::SHARED) ? "shared" : "private")
               << ((params.pool->usage & UsageFlags::SCALAR) ? " scalar" : "") << " buffer #"
               << params.buffer_block->buf_id << " of size " << format_size(params.size()) << " at "
               << params.buffer_block->buffer << " from heap #" << heap->heap_id
               << " (requested: " << format_size(params.requested_size)
               << ", heap: " << format_size(heap->size.available)
-              << ", total: " << format_size(m_total_allocated_memory.current) << ")\n";
+              << ", total: " << format_size(m_total_allocated_memory.current) << ")";
   }
   return true;
 }
@@ -224,12 +222,12 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
 
   if ((m_debug_verbosity & DebugVerbosity::RECYCLES) &&
       (!(m_debug_verbosity & DebugVerbosity::LARGE_ONLY) || !(pool.usage & UsageFlags::SMALL))) {
-    std::cerr << "Reusing " << ((params.pool->usage & UsageFlags::SHARED) ? "shared" : "private")
+    LOG(INFO) << "Reusing " << ((params.pool->usage & UsageFlags::SHARED) ? "shared" : "private")
               << ((params.pool->usage & UsageFlags::SCALAR) ? " scalar" : "") << " buffer #"
               << params.buffer_block->buf_id << " of size " << format_size(params.buffer_block->size) << " at "
               << params.buffer_block->buffer << " (requested: " << format_size(params.requested_size)
               << ", use#: " << params.buffer_block->use_count + 1 << ", retain#: " << params.buffer_block->retainCount()
-              << ")\n";
+              << ")";
   }
   return true;
 }
@@ -243,7 +241,6 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
   // we care about memory pressure if only we're allocating large buffers when the
   // low watermark limit has been reached
   params.has_memory_pressure = !(pool.usage & UsageFlags::SMALL) && getLowWatermarkValue() <= 0;
-  params.has_unified_memory = m_device.hasUnifiedMemory;
 
   // first, try to get a block from the existing pool.
   bool block_found = get_free_buffer(params);
@@ -346,10 +343,10 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
 
   if ((m_debug_verbosity & DebugVerbosity::RELEASES) &&
       (!(m_debug_verbosity & DebugVerbosity::LARGE_ONLY) || !(pool.usage & UsageFlags::SMALL))) {
-    std::cerr << "Released buffer #" << buffer_block->buf_id << " of size " << format_size(buffer_block->size)
+    LOG(INFO) << "Released buffer #" << buffer_block->buf_id << " of size " << format_size(buffer_block->size)
               << " from heap #" << heap_block->heap_id << " (heap size: " << format_size(heap_block->size.available)
               << ", use#: " << buffer_block->use_count << ", retain#: " << retainCount
-              << ", gc#: " << buffer_block->gc_count << ")\n";
+              << ", gc#: " << buffer_block->gc_count << ")";
   }
   delete buffer_block;
 
@@ -358,9 +355,9 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
     m_total_allocated_memory.decrease(heap_block->size.total);
     retainCount = heap_block->releaseMTLHeap();
     if (m_debug_verbosity & DebugVerbosity::RELEASES) {
-      std::cerr << "Released heap #" << heap_block->heap_id << " of size " << format_size(heap_block->size.total)
+      LOG(INFO) << "Released heap #" << heap_block->heap_id << " of size " << format_size(heap_block->size.total)
                 << " (current allocated: " << format_size(current_allocated_size()) << ", retain#: " << retainCount
-                << ")\n";
+                << ")";
     }
     delete heap_block;
     return true;
@@ -392,11 +389,11 @@ void MPSHeapAllocatorImpl::release_buffers(BufferPool& pool) {
     return;
   }
   if ((m_debug_verbosity & DebugVerbosity::RELEASES)) {
-    std::cerr << "Releasing " << pool.available_buffers.size() << " buffers from "
+    LOG(INFO) << "Releasing " << pool.available_buffers.size() << " buffers from "
               << ((pool.usage & UsageFlags::SMALL) ? "small " : "large ")
               << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private")
               << ((pool.usage & UsageFlags::SCALAR) ? " scalar" : "")
-              << " pool (total size: " << format_size(pool.allocated_size) << ", #buffers: " << pool.n_buffers << ")\n";
+              << " pool (total size: " << format_size(pool.allocated_size) << ", #buffers: " << pool.n_buffers << ")";
   }
   auto it = pool.available_buffers.begin();
   while (it != pool.available_buffers.end()) {
@@ -438,10 +435,10 @@ bool MPSHeapAllocatorImpl::release_available_cached_buffers(AllocParams& params)
 
 bool MPSHeapAllocatorImpl::release_cached_buffers() {
   if (m_debug_verbosity >= DebugVerbosity::PROFILING) {
-    std::cerr << "Attempting to release cached buffers (MPS allocated: "
+    LOG(INFO) << "Attempting to release cached buffers (MPS allocated: "
               << format_size(m_total_allocated_memory.current)
               << ", other allocations: " << format_size(current_allocated_size() - m_total_allocated_memory.current)
-              << ")\n";
+              << ")";
   }
   // before releasing the buffers make sure the command buffer has finished.
   // we need to release the lock temporarily as synchronizing may cause deadlock with completion handlers.
@@ -504,10 +501,10 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
     }
   }
   if (m_debug_verbosity & DebugVerbosity::RELEASES) {
-    std::cerr << "Garbage collected " << freed_count << " buffers from large "
+    LOG(INFO) << "Garbage collected " << freed_count << " buffers from large "
               << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private")
               << " pool (total reclaimed: " << format_size(gc_reclaimed)
-              << ", #buffers: " << pool.available_buffers.size() << ")\n";
+              << ", #buffers: " << pool.available_buffers.size() << ")";
   }
 }
 
@@ -814,9 +811,6 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   bool isSharedBuffer(const void* ptr) const override {
     return _getAllocImpl().isSharedBuffer(ptr);
   }
-  bool isSharedStorageSupported() const override {
-    return _getAllocImpl().Device().hasUnifiedMemory;
-  }
   // c10::DeviceAllocator interface
   bool initialized() override {
     return HeapAllocator::s_mps_allocator_initialized.load();
@@ -929,11 +923,9 @@ static MPSAllocatorRegisterer s_mps_allocator_registerer;
 } // anonymous namespace
 
 IMPSAllocator* getIMPSAllocator() {
-  auto& sa = _getSharedAllocator();
-  if (sa.isSharedStorageSupported()) {
-    return &sa;
-  }
-  return nullptr;
+  // MPS requires unified memory (enforced in MPSHeapAllocatorImpl::init_allocator),
+  // so the shared allocator is always usable.
+  return &_getSharedAllocator();
 }
 
 // torch.is_pinned() implementation

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -24,7 +24,6 @@ class IMPSAllocator : public c10::DeviceAllocator {
   virtual void setBufferShape(const void* ptr, const IntArrayRef& shape)
       const = 0;
   virtual bool isSharedBuffer(const void* ptr) const = 0;
-  virtual bool isSharedStorageSupported() const = 0;
   virtual c10::DataPtr allocScalarBufferWithValue(void* value, size_t size)
       const = 0;
   virtual std::string formatSize(size_t size) const = 0;

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -666,22 +666,10 @@ MPSScalar getMPSScalar(const Scalar& scalar, ScalarType type) {
 }
 
 MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar) {
-  MPSGraphTensorData* result = nullptr;
-  // Scalar pools are only supported on devices with unified memory
-  if (mpsStream->device().hasUnifiedMemory) {
-    scalar.buffer = getIMPSAllocator()->allocScalarBufferWithValue(&scalar.value, scalar.size);
-    result = [[[MPSGraphTensorData alloc] initWithMTLBuffer:scalar.getMTLBuffer()
-                                                      shape:@[ @1 ]
-                                                   dataType:getMPSScalarType(scalar.type)] autorelease];
-  } else {
-    MPSNDArrayDescriptor* tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:getMPSScalarType(scalar.type)
-                                                                              shape:@[ @1 ]];
-    MPSNDArray* tensorNDArray = [[[MPSNDArray alloc] initWithDevice:mpsStream->device()
-                                                         descriptor:tensorDesc] autorelease];
-    [tensorNDArray writeBytes:&scalar.value strideBytes:nil];
-    result = [[[MPSGraphTensorData alloc] initWithMPSNDArray:tensorNDArray] autorelease];
-  }
-  return result;
+  scalar.buffer = getIMPSAllocator()->allocScalarBufferWithValue(&scalar.value, scalar.size);
+  return [[[MPSGraphTensorData alloc] initWithMTLBuffer:scalar.getMTLBuffer()
+                                                  shape:@[ @1 ]
+                                               dataType:getMPSScalarType(scalar.type)] autorelease];
 }
 
 void resize_tensor(Tensor* output) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #186806

MPS is only usable on devices with unified memory: getIMPSAllocator() returned nullptr for non-unified devices and EmptyTensor dereferences it without a null check, so a discrete-GPU Mac would crash on the first allocation anyway.
This makes that assumption explicit and removes the now-dead "discrete" code paths.
Logging: replace the verbosity-gated std::cerr diagnostics with LOG(INFO) (matching c10/CUDACachingAllocator), so output goes through the standard c10 logger with timestamps and file:line. The manual "\n" separators are dropped since LOG adds its own.
Test Plan:

```
PYTORCH_DEBUG_MPS_ALLOCATOR=1 TORCH_CPP_LOG_LEVEL=INFO python -c "
import torch; x = torch.rand(256, 256, device='mps'); torch.mps.synchronize()"
```

This change was authored with the assistance of Claude (Claude Code).