### PR TITLE
Fix Cauchy/Gumbel icdf boundary values at q=0/q=1 (#186824)

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4196,6 +4196,29 @@ class TestDistributions(DistributionsTestCase):
                         ]
                     ),
                 )
+                
+    def test_cauchy_gumbel_icdf_boundary(self):
+        # Boundary quantiles map to the (unbounded) support endpoints.
+        # https://github.com/pytorch/pytorch/issues/186824
+        inf = float("inf")
+        for dtype in (torch.float32, torch.float64):
+            loc = torch.tensor(0.0, dtype=dtype)
+            scale = torch.tensor(1.0, dtype=dtype)
+            for ctor in (Cauchy, Gumbel):
+                d = ctor(loc, scale)
+                self.assertEqual(
+                    d.icdf(torch.tensor(0.0, dtype=dtype)),
+                    torch.tensor(-inf, dtype=dtype),
+                )
+                self.assertEqual(
+                    d.icdf(torch.tensor(1.0, dtype=dtype)),
+                    torch.tensor(inf, dtype=dtype),
+                )
+                # per-element boundaries within a batch stay independent
+                self.assertEqual(
+                    d.icdf(torch.tensor([0.0, 1.0], dtype=dtype)),
+                    torch.tensor([-inf, inf], dtype=dtype),
+                )
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gamma_log_prob_at_boundary(self):

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4196,7 +4196,7 @@ class TestDistributions(DistributionsTestCase):
                         ]
                     ),
                 )
-                
+
     def test_cauchy_gumbel_icdf_boundary(self):
         # Boundary quantiles map to the (unbounded) support endpoints.
         # https://github.com/pytorch/pytorch/issues/186824

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -93,7 +93,13 @@ class Cauchy(Distribution):
         return torch.atan((value - self.loc) / self.scale) / math.pi + 0.5
 
     def icdf(self, value):
-        return torch.tan(math.pi * (value - 0.5)) * self.scale + self.loc
+        result = torch.tan(math.pi * (value - 0.5)) * self.scale + self.loc
+        # The tan pole at q=0 / q=1 lands on the wrong side under float
+        # rounding (sign-flips in float32), but the Cauchy support is
+        # unbounded, so the boundary quantiles are -inf / +inf (scale > 0).
+        result = torch.where(torch.as_tensor(value == 0), torch.full_like(result, -inf), result)
+        result = torch.where(torch.as_tensor(value == 1), torch.full_like(result, inf), result)
+        return result
 
     def entropy(self):
         return math.log(4 * math.pi) + self.scale.log()

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -97,8 +97,12 @@ class Cauchy(Distribution):
         # The tan pole at q=0 / q=1 lands on the wrong side under float
         # rounding (sign-flips in float32), but the Cauchy support is
         # unbounded, so the boundary quantiles are -inf / +inf (scale > 0).
-        result = torch.where(torch.as_tensor(value == 0), torch.full_like(result, -inf), result)
-        result = torch.where(torch.as_tensor(value == 1), torch.full_like(result, inf), result)
+        result = torch.where(
+            torch.as_tensor(value == 0), torch.full_like(result, -inf), result
+        )
+        result = torch.where(
+            torch.as_tensor(value == 1), torch.full_like(result, inf), result
+        )
         return result
 
     def entropy(self):

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -58,6 +58,15 @@ class Gumbel(TransformedDistribution):
         ]
         super().__init__(base_dist, transforms, validate_args=validate_args)
 
+    def icdf(self, value):
+        result = super().icdf(value)
+        # The base Uniform is intentionally truncated to (tiny, 1 - eps) for
+        # rsample stability, leaving the boundary quantiles finite. The Gumbel
+        # support is unbounded, so q=0 / q=1 map to -inf / +inf (scale > 0).
+        result = torch.where(torch.as_tensor(value == 0), torch.full_like(result, -float("inf")), result)
+        result = torch.where(torch.as_tensor(value == 1), torch.full_like(result, float("inf")), result)
+        return result
+
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Gumbel, _instance)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -63,8 +63,12 @@ class Gumbel(TransformedDistribution):
         # The base Uniform is intentionally truncated to (tiny, 1 - eps) for
         # rsample stability, leaving the boundary quantiles finite. The Gumbel
         # support is unbounded, so q=0 / q=1 map to -inf / +inf (scale > 0).
-        result = torch.where(torch.as_tensor(value == 0), torch.full_like(result, -float("inf")), result)
-        result = torch.where(torch.as_tensor(value == 1), torch.full_like(result, float("inf")), result)
+        result = torch.where(
+            torch.as_tensor(value == 0), torch.full_like(result, -float("inf")), result
+        )
+        result = torch.where(
+            torch.as_tensor(value == 1), torch.full_like(result, float("inf")), result
+        )
         return result
 
     def expand(self, batch_shape, _instance=None):


### PR DESCRIPTION
Fixes #186824

## Summary

`Cauchy.icdf` and `Gumbel.icdf` return finite values at the support
boundaries `q=0` / `q=1`, where the unbounded support means they should
return `-inf` / `+inf`. For `Cauchy` in float32 the returned value also
has the **wrong sign**:

```python
import torch
torch.distributions.Cauchy(0., 1.).icdf(torch.tensor(0.0))   # tensor(22877332.)  -> should be -inf
torch.distributions.Gumbel(0., 1.).icdf(torch.tensor(0.0))   # tensor(-4.4698)    -> should be -inf
torch.distributions.Normal(0., 1.).icdf(torch.tensor(0.0))   # tensor(-inf)       -> already correct
```

## Root cause

- **Cauchy**: `icdf` is the bare formula `tan(pi * (value - 0.5)) * scale + loc`.
  At `q=0` the argument is exactly the `-pi/2` tan pole; float32 rounding of
  `pi * (q - 0.5)` lands on the far side of the pole, producing a large
  positive value instead of `-inf` (a sign flip). float64 doesn't flip but
  still yields a finite `~ -1.6e16`.
- **Gumbel**: has no `icdf` of its own and inherits `TransformedDistribution.icdf`,
  which routes through the base `Uniform(finfo.tiny, 1 - finfo.eps)`. That
  truncation is intentional for `rsample` stability, but it leaves the boundary
  quantiles finite and dtype-dependent.

`Normal.icdf` (erfinv-based) already returns `±inf` at the boundaries, so this
brings the two outliers in line with the existing module convention.

## Fix

Special-case `q==0` / `q==1` to the support endpoints in both `icdf`
implementations. `scale` is `constraints.positive` in both distributions, so
the endpoint signs are unambiguous (`q=0 -> -inf`, `q=1 -> +inf`) with no
`sign(scale)` handling needed. The truncated base `Uniform` is left untouched,
so sampling behavior is unchanged — only `icdf` is clamped.

The same float32 sign-flip in a direct tan-based quantile was recently
confirmed in JAX (jax-ml/jax#38318).

## Test plan

Added `test_cauchy_gumbel_icdf_boundary` to `test/distributions/test_distributions.py`,
asserting `icdf(0) == -inf` and `icdf(1) == +inf` for both distributions across
float32/float64, including per-element boundaries within a batch.

```bash
python test/distributions/test_distributions.py TestDistributions.test_cauchy_gumbel_icdf_boundary -v
```

Verified locally:
- boundaries return `-inf` / `+inf` in both float32 and float64
- interior quantiles unchanged and match `scipy.stats.cauchy.ppf` / `gumbel_r.ppf`
- `cdf(icdf(q))` round-trips at interior points
- gradients still flow through interior `q`
- `Normal.icdf` unaffected

The change is zero-cost for interior quantiles (one boundary-mask `where`) and
does not alter `rsample`.

cc @fritzo @neerajprad @alicanb @nikitaved