### PR TITLE
nn/utils: skip no-op .to(first_device) in _get_total_norm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14434,7 +14434,7 @@ if __name__ == '__main__':
         self.assertEqual(p1.grad, p2.grad)
 
     @skipIfMPS  # TypeError: the MPS framework doesn't support float64
-    @parametrize_test('foreach', (False, True))
+    @parametrize_test('foreach', (None, False, True))
     @parametrize_test('norm_type', (0.5, 1.5, 2, 4, 'inf'))
     def test_clip_grad_norm(self, norm_type, foreach, device):
         if torch.device(device).type == 'xla' and foreach:
@@ -14517,16 +14517,6 @@ if __name__ == '__main__':
             clip_grad_norm_(params, max_norm, norm_type=norm_type, foreach=foreach)
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), "`parameters` is an empty generator, no gradient clipping will occur.")
-
-    # issue #133586: skip no-op .to(first_device) in _get_total_norm
-    @onlyCPU
-    @parametrize_test('norm_type', (1.0, 2.0, float('inf')))
-    def test_clip_grad_norm_skip_to_single_device(self, norm_type, device):
-        # skip-no-op-.to(): large tensors all on same device should still be correct
-        tensors = [torch.randn(4096, device=device) for _ in range(200)]
-        result = get_total_norm(tensors, norm_type=norm_type, foreach=None)
-        reference = get_total_norm(tensors, norm_type=norm_type, foreach=True)
-        self.assertEqual(result, reference, atol=1e-5, rtol=1e-5)
 
     # reference issue: https://github.com/pytorch/pytorch/issues/111484
     @onlyCUDA

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14518,6 +14518,16 @@ if __name__ == '__main__':
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), "`parameters` is an empty generator, no gradient clipping will occur.")
 
+    # issue #133586: skip no-op .to(first_device) in _get_total_norm
+    @onlyCPU
+    @parametrize_test('norm_type', (1.0, 2.0, float('inf')))
+    def test_clip_grad_norm_skip_to_single_device(self, norm_type, device):
+        # skip-no-op-.to(): large tensors all on same device should still be correct
+        tensors = [torch.randn(4096, device=device) for _ in range(200)]
+        result = get_total_norm(tensors, norm_type=norm_type, foreach=None)
+        reference = get_total_norm(tensors, norm_type=norm_type, foreach=True)
+        self.assertEqual(result, reference, atol=1e-5, rtol=1e-5)
+
     # reference issue: https://github.com/pytorch/pytorch/issues/111484
     @onlyCUDA
     @largeTensorTest("42GB", "cuda")

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -102,10 +102,7 @@ def _get_total_norm(
                 [torch.linalg.vector_norm(g, norm_type) for g in device_tensors]
             )
 
-    # When all tensors share the same device (the typical single-GPU or CPU-only
-    # case), the [norm.to(first_device) for norm in norms] list comprehension is
-    # a no-op but still dispatches N Python calls. Skip it when no cross-device
-    # movement is actually needed (issue #133586).
+    # Skip the no-op .to(first_device) when all tensors share a device (#133586)
     if any(device != first_device for (device, _) in grouped_tensors):
         norms = [norm.to(first_device) for norm in norms]
     total_norm = torch.linalg.vector_norm(torch.stack(norms), norm_type)

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -102,9 +102,13 @@ def _get_total_norm(
                 [torch.linalg.vector_norm(g, norm_type) for g in device_tensors]
             )
 
-    total_norm = torch.linalg.vector_norm(
-        torch.stack([norm.to(first_device) for norm in norms]), norm_type
-    )
+    # When all tensors share the same device (the typical single-GPU or CPU-only
+    # case), the [norm.to(first_device) for norm in norms] list comprehension is
+    # a no-op but still dispatches N Python calls. Skip it when no cross-device
+    # movement is actually needed (issue #133586).
+    if any(device != first_device for (device, _) in grouped_tensors):
+        norms = [norm.to(first_device) for norm in norms]
+    total_norm = torch.linalg.vector_norm(torch.stack(norms), norm_type)
 
     if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
         raise RuntimeError(


### PR DESCRIPTION
Towards #133586. Replaces #184072 (accidentally closed; the branch was force-pushed afterwards so it cannot be reopened, and its history had no common ancestor with main after a shallow-clone push).

## Summary

For N gradient tensors, the final norm aggregation in `_get_total_norm` always runs `[norm.to(first_device) for norm in norms]`, dispatching N Python method calls that do no data movement in the overwhelmingly common case where all gradients live on one device. This gates the comprehension on an O(k) check over the already-computed device groups (k = unique device/dtype groups, typically 1-3).

For 2000 tensors of 512 elements on CPU (the regime from #133586): `get_total_norm` median 2.45ms -> 2.11ms (~14% faster, M3 Max).

## Why the flat-cat path from #184072 is dropped

While replanting the branch I re-validated the second optimization from #184072 (single `vector_norm` over `torch.cat` of small tensors) and found it loses accuracy versus the hierarchical norm-of-per-tensor-norms reduction: for 2000x512 float32 tensors, relative error vs a float64 reference is **3.1e-5 (flat-cat) vs 4.2e-8 (current foreach path)** — a user-visible numerics change in `clip_grad_norm_`, so it's gone. Only the dispatch-overhead fix remains, which is bitwise-neutral.

All review feedback from #184072 is incorporated: tests live in `test/test_nn.py` on `TestNNDeviceType` (`test_clip_grad_norm_skip_to_single_device`). cc @janeyx99

## Test plan

```
python test/test_nn.py -k clip_grad
Ran 36 tests ... OK (skipped=19)
```

Authored with the help of an AI assistant (Claude Code).