### PR TITLE
Add owner headers to docs/lint/benchmark/vllm workflows

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: docs"]
 name: build docs
 
 on:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: lint"]
 name: Run linters
 
 on:

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: vllm"]
 name: vllm-benchmark
 
 on:

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: vllm"]
 name: vllm-build
 
 on:

--- a/.github/workflows/apply-lint.yml
+++ b/.github/workflows/apply-lint.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: lint"]
 name: Apply lint patches
 
 on:

--- a/.github/workflows/assigntome-docathon.yml
+++ b/.github/workflows/assigntome-docathon.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: docs"]
 name: Assign User on Comment
 
 on:

--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: benchmark"]
 name: attention_op_microbenchmark
 
 on:

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: vllm"]
 name: Build vLLM wheels
 
 on:

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: docs"]
 name: Docathon Labels Sync
 
 on:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: docs"]
 name: docs-build
 
 # Standalone docs build so the docs preview can be published as soon as the

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: lint"]
 name: BC Lint
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: lint"]
 name: Lint
 # Workflow that runs lint checks and also unittests for tools, and scripts.
 

--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: benchmark"]
 name: operator_benchmark
 
 on:

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: benchmark"]
 name: operator_microbenchmark
 # NOTE: When adding a new test, please update README: ../../benchmarks/operator_benchmark/README.md
 

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: benchmark"]
 name: operator-microbenchmark-compare
 
 on:

--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: docs"]
 name: Upload docs preview
 
 # Runs in the base-repo context so it has the AWS credentials needed to write

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: vllm"]
 name: vLLM Benchmark
 
 on:

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -1,3 +1,4 @@
+# Owner(s): ["module: vllm"]
 name: vllm-test
 
 on:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #186012
* __->__ #186844
* #186843
* #186842
* #186841
* #186840
* #186839
* #186838

Attribute the remaining developer-tooling workflows under .github/workflows/ to their owning module (docs, lint, benchmark, vllm), following the test-file `# Owner(s): [...]` convention.

Part of a stack that adds owner headers per team; the WORKFLOWOWNERS linter that enforces the convention is added at the top of the stack.

Authored with assistance from Claude Code.