### PR TITLE
[AOTI] Fix S638065: sync default stream after AOTI constant copy (AMD) (#186963)

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -20,6 +20,7 @@
 #include <cuda_runtime.h>
 #endif
 #if defined(USE_CUDA) || defined(USE_ROCM)
+#include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h>
 #endif
 #include <torch/script.h>
@@ -1150,6 +1151,77 @@ void test_concurrent_run_with_const_fold(const std::string& device) {
   ASSERT_FALSE(failed.load())
       << "One or more threads produced incorrect output";
 }
+
+// S638065 regression: with runtime constant folding, update_constant_buffer
+// copies the new weights into the (inactive) constant buffer on the default
+// stream (async device-to-device cudaMemcpy), while run_const_fold reads those
+// constants on a separate stream. On ROCm the default stream is not implicitly
+// ordered with other streams, so without a barrier the fold can read
+// not-yet-copied weights and bake stale values into the folded constants.
+// This exercises that exact edge: fold on a dedicated pool stream, then check
+// the folded result against an independently computed reference. Each iteration
+// uses fresh random weights so a stale read produces a detectably wrong output.
+// The race is timing-dependent (the copy usually wins), hence the loop; a clean
+// run depends on the cudaStreamSynchronize(0) at the end of
+// update_constant_buffer (model_container.h). On NVIDIA the legacy default
+// stream implicitly serializes, so this passes regardless.
+void test_aoti_const_fold_separate_stream() {
+  torch::NoGradGuard no_grad;
+
+  // Use the large (size=4096) model so the per-weight D2D copy is big enough to
+  // still be in flight when the fold starts reading.
+  std::string data_path =
+      (std::filesystem::path(
+           STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "large_data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_use_runtime_constant_folding")
+          .toStringRef();
+  auto input_tensors = data_loader.attr("inputs").toTensorList().vec();
+  const auto& x = input_tensors[0];
+  const int64_t size = x.size(1);
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+
+  // Dedicated non-blocking pool stream for folding, distinct from the default
+  // stream that update_constant_buffer copies the weights on.
+  c10::cuda::CUDAStream fold_stream = c10::cuda::getStreamFromPool();
+
+  constexpr int kIters = 100;
+  for (int i = 0; i < kIters; ++i) {
+    at::Tensor w_pre = at::randn({size, size}, x.options());
+    at::Tensor w_add = at::randn({size, size}, x.options());
+    // Independent reference, mirroring Net.forward in test.py.
+    at::Tensor expected =
+        at::matmul(x, at::relu(at::transpose(w_pre, 0, 1)) + w_add);
+
+    torch::inductor::TensorConstantMap weight_map;
+    weight_map.emplace("L__self___w_pre", &w_pre);
+    weight_map.emplace("L__self___w_add", &w_add);
+
+    // Copy weights into the inactive buffer (default stream), then fold on a
+    // separate stream. We deliberately do NOT synchronize between these two:
+    // ordering the copy before the fold is exactly what the fix must guarantee.
+    runner->update_inactive_constant_buffer(weight_map);
+    runner->run_const_fold(
+        /* use_inactive = */ true,
+        reinterpret_cast<AOTInductorStreamHandle>(fold_stream.stream()));
+    // Isolate the copy->fold edge (under test) from the fold->inference edge by
+    // finishing the fold before swapping the freshly folded buffer in.
+    fold_stream.synchronize();
+    runner->swap_constant_buffer();
+
+    auto actual = runner->run(input_tensors);
+    ASSERT_TRUE(torch::allclose(
+        expected, actual[0], /* rtol = */ 1e-2, /* atol = */ 1e-2))
+        << "iter " << i
+        << ": folded constants reflect stale weights (S638065); the const-fold "
+           "read the constant buffer before the default-stream weight copy "
+           "completed";
+  }
+}
 #endif // USE_CUDA || USE_ROCM
 } // namespace
 
@@ -1246,5 +1318,13 @@ TEST_F(AotInductorTest, ConcurrentRunConstFoldCuda) {
   test_concurrent_run_with_const_fold("cuda");
 }
 #endif
+
+// Registered for ROCm as well as CUDA: the S638065 race only manifests on AMD
+// (on NVIDIA the legacy default stream implicitly orders with the fold stream).
+#if defined(USE_CUDA) || defined(USE_ROCM)
+TEST_F(AotInductorTest, ConstFoldSeparateStreamCuda) {
+  test_aoti_const_fold_separate_stream();
+}
+#endif // USE_CUDA || USE_ROCM
 
 } // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -769,6 +769,17 @@ class AOTInductorModelContainer {
     AOTI_LOG_LOADING(
         "update_constant_buffer: copy completed in " << _update_ms << " ms");
     target.update_array(models_[0].get());
+
+#ifdef USE_CUDA
+    // S638065: the GPU constant copies above run on the default stream (raw
+    // cudaMemcpy), while run_const_fold launches the fold on
+    // getCurrentCUDAStream(). On ROCm the default stream is not implicitly
+    // ordered with the fold's stream, so without this the fold could read
+    // not-yet-copied weights and bake stale values into the folded constants.
+    // Wait for the copies to complete before returning, so any subsequent fold
+    // (on any stream) sees the updated weights.
+    AOTI_RUNTIME_CUDA_CHECK(cudaStreamSynchronize(0));
+#endif // USE_CUDA
   }
 
   void swap_constant_buffer() {


### PR DESCRIPTION
Summary:

On AMD/ROCm, dense delta and full-snapshot in-place weight updates ("XL weight swap") intermittently produce persistent prediction spikes when AOTI runtime constant folding is enabled (SEV S638065). Disabling `aot_inductor.use_runtime_constant_folding` on AMD was the mitigation; this is the root-cause fix.

Root cause: `update_constant_buffer` copies the new weights into the constant buffer via `cudaMemcpy(..., cudaMemcpyDefault)` (`aoti_cuda_memcpy_throttled` in `model_base.h`). For the delta path the source weights are already on device, so this is a device-to-device copy, and `cudaMemcpy` performs no host-side synchronization for D2D transfers -- it is enqueued on the default/null stream and returns to the host immediately. `run_const_fold` then launches the fold on `getCurrentCUDAStream()` (a separate pool stream) with no synchronization in between. On NVIDIA the legacy default stream implicitly serializes with other streams, so the fold waits for the copy; on ROCm the default stream is not implicitly ordered with pool streams, so the fold can read the constant buffer before the D2D copy lands and bake stale weights into the folded constants. The corrupted folded constants are then committed and swapped active, so the bad state persists until the next fold (it does not self-recover) -- hence the persistent, AMD-only spikes.

Fix: add `cudaStreamSynchronize(0)` at the end of `update_constant_buffer` (under `#ifdef USE_CUDA`), after the copy loop and before any subsequent `run_const_fold`. This orders the async D2D copy on the default stream ahead of the fold on the pool stream. It is the minimal correct barrier -- no C-ABI change and no xplat/sigrid ripple -- and `cudaDeviceSynchronize()` is unnecessary because it drains identically but also blocks on inference streams. This targets the fold's INPUT edge (copy -> fold); the previously shipped post-fold syncs (D103105501 `wait_for_completion`, D103228794 `getCurrentCUDAStream().synchronize()`) fenced only the fold -> inference edge, which is transient and self-healing, and were confirmed not to fix the SEV. `model_container.h` is header-only and baked into each `model.so` at lowering time, so this applies to newly lowered models; existing models must be re-lowered to pick it up.

This diff also adds a GPU regression test, `ConstFoldSeparateStreamCuda` in `test/cpp/aoti_inference/test.cpp`: it loads fresh random weights into the inactive buffer (default-stream copy), folds on a dedicated `getStreamFromPool()` stream, swaps, and checks the output against an independently computed reference, so a stale fold read is detectable. It is registered under `#if defined(USE_CUDA) || defined(USE_ROCM)` to run on ROCm/MI300 where the race manifests (the existing GPU tests are `#ifdef USE_CUDA` only). See the Test Plan for its scope and limitations.

Authored with assistance from Claude (AI).

Test Plan:
Reproduced the exact mechanism and verified the fix with a standalone HIP microbenchmark on MI300X (ROCm 6.4.2) using the real primitives: `hipMemcpy(dst, src, bytes, hipMemcpyDefault)` device-to-device on stream 0 (== the `update_constant_buffer` copy), a fold kernel reading the copied buffer on a `hipStreamNonBlocking` pool stream (== `run_const_fold` on `getCurrentCUDAStream()`), and the `cudaStreamSynchronize(0)` barrier between them (== this fix).

Mechanism probes:
- `hipMemcpy` D2D returns in 0.004 ms but completes in 0.71 ms -> the copy is async, not host-blocking.
- A write on stream 0 is read early by a non-blocking pool stream (1-5 of 50 reads stale) -> stream 0 is not implicitly ordered with pool streams on ROCm.
- `hipStreamSynchronize(0)` issued right after the `hipMemcpy` blocks for ~0.54 ms -> it drains the async D2D copy.

End-to-end A/B (128 constants x 2 MB, 100 iters; stale folded values counted):
- no barrier: 53/12800 stale (race reproduced)
- `cudaStreamSynchronize(0)` (this fix): 0/12800
- `cudaDeviceSynchronize()`: 0/12800

The race only triggers at small constant sizes because SDMA D2D is fast enough that the copy usually wins, which matches the intermittent nature of the production SEV.

This diff also adds a real-path regression test `ConstFoldSeparateStreamCuda` in `test/cpp/aoti_inference/test.cpp`: it loads fresh random weights into the inactive buffer (default-stream copy), folds on a dedicated `getStreamFromPool()` stream, swaps, and checks the output against an independently computed reference over 100 iterations, so a stale fold read produces a detectably wrong output. It is registered under `#if defined(USE_CUDA) || defined(USE_ROCM)` so it runs on ROCm/MI300 where the race manifests (the existing GPU tests are `#ifdef USE_CUDA` only). NOTE: it could not be built or run on this devserver (no `torch`/libtorch; `test.cpp` is OSS/CMake-only), so it will be exercised in PyTorch OSS CI; the race is timing-dependent, making it a best-effort guard rather than a deterministic one. The fix itself is validated by the microbenchmark above.

Not exercised end-to-end on a real `model.so` locally: the fix is header-only and baked in at lowering time, and the production race is rare, so a per-model repro would require re-lowering plus many delta cycles to hit it intermittently. The microbenchmark above exercises the identical copy/fold/stream mechanism and the barrier directly.

`arc lint` on both changed files reports no lint issues.

Reviewed By: desertfire

Differential Revision: D108183317


