### PR TITLE
Add owner headers to platform/accelerator workflows

### DIFF
--- a/.github/workflows/_binary-test-xpu-linux.yml
+++ b/.github/workflows/_binary-test-xpu-linux.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: xpu"]
 name: linux-binary-test-xpu
 
 # Reusable workflow that runs the XPU binary test (setup-xpu, ECR login,

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: macos"]
 name: mac-build
 
 on:

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: macos"]
 name: mac-test
 
 on:

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: windows"]
 name: windows-build
 
 on:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: windows"]
 name: win-test
 
 on:

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: xpu"]
 # TODO: this looks sort of similar to _linux-test, but there are like a dozen
 # places where you would have to insert an if statement. Probably it's better to
 # just use a different workflow altogether

--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: POWER"]
 name: Build manywheel docker images for s390x
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: arm"]
 name: inductor-perf-nightly-aarch64
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-macos.yml
+++ b/.github/workflows/inductor-perf-test-nightly-macos.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: macos"]
 name: inductor-perf-nightly-macos
 
 on:

--- a/.github/workflows/inductor-perf-test-nightly-xpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-xpu.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: xpu"]
 name: inductor-perf-nightly-xpu
 
 on:

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: mps"]
 name: Mac MPS
 
 on:

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: risc-v"]
 name: riscv64
 
 on:

--- a/.github/workflows/s390.yml
+++ b/.github/workflows/s390.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: POWER"]
 name: s390
 
 on:

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: POWER"]
 name: s390x-periodic
 
 # DISABLED: this workflow has been failing for months and not providing a useful

--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: cuda"]
 # B200 Smoke Tests CI Workflow
 #
 # This workflow runs smoke tests on B200 hardware

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: cuda"]
 name: Limited CI on H100
 
 on:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: sanitizers"]
 name: TSan
 
 on:

--- a/.github/workflows/win-arm64-build-test.yml
+++ b/.github/workflows/win-arm64-build-test.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: windows", "module: arm"]
 name: windows-arm64-build-test
 
 on:

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: xpu"]
 name: xpu
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* #186844
* __->__ #186843
* #186842
* #186841
* #186840
* #186839
* #186838

Attribute the platform- and accelerator-specific workflows under .github/workflows/ to their owning module (windows, macos, mps, xpu, cuda, POWER, risc-v, sanitizers), following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.