### PR TITLE
fix: handle Bernoulli boundary log probs

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1540,6 +1540,22 @@ class TestDistributions(DistributionsTestCase):
 
         self._check_log_prob(Bernoulli(p), ref_log_prob)
         self._check_log_prob(Bernoulli(logits=p.log() - (-p).log1p()), ref_log_prob)
+        for dtype in (torch.float32, torch.float64):
+            value = torch.tensor([0.0, 1.0, 0.0, 1.0], dtype=dtype)
+            expected = torch.tensor([0.0, -inf, -inf, 0.0], dtype=dtype)
+
+            self.assertEqual(
+                Bernoulli(torch.tensor([0.0, 0.0, 1.0, 1.0], dtype=dtype)).log_prob(
+                    value
+                ),
+                expected,
+            )
+            self.assertEqual(
+                Bernoulli(
+                    logits=torch.tensor([-inf, -inf, inf, inf], dtype=dtype)
+                ).log_prob(value),
+                expected,
+            )
         self.assertRaises(NotImplementedError, Bernoulli(r).rsample)
 
         # check entropy computation
@@ -6133,9 +6149,7 @@ class TestNumericalStability(DistributionsTestCase):
                 dist_class=Bernoulli,
                 probs=tensor_type([0]),
                 x=tensor_type([1]),
-                expected_value=tensor_type(
-                    [torch.finfo(tensor_type([]).dtype).eps]
-                ).log(),
+                expected_value=tensor_type([-inf]),
                 expected_gradient=tensor_type([0]),
             )
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -122,7 +122,26 @@ class Bernoulli(ExponentialFamily):
         if self._validate_args:
             self._validate_sample(value)
         logits, value = broadcast_all(self.logits, value)
-        return -binary_cross_entropy_with_logits(logits, value, reduction="none")
+        log_prob = -binary_cross_entropy_with_logits(logits, value, reduction="none")
+
+        boundary_param = self.__dict__.get("probs", logits)
+        boundary_param, value = broadcast_all(boundary_param, value)
+        if "probs" in self.__dict__:
+            probs_zero = boundary_param == 0
+            probs_one = boundary_param == 1
+        else:
+            probs_zero = boundary_param == -torch.inf
+            probs_one = boundary_param == torch.inf
+
+        return torch.where(
+            (probs_zero & (value == 1)) | (probs_one & (value == 0)),
+            -torch.inf,
+            torch.where(
+                (probs_zero & (value == 0)) | (probs_one & (value == 1)),
+                torch.zeros((), dtype=log_prob.dtype, device=log_prob.device),
+                log_prob,
+            ),
+        )
 
     def entropy(self):
         return binary_cross_entropy_with_logits(


### PR DESCRIPTION
## Summary

- make `Bernoulli.log_prob` return exact boundary values for p=0 and p=1
- return `0` for the matching boundary event and `-inf` for the impossible event
- cover both `probs=` and `logits=±inf` construction paths in the distributions test

Fixes #186825

## To verify

- `python -m py_compile torch\distributions\bernoulli.py test\distributions\test_distributions.py`
- `git diff --check`
- loaded the patched `torch/distributions/bernoulli.py` outside the source checkout with the installed torch package and checked float32/float64 boundary cases for both `probs=` and `logits=` constructors

I could not run the official PyTorch test entrypoint from this source checkout because this worktree is not built; importing `torch` from the checkout fails at `ModuleNotFoundError: No module named 'torch.version'`.

cc @fritzo @neerajprad @alicanb @nikitaved