### PR TITLE
Improve cudagraph stack trace coverage and assertions

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -166,6 +166,54 @@ if HAS_CUDA_AND_TRITON:
     def all_live_block_count():
         return len(all_live_blocks())
 
+    class _AssertOutputStackTraces(torch._inductor.custom_graph_pass.CustomGraphPass):
+        """Asserts all non-placeholder output args have stack traces.
+
+        Only fires on graphs that were traced by Dynamo (which captures
+        stack traces). Graphs from make_fx or compiled autograd may not
+        have stack traces at all, and compiler-synthesized ops (like
+        empty_strided from decompositions) won't have user stack traces.
+        """
+
+        def __init__(self, pass_name: str) -> None:
+            self.pass_name = pass_name
+
+        def __call__(self, graph: torch.fx.Graph) -> None:
+            # Skip graphs where no call_function node has a stack trace,
+            # which indicates the graph wasn't traced by Dynamo (e.g.,
+            # make_fx, compiled autograd).
+            has_any_stack_trace = any(
+                n.meta.get("stack_trace")
+                for n in graph.nodes
+                if n.op == "call_function"
+            )
+            if not has_any_stack_trace:
+                return
+
+            for node in graph.nodes:
+                if node.op != "output":
+                    continue
+                for arg in node.args[0]:
+                    if not isinstance(arg, torch.fx.Node):
+                        continue
+                    if arg.op == "placeholder":
+                        continue
+                    # Skip compiler-synthesized ops that don't originate
+                    # from user code (e.g., empty_strided from decomps).
+                    if not arg.meta.get("source_fn_stack") and not arg.meta.get(
+                        "nn_module_stack"
+                    ):
+                        continue
+                    stack_trace = arg.meta.get("stack_trace")
+                    if not stack_trace:
+                        raise AssertionError(
+                            f"[{self.pass_name}] Missing stack trace on output "
+                            f"'{arg.name}' (op={arg.op}, target={arg.target})"
+                        )
+
+        def uuid(self):
+            return "assert_output_stack_traces"
+
     class CudaGraphTreeTests(TestCase):
         def setUp(self):
             super().setUp()
@@ -177,6 +225,14 @@ if HAS_CUDA_AND_TRITON:
                         "triton.cudagraph_trees": True,
                         "triton.fast_path_cudagraph_asserts": True,  # too slow
                         "triton.slow_path_cudagraph_asserts": True,
+                        "test_configs.cudagraph_assert_stack_traces": True,
+                        "pre_grad_custom_pass": _AssertOutputStackTraces("pre_grad"),
+                        "joint_custom_post_pass": _AssertOutputStackTraces(
+                            "joint_graph"
+                        ),
+                        "post_grad_custom_pre_pass": _AssertOutputStackTraces(
+                            "post_grad"
+                        ),
                     }
                 )
             )
@@ -2557,6 +2613,7 @@ if HAS_CUDA_AND_TRITON:
 
             FileCheck().check("overwritten").check("x * x * x").run(repr(exc.exception))
 
+        @config.patch("test_configs.cudagraph_assert_stack_traces", False)
         def test_grad_accumulation_dealloc_error_message(self):
             model = torch.nn.Linear(10, 1, device="cuda")
             compiled_model = torch.compile(
@@ -2581,61 +2638,45 @@ if HAS_CUDA_AND_TRITON:
             ).check(".grad tensor").run(str(exc.exception))
 
         def test_output_node_has_stack_traces_inference(self):
-            """Test that output_stack_traces on the output node provides
-            stack traces even when a post-grad pass strips them from arg nodes
-            in inference mode."""
+            """Test that cudagraph error messages include user stack traces
+            for inference mode."""
 
-            def strip_stack_traces(graph):
-                for node in graph.nodes:
-                    if node.op not in ("placeholder", "output"):
-                        node.meta.pop("stack_trace", None)
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
 
-            with config.patch(post_grad_custom_post_pass=strip_stack_traces):
+            inp = torch.rand([4], device="cuda")
+            out = foo(inp).detach()
+            out2 = foo(inp).detach()
 
-                @torch.compile(mode="reduce-overhead")
-                def foo(x):
-                    return x * x * x
+            with self.assertRaises(Exception) as exc:
+                out + out
 
-                inp = torch.rand([4], device="cuda")
-                out = foo(inp).detach()
-                out2 = foo(inp).detach()
-
-                with self.assertRaises(Exception) as exc:
-                    out + out
-
-                self.assertIn("x * x * x", repr(exc.exception))
+            self.assertIn("x * x * x", repr(exc.exception))
 
         def test_output_node_has_stack_traces_training(self):
-            """Test that output_stack_traces on the output node provides
-            stack traces even when a post-grad pass strips them from arg nodes
-            in training mode (fwd/bwd graph split via partitioner)."""
+            """Test that cudagraph error messages include user stack traces
+            for training mode (fwd/bwd graph split via partitioner)."""
 
-            def strip_stack_traces(graph):
-                for node in graph.nodes:
-                    if node.op not in ("placeholder", "output"):
-                        node.meta.pop("stack_trace", None)
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
 
-            with config.patch(post_grad_custom_post_pass=strip_stack_traces):
+            inp = torch.rand([4], device="cuda", requires_grad=True)
+            # Complete fwd+bwd to compile both graphs
+            torch.compiler.cudagraph_mark_step_begin()
+            foo(inp).sum().backward()
 
-                @torch.compile(mode="reduce-overhead")
-                def foo(x):
-                    return x * x * x
+            # Now trigger the dealloc error
+            torch.compiler.cudagraph_mark_step_begin()
+            out = foo(inp).detach()
+            torch.compiler.cudagraph_mark_step_begin()
+            out2 = foo(inp).detach()
 
-                inp = torch.rand([4], device="cuda", requires_grad=True)
-                # Complete fwd+bwd to compile both graphs
-                torch.compiler.cudagraph_mark_step_begin()
-                foo(inp).sum().backward()
+            with self.assertRaises(Exception) as exc:
+                out + out
 
-                # Now trigger the dealloc error
-                torch.compiler.cudagraph_mark_step_begin()
-                out = foo(inp).detach()
-                torch.compiler.cudagraph_mark_step_begin()
-                out2 = foo(inp).detach()
-
-                with self.assertRaises(Exception) as exc:
-                    out + out
-
-                self.assertIn("x * x * x", repr(exc.exception))
+            self.assertIn("x * x * x", repr(exc.exception))
 
         @unittest.skipIf(not torch.backends.cudnn.is_available(), "requires cudnn")
         def test_conv_benchmark(self):

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2613,7 +2613,6 @@ if HAS_CUDA_AND_TRITON:
 
             FileCheck().check("overwritten").check("x * x * x").run(repr(exc.exception))
 
-        @config.patch("test_configs.cudagraph_assert_stack_traces", False)
         def test_grad_accumulation_dealloc_error_message(self):
             model = torch.nn.Linear(10, 1, device="cuda")
             compiled_model = torch.compile(

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -150,7 +150,7 @@ def get_stack_traces(gm: torch.fx.GraphModule) -> list[str | None]:
     args = output.args[0]
     if not hasattr(args, "__iter__"):
         return []
-    return [
+    return output.meta.get("output_stack_traces") or [
         (arg.stack_trace if isinstance(arg, torch.fx.node.Node) else None)
         for arg in args  # type: ignore[union-attr]
     ]

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -290,6 +290,14 @@ def _find_input_for_invalid_output(
     return None
 
 
+def _get_first_user_stack_trace(node: fx.Node) -> str | None:
+    """Get a stack trace from the first user of a node (skipping output nodes)."""
+    for user in node.users:
+        if user.op != "output" and (st := user.meta.get("stack_trace")):
+            return st
+    return None
+
+
 def _extract_graph_with_inputs_outputs(
     joint_graph: fx.Graph,
     inputs: list[fx.Node],
@@ -397,9 +405,15 @@ def _extract_graph_with_inputs_outputs(
     out.meta["desc"] = outputs_descs
     # Snapshot stack traces on the output node before passes run,
     # as later passes may strip stack_trace from individual nodes.
+    # Use `x` (original joint graph node) for the fallback since its users
+    # span the full joint graph, not just the extracted subgraph.
     out.meta["output_stack_traces"] = [
-        v.meta.get("stack_trace") if isinstance(v, fx.Node) else None
-        for v in output_values
+        (
+            x.meta.get("stack_trace") or _get_first_user_stack_trace(x)
+            if isinstance(x, fx.Node)
+            else None
+        )
+        for x in outputs
     ]
 
     new_graph.eliminate_dead_code()

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -28,6 +28,7 @@ from torch._functorch._activation_checkpointing.ac_logging_utils import (
 )
 from torch._functorch._aot_autograd.utils import is_with_effects
 from torch._inductor import config as inductor_config
+from torch._inductor.cudagraph_utils import should_assert_cudagraph_output_stack_trace
 from torch._inductor.custom_graph_pass import (
     CustomKnapsackSolver,
     CustomRuntimeEstimator,
@@ -412,6 +413,14 @@ def _extract_graph_with_inputs_outputs(
             x.meta.get("stack_trace") or _get_first_user_stack_trace(x)
             if isinstance(x, fx.Node)
             else None
+        )
+        for x in outputs
+    ]
+    out.meta["output_stack_trace_required"] = [
+        isinstance(x, fx.Node)
+        and (
+            should_assert_cudagraph_output_stack_trace(x)
+            or _get_first_user_stack_trace(x) is not None
         )
         for x in outputs
     ]

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -70,6 +70,7 @@ from torch._inductor.cudagraph_utils import (
     format_default_skip_message,
     log_cudagraph_skip_and_bump_counter,
     PlaceholderInfo,
+    should_assert_cudagraph_output_stack_trace,
 )
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.debug import (
@@ -1891,6 +1892,7 @@ def cudagraphify(
     stack_traces: list[str | None],
     is_backward: bool,
     is_inference: bool,
+    stack_trace_required: list[bool] | None = None,
     constants: tuple[torch.Tensor, ...] = (),
     placeholders: Sequence[PlaceholderInfo] = (),
     mutated_input_idxs: tuple[int, ...] = (),
@@ -1907,6 +1909,7 @@ def cudagraphify(
             new_cudagraphify_impl,
             device_index=device_index,
             stack_traces=stack_traces,
+            stack_trace_required=stack_trace_required,
             is_backward=is_backward,
             is_inference=is_inference,
             constants=constants,
@@ -2499,6 +2502,10 @@ def compile_fx_forward(
                 if isinstance(arg, torch.fx.node.Node)
                 else None
             )
+            for arg in _output.args[0]  # type: ignore[union-attr]
+        ]
+        _output.meta["output_stack_trace_required"] = [
+            should_assert_cudagraph_output_stack_trace(arg)
             for arg in _output.args[0]  # type: ignore[union-attr]
         ]
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2489,16 +2489,17 @@ def compile_fx_forward(
             ),
         )
 
-        # Snapshot stack traces on the output node before passes run,
-        # as later passes may strip stack_trace from individual nodes.
-        output = output_node(gm)
-        output.meta["output_stack_traces"] = [
+        # Snapshot stack traces before passes run. The partitioner does this
+        # for training, but inference skips partitioning. Passes may strip
+        # stack_trace from individual nodes, so we save them early.
+        _output = output_node(gm)
+        _output.meta["output_stack_traces"] = [
             (
                 arg.meta.get("stack_trace")
                 if isinstance(arg, torch.fx.node.Node)
                 else None
             )
-            for arg in output.args[0]  # type: ignore[union-attr]
+            for arg in _output.args[0]  # type: ignore[union-attr]
         ]
 
         inputs_devices = get_inputs_devices(example_inputs, gm)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2884,6 +2884,9 @@ class lookup_table:
 
 
 class test_configs:
+    # assert that stack traces are always present on cudagraph outputs
+    cudagraph_assert_stack_traces = False
+
     force_extern_kernel_in_multi_template: bool = False
 
     # Force custom op autotuning choice selection:

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -504,6 +504,7 @@ def cudagraphify(
     is_backward: bool,
     is_inference: bool,
     stack_traces: StackTraces | None = None,
+    stack_trace_required: StackTraceRequired | None = None,
     constants: tuple[torch.Tensor, ...] = (),
     placeholders: tuple[PlaceholderInfo, ...] = (),
     mutated_input_idxs: tuple[int, ...] = (),
@@ -526,6 +527,7 @@ def cudagraphify(
         inputs,
         static_input_idxs,
         stack_traces,
+        stack_trace_required,
         mode,
         constants,
         placeholders,
@@ -703,6 +705,7 @@ PathOutputIndex = tuple[int, int]
 PathLiveness = list[list[bool]]
 
 StackTraces = list[str | None]
+StackTraceRequired = list[bool]
 
 
 class CUDAWarmupNode:
@@ -732,6 +735,7 @@ class CUDAWarmupNode:
         existing_cuda_graph: torch.cuda.CUDAGraph | None,
         device_index: int,
         stack_traces: StackTraces | None,
+        stack_trace_required: StackTraceRequired | None,
         stream: torch.cuda.Stream,
         already_warm: bool,
         id: GraphID,
@@ -745,6 +749,7 @@ class CUDAWarmupNode:
         self.has_run = False
         self.device_index = device_index
         self.stack_traces = stack_traces
+        self.stack_trace_required = stack_trace_required
         self.stream = stream
         self.already_warm = already_warm
         self.id = id
@@ -805,6 +810,20 @@ class CUDAWarmupNode:
         cloned_output_idxs = expand_cloned_output_idxs(
             out, self.wrapped_function.cloned_output_idxs
         )
+        if self.stack_traces is None:
+            self.stack_traces = [None for _ in range(len(out))]
+        else:
+            assert len(self.stack_traces) == len(out), (
+                "Wrong number of stack traces passed in"
+            )
+        if self.stack_trace_required is None:
+            self.stack_trace_required = [
+                stack_trace is not None for stack_trace in self.stack_traces
+            ]
+        else:
+            assert len(self.stack_trace_required) == len(out), (
+                "Wrong number of stack trace requirements passed in"
+            )
 
         def allocated_in_pool(o: Any) -> bool:
             # sdpa returns cpu tensors when not recording cuda graph
@@ -933,6 +952,7 @@ class CUDAGraphNode:
         cuda_graphs_pool: _POOL_HANDLE,
         device_index: int,
         stack_traces: StackTraces | None,
+        stack_trace_required: StackTraceRequired | None,
         stream: torch.cuda.Stream,
         mode: CompilationMode | None,
         compile_id: CompileId | None,
@@ -943,6 +963,7 @@ class CUDAGraphNode:
         self.id = id
         self.device = device_index
         self.stack_traces = stack_traces
+        self.stack_trace_required = stack_trace_required
         self.stream = stream
 
         # Enable re-record a cudagraph when static tensor address changed.
@@ -1538,6 +1559,14 @@ class CUDAGraphNode:
         else:
             assert len(self.stack_traces) == len(outputs), (
                 "Wrong number of stack traces passed in"
+            )
+        if self.stack_trace_required is None:
+            self.stack_trace_required = [
+                stack_trace is not None for stack_trace in self.stack_traces
+            ]
+        else:
+            assert len(self.stack_trace_required) == len(outputs), (
+                "Wrong number of stack trace requirements passed in"
             )
 
         assert not self.outputs_weakrefs
@@ -2157,6 +2186,9 @@ class CUDAGraphTreeManager:
         self.ids_to_funcs: dict[FunctionID, WrappedFunction] = {}
 
         self.ids_to_stack_traces: dict[FunctionID, StackTraces | None] = {}
+        self.ids_to_stack_trace_required: dict[
+            FunctionID, StackTraceRequired | None
+        ] = {}
 
         self.warmed_up_functions: OrderedSet[FunctionID] = OrderedSet()
         # if we fail to increment generation, and are stuck warming up,
@@ -2650,6 +2682,7 @@ class CUDAGraphTreeManager:
                 self.cuda_graphs_thread_pool,
                 self.device_index,
                 self.ids_to_stack_traces[function_id],
+                self.ids_to_stack_trace_required[function_id],
                 self.stream,
                 self.mode,
                 self.compile_id,
@@ -2700,6 +2733,7 @@ class CUDAGraphTreeManager:
             self.graph,
             self.device_index,
             self.ids_to_stack_traces[function_id],
+            self.ids_to_stack_trace_required[function_id],
             self.stream,
             already_warm,
             self.new_warmup_node_id(),
@@ -2724,6 +2758,7 @@ class CUDAGraphTreeManager:
         inputs: list[InputType],
         static_input_idxs: Sequence[int],
         stack_traces: StackTraces | None,
+        stack_trace_required: StackTraceRequired | None,
         mode: CompilationMode,
         constants: tuple[torch.Tensor, ...],
         placeholders: tuple[PlaceholderInfo, ...],
@@ -2737,6 +2772,7 @@ class CUDAGraphTreeManager:
     ]:
         id = self.new_func_id()
         self.ids_to_stack_traces[id] = stack_traces
+        self.ids_to_stack_trace_required[id] = stack_trace_required
         self.ids_to_funcs[id] = WrappedFunction(
             model,
             list(static_input_idxs),
@@ -2928,21 +2964,31 @@ class CUDAGraphTreeManager:
         # TODO: we could also allow the these weak refs to continue to be allocated,
         # but that adds some complications.
 
-        stor_dealloc_info: dict[int, tuple[str | None, bool]] = {}
+        stor_dealloc_info: dict[int, tuple[str | None, bool, bool]] = {}
         for node in self.current_node._path_from_root:
             assert node.stack_traces is not None
+            assert node.stack_trace_required is not None
             assert len(node.tensor_weakrefs) == len(node.stack_traces)
+            assert len(node.stack_trace_required) == len(node.stack_traces)
             is_grad_output = (
                 self.id_to_mode[node.wrapped_function.id] == CompilationMode.BACKWARD
             )
-            for t, stack_trace in zip(node.tensor_weakrefs, node.stack_traces):
+            for t, stack_trace, stack_trace_required in zip(
+                node.tensor_weakrefs,
+                node.stack_traces,
+                node.stack_trace_required,
+            ):
                 ten = None if t is None else t()
                 if ten is None:
                     continue
 
                 torch._C._set_storage_access_error_msg(
                     ten,
-                    self.format_dealloc_msg(stack_trace, is_grad_output=is_grad_output),
+                    self.format_dealloc_msg(
+                        stack_trace,
+                        is_grad_output=is_grad_output,
+                        assert_stack_trace=stack_trace_required and not is_grad_output,
+                    ),
                 )
 
             # we would to enable the following assertion, but an internal model failed with a command
@@ -2952,8 +2998,10 @@ class CUDAGraphTreeManager:
             if self.disable_invalidate_aliases:
                 continue
 
-            for storage_ref, stack_trace in zip(
-                node.outputs_weakrefs, node.stack_traces
+            for storage_ref, stack_trace, stack_trace_required in zip(
+                node.outputs_weakrefs,
+                node.stack_traces,
+                node.stack_trace_required,
             ):
                 if not storage_ref:
                     continue
@@ -2961,6 +3009,7 @@ class CUDAGraphTreeManager:
                 stor_dealloc_info[storage_ref.data_ptr()] = (
                     stack_trace,
                     is_grad_output,
+                    stack_trace_required,
                 )
 
         deleted = OrderedSet[Any]()
@@ -2971,13 +3020,17 @@ class CUDAGraphTreeManager:
 
                 dealloc_info = stor_dealloc_info.get(storage_ref.data_ptr())
                 if dealloc_info is None:
-                    stack_trace, is_grad_output = None, False
+                    stack_trace, is_grad_output, stack_trace_required = (
+                        None,
+                        False,
+                        False,
+                    )
                 else:
-                    stack_trace, is_grad_output = dealloc_info
+                    stack_trace, is_grad_output, stack_trace_required = dealloc_info
                 msg = self.format_dealloc_msg(
                     stack_trace,
                     is_grad_output=is_grad_output,
-                    assert_stack_trace=dealloc_info is not None,
+                    assert_stack_trace=stack_trace_required and not is_grad_output,
                 )
                 torch._C._free_And_Remove_DeleterFn(_storage_deref)
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2893,8 +2893,15 @@ class CUDAGraphTreeManager:
 
     @staticmethod
     def format_dealloc_msg(
-        stack_trace: str | None, *, is_grad_output: bool = False
+        stack_trace: str | None,
+        *,
+        is_grad_output: bool = False,
+        assert_stack_trace: bool = True,
     ) -> str:
+        if config.test_configs.cudagraph_assert_stack_traces and assert_stack_trace:
+            assert stack_trace is not None, (
+                "Expected stack trace to be set for all cudagraph outputs"
+            )
         stack_trace = (
             stack_trace.strip() if stack_trace else "[Could not find stack trace]"
         )
@@ -2962,11 +2969,15 @@ class CUDAGraphTreeManager:
             if _storage_deref and storage_ref.data_ptr() not in deleted:
                 deleted.add(storage_ref.data_ptr())
 
-                stack_trace, is_grad_output = stor_dealloc_info.get(
-                    storage_ref.data_ptr(), (None, False)
-                )
+                dealloc_info = stor_dealloc_info.get(storage_ref.data_ptr())
+                if dealloc_info is None:
+                    stack_trace, is_grad_output = None, False
+                else:
+                    stack_trace, is_grad_output = dealloc_info
                 msg = self.format_dealloc_msg(
-                    stack_trace, is_grad_output=is_grad_output
+                    stack_trace,
+                    is_grad_output=is_grad_output,
+                    assert_stack_trace=dealloc_info is not None,
                 )
                 torch._C._free_And_Remove_DeleterFn(_storage_deref)
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -593,6 +593,9 @@ def get_partition_cudagraph_metadata(
             partition_stack_traces.append(metadata.stack_traces[graph_output_idx])
             if graph_output_idx in metadata.cloned_output_idxs:
                 partition_cloned_idxs.add(i)
+        elif partition_map.stack_traces and i < len(partition_map.stack_traces):
+            # For partition-internal outputs, use stack traces from IR nodes
+            partition_stack_traces.append(partition_map.stack_traces[i])
         else:
             partition_stack_traces.append(None)
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -530,6 +530,7 @@ class CudagraphCachedInfo:
 
     placeholders: Sequence[PlaceholderInfo]
     stack_traces: list[str | None]
+    stack_trace_required: list[bool]
     cudagraph_fail_reasons: list[str]
 
 
@@ -543,9 +544,21 @@ class CudagraphMetadata:
     static_input_idxs: OrderedSet[int]
     mutated_input_idxs: OrderedSet[int]
     stack_traces: list[str | None]
+    stack_trace_required: list[bool]
     constants: dict[str, torch.Tensor]
     cloned_output_idxs: OrderedSet[int]
     copy_input_idxs: OrderedSet[int]
+
+
+def should_assert_cudagraph_output_stack_trace(node: object) -> bool:
+    return (
+        isinstance(node, torch.fx.Node)
+        and node.op != "placeholder"
+        and (
+            bool(node.meta.get("source_fn_stack"))
+            or bool(node.meta.get("nn_module_stack"))
+        )
+    )
 
 
 def get_partition_cudagraph_metadata(
@@ -587,17 +600,27 @@ def get_partition_cudagraph_metadata(
         partition_placeholders.append(placeholder)
 
     partition_stack_traces = []
+    partition_stack_trace_required = []
     partition_cloned_idxs: OrderedSet[int] = OrderedSet()
     for i, graph_output_idx in enumerate(partition_map.output_index_mapping):
         if graph_output_idx is not None:
             partition_stack_traces.append(metadata.stack_traces[graph_output_idx])
+            partition_stack_trace_required.append(
+                metadata.stack_trace_required[graph_output_idx]
+            )
             if graph_output_idx in metadata.cloned_output_idxs:
                 partition_cloned_idxs.add(i)
         elif partition_map.stack_traces and i < len(partition_map.stack_traces):
             # For partition-internal outputs, use stack traces from IR nodes
             partition_stack_traces.append(partition_map.stack_traces[i])
+            partition_stack_trace_required.append(
+                bool(partition_map.stack_trace_required[i])
+                if i < len(partition_map.stack_trace_required)
+                else False
+            )
         else:
             partition_stack_traces.append(None)
+            partition_stack_trace_required.append(False)
 
     partition_constants = {
         name: metadata.constants[name] for name in partition_map.constant_names
@@ -608,6 +631,7 @@ def get_partition_cudagraph_metadata(
         partition_static_input_idxs,
         partition_mutated_input_idxs,
         partition_stack_traces,
+        partition_stack_trace_required,
         partition_constants,
         partition_cloned_idxs,
         partition_copy_input_idxs,

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -717,9 +717,7 @@ class CompiledFxGraph(OutputCode):
                 output = output_node(gm)
                 # output args are tuple of first argument
                 assert len(output.args) == 1
-                # Use stack traces captured on the output node before
-                # post-grad passes, which may strip stack_trace from
-                # individual arg nodes.
+                # output_stack_traces is set by the partitioner before passes run
                 stack_traces = output.meta.get("output_stack_traces") or [
                     (arg.stack_trace if isinstance(arg, torch.fx.node.Node) else None)
                     for arg in output.args[0]  # type: ignore[union-attr]

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -42,6 +42,7 @@ from torch._inductor.cudagraph_utils import (
     get_partition_cudagraph_metadata,
     get_placeholder_info,
     log_cudagraph_skip_and_bump_counter,
+    should_assert_cudagraph_output_stack_trace,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
 from torch._inductor.utils import (
@@ -258,6 +259,11 @@ def cudagraph_post_compile(
         assert stack_traces is not None, (
             "stack_traces should not be None in cudagraph_post_compile"
         )
+        stack_trace_required = getattr(cached_info, "stack_trace_required", None)
+        if stack_trace_required is None:
+            stack_trace_required = [
+                stack_trace is not None for stack_trace in stack_traces
+            ]
 
         prepare_cudagraph_post_compile(
             compiled_graph, example_inputs, boxed_forward_device_index
@@ -274,6 +280,7 @@ def cudagraph_post_compile(
         cudagraphify_kwargs = dict(
             device_index=device_index,
             stack_traces=stack_traces,
+            stack_trace_required=stack_trace_required,
             is_backward=is_backward,
             is_inference=is_inference,
             constants=tuple(tensor_constants.values()),
@@ -368,11 +375,20 @@ def cudagraph_partition_post_compile(
     assert compiled_graph.cudagraph_info.stack_traces is not None, (
         "stack_traces should not be None in cudagraph_partition_post_compile"
     )
+    stack_trace_required = getattr(
+        compiled_graph.cudagraph_info, "stack_trace_required", None
+    )
+    if stack_trace_required is None:
+        stack_trace_required = [
+            stack_trace is not None
+            for stack_trace in compiled_graph.cudagraph_info.stack_traces
+        ]
     graph_metadata = CudagraphMetadata(
         compiled_graph.cudagraph_info.placeholders,
         static_input_idxs,
         mutated_input_idxs,
         compiled_graph.cudagraph_info.stack_traces,
+        stack_trace_required,
         tensor_constants,
         compiled_graph.cudagraph_cloned_idxs,
         compiled_graph.cudagraph_copy_input_idxs,
@@ -404,6 +420,7 @@ def cudagraph_partition_post_compile(
             static_input_idxs=tuple(partition_static_input_idxs),
             device_index=device_index,
             stack_traces=partition_metadata.stack_traces,
+            stack_trace_required=partition_metadata.stack_trace_required,
             is_backward=is_backward,
             is_inference=is_inference,
             constants=tuple(partition_metadata.constants.values()),
@@ -722,10 +739,19 @@ class CompiledFxGraph(OutputCode):
                     (arg.stack_trace if isinstance(arg, torch.fx.node.Node) else None)
                     for arg in output.args[0]  # type: ignore[union-attr]
                 ]
+                stack_trace_required = output.meta.get("output_stack_trace_required")
+                if stack_trace_required is None:
+                    stack_trace_required = [
+                        should_assert_cudagraph_output_stack_trace(arg)
+                        for arg in output.args[0]  # type: ignore[union-attr]
+                    ]
                 cudagraph_fail_reasons = [s for b, s in cudagraph_tests if not b]
                 placeholders = tuple(get_placeholder_info(gm.graph))
                 cudagraph_info = CudagraphCachedInfo(
-                    placeholders, stack_traces, cudagraph_fail_reasons
+                    placeholders,
+                    stack_traces,
+                    stack_trace_required,
+                    cudagraph_fail_reasons,
                 )
 
         self.cudagraph_info = cudagraph_info

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -8672,13 +8672,14 @@ class Scheduler:
 
         return name_to_node
 
-    def compute_graph_partition_maps(
+    def compute_graph_partition_map(
         self,
-        signatures: list[GraphPartitionSignature],
-    ) -> None:
+        partition_id: int,
+        signature: GraphPartitionSignature,
+    ) -> GraphPartitionMap:
         """
-        computes a mapping from partition input/output indices to graph input/output
-        indices for each partition.
+        computes a mapping from partition input/output indices to graph
+        input/output indices for a partition.
         """
         name_to_graph_input_index = {
             name: idx for idx, name in enumerate(V.graph.graph_inputs)
@@ -8687,35 +8688,49 @@ class Scheduler:
             name: idx for idx, name in enumerate(V.graph.get_output_names())
         }
 
+        input_mapping = []
+        for name in signature.input_nodes:
+            input_mapping.append(name_to_graph_input_index.get(name))
+
+        output_mapping = []
+        output_stack_traces: list[str | None] = []
+        output_stack_trace_required: list[bool] = []
+        for node in signature.output_nodes:
+            output_mapping.append(name_to_graph_output_index.get(node.get_name()))
+            traces = node.get_stack_traces()
+            output_stack_traces.append(next(iter(traces)) if traces else None)
+            output_stack_trace_required.append(bool(traces))
+
+        return GraphPartitionMap(
+            partition_id,
+            input_mapping,
+            output_mapping,
+            signature.constant_names,
+            output_stack_traces,
+            output_stack_trace_required,
+        )
+
+    def compute_graph_partition_maps(
+        self,
+        signatures: list[GraphPartitionSignature],
+    ) -> None:
+        """
+        computes a mapping from partition input/output indices to graph input/output
+        indices for each partition.
+        """
         V.graph.partition_maps = []
-        for partition_id, signature in enumerate(signatures):
+        partition_id = 0
+        for signature in signatures:
             if signature.skip_cudagraph:
                 # Note: [Graph Partition Map for CUDAGraph]
                 # number of partition map should be the same as the number of generated
                 # partition functions. This assumption will be used when cudagraphify
                 # each partition function.
                 continue
-
-            input_mapping = []
-            for name in signature.input_nodes:
-                input_mapping.append(name_to_graph_input_index.get(name))
-
-            output_mapping = []
-            output_stack_traces: list[str | None] = []
-            for node in signature.output_nodes:
-                output_mapping.append(name_to_graph_output_index.get(node.get_name()))
-                traces = node.get_stack_traces()
-                output_stack_traces.append(next(iter(traces)) if traces else None)
-
             V.graph.partition_maps.append(
-                GraphPartitionMap(
-                    partition_id,
-                    input_mapping,
-                    output_mapping,
-                    signature.constant_names,
-                    output_stack_traces,
-                )
+                self.compute_graph_partition_map(partition_id, signature)
             )
+            partition_id += 1
 
     def get_graph_partition_symbol_inputs(
         self,
@@ -9252,6 +9267,10 @@ class Scheduler:
             )
             signature = self.clean_removed_buffer_from_partition_signatures(
                 signature, removed_buffers_during_codegen
+            )
+            assert V.graph.partition_maps is not None
+            V.graph.partition_maps[graph_partition_id] = (
+                self.compute_graph_partition_map(graph_partition_id, signature)
             )
             V.graph.wrapper_code.partition_signatures = signature
             V.graph.wrapper_code.write_prefix()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -8701,8 +8701,11 @@ class Scheduler:
                 input_mapping.append(name_to_graph_input_index.get(name))
 
             output_mapping = []
+            output_stack_traces: list[str | None] = []
             for node in signature.output_nodes:
                 output_mapping.append(name_to_graph_output_index.get(node.get_name()))
+                traces = node.get_stack_traces()
+                output_stack_traces.append(next(iter(traces)) if traces else None)
 
             V.graph.partition_maps.append(
                 GraphPartitionMap(
@@ -8710,6 +8713,7 @@ class Scheduler:
                     input_mapping,
                     output_mapping,
                     signature.constant_names,
+                    output_stack_traces,
                 )
             )
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -231,6 +231,9 @@ class GraphPartitionMap:
     # name of constants read/written by the graph partition
     constant_names: list[str]
 
+    # stack traces for each partition output, populated from IR node origins
+    stack_traces: list[str | None] = dataclasses.field(default_factory=list)
+
 
 def fp8_bench(fn: Callable[[], Any], warmup: int = 25, rep: int = 100) -> float:
     """

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -234,6 +234,9 @@ class GraphPartitionMap:
     # stack traces for each partition output, populated from IR node origins
     stack_traces: list[str | None] = dataclasses.field(default_factory=list)
 
+    # whether runtime should assert a partition output stack trace is present
+    stack_trace_required: list[bool] = dataclasses.field(default_factory=list)
+
 
 def fp8_bench(fn: Callable[[], Any], warmup: int = 25, rep: int = 100) -> float:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186831
* #186830
* #186829
* #186828

Cherry-pick the cudagraph stack trace coverage work from PR 177890 onto the CUDA graph annotation stack. The patch snapshots output stack traces before graph passes can strip them, uses first-user stack traces for placeholder outputs saved for backward, carries partition-internal output stack traces from scheduler IR origins, and adds a test-only runtime assertion for missing cudagraph output traces.

This was applied from merge commit c943557840c with mainline parent 2. Conflict resolution kept the output/input-copy metadata propagation in partition metadata and preserved the existing grad-output deallocation diagnostic path, which can intentionally lack a user stack trace.

Test Plan:
```bash
python -m py_compile test/inductor/test_cudagraph_trees.py torch/_dynamo/backends/cudagraphs.py torch/_functorch/partitioners.py torch/_inductor/compile_fx.py torch/_inductor/config.py torch/_inductor/cudagraph_trees.py torch/_inductor/cudagraph_utils.py torch/_inductor/output_code.py torch/_inductor/scheduler.py torch/_inductor/utils.py
```

```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_grad_accumulation_dealloc_error_message CudaGraphTreeTests.test_output_node_has_stack_traces_inference CudaGraphTreeTests.test_output_node_has_stack_traces_training -q
```

```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_output_node_has_stack_traces_inference CudaGraphTreeTests.test_output_node_has_stack_traces_training CudaGraphTreeTests.test_auto_copy_static_input_after_address_churn CudaGraphTreeTests.test_auto_copy_aliased_input_falls_back CudaGraphTreeTests.test_explicit_copy_static_input_no_rerecord CudaGraphTreeTests.test_explicit_copy_aliased_input_falls_back CudaGraphTreeTests.test_cloned_output_compile CudaGraphTreeTests.test_cloned_output_shutdown CudaGraphTreeTests.test_cloned_output_checkpoint_tracks_original_output CudaGraphTreeTests.test_cloned_output_preserves_output_aliasing CudaGraphTreeTests.test_cloned_output_with_cpu_partition CudaGraphTreeTests.test_cudagraph_disable_region_skips_capture TestMarkOutputsMeta -q
```

```bash
python test/inductor/test_cudagraph_trees.py -q
```

```bash
lintrunner -a
```

`lintrunner -a` reported pyrefly failures in unrelated files: `torch/_inductor/codegen/triton.py`, `torch/export/pt2_archive/_package.py`, and `torch/nn/modules/loss.py`.

Authored with an AI assistant.