### PR TITLE
[profiler] fix flaky test_python_gc_event by disabling automatic GC

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2407,14 +2407,22 @@ class TestProfiler(TestCase):
                         )
 
         for gc_flag in [True, False]:
-            with profile(
-                activities=activities,
-                experimental_config=torch._C._profiler._ExperimentalConfig(
-                    record_python_gc_info=gc_flag
-                ),
-                with_stack=True,
-            ) as prof:
-                payload()
+            # Automatic cyclic GC can fire at any point during profiling
+            # Disable it so only explicit gc.collect() in payload() is captured
+            gc_was_enabled = gc.isenabled()
+            gc.disable()
+            try:
+                with profile(
+                    activities=activities,
+                    experimental_config=torch._C._profiler._ExperimentalConfig(
+                        record_python_gc_info=gc_flag
+                    ),
+                    with_stack=True,
+                ) as prof:
+                    payload()
+            finally:
+                if gc_was_enabled:
+                    gc.enable()
             validate_json(prof, gc_flag)
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")


### PR DESCRIPTION
Summary:
`test_python_gc_event` records "Python GC" trace events via a callback registered into Python's `gc.callbacks` (see `PythonTracer::register_gc_callback` in `torch/csrc/autograd/profiler_python.cpp`), which fires on *every* garbage collection while profiling is active. The test asserts that every recorded "Python GC" event falls strictly between the `pre_gc` and `post_gc` `record_function` blocks, but it never disabled automatic cyclic GC. Python's collector can fire at any time during the profiled region (the tensor allocations, or the profiler's own Python object churn with `with_stack=True`), recording a stray event outside that window and failing the assertion with "Python GC event at <ts> is not correctly placed", leading to flaky test.



Disable automatic GC around the profiled region so only the explicit `gc.collect()` in `payload()` is captured, making event placement deterministic.

`pr-test / linux-cpu-pytorch-build-and-test` is failing on assertion error constantly on base commit.

Test Plan:
```
python test/profiler/test_profiler.py TestProfiler.test_python_gc_event
```

Ran x100 100/100 passed

Differential Revision: D108043968


