### PR TITLE
Add CUDA graph output and input copy annotations

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -25,6 +25,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      set_stance
      set_enable_guard_collectives
      cudagraph_mark_step_begin
+     cudagraph_mark_output_clone
+     cudagraph_mark_input_copy
      is_compiling
      is_dynamo_compiling
      is_exporting

--- a/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
@@ -292,6 +292,24 @@ Currently, CUDAGraph partition supports splitting off the following types of ops
 - **CUDAGraph Unsafe Custom Ops**: Custom ops tagged with `torch._C.Tag.cudagraph_unsafe` are split off. See *CUDAGraph Unsafe Custom Ops* section for details.
 - **Unbacked Symints**: Please refer to *Dynamic Shape Support* section for more information.
 
+### CUDAGraph Annotations
+
+CUDA graphs require stable memory addresses and reuse private-pool memory across
+replays. The following annotations can be used inside a compiled function to
+override the default CUDAGraph handling for specific tensors:
+
+- `torch.compiler.cudagraph_mark_output_clone(tensor)` marks a returned tensor
+  to be cloned out of CUDA graph managed memory. If multiple returned tensors
+  alias the same storage as the marked tensor, the returned alias group is
+  cloned together so output aliasing is preserved.
+- `torch.compiler.cudagraph_mark_input_copy(tensor)` marks a graph input to be
+  copied into CUDA graph managed memory instead of requiring its address to
+  remain stable. Mutated inputs and inputs that alias another graph input are
+  not captured with copy semantics because copying would change user-visible
+  behavior.
+These annotations preserve eager behavior and return `None`; they are metadata
+markers consumed by `torch.compile`.
+
 
 ### Limitations
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1229,6 +1229,54 @@ if HAS_CUDA_AND_TRITON:
         def test_unaligned_static_input_no_cudagraphs(self):
             self._test_unaligned_static_input_impl(expected_clones=0)
 
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        def test_explicit_copy_static_input_no_rerecord(self):
+            def fn(x, y):
+                torch.compiler.cudagraph_mark_input_copy(x)
+                return (x + y,)
+
+            def new_inputs():
+                return [
+                    torch.rand([5, 5], device="cuda"),
+                    torch.rand([5, 5], device="cuda"),
+                ]
+
+            inps = new_inputs()
+            mod = make_fx(fn)(*inps)
+            compiled_f = compile_fx_inner(
+                mod, inps, static_input_idxs=[0], cudagraphs=True
+            )
+
+            for _ in range(3):
+                inps = new_inputs()
+                expected = fn(*inps)
+                self.assertEqual(compiled_f(list(inps)), expected)
+
+            self.assertEqual(self.get_manager().new_graph_id().id, 1)
+
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        def test_explicit_copy_aliased_input_falls_back(self):
+            def foo(args):
+                x, y = args
+                y.add_(1)
+                args.clear()
+                return (x + y,)
+
+            x = torch.rand([5, 5], device="cuda")
+            y = torch.rand([5, 5], device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [x, y], (0,), copy_input_idxs=(0,))
+            foo_cg(
+                [
+                    torch.rand([5, 5], device="cuda"),
+                    torch.rand([5, 5], device="cuda"),
+                ]
+            )
+
+            base = torch.rand([5, 5], device="cuda")
+            expected = 2 * (base + 1)
+            (actual,) = foo_cg([base, base])
+            self.assertEqual(actual, expected)
+
         @torch._inductor.config.patch("graph_partition", True)
         @torch._inductor.config.patch("implicit_fallbacks", True)
         def test_graph_partition_custom_rule(self):
@@ -5334,6 +5382,176 @@ if HAS_CUDA_AND_TRITON:
             result2 = foo_cg([sf, inp])
             self.assertEqual(result2[0], inp * 3.0)
 
+        def test_cloned_output_basic(self):
+            """Cloned outputs get fresh storage on every replay."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return x * 2, x + 1
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0,))
+
+            foo_cg([inp])
+            out1_a, out1_b = foo_cg([inp])
+            out2_a, out2_b = foo_cg([inp])
+            self.assertNotEqual(out1_a.data_ptr(), out2_a.data_ptr())
+            self.assertEqual(out2_a, inp * 2)
+            self.assertEqual(out2_b, inp + 1)
+
+        def test_cloned_output_survives_replay(self):
+            """Cloned outputs remain valid after subsequent replays."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return (x * 3,)
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0,))
+
+            foo_cg([inp])
+            (first,) = foo_cg([inp])
+            expected = first.clone()
+            foo_cg([inp])
+            self.assertEqual(first, expected)
+
+        def test_cloned_output_multiple_idxs(self):
+            """Multiple outputs can be cloned."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return x + 1, x + 2, x + 3
+
+            inp = torch.randn(4, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0, 2))
+
+            foo_cg([inp])
+            a1, b1, c1 = foo_cg([inp])
+            a2, b2, c2 = foo_cg([inp])
+            self.assertNotEqual(a1.data_ptr(), a2.data_ptr())
+            self.assertNotEqual(c1.data_ptr(), c2.data_ptr())
+            self.assertEqual(a2, inp + 1)
+            self.assertEqual(b2, inp + 2)
+            self.assertEqual(c2, inp + 3)
+
+        def test_cloned_output_preserves_output_aliasing(self):
+            """Cloning one returned view clones its returned alias group once."""
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return x[:3], x[1:4]
+
+            inp = torch.randn(8, device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,), cloned_output_idxs=(0,))
+
+            foo_cg([inp])
+            first_a, first_b = foo_cg([inp])
+            second_a, second_b = foo_cg([inp])
+
+            self.assertEqual(first_a, inp[:3])
+            self.assertEqual(first_b, inp[1:4])
+            self.assertEqual(second_a, inp[:3])
+            self.assertEqual(second_b, inp[1:4])
+            self.assertEqual(
+                first_a.untyped_storage()._cdata, first_b.untyped_storage()._cdata
+            )
+            self.assertEqual(
+                second_a.untyped_storage()._cdata, second_b.untyped_storage()._cdata
+            )
+            self.assertNotEqual(
+                first_a.untyped_storage()._cdata, second_a.untyped_storage()._cdata
+            )
+
+        def test_cloned_output_compile(self):
+            """End-to-end test with torch.compile."""
+
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                y = x * 2
+                z = x + 1
+                torch.compiler.cudagraph_mark_output_clone(y)
+                return y, z
+
+            inp = torch.randn(4, device="cuda")
+            for _ in range(3):
+                foo(inp)
+
+            out1_y, _ = foo(inp)
+            out2_y, _ = foo(inp)
+            self.assertNotEqual(out1_y.data_ptr(), out2_y.data_ptr())
+            self.assertEqual(out2_y, inp * 2)
+
+            expected_y = out1_y.clone()
+            foo(inp)
+            self.assertEqual(out1_y, expected_y)
+
+        def test_cloned_output_shutdown(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                y = x * 2
+                torch.compiler.cudagraph_mark_output_clone(y)
+                return y
+
+            inp = torch.randn(4, device="cuda")
+            for _ in range(3):
+                foo(inp)
+
+            self.assertIsNotNone(self.get_manager())
+            torch._inductor.cudagraph_trees.reset_cudagraph_trees()
+            self.assertIsNone(self.get_manager())
+
+        def test_cloned_output_checkpoint_tracks_original_output(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                y = x * 2
+                torch.compiler.cudagraph_mark_output_clone(y)
+                return y
+
+            @torch.compile(mode="reduce-overhead")
+            def bar(x):
+                return x + 1
+
+            inp = torch.randn(4, device="cuda")
+            for _ in range(3):
+                out = foo(inp)
+
+            del out
+            gc.collect()
+            torch.cuda.empty_cache()
+
+            for _ in range(3):
+                self.assertEqual(bar(inp), inp + 1)
+
+        def test_cloned_output_with_cpu_partition(self):
+            """Cloned output works when graph has CPU ops causing partitions."""
+
+            def foo(x):
+                y = x * 2
+                torch.compiler.cudagraph_mark_output_clone(y)
+                cpu_val = x.sum().cpu()
+                z = x + cpu_val.to("cuda")
+                return y, z
+
+            inp = torch.randn(4, device="cuda")
+            f_compiled = torch.compile(foo, mode="reduce-overhead")
+
+            for _ in range(3):
+                f_compiled(inp)
+
+            out1_y, out1_z = f_compiled(inp)
+            out2_y, out2_z = f_compiled(inp)
+            self.assertNotEqual(out1_y.data_ptr(), out2_y.data_ptr())
+            self.assertEqual(out2_y, inp * 2)
+            self.assertEqual(out2_z, inp + inp.sum())
+
+            expected = out1_y.clone()
+            f_compiled(inp)
+            self.assertEqual(out1_y, expected)
+
     class TestCUDAGraphPolicy(TestCase):
         def setUp(self):
             super().setUp()
@@ -6001,6 +6219,78 @@ if HAS_CUDA_AND_TRITON:
         instantiate_device_type_tests(
             TestCudagraphIndexingOps, globals(), only_for=("cuda",)
         )
+
+
+if torch.cuda.is_available():
+
+    class TestMarkOutputsMeta(InductorTestCase):
+        """Tests for cudagraph metadata tracing (no triton needed)."""
+
+        def test_no_annotation(self):
+            """make_fx works normally when no cudagraph annotations exist."""
+            gm = make_fx(lambda x: x * 2, tracing_mode="fake")(
+                torch.randn(4, device="cuda")
+            )
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertNotIn("cloned_idxs", out.meta)
+
+        def test_clone_annotation(self):
+            """exclude_from_cudagraphs with clone=True sets cloned_idxs."""
+
+            def f(x):
+                y = x * 2
+                torch.compiler.cudagraph_mark_output_clone(y)
+                return y, x + 1
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(list(out.meta["cloned_idxs"]), [0])
+
+            # custom op must be erased
+            for node in gm.graph.nodes:
+                self.assertNotIn("exclude", str(node.target))
+
+        def test_clone_annotation_view_alias_group(self):
+            """Annotating one returned view marks the returned alias group."""
+
+            def f(x):
+                y = x * 2
+                a = y[:2]
+                b = y[1:3]
+                torch.compiler.cudagraph_mark_output_clone(a)
+                return a, b
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(list(out.meta["cloned_idxs"]), [0, 1])
+
+        def test_single_output(self):
+            """Cudagraph output metadata handles single outputs."""
+
+            def f(x):
+                y = x * 2
+                torch.compiler.cudagraph_mark_output_clone(y)
+                return y
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(list(out.meta["cloned_idxs"]), [0])
+
+        def test_input_copy_annotation(self):
+            """copy_to_cudagraphs marks the matching placeholder index."""
+
+            def f(x, y):
+                torch.compiler.cudagraph_mark_input_copy(x)
+                return x + y
+
+            gm = make_fx(f, tracing_mode="fake")(
+                torch.randn(4, device="cuda"), torch.randn(4, device="cuda")
+            )
+            out = next(reversed(gm.graph.find_nodes(op="output")))
+            self.assertEqual(list(out.meta["cudagraph_copy_input_idxs"]), [0])
+
+            for node in gm.graph.nodes:
+                self.assertNotIn("copy_to_cudagraphs", str(node.target))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -192,6 +192,8 @@ manual_torch_name_rule_map: dict[
     "torch.compiler.is_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_dynamo_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_exporting": TorchInGraphFunctionVariable,
+    "torch.compiler.cudagraph_mark_output_clone": TorchInGraphFunctionVariable,
+    "torch.compiler.cudagraph_mark_input_copy": TorchInGraphFunctionVariable,
     "torch._dynamo.eval_frame._is_in_optimized_module": TorchInGraphFunctionVariable,
     "torch._C._to_dlpack": SkipFunctionVariable,
     "torch._C._group_tensors_by_device_and_dtype": TorchInGraphFunctionVariable,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -46,6 +46,7 @@ from torch.fx.graph_module import GraphModule
 from torch.fx.passes._tensorify_python_scalars import tensorify_python_scalars
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.types import py_sym_types
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torchgen.utils import dataclass_repr
 
@@ -1348,6 +1349,82 @@ def prepare_hook_gm(
     return gm
 
 
+def propagate_output_meta_to_fw_module(
+    fx_g: torch.fx.GraphModule,
+    fw_module: torch.fx.GraphModule,
+    num_inner_fwd_outputs: int,
+):
+    """
+    Propagate cudagraph metadata from joint graph to forward module.
+    Maps output indices by returned storage and input indices by placeholder storage.
+    """
+    from torch._inductor.fx_utils import get_node_storage
+
+    # Get metadata from joint graph output node
+    joint_output_node = next(reversed(fx_g.graph.find_nodes(op="output")))
+    cloned_idxs = joint_output_node.meta.get("cloned_idxs", OrderedSet())
+    copy_input_idxs = joint_output_node.meta.get(
+        "cudagraph_copy_input_idxs", OrderedSet()
+    )
+
+    if not cloned_idxs and not copy_input_idxs:
+        return  # Nothing to propagate
+
+    # Get joint graph outputs
+    joint_outs = joint_output_node.args[0]
+
+    # Build storage -> joint_idx mapping for user outputs only
+    joint_storage_to_idx = {}
+    for i in range(num_inner_fwd_outputs):
+        node = joint_outs[i]
+        if isinstance(node, torch.fx.Node):
+            storage = get_node_storage(node)
+            if storage is not None:
+                joint_storage_to_idx[storage] = i
+
+    # Get fw_module outputs
+    fw_output_node = next(reversed(fw_module.graph.find_nodes(op="output")))
+    fw_outs = fw_output_node.args[0]
+
+    fw_cloned_idxs: OrderedSet[int] = OrderedSet()
+    if cloned_idxs:
+        for fw_idx, fw_node in enumerate(fw_outs):
+            if not isinstance(fw_node, torch.fx.Node):
+                continue
+
+            fw_storage = get_node_storage(fw_node)
+            if fw_storage is None:
+                continue
+
+            joint_idx = joint_storage_to_idx.get(fw_storage)
+            if joint_idx is not None and joint_idx in cloned_idxs:
+                fw_cloned_idxs.add(fw_idx)
+
+    if fw_cloned_idxs:
+        fw_output_node.meta["cloned_idxs"] = fw_cloned_idxs
+
+    if copy_input_idxs:
+        joint_placeholders = fx_g.graph.find_nodes(op="placeholder")
+        copy_input_storages = OrderedSet()
+        for idx in copy_input_idxs:
+            if idx >= len(joint_placeholders):
+                continue
+            storage = get_node_storage(joint_placeholders[idx])
+            if storage is not None:
+                copy_input_storages.add(storage)
+
+        fw_copy_input_idxs: OrderedSet[int] = OrderedSet()
+        for fw_idx, placeholder in enumerate(
+            fw_module.graph.find_nodes(op="placeholder")
+        ):
+            storage = get_node_storage(placeholder)
+            if storage in copy_input_storages:
+                fw_copy_input_idxs.add(fw_idx)
+
+        if fw_copy_input_idxs:
+            fw_output_node.meta["cudagraph_copy_input_idxs"] = fw_copy_input_idxs
+
+
 # Inline Autograd saved_tensors_hooks into epilogue of forward graph
 # and prologue of backward graph.
 # This changes forward graph outputs and inputs.
@@ -2189,6 +2266,7 @@ def _aot_stage2a_partition(
                     partition_fn,
                 )
             )
+            propagate_output_meta_to_fw_module(fx_g, fw_module, num_inner_fwd_outputs)
             num_inner_fwd_outputs, joint_inputs = (
                 _maybe_unlift_partitioned_effect_tokens(
                     fw_module,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1192,6 +1192,28 @@ class FxGraphHashDetails:
     # just a debug label).
     EXCLUDED_KWARGS = ["graph_id", "compile_region_name"]
 
+    @staticmethod
+    def _cudagraph_metadata_for_cache_key(
+        gm: torch.fx.GraphModule,
+    ) -> tuple[tuple[str, tuple[tuple[int, ...], tuple[int, ...]]], ...]:
+        metadata: list[tuple[str, tuple[tuple[int, ...], tuple[int, ...]]]] = []
+        for module_name, module in gm.named_modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+
+            output_metadata: tuple[tuple[int, ...], tuple[int, ...]] = ((), ())
+            for node in module.graph.nodes:
+                if node.op == "output":
+                    output_metadata = (
+                        tuple(node.meta.get("cloned_idxs", ())),
+                        tuple(node.meta.get("cudagraph_copy_input_idxs", ())),
+                    )
+
+            if output_metadata != ((), ()):
+                metadata.append((module_name, output_metadata))
+
+        return tuple(metadata)
+
     def __init__(
         self,
         gm: torch.fx.GraphModule,
@@ -1317,6 +1339,10 @@ class FxGraphHashDetails:
         # normalize to a simple boolean (equivalent to flipping the config).
         # When fwd and bwd differ, include the full annotation.
         if gm is not None:
+            cudagraph_metadata = self._cudagraph_metadata_for_cache_key(gm)
+            if cudagraph_metadata:
+                self.cudagraph_metadata = cudagraph_metadata
+
             annotation = gm.meta.get("cudagraph_annotation")
             if annotation is not None:
                 default = config.triton.cudagraphs

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -65,6 +65,7 @@ from torch._functorch.aot_autograd import (
 from torch._inductor.codecache import code_hash, FxGraphCache, output_code_log
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
+    clone_outputs_preserving_aliases,
     cudagraphs_log,
     format_default_skip_message,
     log_cudagraph_skip_and_bump_counter,
@@ -1893,6 +1894,8 @@ def cudagraphify(
     constants: tuple[torch.Tensor, ...] = (),
     placeholders: Sequence[PlaceholderInfo] = (),
     mutated_input_idxs: tuple[int, ...] = (),
+    cloned_output_idxs: tuple[int, ...] = (),
+    copy_input_idxs: tuple[int, ...] = (),
 ) -> Callable[..., Any]:
     from torch._inductor.cudagraph_trees import (
         cudagraphify_impl as new_cudagraphify_impl,
@@ -1910,9 +1913,15 @@ def cudagraphify(
             placeholders=placeholders,
             mutated_input_idxs=mutated_input_idxs,
             compile_id=torch._guards.CompileContext.current_compile_id(),
+            cloned_output_idxs=cloned_output_idxs,
+            copy_input_idxs=copy_input_idxs,
         )
     else:
-        cudagraphify_fn = cudagraphify_impl
+        cudagraphify_fn = functools.partial(
+            cudagraphify_impl,
+            cloned_output_idxs=cloned_output_idxs,
+            copy_input_idxs=copy_input_idxs,
+        )
 
     thread_local = threading.local()
 
@@ -1955,6 +1964,9 @@ def cudagraphify_impl(
     model: Callable[..., Any],
     inputs: list[torch.Tensor],
     static_input_idxs: Sequence[int] = (),
+    *,
+    cloned_output_idxs: tuple[int, ...] = (),
+    copy_input_idxs: tuple[int, ...] = (),
 ) -> Callable[[list[InputType]], Any]:
     """
     Assumes inputs[static_input_idxs[i]] are always the same memory address
@@ -2008,9 +2020,28 @@ def cudagraphify_impl(
     if not isinstance(static_outputs, (list, tuple)):
         static_outputs = (static_outputs,)
 
+    def copy_input_aliases_any(new_inputs: list[InputType]) -> bool:
+        for idx in copy_input_idxs:
+            inp = new_inputs[idx]
+            if not isinstance(inp, torch.Tensor) or not torch._C._has_storage(inp):
+                continue
+            storage_cdata = inp.untyped_storage()._cdata
+            for other_idx, other in enumerate(new_inputs):
+                if other_idx == idx:
+                    continue
+                if (
+                    isinstance(other, torch.Tensor)
+                    and torch._C._has_storage(other)
+                    and other.untyped_storage()._cdata == storage_cdata
+                ):
+                    return True
+        return False
+
     if config.size_asserts:
 
         def run(new_inputs: list[InputType]) -> Callable[[list[InputType]], Any]:
+            if copy_input_aliases_any(new_inputs):
+                return model(new_inputs)
             assert len(static_inputs) == len(new_inputs)
             for idx, (dst, src, expanded_dims) in enumerate(
                 zip(static_inputs, new_inputs, inps_expanded_dims)
@@ -2028,7 +2059,7 @@ def cudagraphify_impl(
             new_inputs.clear()
             graph.replay()
             # pyrefly: ignore [bad-return]
-            return static_outputs
+            return clone_outputs_preserving_aliases(static_outputs, cloned_output_idxs)
 
     else:
         copy_indices = [
@@ -2036,6 +2067,8 @@ def cudagraphify_impl(
         ]
 
         def run(new_inputs: list[InputType]) -> Callable[[list[InputType]], Any]:
+            if copy_input_aliases_any(new_inputs):
+                return model(new_inputs)
             for idx in copy_indices:
                 expanded_dims = inps_expanded_dims[idx]
                 src = new_inputs[idx]
@@ -2044,7 +2077,7 @@ def cudagraphify_impl(
             new_inputs.clear()
             graph.replay()
             # pyrefly: ignore [bad-return]
-            return static_outputs
+            return clone_outputs_preserving_aliases(static_outputs, cloned_output_idxs)
 
     return align_inputs_from_check_idxs(run, check_input_idxs, OrderedSet())
 

--- a/torch/_inductor/cudagraph_prims.py
+++ b/torch/_inductor/cudagraph_prims.py
@@ -1,0 +1,35 @@
+import torch
+
+
+@torch.library.custom_op("aten_cudagraphs::exclude_from_cudagraphs", mutates_args={})
+def exclude_from_cudagraphs(
+    inp: torch.Tensor,
+    clone: bool = False,
+) -> None:
+    return None
+
+
+def exclude_from_cudagraphs_fake(
+    inp: torch.Tensor,
+    clone: bool = False,
+) -> None:
+    return None
+
+
+exclude_from_cudagraphs.register_fake(exclude_from_cudagraphs_fake)
+
+
+@torch.library.custom_op("aten_cudagraphs::copy_to_cudagraphs", mutates_args={})
+def copy_to_cudagraphs(
+    inp: torch.Tensor,
+) -> None:
+    return None
+
+
+def copy_to_cudagraphs_fake(
+    inp: torch.Tensor,
+) -> None:
+    return None
+
+
+copy_to_cudagraphs.register_fake(copy_to_cudagraphs_fake)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -79,7 +79,9 @@ from torch._inductor.compile_fx import (
 from torch._inductor.cudagraph_utils import (
     check_for_mutation,
     CheckInvariantStatus,
+    clone_outputs_preserving_aliases,
     collect_cuda_data_ptrs,
+    expand_cloned_output_idxs,
     FunctionID,
     log_cudagraph_skip_and_bump_counter,
     log_data_ptr_mismatch,
@@ -506,6 +508,8 @@ def cudagraphify(
     placeholders: tuple[PlaceholderInfo, ...] = (),
     mutated_input_idxs: tuple[int, ...] = (),
     compile_id: CompileId | None = None,
+    cloned_output_idxs: tuple[int, ...] = (),
+    copy_input_idxs: tuple[int, ...] = (),
 ) -> tuple[ModelType, OutputType]:
     assert not (is_backward and is_inference)
     mode = (
@@ -527,6 +531,8 @@ def cudagraphify(
         placeholders,
         mutated_input_idxs,
         compile_id,
+        cloned_output_idxs,
+        copy_input_idxs,
     )
 
 
@@ -671,6 +677,24 @@ def map_to_ref(t: Tensor | None) -> StorageWeakRefWrapper | None:
     return StorageWeakRefWrapper(t)
 
 
+def _input_idx_aliases_any(idx: int, inputs: list[InputType]) -> bool:
+    inp = inputs[idx]
+    if not isinstance(inp, torch.Tensor) or not torch._C._has_storage(inp):
+        return False
+
+    storage_cdata = inp.untyped_storage()._cdata
+    for other_idx, other in enumerate(inputs):
+        if other_idx == idx:
+            continue
+        if (
+            isinstance(other, torch.Tensor)
+            and torch._C._has_storage(other)
+            and other.untyped_storage()._cdata == storage_cdata
+        ):
+            return True
+    return False
+
+
 # A path index of (depth, offset) indices into a graph that is `depth`` number of nodes from the root
 # at graph output offset
 PathOutputIndex = tuple[int, int]
@@ -726,6 +750,7 @@ class CUDAWarmupNode:
         self.id = id
 
     def run(self, new_inputs: Any) -> OutputType:
+        """Run one eager warmup invocation in the cudagraph memory pool."""
         assert not self.has_run, "Wrapped function should never be run twice"
 
         # See: output_is_alias_of_persistent_static_inputs below. We should only be returning freshly created
@@ -777,8 +802,12 @@ class CUDAWarmupNode:
 
         assert len(new_inputs) == 0
 
-        # sdpa returns cpu tensors when not recording cuda graph
-        def add_ref(o: Any) -> bool:
+        cloned_output_idxs = expand_cloned_output_idxs(
+            out, self.wrapped_function.cloned_output_idxs
+        )
+
+        def allocated_in_pool(o: Any) -> bool:
+            # sdpa returns cpu tensors when not recording cuda graph
             return (
                 isinstance(o, torch.Tensor)
                 and o.is_cuda
@@ -787,17 +816,22 @@ class CUDAWarmupNode:
             )
 
         self.outputs_weakrefs.extend(
-            [map_to_ref(o) if add_ref(o) else None for o in out]
+            [map_to_ref(o) if allocated_in_pool(o) else None for o in out]
         )
         self.tensor_weakrefs.extend(
-            [TensorWeakRef(o) if add_ref(o) else None for o in out]
+            [TensorWeakRef(o) if allocated_in_pool(o) else None for o in out]
         )
 
         if config.triton.slow_path_cudagraph_asserts and not self.already_warm:
-            out_refs = list(self.path_live_weakrefs())
-            check_memory_pool(self.device_index, self.cuda_graphs_pool, out_refs)
+            check_memory_pool(
+                self.device_index,
+                self.cuda_graphs_pool,
+                list(self.path_live_weakrefs()),
+            )
 
-        return out
+        return cast(
+            OutputType, clone_outputs_preserving_aliases(out, cloned_output_idxs)
+        )
 
     @property
     def _path_from_root(
@@ -923,6 +957,11 @@ class CUDAGraphNode:
         # A single wrapped function may be recorded multiple times if memory patterns or
         # invariants change from one execution to the next
         self.children: dict[FunctionID, list[CUDAGraphNode]] = defaultdict(list)
+
+        # user annotated cloned outputs
+        self.cloned_output_idxs: OrderedSet[int] = OrderedSet(
+            wrapped_function.cloned_output_idxs
+        )
 
         # StorageWeakRef maintains whether the Storage C++ object remains allocated,
         # not whether the corresponding memory has been deallocated. In order
@@ -1133,12 +1172,15 @@ class CUDAGraphNode:
             self.recording_outputs: OutputType | None = self._record(
                 wrapped_function.model, recording_inputs
             )
+        assert self.recording_outputs is not None
+        self.cloned_output_idxs = expand_cloned_output_idxs(
+            self.recording_outputs, self.cloned_output_idxs
+        )
         self.outputs_metadata: OutputList[dict[str, Any] | int | None] = []
 
         # As with inputs, we do not want to keep the outputs permanently alive because that would prevent
         # their memory being reclaimed in subsequent cuda graph recordings. We record the tensor metadata
         # needed to reconstruct instead.
-        assert self.recording_outputs is not None
         for out in self.recording_outputs:
             if isinstance(out, torch.Tensor):
                 self.outputs_metadata.append(
@@ -1202,7 +1244,11 @@ class CUDAGraphNode:
         outputs = self.recording_outputs
         self.recording_outputs = None
         assert outputs is not None
-        return outputs
+
+        return cast(
+            OutputType,
+            clone_outputs_preserving_aliases(outputs, self.cloned_output_idxs),
+        )
 
     def run(self, new_inputs: list[InputType]) -> OutputType:
         self.check_static_inputs_are_stable(new_inputs)
@@ -1278,10 +1324,13 @@ class CUDAGraphNode:
 
             outputs.append(out)
             w = self.outputs_weakrefs[i]
-            assert w is not None
-            w.swap_weakref(out.untyped_storage()._weak_ref())
+            if w is not None:
+                w.swap_weakref(out.untyped_storage()._weak_ref())
 
-        return outputs
+        return cast(
+            OutputType,
+            clone_outputs_preserving_aliases(outputs, self.cloned_output_idxs),
+        )
 
     def prepare_alias_info_for_tensor_construction(
         self,
@@ -1386,6 +1435,10 @@ class CUDAGraphNode:
         if not isinstance(static_outputs, (list, tuple)):
             static_outputs = (static_outputs,)
 
+        self.cloned_output_idxs = expand_cloned_output_idxs(
+            static_outputs, self.cloned_output_idxs
+        )
+
         # pyrefly: ignore [bad-argument-type]
         self._add_first_outputs(static_outputs, static_input_persistent_storage_ptrs)
 
@@ -1460,6 +1513,10 @@ class CUDAGraphNode:
             self.output_storage_alias.append(UnaliasedStorage)
             self.unaliased_in_all_paths[i] = True
 
+        for i in self.cloned_output_idxs:
+            if i < len(self.unaliased_in_all_paths):
+                self.unaliased_in_all_paths[i] = False
+
         if self.stack_traces is None:
             self.stack_traces = [None for _ in range(len(outputs))]
         else:
@@ -1468,7 +1525,9 @@ class CUDAGraphNode:
             )
 
         assert not self.outputs_weakrefs
-        for out, static_output_tensor in zip(outputs, self.static_output_tensors):
+        for idx, (out, static_output_tensor) in enumerate(
+            zip(outputs, self.static_output_tensors)
+        ):
             if not isinstance(out, torch.Tensor) or static_output_tensor is not None:
                 self.outputs_weakrefs.append(None)
                 self.tensor_weakrefs.append(None)
@@ -1514,6 +1573,10 @@ class CUDAGraphNode:
                 self.unaliased_in_all_paths,
             )
         ):
+            if i in self.cloned_output_idxs:
+                self.cached_tensor_outputs.append(None)
+                continue
+
             if not make_cached:
                 self.cached_tensor_outputs.append(None)
                 continue
@@ -2078,6 +2141,7 @@ class CUDAGraphTreeManager:
 
         # warn only once if a function mutates inputs
         self.warned_mutation: OrderedSet[FunctionID] = OrderedSet()
+        self.warned_copy_input_alias: OrderedSet[FunctionID] = OrderedSet()
 
         # NB: cuda caching allocator will remember the stream a segment is allocated to
         # and only allocate that segment to the same stream. we need to use a single stream
@@ -2233,6 +2297,22 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
+    def _explicit_copy_input_aliases_any(
+        self, function_id: FunctionID, inputs: list[InputType]
+    ) -> bool:
+        return any(
+            _input_idx_aliases_any(idx, inputs)
+            for idx in self.ids_to_funcs[function_id].copy_input_idxs
+        )
+
+    def _maybe_warn_copy_input_alias(self, function_id: FunctionID) -> None:
+        if function_id in self.warned_copy_input_alias:
+            return
+        self.warned_copy_input_alias.add(function_id)
+        log_cudagraph_skip_and_bump_counter(
+            "skipping cudagraph due to explicit copy of aliased input"
+        )
+
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
         # we dont want to do unnecessary checking of the existing outputs
@@ -2247,6 +2327,10 @@ class CUDAGraphTreeManager:
         node_id = self._get_node_id()
         if function_id not in self.non_cudagraph_managed_mutation_hint[node_id]:
             self._update_non_cudagraph_managed_mutation(function_id, new_inputs)
+
+        if self._explicit_copy_input_aliases_any(function_id, new_inputs):
+            self._maybe_warn_copy_input_alias(function_id)
+            return self.ids_to_funcs[function_id].model(new_inputs)
 
         # Early exit if the function mutates inputs which are neither parameters/buffers nor
         # cudagraph recorded tensors. This check should happen after `try_end_curr_recording`
@@ -2496,6 +2580,8 @@ class CUDAGraphTreeManager:
         placeholders: tuple[PlaceholderInfo, ...],
         mutated_input_idxs: tuple[int, ...],
         compile_id: CompileId | None,
+        cloned_output_idxs: tuple[int, ...],
+        copy_input_idxs: tuple[int, ...],
     ) -> tuple[
         ModelType,
         OutputType,
@@ -2509,6 +2595,8 @@ class CUDAGraphTreeManager:
             tuple(t for t in constants if isinstance(t, torch.Tensor) and t.is_cuda),
             placeholders,
             mutated_input_idxs,
+            cloned_output_idxs,
+            copy_input_idxs,
         )
         self.id_to_mode[id] = mode
         self.id_to_compile_id[id] = compile_id

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from typing import Any, TYPE_CHECKING, TypeVar
 
@@ -16,7 +16,7 @@ from .utils import is_using_cudagraph_partition
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence, Set as AbstractSet
+    from collections.abc import Set as AbstractSet
 
     from torch._inductor.output_code import OutputCode
 
@@ -171,6 +171,8 @@ class WrappedFunction:
     constants: tuple[torch.Tensor, ...]
     placeholders: Sequence[PlaceholderInfo]
     mutated_input_idxs: Sequence[int]
+    cloned_output_idxs: Sequence[int]
+    copy_input_idxs: Sequence[int] = ()
 
 
 def get_mutating_use_stack_trace_from_node(
@@ -541,6 +543,8 @@ class CudagraphMetadata:
     mutated_input_idxs: OrderedSet[int]
     stack_traces: list[str | None]
     constants: dict[str, torch.Tensor]
+    cloned_output_idxs: OrderedSet[int]
+    copy_input_idxs: OrderedSet[int]
 
 
 def get_partition_cudagraph_metadata(
@@ -556,6 +560,7 @@ def get_partition_cudagraph_metadata(
     partition_placeholders = []
     partition_static_input_idxs: OrderedSet[int] = OrderedSet()
     partition_mutated_input_idxs: OrderedSet[int] = OrderedSet()
+    partition_copy_input_idxs: OrderedSet[int] = OrderedSet()
     for partition_input_idx, graph_input_idx in enumerate(
         partition_map.input_index_mapping
     ):
@@ -564,6 +569,9 @@ def get_partition_cudagraph_metadata(
 
         if graph_input_idx in metadata.mutated_input_idxs:
             partition_mutated_input_idxs.add(partition_input_idx)
+
+        if graph_input_idx in metadata.copy_input_idxs:
+            partition_copy_input_idxs.add(partition_input_idx)
 
         if graph_input_idx is not None:
             placeholder = metadata.placeholders[graph_input_idx]
@@ -578,9 +586,12 @@ def get_partition_cudagraph_metadata(
         partition_placeholders.append(placeholder)
 
     partition_stack_traces = []
-    for graph_output_idx in partition_map.output_index_mapping:
+    partition_cloned_idxs: OrderedSet[int] = OrderedSet()
+    for i, graph_output_idx in enumerate(partition_map.output_index_mapping):
         if graph_output_idx is not None:
             partition_stack_traces.append(metadata.stack_traces[graph_output_idx])
+            if graph_output_idx in metadata.cloned_output_idxs:
+                partition_cloned_idxs.add(i)
         else:
             partition_stack_traces.append(None)
 
@@ -594,7 +605,86 @@ def get_partition_cudagraph_metadata(
         partition_mutated_input_idxs,
         partition_stack_traces,
         partition_constants,
+        partition_cloned_idxs,
+        partition_copy_input_idxs,
     )
+
+
+def expand_cloned_output_idxs(
+    outputs: Sequence[object],
+    cloned_output_idxs: Iterable[int],
+) -> OrderedSet[int]:
+    """
+    Promote cloned outputs to whole returned-storage alias groups.
+
+    If one returned view is cloned out of cudagraph memory, all returned tensors
+    sharing that storage must be cloned from the same storage copy to preserve
+    output-output aliasing.
+    """
+    cloned_storages = OrderedSet[int]()
+    for idx in cloned_output_idxs:
+        if idx >= len(outputs):
+            continue
+        output = outputs[idx]
+        if isinstance(output, torch.Tensor) and torch._C._has_storage(output):
+            cloned_storages.add(output.untyped_storage()._cdata)
+
+    expanded = OrderedSet[int]()
+    if not cloned_storages:
+        return expanded
+
+    for idx, output in enumerate(outputs):
+        if (
+            isinstance(output, torch.Tensor)
+            and torch._C._has_storage(output)
+            and output.untyped_storage()._cdata in cloned_storages
+        ):
+            expanded.add(idx)
+    return expanded
+
+
+def _tensor_metadata_for_cudagraph_alias_clone(x: torch.Tensor) -> dict[str, object]:
+    return {
+        "nbytes": x.untyped_storage().nbytes(),
+        "data_ptr": x.untyped_storage().data_ptr(),
+        "size": x.shape,
+        "stride": x.stride(),
+        "dtype": x.dtype,
+        "device": x.device,
+        "storage_offset": x.storage_offset(),
+    }
+
+
+def clone_outputs_preserving_aliases(
+    outputs: Sequence[object],
+    cloned_output_idxs: Iterable[int],
+) -> Sequence[object]:
+    expanded_idxs = expand_cloned_output_idxs(outputs, cloned_output_idxs)
+    if not expanded_idxs:
+        return outputs
+
+    result = list(outputs)
+    cloned_storages: dict[int, torch.UntypedStorage] = {}
+    for idx in expanded_idxs:
+        output = outputs[idx]
+        assert isinstance(output, torch.Tensor)
+        storage = output.untyped_storage()
+        storage_cdata = storage._cdata
+        if storage_cdata not in cloned_storages:
+            nbytes = storage.nbytes()
+            storage_copy = torch.empty(
+                (nbytes,), dtype=torch.uint8, device=output.device
+            ).untyped_storage()
+            if nbytes:
+                storage_copy[:nbytes].copy_(storage[:nbytes])
+            cloned_storages[storage_cdata] = storage_copy
+
+        result[idx] = torch._C._construct_CUDA_Tensor_From_Storage_And_Metadata(
+            _tensor_metadata_for_cudagraph_alias_clone(output),
+            cloned_storages[storage_cdata],  # type: ignore[arg-type]
+        )
+
+    return tuple(result) if isinstance(outputs, tuple) else result
 
 
 def collect_cuda_data_ptrs(obj: object) -> OrderedSet[int]:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -428,6 +428,8 @@ class GraphLowering(torch.fx.Interpreter):
         # as_strided storage offsets are relative to the input's storage.
         self.graph_input_storage_offsets: dict[str, Expr] = {}
         self.partition_maps: list[GraphPartitionMap] | None = None
+        self.cudagraph_cloned_bufs: OrderedSet[str] = OrderedSet()
+        self.cudagraph_copy_input_idxs: OrderedSet[int] = OrderedSet()
         self.zero_dim_cpu_tensor_list: OrderedSet[str] = OrderedSet()
         self.device_types: OrderedSet[str] = (
             const_module.device_types if const_module else OrderedSet()
@@ -1630,6 +1632,10 @@ class GraphLowering(torch.fx.Interpreter):
             for x in result
         ), result
 
+        n_meta = V.graph.current_node.meta
+        self.cudagraph_copy_input_idxs.update(
+            n_meta.get("cudagraph_copy_input_idxs", ())
+        )
         fx_node_args = V.graph.current_node.args[0]  # type: ignore[arg-type]
         if not isinstance(fx_node_args, (tuple, list)):
             # nested subgraphs can have singleton outputs
@@ -1638,7 +1644,7 @@ class GraphLowering(torch.fx.Interpreter):
         result_correct_strides = []
 
         assert len(fx_node_args) == len(result)
-        for r, fx_node in zip(result, fx_node_args):
+        for i, (r, fx_node) in enumerate(zip(result, fx_node_args)):
             if not isinstance(r, (ir.TensorBox, ir.BaseView)):
                 result_correct_strides.append(r)
             elif isinstance(r.get_output_spec(), ir.CommBufferLayout):
@@ -1659,6 +1665,8 @@ class GraphLowering(torch.fx.Interpreter):
                 result_correct_strides.append(
                     ir.try_match_insignificant_strides(r, meta_strides)
                 )
+            if i in n_meta.get("cloned_idxs", ()):
+                self.cudagraph_cloned_bufs.add(result_correct_strides[-1].get_name())
 
         self.graph_outputs = result_correct_strides
         value: ir.IRNode

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -152,6 +152,25 @@ def copy_strided_storage_(dst: torch.Tensor, src: torch.Tensor) -> None:
     )
 
 
+def _has_aliased_cudagraph_copy_input(
+    copy_input_idxs: OrderedSet[int],
+    example_inputs: Sequence[InputType],
+) -> bool:
+    if not copy_input_idxs:
+        return False
+
+    storage_to_idxs: dict[int, list[int]] = {}
+    for idx, inp in enumerate(example_inputs):
+        if isinstance(inp, torch.Tensor) and torch._C._has_storage(inp):
+            storage_to_idxs.setdefault(inp.untyped_storage()._cdata, []).append(idx)
+
+    return any(
+        len(storage_to_idxs.get(inp.untyped_storage()._cdata, ())) > 1
+        for idx, inp in enumerate(example_inputs)
+        if idx in copy_input_idxs and isinstance(inp, torch.Tensor)
+    )
+
+
 def maybe_handle_backward_generation(
     compiled_graph: CompiledFxGraph,
     boxed_forward_device_index: BoxedDeviceIndex | None,
@@ -227,7 +246,12 @@ def cudagraph_post_compile(
 
     if not cudagraph_fail_reasons:
         fx_kwargs = compiled_graph.fx_kwargs
-        static_input_idxs = fx_kwargs["static_input_idxs"]
+        static_input_idxs = OrderedSet(fx_kwargs["static_input_idxs"] or ())
+        static_input_idxs = OrderedSet(
+            i
+            for i in static_input_idxs
+            if i not in compiled_graph.cudagraph_copy_input_idxs
+        )
 
         placeholders = cached_info.placeholders
         stack_traces = cached_info.stack_traces
@@ -255,6 +279,8 @@ def cudagraph_post_compile(
             constants=tuple(tensor_constants.values()),
             placeholders=placeholders,
             mutated_input_idxs=tuple(compiled_graph.mutated_input_idxs),
+            cloned_output_idxs=tuple(compiled_graph.cudagraph_cloned_idxs),
+            copy_input_idxs=tuple(compiled_graph.cudagraph_copy_input_idxs),
         )
 
         policy = config.cudagraph_policy
@@ -262,7 +288,7 @@ def cudagraph_post_compile(
             compiled_graph.current_callable = policy.cudagraphify(
                 current_callable,
                 example_inputs,
-                static_input_idxs or (),
+                tuple(static_input_idxs),
                 **cudagraphify_kwargs,
             )
         else:
@@ -270,7 +296,7 @@ def cudagraph_post_compile(
 
             compiled_graph.current_callable = cudagraphify(
                 current_callable,
-                static_input_idxs=static_input_idxs or (),
+                static_input_idxs=tuple(static_input_idxs),
                 **cudagraphify_kwargs,
             )
 
@@ -348,6 +374,8 @@ def cudagraph_partition_post_compile(
         mutated_input_idxs,
         compiled_graph.cudagraph_info.stack_traces,
         tensor_constants,
+        compiled_graph.cudagraph_cloned_idxs,
+        compiled_graph.cudagraph_copy_input_idxs,
     )
 
     prepare_cudagraph_post_compile(
@@ -366,9 +394,14 @@ def cudagraph_partition_post_compile(
             graph_metadata,
         )
 
+        partition_static_input_idxs = OrderedSet(
+            i
+            for i in partition_metadata.static_input_idxs
+            if i not in partition_metadata.copy_input_idxs
+        )
         cudagraphify_fn = partial(
             cudagraphify,
-            static_input_idxs=tuple(partition_metadata.static_input_idxs),
+            static_input_idxs=tuple(partition_static_input_idxs),
             device_index=device_index,
             stack_traces=partition_metadata.stack_traces,
             is_backward=is_backward,
@@ -376,6 +409,8 @@ def cudagraph_partition_post_compile(
             constants=tuple(partition_metadata.constants.values()),
             placeholders=partition_metadata.placeholders,
             mutated_input_idxs=tuple(partition_metadata.mutated_input_idxs),
+            cloned_output_idxs=tuple(partition_metadata.cloned_output_idxs),
+            copy_input_idxs=tuple(partition_metadata.copy_input_idxs),
         )
         cudagraphify_fns.append(cudagraphify_fn)
 
@@ -561,6 +596,16 @@ class CompiledFxGraph(OutputCode):
         self.device_idxs = OrderedSet(graph.device_idxs)
         self.mutated_inputs = OrderedSet(graph.mutated_inputs)
         self.mutated_input_idxs = OrderedSet(graph.mutated_input_idxs)
+        cloned_bufs = getattr(graph, "cudagraph_cloned_bufs", OrderedSet())
+        self.cudagraph_cloned_idxs: OrderedSet[int] = OrderedSet()
+        if cloned_bufs:
+            output_names = graph.get_output_names()
+            for i, name in enumerate(output_names):
+                if name in cloned_bufs:
+                    self.cudagraph_cloned_idxs.add(i)
+        self.cudagraph_copy_input_idxs: OrderedSet[int] = OrderedSet(
+            getattr(graph, "cudagraph_copy_input_idxs", OrderedSet())
+        )
 
         # We store the constant attributes in the cache entry and re-attach them
         # to the module created in PyCodeCache.load_by_key_path. In the case that
@@ -636,9 +681,19 @@ class CompiledFxGraph(OutputCode):
                 if storage_mutation_reason is not None:
                     self.disabled_cudagraphs_reason = storage_mutation_reason
 
+                copy_input_mutation = any(
+                    idx in self.mutated_input_idxs
+                    for idx in self.cudagraph_copy_input_idxs
+                )
+                copy_input_alias = _has_aliased_cudagraph_copy_input(
+                    self.cudagraph_copy_input_idxs, example_inputs
+                )
+
                 cudagraph_tests = [
                     (storage_mutation_reason is None, "input storage mutation"),
                     (not has_mutation, "mutated inputs"),
+                    (not copy_input_mutation, "explicit copy of mutated input"),
+                    (not copy_input_alias, "explicit copy of aliased input"),
                     (
                         not config.force_disable_cudagraph_TESTING_ONLY,
                         "force_disable_cudagraph_TESTING_ONLY",

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -26,6 +26,8 @@ __all__ = [
     "set_stance",
     "set_enable_guard_collectives",
     "cudagraph_mark_step_begin",
+    "cudagraph_mark_output_clone",
+    "cudagraph_mark_input_copy",
     "load_compiled_function",
     "wrap_numpy",
     "is_compiling",
@@ -435,6 +437,44 @@ def cudagraph_mark_step_begin():
     from torch._inductor import cudagraph_trees
 
     cudagraph_trees.mark_step_begin()
+
+
+def cudagraph_mark_output_clone(tensor: torch.Tensor) -> None:
+    """
+    Mark a tensor output to be cloned out of CUDA graph managed memory.
+
+    The marker is only interpreted by ``torch.compile`` with CUDA graphs
+    enabled. It preserves eager behavior, and the marker itself returns
+    ``None``. If the marked tensor is returned from the compiled graph, the
+    compiled runtime returns a fresh clone instead of returning a tensor backed
+    by CUDA graph private-pool memory.
+
+    If multiple returned tensors alias the same storage as the marked tensor,
+    they are cloned as one alias group so output-output aliasing is preserved.
+    """
+    from torch._inductor import cudagraph_prims
+
+    torch.ops.aten_cudagraphs.exclude_from_cudagraphs(tensor, clone=True)
+
+
+def cudagraph_mark_input_copy(tensor: torch.Tensor) -> None:
+    """
+    Mark a tensor input to be copied into CUDA graph managed memory.
+
+    The marker is only interpreted by ``torch.compile`` with CUDA graphs
+    enabled. It preserves eager behavior, and the marker itself returns
+    ``None``. When the marked tensor corresponds to a graph input that would
+    otherwise be treated as static-address input, the compiled runtime copies
+    it into CUDA graph managed memory for replay instead of requiring the input
+    address to remain stable.
+
+    Marked inputs that are mutated or alias another graph input are not captured
+    with copy semantics, because copying would change user-visible aliasing or
+    mutation behavior.
+    """
+    from torch._inductor import cudagraph_prims
+
+    torch.ops.aten_cudagraphs.copy_to_cudagraphs(tensor)
 
 
 def wrap_numpy(fn):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -67,9 +67,11 @@ from torch.fx.node import (
     Argument,
     Target,
 )
+from torch.fx.operator_schemas import normalize_function
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.nn import Module
 from torch.overrides import TorchFunctionMode
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import (
     _disable_infra_mode,
     _push_mode,
@@ -1660,6 +1662,100 @@ def _make_temp_remove_mode_context_manager(
     return context_manager_fn
 
 
+def _get_cudagraph_op(name: str) -> Any | None:
+    return getattr(
+        getattr(torch.ops, "aten_cudagraphs", None),
+        name,
+        None,
+    )
+
+
+def _normalize_cudagraph_marker_kwargs(op: torch.fx.Node) -> dict[str, Any]:
+    target = typing.cast(Callable[..., Any], op.target)
+    normalized = normalize_function(
+        target, args=op.args, kwargs=op.kwargs, normalize_to_only_use_kwargs=True
+    )
+    if normalized is None:
+        raise RuntimeError(f"Unable to normalize cudagraph marker {op.target}")
+    _, new_kwargs = normalized
+    return new_kwargs
+
+
+def mark_cudagraph_meta(graph: torch.fx.Graph) -> None:
+    exclude_op = _get_cudagraph_op("exclude_from_cudagraphs")
+    copy_op = _get_cudagraph_op("copy_to_cudagraphs")
+
+    output_clone_markers = (
+        []
+        if exclude_op is None
+        else graph.find_nodes(
+            op="call_function",
+            target=exclude_op.default,
+        )
+    )
+    input_copy_markers = (
+        []
+        if copy_op is None
+        else graph.find_nodes(
+            op="call_function",
+            target=copy_op.default,
+        )
+    )
+    cudagraph_markers = output_clone_markers + input_copy_markers
+    if not cudagraph_markers:
+        return
+
+    from torch._inductor.fx_utils import get_node_storage
+
+    cloned_metas = OrderedSet()
+    copy_input_storages = OrderedSet()
+
+    for op in output_clone_markers:
+        new_kwargs = _normalize_cudagraph_marker_kwargs(op)
+        storage = get_node_storage(new_kwargs["inp"])
+        if storage is None:
+            continue
+
+        if new_kwargs["clone"]:
+            cloned_metas.add(storage)
+
+    for op in input_copy_markers:
+        new_kwargs = _normalize_cudagraph_marker_kwargs(op)
+        storage = get_node_storage(new_kwargs["inp"])
+        if storage is not None:
+            copy_input_storages.add(storage)
+
+    output_nodes = graph.find_nodes(op="output")
+    torch._check(len(output_nodes) == 1)
+
+    output_args = output_nodes[0].args[0]
+    if not isinstance(output_args, (tuple, list)):
+        output_args = (output_args,)
+
+    cloned_idxs: OrderedSet[int] = OrderedSet()
+    copy_input_idxs: OrderedSet[int] = OrderedSet()
+
+    for i, inp in enumerate(output_args):
+        if not isinstance(inp, torch.fx.Node):
+            continue
+        stor = get_node_storage(inp)
+        if stor in cloned_metas:
+            cloned_idxs.add(i)
+
+    for i, placeholder in enumerate(graph.find_nodes(op="placeholder")):
+        storage = get_node_storage(placeholder)
+        if storage in copy_input_storages:
+            copy_input_idxs.add(i)
+
+    if cloned_idxs:
+        output_nodes[0].meta["cloned_idxs"] = cloned_idxs
+    if copy_input_idxs:
+        output_nodes[0].meta["cudagraph_copy_input_idxs"] = copy_input_idxs
+
+    for n in cudagraph_markers:
+        n.graph.erase_node(n)
+
+
 @torch._disable_dynamo
 def dispatch_trace(
     root: Module | Callable[..., Any],
@@ -1697,6 +1793,7 @@ def dispatch_trace(
         # No idea, just assume it's not OK
         return True
 
+    mark_cudagraph_meta(graph)
     graph.eliminate_dead_code(impure_pred)
     from torch._inductor.fx_passes.dedupe_symint_uses import dedupe_symints
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186831
* #186830
* #186829
* __->__ #186828

Add explicit torch.compiler annotations for CUDA graph output cloning and input copy semantics, then thread the metadata through AOTAutograd, FX cache hashing, Inductor output code, and CUDA graph trees. Output clone preserves output alias groups while keeping the original private-pool outputs tracked for allocator liveness, and explicit input copy falls back safely when an annotated input aliases another input or is mutated.

The review order is: public APIs and marker prims, AOT/proxy metadata propagation, Inductor runtime handling, then tests and docs.

Test Plan:
```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_explicit_copy_static_input_no_rerecord CudaGraphTreeTests.test_explicit_copy_aliased_input_falls_back CudaGraphTreeTests.test_cloned_output_compile CudaGraphTreeTests.test_cloned_output_shutdown CudaGraphTreeTests.test_cloned_output_checkpoint_tracks_original_output CudaGraphTreeTests.test_cloned_output_preserves_output_aliasing CudaGraphTreeTests.test_cloned_output_with_cpu_partition TestMarkOutputsMeta.test_no_annotation TestMarkOutputsMeta.test_clone_annotation TestMarkOutputsMeta.test_clone_annotation_view_alias_group TestMarkOutputsMeta.test_single_output TestMarkOutputsMeta.test_input_copy_annotation -q
```

```bash
lintrunner -a
```

`lintrunner -a` reported pyrefly failures in unrelated files: `torch/_inductor/codegen/triton.py`, `torch/export/pt2_archive/_package.py`, and `torch/nn/modules/loss.py`.

Authored with an AI assistant.