### PR TITLE
[TEST][CUDA] Query available memory in `test_out_of_memory_retry`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -628,13 +628,13 @@ print(t.is_pinned())
     @serialTest()
     def test_out_of_memory_retry(self):
         torch.cuda.empty_cache()
-        total_memory = torch.cuda.get_device_properties(0).total_memory
+        available_memory = torch.cuda.mem_get_info(0)[0]
         oom_regex = (
             "would exceed allowed memory"
             if TEST_CUDAMALLOCASYNC
             else "Tried to allocate"
         )
-        size = int(total_memory * 0.5)
+        size = int(available_memory * 0.5)
         a = torch.empty(size, dtype=torch.int8, device="cuda")
         with self.assertRaisesRegex(RuntimeError, oom_regex):
             b = torch.empty(size, dtype=torch.int8, device="cuda")


### PR DESCRIPTION
Per title. Since the test script attempts to allocate a large tensor of the size of the half of total system memory, it may OOM at the first `torch.empty` call:
https://github.com/pytorch/pytorch/blob/d2bb2b5948498b1cf797b20daa18a136198650f8/test/test_cuda.py#L638
Causing the test to fail. This is especially true when the `per_process_memory_fraction`  is set close to 50% of system memory:
```bash
export PYTORCH_CUDA_ALLOC_CONF="per_process_memory_fraction:0.5"
pytest test_cuda.py -v test_out_of_memory_retry
```