### PR TITLE
[Test] Add test hardware classification for test classes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -113,14 +113,13 @@ class HardwareClassificationPytestPlugin:
         filtered = []
         for item in items:
             # hw_classification is a class-level attribute. Function-based tests
-            # do not have item.cls and are therefore not filtered.
+            # do not have item.cls and are therefore filtered.
             cls = getattr(item, "cls", None)
             if cls is not None:
                 req = _cu._get_hw_classification(cls)
                 if req is not None and req in self.requirement:
                     filtered.append(item)
-            else:
-                filtered.append(item)
+
         items[:] = filtered
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,7 +50,7 @@ def pytest_addoption(parser: Parser) -> None:
         nargs="+",
         default=None,
         metavar="SCOPE",
-        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CUDA XPU MPS)",
+        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
     )
 
     parser.addoption("--use-main-module", action="store_true")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,6 +45,13 @@ def pytest_addoption(parser: Parser) -> None:
     group.addoption("--scs", action="store", default=None, dest="stepcurrent_skip")
     group.addoption("--sc", action="store", default=None, dest="stepcurrent")
     group.addoption("--rs", action="store", default=None, dest="run_single")
+    parser.addoption(
+        "--hw-classification",
+        nargs="+",
+        default=None,
+        metavar="SCOPE",
+        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CUDA XPU MPS)",
+    )
 
     parser.addoption("--use-main-module", action="store_true")
     group = parser.getgroup("terminal reporting")
@@ -92,8 +99,52 @@ def pytest_addoption(parser: Parser) -> None:
     shard_addoptions(parser)
 
 
+class HardwareClassificationPytestPlugin:
+    """Pytest plugin to filter collected tests by hw_classification."""
+
+    def __init__(self, requirement):
+        self.requirement = requirement
+
+    def pytest_collection_modifyitems(self, items):
+        if self.requirement is None:
+            return
+        import torch.testing._internal.common_utils as _cu
+
+        filtered = []
+        for item in items:
+            # hw_classification is a class-level attribute. Function-based tests
+            # do not have item.cls and are therefore not filtered.
+            cls = getattr(item, "cls", None)
+            if cls is not None:
+                req = _cu._get_hw_classification(cls)
+                if req is not None and req in self.requirement:
+                    filtered.append(item)
+            else:
+                filtered.append(item)
+        items[:] = filtered
+
+
 def pytest_configure(config: Config) -> None:
     parse_cmd_line_args()
+
+    # Some pytest jobs (e.g. tools/* tests) run directly from the source tree
+    # without a built torch package. In that environment importing
+    # torch.testing._internal.common_utils may fail because generated files such
+    # as torch.version are not available yet. Skip hardware classification plugin
+    # registration in that case.
+    try:
+        import torch.testing._internal.common_utils as _cu
+    except ImportError:
+        _cu = None
+
+    # Use getattr to handle the case where this conftest.py runs against a nightly
+    # torch that doesn't yet have HW_CLASSIFICATION in common_utils.
+    if _cu is not None and getattr(_cu, "HW_CLASSIFICATION", None) is not None:
+        config.pluginmanager.register(
+            HardwareClassificationPytestPlugin(_cu.HW_CLASSIFICATION),
+            "hw_classification_plugin",
+        )
+
     xmlpath = config.option.xmlpath_reruns
     # Prevent opening xmllog on worker nodes (xdist).
     if xmlpath and not hasattr(config, "workerinput"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -95,7 +95,8 @@ def pytest_addoption(parser: Parser) -> None:
         default=None,
         metavar="SCOPE",
         dest="hw_classification",
-        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
+        type=str.upper,
+        help="filter tests by hardware classification categories (e.g., GENERIC ACCELERATOR CPU CUDA MPS XPU)",
     )
     shard_addoptions(parser)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sys
+import warnings
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from types import MethodType
@@ -45,13 +46,6 @@ def pytest_addoption(parser: Parser) -> None:
     group.addoption("--scs", action="store", default=None, dest="stepcurrent_skip")
     group.addoption("--sc", action="store", default=None, dest="stepcurrent")
     group.addoption("--rs", action="store", default=None, dest="run_single")
-    parser.addoption(
-        "--hw-classification",
-        nargs="+",
-        default=None,
-        metavar="SCOPE",
-        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
-    )
 
     parser.addoption("--use-main-module", action="store_true")
     group = parser.getgroup("terminal reporting")
@@ -96,6 +90,14 @@ def pytest_addoption(parser: Parser) -> None:
         "Emit XML for schema: one of legacy|xunit1|xunit2",
         default="xunit2",
     )
+    parser.addoption(
+        "--hw-classification",
+        nargs="+",
+        default=None,
+        metavar="SCOPE",
+        dest="hw_classification",
+        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
+    )
     shard_addoptions(parser)
 
 
@@ -103,7 +105,17 @@ class HardwareClassificationPytestPlugin:
     """Pytest plugin to filter collected tests by hw_classification."""
 
     def __init__(self, requirement):
-        self.requirement = requirement
+        self.requirement = self._check_requirement(requirement)
+
+    @staticmethod
+    def _check_requirement(hw_classification):
+        if hw_classification is None:
+            return None
+        try:
+            from torch.testing._internal.common_utils import HardwareClassification
+        except ImportError:
+            return None
+        return {HardwareClassification[name] for name in hw_classification}
 
     def pytest_collection_modifyitems(self, items):
         if self.requirement is None:
@@ -111,38 +123,41 @@ class HardwareClassificationPytestPlugin:
         import torch.testing._internal.common_utils as _cu
 
         filtered = []
-        for item in items:
-            # hw_classification is a class-level attribute. Function-based tests
-            # do not have item.cls and are therefore filtered.
-            cls = getattr(item, "cls", None)
-            if cls is not None:
-                req = _cu._get_hw_classification(cls)
-                if req is not None and req in self.requirement:
-                    filtered.append(item)
+        total_count = 0
+        passed_count = 0
+        func_dropped = 0
+        unclassified_dropped = 0
 
+        for item in items:
+            total_count += 1
+            cls = getattr(item, "cls", None)
+            if cls is None:
+                func_dropped += 1
+                continue
+            req = _cu._get_hw_classification(cls)
+            if req is None:
+                unclassified_dropped += 1
+            elif req in self.requirement:
+                filtered.append(item)
+                passed_count += 1
+
+        mismatched_dropped = (
+            total_count - passed_count - func_dropped - unclassified_dropped
+        )
+
+        warnings.warn(
+            f"HW classification mode active "
+            f"({[e.name for e in self.requirement]}): "
+            f"total={total_count}, passed={passed_count}, "
+            f"func_dropped={func_dropped}, "
+            f"unclassified_dropped={unclassified_dropped}, "
+            f"mismatched_dropped={mismatched_dropped}"
+        )
         items[:] = filtered
 
 
 def pytest_configure(config: Config) -> None:
     parse_cmd_line_args()
-
-    # Some pytest jobs (e.g. tools/* tests) run directly from the source tree
-    # without a built torch package. In that environment importing
-    # torch.testing._internal.common_utils may fail because generated files such
-    # as torch.version are not available yet. Skip hardware classification plugin
-    # registration in that case.
-    try:
-        import torch.testing._internal.common_utils as _cu
-    except ImportError:
-        _cu = None
-
-    # Use getattr to handle the case where this conftest.py runs against a nightly
-    # torch that doesn't yet have HW_CLASSIFICATION in common_utils.
-    if _cu is not None and getattr(_cu, "HW_CLASSIFICATION", None) is not None:
-        config.pluginmanager.register(
-            HardwareClassificationPytestPlugin(_cu.HW_CLASSIFICATION),
-            "hw_classification_plugin",
-        )
 
     xmlpath = config.option.xmlpath_reruns
     # Prevent opening xmllog on worker nodes (xdist).
@@ -166,6 +181,11 @@ def pytest_configure(config: Config) -> None:
         config.pluginmanager.register(StepcurrentPlugin(config), "stepcurrentplugin")
     if config.getoption("num_shards"):
         config.pluginmanager.register(PytestShardPlugin(config), "pytestshardplugin")
+    if config.getoption("hw_classification"):
+        config.pluginmanager.register(
+            HardwareClassificationPytestPlugin(config.getoption("hw_classification")),
+            "hw_classification_plugin",
+        )
 
 
 def pytest_unconfigure(config: Config) -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,13 +103,16 @@ def pytest_addoption(parser: Parser) -> None:
 class HardwareClassificationPytestPlugin:
     """Pytest plugin to filter collected tests by hw_classification."""
 
-    def __init__(self, requirement):
-        self.requirement = self._check_requirement(requirement)
+    def __init__(self, hw_classification):
+        self.hw_classification = self._resolve_hw_classification(hw_classification)
 
     @staticmethod
-    def _check_requirement(hw_classification):
+    def _resolve_hw_classification(hw_classification):
         if hw_classification is None:
             return None
+        # Temporary workaround needed until HardwareClassification makes it into a
+        # nightly because main / PR's tests are sometimes run against the previous
+        # day's nightly which won't have this class.
         try:
             from torch.testing._internal.common_utils import HardwareClassification
         except ImportError:
@@ -117,14 +120,14 @@ class HardwareClassificationPytestPlugin:
         return {HardwareClassification[name] for name in hw_classification}
 
     def pytest_collection_modifyitems(self, items):
-        if self.requirement is None:
+        if self.hw_classification is None:
             return
         import torch.testing._internal.common_utils as _cu
 
         filtered = []
         _cu.filter_by_hw_classification(
             items,
-            self.requirement,
+            self.hw_classification,
             get_class=lambda item: getattr(item, "cls", None),
             on_match=filtered.append,
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import sys
-import warnings
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from types import MethodType
@@ -123,35 +122,11 @@ class HardwareClassificationPytestPlugin:
         import torch.testing._internal.common_utils as _cu
 
         filtered = []
-        total_count = 0
-        passed_count = 0
-        func_dropped = 0
-        unclassified_dropped = 0
-
-        for item in items:
-            total_count += 1
-            cls = getattr(item, "cls", None)
-            if cls is None:
-                func_dropped += 1
-                continue
-            req = _cu.get_hw_classification(cls)
-            if req is None:
-                unclassified_dropped += 1
-            elif req in self.requirement:
-                filtered.append(item)
-                passed_count += 1
-
-        mismatched_dropped = (
-            total_count - passed_count - func_dropped - unclassified_dropped
-        )
-
-        warnings.warn(
-            f"HW classification mode active "
-            f"({[e.name for e in self.requirement]}): "
-            f"total={total_count}, passed={passed_count}, "
-            f"func_dropped={func_dropped}, "
-            f"unclassified_dropped={unclassified_dropped}, "
-            f"mismatched_dropped={mismatched_dropped}"
+        _cu.filter_by_hw_classification(
+            items,
+            self.requirement,
+            get_class=lambda item: getattr(item, "cls", None),
+            on_match=filtered.append,
         )
         items[:] = filtered
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -134,7 +134,7 @@ class HardwareClassificationPytestPlugin:
             if cls is None:
                 func_dropped += 1
                 continue
-            req = _cu._get_hw_classification(cls)
+            req = _cu.get_hw_classification(cls)
             if req is None:
                 unclassified_dropped += 1
             elif req in self.requirement:

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import (
     skipXPUIf,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     IS_WINDOWS,
     run_tests,
@@ -53,6 +54,8 @@ def _lookup_tensor_categories(
 
 @skipIfTorchDynamo("TorchDynamo removes profiler altogether.")
 class TestMemoryProfiler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_config_check(self) -> None:
         with torch.profiler.profile() as prof:
             pass
@@ -132,6 +135,8 @@ class RecordInputOutputDispatchMode(torch.utils._python_dispatch.TorchDispatchMo
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestIdentifyGradients(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
+
     def gradient_detected(
         self,
         prof: torch.profiler.profile,
@@ -336,6 +341,8 @@ class TestIdentifyGradients(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo removes profiler altogether.")
 class TestDataFlow(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self.maxDiff = None
@@ -767,6 +774,8 @@ class TestDataFlow(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerE2E(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_and_format_categories(self, fn, indent=12):
         """Generate summary of assigned categories for expecttest."""
 
@@ -1258,6 +1267,8 @@ class TestMemoryProfilerE2E(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerE2EDeviceType(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
+
     def _run_and_check_parameters_and_gradients(
         self, inner_fn, model, grads_none: bool = False
     ):
@@ -1486,6 +1497,8 @@ class TestMemoryProfilerE2EDeviceType(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerTimeline(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
+
     @skipXPUIf(
         True,
         "The XPU Profiler will not cover this case for now. Will support it in next period.",

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -135,7 +135,7 @@ class RecordInputOutputDispatchMode(torch.utils._python_dispatch.TorchDispatchMo
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestIdentifyGradients(TestCase):
-    hw_classification = HardwareClassification.DEVICE_GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def gradient_detected(
         self,
@@ -1267,7 +1267,7 @@ class TestMemoryProfilerE2E(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerE2EDeviceType(TestCase):
-    hw_classification = HardwareClassification.DEVICE_GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _run_and_check_parameters_and_gradients(
         self, inner_fn, model, grads_none: bool = False
@@ -1497,7 +1497,7 @@ class TestMemoryProfilerE2EDeviceType(TestCase):
 
 @skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
 class TestMemoryProfilerTimeline(TestCase):
-    hw_classification = HardwareClassification.DEVICE_GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @skipXPUIf(
         True,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -105,7 +105,7 @@ try:
 except ImportError:
     # Temporary fallback for CI jobs that run the PR's test/run_test.py against a
     # previous nightly torch package that doesn't have HardwareClassification yet.
-    _HC_CHOICES = ["GENERIC", "DEVICE_GENERIC", "CPU", "CUDA", "MPS", "XPU"]
+    _HC_CHOICES = ["GENERIC", "ACCELERATOR", "CPU", "CUDA", "MPS", "XPU"]
 
 
 # Make sure to remove REPO_ROOT after import is done
@@ -1519,7 +1519,7 @@ def parse_args():
         type=str.upper,
         default=None,
         metavar="SCOPE",
-        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
+        help="filter tests by hardware classification categories (e.g., GENERIC ACCELERATOR CPU CUDA MPS XPU)",
     )
     parser.add_argument(
         "-x",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -98,6 +98,14 @@ except ImportError:
         pass
 
 
+try:
+    from torch.testing._internal.common_utils import HardwareClassification
+
+    _HC_CHOICES = [e.name for e in HardwareClassification]
+except ImportError:
+    _HC_CHOICES = ["GENERIC", "DEVICE_GENERIC", "CUDA", "XPU", "MPS"]
+
+
 # Make sure to remove REPO_ROOT after import is done
 sys.path.remove(str(REPO_ROOT))
 
@@ -561,6 +569,10 @@ def run_test(
         unittest_args.extend(test_module.get_pytest_args())
         replacement = {"-f": "-x", "-dist=loadfile": "--dist=loadfile"}
         unittest_args = [replacement.get(arg, arg) for arg in unittest_args]
+
+    if options.hw_classification:
+        # forward hw classification filter to test subprocess
+        unittest_args += ["--hw-classification"] + options.hw_classification
 
     if options.showlocals:
         if options.pytest:
@@ -1497,6 +1509,15 @@ def parse_args():
         metavar="TESTS",
         help="select a set of tests to include (defaults to ALL tests)."
         " tests must be a part of the TESTS list defined in run_test.py",
+    )
+    parser.add_argument(
+        "--hw-classification",
+        nargs="+",
+        choices=_HC_CHOICES,
+        type=str.upper,
+        default=None,
+        metavar="SCOPE",
+        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CUDA XPU MPS)",
     )
     parser.add_argument(
         "-x",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -103,7 +103,9 @@ try:
 
     _HC_CHOICES = [e.name for e in HardwareClassification]
 except ImportError:
-    _HC_CHOICES = ["GENERIC", "DEVICE_GENERIC", "CUDA", "XPU", "MPS"]
+    # Temporary fallback for CI jobs that run the PR's test/run_test.py against a
+    # previous nightly torch package that doesn't have HardwareClassification yet.
+    _HC_CHOICES = ["GENERIC", "DEVICE_GENERIC", "CPU", "CUDA", "MPS", "XPU"]
 
 
 # Make sure to remove REPO_ROOT after import is done
@@ -1517,7 +1519,7 @@ def parse_args():
         type=str.upper,
         default=None,
         metavar="SCOPE",
-        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CUDA XPU MPS)",
+        help="filter tests by hardware classification categories (e.g., GENERIC DEVICE_GENERIC CPU CUDA MPS XPU)",
     )
     parser.add_argument(
         "-x",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2652,6 +2652,148 @@ class TestOpInfoSampleFunctions(TestCase):
         samples = op.error_inputs(device)
         self.assertIsInstance(samples, Iterator)
 
+# Tests test classification.
+class TestHardwareClassifications(TestCase):
+    def setUp(self):
+        super().setUp()
+        import torch.testing._internal.common_utils as _cu
+
+        self._cu = _cu
+
+    def _suite_test_names(self, suite) -> set[str]:
+        return {test_case.id().split(".")[-1] for test_case in self._cu._iter_test_cases_recursively(suite)}
+
+    def test_filter_suite(self):
+        requirement = self._cu.HardwareClassification
+
+        class GenericTest(TestCase):
+            hw_classification = requirement.GENERIC
+
+            def test_generic(self):
+                pass
+
+        class CudaTest(TestCase):
+            hw_classification = requirement.CUDA
+
+            def test_cuda(self):
+                pass
+
+        class MissingClassificationTest(TestCase):
+            def test_missing_classification(self):
+                pass
+
+        suite = unittest.TestSuite(
+            [
+                unittest.defaultTestLoader.loadTestsFromTestCase(GenericTest),
+                unittest.defaultTestLoader.loadTestsFromTestCase(CudaTest),
+                unittest.defaultTestLoader.loadTestsFromTestCase(MissingClassificationTest),
+            ]
+        )
+
+        with unittest.mock.patch.object(
+            self._cu,
+            "HW_CLASSIFICATION",
+            {self._cu.HardwareClassification.GENERIC},
+        ):
+            filtered_suite = self._cu._filter_suite_by_hw_classification(suite)
+
+        self.assertEqual(
+            self._suite_test_names(filtered_suite),
+            {"test_generic"},
+        )
+
+    def test_filter_suite_uses_inherited_metadata(self):
+        requirement = self._cu.HardwareClassification
+
+        class DeviceGenericBase(TestCase):
+            hw_classification = requirement.DEVICE_GENERIC
+
+        class DeviceGenericChild(DeviceGenericBase):
+            def test_inherited_classification(self):
+                pass
+
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
+        with unittest.mock.patch.object(
+            self._cu,
+            "HW_CLASSIFICATION",
+            {self._cu.HardwareClassification.DEVICE_GENERIC},
+        ):
+            filtered_suite = self._cu._filter_suite_by_hw_classification(suite)
+
+        self.assertEqual(
+            self._suite_test_names(filtered_suite),
+            {"test_inherited_classification"},
+        )
+
+    def test_hw_classification_test_loader(self):
+        requirement = self._cu.HardwareClassification
+        import types
+
+        # Build a mock module with test classes
+        class GenericA(TestCase):
+            hw_classification = requirement.GENERIC
+
+            def test_a1(self):
+                pass
+
+            def test_a2(self):
+                pass
+
+        class GenericB(TestCase):
+            hw_classification = requirement.GENERIC
+
+            def test_b1(self):
+                pass
+
+        class Cuda(TestCase):
+            hw_classification = requirement.CUDA
+
+            def test_c1(self):
+                pass
+
+        mod = types.ModuleType("_test_hc_module")
+        mod.GenericA = GenericA
+        mod.GenericB = GenericB
+        mod.Cuda = Cuda
+
+        loader = self._cu.HardwareClassificationTestLoader()
+        with unittest.mock.patch.object(
+            self._cu,
+            "HW_CLASSIFICATION",
+            {requirement.GENERIC},
+        ):
+            suite = loader.loadTestsFromModule(mod)
+
+        self.assertEqual(
+            self._suite_test_names(suite),
+            {"test_a1", "test_a2", "test_b1"},
+        )
+
+    def test_hw_classification_test_loader_no_filter(self):
+        import types
+
+        class GenericA(TestCase):
+            hw_classification = self._cu.HardwareClassification.GENERIC
+
+            def test_a(self):
+                pass
+
+        class Cuda(TestCase):
+            hw_classification = self._cu.HardwareClassification.CUDA
+
+            def test_b(self):
+                pass
+
+        mod = types.ModuleType("_test_hc_module_none")
+        mod.GenericA = GenericA
+        mod.Cuda = Cuda
+
+        loader = self._cu.HardwareClassificationTestLoader()
+        with unittest.mock.patch.object(self._cu, "HW_CLASSIFICATION", None):
+            suite = loader.loadTestsFromModule(mod)
+
+        self.assertEqual(self._suite_test_names(suite), {"test_a", "test_b"})
+
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2690,12 +2690,10 @@ class TestHardwareClassifications(TestCase):
             ]
         )
 
-        with unittest.mock.patch.object(
-            self._cu,
-            "HW_CLASSIFICATION",
+        filtered_suite = self._cu._filter_suite_by_hw_classification(
+            suite,
             {self._cu.HardwareClassification.GENERIC},
-        ):
-            filtered_suite = self._cu._filter_suite_by_hw_classification(suite)
+        )
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),
@@ -2713,12 +2711,10 @@ class TestHardwareClassifications(TestCase):
                 pass
 
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
-        with unittest.mock.patch.object(
-            self._cu,
-            "HW_CLASSIFICATION",
+        filtered_suite = self._cu._filter_suite_by_hw_classification(
+            suite,
             {self._cu.HardwareClassification.DEVICE_GENERIC},
-        ):
-            filtered_suite = self._cu._filter_suite_by_hw_classification(suite)
+        )
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),
@@ -2756,13 +2752,8 @@ class TestHardwareClassifications(TestCase):
         mod.GenericB = GenericB
         mod.Cuda = Cuda
 
-        loader = self._cu.HardwareClassificationTestLoader()
-        with unittest.mock.patch.object(
-            self._cu,
-            "HW_CLASSIFICATION",
-            {requirement.GENERIC},
-        ):
-            suite = loader.loadTestsFromModule(mod)
+        loader = self._cu.HardwareClassificationTestLoader({requirement.GENERIC})
+        suite = loader.loadTestsFromModule(mod)
 
         self.assertEqual(
             self._suite_test_names(suite),
@@ -2788,9 +2779,8 @@ class TestHardwareClassifications(TestCase):
         mod.GenericA = GenericA
         mod.Cuda = Cuda
 
-        loader = self._cu.HardwareClassificationTestLoader()
-        with unittest.mock.patch.object(self._cu, "HW_CLASSIFICATION", None):
-            suite = loader.loadTestsFromModule(mod)
+        loader = self._cu.HardwareClassificationTestLoader(None)
+        suite = loader.loadTestsFromModule(mod)
 
         self.assertEqual(self._suite_test_names(suite), {"test_a", "test_b"})
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2701,15 +2701,15 @@ class TestHardwareClassifications(TestCase):
     def test_filter_suite_uses_inherited_metadata(self):
         requirement = self._cu.HardwareClassification
 
-        class DeviceGenericBase(TestCase):
-            hw_classification = requirement.DEVICE_GENERIC
+        class AcceleratorBase(TestCase):
+            hw_classification = requirement.ACCELERATOR
 
-        class DeviceGenericChild(DeviceGenericBase):
+        class AcceleratorChild(AcceleratorBase):
             def test_inherited_classification(self):
                 pass
 
-        suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
-        loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.DEVICE_GENERIC})
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(AcceleratorChild)
+        loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.ACCELERATOR})
         filtered_suite = loader.get_filtered_suite(suite)
 
         self.assertEqual(

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2691,7 +2691,7 @@ class TestHardwareClassifications(TestCase):
         )
 
         loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.GENERIC})
-        filtered_suite = loader.filter_suite_by_hw_classification(suite)
+        filtered_suite = loader.get_filtered_suite(suite)
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),
@@ -2710,7 +2710,7 @@ class TestHardwareClassifications(TestCase):
 
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
         loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.DEVICE_GENERIC})
-        filtered_suite = loader.filter_suite_by_hw_classification(suite)
+        filtered_suite = loader.get_filtered_suite(suite)
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),
@@ -2749,12 +2749,27 @@ class TestHardwareClassifications(TestCase):
         mod.Cuda = Cuda
 
         loader = self._cu.HardwareClassificationTestLoader({requirement.GENERIC})
-        suite = loader.loadTestsFromModule(mod)
 
-        self.assertEqual(
-            self._suite_test_names(suite),
-            {"test_a1", "test_a2", "test_b1"},
-        )
+        with self.subTest(method="loadTestsFromModule"):
+            suite = loader.loadTestsFromModule(mod)
+            self.assertEqual(
+                self._suite_test_names(suite),
+                {"test_a1", "test_a2", "test_b1"},
+            )
+
+        with self.subTest(method="loadTestsFromNames"):
+            suite = loader.loadTestsFromNames(
+                ["GenericA.test_a1", "Cuda.test_c1"],
+                module=mod,
+            )
+            self.assertEqual(self._suite_test_names(suite), {"test_a1"})
+
+        with self.subTest(method="loadTestsFromName"):
+            suite = loader.loadTestsFromName(
+                "Cuda.test_c1",
+                module=mod,
+            )
+            self.assertEqual(self._suite_test_names(suite), set())
 
     def test_hw_classification_test_loader_no_filter(self):
         import types

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2661,7 +2661,7 @@ class TestHardwareClassifications(TestCase):
         self._cu = _cu
 
     def _suite_test_names(self, suite) -> set[str]:
-        return {test_case.id().split(".")[-1] for test_case in self._cu._iter_test_cases_recursively(suite)}
+        return {test_case.id().split(".")[-1] for test_case in self._cu.HardwareClassificationTestLoader.iter_test_cases_recursively(suite)}
 
     def test_filter_suite(self):
         requirement = self._cu.HardwareClassification
@@ -2690,10 +2690,8 @@ class TestHardwareClassifications(TestCase):
             ]
         )
 
-        filtered_suite = self._cu._filter_suite_by_hw_classification(
-            suite,
-            {self._cu.HardwareClassification.GENERIC},
-        )
+        loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.GENERIC})
+        filtered_suite = loader.filter_suite_by_hw_classification(suite)
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),
@@ -2711,10 +2709,8 @@ class TestHardwareClassifications(TestCase):
                 pass
 
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(DeviceGenericChild)
-        filtered_suite = self._cu._filter_suite_by_hw_classification(
-            suite,
-            {self._cu.HardwareClassification.DEVICE_GENERIC},
-        )
+        loader = self._cu.HardwareClassificationTestLoader({self._cu.HardwareClassification.DEVICE_GENERIC})
+        filtered_suite = loader.filter_suite_by_hw_classification(suite)
 
         self.assertEqual(
             self._suite_test_names(filtered_suite),

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -114,6 +114,15 @@ class ProfilingMode(Enum):
     SIMPLE = 2
     PROFILING = 3
 
+class HardwareClassification(Enum):
+    # Class-level metadata describing the hardware classification of a test.
+    GENERIC = "generic"
+    DEVICE_GENERIC = "device_generic"
+    CUDA = "cuda"
+    XPU = "xpu"
+    MPS = "mps"
+
+
 # Set by parse_cmd_line_args() if called
 DISABLED_TESTS_FILE = ""
 GRAPH_EXECUTOR : ProfilingMode | None = None
@@ -130,6 +139,49 @@ TEST_IN_SUBPROCESS = False
 TEST_SAVE_XML = ""
 UNITTEST_ARGS : list[str] = []
 USE_PYTEST = False
+HW_CLASSIFICATION : set[HardwareClassification] | None = None
+
+
+def _iter_test_cases_recursively(
+    suite_or_case: unittest.TestSuite | unittest.TestCase,
+) -> Iterator[unittest.TestCase]:
+    if isinstance(suite_or_case, unittest.TestCase):
+        yield suite_or_case
+        return
+
+    for element in suite_or_case:
+        yield from _iter_test_cases_recursively(element)
+
+
+def _get_hw_classification(
+    test_case_cls: type[unittest.TestCase],
+) -> HardwareClassification | None:
+    requirement = getattr(test_case_cls, "hw_classification", None)
+    if requirement is None:
+        return None
+
+    if not isinstance(requirement, HardwareClassification):
+        raise TypeError(
+            f"{test_case_cls.__module__}.{test_case_cls.__name__}."
+            "hw_classification must be a HardwareClassification"
+        )
+
+    return requirement
+
+
+def _filter_suite_by_hw_classification(tests: unittest.TestSuite) -> unittest.TestSuite:
+    if HW_CLASSIFICATION is None:
+        return tests
+
+    filtered_suite = unittest.TestSuite()
+
+    for test_case in _iter_test_cases_recursively(tests):
+        requirement = _get_hw_classification(test_case.__class__)
+
+        if requirement is not None and requirement in HW_CLASSIFICATION:
+            filtered_suite.addTest(test_case)
+
+    return filtered_suite
 
 def is_navi3_arch():
     if torch.cuda.is_available():
@@ -1006,6 +1058,7 @@ def parse_cmd_line_args():
     global TEST_SAVE_XML
     global UNITTEST_ARGS
     global USE_PYTEST
+    global HW_CLASSIFICATION
 
     is_running_via_run_test = "run_test.py" in getattr(__main__, "__file__", "")
     parser = argparse.ArgumentParser(add_help=not is_running_via_run_test, allow_abbrev=False)
@@ -1027,6 +1080,7 @@ def parse_cmd_line_args():
     parser.add_argument('--rerun-disabled-tests', action='store_true')
     parser.add_argument('--pytest-single-test', type=str, nargs=1)
     parser.add_argument('--showlocals', action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument('--hw-classification', nargs='+', choices=[e.name for e in HardwareClassification], type=str.upper, default=None)
 
 # Only run when -h or --help flag is active to display both unittest and parser help messages.
     def run_unittest_help(argv):
@@ -1062,6 +1116,11 @@ def parse_cmd_line_args():
     TEST_SAVE_XML = args.save_xml
     REPEAT_COUNT = args.repeat
     SHOWLOCALS = args.showlocals
+    HW_CLASSIFICATION = (
+        {HardwareClassification[name] for name in args.hw_classification}
+        if args.hw_classification is not None
+        else None
+    )
     if not getattr(expecttest, "ACCEPT", False):
         expecttest.ACCEPT = args.accept
     UNITTEST_ARGS = [sys.argv[0]] + remaining
@@ -1267,6 +1326,15 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
     return test_collector_plugin.tests
 
 
+class HardwareClassificationTestLoader(unittest.TestLoader):
+    """Unittest TestLoader that filters loaded tests by hw_classification."""
+    def loadTestsFromModule(self, module, *args, pattern=None, **kwargs):
+        suite = super().loadTestsFromModule(
+            module, *args, pattern=pattern, **kwargs
+        )
+        return _filter_suite_by_hw_classification(suite)
+
+
 def run_tests(argv=None):
     parse_cmd_line_args()
     if argv is None:
@@ -1295,8 +1363,12 @@ def run_tests(argv=None):
         _print_test_names()
         return
 
+    testLoader = unittest.loader.defaultTestLoader
+    if HW_CLASSIFICATION is not None:
+        testLoader = HardwareClassificationTestLoader()
+
     # Before running the tests, lint to check that every test class extends from TestCase
-    suite = unittest.TestLoader().loadTestsFromModule(__main__)
+    suite = testLoader.loadTestsFromModule(__main__)
     if not lint_test_case_extension(suite):
         sys.exit(1)
 
@@ -1319,6 +1391,8 @@ def run_tests(argv=None):
             other_args.append("--rerun-disabled-tests")
         if TEST_SAVE_XML:
             other_args += ['--save-xml', TEST_SAVE_XML]
+        if HW_CLASSIFICATION is not None:
+            other_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
 
         test_cases = (
             get_pytest_test_cases(argv) if USE_PYTEST else
@@ -1423,13 +1497,13 @@ def run_tests(argv=None):
         unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(
             output=test_report_path,
             verbosity=2 if verbose else 1,
-            resultclass=XMLTestResultVerbose))
+            resultclass=XMLTestResultVerbose), testLoader=testLoader)
     elif REPEAT_COUNT > 1:
         for _ in range(REPEAT_COUNT):
-            if not unittest.main(exit=False, argv=argv).result.wasSuccessful():
+            if not unittest.main(exit=False, argv=argv, testLoader=testLoader).result.wasSuccessful():
                 sys.exit(-1)
     else:
-        unittest.main(argv=argv)
+        unittest.main(argv=argv, testLoader=testLoader)
 
 IS_LINUX = sys.platform == "linux"
 IS_WINDOWS = sys.platform == "win32"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -124,12 +124,13 @@ class HardwareClassification(Enum):
 
     Currently there are three hardware classification categories:
 
-    * ``GENERIC`` – tests for shared logic that do not require device
-    execution.
-    * ``DEVICE_GENERIC`` – tests that require device execution but are
-    expected to run on any supported device type.
+    * ``GENERIC`` – tests that validate shared CPU-only logic and do not
+    require any accelerator (CUDA, MPS, XPU, etc.) to run.
+    * ``DEVICE_GENERIC`` – tests that require an accelerator to run and
+    should run for all accelerators.
     * ``CPU``, ``CUDA``, ``MPS``, ``XPU`` – tests that require a specific
-    device type.
+    device type. These should be use very rarely and only to test some
+    specific hw behavior.
 
     Usage::
 
@@ -198,8 +199,8 @@ def _get_hw_classification(
     return requirement
 
 
-def _filter_suite_by_hw_classification(tests: unittest.TestSuite) -> unittest.TestSuite:
-    if HW_CLASSIFICATION is None:
+def _filter_suite_by_hw_classification(tests: unittest.TestSuite, hw_classification: set[HardwareClassification]) -> unittest.TestSuite:
+    if hw_classification is None:
         return tests
 
     filtered_suite = unittest.TestSuite()
@@ -207,7 +208,7 @@ def _filter_suite_by_hw_classification(tests: unittest.TestSuite) -> unittest.Te
     for test_case in _iter_test_cases_recursively(tests):
         requirement = _get_hw_classification(test_case.__class__)
 
-        if requirement is not None and requirement in HW_CLASSIFICATION:
+        if requirement is not None and requirement in hw_classification:
             filtered_suite.addTest(test_case)
 
     return filtered_suite
@@ -1356,12 +1357,16 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
 
 
 class HardwareClassificationTestLoader(unittest.TestLoader):
+    def __init__(self, hw_classification):
+        super().__init__()
+        self.hw_classification = hw_classification
+
     """Unittest TestLoader that filters loaded tests by hw_classification."""
     def loadTestsFromModule(self, module, *args, pattern=None, **kwargs):
         suite = super().loadTestsFromModule(
             module, *args, pattern=pattern, **kwargs
         )
-        return _filter_suite_by_hw_classification(suite)
+        return _filter_suite_by_hw_classification(suite,self.hw_classification)
 
 
 def run_tests(argv=None):
@@ -1394,7 +1399,7 @@ def run_tests(argv=None):
 
     testLoader = unittest.loader.defaultTestLoader
     if HW_CLASSIFICATION is not None:
-        testLoader = HardwareClassificationTestLoader()
+        testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION)
 
     # Before running the tests, lint to check that every test class extends from TestCase
     suite = testLoader.loadTestsFromModule(__main__)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -115,12 +115,41 @@ class ProfilingMode(Enum):
     PROFILING = 3
 
 class HardwareClassification(Enum):
-    # Class-level metadata describing the hardware classification of a test.
+    """Hardware classification metadata for test classes.
+
+    Test classes can declare a ``hw_classification`` class attribute to
+    describe the kind of hardware required to run the tests in that class.
+    When the ``--hw-classification`` CLI flag is passed, only tests whose
+    classification matches one of the requested values are executed.
+
+    Currently there are three hardware classification categories:
+
+    * ``GENERIC`` – tests for shared logic that do not require device
+    execution.
+    * ``DEVICE_GENERIC`` – tests that require device execution but are
+    expected to run on any supported device type.
+    * ``CPU``, ``CUDA``, ``MPS``, ``XPU`` – tests that require a specific
+    device type.
+
+    Usage::
+
+        class TestFoo(TestCase):
+            hw_classification = HardwareClassification.GENERIC
+
+            def test_bar(self):
+                ...
+
+    Run only GENERIC and DEVICE_GENERIC tests::
+
+        python test/test_torch.py --hw-classification GENERIC DEVICE_GENERIC
+
+    """
     GENERIC = "generic"
     DEVICE_GENERIC = "device_generic"
+    CPU = "cpu"
     CUDA = "cuda"
-    XPU = "xpu"
     MPS = "mps"
+    XPU = "xpu"
 
 
 # Set by parse_cmd_line_args() if called

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1366,7 +1366,7 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
         suite = super().loadTestsFromModule(
             module, *args, pattern=pattern, **kwargs
         )
-        return _filter_suite_by_hw_classification(suite,self.hw_classification)
+        return _filter_suite_by_hw_classification(suite, self.hw_classification)
 
 
 def run_tests(argv=None):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -131,7 +131,7 @@ class HardwareClassification(Enum):
       typically do **not** use
       :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
 
-    * ``DEVICE_GENERIC`` – tests that verify behavior which must hold
+    * ``ACCELERATOR`` – tests that verify behavior which must hold
       across every accelerator (e.g. operator semantics, memory profiling).
       These test classes **are** instantiated via
       :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
@@ -148,13 +148,13 @@ class HardwareClassification(Enum):
             def test_bar(self):
                 ...
 
-    Run only GENERIC and DEVICE_GENERIC tests::
+    Run only GENERIC and ACCELERATOR tests:
 
-        python test/test_torch.py --hw-classification GENERIC DEVICE_GENERIC
+        python test/test_torch.py --hw-classification GENERIC ACCELERATOR
 
     """
     GENERIC = "generic"
-    DEVICE_GENERIC = "device_generic"
+    ACCELERATOR = "accelerator"
     CPU = "cpu"
     CUDA = "cuda"
     MPS = "mps"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -188,6 +188,50 @@ def get_hw_classification(
     return requirement
 
 
+def filter_by_hw_classification(
+    items: Iterable[Any],
+    requirement: set[HardwareClassification],
+    get_class: Callable[[Any], type | None],
+    *,
+    on_match: Callable[[Any], None] | None = None,
+) -> None:
+    """Filter items by hardware classification and print a summary.
+
+    For each item, `get_class` extracts the associated test class. Items whose
+    hardware classification is in `requirement` are passed to `on_match`, if
+    provided. Prints a summary of matched, mismatched, unclassified, and
+    classless items.
+    """
+    total = 0
+    passed = 0
+    no_class = 0
+    unclassified = 0
+    for item in items:
+        total += 1
+        cls = get_class(item)
+        if cls is None:
+            no_class += 1
+            continue
+        classification = get_hw_classification(cls)
+        if classification is None:
+            unclassified += 1
+        elif classification in requirement:
+            passed += 1
+            if on_match is not None:
+                on_match(item)
+
+    mismatched = total - passed - unclassified - no_class
+    parts = [
+        f"HW classification mode active ({[e.name for e in requirement]}):",
+        f"total={total}, passed={passed},",
+        f"unclassified={unclassified},",
+    ]
+    if no_class > 0:
+        parts.append(f"no_class={no_class},")
+    parts.append(f"mismatched={mismatched}")
+    print(" ".join(parts))
+
+
 def is_navi3_arch():
     if torch.cuda.is_available():
         prop = torch.cuda.get_device_properties(0)
@@ -1349,32 +1393,21 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
         for element in suite_or_case:
             yield from _iter(element)
 
-    def filter_suite_by_hw_classification(self, tests: unittest.TestSuite) -> unittest.TestSuite:
+    def _has_failed_test(self, suite: unittest.TestSuite) -> bool:
+        _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
+        return any(isinstance(tc, unittest.loader._FailedTest) for tc in _iter(suite))
+
+    def get_filtered_suite(self, tests: unittest.TestSuite) -> unittest.TestSuite:
         if self.hw_classification is None:
             return tests
 
         filtered_suite = unittest.TestSuite()
-        total_count = 0
-        passed_count = 0
-        unclassified_count = 0
-
         _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
-        for test_case in _iter(tests):
-            total_count += 1
-            requirement = get_hw_classification(test_case.__class__)
-
-            if requirement is None:
-                unclassified_count += 1
-            elif requirement in self.hw_classification:
-                filtered_suite.addTest(test_case)
-                passed_count += 1
-
-        mismatched_count = total_count - passed_count - unclassified_count
-
-        warnings.warn(
-            f"HW classification mode active ({[e.name for e in self.hw_classification]}): "
-            f"total={total_count}, passed={passed_count}, "
-            f"unclassified={unclassified_count}, mismatched={mismatched_count}"
+        filter_by_hw_classification(
+            _iter(tests),
+            self.hw_classification,
+            get_class=lambda tc: tc.__class__,
+            on_match=filtered_suite.addTest,
         )
         return filtered_suite
 
@@ -1382,7 +1415,13 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
         suite = super().loadTestsFromModule(
             module, *args, pattern=pattern, **kwargs
         )
-        return self.filter_suite_by_hw_classification(suite)
+        return self.get_filtered_suite(suite)
+
+    def loadTestsFromName(self, name, module=None, *args, **kwargs):
+        suite = super().loadTestsFromName(name, module, *args, **kwargs)
+        if self._has_failed_test(suite):
+            return suite
+        return self.get_filtered_suite(suite)
 
 
 def run_tests(argv=None):
@@ -1418,8 +1457,8 @@ def run_tests(argv=None):
         testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION)
 
     # Before running the tests, lint to check that every test class extends from TestCase
-    suite = testLoader.loadTestsFromModule(__main__)
-    if not lint_test_case_extension(suite):
+    lint_suite = unittest.loader.defaultTestLoader.loadTestsFromModule(__main__)
+    if not lint_test_case_extension(lint_suite):
         sys.exit(1)
 
     if SHOWLOCALS:
@@ -1430,6 +1469,7 @@ def run_tests(argv=None):
         ]
 
     if TEST_IN_SUBPROCESS:
+        suite = testLoader.loadTestsFromModule(__main__)
         other_args = []
         if DISABLED_TESTS_FILE:
             other_args.append("--import-disabled-tests")
@@ -1483,6 +1523,7 @@ def run_tests(argv=None):
             )
 
     elif RUN_PARALLEL > 1:
+        suite = testLoader.loadTestsFromModule(__main__)
         test_cases = discover_test_cases_recursively(suite)
         test_batches = chunk_list(get_test_names(test_cases), RUN_PARALLEL)
         processes = []

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -172,18 +172,7 @@ USE_PYTEST = False
 HW_CLASSIFICATION : set[HardwareClassification] | None = None
 
 
-def _iter_test_cases_recursively(
-    suite_or_case: unittest.TestSuite | unittest.TestCase,
-) -> Iterator[unittest.TestCase]:
-    if isinstance(suite_or_case, unittest.TestCase):
-        yield suite_or_case
-        return
-
-    for element in suite_or_case:
-        yield from _iter_test_cases_recursively(element)
-
-
-def _get_hw_classification(
+def get_hw_classification(
     test_case_cls: type[unittest.TestCase],
 ) -> HardwareClassification | None:
     requirement = getattr(test_case_cls, "hw_classification", None)
@@ -198,34 +187,6 @@ def _get_hw_classification(
 
     return requirement
 
-
-def _filter_suite_by_hw_classification(tests: unittest.TestSuite, hw_classification: set[HardwareClassification]) -> unittest.TestSuite:
-    if hw_classification is None:
-        return tests
-
-    filtered_suite = unittest.TestSuite()
-    total_count = 0
-    passed_count = 0
-    unclassified_count = 0
-
-    for test_case in _iter_test_cases_recursively(tests):
-        total_count += 1
-        requirement = _get_hw_classification(test_case.__class__)
-
-        if requirement is None:
-            unclassified_count += 1
-        elif requirement in hw_classification:
-            filtered_suite.addTest(test_case)
-            passed_count += 1
-
-    mismatched_count = total_count - passed_count - unclassified_count
-
-    warnings.warn(
-        f"HW classification mode active ({[e.name for e in hw_classification]}): "
-        f"total={total_count}, passed={passed_count}, "
-        f"unclassified={unclassified_count}, mismatched={mismatched_count}"
-    )
-    return filtered_suite
 
 def is_navi3_arch():
     if torch.cuda.is_available():
@@ -1371,16 +1332,57 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
 
 
 class HardwareClassificationTestLoader(unittest.TestLoader):
+    """Unittest TestLoader that filters loaded tests by hw_classification."""
     def __init__(self, hw_classification):
         super().__init__()
         self.hw_classification = hw_classification
 
-    """Unittest TestLoader that filters loaded tests by hw_classification."""
+    @staticmethod
+    def iter_test_cases_recursively(
+        suite_or_case: unittest.TestSuite | unittest.TestCase,
+    ) -> Iterator[unittest.TestCase]:
+        if isinstance(suite_or_case, unittest.TestCase):
+            yield suite_or_case
+            return
+
+        _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
+        for element in suite_or_case:
+            yield from _iter(element)
+
+    def filter_suite_by_hw_classification(self, tests: unittest.TestSuite) -> unittest.TestSuite:
+        if self.hw_classification is None:
+            return tests
+
+        filtered_suite = unittest.TestSuite()
+        total_count = 0
+        passed_count = 0
+        unclassified_count = 0
+
+        _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
+        for test_case in _iter(tests):
+            total_count += 1
+            requirement = get_hw_classification(test_case.__class__)
+
+            if requirement is None:
+                unclassified_count += 1
+            elif requirement in self.hw_classification:
+                filtered_suite.addTest(test_case)
+                passed_count += 1
+
+        mismatched_count = total_count - passed_count - unclassified_count
+
+        warnings.warn(
+            f"HW classification mode active ({[e.name for e in self.hw_classification]}): "
+            f"total={total_count}, passed={passed_count}, "
+            f"unclassified={unclassified_count}, mismatched={mismatched_count}"
+        )
+        return filtered_suite
+
     def loadTestsFromModule(self, module, *args, pattern=None, **kwargs):
         suite = super().loadTestsFromModule(
             module, *args, pattern=pattern, **kwargs
         )
-        return _filter_suite_by_hw_classification(suite, self.hw_classification)
+        return self.filter_suite_by_hw_classification(suite)
 
 
 def run_tests(argv=None):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -117,20 +117,28 @@ class ProfilingMode(Enum):
 class HardwareClassification(Enum):
     """Hardware classification metadata for test classes.
 
-    Test classes can declare a ``hw_classification`` class attribute to
-    describe the kind of hardware required to run the tests in that class.
-    When the ``--hw-classification`` CLI flag is passed, only tests whose
-    classification matches one of the requested values are executed.
+    Test classes declare a ``hw_classification`` class attribute to indicate
+    the kind of hardware their tests require.  When ``--hw-classification``
+    is passed, only tests whose classification matches one of the requested
+    values are executed.  When the flag is not specified, all test discovery
+    and execution paths remain unchanged.
 
     Currently there are three hardware classification categories:
 
-    * ``GENERIC`` – tests that validate shared CPU-only logic and do not
-    require any accelerator (CUDA, MPS, XPU, etc.) to run.
-    * ``DEVICE_GENERIC`` – tests that require an accelerator to run and
-    should run for all accelerators.
-    * ``CPU``, ``CUDA``, ``MPS``, ``XPU`` – tests that require a specific
-    device type. These should be use very rarely and only to test some
-    specific hw behavior.
+    * ``GENERIC`` – tests that exercise shared, device-agnostic logic
+      (e.g. Dynamo dispatcher, FX passes, and other framework internals
+      that do not depend on a particular accelerator).  These test classes
+      typically do **not** use
+      :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
+
+    * ``DEVICE_GENERIC`` – tests that verify behavior which must hold
+      across every accelerator (e.g. operator semantics, memory profiling).
+      These test classes **are** instantiated via
+      :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
+
+    * ``CPU``, ``CUDA``, ``MPS``, ``XPU`` – tests tied to a specific device.
+      Use sparingly, and only for device-specific behavior.  These replace
+      ``@onlyCPU``, ``@onlyCUDA``, and similar decorators
 
     Usage::
 
@@ -193,7 +201,7 @@ def filter_by_hw_classification(
     requirement: set[HardwareClassification],
     get_class: Callable[[Any], type | None],
     *,
-    on_match: Callable[[Any], None] | None = None,
+    on_match: Callable[[Any], None],
 ) -> None:
     """Filter items by hardware classification and print a summary.
 
@@ -217,8 +225,7 @@ def filter_by_hw_classification(
             unclassified += 1
         elif classification in requirement:
             passed += 1
-            if on_match is not None:
-                on_match(item)
+            on_match(item)
 
     mismatched = total - passed - unclassified - no_class
     parts = [
@@ -1393,10 +1400,6 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
         for element in suite_or_case:
             yield from _iter(element)
 
-    def _has_failed_test(self, suite: unittest.TestSuite) -> bool:
-        _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
-        return any(isinstance(tc, unittest.loader._FailedTest) for tc in _iter(suite))
-
     def get_filtered_suite(self, tests: unittest.TestSuite) -> unittest.TestSuite:
         if self.hw_classification is None:
             return tests
@@ -1419,7 +1422,13 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
 
     def loadTestsFromName(self, name, module=None, *args, **kwargs):
         suite = super().loadTestsFromName(name, module, *args, **kwargs)
-        if self._has_failed_test(suite):
+        # _FailedTest has no hw_classification attribute, so
+        # get_filtered_suite would count it as unclassified and drop it
+        # silently. But the original unittest behavior is to surface the
+        # error when the test runs (e.g. "test not found" for a typo).
+        # Pass it through unfiltered to preserve that error.
+        tests = list(suite)
+        if tests and isinstance(tests[0], unittest.loader._FailedTest):
             return suite
         return self.get_filtered_suite(suite)
 
@@ -1452,14 +1461,14 @@ def run_tests(argv=None):
         _print_test_names()
         return
 
+    # Before running the tests, lint to check that every test class extends from TestCase
+    suite = unittest.TestLoader().loadTestsFromModule(__main__)
+    if not lint_test_case_extension(suite):
+        sys.exit(1)
+
     testLoader = unittest.loader.defaultTestLoader
     if HW_CLASSIFICATION is not None:
         testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION)
-
-    # Before running the tests, lint to check that every test class extends from TestCase
-    lint_suite = unittest.loader.defaultTestLoader.loadTestsFromModule(__main__)
-    if not lint_test_case_extension(lint_suite):
-        sys.exit(1)
 
     if SHOWLOCALS:
         argv = [

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -204,13 +204,27 @@ def _filter_suite_by_hw_classification(tests: unittest.TestSuite, hw_classificat
         return tests
 
     filtered_suite = unittest.TestSuite()
+    total_count = 0
+    passed_count = 0
+    unclassified_count = 0
 
     for test_case in _iter_test_cases_recursively(tests):
+        total_count += 1
         requirement = _get_hw_classification(test_case.__class__)
 
-        if requirement is not None and requirement in hw_classification:
+        if requirement is None:
+            unclassified_count += 1
+        elif requirement in hw_classification:
             filtered_suite.addTest(test_case)
+            passed_count += 1
 
+    mismatched_count = total_count - passed_count - unclassified_count
+
+    warnings.warn(
+        f"HW classification mode active ({[e.name for e in hw_classification]}): "
+        f"total={total_count}, passed={passed_count}, "
+        f"unclassified={unclassified_count}, mismatched={mismatched_count}"
+    )
     return filtered_suite
 
 def is_navi3_arch():
@@ -1480,6 +1494,8 @@ def run_tests(argv=None):
             raise AssertionError("Some test shards have failed")
     elif USE_PYTEST:
         pytest_args = argv + ["--use-main-module"]
+        if HW_CLASSIFICATION is not None:
+            pytest_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
         test_report_path = ""
         if TEST_SAVE_XML:
             test_report_path = get_report_path(pytest=True)


### PR DESCRIPTION
## Summary

This PR introduces hardware classification for PyTorch test classes.

Tests can now explicitly declare their hardware classification through a `hw_classification` class attribute, and users can filter which categories of tests to run via `--hw-classification`.

When `--hw-classification` is not specified, all existing test discovery and execution paths remain unchanged.

---



## Changes

### Hardware classification

Added `HardwareClassification` with three categories:

- `GENERIC`
- `DEVICE_GENERIC`
- `CPU`, `CUDA`, `XPU`, `MPS` — specific built-in device types

### Test filtering

Added `--hw-classification` support across unittest, pytest, subprocess, parallel, XML, repeat, and `run_test.py` execution paths. Filtering is implemented through:

- `HardwareClassificationTestLoader`
- `HardwareClassificationPytestPlugin`
- `_filter_suite_by_hw_classification()`

### Tests

Added unit tests in `test/test_testing.py` covering:

- hardware classification filtering
- inherited hw classification metadata

### Initial rollout

Annotated test classes in `test/profiler/test_memory_profiler.py` to validate the rollout and provide an initial set of classified tests.

---



## Test Plan

Verified on CUDA



`python test/test_testing.py -v -k 'TestHardwareClassifications'`

```bash
----------------------------------------------------------------------
Ran 4 tests in 0.006s

OK
```





Validated the feature using hardware classification annotations in `test/profiler/test_memory_profiler.py`: 

(34 total test methods: 20 GENERIC + 14 DEVICE_GENERIC)



Verified:

- `GENERIC` runs 20 tests
- `DEVICE_GENERIC` runs 14 tests
- combined `GENERIC` + `DEVICE_GENERIC` runs 34 tests
- unmatched filters run 0 tests

Verified the filter works across the main execution paths:

- direct unittest execution
- pytest / `--use-pytest`
- `python -m pytest`
- `run_test.py` forwarding
- repeat mode
- parallel mode
- XML output



Commands: 

```bash
# direct unittest execution
python test/profiler/test_memory_profiler.py --hw-classification GENERIC

# pytest / --use-pytest
python test/profiler/test_memory_profiler.py --use-pytest --hw-classification GENERIC

# python -m pytest
python -m pytest test/profiler/test_memory_profiler.py --hw-classification GENERIC -v

# run_test.py forwarding
python test/run_test.py -i profiler/test_memory_profiler --hw-classification GENERIC

# repeat mode
python test/profiler/test_memory_profiler.py --repeat 2 --hw-classification GENERIC

# parallel mode
python test/profiler/test_memory_profiler.py --run-parallel 2 --hw-classification GENERIC

# XML output
python test/profiler/test_memory_profiler.py --save-xml /tmp/test_xml2 --hw-classification GENERIC

# unmatched filter (0 tests)
python test/profiler/test_memory_profiler.py --hw-classification CUDA

# combined filter (all tests)
python test/profiler/test_memory_profiler.py --hw-classification GENERIC DEVICE_GENERIC
```



