### PR TITLE
[profiler][cupti] ProfilerObserver + record_function annotation routing

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -15,6 +15,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 import unittest
@@ -94,6 +95,22 @@ if TYPE_CHECKING:
 # cupti-python is pip-installable on ROCm hosts too, but CUPTI itself is a no-op
 # there, so gate the monitor tests off ROCm as well.
 TEST_CUPTI_PYTHON = _check_module_exists("cupti") and not TEST_WITH_ROCM
+
+
+def _cupti_version() -> int:
+    if not TEST_CUPTI_PYTHON:
+        return 0
+    try:
+        from torch.profiler._cupti.cupti_python import pylibcupti
+
+        return pylibcupti().get_version()
+    except Exception:
+        return 0
+
+
+# The CUPTI monitor needs libcupti >= 13.3 (v2 user-defined records + populated
+# pBufferCompleteInfo->ppRecordLayouts); its collection tests skip below that.
+TEST_CUPTI_V13_3 = TEST_CUPTI_PYTHON and _cupti_version() >= 130300
 
 
 def get_profiler_activities(device_type):
@@ -459,78 +476,60 @@ _cupti_monitor.enable_hes_early()
             p.stderr,
         )
 
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
-    def test_cupti_monitor_collection_raw_dump_smoke(self):
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    def test_cupti_monitor_collection_smoke(self):
         from torch.profiler._cupti import monitor as _cupti_monitor
+        from torch.profiler._cupti.observers.profiler import ProfilerObserver
 
-        with TemporaryDirectoryName() as out_dir:
-            self.assertIsNone(_cupti_monitor.get_monitor())
-            monitor = _cupti_monitor.start_collection(out_dir)
-            self.assertIs(monitor, _cupti_monitor.get_monitor())
+        obs = ProfilerObserver()
+        self.assertTrue(obs.available)
 
-            x = torch.randn(64, 64, device="cuda")
-            y = torch.relu(x + 1)
+        x = torch.randn(64, 64, device="cuda")
+        y = torch.relu(x + 1)
+        y.sum().item()
+        torch.cuda.synchronize()
+
+        monitor = _cupti_monitor.instance()
+        monitor.flush(forced=True, sync=True)
+        stats = monitor.stats()
+        window = obs.drain()
+        obs.close()
+
+        # The native C++ pool must actually have been exercised: catches a silent
+        # regression to a no-op (e.g. broken callback registration or symbol
+        # export) that would still pass if the worker never saw a buffer. The
+        # monitor demuxes to columns and the observer builds events, so a real
+        # kernel event must come out the other end.
+        self.assertGreater(stats["buffers_allocated"], 0)
+        self.assertGreater(stats["buffers_completed"], 0)
+        self.assertEqual(stats["buffers_pending"], 0)
+        self.assertGreater(len(window["events"]), 0)
+        self.assertTrue(any(e["kind"] == "kernel" for e in window["events"]))
+
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    def test_cupti_monitor_collection_repeated_lifecycle(self):
+        from torch.profiler._cupti import monitor as _cupti_monitor
+        from torch.profiler._cupti.observers.profiler import ProfilerObserver
+
+        # Register/collect/unregister twice: the last observer leaving stops the
+        # monitor, so the second pass exercises the start-after-stop restart path.
+        for _ in range(2):
+            obs = ProfilerObserver()
+            self.assertTrue(obs.available)
+
+            x = torch.randn(32, 32, device="cuda")
+            y = torch.sigmoid(x)
             y.sum().item()
             torch.cuda.synchronize()
 
-            stats = _cupti_monitor.stop_collection()
-            self.assertIsNotNone(stats)
-            self.assertIsNone(_cupti_monitor.get_monitor())
-            # The native C++ pool must actually have been exercised: catches a
-            # silent regression to a no-op (e.g. broken callback registration or
-            # symbol export) that would still produce passing file-existence
-            # checks if the worker never saw a buffer.
-            self.assertGreater(stats["buffers_allocated"], 0)
-            self.assertGreater(stats["buffers_completed"], 0)
-            self.assertEqual(stats["buffers_pending"], 0)
-            self.assertTrue(
-                os.path.exists(os.path.join(out_dir, _cupti_monitor._META_FILE))
-            )
-            self.assertTrue(
-                os.path.exists(os.path.join(out_dir, _cupti_monitor._RAW_BUFFER_FILE))
-            )
-            self.assertGreater(
-                os.path.getsize(os.path.join(out_dir, _cupti_monitor._META_FILE)), 0
-            )
-            self.assertGreater(
-                os.path.getsize(os.path.join(out_dir, _cupti_monitor._RAW_BUFFER_FILE)),
-                0,
-            )
+            monitor = _cupti_monitor.instance()
+            monitor.flush(forced=True, sync=True)
+            window = obs.drain()
+            obs.close()
 
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
-    def test_cupti_monitor_collection_repeated_lifecycle(self):
-        from torch.profiler._cupti import monitor as _cupti_monitor
+            self.assertGreater(len(window["events"]), 0)
 
-        for _ in range(2):
-            with TemporaryDirectoryName() as out_dir:
-                self.assertIsNone(_cupti_monitor.get_monitor())
-                _cupti_monitor.start_collection(out_dir)
-
-                x = torch.randn(32, 32, device="cuda")
-                y = torch.sigmoid(x)
-                y.sum().item()
-                torch.cuda.synchronize()
-
-                stats = _cupti_monitor.stop_collection()
-                self.assertIsNotNone(stats)
-                self.assertIsNone(_cupti_monitor.get_monitor())
-
-                self.assertTrue(
-                    os.path.exists(os.path.join(out_dir, _cupti_monitor._META_FILE))
-                )
-                self.assertTrue(
-                    os.path.exists(
-                        os.path.join(out_dir, _cupti_monitor._RAW_BUFFER_FILE)
-                    )
-                )
-                self.assertGreater(
-                    os.path.getsize(
-                        os.path.join(out_dir, _cupti_monitor._RAW_BUFFER_FILE)
-                    ),
-                    0,
-                )
-
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_cupti_monitor_multithread_runtime_thread_assignment(self):
         x1 = torch.randn(256, 256, device="cuda")
         x2 = torch.randn(256, 256, device="cuda")
@@ -604,7 +603,7 @@ _cupti_monitor.enable_hes_early()
         self.assertGreater(len(launch_tids), 0)
         self.assertTrue(set(launch_tids).issubset(set(worker_tids)))
 
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_cupti_monitor_trace_has_expected_events(self):
         cfg = _ExperimentalConfig(
             custom_profiler_config='{"backend":"cupti_monitor"}',
@@ -654,7 +653,7 @@ _cupti_monitor.enable_hes_early()
         }
         self.assertIn("monitor_region", user_names)
 
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_cupti_monitor_record_shapes(self):
         cfg = _ExperimentalConfig(
             custom_profiler_config='{"backend":"cupti_monitor"}',
@@ -684,41 +683,76 @@ _cupti_monitor.enable_hes_early()
         self.assertEqual(shaped_cpu_ops(record_shapes=False), [])
         self.assertGreater(len(shaped_cpu_ops(record_shapes=True)), 0)
 
-    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_cupti_monitor_matches_stock_op_and_kernel_names(self):
-        def trace_summary(use_monitor):
-            cfg = _ExperimentalConfig(
-                custom_profiler_config='{"backend":"cupti_monitor"}'
-                if use_monitor
-                else ""
-            )
-            with TemporaryFileName(mode="w+") as trace_path:
-                with profile(
-                    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-                    experimental_config=cfg,
-                ) as prof:
-                    a = torch.randn(128, 128, device="cuda")
-                    b = torch.randn(128, 128, device="cuda")
-                    (a @ b).relu().sum()
-                    torch.cuda.synchronize()
-                prof.export_chrome_trace(trace_path)
-                with open(trace_path) as f:
-                    events = json.load(f)["traceEvents"]
-            aten_ops = {
-                e["name"]
-                for e in events
-                if e.get("cat") == "cpu_op" and e.get("name", "").startswith("aten::")
-            }
-            n_kernels = sum(
-                1 for e in events if e.get("cat") == "kernel" and e.get("ph") == "X"
-            )
-            return aten_ops, n_kernels
+        # Run in a FRESH process. This test needs a stock (Kineto) CUDA baseline and
+        # then a cupti_monitor session, so it must start from a process that hasn't
+        # touched CUPTI -- immune to whatever earlier tests did to this process's
+        # CUPTI. Inside it, stock (Kineto) runs first, then cuptiFinalize() releases
+        # CUPTI synchronously (rather than Kineto's async TEARDOWN_CUPTI, whose
+        # deferred global finalize races and can deadlock the monitor's teardown) so
+        # the following monitor session can subscribe.
+        import subprocess
 
-        stock_ops, stock_kernels = trace_summary(use_monitor=False)
-        monitor_ops, monitor_kernels = trace_summary(use_monitor=True)
-        self.assertGreater(stock_kernels, 0)
-        self.assertGreater(monitor_kernels, 0)
-        self.assertEqual(monitor_ops, stock_ops)
+        script = textwrap.dedent(
+            """
+            import json, tempfile
+            import torch
+            from torch.profiler import profile, ProfilerActivity
+            from torch._C._profiler import _ExperimentalConfig
+
+            def trace_summary(use_monitor):
+                cfg = _ExperimentalConfig(
+                    custom_profiler_config='{"backend":"cupti_monitor"}'
+                    if use_monitor else "")
+                with tempfile.NamedTemporaryFile("w+", suffix=".json") as f:
+                    with profile(
+                        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                        experimental_config=cfg,
+                    ) as prof:
+                        a = torch.randn(128, 128, device="cuda")
+                        b = torch.randn(128, 128, device="cuda")
+                        (a @ b).relu().sum()
+                        torch.cuda.synchronize()
+                    prof.export_chrome_trace(f.name)
+                    events = json.load(open(f.name))["traceEvents"]
+                aten = {e["name"] for e in events
+                        if e.get("cat") == "cpu_op"
+                        and e.get("name", "").startswith("aten::")}
+                nker = sum(1 for e in events
+                           if e.get("cat") == "kernel" and e.get("ph") == "X")
+                return aten, nker
+
+            stock_ops, stock_kernels = trace_summary(False)
+            # Synchronously release CUPTI from the stock (Kineto) session so the
+            # monitor can subscribe -- cuptiFinalize() now, with nothing else using
+            # CUPTI, instead of Kineto's async TEARDOWN_CUPTI finalize (which races
+            # and can deadlock the monitor's teardown).
+            from torch.profiler._cupti.cupti_python import pylibcupti
+            pylibcupti().finalize()
+            monitor_ops, monitor_kernels = trace_summary(True)
+            assert stock_kernels > 0, f"stock kernels={stock_kernels}"
+            assert monitor_kernels > 0, f"monitor kernels={monitor_kernels}"
+            assert monitor_ops == stock_ops, (
+                f"ops differ: only_stock={sorted(stock_ops - monitor_ops)} "
+                f"only_monitor={sorted(monitor_ops - stock_ops)}")
+            print("OK", stock_kernels, monitor_kernels)
+            """
+        )
+        # The child inherits this process's libcupti (LD_PRELOAD/LD_LIBRARY_PATH) via
+        # the environment.
+        p = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            p.returncode,
+            0,
+            f"subprocess failed:\nstdout={p.stdout}\nstderr={p.stderr}",
+        )
+        self.assertIn("OK", p.stdout)
 
 
 @unittest.skipIf(not torch.profiler.itt.is_available(), "ITT is required")
@@ -752,16 +786,14 @@ class TestProfilerITT(TestCase):
 @instantiate_parametrized_tests
 class TestProfiler(TestCase):
     @skipIfTorchDynamo("native ctypes/CUPTI probe; nothing to compile")
-    @parametrize("version", [1, 2])
-    def test_cupti_monitor_buffer_pool_reuse(self, version):
+    def test_cupti_monitor_buffer_pool_reuse(self):
         # The CUPTI monitor's buffer pool is pure C++ (no CUDA/cupti-python), so
         # drive its native buffer-requested / buffer-completed callbacks directly
         # via ctypes to verify returned buffers are recycled rather than
-        # reallocated. Both the v1 (cuptiActivityRegisterCallbacks) and v2
-        # (cuptiActivityRegisterCallbacks_v2) callback signatures feed the same
-        # pool/queue; v2's request appends an (ignored) info pointer, and v2's
-        # complete reorders args and drops the (CUcontext, streamId) that v1
-        # carries, so v2-completed buffers report ctx/stream of 0.
+        # reallocated. The callbacks match cuptiActivityRegisterCallbacks_v2: the
+        # request takes a trailing (ignored) info pointer, and the completion takes
+        # the buffer + a complete-info pointer (no CUcontext/streamId -- those are
+        # selectable record fields -- so completed buffers report ctx/stream of 0).
         import ctypes
 
         pyprof = torch._C._profiler
@@ -770,63 +802,37 @@ class TestProfiler(TestCase):
         buffer_size = 64 * 1024
         pyprof._cupti_monitor.configure_buffers(buffer_size)
 
-        if version == 1:
-            request_t = ctypes.CFUNCTYPE(
-                None,
-                ctypes.POINTER(ctypes.c_void_p),
-                ctypes.POINTER(ctypes.c_size_t),
-                ctypes.POINTER(ctypes.c_size_t),
-            )
-            complete_t = ctypes.CFUNCTYPE(
-                None,
-                ctypes.c_void_p,
-                ctypes.c_uint32,
-                ctypes.c_void_p,
-                ctypes.c_size_t,
-                ctypes.c_size_t,
-            )
-        else:
-            request_t = ctypes.CFUNCTYPE(
-                None,
-                ctypes.POINTER(ctypes.c_void_p),
-                ctypes.POINTER(ctypes.c_size_t),
-                ctypes.POINTER(ctypes.c_size_t),
-                ctypes.c_void_p,
-            )
-            complete_t = ctypes.CFUNCTYPE(
-                None,
-                ctypes.c_void_p,
-                ctypes.c_size_t,
-                ctypes.c_size_t,
-                ctypes.c_void_p,
-            )
-        request = request_t(
-            pyprof._cupti_monitor.buffer_request_callback_address(version)
+        request_t = ctypes.CFUNCTYPE(
+            None,
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.c_void_p,
         )
-        complete = complete_t(
-            pyprof._cupti_monitor.buffer_complete_callback_address(version)
+        complete_t = ctypes.CFUNCTYPE(
+            None,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
         )
+        request = request_t(pyprof._cupti_monitor.buffer_request_callback_address())
+        complete = complete_t(pyprof._cupti_monitor.buffer_complete_callback_address())
 
         def do_request():
             buf = ctypes.c_void_p()
             size = ctypes.c_size_t()
             max_records = ctypes.c_size_t()
-            args = [ctypes.byref(buf), ctypes.byref(size), ctypes.byref(max_records)]
-            if version == 2:
-                args.append(None)  # CUpti_BufferCallbackRequestInfo*
-            request(*args)
+            request(
+                ctypes.byref(buf),
+                ctypes.byref(size),
+                ctypes.byref(max_records),
+                None,  # CUpti_BufferCallbackRequestInfo*
+            )
             return buf.value, size.value
 
         def do_complete(ptr):
-            if version == 1:
-                complete(
-                    ctypes.c_void_p(0xABCD), 7, ctypes.c_void_p(ptr), buffer_size, 4096
-                )
-            else:
-                complete(ctypes.c_void_p(ptr), buffer_size, 4096, None)
-
-        # v1 carries ctx/stream through to the completed record; v2 reports 0.
-        expected_ctx, expected_stream = (0xABCD, 7) if version == 1 else (0, 0)
+            complete(ctypes.c_void_p(ptr), buffer_size, 4096, None)
 
         # First request has an empty free list, so it allocates.
         ptr_a, size_a = do_request()
@@ -837,8 +843,9 @@ class TestProfiler(TestCase):
         do_complete(ptr_a)
         self.assertEqual(pyprof._cupti_monitor.pending_buffers(), 1)
         item = pyprof._cupti_monitor.get_completed()
-        # 5th field is layout_epoch, 0 here (no reconfiguration in this test).
-        self.assertEqual(item, (ptr_a, 4096, expected_ctx, expected_stream, 0))
+        # (ptr, valid_size, ctx, stream, layouts): ctx/stream 0 (not delivered to the
+        # completion callback) and layouts empty (driven with a null complete_info).
+        self.assertEqual(item, (ptr_a, 4096, 0, 0, []))
         self.assertEqual(pyprof._cupti_monitor.pending_buffers(), 0)
         pyprof._cupti_monitor.return_buffer(ptr_a)
 
@@ -854,13 +861,12 @@ class TestProfiler(TestCase):
 
     @skipIfTorchDynamo("native ctypes/CUPTI probe; nothing to compile")
     def test_cupti_monitor_v2_record_layout_capture(self):
-        # The v2 complete callback snapshots the CUPTI user-defined record layout
-        # (valid only during the callback) into the current layout epoch, so the
-        # decode thread can parse records afterward and reconfiguring (a new
-        # epoch) does not clobber the layout of buffers still queued under the old
-        # one. Build the CUPTI >= 13.2 complete-info / record-layout structs with
-        # ctypes and drive the native v2 callbacks directly (no CUDA/cupti-python);
-        # this also pins the C++ ABI mirror of those structs.
+        # The v2 complete callback parses the CUPTI user-defined record layout
+        # (pBufferCompleteInfo->ppRecordLayouts, valid only during the callback) and
+        # attaches it to the completed buffer, so the decode thread parses records
+        # against each buffer's own layout. Build the CUPTI >= 13.3 complete-info /
+        # record-layout structs with ctypes and drive the native v2 callbacks
+        # directly (no CUDA/cupti-python); this also pins the C++ ABI mirror.
         import ctypes
 
         pyprof = torch._C._profiler
@@ -929,8 +935,8 @@ class TestProfiler(TestCase):
             ctypes.c_size_t,
             ctypes.c_void_p,
         )
-        request = request_t(pyprof._cupti_monitor.buffer_request_callback_address(2))
-        complete = complete_t(pyprof._cupti_monitor.buffer_complete_callback_address(2))
+        request = request_t(pyprof._cupti_monitor.buffer_request_callback_address())
+        complete = complete_t(pyprof._cupti_monitor.buffer_complete_callback_address())
 
         buf = ctypes.c_void_p()
         size = ctypes.c_size_t()
@@ -942,19 +948,15 @@ class TestProfiler(TestCase):
             16,
             ctypes.cast(ctypes.pointer(info), ctypes.c_void_p),
         )
-        # Drain the completed buffer so the pool is tidy for the reset cleanup.
+        # The completed buffer carries CUPTI's parsed layout as its 5th field: the
+        # per-kind (kind, record_size, [(field_id, offset, size), ...]) list (here
+        # kind 9). No epoch / shared state -- the layout travels with the buffer.
         item = pyprof._cupti_monitor.get_completed()
+        self.assertEqual(item[4], [(9, 16, [(0, 0, 4), (5, 8, 8)])])
         pyprof._cupti_monitor.return_buffer(item[0])
-        # Captured under the initial epoch 0, and the buffer is tagged with it.
-        self.assertEqual(item[4], 0)
-        self.assertEqual(
-            pyprof._cupti_monitor.record_layouts(0),
-            [(9, 16, [(0, 0, 4), (5, 8, 8)])],
-        )
 
-        # Reconfiguring opens a new epoch with a different layout; the old epoch's
-        # layout is retained so buffers still queued under it decode correctly.
-        self.assertEqual(pyprof._cupti_monitor.next_layout_epoch(), 1)
+        # A second buffer with a different selection carries its own layout -- each
+        # buffer decodes against the layout it was completed with.
         entries_b = (FieldEntry * 1)(FieldEntry(ctypes.sizeof(FieldEntry), 0, 0, 4, 4))
         layout_b = RecordLayout(
             ctypes.sizeof(RecordLayout),
@@ -978,17 +980,8 @@ class TestProfiler(TestCase):
             ctypes.cast(ctypes.pointer(info_b), ctypes.c_void_p),
         )
         item_b = pyprof._cupti_monitor.get_completed()
+        self.assertEqual(item_b[4], [(3, 8, [(0, 0, 4)])])
         pyprof._cupti_monitor.return_buffer(item_b[0])
-        self.assertEqual(item_b[4], 1)
-        self.assertEqual(
-            pyprof._cupti_monitor.record_layouts(1),
-            [(3, 8, [(0, 0, 4)])],
-        )
-        # Epoch 0 still holds the original layout.
-        self.assertEqual(
-            pyprof._cupti_monitor.record_layouts(0),
-            [(9, 16, [(0, 0, 4), (5, 8, 8)])],
-        )
 
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -837,29 +837,29 @@ class profile:
 
 
 # pyrefly: ignore [invalid-inheritance]
-_cupti_monitor_module: Any = None
-_cupti_monitor_checked = False
+_cupti_annotations_module: Any = None
+_cupti_annotations_checked = False
 
 
-def _maybe_cupti_monitor():
+def _maybe_cupti_annotations():
     # The experimental CUPTI monitor lets record_function regions show up as user
-    # annotations in monitor traces. Cache the optional module once so the
-    # record_function hot path never re-imports it.
-    global _cupti_monitor_module, _cupti_monitor_checked
-    if not _cupti_monitor_checked:
-        _cupti_monitor_checked = True
+    # annotations in monitor traces, via push/pop_user_annotation. Cache the
+    # optional module once so the record_function hot path never re-imports it.
+    global _cupti_annotations_module, _cupti_annotations_checked
+    if not _cupti_annotations_checked:
+        _cupti_annotations_checked = True
         try:
-            from torch.profiler._cupti import monitor as _cupti_monitor
+            from torch.profiler._cupti.observers import profiler as _cupti_annotations
 
-            _cupti_monitor_module = _cupti_monitor
+            _cupti_annotations_module = _cupti_annotations
         except ModuleNotFoundError:
             pass
         except Exception:
             log.warning(
-                "Unexpected error importing torch.profiler._cupti.monitor",
+                "Unexpected error importing torch.profiler._cupti.observers.profiler",
                 exc_info=True,
             )
-    return _cupti_monitor_module
+    return _cupti_annotations_module
 
 
 class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritance]
@@ -922,9 +922,9 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
         # Guard the CUPTI monitor hookup behind is_scripting() so TorchScript
         # never compiles _maybe_cupti_monitor (it uses globals/imports).
         if not torch.jit.is_scripting():
-            monitor = _maybe_cupti_monitor()
-            if monitor is not None:
-                self._cupti_monitor_external_id = monitor.push_user_annotation(
+            annotations = _maybe_cupti_annotations()
+            if annotations is not None:
+                self._cupti_monitor_external_id = annotations.push_user_annotation(
                     self.name
                 )
         return self
@@ -932,9 +932,9 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
         if not torch.jit.is_scripting():
             if self._cupti_monitor_external_id is not None:
-                monitor = _maybe_cupti_monitor()
-                if monitor is not None:
-                    monitor.pop_user_annotation()
+                annotations = _maybe_cupti_annotations()
+                if annotations is not None:
+                    annotations.pop_user_annotation()
                 self._cupti_monitor_external_id = None
         if not self.run_callbacks_on_exit:
             return

--- a/torch/profiler/_cupti/observers/__init__.py
+++ b/torch/profiler/_cupti/observers/__init__.py
@@ -1,0 +1,7 @@
+"""Observers for the in-process CUPTI activity monitor.
+
+Each observer registers the activity kinds it needs with the shared monitor
+(``torch.profiler._cupti.monitor.instance()``) and consumes the decoded columns
+delivered to it, aggregating or assembling whatever it exposes to callers.
+``CuptiMonitorObserver`` is the shared base.
+"""

--- a/torch/profiler/_cupti/observers/base.py
+++ b/torch/profiler/_cupti/observers/base.py
@@ -1,0 +1,229 @@
+# mypy: allow-untyped-defs
+"""Base class for CUPTI activity-monitor observers.
+
+An observer registers the activity kinds it wants with the shared CUPTI monitor
+(``torch.profiler._cupti.monitor.instance()``) and, on the monitor's worker
+thread, gets handed the columns the monitor demuxed from each completed buffer
+(``{ActivityKind: {field_id: column}}``) sliced to its selection. What it does
+with them is up to the subclass's ``_on_activities`` hook. This base handles
+registration, availability, teardown, the clock passthroughs, and the
+user-annotation push/pop every observer can use to attribute activity to named
+regions.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# (graph_node_id, activity_kind, correlation_id) -> annotation, or None. The graph
+# naming mechanism shared by observers: map a CUDA-graph node id to its registered
+# region name (survives graph replay, needs no extra record kinds).
+AnnotationResolver = Callable[[int, int, int], "Any | None"]
+
+
+def default_graph_annotation_resolver(
+    graph_node_id: int, activity_kind: int, correlation_id: int
+) -> Any | None:
+    """Default resolver: map a CUDA-graph node id to its registered annotation."""
+    del activity_kind, correlation_id
+    if graph_node_id == 0:
+        return None
+    try:
+        from torch.cuda._graph_annotations import get_kernel_annotations
+
+        annotations = get_kernel_annotations()
+    except Exception:
+        return None
+    return annotations.get(graph_node_id)
+
+
+@dataclass(frozen=True)
+class ObserverAnnotationSettings:
+    """How an observer attributes activity to named regions. With neither ``graph``
+    nor ``eager`` set (the default), no naming is applied and every span falls into
+    the ``""`` bucket in :meth:`NodeTimerObserver.drain_annotated`.
+
+    - ``graph`` -- enable graph-node naming (``graph_node_id -> name``, vectorized,
+      no extra record kinds, survives graph replay). Uses
+      ``custom_graph_annotation_resolver`` if given, else the CUDA-graph annotation
+      registry.
+    - ``eager`` -- enable eager ``record_function`` naming via the
+      ``correlation_id -> external_id -> name`` external-correlation join. Folds
+      EXTERNAL_CORRELATION + RUNTIME into the selection (CUPTI only emits the former
+      when the latter is enabled), which drops decode onto the slower per-record walk.
+    - ``custom_graph_annotation_resolver`` -- override the graph resolver (only used
+      when ``graph`` is set; falls back to the default registry resolver if omitted).
+    """
+
+    eager: bool = False
+    graph: bool = False
+    custom_graph_annotation_resolver: AnnotationResolver | None = None
+
+
+class CuptiMonitorObserver:
+    """Base for observers backed by the shared CUPTI monitor.
+
+    Subclasses set up their state, then call ``super().__init__(activities)`` with
+    the activity kinds they want -- a set of kinds (meaning "all fields"), or a
+    field map ``{kind: iterable of field ids | "all"}``. Registration happens last
+    so the state is ready before the worker thread can deliver buffers. The monitor
+    demuxes every completed buffer to columns, so subclasses implement a single
+    hook, ``_on_activities(columns)`` -- where ``columns`` is ``{ActivityKind:
+    {field_id: column}}`` already sliced to this observer's selection -- and
+    typically a ``drain()`` for callers.
+
+    Any observer can also bracket regions with ``push_annotation``/``pop_annotation``
+    (or ``annotate``): each push registers a global external-correlation id mapped
+    here to a name, so activity recorded until the matching pop can be attributed to
+    the region via ``correlation_id -> external_id -> name`` (eager only -- external
+    ids do not survive CUDA-graph capture/replay; under graphs, attribute by
+    ``graph_node_id`` instead). The push is the monitor's (global) concern; the
+    id->name mapping is the observer's.
+    """
+
+    def __init__(
+        self,
+        activities: Any,
+        *,
+        annotations: ObserverAnnotationSettings | None = None,
+    ) -> None:
+        # Region naming (see ObserverAnnotationSettings): a graph-node resolver (vectorized,
+        # custom or default) and/or the eager external-correlation join. Eager folds
+        # extra record kinds into the selection here -> per-record walk; graph naming
+        # is just a resolver, so it stays on the vectorized path.
+        if annotations is None:
+            self._resolver: AnnotationResolver | None = None
+            self._eager = False
+        else:
+            self._eager = annotations.eager
+            self._resolver = (
+                annotations.custom_graph_annotation_resolver
+                or default_graph_annotation_resolver
+                if annotations.graph
+                else None
+            )
+        if self._eager:
+            activities = self._with_eager_fields(activities)
+        # frozenset of the requested kinds (a field map collapses to its keys) for
+        # the observer's own "is this kind mine?" checks; the full request (incl.
+        # any field selection) is handed to the monitor (the process-wide singleton).
+        self._activities: frozenset[int] = frozenset(activities)
+        self._monitor: Any = None
+        self._obs = None
+        # external_id -> user-annotation name, for the monitor's global
+        # external-correlation pushes. Guarded by _ann_lock (push runs on the
+        # caller's thread; a drain may read/reset it from another).
+        self._ann_lock = threading.Lock()
+        self._ext_names: dict[int, str] = {}
+        # Degrade gracefully (available == False) if the monitor can't be reached or
+        # the registration fails -- e.g. the CUPTI subscribe is rejected because
+        # another subscriber (Kineto) holds it, or libcupti lacks the v2 API. The
+        # profiler must not crash because the optional monitor couldn't start.
+        try:
+            from torch.profiler._cupti.monitor import instance
+
+            self._monitor = instance()
+            self._obs = self._monitor.register(activities, self._on_activities)
+        except Exception:
+            self._obs = None
+
+    @property
+    def available(self) -> bool:
+        """True when the monitor was available and this observer registered."""
+        return self._obs is not None
+
+    def _on_activities(self, columns: dict[Any, dict[int, Any]]) -> None:
+        """Worker-thread hook: ``{ActivityKind: {field_id: column}}`` demuxed by the
+        monitor and sliced to this observer's selection. Implemented by subclasses."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _with_eager_fields(activities: Any) -> dict[int, set[int]]:
+        """Augment a field map so the eager external-correlation join works: add each
+        kind's CORRELATION_ID, plus the EXTERNAL_CORRELATION record and RUNTIME (CUPTI
+        only emits the former when the correlated API kind is enabled; the RUNTIME
+        records themselves go unused -- it's just the carrier for the join). Expects a
+        ``{kind: fields}`` map (the eager path always selects fields)."""
+        from torch.profiler._cupti.cupti_python import ActivityKind
+        from torch.profiler._cupti.records import CORRELATION_FIELD, ExternalCorrelation
+
+        aug: dict[int, set[int]] = {}
+        for kind, sel in dict(activities).items():
+            k = int(kind)
+            fields = {int(f) for f in sel}
+            if k in CORRELATION_FIELD:
+                fields.add(CORRELATION_FIELD[k])
+            aug[k] = fields
+        aug[int(ActivityKind.EXTERNAL_CORRELATION)] = {
+            int(ExternalCorrelation.EXTERNAL_ID),
+            int(ExternalCorrelation.CORRELATION_ID),
+        }
+        aug[int(ActivityKind.RUNTIME)] = {CORRELATION_FIELD[int(ActivityKind.RUNTIME)]}
+        return aug
+
+    # --- user annotations (external-correlation) ---------------------------
+
+    def push_annotation(self, name: str) -> int | None:
+        """Push a global external-correlation id (mapped here to ``name``) so
+        activity recorded until the matching pop is attributed to the region via
+        ``correlation_id -> external_id -> name``. Eager only -- external ids do not
+        survive CUDA-graph capture/replay. No-op returning None when the monitor is
+        unavailable."""
+        if not self.available or self._monitor is None:
+            return None
+        ext_id = self._monitor.push_external_correlation_id()
+        if ext_id is not None:
+            with self._ann_lock:
+                self._ext_names[ext_id] = name
+        return ext_id
+
+    def pop_annotation(self) -> int | None:
+        """Pop the most recent external-correlation id (balances push_annotation)."""
+        if not self.available or self._monitor is None:
+            return None
+        return self._monitor.pop_external_correlation_id()
+
+    @contextlib.contextmanager
+    def annotate(self, name: str) -> Iterator[int | None]:
+        """Context-manager form of push_annotation/pop_annotation."""
+        ext_id = self.push_annotation(name)
+        try:
+            yield ext_id
+        finally:
+            self.pop_annotation()
+
+    def annotation_names(self, *, reset: bool = False) -> dict[int, str]:
+        """Snapshot of the ``external_id -> name`` map pushed so far; pass
+        ``reset=True`` to also clear it (e.g. when closing a window)."""
+        with self._ann_lock:
+            snapshot = dict(self._ext_names)
+            if reset:
+                self._ext_names = {}
+        return snapshot
+
+    # --- clock passthroughs -------------------------------------------------
+
+    def now_ns(self) -> int:
+        """Current time on the same unix-epoch clock as record timestamps --
+        passthrough to the monitor."""
+        return self._monitor.now_unix_ns() if self._monitor is not None else 0
+
+    def convert_time(self, value: int) -> int:
+        """Convert a CUPTI-clock timestamp to unix-epoch ns -- passthrough to the
+        monitor (identity if clock alignment is unavailable)."""
+        return self._monitor.convert_time(value) if self._monitor is not None else value
+
+    def close(self) -> None:
+        """Unregister from the monitor. Idempotent."""
+        if self._obs is not None and self._monitor is not None:
+            self._monitor.unregister(self._obs)
+            self._obs = None

--- a/torch/profiler/_cupti/observers/profiler.py
+++ b/torch/profiler/_cupti/observers/profiler.py
@@ -1,0 +1,443 @@
+# mypy: allow-untyped-defs
+"""Chrome-trace observer for the CUPTI activity multiplexer.
+
+``ProfilerObserver`` is the multiplexer-backed form of the old monitor trace
+path: it wants the trace activity kinds, accumulates the decoded GPU/API records
+the monitor delivers, tracks the user-annotation and thread metadata the chrome
+trace needs, and on ``drain()`` hands them back as a trace-window dict -- the
+exact shape ``monitor_trace.merge_trace_window_into_chrome_trace`` consumes to
+splice CUPTI activity into a stock Kineto chrome trace. The trace assembly is
+entirely ``monitor_trace``'s existing logic; this class is the collection,
+annotation join, and windowing around it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import threading
+from typing import Any, TYPE_CHECKING
+
+import torch
+from torch.profiler._cupti.cupti_python import ActivityKind, OVERHEAD_KIND_NAMES
+from torch.profiler._cupti.monitor_trace import merge_trace_window_into_chrome_trace
+from torch.profiler._cupti.observers.base import (
+    CuptiMonitorObserver,
+    ObserverAnnotationSettings,
+)
+from torch.profiler._cupti.records import (
+    Api,
+    ExternalCorrelation,
+    Field,
+    Kernel,
+    Memcpy,
+    Memset,
+    Overhead,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch.profiler._cupti.observers.base import AnnotationResolver
+
+
+def _current_thread_resource_tuple() -> tuple[int, int, int]:
+    # (pid, opaque 32-bit thread id, system thread id) for trace lane naming.
+    opaque_tid = ctypes.c_int32(threading.get_ident() & 0xFFFFFFFF).value
+    return (os.getpid(), opaque_tid, threading.get_native_id())
+
+
+_DEMANGLE_CACHE: dict[str, str] = {}
+
+
+def _demangle_symbol(name: str) -> str:
+    cached = _DEMANGLE_CACHE.get(name)
+    if cached is None:
+        cached = _DEMANGLE_CACHE[name] = torch._C._demangle(name)
+    return cached
+
+
+# The CUPTI fields ProfilerObserver requests: GPU work plus the CPU-side
+# runtime/driver/overhead records and external correlation for the annotation join.
+# (Omits fields the chrome trace never consumes, e.g. memcpy runtime_correlation_id
+# / overhead object_kind -- which also have no v2 user-defined-record id.)
+PROFILER_FIELDS: dict[ActivityKind, set[Field]] = {
+    ActivityKind.CONCURRENT_KERNEL: {
+        Kernel.START,
+        Kernel.END,
+        Kernel.DEVICE_ID,
+        Kernel.CONTEXT_ID,
+        Kernel.STREAM_ID,
+        Kernel.CORRELATION_ID,
+        Kernel.GRAPH_NODE_ID,
+        Kernel.GRAPH_ID,
+        Kernel.NAME,
+    },
+    ActivityKind.MEMCPY: {
+        Memcpy.START,
+        Memcpy.END,
+        Memcpy.DEVICE_ID,
+        Memcpy.CONTEXT_ID,
+        Memcpy.STREAM_ID,
+        Memcpy.CORRELATION_ID,
+        Memcpy.GRAPH_NODE_ID,
+        Memcpy.GRAPH_ID,
+        Memcpy.BYTES,
+        Memcpy.COPY_KIND,
+        Memcpy.SRC_KIND,
+        Memcpy.DST_KIND,
+        Memcpy.FLAGS,
+    },
+    ActivityKind.MEMSET: {
+        Memset.START,
+        Memset.END,
+        Memset.DEVICE_ID,
+        Memset.CONTEXT_ID,
+        Memset.STREAM_ID,
+        Memset.CORRELATION_ID,
+        Memset.GRAPH_NODE_ID,
+        Memset.GRAPH_ID,
+        Memset.BYTES,
+        Memset.VALUE,
+        Memset.MEMORY_KIND,
+        Memset.FLAGS,
+    },
+    ActivityKind.RUNTIME: {
+        Api.CBID,
+        Api.START,
+        Api.END,
+        Api.PROCESS_ID,
+        Api.THREAD_ID,
+        Api.CORRELATION_ID,
+    },
+    ActivityKind.DRIVER: {
+        Api.CBID,
+        Api.START,
+        Api.END,
+        Api.PROCESS_ID,
+        Api.THREAD_ID,
+        Api.CORRELATION_ID,
+    },
+    ActivityKind.EXTERNAL_CORRELATION: {
+        ExternalCorrelation.EXTERNAL_KIND,
+        ExternalCorrelation.EXTERNAL_ID,
+        ExternalCorrelation.CORRELATION_ID,
+    },
+    ActivityKind.OVERHEAD: {
+        Overhead.OVERHEAD_KIND,
+        Overhead.START,
+        Overhead.END,
+        Overhead.CORRELATION_ID,
+    },
+}
+
+
+class ProfilerObserver(CuptiMonitorObserver):
+    """Accumulates decoded activity records into a trace window for chrome-trace
+    export. Construct it to start collecting, optionally bracket regions with
+    ``annotate(name)``, then ``build_chrome_trace()`` (or ``drain()``) to
+    emit/snapshot it. The observer keeps collecting after a drain, so it can be
+    drained repeatedly (one window per drain).
+
+    It requests the chrome-trace field selection (``PROFILER_FIELDS``) -- GPU work
+    plus the CPU-side runtime/driver/overhead records and external correlation for
+    the annotation join -- and the monitor hands it those fields as columns.
+    """
+
+    def __init__(self, annotation_resolver: AnnotationResolver | None = None) -> None:
+        self._lock = threading.Lock()
+        self._events: list[dict[str, Any]] = []
+        # pid -> {opaque_tid: system_tid}, for naming GPU/CPU lanes in the trace.
+        self._thread_resource_map: dict[int, dict[int, int]] = {}
+        self._window_start_ns = 0
+        # Graph-node naming via the base resolver (self._resolver; custom or default).
+        # PROFILER_FIELDS already selects RUNTIME + EXTERNAL_CORRELATION + correlation
+        # ids and the eager join happens in monitor_trace, so this doesn't opt into the
+        # base's eager augmentation.
+        super().__init__(
+            {k: set(v) for k, v in PROFILER_FIELDS.items()},
+            annotations=ObserverAnnotationSettings(
+                graph=True, custom_graph_annotation_resolver=annotation_resolver
+            ),
+        )
+        if self.available:
+            self._window_start_ns = self.now_ns()
+
+    def _on_activities(self, columns: dict[Any, dict[int, Any]]) -> None:
+        # Worker thread: the monitor has already demuxed the buffer to the columns
+        # we selected; turn each kind's columns into chrome-trace event dicts and
+        # accumulate them.
+        new_events: list[dict[str, Any]] = []
+        for kind, cols in columns.items():
+            new_events.extend(
+                events_from_columns(
+                    int(kind),
+                    cols,
+                    convert_time=self.convert_time,
+                    annotation_resolver=self._resolver,
+                )
+            )
+        if new_events:
+            with self._lock:
+                self._events.extend(new_events)
+
+    def push_annotation(self, name: str) -> int | None:
+        # Record the calling thread (for trace-lane naming) on top of the base
+        # external-correlation push (which owns the id -> name mapping).
+        self._record_calling_thread()
+        return super().push_annotation(name)
+
+    def _record_calling_thread(self) -> None:
+        pid, opaque_tid, sys_tid = _current_thread_resource_tuple()
+        with self._lock:
+            self._thread_resource_map.setdefault(pid, {})[opaque_tid] = sys_tid
+
+    def drain(self) -> dict[str, Any]:
+        """Return the collected records + annotation/thread metadata as a
+        trace-window dict and reset, so the next drain covers only what arrives
+        after this call. Synchronously flushes CUPTI and waits for the worker to
+        process all outstanding records first, so the window is complete."""
+        if self._monitor is not None:
+            self._monitor.flush(forced=True, sync=True)
+        now = self.now_ns()
+        user_annotations = self.annotation_names(reset=True)
+        with self._lock:
+            events = self._events
+            self._events = []
+            thread_resource_map = {
+                pid: dict(mapping) for pid, mapping in self._thread_resource_map.items()
+            }
+            start_ns = self._window_start_ns
+            self._window_start_ns = now
+        return {
+            "events": events,
+            "user_annotations": user_annotations,
+            "thread_resource_map": thread_resource_map,
+            "start_ns": start_ns,
+        }
+
+    def build_chrome_trace(
+        self,
+        cpu_trace_path: str | os.PathLike[str],
+        output_path: str | os.PathLike[str],
+        *,
+        trace_name: str | None = None,
+    ) -> None:
+        """Splice the drained CUPTI activity into the stock Kineto chrome trace
+        at ``cpu_trace_path``, writing the merged trace to ``output_path``."""
+        merge_trace_window_into_chrome_trace(
+            cpu_trace_path,
+            output_path,
+            self.drain(),
+            trace_name=trace_name,
+        )
+
+
+# --- columns -> chrome-trace event dicts -------------------------------------
+# Turn the per-kind columns the monitor delivers into the event dicts
+# monitor_trace splices into the chrome trace. Owns the per-kind event shape, the
+# symbol demangling, the clock conversion, and the graph-annotation resolution --
+# all ProfilerObserver/presentation concerns (the monitor only produces columns).
+
+
+def events_from_columns(
+    kind: int,
+    cols: dict[int, Any],
+    *,
+    convert_time: Callable[[int], int],
+    annotation_resolver: AnnotationResolver | None,
+) -> list[dict[str, Any]]:
+    """Turn one kind's columns (``{field_id: column}``) into chrome-trace event
+    dicts. Returns [] for kinds this builder doesn't render. A None resolver means
+    no graph-node naming (every annotation resolves to None)."""
+    builder = _BUILDERS.get(kind)
+    if builder is None:
+        return []
+    resolver = annotation_resolver or (lambda *_: None)
+    return builder(cols, convert_time, resolver)
+
+
+def _col_len(cols: dict[int, Any]) -> int:
+    return len(next(iter(cols.values()))) if cols else 0
+
+
+def _kernel_events(cols, convert_time, resolver):
+    events = []
+    for i in range(_col_len(cols)):
+        graph_node_id = int(cols[Kernel.GRAPH_NODE_ID.id][i])
+        correlation_id = int(cols[Kernel.CORRELATION_ID.id][i])
+        events.append(
+            {
+                "kind": "kernel",
+                "device_id": int(cols[Kernel.DEVICE_ID.id][i]),
+                "context_id": int(cols[Kernel.CONTEXT_ID.id][i]),
+                "stream_id": int(cols[Kernel.STREAM_ID.id][i]),
+                "correlation_id": correlation_id,
+                "graph_node_id": graph_node_id,
+                "graph_id": int(cols[Kernel.GRAPH_ID.id][i]),
+                "start_ns": convert_time(int(cols[Kernel.START.id][i])),
+                "end_ns": convert_time(int(cols[Kernel.END.id][i])),
+                "annotation": resolver(
+                    graph_node_id, ActivityKind.CONCURRENT_KERNEL, correlation_id
+                ),
+                "name": _demangle_symbol(cols[Kernel.NAME.id][i]),
+            }
+        )
+    return events
+
+
+def _memcpy_events(cols, convert_time, resolver):
+    events = []
+    for i in range(_col_len(cols)):
+        graph_node_id = int(cols[Memcpy.GRAPH_NODE_ID.id][i])
+        correlation_id = int(cols[Memcpy.CORRELATION_ID.id][i])
+        events.append(
+            {
+                "kind": "gpu_memcpy",
+                "device_id": int(cols[Memcpy.DEVICE_ID.id][i]),
+                "context_id": int(cols[Memcpy.CONTEXT_ID.id][i]),
+                "stream_id": int(cols[Memcpy.STREAM_ID.id][i]),
+                "correlation_id": correlation_id,
+                "graph_node_id": graph_node_id,
+                "graph_id": int(cols[Memcpy.GRAPH_ID.id][i]),
+                "start_ns": convert_time(int(cols[Memcpy.START.id][i])),
+                "end_ns": convert_time(int(cols[Memcpy.END.id][i])),
+                "bytes": int(cols[Memcpy.BYTES.id][i]),
+                "copy_kind": int(cols[Memcpy.COPY_KIND.id][i]),
+                "src_kind": int(cols[Memcpy.SRC_KIND.id][i]),
+                "dst_kind": int(cols[Memcpy.DST_KIND.id][i]),
+                "flags": int(cols[Memcpy.FLAGS.id][i]),
+                "annotation": resolver(
+                    graph_node_id, ActivityKind.MEMCPY, correlation_id
+                ),
+                "name": "Memcpy",
+            }
+        )
+    return events
+
+
+def _memset_events(cols, convert_time, resolver):
+    events = []
+    for i in range(_col_len(cols)):
+        graph_node_id = int(cols[Memset.GRAPH_NODE_ID.id][i])
+        correlation_id = int(cols[Memset.CORRELATION_ID.id][i])
+        events.append(
+            {
+                "kind": "gpu_memset",
+                "device_id": int(cols[Memset.DEVICE_ID.id][i]),
+                "context_id": int(cols[Memset.CONTEXT_ID.id][i]),
+                "stream_id": int(cols[Memset.STREAM_ID.id][i]),
+                "correlation_id": correlation_id,
+                "graph_node_id": graph_node_id,
+                "graph_id": int(cols[Memset.GRAPH_ID.id][i]),
+                "start_ns": convert_time(int(cols[Memset.START.id][i])),
+                "end_ns": convert_time(int(cols[Memset.END.id][i])),
+                "bytes": int(cols[Memset.BYTES.id][i]),
+                "value": int(cols[Memset.VALUE.id][i]),
+                "memory_kind": int(cols[Memset.MEMORY_KIND.id][i]),
+                "flags": int(cols[Memset.FLAGS.id][i]),
+                "annotation": resolver(
+                    graph_node_id, ActivityKind.MEMSET, correlation_id
+                ),
+                "name": "Memset",
+            }
+        )
+    return events
+
+
+def _api_events(kind_name):
+    def build(cols, convert_time, resolver):
+        del resolver
+        events = []
+        for i in range(_col_len(cols)):
+            cbid = int(cols[Api.CBID.id][i])
+            events.append(
+                {
+                    "kind": kind_name,
+                    "cbid": cbid,
+                    "start_ns": convert_time(int(cols[Api.START.id][i])),
+                    "end_ns": convert_time(int(cols[Api.END.id][i])),
+                    "process_id": int(cols[Api.PROCESS_ID.id][i]),
+                    "thread_id": int(cols[Api.THREAD_ID.id][i]),
+                    "correlation_id": int(cols[Api.CORRELATION_ID.id][i]),
+                    "name": f"cbid_{cbid}",
+                }
+            )
+        return events
+
+    return build
+
+
+def _external_correlation_events(cols, convert_time, resolver):
+    del convert_time, resolver
+    events = []
+    for i in range(_col_len(cols)):
+        events.append(
+            {
+                "kind": "external_correlation",
+                "external_kind": int(cols[ExternalCorrelation.EXTERNAL_KIND.id][i]),
+                "external_id": int(cols[ExternalCorrelation.EXTERNAL_ID.id][i]),
+                "correlation_id": int(cols[ExternalCorrelation.CORRELATION_ID.id][i]),
+                "name": "external_correlation",
+            }
+        )
+    return events
+
+
+def _overhead_events(cols, convert_time, resolver):
+    del resolver
+    events = []
+    for i in range(_col_len(cols)):
+        overhead_kind = int(cols[Overhead.OVERHEAD_KIND.id][i])
+        events.append(
+            {
+                "kind": "overhead",
+                "object_id": 0,
+                "start_ns": convert_time(int(cols[Overhead.START.id][i])),
+                "end_ns": convert_time(int(cols[Overhead.END.id][i])),
+                "correlation_id": int(cols[Overhead.CORRELATION_ID.id][i]),
+                "name": OVERHEAD_KIND_NAMES.get(
+                    overhead_kind, f"overhead_{overhead_kind}"
+                ),
+            }
+        )
+    return events
+
+
+_BUILDERS: dict[int, Callable[..., list[dict[str, Any]]]] = {
+    ActivityKind.CONCURRENT_KERNEL: _kernel_events,
+    ActivityKind.MEMCPY: _memcpy_events,
+    ActivityKind.MEMSET: _memset_events,
+    ActivityKind.RUNTIME: _api_events("cuda_runtime"),
+    ActivityKind.DRIVER: _api_events("cuda_driver"),
+    ActivityKind.EXTERNAL_CORRELATION: _external_correlation_events,
+    ActivityKind.OVERHEAD: _overhead_events,
+}
+
+
+# The active ProfilerObserver (if any) that record_function user annotations route
+# to. The CUPTI external-correlation push is global (the monitor owns the stack);
+# this just names which observer records the per-push id->name metadata. Set by the
+# torch.profiler backend around a profiling session. This is a ProfilerObserver
+# concern, not the monitor engine's, so it lives here.
+_active_observer: ProfilerObserver | None = None
+
+
+def set_active_profiler_observer(observer: ProfilerObserver | None) -> None:
+    """Set (or clear, with None) the observer that push_user_annotation routes to."""
+    global _active_observer
+    _active_observer = observer
+
+
+def push_user_annotation(name: str) -> int | None:
+    """Push a record_function user annotation onto the active ProfilerObserver (if
+    any). No-op returning None when no observer is active."""
+    observer = _active_observer
+    return observer.push_annotation(name) if observer is not None else None
+
+
+def pop_user_annotation() -> int | None:
+    """Pop the most recent user annotation off the active ProfilerObserver."""
+    observer = _active_observer
+    return observer.pop_annotation() if observer is not None else None

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -276,8 +276,9 @@ class _KinetoProfile:
         self._use_cupti_monitor = self._custom_profiler_config.get(
             "backend"
         ) == "cupti_monitor" or bool(self._custom_profiler_config.get("cupti_monitor"))
-        self._monitor_started_here = False
-        self._monitor_tempdir: tempfile.TemporaryDirectory[str] | None = None
+        # The ProfilerObserver driving the shared CUPTI monitor for this session
+        # (created in prepare_trace, drained in stop_trace).
+        self._cupti_profiler_observer: Any = None
         self._monitor_trace_window: dict[str, object] | None = None
         if self._use_cupti_monitor and ProfilerActivity.CPU not in self.activities:
             raise ValueError(
@@ -322,16 +323,17 @@ class _KinetoProfile:
                 else None,
             )
         if self._use_cupti_monitor:
-            from torch.profiler._cupti import monitor as _mon
+            from torch.profiler._cupti.observers.profiler import (
+                ProfilerObserver,
+                set_active_profiler_observer,
+            )
 
-            if _mon.get_monitor() is None:
-                self._monitor_tempdir = tempfile.TemporaryDirectory(
-                    prefix="torch_cupti_profiler_"
-                )
-                _mon.start_collection(self._monitor_tempdir.name)
-                self._monitor_started_here = True
             self._monitor_trace_window = None
-            _mon.prepare_trace_window()
+            # Constructing the observer registers it with the shared CUPTI
+            # monitor and starts collection; mark it active so record_function
+            # user annotations route to it.
+            self._cupti_profiler_observer = ProfilerObserver()
+            set_active_profiler_observer(self._cupti_profiler_observer)
         self.profiler._prepare_trace()
 
     def start_trace(self) -> None:
@@ -340,10 +342,10 @@ class _KinetoProfile:
         if self.profiler is None:
             raise AssertionError("Profiler must be initialized before starting trace")
         self.profiler._start_trace()
-        if self._use_cupti_monitor:
-            from torch.profiler._cupti import monitor as _mon
-
-            _mon.start_trace_window()
+        if self._use_cupti_monitor and self._cupti_profiler_observer is not None:
+            # Discard records collected during prepare so the trace window
+            # starts here (drain resets the observer's window boundary).
+            self._cupti_profiler_observer.drain()
 
         if self.profile_memory:
             self.add_metadata_json("profile_memory", "1")
@@ -391,20 +393,20 @@ class _KinetoProfile:
         if self.profiler is None:
             raise AssertionError("Profiler must be initialized before stopping trace")
         if self._use_cupti_monitor:
-            from torch.profiler._cupti import monitor as _mon
+            from torch.profiler._cupti.observers.profiler import (
+                set_active_profiler_observer,
+            )
 
             if self.use_device:
                 torch.accelerator.synchronize()
-            self._monitor_trace_window = _mon.end_trace_window()
+            set_active_profiler_observer(None)
+            if self._cupti_profiler_observer is not None:
+                self._monitor_trace_window = self._cupti_profiler_observer.drain()
         self.profiler.__exit__(None, None, None)
-        if self._use_cupti_monitor and self._monitor_started_here:
-            from torch.profiler._cupti import monitor as _mon
-
-            _mon.stop_collection()
-            self._monitor_started_here = False
-            if self._monitor_tempdir is not None:
-                self._monitor_tempdir.cleanup()
-                self._monitor_tempdir = None
+        if self._use_cupti_monitor and self._cupti_profiler_observer is not None:
+            # Unregister from the monitor (stops it once the last observer goes).
+            self._cupti_profiler_observer.close()
+            self._cupti_profiler_observer = None
 
     def export_chrome_trace(self, path: str, use_python_export: bool = False):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186655
* #186802
* #186812
* __->__ #186851
* #186439
* #186811
* #186438
* #186437
* #186436

Splits the consumer half out of the CUPTI multiplexer engine (the parent PR).
The engine is one shared CUPTI subscription that demuxes decoded columns to
registered observers; this PR adds the observer abstraction and the single
profiler consumer that drives it:

- observers/base.py: the Observer base that registers a per-kind field selection
  with the shared monitor, buffers the columns the monitor demuxes to it, and
  exposes drain()/close() for windowing and teardown.
- observers/profiler.py: ProfilerObserver builds the chrome trace from the
  demuxed columns, and record_function user-annotation routing
  (push/pop_user_annotation, set_active_profiler_observer) lives here with the
  observer, not in the engine.
- Routing moves to the single shared monitor: autograd.profiler record_function
  resolves the optional observers.profiler module (not the monitor) for
  push/pop, and torch.profiler constructs a ProfilerObserver per session and
  drains/closes it across prepare/start/stop instead of driving the monitor's
  collection lifecycle directly.

Test plan:
```
python test/profiler/test_profiler.py -k cupti
```
on libcupti 13.3: records/decode unit tests, collection, chrome-trace,
multithread thread-assignment, matches-stock op/kernel names, and the fence /
observer / layout-capture tests.

This PR was authored with the assistance of an AI coding assistant.