### PR TITLE
fix(mps): raise RuntimeError instead of SIGABRT for high-rank FFT with partial dims

### DIFF
--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -36,6 +36,17 @@ NSArray<NSNumber*>* IntArrayToNSArray(IntArrayRef arr) {
   return rc;
 }
 
+void check_mps_fft_subset_dims(const Tensor& self, IntArrayRef dim) {
+  TORCH_CHECK(
+      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
+      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
+      "Got ndim=",
+      self.dim(),
+      " with ",
+      dim.size(),
+      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
+}
+
 } // anonymous namespace
 
 Tensor _fft_c2r_mps(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
@@ -63,14 +74,7 @@ using namespace mps;
 Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided, Tensor& out) {
   TORCH_CHECK(self.scalar_type() == kFloat || self.scalar_type() == kHalf, "Only float and half dtypes are supported");
   TORCH_CHECK(out.scalar_type() == c10::toComplexType(self.scalar_type()));
-  TORCH_CHECK(
-      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
-      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
-      "Got ndim=",
-      self.dim(),
-      " with ",
-      dim.size(),
-      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
+  check_mps_fft_subset_dims(self, dim);
   const auto input_sizes = self.sym_sizes();
   SymDimVector out_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();
@@ -122,14 +126,7 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
                          Tensor& out) {
   TORCH_CHECK(self.is_complex(), "Input must be complex");
   TORCH_CHECK(out.scalar_type() == c10::toRealValueType(self.scalar_type()), "Unexpected output type");
-  TORCH_CHECK(
-      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
-      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
-      "Got ndim=",
-      self.dim(),
-      " with ",
-      dim.size(),
-      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
+  check_mps_fft_subset_dims(self, dim);
   const auto in_sizes = self.sym_sizes();
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
@@ -159,14 +156,7 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
 }
 
 Tensor& _fft_c2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool forward, Tensor& out) {
-  TORCH_CHECK(
-      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
-      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
-      "Got ndim=",
-      self.dim(),
-      " with ",
-      dim.size(),
-      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
+  check_mps_fft_subset_dims(self, dim);
   auto key = __func__ + getTensorsStringKey({self}) + ":" + getArrayRefString(dim) + ":" +
       std::to_string(normalization) + ":" + std::to_string(forward);
   @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -63,6 +63,14 @@ using namespace mps;
 Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided, Tensor& out) {
   TORCH_CHECK(self.scalar_type() == kFloat || self.scalar_type() == kHalf, "Only float and half dtypes are supported");
   TORCH_CHECK(out.scalar_type() == c10::toComplexType(self.scalar_type()));
+  TORCH_CHECK(
+      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
+      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
+      "Got ndim=",
+      self.dim(),
+      " with ",
+      dim.size(),
+      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
   const auto input_sizes = self.sym_sizes();
   SymDimVector out_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();
@@ -114,6 +122,14 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
                          Tensor& out) {
   TORCH_CHECK(self.is_complex(), "Input must be complex");
   TORCH_CHECK(out.scalar_type() == c10::toRealValueType(self.scalar_type()), "Unexpected output type");
+  TORCH_CHECK(
+      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
+      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
+      "Got ndim=",
+      self.dim(),
+      " with ",
+      dim.size(),
+      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
   const auto in_sizes = self.sym_sizes();
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
@@ -143,6 +159,14 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
 }
 
 Tensor& _fft_c2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool forward, Tensor& out) {
+  TORCH_CHECK(
+      self.dim() <= 4 || static_cast<int64_t>(dim.size()) == self.dim(),
+      "MPS FFT does not support transforming a subset of dimensions on tensors with more than 4 dimensions. "
+      "Got ndim=",
+      self.dim(),
+      " with ",
+      dim.size(),
+      " transform dim(s). Consider moving the tensor to CPU first: tensor.cpu()");
   auto key = __func__ + getTensorsStringKey({self}) + ":" + getArrayRefString(dim) + ":" +
       std::to_string(normalization) + ":" + std::to_string(forward);
   @autoreleasepool {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2492,6 +2492,32 @@ class TestMPS(TestCaseMPS):
         freq_mps = torch.fft.fftfreq(10**4, device='mps')
         self.assertEqual(freq_cpu, freq_mps)
 
+    def test_fft_high_rank_subset_dims_error(self):
+        # MPS FFT does not support transforming a subset of dims on >4-D tensors.
+        # Transforming all dims (or <=4-D tensors) must still work.
+        # Regression test for https://github.com/pytorch/pytorch/pull/186896
+        device = 'mps'
+
+        # 5-D real tensor: subset of dims should raise, all dims should pass
+        x_real = torch.randn(2, 2, 2, 2, 2, device=device)
+        with self.assertRaisesRegex(RuntimeError, "MPS FFT does not support"):
+            torch.fft.rfftn(x_real, dim=(0, 1))
+        # All dims: should not raise
+        torch.fft.rfftn(x_real)
+
+        # 5-D complex tensor: subset of dims should raise for fftn and irfftn
+        x_complex = torch.randn(2, 2, 2, 2, 2, device=device, dtype=torch.complex64)
+        with self.assertRaisesRegex(RuntimeError, "MPS FFT does not support"):
+            torch.fft.fftn(x_complex, dim=(0, 1))
+        with self.assertRaisesRegex(RuntimeError, "MPS FFT does not support"):
+            torch.fft.irfftn(x_complex, dim=(0, 1))
+        # All dims: should not raise
+        torch.fft.fftn(x_complex)
+
+        # 4-D tensor: subset of dims is fine (MPS supports up to 4-D freely)
+        x_4d = torch.randn(2, 2, 2, 2, device=device)
+        torch.fft.rfftn(x_4d, dim=(0, 1))
+
     def test_instance_norm(self):
         def helper(shape, eps=1, momentum=0.1, wts=False, channels_last=False, track_running_stats=True, test_module=False):
 


### PR DESCRIPTION
## Summary

Fixes #186885

`torch.fft.fftn` (and related `rfftn`/`irfftn` variants) crash the Python process with `SIGABRT` on MPS when:
- Input tensor has `ndim > 4`, **and**
- `dim` is a strict subset of all dimensions (not all axes)

The crash originates inside `MPSGraphExecutable` verification (`MPSGraphExecutable.mm:1484: failed assertion 'original module failed verification'`) and cannot be caught with `try/except`.

### Root cause

`_fft_c2c_mps_out`, `_fft_r2c_mps_out`, and `_fft_c2r_mps_out` dispatch directly to `MPSGraph fastFourierTransformWithTensor:axes:` without validating the rank/dim combination first. For `ndim > 4` with a partial `dim`, MPSGraph's graph verification fails fatally.

### Fix

Add a `TORCH_CHECK` guard in all three `_fft_*_mps_out` functions to detect the unsupported configuration early and raise a catchable `RuntimeError` with a clear message pointing users to `.cpu()` as the workaround.

```python
# Before fix — kills the process
x = torch.randn(2, 1, 1, 1, 2, 2, dtype=torch.complex64, device="mps")
torch.fft.fftn(x, dim=(1, 2))  # SIGABRT

# After fix — raises RuntimeError
# RuntimeError: MPS FFT does not support transforming a subset of dimensions
# on tensors with more than 4 dimensions. Got ndim=6 with 2 transform dim(s).
# Consider moving the tensor to CPU first: tensor.cpu()
```

### Configurations verified not affected (still work)

- `ndim <= 4` with any `dim` subset
- `ndim > 4` with `dim=None` (all axes)
- Same inputs on CPU

