### PR TITLE
Add CUDA graph disable regions

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -27,6 +27,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      cudagraph_mark_step_begin
      cudagraph_mark_output_clone
      cudagraph_mark_input_copy
+     cudagraph_disable
      is_compiling
      is_dynamo_compiling
      is_exporting

--- a/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
@@ -307,8 +307,13 @@ override the default CUDAGraph handling for specific tensors:
   remain stable. Mutated inputs and inputs that alias another graph input are
   not captured with copy semantics because copying would change user-visible
   behavior.
-These annotations preserve eager behavior and return `None`; they are metadata
-markers consumed by `torch.compile`.
+- `torch.compiler.cudagraph_disable()` disables CUDA graph capture for the
+  operations traced inside the context manager. Without graph partitioning, this
+  skips CUDA graph capture for the compiled function. With graph partitioning,
+  the compiler partitions around the marked region where possible.
+
+These annotations preserve eager behavior; they are metadata markers consumed by
+`torch.compile`.
 
 
 ### Limitations

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -5608,6 +5608,23 @@ if HAS_CUDA_AND_TRITON:
             f_compiled(inp)
             self.assertEqual(out1_y, expected)
 
+        @torch._inductor.config.patch("graph_partition", False)
+        def test_cudagraph_disable_region_skips_capture(self):
+            def foo(x):
+                y = x + 1
+                with torch.compiler.cudagraph_disable():
+                    z = y.sin()
+                    w = z.cos()
+                return w + 1
+
+            inp = torch.randn(4, device="cuda")
+            f_compiled = torch.compile(foo, mode="reduce-overhead")
+
+            for _ in range(3):
+                self.assertEqual(f_compiled(inp), foo(inp))
+
+            self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
+
     class TestCUDAGraphPolicy(TestCase):
         def setUp(self):
             super().setUp()
@@ -6347,6 +6364,54 @@ if torch.cuda.is_available():
 
             for node in gm.graph.nodes:
                 self.assertNotIn("copy_to_cudagraphs", str(node.target))
+
+        def test_cudagraph_disable_region_annotation(self):
+            """cudagraph_disable marks traced nodes inside the region."""
+
+            def f(x):
+                a = x + 1
+                with torch.compiler.cudagraph_disable():
+                    b = a.sin()
+                    c = b.cos()
+                return c + 1
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            unsafe_targets = [
+                node.target
+                for node in gm.graph.nodes
+                if node.meta.get("cudagraph_unsafe", False)
+            ]
+            self.assertEqual(
+                unsafe_targets,
+                [torch.ops.aten.sin.default, torch.ops.aten.cos.default],
+            )
+
+            for node in gm.graph.nodes:
+                self.assertNotIn("disable_cudagraphs", str(node.target))
+
+        def test_cudagraph_disable_region_nested_view(self):
+            """Region annotations cover all traced nodes without view chasing."""
+
+            def f(x):
+                a = x + 1
+                with torch.compiler.cudagraph_disable():
+                    b = a.view(-1)
+                    c = b[1:]
+                    d = c.sin()
+                return d + 1
+
+            gm = make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda"))
+            unsafe_targets = [
+                node.target
+                for node in gm.graph.nodes
+                if node.meta.get("cudagraph_unsafe", False)
+            ]
+            self.assertIn(torch.ops.aten.view.default, unsafe_targets)
+            self.assertIn(torch.ops.aten.slice.Tensor, unsafe_targets)
+            self.assertIn(torch.ops.aten.sin.default, unsafe_targets)
+
+            for node in gm.graph.nodes:
+                self.assertNotIn("disable_cudagraphs", str(node.target))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -194,6 +194,8 @@ manual_torch_name_rule_map: dict[
     "torch.compiler.is_exporting": TorchInGraphFunctionVariable,
     "torch.compiler.cudagraph_mark_output_clone": TorchInGraphFunctionVariable,
     "torch.compiler.cudagraph_mark_input_copy": TorchInGraphFunctionVariable,
+    "torch.compiler.cudagraph_disable#__enter__": UserFunctionVariable,
+    "torch.compiler.cudagraph_disable#__exit__": UserFunctionVariable,
     "torch._dynamo.eval_frame._is_in_optimized_module": TorchInGraphFunctionVariable,
     "torch._C._to_dlpack": SkipFunctionVariable,
     "torch._C._group_tensors_by_device_and_dtype": TorchInGraphFunctionVariable,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1195,22 +1195,29 @@ class FxGraphHashDetails:
     @staticmethod
     def _cudagraph_metadata_for_cache_key(
         gm: torch.fx.GraphModule,
-    ) -> tuple[tuple[str, tuple[tuple[int, ...], tuple[int, ...]]], ...]:
-        metadata: list[tuple[str, tuple[tuple[int, ...], tuple[int, ...]]]] = []
+    ) -> tuple[
+        tuple[str, tuple[tuple[int, ...], tuple[int, ...]], tuple[str, ...]], ...
+    ]:
+        metadata: list[
+            tuple[str, tuple[tuple[int, ...], tuple[int, ...]], tuple[str, ...]]
+        ] = []
         for module_name, module in gm.named_modules():
             if not isinstance(module, torch.fx.GraphModule):
                 continue
 
             output_metadata: tuple[tuple[int, ...], tuple[int, ...]] = ((), ())
+            unsafe_nodes: list[str] = []
             for node in module.graph.nodes:
                 if node.op == "output":
                     output_metadata = (
                         tuple(node.meta.get("cloned_idxs", ())),
                         tuple(node.meta.get("cudagraph_copy_input_idxs", ())),
                     )
+                elif node.meta.get("cudagraph_unsafe", False):
+                    unsafe_nodes.append(node.name)
 
-            if output_metadata != ((), ()):
-                metadata.append((module_name, output_metadata))
+            if output_metadata != ((), ()) or unsafe_nodes:
+                metadata.append((module_name, output_metadata, tuple(unsafe_nodes)))
 
         return tuple(metadata)
 

--- a/torch/_inductor/cudagraph_prims.py
+++ b/torch/_inductor/cudagraph_prims.py
@@ -33,3 +33,27 @@ def copy_to_cudagraphs_fake(
 
 
 copy_to_cudagraphs.register_fake(copy_to_cudagraphs_fake)
+
+
+@torch.library.custom_op("aten_cudagraphs::disable_cudagraphs_begin", mutates_args={})
+def disable_cudagraphs_begin() -> None:
+    return None
+
+
+def disable_cudagraphs_begin_fake() -> None:
+    return None
+
+
+disable_cudagraphs_begin.register_fake(disable_cudagraphs_begin_fake)
+
+
+@torch.library.custom_op("aten_cudagraphs::disable_cudagraphs_end", mutates_args={})
+def disable_cudagraphs_end() -> None:
+    return None
+
+
+def disable_cudagraphs_end_fake() -> None:
+    return None
+
+
+disable_cudagraphs_end.register_fake(disable_cudagraphs_end_fake)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -8560,6 +8560,9 @@ class Scheduler:
 
         assert node.node is not None
 
+        if self._has_cudagraph_unsafe_origin(node):
+            return "user disabled cudagraph capture"
+
         if not node.is_gpu():
             return f"{node.get_device()} ops"
 
@@ -8584,6 +8587,21 @@ class Scheduler:
                 return "dynamic shape ops"
 
         return None
+
+    @staticmethod
+    def _has_cudagraph_unsafe_origin(node: BaseSchedulerNode) -> bool:
+        if node.node is None:
+            return False
+
+        origin_node = node.node.get_origin_node()
+        if origin_node is not None and origin_node.meta.get("cudagraph_unsafe", False):
+            return True
+
+        return any(
+            isinstance(origin, torch.fx.Node)
+            and origin.meta.get("cudagraph_unsafe", False)
+            for origin in node.node.get_origins()
+        )
 
     @cache_on_self
     def _get_cudagraph_unsafe_unbacked_symints(self) -> OrderedSet[sympy.Symbol]:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4293,6 +4293,9 @@ def is_cudagraph_unsafe_fx_node(fx_node: torch.fx.Node) -> bool:
     """
     target = fx_node.target
 
+    if fx_node.meta.get("cudagraph_unsafe", False):
+        return True
+
     # Check against the forbidden ops set
     if str(target) in FORBIDDEN_CUDAGRAPH_OPS:
         return True

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "cudagraph_mark_step_begin",
     "cudagraph_mark_output_clone",
     "cudagraph_mark_input_copy",
+    "cudagraph_disable",
     "load_compiled_function",
     "wrap_numpy",
     "is_compiling",
@@ -475,6 +476,29 @@ def cudagraph_mark_input_copy(tensor: torch.Tensor) -> None:
     from torch._inductor import cudagraph_prims
 
     torch.ops.aten_cudagraphs.copy_to_cudagraphs(tensor)
+
+
+class cudagraph_disable:
+    """
+    Disable CUDA graph capture for a region.
+
+    The marker is only interpreted by ``torch.compile`` with CUDA graphs
+    enabled. It preserves eager behavior. The compiler uses the marker to skip
+    or partition CUDA graph capture around operations traced inside the region.
+
+    This is useful when user code knows a region should not be captured by CUDA
+    graphs but should still otherwise remain in the compiled program.
+    """
+
+    def __enter__(self) -> None:
+        from torch._inductor import cudagraph_prims
+
+        torch.ops.aten_cudagraphs.disable_cudagraphs_begin()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        from torch._inductor import cudagraph_prims
+
+        torch.ops.aten_cudagraphs.disable_cudagraphs_end()
 
 
 def wrap_numpy(fn):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1684,6 +1684,8 @@ def _normalize_cudagraph_marker_kwargs(op: torch.fx.Node) -> dict[str, Any]:
 def mark_cudagraph_meta(graph: torch.fx.Graph) -> None:
     exclude_op = _get_cudagraph_op("exclude_from_cudagraphs")
     copy_op = _get_cudagraph_op("copy_to_cudagraphs")
+    disable_begin_op = _get_cudagraph_op("disable_cudagraphs_begin")
+    disable_end_op = _get_cudagraph_op("disable_cudagraphs_end")
 
     output_clone_markers = (
         []
@@ -1701,7 +1703,28 @@ def mark_cudagraph_meta(graph: torch.fx.Graph) -> None:
             target=copy_op.default,
         )
     )
-    cudagraph_markers = output_clone_markers + input_copy_markers
+    disable_begin_markers = (
+        []
+        if disable_begin_op is None
+        else graph.find_nodes(
+            op="call_function",
+            target=disable_begin_op.default,
+        )
+    )
+    disable_end_markers = (
+        []
+        if disable_end_op is None
+        else graph.find_nodes(
+            op="call_function",
+            target=disable_end_op.default,
+        )
+    )
+    cudagraph_markers = (
+        output_clone_markers
+        + input_copy_markers
+        + disable_begin_markers
+        + disable_end_markers
+    )
     if not cudagraph_markers:
         return
 
@@ -1724,6 +1747,22 @@ def mark_cudagraph_meta(graph: torch.fx.Graph) -> None:
         storage = get_node_storage(new_kwargs["inp"])
         if storage is not None:
             copy_input_storages.add(storage)
+
+    disable_begin_markers_set = set(disable_begin_markers)
+    disable_end_markers_set = set(disable_end_markers)
+    disable_depth = 0
+    for node in graph.nodes:
+        if node in disable_begin_markers_set:
+            disable_depth += 1
+            continue
+        if node in disable_end_markers_set:
+            torch._check(disable_depth > 0, lambda: "unmatched cudagraph disable end")
+            disable_depth -= 1
+            continue
+        if disable_depth and node.op not in ("placeholder", "output"):
+            node.meta["cudagraph_unsafe"] = True
+
+    torch._check(disable_depth == 0, lambda: "unmatched cudagraph disable begin")
 
     output_nodes = graph.find_nodes(op="output")
     torch._check(len(output_nodes) == 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186831
* __->__ #186830
* #186829
* #186828

Add `torch.compiler.cudagraph_disable()` as a metadata-based region annotation. The context manager emits begin/end marker ops during tracing, the proxy-tensor metadata pass marks traced nodes inside the region as cudagraph-unsafe and erases the markers, and Inductor partitions/skips CUDA graph capture for those nodes. The cudagraph metadata is included in the FX graph cache key so marked and unmarked graphs do not collide.

Test Plan:
```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_cudagraph_disable_region_skips_capture TestMarkOutputsMeta.test_cudagraph_disable_region_annotation TestMarkOutputsMeta.test_cudagraph_disable_region_nested_view -q
```

```bash
lintrunner -a
```

`lintrunner -a` reported pyrefly failures in unrelated files: `torch/_inductor/codegen/triton.py`, `torch/export/pt2_archive/_package.py`, and `torch/nn/modules/loss.py`.

Authored with an AI assistant.