### PR TITLE
[BE][MPS] Fix flase-positive compiler warnings

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ScanKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ScanKernel.metal
@@ -956,10 +956,12 @@ kernel void scan_contig_decoupled(
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
   Op op;
-  threadgroup uint tg_tile_id;
+  // Initializing thread-group vars is a no-op, but squashes false-positive
+  // compiler warning
+  threadgroup uint tg_tile_id{};
   threadgroup acc_t simdgroup_sums[simd_size];
-  threadgroup acc_t tg_total;
-  threadgroup acc_t tg_carry;
+  threadgroup acc_t tg_total{};
+  threadgroup acc_t tg_carry{};
 
   // 1) Dynamically claim a tile id (the forward-progress guarantee).
   if (lid == 0) {
@@ -1169,7 +1171,9 @@ kernel void scan_strided_decoupled(
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
   Op op;
-  threadgroup uint tg_tile_id;
+  // See scan_contig_decoupled: static init silences a barrier-unaware
+  // -Wsometimes-uninitialized false positive at zero runtime cost.
+  threadgroup uint tg_tile_id{};
   threadgroup acc_t simdgroup_sums[simd_size * VEC];
   threadgroup acc_t tg_total[VEC];
   threadgroup acc_t tg_carry[VEC];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #186822

By "initializing" threadgroup variables

Otherwise once gets bombardbed by
```
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1017:7: warning: variable 'tg_carry' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  if (lid == 0) {
      ^~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:2169:1: note: in instantiation of function template specialization 'scan_contig_decoupled<float, CumSumOp<float, float>, 16, float>' requested here
REGISTER_DECOUPLED_SCAN_OP(cumsum, CumSumOp, float, 16);
^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1789:3: note: expanded from macro 'REGISTER_DECOUPLED_SCAN_OP'
  scan_contig_decoupled<DTYPE, OP_CLASS<DTYPE>, NREADS>(                       \
  ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1039:23: note: uninitialized use occurs here
  const acc_t carry = tg_carry;
                      ^~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1017:3: note: remove the 'if' if its condition is always true
  if (lid == 0) {
  ^~~~~~~~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:962:29: note: initialize the variable 'tg_carry' to silence this warning
  threadgroup acc_t tg_carry;
                            ^
                             = 0.0
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1008:7: warning: variable 'tg_total' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  if (simd_group_id == simd_groups - 1 && simd_lane_id == simd_size - 1) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1012:29: note: uninitialized use occurs here
  const acc_t block_total = tg_total;
                            ^~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1008:3: note: remove the 'if' if its condition is always true
  if (simd_group_id == simd_groups - 1 && simd_lane_id == simd_size - 1) {
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1008:7: warning: variable 'tg_total' is used uninitialized whenever '&&' condition is false [-Wsometimes-uninitialized]
  if (simd_group_id == simd_groups - 1 && simd_lane_id == simd_size - 1) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1012:29: note: uninitialized use occurs here
  const acc_t block_total = tg_total;
                            ^~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:1008:7: note: remove the '&&' if its condition is always true
  if (simd_group_id == simd_groups - 1 && simd_lane_id == simd_size - 1) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:961:29: note: initialize the variable 'tg_total' to silence this warning
  threadgroup acc_t tg_total;
                            ^
                             = 0.0
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/ScanKernel.metal:965:7: warning: variable 'tg_tile_id' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  if (lid == 0) {
      ^~~~~~~~
```