### PR TITLE
Add owner headers to ROCm workflows

### DIFF
--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: linux-binary-test-rocm
 
 # Reusable workflow that runs the ROCm binary test (setup-rocm, GPU device

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 # TODO: this looks sort of similar to _linux-test, but there are like a dozen
 # places where you would have to insert an if statement. Probably it's better to
 # just use a different workflow altogether

--- a/.github/workflows/build-magma-rocm-linux.yml
+++ b/.github/workflows/build-magma-rocm-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: build-linux-magma-rocm
 
 on:

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: docker-cache-rocm
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: inductor-perf-nightly-rocm-mi300
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi355.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: inductor-perf-nightly-rocm-mi355
 
 on:

--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: inductor-rocm-mi200
 
 on:

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: inductor-rocm-mi300
 
 on:

--- a/.github/workflows/inductor-rocm-mi355.yml
+++ b/.github/workflows/inductor-rocm-mi355.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 # Unneeded for CI: trunk.yml covers the same ROCm testing.
 # Kept in-repo for metrics; auto-triggers below are commented out.
 # workflow_dispatch remains for manual runs.

--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: periodic-rocm-mi200
 
 on:

--- a/.github/workflows/periodic-rocm-mi300.yml
+++ b/.github/workflows/periodic-rocm-mi300.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: periodic-rocm-mi300
 
 on:

--- a/.github/workflows/periodic-rocm-mi355.yml
+++ b/.github/workflows/periodic-rocm-mi355.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 # Unneeded for CI: trunk.yml covers the same ROCm testing.
 # Kept in-repo for metrics; auto-triggers below are commented out.
 # workflow_dispatch remains for manual runs.

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: rocm-mi200
 
 on:

--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: rocm-mi300
 
 on:

--- a/.github/workflows/rocm-mi355.yml
+++ b/.github/workflows/rocm-mi355.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 # Unneeded for CI: trunk.yml covers the same ROCm testing.
 # Kept in-repo for metrics; auto-triggers below are commented out.
 # workflow_dispatch remains for manual runs.

--- a/.github/workflows/rocm-navi31.yml
+++ b/.github/workflows/rocm-navi31.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: rocm-navi31
 
 on:

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: rocm-nightly
 
 on:

--- a/.github/workflows/slow-rocm-mi200.yml
+++ b/.github/workflows/slow-rocm-mi200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 # This workflow is dedicated to host slow jobs that are run only periodically because
 # they are too slow to run in every commit.  The list of slow tests can be found in
 # https://github.com/pytorch/test-infra/blob/generated-stats/stats/slow-tests.json

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: rocm"]
 name: trunk-rocm-sandbox
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* #186843
* #186842
* #186841
* #186840
* __->__ #186839
* #186838

Attribute the ROCm CI workflows under .github/workflows/ to `module: rocm`, following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang