### PR TITLE
Fetch tags in unified manywheel build job so release tags are detected

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -174,6 +174,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -74,6 +74,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -160,6 +164,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -246,6 +254,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -332,6 +344,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -161,6 +165,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -247,6 +255,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -333,6 +345,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
+          # Fetch tags so binary_populate_env.sh can detect the release tag via
+          # `git describe --tags --exact`; without this a tag-triggered build is
+          # mistaken for a dev build and pins triton to a +git<hash> version.
+          fetch-tags: true
           submodules: recursive
           show-progress: false
       - name: Populate binary env


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/pytorch/commit/ce9267a4585256d1465a00a6a7687ce76f3784a5 to release/2.13 branch

Fetch tags in unified manywheel build job so release tags are detected
Release candidate builds triggered by a tag (e.g. v2.13.0-rc1) were
producing wheels that pinned triton to a dev-style version such as
triton==3.7.1+git5d6048aa instead of the release triton==3.7.1, which
then fails to install in the test job because that version does not
exist on the test index.

Root cause: the unified inline manywheel build job (cpu/cpu-aarch64/
cuda/cuda-aarch64) checks out the raw commit via `ref: github.sha` with
`fetch-depth: 2`. Checking out a bare SHA does not fetch the tag ref, so
`tagged_version()` in .ci/pytorch/binary_populate_env.sh
(`git describe --tags --exact`) fails and the build falls through to the
`<version>.dev<DATE>` default. binary_populate_env.sh then takes its
`.*dev.*` branch and appends `+git<triton-shorthash>` to the triton
requirement that gets baked into the wheel metadata.

Fix: add `fetch-tags: true` to the inline build job checkout in the
linux binary build template so the tag pointing at the checked-out
commit is fetched, letting `git describe --tags --exact` succeed and the
build resolve to the release version. The ROCm/XPU/s390x builds use the
reusable _binary-build-linux.yml whose checkout has no pinned ref (it
uses the default tag ref for a tag push) and are unaffected.

This is the same class of bug fixed for the older checkout-pytorch path
in https://github.com/pytorch/pytorch/pull/180508; this covers the inlined unified build job introduced since.

Test Plan:

Regenerated the workflows from the template and confirmed only the two
linux manywheel workflows change, each gaining `fetch-tags: true` on its
four unified build jobs:

```
python3 .github/scripts/generate_ci_workflows.py
git diff --stat .github/workflows
grep -c 'fetch-tags: true' \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

Validated the regenerated YAML parses and passes actionlint (the only
reported shellcheck warnings are pre-existing on the base files):

```
python3 -c "import yaml; yaml.safe_load(open(f)) for f in (...)"
lintrunner --take ACTIONLINT \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

This PR was authored with the assistance of an AI coding assistant.