### PR TITLE
Fix distributed triage MCP startup

### DIFF
--- a/.github/workflows/claude-distributed-triage.yml
+++ b/.github/workflows/claude-distributed-triage.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Setup GitHub MCP Server
         if: steps.gate.outputs.proceed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          docker pull ghcr.io/github/github-mcp-server:v0.30.1
           mkdir -p /tmp/mcp-config
           cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
           {
@@ -84,12 +87,13 @@ jobs:
                   "run",
                   "-i",
                   "--rm",
+                  "--pull=never",
                   "-e",
                   "GITHUB_PERSONAL_ACCESS_TOKEN",
                   "ghcr.io/github/github-mcp-server:v0.30.1"
                 ],
                 "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
                 }
               }
             }
@@ -119,7 +123,7 @@ jobs:
           claude_args: |
             --model global.anthropic.claude-sonnet-4-5-20250929-v1:0
             --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
+            --allowedTools "Skill,mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |
             /distributed-triage #${{ steps.issue.outputs.number }}
 

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -87,7 +87,7 @@ jobs:
           claude_args: |
             --model global.anthropic.claude-sonnet-4-5-20250929-v1:0
             --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
+            --allowedTools "Skill,mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |
             /triaging-issues #${{ steps.issue.outputs.number }}
 


### PR DESCRIPTION
Summary:
- pre-pull the GitHub MCP Docker image before the distributed triage Claude step
- run the MCP container with `--pull=never` so Claude does not block on Docker image pulls during MCP initialization
- allow the `Skill` tool in both parent and distributed triage workflows

Root cause:
The distributed triage workflow starts GitHub MCP through Docker. If the MCP image is not already cached, Docker can pull the image while Claude is trying to initialize MCP, leaving the GitHub MCP server pending and making `mcp__github__...` tools unavailable. That can make the bot appear to run while it cannot actually read or update the issue.

Test Plan:
Run in ci-forge

```bash
eval "$(/usr/bin/conda shell.bash hook)" && conda activate pytorch-3.12 && python - <<'PY'
from pathlib import Path
import yaml
for path in [
    Path('.github/workflows/claude-distributed-triage.yml'),
    Path('.github/workflows/claude-issue-triage-run.yml'),
]:
    with path.open() as f:
        yaml.safe_load(f)
PY
```

```bash
eval "$(/usr/bin/conda shell.bash hook)" && conda activate pytorch-3.12 && lintrunner -a
```

Additional validation:
A ciforge PR-merge-ref harness run validated the MCP startup path with the same production change: Docker pulled `ghcr.io/github/github-mcp-server:v0.30.1` before Claude started, Claude received GitHub MCP tools, and `mcp__github__update_issue` succeeded. Run: https://github.com/pytorch/ciforge/actions/runs/27312113893

Authored with assistance from an AI assistant.
