### PR TITLE
dynamo: enforce target_values is None|Sequence.

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -2068,6 +2068,17 @@ class GraphModule(torch.nn.Module):
         retraced_graph = normalize_gm(eager.graphs[0].print_readable(False))
         self.assertEqual(first_graph, retraced_graph)
 
+    def test_context_wrapping_variable_rejects_dict_target_values(self):
+        # target_values must be None or a Sequence; a dict silently iterates
+        # only its keys, which is the bug pattern we want to catch early.
+        from torch._dynamo.variables.ctx_manager import ContextWrappingVariable
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "ContextWrappingVariable.target_values must be None or a Sequence",
+        ):
+            ContextWrappingVariable(target_values={"key": "val"})
+
 
 class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
     def test_cuda_use_mem_pool_fx_cse_preserves_distinct_contexts(self):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -74,6 +74,13 @@ class ContextWrappingVariable(VariableTracker):
         super().__init__(**kwargs)
         self.target_values = target_values
         self.initial_values = initial_values
+        # target_values must be None or a Sequence for reconstruct / _call_func
+        # etc. to work properly.
+        if not (target_values is None or isinstance(target_values, Sequence)):
+            raise TypeError(
+                "ContextWrappingVariable.target_values must be None or a "
+                f"Sequence, got {type(target_values).__name__}"
+            )
 
     def richcompare_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker, op: str
@@ -1147,12 +1154,16 @@ class NullContextVariable(ContextWrappingVariable):
     This class represents Python contextlib.nullcontext.
     """
 
-    def __init__(self, target_values: Any | None = None, **kwargs: Any) -> None:
-        super().__init__(target_values=target_values, **kwargs)
+    def __init__(
+        self, enter_result: VariableTracker | None = None, **kwargs: Any
+    ) -> None:
+        self.enter_result = enter_result
+        super().__init__(target_values=(), **kwargs)
 
     def enter(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        none = variables.ConstantVariable.create(None)
-        return self.target_values if self.target_values else none
+        if self.enter_result is None:
+            return variables.ConstantVariable.create(None)
+        return self.enter_result
 
     def exit(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
@@ -1588,12 +1599,16 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
     __exit__ method (instead of tracing).
     """
 
+    _nonvar_fields = {
+        "annotation",
+        *ContextWrappingVariable._nonvar_fields,
+    }
+
     def __init__(
-        self, target_values: Any, initial_values: Any = None, **kwargs: Any
+        self, annotation: dict[str, Any], initial_values: Any = None, **kwargs: Any
     ) -> None:
-        super().__init__(
-            target_values=target_values, initial_values=initial_values, **kwargs
-        )
+        self.annotation = annotation
+        super().__init__(target_values=(), initial_values=initial_values, **kwargs)
 
     def enter(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
@@ -1602,7 +1617,7 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         # preserve_node_meta context manager is setup. This is important to pass
         # on the metadata to the create_proxy nodes.
         stack = ExitStack()
-        stack.enter_context(torch.fx.traceback.annotate(self.target_values))
+        stack.enter_context(torch.fx.traceback.annotate(self.annotation))
         stack.enter_context(torch.fx.traceback.preserve_node_meta())
         self.set_cleanup_hook(tx, lambda: stack.close())
         return variables.ConstantVariable.create(None)

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -336,7 +336,7 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
         super().__init__(
-            target_values={"stream": self.get_stream().user_object_index},
+            annotation={"stream": self.get_stream().user_object_index},
             initial_values=None,
             **kwargs,
         )


### PR DESCRIPTION
In #184487, @kshitij12345 recommended we validate that target_values is actually what it should be. This does that validation---and as Kshiteej probably suspected, it indeed flags a bug (also fixed).

This bug was: FxTracebackAnnotateVariable passed the torch.fx.traceback.annotate() dict straight into target_values (safe today only because its reconstruct_type raises Unsupported, so the positional path is never hit). Give it a dedicated self.annotation attribute and pass target_values=(), mirroring StreamContextVariable from #184487.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98