### PR TITLE
[profiler][cupti] User-configurable monitor buffer size + singleton/flush tests

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -191,6 +191,22 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(fields[kernel], frozenset({0, int(Kernel.START)}))
         self.assertEqual(fields[memcpy], all_memcpy)
 
+    def test_monitor_buffer_size_from_env(self):
+        # The per-buffer pool size is user-configurable: an explicit buffer_size
+        # arg wins, otherwise TORCH_CUPTI_MONITOR_BUFFER_SIZE is honored, else the
+        # 4 MiB default. No CUDA -- this only reads the constructor config.
+        import unittest.mock
+
+        from torch.profiler._cupti.monitor import _DEFAULT_BUFFER_SIZE, CuptiMonitor
+
+        self.assertEqual(CuptiMonitor().buffer_size, _DEFAULT_BUFFER_SIZE)
+        with unittest.mock.patch.dict(
+            "os.environ", {"TORCH_CUPTI_MONITOR_BUFFER_SIZE": "1048576"}
+        ):
+            self.assertEqual(CuptiMonitor().buffer_size, 1048576)
+            # An explicit arg overrides the env var.
+            self.assertEqual(CuptiMonitor(buffer_size=2048).buffer_size, 2048)
+
     def test_monitor_external_correlation_not_started(self):
         # External-correlation push/pop are no-ops until the monitor is started (no
         # subscriber yet), returning None rather than touching CUPTI's global stack.
@@ -278,6 +294,49 @@ class TestCuptiMonitorCUDA(TestCase):
             self.assertEqual(len(start), len(name))
             self.assertTrue(all(int(e) - int(s) >= 0 for s, e in zip(start, end)))
         self.assertTrue(any(len(n) > 0 for c in columns for n in c[int(Kernel.NAME)]))
+
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    def test_singleton_flush_accessible(self):
+        # A user can reach the process-wide monitor singleton through the public
+        # accessors and flush it: instance() constructs/returns it, get_monitor()
+        # hands back that same object, and flush(sync=True) on the singleton
+        # delivers everything collected up to the call.
+        from torch.profiler._cupti import monitor as cupti_monitor
+        from torch.profiler._cupti.cupti_python import ActivityKind, CuptiError
+        from torch.profiler._cupti.records import Kernel
+
+        kernel = ActivityKind.CONCURRENT_KERNEL
+        lock = threading.Lock()
+        columns: list = []
+
+        def on_columns(cols):
+            if kernel in cols:
+                with lock:
+                    columns.append(cols[kernel])
+
+        mon = cupti_monitor.instance()
+        self.assertIs(cupti_monitor.get_monitor(), mon)
+        # Drop the singleton after the observer is torn down so the next instance()
+        # caller gets a fresh monitor (cleanups run LIFO: unregister first).
+        self.addCleanup(setattr, cupti_monitor, "_instance", None)
+        try:
+            obs = mon.register({kernel: {Kernel.START, Kernel.END}}, on_columns)
+        except CuptiError as e:
+            self.skipTest(f"v2 subscribe unavailable on this driver/cupti: {e}")
+        self.addCleanup(mon.unregister, obs)
+
+        x = torch.randn(128, 128, device="cuda")
+        for _ in range(3):
+            x = torch.relu(x @ x)
+        x.sum().item()
+        torch.cuda.synchronize()
+
+        # Flush via the singleton fetched from the public accessor, not the local
+        # handle, to exercise the user-visible path.
+        cupti_monitor.get_monitor().flush(forced=True, sync=True)
+
+        total = sum(len(c[int(Kernel.START)]) for c in columns)
+        self.assertGreater(total, 0)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_multiple_observers(self):

--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -218,7 +218,7 @@ class CuptiMonitor:
     def __init__(
         self,
         *,
-        buffer_size: int = _DEFAULT_BUFFER_SIZE,
+        buffer_size: int | None = None,
         flush_period_s: float | None = None,
     ) -> None:
         # The monitor is the engine and the multiplexer: it owns the single CUPTI
@@ -229,6 +229,15 @@ class CuptiMonitor:
         # It uses CUPTI's v2 user-defined-record API: a subscriber + per-field
         # selection, decoded columnar against a record layout computed from the
         # field-size spec (no captured layout needed). This requires libcupti >= 13.2.
+        #
+        # Per-buffer pool size (bytes). An explicit arg wins; otherwise it comes from
+        # TORCH_CUPTI_MONITOR_BUFFER_SIZE (default 4 MiB). Bigger buffers complete less
+        # often (fewer worker wakeups, lower overhead) at the cost of more pinned host
+        # memory and coarser delivery.
+        if buffer_size is None:
+            buffer_size = int(
+                os.environ.get("TORCH_CUPTI_MONITOR_BUFFER_SIZE", _DEFAULT_BUFFER_SIZE)
+            )
         self.buffer_size = buffer_size
         # Background-drain flush period (seconds). An explicit arg wins; otherwise it
         # comes from TORCH_CUPTI_MONITOR_FLUSH_PERIOD_S (default 1.0). Sign-encoded:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186862
* #186861
* #186655
* #186802
* #186812
* #186855
* #186439
* #186811
* #186438
* #186437
* #186436

Two small follow-ups on the CUPTI monitor's public surface:

- The per-buffer CUPTI pool size is now user-configurable via the
  TORCH_CUPTI_MONITOR_BUFFER_SIZE env var (default 4 MiB), mirroring the existing
  TORCH_CUPTI_MONITOR_FLUSH_PERIOD_S knob: an explicit CuptiMonitor(buffer_size=)
  arg still wins, otherwise the env var is read, otherwise the default. Bigger
  buffers complete less often (fewer worker wakeups) at the cost of more pinned
  host memory and coarser delivery.

- Tests that the singleton is reachable and flushable through the public
  accessors (instance() / get_monitor().flush()), and that the buffer-size env
  var / explicit-arg precedence is honored (the latter is pure, so it runs in CI
  without CUDA).

Test Plan:
```
# Pure (runs in CI, no CUDA):
python test/profiler/test_cupti_monitor.py TestCuptiRecords.test_monitor_buffer_size_from_env

# On a libcupti >= 13.3 host (LD_PRELOAD so torch and the monitor share one CUPTI):
LD_PRELOAD=$CUPTI133/libcupti.so.13 LD_LIBRARY_PATH=$CONDA_PREFIX/cuda-compat:$LD_LIBRARY_PATH \
  python test/profiler/test_cupti_monitor.py
```
Full test_cupti_monitor.py suite green on a GB200 host (12 tests).

This PR was authored with the assistance of an AI coding assistant.