### PR TITLE
Remove stale expectedFailure markers for SM90 in test_flex_flash

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -908,10 +908,6 @@ GQA_MQA_BLOCK_MASK_CASES = [
 class TestFlexFlash(InductorTestCase):
     # `FlashAttentionForwardSm120` does not have `apply_score_mod`.
     @xfailIfSM120OrLater
-    @decorateIf(
-        unittest.expectedFailure,
-        lambda params: params["case"].requires_grad and IS_SM90,
-    )
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", SCORE_MOD_CASES, name_fn=score_case_name)
     def test_flash_attention_score_mod_cases(self, device, dtype, case):
@@ -2470,14 +2466,12 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
             self._flash_triton_dynamic(q, k, v)
 
     @xfailIfSM120OrLater
-    @xfailIfSM90
     def test_dynamic_backward(self):
         """Test backward with dynamic sequence lengths."""
         self._run_dynamic_test(seq_lens=[128, 256, 512], requires_grad=True)
 
     # 'FlashAttentionForwardSm120' object has no attribute 'apply_score_mod'
     @xfailIfSM120OrLater
-    @xfailIfSM90
     def test_dynamic_backward_with_score_mod(self):
         """Test backward with score_mod and dynamic sequence lengths."""
 
@@ -2715,7 +2709,6 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
         self.assertEqual(out.shape, q.shape)
 
     @xfailIfSM120OrLater
-    @xfailIfSM90
     def test_dynamic_captured_buffer_varying_heads(self):
         """Dynamic head_count with captured tensor buffer under FLASH/TRITON parity."""
         torch._dynamo.reset()

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_cuda import (
     SM90OrLater,
     xfailIfSM120OrLater,
     xfailIfSM12X,
-    xfailIfSM90,
 )
 from torch.testing._internal.common_device_type import (
     dtypes,


### PR DESCRIPTION
Test result on H100:
```
root@0b28eef4a683:/opt/pytorch/pytorch# pytest test/inductor/test_flex_flash.py -k "test_flash_attention_score_mod_cases or test_dynamic_backward or test_dynamic_backward_with_score_mod or test_dynamic_captured_buffer_varying_heads"
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.12.3, pytest-7.3.2, pluggy-1.6.0
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /opt/pytorch/pytorch
configfile: pytest.ini
plugins: hypothesis-6.56.4, xdoctest-1.3.0, cpp-2.3.0, xdist-3.3.1, rerunfailures-14.0, subtests-0.13.1, benchmark-5.2.3, anyio-4.13.0, mpi-0.6, flakefinder-1.1.0
collected 250 items / 178 deselected / 72 selected                                                                                                                             
Running 72 items in this shard

test/inductor/test_flex_flash.py ........................................................................                                                                [100%]

================================================================ 72 passed, 178 deselected in 420.36s (0:07:00) ================================================================
```

cc: @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo