### PR TITLE
[dynamo] Add regression for unregistered module globals

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -292,6 +292,30 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_functools_partial(a, b):
         return clip01(a + b)
 
+    def test_functools_partial_from_unregistered_module(self):
+        module_name = "test_dynamo_unregistered_module"
+        self.assertNotIn(module_name, sys.modules)
+        module = types.ModuleType(module_name)
+        exec(
+            """
+import functools
+import torch
+
+def helper(x, scale):
+    return torch.nn.functional.normalize(x, dim=-1) * scale
+
+def fn(x, scale):
+    return helper(x, scale)
+
+partial_fn = functools.partial(fn, scale=2)
+""",
+            module.__dict__,
+        )
+
+        x = torch.randn(4, 4)
+        compiled_fn = torch.compile(module.partial_fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled_fn(x), module.partial_fn(x))
+
     @make_test
     def test_itertools_product(a, b):
         v = a


### PR DESCRIPTION
## Summary

- add a focused regression for a `functools.partial` defined in an unregistered `ModuleType`
- verify Dynamo can compile functions whose globals dictionary is not owned by an importable module
- preserve coverage for the unnamed-scope dictionary fallback

The production fix has since landed through #184653 (`b0ba21631365`). After rebasing onto current `viable/strict`, this PR now contributes the remaining regression coverage without duplicating the implementation.

## Testing

- `python -m compileall -q test/dynamo/test_functions.py`
- `python -m ruff check --config pyproject.toml test/dynamo/test_functions.py`
- `python tools/linter/adapters/pyfmt_linter.py test/dynamo/test_functions.py`
- `git diff --check`

The focused repository test runner is not available in this Windows checkout because the generated local PyTorch build artifacts are absent; GitHub CI remains the authoritative runtime test.

Refs #181243.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98