### PR TITLE
[dynamo] Replace itertools.islice polyfill with native IsliceVariable

### DIFF
--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -24,7 +24,6 @@ __all__ = [
     "cycle",
     "dropwhile",
     "filterfalse",
-    "islice",
     "pairwise",
     "starmap",
     "takewhile",
@@ -178,35 +177,6 @@ def filterfalse(function: _Predicate[_T], iterable: Iterable[_T], /) -> Iterator
         return filter(lambda x: not function(x), it)
 
 
-# Reference: https://docs.python.org/3/library/itertools.html#itertools.islice
-@substitute_in_graph(itertools.islice, is_embedded_type=True)  # type: ignore[arg-type]
-def islice(iterable: Iterable[_T], /, *args: int | None) -> Iterator[_T]:
-    s = slice(*args)
-    start = 0 if s.start is None else s.start
-    stop = s.stop
-    step = 1 if s.step is None else s.step
-    if start < 0 or (stop is not None and stop < 0) or step <= 0:
-        raise ValueError(
-            "Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.",
-        )
-
-    if stop is None:
-        # TODO: use indices = itertools.count() and merge implementation with the else branch
-        #       when we support infinite iterators
-        next_i = start
-        for i, element in enumerate(iterable):
-            if i == next_i:
-                yield element
-                next_i += step
-    else:
-        indices = range(max(start, stop))
-        next_i = start
-        for i, element in zip(indices, iterable):
-            if i == next_i:
-                yield element
-                next_i += step
-
-
 # Reference: https://docs.python.org/3/library/itertools.html#itertools.pairwise
 @substitute_in_graph(itertools.pairwise, is_embedded_type=True)  # type: ignore[arg-type]
 def pairwise(iterable: Iterable[_T], /) -> Iterator[tuple[_T, _T]]:
@@ -295,7 +265,7 @@ if sys.version_info >= (3, 12):
         iterator = iter(iterable)
 
         def _batched(iterator: Iterator[_T]) -> Iterator[tuple[_T, ...]]:
-            while batch := tuple(islice(iterator, n)):
+            while batch := tuple(itertools.islice(iterator, n)):
                 if strict and len(batch) != n:
                     raise ValueError("batched(): incomplete batch")
                 yield batch

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -110,6 +110,7 @@ from .iter import (
     ChainVariable,
     CountIteratorVariable,
     FilterVariable,
+    IsliceVariable,
     IteratorVariable,
     ItertoolsVariable,
     MapVariable,
@@ -287,5 +288,6 @@ __all__ = [
     "WithEnterFunctionVariable",
     "WithExitFunctionVariable",
     "XPUDeviceVariable",
+    "IsliceVariable",
     "ZipLongestVariable",
 ]

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -125,6 +125,29 @@ class ItertoolsVariable(VariableTracker):
                 fillvalue=fillvalue_vt,
                 mutation_type=ValueMutationNew(),
             )
+        elif self.value is itertools.islice and not kwargs and 2 <= len(args) <= 4:
+            slice_args = args[1:]
+            if not all(a.is_python_constant() for a in slice_args):
+                return super().call_function(tx, args, kwargs)
+            py_vals = [a.as_python_constant() for a in slice_args]
+            s = slice(*py_vals)
+            start = 0 if s.start is None else s.start
+            stop = s.stop
+            step = 1 if s.step is None else s.step
+            if start < 0 or (stop is not None and stop < 0) or step <= 0:
+                raise_value_error(
+                    tx,
+                    "Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.",
+                )
+            # Fast path: list/tuple literal — nobody holds a reference to the fresh iterator,
+            # so we can slice items directly without advancing any shared state.
+            if isinstance(args[0], (variables.ListVariable, variables.TupleVariable)):
+                sliced = list(args[0].items[start:stop:step])
+                return variables.ListIteratorVariable(sliced, mutation_type=ValueMutationNew())
+            it = generic_getiter(tx, args[0])
+            return IsliceVariable(
+                it, start=start, stop=stop, step=step, mutation_type=ValueMutationNew()
+            )
         elif self.value is itertools.product:
             if any(kw != "repeat" for kw in kwargs):
                 unimplemented(
@@ -646,6 +669,104 @@ class ZipLongestVariable(IteratorVariable):
                 *create_call_function_ex(True, False),
             ]
         )
+
+
+class IsliceVariable(IteratorVariable):
+    """
+    Represents itertools.islice(iterable, [start,] stop [, step])
+    """
+
+    # ref: https://github.com/python/cpython/blob/3.13/Modules/itertoolsmodule.c#L937-L1020
+    _cpython_type = itertools.islice
+
+    _nonvar_fields = {
+        "current_pos",  # items consumed from underlying iterator
+        "next_i",       # absolute index of next item to yield
+        "stop",         # absolute stop (None = unlimited)
+        "step",
+        *IteratorVariable._nonvar_fields,
+    }
+
+    def __init__(
+        self,
+        iterable: "VariableTracker",
+        *,
+        start: int = 0,
+        stop: "int | None" = None,
+        step: int = 1,
+        current_pos: "int | None" = None,
+        next_i: "int | None" = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.iterable = iterable
+        self.stop = stop
+        self.step = step
+        self.current_pos = current_pos if current_pos is not None else 0
+        self.next_i = next_i if next_i is not None else start
+
+    def python_type(self) -> type:
+        return itertools.islice
+
+    def tp_iternext_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+        # ref: https://github.com/python/cpython/blob/3.13/Modules/itertoolsmodule.c#L937-L1020
+        if not self.is_mutable():
+            raise AssertionError("IsliceVariable must be mutable for next()")
+        if self.stop is not None and self.next_i >= self.stop:
+            # CPython drains to stop before returning StopIteration so the underlying
+            # iterator is advanced to the stop position.
+            tx.output.side_effects.mutation(self)
+            while self.current_pos < self.stop:
+                try:
+                    generic_iternext(tx, self.iterable)
+                    self.current_pos += 1
+                except ObservedUserStopIteration:
+                    handle_observed_exception(tx)
+                    break
+            raise_observed_exception(StopIteration, tx)
+        tx.output.side_effects.mutation(self)
+        # Skip from current_pos to next_i
+        while self.current_pos < self.next_i:
+            try:
+                generic_iternext(tx, self.iterable)
+                self.current_pos += 1
+            except ObservedUserStopIteration:
+                handle_observed_exception(tx)
+                raise_observed_exception(StopIteration, tx)
+        # Yield item at next_i
+        try:
+            item = generic_iternext(tx, self.iterable)
+        except ObservedUserStopIteration:
+            handle_observed_exception(tx)
+            raise_observed_exception(StopIteration, tx)
+        self.current_pos += 1
+        # Clamp next_i to stop (CPython: overshoot → stop, triggers drain on next call)
+        new_next_i = self.next_i + self.step
+        if self.stop is not None and new_next_i > self.stop:
+            new_next_i = self.stop
+        self.next_i = new_next_i
+        return item
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.add_push_null(
+            lambda: codegen.extend_output(
+                [
+                    codegen.create_load_python_module(itertools),
+                    codegen.create_load_attr("islice"),
+                ]
+            )
+        )
+        codegen(self.iterable)
+        new_start = self.next_i - self.current_pos
+        new_stop = self.stop - self.current_pos if self.stop is not None else None
+        codegen.extend_output(
+            [
+                codegen.create_load_const(new_start),
+                codegen.create_load_const(new_stop),
+                codegen.create_load_const(self.step),
+            ]
+        )
+        codegen.extend_output(create_call_function(4, False))
 
 
 class MapVariable(IteratorVariable):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #186976
* __->__ #186975
* #186974
* #186973
* #186240

IsliceVariable avoids the O(stop) enumerate loop in the polyfill. For
list/tuple inputs, a fast path slices items directly at construction
(O(output) not O(input)). For general iterators, IsliceVariable tracks
current_pos and next_i, advancing the underlying iterator lazily and
clamping next_i to stop after each yield to match CPython's behavior of
draining to stop when the islice is exhausted.

Also updates the batched polyfill to reference itertools.islice directly
since the islice polyfill is removed.

Benchmark (dynamo compile time, eager backend, fullgraph, median of 15
cold compiles over a length-2048 list; agent_space/bench_itertools.py):

| variant  | compile (s) | speedup |
| -------- | ----------- | ------- |
| polyfill |       0.586 |   1.00x |
| native   |       0.246 |   2.39x |

Test Plan:

```bash
python test/dynamo/test_functions.py -k islice
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98