### PR TITLE
[Profiler] Fix a set of profiler tests

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 
 import expecttest
 
+
 # Suppress libkineto USDT profiler_start/profiler_stop logs in this verbose
 # profiler test file. USDT is the highest libkineto log type, so use one level
 # above it.

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -25,6 +25,11 @@ from unittest.mock import patch
 
 import expecttest
 
+# Suppress libkineto USDT profiler_start/profiler_stop logs in this verbose
+# profiler test file. USDT is the highest libkineto log type, so use one level
+# above it.
+os.environ.setdefault("KINETO_LOG_LEVEL", "6")
+
 import torch
 import torch.nn as nn
 import torch.optim
@@ -103,6 +108,21 @@ def get_profiler_activities(device_type):
         if device_activity and device_activity in supported_activities():
             activities.append(device_activity)
     return activities
+
+
+def setUpModule():
+    if (
+        kineto_available()
+        and torch.cuda.is_available()
+        and ProfilerActivity.CUDA in supported_activities()
+    ):
+        # Kineto's process-global profiler cannot currently upgrade from a
+        # CPU-only first initialization to CUDA-capable profiling. Prime it with
+        # CUDA so CPU-only tests do not poison later CUDA profiler tests.
+        x = torch.ones(1, device="cuda")
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]):
+            x + x
+            torch.cuda.synchronize()
 
 
 # if tqdm is not shutdown properly, it will leave the monitor thread alive.
@@ -3060,18 +3080,24 @@ class TestProfilerDevice(TestCase):
             opt.step()
             optimizer_step()
 
-        for _ in range(niters):
-            run_batch()
-
-        with profile(
-            activities=supported_activities(),
-            schedule=torch.profiler.schedule(wait=1, warmup=1, active=2),
-        ) as p:
+        try:
             for _ in range(niters):
                 run_batch()
-                p.step()
 
-        self.assertEqual(KinetoStepTracker.current_step(), initial_step + 2 * niters)
+            with profile(
+                activities=supported_activities(),
+                schedule=torch.profiler.schedule(wait=1, warmup=1, active=2),
+            ) as p:
+                for _ in range(niters):
+                    run_batch()
+                    p.step()
+
+            self.assertEqual(
+                KinetoStepTracker.current_step(), initial_step + 2 * niters
+            )
+        finally:
+            # KinetoStepTracker is global across device-specialized test runs.
+            KinetoStepTracker.erase_step_count("yet_another_step")
 
     @unittest.skipIf(
         IS_MACOS or IS_WINDOWS, "https://github.com/pytorch/pytorch/issues/82915"
@@ -3352,12 +3378,12 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
 
         cpu_op_found = False
         parent_tid = threading.current_thread().ident
-        with profile() as p:
+        with profile(activities=[ProfilerActivity.CPU]) as p:
             self.payload()
         pid = os.fork()
         if pid == 0:
             child_pid = os.getpid()
-            with profile() as p:
+            with profile(activities=[ProfilerActivity.CPU]) as p:
                 self.payload()
             validate_forked_json(p)
             self.assertTrue(cpu_op_found)


### PR DESCRIPTION
A couple changes for https://github.com/pytorch/kineto/issues/1429 and https://github.com/pytorch/kineto/issues/1430:

1. Add `setUpModule` to make sure Kineto is created with CUDA support. https://github.com/pytorch/pytorch/pull/186036 recently changed the behavior to not initialize Kineto with GPU tracing if only CPU activities are requested, which is more correct behavior. However, this changes the behavior of the following code:

```
with profile(activities=[ProfilerActivity.CPU]) as prof:
   ...

with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
   ...
```

Now Kineto is armed to only do CPU tracing. The issue is that Kineto is only registered once, so even though you added ProfilerActivity.CUDA in the second pass, the profiler still latches on to the CPU-only session, leading to no device-side activities being recorded. We need to find a more complete solution but to unblock the tests we can hack around it by forcing Kineto to instantiate with GPU-tracing before running any tests.

2. Clear KinetoStepTracker to make sure repeat runs with different activity types don't pollute `test_kineto_profiler_multiple_steppers`.
3. Make sure `test_forked_process` explicitly runs with CPU activities only.

There are a few more failures due to test pollution, but I haven't tracked those down yet.