### PR TITLE
[MPS] Fix the fft issues if target dim not among the last four

### DIFF
--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -1,7 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/SpectralOpsUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <algorithm>
+#include <numeric>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -34,6 +37,62 @@ NSArray<NSNumber*>* IntArrayToNSArray(IntArrayRef arr) {
     rc[idx] = [NSNumber numberWithInteger:arr[idx]];
   }
   return rc;
+}
+
+// MPSGraph FFT can only transform axes within the last four dimensions, so when
+// an axis falls outside that window we permute it into the trailing dims, transform, then invert.
+struct FFTAxisPlan {
+  bool needsTranspose = false;
+  NSArray<NSNumber*>* axes = nil;
+  NSArray<NSNumber*>* permutation = nil;
+  NSArray<NSNumber*>* inversePermutation = nil;
+};
+
+FFTAxisPlan computeFFTAxisPlan(IntArrayRef dim, int64_t ndim) {
+  TORCH_CHECK(static_cast<int64_t>(dim.size()) <= 4,
+              "MPS FFT only supports transforming up to 4 dimensions, but got ",
+              dim.size(),
+              " dimensions");
+  FFTAxisPlan plan;
+  if (std::all_of(dim.begin(), dim.end(), [&](int64_t d) { return d >= ndim - 4; })) {
+    plan.axes = IntArrayToNSArray(dim);
+    return plan;
+  }
+
+  plan.needsTranspose = true;
+  const auto isTransformDim = at::dim_list_to_bitset(dim, ndim);
+  std::vector<int64_t> perm;
+  perm.reserve(ndim);
+  for (const auto i : c10::irange(ndim)) {
+    if (!isTransformDim[i]) {
+      perm.push_back(i);
+    }
+  }
+  perm.insert(perm.end(), dim.begin(), dim.end());
+  std::vector<int64_t> inverse(ndim);
+  for (const auto i : c10::irange(ndim)) {
+    inverse[perm[i]] = i;
+  }
+  std::vector<int64_t> remappedAxes(dim.size());
+  std::iota(remappedAxes.begin(), remappedAxes.end(), ndim - static_cast<int64_t>(dim.size()));
+  plan.axes = IntArrayToNSArray(remappedAxes);
+  plan.permutation = IntArrayToNSArray(perm);
+  plan.inversePermutation = IntArrayToNSArray(inverse);
+  return plan;
+}
+
+MPSGraphTensor* applyFFTInputPlan(MPSGraph* mpsGraph, MPSGraphTensor* input, const FFTAxisPlan& plan) {
+  if (!plan.needsTranspose) {
+    return input;
+  }
+  return [mpsGraph transposeTensor:input permutation:plan.permutation name:nil];
+}
+
+MPSGraphTensor* applyFFTOutputPlan(MPSGraph* mpsGraph, MPSGraphTensor* output, const FFTAxisPlan& plan) {
+  if (!plan.needsTranspose) {
+    return output;
+  }
+  return [mpsGraph transposeTensor:output permutation:plan.inversePermutation name:nil];
 }
 
 } // anonymous namespace
@@ -77,25 +136,28 @@ Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalizat
   @autoreleasepool {
     auto cachedGraph = LookUpOrCreateCachedGraph<MPSUnaryCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      auto axisPlan = computeFFTAxisPlan(dim, self.dim());
+      auto fftInput = applyFFTInputPlan(mpsGraph, inputTensor, axisPlan);
       auto descriptor = [MPSGraphFFTDescriptor descriptor];
       descriptor.scalingMode = normalization_to_ScalingMode(normalization);
       MPSGraphTensor* outputTensor;
       if (onesided) {
         // Return only unique results:
-        outputTensor = [mpsGraph realToHermiteanFFTWithTensor:inputTensor
-                                                         axes:IntArrayToNSArray(dim)
+        outputTensor = [mpsGraph realToHermiteanFFTWithTensor:fftInput
+                                                         axes:axisPlan.axes
                                                    descriptor:descriptor
                                                          name:nil];
       } else {
         // Return with Hermitean conjugate results:
         auto useDataType =
-            (inputTensor.dataType == MPSDataTypeFloat16) ? MPSDataTypeComplexFloat16 : MPSDataTypeComplexFloat32;
-        auto cTensor = [mpsGraph castTensor:inputTensor toType:useDataType name:nil];
+            (fftInput.dataType == MPSDataTypeFloat16) ? MPSDataTypeComplexFloat16 : MPSDataTypeComplexFloat32;
+        auto cTensor = [mpsGraph castTensor:fftInput toType:useDataType name:nil];
         outputTensor = [mpsGraph fastFourierTransformWithTensor:cTensor
-                                                           axes:IntArrayToNSArray(dim)
+                                                           axes:axisPlan.axes
                                                      descriptor:descriptor
                                                            name:nil];
       }
+      outputTensor = applyFFTOutputPlan(mpsGraph, outputTensor, axisPlan);
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });
@@ -123,14 +185,17 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
   @autoreleasepool {
     auto cachedGraph = LookUpOrCreateCachedGraph<MPSUnaryCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      auto axisPlan = computeFFTAxisPlan(dim, self.dim());
+      auto fftInput = applyFFTInputPlan(mpsGraph, inputTensor, axisPlan);
       auto descriptor = [MPSGraphFFTDescriptor descriptor];
       descriptor.scalingMode = normalization_to_ScalingMode(normalization);
       descriptor.inverse = YES;
       descriptor.roundToOddHermitean = ((last_dim_size % 2) == 1) ? YES : NO;
-      auto outputTensor = [mpsGraph HermiteanToRealFFTWithTensor:inputTensor
-                                                            axes:IntArrayToNSArray(dim)
+      auto outputTensor = [mpsGraph HermiteanToRealFFTWithTensor:fftInput
+                                                            axes:axisPlan.axes
                                                       descriptor:descriptor
                                                             name:nil];
+      outputTensor = applyFFTOutputPlan(mpsGraph, outputTensor, axisPlan);
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });
@@ -148,13 +213,16 @@ Tensor& _fft_c2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalizat
   @autoreleasepool {
     auto cachedGraph = LookUpOrCreateCachedGraph<MPSUnaryCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      auto axisPlan = computeFFTAxisPlan(dim, self.dim());
+      auto fftInput = applyFFTInputPlan(mpsGraph, inputTensor, axisPlan);
       auto descriptor = [MPSGraphFFTDescriptor descriptor];
       descriptor.scalingMode = normalization_to_ScalingMode(normalization);
       descriptor.inverse = !forward;
-      auto outputTensor = [mpsGraph fastFourierTransformWithTensor:inputTensor
-                                                              axes:IntArrayToNSArray(dim)
+      auto outputTensor = [mpsGraph fastFourierTransformWithTensor:fftInput
+                                                              axes:axisPlan.axes
                                                         descriptor:descriptor
                                                               name:nil];
+      outputTensor = applyFFTOutputPlan(mpsGraph, outputTensor, axisPlan);
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -4,7 +4,6 @@
 #include <ATen/native/SpectralOpsUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <algorithm>
-#include <numeric>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -73,8 +72,11 @@ FFTAxisPlan computeFFTAxisPlan(IntArrayRef dim, int64_t ndim) {
   for (const auto i : c10::irange(ndim)) {
     inverse[perm[i]] = i;
   }
-  std::vector<int64_t> remappedAxes(dim.size());
-  std::iota(remappedAxes.begin(), remappedAxes.end(), ndim - static_cast<int64_t>(dim.size()));
+  std::vector<int64_t> remappedAxes;
+  remappedAxes.reserve(dim.size());
+  for (const auto i : c10::irange(ndim - static_cast<int64_t>(dim.size()), ndim)) {
+    remappedAxes.push_back(i);
+  }
   plan.axes = IntArrayToNSArray(remappedAxes);
   plan.permutation = IntArrayToNSArray(perm);
   plan.inversePermutation = IntArrayToNSArray(inverse);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2492,6 +2492,45 @@ class TestMPS(TestCaseMPS):
         freq_mps = torch.fft.fftfreq(10**4, device='mps')
         self.assertEqual(freq_cpu, freq_mps)
 
+    def test_fft_transform_dims_outside_last_four(self):
+        # MPSGraph FFT only handles the last four dims; the backend transposes
+        # outer transform dims into that window. See https://github.com/pytorch/pytorch/issues/124096
+        def check(fn, x_cpu, **kwargs):
+            x_mps = x_cpu.detach().to("mps")
+            self.assertEqual(fn(x_cpu, **kwargs), fn(x_mps, **kwargs).cpu())
+
+        # Exact repro from the issue.
+        check(torch.fft.fftn, torch.randn(2, 1, 1, 1, 2, 2, dtype=torch.complex64), dim=(1, 2))
+
+        # complex-to-complex over outer dims
+        cdata = torch.randn(3, 4, 2, 1, 2, dtype=torch.complex64)
+        check(torch.fft.fftn, cdata, dim=(0, 1))
+        check(torch.fft.ifftn, cdata, dim=(0, 1))
+        check(torch.fft.fft, cdata, dim=0)
+
+        # real-to-complex over outer dims
+        rdata = torch.randn(3, 4, 2, 1, 4)
+        check(torch.fft.rfftn, rdata, dim=(0, 4))
+        check(torch.fft.rfftn, rdata, dim=(0, 1, 4))
+        check(torch.fft.rfft, torch.randn(3, 1, 1, 1, 1), dim=0)
+
+        # complex-to-real round trip
+        fwd = torch.fft.rfftn(rdata, dim=(0, 4))
+        check(lambda y: torch.fft.irfftn(y, s=(rdata.size(0), rdata.size(4)), dim=(0, 4)), fwd)
+
+        # Unsorted dims: dim.back() is an outer axis, exercising the inverse permutation.
+        check(torch.fft.fftn, cdata, dim=(2, 0))
+        check(torch.fft.ifftn, cdata, dim=(2, 0))
+        check(torch.fft.rfftn, rdata, dim=(3, 0))
+        rev = torch.fft.rfftn(rdata, dim=(3, 0))
+        check(lambda y: torch.fft.irfftn(y, s=(rdata.size(3), rdata.size(0)), dim=(3, 0)), rev)
+
+    def test_fftn_too_many_dims(self):
+        # MPSGraph cannot transform more than four dims.
+        x = torch.randn(2, 2, 2, 2, 2, device="mps", dtype=torch.complex64)
+        with self.assertRaisesRegex(RuntimeError, "up to 4 dimensions"):
+            torch.fft.fftn(x, dim=(0, 1, 2, 3, 4))
+
     def test_instance_norm(self):
         def helper(shape, eps=1, momentum=0.1, wts=False, channels_last=False, track_running_stats=True, test_module=False):
 


### PR DESCRIPTION
Fixes issue https://github.com/pytorch/pytorch/issues/186885

The behavior of MPSGraph fastFourierTransform https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph/fastfouriertransform(_:axestensor:descriptor:name:)?language=objc declares that the transformation is supported only within the last four dimensions and the input should be permuted to make this the case. We weren't following those directions earlier. Adding the necessary code to perform the input/output permutations and track them in a struct.

Adding regression tests for the cases.