### PR TITLE
Update test_mm_sparse_first_NT/NN input generation

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -337,7 +337,10 @@ class TestSparseSemiStructured(TestCase):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
         A_sparse = to_sparse_semi_structured(A)
 
-        B = torch.rand(dense_input_shape, device=A_sparse.device).to(dtype)
+        if dtype is torch.int8:
+            B = torch.randint(-3, 4, dense_input_shape, device=A_sparse.device, dtype=torch.int8)
+        else:
+            B = torch.rand(dense_input_shape, device=A_sparse.device).to(dtype)
 
         # Currently we don't support int matmul on GPU, so evaluate on CPU and copy over
         if dtype is torch.int8:
@@ -375,7 +378,10 @@ class TestSparseSemiStructured(TestCase):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
         A_sparse = to_sparse_semi_structured(A)
 
-        B = torch.rand(dense_input_shape, device=A_sparse.device).to(dtype)
+        if dtype is torch.int8:
+            B = torch.randint(-3, 4, dense_input_shape, device=A_sparse.device, dtype=torch.int8)
+        else:
+            B = torch.rand(dense_input_shape, device=A_sparse.device).to(dtype)
 
         # Currently we don't support int matmul on GPU, so evaluate on CPU and copy over
         if dtype is torch.int8 and dense_input_shape == (1, 128):


### PR DESCRIPTION
In `B = torch.rand(dense_input_shape, device=A_sparse.device).to(dtype)`, torch.rand() generates values in [0, 1), converting to int8 produces an all-zero tensor. As a result, both dense and sparse matmul paths operate on a zero matrix and produce all-zero outputs, allowing the test to pass without validating INT8 numerical correctness.

This change generates INT8 inputs using torch.randint(...) for INT8 test cases, ensuring that the sparse and dense matmul results are compared on meaningful non-zero data.

cc @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip