### PR TITLE
fix test_memory tests by gc.collect()

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5069,9 +5069,6 @@ class TestCudaAllocator(TestCase):
         self.assertEqual(md["expandable_segments"], EXPANDABLE_SEGMENTS)
 
     @unittest.skipIf(
-        IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/179745"
-    )
-    @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
     def test_memory_snapshot(self):
@@ -5286,9 +5283,6 @@ class TestCudaAllocator(TestCase):
             disarm()
 
     @unittest.skipIf(
-        IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/179744"
-    )
-    @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
     @requiresCppContext
@@ -5413,6 +5407,9 @@ class TestCudaAllocator(TestCase):
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
+            # This test requires to run gc.collec() to fix other memory tests
+            torch.cuda.synchronize()
+            gc.collect()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
@@ -5452,9 +5449,6 @@ class TestCudaAllocator(TestCase):
         finally:
             torch.cuda.memory._record_memory_history(None)
 
-    @unittest.skipIf(
-        IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/179798"
-    )
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )


### PR DESCRIPTION
This PR fixes the tests, but not the root cause of the issue.
It seems like we're left with garbage in memory after the `test_cuda.py::TestCudaAllocator::test_memory_compile_regions`. The test uses a compiled model with _record_memory_history. 
gc.collect() at the end of the test fixes several memory tests.

Modified test:
- test_cuda.py::TestCudaAllocator::test_memory_compile_regions

Fixed tests:
- test_cuda.py::TestCudaAllocator::test_memory_plots 
- test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack
- test_cuda.py::TestCudaAllocator::test_memory_snapshot

Fixes https://github.com/pytorch/pytorch/issues/163202
Fixes https://github.com/pytorch/pytorch/issues/179744
Fixes https://github.com/pytorch/pytorch/issues/179798
Fixes https://github.com/pytorch/pytorch/issues/179745