### PR TITLE
[fx] fix _patch_function using wrong function when forward is wrapped

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2456,6 +2456,26 @@ class TestFX(JitTestCase):
         x, w = torch.rand(3, 4), torch.rand(4, 4)
         self.assertTrue(any(n.target == torch.relu for n in traced.graph.nodes))
 
+    def test_wrapped_method_with_kwargs(self):
+        def foo():
+            def wrapped_fn(func):
+                @functools.wraps(func)
+                def wrapper(self, *args, **kwargs):
+                    return func(self, *args, **kwargs)
+                return wrapper
+            return wrapped_fn
+
+        class MyModule(torch.nn.Module):
+            @foo()
+            def forward(self, x, a, **kwargs):
+                return torch.relu(x + a)
+
+        tracer = torch.fx.Tracer()
+        graph = tracer.trace(MyModule())
+        gm = torch.fx.GraphModule(MyModule(), graph)
+        x, a = torch.rand(3), torch.rand(3)
+        self.assertEqual(gm(x, a), torch.relu(x + a))
+
     def test_empty_graph_codegen(self):
         graph = torch.fx.Graph()
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -37,8 +37,9 @@ from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.operator_schemas import get_signature_for_torch_op
 from copy import deepcopy
 from collections import namedtuple
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypeVar
 from collections.abc import Callable
+from typing_extensions import ParamSpec
 
 import torch
 
@@ -168,6 +169,17 @@ def my_decorator(f):
         return f(*args, **kwargs)
 
     return wrapper_inside_decorator
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _passthrough_decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
+    @functools.wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        return func(*args, **kwargs)
+    return wrapper
 
 
 @wrap
@@ -2457,24 +2469,53 @@ class TestFX(JitTestCase):
         self.assertTrue(any(n.target == torch.relu for n in traced.graph.nodes))
 
     def test_wrapped_method_with_kwargs(self):
-        def foo():
-            def wrapped_fn(func):
-                @functools.wraps(func)
-                def wrapper(self, *args, **kwargs):
-                    return func(self, *args, **kwargs)
-                return wrapper
-            return wrapped_fn
-
         class MyModule(torch.nn.Module):
-            @foo()
+            @_passthrough_decorator
             def forward(self, x, a, **kwargs):
                 return torch.relu(x + a)
 
         tracer = torch.fx.Tracer()
-        graph = tracer.trace(MyModule())
-        gm = torch.fx.GraphModule(MyModule(), graph)
+        model = MyModule()
+        graph = tracer.trace(model)
+        gm = torch.fx.GraphModule(tracer.root, graph)
         x, a = torch.rand(3), torch.rand(3)
         self.assertEqual(gm(x, a), torch.relu(x + a))
+        self.assertEqual(gm(x, a, extra=1), torch.relu(x + a))
+
+    def test_wrapped_method_with_varargs(self):
+        class MyModule(torch.nn.Module):
+            @_passthrough_decorator
+            def forward(self, x, *args):
+                return torch.relu(x)
+
+        tracer = torch.fx.Tracer()
+        model = MyModule()
+        graph = tracer.trace(model)
+        gm = torch.fx.GraphModule(tracer.root, graph)
+        x = torch.rand(3)
+        self.assertEqual(gm(x), torch.relu(x))
+        self.assertEqual(gm(x, torch.rand(3)), torch.relu(x))
+
+    def test_wrapped_method_with_kwargs_wrapper_not_traced(self):
+        def wrap_with_relu(fn):
+            @functools.wraps(fn)
+            def wrapper(self, *args, **kwargs):
+                return torch.relu(fn(self, *args, **kwargs))
+            return wrapper
+
+        class MyModule(torch.nn.Module):
+            @wrap_with_relu
+            def forward(self, x, a, **kwargs):
+                return x + a
+
+        tracer = torch.fx.Tracer()
+        model = MyModule()
+        graph = tracer.trace(model)
+        gm = torch.fx.GraphModule(tracer.root, graph)
+        x, a = torch.rand(3), torch.rand(3)
+        self.assertEqual(gm(x, a), x + a)
+        self.assertEqual(gm(x, a, extra=1), x + a)
+        self.assertFalse(any(n.target == torch.relu for n in gm.graph.nodes))
 
     def test_empty_graph_codegen(self):
         graph = torch.fx.Graph()

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -733,7 +733,7 @@ class Tracer(TracerBase):
                 args.append(proxy_placeholder("*" + next(names_iter)))
             if co.co_flags & inspect.CO_VARKEYWORDS:
                 args.append(proxy_placeholder("**" + next(names_iter)))
-            root_fn = _patch_function(root_fn, len(args))
+            root_fn = _patch_function(fn_for_analysis, len(args))
 
         flat_args, in_spec = pytree.tree_flatten(tuple(args))
         if not all(child.is_leaf() for child in in_spec.children()):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -733,6 +733,14 @@ class Tracer(TracerBase):
                 args.append(proxy_placeholder("*" + next(names_iter)))
             if co.co_flags & inspect.CO_VARKEYWORDS:
                 args.append(proxy_placeholder("**" + next(names_iter)))
+            # Use fn_for_analysis as the base for patching, not root_fn:
+            # when root_fn is a functools.wraps wrapper its co_varnames
+            # covers only its own (*args, **kwargs) parameters, which are
+            # fewer than the named args derived from fn_for_analysis.
+            # Patching root_fn would violate the CPython invariant
+            # len(co_varnames) >= co_argcount. root_fn is intentionally
+            # reassigned to the patched inner function; any behavior added
+            # by the wrapper is not traced when forward has variadic args.
             root_fn = _patch_function(fn_for_analysis, len(args))
 
         flat_args, in_spec = pytree.tree_flatten(tuple(args))


### PR DESCRIPTION
## Summary

`create_args_for_root` uses `inspect.unwrap(root_fn)` to get `fn_for_analysis` (the innermost callable) and derives argument count and names from its code object. When `forward` has variadic arguments (`*args` or `**kwargs`), it then calls `_patch_function(root_fn, len(args))` — but `root_fn` is the outer wrapper, whose `co_varnames` only covers its own `(self, *args, **kwargs)` parameters. Setting `co_argcount` to a larger value derived from the unwrapped signature violates the CPython invariant `len(co_varnames) >= co_argcount`:

```
ValueError: code: co_varnames is too small
```

Pass `fn_for_analysis` instead of `root_fn` to `_patch_function`, consistent with every other use of signature information in the same function.

Fixes #171981
Fixes #163312
Fixes #149497

## Test plan

```bash
python test/test_fx.py -k test_wrapped_method -v  # new regression test passes
python test/test_fx.py                             # all 1858 tests pass
python test/test_fx_experimental.py               # all 1409 tests pass
python test/test_fx_passes.py                      # all 55 tests pass
python test/test_fx_graph_print.py                 # all 9 tests pass
```