### PR TITLE
CUDA 12 wheels: relax nvidia-nvjitlink-cu12 runtime dependency

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -57,12 +57,13 @@ CUDA_AARCH64_ARCHES = [
 # silently pulled in.
 PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
     "12.6": (
-        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.6.3; platform_system == 'Linux' | "
+        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvtx]==12.6.3; platform_system == 'Linux' | "
         "cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15' | "
         "nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | "
         "nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | "
         "nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | "
-        "nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+        "nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux' | "
+        "nvidia-nvjitlink-cu12>=12.6.85,<13; platform_system == 'Linux'"
     ),
     "13.0": (
         "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cufile,nvjitlink,nvtx]==13.0.2; platform_system == 'Linux' | "

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -151,7 +151,7 @@ jobs:
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda-aarch64-12_6"
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux' | nvidia-nvjitlink-cu12>=12.6.85,<13; platform_system == 'Linux'"
     steps:
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -152,7 +152,7 @@ jobs:
       DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda12_6"
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux' | nvidia-nvjitlink-cu12>=12.6.85,<13; platform_system == 'Linux'"
     steps:
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION

## Description

Proposes loosening the `nvidia-nvjitlink-cu12` dependency for CUDA 12.6 wheels.

```text
# before
cuda-toolkit[..., nvjitlink]==12.6.5

# after
cuda-toolkit[...]==12.6.5
nvidia-nvjitlink-cu12>=12.6.85,<13
```

## Motivation

Would allow `torch` CUDA 12.6 wheels to be installable alongside projects requiring a newer nvJitLink, without needing workarounds like `pip install --no-deps`.

My immediate motivation is for RAPIDS (https://github.com/rapidsai/build-planning/issues/289).

Today, they have conflicting dependencies.

> ERROR: Cannot install cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==12.6.3 and cuml-cu12==26.6.0 because these package versions have conflicting dependencies.
>
> The conflict is caused by:
>   cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx] 12.6.3 depends on nvidia-nvjitlink-cu12==12.6.85.*; (sys_platform == "linux" or sys_platform == "win32") and extra == "nvjitlink"
>   cuml-cu12 26.6.0 depends on nvidia-nvjitlink-cu12<13 and >=12.9

<details><summary>reproducible example (click me)</summary>

```shell
docker run \
  --rm \
  --gpus all \
  -v $(pwd):/opt/work \
  -w /opt/work \
  -it rapidsai/citestwheel:26.06-cuda12.9.1-ubuntu24.04-py3.13 \
  bash

pip install \
  --extra-index-url https://download.pytorch.org/whl/cu126 \
  'cuml-cu12==26.6.*' \
  'torch==2.12.0+cu126'
```

</details>

But this is generically useful... it allows projects to build wheels using NVCC and nvJitLink 12.9 (for example) that are still installable with `torch`'s official CUDA 12.6 wheels. 

Projects may prefer to build with a newer compiler toolchain, for example, to take advantage of Blackwell support that landed in CTK 12.8 (https://docs.nvidia.com/cuda/archive/12.8.0/cuda-toolkit-release-notes/index.html). Building with `libnvJitLink==12.x` imposes a runtime requirement of `libnvJitLink>=12.x`.

## Is this safe?

Yes. nvJitLink's docs make explicit minor version compatibility guarantees.

> _The nvJitLink library is compatible across minor versions in a release, but may not be compatible across major versions. The library version itself must be >= the maximum version of the inputs, and the shared library version must be >= the version that was linked with._

https://docs.nvidia.com/cuda/nvjitlink/index.html#compatibility

Objects built with nvJitLink 12.6.x will be safely and correctly handled by any later nvJitLink 12.x.

Examples of other projects depending on these guarantees:

* **`cuda-toolkit` wheels**
  - a floor like this is included in the `cuda-toolkit` wheels for versions 12.8.2, 12.9.2, 13.0.3, 13.1.2, 13.2.1+
* **CUDA toolkit on conda-forge**
  - this is how `libnvjitlink` has been packaged on `conda-forge` for a while
  - see @leofang's comments on https://github.com/conda-forge/libnvjitlink-feedstock/issues/15 and the things linked to it)
* **JAX**
  - builds its CUDA 12 wheels using CTK 12.1 and and ships with a runtime dependency `nvidia-nvjitlink-cu12>=12.1.105` ([jax-ml/jax](https://github.com/jax-ml/jax/blob/221b3053539482b51dd2271ee8c2899e6cb17426/build/nvidia-requirements.txt#L13))
* **`numba-cuda`**
  - uses a similar decoupling strategy as this PR proposes, and its CUDA 12 wheels depend on `nvidia-nvjitlink-cu12>=12.3` (https://github.com/NVIDIA/numba-cuda/pull/809)
* **RAPIDS (`cudf`, `cugraph-pyg`, `cuml`, `cuvs`, etc.)**
  - have been relying on these compatibility guarantees and explicitly testing them in wheels for a while (https://github.com/rapidsai/build-planning/issues/256). Today that looks like:
    - CUDA 12: build against nvJitLink 12.9.x, run on CUDA 12.2-12.9 (w/ nvJitLink 12.9.x)
    - CUDA 13: build against nvJitLink 13.0.x, run on CUDA 13.0-13.2 (w/ nvJitLink 13.0-13.2)

## Why only CUDA 12?

CUDA 13 `torch` wheels already carry a version range for this dependency via the `cuda-toolkit` package or will soon:

* 13.0: https://github.com/pytorch/pytorch/pull/179758
* 13.2: https://github.com/pytorch/pytorch/blob/56dc9a469c0d3e1a3c2e303c7dab35200ecabe6b/.github/scripts/generate_binary_build_matrix.py#L77

## How I tested this

Pulled `torch==2.12.0+cu126`'s dependencies out into a requirements file, and modified it to match the changes in this PR.

<details><summary>requirements-cuda12.txt (click me)</summary>

```text
# CUDA dependencies
cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvtx]==12.6.3; platform_system == 'Linux'
cuda-bindings>=12.9.4,<13; platform_system == 'Linux' and python_version < '3.15'
nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux'
nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux'
nvidia-nccl-cu12==2.29.3; platform_system == 'Linux'
nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'
nvidia-nvjitlink-cu12>=12.6.85,<13; platform_system == 'Linux'

# non-CUDA dependencies
filelock
typing-extensions>=4.10.0
setuptools<82
sympy>=1.13.3
networkx>=2.5.1
jinja2
fsspec>=0.8.5
```

</details>

Confirmed that relaxing that one dependency allows the environment to solve.

Ran an example from https://docs.pytorch.org/tutorials/beginner/pytorch_with_examples.html#pytorch-tensors as a smoke test.

<details><summary>code (click me)</summary>

Set up the environment as described above.

```shell
docker run \
  --rm \
  --gpus all \
  -v $(pwd):/opt/work \
  -w /opt/work \
  -it rapidsai/citestwheel:26.06-cuda12.9.1-ubuntu24.04-py3.13 \
  bash

pip install \
  'cuml-cu12==26.6.*' \
  -r ./requirements-cuda12.txt

pip install \
  --index-url https://download.pytorch.org/whl/cu126 \
  --no-deps \
  'torch==2.12.0+cu126'
```

```console
$ pip list
Package                          Version
-------------------------------- ------------
attrs                            26.1.0
cachetools                       7.1.4
certifi                          2026.4.22
cuda-bindings                    12.9.7
cuda-core                        0.7.0
cuda-pathfinder                  1.5.5
cuda-python                      12.9.7
cuda-toolkit                     12.6.3
cudf-cu12                        26.6.1
cuml-cu12                        26.6.0
cupy-cuda12x                     14.1.1
filelock                         3.29.3
fsspec                           2026.4.0
Jinja2                           3.1.6
joblib                           1.5.3
jsonschema                       4.26.0
jsonschema-specifications        2025.9.1
libcudf-cu12                     26.6.1
libcuml-cu12                     26.6.0
libkvikio-cu12                   26.6.0
libnvforest-cu12                 26.6.0
libraft-cu12                     26.6.0
librmm-cu12                      26.6.0
llvmlite                         0.46.0
markdown-it-py                   4.2.0
MarkupSafe                       3.0.3
mdurl                            0.1.2
mpmath                           1.3.0
narwhals                         2.22.1
networkx                         3.6.1
numba                            0.64.0
numba-cuda                       0.28.2
numpy                            2.4.6
nvforest-cu12                    26.6.0
nvidia-cublas-cu12               12.6.4.1
nvidia-cuda-cccl-cu12            12.6.77
nvidia-cuda-cupti-cu12           12.6.80
nvidia-cuda-nvcc-cu12            12.6.85
nvidia-cuda-nvrtc-cu12           12.6.85
nvidia-cuda-runtime-cu12         12.6.77
nvidia-cudnn-cu12                9.10.2.21
nvidia-cufft-cu12                11.3.0.4
nvidia-cufile-cu12               1.11.1.6
nvidia-curand-cu12               10.3.7.77
nvidia-cusolver-cu12             11.7.1.2
nvidia-cusparse-cu12             12.5.4.2
nvidia-cusparselt-cu12           0.7.1
nvidia-libnvcomp-cu12            5.2.0.13
nvidia-nccl-cu12                 2.29.3
nvidia-nvjitlink-cu12            12.9.86
nvidia-nvshmem-cu12              3.4.5
nvidia-nvtx-cu12                 12.6.77
nvtx                             0.2.15
packaging                        26.2
pandas                           2.3.3
pip                              26.1.1
pyarrow                          23.0.1
Pygments                         2.20.0
pylibcudf-cu12                   26.6.1
pylibraft-cu12                   26.6.0
python-dateutil                  2.9.0.post0
pytz                             2026.2
PyYAML                           6.0.3
rapids-dependency-file-generator 1.20.3
rapids-logger                    0.2.3
referencing                      0.37.0
rich                             15.0.0
rmm-cu12                         26.6.0
rpds-py                          0.30.0
scikit-learn                     1.9.0
scipy                            1.17.1
setuptools                       81.0.0
six                              1.17.0
sympy                            1.14.0
threadpoolctl                    3.6.0
tomlkit                          0.14.0
torch                            2.12.0+cu126
treelite                         4.7.0
typing_extensions                4.15.0
tzdata                           2026.2
```

```console
$ nvidia-smi
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA RTX A6000               Off |   00000000:01:00.0  On |                  Off |
| 30%   39C    P8             18W /  300W |    1248MiB /  49140MiB |     13%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
```

Put that example code (modified to use the GPU) in `/tmp/test.py`

```python
import torch

dtype = torch.float
device = torch.device("cuda:0")

# Create random input and output data
x = torch.linspace(-torch.pi, torch.pi, 2000, device=device, dtype=dtype)
y = torch.sin(x)

# Randomly initialize weights
a = torch.randn((), device=device, dtype=dtype)
b = torch.randn((), device=device, dtype=dtype)
c = torch.randn((), device=device, dtype=dtype)
d = torch.randn((), device=device, dtype=dtype)

learning_rate = 1e-6
for t in range(2000):
    # Forward pass: compute predicted y
    y_pred = a + b * x + c * x ** 2 + d * x ** 3

    # Compute and print loss
    loss = (y_pred - y).pow(2).sum().item()
    if t % 100 == 99:
        print(t, loss)

    # Backprop to compute gradients of a, b, c, d with respect to loss
    grad_y_pred = 2.0 * (y_pred - y)
    grad_a = grad_y_pred.sum()
    grad_b = (grad_y_pred * x).sum()
    grad_c = (grad_y_pred * x ** 2).sum()
    grad_d = (grad_y_pred * x ** 3).sum()

    # Update weights using gradient descent
    a -= learning_rate * grad_a
    b -= learning_rate * grad_b
    c -= learning_rate * grad_c
    d -= learning_rate * grad_d


print(f'Result: y = {a.item()} + {b.item()} x + {c.item()} x^2 + {d.item()} x^3')
```

Ran it

```console
$ pushd /tmp
$ python -c "import torch; print(torch.cuda.is_available())"
True

$ python ./test.py
99 4232.970703125
199 2819.39501953125
299 1879.59423828125
399 1254.56005859375
499 838.7152099609375
599 561.9395751953125
699 377.64935302734375
799 254.88706970214844
899 173.07321166992188
999 118.52290344238281
1099 82.1324462890625
1199 57.84347152709961
1299 41.62266540527344
1399 30.783538818359375
1499 23.536087036132812
1599 18.68706512451172
1699 15.440637588500977
1799 13.265575408935547
1899 11.807257652282715
1999 10.828742980957031
Result: y = 0.024233069270849228 + 0.8192500472068787 x + -0.0041806078515946865 x^2 + -0.08799765259027481 x^3
```

</details>

## Notes for Reviewers

I generated this changeset by manually updating `generate_binary_build_matrix.py` and then running this:

```shell
python .github/scripts/generate_ci_workflows.py
```

It looks to touch the right parts of the right files, based on my read of @tinglvv 's similar change in https://github.com/pytorch/pytorch/pull/179758

Thanks for your time and consideration.

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia