### PR TITLE
Bump onnx to 1.22.0 (stable) and unify typing-extensions to 4.15.0

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -346,7 +346,7 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.21.0
+onnx==1.22.0rc1
 #Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -270,8 +270,7 @@ scipy==1.16.2 ; python_version >= "3.14"
 #test that import:
 
 # needed by torchgen utils
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0
 #Description: type hints for python
 #Pinned versions:
 #test that import:
@@ -346,7 +345,7 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.22.0rc1
+onnx==1.22.0
 #Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -346,7 +346,7 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.22.0rc2
+onnx==1.22.0rc1
 #Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -346,7 +346,7 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.22.0rc1
+onnx==1.22.0rc2
 #Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
## Summary

Integrates the ONNX 1.22.0 release by pinning `onnx==1.22.0` (stable GA, now
released on PyPI) in `.ci/docker/requirements-ci.txt`, and resolves the `pip`
dependency conflict that the onnx bump exposed. This supersedes the earlier
release-candidate pins (`1.22.0rc1`/`1.22.0rc2`).

## Root cause

onnx 1.22.0 raised its dependency floor to `typing_extensions>=4.15.0`, but
`.ci/docker/requirements-ci.txt` pinned `typing-extensions==4.12.2` for
`python_version < "3.14"`. Since `4.12.2 < 4.15.0`, `pip` hit `ResolutionImpossible`
on every Python < 3.14 `docker-build` image. The `python >= 3.14` lane already
pinned `4.15.0`, which is why only those docker-build jobs passed.

## Fix

- Pin `onnx==1.22.0` (stable).
- Unify the typing-extensions pin to a single unconditional `typing-extensions==4.15.0`.

Verified no other requirement caps typing-extensions below 4.15.0
(`requirements-build.txt` already uses `>=4.15.0`; `regenerate-requirements.txt`
uses `>=4.8.0`; `mypy==1.16.0` `>=4.6.0`; `optree==0.13.0` `>=4.5.0`).
`typing-extensions==4.15.0` supports `python>=3.9`. onnx 1.22.0 ships binary wheels
covering CPython 3.10-3.14 (the cp312 wheels are abi3, forward-covering 3.13 and
3.14), so no CI job is forced to source-build.

## Verification

Triple-reviewed and QA-verified. Resolver dry-run (wheel actually downloaded):

```
pip install --dry-run --ignore-installed onnx==1.22.0 typing-extensions==4.15.0
# Would install ml_dtypes-0.5.4 numpy-2.4.6 onnx-1.22.0 protobuf-7.35.1 typing_extensions-4.15.0
```

## Notes

- This touches `.ci/docker/`, so it triggers a full CI Docker image rebuild (expected).
- Context: supersedes/continues the work in #185989.
- Authored with assistance from an AI agent.


cc @justinchuby @malfet @pytorch/pytorch-dev-infra