### PR TITLE
Auto-promote CUDA graph static input copies

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1277,6 +1277,62 @@ if HAS_CUDA_AND_TRITON:
             (actual,) = foo_cg([base, base])
             self.assertEqual(actual, expected)
 
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        @torch._inductor.config.patch(
+            "triton.cudagraph_static_input_auto_copy_threshold", 1
+        )
+        def test_auto_copy_static_input_after_address_churn(self):
+            def fn(x, y):
+                return (x + y,)
+
+            def new_inputs():
+                return [
+                    torch.rand([5, 5], device="cuda"),
+                    torch.rand([5, 5], device="cuda"),
+                ]
+
+            inps = new_inputs()
+            mod = make_fx(fn)(*inps)
+            compiled_f = compile_fx_inner(
+                mod, inps, static_input_idxs=[0], cudagraphs=True
+            )
+
+            for _ in range(3):
+                inps = new_inputs()
+                expected = fn(*inps)
+                actual = compiled_f(list(inps))
+                self.assertEqual(actual, expected)
+                del actual, expected
+
+            self.assertEqual(self.get_manager().new_graph_id().id, 2)
+
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        @torch._inductor.config.patch(
+            "triton.cudagraph_static_input_auto_copy_threshold", 1
+        )
+        def test_auto_copy_aliased_input_falls_back(self):
+            def fn(x, y):
+                return (x + y,)
+
+            def new_inputs():
+                return [
+                    torch.rand([5, 5], device="cuda"),
+                    torch.rand([5, 5], device="cuda"),
+                ]
+
+            inps = new_inputs()
+            mod = make_fx(fn)(*inps)
+            compiled_f = compile_fx_inner(
+                mod, inps, static_input_idxs=[0], cudagraphs=True
+            )
+
+            inps = new_inputs()
+            self.assertEqual(compiled_f(list(inps)), fn(*inps))
+
+            base = torch.rand([5, 5], device="cuda")
+            self.assertEqual(compiled_f([base, base]), fn(base, base))
+            self.assertEqual(self.get_manager().new_graph_id().id, 2)
+
         @torch._inductor.config.patch("graph_partition", True)
         @torch._inductor.config.patch("implicit_fallbacks", True)
         def test_graph_partition_custom_rule(self):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1833,6 +1833,11 @@ class triton:
     # note: we are conservative here and choose a large limit.
     cudagraph_unexpected_rerecord_limit = 128
 
+    # Number of observed static-input address changes for the same
+    # cudagraph parent/function/input before treating that input as copied
+    # for future recordings. Set to None to disable.
+    cudagraph_static_input_auto_copy_threshold: int | None = None
+
     # Warn loudly when the number of cudagraphs due to dynamic shape
     # exceeds this limit
     cudagraph_dynamic_shape_warn_limit: int | None = 8

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -962,6 +962,9 @@ class CUDAGraphNode:
         self.cloned_output_idxs: OrderedSet[int] = OrderedSet(
             wrapped_function.cloned_output_idxs
         )
+        self.auto_copy_input_idxs: OrderedSet[int] = OrderedSet(
+            wrapped_function.auto_copy_input_idxs
+        )
 
         # StorageWeakRef maintains whether the Storage C++ object remains allocated,
         # not whether the corresponding memory has been deallocated. In order
@@ -1233,6 +1236,19 @@ class CUDAGraphNode:
                 CheckInvariantStatus.StaticInputIdxMismatch,
             )
             torch._check(False, lambda: error_msg)
+
+    def static_input_data_ptr_mismatch_idxs(
+        self, new_inputs: list[InputType]
+    ) -> OrderedSet[int]:
+        mismatch_idxs: OrderedSet[int] = OrderedSet()
+        for idx in self.non_managed_static_input_idxs:
+            inp = new_inputs[idx]
+            if (
+                isinstance(inp, torch.Tensor)
+                and inp.data_ptr() != self.static_input_data_ptrs[idx]
+            ):
+                mismatch_idxs.add(idx)
+        return mismatch_idxs
 
     def run_first_inputs(self, new_inputs: list[InputType]) -> OutputType:
         if config.triton.fast_path_cudagraph_asserts:
@@ -1882,6 +1898,15 @@ class CUDAGraphNode:
             self.static_input_data_ptrs,
         )
 
+        if any(
+            _input_idx_aliases_any(idx, inputs) for idx in self.auto_copy_input_idxs
+        ):
+            status = CheckInvariantStatus.StaticInputIdxMismatch
+            return (
+                status,
+                lambda: "auto-copied static input aliases another graph input",
+            )
+
         # previously managed data pointers remain stable
         # this is on the hot path so moved to C++. equivalent to:
         # return all(t.data_ptr() == data_ptr for (t, data_ptr) in zip(tensors, data_ptrs))
@@ -2142,6 +2167,7 @@ class CUDAGraphTreeManager:
         # warn only once if a function mutates inputs
         self.warned_mutation: OrderedSet[FunctionID] = OrderedSet()
         self.warned_copy_input_alias: OrderedSet[FunctionID] = OrderedSet()
+        self.warned_auto_copy_input_alias: OrderedSet[FunctionID] = OrderedSet()
 
         # NB: cuda caching allocator will remember the stream a segment is allocated to
         # and only allocate that segment to the same stream. we need to use a single stream
@@ -2184,6 +2210,13 @@ class CUDAGraphTreeManager:
         self.num_rerecord: dict[GraphID | None, dict[FunctionID, int]] = defaultdict(
             lambda: defaultdict(lambda: 0)
         )
+
+        self.static_input_data_ptr_mismatch_counts: defaultdict[
+            GraphID | None, defaultdict[FunctionID, defaultdict[int, int]]
+        ] = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: 0)))
+        self.promoted_static_input_copy_idxs: dict[
+            GraphID | None, dict[FunctionID, OrderedSet[int]]
+        ] = defaultdict(lambda: defaultdict(OrderedSet))
 
         # whether we the current node is in a state of warmup, recording, execution. If
         # there is no current node the state will be ExecutionState.None.
@@ -2313,6 +2346,101 @@ class CUDAGraphTreeManager:
             "skipping cudagraph due to explicit copy of aliased input"
         )
 
+    def _auto_copy_input_aliases_any(
+        self, node_id: GraphID | None, function_id: FunctionID, inputs: list[InputType]
+    ) -> bool:
+        return any(
+            _input_idx_aliases_any(idx, inputs)
+            for idx in self.promoted_static_input_copy_idxs[node_id][function_id]
+        )
+
+    def _maybe_warn_auto_copy_input_alias(self, function_id: FunctionID) -> None:
+        if function_id in self.warned_auto_copy_input_alias:
+            return
+        self.warned_auto_copy_input_alias.add(function_id)
+        log_cudagraph_skip_and_bump_counter(
+            "skipping cudagraph due to auto copy of aliased input"
+        )
+
+    def _static_input_auto_copy_threshold(self) -> int | None:
+        threshold = config.triton.cudagraph_static_input_auto_copy_threshold
+        if threshold is None or threshold <= 0:
+            return None
+        return threshold
+
+    def _promotable_static_input_idxs(
+        self,
+        function_id: FunctionID,
+        input_idxs: OrderedSet[int],
+        inputs: list[InputType],
+    ) -> OrderedSet[int]:
+        mutated_input_idxs = OrderedSet(
+            self.ids_to_funcs[function_id].mutated_input_idxs
+        )
+        return OrderedSet(
+            idx
+            for idx in input_idxs
+            if idx not in mutated_input_idxs
+            and isinstance(inputs[idx], torch.Tensor)
+            and not _input_idx_aliases_any(idx, inputs)
+        )
+
+    def _record_static_input_address_mismatches(
+        self,
+        node_id: GraphID | None,
+        function_id: FunctionID,
+        input_idxs: OrderedSet[int],
+        inputs: list[InputType],
+    ) -> None:
+        threshold = self._static_input_auto_copy_threshold()
+        if threshold is None:
+            return
+
+        counts = self.static_input_data_ptr_mismatch_counts[node_id][function_id]
+        copy_input_idxs = self.promoted_static_input_copy_idxs[node_id][function_id]
+        for idx in self._promotable_static_input_idxs(function_id, input_idxs, inputs):
+            if idx in copy_input_idxs:
+                continue
+            counts[idx] += 1
+            if counts[idx] >= threshold:
+                copy_input_idxs.add(idx)
+                log.debug(
+                    "[%s] Auto-promoting static input %d to copy semantics "
+                    "for function=%s on cudagraph node=%s after %d address changes",
+                    self.compile_id,
+                    idx,
+                    self.get_func_name(function_id),
+                    node_id.id if node_id is not None else None,
+                    counts[idx],
+                )
+
+    def _recording_auto_copy_input_idxs(
+        self, function_id: FunctionID, inputs: list[InputType]
+    ) -> OrderedSet[int]:
+        node_id = self._get_node_id()
+        copy_input_idxs = self.promoted_static_input_copy_idxs[node_id][function_id]
+        if not copy_input_idxs:
+            return OrderedSet()
+        return self._promotable_static_input_idxs(function_id, copy_input_idxs, inputs)
+
+    def _wrapped_function_for_recording(
+        self, function_id: FunctionID, inputs: list[InputType]
+    ) -> WrappedFunction:
+        wrapped_function = self.ids_to_funcs[function_id]
+        copy_input_idxs = self._recording_auto_copy_input_idxs(function_id, inputs)
+        if not copy_input_idxs:
+            return wrapped_function
+
+        return dataclasses.replace(
+            wrapped_function,
+            static_input_idxs=[
+                idx
+                for idx in wrapped_function.static_input_idxs
+                if idx not in copy_input_idxs
+            ],
+            auto_copy_input_idxs=tuple(copy_input_idxs),
+        )
+
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
         # we dont want to do unnecessary checking of the existing outputs
@@ -2330,6 +2458,10 @@ class CUDAGraphTreeManager:
 
         if self._explicit_copy_input_aliases_any(function_id, new_inputs):
             self._maybe_warn_copy_input_alias(function_id)
+            return self.ids_to_funcs[function_id].model(new_inputs)
+
+        if self._auto_copy_input_aliases_any(node_id, function_id, new_inputs):
+            self._maybe_warn_auto_copy_input_alias(function_id)
             return self.ids_to_funcs[function_id].model(new_inputs)
 
         # Early exit if the function mutates inputs which are neither parameters/buffers nor
@@ -2369,6 +2501,8 @@ class CUDAGraphTreeManager:
         )
 
         if not self.in_recording:
+            static_input_mismatch_idxs: OrderedSet[int] = OrderedSet()
+            mismatch_node_id = self._get_node_id()
             unexpected_rerecord = False
             unexpected_rerecord_reason = None
             for child in child_nodes[function_id]:
@@ -2388,6 +2522,10 @@ class CUDAGraphTreeManager:
                     # other mismatch reasons do count.
                     if status != CheckInvariantStatus.StaticInputIdxMismatch:
                         unexpected_rerecord = True
+                    else:
+                        static_input_mismatch_idxs.update(
+                            child.static_input_data_ptr_mismatch_idxs(new_inputs)
+                        )
                     # Only compute detailed reason when debug logging is enabled
                     if log.isEnabledFor(logging.DEBUG):
                         unexpected_rerecord_reason = status_logger()
@@ -2401,6 +2539,14 @@ class CUDAGraphTreeManager:
                     else:
                         # Defer reason computation until needed (for exceed_rerecord_limit)
                         unexpected_rerecord_reason = status_logger
+
+            if static_input_mismatch_idxs:
+                self._record_static_input_address_mismatches(
+                    mismatch_node_id,
+                    function_id,
+                    static_input_mismatch_idxs,
+                    new_inputs,
+                )
 
             # now that we know the new function can't be run as a child of the
             # current node, if it is a root, try to end the current execution.
@@ -2493,8 +2639,11 @@ class CUDAGraphTreeManager:
                 format_inputs_log(new_inputs),
             )
             torch.cuda.synchronize()
+            wrapped_function = self._wrapped_function_for_recording(
+                function_id, new_inputs
+            )
             node = CUDAGraphNode(
-                self.ids_to_funcs[function_id],
+                wrapped_function,
                 graph_id,
                 self.current_node,
                 new_inputs,

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -173,6 +173,7 @@ class WrappedFunction:
     mutated_input_idxs: Sequence[int]
     cloned_output_idxs: Sequence[int]
     copy_input_idxs: Sequence[int] = ()
+    auto_copy_input_idxs: Sequence[int] = ()
 
 
 def get_mutating_use_stack_trace_from_node(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186831
* #186830
* __->__ #186829
* #186828

Add a runtime option that promotes repeatedly changing static input addresses to copy semantics for a CUDA graph function. The tree tracks static-input address churn by function and parent node, records promoted indices into the wrapped function metadata, and falls back when the promoted input aliases another input so we do not enter a rerecord loop.

Test Plan:
```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_auto_copy_static_input_after_address_churn CudaGraphTreeTests.test_auto_copy_aliased_input_falls_back -q
```

```bash
lintrunner -a
```

`lintrunner -a` reported pyrefly failures in unrelated files: `torch/_inductor/codegen/triton.py`, `torch/export/pt2_archive/_package.py`, and `torch/nn/modules/loss.py`.

Authored with an AI assistant.