### PR TITLE
PyProcessGroup: support batch_isend_irecv and the coalescing manager

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import os
 import time
 import unittest
 import weakref
@@ -10,10 +11,14 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch._C._distributed_c10d import _create_work_from_future
+from torch.distributed.distributed_c10d import _coalescing_manager, _get_default_group
 from torch.futures import Future
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_distributed import MultiThreadedTestCase
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    MultiThreadedTestCase,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -133,6 +138,31 @@ class StoreProcessGroup(dist.ProcessGroup):
         return "store-pg"
 
 
+class CoalescingProcessGroup(test_c10d_common.DummyProcessGroup):
+    """
+    A ProcessGroup that advertises coalescing support and records coalescing
+    calls, so both the coalescing manager and the batch_isend_irecv coalescing
+    path can be exercised against a pure-Python backend. send/recv (which add 1
+    and 2 respectively) are inherited from DummyProcessGroup.
+    """
+
+    def __init__(self, rank, world):
+        super().__init__(rank, world)
+        self.start_coalescing_count = 0
+        self.end_coalescing_count = 0
+
+    @property
+    def supports_coalescing(self):
+        return True
+
+    def start_coalescing(self, device):
+        self.start_coalescing_count += 1
+
+    def end_coalescing(self, device):
+        self.end_coalescing_count += 1
+        return create_work([])
+
+
 # We cannot use parametrize as some tests are defined on the base class and use _get_process_group
 class AbstractDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest):
     def setUp(self):
@@ -243,6 +273,21 @@ class TestPyProcessGroup(TestCase):
         # base backend name ("undefined") instead.
         self.assertEqual(pg.name(), "store-pg")
 
+    def test_coalescing_manager(self):
+        # The coalescing manager calls _start_coalescing / _end_coalescing, which
+        # route through the C++ virtual into the PyProcessGroup trampoline and
+        # dispatch to the start_coalescing / end_coalescing overrides; the work
+        # returned by end_coalescing is collected.
+        pg = CoalescingProcessGroup(0, 1)
+        device = torch.device("cpu")
+        with _coalescing_manager(pg, device, async_ops=True) as cm:
+            pass
+        cm.wait()
+
+        self.assertEqual(pg.start_coalescing_count, 1)
+        self.assertEqual(pg.end_coalescing_count, 1)
+        self.assertEqual(len(cm.works), 1)
+
     def test_abort_shutdown(self) -> None:
         # verify this are noops
         pg = DummyAttrProcessGroup(0, 1)
@@ -306,6 +351,89 @@ class TestPyProcessGroup(TestCase):
 
             stream.synchronize()
             self.assertTrue(event.query())
+
+
+class TestBatchSendRecv(MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @staticmethod
+    def create_dummy(store, group_rank, group_size, timeout):
+        return test_c10d_common.DummyProcessGroup(group_rank, group_size)
+
+    @staticmethod
+    def create_coalescing(store, group_rank, group_size, timeout):
+        return CoalescingProcessGroup(group_rank, group_size)
+
+    def test_batch_isend_irecv(self):
+        # batch_isend_irecv over a Python ProcessGroup that does not advertise
+        # coalescing falls back to per-op send/recv. DummyProcessGroup.send adds
+        # 1 and recv adds 2 to verify the ops are dispatched into Python.
+        dist.Backend.register_backend("dummy", TestBatchSendRecv.create_dummy)
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+
+        peer = (self.rank + 1) % self.world_size
+        send_tensor = torch.zeros(2, 2)
+        recv_tensor = torch.zeros(2, 2)
+        reqs = dist.batch_isend_irecv(
+            [
+                dist.P2POp(dist.isend, send_tensor, peer),
+                dist.P2POp(dist.irecv, recv_tensor, peer),
+            ]
+        )
+        for req in reqs:
+            req.wait()
+
+        self.assertEqual(send_tensor, torch.zeros(2, 2) + 1)
+        self.assertEqual(recv_tensor, torch.zeros(2, 2) + 2)
+
+        dist.barrier()
+        dist.destroy_process_group()
+
+    def test_batch_isend_irecv_coalescing(self):
+        # A Python ProcessGroup that advertises supports_coalescing routes
+        # batch_isend_irecv through the coalescing manager: start/endCoalescing
+        # wrap the sends/recvs and the single end-coalescing work is returned.
+        dist.Backend.register_backend("coalescing", TestBatchSendRecv.create_coalescing)
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "coalescing", rank=self.rank, world_size=self.world_size
+        )
+
+        pg = _get_default_group()
+        peer = (self.rank + 1) % self.world_size
+        send_tensor = torch.zeros(2, 2)
+        recv_tensor = torch.zeros(2, 2)
+        works = dist.batch_isend_irecv(
+            [
+                dist.P2POp(dist.isend, send_tensor, peer),
+                dist.P2POp(dist.irecv, recv_tensor, peer),
+            ]
+        )
+        for work in works:
+            work.wait()
+
+        self.assertEqual(pg.start_coalescing_count, 1)
+        self.assertEqual(pg.end_coalescing_count, 1)
+        self.assertEqual(len(works), 1)
+        self.assertEqual(send_tensor, torch.zeros(2, 2) + 1)
+        self.assertEqual(recv_tensor, torch.zeros(2, 2) + 2)
+
+        dist.barrier()
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -341,6 +341,35 @@ class PyProcessGroup : public ProcessGroup {
         srcRank,
         tag);
   }
+
+  // startCoalescing/endCoalescing dispatch into the Python ProcessGroup so a
+  // C++ caller (e.g. functional collectives in Functional.cpp) and the Python
+  // _start_coalescing/_end_coalescing bindings both reach the Python
+  // start_coalescing/end_coalescing overrides; without them the base
+  // ProcessGroup routes through getBackend(), which a backend-less Python PG
+  // does not have. The override is passed a c10::Device (torch.device) rather
+  // than the bare DeviceType, matching the device the bindings accept.
+  void startCoalescing(c10::DeviceType deviceType) override {
+    pybind11::gil_scoped_acquire gil;
+    pybind11::function override = pybind11::get_override(
+        static_cast<const ProcessGroup*>(this), "start_coalescing");
+    if (override) {
+      override(c10::Device(deviceType));
+      return;
+    }
+    return ProcessGroup::startCoalescing(deviceType);
+  }
+
+  c10::intrusive_ptr<Work> endCoalescing(c10::DeviceType deviceType) override {
+    pybind11::gil_scoped_acquire gil;
+    pybind11::function override = pybind11::get_override(
+        static_cast<const ProcessGroup*>(this), "end_coalescing");
+    if (override) {
+      auto o = override(c10::Device(deviceType));
+      return c10::make_intrusive<PyWorkHolder>(o);
+    }
+    return ProcessGroup::endCoalescing(deviceType);
+  }
 };
 
 class TORCH_PYTHON_API PythonOnCompletionHook {

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3046,7 +3046,9 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         key = "group_dst" if op.op is isend else "group_src"
         return {key: op.group_peer}
 
-    if type(group) is ProcessGroup and group._get_backend(device).supports_coalescing:
+    if isinstance(group, ProcessGroup) and getattr(
+        group._get_backend(device), "supports_coalescing", False
+    ):
         # NCCL style coalescing
         with _coalescing_manager(group, device, async_ops=True) as cm:
             for p2p_op in p2p_op_list:


### PR DESCRIPTION
## Summary

Enables a Python `ProcessGroup` to use the coalescing manager and the `batch_isend_irecv` coalescing path, from both the Python and C++ frontends.

- **`PyProcessGroup` trampoline**: adds `startCoalescing`/`endCoalescing` overrides so a Python subclass's `start_coalescing`/`end_coalescing` methods are dispatched whether the call comes via the Python `_start_coalescing`/`_end_coalescing` bindings (used by the coalescing manager) or from C++ (e.g. functional collectives in `Functional.cpp`). Without these the base `ProcessGroup` routes through `getBackend()`, which a backend-less Python PG does not have. The override is passed a `torch.device` for parity with the bindings.
- **`batch_isend_irecv`**: relaxes the coalescing gate from `type(group) is ProcessGroup` to `isinstance`, so a Python subclass is eligible. `supports_coalescing` is read with a default of `False` (`getattr(group._get_backend(device), "supports_coalescing", False)`), so it is **not required** — a Python PG that doesn't advertise it falls back to per-op `send`/`recv`. A Python PG opts in by acting as its own backend via `_get_backend` and a `supports_coalescing` property, the same pattern as `supports_splitting`. Built-in `ProcessGroup` behavior is unchanged.

## Test plan

- `python test/distributed/test_c10d_pypg.py` — adds `test_coalescing_manager`, `test_batch_isend_irecv` (fallback path; a PG with no `supports_coalescing`), and `test_batch_isend_irecv_coalescing` (coalescing path).
- `python test/distributed/test_c10d_common.py PythonProcessGroupExtensionTest`.
- Confirmed the built-in backend path is unchanged with a 2-process gloo `batch_isend_irecv` run.
