### PR TITLE
Skip `test_int8_woq_mm` when MKLDNN-ACL is enabled

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     requires_mkl,
     requires_onednn,
+    TEST_ACL,
     TEST_MKL,
     xfailIf,
 )
@@ -1722,9 +1723,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @unittest.skipIf(
         IS_ARM64 and not IS_CPU_EXT_SVE_SUPPORTED, "flaky on AArch64 (no SVE)"
     )
-    @unittest.skipIf(
-        torch.ops.mkldnn._is_mkldnn_acl_supported(), "OP fusion disabled with ACL"
-    )
+    @unittest.skipIf(TEST_ACL, "OP fusion disabled with ACL")
     def test_int8_woq_mm(self, dtype, batch_size, mid_dim, in_features, out_features):
         def _convert_weight_to_int8pack(w):
             scale, zp = _calculate_dynamic_per_channel_qparams(

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -1722,6 +1722,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @unittest.skipIf(
         IS_ARM64 and not IS_CPU_EXT_SVE_SUPPORTED, "flaky on AArch64 (no SVE)"
     )
+    @unittest.skipIf(
+        torch.ops.mkldnn._is_mkldnn_acl_supported(), "OP fusion disabled with ACL"
+    )
     def test_int8_woq_mm(self, dtype, batch_size, mid_dim, in_features, out_features):
         def _convert_weight_to_int8pack(w):
             scale, zp = _calculate_dynamic_per_channel_qparams(


### PR DESCRIPTION
The fusion tested is skipped in `_mkldnn_fusion_init`.

See comment: https://github.com/pytorch/pytorch/blob/d2bb2b5948498b1cf797b20daa18a136198650f8/torch/_inductor/fx_passes/mkldnn_fusion.py#L1567-L1568

And:
https://github.com/pytorch/pytorch/blob/d2bb2b5948498b1cf797b20daa18a136198650f8/torch/_inductor/fx_passes/mkldnn_fusion.py#L1575

We've seen this failing when adding ACL for NVIDIA Grace builds

Followup to https://github.com/pytorch/pytorch/pull/177387
See https://github.com/pytorch/pytorch/issues/146914

I see 2 different failures:
1. For `in_features=1024` it fails with large differences (absolutes of 0.015625 to 0.03125)
2. For others it fails the `counters["inductor"]["cpp_templated_kernel_counter"]` check (stays 0)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo