### PR TITLE
[ROCm] Guard NCCL one-sided API behind device support

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -16,7 +16,8 @@
 #endif
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+#if defined(NCCL_HAS_SYMMEM_DEVICE_SUPPORT) && \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
 #define NCCL_HAS_ONE_SIDED_API
 #endif
 


### PR DESCRIPTION
## Summary

This updates `NCCL_HAS_ONE_SIDED_API` to require `NCCL_HAS_SYMMEM_DEVICE_SUPPORT`, matching the existing guard pattern used for NCCL device-side support.

`NCCL_HAS_SYMMEM_DEVICE_SUPPORT` is not enabled for ROCm builds because `nccl_device.h` is excluded there. Without this additional guard, ROCm release branches can still compile one-sided NCCL paths that reference device-side support such as `NCCLDevCommManager`, causing build failures.

A related guard already exists from https://github.com/pytorch/pytorch/pull/186794; this extends the same protection to the one-sided API path after it caused issues on another ROCm branch.

## Testing

- Verified the merge conflict is resolved.
- Verified `nccl_dev_cap.hpp` has no conflict markers.
- Verified `git diff --check` passes for the changed file.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang