### PR TITLE
RFC Change error order

### DIFF
--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -75,7 +75,7 @@ class LoweringException(OperatorIssue):
         root_cause = textwrap.indent(
             textwrap.fill(f"{type(exc).__name__}: {exc}", width=100), "  "
         )
-        msg += f"\n\nWhile lowering, an exception was raised:\n{root_cause}"
+        msg += f"\nWhile lowering, an exception was raised:\n{root_cause}"
         super().__init__(msg)
 
 

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -69,9 +69,13 @@ class LoweringException(OperatorIssue):
         kwargs: dict[str, Any],
         stack_trace: str | None = None,
     ) -> None:
-        msg = f"{type(exc).__name__}: {exc}\n{self.operator_str(target, args, kwargs)}"
+        msg = f"While lowering:\n{self.operator_str(target, args, kwargs)}"
         if stack_trace:
-            msg += f"{msg}\nFound from : \n {stack_trace}"
+            msg += f"\nFound from : \n {stack_trace}"
+        root_cause = textwrap.indent(
+            textwrap.fill(f"{type(exc).__name__}: {exc}", width=100), "  "
+        )
+        msg += f"\n\nWhile lowering, an exception was raised:\n{root_cause}"
         super().__init__(msg)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186882
* #186880
* #186876

Before:
<img width="1140" height="910" alt="image" src="https://github.com/user-attachments/assets/e184823e-efe1-4983-ab67-297d2eb7f00e" />
<img width="1175" height="499" alt="image" src="https://github.com/user-attachments/assets/68e5c250-7450-40df-ad7d-61a178a5559c" />


After:
<img width="1181" height="767" alt="image" src="https://github.com/user-attachments/assets/cd08c258-7e8f-44b1-9d8a-a2aedff39178" />

