### PR TITLE
[MPS] Register unsigned binary Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -500,7 +500,10 @@ DEFINE_BINARY_COMPARISON_FUNCTOR(ge, >=);
   REGISTER_BINARY_OP(NAME, int, int);            \
   REGISTER_BINARY_OP(NAME, short, short);        \
   REGISTER_BINARY_OP(NAME, uchar, uchar);        \
-  REGISTER_BINARY_OP(NAME, char, char)
+  REGISTER_BINARY_OP(NAME, char, char);          \
+  REGISTER_BINARY_OP(NAME, ushort, ushort);      \
+  REGISTER_BINARY_OP(NAME, uint, uint);          \
+  REGISTER_BINARY_OP(NAME, ulong, ulong)
 
 #define REGISTER_INTEGER_BINARY_OP(NAME)    \
   REGISTER_INTEGER_BINARY_OP_NO_BOOL(NAME); \
@@ -512,7 +515,10 @@ DEFINE_BINARY_COMPARISON_FUNCTOR(ge, >=);
   REGISTER_BINARY_OP(NAME, short, float);  \
   REGISTER_BINARY_OP(NAME, uchar, float);  \
   REGISTER_BINARY_OP(NAME, char, float);   \
-  REGISTER_BINARY_OP(NAME, bool, float)
+  REGISTER_BINARY_OP(NAME, bool, float);   \
+  REGISTER_BINARY_OP(NAME, ushort, float); \
+  REGISTER_BINARY_OP(NAME, uint, float);   \
+  REGISTER_BINARY_OP(NAME, ulong, float)
 
 #define REGISTER_FLOAT_BINARY_OP(NAME)    \
   REGISTER_BINARY_OP(NAME, float, float); \
@@ -546,7 +552,13 @@ DEFINE_BINARY_COMPARISON_FUNCTOR(ge, >=);
   REGISTER_BINARY_OP(NAME, char, bool);           \
   REGISTER_BINARY_CASTOUT_OP(NAME, char, bool);   \
   REGISTER_BINARY_OP(NAME, bool, bool);           \
-  REGISTER_BINARY_CASTOUT_OP(NAME, bool, bool)
+  REGISTER_BINARY_CASTOUT_OP(NAME, bool, bool);   \
+  REGISTER_BINARY_OP(NAME, ushort, bool);         \
+  REGISTER_BINARY_CASTOUT_OP(NAME, ushort, bool); \
+  REGISTER_BINARY_OP(NAME, uint, bool);           \
+  REGISTER_BINARY_CASTOUT_OP(NAME, uint, bool);   \
+  REGISTER_BINARY_OP(NAME, ulong, bool);          \
+  REGISTER_BINARY_CASTOUT_OP(NAME, ulong, bool)
 
 // Complex variants for eq/ne only -- lt/le/gt/ge are not well-defined on
 // complex numbers.
@@ -638,6 +650,9 @@ REGISTER_BINARY_ALPHA_OP(add_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(add_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(add_alpha, uchar, uchar, uchar);
 REGISTER_BINARY_ALPHA_OP(add_alpha, char, char, char);
+REGISTER_BINARY_ALPHA_OP(add_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(add_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(add_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(add_alpha, bool, bool, bool);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, int, int, int);
@@ -646,6 +661,9 @@ REGISTER_BINARY_ALPHA_OP(sub_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, uchar, uchar, uchar);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, char, char, char);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(sub_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(sub_alpha, bool, bool, bool);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, int, int, int);
@@ -654,6 +672,9 @@ REGISTER_BINARY_ALPHA_OP(lerp_alpha, half, half, half);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, short, short, short);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, uchar, uchar, uchar);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, char, char, char);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, ushort, ushort, ushort);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, uint, uint, uint);
+REGISTER_BINARY_ALPHA_OP(lerp_alpha, ulong, ulong, ulong);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, bool, bool, bool);
 
 REGISTER_BINARY_ALPHA_OP(add_alpha, bfloat, bfloat, bfloat);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9356,6 +9356,108 @@ class TestMPS(TestCaseMPS):
         y = x / 64
         self.assertEqual(y, torch.tensor([0., 1023.9844], device="mps"))
 
+    @parametrize(
+        "op_name",
+        [
+            "add", "sub", "mul", "div", "div_trunc", "floor_divide",
+            "fmod", "remainder", "maximum", "minimum", "gcd", "lcm",
+            "bitwise_and", "bitwise_or", "bitwise_xor", "atan2",
+            "copysign", "xlogy", "eq", "ne", "lt", "le", "gt", "ge",
+        ],
+    )
+    @parametrize("dtype", [torch.uint16, torch.uint32, torch.uint64])
+    def test_unsigned_binary_op(self, op_name, dtype):
+        # See https://github.com/pytorch/pytorch/issues/176296
+        if op_name == "div_trunc":
+            def op(x, y):
+                return torch.div(x, y, rounding_mode="trunc")
+        else:
+            op = getattr(torch, op_name)
+        comparison_ops = {"eq", "ne", "lt", "le", "gt", "ge"}
+        float_ops = {"div", "atan2", "copysign", "xlogy"}
+        out_dtype = (
+            torch.bool if op_name in comparison_ops
+            else torch.float32 if op_name in float_ops
+            else dtype
+        )
+        # Keep values int64-safe so results can be validated against the same
+        # op on int64 upcasts; integer wraparound matches via .to(dtype)
+        hi = 1000 if op_name in ["lcm", "copysign", "xlogy"] else min(torch.iinfo(dtype).max, 2**31)
+        a = torch.randint(0, hi, (64,), device="mps", dtype=dtype)
+        b = torch.randint(1, hi, (64,), device="mps", dtype=dtype)
+
+        def check(x, y):
+            res = op(x, y)
+            self.assertEqual(res.dtype, out_dtype)
+            y_ref = y.cpu().to(torch.int64) if isinstance(y, torch.Tensor) else y
+            ref = op(x.cpu().to(torch.int64), y_ref)
+            self.assertEqual(res.cpu(), ref.to(out_dtype))
+            if op_name in comparison_ops and isinstance(y, torch.Tensor):
+                out = torch.empty(x.shape, device="mps", dtype=torch.float32)
+                getattr(torch, op_name)(x, y, out=out)
+                self.assertEqual(out.cpu(), ref.to(torch.float32))
+
+        check(a, b)
+        check(a[::2], b[::2])
+        if op_name not in ["maximum", "minimum", "gcd", "lcm", "atan2", "copysign", "xlogy"]:
+            check(a, 7)
+
+    @parametrize("op_name", ["bitwise_left_shift", "bitwise_right_shift"])
+    @parametrize("dtype", [torch.uint16, torch.uint32, torch.uint64])
+    def test_unsigned_binary_shift_op(self, op_name, dtype):
+        # See https://github.com/pytorch/pytorch/issues/176296
+        op = getattr(torch, op_name)
+        a = torch.randint(0, 1000, (64,), device="mps", dtype=dtype)
+        b = torch.randint(0, 4, (64,), device="mps", dtype=dtype)
+
+        def check(x, y):
+            res = op(x, y)
+            self.assertEqual(res.dtype, dtype)
+            y_ref = y.cpu().to(torch.int64) if isinstance(y, torch.Tensor) else y
+            ref = op(x.cpu().to(torch.int64), y_ref)
+            self.assertEqual(res.cpu(), ref.to(dtype))
+
+        check(a, b)
+        check(a[::2], b[::2])
+        check(a, 2)
+
+    @parametrize("op_name", ["add", "sub"])
+    @parametrize("dtype", [torch.uint16, torch.uint32, torch.uint64])
+    def test_unsigned_binary_op_alpha(self, op_name, dtype):
+        # See https://github.com/pytorch/pytorch/issues/176296
+        op = getattr(torch, op_name)
+        a = torch.randint(0, 1000, (64,), device="mps", dtype=dtype)
+        b = torch.randint(0, 1000, (64,), device="mps", dtype=dtype)
+
+        def check(x, other):
+            res = op(x, other, alpha=3)
+            self.assertEqual(res.dtype, dtype)
+            other_ref = other.cpu().to(torch.int64) if isinstance(other, torch.Tensor) else other
+            ref = op(x.cpu().to(torch.int64), other_ref, alpha=3)
+            self.assertEqual(res.cpu(), ref.to(dtype))
+
+        check(a, b)
+        check(a[::2], b[::2])
+        check(a, 7)
+
+    @parametrize("dtype", [torch.uint16, torch.uint32, torch.uint64])
+    def test_unsigned_lerp_scalar_weight(self, dtype):
+        # See https://github.com/pytorch/pytorch/issues/176296
+        # CPU does not implement integer lerp, so compute the int64 reference
+        # manually; .to(dtype) truncation matches Metal modular wraparound.
+        a = torch.randint(0, 1000, (64,), device="mps", dtype=dtype)
+        b = torch.randint(0, 1000, (64,), device="mps", dtype=dtype)
+
+        def check(x, y):
+            res = torch.lerp(x, y, 3)
+            self.assertEqual(res.dtype, dtype)
+            x64, y64 = x.cpu().to(torch.int64), y.cpu().to(torch.int64)
+            ref = x64 + 3 * (y64 - x64)
+            self.assertEqual(res.cpu(), ref.to(dtype))
+
+        check(a, b)
+        check(a[::2], b[::2])
+
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
Summary:
- Register MPS binary Metal kernels for uint16, uint32, and uint64 across integer, int-to-float, comparison castout, and add/sub/lerp alpha families.
- Add unsigned MPS regression coverage for tensor, scalar, strided, comparison out=, shift, alpha, and lerp scalar-weight paths.

Fixes #176296

After #176343 fixed the cast/indexing layers, current main fails during Metal pipeline creation for missing dtype-suffixed functions such as `add_dense_uint_uint`. This PR adds the missing binary registrations.

Test Plan:
```bash
source .venv/bin/activate && lintrunner -a
source .venv/bin/activate && spin quicklint
source .venv/bin/activate && python test/test_mps.py TestMPS -k unsigned
source .venv/bin/activate && python test/test_mps.py TestBinaryIteratorConformance TestBinaryDispatchRouting
python -m py_compile test/test_mps.py
git diff --cached --check
```