### PR TITLE
[claude][triage] retry cross-run artifact download in issue triage

### DIFF
--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -22,11 +22,32 @@ jobs:
 
     steps:
       - name: Download issue number artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: issue-triage-data
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The upstream "Claude Issue Triage" run uploads the issue number as a
+          # cross-run artifact that this workflow downloads. actions/download-artifact@v4
+          # has no built-in retry and intermittently fails to find a cross-run
+          # artifact even when it exists (the failure rate spikes when many issues
+          # are opened at once) -- when that happens every downstream step is
+          # skipped and the issue is silently never triaged. Retry with backoff so
+          # a transient download failure no longer drops triage for an issue.
+          for attempt in 1 2 3 4 5; do
+            if gh run download "$RUN_ID" --repo "$REPO" --name issue-triage-data --dir .; then
+              echo "Downloaded issue-triage-data on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Failed to download issue-triage-data from run $RUN_ID after $attempt attempts"
+              echo "Artifacts present on run $RUN_ID:"
+              gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[].name' || true
+              exit 1
+            fi
+            echo "Attempt $attempt failed to download artifact from run $RUN_ID; retrying in $((attempt * 5))s"
+            sleep "$((attempt * 5))"
+          done
 
       - name: Read issue number
         id: issue

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -35,6 +35,9 @@ jobs:
           # skipped and the issue is silently never triaged. Retry with backoff so
           # a transient download failure no longer drops triage for an issue.
           for attempt in 1 2 3 4 5; do
+            # gh extracts with O_EXCL; clear any partial file from a prior
+            # attempt so a retry can't fail deterministically with "file exists".
+            rm -f issue_number.txt
             if gh run download "$RUN_ID" --repo "$REPO" --name issue-triage-data --dir .; then
               echo "Downloaded issue-triage-data on attempt $attempt"
               break
@@ -42,7 +45,7 @@ jobs:
             if [ "$attempt" -eq 5 ]; then
               echo "::error::Failed to download issue-triage-data from run $RUN_ID after $attempt attempts"
               echo "Artifacts present on run $RUN_ID:"
-              gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[].name' || true
+              gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[] | "\(.name) expired=\(.expired)"' || true
               exit 1
             fi
             echo "Attempt $attempt failed to download artifact from run $RUN_ID; retrying in $((attempt * 5))s"


### PR DESCRIPTION
## Summary

Claude issue-triage runs as a two-stage workflow:
- `claude-issue-triage.yml` (untrusted, `issues.opened`, `contents: read` only) writes the issue number to an artifact (`issue-triage-data`).
- `claude-issue-triage-run.yml` (trusted `workflow_run`, `issues: write` + Bedrock OIDC) downloads that artifact and runs the triage.

The download step (`actions/download-artifact@v4`, cross-run via `run-id`) **intermittently fails to find the artifact even though it exists**. The failure rate spikes when many issues are opened in a short window (e.g. batches of auto-filed `DISABLED test_*` issues), but it also hits singleton user-filed issues. `download-artifact@v4` has **no built-in retry**, so when the download fails, every downstream step is skipped and **the issue is silently never triaged**.

Roughly **40% of recent downstream runs** failed this way (failure localized to the "Download issue number artifact" step; the upstream artifact was verified present via the API in the failing runs).

## Fix

Replace the action with a `gh run download` retry loop (5 attempts, linear backoff). On final failure it lists the artifacts present on the upstream run for diagnosis. All `workflow_run` expressions are extracted into `env:` vars (injection-safe). The two-stage split is preserved — it's the trusted/untrusted security boundary.

## Test plan

Verified end-to-end in `pytorch/ciforge` with an isolated two-stage harness (capture → `workflow_run` → gh-based retry download → assert issue number). Both stages passed; the cross-run download succeeded and the issue number was recovered into the working dir as the existing "Read issue number" step expects. Temp workflows + test issue cleaned up after.

Cross-model review (codex / gpt-5.5): SHIP — confirmed `gh run download -n <name> -D .` flattens the single artifact into CWD, retry/`exit 1` logic is correct, no security weakening, `gh` is preinstalled on `ubuntu-latest`.



----


live-tested in ciforge: https://github.com/pytorch/ciforge/actions/runs/27311548072/job/80682640682