### PR TITLE
[Inductor] Enable host-side TMA descriptors for pointwise/reduction kernels

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -2310,10 +2310,36 @@ class TritonHostSideTMATestCUDA(BlockDescriptorTestBase):
         kwargs["expected_num_block_pointers"] = None
         return super()._run_and_compare(*args, **kwargs)
 
+    def test_host_tma_codegen_markers(self):
+        # Host-side TMA builds descriptors in the launcher, not the kernel: the
+        # kernel body must have no in-kernel tl.make_tensor_descriptor, and the
+        # inductor metadata must carry host_tma_descriptor_args.
+        def fn(a, b):
+            return a + b
 
-test_torchinductor.copy_tests(
-    CommonTemplate, TritonHostSideTMATestCUDA, GPU_TYPE
-)
+        a = torch.randn(1024, 1024, device=self.device, dtype=torch.bfloat16)
+        b = torch.randn(1024, 1024, device=self.device, dtype=torch.bfloat16)
+        result, code_list = run_and_get_code(torch.compile(fn), a, b)
+        self.assertTrue(torch.allclose(result, fn(a, b)))
+        code = "\n".join(code_list)
+        self.assertNotIn("tl.make_tensor_descriptor", code)
+        self.assertIn("host_tma_descriptor_args", code)
+
+    def test_misaligned_offset_disables_host_tma(self):
+        # A 4-byte (float32) storage offset is not 16-byte aligned, so the
+        # misaligned input can't be host-TMA'd and falls back to a plain
+        # tl.load. (Disabling is per-buffer: the aligned output may still use a
+        # descriptor, so host_tma_descriptor_args can still appear.)
+        def fn(x):
+            return x[1:] + 1
+
+        x = torch.randn(1025, device=self.device)
+        result, code_list = run_and_get_code(torch.compile(fn), x)
+        self.assertTrue(torch.allclose(result, fn(x)))
+        self.assertIn("tl.load", "\n".join(code_list))
+
+
+test_torchinductor.copy_tests(CommonTemplate, TritonHostSideTMATestCUDA, GPU_TYPE)
 
 # The (9, True) meta-test checks that _run_and_compare raises on wrong block
 # pointer counts. Host-side TMA disables this count check, so skip it.
@@ -2348,6 +2374,64 @@ for _name in _HOST_TMA_EXPECTED_FAILURES:
 TritonHostSideTMATestCUDA.test_dynamic_shapes_pointwise_nd_tiling_False_num_block_pointers_1_cuda = unittest.expectedFailure(
     TritonHostSideTMATestCUDA.test_dynamic_shapes_pointwise_nd_tiling_False_num_block_pointers_1_cuda
 )
+
+# Unlike the cases above (which also fail device-side), this one passes for
+# device-side TMA and non-TMA. Its im2col output store is emitted as a host-side
+# TMA tensordesc store, so the generated code has no tl.make_block_ptr and the
+# base block_descriptor_constructor_str assert does not hold. Numerics still
+# match (the _run_and_compare check passes before the code-string assert).
+TritonHostSideTMATestCUDA.test_ensure_integral_dims_and_strides_cuda = (
+    unittest.expectedFailure(
+        TritonHostSideTMATestCUDA.test_ensure_integral_dims_and_strides_cuda
+    )
+)
+
+
+class HostTMAHelperTest(InductorTestCase):
+    """Device-independent unit tests for host-side TMA helpers."""
+
+    def test_host_tma_aligned_clone_fallback(self):
+        from torch._inductor.runtime.triton_heuristics import _host_tma_aligned
+
+        # 16-byte-aligned base -> returned as-is (no clone).
+        aligned = torch.randn(1024)
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        self.assertIs(_host_tma_aligned(aligned, "aligned"), aligned)
+
+        # Misaligned base -> cloned into an aligned buffer, values preserved.
+        base = torch.randn(1024 + 8, dtype=torch.float16)
+        misaligned = base[1:]
+        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
+        cloned = _host_tma_aligned(misaligned, "misaligned")
+        self.assertIsNot(cloned, misaligned)
+        self.assertEqual(cloned.data_ptr() % 16, 0)
+        self.assertTrue(torch.equal(cloned, misaligned))
+
+
+@unittest.skipIf(
+    not (HAS_CUDA_AND_TRITON and torch.cuda.get_device_capability()[0] >= 9)
+    or torch.version.hip,
+    "Requires Triton CUDA backend and CUDA compute capability >= 9.0. Not supported on ROCm",
+)
+class TritonHostSideTMAConfigTestCUDA(InductorTestCase):
+    @config.patch(
+        {
+            "triton.enable_host_side_tma": True,
+            "triton.use_tensor_descriptor": False,
+        }
+    )
+    def test_enable_host_side_tma_without_prereqs_warns(self):
+        # enable_host_side_tma only selects the descriptor flavor; without
+        # use_tensor_descriptor + assume_aligned_inputs it has no effect and
+        # should warn rather than silently no-op.
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(1024, device=GPU_TYPE)
+        with self.assertWarnsRegex(UserWarning, "no effect"):
+            result, code_list = run_and_get_code(torch.compile(fn), x)
+        self.assertTrue(torch.allclose(result, fn(x)))
+        self.assertNotIn("host_tma_descriptor_args", "\n".join(code_list))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -2286,6 +2286,70 @@ class TestTilingExtra(InductorTestCase):
             )
 
 
+@unittest.skipIf(
+    not (HAS_CUDA_AND_TRITON and torch.cuda.get_device_capability()[0] >= 9)
+    or torch.version.hip,
+    "Requires Triton CUDA backend and CUDA compute capability >= 9.0. Not supported on ROCm",
+)
+@config.patch(
+    {
+        "triton.use_tensor_descriptor": True,
+        "triton.enable_host_side_tma": True,
+        "assume_aligned_inputs": True,
+    }
+)
+@instantiate_parametrized_tests
+class TritonHostSideTMATestCUDA(BlockDescriptorTestBase):
+    """Run the full pointwise/reduction suite with host-side TMA.
+    Block pointer count is skipped because host-side TMA creates
+    descriptors in the launcher, not the kernel."""
+
+    device = GPU_TYPE
+
+    def _run_and_compare(self, *args, **kwargs):
+        kwargs["expected_num_block_pointers"] = None
+        return super()._run_and_compare(*args, **kwargs)
+
+
+test_torchinductor.copy_tests(
+    CommonTemplate, TritonHostSideTMATestCUDA, GPU_TYPE
+)
+
+# The (9, True) meta-test checks that _run_and_compare raises on wrong block
+# pointer counts. Host-side TMA disables this count check, so skip it.
+TritonHostSideTMATestCUDA.test_expected_num_block_pointers_expected_num_block_pointers_9_raises_True_cuda = unittest.skip(
+    "block pointer count check is disabled for host-side TMA"
+)(
+    TritonHostSideTMATestCUDA.test_expected_num_block_pointers_expected_num_block_pointers_9_raises_True_cuda
+)
+
+# Known TMA API limitations: these cases also fail for device-side TMA (they
+# carry @xfail_if_use_tensor_descriptor). For host-side TMA they either produce
+# different (still-correct) codegen that breaks the device-specific code asserts,
+# or hit the same descriptor constraints (e.g. the 16-byte last-dim minimum in
+# test_reduction_padded_output_tiling).
+_HOST_TMA_EXPECTED_FAILURES = [
+    "test_boundary_check_block_multiple_False_ynumel_exceed_ygrid_size_False_include_z_True_cuda",
+    "test_boundary_check_block_multiple_True_ynumel_exceed_ygrid_size_True_include_z_False_cuda",
+    "test_pointwise_broadcast_nonzero_strides_prefer_nd_tiling_False_cuda",
+    "test_pointwise_broadcast_nonzero_strides_prefer_nd_tiling_True_cuda",
+    "test_pointwise_index_order_cuda",
+    "test_reduction_padded_output_tiling_cuda",
+]
+for _name in _HOST_TMA_EXPECTED_FAILURES:
+    setattr(
+        TritonHostSideTMATestCUDA,
+        _name,
+        unittest.expectedFailure(getattr(TritonHostSideTMATestCUDA, _name)),
+    )
+
+# Dynamic shapes are not yet supported for host-side TMA (the launcher cannot
+# resolve symbolic block/shape dims). Tracked as a follow-up.
+TritonHostSideTMATestCUDA.test_dynamic_shapes_pointwise_nd_tiling_False_num_block_pointers_1_cuda = unittest.expectedFailure(
+    TritonHostSideTMATestCUDA.test_dynamic_shapes_pointwise_nd_tiling_False_num_block_pointers_1_cuda
+)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -96,7 +96,6 @@ from .common import (
     ArgName,
     BackendFeature,
     ConstexprArg,
-    TMADescriptorArg,
     CSE,
     CSEVariable,
     DeferredLine,
@@ -2846,16 +2845,18 @@ class TMACompatibilityChecker:
     ) -> bool:
         if self.force:
             return True
+        use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
+        assume_aligned = config.assume_aligned_inputs or config.triton.enable_host_side_tma
         if not (
             (
                 (
                     V.graph.get_current_device_or_throw().type == "cuda"
                     and torch.cuda.get_device_capability()[0] >= 9
-                    and config.assume_aligned_inputs
+                    and assume_aligned
                 )
                 or V.graph.get_current_device_or_throw().type == "xpu"
             )
-            and config.triton.use_tensor_descriptor
+            and use_tma
             and has_triton_stable_tma_api()
             # For CUDA The base ptr needs to be aligned
         ):
@@ -3216,6 +3217,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # before kernel launch instead of every CTA calling
         # tl.make_tensor_descriptor() (fixes issue #185819).
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
+        # Buffers that have any non-TMA access (pointer arithmetic, non-zero
+        # offset) and cannot be replaced with host-side TMA descriptors.
+        self._host_tma_ineligible: OrderedSet[str] = OrderedSet()
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3298,6 +3302,118 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return False
 
         return any(stride == 1 for stride in stride_vars)
+
+    @staticmethod
+    def _is_host_tma_eligible(
+        indexing: TensorDescriptorOptions,
+        dtype: torch.dtype | None = None,
+    ) -> bool:
+        """Check if an access pattern is eligible for host-side TMA.
+
+        Rejects:
+        - Complex block shape expressions (floor division, etc.)
+        - Sub-byte dtypes (i1/bool) that TMA can't handle
+        """
+        if dtype is not None and dtype == torch.bool:
+            return False
+        for dim in indexing.block_shape:
+            if isinstance(dim, (int, sympy.Integer)):
+                continue
+            if isinstance(dim, sympy.Symbol):
+                continue
+            return False
+        return True
+
+    def _prescan_host_tma_eligibility(self) -> None:
+        """Pre-scan all buffer reads to identify those with non-block-ptr access.
+
+        Populates _host_tma_ineligible_buffers (buffer names) with buffers
+        that have any read which can't be expressed as a block pointer.
+        During codegen, load() maps these names to var names and adds them
+        to _host_tma_ineligible.
+        """
+        self._host_tma_ineligible_buffers = set()
+        if not (config.triton.enable_host_side_tma or config.triton.use_tensor_descriptor):
+            return
+        if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
+            return
+
+        from .simd_kernel_features import NodeScheduleMarker
+
+        range_tree_symbols = OrderedSet(
+            tree.symbol() for tree in self.range_trees
+        )
+        if not range_tree_symbols:
+            return
+
+        from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+
+        buffer_read_indices: dict[str, list[tuple[sympy.Expr, tuple[sympy.Symbol, ...]]]] = (
+            collections.defaultdict(list)
+        )
+        for node in NodeScheduleMarker.only_nodes(self.features.node_schedule):
+            for dep in node.read_writes.reads:
+                if not hasattr(dep, "var_names"):
+                    if hasattr(dep, "name"):
+                        self._host_tma_ineligible_buffers.add(dep.name)
+                    continue
+                buffer_read_indices[dep.name].append((dep.index, dep.var_names))
+
+        for buf_name, reads in buffer_read_indices.items():
+            if buf_name in self._host_tma_ineligible_buffers:
+                continue
+
+            for index, var_names in reads:
+                dep_vars = set(var_names)
+
+                if any(symbol_is_type(s, SymT.TMP) for s in index.free_symbols):
+                    self._host_tma_ineligible_buffers.add(buf_name)
+                    break
+
+                for expr_node in sympy.preorder_traversal(index):
+                    if isinstance(expr_node, (FloorDiv, ModularIndexing)):
+                        if expr_node.free_symbols & dep_vars:
+                            self._host_tma_ineligible_buffers.add(buf_name)
+                            break
+                else:
+                    continue
+                break
+
+            if buf_name in self._host_tma_ineligible_buffers:
+                continue
+
+            # Multiple reads from the same buffer may have different access
+            # patterns (different strides, offsets). Since we can't verify
+            # compatibility until codegen runs, conservatively mark buffers
+            # with >1 read as ineligible.
+            if len(reads) > 1:
+                self._host_tma_ineligible_buffers.add(buf_name)
+
+    def _check_buffer_alignment(self, name: str, var: str, dtype: torch.dtype) -> bool:
+        """Check if a buffer has a misaligned layout offset that prevents TMA use.
+
+        Returns True if the buffer is misaligned (TMA should be skipped).
+        """
+        if not (config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma):
+            return False
+        try:
+            buf = V.graph.try_get_buffer(name)
+            if buf is None and hasattr(V.graph, "scheduler") and V.graph.scheduler:
+                real_name = V.graph.scheduler.mutation_real_name.get(name, name)
+                if real_name != name:
+                    buf = V.graph.try_get_buffer(real_name)
+            if buf is not None:
+                layout = buf.get_layout()
+                layout_offset = getattr(layout, "offset", 0)
+                if layout_offset != 0:
+                    offset_bytes = int(layout_offset) * dtype.itemsize
+                    if offset_bytes % 16 != 0:
+                        self._host_tma_ineligible.add(var)
+                        self.host_tma_descriptor_args.pop(var, None)
+                        return True
+        except (TypeError, ValueError):
+            pass
+        return False
 
     @property
     def has_store_with_contiguous_rdim(self) -> bool:
@@ -3959,16 +4075,30 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             #
             # Template-forced paths (can_lift=True) manage their own
             # host-side descriptors via ir.TMADescriptor; skip them.
+            use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
             if (
                 has_triton_stable_tma_api()
-                and config.triton.use_tensor_descriptor
+                and use_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
+                and var not in self._host_tma_ineligible
+                and self._is_host_tma_eligible(indexing, V.graph.get_dtype(name))
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
                 return var, other  # arg IS the pre-created descriptor
+            elif (
+                has_triton_stable_tma_api()
+                and use_tma
+                and not indexing.can_lift
+                and indexing.constant_offset != 0
+            ):
+                # Non-zero offset access — this buffer can't be host-side TMA
+                self._host_tma_ineligible.add(var)
+                if var in self.host_tma_descriptor_args:
+                    del self.host_tma_descriptor_args[var]
             # ── end host-side TMA fast path ──────────────────────────────
+
 
         else:
             if not check:
@@ -4275,16 +4405,32 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         original_index = index
         dtype = V.graph.get_dtype(name)
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
-        indexing = self.indexing(
-            index,
-            block_ptr=True,
-            tma_compatibility_checker=self.tma_compatibility_checker_cls(
+
+        # Apply pre-scan results: if the buffer was identified as having
+        # non-block-ptr reads, mark the var as ineligible for host-side TMA.
+        if not hasattr(self, "_host_tma_ineligible_buffers"):
+            self._prescan_host_tma_eligibility()
+        prescan_ineligible = name in self._host_tma_ineligible_buffers
+        if prescan_ineligible:
+            self._host_tma_ineligible.add(var)
+
+        buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
+
+        skip_tma = buffer_misaligned or prescan_ineligible
+        tma_checker = (
+            None if skip_tma
+            else self.tma_compatibility_checker_cls(
                 self,
                 dtype,
                 for_store=False,
                 force=getattr(self, "tma_load_for_template_epilogue", False),
                 buffer_name=name,
-            ),
+            )
+        )
+        indexing = self.indexing(
+            index,
+            block_ptr=True,
+            tma_compatibility_checker=tma_checker,
         )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
@@ -4394,10 +4540,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     for_store=False,
                 )
             elif is_sympy_integer_like(original_index):
+                self._host_tma_ineligible.add(var)
+                self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:
+                self._host_tma_ineligible.add(var)
+                self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({indexing.index_str}), {indexing.mask_str}{ep}{other}{cachemod})"
 
                 # The block shape of tl.load depends on the indexing expression.
@@ -4480,8 +4630,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         original_index = index
         dtype = V.graph.get_dtype(name)
 
+        buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
+
         tma_compatibility_checker = None
-        if mode is None or mode == "tma":
+        if not buffer_misaligned and (mode is None or mode == "tma"):
             force = mode == "tma" or getattr(self, "tma_store", False)
             tma_compatibility_checker = self.tma_compatibility_checker_cls(
                 self,
@@ -4497,6 +4649,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mode == "atomic_add",
         )
+
+        if (
+            isinstance(indexing, TensorDescriptorOptions)
+            and config.triton.enable_host_side_tma
+            and not config.triton.use_tensor_descriptor
+            and not self._is_host_tma_eligible(indexing, dtype)
+        ):
+            indexing = self.indexing(
+                index,
+                dense_indexing=True,
+                block_ptr=mode is None,
+                tma_compatibility_checker=None,
+                mask_constant_index=mode == "atomic_add",
+            )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
             indexing.index
@@ -4538,6 +4704,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 ):
                     value_shape = ", ".join(map(str, value.shape))
                     indexing_str += f".broadcast_to({value_shape})"
+            self._host_tma_ineligible.add(var)
+            self.host_tma_descriptor_args.pop(var, None)
             line = f"tl.store({var} + ({indexing_str}), {value}, {indexing.mask_str})"
         elif mode == "atomic_add":
             self.atomic_add_found = True
@@ -6460,13 +6628,58 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 out["kernel_flop"] = flops
         if self.host_tma_descriptor_args:
-            # Pass {inner_arg: [block_dim_str, ...]} to the per-config
-            # launcher so it can call TensorDescriptor.from_tensor() with
-            # the actual autotuned XBLOCK / YBLOCK values (issue #185819).
-            out["host_tma_descriptor_args"] = {
-                inner: [str(s) for s in opts.block_shape]
-                for inner, opts in self.host_tma_descriptor_args.items()
-            }
+            # Block shapes contain sympy expressions (XBLOCK, R0_BLOCK, etc).
+            # We need to distinguish autotuned symbols (kernel function args
+            # whose values vary per-config) from fixed symbols (defined in
+            # the kernel body with concrete values).
+            # Build a mapping of fixed block sizes from the range trees.
+            _, _, signature, _ = self.args.python_argdefs()
+            sig_arg_names = OrderedSet(
+                arg.name for arg in signature if hasattr(arg, "name")
+            )
+            # Map non-argument block size symbols to concrete values.
+            # For persistent reductions, R0_BLOCK is defined in the kernel
+            # body (not a function arg) with a concrete value computed from
+            # the reduction dimension numel.
+            fixed_blocks: dict[str, int] = {}
+            if self.persistent_reduction:
+                for rt in self.range_trees:
+                    if rt.is_reduction:
+                        block_name = f"{rt.prefix.upper()}BLOCK"
+                        if block_name not in sig_arg_names:
+                            try:
+                                val = self._get_persistent_RBLOCK(rt.numel)
+                                if self.is_native_matmul:
+                                    val = max(val, 16)
+                                fixed_blocks[block_name] = val
+                            except (TypeError, ValueError):
+                                pass
+
+            def _resolve_block_dim(s):
+                s_str = str(s)
+                if s_str in sig_arg_names:
+                    return s_str
+                if s_str in fixed_blocks:
+                    return fixed_blocks[s_str]
+                try:
+                    return int(s)
+                except (TypeError, ValueError):
+                    return s_str
+
+            resolved = {}
+            for inner, opts in self.host_tma_descriptor_args.items():
+                dims = [_resolve_block_dim(s) for s in opts.block_shape]
+                # Skip buffers with degenerate block shapes (any dim <= 0)
+                if any(isinstance(d, int) and d <= 0 for d in dims):
+                    continue
+                shape_dims = [_resolve_block_dim(s) for s in opts.shape]
+                stride_dims = [_resolve_block_dim(s) for s in opts.strides]
+                resolved[inner] = {
+                    "block_shape": dims,
+                    "shape": shape_dims,
+                    "strides": stride_dims,
+                }
+            out["host_tma_descriptor_args"] = resolved
         return out
 
     @functools.cached_property
@@ -6561,22 +6774,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
                     )
 
-        # Upgrade TensorArg -> TMADescriptorArg for host-side TMA buffers
-        # so Triton compiles the kernel with tensordesc<dtype[B0, B1]>
-        # argument types instead of raw pointers (issue #185819).
-        if self.host_tma_descriptor_args:
-            for i, (argname, arg) in enumerate(zip(argdefs, signature)):
-                if (
-                    isinstance(arg, TensorArg)
-                    and argname.name in self.host_tma_descriptor_args
-                ):
-                    tma_opts = self.host_tma_descriptor_args[argname.name]
-                    signature[i] = TMADescriptorArg(
-                        name=argname.name,
-                        api_type="stable",
-                        block_shape=list(tma_opts.block_shape),
-                        dtype=V.graph.get_dtype(arg.buffer),
-                    )
+        # NOTE: host-side TMA signature upgrade (TensorArg -> tensordesc<>)
+        # is deferred to _precompile_config() where concrete block sizes are
+        # available. The triton_meta signature keeps pointer types here.
 
         mutated_args: OrderedSet[str] = OrderedSet()
         for mutation in self.mutations:
@@ -6695,7 +6895,35 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.inductor_meta = inductor_meta
 
         self.codegen_prologue(self.body)
+        self._prescan_host_tma_eligibility()
         self.codegen_body()
+
+        # After codegen_body, host_tma_descriptor_args may have been pruned
+        # (buffers with mixed TMA/pointer accesses are removed). Update
+        # inductor_meta with the final set.
+        if self.host_tma_descriptor_args:
+            self.inductor_meta["host_tma_descriptor_args"] = (
+                self.inductor_meta.get("host_tma_descriptor_args", {})
+            )
+            # Re-filter: only keep buffers still in host_tma_descriptor_args
+            kept = {
+                k: v
+                for k, v in self.inductor_meta["host_tma_descriptor_args"].items()
+                if k in self.host_tma_descriptor_args
+            }
+            self.inductor_meta["host_tma_descriptor_args"] = kept
+        elif "host_tma_descriptor_args" in self.inductor_meta:
+            del self.inductor_meta["host_tma_descriptor_args"]
+
+        # If no buffers use host-side TMA and device-side TMA is off,
+        # clear tma_min_block_sizes to avoid overly aggressive config filtering.
+        if (
+            config.triton.enable_host_side_tma
+            and not config.triton.use_tensor_descriptor
+            and not self.inductor_meta.get("host_tma_descriptor_args")
+        ):
+            self.inductor_meta.pop("tma_min_block_sizes", None)
+
         self._filter_pdl(self.body)
 
         # Compute configs after codegen_body() so we know if the kernel
@@ -6875,9 +7103,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         val = max(val, 16)
 
                 code.writeline(f"{tree.prefix.upper()}BLOCK: tl.constexpr = {val}")
+                # Store resolved block size for host-side TMA descriptor args
+                if not hasattr(self, "_resolved_block_sizes"):
+                    self._resolved_block_sizes = {}
+                self._resolved_block_sizes[f"{tree.prefix.upper()}BLOCK"] = val
 
             if tree.prefix == "x" and self.no_x_dim:
                 code.writeline("XBLOCK: tl.constexpr = 1")
+                if not hasattr(self, "_resolved_block_sizes"):
+                    self._resolved_block_sizes = {}
+                self._resolved_block_sizes["XBLOCK"] = 1
 
     def _get_grid_type(self) -> type[triton_heuristics.GridExpr]:
         n = sum([int(not tree.is_reduction) for tree in self.range_trees])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3217,9 +3217,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # before kernel launch instead of every CTA calling
         # tl.make_tensor_descriptor() (fixes issue #185819).
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
-        # Buffers that have any non-TMA access (pointer arithmetic, non-zero
-        # offset) and cannot be replaced with host-side TMA descriptors.
-        self._host_tma_ineligible: OrderedSet[str] = OrderedSet()
+        # Vars whose access the host launcher cannot materialize a
+        # TensorDescriptor for (indirect/ModularIndexing indexing, non-zero
+        # offset, misalignment, complex block shape, or >1 read). This is NOT
+        # a TMA eligibility check -- such accesses may still be device-TMA
+        # eligible; eligibility is decided by TMACompatibilityChecker.
+        self._host_tma_non_materializable: OrderedSet[str] = OrderedSet()
+        # True once any access in this kernel is emitted as a device-side TMA
+        # descriptor (tl.make_tensor_descriptor). Used after codegen to decide
+        # whether tma_min_block_sizes constraints are still relevant.
+        self._emitted_device_tma = False
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3304,15 +3311,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return any(stride == 1 for stride in stride_vars)
 
     @staticmethod
-    def _is_host_tma_eligible(
+    def _is_host_tma_materializable(
         indexing: TensorDescriptorOptions,
         dtype: torch.dtype | None = None,
     ) -> bool:
-        """Check if an access pattern is eligible for host-side TMA.
+        """Whether the host launcher can materialize a TensorDescriptor for
+        this access. This is NOT a TMA eligibility (possibility) check --
+        eligibility is decided by TMACompatibilityChecker.
 
-        Rejects:
-        - Complex block shape expressions (floor division, etc.)
-        - Sub-byte dtypes (i1/bool) that TMA can't handle
+        Returns False when:
+        - the block_shape contains non-trivial expressions (e.g. the nested
+          min/max clamps produced by a transpose/reshape) that can't be
+          resolved to concrete host-side dims, or
+        - the dtype is sub-byte i1/bool (no CUtensorMap mapping).
         """
         if dtype is not None and dtype == torch.bool:
             return False
@@ -3324,15 +3335,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return False
         return True
 
-    def _prescan_host_tma_eligibility(self) -> None:
-        """Pre-scan all buffer reads to identify those with non-block-ptr access.
+    def _prescan_host_tma_materializability(self) -> None:
+        """Pre-scan all buffer reads to find those the host launcher cannot
+        materialize a TMA descriptor for.
 
-        Populates _host_tma_ineligible_buffers (buffer names) with buffers
-        that have any read which can't be expressed as a block pointer.
-        During codegen, load() maps these names to var names and adds them
-        to _host_tma_ineligible.
+        Populates _host_tma_non_materializable_buffers (buffer names) with
+        buffers whose reads can't be expressed as a single host-side block
+        descriptor: indirect (TMP) indexing, FloorDiv/ModularIndexing access,
+        or (conservatively) more than one read. During codegen, load() maps
+        these names to var names and adds them to _host_tma_non_materializable.
+
+        Non-materializable means "the host can't build the descriptor", not
+        "TMA is impossible" -- such accesses may still be device-TMA eligible.
         """
-        self._host_tma_ineligible_buffers = set()
+        self._host_tma_non_materializable_buffers = set()
         if not (config.triton.enable_host_side_tma or config.triton.use_tensor_descriptor):
             return
         if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
@@ -3355,31 +3371,31 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for dep in node.read_writes.reads:
                 if not hasattr(dep, "var_names"):
                     if hasattr(dep, "name"):
-                        self._host_tma_ineligible_buffers.add(dep.name)
+                        self._host_tma_non_materializable_buffers.add(dep.name)
                     continue
                 buffer_read_indices[dep.name].append((dep.index, dep.var_names))
 
         for buf_name, reads in buffer_read_indices.items():
-            if buf_name in self._host_tma_ineligible_buffers:
+            if buf_name in self._host_tma_non_materializable_buffers:
                 continue
 
             for index, var_names in reads:
                 dep_vars = set(var_names)
 
                 if any(symbol_is_type(s, SymT.TMP) for s in index.free_symbols):
-                    self._host_tma_ineligible_buffers.add(buf_name)
+                    self._host_tma_non_materializable_buffers.add(buf_name)
                     break
 
                 for expr_node in sympy.preorder_traversal(index):
                     if isinstance(expr_node, (FloorDiv, ModularIndexing)):
                         if expr_node.free_symbols & dep_vars:
-                            self._host_tma_ineligible_buffers.add(buf_name)
+                            self._host_tma_non_materializable_buffers.add(buf_name)
                             break
                 else:
                     continue
                 break
 
-            if buf_name in self._host_tma_ineligible_buffers:
+            if buf_name in self._host_tma_non_materializable_buffers:
                 continue
 
             # Multiple reads from the same buffer may have different access
@@ -3387,7 +3403,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             # compatibility until codegen runs, conservatively mark buffers
             # with >1 read as ineligible.
             if len(reads) > 1:
-                self._host_tma_ineligible_buffers.add(buf_name)
+                self._host_tma_non_materializable_buffers.add(buf_name)
 
     def _check_buffer_alignment(self, name: str, var: str, dtype: torch.dtype) -> bool:
         """Check if a buffer has a misaligned layout offset that prevents TMA use.
@@ -3408,7 +3424,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if layout_offset != 0:
                     offset_bytes = int(layout_offset) * dtype.itemsize
                     if offset_bytes % 16 != 0:
-                        self._host_tma_ineligible.add(var)
+                        self._host_tma_non_materializable.add(var)
                         self.host_tma_descriptor_args.pop(var, None)
                         return True
         except (TypeError, ValueError):
@@ -4081,8 +4097,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 and use_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
-                and var not in self._host_tma_ineligible
-                and self._is_host_tma_eligible(indexing, V.graph.get_dtype(name))
+                and var not in self._host_tma_non_materializable
+                and self._is_host_tma_materializable(
+                    indexing, V.graph.get_dtype(name)
+                )
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
@@ -4094,11 +4112,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 and indexing.constant_offset != 0
             ):
                 # Non-zero offset access — this buffer can't be host-side TMA
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 if var in self.host_tma_descriptor_args:
                     del self.host_tma_descriptor_args[var]
             # ── end host-side TMA fast path ──────────────────────────────
 
+            # Reaching here with a TensorDescriptorOptions means the host fast
+            # path did not claim this access (host-non-materializable), so it
+            # is emitted as a device-side TMA descriptor below.
+            self._emitted_device_tma = True
 
         else:
             if not check:
@@ -4407,16 +4429,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
 
         # Apply pre-scan results: if the buffer was identified as having
-        # non-block-ptr reads, mark the var as ineligible for host-side TMA.
-        if not hasattr(self, "_host_tma_ineligible_buffers"):
-            self._prescan_host_tma_eligibility()
-        prescan_ineligible = name in self._host_tma_ineligible_buffers
-        if prescan_ineligible:
-            self._host_tma_ineligible.add(var)
+        # reads the host launcher can't materialize a descriptor for, mark
+        # the var as non-materializable for host-side TMA.
+        if not hasattr(self, "_host_tma_non_materializable_buffers"):
+            self._prescan_host_tma_materializability()
+        prescan_non_materializable = (
+            name in self._host_tma_non_materializable_buffers
+        )
+        if prescan_non_materializable:
+            self._host_tma_non_materializable.add(var)
 
         buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
 
-        skip_tma = buffer_misaligned or prescan_ineligible
+        skip_tma = buffer_misaligned or prescan_non_materializable
         tma_checker = (
             None if skip_tma
             else self.tma_compatibility_checker_cls(
@@ -4540,13 +4565,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     for_store=False,
                 )
             elif is_sympy_integer_like(original_index):
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({original_index}))"
                 append_broadcast = indexing.expand_str
                 shape = ()
             else:
-                self._host_tma_ineligible.add(var)
+                self._host_tma_non_materializable.add(var)
                 self.host_tma_descriptor_args.pop(var, None)
                 line = f"tl.load({var} + ({indexing.index_str}), {indexing.mask_str}{ep}{other}{cachemod})"
 
@@ -4654,7 +4679,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             isinstance(indexing, TensorDescriptorOptions)
             and config.triton.enable_host_side_tma
             and not config.triton.use_tensor_descriptor
-            and not self._is_host_tma_eligible(indexing, dtype)
+            and not self._is_host_tma_materializable(indexing, dtype)
         ):
             indexing = self.indexing(
                 index,
@@ -4704,7 +4729,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 ):
                     value_shape = ", ".join(map(str, value.shape))
                     indexing_str += f".broadcast_to({value_shape})"
-            self._host_tma_ineligible.add(var)
+            self._host_tma_non_materializable.add(var)
             self.host_tma_descriptor_args.pop(var, None)
             line = f"tl.store({var} + ({indexing_str}), {value}, {indexing.mask_str})"
         elif mode == "atomic_add":
@@ -6895,7 +6920,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.inductor_meta = inductor_meta
 
         self.codegen_prologue(self.body)
-        self._prescan_host_tma_eligibility()
+        self._prescan_host_tma_materializability()
         self.codegen_body()
 
         # After codegen_body, host_tma_descriptor_args may have been pruned
@@ -6915,12 +6940,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         elif "host_tma_descriptor_args" in self.inductor_meta:
             del self.inductor_meta["host_tma_descriptor_args"]
 
-        # If no buffers use host-side TMA and device-side TMA is off,
-        # clear tma_min_block_sizes to avoid overly aggressive config filtering.
+        # Clear tma_min_block_sizes when this kernel emitted no TMA descriptor
+        # (neither host- nor device-side). The constraint is set during TMA
+        # compatibility probing (are_block_parameters_compatible), which fires
+        # even when the access ultimately falls back to a plain tl.load (e.g.
+        # looping reductions). A stale constraint over-filters the autotune
+        # config space and can severely regress otherwise non-TMA kernels.
         if (
-            config.triton.enable_host_side_tma
-            and not config.triton.use_tensor_descriptor
-            and not self.inductor_meta.get("host_tma_descriptor_args")
+            not self.inductor_meta.get("host_tma_descriptor_args")
+            and not self._emitted_device_tma
         ):
             self.inductor_meta.pop("tma_min_block_sizes", None)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -85,6 +85,7 @@ from ..utils import (
     sympy_dot,
     sympy_product,
     sympy_subs,
+    TMA_ALIGNMENT,
     triton_type,
     triton_version_uses_attrs_dict,
     upcast_compute_type,
@@ -3208,7 +3209,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.tma_min_block_sizes = dict[str, int]()
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
         self._host_tma_non_materializable: OrderedSet[str] = OrderedSet()
-        self._host_tma_non_materializable_buffers: set[str] | None = None
+        self._host_tma_non_materializable_buffers: OrderedSet[str] | None = None
         self._emitted_device_tma = False
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
@@ -3314,25 +3315,23 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     def _prescan_host_tma_materializability(self) -> None:
         """Populate _host_tma_non_materializable_buffers with buffers that
         can't be expressed as a single host-side TMA descriptor."""
-        self._host_tma_non_materializable_buffers = set()
         if not config.triton.use_tensor_descriptor:
+            # Host TMA is off; mark as scanned (no bad buffers, won't change).
+            self._host_tma_non_materializable_buffers = OrderedSet()
             return
-        if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
-            return
+        self._host_tma_non_materializable_buffers = OrderedSet()
 
         from .simd_kernel_features import NodeScheduleMarker
 
-        range_tree_symbols = OrderedSet(
-            tree.symbol() for tree in self.range_trees
-        )
+        range_tree_symbols = OrderedSet(tree.symbol() for tree in self.range_trees)
         if not range_tree_symbols:
             return
 
         from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
-        buffer_read_indices: dict[str, list[tuple[sympy.Expr, tuple[sympy.Symbol, ...]]]] = (
-            collections.defaultdict(list)
-        )
+        buffer_read_indices: dict[
+            str, list[tuple[sympy.Expr, tuple[sympy.Symbol, ...]]]
+        ] = collections.defaultdict(list)
         for node in NodeScheduleMarker.only_nodes(self.features.node_schedule):
             for dep in node.read_writes.reads:
                 if not hasattr(dep, "var_names"):
@@ -3346,7 +3345,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 continue
 
             for index, var_names in reads:
-                dep_vars = set(var_names)
+                dep_vars = OrderedSet(var_names)
 
                 if any(symbol_is_type(s, SymT.TMP) for s in index.free_symbols):
                     self._host_tma_non_materializable_buffers.add(buf_name)
@@ -3368,30 +3367,32 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self._host_tma_non_materializable_buffers.add(buf_name)
 
     def _check_buffer_alignment(self, name: str, var: str, dtype: torch.dtype) -> bool:
-        """Check if a buffer has a misaligned layout offset that prevents TMA use.
-
-        Returns True if the buffer is misaligned (TMA should be skipped).
+        """Whether a buffer's layout offset can't be proven TMA-aligned, so
+        host-side TMA must be skipped. The CUtensorMap alignment requirement is
+        CUDA-specific, so this only applies on CUDA; an offset that is not
+        statically known to be a multiple of TMA_ALIGNMENT is treated as
+        misaligned (conservative).
         """
         if not config.triton.use_tensor_descriptor:
             return False
-        try:
-            buf = V.graph.try_get_buffer(name)
-            if buf is None and hasattr(V.graph, "scheduler") and V.graph.scheduler:
-                real_name = V.graph.scheduler.mutation_real_name.get(name, name)
-                if real_name != name:
-                    buf = V.graph.try_get_buffer(real_name)
-            if buf is not None:
-                layout = buf.get_layout()
-                layout_offset = getattr(layout, "offset", 0)
-                if layout_offset != 0:
-                    offset_bytes = int(layout_offset) * dtype.itemsize
-                    if offset_bytes % 16 != 0:
-                        self._host_tma_non_materializable.add(var)
-                        self.host_tma_descriptor_args.pop(var, None)
-                        return True
-        except (TypeError, ValueError):
-            pass
-        return False
+        if V.graph.get_current_device_or_throw().type != "cuda":
+            return False
+        buf = V.graph.try_get_buffer(name)
+        if buf is None and hasattr(V.graph, "scheduler") and V.graph.scheduler:
+            real_name = V.graph.scheduler.mutation_real_name.get(name, name)
+            if real_name != name:
+                buf = V.graph.try_get_buffer(real_name)
+        if buf is None:
+            return False
+        layout_offset = getattr(buf.get_layout(), "offset", 0)
+        if layout_offset == 0:
+            return False
+        offset_bytes = layout_offset * dtype.itemsize
+        if V.graph.sizevars.statically_known_multiple_of(offset_bytes, TMA_ALIGNMENT):
+            return False
+        self._host_tma_non_materializable.add(var)
+        self.host_tma_descriptor_args.pop(var, None)
+        return True
 
     @property
     def has_store_with_contiguous_rdim(self) -> bool:
@@ -4044,19 +4045,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     raise AssertionError(f"expected ', other=0.0', got {other!r}")
                 other = ""
 
+            # Host-side TMA: an aligned, zero-offset, materializable buffer whose
+            # descriptor can be built on the host. Register it and return early --
+            # no in-kernel tl.make_tensor_descriptor is emitted for it.
             if (
                 has_triton_stable_tma_api()
                 and config.triton.enable_host_side_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
                 and var not in self._host_tma_non_materializable
-                and self._is_host_tma_materializable(
-                    indexing, V.graph.get_dtype(name)
-                )
+                and self._is_host_tma_materializable(indexing, V.graph.get_dtype(name))
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
                 return var, other
+            # A non-zero constant offset can't be host-TMA'd: mark it
+            # non-materializable and fall through to device-side TMA below.
             elif (
                 has_triton_stable_tma_api()
                 and config.triton.enable_host_side_tma
@@ -4067,6 +4071,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if var in self.host_tma_descriptor_args:
                     del self.host_tma_descriptor_args[var]
 
+            # Device-side TMA: reached for every case except the host-TMA branch
+            # above (which returned) -- emit an in-kernel tl.make_tensor_descriptor.
             self._emitted_device_tma = True
 
         else:
@@ -4378,15 +4384,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if config.triton.enable_host_side_tma:
             if self._host_tma_non_materializable_buffers is None:
                 self._prescan_host_tma_materializability()
-            if name in self._host_tma_non_materializable_buffers:
+            if name in (self._host_tma_non_materializable_buffers or ()):
                 self._host_tma_non_materializable.add(var)
 
-        skip_tma = (
-            config.triton.enable_host_side_tma
-            and self._check_buffer_alignment(name, var, dtype)
+        skip_tma = config.triton.enable_host_side_tma and self._check_buffer_alignment(
+            name, var, dtype
         )
         tma_checker = (
-            None if skip_tma
+            None
+            if skip_tma
             else self.tma_compatibility_checker_cls(
                 self,
                 dtype,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -96,6 +96,7 @@ from .common import (
     ArgName,
     BackendFeature,
     ConstexprArg,
+    TMADescriptorArg,
     CSE,
     CSEVariable,
     DeferredLine,
@@ -3209,6 +3210,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
+        # Maps inner kernel-arg name (e.g. "in_ptr0") to the
+        # TensorDescriptorOptions for host-side TMA descriptor creation.
+        # The per-config launcher calls TensorDescriptor.from_tensor()
+        # before kernel launch instead of every CTA calling
+        # tl.make_tensor_descriptor() (fixes issue #185819).
+        self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3942,6 +3949,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if other != ", other=0.0":
                     raise AssertionError(f"expected ', other=0.0', got {other!r}")
                 other = ""
+
+            # ── Host-side TMA fast path (issue #185819) ─────────────────
+            # When the stable Triton TMA API is available and this buffer
+            # has no constant offset, skip kernel-side descriptor creation.
+            # The kernel receives a pre-built TensorDescriptor from the
+            # host launcher, eliminating per-CTA construction overhead that
+            # causes a 1.4-1.6x slowdown for simple pointwise ops.
+            #
+            # Template-forced paths (can_lift=True) manage their own
+            # host-side descriptors via ir.TMADescriptor; skip them.
+            if (
+                has_triton_stable_tma_api()
+                and config.triton.use_tensor_descriptor
+                and not indexing.can_lift
+                and indexing.constant_offset == 0
+            ):
+                if var not in self.host_tma_descriptor_args:
+                    self.host_tma_descriptor_args[var] = indexing
+                return var, other  # arg IS the pre-created descriptor
+            # ── end host-side TMA fast path ──────────────────────────────
+
         else:
             if not check:
                 # workaround https://github.com/triton-lang/triton/issues/2813
@@ -6431,6 +6459,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             flops = self.estimate_flops()
             if flops is not None:
                 out["kernel_flop"] = flops
+        if self.host_tma_descriptor_args:
+            # Pass {inner_arg: [block_dim_str, ...]} to the per-config
+            # launcher so it can call TensorDescriptor.from_tensor() with
+            # the actual autotuned XBLOCK / YBLOCK values (issue #185819).
+            out["host_tma_descriptor_args"] = {
+                inner: [str(s) for s in opts.block_shape]
+                for inner, opts in self.host_tma_descriptor_args.items()
+            }
         return out
 
     @functools.cached_property
@@ -6523,6 +6559,23 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if symbol in V.graph.sizevars.inv_precomputed_replacements:
                     signature[i] = SizeArg(
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
+                    )
+
+        # Upgrade TensorArg -> TMADescriptorArg for host-side TMA buffers
+        # so Triton compiles the kernel with tensordesc<dtype[B0, B1]>
+        # argument types instead of raw pointers (issue #185819).
+        if self.host_tma_descriptor_args:
+            for i, (argname, arg) in enumerate(zip(argdefs, signature)):
+                if (
+                    isinstance(arg, TensorArg)
+                    and argname.name in self.host_tma_descriptor_args
+                ):
+                    tma_opts = self.host_tma_descriptor_args[argname.name]
+                    signature[i] = TMADescriptorArg(
+                        name=argname.name,
+                        api_type="stable",
+                        block_shape=list(tma_opts.block_shape),
+                        dtype=V.graph.get_dtype(arg.buffer),
                     )
 
         mutated_args: OrderedSet[str] = OrderedSet()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2845,26 +2845,21 @@ class TMACompatibilityChecker:
     ) -> bool:
         if self.force:
             return True
-        use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
-        assume_aligned = config.assume_aligned_inputs or config.triton.enable_host_side_tma
         if not (
             (
                 (
                     V.graph.get_current_device_or_throw().type == "cuda"
                     and torch.cuda.get_device_capability()[0] >= 9
-                    and assume_aligned
+                    and config.assume_aligned_inputs
                 )
                 or V.graph.get_current_device_or_throw().type == "xpu"
             )
-            and use_tma
+            and config.triton.use_tensor_descriptor
             and has_triton_stable_tma_api()
-            # For CUDA The base ptr needs to be aligned
         ):
             log.debug(
-                (
-                    "%s Requires triton>=3.4.0, a CUDA device with cc>=9.0 and"
-                    " `use_tensor_descriptor` and `assume_aligned_inputs` options enabled"
-                ),
+                "%s Requires triton>=3.4.0, a CUDA device with cc>=9.0,"
+                " use_tensor_descriptor=True, and assume_aligned_inputs=True",
                 self.failed_debug_prefix,
             )
             return False
@@ -3211,21 +3206,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
-        # Maps inner kernel-arg name (e.g. "in_ptr0") to the
-        # TensorDescriptorOptions for host-side TMA descriptor creation.
-        # The per-config launcher calls TensorDescriptor.from_tensor()
-        # before kernel launch instead of every CTA calling
-        # tl.make_tensor_descriptor() (fixes issue #185819).
         self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
-        # Vars whose access the host launcher cannot materialize a
-        # TensorDescriptor for (indirect/ModularIndexing indexing, non-zero
-        # offset, misalignment, complex block shape, or >1 read). This is NOT
-        # a TMA eligibility check -- such accesses may still be device-TMA
-        # eligible; eligibility is decided by TMACompatibilityChecker.
         self._host_tma_non_materializable: OrderedSet[str] = OrderedSet()
-        # True once any access in this kernel is emitted as a device-side TMA
-        # descriptor (tl.make_tensor_descriptor). Used after codegen to decide
-        # whether tma_min_block_sizes constraints are still relevant.
+        self._host_tma_non_materializable_buffers: set[str] | None = None
         self._emitted_device_tma = False
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
@@ -3315,15 +3298,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         indexing: TensorDescriptorOptions,
         dtype: torch.dtype | None = None,
     ) -> bool:
-        """Whether the host launcher can materialize a TensorDescriptor for
-        this access. This is NOT a TMA eligibility (possibility) check --
-        eligibility is decided by TMACompatibilityChecker.
-
-        Returns False when:
-        - the block_shape contains non-trivial expressions (e.g. the nested
-          min/max clamps produced by a transpose/reshape) that can't be
-          resolved to concrete host-side dims, or
-        - the dtype is sub-byte i1/bool (no CUtensorMap mapping).
+        """Whether the host launcher can build a TensorDescriptor for this
+        access (not a TMA eligibility check -- that's TMACompatibilityChecker).
         """
         if dtype is not None and dtype == torch.bool:
             return False
@@ -3336,20 +3312,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return True
 
     def _prescan_host_tma_materializability(self) -> None:
-        """Pre-scan all buffer reads to find those the host launcher cannot
-        materialize a TMA descriptor for.
-
-        Populates _host_tma_non_materializable_buffers (buffer names) with
-        buffers whose reads can't be expressed as a single host-side block
-        descriptor: indirect (TMP) indexing, FloorDiv/ModularIndexing access,
-        or (conservatively) more than one read. During codegen, load() maps
-        these names to var names and adds them to _host_tma_non_materializable.
-
-        Non-materializable means "the host can't build the descriptor", not
-        "TMA is impossible" -- such accesses may still be device-TMA eligible.
-        """
+        """Populate _host_tma_non_materializable_buffers with buffers that
+        can't be expressed as a single host-side TMA descriptor."""
         self._host_tma_non_materializable_buffers = set()
-        if not (config.triton.enable_host_side_tma or config.triton.use_tensor_descriptor):
+        if not config.triton.use_tensor_descriptor:
             return
         if not hasattr(self, "features") or not hasattr(self.features, "node_schedule"):
             return
@@ -3398,10 +3364,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if buf_name in self._host_tma_non_materializable_buffers:
                 continue
 
-            # Multiple reads from the same buffer may have different access
-            # patterns (different strides, offsets). Since we can't verify
-            # compatibility until codegen runs, conservatively mark buffers
-            # with >1 read as ineligible.
             if len(reads) > 1:
                 self._host_tma_non_materializable_buffers.add(buf_name)
 
@@ -3410,7 +3372,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         Returns True if the buffer is misaligned (TMA should be skipped).
         """
-        if not (config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma):
+        if not config.triton.use_tensor_descriptor:
             return False
         try:
             buf = V.graph.try_get_buffer(name)
@@ -4082,19 +4044,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     raise AssertionError(f"expected ', other=0.0', got {other!r}")
                 other = ""
 
-            # ── Host-side TMA fast path (issue #185819) ─────────────────
-            # When the stable Triton TMA API is available and this buffer
-            # has no constant offset, skip kernel-side descriptor creation.
-            # The kernel receives a pre-built TensorDescriptor from the
-            # host launcher, eliminating per-CTA construction overhead that
-            # causes a 1.4-1.6x slowdown for simple pointwise ops.
-            #
-            # Template-forced paths (can_lift=True) manage their own
-            # host-side descriptors via ir.TMADescriptor; skip them.
-            use_tma = config.triton.use_tensor_descriptor or config.triton.enable_host_side_tma
             if (
                 has_triton_stable_tma_api()
-                and use_tma
+                and config.triton.enable_host_side_tma
                 and not indexing.can_lift
                 and indexing.constant_offset == 0
                 and var not in self._host_tma_non_materializable
@@ -4104,22 +4056,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             ):
                 if var not in self.host_tma_descriptor_args:
                     self.host_tma_descriptor_args[var] = indexing
-                return var, other  # arg IS the pre-created descriptor
+                return var, other
             elif (
                 has_triton_stable_tma_api()
-                and use_tma
+                and config.triton.enable_host_side_tma
                 and not indexing.can_lift
                 and indexing.constant_offset != 0
             ):
-                # Non-zero offset access — this buffer can't be host-side TMA
                 self._host_tma_non_materializable.add(var)
                 if var in self.host_tma_descriptor_args:
                     del self.host_tma_descriptor_args[var]
-            # ── end host-side TMA fast path ──────────────────────────────
 
-            # Reaching here with a TensorDescriptorOptions means the host fast
-            # path did not claim this access (host-non-materializable), so it
-            # is emitted as a device-side TMA descriptor below.
             self._emitted_device_tma = True
 
         else:
@@ -4428,20 +4375,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         dtype = V.graph.get_dtype(name)
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
 
-        # Apply pre-scan results: if the buffer was identified as having
-        # reads the host launcher can't materialize a descriptor for, mark
-        # the var as non-materializable for host-side TMA.
-        if not hasattr(self, "_host_tma_non_materializable_buffers"):
-            self._prescan_host_tma_materializability()
-        prescan_non_materializable = (
-            name in self._host_tma_non_materializable_buffers
+        if config.triton.enable_host_side_tma:
+            if self._host_tma_non_materializable_buffers is None:
+                self._prescan_host_tma_materializability()
+            if name in self._host_tma_non_materializable_buffers:
+                self._host_tma_non_materializable.add(var)
+
+        skip_tma = (
+            config.triton.enable_host_side_tma
+            and self._check_buffer_alignment(name, var, dtype)
         )
-        if prescan_non_materializable:
-            self._host_tma_non_materializable.add(var)
-
-        buffer_misaligned = self._check_buffer_alignment(name, var, dtype)
-
-        skip_tma = buffer_misaligned or prescan_non_materializable
         tma_checker = (
             None if skip_tma
             else self.tma_compatibility_checker_cls(
@@ -4674,20 +4617,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mode == "atomic_add",
         )
-
-        if (
-            isinstance(indexing, TensorDescriptorOptions)
-            and config.triton.enable_host_side_tma
-            and not config.triton.use_tensor_descriptor
-            and not self._is_host_tma_materializable(indexing, dtype)
-        ):
-            indexing = self.indexing(
-                index,
-                dense_indexing=True,
-                block_ptr=mode is None,
-                tma_compatibility_checker=None,
-                mask_constant_index=mode == "atomic_add",
-            )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
             indexing.index
@@ -6653,19 +6582,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if flops is not None:
                 out["kernel_flop"] = flops
         if self.host_tma_descriptor_args:
-            # Block shapes contain sympy expressions (XBLOCK, R0_BLOCK, etc).
-            # We need to distinguish autotuned symbols (kernel function args
-            # whose values vary per-config) from fixed symbols (defined in
-            # the kernel body with concrete values).
-            # Build a mapping of fixed block sizes from the range trees.
             _, _, signature, _ = self.args.python_argdefs()
             sig_arg_names = OrderedSet(
                 arg.name for arg in signature if hasattr(arg, "name")
             )
-            # Map non-argument block size symbols to concrete values.
-            # For persistent reductions, R0_BLOCK is defined in the kernel
-            # body (not a function arg) with a concrete value computed from
-            # the reduction dimension numel.
             fixed_blocks: dict[str, int] = {}
             if self.persistent_reduction:
                 for rt in self.range_trees:
@@ -6691,18 +6611,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 except (TypeError, ValueError):
                     return s_str
 
+            def _resolve_tensor_dim(s):
+                try:
+                    return int(s)
+                except (TypeError, ValueError):
+                    return str(s)
+
             resolved = {}
             for inner, opts in self.host_tma_descriptor_args.items():
                 dims = [_resolve_block_dim(s) for s in opts.block_shape]
-                # Skip buffers with degenerate block shapes (any dim <= 0)
-                if any(isinstance(d, int) and d <= 0 for d in dims):
-                    continue
-                shape_dims = [_resolve_block_dim(s) for s in opts.shape]
-                stride_dims = [_resolve_block_dim(s) for s in opts.strides]
                 resolved[inner] = {
                     "block_shape": dims,
-                    "shape": shape_dims,
-                    "strides": stride_dims,
+                    "shape": [_resolve_tensor_dim(s) for s in opts.shape],
+                    "strides": [_resolve_tensor_dim(s) for s in opts.strides],
                 }
             out["host_tma_descriptor_args"] = resolved
         return out
@@ -6798,10 +6719,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     signature[i] = SizeArg(
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
                     )
-
-        # NOTE: host-side TMA signature upgrade (TensorArg -> tensordesc<>)
-        # is deferred to _precompile_config() where concrete block sizes are
-        # available. The triton_meta signature keeps pointer types here.
 
         mutated_args: OrderedSet[str] = OrderedSet()
         for mutation in self.mutations:
@@ -6923,29 +6840,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._prescan_host_tma_materializability()
         self.codegen_body()
 
-        # After codegen_body, host_tma_descriptor_args may have been pruned
-        # (buffers with mixed TMA/pointer accesses are removed). Update
-        # inductor_meta with the final set.
-        if self.host_tma_descriptor_args:
-            self.inductor_meta["host_tma_descriptor_args"] = (
-                self.inductor_meta.get("host_tma_descriptor_args", {})
-            )
-            # Re-filter: only keep buffers still in host_tma_descriptor_args
-            kept = {
-                k: v
-                for k, v in self.inductor_meta["host_tma_descriptor_args"].items()
-                if k in self.host_tma_descriptor_args
-            }
-            self.inductor_meta["host_tma_descriptor_args"] = kept
-        elif "host_tma_descriptor_args" in self.inductor_meta:
-            del self.inductor_meta["host_tma_descriptor_args"]
-
-        # Clear tma_min_block_sizes when this kernel emitted no TMA descriptor
-        # (neither host- nor device-side). The constraint is set during TMA
-        # compatibility probing (are_block_parameters_compatible), which fires
-        # even when the access ultimately falls back to a plain tl.load (e.g.
-        # looping reductions). A stale constraint over-filters the autotune
-        # config space and can severely regress otherwise non-TMA kernels.
+        # TMA probing sets tma_min_block_sizes even when the access falls back
+        # to tl.load; a stale constraint regresses non-TMA kernels.
         if (
             not self.inductor_meta.get("host_tma_descriptor_args")
             and not self._emitted_device_tma
@@ -7131,16 +7027,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         val = max(val, 16)
 
                 code.writeline(f"{tree.prefix.upper()}BLOCK: tl.constexpr = {val}")
-                # Store resolved block size for host-side TMA descriptor args
-                if not hasattr(self, "_resolved_block_sizes"):
-                    self._resolved_block_sizes = {}
-                self._resolved_block_sizes[f"{tree.prefix.upper()}BLOCK"] = val
 
             if tree.prefix == "x" and self.no_x_dim:
                 code.writeline("XBLOCK: tl.constexpr = 1")
-                if not hasattr(self, "_resolved_block_sizes"):
-                    self._resolved_block_sizes = {}
-                self._resolved_block_sizes["XBLOCK"] = 1
 
     def _get_grid_type(self) -> type[triton_heuristics.GridExpr]:
         n = sum([int(not tree.is_reduction) for tree in self.range_trees])

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -827,6 +827,19 @@ def compile_fx_inner(
             stack.enter_context(
                 config.patch(get_cpp_wrapper_config(log_cudagraph_skip=False))
             )
+        # Host-side TMA only selects the descriptor flavor; it needs the TMA path
+        # itself enabled. Warn (don't silently no-op) if it's set without its
+        # prerequisites.
+        if config.triton.enable_host_side_tma and not (
+            config.triton.use_tensor_descriptor and config.assume_aligned_inputs
+        ):
+            warnings.warn(
+                "config.triton.enable_host_side_tma has no effect unless both "
+                "config.triton.use_tensor_descriptor and "
+                "config.assume_aligned_inputs are also enabled; host-side TMA "
+                "will be skipped.",
+                stacklevel=2,
+            )
         stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
         stack.enter_context(_use_lazy_graph_module(dynamo_config.use_lazy_graph_module))
         stack.enter_context(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2101,7 +2101,7 @@ class triton:
     #   assume_aligned_inputs to also be enabled
     # TMA descriptors are only going to be generated if the above conditions
     # can be satisfied, along with any existing requirements for index expressions
-    use_tensor_descriptor = True
+    use_tensor_descriptor = False
 
     # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending
@@ -2129,9 +2129,10 @@ class triton:
     enable_tma_load_for_template_epilogue = (
         os.environ.get("ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE", "0") == "1"
     )
-    # Host-side TMA: create TensorDescriptors on CPU and pass as kernel args
-    # instead of creating them device-side inside the kernel. Enables
-    # use_tensor_descriptor and assume_aligned_inputs automatically.
+    # Host-side TMA: build TensorDescriptors on the host and pass them as kernel
+    # args instead of creating them device-side inside the kernel. Selects the
+    # descriptor flavor only; requires use_tensor_descriptor and
+    # assume_aligned_inputs to also be enabled (no effect otherwise).
     enable_host_side_tma = os.environ.get("ENABLE_HOST_SIDE_TMA", "0") == "1"
 
     # Skip L1 cache for buffers that are used only once.  Disabled by default

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2129,6 +2129,11 @@ class triton:
     enable_tma_load_for_template_epilogue = (
         os.environ.get("ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE", "0") == "1"
     )
+    # Host-side TMA: create TensorDescriptors on CPU and pass as kernel args
+    # instead of creating them device-side inside the kernel. Enables
+    # use_tensor_descriptor and assume_aligned_inputs automatically.
+    enable_host_side_tma = os.environ.get("ENABLE_HOST_SIDE_TMA", "0") == "1"
+
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2101,7 +2101,7 @@ class triton:
     #   assume_aligned_inputs to also be enabled
     # TMA descriptors are only going to be generated if the above conditions
     # can be satisfied, along with any existing requirements for index expressions
-    use_tensor_descriptor = False
+    use_tensor_descriptor = True
 
     # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -199,8 +199,8 @@ class StaticallyLaunchedTritonKernel:
         """
         if ty[0] == "*":
             return "O"
-        elif ty == "nvTmaDesc":
-            raise NotImplementedError("nvTmaDesc kernels are not yet supported")
+        elif ty == "nvTmaDesc" or ty.startswith("tensordesc<"):
+            raise NotImplementedError("TMA descriptor kernels are not yet supported")
         return StaticallyLaunchedTritonKernel.type_mappings()[ty]
 
     def arg_ty_from_signature(self, src: ASTSource) -> str:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -37,13 +37,14 @@ from torch._inductor.config import triton as inductor_triton_config
 from torch._prims_common import compute_required_storage_length
 from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._triton import get_triton_version
+from torch.utils._triton import get_triton_version, has_triton_stable_tma_api
 
 from ..triton_bundler import TritonBundler
 from ..utils import (
     GPU_KERNEL_BIN_EXTS,
     prefix_is_reduction,
     tlx_only_cuda_options,
+    TMA_ALIGNMENT,
     triton_version_uses_attrs_dict,
     XPU_KERNEL_FORMAT,
 )
@@ -209,6 +210,26 @@ def _resolve_dims(dims, cfg_kwargs, constants):
             log.debug("host-side TMA: unresolved descriptor dim %r; skipping", s)
             return None
     return result
+
+
+@functools.lru_cache(None)
+def _warn_host_tma_clone(name: str) -> None:
+    log.warning(
+        "host-side TMA: input %s is not %d-byte aligned; cloning it (an extra "
+        "copy per launch). Pass aligned inputs to avoid this.",
+        name,
+        TMA_ALIGNMENT,
+    )
+
+
+def _host_tma_aligned(tensor, name):
+    """Return a TMA_ALIGNMENT-aligned view of `tensor`, cloning (with a one-time
+    warning) only if its base address is not aligned. Used by the host-side TMA
+    launcher to build TensorDescriptors from aligned storage."""
+    if tensor.data_ptr() % TMA_ALIGNMENT == 0:
+        return tensor
+    _warn_host_tma_clone(name)
+    return tensor.clone()
 
 
 def autotune_hints_to_configs(
@@ -1187,7 +1208,18 @@ class CachingAutotuner(KernelInterface):
                 block_shape_vals = _resolve_dims(
                     desc_info["block_shape"], cfg_kwargs, all_constants
                 )
-                if block_shape_vals is None or any(v <= 0 for v in block_shape_vals):
+                shape_vals = _resolve_dims(
+                    desc_info["shape"], cfg_kwargs, all_constants
+                )
+                stride_vals = _resolve_dims(
+                    desc_info["strides"], cfg_kwargs, all_constants
+                )
+                if (
+                    block_shape_vals is None
+                    or shape_vals is None
+                    or stride_vals is None
+                    or any(v <= 0 for v in block_shape_vals)
+                ):
                     continue
                 ty = compile_meta["signature"][key]
                 if isinstance(ty, str) and ty.startswith("*"):
@@ -3117,6 +3149,15 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
         host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
         pre_runner_lines: list[str] = []
         if host_tma_args:
+            if not has_triton_stable_tma_api():
+                raise RuntimeError(
+                    "host-side TMA requires a Triton with the stable TMA API "
+                    "(triton.tools.tensor_descriptor.TensorDescriptor)"
+                )
+            from triton.tools.tensor_descriptor import TensorDescriptor
+
+            scope["_host_tma_aligned"] = _host_tma_aligned
+            scope["TensorDescriptor"] = TensorDescriptor
             cfg_kwargs = cfg.kwargs
             all_constants = compile_meta["constants"]
 
@@ -3132,22 +3173,22 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 stride_vals = _resolve_dims(
                     desc_info["strides"], cfg_kwargs, all_constants
                 )
-                if block_shape_vals is None or shape_vals is None or stride_vals is None:
+                if (
+                    block_shape_vals is None
+                    or shape_vals is None
+                    or stride_vals is None
+                ):
                     continue
                 desc_var = f"{inner_name}_host_tma_desc"
                 aligned_var = f"{inner_name}_aligned"
                 pre_runner_lines.append(
-                    f"{aligned_var} = {inner_name} if {inner_name}.data_ptr() % 16 == 0"
-                    f" else {inner_name}.clone()"
+                    f'{aligned_var} = _host_tma_aligned({inner_name}, "{inner_name}")'
                 )
                 pre_runner_lines.append(
-                    f"{desc_var} = triton.tools.tensor_descriptor"
-                    f".TensorDescriptor({aligned_var}, {shape_vals},"
+                    f"{desc_var} = TensorDescriptor({aligned_var}, {shape_vals},"
                     f" {stride_vals}, {block_shape_vals})"
                 )
-                runner_args = [
-                    desc_var if a == inner_name else a for a in runner_args
-                ]
+                runner_args = [desc_var if a == inner_name else a for a in runner_args]
 
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -195,6 +195,22 @@ def get_total_reduction_numel(numels: dict[str, int]) -> int:
     )
 
 
+def _resolve_dims(dims, cfg_kwargs, constants):
+    """Resolve a list of block/shape/stride dims to concrete ints."""
+    result = []
+    for s in dims:
+        if isinstance(s, int):
+            result.append(s)
+        elif isinstance(s, str) and s in constants:
+            result.append(int(constants[s]))
+        elif isinstance(s, str) and s in cfg_kwargs:
+            result.append(int(cfg_kwargs[s]))
+        else:
+            log.debug("host-side TMA: unresolved descriptor dim %r; skipping", s)
+            return None
+    return result
+
+
 def autotune_hints_to_configs(
     hints: OrderedSet[AutotuneHint],
     size_hints,
@@ -711,42 +727,15 @@ class CachingAutotuner(KernelInterface):
 
         compile_results = []
         exc = None
-        saved_configs = list(self.configs)
         for c in self.configs:
             try:
                 compile_results.append(self._precompile_config(c))
-            except (
-                OutOfResources,
-                PTXASError,
-                IntelGPUError,
-            ) as e:
-                exc = e
-            except Exception as e:
+            except (OutOfResources, PTXASError, IntelGPUError) as e:
                 exc = e
         if len(compile_results) == 0:
-            # If host-side TMA is enabled, retry without TMA signature upgrade.
-            # The kernel source may have .load() calls that only work with
-            # tensordesc args, but without the upgrade they'll get raw pointers
-            # and fail. This retry only helps for configs where the TMA upgrade
-            # was the ONLY issue (e.g., degenerate block shapes).
-            host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
-            if host_tma_args:
-                log.debug(
-                    "All TMA configs failed, retrying without host-side TMA"
-                )
-                saved_tma = self.inductor_meta.pop("host_tma_descriptor_args")
-                try:
-                    for c in saved_configs:
-                        try:
-                            compile_results.append(self._precompile_config(c))
-                        except Exception:
-                            pass
-                finally:
-                    self.inductor_meta["host_tma_descriptor_args"] = saved_tma
-            if len(compile_results) == 0:
-                raise NoTritonConfigsError(
-                    f"No valid triton configs. {type(exc).__name__}: {exc}"
-                )
+            raise NoTritonConfigsError(
+                f"No valid triton configs. {type(exc).__name__}: {exc}"
+            )
         self.compile_results = compile_results
         self.configs = None
 
@@ -1178,53 +1167,38 @@ class CachingAutotuner(KernelInterface):
 
         for i in get_constexprs(self.fn):
             arg_name = self.fn.arg_names[i]
-            if arg_name not in compile_meta["constants"]:
-                if arg_name == "num_warps" or arg_name == "num_stages":
-                    compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
+            if arg_name not in compile_meta["constants"] and (
+                arg_name == "num_warps" or arg_name == "num_stages"
+            ):
+                compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
         if HAS_WARP_SPEC:
             compile_meta["num_consumer_groups"] = getattr(cfg, "num_consumer_groups", 0)
             compile_meta["num_buffers_warp_spec"] = getattr(
                 cfg, "num_buffers_warp_spec", 0
             )
 
-        # Upgrade pointer args to tensordesc for host-side TMA buffers.
-        # The triton_meta signature keeps the original pointer types (*bf16);
-        # here we upgrade to tensordesc<bf16[block_shape]> per-config with
-        # concrete block sizes resolved from cfg_kwargs and constants.
         host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
         if host_tma_args:
             all_constants = compile_meta["constants"]
-            for key, ty in compile_meta["signature"].items():
-                if key in host_tma_args:
-                    block_shape_strs = host_tma_args[key]
-                    if isinstance(block_shape_strs, dict):
-                        block_shape_strs = block_shape_strs.get("block_shape", block_shape_strs)
-                    block_shape_vals = []
-                    for s in block_shape_strs:
-                        if isinstance(s, int):
-                            block_shape_vals.append(s)
-                        elif s in all_constants:
-                            block_shape_vals.append(int(all_constants[s]))
-                        elif s in cfg_kwargs:
-                            block_shape_vals.append(int(cfg_kwargs[s]))
-                        else:
-                            eval_ns = {
-                                "__builtins__": {},
-                                "Min": min, "Max": max,
-                                **cfg_kwargs, **all_constants,
-                            }
-                            block_shape_vals.append(int(eval(s, eval_ns)))
-                    if any(v <= 0 for v in block_shape_vals):
-                        continue
-                    if isinstance(ty, str) and ty.startswith("*"):
-                        dtype_str = ty[1:]
-                    elif isinstance(ty, str) and "tensordesc<" in ty:
-                        dtype_str = ty.split("<")[1].split("[")[0]
-                    else:
-                        continue
-                    compile_meta["signature"][key] = (
-                        f"tensordesc<{dtype_str}{list(block_shape_vals)}>"
-                    )
+            for key in list(compile_meta["signature"]):
+                desc_info = host_tma_args.get(key)
+                if desc_info is None or not isinstance(desc_info, dict):
+                    continue
+                block_shape_vals = _resolve_dims(
+                    desc_info["block_shape"], cfg_kwargs, all_constants
+                )
+                if block_shape_vals is None or any(v <= 0 for v in block_shape_vals):
+                    continue
+                ty = compile_meta["signature"][key]
+                if isinstance(ty, str) and ty.startswith("*"):
+                    dtype_str = ty[1:]
+                elif isinstance(ty, str) and ty.startswith("tensordesc<"):
+                    dtype_str = ty.split("<")[1].split("[")[0]
+                else:
+                    continue
+                compile_meta["signature"][key] = (
+                    f"tensordesc<{dtype_str}{list(block_shape_vals)}>"
+                )
 
         compile_meta["debug"] = _should_enable_triton_debug_asserts(self.inductor_meta)
 
@@ -3140,64 +3114,40 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 *call_args,
             ]
 
-        # ── Host-side TMA descriptors (issue #185819) ───────────────────
-        # For each buffer in host_tma_descriptor_args the compiled Triton
-        # kernel expects a TensorDescriptor argument rather than a raw
-        # pointer.  Create those descriptors here — once per launcher
-        # invocation using this config's concrete block sizes — eliminating
-        # the per-CTA tl.make_tensor_descriptor() overhead.
         host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
         pre_runner_lines: list[str] = []
         if host_tma_args:
             cfg_kwargs = cfg.kwargs
             all_constants = compile_meta["constants"]
 
-            def _eval_dim(s):
-                if isinstance(s, int):
-                    return s
-                if s in cfg_kwargs:
-                    return int(cfg_kwargs[s])
-                if s in all_constants:
-                    return int(all_constants[s])
-                eval_ns = {
-                    "__builtins__": {},
-                    "Min": min, "Max": max,
-                    **cfg_kwargs, **all_constants,
-                }
-                return int(eval(s, eval_ns))
-
             for inner_name, desc_info in host_tma_args.items():
-                if inner_name not in call_args:
+                if inner_name not in call_args or not isinstance(desc_info, dict):
                     continue
-                if isinstance(desc_info, dict):
-                    block_shape_vals = [_eval_dim(s) for s in desc_info["block_shape"]]
-                    shape_vals = [_eval_dim(s) for s in desc_info["shape"]]
-                    stride_vals = [_eval_dim(s) for s in desc_info["strides"]]
-                else:
-                    block_shape_vals = [cfg_kwargs.get(s, s) for s in desc_info]
-                    shape_vals = None
-                    stride_vals = None
+                block_shape_vals = _resolve_dims(
+                    desc_info["block_shape"], cfg_kwargs, all_constants
+                )
+                shape_vals = _resolve_dims(
+                    desc_info["shape"], cfg_kwargs, all_constants
+                )
+                stride_vals = _resolve_dims(
+                    desc_info["strides"], cfg_kwargs, all_constants
+                )
+                if block_shape_vals is None or shape_vals is None or stride_vals is None:
+                    continue
                 desc_var = f"{inner_name}_host_tma_desc"
                 aligned_var = f"{inner_name}_aligned"
                 pre_runner_lines.append(
                     f"{aligned_var} = {inner_name} if {inner_name}.data_ptr() % 16 == 0"
                     f" else {inner_name}.clone()"
                 )
-                if shape_vals is not None and stride_vals is not None:
-                    pre_runner_lines.append(
-                        f"{desc_var} = triton.tools.tensor_descriptor"
-                        f".TensorDescriptor({aligned_var}, {shape_vals},"
-                        f" {stride_vals}, {block_shape_vals})"
-                    )
-                else:
-                    pre_runner_lines.append(
-                        f"{desc_var} = triton.tools.tensor_descriptor"
-                        f".TensorDescriptor.from_tensor({aligned_var}, {block_shape_vals})"
-                    )
+                pre_runner_lines.append(
+                    f"{desc_var} = triton.tools.tensor_descriptor"
+                    f".TensorDescriptor({aligned_var}, {shape_vals},"
+                    f" {stride_vals}, {block_shape_vals})"
+                )
                 runner_args = [
                     desc_var if a == inner_name else a for a in runner_args
                 ]
-        # ── end host-side TMA ─────────────────────────────────────────────
 
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2608,7 +2608,9 @@ class CompileResult(Generic[_T]):
 
     def make_launcher(self) -> LauncherType: ...
 
-    def _gen_launcher_code(self, scope, def_args, runner_args) -> LauncherType:
+    def _gen_launcher_code(
+        self, scope, def_args, runner_args, pre_runner_lines=None
+    ) -> LauncherType:
         grid = GridExpr.from_meta(self.inductor_meta, self.config)
         # grid.prefix is usually empty, grid.x_grid is something like `-(xnumel//-1024)`
         lines = [
@@ -2617,6 +2619,7 @@ class CompileResult(Generic[_T]):
             f"    grid_0 = {grid.x_grid}",
             f"    grid_1 = {grid.y_grid}",
             f"    grid_2 = {grid.z_grid}",
+            *(f"    {l}" for l in (pre_runner_lines or [])),
             f"    runner({', '.join(runner_args)})",
         ]
         launcher_code = "\n".join(lines)
@@ -3072,7 +3075,35 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 *call_args,
             ]
 
-        launcher = self._gen_launcher_code(scope, def_args, runner_args)
+        # ── Host-side TMA descriptors (issue #185819) ───────────────────
+        # For each buffer in host_tma_descriptor_args the compiled Triton
+        # kernel expects a TensorDescriptor argument rather than a raw
+        # pointer.  Create those descriptors here — once per launcher
+        # invocation using this config's concrete block sizes — eliminating
+        # the per-CTA tl.make_tensor_descriptor() overhead.
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        pre_runner_lines: list[str] = []
+        if host_tma_args:
+            cfg_kwargs = cfg.kwargs
+            for inner_name, block_shape_strs in host_tma_args.items():
+                if inner_name not in call_args:
+                    continue
+                block_shape_vals = [
+                    cfg_kwargs.get(s, s) for s in block_shape_strs
+                ]
+                desc_var = f"{inner_name}_host_tma_desc"
+                pre_runner_lines.append(
+                    f"{desc_var} = triton.tools.tensor_descriptor"
+                    f".TensorDescriptor.from_tensor({inner_name}, {block_shape_vals})"
+                )
+                runner_args = [
+                    desc_var if a == inner_name else a for a in runner_args
+                ]
+        # ── end host-side TMA ─────────────────────────────────────────────
+
+        launcher = self._gen_launcher_code(
+            scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
+        )
 
         launcher = scope["launcher"]
         launcher.config = cfg

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -711,15 +711,42 @@ class CachingAutotuner(KernelInterface):
 
         compile_results = []
         exc = None
+        saved_configs = list(self.configs)
         for c in self.configs:
             try:
                 compile_results.append(self._precompile_config(c))
-            except (OutOfResources, PTXASError, IntelGPUError) as e:
+            except (
+                OutOfResources,
+                PTXASError,
+                IntelGPUError,
+            ) as e:
+                exc = e
+            except Exception as e:
                 exc = e
         if len(compile_results) == 0:
-            raise NoTritonConfigsError(
-                f"No valid triton configs. {type(exc).__name__}: {exc}"
-            )
+            # If host-side TMA is enabled, retry without TMA signature upgrade.
+            # The kernel source may have .load() calls that only work with
+            # tensordesc args, but without the upgrade they'll get raw pointers
+            # and fail. This retry only helps for configs where the TMA upgrade
+            # was the ONLY issue (e.g., degenerate block shapes).
+            host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+            if host_tma_args:
+                log.debug(
+                    "All TMA configs failed, retrying without host-side TMA"
+                )
+                saved_tma = self.inductor_meta.pop("host_tma_descriptor_args")
+                try:
+                    for c in saved_configs:
+                        try:
+                            compile_results.append(self._precompile_config(c))
+                        except Exception:
+                            pass
+                finally:
+                    self.inductor_meta["host_tma_descriptor_args"] = saved_tma
+            if len(compile_results) == 0:
+                raise NoTritonConfigsError(
+                    f"No valid triton configs. {type(exc).__name__}: {exc}"
+                )
         self.compile_results = compile_results
         self.configs = None
 
@@ -1151,15 +1178,53 @@ class CachingAutotuner(KernelInterface):
 
         for i in get_constexprs(self.fn):
             arg_name = self.fn.arg_names[i]
-            if arg_name not in compile_meta["constants"] and (
-                arg_name == "num_warps" or arg_name == "num_stages"
-            ):
-                compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
+            if arg_name not in compile_meta["constants"]:
+                if arg_name == "num_warps" or arg_name == "num_stages":
+                    compile_meta["constants"][arg_name] = getattr(cfg, arg_name)
         if HAS_WARP_SPEC:
             compile_meta["num_consumer_groups"] = getattr(cfg, "num_consumer_groups", 0)
             compile_meta["num_buffers_warp_spec"] = getattr(
                 cfg, "num_buffers_warp_spec", 0
             )
+
+        # Upgrade pointer args to tensordesc for host-side TMA buffers.
+        # The triton_meta signature keeps the original pointer types (*bf16);
+        # here we upgrade to tensordesc<bf16[block_shape]> per-config with
+        # concrete block sizes resolved from cfg_kwargs and constants.
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        if host_tma_args:
+            all_constants = compile_meta["constants"]
+            for key, ty in compile_meta["signature"].items():
+                if key in host_tma_args:
+                    block_shape_strs = host_tma_args[key]
+                    if isinstance(block_shape_strs, dict):
+                        block_shape_strs = block_shape_strs.get("block_shape", block_shape_strs)
+                    block_shape_vals = []
+                    for s in block_shape_strs:
+                        if isinstance(s, int):
+                            block_shape_vals.append(s)
+                        elif s in all_constants:
+                            block_shape_vals.append(int(all_constants[s]))
+                        elif s in cfg_kwargs:
+                            block_shape_vals.append(int(cfg_kwargs[s]))
+                        else:
+                            eval_ns = {
+                                "__builtins__": {},
+                                "Min": min, "Max": max,
+                                **cfg_kwargs, **all_constants,
+                            }
+                            block_shape_vals.append(int(eval(s, eval_ns)))
+                    if any(v <= 0 for v in block_shape_vals):
+                        continue
+                    if isinstance(ty, str) and ty.startswith("*"):
+                        dtype_str = ty[1:]
+                    elif isinstance(ty, str) and "tensordesc<" in ty:
+                        dtype_str = ty.split("<")[1].split("[")[0]
+                    else:
+                        continue
+                    compile_meta["signature"][key] = (
+                        f"tensordesc<{dtype_str}{list(block_shape_vals)}>"
+                    )
 
         compile_meta["debug"] = _should_enable_triton_debug_asserts(self.inductor_meta)
 
@@ -3085,17 +3150,50 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
         pre_runner_lines: list[str] = []
         if host_tma_args:
             cfg_kwargs = cfg.kwargs
-            for inner_name, block_shape_strs in host_tma_args.items():
+            all_constants = compile_meta["constants"]
+
+            def _eval_dim(s):
+                if isinstance(s, int):
+                    return s
+                if s in cfg_kwargs:
+                    return int(cfg_kwargs[s])
+                if s in all_constants:
+                    return int(all_constants[s])
+                eval_ns = {
+                    "__builtins__": {},
+                    "Min": min, "Max": max,
+                    **cfg_kwargs, **all_constants,
+                }
+                return int(eval(s, eval_ns))
+
+            for inner_name, desc_info in host_tma_args.items():
                 if inner_name not in call_args:
                     continue
-                block_shape_vals = [
-                    cfg_kwargs.get(s, s) for s in block_shape_strs
-                ]
+                if isinstance(desc_info, dict):
+                    block_shape_vals = [_eval_dim(s) for s in desc_info["block_shape"]]
+                    shape_vals = [_eval_dim(s) for s in desc_info["shape"]]
+                    stride_vals = [_eval_dim(s) for s in desc_info["strides"]]
+                else:
+                    block_shape_vals = [cfg_kwargs.get(s, s) for s in desc_info]
+                    shape_vals = None
+                    stride_vals = None
                 desc_var = f"{inner_name}_host_tma_desc"
+                aligned_var = f"{inner_name}_aligned"
                 pre_runner_lines.append(
-                    f"{desc_var} = triton.tools.tensor_descriptor"
-                    f".TensorDescriptor.from_tensor({inner_name}, {block_shape_vals})"
+                    f"{aligned_var} = {inner_name} if {inner_name}.data_ptr() % 16 == 0"
+                    f" else {inner_name}.clone()"
                 )
+                if shape_vals is not None and stride_vals is not None:
+                    pre_runner_lines.append(
+                        f"{desc_var} = triton.tools.tensor_descriptor"
+                        f".TensorDescriptor({aligned_var}, {shape_vals},"
+                        f" {stride_vals}, {block_shape_vals})"
+                    )
+                else:
+                    pre_runner_lines.append(
+                        f"{desc_var} = triton.tools.tensor_descriptor"
+                        f".TensorDescriptor.from_tensor({aligned_var}, {block_shape_vals})"
+                    )
                 runner_args = [
                     desc_var if a == inner_name else a for a in runner_args
                 ]


### PR DESCRIPTION
Local copy of https://github.com/pytorch/pytorch/pull/185825 for CI/benchmarking (tracking issue https://github.com/pytorch/pytorch/issues/185819), with the following improvements:
- Pre-scan pass enables host-side TMA for loads (not just stores): gates against creating TMA descriptors for downstream loads that are TMA-ineligible
- Fallback to dynamic launcher
- Move signature upgrade (dtype --> `tensordesc`) to precompilation, where per-config values are available (fixes symbolic `XBLOCK` issue)
- Adds restrictions for TMA-ineligible cases (`_is_host_tma_materializable()`)
-  Fix leak of stale autotuning constraint (`tma_min_block_sizes={'XBLOCK':4}`) into non-TMA kernels, which restricted autotuning space and regressed performance

Note that `enable_host_side_tma=True` by default for testing; this will be turned off before merging.

Original PR by @Yba1.

### Performance

#### [TorchBench](https://github.com/pytorch/benchmark) models (OSS), measuring e2e performance on models with pointwise and reduction kernels
| Model         | no-TMA | device  | host  | device/base | host/base |
|---------------|--------|---------|-------|-------------|-----------|
| hf_DistilBert | 64.4   | 79.3    | 79.6  | 1.23x       | 1.24x     |
| hf_Bert       | 64.2   | 80.1    | 79.8  | 1.25x       | 1.24x     |
| hf_Albert     | 69.4   | 85.1    | 82.1  | 1.23x       | 1.18x     |
| BERT_pytorch  | 208.3  | 224.9 + | 241.1 | 1.08x +     | 1.16x     |
| hf_GPT2       | 136.0  | 87.8 *  | 152.4 | 0.65x *     | 1.12x     |

BERT_pytorch measurements include a fix for the `tma_min_block_sizes` leak, which carried a stale autotuning constraint (`tma_min_block_sizes={'XBLOCK':4}`) into kernels that are unable to use TMA descriptors downstream (pre-fix 406.8us/2.72x).

hf_GPT2 (*) and BERT_pytorch (+) dropped kernels --> incomparable measurements. 

Pointwise / reduction split (us):
| Model         | poi base | poi dev | poi host | red base | red dev | red host |
|---------------|----------|---------|----------|----------|---------|----------|
| hf_DistilBert | 32.5     | 36.8    | 37.2     | 31.8     | 42.5    | 42.3     |
| hf_Bert       | 32.2     | 36.6    | 36.6     | 32.0     | 43.5    | 43.2     |
| hf_Albert     | 31.2     | 35.7    | 35.1     | 38.2     | 49.4    | 47.0     |
| BERT_pytorch  | 59.6     | 52.5    | 67.6     | 148.8    | 172.4   | 173.5    |
| hf_GPT2       | 68.5     | 26.0    | 69.5     | 67.5     | 61.8    | 82.9     |

#### SiLU repro (issue #185819)

Device-side TMA emits 2 `tl.make_tensor_descriptor` ops, while host-side TMA emits none. This results in 43% kernel speedup (based on single-launch GPU kernel time; 8.67 us -> 4.9 us) for a 1024x1024 bf16 tensor.

No win for cudagraph e2e runs (cudagraph already eliminates host-side overhead by recording GPU ops) or repeated kernel launches without syncs (SiLU kernel is memory bound, but descriptor creation is on the compute path, so fix is not on the critical path). Host-side TMA will be beneficial for compute-bound kernels.

#### Additional Inductor CI
- [inductor-perf-nightly-h100](https://github.com/pytorch/pytorch/actions/runs/27713768140)
- [inductor-perf-b200](https://github.com/pytorch/pytorch/actions/runs/27713776732)

### TODOs
- [ ] Eliminate dynamic launcher overhead
- [ ] Improve performance on pointwise kernels
- [ ] Improve performance on reduction kernels
- [ ] Enable Inductor GEMM templates with host-side TMA


cc @riccardofelluga @Yba1 @kshitij12345 