### PR TITLE
Add owner headers to distributed workflows

### DIFF
--- a/.github/workflows/b200-distributed.yml
+++ b/.github/workflows/b200-distributed.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed"]
 name: CI for distributed tests on B200
 
 on:

--- a/.github/workflows/b200-symm-mem.yml
+++ b/.github/workflows/b200-symm-mem.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed", "module: symm_mem"]
 name: Limited CI for symmetric memory tests on B200
 
 on:

--- a/.github/workflows/claude-distributed-triage-cron.yml
+++ b/.github/workflows/claude-distributed-triage-cron.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed"]
 name: Claude Distributed Triage Cron
 
 on:

--- a/.github/workflows/claude-distributed-triage.yml
+++ b/.github/workflows/claude-distributed-triage.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed"]
 name: Claude Distributed Triage
 
 on:

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed", "module: dtensor"]
 # Workflow: DTensor Unit Test
 # Runs unit tests for DTensor (test/distributed/tensor/).
 name: dtensor

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed"]
 name: Limited CI for distributed tests on H100
 
 on:

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed", "module: symm_mem"]
 name: Limited CI for symmetric memory tests on H100
 
 on:

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: distributed"]
 name: torchtitan-test
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* #186843
* #186842
* #186841
* __->__ #186840
* #186839
* #186838

Attribute the distributed CI workflows under .github/workflows/ to `oncall: distributed` (plus the relevant module for symm_mem/dtensor), following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.