### PR TITLE
[TMA] Fix persistent reduction store bypassing 16-byte minimum check

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1719,7 +1719,10 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
             torch.compile(fn), x, running_mean, running_var, weight, bias
         )
         expected = fn(x, running_mean, running_var, weight, bias)
-        self.assertTrue(torch.allclose(result[0], expected[0], atol=1e-5))
+        self.assertEqual(result, expected)
+        # The store must fall back to scalar indexing, not TMA.
+        self.assertIn("tl.store", code)
+        self.assertNotIn("make_tensor_descriptor", code)
 
     def test_bool_dtype_skips_tma(self):
         """

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1695,6 +1695,32 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         actual = torch.compile(f)(x)
         self.assertEqual(actual, expected)
 
+    def test_persistent_reduction_store_small_rblock_skips_tma(self):
+        """
+        When a persistent reduction has rnumel < 16/element_size, the fixed
+        R0_BLOCK cannot satisfy TMA's 16-byte minimum.  The store must fall
+        back to scalar indexing instead of emitting an invalid descriptor.
+        """
+
+        def fn(x, running_mean, running_var, weight, bias):
+            return torch.nn.functional.batch_norm(
+                x, running_mean, running_var, weight, bias, training=True
+            )
+
+        # Input (2, 1): reduction over batch dim of size 2.
+        # R0_BLOCK = next_power_of_2(2) = 2, so 2 * 4 bytes = 8 < 16.
+        x = torch.randn(2, 1, device=GPU_TYPE)
+        weight = torch.randn(1, device=GPU_TYPE)
+        bias = torch.randn(1, device=GPU_TYPE)
+        running_mean = torch.randn(1, device=GPU_TYPE)
+        running_var = torch.randn(1, device=GPU_TYPE).abs()
+
+        result, (code,) = run_and_get_code(
+            torch.compile(fn), x, running_mean, running_var, weight, bias
+        )
+        expected = fn(x, running_mean, running_var, weight, bias)
+        self.assertTrue(torch.allclose(result[0], expected[0], atol=1e-5))
+
     def test_bool_dtype_skips_tma(self):
         """
         torch.bool buffers map to Triton tl.int1 which has no

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2999,7 +2999,6 @@ class TMACompatibilityChecker:
         # and in that case we should fall back to the generic analysis below.
         if (
             self.kernel.persistent_reduction
-            and not self.for_store
             and innermost_block_symt in TritonSymbols.reduction_types
         ):
             # For a discontiguous tensor, a 1D block will be split across several
@@ -3034,7 +3033,7 @@ class TMACompatibilityChecker:
                 innermost_block_bytes, sympy.Integer(16)
             ):
                 log.debug(
-                    "%s persistent reduction innermost block shape cannot load 16 bytes. Block shape: %s, persistent RBLOCK: %d",
+                    "%s persistent reduction innermost block shape cannot transfer 16 bytes. Block shape: %s, persistent RBLOCK: %d",
                     self.failed_debug_prefix,
                     block_params.block_shape,
                     persistent_rblock,


### PR DESCRIPTION
The persistent-reduction path in TMACompatibilityChecker.are_block_parameters_compatible() checks whether persistent_rblock * element_size >= 16 and rejects TMA when the block is too small. However, this check was gated on `not self.for_store`, meaning stores were excluded.

For stores in persistent-reduction kernels where the innermost block is a reduction type (e.g. R0_BLOCK), the code fell through to the generic else branch which recorded min_block_size in tma_min_block_sizes -- expecting the autotuner to enforce it. But persistent reduction blocks are fixed at compile time via _get_persistent_RBLOCK() (next_power_of_2(rnumel)), so the autotuner never constrains them.

When rnumel is small (e.g. batch_norm on input (2, 1) reduces over batch dim=2), R0_BLOCK=2 and 2*4=8 bytes < 16, causing Triton to throw:
  "Descriptor block shape must have at least 16 bytes in the last dimension"

The fix removes `not self.for_store` so both loads and stores go through the persistent-reduction path and correctly fall back to non-TMA when the fixed block size cannot meet the 16-byte minimum.

Test Plan:

```bash

python -m pytest test/inductor/test_torchinductor_strided_blocks.py::TritonTensorDescriptorTestCUDA::test_persistent_reduction_store_small_rblock_skips_tma -xvs

```

Co-authored with an AI assistant.

cc: @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo