### PR TITLE
[RFC]: Auto-select and run Operator Performance Benchmarks from PR Diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,4 @@ CLAUDE.local.md
 /debug_*.py
 CLAUDE_CONTEXT/
 /.claude/settings.local.json
+.perfmap/

--- a/tools/testing/perfmap.py
+++ b/tools/testing/perfmap.py
@@ -39,7 +39,7 @@ def detect(base):
 
     if not files:
         print(f"No changes found between {base} and HEAD.")
-        return []
+        return [], []
 
     all_changed_functions = set()
 
@@ -170,29 +170,36 @@ def detect(base):
 
     test_names = sorted(t.replace("_test.py", "") for t in matched_tests)
     print(f"\nOP_BENCHMARK_TESTS={' '.join(test_names)}")
-    return test_names
+    return test_names, sorted(matched_ops)
 
 
-def run(label, base):
+def run(label, base, tag="short"):
     label_dir = os.path.join(PERFMAP_DIR, label)
     os.makedirs(label_dir, exist_ok=True)
     tests_file = os.path.join(label_dir, "tests.txt")
 
+    ops_file = os.path.join(label_dir, "ops.txt")
+
     # First run: detect tests and save. Later runs: reuse saved list.
     if not os.path.exists(tests_file):
-        test_names = detect(base)
-        if not test_names:
-            print("No benchmarks found. Run on a branch with operator changes first.")
-            return
+        test_names, op_names = detect(base)
         with open(tests_file, "w") as f:
             f.write("\n".join(test_names))
+        with open(ops_file, "w") as f:
+            f.write("\n".join(op_names))
+        if not test_names:
+            print("No benchmarks found. Delete .perfmap/" + label + "/ and run on a branch with operator changes.")
+            return
     else:
         with open(tests_file) as f:
             test_names = [l.strip() for l in f if l.strip()]
+        with open(ops_file) as f:
+            op_names = [l.strip() for l in f if l.strip()]
         if not test_names:
-            print("Saved test list is empty. Delete .perfmap/{label}/ and run on a branch with changes.")
+            print("Saved test list is empty. Delete .perfmap/" + label + "/ and run on a branch with changes.")
             return
         print(f"Using saved test list: {' '.join(test_names)}")
+        print(f"Operators: {' '.join(op_names)}")
 
     branch = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -203,17 +210,42 @@ def run(label, base):
         capture_output=True, text=True,
     ).stdout.strip()
 
+    # Check benchmark dependencies
+    try:
+        import torch
+        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+    except ImportError:
+        print("PyTorch is not installed. Build and install it first.")
+        return
+
+    try:
+        import benchmark_cpp_extension  # noqa: F401
+    except ImportError:
+        print("Benchmark C++ extension not installed. Build it with:")
+        print("  cd benchmarks/operator_benchmark/pt_extension && pip install . --no-build-isolation && cd -")
+        return
+    except OSError as e:
+        print(f"Benchmark extension found but failed to load: {e}")
+        print("Torch shared libraries may not be on LD_LIBRARY_PATH. Try:")
+        print(f"  export LD_LIBRARY_PATH={torch_lib}:$LD_LIBRARY_PATH")
+        return
+
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = torch_lib + ":" + env.get("LD_LIBRARY_PATH", "")
+
     run_dir = os.path.join(label_dir, f"{branch}_{commit}")
     os.makedirs(run_dir, exist_ok=True)
+
+    operators_flag = ",".join(op_names) if op_names else None
 
     for test in test_names:
         out_file = os.path.join(run_dir, f"{test}.json")
         print(f"Running {test}...")
-        subprocess.run(
-            [sys.executable, "-m", f"pt.{test}_test",
-             "--tag-filter", "long", "--output-json", os.path.abspath(out_file)],
-            cwd="benchmarks/operator_benchmark",
-        )
+        cmd = [sys.executable, "-m", f"pt.{test}_test",
+               "--tag-filter", tag, "--output-json", os.path.abspath(out_file)]
+        if operators_flag:
+            cmd += ["--operators", operators_flag]
+        subprocess.run(cmd, cwd="benchmarks/operator_benchmark", env=env)
 
     print(f"\nResults saved to {run_dir}")
 
@@ -290,7 +322,7 @@ if __name__ == "__main__":
         detect(base)
 
     elif args[0] == "run":
-        label, base = None, "upstream/viable/strict"
+        label, base, tag = None, "upstream/viable/strict", "short"
         i = 1
         while i < len(args):
             if args[i] == "--label" and i + 1 < len(args):
@@ -299,12 +331,15 @@ if __name__ == "__main__":
             elif args[i] == "--base" and i + 1 < len(args):
                 base = args[i + 1]
                 i += 2
+            elif args[i] == "--tag" and i + 1 < len(args):
+                tag = args[i + 1]
+                i += 2
             else:
                 i += 1
         if not label:
-            print("Usage: perfmap.py run --label <name>")
+            print("Usage: perfmap.py run --label <name> [--tag short|long]")
             sys.exit(1)
-        run(label, base)
+        run(label, base, tag)
 
     elif args[0] == "compare":
         label = None

--- a/tools/testing/perfmap.py
+++ b/tools/testing/perfmap.py
@@ -1,0 +1,173 @@
+# perfmap: map code changes to operator benchmarks
+
+import subprocess
+import sys
+
+# Get diff against base ref (default: upstream/viable/strict)
+base = sys.argv[1] if len(sys.argv) > 1 else "upstream/viable/strict"
+diff = subprocess.run(
+    ["git", "diff", "-p", "-U0", f"{base}...HEAD"],
+    capture_output=True, text=True, check=True,
+).stdout
+
+import re
+
+# Parse diff to get changed line ranges per file
+files = {}
+current = None
+for line in diff.splitlines():
+    if line.startswith("+++ b/"):
+        current = line[6:]
+    elif line.startswith("@@") and current:
+        m = re.search(r"-(\d+)(?:,(\d+))?", line)
+        if m:
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) else 1
+            end = start + count - 1 if count > 0 else start
+            files.setdefault(current, []).append((start, end))
+
+import tree_sitter_cpp
+import tree_sitter_python
+from tree_sitter import Language, Parser
+
+CPP = Language(tree_sitter_cpp.language())
+PY = Language(tree_sitter_python.language())
+
+CPP_EXTS = {"cpp", "cu", "h", "cuh", "cc", "mm"}
+
+all_changed_functions = set()
+
+for path, ranges in files.items():
+    if path.startswith("test/"):
+        continue
+    ext = path.rsplit(".", 1)[-1] if "." in path else ""
+    if ext in CPP_EXTS:
+        lang = CPP
+    elif ext == "py":
+        lang = PY
+    else:
+        continue
+
+    try:
+        source = subprocess.run(
+            ["git", "show", f"{base}:{path}"],
+            capture_output=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        continue
+
+    tree = Parser(lang).parse(source)
+
+    # Find all function definitions and their line ranges in the file
+    funcs = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if node.type == "function_definition":
+            name = None
+            for child in node.children:
+                if lang == PY and child.type == "identifier":
+                    name = child.text.decode()
+                    break
+                if lang == CPP and "declarator" in child.type:
+                    t = child.text.decode()
+                    p = t.find("(")
+                    if p != -1:
+                        prefix = t[:p]
+                        for macro in ("TORCH_META_FUNC", "TORCH_IMPL_FUNC"):
+                            if macro in prefix:
+                                inner = t[t.find("(") + 1 : t.find(")")]
+                                name = inner.split(",")[0].strip()
+                                break
+                        else:
+                            name = prefix.split()[-1].lstrip("&*")
+                    break
+            if name:
+                funcs.append((name, node.start_point[0] + 1, node.end_point[0] + 1))
+        else:
+            stack.extend(node.children)
+
+    # Find functions whose line ranges overlap with changed lines
+    matched = set()
+    for name, fs, fe in funcs:
+        for cs, ce in ranges:
+            if fs <= ce and cs <= fe:
+                matched.add(name)
+                break
+
+    print(f"\n{path}")
+    if matched:
+        for f in sorted(matched):
+            print(f"  {f}")
+    else:
+        print(f"  (no functions found, file-level change)")
+    all_changed_functions.update(matched)
+
+# Map function names to operator names via native_functions.yaml
+import yaml
+
+with open("aten/src/ATen/native/native_functions.yaml") as f:
+    ops = yaml.safe_load(f)
+
+kernel_to_op = {}
+op_names = set()
+for entry in ops:
+    if "func" not in entry:
+        continue
+    func_str = entry["func"].split("(")[0].split(".")[0]
+    op_names.add(func_str)
+    if "dispatch" in entry:
+        for kernel in entry["dispatch"].values():
+            kernel_to_op[kernel] = func_str
+
+# Look up each changed function
+print("\n--- Operator mapping ---")
+matched_ops = set()
+for func in sorted(all_changed_functions):
+    if func in kernel_to_op:
+        op = kernel_to_op[func]
+        print(f"  {func} -> {op} (kernel match)")
+        matched_ops.add(op)
+    elif func in op_names:
+        print(f"  {func} -> {func} (direct match)")
+        matched_ops.add(func)
+    else:
+        print(f"  {func} -> (no operator match)")
+
+# Map operators to benchmark tests
+import glob
+
+benchmark_modules = {}
+for f in glob.glob("benchmarks/operator_benchmark/pt/*_test.py"):
+    with open(f) as fh:
+        content = fh.read()
+        for m in re.finditer(r'set_module_name\("(\w+)"\)', content):
+            benchmark_modules.setdefault(m.group(1).lower(), set()).add(f.split("/")[-1])
+        for line in content.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            for m in re.finditer(r'\["(\w+)",\s*torch\.', line):
+                benchmark_modules.setdefault(m.group(1).lower(), set()).add(f.split("/")[-1])
+
+# Map operators to benchmark test names
+print("\n--- Benchmark mapping ---")
+matched_tests = set()
+for op in sorted(matched_ops):
+    if op in benchmark_modules:
+        print(f"  {op} -> {benchmark_modules[op]}")
+        matched_tests.update(benchmark_modules[op])
+    else:
+        best = ""
+        for mod in benchmark_modules:
+            if op.startswith(mod) and (len(op) == len(mod) or op[len(mod)] == "_"):
+                if len(mod) > len(best):
+                    best = mod
+        if best:
+            print(f"  {op} -> {benchmark_modules[best]} (via {best})")
+            matched_tests.update(benchmark_modules[best])
+        else:
+            print(f"  {op} -> NO BENCHMARK")
+
+# Output for CI: space-separated test names (strip _test.py suffix)
+test_names = sorted(t.replace("_test.py", "") for t in matched_tests)
+print(f"\nOP_BENCHMARK_TESTS={' '.join(test_names)}")

--- a/tools/testing/perfmap.py
+++ b/tools/testing/perfmap.py
@@ -1,173 +1,321 @@
 # perfmap: map code changes to operator benchmarks
 
+import glob
+import json
+import os
+import re
 import subprocess
 import sys
 
-# Get diff against base ref (default: upstream/viable/strict)
-base = sys.argv[1] if len(sys.argv) > 1 else "upstream/viable/strict"
-diff = subprocess.run(
-    ["git", "diff", "-p", "-U0", f"{base}...HEAD"],
-    capture_output=True, text=True, check=True,
-).stdout
-
-import re
-
-# Parse diff to get changed line ranges per file
-files = {}
-current = None
-for line in diff.splitlines():
-    if line.startswith("+++ b/"):
-        current = line[6:]
-    elif line.startswith("@@") and current:
-        m = re.search(r"-(\d+)(?:,(\d+))?", line)
-        if m:
-            start = int(m.group(1))
-            count = int(m.group(2)) if m.group(2) else 1
-            end = start + count - 1 if count > 0 else start
-            files.setdefault(current, []).append((start, end))
-
 import tree_sitter_cpp
 import tree_sitter_python
+import yaml
 from tree_sitter import Language, Parser
 
 CPP = Language(tree_sitter_cpp.language())
 PY = Language(tree_sitter_python.language())
-
 CPP_EXTS = {"cpp", "cu", "h", "cuh", "cc", "mm"}
+PERFMAP_DIR = ".perfmap"
 
-all_changed_functions = set()
+def detect(base):
+    diff = subprocess.run(
+        ["git", "diff", "-p", "-U0", f"{base}...HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout
 
-for path, ranges in files.items():
-    if path.startswith("test/"):
-        continue
-    ext = path.rsplit(".", 1)[-1] if "." in path else ""
-    if ext in CPP_EXTS:
-        lang = CPP
-    elif ext == "py":
-        lang = PY
-    else:
-        continue
+    # Parse diff to get changed line ranges per file
+    files = {}
+    current = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+        elif line.startswith("@@") and current:
+            m = re.search(r"-(\d+)(?:,(\d+))?", line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2)) if m.group(2) else 1
+                end = start + count - 1 if count > 0 else start
+                files.setdefault(current, []).append((start, end))
 
-    try:
-        source = subprocess.run(
-            ["git", "show", f"{base}:{path}"],
-            capture_output=True, check=True,
-        ).stdout
-    except subprocess.CalledProcessError:
-        continue
+    if not files:
+        print(f"No changes found between {base} and HEAD.")
+        return []
 
-    tree = Parser(lang).parse(source)
+    all_changed_functions = set()
 
-    # Find all function definitions and their line ranges in the file
-    funcs = []
-    stack = [tree.root_node]
-    while stack:
-        node = stack.pop()
-        if node.type == "function_definition":
-            name = None
-            for child in node.children:
-                if lang == PY and child.type == "identifier":
-                    name = child.text.decode()
-                    break
-                if lang == CPP and "declarator" in child.type:
-                    t = child.text.decode()
-                    p = t.find("(")
-                    if p != -1:
-                        prefix = t[:p]
-                        for macro in ("TORCH_META_FUNC", "TORCH_IMPL_FUNC"):
-                            if macro in prefix:
-                                inner = t[t.find("(") + 1 : t.find(")")]
-                                name = inner.split(",")[0].strip()
-                                break
-                        else:
-                            name = prefix.split()[-1].lstrip("&*")
-                    break
-            if name:
-                funcs.append((name, node.start_point[0] + 1, node.end_point[0] + 1))
+    for path, ranges in files.items():
+        if path.startswith("test/"):
+            continue
+        ext = path.rsplit(".", 1)[-1] if "." in path else ""
+        if ext in CPP_EXTS:
+            lang = CPP
+        elif ext == "py":
+            lang = PY
         else:
-            stack.extend(node.children)
+            continue
 
-    # Find functions whose line ranges overlap with changed lines
-    matched = set()
-    for name, fs, fe in funcs:
-        for cs, ce in ranges:
-            if fs <= ce and cs <= fe:
-                matched.add(name)
-                break
+        try:
+            source = subprocess.run(
+                ["git", "show", f"{base}:{path}"],
+                capture_output=True, check=True,
+            ).stdout
+        except subprocess.CalledProcessError:
+            continue
 
-    print(f"\n{path}")
-    if matched:
-        for f in sorted(matched):
-            print(f"  {f}")
-    else:
-        print(f"  (no functions found, file-level change)")
-    all_changed_functions.update(matched)
+        tree = Parser(lang).parse(source)
 
-# Map function names to operator names via native_functions.yaml
-import yaml
+        # Find all function definitions and their line ranges in the file
+        funcs = []
+        stack = [tree.root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == "function_definition":
+                name = None
+                for child in node.children:
+                    if lang == PY and child.type == "identifier":
+                        name = child.text.decode()
+                        break
+                    if lang == CPP and "declarator" in child.type:
+                        t = child.text.decode()
+                        p = t.find("(")
+                        if p != -1:
+                            prefix = t[:p]
+                            for macro in ("TORCH_META_FUNC", "TORCH_IMPL_FUNC"):
+                                if macro in prefix:
+                                    inner = t[t.find("(") + 1 : t.find(")")]
+                                    name = inner.split(",")[0].strip()
+                                    break
+                            else:
+                                name = prefix.split()[-1].lstrip("&*")
+                        break
+                if name:
+                    funcs.append((name, node.start_point[0] + 1, node.end_point[0] + 1))
+            else:
+                stack.extend(node.children)
 
-with open("aten/src/ATen/native/native_functions.yaml") as f:
-    ops = yaml.safe_load(f)
+        # Find functions whose line ranges overlap with changed lines
+        matched = set()
+        for name, fs, fe in funcs:
+            for cs, ce in ranges:
+                if fs <= ce and cs <= fe:
+                    matched.add(name)
+                    break
 
-kernel_to_op = {}
-op_names = set()
-for entry in ops:
-    if "func" not in entry:
-        continue
-    func_str = entry["func"].split("(")[0].split(".")[0]
-    op_names.add(func_str)
-    if "dispatch" in entry:
-        for kernel in entry["dispatch"].values():
-            kernel_to_op[kernel] = func_str
+        print(f"\n{path}")
+        if matched:
+            for f in sorted(matched):
+                print(f"  {f}")
+        else:
+            print(f"  (no functions found, file-level change)")
+        all_changed_functions.update(matched)
 
-# Look up each changed function
-print("\n--- Operator mapping ---")
-matched_ops = set()
-for func in sorted(all_changed_functions):
-    if func in kernel_to_op:
-        op = kernel_to_op[func]
-        print(f"  {func} -> {op} (kernel match)")
-        matched_ops.add(op)
-    elif func in op_names:
-        print(f"  {func} -> {func} (direct match)")
-        matched_ops.add(func)
-    else:
-        print(f"  {func} -> (no operator match)")
+    # Map function names to operator names via native_functions.yaml
+    with open("aten/src/ATen/native/native_functions.yaml") as f:
+        ops = yaml.safe_load(f)
 
-# Map operators to benchmark tests
-import glob
+    kernel_to_op = {}
+    op_names = set()
+    for entry in ops:
+        if "func" not in entry:
+            continue
+        func_str = entry["func"].split("(")[0].split(".")[0]
+        op_names.add(func_str)
+        if "dispatch" in entry:
+            for kernel in entry["dispatch"].values():
+                kernel_to_op[kernel] = func_str
 
-benchmark_modules = {}
-for f in glob.glob("benchmarks/operator_benchmark/pt/*_test.py"):
-    with open(f) as fh:
-        content = fh.read()
-        for m in re.finditer(r'set_module_name\("(\w+)"\)', content):
-            benchmark_modules.setdefault(m.group(1).lower(), set()).add(f.split("/")[-1])
-        for line in content.splitlines():
-            if line.lstrip().startswith("#"):
-                continue
-            for m in re.finditer(r'\["(\w+)",\s*torch\.', line):
+    print("\n--- Operator mapping ---")
+    matched_ops = set()
+    for func in sorted(all_changed_functions):
+        if func in kernel_to_op:
+            op = kernel_to_op[func]
+            print(f"  {func} -> {op} (kernel match)")
+            matched_ops.add(op)
+        elif func in op_names:
+            print(f"  {func} -> {func} (direct match)")
+            matched_ops.add(func)
+        else:
+            print(f"  {func} -> (no operator match)")
+
+    # Map operators to benchmark tests
+    benchmark_modules = {}
+    for f in glob.glob("benchmarks/operator_benchmark/pt/*_test.py"):
+        with open(f) as fh:
+            content = fh.read()
+            for m in re.finditer(r'set_module_name\("(\w+)"\)', content):
                 benchmark_modules.setdefault(m.group(1).lower(), set()).add(f.split("/")[-1])
+            for line in content.splitlines():
+                if line.lstrip().startswith("#"):
+                    continue
+                for m in re.finditer(r'\["(\w+)",\s*torch\.', line):
+                    benchmark_modules.setdefault(m.group(1).lower(), set()).add(f.split("/")[-1])
 
-# Map operators to benchmark test names
-print("\n--- Benchmark mapping ---")
-matched_tests = set()
-for op in sorted(matched_ops):
-    if op in benchmark_modules:
-        print(f"  {op} -> {benchmark_modules[op]}")
-        matched_tests.update(benchmark_modules[op])
-    else:
-        best = ""
-        for mod in benchmark_modules:
-            if op.startswith(mod) and (len(op) == len(mod) or op[len(mod)] == "_"):
-                if len(mod) > len(best):
-                    best = mod
-        if best:
-            print(f"  {op} -> {benchmark_modules[best]} (via {best})")
-            matched_tests.update(benchmark_modules[best])
+    print("\n--- Benchmark mapping ---")
+    matched_tests = set()
+    for op in sorted(matched_ops):
+        if op in benchmark_modules:
+            print(f"  {op} -> {benchmark_modules[op]}")
+            matched_tests.update(benchmark_modules[op])
         else:
-            print(f"  {op} -> NO BENCHMARK")
+            best = ""
+            for mod in benchmark_modules:
+                if op.startswith(mod) and (len(op) == len(mod) or op[len(mod)] == "_"):
+                    if len(mod) > len(best):
+                        best = mod
+            if best:
+                print(f"  {op} -> {benchmark_modules[best]} (via {best})")
+                matched_tests.update(benchmark_modules[best])
+            else:
+                print(f"  {op} -> NO BENCHMARK")
 
-# Output for CI: space-separated test names (strip _test.py suffix)
-test_names = sorted(t.replace("_test.py", "") for t in matched_tests)
-print(f"\nOP_BENCHMARK_TESTS={' '.join(test_names)}")
+    test_names = sorted(t.replace("_test.py", "") for t in matched_tests)
+    print(f"\nOP_BENCHMARK_TESTS={' '.join(test_names)}")
+    return test_names
+
+
+def run(label, base):
+    label_dir = os.path.join(PERFMAP_DIR, label)
+    os.makedirs(label_dir, exist_ok=True)
+    tests_file = os.path.join(label_dir, "tests.txt")
+
+    # First run: detect tests and save. Later runs: reuse saved list.
+    if not os.path.exists(tests_file):
+        test_names = detect(base)
+        if not test_names:
+            print("No benchmarks found. Run on a branch with operator changes first.")
+            return
+        with open(tests_file, "w") as f:
+            f.write("\n".join(test_names))
+    else:
+        with open(tests_file) as f:
+            test_names = [l.strip() for l in f if l.strip()]
+        if not test_names:
+            print("Saved test list is empty. Delete .perfmap/{label}/ and run on a branch with changes.")
+            return
+        print(f"Using saved test list: {' '.join(test_names)}")
+
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+    run_dir = os.path.join(label_dir, f"{branch}_{commit}")
+    os.makedirs(run_dir, exist_ok=True)
+
+    for test in test_names:
+        out_file = os.path.join(run_dir, f"{test}.json")
+        print(f"Running {test}...")
+        subprocess.run(
+            [sys.executable, "-m", f"pt.{test}_test",
+             "--tag-filter", "long", "--output-json", os.path.abspath(out_file)],
+            cwd="benchmarks/operator_benchmark",
+        )
+
+    print(f"\nResults saved to {run_dir}")
+
+
+def compare(label):
+    label_dir = os.path.join(PERFMAP_DIR, label)
+    if not os.path.exists(label_dir):
+        print(f"No runs found for label '{label}'. Run benchmarks first with: perfmap.py run --label {label}")
+        return
+
+    runs = sorted(
+        d for d in os.listdir(label_dir)
+        if os.path.isdir(os.path.join(label_dir, d))
+    )
+    if len(runs) < 2:
+        print(f"Need at least 2 runs to compare, found {len(runs)}. Run benchmarks on another branch.")
+        return
+
+    # Load latencies: {test_name: latency}
+    def load_run(run_tag):
+        run_dir = os.path.join(label_dir, run_tag)
+        latencies = {}
+        for f in sorted(os.listdir(run_dir)):
+            if not f.endswith(".json"):
+                continue
+            with open(os.path.join(run_dir, f)) as fh:
+                for entry in json.load(fh):
+                    key = entry.get("test_name", "unknown")
+                    latency = entry.get("latency", 0)
+                    if latency > 0:
+                        latencies[key] = latency
+        return latencies
+
+    baseline_tag, branch_tag = runs[0], runs[1]
+    baseline = load_run(baseline_tag)
+    branch = load_run(branch_tag)
+
+    all_tests = sorted(set(baseline.keys()) | set(branch.keys()))
+    if not all_tests:
+        print("No benchmark results found in either run.")
+        return
+
+    lines = []
+    lines.append(f"## Benchmark Comparison: `{baseline_tag}` vs `{branch_tag}`\n")
+    lines.append(f"| Test | {baseline_tag} (us) | {branch_tag} (us) | Diff (us) | Change |")
+    lines.append("|------|------|------|------|--------|")
+    for test in all_tests:
+        b = baseline.get(test)
+        r = branch.get(test)
+        if b is None or r is None:
+            continue
+        diff = r - b
+        pct = (diff / b) * 100 if b > 0 else 0
+        lines.append(f"| {test} | {b:.2f} | {r:.2f} | {diff:+.2f} | {pct:+.1f}% |")
+
+    output = "\n".join(lines)
+    print(f"\n{output}")
+
+    out_file = os.path.join(label_dir, "comparison.md")
+    with open(out_file, "w") as f:
+        f.write(output + "\n")
+    print(f"\nSaved to {out_file}")
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+
+    if not args or args[0] not in ("detect", "run", "compare"):
+        base = args[0] if args else "upstream/viable/strict"
+        detect(base)
+
+    elif args[0] == "detect":
+        base = args[1] if len(args) > 1 else "upstream/viable/strict"
+        detect(base)
+
+    elif args[0] == "run":
+        label, base = None, "upstream/viable/strict"
+        i = 1
+        while i < len(args):
+            if args[i] == "--label" and i + 1 < len(args):
+                label = args[i + 1]
+                i += 2
+            elif args[i] == "--base" and i + 1 < len(args):
+                base = args[i + 1]
+                i += 2
+            else:
+                i += 1
+        if not label:
+            print("Usage: perfmap.py run --label <name>")
+            sys.exit(1)
+        run(label, base)
+
+    elif args[0] == "compare":
+        label = None
+        i = 1
+        while i < len(args):
+            if args[i] == "--label" and i + 1 < len(args):
+                label = args[i + 1]
+                i += 2
+            else:
+                i += 1
+        if not label:
+            print("Usage: perfmap.py compare --label <name>")
+            sys.exit(1)
+        compare(label)


### PR DESCRIPTION
# RFC: Auto-select and run Operator Performance Benchmarks from PR Diffs

## Summary

This RFC explores automatically mapping code changes in a PR to the operator performance benchmarks that should run against those changes. Today this mapping does not exist. The benchmarks exist, the comparison workflow exists, but nothing connects a diff to the right benchmarks. This RFC presents a script that does that mapping, discusses adding missing benchmark tests over time, and outlines how CI integration could work as a next step. Feedback on the approach is welcome.

## Problem

When a PR modifies operator kernel code, reviewers have no performance signal before merging. Regressions show up later in model-level benchmarks or user reports. By then, finding the responsible PR means bisecting across hundreds of commits.

The infrastructure to catch this already exists. `benchmarks/operator_benchmark/` has test files covering some of operators, and `operator_microbenchmark_compare.yml` can build two wheels, run benchmarks on both, and post a comparison as a PR comment. But the workflow is manual: someone picks an operator from a dropdown, picks a GPU, and triggers it. For most PRs, nobody does this.

The missing piece is the mapping: given a diff, which benchmarks should run? And when a benchmark doesn't exist for an affected operator, how do we know its missing?

## The script

The RFC includes a single Python script (`tools/testing/perfmap.py`, ~250 lines) that takes a base ref, maps the diff to operators and benchmarks, runs the benchmarks, and produces a comparison across branches:

    # On your feature branch
    python tools/testing/perfmap.py run --label my-feature

    # Switch to baseline, build, run again
    python tools/testing/perfmap.py run --label my-feature

    # Compare
    python tools/testing/perfmap.py compare --label my-feature

Internally the script walks this chain:

1. Parse `git diff` to get changed files and line ranges
2. Find which functions enclose those changed lines using an AST parser
3. Look up those function names in `native_functions.yaml` to get operator names
4. Match operator names to benchmark test files in `operator_benchmark/pt/`
5. Run the matched benchmarks and save results
6. On compare, produce a markdown table

The comparison output looks like this and can be pasted directly into a PR description or GitHub comment to give reviewers a performance signal:

| Test | baseline (us) | branch (us) | Diff (us) | Change |
|------|------|------|------|--------|
| addmm_M1_N1_K1_cpu f32 | 1.91 | 1.90 | -0.01 | -0.5% |
| addmm_M1_N1_K1_cuda f32 | 2934.80 | 2872.26 | -62.54 | -2.1% |
| addmm_M64_N64_K128_cpu f32 | 48.63 | 49.97 | +1.34 | +2.8% |
| addmm_M64_N64_K64_cuda f32 | 2854.87 | 2982.91 | +128.04 | +4.5% |
| mm_M1_N1_K1_cpu f32 | 1.29 | 1.32 | +0.03 | +1.9% |
| mm_M64_N64_K128_cpu f32 | 44.22 | 43.07 | -1.15 | -2.6% |
| mm_M64_N64_K64_cpu f32 | 24.49 | 25.20 | +0.71 | +2.9% |

For function detection, the script currently uses tree-sitter with C++ and Python grammars. This gives exact function boundaries rather than relying on git's hunk headers. tree-sitter adds pip dependencies (tree-sitter, tree-sitter-cpp, tree-sitter-python). Alternatives include ctags, libclang, or a hand-written parser. Input on the right choice here is welcome.

## Adding missing benchmarks

The script reports "NO BENCHMARK" when an operator is affected but has no benchmark test file. This is useful on its own: it tells us exactly which operators need benchmarks and prioritizes them by how often their kernels are changed.

Currently a small fraction of operators have benchmarks. Growing this coverage is an incremental effort, independent of the mapping script itself. Each new benchmark test file is automatically discovered by the script on its next run.

## Future goals

- **CI integration.** If this approach proves useful, the script can plug into the existing `operator_microbenchmark_compare.yml` workflow by adding a `pull_request` trigger and a detect-operators job that feeds the results to the existing benchmark runner. This would automate the process so reviewers get a performance comparison comment on every PR that touches operator code.
- **Increase benchmark coverage.** Most operators registered through `native_functions.yaml` don't have benchmarks yet. The script identifies which operators are missing coverage, which helps prioritize adding new benchmark test files. Each new file is automatically discovered.
- **Cover operators outside `native_functions.yaml`.** Code not reachable through o`native_functions.yaml` needs to be benchamrked. Extending the mapping to cover these would improve recall.
- **Eager + compiled benchmarks.** The benchmark runner supports `--use-compile`. Changes to inductor/dynamo only affect the compile path, so triggering both modes selectively would be valuable.
- **File-level fallback.** When function-level matching fails, falling back to all operators in the changed file would catch more regressions at the cost of running more benchmarks.
- **Canary set for shared infrastructure.** Changes to code like CUDACachingAllocator or TensorIterator affect many operators but can't map to specific ones. A fixed set of representative benchmarks for these paths would catch broad regressions.

Comments and suggestions welcome.