### PR TITLE
Add owner headers to CI-infrastructure workflows

### DIFF
--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Get Changed Files
 
 on:

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: linux-build
 
 on:

--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 # The point of this workflow is to test that a FA3 wheel that was built based off the
 # stable ABI targeting 2.9 can still run on the newer torch.
 #

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: linux-test
 
 on:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Check whether the workflow owner can use ARC runners
 
 on:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Auto Request Review
 
 on:

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Check mergeability of ghstack PR
 
 on:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Create a cherry pick from a PR
 
 on:

--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Claude Autorevert Advisor
 
 on:

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Claude Code
 
 on:

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Claude Issue Triage Run
 
 on:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Claude Issue Triage
 
 on:

--- a/.github/workflows/close-nonexistent-disable-issues.yml
+++ b/.github/workflows/close-nonexistent-disable-issues.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Close nonexistent disable issues
 
 on:

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 # A workflow that deletes branches of closed PRs
 
 name: Delete old branches

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: docker-builds
 
 on:

--- a/.github/workflows/job-filter.yml
+++ b/.github/workflows/job-filter.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: job-filter
 
 # Job Filter Rules (for trunk.yml, pull.yml)

--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Retrieval PyTorch Tests for Target Determination
 
 on:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: periodic
 
 on:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: pull
 
 on:

--- a/.github/workflows/quack-vendor-reproducibility.yml
+++ b/.github/workflows/quack-vendor-reproducibility.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 # Reproducibility guard for the vendored quack subset (torch/_vendor/quack).
 #
 # Runs tools/vendoring/quack/vendor.sh --check against the SHA pinned in

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Revert merged PR
 
 on:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: ossf-scorecard
 on:
   # Only the default branch is supported.

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 # This workflow is dedicated to host slow jobs that are run only periodically because
 # they are too slow to run in every commit.  The list of slow tests can be found in
 # https://github.com/pytorch/test-infra/blob/generated-stats/stats/slow-tests.json

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 # A workflow that implements similar logic to actions/stale.
 #
 # Compared to actions/stale, it is implemented to make API requests proportional

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Index PyTorch Tests for Target Determination
 
 on:

--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: target-determination
 
 on:

--- a/.github/workflows/tools-unit-tests.yml
+++ b/.github/workflows/tools-unit-tests.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: test-scripts-and-ci-tools
 
 on:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: trunk
 
 on:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Validate and merge PR
 
 on:

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Rebase PR
 
 on:

--- a/.github/workflows/unstable-periodic.yml
+++ b/.github/workflows/unstable-periodic.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: unstable-periodic
 
 on:

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: unstable
 
 on:

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Update viable/strict
 
 on:

--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Update PyTorch Labels in S3
 
 on:

--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Upload test stats while running
 
 on:

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Upload test stats
 
 on:

--- a/.github/workflows/upload_test_stats_intermediate.yml
+++ b/.github/workflows/upload_test_stats_intermediate.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: ci"]
 name: Upload test stats intermediate
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* #186843
* __->__ #186842
* #186841
* #186840
* #186839
* #186838

Attribute the CI-infrastructure workflows under .github/workflows/ (the shared _linux-* building blocks, merge/rebase/revert tooling, target determination, stats uploads, and the pull/trunk/periodic drivers) to `module: ci`, following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.