### PR TITLE
[export] avoid RecursionError in guards-fn codegen for deeply nested guards (#186993)

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -595,6 +595,27 @@ class TestExport(TestCase):
         #     exported_program.module()(*args, **reversed_kwargs), f(*args, **reversed_kwargs)
         # )
 
+    def test_guards_fn_recovers_from_unparse_recursion_error(self):
+        # Regression test: guards-fn codegen pretty-prints each guard for the
+        # assert error message via ast.unparse(ast.parse(...)), which recurses
+        # once per AST node. A deeply-nested guard (e.g. a sum over thousands of
+        # symbolic sizes) overflowed the recursion limit there, crashing export
+        # even though the pretty-printing is cosmetic and the executed guard
+        # does not depend on it. Codegen must fall back to the raw guard string
+        # instead of propagating the error.
+        #
+        # We inject the overflow via a mocked ast.unparse rather than building a
+        # genuinely deep expression: the test target is ASAN-instrumented, where
+        # deep ast.parse/compile recursion can abort the process before the
+        # pure-Python RecursionError is reached.
+        from torch.export._unlift import _convert_guards_code_to_fn
+
+        guard = "args[0] == 0"
+        with patch("ast.unparse", side_effect=RecursionError):
+            guards_fn = _convert_guards_code_to_fn([guard], [])
+
+        self.assertIsNotNone(guards_fn)
+
     def _check_dynamic_shapes_specs_and_shapes(
         self,
         model,

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -199,7 +199,15 @@ def _convert_guards_code_to_fn(
         # printing guards code may potentially introduce redundant parens;
         # we can normalize them out for readability by parsing/unparsing
         # NOTE: this is not necessary for correctness, just deemed desirable
-        _shadow = ast.unparse(ast.parse(shadow, mode="eval"))
+        try:
+            _shadow = ast.unparse(ast.parse(shadow, mode="eval"))
+        except RecursionError as e:
+            # A deeply nested guard expression (e.g. a sum over many symbolic
+            # sizes) can exceed the recursion limit in ast.parse/ast.unparse.
+            # This normalization only affects the assert error message, so fall
+            # back to the un-normalized guard string instead of crashing.
+            warnings.warn(f"ast.unparse failed for guard expression: {e}", stacklevel=2)
+            _shadow = shadow
         # actual code and shadow error message
         code_str += f'  torch._assert({actual}, "Guard failed: {_shadow}")\n'
     code_str += "  return\n"


### PR DESCRIPTION
Summary:

`ExportedProgram.module()` builds a `_guards_fn` submodule that re-asserts the exported shape guards. For each assert's human-readable error message, `_convert_guards_code_to_fn` (in `torch/export/_unlift.py`) pretty-prints the guard via `ast.unparse(ast.parse(shadow))`. Both `ast.parse` and `ast.unparse` recurse once per AST node, so a guard whose expression is very deeply nested -- e.g. a sum over many symbolic sizes, as produced when exporting a recommendation model with `auto_dynamic_shapes` over hundreds of jagged/KJT features -- exceeds Python's recursion limit and raises `RecursionError`, aborting the entire export (including standalone publish, which reaches this code via `run_decompositions()` -> `module()`).

Root cause: the `ast.unparse(ast.parse(...))` round-trip is purely cosmetic; as the existing comment states, it "is not necessary for correctness, just deemed desirable" -- it only normalizes redundant parentheses in the assert error string. The executed runtime check uses the separate `actual` expression and does not depend on the pretty-printed `shadow`, so a deep guard should never be fatal.

Fix: wrap the normalization in `try/except RecursionError` and fall back to the un-normalized guard string. The emitted runtime assert is unchanged; only the readability of the guard-failure message degrades slightly in the rare deep-guard case.

Test Plan:
Built custom aps package and publish f1096406197

Added `test_guards_fn_recovers_from_unparse_recursion_error`, which mocks `ast.unparse` to raise `RecursionError` and asserts `_convert_guards_code_to_fn` still returns a guards fn instead of propagating the error. A mock is used rather than a genuinely deep expression because the test target is ASAN-instrumented, where deep `ast.parse`/`compile` recursion can abort the process before the pure-Python `RecursionError` is reached.

```
buck2 test fbcode//caffe2/test:test_export -- --regex 'test_guards_fn_recovers_from_unparse_recursion_error'
```

After the fix: `Pass 11. Fail 0. Fatal 0.` (the test is fanned out across export modes: strict, nonstrict, serdes, retraceability, cpp_serdes, training_ir, nativert, ...). Before the fix the same test fails with `RecursionError: maximum recursion depth exceeded` at `_unlift.py` (`Pass 0, Fail 11`).

Authored with the assistance of an AI coding assistant.

Reviewed By: jijunyan, sophielin508

Differential Revision: D108111211


