### PR TITLE
[Profiler] Fix gc test by checking for at least one gc event between bounds

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2388,15 +2388,19 @@ class TestProfiler(TestCase):
                         # Calculate boundaries
                         pre_gc_end = pre_gc["ts"] + pre_gc.get("dur", 0)
                         post_gc_start = post_gc["ts"]
-                        # Assert each Python GC event is correctly placed
-                        for python_gc in python_gc_events:
-                            python_gc_start = python_gc["ts"]
-                            python_gc_end = python_gc["ts"] + python_gc.get("dur", 0)
-                            self.assertTrue(
-                                python_gc_start > pre_gc_end
-                                and python_gc_end < post_gc_start,
-                                f"Python GC event at {python_gc_start} is not correctly placed.",
-                            )
+                        # Assert at least one Python GC event is correctly placed.
+                        # Other automatic GC events can happen while the profiler is
+                        # active, especially during first-run initialization.
+                        python_gc_events_between = [
+                            e
+                            for e in python_gc_events
+                            if e["ts"] > pre_gc_end
+                            and e["ts"] + e.get("dur", 0) < post_gc_start
+                        ]
+                        self.assertTrue(
+                            len(python_gc_events_between) > 0,
+                            "No Python GC events found between pre_gc and post_gc",
+                        )
                     else:
                         python_gc_events = [
                             e for e in events if e["name"] == "Python GC"


### PR DESCRIPTION
This test has been failing in CI: https://github.com/pytorch/kineto/actions/runs/27210714257/job/80338678706

It runs profiling with gc enabled and inserts a gc event between two `record_function` blocks, then expects that all gc events in the produced trace are between the two `record_function` timestamps. However, on a fresh build, there's something else that triggers python gc which is causing a spurious event to show up in the profile, leading to test failure.

We are really just checking that the singular gc event we induce is in the profile, so instead of checking that all events fall within the timeframe, just check if at least one does.