### PR TITLE
[inductor] Round bf16/fp16 scalars to tensor dtype for add/sub on CPU and MPS

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3298,6 +3298,42 @@ class CommonTemplate:
         actual = torch.compile(fn)(x)
         self.assertEqual(actual, expected)
 
+    def test_add_scalar_type_promotion_bf16(self):
+        # https://github.com/pytorch/pytorch/issues/185517
+        def fwd(x):
+            return x + 1.7, x - 1.7
+
+        x = torch.tensor(
+            [-1.703125, 1.703125, 0.5], dtype=torch.bfloat16, device=self.device
+        )
+        self.assertEqual(torch.compile(fwd)(x), fwd(x))
+
+        # Eager CPU/MPS round margin to bf16, making the pre-clamp value of
+        # margin_ranking_loss exactly 0.0, so the clamp_min backward passes
+        # gradient at the boundary. The compiled backward must agree.
+        def loss_fn(a, b, t):
+            return torch.nn.functional.margin_ranking_loss(
+                a, b, t, margin=1.7, reduction="mean"
+            )
+
+        def grads(f):
+            a = torch.tensor(
+                [1.703125] * 2,
+                dtype=torch.bfloat16,
+                device=self.device,
+                requires_grad=True,
+            )
+            b = torch.zeros(
+                2, dtype=torch.bfloat16, device=self.device, requires_grad=True
+            )
+            t = torch.ones(2, dtype=torch.bfloat16, device=self.device)
+            f(a, b, t).backward()
+            return a.grad, b.grad
+
+        expected = grads(loss_fn)
+        actual = grads(torch.compile(loss_fn))
+        self.assertEqual(actual, expected)
+
     @skip_if_gpu_halide
     @xfail_if_triton_cpu
     def test_dist(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -589,6 +589,7 @@ def promote_constants(
     override_return_dtype: torch.dtype | None = None,
     type_promotion_kind: ELEMENTWISE_TYPE_PROMOTION_KIND | None = None,
     round_scalar_constants: bool = False,
+    round_scalars_to_tensor_dtype: bool = False,
 ) -> Sequence[_T | BaseView | BaseConstant]:
     if not (override_return_dtype is None or type_promotion_kind is None):
         raise AssertionError(
@@ -619,12 +620,21 @@ def promote_constants(
     ex = next(x for x in inputs if isinstance(x, (TensorBox, ExpandView, ir.Constant)))
     tensor_dtype = ex.get_dtype()
 
-    # Round scalar to tensor's dtype to match eager
-    if (
-        override_return_dtype == torch.bool or round_scalar_constants
-    ) and tensor_dtype in (
+    # Round scalars to the tensor's dtype to match eager: comparison ops and
+    # callers passing round_scalar_constants (e.g. remainder) round on all
+    # devices, and ops like add/sub round on CPU and MPS, whose eager kernels
+    # cast scalar operands to the common dtype (CUDA and the CPU mul/div
+    # kernels keep scalars at opmath precision instead).
+    if tensor_dtype in (
         torch.bfloat16,
         torch.float16,
+    ) and (
+        override_return_dtype == torch.bool
+        or round_scalar_constants
+        or (
+            round_scalars_to_tensor_dtype
+            and ex.get_device_or_error().type in ("cpu", "mps")
+        )
     ):
         _round_scalar = lambda v: torch.tensor(v, dtype=tensor_dtype).item()  # noqa: E731
     else:
@@ -724,6 +734,7 @@ def make_pointwise(
     allow_alpha: bool = False,
     use_fma_for_alpha: bool = False,
     triton_fallback: Callable[..., _T] | None = None,
+    round_scalars_to_tensor_dtype: bool = False,
 ) -> Callable[..., TensorBox | _T]:
     """Wraps a pointwise fn and returns a function representing the pointwise in
     the define-by-run IR."""
@@ -737,7 +748,11 @@ def make_pointwise(
             return triton_fallback(*inputs)
 
         # pyrefly: ignore [bad-assignment]
-        inputs = promote_constants(inputs, override_return_dtype)
+        inputs = promote_constants(
+            inputs,
+            override_return_dtype,
+            round_scalars_to_tensor_dtype=round_scalars_to_tensor_dtype,
+        )
         if allow_alpha:
             if alpha is not None and alpha != 1:
                 # Use FMA for add-with-alpha on CUDA floating-point.
@@ -1089,6 +1104,7 @@ def register_pointwise(
     allow_alpha=False,
     use_fma_for_alpha=False,
     triton_fallback=None,
+    round_scalars_to_tensor_dtype=False,
 ):
     """A pointwise function that maps ops.{name} to inputs"""
     name = name or aten_fn.__name__
@@ -1108,6 +1124,7 @@ def register_pointwise(
         allow_alpha=allow_alpha,
         use_fma_for_alpha=use_fma_for_alpha,
         triton_fallback=triton_fallback,
+        round_scalars_to_tensor_dtype=round_scalars_to_tensor_dtype,
     )
     fn = register_lowering(
         aten_fn,
@@ -7874,6 +7891,7 @@ add = register_pointwise(
     allow_alpha=True,
     use_fma_for_alpha=True,
     override_fn_when_input_bool="logical_or",
+    round_scalars_to_tensor_dtype=True,
 )
 
 sort_fallback = fallback_handler(aten.sort.stable, add_to_fallback_set=False)
@@ -8152,7 +8170,7 @@ relu = register_pointwise(aten.relu)
 sigmoid = register_pointwise_numeric_ldf64(aten.sigmoid)
 sqrt = register_pointwise_numeric_ldf64(aten.sqrt)
 square = register_pointwise(aten.square)
-sub = register_pointwise(aten.sub, allow_alpha=True)
+sub = register_pointwise(aten.sub, allow_alpha=True, round_scalars_to_tensor_dtype=True)
 
 
 @register_lowering(aten.addcmul, broadcast=True)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -591,6 +591,17 @@ def promote_constants(
     round_scalar_constants: bool = False,
     round_scalars_to_tensor_dtype: bool = False,
 ) -> Sequence[_T | BaseView | BaseConstant]:
+    """Convert raw Python scalars and sympy expressions in inputs to IR constants.
+
+    When a tensor input is present, scalars become Constants of the tensor's
+    dtype, broadcast to its size. For bf16/fp16 tensors, the scalar value is
+    additionally rounded to the tensor dtype to match eager kernels that cast
+    scalar operands to the common dtype: always for comparison ops
+    (override_return_dtype == torch.bool) and for callers passing
+    round_scalar_constants (e.g. remainder); on CPU and MPS only for ops
+    passing round_scalars_to_tensor_dtype (e.g. add/sub, whose CUDA eager
+    kernels keep scalars at opmath precision).
+    """
     if not (override_return_dtype is None or type_promotion_kind is None):
         raise AssertionError(
             "only one of override_return_dtype or type_promotion_kind may be given"
@@ -620,11 +631,7 @@ def promote_constants(
     ex = next(x for x in inputs if isinstance(x, (TensorBox, ExpandView, ir.Constant)))
     tensor_dtype = ex.get_dtype()
 
-    # Round scalars to the tensor's dtype to match eager: comparison ops and
-    # callers passing round_scalar_constants (e.g. remainder) round on all
-    # devices, and ops like add/sub round on CPU and MPS, whose eager kernels
-    # cast scalar operands to the common dtype (CUDA and the CPU mul/div
-    # kernels keep scalars at opmath precision instead).
+    # Round scalars to the tensor's dtype where eager does; see docstring.
     if tensor_dtype in (
         torch.bfloat16,
         torch.float16,


### PR DESCRIPTION
Fixes #185517

## Root cause

`F.margin_ranking_loss` with a Python float `margin` and bf16 inputs computes `clamp_min(-target * (input1 - input2) + margin, 0)`. Eager CPU (and MPS) `add`/`sub` kernels cast scalar operands to the common dtype, so `margin=1.7` becomes `bf16(1.7) = 1.703125` and the pre-clamp value in the issue's repro is exactly `0.0`. `clamp_min`'s backward passes gradient at the boundary (`self >= min`), giving `grad = -0.5`.

Inductor keeps the scalar at full precision in the compute type — the generated CPP kernel contains `auto tmp9 = static_cast<float>(1.7);` — so the pre-clamp value is `-0.003125 < 0`, the saved `ge` mask is false, and the gradient is silently zeroed. The forward output is identical (clamped to 0 either way), which is why only gradients diverge.

## Approach

#175807 already rounds scalars to the tensor dtype in `promote_constants`, but only for comparison ops (`override_return_dtype == torch.bool`). This PR extends that mechanism with an opt-in `round_scalars_to_tensor_dtype` flag threaded through `register_pointwise` / `make_pointwise`, enabled for `aten.add` and `aten.sub` on CPU and MPS.

Universal rounding was considered and rejected: eager scalar handling is op-dependent. Verified empirically on nightly — eager rounds the scalar to the tensor dtype for add/sub/rsub/fmod/remainder on CPU, but keeps it at opmath precision for mul/div (49/448 sampled values mismatch exactly if you round there) and for everything on CUDA (which is why eager and inductor already agree on CUDA for this repro, as the issue notes). Rounding is therefore applied only where eager rounds; fmod/remainder could be enabled later if someone hits them.

## Test plan

New regression test `test_add_scalar_type_promotion_bf16` (next to the #175807 test) covers both the forward `x ± 1.7` values and the margin_ranking_loss backward from the issue. It fails without the fix and passes with it on both instantiations:

```
python test/inductor/test_torchinductor.py -k test_add_scalar_type_promotion_bf16 -v
test_add_scalar_type_promotion_bf16_cpu ... ok
test_add_scalar_type_promotion_bf16_mps ... ok
```

Neighboring coverage (macOS arm64, CPU + MPS):

```
python -m pytest test/inductor/test_torchinductor.py -k "(add or promotion or loss or margin or sub) and cpu"   # 40 passed
python -m pytest test/inductor/test_torchinductor.py -k "(add or promotion or loss or margin or sub) and mps"   # 233 passed
```

`lintrunner` clean on changed files (PYFMT applied; PYREFLY findings are pre-existing/env-only).

## Risk

Numerics change only for compiled bf16/fp16 add/sub with Python float scalars on CPU/MPS, moving them to exact eager parity (<= 1 ulp shift). CUDA and all other ops are unchanged.

Authored with the help of an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos