### PR TITLE
[Windows CI] Pin openssl=3.5.6 to fix Windows cert-store ASN.1 failure

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -59,7 +59,8 @@ runs:
         set -x
 
         # Create new py_tmp env with python-version
-        ${CONDA} create -y -n py_tmp python=${PYTHON_VERSION} intel-openmp libuv
+        # Pin openssl=3.5.6: 3.5.7 breaks Windows cert-store parsing (ASN1: NOT_ENOUGH_DATA)
+        ${CONDA} create -y -n py_tmp python=${PYTHON_VERSION} intel-openmp libuv "openssl=3.5.6"
 
         PYTHON3=$(${CONDA_RUN} -n py_tmp which python3)
         EXIT_CODE=$?


### PR DESCRIPTION
## Summary

All Windows test shards started failing at **import time** (before any test runs) with:

```
ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4040)
```

in `ssl.create_default_context() -> load_default_certs -> _load_windows_store_certs`, triggered when `aiohttp` (pulled via `fbscribelogger` via `torch._logging.scribe`) builds its default SSL context at import.

## Root cause

Comparing the last green run with the first red run (both on `main`, ~3.5h apart), **nothing in the repo changed** — `aiohttp==3.13.4` and `fbscribelogger==0.1.7` are identical. The only difference is conda's **`openssl`**, which is an *unpinned* transitive dep of the env creation in `.github/actions/setup-win/action.yml`:

| package | green run | red run |
|---|---|---|
| **openssl** | **3.5.6** | **3.5.7** |
| ca-certificates | 2026.5.14 | 2026.5.14 |
| python | 3.10.20 | 3.10.20 |

conda silently pulled the newly-released **openssl 3.5.7**, which tightened/regressed ASN.1 parsing and now hard-rejects a malformed certificate in the Windows machine cert store that 3.5.6 tolerated.

## Fix

Pin `openssl=3.5.6` in the `conda create` for the `py_tmp` env until 3.5.7+ is fixed (or the bad runner cert is cleaned up).

## Test plan

- Windows test jobs in CI should get openssl 3.5.6 and import `torch.testing._internal.common_utils` / `aiohttp` without the ASN.1 error.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv