### PR TITLE
[CD] Only push base manylinux Docker tag from main branch

### DIFF
--- a/.github/actions/binary-docker-build/action.yml
+++ b/.github/actions/binary-docker-build/action.yml
@@ -63,7 +63,9 @@ runs:
         set +x
         if [[ ${WITH_PUSH:-false} == "true" ]]; then
           echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
-          docker push ${DOCKER_IMAGE_NAME_PREFIX}
+          if [[ "${GIT_BRANCH_NAME}" == "main" ]]; then
+            docker push ${DOCKER_IMAGE_NAME_PREFIX}
+          fi
           docker push ${DOCKER_IMAGE_NAME_PREFIX}-${GIT_BRANCH_NAME}
           docker push ${DOCKER_IMAGE_NAME_PREFIX}-${GIT_COMMIT_SHA}
           docker push ${DOCKER_IMAGE_NAME_PREFIX}-${CI_FOLDER_SHA}


### PR DESCRIPTION
## Summary

Release RC tag builds (e.g., `v2.12.1-rc1`) were overwriting the base Docker image tag (e.g., `pytorch/manylinux2_28-builder:xpu`) that main branch builds also push to. This caused main branch wheel builds to fail because they picked up a stale image with an older toolchain.

This PR restricts the base tag push to main branch only. RC tag builds still push their branch-specific, commit SHA, and CI folder SHA tags as before.

Fixes #186916

## Test Plan

- **Main branch builds:** push all four tags (base, branch, commit SHA, CI SHA) — no behavior change
- **RC tag builds:** push three tags (branch, commit SHA, CI SHA), skip base tag — prevents overwriting
- Base tag (e.g., `pytorch/manylinux2_28-builder:xpu`) stays consistent with the main branch image