### PR TITLE
[cudaMallocAsync] Count graph-mem pool in memory_reserved()

### DIFF
--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -788,16 +788,9 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
       used_mem_current += graph_used_current;
 
       // The two high-water marks need not peak at the same instant, so their sum
-      // is an upper bound on the true simultaneous peak; clamp to total device
-      // memory so the reported peak never exceeds physical capacity.
+      // is a conservative upper bound on the true simultaneous peak.
       reserved_mem_peak += graph_reserved_peak;
       used_mem_peak += graph_used_peak;
-
-      size_t device_free = 0;
-      size_t device_total = 0;
-      C10_CUDA_CHECK(cudaMemGetInfo(&device_free, &device_total));
-      reserved_mem_peak = std::min(reserved_mem_peak, uint64_t{device_total});
-      used_mem_peak = std::min(used_mem_peak, uint64_t{device_total});
     }
 
     // Many stat types are specific to the native allocator. We leave these

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -760,6 +760,44 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
 
       C10_CUDA_CHECK(cudaMemPoolGetAttribute(
           mempool, cudaMemPoolAttrUsedMemHigh, &used_mem_peak));
+
+      // Allocations captured into a CUDA graph live in the device's graph-memory
+      // pool, not the default mempool, so add that pool's stats here -- otherwise
+      // memory_reserved() undercounts any graph-capturing workload. Tolerate
+      // cudaErrorNotSupported on drivers without graph-mem attributes (treat as 0).
+      auto get_graph_attr = [device](cudaGraphMemAttributeType attr) -> uint64_t {
+        uint64_t value = 0;
+        cudaError_t err = cudaDeviceGetGraphMemAttribute(device, attr, &value);
+        if (err == cudaErrorNotSupported) {
+          (void)cudaGetLastError(); // clear the sticky error
+          return 0;
+        }
+        C10_CUDA_CHECK(err);
+        return value;
+      };
+      uint64_t graph_reserved_current =
+          get_graph_attr(cudaGraphMemAttrReservedMemCurrent);
+      uint64_t graph_reserved_peak =
+          get_graph_attr(cudaGraphMemAttrReservedMemHigh);
+      uint64_t graph_used_current =
+          get_graph_attr(cudaGraphMemAttrUsedMemCurrent);
+      uint64_t graph_used_peak = get_graph_attr(cudaGraphMemAttrUsedMemHigh);
+
+      // Current counters are instantaneous, so they sum exactly.
+      reserved_mem_current += graph_reserved_current;
+      used_mem_current += graph_used_current;
+
+      // The two high-water marks need not peak at the same instant, so their sum
+      // is an upper bound on the true simultaneous peak; clamp to total device
+      // memory so the reported peak never exceeds physical capacity.
+      reserved_mem_peak += graph_reserved_peak;
+      used_mem_peak += graph_used_peak;
+
+      size_t device_free = 0;
+      size_t device_total = 0;
+      C10_CUDA_CHECK(cudaMemGetInfo(&device_free, &device_total));
+      reserved_mem_peak = std::min(reserved_mem_peak, uint64_t{device_total});
+      used_mem_peak = std::min(used_mem_peak, uint64_t{device_total});
     }
 
     // Many stat types are specific to the native allocator. We leave these
@@ -816,6 +854,22 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
         mempool, cudaMemPoolAttrReservedMemHigh, &zero));
     C10_CUDA_CHECK(
         cudaMemPoolSetAttribute(mempool, cudaMemPoolAttrUsedMemHigh, &zero));
+
+    // Also reset the graph-mem pool high-water marks, to match the term
+    // getDeviceStats adds for graph-captured allocations. Setting High to 0
+    // resets it to Current (same as the default-pool attributes above).
+    uint64_t graph_zero = 0;
+    auto reset_graph_high = [device, &graph_zero](cudaGraphMemAttributeType attr) {
+      cudaError_t err =
+          cudaDeviceSetGraphMemAttribute(device, attr, &graph_zero);
+      if (err == cudaErrorNotSupported) {
+        (void)cudaGetLastError(); // clear the sticky error
+        return;
+      }
+      C10_CUDA_CHECK(err);
+    };
+    reset_graph_high(cudaGraphMemAttrReservedMemHigh);
+    reset_graph_high(cudaGraphMemAttrUsedMemHigh);
   }
 
   SnapshotInfo snapshot(MempoolId_t mempool_id, bool include_traces) override {

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -761,11 +761,13 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
       C10_CUDA_CHECK(cudaMemPoolGetAttribute(
           mempool, cudaMemPoolAttrUsedMemHigh, &used_mem_peak));
 
-      // Allocations captured into a CUDA graph live in the device's graph-memory
-      // pool, not the default mempool, so add that pool's stats here -- otherwise
-      // memory_reserved() undercounts any graph-capturing workload. Tolerate
-      // cudaErrorNotSupported on drivers without graph-mem attributes (treat as 0).
-      auto get_graph_attr = [device](cudaGraphMemAttributeType attr) -> uint64_t {
+      // Allocations captured into a CUDA graph live in the device's
+      // graph-memory pool, not the default mempool, so add that pool's stats
+      // here -- otherwise memory_reserved() undercounts any graph-capturing
+      // workload. Tolerate cudaErrorNotSupported on drivers without graph-mem
+      // attributes (treat as 0).
+      auto get_graph_attr =
+          [device](cudaGraphMemAttributeType attr) -> uint64_t {
         uint64_t value = 0;
         cudaError_t err = cudaDeviceGetGraphMemAttribute(device, attr, &value);
         if (err == cudaErrorNotSupported) {
@@ -787,8 +789,8 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
       reserved_mem_current += graph_reserved_current;
       used_mem_current += graph_used_current;
 
-      // The two high-water marks need not peak at the same instant, so their sum
-      // is a conservative upper bound on the true simultaneous peak.
+      // The two high-water marks need not peak at the same instant, so their
+      // sum is a conservative upper bound on the true simultaneous peak.
       reserved_mem_peak += graph_reserved_peak;
       used_mem_peak += graph_used_peak;
     }
@@ -852,7 +854,8 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     // getDeviceStats adds for graph-captured allocations. Setting High to 0
     // resets it to Current (same as the default-pool attributes above).
     uint64_t graph_zero = 0;
-    auto reset_graph_high = [device, &graph_zero](cudaGraphMemAttributeType attr) {
+    auto reset_graph_high = [device,
+                             &graph_zero](cudaGraphMemAttributeType attr) {
       cudaError_t err =
           cudaDeviceSetGraphMemAttribute(device, attr, &graph_zero);
       if (err == cudaErrorNotSupported) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4071,9 +4071,7 @@ exit(2)
             buffers = []
             with torch.cuda.graph(g):
                 for _ in range(NCHUNK):
-                    buffers.append(
-                        torch.empty(CHUNK, dtype=torch.uint8, device=device)
-                    )
+                    buffers.append(torch.empty(CHUNK, dtype=torch.uint8, device=device))
             g.replay()  # graph-mem commits at first replay, not at capture
             torch.cuda.synchronize()
             return g, buffers

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4044,6 +4044,74 @@ exit(2)
             torch.cuda.empty_cache()
 
     @unittest.skipIf(
+        (not TEST_CUDA_GRAPH) or (not TEST_CUDAMALLOCASYNC),
+        "graph-mem-pool stat undercount is specific to the cudaMallocAsync backend",
+    )
+    def test_graph_mem_counted_in_reserved_async(self):
+        # cudaMallocAsync graph captures reserve backing in the per-device graph-mem
+        # pool, not the default mempool; memory_reserved() must include it. That pool
+        # is shared by all graphs, so a second graph must grow reserved again.
+        device = torch.cuda.current_device()
+
+        CHUNK = 256 * 1024 * 1024  # 256 MiB
+        NCHUNK = 4  # 1 GiB per graph
+        expected = CHUNK * NCHUNK
+
+        def capture_and_replay():
+            g = torch.cuda.CUDAGraph()
+            s = torch.cuda.Stream()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):  # warm up workspace allocs outside capture
+                _ = torch.empty(CHUNK, dtype=torch.uint8, device=device)
+            torch.cuda.current_stream().wait_stream(s)
+            del _
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+
+            buffers = []
+            with torch.cuda.graph(g):
+                for _ in range(NCHUNK):
+                    buffers.append(
+                        torch.empty(CHUNK, dtype=torch.uint8, device=device)
+                    )
+            g.replay()  # graph-mem commits at first replay, not at capture
+            torch.cuda.synchronize()
+            return g, buffers
+
+        def assert_grew(before, after):
+            # The NCHUNK live tensors can't be reused within the graph and reserved
+            # only rounds up, so growth is exactly `expected`.
+            self.assertGreaterEqual(
+                after - before,
+                expected,
+                f"memory_reserved() undercounts the graph-mem pool: grew "
+                f"{after - before}, expected >= {expected}",
+            )
+
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        r0 = torch.cuda.memory_reserved(device)
+        g1, b1 = capture_and_replay()
+        r1 = torch.cuda.memory_reserved(device)
+        assert_grew(r0, r1)
+
+        g2, b2 = capture_and_replay()
+        r2 = torch.cuda.memory_reserved(device)
+        assert_grew(r1, r2)
+
+        # Reset the graphs before freeing the tensors that alias their alloc nodes,
+        # then clear stats so this test's ~2 GiB doesn't bleed into siblings.
+        g1.reset()
+        g2.reset()
+        del b1, b2, g1, g2
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+    @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
     def test_graph_record_stream(self):

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -608,7 +608,7 @@ def max_memory_reserved(device: "Device" = None) -> int:
         device graph-memory pool (CUDA graph captures reserve backing in the
         latter). Because those two high-water marks need not occur at the same
         instant, the reported peak is a conservative *upper bound* on the true
-        simultaneous peak (clamped to total device memory). The current value
+        simultaneous peak. The current value
         (:func:`~torch.cuda.memory_reserved`) is exact.
     """
     return memory_stats(device=device).get("reserved_bytes.all.peak", 0)

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -601,6 +601,15 @@ def max_memory_reserved(device: "Device" = None) -> int:
     .. note::
         See :ref:`cuda-memory-management` for more details about GPU memory
         management.
+
+    .. note::
+        Under ``PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync``, the peak is
+        computed by summing the high-water marks of the default mempool and the
+        device graph-memory pool (CUDA graph captures reserve backing in the
+        latter). Because those two high-water marks need not occur at the same
+        instant, the reported peak is a conservative *upper bound* on the true
+        simultaneous peak (clamped to total device memory). The current value
+        (:func:`~torch.cuda.memory_reserved`) is exact.
     """
     return memory_stats(device=device).get("reserved_bytes.all.peak", 0)
 


### PR DESCRIPTION
Under `PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync`, CUDA-graph captures reserve their backing in the device's graph-memory pool, which getDeviceStats never queried — so memory_reserved() / memory_stats() silently undercounted every graph-capturing workload. This adds the cudaDeviceGetGraphMemAttribute (current + peak) term to the cudaMallocAsync stats, resets it in resetPeakStats, and adds a regression test.