### PR TITLE
Add owner headers to inductor/dynamo workflows

### DIFF
--- a/.github/workflows/dynamo-unittest.yml
+++ b/.github/workflows/dynamo-unittest.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 # Workflow: Dynamo Unit Test
 # runs unit tests for dynamo.
 name: dynamo-unittest

--- a/.github/workflows/h100-cutlass-backend.yml
+++ b/.github/workflows/h100-cutlass-backend.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: Limited CI for CUTLASS backend on H100
 
 on:

--- a/.github/workflows/inductor-micro-benchmark-x86.yml
+++ b/.github/workflows/inductor-micro-benchmark-x86.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-micro-benchmark-x86
 
 on:

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-micro-benchmark
 
 on:

--- a/.github/workflows/inductor-nightly.yml
+++ b/.github/workflows/inductor-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-nightly
 
 on:

--- a/.github/workflows/inductor-pallas.yml
+++ b/.github/workflows/inductor-pallas.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-pallas
 
 on:

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-A100-perf-compare
 
 on:

--- a/.github/workflows/inductor-perf-test-b200.yml
+++ b/.github/workflows/inductor-perf-test-b200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-perf-b200
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-perf-nightly-h100
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-perf-nightly-x86-zen
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-perf-nightly-x86
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-A100-perf-nightly
 
 on:

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: inductor-periodic
 
 on:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 # Workflow: Inductor Unit Test
 # 1. runs unit tests for inductor.
 # 2. performs daily memory leak checks and reruns of disabled tests, scheduled at `29 8 * * *`.

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 # Workflow: Inductor
 # runs all inductor tests, including both benchmark tests and unit tests.
 # adding New Tests:

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["oncall: pt2"]
 name: Upload torch dynamo performance stats
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* #186843
* #186842
* __->__ #186841
* #186840
* #186839
* #186838

Attribute the inductor and dynamo CI workflows under .github/workflows/ to `oncall: pt2` (plus the platform/accelerator team for OS- or arch-specific variants), following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.