### PR TITLE
[ROCm] Add PYTORCH_HIP_NO_STREAM_POOL non-pooled stream debug mode

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -137,6 +137,13 @@ struct CUDACachingHostAllocatorImpl
   void record_stream(
       std::optional<std::vector<CUDAEventPool::Event>>& events,
       CUDAStream stream) override {
+#ifdef USE_ROCM
+    // The stream was synchronized before destruction, so no event is needed
+    // to order its work. See Note [HIP Non-pooled Streams]
+    if (c10::cuda::isDestroyedNonPooledStream(stream)) {
+      return;
+    }
+#endif
     auto event = create_event_internal(stream.device_index());
     event->record(stream);
     events->push_back(std::move(event));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -4349,6 +4349,13 @@ class DeviceCachingAllocator {
     stream_set streams(std::move(block->stream_uses));
     AT_ASSERT(block->stream_uses.empty());
     for (auto& stream : streams) {
+#ifdef USE_ROCM
+      // The stream was synchronized before destruction, so no event is
+      // needed to order its work. See Note [HIP Non-pooled Streams]
+      if (c10::cuda::isDestroyedNonPooledStream(stream)) {
+        continue;
+      }
+#endif
       C10_CUDA_CHECK(c10::cuda::SetDevice(stream.device_index()));
 
       EventPool::Event event = create_event_internal(stream.device_index());

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -1,14 +1,19 @@
 #include <c10/core/impl/GPUTrace.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <c10/util/CallOnce.h>
 #include <c10/util/Exception.h>
+#include <c10/util/env.h>
 #include <c10/util/irange.h>
 
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace c10::cuda {
 
@@ -269,6 +274,176 @@ CUDAStream CUDAStreamForId(DeviceIndex device_index, StreamId stream_id) {
           stream_id));
 }
 
+#ifdef USE_ROCM
+// Note [HIP Non-pooled Streams]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Debug mode, enabled via PYTORCH_HIP_NO_STREAM_POOL=1. Bypasses the stream
+// pool entirely: every getStreamFromPool call immediately creates a fresh
+// stream with cudaStreamCreateWithPriority and returns it as a
+// pointer-encoded StreamId (the same encoding used for external streams).
+// Nothing is ever recycled back into a pool; a stream is destroyed as soon
+// as it is no longer needed. Need is reference-counted, with references held
+// by: the creator (the Python Stream object that called getStreamFromPool;
+// C++ callers have no release point, so their streams stay alive for the
+// process lifetime just like pool streams), every other Python Stream object
+// wrapping the stream (taken at construction, dropped at dealloc, so the
+// save/restore pattern around torch.cuda.stream() keeps the saved previous
+// stream alive), and each thread/device current-stream slot (taken and
+// dropped in setCurrentCUDAStream). The last release synchronizes the stream,
+// destroys it, and tombstones the handle; the caching allocators consult the
+// tombstones (isDestroyedNonPooledStream) to skip recording events against
+// destroyed handles, which is safe because the destroy-time synchronize
+// already ordered all of the stream's work. A stream whose last reference
+// drops during graph capture cannot be synchronized or destroyed yet; its
+// destruction is deferred until after the capture ends and is drained on
+// subsequent stream activity. Remaining caveats: a thread that
+// exits while a non-pooled stream is its current stream pins that stream's
+// reference forever; C++ StreamGuards hold only a borrowed Stream value, so
+// a guard that displaces and later restores a stream whose other references
+// all dropped in between will restore a destroyed handle; and consumers that
+// cache the raw handle elsewhere and call into HIP with it after destruction
+// will crash. Don't drop all Python references to a stream while such uses
+// are pending.
+std::mutex non_pooled_mutex;
+// stream -> outstanding references (creator + current-stream slots)
+std::unordered_map<cudaStream_t, int64_t> non_pooled_refs;
+// handles destroyed by this mode; cleared if the runtime reuses the address
+std::unordered_set<cudaStream_t> destroyed_non_pooled_streams;
+
+bool noStreamPool() {
+  static bool enabled =
+      c10::utils::check_env("PYTORCH_HIP_NO_STREAM_POOL") == true;
+  return enabled;
+}
+
+void drainDeferredNonPooledDestroys();
+
+CUDAStream getNonPooledStream(const int priority, DeviceIndex device_index) {
+  drainDeferredNonPooledDestroys();
+  CUDAGuard device_guard(device_index);
+  cudaStream_t stream = nullptr;
+  auto pri = -std::clamp(-priority, 0, max_stream_priorities - 1);
+  C10_CUDA_CHECK(cudaStreamCreateWithPriority(&stream, kDefaultFlags, pri));
+  // Pointer-encoded StreamIds rely on the low bit being zero, see
+  // Note [StreamId assignment]
+  TORCH_INTERNAL_ASSERT(
+      !(reinterpret_cast<uintptr_t>(stream) & 1),
+      "Misaligned stream handle cannot be encoded as a StreamId");
+  const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+  if (C10_UNLIKELY(interp)) {
+    (*interp)->trace_gpu_stream_creation(
+        c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
+  }
+  {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    non_pooled_refs.emplace(stream, 1);
+    destroyed_non_pooled_streams.erase(stream);
+  }
+  return CUDAStreamForId(device_index, reinterpret_cast<StreamId>(stream));
+}
+
+// The helpers below assume the mode is enabled; callers check noStreamPool().
+bool retainNonPooledStreamId(StreamId stream_id) {
+  if (!streamIdType(stream_id).isExt()) {
+    return false;
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  auto raw_stream = reinterpret_cast<cudaStream_t>(stream_id);
+  std::lock_guard<std::mutex> lock(non_pooled_mutex);
+  auto it = non_pooled_refs.find(raw_stream);
+  if (it == non_pooled_refs.end()) {
+    return false;
+  }
+  it->second++;
+  return true;
+}
+
+// Streams whose last reference dropped during graph capture; destroying or
+// synchronizing a capturing stream is illegal, so destruction is deferred
+// until after the capture ends (drained on subsequent stream activity).
+std::vector<std::pair<DeviceIndex, cudaStream_t>> deferred_non_pooled_destroys;
+
+// Conservatively treats a failed capture-status query as capturing.
+cudaStreamCaptureStatus queryCaptureStatus(cudaStream_t raw_stream) {
+  cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+  cudaError_t err =
+      C10_CUDA_ERROR_HANDLED(cudaStreamIsCapturing(raw_stream, &status));
+  if (err != cudaSuccess) {
+    (void)cudaGetLastError();
+    return cudaStreamCaptureStatusActive;
+  }
+  return status;
+}
+
+void destroyNonPooledStreamHandle(
+    DeviceIndex device_index,
+    cudaStream_t raw_stream) {
+  CUDAGuard device_guard(device_index);
+  // Defer if the stream joined an ongoing capture, or if this thread's
+  // current stream is capturing: synchronization APIs called during capture
+  // invalidate it even when the synchronized stream is not the captured one.
+  auto status = queryCaptureStatus(raw_stream);
+  if (status == cudaStreamCaptureStatusNone) {
+    status = queryCaptureStatus(getCurrentCUDAStream(device_index).stream());
+  }
+  if (status != cudaStreamCaptureStatusNone) {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    deferred_non_pooled_destroys.emplace_back(device_index, raw_stream);
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    destroyed_non_pooled_streams.insert(raw_stream);
+  }
+  // Relaxed mode so a global-mode capture on another thread is not
+  // invalidated by this synchronize/destroy.
+  CUDAStreamCaptureModeGuard mode_guard{cudaStreamCaptureModeRelaxed};
+  // Synchronize before destroying so that skipping allocator events recorded
+  // against this handle (see isDestroyedNonPooledStream) is safe. This can
+  // run inside dealloc paths, so swallow errors rather than throw.
+  try {
+    c10::cuda::stream_synchronize(raw_stream);
+  } catch (const c10::Error& e) {
+    TORCH_WARN(
+        "Failed to synchronize non-pooled stream before destruction: ",
+        e.what_without_backtrace());
+  }
+  C10_CUDA_CHECK_WARN(cudaStreamDestroy(raw_stream));
+}
+
+void drainDeferredNonPooledDestroys() {
+  std::vector<std::pair<DeviceIndex, cudaStream_t>> pending;
+  {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    if (deferred_non_pooled_destroys.empty()) {
+      return;
+    }
+    pending.swap(deferred_non_pooled_destroys);
+  }
+  for (auto& [device_index, raw_stream] : pending) {
+    destroyNonPooledStreamHandle(device_index, raw_stream);
+  }
+}
+
+void releaseNonPooledStreamId(DeviceIndex device_index, StreamId stream_id) {
+  drainDeferredNonPooledDestroys();
+  if (!streamIdType(stream_id).isExt()) {
+    return;
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  auto raw_stream = reinterpret_cast<cudaStream_t>(stream_id);
+  {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    auto it = non_pooled_refs.find(raw_stream);
+    if (it == non_pooled_refs.end() || --it->second > 0) {
+      return;
+    }
+    non_pooled_refs.erase(it);
+  }
+  destroyNonPooledStreamHandle(device_index, raw_stream);
+}
+#endif
+
 } // anonymous namespace
 
 bool CUDAStream::query() const {
@@ -348,7 +523,12 @@ CUDAStream getStreamFromPool(const int priority, DeviceIndex device_index) {
     c10::cuda::SetTargetDevice();
   }
   check_gpu(device_index);
-#if !defined(USE_ROCM)
+#ifdef USE_ROCM
+  // See Note [HIP Non-pooled Streams]
+  if (noStreamPool()) {
+    return getNonPooledStream(priority, device_index);
+  }
+#else
   // See Note [HIP Lazy Streams]
   // CUDA-only: Initializes the stream pools (once)
   c10::call_once(
@@ -369,9 +549,48 @@ CUDAStream getStreamFromPool(const bool isHighPriority, DeviceIndex device) {
 CUDAStream getStreamFromExternal(
     cudaStream_t ext_stream,
     DeviceIndex device_index) {
+#ifdef USE_ROCM
+  // A live external stream proves the runtime reused a destroyed handle's
+  // address, so the tombstone is stale. See Note [HIP Non-pooled Streams]
+  if (noStreamPool()) {
+    std::lock_guard<std::mutex> lock(non_pooled_mutex);
+    destroyed_non_pooled_streams.erase(ext_stream);
+  }
+#endif
   // The stream pointer will be the actual id
   return CUDAStreamForId(device_index, reinterpret_cast<int64_t>(ext_stream));
 }
+
+#ifdef USE_ROCM
+// See Note [HIP Non-pooled Streams]
+bool retainNonPooledStream(CUDAStream stream) {
+  if (!noStreamPool()) {
+    return false;
+  }
+  return retainNonPooledStreamId(stream.id());
+}
+
+void releaseNonPooledStream(CUDAStream stream) {
+  if (!noStreamPool()) {
+    return;
+  }
+  releaseNonPooledStreamId(stream.device_index(), stream.id());
+}
+
+bool isDestroyedNonPooledStream(CUDAStream stream) {
+  if (!noStreamPool()) {
+    return false;
+  }
+  StreamId stream_id = stream.id();
+  if (!streamIdType(stream_id).isExt()) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(non_pooled_mutex);
+  return destroyed_non_pooled_streams.count(
+             // NOLINTNEXTLINE(performance-no-int-to-ptr)
+             reinterpret_cast<cudaStream_t>(stream_id)) > 0;
+}
+#endif
 
 CUDAStream getDefaultCUDAStream(DeviceIndex device_index) {
   initCUDAStreamsOnce();
@@ -397,6 +616,20 @@ void setCurrentCUDAStream(CUDAStream stream) {
   initCUDAStreamsOnce();
   auto device_index = stream.device_index();
   check_gpu(device_index);
+#ifdef USE_ROCM
+  // The current-stream slot holds a reference; the displaced stream may be
+  // destroyed here if this was its last one. See Note [HIP Non-pooled Streams]
+  if (noStreamPool()) {
+    StreamId old_id = current_streams[device_index];
+    StreamId new_id = stream.id();
+    if (old_id != new_id) {
+      retainNonPooledStreamId(new_id);
+      current_streams[device_index] = new_id;
+      releaseNonPooledStreamId(device_index, old_id);
+    }
+    return;
+  }
+#endif
   current_streams[device_index] = stream.id();
 }
 

--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -215,6 +215,35 @@ getStreamFromPool(const int priority, DeviceIndex device = -1);
 C10_CUDA_API CUDAStream
 getStreamFromExternal(cudaStream_t ext_stream, DeviceIndex device_index);
 
+#ifdef USE_ROCM
+/**
+ * Take a reference on a stream that getStreamFromPool created in non-pooled
+ * debug mode (PYTORCH_HIP_NO_STREAM_POOL=1, see
+ * Note [HIP Non-pooled Streams]). Returns true if a reference was taken;
+ * false if the mode is disabled or the stream is not a live non-pooled
+ * stream (e.g. pool, default, external, or already-destroyed streams). The
+ * caller must pair a successful retain with releaseNonPooledStream.
+ */
+C10_CUDA_API bool retainNonPooledStream(CUDAStream stream);
+
+/**
+ * Drop a reference to a stream that getStreamFromPool created in non-pooled
+ * debug mode; the stream is synchronized and destroyed when its last
+ * reference drops. No-op if the mode is disabled or the stream was not
+ * created by that mode, so it is safe to call unconditionally from owner
+ * teardown paths.
+ */
+C10_CUDA_API void releaseNonPooledStream(CUDAStream stream);
+
+/**
+ * True if the stream's handle was destroyed by non-pooled debug mode.
+ * Consumers that cache streams and later record events against them (the
+ * caching allocators) use this to skip destroyed handles; the destroy-time
+ * synchronize makes that safe. See Note [HIP Non-pooled Streams].
+ */
+C10_CUDA_API bool isDestroyedNonPooledStream(CUDAStream stream);
+#endif
+
 /**
  * Get the default CUDA stream, for the passed CUDA device, or for the
  * current device if no device index is passed.  The default stream is

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1390,6 +1390,101 @@ print(t.is_pinned())
         default_stream.synchronize()
         self.assertTrue(default_stream.query())
 
+    @unittest.skipUnless(TEST_WITH_ROCM, "ROCm-only non-pooled stream debug mode")
+    def test_hip_non_pooled_streams(self):
+        # See Note [HIP Non-pooled Streams]: with PYTORCH_HIP_NO_STREAM_POOL=1
+        # every torch.cuda.Stream() must be a freshly created HIP stream
+        # (no round-robin aliasing past 32 streams) that is destroyed when the
+        # owning Python object is deallocated.
+        test_script = """\
+import torch
+
+# the pool holds 32 streams per priority; 40 live streams would alias
+streams = [torch.cuda.Stream() for _ in range(40)]
+ptrs = [s.cuda_stream for s in streams]
+assert len(set(ptrs)) == len(ptrs), "stream handles aliased; pool still active"
+
+x = torch.ones(64, device="cuda")
+with torch.cuda.stream(streams[0]):
+    y = x * 2
+streams[0].synchronize()
+assert (y == 2).all().item()
+
+# a weak wrapper from current_stream() must not destroy the owned stream
+with torch.cuda.stream(streams[1]):
+    wrapper = torch.cuda.current_stream()
+del wrapper
+with torch.cuda.stream(streams[1]):
+    z = x + 1
+streams[1].synchronize()
+assert (z == 2).all().item()
+
+# dealloc destroys the streams; later work must be unaffected
+del streams
+torch.cuda.synchronize()
+w = x + 3
+torch.cuda.synchronize()
+assert (w == 4).all().item()
+
+# the current-stream slot holds a reference: dropping the only Python
+# reference must keep the stream alive until it is displaced
+s = torch.cuda.Stream()
+torch.cuda.set_stream(s)
+del s
+q = x * 5
+torch.cuda.current_stream().synchronize()
+assert (q == 5).all().item()
+torch.cuda.set_stream(torch.cuda.default_stream())
+
+# allocator-cached streams: record_stream on device and pinned blocks must
+# tolerate the stream being destroyed before the blocks are freed
+s = torch.cuda.Stream()
+h = torch.randn(1024, pin_memory=True)
+with torch.cuda.stream(s):
+    d = h.to("cuda", non_blocking=True)
+t = torch.ones(1024, device="cuda")
+t.record_stream(s)
+s.synchronize()
+del s
+del h, d, t
+torch.cuda.synchronize()
+
+# generic torch.Stream owners destroy their stream on dealloc as well;
+# any handle reuse across create/delete cycles proves destruction happens
+gptrs = []
+for _ in range(50):
+    g = torch.Stream("cuda")
+    gptrs.append(g.stream_id)
+    del g
+assert len(set(gptrs)) < 50, "generic torch.Stream streams were not destroyed"
+
+# a stream whose last reference drops during graph capture must have its
+# destruction deferred (sync/destroy would invalidate the capture)
+graph = torch.cuda.CUDAGraph()
+cap = torch.cuda.Stream()
+y = torch.zeros(64, device="cuda")
+with torch.cuda.stream(cap):
+    with torch.cuda.graph(graph):
+        side = torch.cuda.Stream()
+        y += 1
+        del side
+graph.replay()
+graph.replay()
+torch.cuda.synchronize()
+assert (y == 2).all().item()
+print("OK")
+"""
+        env = os.environ.copy()
+        env["PYTORCH_HIP_NO_STREAM_POOL"] = "1"
+        r = subprocess.run(
+            [sys.executable, "-c", test_script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertIn("OK", r.stdout)
+
     def test_stream_invalid_device_index(self):
         # Regression test for #184034: constructing a CUDAStream with an
         # out-of-range device_index must not OOB-index the static stream pool.

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -12,6 +12,10 @@
 #include <structmember.h>
 #include <cstdint>
 
+#ifdef USE_ROCM
+#include <c10/cuda/CUDAStream.h>
+#endif
+
 PyTypeObject* THPStreamClass = nullptr;
 
 static PyObject* THPStream_pynew(
@@ -93,6 +97,16 @@ static PyObject* THPStream_pynew(
   self->device_type = static_cast<int64_t>(stream_opt->device_type());
   self->context = nullptr;
   self->weakreflist = nullptr;
+  self->holds_non_pooled_stream_ref = false;
+#ifdef USE_ROCM
+  // See Note [HIP Non-pooled Streams]: getNewStream transfers the creator's
+  // reference to this object; a wrapper of an existing stream takes its own.
+  if (stream_opt->device_type() == c10::DeviceType::CUDA) {
+    self->holds_non_pooled_stream_ref = (r.idx == 0) ||
+        c10::cuda::retainNonPooledStream(c10::cuda::CUDAStream(
+            c10::cuda::CUDAStream::UNCHECKED, *stream_opt));
+  }
+#endif
 
   return static_cast<PyObject*>(ptr.release());
   END_HANDLE_TH_ERRORS
@@ -113,11 +127,30 @@ PyObject* THPStream_Wrap(const c10::Stream& stream) {
   self->device_type = static_cast<int64_t>(stream.device_type());
   self->context = nullptr;
   self->weakreflist = nullptr;
+  self->holds_non_pooled_stream_ref = false;
+#ifdef USE_ROCM
+  // See Note [HIP Non-pooled Streams]
+  if (stream.device_type() == c10::DeviceType::CUDA) {
+    self->holds_non_pooled_stream_ref = c10::cuda::retainNonPooledStream(
+        c10::cuda::CUDAStream(c10::cuda::CUDAStream::UNCHECKED, stream));
+  }
+#endif
   return ptr.release();
   END_HANDLE_TH_ERRORS
 }
 
 void THPStream_dealloc_common(THPStream* self) {
+#ifdef USE_ROCM
+  // See Note [HIP Non-pooled Streams]
+  if (self->holds_non_pooled_stream_ref) {
+    c10::cuda::releaseNonPooledStream(c10::cuda::CUDAStream(
+        c10::cuda::CUDAStream::UNCHECKED,
+        c10::Stream::unpack3(
+            self->stream_id,
+            static_cast<c10::DeviceIndex>(self->device_index),
+            static_cast<c10::DeviceType>(self->device_type))));
+  }
+#endif
   PyObject_ClearWeakRefs((PyObject*)self);
   Py_CLEAR(self->context);
   Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));

--- a/torch/csrc/Stream.h
+++ b/torch/csrc/Stream.h
@@ -13,6 +13,10 @@ struct TORCH_PYTHON_API THPStream {
   // Used to switch stream context management, initialized lazily.
   PyObject* context;
   PyObject* weakreflist;
+  // True when this object holds a reference on the underlying stream in
+  // ROCm's non-pooled debug mode, either as its creator or as a wrapper
+  // that successfully retained it. See Note [HIP Non-pooled Streams]
+  bool holds_non_pooled_stream_ref;
 };
 extern TORCH_PYTHON_API PyTypeObject* THPStreamClass;
 

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -75,6 +75,8 @@ static PyObject* THCPStream_pynew(
     TORCH_CHECK(
         priority == 0, "Priority was explicitly set for an external stream")
   }
+  const bool from_pool =
+      !(stream_id || device_index || device_type) && !stream_ptr_provided;
   at::cuda::CUDAStream stream = (stream_id || device_index || device_type)
       ? at::cuda::CUDAStream::unpack3(
             stream_id,
@@ -92,6 +94,15 @@ static PyObject* THCPStream_pynew(
   self->device_index = static_cast<int64_t>(stream.device_index());
   self->device_type = static_cast<int64_t>(stream.device_type());
   new (&self->cuda_stream) at::cuda::CUDAStream(stream);
+  self->holds_non_pooled_stream_ref = from_pool;
+#ifdef USE_ROCM
+  // See Note [HIP Non-pooled Streams]: the pool branch transfers the
+  // creator's reference to this object; wrappers take their own.
+  if (!from_pool) {
+    self->holds_non_pooled_stream_ref =
+        c10::cuda::retainNonPooledStream(stream);
+  }
+#endif
 
   return (PyObject*)ptr.release();
   END_HANDLE_TH_ERRORS


### PR DESCRIPTION
The CUDA stream pool (inherited by ROCm via hipify) hands out 32 recycled, never-destroyed streams per priority per device. That hides hipStreamCreate/hipStreamDestroy activity from the HIP runtime, which gets in the way when debugging runtime stream lifetime behavior. With PYTORCH_HIP_NO_STREAM_POOL=1 (ROCm builds only), getStreamFromPool bypasses the pool: every request immediately creates a fresh stream with hipStreamCreateWithPriority, and each stream is destroyed as soon as it is no longer needed. Nothing is recycled and nothing leaks.

Review order: c10/cuda/CUDAStream.cpp is the core; start with Note [HIP Non-pooled Streams]. Non-pooled streams are returned as pointer-encoded StreamIds (the same encoding as external streams), so stream(), packing, and priority queries work without the pool tables. Destruction is reference-counted. References are held by the creating Python Stream object; by every other Python Stream object wrapping the same stream, which keeps the ubiquitous "prev = current_stream(); set_stream(s); ...; set_stream(prev)" pattern safe when prev's owner died while prev was current; and by each thread/device current-stream slot (setCurrentCUDAStream retains the incoming stream and releases the displaced one). The last release synchronizes and destroys the stream. Synchronizing or destroying during graph capture would invalidate the capture, so destruction is then deferred and drained on later stream activity; the capture check covers both the dying stream and the calling thread, and the destroy runs under a relaxed capture-mode guard so cross-thread global-mode captures are not invalidated. Destroyed handles are tombstoned so the two caching allocators (device allocator stream_uses, pinned host allocator block streams), which record events on cached stream handles long after the fact, skip destroyed handles; the destroy-time synchronize is what makes skipping safe.

torch/csrc/Stream.cpp and torch/csrc/cuda/Stream.cpp then wire Python object lifetime to the refcount: the creating object inherits the creator reference, wrapper objects take their own via retainNonPooledStream (which reports whether the stream was live, so a stale wrapper cannot release a reused handle), and THPStream_dealloc_common releases. C++ callers of getStreamFromPool have no release point; their streams live for the process lifetime, matching pool behavior.

A simpler ownership model (destroy when the creating Python object is deallocated, no wrapper references) was tried first and rejected: it destroys streams out from under save/restore contexts and the caching allocators (segfaults in test_record_stream and capture invalidation in the graph tests). C++ StreamGuards hold only a borrowed c10::Stream value, so a guard restoring a stream whose other references all dropped in between remains a documented caveat of the debug mode.

Test Plan

On gfx90a, with and without the env var:

```
PYTORCH_HIP_NO_STREAM_POOL=1 python test/test_cuda.py -k stream   # 29 OK
PYTORCH_HIP_NO_STREAM_POOL=1 python test/test_cuda.py -k graph    # 119 OK
python test/test_cuda.py -k stream                                # 29 OK
python test/test_cuda.py TestCuda.test_hip_non_pooled_streams     # new test
```

The new test exercises pool bypass (40 live streams, 40 unique HIP handles), weak wrappers, current-slot survival, allocator-recorded streams destroyed before block free, generic torch.Stream destruction, and capture-deferred destruction. Destruction was additionally confirmed by observing that 100 create/delete cycles reuse a single HIP handle while 100 live streams have 100 distinct handles.

Authored with Claude (AI assistant).

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang