### PR TITLE
Fail fast loading CUDA AOTI packages without CUDA

### DIFF
--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -1,10 +1,17 @@
 # Owner(s): ["oncall: export"]
+import json
+import sys
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 import torch
 from torch._dynamo.eval_frame import is_dynamo_supported
+from torch._inductor.package import load_package
 from torch.export import Dim
 from torch.export.experimental import _ExportPackage
+from torch.export.pt2_archive._package import _load_aoti
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -88,6 +95,76 @@ class TestPackage(TestCase):
         self.assertEqual(exporter(x3), x3 + 2)
         self.assertEqual(len(package.methods), 1)
         self.assertEqual(len(package.methods["fn"].overloads), 3)
+
+
+class TestAOTIPackageDeviceValidation(TestCase):
+    def test_aoti_load_uses_cpp_device_validation_before_device_info(self):
+        class FakeAOTIModelPackageLoader:
+            @staticmethod
+            def load_metadata_from_package(file, model_name):
+                return {"AOTI_DEVICE_KEY": "cuda"}
+
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError(
+                    "Cannot load AOTInductor package for device 'cuda' because "
+                    "CUDA is not available in this process."
+                )
+
+        with (
+            mock.patch.object(
+                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoader
+            ),
+            mock.patch("torch._inductor.codecache.get_device_information") as get_info,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot load AOTInductor package.*CUDA is not available",
+            ):
+                _load_aoti("model.pt2", "model", False, 1, -1)
+
+            get_info.assert_not_called()
+
+    def test_load_package_does_not_fallback_on_device_validation_error(self):
+        class FakeAOTIModelPackageLoader:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("AOTI fallback loader should not be constructed")
+
+        with (
+            mock.patch(
+                "torch._inductor.package.package.load_pt2",
+                side_effect=RuntimeError(
+                    "Cannot load AOTInductor package for device 'cuda' because "
+                    "CUDA is not available in this process."
+                ),
+            ),
+            mock.patch.object(
+                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoader
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot load AOTInductor package.*CUDA is not available",
+            ):
+                load_package("model.pt2")
+
+    @unittest.skipIf(
+        torch.cuda.is_available(), "requires CUDA to be unavailable in this process"
+    )
+    def test_cpp_aoti_package_loader_validates_cuda_availability(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp) / "data" / "aotinductor" / "model"
+            model_dir.mkdir(parents=True)
+            extension = ".pyd" if sys.platform == "win32" else ".so"
+            (model_dir / f"model{extension}").touch()
+            (model_dir / "model_metadata.json").write_text(
+                json.dumps({"AOTI_DEVICE_KEY": "cuda"}), encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot load AOTInductor package.*(CUDA|ROCm) is not available",
+            ):
+                torch._C._aoti.AOTIModelPackageLoader(str(tmp), "model", False, 1, -1)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -18,6 +18,7 @@ from torch.types import FileLike
 
 
 log = logging.getLogger(__name__)
+AOTI_PACKAGE_DEVICE_ERROR = "Cannot load AOTInductor package for device"
 
 
 def compile_so(aoti_dir: str, aoti_files: list[str], so_path: str) -> str:
@@ -116,7 +117,9 @@ def load_package(
         if model_name not in pt2_contents.aoti_runners:
             raise RuntimeError(f"Model {model_name} not found in package")
         return pt2_contents.aoti_runners[model_name]
-    except RuntimeError:
+    except RuntimeError as e:
+        if AOTI_PACKAGE_DEVICE_ERROR in str(e):
+            raise
         log.warning("Loading outdated pt2 file. Please regenerate your package.")
 
     if isinstance(path, (io.IOBase, IO)):

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -1,5 +1,6 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
 
+#include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/FileSystem.h>
 #include <c10/util/error.h>
 #include <c10/util/string_view.h>
@@ -14,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <utility>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -451,6 +453,27 @@ std::unordered_set<std::string> find_model_names(
   return model_names;
 }
 
+void validate_package_device(
+    const std::unordered_map<std::string, std::string>& metadata) {
+  const auto device_key_iter = metadata.find("AOTI_DEVICE_KEY");
+  TORCH_CHECK(
+      device_key_iter != metadata.end() && !device_key_iter->second.empty(),
+      "No device information found.");
+
+  if (device_key_iter->second == "cuda") {
+#if defined(USE_ROCM)
+    const char* backend_name = "ROCm";
+#else
+    const char* backend_name = "CUDA";
+#endif
+    TORCH_CHECK(
+        at::detail::getCUDAHooks().getNumGPUs() > 0,
+        "Cannot load AOTInductor package for device 'cuda' because ",
+        backend_name,
+        " is not available in this process. Check that this host or container has GPU access, or compile/package the model for CPU.");
+  }
+}
+
 } // namespace
 
 void AOTIModelPackageLoader::load_metadata(const std::string& cpp_filename) {
@@ -698,12 +721,14 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
   return metadata;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 AOTIModelPackageLoader::AOTIModelPackageLoader(
     const std::string& model_package_path,
     const std::string& model_name,
     const bool run_single_threaded,
     const size_t num_runners,
-    const c10::DeviceIndex device_index) {
+    const c10::DeviceIndex device_index)
+    : runner_(nullptr), metadata_{} {
   if (run_single_threaded) {
     TORCH_CHECK(
         num_runners == 1,
@@ -891,17 +916,18 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
         found_filenames_str);
   }
 
+  // Load metadata which can be queried by user and validated before compiling
+  // source-only packages or constructing the device-specific runner.
+  load_metadata(!cpp_filename.empty() ? cpp_filename : so_filename);
+  validate_package_device(metadata_);
+
   // Compile the .so
   std::string so_path = !so_filename.empty()
       ? so_filename
       : compile_so(cpp_filename, obj_filenames);
 
-  // Load metadata which can be queried by user
-  load_metadata(!cpp_filename.empty() ? cpp_filename : so_path);
-
   // Construct the runner depending on the device information
   std::string device_key = metadata_["AOTI_DEVICE_KEY"];
-  TORCH_CHECK(!device_key.empty(), "No device information found.");
 
   std::unordered_map<std::string, CreateAOTIModelRunnerFunc>
       registered_aoti_runner = getAOTIModelRunnerRegistry();
@@ -946,6 +972,7 @@ std::vector<at::Tensor> AOTIModelPackageLoader::run(
 }
 
 std::vector<at::Tensor> AOTIModelPackageLoader::boxed_run(
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     std::vector<at::Tensor>&& inputs,
     void* stream_handle) {
   return runner_->boxed_run(std::move(inputs), stream_handle);

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1048,6 +1048,16 @@ def _load_aoti(
         file, model_name
     )
 
+    aoti_compiled_model = AOTICompiledModel(
+        torch._C._aoti.AOTIModelPackageLoader(
+            file,
+            model_name,
+            run_single_threaded,
+            num_runners,
+            device_idx,
+        )
+    )
+
     device = loaded_metadata["AOTI_DEVICE_KEY"]
     from torch._inductor.codecache import get_device_information
 
@@ -1063,16 +1073,6 @@ def _load_aoti(
                     v,
                     loaded_metadata[k],
                 )
-
-    aoti_compiled_model = AOTICompiledModel(
-        torch._C._aoti.AOTIModelPackageLoader(
-            file,
-            model_name,
-            run_single_threaded,
-            num_runners,
-            device_idx,
-        )
-    )
 
     return aoti_compiled_model
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #186943

AOTI package loading already reads wrapper metadata before constructing the runtime loader. For CUDA packages loaded in a process without visible CUDA hardware, the PT2 load path reached device metadata comparison and raised a plain RuntimeError from CUDA device probing. The public load_package wrapper then treated that as an outdated-package signal and fell back to the legacy C++ loader, which initialized lower-level CUDA/Triton runtime state and produced a much less actionable error.

Move the availability validation into AOTIModelPackageLoader itself, after metadata is loaded and before source-only compilation or runner construction. CUDA AOTI packages now fail fast with a clear PyTorch-side message when CUDA or ROCm is unavailable in the current process, including direct C++/pybind loader usage. The Python PT2 path now constructs the loader before device metadata comparison so the C++ validation owns the no-CUDA error, and load_package preserves that validation error instead of classifying it as an outdated archive.

I considered keeping the Python-side CUDA check, but the C++ loader is the shared boundary for Python fallback and direct C++ callers. Keeping validation there avoids duplicated availability logic while still preserving old-package fallback behavior for unrelated RuntimeError cases.

Fixes #145730
Generated by my agent

Test Plan:
- python test/export/test_package.py TestAOTIPackageDeviceValidation
- CUDA_VISIBLE_DEVICES= python test/export/test_package.py TestAOTIPackageDeviceValidation
- python test/export/test_package.py TestPackage.test_basic
- lintrunner -a
- git diff --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo