### PR TITLE
Route ProcessGroup Python constructors through the PyProcessGroup trampoline

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -117,6 +117,22 @@ class DummyAttrProcessGroup(dist.ProcessGroup):
         return self._group_desc
 
 
+class StoreProcessGroup(dist.ProcessGroup):
+    """
+    A ProcessGroup constructed with the 3-arg (store, rank, size) constructor.
+    Used to verify the store is accessible and that a Python subclass built
+    this way is routed through the PyProcessGroup trampoline.
+    """
+
+    def __init__(self, store, rank, world):
+        super().__init__(store, rank, world)
+        self._rank = rank
+        self._world = world
+
+    def getBackendName(self):
+        return "store-pg"
+
+
 # We cannot use parametrize as some tests are defined on the base class and use _get_process_group
 class AbstractDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest):
     def setUp(self):
@@ -208,6 +224,24 @@ class TestPyProcessGroup(TestCase):
 
         pg._set_group_desc("desc")
         self.assertEqual(pg.group_desc, "py:desc")
+
+    def test_store_constructor(self):
+        store = dist.HashStore()
+        store.set("test_key", "test_value")
+
+        pg = StoreProcessGroup(store, 0, 1)
+
+        # The store passed to the 3-arg constructor is accessible via the PG
+        # and is the same store object we passed in.
+        group_store = pg.get_group_store()
+        self.assertIs(group_store, store)
+        self.assertEqual(group_store.get("test_key"), b"test_value")
+
+        # A Python subclass built via the 3-arg constructor must be routed
+        # through the PyProcessGroup trampoline so the getBackendName override
+        # dispatches back into Python; a raw C++ ProcessGroup would return the
+        # base backend name ("undefined") instead.
+        self.assertEqual(pg.name(), "store-pg")
 
     def test_abort_shutdown(self) -> None:
         # verify this are noops

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -204,6 +204,25 @@ template <typename T, typename Trampoline>
 using intrusive_ptr_no_gil_destructor_trampoline_class_ =
     py::class_<T, IntrusivePtrNoGilDestructor<T>, Trampoline>;
 
+// pybind11 init factory that releases the GIL during construction and routes
+// Python subclasses through the Trampoline so overridden methods dispatch back
+// into Python. It uses the two-callback factory form: the first callback builds
+// a plain T, the second builds the Trampoline (needed when a Python subclass is
+// constructed). A local gil_scoped_release is used rather than a call_guard,
+// which is not safe in init. https://github.com/pybind/pybind11/issues/5473
+template <typename T, typename Trampoline, typename... Args>
+auto init_nogil() {
+  return py::init(
+      [](Args... args) {
+        py::gil_scoped_release nogil{};
+        return c10::make_intrusive<T>(std::forward<Args>(args)...);
+      },
+      [](Args... args) -> c10::intrusive_ptr<T> {
+        py::gil_scoped_release nogil{};
+        return c10::make_intrusive<Trampoline>(std::forward<Args>(args)...);
+      });
+}
+
 // PythonStore is a pybind11 trampoline class to allow a Python
 // class to inherit from c10d.Store and implement its interface.
 class PythonStore : public ::c10d::Store {
@@ -2216,22 +2235,21 @@ communication mechanism.
           ProcessGroups. It is not meant to be used directly, but rather
           extended by subclasses.)")
           .def(
-              py::init<int, int>(),
+              init_nogil<
+                  ::c10d::ProcessGroup,
+                  ::c10d::PyProcessGroup,
+                  int,
+                  int>(),
               py::arg("rank"),
               py::arg("size"),
               R"(Create a new ProcessGroup instance.)")
           .def(
-              py::init([](
-                const c10::intrusive_ptr<::c10d::Store>& store,
-                int rank,
-                int size) {
-                // gil_scoped_release is not safe as a call_guard in init.
-                // https://github.com/pybind/pybind11/issues/5473
-                py::gil_scoped_release nogil{};
-
-                return c10::make_intrusive<::c10d::ProcessGroup>(
-                    store, rank, size);
-              }),
+              init_nogil<
+                  ::c10d::ProcessGroup,
+                  ::c10d::PyProcessGroup,
+                  const c10::intrusive_ptr<::c10d::Store>&,
+                  int,
+                  int>(),
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),


### PR DESCRIPTION
The 3-arg ProcessGroup constructor exposed to Python used a single-callback
py::init factory that unconditionally returned
c10::make_intrusive<ProcessGroup>(...). When a Python subclass of ProcessGroup
was constructed via this path, pybind11 needs the most-derived (alias)
instance, so it runs an is_alias dynamic_cast check on the returned holder.
Because the factory returned a base ProcessGroup rather than the PyProcessGroup
trampoline, that check failed and construction raised:

    TypeError: pybind11::init(): construction failed: returned holder-wrapped
    instance is not an alias instance

So any Python ProcessGroup subclass that called
super().__init__(store, rank, size) was unusable; even had it succeeded, the
object would have been a raw C++ ProcessGroup with no dispatch back into the
Python overrides.

The fix switches both Python-facing constructors to pybind11's two-callback
factory form: the first callback builds a plain ProcessGroup (used when
ProcessGroup itself is constructed), the second builds the PyProcessGroup
trampoline (used when a Python subclass is constructed) so overridden virtual
methods dispatch back into Python. This is factored into an init_nogil helper.
Both callbacks release the GIL via a local gil_scoped_release rather than a
call_guard, which is unsafe in init (pybind/pybind11#5473); the 2-arg
constructor previously used py::init<int, int>() and now releases the GIL the
same way for consistency.

A two-callback factory is required (rather than reverting to py::init<...>())
because the 3-arg constructor must release the GIL during construction, which
is only expressible through a factory lambda.

Test Plan:

Added test_store_constructor to test_c10d_pypg. It constructs a ProcessGroup
subclass via the 3-arg (store, rank, size) constructor, verifies the store is
accessible through get_group_store(), and verifies that a getBackendName()
override dispatches back into Python (proving the trampoline is in use). Before
the fix this test failed at construction with the TypeError above.

    pip install -e . -v --no-build-isolation
    python test/distributed/test_c10d_pypg.py

All 51 tests pass.

