### PR TITLE
[ROCm] Fix layer_norm fallback launch limit

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1156,6 +1156,39 @@ void LayerNormKernelImplInternal(
     launch_vectorized_layer_norm_kernel<T, T_ACC, rms_norm>(static_cast<int>(N), M, eps, X_data, gamma_data, beta_data, Y_data, mean_data, rstd_data);
   } else {
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
+#ifdef USE_ROCM
+  // ROCm rejects launches where gridDim.x * blockDim.x exceeds uint32_t max.
+  // Chunk the non-vectorized fallback just like the vectorized path above.
+  constexpr int64_t max_rowwise_blocks =
+      std::numeric_limits<uint32_t>::max() / cuda_utils::kCUDABlockReduceNumThreads;
+
+  int64_t remaining = M;
+  const T* X_data_cur = X_data;
+  T* Y_data_cur = Y_data;
+  T_ACC* mean_data_cur = mean_data;
+  T_ACC* rstd_data_cur = rstd_data;
+
+  while (remaining > 0) {
+    const int64_t rows = remaining > max_rowwise_blocks ? max_rowwise_blocks : remaining;
+    const dim3 blocks(static_cast<uint32_t>(rows));
+
+    RowwiseMomentsCUDAKernel<T, T_ACC, rms_norm>
+        <<<blocks, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
+            N, eps, X_data_cur, mean_data_cur, rstd_data_cur);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    LayerNormForwardCUDAKernel<T, T_ACC, rms_norm><<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
+        N, X_data_cur, mean_data_cur, rstd_data_cur, gamma_data, beta_data, Y_data_cur);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    X_data_cur += N * rows;
+    Y_data_cur += N * rows;
+    if constexpr (!rms_norm) {
+      mean_data_cur += rows;
+    }
+    rstd_data_cur += rows;
+    remaining -= rows;
+  }
+#else
   RowwiseMomentsCUDAKernel<T, T_ACC, rms_norm>
       <<<M, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
           N, eps, X_data, mean_data, rstd_data);
@@ -1163,6 +1196,7 @@ void LayerNormKernelImplInternal(
   LayerNormForwardCUDAKernel<T, T_ACC, rms_norm><<<M, kCUDANumThreads, 0, cuda_stream>>>(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+#endif
   }
 }
 

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -54,6 +54,7 @@ bool can_vectorize(const T * ptr, int alignment) {
 
 template <typename T, typename T_ACC, bool rms_norm>
 __global__ void RowwiseMomentsCUDAKernel(
+    int64_t M,
     int64_t N,
     T_ACC eps,
     const T* X,
@@ -67,7 +68,12 @@ __global__ void RowwiseMomentsCUDAKernel(
       char val_shared[sizeof(WelfordType) * C10_WARP_SIZE_UPPER_BOUND];
   WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
 
+#if defined(USE_ROCM)
+  for (int64_t i = blockIdx.x; i < M; i += gridDim.x) {
+#else
+  (void)M;
   const int64_t i = blockIdx.x;
+#endif
   WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};
   WelfordType val(0, 0, 0, 0);
 
@@ -91,10 +97,14 @@ __global__ void RowwiseMomentsCUDAKernel(
     }
 
   }
+#if defined(USE_ROCM)
+  }
+#endif
 }
 
 template <typename T, typename T_ACC, bool rms_norm>
 __global__ void LayerNormForwardCUDAKernel(
+    int64_t M,
     int64_t N,
     const T* X,
     const T_ACC* mean,
@@ -102,7 +112,12 @@ __global__ void LayerNormForwardCUDAKernel(
     const T* gamma,
     const T* beta,
     T* Y) {
+#if defined(USE_ROCM)
+  for (int64_t i = blockIdx.x; i < M; i += gridDim.x) {
+#else
+  (void)M;
   const int64_t i = blockIdx.x;
+#endif
   for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
     const int64_t index = i * N + j;
     const T_ACC gamma_v =
@@ -117,6 +132,9 @@ __global__ void LayerNormForwardCUDAKernel(
       Y[index] = (static_cast<T_ACC>(X[index])) * static_cast<T_ACC>(rstd[i]) * gamma_v;
     }
   }
+#if defined(USE_ROCM)
+  }
+#endif
 }
 
 struct WelfordDataLN{
@@ -1158,43 +1176,24 @@ void LayerNormKernelImplInternal(
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
 #ifdef USE_ROCM
   // ROCm rejects launches where gridDim.x * blockDim.x exceeds uint32_t max.
-  // Chunk the non-vectorized fallback just like the vectorized path above.
+  // Bound the fallback launch and let each block stride over remaining rows.
   constexpr int64_t max_rowwise_blocks =
       std::numeric_limits<uint32_t>::max() / cuda_utils::kCUDABlockReduceNumThreads;
-
-  int64_t remaining = M;
-  const T* X_data_cur = X_data;
-  T* Y_data_cur = Y_data;
-  T_ACC* mean_data_cur = mean_data;
-  T_ACC* rstd_data_cur = rstd_data;
-
-  while (remaining > 0) {
-    const int64_t rows = remaining > max_rowwise_blocks ? max_rowwise_blocks : remaining;
-    const dim3 blocks(static_cast<uint32_t>(rows));
-
-    RowwiseMomentsCUDAKernel<T, T_ACC, rms_norm>
-        <<<blocks, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
-            N, eps, X_data_cur, mean_data_cur, rstd_data_cur);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    LayerNormForwardCUDAKernel<T, T_ACC, rms_norm><<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
-        N, X_data_cur, mean_data_cur, rstd_data_cur, gamma_data, beta_data, Y_data_cur);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-    X_data_cur += N * rows;
-    Y_data_cur += N * rows;
-    if constexpr (!rms_norm) {
-      mean_data_cur += rows;
-    }
-    rstd_data_cur += rows;
-    remaining -= rows;
-  }
+  const dim3 blocks(static_cast<uint32_t>(std::min(M, max_rowwise_blocks)));
+  RowwiseMomentsCUDAKernel<T, T_ACC, rms_norm>
+      <<<blocks, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
+          M, N, eps, X_data, mean_data, rstd_data);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  LayerNormForwardCUDAKernel<T, T_ACC, rms_norm><<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
+      M, N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 #else
   RowwiseMomentsCUDAKernel<T, T_ACC, rms_norm>
       <<<M, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
-          N, eps, X_data, mean_data, rstd_data);
+          M, N, eps, X_data, mean_data, rstd_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   LayerNormForwardCUDAKernel<T, T_ACC, rms_norm><<<M, kCUDANumThreads, 0, cuda_stream>>>(
-      N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
+      M, N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 #endif
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7857,6 +7857,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             ref = torch.layer_norm(x[row:row + 1], [N], gamma, beta)
             self.assertEqual(y[row], ref[0])
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @largeTensorTest("1GB", device="cuda")
+    def test_layer_norm_large_m_non_vectorized(self):
+        # test for https://github.com/pytorch/pytorch/issues/184826
+        # N is intentionally not divisible by 4 so the vectorized kernel is skipped.
+        N = 3
+        gamma = torch.ones(N, dtype=torch.float32, device="cuda")
+
+        for M in (2**23, 2**23 + 1):
+            x = torch.randn(M, N, dtype=torch.float32, device="cuda")
+            y = torch.layer_norm(x, [N], gamma, None)
+
+            for start in (0, M - 8192):
+                x_chunk = x[start:start + 8192].contiguous()
+                ref = torch.layer_norm(x_chunk, [N], gamma, None)
+                self.assertEqual(y[start:start + 8192], ref, atol=1e-5, rtol=1e-5)
+
     def test_padding_list(self):
         # Padding can be a list, or tuple (regression test for gh-54452)
         x = torch.randn(4, 8, 32, 32)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/184826

## Summary
- Bound the ROCm non-vectorized `layer_norm` fallback launch so `gridDim.x * blockDim.x` stays within HIP's launch limit.
- Use an in-kernel grid-stride loop over rows for the ROCm fallback, following the same style as prior ROCm launch-limit fixes in `roll` and `triu`/`tril`.
- Keep the existing CUDA fallback launch path unchanged.
- Preserve existing vectorized path behavior while covering `C % 4 != 0` cases that skip vectorization.
- Add a regression unit test for the large-`M`, non-vectorized `layer_norm` path.

## Alternatives considered
I first implemented host-side chunking, mirroring the existing vectorized `layer_norm` workaround. That fixed correctness, but it can require multiple rowwise and forward launches for large `M`.

I also evaluated the approach used by https://github.com/pytorch/pytorch/pull/169474 and https://github.com/pytorch/pytorch/pull/179717: bound the ROCm grid and let the kernel walk remaining work with a grid-stride loop. That also fixes correctness while preserving two fallback launches total.

On MI300X / ROCm 7.2, the grid-stride approach was comparable near the boundary and faster on the real failing shape:

| shape | M | N | host chunking median ms | grid-stride median ms |
| --- | ---: | ---: | ---: | ---: |
| boundary_n3 | 8,388,608 | 3 | 27.163 | 27.185 |
| over_boundary_n3 | 8,388,609 | 3 | 27.159 | 27.187 |
| over_boundary_n257 | 8,388,609 | 257 | 33.883 | 34.483 |
| over_boundary_n267 | 8,388,609 | 267 | 34.417 | 34.722 |
| real_n267 | 27,531,009 | 267 | 112.559 | 108.288 |
| real_n268_vectorized | 27,531,009 | 268 | 40.192 | 40.263 |

Given the real repro shape improves and the near-boundary cases are close, this PR uses the grid-stride row loop.

## Test plan
- Added `TestNN.test_layer_norm_large_m_non_vectorized` in `test/test_nn.py` to cover `M=2^23`, `M=2^23+1`, and `N=3` (`N % 4 != 0`).
- `python test/test_nn.py TestNN.test_layer_norm_large_m_non_vectorized`
- Verified previously failing cases now pass with `bad_rows=0`, including `M=2^23`, `M=2^23+1`, `C % 4 != 0`, and the real shape `M=5247*5247, C=267` on MI300X / ROCm 7.2.


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @manuelcandales @angelayi