### PR TITLE
Add owner headers to binary build/release workflows

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import os
 import sys
 from collections.abc import Iterable
@@ -65,6 +66,8 @@ class BinaryBuildWorkflow:
     # Libtorch extraction configs: lightweight jobs that extract libtorch
     # from a wheel build instead of building libtorch from scratch
     libtorch_extraction_configs: list[dict[str, str]] = field(default_factory=list)
+    # Owner labels emitted as the "# Owner(s):" header; see WORKFLOWOWNERS lint.
+    owners: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.build_environment == "":
@@ -73,6 +76,19 @@ class BinaryBuildWorkflow:
                 for item in [self.os, "binary", self.package_type, self.build_variant]
                 if item != ""
             )
+        if not self.owners:
+            self.owners = ["oncall: releng"]
+            if self.os in (OperatingSystem.MACOS, OperatingSystem.MACOS_ARM64):
+                self.owners.append("module: macos")
+            elif self.os in (OperatingSystem.WINDOWS, OperatingSystem.WINDOWS_ARM64):
+                self.owners.append("module: windows")
+            # A single binary workflow bundles configs for every gpu_arch_type, so
+            # add the accelerator-team owners for whichever ones the matrix includes.
+            arches = {config.get("gpu_arch_type") for config in self.build_configs}
+            if "rocm" in arches:
+                self.owners.append("module: rocm")
+            if "xpu" in arches:
+                self.owners.append("module: xpu")
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
         output_file_path = (
@@ -81,7 +97,12 @@ class BinaryBuildWorkflow:
         )
         with open(output_file_path, "w") as output_file:
             GENERATED = "generated"  # Note that please keep the variable GENERATED otherwise phabricator will hide the whole file
-            output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
+            output_file.writelines(
+                [
+                    f"# Owner(s): {json.dumps(self.owners)}\n",
+                    f"# @{GENERATED} DO NOT EDIT MANUALLY\n",
+                ]
+            )
             try:
                 content = workflow_template.render(asdict(self))
             except Exception as e:

--- a/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Build Flash Attention 3 wheels
 
 on:

--- a/.github/workflows/_binary-build-flash-attention-wheel-windows.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-windows.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows"]
 name: Build Flash Attention 3 wheels (Windows)
 
 on:

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: linux-binary-build
 
 # Reusable build workflow for linux binary (manywheel/libtorch).

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: linux-binary-test
 
 # Reusable test workflow for linux binary (manywheel/libtorch).

--- a/.github/workflows/_binary-test-macos.yml
+++ b/.github/workflows/_binary-test-macos.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: macos"]
 name: test-and-upload (macOS wheel)
 
 # Run the smoke-test of a built macOS arm64 wheel on a fresh macos runner,

--- a/.github/workflows/_binary-upload-flash-attention-wheel.yml
+++ b/.github/workflows/_binary-upload-flash-attention-wheel.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Upload Flash Attention 3 wheels
 
 on:

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: upload
 
 on:

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Build almalinux docker images
 
 on:

--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: build-linux-magma
 
 on:

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows"]
 name: Build MAGMA for Windows
 
 on:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Build manywheel docker images
 
 on:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Build Triton wheels
 
 on:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Create Release
 
 on:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Build Official Docker Images
 
 on:

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/linux_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: rocm", "module: xpu"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/linux_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/linux_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: macos"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/macos_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-windows-arm64-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-libtorch-debug-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng", "module: windows", "module: xpu"]
 # @generated DO NOT EDIT MANUALLY
 
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2

--- a/.github/workflows/nightly-s3-uploads.yml
+++ b/.github/workflows/nightly-s3-uploads.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Nightly Upload to s3
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: nightly
 
 on:

--- a/.github/workflows/test-check-binary.yml
+++ b/.github/workflows/test-check-binary.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: Test check_binary
 
 on:

--- a/.github/workflows/trunk-tagging.yml
+++ b/.github/workflows/trunk-tagging.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: trunk-tagging
 
 on:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: releng"]
 name: weekly
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* #186843
* #186842
* #186841
* #186840
* #186839
* __->__ #186838

Mirror the test-file `# Owner(s): [...]` convention for the binary build, test, upload, and release-engineering workflows under .github/workflows/,
attributing them to `oncall: releng` (plus the platform/accelerator team for OS- or arch-specific variants).

This is the first commit in a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.