### PR TITLE
docker-builds: retry remote BuildKit connect on the autoscaled pool

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -333,7 +333,8 @@ if [[ -n "${REMOTE_BUILDKIT:-}" ]]; then
 fi
 
 # Build image
-docker buildx build \
+build_image() {
+  docker buildx build \
        ${progress_flag} \
        ${cache_flag} \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
@@ -371,6 +372,39 @@ docker buildx build \
        ${output_flag} \
        "$@" \
        .
+}
+
+if [[ -z "${REMOTE_BUILDKIT:-}" ]]; then
+  build_image "$@"
+else
+  # The autoscaled pool may be cold / at capacity at start, where buildx's ~20s
+  # connect (gRPC default) fails before scale-up. Retry connection failures (not
+  # build errors) for ~2h so a capacity-limited build waits for a free pod instead
+  # of hard-failing — still within the 240m job timeout.
+  attempts="${REMOTE_BUILDKIT_CONNECT_ATTEMPTS:-360}"
+  delay="${REMOTE_BUILDKIT_CONNECT_DELAY:-15}"
+  for attempt in $(seq 1 "${attempts}"); do
+    build_log="$(mktemp)"
+    set +e
+    build_image "$@" 2>&1 | tee "${build_log}"
+    rc="${PIPESTATUS[0]}"
+    set -e
+    if [[ "${rc}" -eq 0 ]]; then
+      rm -f "${build_log}"
+      break
+    fi
+    if [[ "${attempt}" -lt "${attempts}" ]] && grep -qiE \
+      "waiting for connection|context deadline exceeded|server preface|failed to (dial|list workers)|connection (refused|reset)|no such host|transport: Error|i/o timeout|use of closed network connection|EOF" \
+      "${build_log}"; then
+      echo "Remote BuildKit not ready yet (attempt ${attempt}/${attempts}); retrying in ${delay}s..." >&2
+      rm -f "${build_log}"
+      sleep "${delay}"
+      continue
+    fi
+    rm -f "${build_log}"
+    exit "${rc}"
+  done
+fi
 
 # NVIDIA dockers for RC releases use tag names like `11.0-cudnn9-devel-ubuntu18.04-rc`,
 # for this case we will set UBUNTU_VERSION to `18.04-rc` so that the Dockerfile could

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -110,11 +110,19 @@ jobs:
           username: pytorch
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: Set up Docker Buildx (remote)
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: remote
-          endpoint: ${{ matrix.buildkit_addr }}
+      - name: Set up Docker Buildx (remote, no bootstrap)
+        shell: bash
+        # NOT docker/setup-buildx-action: it runs `buildx inspect --bootstrap`,
+        # whose ~20s connect timeout fails on a cold/burst start before the
+        # autoscaled pool can add a pod. `create` (no --bootstrap) just registers
+        # the builder; build.sh retries the build to wait out scale-up.
+        run: |
+          set -ex
+          docker buildx create \
+            --name remote-buildkit \
+            --driver remote \
+            --use \
+            "${{ matrix.buildkit_addr }}"
 
       - name: Compute image tag
         id: tag


### PR DESCRIPTION
## Why

`docker-builds` builds on the OSDC remote BuildKit pool, which is **autoscaled** (small warm baseline, scales up on a burst). When a `ciflow/docker` burst hits a cold or at-capacity pool, a build's connection finds no free pod and is dropped after **~20s** — well before KEDA/Karpenter can add one (minutes).

That ~20s is **not** buildx-specific: the `moby/buildkit` Go client (used by `docker buildx` *and* `buildctl`) dials with gRPC's default `MinConnectTimeout` (~20s) and fail-fast RPCs, with no client-side flag to widen it. So no client choice fixes it — the client has to **retry**.

Two parts to the fix:
1. The workflow creates the remote builder with `docker buildx create … --driver remote` **without `--bootstrap`** — `docker/setup-buildx-action` runs `buildx inspect --bootstrap`, which hits the same 20s gate at setup time.
2. `build.sh` retries `docker buildx build` on connection/boot failures until a pod is free (real build errors are not retried; the registry build cache makes any re-run skip completed layers). The repeated attempts also keep the autoscaler's load signal alive.

## What

- `.ci/docker/build.sh`: wrap the `docker buildx build` in `build_image()` and, when `REMOTE_BUILDKIT` is set, retry it on connection failures (tunable via `REMOTE_BUILDKIT_CONNECT_ATTEMPTS`/`_DELAY`). Local builds unchanged.
- `.github/workflows/docker-builds.yml`: replace `setup-buildx-action` with a manual no-bootstrap `docker buildx create`.
