### PR TITLE
perf(dynamo): add guard lookup fast paths

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
+++ b/benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
@@ -1,0 +1,224 @@
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+
+def fn(x, y, scale: int):
+    return (x + y) * scale
+
+
+def avg_ns(stats, key):
+    count = max(int(stats["lookup_count"]), 1)
+    return int(stats.get(key, 0)) / count
+
+
+def child_main(args):
+    import torch
+    from torch._C._dynamo import guards
+
+    opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+    x = torch.randn(4)
+    y = torch.randn(4)
+
+    for _ in range(args.warmup):
+        opt_fn(x, y, 3)
+
+    guards.reset_guard_lookup_stats()
+    start_ns = time.perf_counter_ns()
+    for _ in range(args.iters):
+        opt_fn(x, y, 3)
+    elapsed_ns = time.perf_counter_ns() - start_ns
+
+    stats = guards.get_guard_lookup_stats()
+    accessor_type_stats = {
+        str(name): dict(value)
+        for name, value in stats["root_guard_accessor_type_stats"].items()
+    }
+    accessor_detail_topk = {
+        str(name): dict(value)
+        for name, value in stats["root_guard_accessor_detail_topk"].items()
+    }
+    payload = {
+        "iters": args.iters,
+        "call_avg_ns": elapsed_ns / args.iters,
+        "lookup_count": stats["lookup_count"],
+        "lookup_avg_ns": avg_ns(stats, "lookup_total_ns"),
+        "backend_match_avg_ns": avg_ns(stats, "backend_match_ns"),
+        "slow_guard_avg_ns": avg_ns(stats, "slow_guard_ns"),
+        "move_to_front_avg_ns": avg_ns(stats, "move_to_front_ns"),
+        "root_guard_avg_ns": avg_ns(stats, "root_guard_total_ns"),
+        "root_guard_lock_avg_ns": avg_ns(stats, "root_guard_lock_ns"),
+        "root_guard_local_state_avg_ns": avg_ns(
+            stats, "root_guard_local_state_ns"
+        ),
+        "root_guard_leaf_avg_ns": avg_ns(stats, "root_guard_leaf_ns"),
+        "root_guard_accessor_avg_ns": avg_ns(stats, "root_guard_accessor_ns"),
+        "root_guard_tls_avg_ns": avg_ns(stats, "root_guard_tls_ns"),
+        "root_guard_count": stats["root_guard_count"],
+        "cache_entry_count_sum": stats["cache_entry_count_sum"],
+        "cache_entry_hit_index_sum": stats["cache_entry_hit_index_sum"],
+        "root_guard_accessor_type_stats": accessor_type_stats,
+        "root_guard_accessor_detail_topk": accessor_detail_topk,
+        "unsafe_mock_guard_bypass_enabled": bool(
+            stats["unsafe_mock_guard_bypass_enabled"]
+        ),
+        "unsafe_mock_guard_bypass_count": stats["unsafe_mock_guard_bypass_count"],
+        "unsafe_mock_guard_bypass_hit_index_sum": stats[
+            "unsafe_mock_guard_bypass_hit_index_sum"
+        ],
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
+def run_once(iters, warmup):
+    env = os.environ.copy()
+    env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+    if os.environ.get("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == "1":
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+    output = subprocess.check_output(
+        [
+            sys.executable,
+            __file__,
+            "--child",
+            "--iters",
+            str(iters),
+            "--warmup",
+            str(warmup),
+        ],
+        env=env,
+        text=True,
+    )
+    return json.loads(output.splitlines()[-1])
+
+
+def median(rows, key):
+    return statistics.median(float(row[key]) for row in rows)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=10000)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--child", action="store_true")
+    args = parser.parse_args()
+
+    if args.child:
+        child_main(args)
+        return
+
+    rows = [run_once(args.iters, args.warmup) for _ in range(args.repeats)]
+
+    columns = [
+        "call_us",
+        "lookup_us",
+        "backend_us",
+        "slow_guard_us",
+        "move_to_front_us",
+        "root_guard_us",
+        "root_lock_us",
+        "root_local_state_us",
+        "root_leaf_us",
+        "root_accessor_us",
+        "root_tls_us",
+        "lookup_count",
+        "root_guard_count",
+        "mock_bypass_count",
+    ]
+    values = [
+        f"{median(rows, 'call_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'lookup_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'backend_match_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'slow_guard_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'move_to_front_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_lock_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_local_state_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_leaf_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_accessor_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_tls_avg_ns') / 1000:.3f}",
+        str(int(median(rows, "lookup_count"))),
+        str(int(median(rows, "root_guard_count"))),
+        str(int(median(rows, "unsafe_mock_guard_bypass_count"))),
+    ]
+    print(" ".join(columns))
+    print(" ".join(values))
+    accessor_totals = {}
+    for row in rows:
+        for name, item in row["root_guard_accessor_type_stats"].items():
+            total = accessor_totals.setdefault(
+                name, {"count": 0, "fail_count": 0, "inclusive_ns": 0}
+            )
+            total["count"] += int(item["count"])
+            total["fail_count"] += int(item["fail_count"])
+            total["inclusive_ns"] += int(item["inclusive_ns"])
+
+    print("\naccessor_type_stats:")
+    print("name count fail_count inclusive_us avg_inclusive_us")
+    for name, item in sorted(
+        accessor_totals.items(),
+        key=lambda pair: pair[1]["inclusive_ns"],
+        reverse=True,
+    ):
+        count = max(item["count"], 1)
+        print(
+            " ".join(
+                [
+                    name,
+                    str(item["count"]),
+                    str(item["fail_count"]),
+                    f"{item['inclusive_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / count / 1000:.3f}",
+                ]
+            )
+        )
+    print("\naccessor_detail_topk:")
+    print("name count fail_count self_us child_us inclusive_us avg_inclusive_us")
+    detail_totals = {}
+    for row in rows:
+        for name, item in row["root_guard_accessor_detail_topk"].items():
+            total = detail_totals.setdefault(
+                name,
+                {
+                    "count": 0,
+                    "fail_count": 0,
+                    "self_ns": 0,
+                    "child_ns": 0,
+                    "inclusive_ns": 0,
+                },
+            )
+            total["count"] += int(item["count"])
+            total["fail_count"] += int(item["fail_count"])
+            total["self_ns"] += int(item["self_ns"])
+            total["child_ns"] += int(item["child_ns"])
+            total["inclusive_ns"] += int(item["inclusive_ns"])
+    for name, item in sorted(
+        detail_totals.items(),
+        key=lambda pair: pair[1]["inclusive_ns"],
+        reverse=True,
+    ):
+        count = max(item["count"], 1)
+        print(
+            " ".join(
+                [
+                    name,
+                    str(item["count"]),
+                    str(item["fail_count"]),
+                    f"{item['self_ns'] / 1000:.3f}",
+                    f"{item['child_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / count / 1000:.3f}",
+                ]
+            )
+        )
+
+    print("\nraw_json:")
+    print(json.dumps(rows, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1831,6 +1831,45 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_last_success_shadow_records_lookup_attempts(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "lookup_count": stats["lookup_count"],
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "incomplete": stats["guard_last_success_shadow_incomplete"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["lookup_count"], 0)
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["incomplete"], 0)
+        self.assertGreater(len(stats["disabled_reasons"]), 0)
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2271,7 +2271,7 @@ print(json.dumps({
         self.assertGreaterEqual(stats["actual_token_check_ns"], 0)
         self.assertGreaterEqual(stats["actual_train_ns"], 0)
 
-    def test_guard_last_success_actual_hits_after_stable_self_receipt(self):
+    def test_guard_last_success_full_actual_stays_disabled(self):
         script = r"""
 import json
 import torch
@@ -2316,9 +2316,9 @@ print(json.dumps({
         )
         stats = json.loads(out.splitlines()[-1])
 
-        self.assertGreater(stats["actual_attempt"], 0)
-        self.assertGreater(stats["actual_enable"], 0)
-        self.assertGreater(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_attempt"], 0)
+        self.assertEqual(stats["actual_enable"], 0)
+        self.assertEqual(stats["actual_hit"], 0)
         self.assertEqual(stats["actual_miss"], 0)
         self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
 
@@ -2356,6 +2356,18 @@ print(json.dumps({
     "partial_hit": stats["guard_last_success_actual_partial_hit"],
     "partial_miss": stats["guard_last_success_actual_partial_miss"],
     "partial_disabled": stats["guard_last_success_actual_partial_disabled"],
+    "partial_hot_tokens": stats[
+        "guard_last_success_actual_partial_hot_token_count_sum"
+    ],
+    "partial_hot_token_unique": stats[
+        "guard_last_success_actual_partial_hot_token_unique_count_sum"
+    ],
+    "partial_hot_token_duplicate": stats[
+        "guard_last_success_actual_partial_hot_token_duplicate_count_sum"
+    ],
+    "partial_hot_token_duplicate_kinds": stats[
+        "guard_last_success_actual_partial_hot_token_duplicate_kind_counts"
+    ],
     "partial_residual_fail": stats[
         "guard_last_success_actual_partial_residual_fail"
     ],
@@ -2379,8 +2391,18 @@ print(json.dumps({
         self.assertEqual(stats["partial_miss"], 0)
         self.assertEqual(stats["partial_disabled"], 0)
         self.assertEqual(stats["partial_residual_fail"], 0)
+        self.assertGreater(stats["partial_hot_tokens"], 0)
+        self.assertGreater(stats["partial_hot_token_unique"], 0)
+        self.assertLessEqual(
+            stats["partial_hot_token_unique"], stats["partial_hot_tokens"]
+        )
+        self.assertEqual(
+            stats["partial_hot_token_unique"] + stats["partial_hot_token_duplicate"],
+            stats["partial_hot_tokens"],
+        )
+        self.assertIsInstance(stats["partial_hot_token_duplicate_kinds"], dict)
 
-    def test_guard_last_success_actual_hits_with_stable_global_dict(self):
+    def test_guard_last_success_full_actual_disabled_with_stable_global_dict(self):
         script = r"""
 import json
 import torch
@@ -2431,12 +2453,13 @@ print(json.dumps({
         )
         stats = json.loads(out.splitlines()[-1])
 
-        self.assertGreater(stats["actual_attempt"], 0)
-        self.assertGreater(stats["actual_enable"], 0)
-        self.assertGreater(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_attempt"], 0)
+        self.assertEqual(stats["actual_enable"], 0)
+        self.assertEqual(stats["actual_hit"], 0)
         self.assertEqual(stats["actual_miss"], 0)
         self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
-        self.assertGreater(stats["actual_hot_token_count_sum"], 0)
+        self.assertEqual(stats["actual_hot_token_count_sum"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
 
     def test_guard_last_success_respects_global_tensor_replacement(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1489,6 +1489,8 @@ print(json.dumps({
     "enabled": stats["guard_fastplan_enabled"],
     "candidate_top": stats["guard_fastplan_candidate_top"],
     "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "partial_enable": stats["guard_fastplan_partial_enable"],
+    "partial_hit": stats["guard_fastplan_partial_hit"],
     "enable_nested": stats["guard_fastplan_enable_nested"],
     "hit_nested": stats["guard_fastplan_hit_nested"],
     "disabled": stats["guard_fastplan_disabled"],
@@ -1509,10 +1511,149 @@ print(json.dumps({
         self.assertTrue(stats["enabled"])
         self.assertGreater(stats["candidate_top"], 0)
         self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["partial_enable"], 0)
+        self.assertGreater(stats["partial_hit"], 0)
         self.assertGreater(stats["enable_nested"], 0)
         self.assertGreater(stats["hit_nested"], 0)
         self.assertGreater(stats["disabled"], 0)
         self.assertGreater(stats["disabled_nested"], 0)
+        self.assertGreaterEqual(
+            stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
+        )
+
+    def test_guard_fast_plan_partial_hit_checks_unsupported_child(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def is_original_dict(x, expected):
+    return x is expected
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Parent(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+        self.blocked = Child()
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.parent = Parent()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_mgr = modules_mgr.getitem_manager(
+    "parent",
+    "L['self']._modules['parent']",
+    model.parent,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_dict_mgr = parent_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent'].__dict__",
+    model.parent.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_modules_mgr = parent_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules",
+    model.parent._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+
+clean_mgr = parent_modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['parent']._modules['clean']",
+    model.parent.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent']._modules['clean'].__dict__",
+    model.parent.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules['clean']._modules",
+    model.parent.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.parent.clean._modules),
+    ["len(L['self']._modules['parent']._modules['clean']._modules) == 1"],
+)
+
+blocked_mgr = parent_modules_mgr.getitem_manager(
+    "blocked",
+    "L['self']._modules['parent']._modules['blocked']",
+    model.parent.blocked,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_dict_mgr = blocked_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent']._modules['blocked'].__dict__",
+    model.parent.blocked.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr = blocked_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules['blocked']._modules",
+    model.parent.blocked._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr.add_lambda_guard(
+    functools.partial(is_original_dict, expected=model.parent.blocked._modules),
+    ["blocked._modules is original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.parent.blocked._modules = {}
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_enable": stats["guard_fastplan_partial_enable"],
+    "partial_hit": stats["guard_fastplan_partial_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["partial_enable"], 0)
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertEqual(stats["miss"], 0)
         self.assertGreaterEqual(
             stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
         )

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1060,6 +1060,31 @@ print(json.dumps({
         self.assertGreater(stats["unsafe_mock_guard_bypass_count"], 0)
         self.assertEqual(stats["slow_guard_ns"], 0)
 
+    def test_unsafe_mock_guard_bypass_requires_stats_collection(self):
+        script = r"""
+import json
+from torch._C._dynamo import guards
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "unsafe_mock_guard_bypass_enabled": stats[
+        "unsafe_mock_guard_bypass_enabled"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertFalse(stats["unsafe_mock_guard_bypass_enabled"])
+
     def test_guard_subtree_probe_is_off_by_default(self):
         guards.reset_guard_lookup_stats()
         stats = guards.get_guard_lookup_stats()
@@ -2354,6 +2379,204 @@ print(json.dumps({
         self.assertEqual(stats["partial_miss"], 0)
         self.assertEqual(stats["partial_disabled"], 0)
         self.assertEqual(stats["partial_residual_fail"], 0)
+
+    def test_guard_last_success_actual_hits_with_stable_global_dict(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + GLOBAL_DICT["used"]
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "actual_hot_token_count_sum": stats[
+        "guard_last_success_actual_hot_token_count_sum"
+    ],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["actual_attempt"], 0)
+        self.assertGreater(stats["actual_enable"], 0)
+        self.assertGreater(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_miss"], 0)
+        self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
+        self.assertGreater(stats["actual_hot_token_count_sum"], 0)
+
+    def test_guard_last_success_respects_global_tensor_replacement(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_TENSOR = torch.ones(4)
+
+def fn(x):
+    return x + GLOBAL_TENSOR
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.zeros(4)
+assert torch.equal(compiled(x), torch.ones(4))
+
+guards.reset_guard_lookup_stats()
+for value in (2.0, 3.0, 4.0):
+    GLOBAL_TENSOR = torch.full((4,), value)
+    out = compiled(x)
+    assert torch.equal(out, torch.full((4,), value)), out
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+
+    def test_guard_last_success_respects_module_buffer_replacement(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self, x):
+        return x + self.bias
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+x = torch.zeros(4)
+assert torch.equal(compiled(x), torch.ones(4))
+
+guards.reset_guard_lookup_stats()
+for value in (2.0, 3.0, 4.0):
+    m.bias = torch.full((4,), value)
+    out = compiled(x)
+    assert torch.equal(out, torch.full((4,), value)), out
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+
+    def test_guard_last_success_dynamic_shape_inputs_keep_working(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x.sin() + 1
+
+compiled = torch.compile(fn, backend="eager", dynamic=True)
+guards.reset_guard_lookup_stats()
+for batch in (2, 5, 3, 7):
+    x = torch.randn(batch, 4)
+    out = compiled(x)
+    expected = fn(x)
+    assert out.shape == (batch, 4)
+    assert torch.allclose(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "tensor_miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertIsInstance(stats["tensor_miss_reasons"], dict)
 
     def test_guard_last_success_global_dict_ignores_unrelated_version(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1172,6 +1172,135 @@ print(json.dumps({
             any(value["attempt"] > 0 for value in stats["top_path_values"])
         )
 
+    def test_guard_fast_plan_subtree_memo_records_hits(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+modules_mgr.add_dict_length_check_guard(
+    len(model._modules), ["len(L['self']._modules) == 1"]
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate": stats["guard_fastplan_candidate"],
+    "shadow_pass": stats["guard_fastplan_shadow_pass"],
+    "enable": stats["guard_fastplan_enable"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "token_count_sum": stats["guard_fastplan_token_count_sum"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["candidate"], 0)
+        self.assertGreater(stats["shadow_pass"], 0)
+        self.assertGreater(stats["enable"], 0)
+        self.assertGreater(stats["hit"], 0)
+        self.assertEqual(stats["miss"], 0)
+        self.assertEqual(stats["disabled"], 0)
+        self.assertGreater(stats["token_count_sum"], 0)
+
+    def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+modules_mgr.add_dict_length_check_guard(
+    len(model._modules), ["len(L['self']._modules) == 1"]
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.extra = torch.nn.ReLU()
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["hit"], 0)
+        self.assertGreater(stats["miss"], 0)
+        self.assertGreater(stats["disabled"], 0)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1658,6 +1658,179 @@ print(json.dumps({
             stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
         )
 
+    def test_guard_fast_plan_tensor_match_token_hits_and_checks_metadata(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+model = torch.nn.Sequential(torch.nn.Linear(4, 4))
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+linear_mgr = modules_mgr.getitem_manager(
+    "0",
+    "L['self']._modules['0']",
+    model[0],
+    GuardManagerType.GUARD_MANAGER,
+)
+linear_dict_mgr = linear_mgr.get_generic_dict_manager(
+    "L['self']._modules['0'].__dict__",
+    model[0].__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+parameters_mgr = linear_dict_mgr.getitem_manager(
+    "_parameters",
+    "L['self']._modules['0']._parameters",
+    model[0]._parameters,
+    GuardManagerType.GUARD_MANAGER,
+)
+weight_mgr = parameters_mgr.getitem_manager(
+    "weight",
+    "L['self']._modules['0']._parameters['weight']",
+    model[0].weight,
+    GuardManagerType.GUARD_MANAGER,
+)
+weight_mgr.add_tensor_match_guard(
+    model[0].weight,
+    list(model[0].weight.size()),
+    list(model[0].weight.stride()),
+    "L['self']._modules['0']._parameters['weight']",
+    ["check_tensor(weight)"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+with torch.no_grad():
+    model[0].weight.add_(1)
+assert root.check(f_locals)
+
+model[0].weight.requires_grad_(False)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(
+            stats["miss_reasons"].get("requires_grad", 0), 0
+        )
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_tensor_match_token_skips_attr_sources(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._cached_tensor = torch.ones(2)
+
+model = Mod()
+container = torch.nn.Module()
+container.child = model
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr = child_mgr.getattr_manager(
+    "_cached_tensor",
+    "L['self']._modules['child']._cached_tensor",
+    model._cached_tensor,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr.add_tensor_match_guard(
+    model._cached_tensor,
+    list(model._cached_tensor.size()),
+    list(model._cached_tensor.stride()),
+    "L['self']._modules['child']._cached_tensor",
+    ["check_tensor(cached)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(4):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["tensor_shadow"], 0)
+        self.assertGreater(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1060,6 +1060,118 @@ print(json.dumps({
         self.assertGreater(stats["unsafe_mock_guard_bypass_count"], 0)
         self.assertEqual(stats["slow_guard_ns"], 0)
 
+    def test_guard_subtree_probe_is_off_by_default(self):
+        guards.reset_guard_lookup_stats()
+        stats = guards.get_guard_lookup_stats()
+
+        self.assertEqual(stats["guard_subtree_probe_mode"], "off")
+        self.assertEqual(stats["guard_subtree_probe_attempt"], 0)
+        self.assertEqual(stats["guard_subtree_probe_entry_match"], 0)
+        self.assertNotIn("guard_subtree_probe_top_paths", stats)
+
+    def test_guard_subtree_probe_summary_records_shadow_entries(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+    def forward(self, x):
+        return self.seq(x)
+
+model = Mod()
+opt_model = torch.compile(model, backend="eager", fullgraph=True)
+x = torch.randn(2, 4)
+
+opt_model(x)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_model(x)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "mode": stats["guard_subtree_probe_mode"],
+    "attempt": stats["guard_subtree_probe_attempt"],
+    "entry_match": stats["guard_subtree_probe_entry_match"],
+    "shadow_ok": stats["guard_subtree_probe_shadow_ok"],
+    "child_check_ns": stats["guard_subtree_probe_child_check_ns"],
+    "has_top_paths": "guard_subtree_probe_top_paths" in stats,
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_SUBTREE_PROBE"] = "summary"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["mode"], "summary")
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["entry_match"], 0)
+        self.assertGreater(stats["shadow_ok"], 0)
+        self.assertGreater(stats["child_check_ns"], 0)
+        self.assertFalse(stats["has_top_paths"])
+
+    def test_guard_subtree_probe_detail_records_top_paths(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+    def forward(self, x):
+        return self.seq(x)
+
+model = Mod()
+opt_model = torch.compile(model, backend="eager", fullgraph=True)
+x = torch.randn(2, 4)
+
+opt_model(x)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_model(x)
+
+stats = guards.get_guard_lookup_stats()
+top_paths = stats["guard_subtree_probe_top_paths"]
+print(json.dumps({
+    "mode": stats["guard_subtree_probe_mode"],
+    "attempt": stats["guard_subtree_probe_attempt"],
+    "entry_match": stats["guard_subtree_probe_entry_match"],
+    "shadow_ok": stats["guard_subtree_probe_shadow_ok"],
+    "top_path_count": len(top_paths),
+    "top_path_values": list(top_paths.values()),
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_SUBTREE_PROBE"] = "detail"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["mode"], "detail")
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["entry_match"], 0)
+        self.assertGreater(stats["shadow_ok"], 0)
+        self.assertGreater(stats["top_path_count"], 0)
+        self.assertTrue(
+            any(value["attempt"] > 0 for value in stats["top_path_values"])
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2297,6 +2297,64 @@ print(json.dumps({
         self.assertEqual(stats["actual_miss"], 0)
         self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
 
+    def test_guard_last_success_partial_self_hits_with_unstable_global(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    GLOBAL_DICT["noise"] = [1]
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_attempt": stats["guard_last_success_actual_partial_attempt"],
+    "partial_enable": stats["guard_last_success_actual_partial_enable"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_miss": stats["guard_last_success_actual_partial_miss"],
+    "partial_disabled": stats["guard_last_success_actual_partial_disabled"],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["partial_attempt"], 0)
+        self.assertGreater(stats["partial_enable"], 0)
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_miss"], 0)
+        self.assertEqual(stats["partial_disabled"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+
     def test_guard_last_success_global_dict_ignores_unrelated_version(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2209,6 +2209,13 @@ print(json.dumps({
     "mismatch_token_kinds": stats["guard_last_success_mismatch_token_kinds"],
     "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "actual_token_check_ns": stats["guard_last_success_actual_token_check_ns"],
+    "actual_train_ns": stats["guard_last_success_actual_train_ns"],
 }))
 """
         env = os.environ.copy()
@@ -2231,6 +2238,64 @@ print(json.dumps({
         self.assertIsInstance(stats["mismatch_reasons"], dict)
         self.assertIsInstance(stats["mismatch_token_kinds"], dict)
         self.assertIsInstance(stats["mismatch_top_paths"], dict)
+        self.assertGreaterEqual(stats["actual_attempt"], 0)
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["actual_enable"], 0)
+        self.assertGreaterEqual(stats["actual_disabled"], 0)
+        self.assertGreaterEqual(stats["actual_token_check_ns"], 0)
+        self.assertGreaterEqual(stats["actual_train_ns"], 0)
+
+    def test_guard_last_success_actual_hits_after_stable_self_receipt(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + 1
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["actual_attempt"], 0)
+        self.assertGreater(stats["actual_enable"], 0)
+        self.assertGreater(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_miss"], 0)
+        self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
 
     def test_guard_last_success_global_dict_ignores_unrelated_version(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2406,15 +2406,11 @@ print(json.dumps({
         self.assertEqual(stats["partial_miss"], 0)
         self.assertEqual(stats["partial_disabled"], 0)
         self.assertEqual(stats["partial_residual_fail"], 0)
-        self.assertGreater(stats["partial_shadow_full_pass"], 0)
+        self.assertEqual(stats["partial_shadow_full_pass"], 0)
         self.assertEqual(stats["partial_shadow_full_fail"], 0)
-        self.assertEqual(
-            stats["partial_shadow_full_pass"] + stats["partial_shadow_full_fail"],
-            stats["partial_hit"],
-        )
-        self.assertGreaterEqual(stats["partial_shadow_full_ns"], 0)
-        self.assertIsInstance(stats["partial_shadow_fail_reasons"], dict)
-        self.assertIsInstance(stats["partial_shadow_fail_top_paths"], dict)
+        self.assertEqual(stats["partial_shadow_full_ns"], 0)
+        self.assertEqual(stats["partial_shadow_fail_reasons"], {})
+        self.assertEqual(stats["partial_shadow_fail_top_paths"], {})
         self.assertGreater(stats["partial_hot_tokens"], 0)
         self.assertGreater(stats["partial_hot_token_unique"], 0)
         self.assertLessEqual(
@@ -2425,6 +2421,76 @@ print(json.dumps({
             stats["partial_hot_tokens"],
         )
         self.assertIsInstance(stats["partial_hot_token_duplicate_kinds"], dict)
+
+    def test_guard_last_success_partial_shadow_full_requires_env(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    GLOBAL_DICT["noise"] = [1]
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_shadow_full_pass": stats[
+        "guard_last_success_actual_partial_shadow_full_pass"
+    ],
+    "partial_shadow_full_fail": stats[
+        "guard_last_success_actual_partial_shadow_full_fail"
+    ],
+    "partial_shadow_full_ns": stats[
+        "guard_last_success_actual_partial_shadow_full_ns"
+    ],
+    "partial_shadow_fail_reasons": stats[
+        "guard_last_success_actual_partial_shadow_fail_reasons"
+    ],
+    "partial_shadow_fail_top_paths": stats[
+        "guard_last_success_actual_partial_shadow_fail_top_paths"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        env["TORCHDYNAMO_GUARD_LAST_SUCCESS_SHADOW_FULL"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertGreater(stats["partial_shadow_full_pass"], 0)
+        self.assertEqual(stats["partial_shadow_full_fail"], 0)
+        self.assertEqual(
+            stats["partial_shadow_full_pass"] + stats["partial_shadow_full_fail"],
+            stats["partial_hit"],
+        )
+        self.assertGreaterEqual(stats["partial_shadow_full_ns"], 0)
+        self.assertIsInstance(stats["partial_shadow_fail_reasons"], dict)
+        self.assertIsInstance(stats["partial_shadow_fail_top_paths"], dict)
 
     def test_guard_last_success_full_actual_disabled_with_stable_global_dict(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2371,6 +2371,21 @@ print(json.dumps({
     "partial_residual_fail": stats[
         "guard_last_success_actual_partial_residual_fail"
     ],
+    "partial_shadow_full_pass": stats[
+        "guard_last_success_actual_partial_shadow_full_pass"
+    ],
+    "partial_shadow_full_fail": stats[
+        "guard_last_success_actual_partial_shadow_full_fail"
+    ],
+    "partial_shadow_full_ns": stats[
+        "guard_last_success_actual_partial_shadow_full_ns"
+    ],
+    "partial_shadow_fail_reasons": stats[
+        "guard_last_success_actual_partial_shadow_fail_reasons"
+    ],
+    "partial_shadow_fail_top_paths": stats[
+        "guard_last_success_actual_partial_shadow_fail_top_paths"
+    ],
     "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
 }))
 """
@@ -2391,6 +2406,15 @@ print(json.dumps({
         self.assertEqual(stats["partial_miss"], 0)
         self.assertEqual(stats["partial_disabled"], 0)
         self.assertEqual(stats["partial_residual_fail"], 0)
+        self.assertGreater(stats["partial_shadow_full_pass"], 0)
+        self.assertEqual(stats["partial_shadow_full_fail"], 0)
+        self.assertEqual(
+            stats["partial_shadow_full_pass"] + stats["partial_shadow_full_fail"],
+            stats["partial_hit"],
+        )
+        self.assertGreaterEqual(stats["partial_shadow_full_ns"], 0)
+        self.assertIsInstance(stats["partial_shadow_fail_reasons"], dict)
+        self.assertIsInstance(stats["partial_shadow_fail_top_paths"], dict)
         self.assertGreater(stats["partial_hot_tokens"], 0)
         self.assertGreater(stats["partial_hot_token_unique"], 0)
         self.assertLessEqual(

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1766,6 +1766,82 @@ from torch._dynamo.guards import GuardManagerType
 class Mod(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.other_tensor = torch.ones(2)
+
+model = Mod()
+container = torch.nn.Module()
+container.child = model
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr = child_mgr.getattr_manager(
+    "other_tensor",
+    "L['self']._modules['child'].other_tensor",
+    model.other_tensor,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr.add_tensor_match_guard(
+    model.other_tensor,
+    list(model.other_tensor.size()),
+    list(model.other_tensor.stride()),
+    "L['self']._modules['child'].other_tensor",
+    ["check_tensor(cached)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(4):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["tensor_shadow"], 0)
+        self.assertGreater(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_tensor_match_token_supports_cached_tensor_attr(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
         self._cached_tensor = torch.ones(2)
 
 model = Mod()
@@ -1806,12 +1882,19 @@ cached_mgr.add_tensor_match_guard(
 
 f_locals = {"self": container}
 guards.reset_guard_lookup_stats()
-for _ in range(4):
+for _ in range(6):
     assert root.check(f_locals)
+
+model._cached_tensor.resize_(3)
+assert not root.check(f_locals)
 
 stats = guards.get_guard_lookup_stats()
 print(json.dumps({
     "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
     "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
 }))
 """
@@ -1825,8 +1908,12 @@ print(json.dumps({
         )
         stats = json.loads(out.splitlines()[-1])
 
-        self.assertEqual(stats["tensor_shadow"], 0)
-        self.assertGreater(
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(stats["miss_reasons"].get("size", 0), 0)
+        self.assertEqual(
             stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
             0,
         )

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1310,6 +1310,213 @@ print(json.dumps({
             "unsupported_leaf:LAMBDA_GUARD",
         )
 
+    def test_guard_fast_plan_nested_modules_records_hits(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_mgr = modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['clean']",
+    model.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['clean'].__dict__",
+    model.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['clean']._modules",
+    model.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.clean._modules),
+    ["len(L['self']._modules['clean']._modules) == 1"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "shadow_pass_nested": stats["guard_fastplan_shadow_pass_nested"],
+    "enable_nested": stats["guard_fastplan_enable_nested"],
+    "hit_nested": stats["guard_fastplan_hit_nested"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled_nested": stats["guard_fastplan_disabled_nested"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["shadow_pass_nested"], 0)
+        self.assertGreater(stats["enable_nested"], 0)
+        self.assertGreater(stats["hit_nested"], 0)
+        self.assertEqual(stats["miss"], 0)
+        self.assertEqual(stats["disabled_nested"], 0)
+
+    def test_guard_fast_plan_blocked_sibling_does_not_disable_clean_nested(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def equals_match(x, expected):
+    return x == expected
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+        self.blocked = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_mgr = modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['clean']",
+    model.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['clean'].__dict__",
+    model.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['clean']._modules",
+    model.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.clean._modules),
+    ["len(L['self']._modules['clean']._modules) == 1"],
+)
+
+blocked_mgr = modules_mgr.getitem_manager(
+    "blocked",
+    "L['self']._modules['blocked']",
+    model.blocked,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_dict_mgr = blocked_mgr.get_generic_dict_manager(
+    "L['self']._modules['blocked'].__dict__",
+    model.blocked.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr = blocked_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['blocked']._modules",
+    model.blocked._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr.add_lambda_guard(
+    functools.partial(equals_match, expected=model.blocked._modules),
+    ["L['self']._modules['blocked']._modules == original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate_top": stats["guard_fastplan_candidate_top"],
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "enable_nested": stats["guard_fastplan_enable_nested"],
+    "hit_nested": stats["guard_fastplan_hit_nested"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "disabled_nested": stats["guard_fastplan_disabled_nested"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["candidate_top"], 0)
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["enable_nested"], 0)
+        self.assertGreater(stats["hit_nested"], 0)
+        self.assertGreater(stats["disabled"], 0)
+        self.assertGreater(stats["disabled_nested"], 0)
+        self.assertGreaterEqual(
+            stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
+        )
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2005,6 +2005,93 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_fast_plan_supports_object_aliasing_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.ones(2)
+        self.b = self.a
+
+container = torch.nn.Module()
+container.child = Child()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    container.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+a_mgr = child_mgr.getattr_manager(
+    "a",
+    "L['self']._modules['child'].a",
+    container.child.a,
+    GuardManagerType.GUARD_MANAGER,
+)
+b_mgr = child_mgr.getattr_manager(
+    "b",
+    "L['self']._modules['child'].b",
+    container.child.b,
+    GuardManagerType.GUARD_MANAGER,
+)
+guards.install_object_aliasing_guard(
+    a_mgr,
+    b_mgr,
+    ["aliasing(a, b)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+container.child.b = torch.zeros(2)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "fastplan_hit": stats["guard_fastplan_hit"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["fastplan_hit"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:OBJECT_ALIASING", 0
+            ),
+            0,
+        )
+
     def test_guard_last_success_shadow_records_lookup_attempts(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2207,6 +2207,7 @@ print(json.dumps({
     "compare_mismatch": stats["guard_last_success_compare_mismatch"],
     "mismatch_reasons": stats["guard_last_success_mismatch_reasons"],
     "mismatch_token_kinds": stats["guard_last_success_mismatch_token_kinds"],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
 }))
 """
@@ -2229,6 +2230,7 @@ print(json.dumps({
         self.assertGreaterEqual(stats["compare_mismatch"], 0)
         self.assertIsInstance(stats["mismatch_reasons"], dict)
         self.assertIsInstance(stats["mismatch_token_kinds"], dict)
+        self.assertIsInstance(stats["mismatch_top_paths"], dict)
 
     def test_guard_last_success_supports_default_device_token(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2202,6 +2202,8 @@ print(json.dumps({
     "success": stats["guard_last_success_shadow_success"],
     "incomplete": stats["guard_last_success_shadow_incomplete"],
     "support_check_ns": stats["guard_last_success_support_check_ns"],
+    "token_cap_count_sum": stats["guard_last_success_token_cap_count_sum"],
+    "token_cap_count_max": stats["guard_last_success_token_cap_count_max"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
 }))
 """
@@ -2219,6 +2221,8 @@ print(json.dumps({
         self.assertGreater(stats["attempt"], 0)
         self.assertGreater(stats["incomplete"] + stats["success"], 0)
         self.assertGreaterEqual(stats["support_check_ns"], 0)
+        self.assertGreaterEqual(stats["token_cap_count_sum"], 0)
+        self.assertGreaterEqual(stats["token_cap_count_max"], 0)
 
     def test_guard_last_success_supports_default_device_token(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1918,6 +1918,93 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_fast_plan_supports_no_tensor_aliasing_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.ones(2)
+        self.b = torch.zeros(2)
+
+container = torch.nn.Module()
+container.child = Child()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    container.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+a_mgr = child_mgr.getattr_manager(
+    "a",
+    "L['self']._modules['child'].a",
+    container.child.a,
+    GuardManagerType.GUARD_MANAGER,
+)
+b_mgr = child_mgr.getattr_manager(
+    "b",
+    "L['self']._modules['child'].b",
+    container.child.b,
+    GuardManagerType.GUARD_MANAGER,
+)
+guards.install_no_tensor_aliasing_guard(
+    [a_mgr, b_mgr],
+    ["a", "b"],
+    ["no_aliasing(a, b)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+container.child.b = container.child.a
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "fastplan_hit": stats["guard_fastplan_hit"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["fastplan_hit"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:NO_TENSOR_ALIASING", 0
+            ),
+            0,
+        )
+
     def test_guard_last_success_shadow_records_lookup_attempts(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1239,6 +1239,77 @@ print(json.dumps({
         self.assertEqual(stats["disabled"], 0)
         self.assertGreater(stats["token_count_sum"], 0)
 
+    def test_guard_fast_plan_records_disabled_reasons(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def equals_match(x, expected):
+    return x == expected
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+modules_mgr.add_lambda_guard(
+    functools.partial(equals_match, expected=model._modules),
+    ["L['self']._modules == original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate": stats["guard_fastplan_candidate"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+    "top_paths": stats["guard_fastplan_disabled_top_paths"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["candidate"], 0)
+        self.assertGreater(stats["disabled"], 0)
+        self.assertEqual(
+            stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD"), 1
+        )
+        self.assertIn("L['self']._modules", stats["top_paths"])
+        self.assertEqual(
+            stats["top_paths"]["L['self']._modules"]["reason"],
+            "unsupported_leaf:LAMBDA_GUARD",
+        )
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1,5 +1,10 @@
 # Owner(s): ["module: dynamo"]
 import functools
+import json
+import os
+import subprocess
+import sys
+import textwrap
 import unittest
 import weakref
 
@@ -898,6 +903,162 @@ num_guards_executed=0)
 
             foo = (10.0, 11)
             opt_fn(x, foo, bar)
+
+    def test_guard_lookup_stats_api_records_cache_hits(self):
+        def fn(x, y, scale: int):
+            return (x + y) * scale
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        x = torch.randn(4)
+        y = torch.randn(4)
+
+        opt_fn(x, y, 3)
+        guards.reset_guard_lookup_stats()
+        before = guards.get_guard_lookup_stats()
+        self.assertEqual(before["lookup_count"], 0)
+
+        opt_fn(x, y, 3)
+
+        after = guards.get_guard_lookup_stats()
+        self.assertGreater(after["lookup_count"], 0)
+        self.assertGreater(after["lookup_total_ns"], 0)
+        self.assertGreater(after["slow_guard_ns"], 0)
+        self.assertGreater(after["root_guard_count"], 0)
+        self.assertGreater(after["root_guard_total_ns"], 0)
+        self.assertFalse(after["unsafe_mock_guard_bypass_enabled"])
+        self.assertEqual(after["unsafe_mock_guard_bypass_count"], 0)
+
+    def test_guard_lookup_stats_records_accessor_types(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+        foo = Foo(1)
+
+        guards.reset_guard_lookup_stats()
+
+        attr_root = RootGuardManager()
+        attr_root.getattr_manager("x", "x", 1, default_mgr_enum).add_lambda_guard(
+            functools.partial(equals_match, expected=1),
+            equals_match_verbose_code_parts(1),
+        )
+        self.assertTrue(attr_root.check(foo))
+
+        item_root = RootGuardManager()
+        item_root.getitem_manager(0, "", 1, default_mgr_enum).add_lambda_guard(
+            functools.partial(equals_match, expected=1),
+            equals_match_verbose_code_parts(1),
+        )
+        self.assertTrue(item_root.check([1]))
+
+        type_root = RootGuardManager()
+        type_root.getitem_manager("foo", "", foo, default_mgr_enum).type_manager(
+            "", type(foo), default_mgr_enum
+        ).add_lambda_guard(lambda x: x is type(foo), ["type(foo)"])
+        self.assertTrue(type_root.check({"foo": foo}))
+
+        generic_dict_root = RootGuardManager()
+        generic_dict_root.get_generic_dict_manager(
+            "foo.__dict__", foo.__dict__, default_mgr_enum
+        ).add_lambda_guard(lambda x: x["x"] == 1, ["foo.__dict__['x'] == 1"])
+        self.assertTrue(generic_dict_root.check(foo))
+
+        dict_root = RootGuardManager()
+        f_locals = {"d": {"a": 1}}
+        dict_mgr = dict_root.getitem_manager(
+            "d",
+            "",
+            f_locals["d"],
+            torch._dynamo.guards.GuardManagerType.DICT_GUARD_MANAGER,
+        )
+        dict_mgr.get_key_manager(0, "", "a", default_mgr_enum).add_equals_match_guard(
+            "a",
+            ["dict.keys()[0] == a"],
+        )
+        dict_mgr.get_value_manager(0, "", 1, default_mgr_enum).add_equals_match_guard(
+            1,
+            ["d[0] == 1"],
+        )
+        self.assertTrue(dict_root.check(f_locals))
+
+        accessor_stats = guards.get_guard_lookup_stats()[
+            "root_guard_accessor_type_stats"
+        ]
+        for name in (
+            "GetAttrGuardAccessor",
+            "GetItemGuardAccessor",
+            "TypeGuardAccessor",
+            "DictGetItemGuardAccessor",
+        ):
+            self.assertIn(name, accessor_stats)
+            self.assertGreater(accessor_stats[name]["count"], 0)
+            self.assertGreater(accessor_stats[name]["inclusive_ns"], 0)
+
+        detail_stats = guards.get_guard_lookup_stats()[
+            "root_guard_accessor_detail_topk"
+        ]
+        for name in (
+            "GetAttrGuardAccessor",
+            "GetItemGuardAccessor",
+            "GetGenericDictGuardAccessor",
+            "TypeGuardAccessor",
+            "DictGetItemGuardAccessor",
+        ):
+            matches = [
+                stats
+                for key, stats in detail_stats.items()
+                if key.startswith(f"{name}:")
+            ]
+            self.assertTrue(matches)
+            self.assertGreater(matches[0]["count"], 0)
+            self.assertGreater(matches[0]["inclusive_ns"], 0)
+            self.assertIn("self_ns", matches[0])
+            self.assertIn("child_ns", matches[0])
+
+    def test_unsafe_mock_guard_bypass_skips_slow_guard(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x, y, scale: int):
+    return (x + y) * scale
+
+opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+x = torch.randn(4)
+y = torch.randn(4)
+
+opt_fn(x, y, 3)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_fn(x, y, 3)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "lookup_count": stats["lookup_count"],
+    "slow_guard_ns": stats["slow_guard_ns"],
+    "unsafe_mock_guard_bypass_enabled": stats[
+        "unsafe_mock_guard_bypass_enabled"
+    ],
+    "unsafe_mock_guard_bypass_count": stats[
+        "unsafe_mock_guard_bypass_count"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["lookup_count"], 0)
+        self.assertTrue(stats["unsafe_mock_guard_bypass_enabled"])
+        self.assertGreater(stats["unsafe_mock_guard_bypass_count"], 0)
+        self.assertEqual(stats["slow_guard_ns"], 0)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1918,6 +1918,93 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_fast_plan_tensor_match_token_supports_scale_attr(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = torch.ones(2)
+
+model = Mod()
+container = torch.nn.Module()
+container.child = model
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+scale_mgr = child_mgr.getattr_manager(
+    "scale",
+    "L['self']._modules['child'].scale",
+    model.scale,
+    GuardManagerType.GUARD_MANAGER,
+)
+scale_mgr.add_tensor_match_guard(
+    model.scale,
+    list(model.scale.size()),
+    list(model.scale.stride()),
+    "L['self']._modules['child'].scale",
+    ["check_tensor(scale)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.scale.resize_(3)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(stats["miss_reasons"].get("size", 0), 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
     def test_guard_fast_plan_supports_no_tensor_aliasing_token(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1852,6 +1852,7 @@ print(json.dumps({
     "lookup_count": stats["lookup_count"],
     "attempt": stats["guard_last_success_shadow_attempt"],
     "incomplete": stats["guard_last_success_shadow_incomplete"],
+    "support_check_ns": stats["guard_last_success_support_check_ns"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
 }))
 """
@@ -1868,6 +1869,7 @@ print(json.dumps({
         self.assertGreater(stats["lookup_count"], 0)
         self.assertGreater(stats["attempt"], 0)
         self.assertGreater(stats["incomplete"], 0)
+        self.assertGreaterEqual(stats["support_check_ns"], 0)
         self.assertGreater(len(stats["disabled_reasons"]), 0)
 
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2232,6 +2232,52 @@ print(json.dumps({
         self.assertIsInstance(stats["mismatch_token_kinds"], dict)
         self.assertIsInstance(stats["mismatch_top_paths"], dict)
 
+    def test_guard_last_success_frame_globals_ignores_unrelated_version(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_CONST = 1
+
+def fn(x):
+    return x + GLOBAL_CONST
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+assert torch.equal(compiled(x), x + GLOBAL_CONST)
+
+guards.reset_guard_lookup_stats()
+for i in range(5):
+    globals()["_unrelated_guard_last_success_noise"] = i
+    out = compiled(x)
+    assert torch.equal(out, x + GLOBAL_CONST)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "success": stats["guard_last_success_shadow_success"],
+    "stable": stats["guard_last_success_shadow_stable"],
+    "reset": stats["guard_last_success_shadow_reset"],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["success"], 0)
+        self.assertGreater(stats["stable"], 0)
+        self.assertNotEqual(
+            stats["mismatch_top_paths"].get("G", {}).get("reason"),
+            "version",
+        )
+
     def test_guard_last_success_supports_default_device_token(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1912,6 +1912,46 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_last_success_supports_global_state_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:GLOBAL_STATE", 0),
+            0,
+        )
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1021,32 +1021,33 @@ import json
 import torch
 from torch._C._dynamo import guards
 
-def fn(x, y, scale: int):
-    return (x + y) * scale
+SCALE = 3
+
+def fn(x, y):
+    return (x + y) * SCALE
 
 opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
 x = torch.randn(4)
 y = torch.randn(4)
 
-opt_fn(x, y, 3)
-guards.reset_guard_lookup_stats()
-for _ in range(3):
-    opt_fn(x, y, 3)
+expected = fn(x, y)
+assert torch.equal(opt_fn(x, y), expected)
+
+SCALE = 5
+out = opt_fn(x, y)
 
 stats = guards.get_guard_lookup_stats()
 print(json.dumps({
-    "lookup_count": stats["lookup_count"],
-    "slow_guard_ns": stats["slow_guard_ns"],
     "unsafe_mock_guard_bypass_enabled": stats[
         "unsafe_mock_guard_bypass_enabled"
     ],
-    "unsafe_mock_guard_bypass_count": stats[
-        "unsafe_mock_guard_bypass_count"
-    ],
+    "stale_cached_result": torch.equal(out, expected),
+    "fresh_result": torch.equal(out, fn(x, y)),
 }))
 """
         env = os.environ.copy()
         env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
         out = subprocess.check_output(
             [sys.executable, "-c", textwrap.dedent(script)],
             cwd=os.getcwd(),
@@ -1055,12 +1056,11 @@ print(json.dumps({
         )
         stats = json.loads(out.splitlines()[-1])
 
-        self.assertGreater(stats["lookup_count"], 0)
         self.assertTrue(stats["unsafe_mock_guard_bypass_enabled"])
-        self.assertGreater(stats["unsafe_mock_guard_bypass_count"], 0)
-        self.assertEqual(stats["slow_guard_ns"], 0)
+        self.assertTrue(stats["stale_cached_result"])
+        self.assertFalse(stats["fresh_result"])
 
-    def test_unsafe_mock_guard_bypass_requires_stats_collection(self):
+    def test_unsafe_mock_guard_bypass_does_not_require_stats_collection(self):
         script = r"""
 import json
 from torch._C._dynamo import guards
@@ -1083,7 +1083,7 @@ print(json.dumps({
         )
         stats = json.loads(out.splitlines()[-1])
 
-        self.assertFalse(stats["unsafe_mock_guard_bypass_enabled"])
+        self.assertTrue(stats["unsafe_mock_guard_bypass_enabled"])
 
     def test_guard_subtree_probe_is_off_by_default(self):
         guards.reset_guard_lookup_stats()

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2204,6 +2204,9 @@ print(json.dumps({
     "support_check_ns": stats["guard_last_success_support_check_ns"],
     "token_cap_count_sum": stats["guard_last_success_token_cap_count_sum"],
     "token_cap_count_max": stats["guard_last_success_token_cap_count_max"],
+    "compare_mismatch": stats["guard_last_success_compare_mismatch"],
+    "mismatch_reasons": stats["guard_last_success_mismatch_reasons"],
+    "mismatch_token_kinds": stats["guard_last_success_mismatch_token_kinds"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
 }))
 """
@@ -2223,6 +2226,9 @@ print(json.dumps({
         self.assertGreaterEqual(stats["support_check_ns"], 0)
         self.assertGreaterEqual(stats["token_cap_count_sum"], 0)
         self.assertGreaterEqual(stats["token_cap_count_max"], 0)
+        self.assertGreaterEqual(stats["compare_mismatch"], 0)
+        self.assertIsInstance(stats["mismatch_reasons"], dict)
+        self.assertIsInstance(stats["mismatch_token_kinds"], dict)
 
     def test_guard_last_success_supports_default_device_token(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1952,6 +1952,48 @@ print(json.dumps({
             0,
         )
 
+    def test_guard_last_success_supports_torch_function_mode_stack_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:TORCH_FUNCTION_MODE_STACK", 0
+            ),
+            0,
+        )
+
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""
 import json

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2232,26 +2232,26 @@ print(json.dumps({
         self.assertIsInstance(stats["mismatch_token_kinds"], dict)
         self.assertIsInstance(stats["mismatch_top_paths"], dict)
 
-    def test_guard_last_success_frame_globals_ignores_unrelated_version(self):
+    def test_guard_last_success_global_dict_ignores_unrelated_version(self):
         script = r"""
 import json
 import torch
 from torch._C._dynamo import guards
 
-GLOBAL_CONST = 1
+GLOBAL_DICT = {"used": 1, "noise": 0}
 
 def fn(x):
-    return x + GLOBAL_CONST
+    return x + GLOBAL_DICT["used"]
 
 compiled = torch.compile(fn, backend="eager")
 x = torch.ones(4)
-assert torch.equal(compiled(x), x + GLOBAL_CONST)
+assert torch.equal(compiled(x), x + GLOBAL_DICT["used"])
 
 guards.reset_guard_lookup_stats()
 for i in range(5):
-    globals()["_unrelated_guard_last_success_noise"] = i
+    GLOBAL_DICT["noise"] = i
     out = compiled(x)
-    assert torch.equal(out, x + GLOBAL_CONST)
+    assert torch.equal(out, x + GLOBAL_DICT["used"])
 
 stats = guards.get_guard_lookup_stats()
 print(json.dumps({
@@ -2273,10 +2273,8 @@ print(json.dumps({
 
         self.assertGreater(stats["success"], 0)
         self.assertGreater(stats["stable"], 0)
-        self.assertNotEqual(
-            stats["mismatch_top_paths"].get("G", {}).get("reason"),
-            "version",
-        )
+        for path, item in stats["mismatch_top_paths"].items():
+            self.assertFalse(path.startswith("G") and item.get("reason") == "version")
 
     def test_guard_last_success_supports_default_device_token(self):
         script = r"""

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1301,6 +1301,97 @@ print(json.dumps({
         self.assertGreater(stats["miss"], 0)
         self.assertGreater(stats["disabled"], 0)
 
+    def test_guard_fast_plan_subtree_memo_detects_list_item_change(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.items = [1]
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.child = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    model.child.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+items_mgr = child_dict_mgr.getitem_manager(
+    "items",
+    "L['self']._modules['child'].items",
+    model.child.items,
+    GuardManagerType.GUARD_MANAGER,
+)
+item_mgr = items_mgr.getitem_manager(
+    0,
+    "L['self']._modules['child'].items[0]",
+    model.child.items[0],
+    GuardManagerType.GUARD_MANAGER,
+)
+item_mgr.add_equals_match_guard(
+    model.child.items[0],
+    ["L['self']._modules['child'].items[0] == 1"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.child.items[0] = 2
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["hit"], 0)
+        self.assertGreater(stats["miss"], 0)
+        self.assertGreater(stats["disabled"], 0)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1851,6 +1851,7 @@ stats = guards.get_guard_lookup_stats()
 print(json.dumps({
     "lookup_count": stats["lookup_count"],
     "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
     "incomplete": stats["guard_last_success_shadow_incomplete"],
     "support_check_ns": stats["guard_last_success_support_check_ns"],
     "disabled_reasons": stats["guard_last_success_disabled_reasons"],
@@ -1868,9 +1869,48 @@ print(json.dumps({
 
         self.assertGreater(stats["lookup_count"], 0)
         self.assertGreater(stats["attempt"], 0)
-        self.assertGreater(stats["incomplete"], 0)
+        self.assertGreater(stats["incomplete"] + stats["success"], 0)
         self.assertGreaterEqual(stats["support_check_ns"], 0)
-        self.assertGreater(len(stats["disabled_reasons"]), 0)
+
+    def test_guard_last_success_supports_default_device_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:DEFAULT_DEVICE", 0),
+            0,
+        )
 
     def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
         script = r"""

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -455,6 +455,7 @@ class EnterDeviceContextManagerLine(WrapperLine):
             code.writeline(f"with {V.graph.device_ops.device_guard(self.device_idx)}:")
             code.do_indent()
             code.writeline(V.graph.device_ops.set_device(self.device_idx))
+            code.writeline(f"stream{self.device_idx} = get_raw_stream({self.device_idx})")
 
 
 class ExitDeviceContextManagerLine(WrapperLine):
@@ -1009,7 +1010,6 @@ class PythonWrapperCodegen(CodeGen):
             if V.graph.cpp_wrapper:
                 # For cpp wrapper, no need to continue codegen for the main body
                 return name
-        self.writeline(f"{name} = get_raw_stream({device_idx})")
         return name
 
     def get_codegened_graph(self):

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -22,7 +22,13 @@ CacheEntry* ExtraState::get_first_entry() {
 }
 
 ExtraState::ExtraState(PyCodeObject* orig_code_arg)
-    : orig_code(orig_code_arg) {}
+    : orig_code(orig_code_arg),
+      last_success_receipt(
+          torch::dynamo::create_guard_last_success_receipt()) {}
+
+ExtraState::~ExtraState() {
+  torch::dynamo::destroy_guard_last_success_receipt(last_success_receipt);
+}
 
 void ExtraState::move_to_front(CacheEntry* cache_entry) {
   CHECK(cache_entry->_owner == this);
@@ -58,6 +64,7 @@ void ExtraState::invalidate(
   CHECK(cache_entry->_owner == this);
   CHECK(!this->cache_entry_list.empty());
   CHECK(cache_entry == &*cache_entry->_owner_loc);
+  torch::dynamo::reset_guard_last_success_receipt(last_success_receipt);
   cache_entry->invalidate(std::move(deleted_guard_manager));
   // Move the cache entry to the end of the list because these will always
   // return False.
@@ -171,7 +178,12 @@ void lookup(
             const uint64_t slow_guard_start_ns =
                 collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
             const bool slow_guard_result =
-                torch::dynamo::run_root_guard_manager(root_mgr, f_locals);
+                torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+                    extra_state->last_success_receipt,
+                    &cache_entry,
+                    root_mgr,
+                    f_locals,
+                    is_skip_guard_eval_unsafe);
             if (collect_stats) {
               slow_guard_ns +=
                   torch::dynamo::guard_lookup_time_ns() - slow_guard_start_ns;
@@ -243,6 +255,8 @@ CacheEntry* create_cache_entry(
     ExtraState* extra_state,
     PyObject* guarded_code,
     PyObject* backend) {
+  torch::dynamo::reset_guard_last_success_receipt(
+      extra_state->last_success_receipt);
   extra_state->cache_entry_list.emplace_front(guarded_code, backend);
   auto new_iter = extra_state->cache_entry_list.begin();
   new_iter->_owner = extra_state;

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -138,22 +138,51 @@ void lookup(
     PyObject** maybe_cached_code,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
+  const bool collect_stats = torch::dynamo::guard_lookup_stats_enabled();
+  const bool unsafe_mock_guard_bypass =
+      torch::dynamo::unsafe_mock_guard_bypass_enabled() &&
+      !is_skip_guard_eval_unsafe;
+  const uint64_t lookup_start_ns =
+      collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+  uint64_t backend_match_ns = 0;
+  uint64_t slow_guard_ns = 0;
+  uint64_t move_to_front_ns = 0;
   size_t index = 0;
   CacheEntry* found = nullptr;
   for (CacheEntry& cache_entry : extra_state->cache_entry_list) {
     // Check backend. Py_False means run only mode.
 
+    const uint64_t backend_match_start_ns =
+        collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
     bool valid =
         backend == Py_False || backend_match(cache_entry.backend, backend);
+    if (collect_stats) {
+      backend_match_ns +=
+          torch::dynamo::guard_lookup_time_ns() - backend_match_start_ns;
+    }
 
     if (valid) {
       try {
-        if (is_skip_guard_eval_unsafe) {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.diff_guard_root_mgr, f_locals);
+        if (unsafe_mock_guard_bypass) {
+          torch::dynamo::record_unsafe_mock_guard_bypass_stats(index);
+          valid = true;
         } else {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.root_mgr, f_locals);
+          auto run_slow_guard = [&](void* root_mgr) {
+            const uint64_t slow_guard_start_ns =
+                collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+            const bool slow_guard_result =
+                torch::dynamo::run_root_guard_manager(root_mgr, f_locals);
+            if (collect_stats) {
+              slow_guard_ns +=
+                  torch::dynamo::guard_lookup_time_ns() - slow_guard_start_ns;
+            }
+            return slow_guard_result;
+          };
+          if (is_skip_guard_eval_unsafe) {
+            valid = run_slow_guard(cache_entry.diff_guard_root_mgr);
+          } else {
+            valid = run_slow_guard(cache_entry.root_mgr);
+          }
         }
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {
@@ -180,10 +209,32 @@ void lookup(
     ++index;
   }
   if (found) {
+    const uint64_t move_to_front_start_ns =
+        collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
     extra_state->move_to_front(found);
+    if (collect_stats) {
+      move_to_front_ns =
+          torch::dynamo::guard_lookup_time_ns() - move_to_front_start_ns;
+      torch::dynamo::record_guard_lookup_stats(
+          torch::dynamo::guard_lookup_time_ns() - lookup_start_ns,
+          backend_match_ns,
+          slow_guard_ns,
+          move_to_front_ns,
+          extra_state->cache_entry_list.size(),
+          index);
+    }
     *maybe_cached_code = found->code.ptr();
     *trace_annotation = found->trace_annotation.c_str();
     return;
+  }
+  if (collect_stats) {
+    torch::dynamo::record_guard_lookup_stats(
+        torch::dynamo::guard_lookup_time_ns() - lookup_start_ns,
+        backend_match_ns,
+        slow_guard_ns,
+        move_to_front_ns,
+        extra_state->cache_entry_list.size(),
+        extra_state->cache_entry_list.size());
   }
   *maybe_cached_code = py::none().ptr();
 }

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -57,8 +57,11 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   py::dict frame_state;
   // Actions to apply to all frames with this code object
   FrameExecStrategy strategy{DEFAULT, DEFAULT};
+  // Opaque guard receipt used by Dynamo guard shadow diagnostics.
+  void* last_success_receipt{nullptr};
 
   ExtraState(PyCodeObject* orig_code_arg);
+  ~ExtraState();
   CacheEntry* get_first_entry();
   void move_to_front(CacheEntry* cache_entry);
   void move_to_back(CacheEntry* cache_entry);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -124,6 +124,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   GlobalState,
   TorchFunctionModeStack,
   NoTensorAliasing,
+  ObjectAliasing,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -166,6 +167,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_global_state{0};
   std::atomic<uint64_t> token_torch_function_mode_stack{0};
   std::atomic<uint64_t> token_no_tensor_aliasing{0};
+  std::atomic<uint64_t> token_object_aliasing{0};
 };
 
 struct GuardFastPlanStats {
@@ -263,6 +265,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_global_state{0};
   uint64_t token_torch_function_mode_stack{0};
   uint64_t token_no_tensor_aliasing{0};
+  uint64_t token_object_aliasing{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -510,6 +513,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_global_state);
   store_zero(subtree_stats.token_torch_function_mode_stack);
   store_zero(subtree_stats.token_no_tensor_aliasing);
+  store_zero(subtree_stats.token_object_aliasing);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -651,6 +655,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_torch_function_mode_stack);
   subtree_token_kind_counts["NoTensorAliasing"] =
       load_relaxed(subtree_stats.token_no_tensor_aliasing);
+  subtree_token_kind_counts["ObjectAliasing"] =
+      load_relaxed(subtree_stats.token_object_aliasing);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -1024,6 +1030,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::NoTensorAliasing:
       add_relaxed(stats.token_no_tensor_aliasing, 1);
       break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      add_relaxed(stats.token_object_aliasing, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1057,6 +1066,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::NoTensorAliasing:
       stats.token_no_tensor_aliasing += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      stats.token_object_aliasing += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2222,6 +2234,7 @@ struct GuardSubtreeEntryToken {
   GlobalStateGuard* global_state_guard{nullptr};
   const void* torch_function_mode_stack_guard{nullptr};
   const void* no_tensor_aliasing_guard{nullptr};
+  const void* object_aliasing_guard{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -2333,6 +2346,17 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_object_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::ObjectAliasing;
+    token.object_aliasing_guard = guard;
+    return token;
+  }
+
   bool matches_tensor_current(
       const LocalState* state,
       GuardFastPlanTensorTokenMissReason& reason) const {
@@ -2430,6 +2454,9 @@ struct GuardSubtreeEntryToken {
     }
     if (kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
       return no_tensor_aliasing_guard == other.no_tensor_aliasing_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+      return object_aliasing_guard == other.object_aliasing_guard;
     }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
@@ -2536,6 +2563,12 @@ static bool guard_subtree_memo_tokens_match(
       continue;
     }
     if (token.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+      if (token.object == nullptr || Py_TYPE(token.object) != token.type) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
       if (token.object == nullptr || Py_TYPE(token.object) != token.type) {
         return false;
       }
@@ -3802,8 +3835,24 @@ class OBJECT_ALIASING : public RelationalGuard {
     _is_first_call = true;
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:OBJECT_ALIASING";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    tokens->emplace_back(GuardSubtreeEntryToken::make_object_aliasing(
+        value, static_cast<const void*>(this)));
+    return true;
   }
 
  private:

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -121,6 +121,13 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   ExactTuple,
 };
 
+enum class GuardFastPlanCandidateKind : uint8_t {
+  Unknown,
+  None,
+  TopModules,
+  NestedModules,
+};
+
 struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> attempt{0};
   std::atomic<uint64_t> entry_match{0};
@@ -138,11 +145,23 @@ struct GuardSubtreeProbeStats {
 
 struct GuardFastPlanStats {
   std::atomic<uint64_t> candidate{0};
+  std::atomic<uint64_t> candidate_top{0};
+  std::atomic<uint64_t> candidate_nested{0};
   std::atomic<uint64_t> shadow_pass{0};
+  std::atomic<uint64_t> shadow_pass_top{0};
+  std::atomic<uint64_t> shadow_pass_nested{0};
   std::atomic<uint64_t> enable{0};
+  std::atomic<uint64_t> enable_top{0};
+  std::atomic<uint64_t> enable_nested{0};
   std::atomic<uint64_t> hit{0};
+  std::atomic<uint64_t> hit_top{0};
+  std::atomic<uint64_t> hit_nested{0};
   std::atomic<uint64_t> miss{0};
+  std::atomic<uint64_t> miss_top{0};
+  std::atomic<uint64_t> miss_nested{0};
   std::atomic<uint64_t> disabled{0};
+  std::atomic<uint64_t> disabled_top{0};
+  std::atomic<uint64_t> disabled_nested{0};
   std::atomic<uint64_t> token_count_sum{0};
   std::atomic<uint64_t> token_check_ns{0};
   std::atomic<uint64_t> slow_check_ns{0};
@@ -388,11 +407,23 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_exact_list);
   store_zero(subtree_stats.token_exact_tuple);
   store_zero(fastplan_stats.candidate);
+  store_zero(fastplan_stats.candidate_top);
+  store_zero(fastplan_stats.candidate_nested);
   store_zero(fastplan_stats.shadow_pass);
+  store_zero(fastplan_stats.shadow_pass_top);
+  store_zero(fastplan_stats.shadow_pass_nested);
   store_zero(fastplan_stats.enable);
+  store_zero(fastplan_stats.enable_top);
+  store_zero(fastplan_stats.enable_nested);
   store_zero(fastplan_stats.hit);
+  store_zero(fastplan_stats.hit_top);
+  store_zero(fastplan_stats.hit_nested);
   store_zero(fastplan_stats.miss);
+  store_zero(fastplan_stats.miss_top);
+  store_zero(fastplan_stats.miss_nested);
   store_zero(fastplan_stats.disabled);
+  store_zero(fastplan_stats.disabled_top);
+  store_zero(fastplan_stats.disabled_nested);
   store_zero(fastplan_stats.token_count_sum);
   store_zero(fastplan_stats.token_check_ns);
   store_zero(fastplan_stats.slow_check_ns);
@@ -475,13 +506,35 @@ py::dict get_guard_lookup_stats() {
   result["guard_fastplan_enabled"] = guard_fast_plan_enabled();
   result["guard_fastplan_candidate"] =
       load_relaxed(fastplan_stats.candidate);
+  result["guard_fastplan_candidate_top"] =
+      load_relaxed(fastplan_stats.candidate_top);
+  result["guard_fastplan_candidate_nested"] =
+      load_relaxed(fastplan_stats.candidate_nested);
   result["guard_fastplan_shadow_pass"] =
       load_relaxed(fastplan_stats.shadow_pass);
+  result["guard_fastplan_shadow_pass_top"] =
+      load_relaxed(fastplan_stats.shadow_pass_top);
+  result["guard_fastplan_shadow_pass_nested"] =
+      load_relaxed(fastplan_stats.shadow_pass_nested);
   result["guard_fastplan_enable"] = load_relaxed(fastplan_stats.enable);
+  result["guard_fastplan_enable_top"] =
+      load_relaxed(fastplan_stats.enable_top);
+  result["guard_fastplan_enable_nested"] =
+      load_relaxed(fastplan_stats.enable_nested);
   result["guard_fastplan_hit"] = load_relaxed(fastplan_stats.hit);
+  result["guard_fastplan_hit_top"] = load_relaxed(fastplan_stats.hit_top);
+  result["guard_fastplan_hit_nested"] =
+      load_relaxed(fastplan_stats.hit_nested);
   result["guard_fastplan_miss"] = load_relaxed(fastplan_stats.miss);
+  result["guard_fastplan_miss_top"] = load_relaxed(fastplan_stats.miss_top);
+  result["guard_fastplan_miss_nested"] =
+      load_relaxed(fastplan_stats.miss_nested);
   result["guard_fastplan_disabled"] =
       load_relaxed(fastplan_stats.disabled);
+  result["guard_fastplan_disabled_top"] =
+      load_relaxed(fastplan_stats.disabled_top);
+  result["guard_fastplan_disabled_nested"] =
+      load_relaxed(fastplan_stats.disabled_nested);
   result["guard_fastplan_token_count_sum"] =
       load_relaxed(fastplan_stats.token_count_sum);
   result["guard_fastplan_token_check_ns"] =
@@ -781,15 +834,36 @@ static void record_guard_subtree_probe_stats(
   }
 }
 
-static void record_guard_fastplan_candidate() {
+static void add_guard_fastplan_kind_count(
+    std::atomic<uint64_t>& top,
+    std::atomic<uint64_t>& nested,
+    GuardFastPlanCandidateKind kind) {
+  switch (kind) {
+    case GuardFastPlanCandidateKind::TopModules:
+      add_relaxed(top, 1);
+      break;
+    case GuardFastPlanCandidateKind::NestedModules:
+      add_relaxed(nested, 1);
+      break;
+    case GuardFastPlanCandidateKind::Unknown:
+    case GuardFastPlanCandidateKind::None:
+      break;
+  }
+}
+
+static void record_guard_fastplan_candidate(
+    GuardFastPlanCandidateKind kind) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.candidate, 1);
+  add_guard_fastplan_kind_count(
+      stats.candidate_top, stats.candidate_nested, kind);
 }
 
 static void record_guard_fastplan_shadow_pass(
+    GuardFastPlanCandidateKind kind,
     size_t token_count,
     uint64_t slow_check_ns) {
   if (!guard_lookup_stats_enabled()) {
@@ -797,23 +871,31 @@ static void record_guard_fastplan_shadow_pass(
   }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.shadow_pass, 1);
+  add_guard_fastplan_kind_count(
+      stats.shadow_pass_top, stats.shadow_pass_nested, kind);
   add_relaxed(stats.token_count_sum, token_count);
   add_relaxed(stats.slow_check_ns, slow_check_ns);
 }
 
-static void record_guard_fastplan_enable() {
+static void record_guard_fastplan_enable(GuardFastPlanCandidateKind kind) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
-  add_relaxed(guard_fastplan_stats().enable, 1);
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.enable, 1);
+  add_guard_fastplan_kind_count(stats.enable_top, stats.enable_nested, kind);
 }
 
 static void record_guard_fastplan_disabled(
+    GuardFastPlanCandidateKind kind,
     const GuardSubtreeMemoSupportAnalysis& analysis) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
-  add_relaxed(guard_fastplan_stats().disabled, 1);
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.disabled, 1);
+  add_guard_fastplan_kind_count(
+      stats.disabled_top, stats.disabled_nested, kind);
   if (analysis.reason.empty()) {
     return;
   }
@@ -830,6 +912,7 @@ static void record_guard_fastplan_disabled(
 }
 
 static void record_guard_fastplan_hit(
+    GuardFastPlanCandidateKind kind,
     size_t token_count,
     uint64_t token_check_ns) {
   if (!guard_lookup_stats_enabled()) {
@@ -837,11 +920,13 @@ static void record_guard_fastplan_hit(
   }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.hit, 1);
+  add_guard_fastplan_kind_count(stats.hit_top, stats.hit_nested, kind);
   add_relaxed(stats.token_count_sum, token_count);
   add_relaxed(stats.token_check_ns, token_check_ns);
 }
 
 static void record_guard_fastplan_miss(
+    GuardFastPlanCandidateKind kind,
     size_t token_count,
     uint64_t token_check_ns,
     uint64_t slow_check_ns,
@@ -851,12 +936,34 @@ static void record_guard_fastplan_miss(
   }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.miss, 1);
+  add_guard_fastplan_kind_count(stats.miss_top, stats.miss_nested, kind);
   add_relaxed(stats.token_count_sum, token_count);
   add_relaxed(stats.token_check_ns, token_check_ns);
   add_relaxed(stats.slow_check_ns, slow_check_ns);
   if (disabled_now) {
     add_relaxed(stats.disabled, 1);
+    add_guard_fastplan_kind_count(
+        stats.disabled_top, stats.disabled_nested, kind);
   }
+}
+
+static GuardFastPlanCandidateKind compute_guard_fastplan_candidate_kind(
+    const std::string& source) {
+  static constexpr const char* kModulesSuffix = "._modules";
+  static constexpr const char* kSelfModules = "L['self']._modules";
+  const size_t suffix_len = std::strlen(kModulesSuffix);
+  if (source.size() < suffix_len ||
+      source.compare(source.size() - suffix_len, suffix_len, kModulesSuffix) !=
+          0) {
+    return GuardFastPlanCandidateKind::None;
+  }
+  if (source.find(kSelfModules) == std::string::npos) {
+    return GuardFastPlanCandidateKind::None;
+  }
+  if (source.find("._modules[") == std::string::npos) {
+    return GuardFastPlanCandidateKind::TopModules;
+  }
+  return GuardFastPlanCandidateKind::NestedModules;
 }
 
 std::string guard_accessor_stats_key(PyObject* key) {
@@ -3271,7 +3378,11 @@ class GuardManager {
  public:
   GuardManager() = delete;
   GuardManager(RootGuardManager* root, std::string source)
-      : _root(root), _source(std::move(source)), _is_dict(false) {}
+      : _root(root),
+        _source(std::move(source)),
+        _is_dict(false),
+        _fastplan_candidate_kind(
+            compute_guard_fastplan_candidate_kind(_source)) {}
 
   GuardManager(
       RootGuardManager* root,
@@ -3280,6 +3391,7 @@ class GuardManager {
       : _root(root),
         _source(std::move(source)),
         _is_dict(py::isinstance<py::dict>(example_value)) {
+    _fastplan_candidate_kind = compute_guard_fastplan_candidate_kind(_source);
     if (_is_dict) {
       _dict_tag = get_dict_version_unchecked(example_value.ptr());
     }
@@ -3304,7 +3416,11 @@ class GuardManager {
  public:
   // For cloning
   GuardManager(RootGuardManager* root, std::string source, bool is_dict)
-      : _root(root), _source(std::move(source)), _is_dict(is_dict) {}
+      : _root(root),
+        _source(std::move(source)),
+        _is_dict(is_dict),
+        _fastplan_candidate_kind(
+            compute_guard_fastplan_candidate_kind(_source)) {}
 
   void clone_common(
       RootGuardManager* cloned_root,
@@ -3400,17 +3516,12 @@ class GuardManager {
     return check_nopybind_template(value);
   }
 
+  GuardFastPlanCandidateKind guard_fastplan_candidate_kind() const {
+    return _fastplan_candidate_kind;
+  }
+
   bool is_guard_fastplan_candidate() const {
-    static constexpr const char* kModulesSuffix = "._modules";
-    const size_t suffix_len = std::strlen(kModulesSuffix);
-    if (_source.size() < suffix_len ||
-        _source.compare(
-            _source.size() - suffix_len, suffix_len, kModulesSuffix) != 0) {
-      return false;
-    }
-    // P1a only targets the top module registry, e.g. L['self']._modules.
-    // Nested module registries are left to P1 candidate selection.
-    return _source.find("._modules[") == std::string::npos;
+    return guard_fastplan_candidate_kind() != GuardFastPlanCandidateKind::None;
   }
 
   virtual bool supports_subtree_memo_recursive(
@@ -3446,14 +3557,16 @@ class GuardManager {
 
   bool check_nopybind_with_fastplan(PyObject* value) {
     GuardSubtreeMemoState& memo = _subtree_probe_state.memo;
+    const GuardFastPlanCandidateKind candidate_kind =
+        guard_fastplan_candidate_kind();
     if (!guard_fast_plan_enabled() || memo.disabled ||
-        !is_guard_fastplan_candidate()) {
+        candidate_kind == GuardFastPlanCandidateKind::None) {
       return check_nopybind(value);
     }
 
     const bool collect_stats = guard_lookup_stats_enabled();
     if (collect_stats) {
-      record_guard_fastplan_candidate();
+      record_guard_fastplan_candidate(candidate_kind);
     }
     GuardSubtreeMemoSupportAnalysis analysis;
     GuardSubtreeMemoSupportAnalysis* analysis_ptr =
@@ -3462,7 +3575,7 @@ class GuardManager {
         !supports_subtree_memo_recursive(analysis_ptr)) {
       memo.disabled = true;
       if (collect_stats) {
-        record_guard_fastplan_disabled(analysis);
+        record_guard_fastplan_disabled(candidate_kind, analysis);
       }
       return check_nopybind(value);
     }
@@ -3476,7 +3589,8 @@ class GuardManager {
           collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
       if (token_match) {
         if (collect_stats) {
-          record_guard_fastplan_hit(memo.tokens.size(), token_check_ns);
+          record_guard_fastplan_hit(
+              candidate_kind, memo.tokens.size(), token_check_ns);
         }
         return true;
       }
@@ -3489,7 +3603,11 @@ class GuardManager {
           collect_stats ? guard_lookup_time_ns() - slow_start_ns : 0;
       if (collect_stats) {
         record_guard_fastplan_miss(
-            memo.tokens.size(), token_check_ns, slow_check_ns, true);
+            candidate_kind,
+            memo.tokens.size(),
+            token_check_ns,
+            slow_check_ns,
+            true);
       }
       return result;
     }
@@ -3520,12 +3638,13 @@ class GuardManager {
     }
 
     if (collect_stats) {
-      record_guard_fastplan_shadow_pass(memo.tokens.size(), slow_check_ns);
+      record_guard_fastplan_shadow_pass(
+          candidate_kind, memo.tokens.size(), slow_check_ns);
     }
     if (memo.shadow_passes >= 3) {
       memo.enabled = true;
       if (collect_stats) {
-        record_guard_fastplan_enable();
+        record_guard_fastplan_enable(candidate_kind);
       }
     }
     return true;
@@ -3534,7 +3653,9 @@ class GuardManager {
   bool check_nopybind_with_subtree_probe(
       PyObject* value,
       const std::string& path) {
-    if (guard_fast_plan_enabled() && is_guard_fastplan_candidate()) {
+    if (guard_fast_plan_enabled() &&
+        active_guard_subtree_memo_recorder == nullptr &&
+        is_guard_fastplan_candidate()) {
       return check_nopybind_with_fastplan(value);
     }
     if (!guard_subtree_probe_enabled() || _subtree_probe_state.disabled) {
@@ -3808,6 +3929,8 @@ class GuardManager {
   bool _is_dict;
   uint64_t _dict_tag{0};
   GuardSubtreeProbeState _subtree_probe_state;
+  GuardFastPlanCandidateKind _fastplan_candidate_kind{
+      GuardFastPlanCandidateKind::None};
 };
 
 GuardAccessor::GuardAccessor(

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -264,6 +264,15 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> actual_disabled{0};
   std::atomic<uint64_t> actual_token_check_ns{0};
   std::atomic<uint64_t> actual_train_ns{0};
+  std::atomic<uint64_t> actual_partial_attempt{0};
+  std::atomic<uint64_t> actual_partial_hit{0};
+  std::atomic<uint64_t> actual_partial_miss{0};
+  std::atomic<uint64_t> actual_partial_enable{0};
+  std::atomic<uint64_t> actual_partial_disabled{0};
+  std::atomic<uint64_t> actual_partial_residual_fail{0};
+  std::atomic<uint64_t> actual_partial_token_check_ns{0};
+  std::atomic<uint64_t> actual_partial_residual_ns{0};
+  std::atomic<uint64_t> actual_partial_train_ns{0};
 };
 
 struct GuardFastPlanDisabledPathStats {
@@ -666,6 +675,15 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.actual_disabled);
   store_zero(last_success_stats.actual_token_check_ns);
   store_zero(last_success_stats.actual_train_ns);
+  store_zero(last_success_stats.actual_partial_attempt);
+  store_zero(last_success_stats.actual_partial_hit);
+  store_zero(last_success_stats.actual_partial_miss);
+  store_zero(last_success_stats.actual_partial_enable);
+  store_zero(last_success_stats.actual_partial_disabled);
+  store_zero(last_success_stats.actual_partial_residual_fail);
+  store_zero(last_success_stats.actual_partial_token_check_ns);
+  store_zero(last_success_stats.actual_partial_residual_ns);
+  store_zero(last_success_stats.actual_partial_train_ns);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -931,6 +949,24 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.actual_token_check_ns);
   result["guard_last_success_actual_train_ns"] =
       load_relaxed(last_success_stats.actual_train_ns);
+  result["guard_last_success_actual_partial_attempt"] =
+      load_relaxed(last_success_stats.actual_partial_attempt);
+  result["guard_last_success_actual_partial_hit"] =
+      load_relaxed(last_success_stats.actual_partial_hit);
+  result["guard_last_success_actual_partial_miss"] =
+      load_relaxed(last_success_stats.actual_partial_miss);
+  result["guard_last_success_actual_partial_enable"] =
+      load_relaxed(last_success_stats.actual_partial_enable);
+  result["guard_last_success_actual_partial_disabled"] =
+      load_relaxed(last_success_stats.actual_partial_disabled);
+  result["guard_last_success_actual_partial_residual_fail"] =
+      load_relaxed(last_success_stats.actual_partial_residual_fail);
+  result["guard_last_success_actual_partial_token_check_ns"] =
+      load_relaxed(last_success_stats.actual_partial_token_check_ns);
+  result["guard_last_success_actual_partial_residual_ns"] =
+      load_relaxed(last_success_stats.actual_partial_residual_ns);
+  result["guard_last_success_actual_partial_train_ns"] =
+      load_relaxed(last_success_stats.actual_partial_train_ns);
   py::dict last_success_disabled_reasons;
   py::dict last_success_disabled_top_paths;
   {
@@ -1660,6 +1696,68 @@ static void record_guard_last_success_actual_train(uint64_t train_ns) {
     return;
   }
   add_relaxed(guard_last_success_stats().actual_train_ns, train_ns);
+}
+
+static void record_guard_last_success_actual_partial_attempt() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_attempt, 1);
+}
+
+static void record_guard_last_success_actual_partial_hit(
+    uint64_t token_check_ns,
+    uint64_t residual_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_hit, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+  add_relaxed(stats.actual_partial_residual_ns, residual_ns);
+}
+
+static void record_guard_last_success_actual_partial_miss(
+    uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_miss, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+}
+
+static void record_guard_last_success_actual_partial_enable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_enable, 1);
+}
+
+static void record_guard_last_success_actual_partial_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_disabled, 1);
+}
+
+static void record_guard_last_success_actual_partial_residual_fail(
+    uint64_t token_check_ns,
+    uint64_t residual_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_residual_fail, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+  add_relaxed(stats.actual_partial_residual_ns, residual_ns);
+}
+
+static void record_guard_last_success_actual_partial_train(uint64_t train_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_train_ns, train_ns);
 }
 
 static void record_guard_last_success_disabled_item_locked(
@@ -3071,6 +3169,7 @@ struct GuardLastSuccessReceipt {
     tokens.clear();
     debug_paths.clear();
     reset_actual();
+    reset_actual_partial();
   }
 
   void reset_actual() {
@@ -3083,6 +3182,17 @@ struct GuardLastSuccessReceipt {
     actual_self_object = nullptr;
     actual_self_type = nullptr;
     actual_tokens.clear();
+  }
+
+  void reset_actual_partial() {
+    actual_partial_entry_key = nullptr;
+    actual_partial_root_key = nullptr;
+    actual_partial_shadow_passes = 0;
+    actual_partial_enabled = false;
+    actual_partial_disabled = false;
+    actual_partial_self_object = nullptr;
+    actual_partial_self_type = nullptr;
+    actual_partial_tokens.clear();
   }
 
   uint64_t update(
@@ -3164,6 +3274,15 @@ struct GuardLastSuccessReceipt {
   PyObject* actual_self_object{nullptr};
   PyTypeObject* actual_self_type{nullptr};
   std::vector<GuardSubtreeEntryToken> actual_tokens;
+
+  void* actual_partial_entry_key{nullptr};
+  void* actual_partial_root_key{nullptr};
+  uint64_t actual_partial_shadow_passes{0};
+  bool actual_partial_enabled{false};
+  bool actual_partial_disabled{false};
+  PyObject* actual_partial_self_object{nullptr};
+  PyTypeObject* actual_partial_self_type{nullptr};
+  std::vector<GuardSubtreeEntryToken> actual_partial_tokens;
 };
 
 extern thread_local const LocalState* active_guard_local_state;
@@ -3401,6 +3520,124 @@ static bool guard_last_success_actual_tokens_match(
   const bool result =
       guard_subtree_memo_tokens_match(receipt->actual_tokens, root_value);
   return result;
+}
+
+static bool guard_last_success_extract_self_partial_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  partial_tokens.clear();
+  if (tokens.empty()) {
+    disabled_reason = "actual_partial_empty_receipt";
+    return false;
+  }
+  if (tokens.size() != debug_paths.size()) {
+    disabled_reason = "actual_partial_missing_debug_paths";
+    return false;
+  }
+
+  size_t start = tokens.size();
+  for (size_t i = 0; i < debug_paths.size(); ++i) {
+    if (debug_paths[i] == "L['self']") {
+      start = i;
+      break;
+    }
+  }
+  if (start == tokens.size()) {
+    disabled_reason = "actual_partial_missing_self";
+    disabled_path = "L['self']";
+    return false;
+  }
+
+  size_t end = tokens.size();
+  for (size_t i = start + 1; i < debug_paths.size(); ++i) {
+    const auto& path = debug_paths[i];
+    if (is_global_source_path(path) ||
+        (is_local_source_path(path) && !is_self_local_source_path(path))) {
+      end = i;
+      break;
+    }
+  }
+  if (end <= start) {
+    disabled_reason = "actual_partial_empty_self";
+    disabled_path = "L['self']";
+    return false;
+  }
+
+  partial_tokens.assign(tokens.begin() + start, tokens.begin() + end);
+  return true;
+}
+
+static bool guard_last_success_prepare_actual_partial(
+    GuardLastSuccessReceipt* receipt,
+    FrameLocalsMapping* f_locals,
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  if (!guard_last_success_extract_self_partial_tokens(
+          tokens, debug_paths, partial_tokens, disabled_reason, disabled_path)) {
+    return false;
+  }
+  if (partial_tokens.size() > kGuardLastSuccessActualMaxTokens) {
+    disabled_reason = "actual_partial_token_cap_exceeded";
+    disabled_path = "L['self']";
+    return false;
+  }
+  if (partial_tokens.empty() ||
+      partial_tokens[0].kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+    disabled_reason = "actual_partial_invalid_self_token";
+    disabled_path = "L['self']";
+    return false;
+  }
+
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    disabled_reason = "actual_partial_missing_self_key";
+    return false;
+  }
+  PyObject* current_self = PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+  if (current_self == nullptr) {
+    disabled_reason = "actual_partial_missing_self";
+    disabled_path = "L['self']";
+    return false;
+  }
+  if (partial_tokens[0].object != current_self) {
+    disabled_reason = "actual_partial_self_object_mismatch";
+    disabled_path = "L['self']";
+    return false;
+  }
+  receipt->actual_partial_self_object = current_self;
+  receipt->actual_partial_self_type = Py_TYPE(current_self);
+  return true;
+}
+
+static bool guard_last_success_actual_partial_tokens_match(
+    GuardLastSuccessReceipt* receipt,
+    FrameLocalsMapping* f_locals) {
+  if (receipt->actual_partial_tokens.empty()) {
+    return false;
+  }
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  PyObject* current_self = PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+  if (current_self == nullptr ||
+      current_self != receipt->actual_partial_self_object ||
+      Py_TYPE(current_self) != receipt->actual_partial_self_type) {
+    return false;
+  }
+  LocalState state;
+  GuardLocalStateScope local_state_scope(&state);
+  return guard_subtree_memo_tokens_match(
+      receipt->actual_partial_tokens,
+      receipt->actual_partial_tokens[0].object);
 }
 
 struct GuardSubtreeMemoState {
@@ -5031,11 +5268,15 @@ class GuardAccessor {
     return _guard_manager;
   }
 
+  const std::unique_ptr<GuardManager>& get_guard_manager() const {
+    return _guard_manager;
+  }
+
   bool matches_key(const py::handle& key) const {
     return _accessor_key.equal(key);
   }
 
-  std::string get_source() {
+  const std::string& get_source() const {
     return _source;
   }
 
@@ -5373,6 +5614,36 @@ class GuardManager {
       }
     }
     return supported;
+  }
+
+  bool supports_accessor_subtree_memo_recursive(
+      const std::string& source,
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const {
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() != source) {
+        continue;
+      }
+      if (!accessor->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        }
+        return false;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              analysis)) {
+        if (analysis != nullptr && analysis->path.empty()) {
+          analysis->path = accessor->get_source();
+        }
+        return false;
+      }
+      return true;
+    }
+    if (analysis != nullptr) {
+      analysis->set_if_empty("partial_missing_accessor", source);
+    }
+    return false;
   }
 
   bool prepare_partial_subtree_memo(
@@ -5803,6 +6074,63 @@ class GuardManager {
     return result;
   }
 
+  template <typename T>
+  bool check_accessors_nopybind_skipping_source(
+      T* value,
+      const std::string& skip_source) {
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (_is_dict) {
+        new_tag = get_dict_version_unchecked(value);
+        matches_dict_tag = (new_tag == _dict_tag);
+      }
+    }
+
+    const bool collect_stats = guard_lookup_stats_enabled();
+    bool result = true;
+    bool failed_on_first = true;
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() == skip_source) {
+        failed_on_first = false;
+        continue;
+      }
+      const uint64_t accessor_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (collect_stats) {
+        record_guard_accessor_type_stats(
+            accessor->stats_name(),
+            guard_lookup_time_ns() - accessor_start_ns,
+            !accessor_result);
+      }
+      if (!accessor_result) {
+        _fail_count += 1;
+        result = false;
+        break;
+      }
+      failed_on_first = false;
+    }
+
+    if (!result && !failed_on_first) {
+      std::sort(
+          _accessors.begin(),
+          _accessors.end(),
+          [](const std::unique_ptr<GuardAccessor>& a,
+             const std::unique_ptr<GuardAccessor>& b) {
+            return a->get_guard_manager()->fail_count() >
+                b->get_guard_manager()->fail_count();
+          });
+    }
+
+    if (_is_dict && result) {
+      _dict_tag = new_tag;
+    }
+
+    return result;
+  }
+
   // This function has some code duplication with function check. This is
   // deliberate to keep check function simple and fast.
   virtual GuardDebugInfo check_verbose_nopybind(
@@ -6025,7 +6353,9 @@ class RootGuardManager : public GuardManager {
 
   // Fast check function.
   template <typename T>
-  bool check_nopybind_template(T* value) { // borrowed ref
+  bool check_nopybind_template(
+      T* value,
+      const std::string* skip_accessor_source = nullptr) { // borrowed ref
     const bool collect_stats = guard_lookup_stats_enabled();
     const uint64_t total_start_ns =
         collect_stats ? guard_lookup_time_ns() : 0;
@@ -6102,7 +6432,11 @@ class RootGuardManager : public GuardManager {
 
     const uint64_t accessor_start_ns =
         collect_stats ? guard_lookup_time_ns() : 0;
-    if (!GuardManager::check_accessors_nopybind(value)) {
+    const bool accessor_result = skip_accessor_source == nullptr
+        ? GuardManager::check_accessors_nopybind(value)
+        : GuardManager::check_accessors_nopybind_skipping_source(
+              value, *skip_accessor_source);
+    if (!accessor_result) {
       if (collect_stats) {
         accessor_ns += guard_lookup_time_ns() - accessor_start_ns;
       }
@@ -6157,6 +6491,12 @@ class RootGuardManager : public GuardManager {
 
   bool check_nopybind(FrameLocalsMapping* value) override {
     return check_nopybind_template(value);
+  }
+
+  bool check_nopybind_skipping_source(
+      FrameLocalsMapping* value,
+      const std::string& skip_accessor_source) {
+    return check_nopybind_template(value, &skip_accessor_source);
   }
 
   bool supports_subtree_memo_recursive(
@@ -9034,6 +9374,9 @@ bool run_root_guard_manager_with_last_success_receipt(
     return run_root_guard_manager(root, f_locals);
   }
 
+  RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
+  static const std::string self_source = "L['self']";
+
   if (state->actual_enabled && state->actual_entry_key == entry_key &&
       state->actual_root_key == root) {
     const bool collect_stats = guard_lookup_stats_enabled();
@@ -9051,11 +9394,42 @@ bool run_root_guard_manager_with_last_success_receipt(
     state->reset_actual();
   }
 
-  if (state->actual_disabled && !guard_last_success_shadow_enabled()) {
+  record_guard_last_success_actual_partial_attempt();
+  if (state->actual_partial_enabled &&
+      state->actual_partial_entry_key == entry_key &&
+      state->actual_partial_root_key == root) {
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t token_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool partial_match =
+        guard_last_success_actual_partial_tokens_match(state, f_locals);
+    const uint64_t token_check_ns =
+        collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
+    if (partial_match) {
+      const uint64_t residual_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool residual_result =
+          root_mgr->check_nopybind_skipping_source(f_locals, self_source);
+      const uint64_t residual_ns =
+          collect_stats ? guard_lookup_time_ns() - residual_start_ns : 0;
+      if (residual_result) {
+        record_guard_last_success_actual_partial_hit(
+            token_check_ns, residual_ns);
+      } else {
+        record_guard_last_success_actual_partial_residual_fail(
+            token_check_ns, residual_ns);
+      }
+      return residual_result;
+    }
+    record_guard_last_success_actual_partial_miss(token_check_ns);
+    state->reset_actual_partial();
+  }
+
+  if (state->actual_disabled && state->actual_partial_disabled &&
+      !guard_last_success_shadow_enabled()) {
     return run_root_guard_manager(root, f_locals);
   }
 
-  RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
   GuardSubtreeMemoSupportAnalysis analysis;
   analysis.collect_all = guard_lookup_stats_enabled();
   const bool should_train_actual = !state->actual_disabled;
@@ -9075,9 +9449,31 @@ bool run_root_guard_manager_with_last_success_receipt(
       state->actual_disabled = true;
       record_guard_last_success_actual_disabled();
     }
-    if (!guard_last_success_shadow_enabled()) {
-      return run_root_guard_manager(root, f_locals);
+  }
+
+  GuardSubtreeMemoSupportAnalysis partial_analysis;
+  partial_analysis.collect_all = guard_lookup_stats_enabled();
+  const bool should_train_partial = !state->actual_partial_disabled;
+  const bool partial_supported = should_train_partial &&
+      root_mgr->supports_accessor_subtree_memo_recursive(
+          self_source, &partial_analysis);
+  if (!partial_supported && should_train_partial) {
+    state->reset_actual_partial();
+    state->actual_partial_disabled = true;
+    record_guard_last_success_actual_partial_disabled();
+    if (guard_lookup_stats_enabled()) {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_disabled_stats_mutex());
+      record_guard_last_success_disabled_item_locked(
+          partial_analysis.reason.empty()
+              ? "actual_partial_unsupported"
+              : partial_analysis.reason.c_str(),
+          partial_analysis.path.empty() ? self_source : partial_analysis.path);
     }
+  }
+
+  if (!supported && !partial_supported && !guard_last_success_shadow_enabled()) {
+    return run_root_guard_manager(root, f_locals);
   }
 
   std::vector<GuardSubtreeEntryToken> tokens;
@@ -9150,6 +9546,53 @@ bool run_root_guard_manager_with_last_success_receipt(
       guard_lookup_stats_enabled() ? guard_lookup_time_ns() - actual_train_start_ns
                                    : 0);
 
+  const uint64_t partial_train_start_ns =
+      guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
+  std::vector<GuardSubtreeEntryToken> partial_tokens;
+  std::string partial_disabled_reason;
+  std::string partial_disabled_path;
+  bool partial_disabled_now = false;
+  const bool actual_partial_supported = should_train_partial &&
+      partial_supported &&
+      guard_last_success_prepare_actual_partial(
+          state,
+          f_locals,
+          tokens,
+          debug_paths,
+          partial_tokens,
+          partial_disabled_reason,
+          partial_disabled_path);
+  if (actual_partial_supported) {
+    if (state->actual_partial_entry_key == entry_key &&
+        state->actual_partial_root_key == root &&
+        !state->actual_partial_tokens.empty() &&
+        guard_subtree_token_vectors_match(
+            partial_tokens, state->actual_partial_tokens)) {
+      state->actual_partial_shadow_passes += 1;
+    } else {
+      state->actual_partial_entry_key = entry_key;
+      state->actual_partial_root_key = root;
+      state->actual_partial_tokens = std::move(partial_tokens);
+      state->actual_partial_shadow_passes = 1;
+      state->actual_partial_enabled = false;
+    }
+    if (!state->actual_partial_enabled &&
+        state->actual_partial_shadow_passes >=
+            kGuardLastSuccessActualStablePasses) {
+      state->actual_partial_enabled = true;
+      record_guard_last_success_actual_partial_enable();
+    }
+  } else if (should_train_partial && partial_supported) {
+    state->reset_actual_partial();
+    state->actual_partial_disabled = true;
+    partial_disabled_now = true;
+    record_guard_last_success_actual_partial_disabled();
+  }
+  record_guard_last_success_actual_partial_train(
+      guard_lookup_stats_enabled()
+          ? guard_lookup_time_ns() - partial_train_start_ns
+          : 0);
+
   std::vector<GuardSubtreeEntryToken> diagnostic_tokens =
       guard_last_success_make_diagnostic_tokens(tokens, debug_paths);
   const uint64_t update_start_ns = guard_lookup_time_ns();
@@ -9180,6 +9623,14 @@ bool run_root_guard_manager_with_last_success_receipt(
         actual_disabled_reason.empty() ? "actual_unsupported"
                                        : actual_disabled_reason.c_str(),
         actual_disabled_path);
+  }
+  if (partial_disabled_now && guard_lookup_stats_enabled()) {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_disabled_stats_mutex());
+    record_guard_last_success_disabled_item_locked(
+        partial_disabled_reason.empty() ? "actual_partial_unsupported"
+                                        : partial_disabled_reason.c_str(),
+        partial_disabled_path);
   }
   return true;
 }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -125,6 +125,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   TorchFunctionModeStack,
   NoTensorAliasing,
   ObjectAliasing,
+  BoundMethod,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -163,6 +164,7 @@ enum class GuardLastSuccessCompareMismatchReason : uint8_t {
   TorchFunctionModeStack,
   NoTensorAliasing,
   ObjectAliasing,
+  BoundMethod,
   Version,
   DictSize,
   ListItems,
@@ -188,6 +190,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_torch_function_mode_stack{0};
   std::atomic<uint64_t> token_no_tensor_aliasing{0};
   std::atomic<uint64_t> token_object_aliasing{0};
+  std::atomic<uint64_t> token_bound_method{0};
 };
 
 struct GuardFastPlanStats {
@@ -291,6 +294,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_torch_function_mode_stack{0};
   uint64_t token_no_tensor_aliasing{0};
   uint64_t token_object_aliasing{0};
+  uint64_t token_bound_method{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -572,6 +576,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_torch_function_mode_stack);
   store_zero(subtree_stats.token_no_tensor_aliasing);
   store_zero(subtree_stats.token_object_aliasing);
+  store_zero(subtree_stats.token_bound_method);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -727,6 +732,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_no_tensor_aliasing);
   subtree_token_kind_counts["ObjectAliasing"] =
       load_relaxed(subtree_stats.token_object_aliasing);
+  subtree_token_kind_counts["BoundMethod"] =
+      load_relaxed(subtree_stats.token_bound_method);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -985,6 +992,14 @@ py::dict get_guard_lookup_stats() {
       token_counts["ExactList"] = items[i].second.token_exact_list;
       token_counts["ExactTuple"] = items[i].second.token_exact_tuple;
       token_counts["TensorMatch"] = items[i].second.token_tensor_match;
+      token_counts["DefaultDevice"] = items[i].second.token_default_device;
+      token_counts["GlobalState"] = items[i].second.token_global_state;
+      token_counts["TorchFunctionModeStack"] =
+          items[i].second.token_torch_function_mode_stack;
+      token_counts["NoTensorAliasing"] =
+          items[i].second.token_no_tensor_aliasing;
+      token_counts["ObjectAliasing"] = items[i].second.token_object_aliasing;
+      token_counts["BoundMethod"] = items[i].second.token_bound_method;
       item_stats["token_kind_counts"] = token_counts;
       path_stats[py::str(items[i].first)] = item_stats;
     }
@@ -1109,6 +1124,8 @@ static const char* guard_subtree_token_kind_name(
       return "NoTensorAliasing";
     case GuardSubtreeProbeTokenKind::ObjectAliasing:
       return "ObjectAliasing";
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      return "BoundMethod";
   }
   return "Unknown";
 }
@@ -1142,6 +1159,8 @@ static const char* guard_last_success_mismatch_reason_name(
       return "no_tensor_aliasing";
     case GuardLastSuccessCompareMismatchReason::ObjectAliasing:
       return "object_aliasing";
+    case GuardLastSuccessCompareMismatchReason::BoundMethod:
+      return "bound_method";
     case GuardLastSuccessCompareMismatchReason::Version:
       return "version";
     case GuardLastSuccessCompareMismatchReason::DictSize:
@@ -1221,6 +1240,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::ObjectAliasing:
       add_relaxed(stats.token_object_aliasing, 1);
       break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      add_relaxed(stats.token_bound_method, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1257,6 +1279,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::ObjectAliasing:
       stats.token_object_aliasing += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      stats.token_bound_method += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2485,12 +2510,29 @@ struct GuardSubtreeEntryToken {
   const void* torch_function_mode_stack_guard{nullptr};
   const void* no_tensor_aliasing_guard{nullptr};
   const void* object_aliasing_guard{nullptr};
+  PyObject* bound_method_self{nullptr};
+  PyObject* bound_method_func{nullptr};
+  PyCFunction bound_c_method_func{nullptr};
+  PyTypeObject* bound_c_method_class{nullptr};
+  int bound_c_method_flags{0};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
     token.object = obj;
     token.type = Py_TYPE(obj);
-    if (PyDict_CheckExact(obj)) {
+    if (PyMethod_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyMethod_GET_SELF(obj);
+      token.bound_method_func = PyMethod_GET_FUNCTION(obj);
+    } else if (PyCFunction_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyCFunction_GET_SELF(obj);
+      token.bound_c_method_func = PyCFunction_GET_FUNCTION(obj);
+      token.bound_c_method_flags = PyCFunction_GET_FLAGS(obj);
+#ifdef PyCFunction_GET_CLASS
+      token.bound_c_method_class = PyCFunction_GET_CLASS(obj);
+#endif
+    } else if (PyDict_CheckExact(obj)) {
       token.kind = GuardSubtreeProbeTokenKind::ExactDict;
       token.version = get_dict_version_unchecked(obj);
       token.size = PyDict_GET_SIZE(obj);
@@ -2677,7 +2719,17 @@ struct GuardSubtreeEntryToken {
   }
 
   bool matches(const GuardSubtreeEntryToken& other) const {
-    if (kind != other.kind || object != other.object || type != other.type) {
+    if (kind != other.kind || type != other.type) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      return bound_method_self == other.bound_method_self &&
+          bound_method_func == other.bound_method_func &&
+          bound_c_method_func == other.bound_c_method_func &&
+          bound_c_method_class == other.bound_c_method_class &&
+          bound_c_method_flags == other.bound_c_method_flags;
+    }
+    if (object != other.object) {
       return false;
     }
     if (kind == GuardSubtreeProbeTokenKind::TensorMatch) {
@@ -2720,11 +2772,21 @@ guard_subtree_token_mismatch_reason(
   if (lhs.kind != rhs.kind) {
     return GuardLastSuccessCompareMismatchReason::Kind;
   }
-  if (lhs.object != rhs.object) {
-    return GuardLastSuccessCompareMismatchReason::Object;
-  }
   if (lhs.type != rhs.type) {
     return GuardLastSuccessCompareMismatchReason::Type;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+    if (lhs.bound_method_self != rhs.bound_method_self ||
+        lhs.bound_method_func != rhs.bound_method_func ||
+        lhs.bound_c_method_func != rhs.bound_c_method_func ||
+        lhs.bound_c_method_class != rhs.bound_c_method_class ||
+        lhs.bound_c_method_flags != rhs.bound_c_method_flags) {
+      return GuardLastSuccessCompareMismatchReason::BoundMethod;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.object != rhs.object) {
+    return GuardLastSuccessCompareMismatchReason::Object;
   }
   if (lhs.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
     if (lhs.tensor_dispatch_key != rhs.tensor_dispatch_key ||
@@ -2950,8 +3012,10 @@ static bool guard_subtree_memo_tokens_match(
       }
       continue;
     }
-    if (i != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly) {
-      // Parent dict/list tokens prove whether this object is still reachable.
+    if (i != 0 &&
+        (token.kind == GuardSubtreeProbeTokenKind::ObjectOnly ||
+         token.kind == GuardSubtreeProbeTokenKind::BoundMethod)) {
+      // Parent tokens prove whether this non-root object is still reachable.
       continue;
     }
     GuardSubtreeEntryToken current =

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2,11 +2,13 @@
 #include <ATen/autocast_mode.h>
 #include <c10/core/SafePyObject.h>
 #include <c10/core/impl/PyInterpreter.h>
+#include <c10/util/env.h>
 #define PY_SSIZE_T_CLEAN
 #include <ATen/EmptyTensor.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <c10/util/flat_hash_map.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/inductor/inductor_ops.h>
@@ -28,10 +30,16 @@
 #include <ATen/xpu/EmptyTensor.h>
 #endif
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <mutex>
+#include <optional>
 #include <sstream>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 // Certain CPython data structures are defined in `.c` files in earlier Python
 // versions, e.g., for TupleIteratorGetItemAccessor, we need a fast way to
@@ -75,12 +83,344 @@ typedef struct {
 
 namespace torch::dynamo {
 
+namespace {
+
+struct GuardLookupStats {
+  std::atomic<uint64_t> lookup_count{0};
+  std::atomic<uint64_t> lookup_total_ns{0};
+  std::atomic<uint64_t> backend_match_ns{0};
+  std::atomic<uint64_t> slow_guard_ns{0};
+  std::atomic<uint64_t> move_to_front_ns{0};
+  std::atomic<uint64_t> cache_entry_count_sum{0};
+  std::atomic<uint64_t> cache_entry_hit_index_sum{0};
+
+  std::atomic<uint64_t> root_guard_count{0};
+  std::atomic<uint64_t> root_guard_total_ns{0};
+  std::atomic<uint64_t> root_guard_lock_ns{0};
+  std::atomic<uint64_t> root_guard_local_state_ns{0};
+  std::atomic<uint64_t> root_guard_leaf_ns{0};
+  std::atomic<uint64_t> root_guard_accessor_ns{0};
+  std::atomic<uint64_t> root_guard_epilogue_ns{0};
+  std::atomic<uint64_t> root_guard_tls_ns{0};
+
+  std::atomic<uint64_t> unsafe_mock_guard_bypass_count{0};
+  std::atomic<uint64_t> unsafe_mock_guard_bypass_hit_index_sum{0};
+};
+
+struct GuardAccessorTypeStats {
+  uint64_t count{0};
+  uint64_t fail_count{0};
+  uint64_t inclusive_ns{0};
+};
+
+struct GuardAccessorDetailStats {
+  uint64_t count{0};
+  uint64_t fail_count{0};
+  uint64_t self_ns{0};
+  uint64_t child_ns{0};
+  uint64_t inclusive_ns{0};
+};
+
+constexpr size_t kGuardAccessorDetailStatsTopK = 64;
+
+GuardLookupStats& guard_lookup_stats() {
+  static GuardLookupStats stats;
+  return stats;
+}
+
+std::atomic<bool>& guard_lookup_stats_force_enabled() {
+  static std::atomic<bool> enabled{false};
+  return enabled;
+}
+
+void store_zero(std::atomic<uint64_t>& value) {
+  value.store(0, std::memory_order_relaxed);
+}
+
+uint64_t load_relaxed(const std::atomic<uint64_t>& value) {
+  return value.load(std::memory_order_relaxed);
+}
+
+void add_relaxed(std::atomic<uint64_t>& value, uint64_t delta) {
+  value.fetch_add(delta, std::memory_order_relaxed);
+}
+
+std::mutex& guard_accessor_type_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardAccessorTypeStats>&
+guard_accessor_type_stats() {
+  static std::unordered_map<std::string, GuardAccessorTypeStats> stats;
+  return stats;
+}
+
+std::mutex& guard_accessor_detail_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardAccessorDetailStats>&
+guard_accessor_detail_stats() {
+  static std::unordered_map<std::string, GuardAccessorDetailStats> stats;
+  return stats;
+}
+
+} // namespace
+
+bool guard_lookup_stats_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_GUARD_LOOKUP_STATS") == true;
+  const bool force_enabled =
+      guard_lookup_stats_force_enabled().load(std::memory_order_relaxed);
+  return C10_UNLIKELY(env_enabled) || C10_UNLIKELY(force_enabled);
+}
+
+bool unsafe_mock_guard_bypass_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == true;
+  return C10_UNLIKELY(env_enabled);
+}
+
+uint64_t guard_lookup_time_ns() {
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
+
+void reset_guard_lookup_stats() {
+  auto& stats = guard_lookup_stats();
+  store_zero(stats.lookup_count);
+  store_zero(stats.lookup_total_ns);
+  store_zero(stats.backend_match_ns);
+  store_zero(stats.slow_guard_ns);
+  store_zero(stats.move_to_front_ns);
+  store_zero(stats.cache_entry_count_sum);
+  store_zero(stats.cache_entry_hit_index_sum);
+  store_zero(stats.root_guard_count);
+  store_zero(stats.root_guard_total_ns);
+  store_zero(stats.root_guard_lock_ns);
+  store_zero(stats.root_guard_local_state_ns);
+  store_zero(stats.root_guard_leaf_ns);
+  store_zero(stats.root_guard_accessor_ns);
+  store_zero(stats.root_guard_epilogue_ns);
+  store_zero(stats.root_guard_tls_ns);
+  store_zero(stats.unsafe_mock_guard_bypass_count);
+  store_zero(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+    guard_accessor_type_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+    guard_accessor_detail_stats().clear();
+  }
+  guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
+}
+
+py::dict get_guard_lookup_stats() {
+  auto& stats = guard_lookup_stats();
+  py::dict result;
+  result["lookup_count"] = load_relaxed(stats.lookup_count);
+  result["lookup_total_ns"] = load_relaxed(stats.lookup_total_ns);
+  result["backend_match_ns"] = load_relaxed(stats.backend_match_ns);
+  result["slow_guard_ns"] = load_relaxed(stats.slow_guard_ns);
+  result["move_to_front_ns"] = load_relaxed(stats.move_to_front_ns);
+  result["cache_entry_count_sum"] = load_relaxed(stats.cache_entry_count_sum);
+  result["cache_entry_hit_index_sum"] =
+      load_relaxed(stats.cache_entry_hit_index_sum);
+  result["root_guard_count"] = load_relaxed(stats.root_guard_count);
+  result["root_guard_total_ns"] = load_relaxed(stats.root_guard_total_ns);
+  result["root_guard_lock_ns"] = load_relaxed(stats.root_guard_lock_ns);
+  result["root_guard_local_state_ns"] =
+      load_relaxed(stats.root_guard_local_state_ns);
+  result["root_guard_leaf_ns"] = load_relaxed(stats.root_guard_leaf_ns);
+  result["root_guard_accessor_ns"] = load_relaxed(stats.root_guard_accessor_ns);
+  result["root_guard_epilogue_ns"] = load_relaxed(stats.root_guard_epilogue_ns);
+  result["root_guard_tls_ns"] = load_relaxed(stats.root_guard_tls_ns);
+  result["unsafe_mock_guard_bypass_enabled"] =
+      unsafe_mock_guard_bypass_enabled();
+  result["unsafe_mock_guard_bypass_count"] =
+      load_relaxed(stats.unsafe_mock_guard_bypass_count);
+  result["unsafe_mock_guard_bypass_hit_index_sum"] =
+      load_relaxed(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  py::dict accessor_type_stats;
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+    for (const auto& item : guard_accessor_type_stats()) {
+      py::dict item_stats;
+      item_stats["count"] = item.second.count;
+      item_stats["fail_count"] = item.second.fail_count;
+      item_stats["inclusive_ns"] = item.second.inclusive_ns;
+      accessor_type_stats[py::str(item.first)] = item_stats;
+    }
+  }
+  result["root_guard_accessor_type_stats"] = accessor_type_stats;
+  py::dict accessor_detail_stats;
+  {
+    std::vector<std::pair<std::string, GuardAccessorDetailStats>> items;
+    {
+      std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+      items.reserve(guard_accessor_detail_stats().size());
+      for (const auto& item : guard_accessor_detail_stats()) {
+        items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        items.begin(),
+        items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.inclusive_ns > b.second.inclusive_ns;
+        });
+    const size_t limit =
+        std::min(items.size(), kGuardAccessorDetailStatsTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = items[i].second.count;
+      item_stats["fail_count"] = items[i].second.fail_count;
+      item_stats["self_ns"] = items[i].second.self_ns;
+      item_stats["child_ns"] = items[i].second.child_ns;
+      item_stats["inclusive_ns"] = items[i].second.inclusive_ns;
+      accessor_detail_stats[py::str(items[i].first)] = item_stats;
+    }
+  }
+  result["root_guard_accessor_detail_topk"] = accessor_detail_stats;
+  return result;
+}
+
+void record_guard_lookup_stats(
+    uint64_t total_ns,
+    uint64_t backend_match_ns,
+    uint64_t slow_guard_ns,
+    uint64_t move_to_front_ns,
+    uint64_t cache_entry_count,
+    uint64_t cache_entry_hit_index) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.lookup_count, 1);
+  add_relaxed(stats.lookup_total_ns, total_ns);
+  add_relaxed(stats.backend_match_ns, backend_match_ns);
+  add_relaxed(stats.slow_guard_ns, slow_guard_ns);
+  add_relaxed(stats.move_to_front_ns, move_to_front_ns);
+  add_relaxed(stats.cache_entry_count_sum, cache_entry_count);
+  add_relaxed(stats.cache_entry_hit_index_sum, cache_entry_hit_index);
+}
+
+void record_root_guard_stats(
+    uint64_t total_ns,
+    uint64_t lock_ns,
+    uint64_t local_state_ns,
+    uint64_t leaf_ns,
+    uint64_t accessor_ns,
+    uint64_t epilogue_ns,
+    uint64_t tls_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.root_guard_count, 1);
+  add_relaxed(stats.root_guard_total_ns, total_ns);
+  add_relaxed(stats.root_guard_lock_ns, lock_ns);
+  add_relaxed(stats.root_guard_local_state_ns, local_state_ns);
+  add_relaxed(stats.root_guard_leaf_ns, leaf_ns);
+  add_relaxed(stats.root_guard_accessor_ns, accessor_ns);
+  add_relaxed(stats.root_guard_epilogue_ns, epilogue_ns);
+  add_relaxed(stats.root_guard_tls_ns, tls_ns);
+}
+
+void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.unsafe_mock_guard_bypass_count, 1);
+  add_relaxed(
+      stats.unsafe_mock_guard_bypass_hit_index_sum, cache_entry_hit_index);
+}
+
+void record_guard_accessor_type_stats(
+    const std::string& name,
+    uint64_t inclusive_ns,
+    bool failed) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+  auto& stats = guard_accessor_type_stats()[name];
+  stats.count += 1;
+  stats.inclusive_ns += inclusive_ns;
+  if (failed) {
+    stats.fail_count += 1;
+  }
+}
+
+void record_guard_accessor_detail_stats(
+    const std::string& name,
+    uint64_t self_ns,
+    uint64_t child_ns,
+    uint64_t inclusive_ns,
+    bool failed) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+  auto& stats = guard_accessor_detail_stats()[name];
+  stats.count += 1;
+  stats.self_ns += self_ns;
+  stats.child_ns += child_ns;
+  stats.inclusive_ns += inclusive_ns;
+  if (failed) {
+    stats.fail_count += 1;
+  }
+}
+
+std::string guard_accessor_stats_key(PyObject* key) {
+  if (key == nullptr) {
+    return "<unknown>";
+  }
+  if (key == Py_None) {
+    return "None";
+  }
+  if (key == Py_True) {
+    return "True";
+  }
+  if (key == Py_False) {
+    return "False";
+  }
+  if (PyUnicode_CheckExact(key)) {
+    const char* value = PyUnicode_AsUTF8(key);
+    if (value == nullptr) {
+      PyErr_Clear();
+      return "<str>";
+    }
+    return std::string("'") + value + "'";
+  }
+  if (PyLong_CheckExact(key)) {
+    long long value = PyLong_AsLongLong(key);
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      return "<int>";
+    }
+    return std::to_string(value);
+  }
+  return "<unknown>";
+}
+
 // Macro to skip addition of duplicate guards like EQUALS_MATCH
 #define SKIP_IF_GUARD_ALREADY_PRESENT(name) \
   if (self.is_leaf_guard_present(name)) {   \
     return;                                 \
   }                                         \
   self.insert_leaf_guard(name);
+
+#define GUARD_ACCESSOR_STATS_NAME(name) \
+  const char* stats_name() const override { \
+    return #name;                           \
+  }
 
 TensorCheck::TensorCheck(
     const LocalState& state,
@@ -2167,6 +2507,35 @@ class GuardAccessor {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
   }
+  virtual const char* stats_name() const {
+    return "GuardAccessor";
+  }
+  const std::string& stats_detail_name() {
+    if (_stats_detail_name.empty()) {
+      _stats_detail_name = stats_name();
+      _stats_detail_name += ":";
+      if (_source.empty()) {
+        _stats_detail_name += "key=";
+        _stats_detail_name += guard_accessor_stats_key(_accessor_key.ptr());
+      } else {
+        _stats_detail_name += _source;
+        const std::string key = guard_accessor_stats_key(_accessor_key.ptr());
+        if (key != "<unknown>") {
+          _stats_detail_name += "|key=";
+          _stats_detail_name += key;
+        }
+      }
+    }
+    return _stats_detail_name;
+  }
+  void record_detail_stats(
+      uint64_t self_ns,
+      uint64_t child_ns,
+      uint64_t inclusive_ns,
+      bool failed) {
+    record_guard_accessor_detail_stats(
+        stats_detail_name(), self_ns, child_ns, inclusive_ns, failed);
+  }
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
   virtual std::string repr() const = 0;
 
@@ -2210,6 +2579,9 @@ class GuardAccessor {
   // A string that can be eval'd on f_locals or f_globals to access the variable
   // value. Only used for debugging.
   std::string _source;
+
+  // Lazily initialized only while guard lookup stats are enabled.
+  std::string _stats_detail_name;
 };
 
 /**
@@ -2422,10 +2794,21 @@ class GuardManager {
     }
 
     // Iterate over accessors.
+    const bool collect_stats = guard_lookup_stats_enabled();
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
-      if (!accessor->check_nopybind(value, matches_dict_tag)) { // early exit
+      const uint64_t accessor_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (collect_stats) {
+        record_guard_accessor_type_stats(
+            accessor->stats_name(),
+            guard_lookup_time_ns() - accessor_start_ns,
+            !accessor_result);
+      }
+      if (!accessor_result) { // early exit
         _fail_count += 1;
         result = false;
         // need to sort, so break the loop.
@@ -2674,51 +3057,128 @@ class RootGuardManager : public GuardManager {
   // Fast check function.
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t total_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    uint64_t lock_ns = 0;
+    uint64_t local_state_ns = 0;
+    uint64_t leaf_ns = 0;
+    uint64_t accessor_ns = 0;
+    uint64_t epilogue_ns = 0;
+    uint64_t tls_ns = 0;
+    auto record_and_return = [&](bool result) {
+      if (collect_stats) {
+        record_root_guard_stats(
+            guard_lookup_time_ns() - total_start_ns,
+            lock_ns,
+            local_state_ns,
+            leaf_ns,
+            accessor_ns,
+            epilogue_ns,
+            tls_ns);
+      }
+      return result;
+    };
+
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions wth GIL.
     PyThreadState* _save = nullptr;
+    const uint64_t lock_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     Py_UNBLOCK_THREADS; // ; is added to avoid clang-formatting
     std::lock_guard<std::mutex> lock_guard(_lock);
     Py_BLOCK_THREADS; // ; is added to avoid clang-formatting
+    if (collect_stats) {
+      lock_ns += guard_lookup_time_ns() - lock_start_ns;
+    }
 
     // Get the local state. This will be used for TENSOR_MATCH guards.
+    const uint64_t local_state_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     if (_init_local_state) {
       LocalState state;
       _local_state = state;
     }
+    if (collect_stats) {
+      local_state_ns += guard_lookup_time_ns() - local_state_start_ns;
+    }
 
+    const uint64_t leaf_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     if (!GuardManager::check_leaf_guards_nopybind(value)) {
+      if (collect_stats) {
+        leaf_ns += guard_lookup_time_ns() - leaf_start_ns;
+      }
       _reset_relational_guard_state();
-      return false;
+      return record_and_return(false);
+    }
+    if (collect_stats) {
+      leaf_ns += guard_lookup_time_ns() - leaf_start_ns;
     }
 
     // Run accessor guards without TorchFunction enabled
     // Dynamo should only be adding guards on values without
     // torch function at this point, because if there
     // was a torch function, we should've traced through it
+    const uint64_t tls_disable_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     const at::impl::TorchFunctionDisabledState old_state =
         at::impl::PythonTorchFunctionTLS::get_disabled_state();
     at::impl::PythonTorchFunctionTLS::set_disabled_state(
         at::impl::TorchFunctionDisabledState::ALL_DISABLED);
+    if (collect_stats) {
+      tls_ns += guard_lookup_time_ns() - tls_disable_start_ns;
+    }
 
+    const uint64_t accessor_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     if (!GuardManager::check_accessors_nopybind(value)) {
+      if (collect_stats) {
+        accessor_ns += guard_lookup_time_ns() - accessor_start_ns;
+      }
+      const uint64_t tls_restore_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
       at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+      if (collect_stats) {
+        tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+      }
       _reset_relational_guard_state();
-      return false;
+      return record_and_return(false);
+    }
+    if (collect_stats) {
+      accessor_ns += guard_lookup_time_ns() - accessor_start_ns;
     }
 
     // Iterate over epilogue leaf guards.
     for (const auto& guard : _epilogue_lambda_guards) {
+      const uint64_t epilogue_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
       if (!guard->check_nopybind(value)) { // early exit
+        if (collect_stats) {
+          epilogue_ns += guard_lookup_time_ns() - epilogue_start_ns;
+        }
+        const uint64_t tls_restore_start_ns =
+            collect_stats ? guard_lookup_time_ns() : 0;
         at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+        if (collect_stats) {
+          tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+        }
         _reset_relational_guard_state();
-        return false;
+        return record_and_return(false);
+      }
+      if (collect_stats) {
+        epilogue_ns += guard_lookup_time_ns() - epilogue_start_ns;
       }
     }
 
+    const uint64_t tls_restore_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+    if (collect_stats) {
+      tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+    }
     _reset_relational_guard_state();
-    return true;
+    return record_and_return(true);
   }
 
   bool check_nopybind(PyObject* value) override {
@@ -3416,6 +3876,8 @@ class TENSOR_MATCH : public LeafGuard {
  */
 class GetAttrGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetAttrGuardAccessor)
+
   GetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -3493,6 +3955,8 @@ class GetAttrGuardAccessor : public GuardAccessor {
  */
 class GenericGetAttrGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GenericGetAttrGuardAccessor)
+
   GenericGetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -3572,6 +4036,8 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
  */
 class GetGenericDictGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetGenericDictGuardAccessor)
+
   GetGenericDictGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -3589,14 +4055,35 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
+      if (x == nullptr) {
+        // Attribute absent, clear the exception and return false.
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      Py_DECREF(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       // Attribute absent, clear the exception and return false.
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -3641,6 +4128,8 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
  */
 class GetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetItemGuardAccessor)
+
   GetItemGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -3659,13 +4148,33 @@ class GetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyObject_GetItem(obj, _attr_name); // new ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      Py_DECREF(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyObject_GetItem(obj, _attr_name); // new ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -3718,6 +4227,8 @@ class GetItemGuardAccessor : public GuardAccessor {
  */
 class FrameLocalsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FrameLocalsGuardAccessor)
+
   FrameLocalsGuardAccessor(
       RootGuardManager* root,
       const py::tuple& key,
@@ -3740,17 +4251,39 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
   bool check_nopybind(
       FrameLocalsMapping* obj,
       bool matches_dict_tag = false) override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object) {
       // immutable object and dict tag matches, we can skip the guard subtree.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = obj->get(_framelocals_idx);
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      return _guard_manager->check_nopybind(x);
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = obj->get(_framelocals_idx);
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
+    return result;
   }
 
   // Run as a result of calling check(), e.g. from Python
@@ -3765,17 +4298,39 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
           "FrameLocalsGuardAccessor check expected dict() input");
     }
 
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object) {
       // immutable object and dict tag matches, we can skip the guard subtree.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -3842,6 +4397,8 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
  */
 class DictGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(DictGetItemGuardAccessor)
+
   DictGetItemGuardAccessor(
       RootGuardManager* root,
       py::object key,
@@ -3860,21 +4417,43 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object &&
         _guard_manager->has_no_accessors()) {
       // immutable object and dict tag matches, we can skip the guard subtree.
       // NB: We only skip the subtree if there are no accessors in the subtree.
       // This is specificallly for tensors which are used in symbolic shape C++
       // guards, and therefore have accessors on the tensor GuardManager itself.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -3929,6 +4508,8 @@ class DictGetItemGuardAccessor : public GuardAccessor {
  */
 class ListGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(ListGetItemGuardAccessor)
+
   ListGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -3947,12 +4528,31 @@ class ListGetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyList_GetItem(obj, _index); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyList_GetItem(obj, _index); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4001,6 +4601,8 @@ class ListGetItemGuardAccessor : public GuardAccessor {
  */
 class TupleGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TupleGetItemGuardAccessor)
+
   TupleGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -4019,12 +4621,31 @@ class TupleGetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyTuple_GetItem(obj, _index); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = _guard_manager->check_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyTuple_GetItem(obj, _index); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
+    const uint64_t child_start_ns = guard_lookup_time_ns();
     bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4093,6 +4714,8 @@ std::string to_string(TensorProperty prop) {
 template <TensorProperty _prop>
 class TensorPropertyGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TensorPropertyGuardAccessor)
+
   TensorPropertyGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -4221,6 +4844,8 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
  */
 class IndexedGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(IndexedGuardAccessor)
+
   IndexedGuardAccessor(
       RootGuardManager* root,
       py::int_ index,
@@ -4284,6 +4909,8 @@ class IndexedGuardAccessor : public GuardAccessor {
  */
 class GradGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GradGuardAccessor)
+
   GradGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4354,6 +4981,8 @@ class GradGuardAccessor : public GuardAccessor {
  */
 class FuncDefaultsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FuncDefaultsGuardAccessor)
+
   FuncDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -4430,6 +5059,8 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
  */
 class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FuncKwDefaultsGuardAccessor)
+
   FuncKwDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -4508,6 +5139,8 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  */
 class GlobalsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GlobalsGuardAccessor)
+
   GlobalsGuardAccessor(
       RootGuardManager* root,
       py::dict globals_dict,
@@ -4570,6 +5203,8 @@ class GlobalsGuardAccessor : public GuardAccessor {
  */
 class TypeGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TypeGuardAccessor)
+
   // name = __type_accessor__, a unique string used as attribute name.
   TypeGuardAccessor(
       RootGuardManager* root,
@@ -4623,6 +5258,8 @@ class TypeGuardAccessor : public GuardAccessor {
  */
 class TupleIteratorGetItemAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TupleIteratorGetItemAccessor)
+
   TupleIteratorGetItemAccessor(
       RootGuardManager* root,
       py::object index,
@@ -4703,6 +5340,8 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
  */
 class GlobalWeakRefGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GlobalWeakRefGuardAccessor)
+
   GlobalWeakRefGuardAccessor(
       RootGuardManager* root,
       py::object global_name,
@@ -4815,6 +5454,8 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
  */
 class WeakRefCallGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(WeakRefCallGuardAccessor)
+
   WeakRefCallGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4901,6 +5542,8 @@ class WeakRefCallGuardAccessor : public GuardAccessor {
  */
 class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(CallFunctionNoArgsGuardAccessor)
+
   CallFunctionNoArgsGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4983,6 +5626,8 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  */
 class PythonLambdaGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(PythonLambdaGuardAccessor)
+
   PythonLambdaGuardAccessor(
       RootGuardManager* root,
       py::function accessor_fn,
@@ -6183,6 +6828,8 @@ PyObject* torch_c_dynamo_guards_init() {
       py::arg("symbolic") = true);
   py_m.def("install_symbolic_shape_guard", install_symbolic_shape_guard);
   py_m.def("profile_guard_manager", profile_guard_manager);
+  py_m.def("reset_guard_lookup_stats", reset_guard_lookup_stats);
+  py_m.def("get_guard_lookup_stats", get_guard_lookup_stats);
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -129,6 +130,8 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   BoundMethod,
   FrameGlobals,
 };
+
+constexpr size_t kGuardSubtreeProbeTokenKindCount = 12;
 
 enum class GuardFastPlanCandidateKind : uint8_t {
   Unknown,
@@ -272,6 +275,21 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> actual_partial_disabled{0};
   std::atomic<uint64_t> actual_partial_residual_fail{0};
   std::atomic<uint64_t> actual_partial_hot_token_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_unique_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_object_only{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_dict{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_list{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_tuple{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_tensor_match{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_default_device{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_global_state{0};
+  std::atomic<uint64_t>
+      actual_partial_hot_token_duplicate_torch_function_mode_stack{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_no_tensor_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_object_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_bound_method{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_frame_globals{0};
   std::atomic<uint64_t> actual_partial_token_check_ns{0};
   std::atomic<uint64_t> actual_partial_residual_ns{0};
   std::atomic<uint64_t> actual_partial_train_ns{0};
@@ -688,6 +706,25 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.actual_partial_disabled);
   store_zero(last_success_stats.actual_partial_residual_fail);
   store_zero(last_success_stats.actual_partial_hot_token_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_unique_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_object_only);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_dict);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_list);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_tuple);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_tensor_match);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_default_device);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_global_state);
+  store_zero(
+      last_success_stats
+          .actual_partial_hot_token_duplicate_torch_function_mode_stack);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_no_tensor_aliasing);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_object_aliasing);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_bound_method);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_frame_globals);
   store_zero(last_success_stats.actual_partial_token_check_ns);
   store_zero(last_success_stats.actual_partial_residual_ns);
   store_zero(last_success_stats.actual_partial_train_ns);
@@ -972,6 +1009,41 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.actual_partial_residual_fail);
   result["guard_last_success_actual_partial_hot_token_count_sum"] =
       load_relaxed(last_success_stats.actual_partial_hot_token_count_sum);
+  result["guard_last_success_actual_partial_hot_token_unique_count_sum"] =
+      load_relaxed(
+          last_success_stats.actual_partial_hot_token_unique_count_sum);
+  result["guard_last_success_actual_partial_hot_token_duplicate_count_sum"] =
+      load_relaxed(
+          last_success_stats.actual_partial_hot_token_duplicate_count_sum);
+  py::dict actual_partial_duplicate_kind_counts;
+  actual_partial_duplicate_kind_counts["ObjectOnly"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_object_only);
+  actual_partial_duplicate_kind_counts["ExactDict"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_dict);
+  actual_partial_duplicate_kind_counts["ExactList"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_list);
+  actual_partial_duplicate_kind_counts["ExactTuple"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_tuple);
+  actual_partial_duplicate_kind_counts["TensorMatch"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_tensor_match);
+  actual_partial_duplicate_kind_counts["DefaultDevice"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_default_device);
+  actual_partial_duplicate_kind_counts["GlobalState"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_global_state);
+  actual_partial_duplicate_kind_counts["TorchFunctionModeStack"] = load_relaxed(
+      last_success_stats
+          .actual_partial_hot_token_duplicate_torch_function_mode_stack);
+  actual_partial_duplicate_kind_counts["NoTensorAliasing"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_no_tensor_aliasing);
+  actual_partial_duplicate_kind_counts["ObjectAliasing"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_object_aliasing);
+  actual_partial_duplicate_kind_counts["BoundMethod"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_bound_method);
+  actual_partial_duplicate_kind_counts["FrameGlobals"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_frame_globals);
+  result
+      ["guard_last_success_actual_partial_hot_token_duplicate_kind_counts"] =
+          actual_partial_duplicate_kind_counts;
   result["guard_last_success_actual_partial_token_check_ns"] =
       load_relaxed(last_success_stats.actual_partial_token_check_ns);
   result["guard_last_success_actual_partial_residual_ns"] =
@@ -1768,6 +1840,81 @@ static void record_guard_last_success_actual_partial_hot_tokens(
   add_relaxed(
       guard_last_success_stats().actual_partial_hot_token_count_sum,
       token_count);
+}
+
+static void add_guard_last_success_actual_partial_duplicate_kind_count(
+    GuardLastSuccessStats& stats,
+    GuardSubtreeProbeTokenKind kind,
+    uint64_t count) {
+  switch (kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_object_only, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_dict, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_list, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_tuple, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_tensor_match, count);
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_default_device, count);
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_global_state, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      add_relaxed(
+          stats
+              .actual_partial_hot_token_duplicate_torch_function_mode_stack,
+          count);
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_no_tensor_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_object_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_bound_method, count);
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_frame_globals, count);
+      break;
+  }
+}
+
+static void record_guard_last_success_actual_partial_hot_token_duplicates(
+    size_t unique_count,
+    size_t duplicate_count,
+    const std::array<uint64_t, kGuardSubtreeProbeTokenKindCount>&
+        duplicate_kind_counts) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(
+      stats.actual_partial_hot_token_unique_count_sum, unique_count);
+  add_relaxed(
+      stats.actual_partial_hot_token_duplicate_count_sum, duplicate_count);
+  for (size_t i = 0; i < duplicate_kind_counts.size(); ++i) {
+    if (duplicate_kind_counts[i] == 0) {
+      continue;
+    }
+    add_guard_last_success_actual_partial_duplicate_kind_count(
+        stats,
+        static_cast<GuardSubtreeProbeTokenKind>(i),
+        duplicate_kind_counts[i]);
+  }
 }
 
 static void record_guard_last_success_actual_partial_residual_fail(
@@ -3151,6 +3298,88 @@ static std::vector<GuardSubtreeEntryToken> guard_subtree_make_hot_tokens(
     }
   }
   return hot_tokens;
+}
+
+static uintptr_t guard_subtree_duplicate_hash_combine(
+    uintptr_t seed,
+    uintptr_t value) {
+  return seed ^ (value + static_cast<uintptr_t>(0x9e3779b97f4a7c15ULL) +
+                 (seed << 6) + (seed >> 2));
+}
+
+static uintptr_t guard_subtree_duplicate_bucket_key(
+    const GuardSubtreeEntryToken& token) {
+  uintptr_t key = static_cast<uintptr_t>(token.kind);
+  key = guard_subtree_duplicate_hash_combine(
+      key, reinterpret_cast<uintptr_t>(token.type));
+  if (token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+    key = guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.bound_method_self));
+    key = guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.bound_method_func));
+    key = guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.bound_c_method_class));
+    key = guard_subtree_duplicate_hash_combine(
+        key, static_cast<uintptr_t>(token.bound_c_method_flags));
+    return key;
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::GlobalState) {
+    return guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.global_state_guard));
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+    return guard_subtree_duplicate_hash_combine(
+        key,
+        reinterpret_cast<uintptr_t>(token.torch_function_mode_stack_guard));
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+    key = guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.object));
+    return guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.no_tensor_aliasing_guard));
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+    key = guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.object));
+    return guard_subtree_duplicate_hash_combine(
+        key, reinterpret_cast<uintptr_t>(token.object_aliasing_guard));
+  }
+  return guard_subtree_duplicate_hash_combine(
+      key, reinterpret_cast<uintptr_t>(token.object));
+}
+
+static void record_guard_last_success_actual_partial_hot_token_duplicate_stats(
+    const std::vector<GuardSubtreeEntryToken>& tokens) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  ska::flat_hash_map<uintptr_t, std::vector<size_t>> buckets;
+  buckets.reserve(tokens.size());
+  size_t unique_count = 0;
+  size_t duplicate_count = 0;
+  std::array<uint64_t, kGuardSubtreeProbeTokenKindCount>
+      duplicate_kind_counts{};
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    const uintptr_t bucket_key = guard_subtree_duplicate_bucket_key(token);
+    auto& bucket = buckets[bucket_key];
+    bool duplicate = false;
+    for (size_t existing_index : bucket) {
+      if (token.matches(tokens[existing_index])) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      duplicate_count += 1;
+      duplicate_kind_counts[static_cast<size_t>(token.kind)] += 1;
+    } else {
+      bucket.push_back(i);
+      unique_count += 1;
+    }
+  }
+  record_guard_last_success_actual_partial_hot_token_duplicates(
+      unique_count, duplicate_count, duplicate_kind_counts);
 }
 
 static bool guard_subtree_token_vectors_match(
@@ -9419,6 +9648,12 @@ static bool guard_last_success_actual_enabled() {
   return C10_UNLIKELY(guard_fast_plan_enabled());
 }
 
+static bool guard_last_success_full_actual_enabled() {
+  // Keep the full-root last-success fast path disabled for now: unlike the
+  // partial path below, it would skip the entire root guard on token match.
+  return false;
+}
+
 bool run_root_guard_manager_with_last_success_receipt(
     void* receipt,
     void* entry_key,
@@ -9430,9 +9665,12 @@ bool run_root_guard_manager_with_last_success_receipt(
   }
 
   record_guard_last_success_shadow_attempt();
-  record_guard_last_success_actual_attempt();
   GuardLastSuccessReceipt* state =
       static_cast<GuardLastSuccessReceipt*>(receipt);
+  const bool full_actual_enabled = guard_last_success_full_actual_enabled();
+  if (full_actual_enabled) {
+    record_guard_last_success_actual_attempt();
+  }
   if (is_skip_guard_eval_unsafe) {
     record_guard_last_success_incomplete("skip_guard_eval_unsafe");
     state->reset();
@@ -9447,8 +9685,8 @@ bool run_root_guard_manager_with_last_success_receipt(
   RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
   static const std::string self_source = "L['self']";
 
-  if (state->actual_enabled && state->actual_entry_key == entry_key &&
-      state->actual_root_key == root) {
+  if (full_actual_enabled && state->actual_enabled &&
+      state->actual_entry_key == entry_key && state->actual_root_key == root) {
     const bool collect_stats = guard_lookup_stats_enabled();
     const uint64_t token_start_ns =
         collect_stats ? guard_lookup_time_ns() : 0;
@@ -9502,7 +9740,8 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   GuardSubtreeMemoSupportAnalysis analysis;
   analysis.collect_all = guard_lookup_stats_enabled();
-  const bool should_train_actual = !state->actual_disabled;
+  const bool should_train_actual =
+      full_actual_enabled && !state->actual_disabled;
   const uint64_t support_start_ns =
       guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
   const bool supported = should_train_actual &&
@@ -9617,9 +9856,12 @@ bool run_root_guard_manager_with_last_success_receipt(
     actual_disabled_now = true;
     record_guard_last_success_actual_disabled();
   }
-  record_guard_last_success_actual_train(
-      guard_lookup_stats_enabled() ? guard_lookup_time_ns() - actual_train_start_ns
-                                   : 0);
+  if (full_actual_enabled) {
+    record_guard_last_success_actual_train(
+        guard_lookup_stats_enabled()
+            ? guard_lookup_time_ns() - actual_train_start_ns
+            : 0);
+  }
 
   const uint64_t partial_train_start_ns =
       guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
@@ -9641,6 +9883,8 @@ bool run_root_guard_manager_with_last_success_receipt(
     std::vector<GuardSubtreeEntryToken> partial_stability_tokens =
         partial_tokens;
     partial_tokens = guard_subtree_make_hot_tokens(partial_tokens);
+    record_guard_last_success_actual_partial_hot_token_duplicate_stats(
+        partial_tokens);
     record_guard_last_success_actual_partial_hot_tokens(partial_tokens.size());
     if (state->actual_partial_entry_key == entry_key &&
         state->actual_partial_root_key == root &&

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -107,6 +107,34 @@ struct GuardLookupStats {
   std::atomic<uint64_t> unsafe_mock_guard_bypass_hit_index_sum{0};
 };
 
+enum class GuardSubtreeProbeMode {
+  Off,
+  Summary,
+  Detail,
+};
+
+enum class GuardSubtreeProbeTokenKind : uint8_t {
+  ObjectOnly,
+  ExactDict,
+  ExactList,
+  ExactTuple,
+};
+
+struct GuardSubtreeProbeStats {
+  std::atomic<uint64_t> attempt{0};
+  std::atomic<uint64_t> entry_match{0};
+  std::atomic<uint64_t> entry_miss{0};
+  std::atomic<uint64_t> shadow_ok{0};
+  std::atomic<uint64_t> mismatch{0};
+  std::atomic<uint64_t> disabled{0};
+  std::atomic<uint64_t> entry_check_ns{0};
+  std::atomic<uint64_t> child_check_ns{0};
+  std::atomic<uint64_t> token_object_only{0};
+  std::atomic<uint64_t> token_exact_dict{0};
+  std::atomic<uint64_t> token_exact_list{0};
+  std::atomic<uint64_t> token_exact_tuple{0};
+};
+
 struct GuardAccessorTypeStats {
   uint64_t count{0};
   uint64_t fail_count{0};
@@ -121,10 +149,31 @@ struct GuardAccessorDetailStats {
   uint64_t inclusive_ns{0};
 };
 
+struct GuardSubtreeProbePathStats {
+  uint64_t attempt{0};
+  uint64_t entry_match{0};
+  uint64_t entry_miss{0};
+  uint64_t shadow_ok{0};
+  uint64_t mismatch{0};
+  uint64_t disabled{0};
+  uint64_t entry_check_ns{0};
+  uint64_t child_check_ns{0};
+  uint64_t token_object_only{0};
+  uint64_t token_exact_dict{0};
+  uint64_t token_exact_list{0};
+  uint64_t token_exact_tuple{0};
+};
+
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
+constexpr size_t kGuardSubtreeProbeTopK = 64;
 
 GuardLookupStats& guard_lookup_stats() {
   static GuardLookupStats stats;
+  return stats;
+}
+
+GuardSubtreeProbeStats& guard_subtree_probe_stats() {
+  static GuardSubtreeProbeStats stats;
   return stats;
 }
 
@@ -167,6 +216,17 @@ guard_accessor_detail_stats() {
   return stats;
 }
 
+std::mutex& guard_subtree_probe_path_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardSubtreeProbePathStats>&
+guard_subtree_probe_path_stats() {
+  static std::unordered_map<std::string, GuardSubtreeProbePathStats> stats;
+  return stats;
+}
+
 } // namespace
 
 bool guard_lookup_stats_enabled() {
@@ -175,6 +235,50 @@ bool guard_lookup_stats_enabled() {
   const bool force_enabled =
       guard_lookup_stats_force_enabled().load(std::memory_order_relaxed);
   return C10_UNLIKELY(env_enabled) || C10_UNLIKELY(force_enabled);
+}
+
+static GuardSubtreeProbeMode guard_subtree_probe_mode() {
+  static const GuardSubtreeProbeMode mode = [] {
+    const auto env = c10::utils::get_env("TORCHDYNAMO_GUARD_SUBTREE_PROBE");
+    const std::string value = env.value_or("");
+    if (value.empty() || value == "0" || value == "false" ||
+        value == "False" || value == "off") {
+      return GuardSubtreeProbeMode::Off;
+    }
+    if (value == "detail") {
+      return GuardSubtreeProbeMode::Detail;
+    }
+    if (value == "summary" || value == "1" || value == "true" ||
+        value == "True") {
+      return GuardSubtreeProbeMode::Summary;
+    }
+    return GuardSubtreeProbeMode::Off;
+  }();
+  return mode;
+}
+
+static const char* guard_subtree_probe_mode_name() {
+  switch (guard_subtree_probe_mode()) {
+    case GuardSubtreeProbeMode::Summary:
+      return "summary";
+    case GuardSubtreeProbeMode::Detail:
+      return "detail";
+    case GuardSubtreeProbeMode::Off:
+      return "off";
+  }
+  return "off";
+}
+
+static bool guard_subtree_probe_enabled() {
+  static const bool enabled =
+      guard_subtree_probe_mode() != GuardSubtreeProbeMode::Off;
+  return C10_UNLIKELY(enabled);
+}
+
+static bool guard_subtree_probe_detail_enabled() {
+  static const bool detail_enabled =
+      guard_subtree_probe_mode() == GuardSubtreeProbeMode::Detail;
+  return C10_UNLIKELY(detail_enabled);
 }
 
 bool unsafe_mock_guard_bypass_enabled() {
@@ -192,6 +296,7 @@ uint64_t guard_lookup_time_ns() {
 
 void reset_guard_lookup_stats() {
   auto& stats = guard_lookup_stats();
+  auto& subtree_stats = guard_subtree_probe_stats();
   store_zero(stats.lookup_count);
   store_zero(stats.lookup_total_ns);
   store_zero(stats.backend_match_ns);
@@ -209,6 +314,18 @@ void reset_guard_lookup_stats() {
   store_zero(stats.root_guard_tls_ns);
   store_zero(stats.unsafe_mock_guard_bypass_count);
   store_zero(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  store_zero(subtree_stats.attempt);
+  store_zero(subtree_stats.entry_match);
+  store_zero(subtree_stats.entry_miss);
+  store_zero(subtree_stats.shadow_ok);
+  store_zero(subtree_stats.mismatch);
+  store_zero(subtree_stats.disabled);
+  store_zero(subtree_stats.entry_check_ns);
+  store_zero(subtree_stats.child_check_ns);
+  store_zero(subtree_stats.token_object_only);
+  store_zero(subtree_stats.token_exact_dict);
+  store_zero(subtree_stats.token_exact_list);
+  store_zero(subtree_stats.token_exact_tuple);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -216,6 +333,10 @@ void reset_guard_lookup_stats() {
   {
     std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
     guard_accessor_detail_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+    guard_subtree_probe_path_stats().clear();
   }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
@@ -246,6 +367,72 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(stats.unsafe_mock_guard_bypass_count);
   result["unsafe_mock_guard_bypass_hit_index_sum"] =
       load_relaxed(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  auto& subtree_stats = guard_subtree_probe_stats();
+  result["guard_subtree_probe_mode"] = guard_subtree_probe_mode_name();
+  result["guard_subtree_probe_attempt"] =
+      load_relaxed(subtree_stats.attempt);
+  result["guard_subtree_probe_entry_match"] =
+      load_relaxed(subtree_stats.entry_match);
+  result["guard_subtree_probe_entry_miss"] =
+      load_relaxed(subtree_stats.entry_miss);
+  result["guard_subtree_probe_shadow_ok"] =
+      load_relaxed(subtree_stats.shadow_ok);
+  result["guard_subtree_probe_mismatch"] =
+      load_relaxed(subtree_stats.mismatch);
+  result["guard_subtree_probe_disabled"] =
+      load_relaxed(subtree_stats.disabled);
+  result["guard_subtree_probe_entry_check_ns"] =
+      load_relaxed(subtree_stats.entry_check_ns);
+  result["guard_subtree_probe_child_check_ns"] =
+      load_relaxed(subtree_stats.child_check_ns);
+  py::dict subtree_token_kind_counts;
+  subtree_token_kind_counts["ObjectOnly"] =
+      load_relaxed(subtree_stats.token_object_only);
+  subtree_token_kind_counts["ExactDict"] =
+      load_relaxed(subtree_stats.token_exact_dict);
+  subtree_token_kind_counts["ExactList"] =
+      load_relaxed(subtree_stats.token_exact_list);
+  subtree_token_kind_counts["ExactTuple"] =
+      load_relaxed(subtree_stats.token_exact_tuple);
+  result["guard_subtree_probe_token_kind_counts"] =
+      subtree_token_kind_counts;
+  if (guard_subtree_probe_detail_enabled()) {
+    py::dict path_stats;
+    std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
+    {
+      std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+      items.reserve(guard_subtree_probe_path_stats().size());
+      for (const auto& item : guard_subtree_probe_path_stats()) {
+        items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        items.begin(),
+        items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.child_check_ns > b.second.child_check_ns;
+        });
+    const size_t limit = std::min(items.size(), kGuardSubtreeProbeTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["attempt"] = items[i].second.attempt;
+      item_stats["entry_match"] = items[i].second.entry_match;
+      item_stats["entry_miss"] = items[i].second.entry_miss;
+      item_stats["shadow_ok"] = items[i].second.shadow_ok;
+      item_stats["mismatch"] = items[i].second.mismatch;
+      item_stats["disabled"] = items[i].second.disabled;
+      item_stats["entry_check_ns"] = items[i].second.entry_check_ns;
+      item_stats["child_check_ns"] = items[i].second.child_check_ns;
+      py::dict token_counts;
+      token_counts["ObjectOnly"] = items[i].second.token_object_only;
+      token_counts["ExactDict"] = items[i].second.token_exact_dict;
+      token_counts["ExactList"] = items[i].second.token_exact_list;
+      token_counts["ExactTuple"] = items[i].second.token_exact_tuple;
+      item_stats["token_kind_counts"] = token_counts;
+      path_stats[py::str(items[i].first)] = item_stats;
+    }
+    result["guard_subtree_probe_top_paths"] = path_stats;
+  }
   py::dict accessor_type_stats;
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
@@ -375,6 +562,98 @@ void record_guard_accessor_detail_stats(
   stats.inclusive_ns += inclusive_ns;
   if (failed) {
     stats.fail_count += 1;
+  }
+}
+
+static void add_guard_subtree_probe_token_kind(
+    GuardSubtreeProbeStats& stats,
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      add_relaxed(stats.token_exact_dict, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      add_relaxed(stats.token_exact_list, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      add_relaxed(stats.token_exact_tuple, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      add_relaxed(stats.token_object_only, 1);
+      break;
+  }
+}
+
+static void add_guard_subtree_probe_token_kind(
+    GuardSubtreeProbePathStats& stats,
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      stats.token_exact_dict += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      stats.token_exact_list += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      stats.token_exact_tuple += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      stats.token_object_only += 1;
+      break;
+  }
+}
+
+static void record_guard_subtree_probe_stats(
+    const std::string& path,
+    bool entry_match,
+    bool child_result,
+    bool disabled_now,
+    uint64_t entry_check_ns,
+    uint64_t child_check_ns,
+    GuardSubtreeProbeTokenKind token_kind) {
+  if (!guard_subtree_probe_enabled()) {
+    return;
+  }
+  auto& stats = guard_subtree_probe_stats();
+  add_relaxed(stats.attempt, 1);
+  add_relaxed(stats.entry_check_ns, entry_check_ns);
+  add_relaxed(stats.child_check_ns, child_check_ns);
+  add_guard_subtree_probe_token_kind(stats, token_kind);
+  if (entry_match) {
+    add_relaxed(stats.entry_match, 1);
+    if (child_result) {
+      add_relaxed(stats.shadow_ok, 1);
+    } else {
+      add_relaxed(stats.mismatch, 1);
+    }
+  } else {
+    add_relaxed(stats.entry_miss, 1);
+  }
+  if (disabled_now) {
+    add_relaxed(stats.disabled, 1);
+  }
+
+  if (!guard_subtree_probe_detail_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+  auto& path_stats = guard_subtree_probe_path_stats()[path];
+  path_stats.attempt += 1;
+  path_stats.entry_check_ns += entry_check_ns;
+  path_stats.child_check_ns += child_check_ns;
+  add_guard_subtree_probe_token_kind(path_stats, token_kind);
+  if (entry_match) {
+    path_stats.entry_match += 1;
+    if (child_result) {
+      path_stats.shadow_ok += 1;
+    } else {
+      path_stats.mismatch += 1;
+    }
+  } else {
+    path_stats.entry_miss += 1;
+  }
+  if (disabled_now) {
+    path_stats.disabled += 1;
   }
 }
 
@@ -1084,6 +1363,43 @@ static uint64_t get_dict_version_unchecked(PyObject* dict) {
 
 #endif
 }
+
+struct GuardSubtreeEntryToken {
+  PyObject* object{nullptr};
+  PyTypeObject* type{nullptr};
+  GuardSubtreeProbeTokenKind kind{GuardSubtreeProbeTokenKind::ObjectOnly};
+  uint64_t version{0};
+  Py_ssize_t size{0};
+
+  static GuardSubtreeEntryToken make(PyObject* obj) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    if (PyDict_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactDict;
+      token.version = get_dict_version_unchecked(obj);
+      token.size = PyDict_GET_SIZE(obj);
+    } else if (PyList_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactList;
+      token.size = PyList_GET_SIZE(obj);
+    } else if (PyTuple_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactTuple;
+      token.size = PyTuple_GET_SIZE(obj);
+    }
+    return token;
+  }
+
+  bool matches(const GuardSubtreeEntryToken& other) const {
+    return object == other.object && type == other.type && kind == other.kind &&
+        version == other.version && size == other.size;
+  }
+};
+
+struct GuardSubtreeProbeState {
+  bool has_last_token{false};
+  bool disabled{false};
+  GuardSubtreeEntryToken last_token;
+};
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   // Retrieves the version of a dictionary.
@@ -2507,6 +2823,7 @@ class GuardAccessor {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
   }
+  bool check_child_manager_nopybind(PyObject* obj);
   virtual const char* stats_name() const {
     return "GuardAccessor";
   }
@@ -2758,6 +3075,45 @@ class GuardManager {
     return check_nopybind_template(value);
   }
 
+  bool check_nopybind_with_subtree_probe(
+      PyObject* value,
+      const std::string& path) {
+    if (!guard_subtree_probe_enabled() || _subtree_probe_state.disabled) {
+      return check_nopybind(value);
+    }
+
+    const uint64_t entry_start_ns = guard_lookup_time_ns();
+    GuardSubtreeEntryToken token = GuardSubtreeEntryToken::make(value);
+    const bool entry_match = _subtree_probe_state.has_last_token &&
+        token.matches(_subtree_probe_state.last_token);
+    const uint64_t entry_check_ns = guard_lookup_time_ns() - entry_start_ns;
+
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    const bool child_result = check_nopybind(value);
+    const uint64_t child_check_ns = guard_lookup_time_ns() - child_start_ns;
+
+    bool disabled_now = false;
+    if (entry_match && !child_result) {
+      _subtree_probe_state.disabled = true;
+      disabled_now = true;
+    }
+    if (child_result) {
+      _subtree_probe_state.last_token = std::move(token);
+      _subtree_probe_state.has_last_token = true;
+    }
+    record_guard_subtree_probe_stats(
+        path,
+        entry_match,
+        child_result,
+        disabled_now,
+        entry_check_ns,
+        child_check_ns,
+        _subtree_probe_state.has_last_token
+            ? _subtree_probe_state.last_token.kind
+            : token.kind);
+    return child_result;
+  }
+
   virtual bool check_nopybind(FrameLocalsMapping* value) {
     return check_nopybind_template(value);
   }
@@ -2992,6 +3348,7 @@ class GuardManager {
 
   bool _is_dict;
   uint64_t _dict_tag{0};
+  GuardSubtreeProbeState _subtree_probe_state;
 };
 
 GuardAccessor::GuardAccessor(
@@ -3009,6 +3366,18 @@ GuardAccessor::GuardAccessor(
 GuardAccessor::GuardAccessor(GuardManager* guard_manager, GuardAccessor* from)
     : _guard_manager(std::unique_ptr<GuardManager>(guard_manager)) {
   from->clone_visitor(this);
+}
+
+inline bool GuardAccessor::check_child_manager_nopybind(PyObject* obj) {
+  if (C10_LIKELY(!guard_subtree_probe_enabled())) {
+    return _guard_manager->check_nopybind(obj);
+  }
+  static const std::string empty_path = "";
+  if (!guard_subtree_probe_detail_enabled()) {
+    return _guard_manager->check_nopybind_with_subtree_probe(obj, empty_path);
+  }
+  return _guard_manager->check_nopybind_with_subtree_probe(
+      obj, stats_detail_name());
 }
 
 /**
@@ -3902,7 +4271,7 @@ class GetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -3981,7 +4350,7 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -4063,7 +4432,7 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       Py_DECREF(x);
       return result;
     }
@@ -4079,7 +4448,7 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
     record_detail_stats(
@@ -4155,7 +4524,7 @@ class GetItemGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       Py_DECREF(x);
       return result;
     }
@@ -4170,7 +4539,7 @@ class GetItemGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
     record_detail_stats(
@@ -4266,7 +4635,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      return _guard_manager->check_nopybind(x);
+      return check_child_manager_nopybind(x);
     }
 
     const uint64_t total_start_ns = guard_lookup_time_ns();
@@ -4279,7 +4648,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     record_detail_stats(
         self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
@@ -4313,7 +4682,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       return result;
     }
 
@@ -4327,7 +4696,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     record_detail_stats(
         self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
@@ -4436,7 +4805,7 @@ class DictGetItemGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       return result;
     }
 
@@ -4450,7 +4819,7 @@ class DictGetItemGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     record_detail_stats(
         self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
@@ -4535,7 +4904,7 @@ class ListGetItemGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       return result;
     }
 
@@ -4549,7 +4918,7 @@ class ListGetItemGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     record_detail_stats(
         self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
@@ -4628,7 +4997,7 @@ class TupleGetItemGuardAccessor : public GuardAccessor {
         PyErr_Clear();
         return false;
       }
-      bool result = _guard_manager->check_nopybind(x);
+      bool result = check_child_manager_nopybind(x);
       return result;
     }
 
@@ -4642,7 +5011,7 @@ class TupleGetItemGuardAccessor : public GuardAccessor {
       return false;
     }
     const uint64_t child_start_ns = guard_lookup_time_ns();
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     record_detail_stats(
         self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
@@ -4768,7 +5137,7 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
 
     PyObject* py_value =
         PyLong_FromLongLong(opt_value.value()); // New reference
-    bool result = _guard_manager->check_nopybind(py_value);
+    bool result = check_child_manager_nopybind(py_value);
     Py_DECREF(py_value);
     return result;
   }
@@ -4864,7 +5233,7 @@ class IndexedGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* tuple = PyTuple_Pack(2, _index.ptr(), obj); // New reference
-    bool result = _guard_manager->check_nopybind(tuple);
+    bool result = check_child_manager_nopybind(tuple);
     Py_DECREF(tuple);
     return result;
   }
@@ -4934,7 +5303,7 @@ class GradGuardAccessor : public GuardAccessor {
     }
     PyObject* grad =
         THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
-    bool result = _guard_manager->check_nopybind(grad);
+    bool result = check_child_manager_nopybind(grad);
     // For undefined tensor, THPVariable_Wrap returns Py_RETURN_NONE. So, no
     // need of Py_XDECREF.
     Py_DECREF(grad);
@@ -5011,7 +5380,7 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5089,7 +5458,7 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5161,7 +5530,7 @@ class GlobalsGuardAccessor : public GuardAccessor {
       override { // borrowed ref
     // Ignore the obj arg. This is required to satisfy the function signature.
     // Just pass on the globals dict to the child manager.
-    return _guard_manager->check_nopybind(_globals_dict);
+    return check_child_manager_nopybind(_globals_dict);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5224,7 +5593,7 @@ class TypeGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* x = (PyObject*)Py_TYPE(obj); // borrowed ref
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5286,7 +5655,7 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     return result;
   }
 
@@ -5383,7 +5752,7 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -5487,7 +5856,7 @@ class WeakRefCallGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -5572,7 +5941,7 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
       return false;
     }
 
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -5652,7 +6021,7 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2503,6 +2503,12 @@ static bool default_device_matches(
 
 static bool torch_function_mode_stack_guard_matches(const void* guard);
 
+static bool is_global_source_path(const std::string& source) {
+  return source == "G" ||
+      (source.size() > 1 && source[0] == 'G' &&
+       (source[1] == '[' || source[1] == '.'));
+}
+
 struct GuardSubtreeEntryToken {
   PyObject* object{nullptr};
   PyTypeObject* type{nullptr};
@@ -2568,7 +2574,7 @@ struct GuardSubtreeEntryToken {
   static GuardSubtreeEntryToken make_for_source(
       PyObject* obj,
       const std::string& source) {
-    if (source == "G" && PyDict_CheckExact(obj)) {
+    if (is_global_source_path(source) && PyDict_CheckExact(obj)) {
       GuardSubtreeEntryToken token;
       token.object = obj;
       token.type = Py_TYPE(obj);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -709,6 +709,9 @@ static void record_guard_subtree_probe_stats(
 }
 
 static void record_guard_fastplan_candidate() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.candidate, 1);
 }
@@ -716,6 +719,9 @@ static void record_guard_fastplan_candidate() {
 static void record_guard_fastplan_shadow_pass(
     size_t token_count,
     uint64_t slow_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.shadow_pass, 1);
   add_relaxed(stats.token_count_sum, token_count);
@@ -723,16 +729,25 @@ static void record_guard_fastplan_shadow_pass(
 }
 
 static void record_guard_fastplan_enable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   add_relaxed(guard_fastplan_stats().enable, 1);
 }
 
 static void record_guard_fastplan_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   add_relaxed(guard_fastplan_stats().disabled, 1);
 }
 
 static void record_guard_fastplan_hit(
     size_t token_count,
     uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.hit, 1);
   add_relaxed(stats.token_count_sum, token_count);
@@ -744,6 +759,9 @@ static void record_guard_fastplan_miss(
     uint64_t token_check_ns,
     uint64_t slow_check_ns,
     bool disabled_now) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.miss, 1);
   add_relaxed(stats.token_count_sum, token_count);
@@ -1467,6 +1485,7 @@ struct GuardSubtreeEntryToken {
   GuardSubtreeProbeTokenKind kind{GuardSubtreeProbeTokenKind::ObjectOnly};
   uint64_t version{0};
   Py_ssize_t size{0};
+  std::vector<PyObject*> list_items;
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -1479,6 +1498,10 @@ struct GuardSubtreeEntryToken {
     } else if (PyList_CheckExact(obj)) {
       token.kind = GuardSubtreeProbeTokenKind::ExactList;
       token.size = PyList_GET_SIZE(obj);
+      token.list_items.reserve(static_cast<size_t>(token.size));
+      for (Py_ssize_t i = 0; i < token.size; ++i) {
+        token.list_items.push_back(PyList_GET_ITEM(obj, i));
+      }
     } else if (PyTuple_CheckExact(obj)) {
       token.kind = GuardSubtreeProbeTokenKind::ExactTuple;
       token.size = PyTuple_GET_SIZE(obj);
@@ -1488,7 +1511,8 @@ struct GuardSubtreeEntryToken {
 
   bool matches(const GuardSubtreeEntryToken& other) const {
     return object == other.object && type == other.type && kind == other.kind &&
-        version == other.version && size == other.size;
+        version == other.version && size == other.size &&
+        list_items == other.list_items;
   }
 };
 
@@ -1507,10 +1531,16 @@ static bool guard_subtree_token_vectors_match(
 }
 
 static bool guard_subtree_memo_tokens_match(
-    const std::vector<GuardSubtreeEntryToken>& tokens) {
-  for (const auto& token : tokens) {
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    PyObject* root_value) {
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    if (i != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly) {
+      // Parent dict/list tokens prove whether this object is still reachable.
+      continue;
+    }
     GuardSubtreeEntryToken current =
-        GuardSubtreeEntryToken::make(token.object);
+        GuardSubtreeEntryToken::make(i == 0 ? root_value : token.object);
     if (!current.matches(token)) {
       return false;
     }
@@ -1548,13 +1578,6 @@ struct GuardSubtreeMemoRecorderScope {
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
 };
-
-static void record_guard_subtree_memo_token(PyObject* obj) {
-  if (active_guard_subtree_memo_recorder != nullptr) {
-    active_guard_subtree_memo_recorder->emplace_back(
-        GuardSubtreeEntryToken::make(obj));
-  }
-}
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   // Retrieves the version of a dictionary.
@@ -3249,7 +3272,10 @@ class GuardManager {
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
     if constexpr (std::is_same_v<T, PyObject>) {
-      record_guard_subtree_memo_token(value);
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        active_guard_subtree_memo_recorder->emplace_back(
+            GuardSubtreeEntryToken::make(value));
+      }
     }
 
     if (!this->check_leaf_guards_nopybind(value)) {
@@ -3300,39 +3326,55 @@ class GuardManager {
       return check_nopybind(value);
     }
 
-    record_guard_fastplan_candidate();
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (collect_stats) {
+      record_guard_fastplan_candidate();
+    }
     if (memo.tokens.empty() && !supports_subtree_memo_recursive()) {
       memo.disabled = true;
-      record_guard_fastplan_disabled();
+      if (collect_stats) {
+        record_guard_fastplan_disabled();
+      }
       return check_nopybind(value);
     }
 
     if (memo.enabled) {
-      const uint64_t token_start_ns = guard_lookup_time_ns();
-      const bool token_match = guard_subtree_memo_tokens_match(memo.tokens);
-      const uint64_t token_check_ns = guard_lookup_time_ns() - token_start_ns;
+      const uint64_t token_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool token_match =
+          guard_subtree_memo_tokens_match(memo.tokens, value);
+      const uint64_t token_check_ns =
+          collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
       if (token_match) {
-        record_guard_fastplan_hit(memo.tokens.size(), token_check_ns);
+        if (collect_stats) {
+          record_guard_fastplan_hit(memo.tokens.size(), token_check_ns);
+        }
         return true;
       }
 
       memo.disabled = true;
-      const uint64_t slow_start_ns = guard_lookup_time_ns();
+      const uint64_t slow_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
       const bool result = check_nopybind(value);
-      const uint64_t slow_check_ns = guard_lookup_time_ns() - slow_start_ns;
-      record_guard_fastplan_miss(
-          memo.tokens.size(), token_check_ns, slow_check_ns, true);
+      const uint64_t slow_check_ns =
+          collect_stats ? guard_lookup_time_ns() - slow_start_ns : 0;
+      if (collect_stats) {
+        record_guard_fastplan_miss(
+            memo.tokens.size(), token_check_ns, slow_check_ns, true);
+      }
       return result;
     }
 
     std::vector<GuardSubtreeEntryToken> tokens;
-    const uint64_t slow_start_ns = guard_lookup_time_ns();
+    const uint64_t slow_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     bool result = false;
     {
       GuardSubtreeMemoRecorderScope recorder(&tokens);
       result = check_nopybind(value);
     }
-    const uint64_t slow_check_ns = guard_lookup_time_ns() - slow_start_ns;
+    const uint64_t slow_check_ns =
+        collect_stats ? guard_lookup_time_ns() - slow_start_ns : 0;
 
     if (!result) {
       memo.shadow_passes = 0;
@@ -3348,10 +3390,14 @@ class GuardManager {
       memo.shadow_passes = 1;
     }
 
-    record_guard_fastplan_shadow_pass(memo.tokens.size(), slow_check_ns);
+    if (collect_stats) {
+      record_guard_fastplan_shadow_pass(memo.tokens.size(), slow_check_ns);
+    }
     if (memo.shadow_passes >= 3) {
       memo.enabled = true;
-      record_guard_fastplan_enable();
+      if (collect_stats) {
+        record_guard_fastplan_enable();
+      }
     }
     return true;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -262,6 +262,7 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> actual_miss{0};
   std::atomic<uint64_t> actual_enable{0};
   std::atomic<uint64_t> actual_disabled{0};
+  std::atomic<uint64_t> actual_hot_token_count_sum{0};
   std::atomic<uint64_t> actual_token_check_ns{0};
   std::atomic<uint64_t> actual_train_ns{0};
   std::atomic<uint64_t> actual_partial_attempt{0};
@@ -270,6 +271,7 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> actual_partial_enable{0};
   std::atomic<uint64_t> actual_partial_disabled{0};
   std::atomic<uint64_t> actual_partial_residual_fail{0};
+  std::atomic<uint64_t> actual_partial_hot_token_count_sum{0};
   std::atomic<uint64_t> actual_partial_token_check_ns{0};
   std::atomic<uint64_t> actual_partial_residual_ns{0};
   std::atomic<uint64_t> actual_partial_train_ns{0};
@@ -553,7 +555,10 @@ static bool guard_subtree_probe_detail_enabled() {
 bool unsafe_mock_guard_bypass_enabled() {
   static const bool env_enabled =
       c10::utils::check_env("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == true;
-  return C10_UNLIKELY(env_enabled);
+  // This bypass is an unsafe measurement aid. Keep it tied to the guard lookup
+  // stats path so accidentally exporting the env var does not skip guards in a
+  // normal performance run.
+  return C10_UNLIKELY(env_enabled) && C10_UNLIKELY(guard_lookup_stats_enabled());
 }
 
 static bool guard_fast_plan_enabled() {
@@ -673,6 +678,7 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.actual_miss);
   store_zero(last_success_stats.actual_enable);
   store_zero(last_success_stats.actual_disabled);
+  store_zero(last_success_stats.actual_hot_token_count_sum);
   store_zero(last_success_stats.actual_token_check_ns);
   store_zero(last_success_stats.actual_train_ns);
   store_zero(last_success_stats.actual_partial_attempt);
@@ -681,6 +687,7 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.actual_partial_enable);
   store_zero(last_success_stats.actual_partial_disabled);
   store_zero(last_success_stats.actual_partial_residual_fail);
+  store_zero(last_success_stats.actual_partial_hot_token_count_sum);
   store_zero(last_success_stats.actual_partial_token_check_ns);
   store_zero(last_success_stats.actual_partial_residual_ns);
   store_zero(last_success_stats.actual_partial_train_ns);
@@ -945,6 +952,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.actual_enable);
   result["guard_last_success_actual_disabled"] =
       load_relaxed(last_success_stats.actual_disabled);
+  result["guard_last_success_actual_hot_token_count_sum"] =
+      load_relaxed(last_success_stats.actual_hot_token_count_sum);
   result["guard_last_success_actual_token_check_ns"] =
       load_relaxed(last_success_stats.actual_token_check_ns);
   result["guard_last_success_actual_train_ns"] =
@@ -961,6 +970,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.actual_partial_disabled);
   result["guard_last_success_actual_partial_residual_fail"] =
       load_relaxed(last_success_stats.actual_partial_residual_fail);
+  result["guard_last_success_actual_partial_hot_token_count_sum"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_count_sum);
   result["guard_last_success_actual_partial_token_check_ns"] =
       load_relaxed(last_success_stats.actual_partial_token_check_ns);
   result["guard_last_success_actual_partial_residual_ns"] =
@@ -1691,6 +1702,14 @@ static void record_guard_last_success_actual_disabled() {
   add_relaxed(guard_last_success_stats().actual_disabled, 1);
 }
 
+static void record_guard_last_success_actual_hot_tokens(size_t token_count) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(
+      guard_last_success_stats().actual_hot_token_count_sum, token_count);
+}
+
 static void record_guard_last_success_actual_train(uint64_t train_ns) {
   if (!guard_lookup_stats_enabled()) {
     return;
@@ -1739,6 +1758,16 @@ static void record_guard_last_success_actual_partial_disabled() {
     return;
   }
   add_relaxed(guard_last_success_stats().actual_partial_disabled, 1);
+}
+
+static void record_guard_last_success_actual_partial_hot_tokens(
+    size_t token_count) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(
+      guard_last_success_stats().actual_partial_hot_token_count_sum,
+      token_count);
 }
 
 static void record_guard_last_success_actual_partial_residual_fail(
@@ -2814,6 +2843,9 @@ struct GuardSubtreeEntryToken {
     for (auto i : c10::irange(expected_sizes.size())) {
       const auto& expected_size = expected_sizes[i];
       if (expected_size.has_value()) {
+        // Dynamic dimensions are represented as nullopt by TensorCheck and are
+        // deliberately not tokenized. Fast-path tensor tokens must not make a
+        // dynamic dimension more static than the original guard.
         token->tensor_size_indices.push_back(static_cast<int64_t>(i));
         token->tensor_size_values.push_back(expected_size.value());
       }
@@ -2825,6 +2857,8 @@ struct GuardSubtreeEntryToken {
     for (auto i : c10::irange(expected_strides.size())) {
       const auto& expected_stride = expected_strides[i];
       if (expected_stride.has_value()) {
+        // Same rule as sizes: only original static stride guards become token
+        // checks; dynamic stride entries stay unchecked here.
         token->tensor_stride_indices.push_back(static_cast<int64_t>(i));
         token->tensor_stride_values.push_back(expected_stride.value());
       }
@@ -3091,6 +3125,34 @@ static bool guard_subtree_token_vectors_match(
   return true;
 }
 
+static bool guard_subtree_hot_token_needed(
+    const GuardSubtreeEntryToken& token,
+    size_t index) {
+  if (index == 0) {
+    return true;
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::ObjectOnly ||
+      token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+    // Parent container tokens prove reachability for these tokens. The hot
+    // matcher already skips them, so keeping them only adds runtime loop
+    // overhead. Stability is still proven with the full uncompressed receipt.
+    return false;
+  }
+  return true;
+}
+
+static std::vector<GuardSubtreeEntryToken> guard_subtree_make_hot_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens) {
+  std::vector<GuardSubtreeEntryToken> hot_tokens;
+  hot_tokens.reserve(tokens.size());
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    if (guard_subtree_hot_token_needed(tokens[i], i)) {
+      hot_tokens.push_back(tokens[i]);
+    }
+  }
+  return hot_tokens;
+}
+
 static bool guard_subtree_token_vectors_match(
     const std::vector<GuardSubtreeEntryToken>& lhs,
     const std::vector<GuardSubtreeEntryToken>& rhs,
@@ -3181,6 +3243,7 @@ struct GuardLastSuccessReceipt {
     actual_requires_self = false;
     actual_self_object = nullptr;
     actual_self_type = nullptr;
+    actual_stability_tokens.clear();
     actual_tokens.clear();
   }
 
@@ -3192,6 +3255,7 @@ struct GuardLastSuccessReceipt {
     actual_partial_disabled = false;
     actual_partial_self_object = nullptr;
     actual_partial_self_type = nullptr;
+    actual_partial_stability_tokens.clear();
     actual_partial_tokens.clear();
   }
 
@@ -3273,6 +3337,11 @@ struct GuardLastSuccessReceipt {
   bool actual_requires_self{false};
   PyObject* actual_self_object{nullptr};
   PyTypeObject* actual_self_type{nullptr};
+  // Full token vector used only to prove consecutive slow-guard receipts are
+  // stable enough to enable the fast path.
+  std::vector<GuardSubtreeEntryToken> actual_stability_tokens;
+  // Compacted token vector used by the runtime fast path after stability is
+  // proven. This may omit tokens that are redundant for hot matching.
   std::vector<GuardSubtreeEntryToken> actual_tokens;
 
   void* actual_partial_entry_key{nullptr};
@@ -3282,6 +3351,7 @@ struct GuardLastSuccessReceipt {
   bool actual_partial_disabled{false};
   PyObject* actual_partial_self_object{nullptr};
   PyTypeObject* actual_partial_self_type{nullptr};
+  std::vector<GuardSubtreeEntryToken> actual_partial_stability_tokens;
   std::vector<GuardSubtreeEntryToken> actual_partial_tokens;
 };
 
@@ -9519,15 +9589,20 @@ bool run_root_guard_manager_with_last_success_receipt(
           actual_disabled_reason,
           actual_disabled_path);
   if (actual_supported) {
+    std::vector<GuardSubtreeEntryToken> actual_hot_tokens =
+        guard_subtree_make_hot_tokens(tokens);
+    record_guard_last_success_actual_hot_tokens(actual_hot_tokens.size());
     if (state->actual_entry_key == entry_key &&
         state->actual_root_key == root &&
-        !state->actual_tokens.empty() &&
-        guard_subtree_token_vectors_match(tokens, state->actual_tokens)) {
+        !state->actual_stability_tokens.empty() &&
+        guard_subtree_token_vectors_match(
+            tokens, state->actual_stability_tokens)) {
       state->actual_shadow_passes += 1;
     } else {
       state->actual_entry_key = entry_key;
       state->actual_root_key = root;
-      state->actual_tokens = tokens;
+      state->actual_stability_tokens = tokens;
+      state->actual_tokens = std::move(actual_hot_tokens);
       state->actual_shadow_passes = 1;
       state->actual_enabled = false;
     }
@@ -9563,15 +9638,22 @@ bool run_root_guard_manager_with_last_success_receipt(
           partial_disabled_reason,
           partial_disabled_path);
   if (actual_partial_supported) {
+    std::vector<GuardSubtreeEntryToken> partial_stability_tokens =
+        partial_tokens;
+    partial_tokens = guard_subtree_make_hot_tokens(partial_tokens);
+    record_guard_last_success_actual_partial_hot_tokens(partial_tokens.size());
     if (state->actual_partial_entry_key == entry_key &&
         state->actual_partial_root_key == root &&
-        !state->actual_partial_tokens.empty() &&
+        !state->actual_partial_stability_tokens.empty() &&
         guard_subtree_token_vectors_match(
-            partial_tokens, state->actual_partial_tokens)) {
+            partial_stability_tokens,
+            state->actual_partial_stability_tokens)) {
       state->actual_partial_shadow_passes += 1;
     } else {
       state->actual_partial_entry_key = entry_key;
       state->actual_partial_root_key = root;
+      state->actual_partial_stability_tokens =
+          std::move(partial_stability_tokens);
       state->actual_partial_tokens = std::move(partial_tokens);
       state->actual_partial_shadow_passes = 1;
       state->actual_partial_enabled = false;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3769,6 +3769,10 @@ class OBJECT_ALIASING : public RelationalGuard {
     _is_first_call = true;
   }
 
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:OBJECT_ALIASING";
+  }
+
  private:
   bool _is_first_call{true};
   PyObject* _first_tensor{nullptr};
@@ -3811,6 +3815,10 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     _unique_tensors.clear();
   }
 
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:NO_TENSOR_ALIASING";
+  }
+
  private:
   py::list _tensor_names;
   ska::flat_hash_map<PyObject*, std::nullptr_t> _unique_tensors;
@@ -3844,6 +3852,10 @@ class STORAGE_OVERLAPPING : public RelationalGuard {
 
   void reset_state() final {
     _checker->reset(_overlapping);
+  }
+
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:STORAGE_OVERLAPPING";
   }
 
  private:
@@ -3958,6 +3970,10 @@ class SYMBOLIC_SHAPE_GUARD : public RelationalGuard {
 
   void reset_state() final {
     _args_seen = 0;
+  }
+
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:SYMBOLIC_SHAPE_GUARD";
   }
 
  private:

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -150,12 +150,15 @@ struct GuardFastPlanStats {
   std::atomic<uint64_t> shadow_pass{0};
   std::atomic<uint64_t> shadow_pass_top{0};
   std::atomic<uint64_t> shadow_pass_nested{0};
+  std::atomic<uint64_t> partial_shadow_pass{0};
   std::atomic<uint64_t> enable{0};
   std::atomic<uint64_t> enable_top{0};
   std::atomic<uint64_t> enable_nested{0};
+  std::atomic<uint64_t> partial_enable{0};
   std::atomic<uint64_t> hit{0};
   std::atomic<uint64_t> hit_top{0};
   std::atomic<uint64_t> hit_nested{0};
+  std::atomic<uint64_t> partial_hit{0};
   std::atomic<uint64_t> miss{0};
   std::atomic<uint64_t> miss_top{0};
   std::atomic<uint64_t> miss_nested{0};
@@ -412,12 +415,15 @@ void reset_guard_lookup_stats() {
   store_zero(fastplan_stats.shadow_pass);
   store_zero(fastplan_stats.shadow_pass_top);
   store_zero(fastplan_stats.shadow_pass_nested);
+  store_zero(fastplan_stats.partial_shadow_pass);
   store_zero(fastplan_stats.enable);
   store_zero(fastplan_stats.enable_top);
   store_zero(fastplan_stats.enable_nested);
+  store_zero(fastplan_stats.partial_enable);
   store_zero(fastplan_stats.hit);
   store_zero(fastplan_stats.hit_top);
   store_zero(fastplan_stats.hit_nested);
+  store_zero(fastplan_stats.partial_hit);
   store_zero(fastplan_stats.miss);
   store_zero(fastplan_stats.miss_top);
   store_zero(fastplan_stats.miss_nested);
@@ -516,15 +522,21 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(fastplan_stats.shadow_pass_top);
   result["guard_fastplan_shadow_pass_nested"] =
       load_relaxed(fastplan_stats.shadow_pass_nested);
+  result["guard_fastplan_partial_shadow_pass"] =
+      load_relaxed(fastplan_stats.partial_shadow_pass);
   result["guard_fastplan_enable"] = load_relaxed(fastplan_stats.enable);
   result["guard_fastplan_enable_top"] =
       load_relaxed(fastplan_stats.enable_top);
   result["guard_fastplan_enable_nested"] =
       load_relaxed(fastplan_stats.enable_nested);
+  result["guard_fastplan_partial_enable"] =
+      load_relaxed(fastplan_stats.partial_enable);
   result["guard_fastplan_hit"] = load_relaxed(fastplan_stats.hit);
   result["guard_fastplan_hit_top"] = load_relaxed(fastplan_stats.hit_top);
   result["guard_fastplan_hit_nested"] =
       load_relaxed(fastplan_stats.hit_nested);
+  result["guard_fastplan_partial_hit"] =
+      load_relaxed(fastplan_stats.partial_hit);
   result["guard_fastplan_miss"] = load_relaxed(fastplan_stats.miss);
   result["guard_fastplan_miss_top"] = load_relaxed(fastplan_stats.miss_top);
   result["guard_fastplan_miss_nested"] =
@@ -864,6 +876,7 @@ static void record_guard_fastplan_candidate(
 
 static void record_guard_fastplan_shadow_pass(
     GuardFastPlanCandidateKind kind,
+    bool partial,
     size_t token_count,
     uint64_t slow_check_ns) {
   if (!guard_lookup_stats_enabled()) {
@@ -873,17 +886,25 @@ static void record_guard_fastplan_shadow_pass(
   add_relaxed(stats.shadow_pass, 1);
   add_guard_fastplan_kind_count(
       stats.shadow_pass_top, stats.shadow_pass_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_shadow_pass, 1);
+  }
   add_relaxed(stats.token_count_sum, token_count);
   add_relaxed(stats.slow_check_ns, slow_check_ns);
 }
 
-static void record_guard_fastplan_enable(GuardFastPlanCandidateKind kind) {
+static void record_guard_fastplan_enable(
+    GuardFastPlanCandidateKind kind,
+    bool partial) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.enable, 1);
   add_guard_fastplan_kind_count(stats.enable_top, stats.enable_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_enable, 1);
+  }
 }
 
 static void record_guard_fastplan_disabled(
@@ -913,6 +934,7 @@ static void record_guard_fastplan_disabled(
 
 static void record_guard_fastplan_hit(
     GuardFastPlanCandidateKind kind,
+    bool partial,
     size_t token_count,
     uint64_t token_check_ns) {
   if (!guard_lookup_stats_enabled()) {
@@ -921,6 +943,9 @@ static void record_guard_fastplan_hit(
   auto& stats = guard_fastplan_stats();
   add_relaxed(stats.hit, 1);
   add_guard_fastplan_kind_count(stats.hit_top, stats.hit_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_hit, 1);
+  }
   add_relaxed(stats.token_count_sum, token_count);
   add_relaxed(stats.token_check_ns, token_check_ns);
 }
@@ -1745,8 +1770,10 @@ static bool guard_subtree_memo_tokens_match(
 struct GuardSubtreeMemoState {
   bool enabled{false};
   bool disabled{false};
+  bool partial{false};
   uint8_t shadow_passes{0};
   std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<size_t> slow_accessor_indices;
 };
 
 struct GuardSubtreeProbeState {
@@ -3555,6 +3582,165 @@ class GuardManager {
     return true;
   }
 
+  bool prepare_partial_subtree_memo(
+      GuardSubtreeMemoState& memo,
+      GuardSubtreeMemoSupportAnalysis* analysis) const {
+    memo.partial = false;
+    memo.slow_accessor_indices.clear();
+
+    bool has_supported_accessor = false;
+    bool has_slow_work = false;
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->supports_subtree_memo()) {
+        has_slow_work = true;
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), _source);
+        }
+      }
+    }
+
+    for (size_t i = 0; i < _accessors.size(); ++i) {
+      const auto& accessor = _accessors[i];
+      GuardSubtreeMemoSupportAnalysis child_analysis;
+      GuardSubtreeMemoSupportAnalysis* child_analysis_ptr =
+          analysis == nullptr ? nullptr : &child_analysis;
+      const bool accessor_supported = accessor->supports_subtree_memo() &&
+          accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              child_analysis_ptr);
+      if (accessor_supported) {
+        has_supported_accessor = true;
+        continue;
+      }
+
+      has_slow_work = true;
+      memo.slow_accessor_indices.push_back(i);
+      if (analysis != nullptr) {
+        if (!accessor->supports_subtree_memo()) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        } else {
+          analysis->set_if_empty(
+              child_analysis.reason.empty() ? "unsupported:unknown"
+                                            : child_analysis.reason.c_str(),
+              child_analysis.path.empty() ? accessor->get_source()
+                                          : child_analysis.path);
+        }
+      }
+    }
+
+    if (!has_supported_accessor || !has_slow_work) {
+      memo.slow_accessor_indices.clear();
+      return false;
+    }
+    memo.partial = true;
+    return true;
+  }
+
+  bool is_partial_slow_accessor(
+      const GuardSubtreeMemoState& memo,
+      size_t accessor_index) const {
+    return std::find(
+               memo.slow_accessor_indices.begin(),
+               memo.slow_accessor_indices.end(),
+               accessor_index) != memo.slow_accessor_indices.end();
+  }
+
+  void get_dict_tag_match_for_accessors(
+      PyObject* value,
+      bool& matches_dict_tag,
+      uint64_t& new_tag) {
+    matches_dict_tag = false;
+    new_tag = 0;
+    if (_is_dict) {
+      new_tag = get_dict_version_unchecked(value);
+      matches_dict_tag = (new_tag == _dict_tag);
+    }
+  }
+
+  void maybe_update_dict_tag_after_accessors(bool result, uint64_t new_tag) {
+    if (_is_dict && result) {
+      _dict_tag = new_tag;
+    }
+  }
+
+  bool check_accessor_nopybind_with_stats(
+      const std::unique_ptr<GuardAccessor>& accessor,
+      PyObject* value,
+      bool matches_dict_tag) {
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t accessor_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool accessor_result =
+        accessor->check_nopybind(value, matches_dict_tag);
+    if (collect_stats) {
+      record_guard_accessor_type_stats(
+          accessor->stats_name(),
+          guard_lookup_time_ns() - accessor_start_ns,
+          !accessor_result);
+    }
+    return accessor_result;
+  }
+
+  bool check_partial_shadow_nopybind(
+      PyObject* value,
+      const GuardSubtreeMemoState& memo,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    tokens->emplace_back(GuardSubtreeEntryToken::make(value));
+    if (!this->check_leaf_guards_nopybind(value)) {
+      return false;
+    }
+
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    get_dict_tag_match_for_accessors(value, matches_dict_tag, new_tag);
+    for (size_t i = 0; i < _accessors.size(); ++i) {
+      const auto& accessor = _accessors[i];
+      bool accessor_result = false;
+      if (is_partial_slow_accessor(memo, i)) {
+        accessor_result = check_accessor_nopybind_with_stats(
+            accessor, value, matches_dict_tag);
+      } else {
+        GuardSubtreeMemoRecorderScope recorder(tokens);
+        accessor_result = check_accessor_nopybind_with_stats(
+            accessor, value, matches_dict_tag);
+      }
+      if (!accessor_result) {
+        _fail_count += 1;
+        return false;
+      }
+    }
+
+    maybe_update_dict_tag_after_accessors(true, new_tag);
+    return true;
+  }
+
+  bool check_partial_slow_accessors_nopybind(
+      PyObject* value,
+      const GuardSubtreeMemoState& memo) {
+    if (!this->check_leaf_guards_nopybind(value)) {
+      return false;
+    }
+
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    get_dict_tag_match_for_accessors(value, matches_dict_tag, new_tag);
+    for (const size_t accessor_index : memo.slow_accessor_indices) {
+      if (accessor_index >= _accessors.size()) {
+        return false;
+      }
+      if (!check_accessor_nopybind_with_stats(
+              _accessors[accessor_index], value, matches_dict_tag)) {
+        _fail_count += 1;
+        return false;
+      }
+    }
+
+    maybe_update_dict_tag_after_accessors(true, new_tag);
+    return true;
+  }
+
   bool check_nopybind_with_fastplan(PyObject* value) {
     GuardSubtreeMemoState& memo = _subtree_probe_state.memo;
     const GuardFastPlanCandidateKind candidate_kind =
@@ -3573,11 +3759,13 @@ class GuardManager {
         collect_stats ? &analysis : nullptr;
     if (memo.tokens.empty() &&
         !supports_subtree_memo_recursive(analysis_ptr)) {
-      memo.disabled = true;
-      if (collect_stats) {
-        record_guard_fastplan_disabled(candidate_kind, analysis);
+      if (!prepare_partial_subtree_memo(memo, analysis_ptr)) {
+        memo.disabled = true;
+        if (collect_stats) {
+          record_guard_fastplan_disabled(candidate_kind, analysis);
+        }
+        return check_nopybind(value);
       }
-      return check_nopybind(value);
     }
 
     if (memo.enabled) {
@@ -3590,12 +3778,16 @@ class GuardManager {
       if (token_match) {
         if (collect_stats) {
           record_guard_fastplan_hit(
-              candidate_kind, memo.tokens.size(), token_check_ns);
+              candidate_kind, memo.partial, memo.tokens.size(), token_check_ns);
+        }
+        if (memo.partial) {
+          return check_partial_slow_accessors_nopybind(value, memo);
         }
         return true;
       }
 
       memo.disabled = true;
+      memo.partial = false;
       const uint64_t slow_start_ns =
           collect_stats ? guard_lookup_time_ns() : 0;
       const bool result = check_nopybind(value);
@@ -3616,7 +3808,9 @@ class GuardManager {
     const uint64_t slow_start_ns =
         collect_stats ? guard_lookup_time_ns() : 0;
     bool result = false;
-    {
+    if (memo.partial) {
+      result = check_partial_shadow_nopybind(value, memo, &tokens);
+    } else {
       GuardSubtreeMemoRecorderScope recorder(&tokens);
       result = check_nopybind(value);
     }
@@ -3639,12 +3833,12 @@ class GuardManager {
 
     if (collect_stats) {
       record_guard_fastplan_shadow_pass(
-          candidate_kind, memo.tokens.size(), slow_check_ns);
+          candidate_kind, memo.partial, memo.tokens.size(), slow_check_ns);
     }
     if (memo.shadow_passes >= 3) {
       memo.enabled = true;
       if (collect_stats) {
-        record_guard_fastplan_enable(candidate_kind);
+        record_guard_fastplan_enable(candidate_kind, memo.partial);
       }
     }
     return true;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -546,6 +546,13 @@ bool guard_lookup_stats_enabled() {
   return C10_UNLIKELY(env_enabled) || C10_UNLIKELY(force_enabled);
 }
 
+static bool guard_last_success_shadow_full_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_GUARD_LAST_SUCCESS_SHADOW_FULL") ==
+      true;
+  return C10_UNLIKELY(env_enabled) && C10_UNLIKELY(guard_lookup_stats_enabled());
+}
+
 static GuardSubtreeProbeMode guard_subtree_probe_mode() {
   static const GuardSubtreeProbeMode mode = [] {
     const auto env = c10::utils::get_env("TORCHDYNAMO_GUARD_SUBTREE_PROBE");
@@ -9848,7 +9855,8 @@ bool run_root_guard_manager_with_last_success_receipt(
         record_guard_last_success_actual_partial_residual_fail(
             token_check_ns, residual_ns);
       }
-      if (residual_result && C10_UNLIKELY(guard_lookup_stats_enabled())) {
+      if (residual_result &&
+          C10_UNLIKELY(guard_last_success_shadow_full_enabled())) {
         const uint64_t shadow_full_start_ns = guard_lookup_time_ns();
         bool shadow_full_result = false;
         {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <optional>
 #include <sstream>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -204,6 +205,19 @@ struct GuardFastPlanStats {
   std::atomic<uint64_t> tensor_token_miss_stride{0};
 };
 
+struct GuardLastSuccessStats {
+  std::atomic<uint64_t> shadow_attempt{0};
+  std::atomic<uint64_t> shadow_success{0};
+  std::atomic<uint64_t> shadow_incomplete{0};
+  std::atomic<uint64_t> shadow_stable{0};
+  std::atomic<uint64_t> shadow_reset{0};
+  std::atomic<uint64_t> shadow_max_passes{0};
+  std::atomic<uint64_t> token_count_sum{0};
+  std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> receipt_update_ns{0};
+  std::atomic<uint64_t> receipt_compare_ns{0};
+};
+
 struct GuardFastPlanDisabledPathStats {
   uint64_t count{0};
   std::string reason;
@@ -272,6 +286,11 @@ GuardFastPlanStats& guard_fastplan_stats() {
   return stats;
 }
 
+GuardLastSuccessStats& guard_last_success_stats() {
+  static GuardLastSuccessStats stats;
+  return stats;
+}
+
 std::atomic<bool>& guard_lookup_stats_force_enabled() {
   static std::atomic<bool> enabled{false};
   return enabled;
@@ -287,6 +306,17 @@ uint64_t load_relaxed(const std::atomic<uint64_t>& value) {
 
 void add_relaxed(std::atomic<uint64_t>& value, uint64_t delta) {
   value.fetch_add(delta, std::memory_order_relaxed);
+}
+
+void max_relaxed(std::atomic<uint64_t>& value, uint64_t candidate) {
+  uint64_t current = value.load(std::memory_order_relaxed);
+  while (candidate > current &&
+         !value.compare_exchange_weak(
+             current,
+             candidate,
+             std::memory_order_relaxed,
+             std::memory_order_relaxed)) {
+  }
 }
 
 std::mutex& guard_accessor_type_stats_mutex() {
@@ -335,6 +365,23 @@ guard_fastplan_disabled_reason_stats() {
 
 std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
 guard_fastplan_disabled_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_last_success_disabled_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_disabled_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_disabled_path_stats() {
   static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
   return stats;
 }
@@ -416,6 +463,7 @@ void reset_guard_lookup_stats() {
   auto& stats = guard_lookup_stats();
   auto& subtree_stats = guard_subtree_probe_stats();
   auto& fastplan_stats = guard_fastplan_stats();
+  auto& last_success_stats = guard_last_success_stats();
   store_zero(stats.lookup_count);
   store_zero(stats.lookup_total_ns);
   store_zero(stats.backend_match_ns);
@@ -487,6 +535,16 @@ void reset_guard_lookup_stats() {
   store_zero(fastplan_stats.tensor_token_miss_dim);
   store_zero(fastplan_stats.tensor_token_miss_size);
   store_zero(fastplan_stats.tensor_token_miss_stride);
+  store_zero(last_success_stats.shadow_attempt);
+  store_zero(last_success_stats.shadow_success);
+  store_zero(last_success_stats.shadow_incomplete);
+  store_zero(last_success_stats.shadow_stable);
+  store_zero(last_success_stats.shadow_reset);
+  store_zero(last_success_stats.shadow_max_passes);
+  store_zero(last_success_stats.token_count_sum);
+  store_zero(last_success_stats.token_cap_disabled);
+  store_zero(last_success_stats.receipt_update_ns);
+  store_zero(last_success_stats.receipt_compare_ns);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -503,6 +561,12 @@ void reset_guard_lookup_stats() {
     std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
     guard_fastplan_disabled_reason_stats().clear();
     guard_fastplan_disabled_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_disabled_stats_mutex());
+    guard_last_success_disabled_reason_stats().clear();
+    guard_last_success_disabled_path_stats().clear();
   }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
@@ -678,6 +742,63 @@ py::dict get_guard_lookup_stats() {
   }
   result["guard_fastplan_disabled_reasons"] = fastplan_disabled_reasons;
   result["guard_fastplan_disabled_top_paths"] = fastplan_disabled_top_paths;
+  auto& last_success_stats = guard_last_success_stats();
+  result["guard_last_success_shadow_attempt"] =
+      load_relaxed(last_success_stats.shadow_attempt);
+  result["guard_last_success_shadow_success"] =
+      load_relaxed(last_success_stats.shadow_success);
+  result["guard_last_success_shadow_incomplete"] =
+      load_relaxed(last_success_stats.shadow_incomplete);
+  result["guard_last_success_shadow_stable"] =
+      load_relaxed(last_success_stats.shadow_stable);
+  result["guard_last_success_shadow_reset"] =
+      load_relaxed(last_success_stats.shadow_reset);
+  result["guard_last_success_shadow_max_passes"] =
+      load_relaxed(last_success_stats.shadow_max_passes);
+  result["guard_last_success_token_count_sum"] =
+      load_relaxed(last_success_stats.token_count_sum);
+  result["guard_last_success_token_cap_disabled"] =
+      load_relaxed(last_success_stats.token_cap_disabled);
+  result["guard_last_success_receipt_update_ns"] =
+      load_relaxed(last_success_stats.receipt_update_ns);
+  result["guard_last_success_receipt_compare_ns"] =
+      load_relaxed(last_success_stats.receipt_compare_ns);
+  py::dict last_success_disabled_reasons;
+  py::dict last_success_disabled_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_disabled_stats_mutex());
+      for (const auto& item : guard_last_success_disabled_reason_stats()) {
+        last_success_disabled_reasons[py::str(item.first)] = item.second;
+      }
+      path_items.reserve(guard_last_success_disabled_path_stats().size());
+      for (const auto& item : guard_last_success_disabled_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      last_success_disabled_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
+  }
+  result["guard_last_success_disabled_reasons"] =
+      last_success_disabled_reasons;
+  result["guard_last_success_disabled_top_paths"] =
+      last_success_disabled_top_paths;
   if (guard_subtree_probe_detail_enabled()) {
     py::dict path_stats;
     std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
@@ -1077,6 +1198,66 @@ static void record_guard_fastplan_token_cap_disabled() {
     return;
   }
   add_relaxed(guard_fastplan_stats().token_cap_disabled, 1);
+}
+
+static void record_guard_last_success_shadow_attempt() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_attempt, 1);
+}
+
+static void record_guard_last_success_shadow_success(
+    size_t token_count,
+    uint64_t update_ns,
+    uint64_t compare_ns,
+    uint64_t shadow_passes) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_success, 1);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.receipt_update_ns, update_ns);
+  add_relaxed(stats.receipt_compare_ns, compare_ns);
+  max_relaxed(stats.shadow_max_passes, shadow_passes);
+}
+
+static void record_guard_last_success_shadow_stable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_stable, 1);
+}
+
+static void record_guard_last_success_shadow_reset() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_reset, 1);
+}
+
+static void record_guard_last_success_incomplete(
+    const char* reason,
+    const std::string& path = "") {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_incomplete, 1);
+  if (std::string_view(reason) == "token_cap_exceeded") {
+    add_relaxed(stats.token_cap_disabled, 1);
+  }
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_disabled_stats_mutex());
+  guard_last_success_disabled_reason_stats()[reason] += 1;
+  if (!path.empty()) {
+    auto& path_stats = guard_last_success_disabled_path_stats()[path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = reason;
+    }
+  }
 }
 
 static void record_guard_fastplan_tensor_token_shadow() {
@@ -2085,6 +2266,44 @@ static bool guard_subtree_token_vectors_match(
   }
   return true;
 }
+
+struct GuardLastSuccessReceipt {
+  void reset() {
+    entry_key = nullptr;
+    root_key = nullptr;
+    shadow_passes = 0;
+    tokens.clear();
+  }
+
+  uint64_t update(
+      void* new_entry_key,
+      void* new_root_key,
+      std::vector<GuardSubtreeEntryToken>&& new_tokens,
+      bool& stable,
+      bool& reset_state,
+      uint64_t& compare_ns) {
+    const uint64_t compare_start_ns = guard_lookup_time_ns();
+    stable = entry_key == new_entry_key && root_key == new_root_key &&
+        !tokens.empty() && guard_subtree_token_vectors_match(tokens, new_tokens);
+    compare_ns = guard_lookup_time_ns() - compare_start_ns;
+    reset_state = !stable && !tokens.empty();
+
+    if (stable) {
+      shadow_passes += 1;
+    } else {
+      entry_key = new_entry_key;
+      root_key = new_root_key;
+      tokens = std::move(new_tokens);
+      shadow_passes = 1;
+    }
+    return shadow_passes;
+  }
+
+  void* entry_key{nullptr};
+  void* root_key{nullptr};
+  uint64_t shadow_passes{0};
+  std::vector<GuardSubtreeEntryToken> tokens;
+};
 
 extern thread_local const LocalState* active_guard_local_state;
 
@@ -7493,6 +7712,100 @@ bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals) {
     return ((RootGuardManager*)root)
         ->check_nopybind((PyObject*)f_locals->to_dict());
   }
+}
+
+void* create_guard_last_success_receipt() {
+  return new GuardLastSuccessReceipt();
+}
+
+void destroy_guard_last_success_receipt(void* receipt) {
+  delete static_cast<GuardLastSuccessReceipt*>(receipt);
+}
+
+void reset_guard_last_success_receipt(void* receipt) {
+  if (receipt == nullptr) {
+    return;
+  }
+  static_cast<GuardLastSuccessReceipt*>(receipt)->reset();
+}
+
+static bool guard_last_success_shadow_enabled() {
+  return C10_UNLIKELY(guard_fast_plan_enabled()) &&
+      C10_UNLIKELY(guard_lookup_stats_enabled());
+}
+
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe) {
+  if (!guard_last_success_shadow_enabled() || receipt == nullptr) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  record_guard_last_success_shadow_attempt();
+  GuardLastSuccessReceipt* state =
+      static_cast<GuardLastSuccessReceipt*>(receipt);
+  if (is_skip_guard_eval_unsafe) {
+    record_guard_last_success_incomplete("skip_guard_eval_unsafe");
+    state->reset();
+    return run_root_guard_manager(root, f_locals);
+  }
+  if (root == nullptr) {
+    record_guard_last_success_incomplete("null_root");
+    state->reset();
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
+  GuardSubtreeMemoSupportAnalysis analysis;
+  if (!root_mgr->supports_subtree_memo_recursive(&analysis)) {
+    record_guard_last_success_incomplete(
+        analysis.reason.empty() ? "unsupported:unknown"
+                                : analysis.reason.c_str(),
+        analysis.path);
+    state->reset();
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  std::vector<GuardSubtreeEntryToken> tokens;
+  {
+    GuardSubtreeMemoRecorderScope recorder(&tokens);
+    const bool result = run_root_guard_manager(root, f_locals);
+    if (!result) {
+      state->reset();
+      return false;
+    }
+  }
+
+  if (tokens.empty()) {
+    record_guard_last_success_incomplete("empty_receipt");
+    state->reset();
+    return true;
+  }
+  if (tokens.size() > kGuardFastPlanMaxTokens) {
+    record_guard_last_success_incomplete("token_cap_exceeded");
+    state->reset();
+    return true;
+  }
+
+  const uint64_t update_start_ns = guard_lookup_time_ns();
+  bool stable = false;
+  bool reset_state = false;
+  uint64_t compare_ns = 0;
+  const uint64_t shadow_passes = state->update(
+      entry_key, root, std::move(tokens), stable, reset_state, compare_ns);
+  const uint64_t update_ns = guard_lookup_time_ns() - update_start_ns;
+  if (stable) {
+    record_guard_last_success_shadow_stable();
+  }
+  if (reset_state) {
+    record_guard_last_success_shadow_reset();
+  }
+  record_guard_last_success_shadow_success(
+      state->tokens.size(), update_ns, compare_ns, shadow_passes);
+  return true;
 }
 
 PyObject* torch_c_dynamo_guards_init() {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -256,6 +256,13 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> compare_mismatch{0};
   std::atomic<uint64_t> compare_mismatch_index_sum{0};
   std::atomic<uint64_t> compare_mismatch_index_max{0};
+  std::atomic<uint64_t> actual_attempt{0};
+  std::atomic<uint64_t> actual_hit{0};
+  std::atomic<uint64_t> actual_miss{0};
+  std::atomic<uint64_t> actual_enable{0};
+  std::atomic<uint64_t> actual_disabled{0};
+  std::atomic<uint64_t> actual_token_check_ns{0};
+  std::atomic<uint64_t> actual_train_ns{0};
 };
 
 struct GuardFastPlanDisabledPathStats {
@@ -305,6 +312,8 @@ constexpr size_t kGuardSubtreeProbeTopK = 64;
 constexpr size_t kGuardFastPlanDisabledTopK = 64;
 constexpr size_t kGuardFastPlanMaxTokens = 1024;
 constexpr size_t kGuardLastSuccessShadowMaxTokens = 65536;
+constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
+constexpr uint64_t kGuardLastSuccessActualStablePasses = 3;
 constexpr size_t kGuardSubtreeMemoSupportAnalysisMaxItems = 1024;
 
 struct GuardSubtreeMemoSupportAnalysis {
@@ -638,6 +647,13 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.compare_mismatch);
   store_zero(last_success_stats.compare_mismatch_index_sum);
   store_zero(last_success_stats.compare_mismatch_index_max);
+  store_zero(last_success_stats.actual_attempt);
+  store_zero(last_success_stats.actual_hit);
+  store_zero(last_success_stats.actual_miss);
+  store_zero(last_success_stats.actual_enable);
+  store_zero(last_success_stats.actual_disabled);
+  store_zero(last_success_stats.actual_token_check_ns);
+  store_zero(last_success_stats.actual_train_ns);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -889,6 +905,20 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.compare_mismatch_index_sum);
   result["guard_last_success_compare_mismatch_index_max"] =
       load_relaxed(last_success_stats.compare_mismatch_index_max);
+  result["guard_last_success_actual_attempt"] =
+      load_relaxed(last_success_stats.actual_attempt);
+  result["guard_last_success_actual_hit"] =
+      load_relaxed(last_success_stats.actual_hit);
+  result["guard_last_success_actual_miss"] =
+      load_relaxed(last_success_stats.actual_miss);
+  result["guard_last_success_actual_enable"] =
+      load_relaxed(last_success_stats.actual_enable);
+  result["guard_last_success_actual_disabled"] =
+      load_relaxed(last_success_stats.actual_disabled);
+  result["guard_last_success_actual_token_check_ns"] =
+      load_relaxed(last_success_stats.actual_token_check_ns);
+  result["guard_last_success_actual_train_ns"] =
+      load_relaxed(last_success_stats.actual_train_ns);
   py::dict last_success_disabled_reasons;
   py::dict last_success_disabled_top_paths;
   {
@@ -1560,6 +1590,52 @@ static void record_guard_last_success_support_check(uint64_t check_ns) {
     return;
   }
   add_relaxed(guard_last_success_stats().support_check_ns, check_ns);
+}
+
+static void record_guard_last_success_actual_attempt() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_attempt, 1);
+}
+
+static void record_guard_last_success_actual_hit(uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_hit, 1);
+  add_relaxed(stats.actual_token_check_ns, token_check_ns);
+}
+
+static void record_guard_last_success_actual_miss(uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_miss, 1);
+  add_relaxed(stats.actual_token_check_ns, token_check_ns);
+}
+
+static void record_guard_last_success_actual_enable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_enable, 1);
+}
+
+static void record_guard_last_success_actual_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_disabled, 1);
+}
+
+static void record_guard_last_success_actual_train(uint64_t train_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_train_ns, train_ns);
 }
 
 static void record_guard_last_success_disabled_item_locked(
@@ -2926,6 +3002,19 @@ struct GuardLastSuccessReceipt {
     shadow_passes = 0;
     tokens.clear();
     debug_paths.clear();
+    reset_actual();
+  }
+
+  void reset_actual() {
+    actual_entry_key = nullptr;
+    actual_root_key = nullptr;
+    actual_shadow_passes = 0;
+    actual_enabled = false;
+    actual_disabled = false;
+    actual_requires_self = false;
+    actual_self_object = nullptr;
+    actual_self_type = nullptr;
+    actual_tokens.clear();
   }
 
   uint64_t update(
@@ -2988,9 +3077,32 @@ struct GuardLastSuccessReceipt {
   uint64_t shadow_passes{0};
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<std::string> debug_paths;
+
+  void* actual_entry_key{nullptr};
+  void* actual_root_key{nullptr};
+  uint64_t actual_shadow_passes{0};
+  bool actual_enabled{false};
+  bool actual_disabled{false};
+  bool actual_requires_self{false};
+  PyObject* actual_self_object{nullptr};
+  PyTypeObject* actual_self_type{nullptr};
+  std::vector<GuardSubtreeEntryToken> actual_tokens;
 };
 
 extern thread_local const LocalState* active_guard_local_state;
+
+struct GuardLocalStateScope {
+  explicit GuardLocalStateScope(const LocalState* state)
+      : previous(active_guard_local_state) {
+    active_guard_local_state = state;
+  }
+
+  ~GuardLocalStateScope() {
+    active_guard_local_state = previous;
+  }
+
+  const LocalState* previous{nullptr};
+};
 
 static bool guard_subtree_memo_tokens_match(
     const std::vector<GuardSubtreeEntryToken>& tokens,
@@ -3071,6 +3183,149 @@ static bool guard_subtree_memo_tokens_match(
   return true;
 }
 
+static bool source_starts_with(
+    const std::string& source,
+    const char* prefix) {
+  const size_t prefix_len = std::strlen(prefix);
+  return source.size() >= prefix_len &&
+      source.compare(0, prefix_len, prefix) == 0;
+}
+
+static bool is_self_local_source_path(const std::string& source) {
+  static constexpr const char* kSelf = "L['self']";
+  if (!source_starts_with(source, kSelf)) {
+    return false;
+  }
+  return source.size() == std::strlen(kSelf) ||
+      source[std::strlen(kSelf)] == '.' ||
+      source[std::strlen(kSelf)] == '[';
+}
+
+static bool is_local_source_path(const std::string& source) {
+  return source_starts_with(source, "L[");
+}
+
+static PyObject* guard_last_success_self_key() {
+  static PyObject* key = PyUnicode_InternFromString("self");
+  return key;
+}
+
+static bool guard_last_success_current_self_matches(
+    GuardLastSuccessReceipt* receipt,
+    FrameLocalsMapping* f_locals) {
+  if (!receipt->actual_requires_self) {
+    return true;
+  }
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  PyObject* current_self = PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+  return current_self != nullptr && current_self == receipt->actual_self_object &&
+      Py_TYPE(current_self) == receipt->actual_self_type;
+}
+
+static bool guard_last_success_prepare_actual(
+    GuardLastSuccessReceipt* receipt,
+    FrameLocalsMapping* f_locals,
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  if (tokens.empty()) {
+    disabled_reason = "actual_empty_receipt";
+    return false;
+  }
+  if (tokens.size() != debug_paths.size()) {
+    disabled_reason = "actual_missing_debug_paths";
+    return false;
+  }
+  if (tokens.size() > kGuardLastSuccessActualMaxTokens) {
+    disabled_reason = "actual_token_cap_exceeded";
+    return false;
+  }
+
+  bool requires_self = false;
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    const auto& path = debug_paths[i];
+    if (token.kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      disabled_reason = "actual_relaxed_token";
+      disabled_path = path;
+      return false;
+    }
+    if (is_local_source_path(path)) {
+      if (!is_self_local_source_path(path)) {
+        disabled_reason = "actual_unsupported_local";
+        disabled_path = path;
+        return false;
+      }
+      requires_self = true;
+    }
+  }
+
+  receipt->actual_requires_self = requires_self;
+  receipt->actual_self_object = nullptr;
+  receipt->actual_self_type = nullptr;
+  if (requires_self) {
+    PyObject* key = guard_last_success_self_key();
+    if (key == nullptr) {
+      PyErr_Clear();
+      disabled_reason = "actual_missing_self_key";
+      return false;
+    }
+    PyObject* current_self =
+        PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+    if (current_self == nullptr) {
+      disabled_reason = "actual_missing_self";
+      disabled_path = "L['self']";
+      return false;
+    }
+    receipt->actual_self_object = current_self;
+    receipt->actual_self_type = Py_TYPE(current_self);
+  }
+  return true;
+}
+
+static std::vector<GuardSubtreeEntryToken>
+guard_last_success_make_diagnostic_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths) {
+  std::vector<GuardSubtreeEntryToken> diagnostic_tokens = tokens;
+  if (diagnostic_tokens.size() != debug_paths.size()) {
+    return diagnostic_tokens;
+  }
+  for (size_t i = 0; i < diagnostic_tokens.size(); ++i) {
+    auto& token = diagnostic_tokens[i];
+    if (is_global_source_path(debug_paths[i]) &&
+        token.object != nullptr && PyDict_CheckExact(token.object)) {
+      token.kind = GuardSubtreeProbeTokenKind::FrameGlobals;
+      token.version = 0;
+      token.size = 0;
+      token.list_items.clear();
+    }
+  }
+  return diagnostic_tokens;
+}
+
+static bool guard_last_success_actual_tokens_match(
+    GuardLastSuccessReceipt* receipt,
+    FrameLocalsMapping* f_locals) {
+  if (!guard_last_success_current_self_matches(receipt, f_locals)) {
+    return false;
+  }
+  if (receipt->actual_tokens.empty()) {
+    return false;
+  }
+  LocalState state;
+  GuardLocalStateScope local_state_scope(&state);
+  PyObject* root_value = receipt->actual_tokens[0].object;
+  const bool result =
+      guard_subtree_memo_tokens_match(receipt->actual_tokens, root_value);
+  return result;
+}
+
 struct GuardSubtreeMemoState {
   bool enabled{false};
   bool disabled{false};
@@ -3091,25 +3346,33 @@ thread_local std::vector<GuardSubtreeEntryToken>*
     active_guard_subtree_memo_recorder = nullptr;
 thread_local std::vector<std::string>*
     active_guard_subtree_memo_debug_paths = nullptr;
+thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
 thread_local const LocalState* active_guard_local_state = nullptr;
 
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
       std::vector<GuardSubtreeEntryToken>* tokens,
-      std::vector<std::string>* debug_paths = nullptr)
+      std::vector<std::string>* debug_paths = nullptr,
+      bool relax_global_dicts = false)
       : previous(active_guard_subtree_memo_recorder),
-        previous_debug_paths(active_guard_subtree_memo_debug_paths) {
+        previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_relax_global_dicts(
+            active_guard_subtree_memo_relax_global_dicts) {
     active_guard_subtree_memo_recorder = tokens;
     active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
   }
 
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
     active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_subtree_memo_relax_global_dicts =
+        previous_relax_global_dicts;
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
   std::vector<std::string>* previous_debug_paths{nullptr};
+  bool previous_relax_global_dicts{false};
 };
 
 static void append_guard_subtree_memo_token(
@@ -3121,19 +3384,6 @@ static void append_guard_subtree_memo_token(
     active_guard_subtree_memo_debug_paths->push_back(debug_path);
   }
 }
-
-struct GuardLocalStateScope {
-  explicit GuardLocalStateScope(const LocalState* state)
-      : previous(active_guard_local_state) {
-    active_guard_local_state = state;
-  }
-
-  ~GuardLocalStateScope() {
-    active_guard_local_state = previous;
-  }
-
-  const LocalState* previous{nullptr};
-};
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   // Retrieves the version of a dictionary.
@@ -4979,7 +5229,7 @@ class GuardManager {
       if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
         append_guard_subtree_memo_token(
             active_guard_subtree_memo_recorder,
-            active_guard_subtree_memo_debug_paths != nullptr
+            active_guard_subtree_memo_relax_global_dicts
                 ? GuardSubtreeEntryToken::make_for_source(value, _source)
                 : GuardSubtreeEntryToken::make(value),
             _source);
@@ -5830,6 +6080,28 @@ class RootGuardManager : public GuardManager {
 
   bool check_nopybind(FrameLocalsMapping* value) override {
     return check_nopybind_template(value);
+  }
+
+  bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const override {
+    bool supported = GuardManager::supports_subtree_memo_recursive(analysis);
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
+    if (!supported && !collect_all) {
+      return false;
+    }
+    for (const auto& guard : _epilogue_lambda_guards) {
+      if (!guard->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), "L");
+        }
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+    }
+    return supported;
   }
 
   // Fast check_verbose function.
@@ -8656,17 +8928,22 @@ static bool guard_last_success_shadow_enabled() {
       C10_UNLIKELY(guard_lookup_stats_enabled());
 }
 
+static bool guard_last_success_actual_enabled() {
+  return C10_UNLIKELY(guard_fast_plan_enabled());
+}
+
 bool run_root_guard_manager_with_last_success_receipt(
     void* receipt,
     void* entry_key,
     void* root,
     FrameLocalsMapping* f_locals,
     bool is_skip_guard_eval_unsafe) {
-  if (!guard_last_success_shadow_enabled() || receipt == nullptr) {
+  if (!guard_last_success_actual_enabled() || receipt == nullptr) {
     return run_root_guard_manager(root, f_locals);
   }
 
   record_guard_last_success_shadow_attempt();
+  record_guard_last_success_actual_attempt();
   GuardLastSuccessReceipt* state =
       static_cast<GuardLastSuccessReceipt*>(receipt);
   if (is_skip_guard_eval_unsafe) {
@@ -8680,24 +8957,58 @@ bool run_root_guard_manager_with_last_success_receipt(
     return run_root_guard_manager(root, f_locals);
   }
 
+  if (state->actual_enabled && state->actual_entry_key == entry_key &&
+      state->actual_root_key == root) {
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t token_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool actual_match =
+        guard_last_success_actual_tokens_match(state, f_locals);
+    const uint64_t token_check_ns =
+        collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
+    if (actual_match) {
+      record_guard_last_success_actual_hit(token_check_ns);
+      return true;
+    }
+    record_guard_last_success_actual_miss(token_check_ns);
+    state->reset_actual();
+  }
+
+  if (state->actual_disabled && !guard_last_success_shadow_enabled()) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
   RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
   GuardSubtreeMemoSupportAnalysis analysis;
   analysis.collect_all = guard_lookup_stats_enabled();
-  const uint64_t support_start_ns = guard_lookup_time_ns();
-  const bool supported = root_mgr->supports_subtree_memo_recursive(&analysis);
-  record_guard_last_success_support_check(
-      guard_lookup_time_ns() - support_start_ns);
+  const bool should_train_actual = !state->actual_disabled;
+  const uint64_t support_start_ns =
+      guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
+  const bool supported = should_train_actual &&
+      root_mgr->supports_subtree_memo_recursive(&analysis);
+  if (should_train_actual) {
+    record_guard_last_success_support_check(
+        guard_lookup_stats_enabled() ? guard_lookup_time_ns() - support_start_ns
+                                     : 0);
+  }
   if (!supported) {
-    record_guard_last_success_incomplete(analysis);
-    state->reset();
-    return run_root_guard_manager(root, f_locals);
+    if (should_train_actual) {
+      record_guard_last_success_incomplete(analysis);
+      state->reset_actual();
+      state->actual_disabled = true;
+      record_guard_last_success_actual_disabled();
+    }
+    if (!guard_last_success_shadow_enabled()) {
+      return run_root_guard_manager(root, f_locals);
+    }
   }
 
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<std::string> debug_paths;
   {
-    // This receipt is shadow-only diagnostics. The recorder deliberately
-    // disables nested manager fastplan so it can observe the full guard tree.
+    // The recorder deliberately disables nested manager fastplan so it can
+    // observe the full guard tree. Actual fast path uses the strict tokens;
+    // diagnostics derive a relaxed copy below.
     GuardSubtreeMemoRecorderScope recorder(&tokens, &debug_paths);
     const bool result = run_root_guard_manager(root, f_locals);
     if (!result) {
@@ -8721,6 +9032,49 @@ bool run_root_guard_manager_with_last_success_receipt(
     return true;
   }
 
+  const uint64_t actual_train_start_ns =
+      guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
+  std::string actual_disabled_reason;
+  std::string actual_disabled_path;
+  bool actual_disabled_now = false;
+  const bool actual_supported = should_train_actual && supported &&
+      guard_last_success_prepare_actual(
+          state,
+          f_locals,
+          tokens,
+          debug_paths,
+          actual_disabled_reason,
+          actual_disabled_path);
+  if (actual_supported) {
+    if (state->actual_entry_key == entry_key &&
+        state->actual_root_key == root &&
+        !state->actual_tokens.empty() &&
+        guard_subtree_token_vectors_match(tokens, state->actual_tokens)) {
+      state->actual_shadow_passes += 1;
+    } else {
+      state->actual_entry_key = entry_key;
+      state->actual_root_key = root;
+      state->actual_tokens = tokens;
+      state->actual_shadow_passes = 1;
+      state->actual_enabled = false;
+    }
+    if (!state->actual_enabled &&
+        state->actual_shadow_passes >= kGuardLastSuccessActualStablePasses) {
+      state->actual_enabled = true;
+      record_guard_last_success_actual_enable();
+    }
+  } else if (should_train_actual && supported) {
+    state->reset_actual();
+    state->actual_disabled = true;
+    actual_disabled_now = true;
+    record_guard_last_success_actual_disabled();
+  }
+  record_guard_last_success_actual_train(
+      guard_lookup_stats_enabled() ? guard_lookup_time_ns() - actual_train_start_ns
+                                   : 0);
+
+  std::vector<GuardSubtreeEntryToken> diagnostic_tokens =
+      guard_last_success_make_diagnostic_tokens(tokens, debug_paths);
   const uint64_t update_start_ns = guard_lookup_time_ns();
   bool stable = false;
   bool reset_state = false;
@@ -8728,7 +9082,7 @@ bool run_root_guard_manager_with_last_success_receipt(
   const uint64_t shadow_passes = state->update(
       entry_key,
       root,
-      std::move(tokens),
+      std::move(diagnostic_tokens),
       std::move(debug_paths),
       stable,
       reset_state,
@@ -8742,6 +9096,14 @@ bool run_root_guard_manager_with_last_success_receipt(
   }
   record_guard_last_success_shadow_success(
       state->tokens.size(), update_ns, compare_ns, shadow_passes);
+  if (actual_disabled_now && guard_lookup_stats_enabled()) {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_disabled_stats_mutex());
+    record_guard_last_success_disabled_item_locked(
+        actual_disabled_reason.empty() ? "actual_unsupported"
+                                       : actual_disabled_reason.c_str(),
+        actual_disabled_path);
+  }
   return true;
 }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -272,16 +272,25 @@ constexpr size_t kGuardAccessorDetailStatsTopK = 64;
 constexpr size_t kGuardSubtreeProbeTopK = 64;
 constexpr size_t kGuardFastPlanDisabledTopK = 64;
 constexpr size_t kGuardFastPlanMaxTokens = 1024;
+constexpr size_t kGuardSubtreeMemoSupportAnalysisMaxItems = 1024;
 
 struct GuardSubtreeMemoSupportAnalysis {
   std::string reason;
   std::string path;
+  bool collect_all{false};
+  std::vector<std::pair<std::string, std::string>> unsupported;
 
   void set_if_empty(const char* new_reason, const std::string& new_path) {
+    const std::string resolved_reason =
+        new_reason == nullptr ? "unsupported:unknown" : new_reason;
+    if (collect_all &&
+        unsupported.size() < kGuardSubtreeMemoSupportAnalysisMaxItems) {
+      unsupported.emplace_back(resolved_reason, new_path);
+    }
     if (!reason.empty()) {
       return;
     }
-    reason = new_reason == nullptr ? "unsupported:unknown" : new_reason;
+    reason = resolved_reason;
     path = new_path;
   }
 };
@@ -1307,6 +1316,22 @@ static void record_guard_last_success_support_check(uint64_t check_ns) {
   add_relaxed(guard_last_success_stats().support_check_ns, check_ns);
 }
 
+static void record_guard_last_success_disabled_item_locked(
+    const char* reason,
+    const std::string& path) {
+  if (reason == nullptr) {
+    reason = "unsupported:unknown";
+  }
+  guard_last_success_disabled_reason_stats()[reason] += 1;
+  if (!path.empty()) {
+    auto& path_stats = guard_last_success_disabled_path_stats()[path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = reason;
+    }
+  }
+}
+
 static void record_guard_last_success_incomplete(
     const char* reason,
     const std::string& path = "") {
@@ -1323,13 +1348,27 @@ static void record_guard_last_success_incomplete(
   }
   std::lock_guard<std::mutex> lock(
       guard_last_success_disabled_stats_mutex());
-  guard_last_success_disabled_reason_stats()[reason] += 1;
-  if (!path.empty()) {
-    auto& path_stats = guard_last_success_disabled_path_stats()[path];
-    path_stats.count += 1;
-    if (path_stats.reason.empty()) {
-      path_stats.reason = reason;
-    }
+  record_guard_last_success_disabled_item_locked(reason, path);
+}
+
+static void record_guard_last_success_incomplete(
+    const GuardSubtreeMemoSupportAnalysis& analysis) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_incomplete, 1);
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_disabled_stats_mutex());
+  if (analysis.unsupported.empty()) {
+    record_guard_last_success_disabled_item_locked(
+        analysis.reason.empty() ? "unsupported:unknown" : analysis.reason.c_str(),
+        analysis.path);
+    return;
+  }
+  for (const auto& item : analysis.unsupported) {
+    record_guard_last_success_disabled_item_locked(
+        item.first.c_str(), item.second);
   }
 }
 
@@ -4491,13 +4530,18 @@ class GuardManager {
 
   virtual bool supports_subtree_memo_recursive(
       GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const {
+    bool supported = true;
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
     for (const auto& guard : _leaf_guards) {
       if (!guard->supports_subtree_memo()) {
         if (analysis != nullptr) {
           analysis->set_if_empty(
               guard->subtree_memo_unsupported_reason(), _source);
         }
-        return false;
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
       }
     }
     for (const auto& accessor : _accessors) {
@@ -4507,17 +4551,24 @@ class GuardManager {
               accessor->subtree_memo_unsupported_reason(),
               accessor->get_source());
         }
-        return false;
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+        continue;
       }
       if (!accessor->get_guard_manager()->supports_subtree_memo_recursive(
               analysis)) {
         if (analysis != nullptr && analysis->path.empty()) {
           analysis->path = accessor->get_source();
         }
-        return false;
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
       }
     }
-    return true;
+    return supported;
   }
 
   bool prepare_partial_subtree_memo(
@@ -5675,22 +5726,33 @@ class DictGuardManager : public GuardManager {
 
   bool supports_subtree_memo_recursive(
       GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const override {
+    bool supported = true;
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
     if (!GuardManager::supports_subtree_memo_recursive(analysis)) {
-      return false;
+      supported = false;
+      if (!collect_all) {
+        return false;
+      }
     }
     for (const auto& item : _key_value_managers) {
       const auto& key_manager = item.second.first;
       if (key_manager && !key_manager->supports_subtree_memo_recursive(
                              analysis)) {
-        return false;
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
       }
       const auto& value_manager = item.second.second;
       if (value_manager && !value_manager->supports_subtree_memo_recursive(
-                               analysis)) {
-        return false;
+                                analysis)) {
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
       }
     }
-    return true;
+    return supported;
   }
 
  public: // cloning functions
@@ -8137,15 +8199,13 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
   GuardSubtreeMemoSupportAnalysis analysis;
+  analysis.collect_all = guard_lookup_stats_enabled();
   const uint64_t support_start_ns = guard_lookup_time_ns();
   const bool supported = root_mgr->supports_subtree_memo_recursive(&analysis);
   record_guard_last_success_support_check(
       guard_lookup_time_ns() - support_start_ns);
   if (!supported) {
-    record_guard_last_success_incomplete(
-        analysis.reason.empty() ? "unsupported:unknown"
-                                : analysis.reason.c_str(),
-        analysis.path);
+    record_guard_last_success_incomplete(analysis);
     state->reset();
     return run_root_guard_manager(root, f_locals);
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -5811,7 +5811,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
 static bool torch_function_mode_stack_guard_matches(const void* guard) {
   return guard != nullptr &&
       static_cast<const TORCH_FUNCTION_MODE_STACK*>(guard)
-          ->check_nopybind_template(nullptr);
+          ->check_nopybind_template(static_cast<PyObject*>(nullptr));
 }
 
 class DISPATCH_KEY_SET_MATCH : public LeafGuard {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -121,6 +121,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   ExactTuple,
   TensorMatch,
   DefaultDevice,
+  GlobalState,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -160,6 +161,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_exact_tuple{0};
   std::atomic<uint64_t> token_tensor_match{0};
   std::atomic<uint64_t> token_default_device{0};
+  std::atomic<uint64_t> token_global_state{0};
 };
 
 struct GuardFastPlanStats {
@@ -254,6 +256,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_exact_tuple{0};
   uint64_t token_tensor_match{0};
   uint64_t token_default_device{0};
+  uint64_t token_global_state{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -498,6 +501,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_exact_tuple);
   store_zero(subtree_stats.token_tensor_match);
   store_zero(subtree_stats.token_default_device);
+  store_zero(subtree_stats.token_global_state);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -633,6 +637,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_tensor_match);
   subtree_token_kind_counts["DefaultDevice"] =
       load_relaxed(subtree_stats.token_default_device);
+  subtree_token_kind_counts["GlobalState"] =
+      load_relaxed(subtree_stats.token_global_state);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -997,6 +1003,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::DefaultDevice:
       add_relaxed(stats.token_default_device, 1);
       break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      add_relaxed(stats.token_global_state, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1021,6 +1030,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::DefaultDevice:
       stats.token_default_device += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      stats.token_global_state += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2172,6 +2184,7 @@ struct GuardSubtreeEntryToken {
   std::vector<c10::SymInt> tensor_stride_values;
   PyObject* default_device_dict{nullptr};
   PyObject* default_device{nullptr};
+  GlobalStateGuard* global_state_guard{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -2257,6 +2270,13 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_global_state(GlobalStateGuard* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::GlobalState;
+    token.global_state_guard = guard;
+    return token;
+  }
+
   bool matches_tensor_current(
       const LocalState* state,
       GuardFastPlanTensorTokenMissReason& reason) const {
@@ -2322,6 +2342,10 @@ struct GuardSubtreeEntryToken {
     return default_device_matches(default_device_dict, default_device);
   }
 
+  bool matches_global_state_current() const {
+    return global_state_guard != nullptr && global_state_guard->check();
+  }
+
   bool matches(const GuardSubtreeEntryToken& other) const {
     if (kind != other.kind || object != other.object || type != other.type) {
       return false;
@@ -2340,6 +2364,9 @@ struct GuardSubtreeEntryToken {
     if (kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
       return default_device_dict == other.default_device_dict &&
           default_device == other.default_device;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::GlobalState) {
+      return global_state_guard == other.global_state_guard;
     }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
@@ -2428,6 +2455,12 @@ static bool guard_subtree_memo_tokens_match(
     }
     if (token.kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
       if (!token.matches_default_device_current()) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::GlobalState) {
+      if (!token.matches_global_state_current()) {
         return false;
       }
       continue;
@@ -3528,13 +3561,41 @@ class GLOBAL_STATE : public LeafGuard {
   }
 
   bool supports_subtree_memo() const override {
-    return false;
+    return true;
   }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:GLOBAL_STATE";
   }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
 
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    tokens->emplace_back(
+        GuardSubtreeEntryToken::make_global_state(_guard.get()));
+    return true;
+  }
+
   std::unique_ptr<GlobalStateGuard> _guard;
 };
 
@@ -4626,14 +4687,20 @@ class GuardManager {
     // Iterate over leaf guards
     for (const auto& guard : _leaf_guards) {
       bool result = false;
-      const bool emit_subtree_memo_token =
-          std::is_same_v<T, PyObject>
-          ? guard->emits_subtree_memo_token()
-          : guard->emits_subtree_memo_token_for_frame_locals();
-      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr &&
-                       emit_subtree_memo_token)) {
-        result = guard->append_subtree_memo_token(
-            value, active_guard_subtree_memo_recorder);
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        bool emit_subtree_memo_token = false;
+        if constexpr (std::is_same_v<T, PyObject>) {
+          emit_subtree_memo_token = guard->emits_subtree_memo_token();
+        } else {
+          emit_subtree_memo_token =
+              guard->emits_subtree_memo_token_for_frame_locals();
+        }
+        if (emit_subtree_memo_token) {
+          result = guard->append_subtree_memo_token(
+              value, active_guard_subtree_memo_recorder);
+        } else {
+          result = guard->check_nopybind(value);
+        }
       } else {
         result = guard->check_nopybind(value);
       }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -292,6 +292,9 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> actual_partial_hot_token_duplicate_frame_globals{0};
   std::atomic<uint64_t> actual_partial_token_check_ns{0};
   std::atomic<uint64_t> actual_partial_residual_ns{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_pass{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_fail{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_ns{0};
   std::atomic<uint64_t> actual_partial_train_ns{0};
 };
 
@@ -516,6 +519,23 @@ guard_last_success_mismatch_path_stats() {
   return stats;
 }
 
+std::mutex& guard_last_success_partial_shadow_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_partial_shadow_fail_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_partial_shadow_fail_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
 } // namespace
 
 bool guard_lookup_stats_enabled() {
@@ -727,6 +747,9 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.actual_partial_hot_token_duplicate_frame_globals);
   store_zero(last_success_stats.actual_partial_token_check_ns);
   store_zero(last_success_stats.actual_partial_residual_ns);
+  store_zero(last_success_stats.actual_partial_shadow_full_pass);
+  store_zero(last_success_stats.actual_partial_shadow_full_fail);
+  store_zero(last_success_stats.actual_partial_shadow_full_ns);
   store_zero(last_success_stats.actual_partial_train_ns);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
@@ -757,6 +780,12 @@ void reset_guard_lookup_stats() {
     guard_last_success_mismatch_reason_stats().clear();
     guard_last_success_mismatch_kind_stats().clear();
     guard_last_success_mismatch_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_partial_shadow_stats_mutex());
+    guard_last_success_partial_shadow_fail_reason_stats().clear();
+    guard_last_success_partial_shadow_fail_path_stats().clear();
   }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
@@ -1048,6 +1077,52 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.actual_partial_token_check_ns);
   result["guard_last_success_actual_partial_residual_ns"] =
       load_relaxed(last_success_stats.actual_partial_residual_ns);
+  result["guard_last_success_actual_partial_shadow_full_pass"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_pass);
+  result["guard_last_success_actual_partial_shadow_full_fail"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_fail);
+  result["guard_last_success_actual_partial_shadow_full_ns"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_ns);
+  py::dict last_success_partial_shadow_fail_reasons;
+  py::dict last_success_partial_shadow_fail_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_partial_shadow_stats_mutex());
+      for (const auto& item :
+           guard_last_success_partial_shadow_fail_reason_stats()) {
+        last_success_partial_shadow_fail_reasons[py::str(item.first)] =
+            item.second;
+      }
+      path_items.reserve(
+          guard_last_success_partial_shadow_fail_path_stats().size());
+      for (const auto& item :
+           guard_last_success_partial_shadow_fail_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      last_success_partial_shadow_fail_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
+  }
+  result["guard_last_success_actual_partial_shadow_fail_reasons"] =
+      last_success_partial_shadow_fail_reasons;
+  result["guard_last_success_actual_partial_shadow_fail_top_paths"] =
+      last_success_partial_shadow_fail_top_paths;
   result["guard_last_success_actual_partial_train_ns"] =
       load_relaxed(last_success_stats.actual_partial_train_ns);
   py::dict last_success_disabled_reasons;
@@ -4585,6 +4660,52 @@ class GuardDebugInfo {
   // shuffling is working.
   int num_guards_executed;
 };
+
+static std::string guard_debug_info_first_reason(
+    const GuardDebugInfo& debug_info) {
+  Py_ssize_t size = PyList_Size(debug_info.verbose_code_parts.ptr());
+  if (size <= 0) {
+    PyErr_Clear();
+    return "unknown_guard_failure";
+  }
+  PyObject* item = PyList_GetItem(debug_info.verbose_code_parts.ptr(), 0);
+  if (item == nullptr) {
+    PyErr_Clear();
+    return "unknown_guard_failure";
+  }
+  try {
+    return py::str(py::handle(item)).cast<std::string>();
+  } catch (py::error_already_set& e) {
+    e.clear();
+    return "unknown_guard_failure";
+  }
+}
+
+static void record_guard_last_success_actual_partial_shadow_full(
+    bool shadow_result,
+    uint64_t shadow_ns,
+    const std::string& failure_reason = "") {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_shadow_full_ns, shadow_ns);
+  if (shadow_result) {
+    add_relaxed(stats.actual_partial_shadow_full_pass, 1);
+    return;
+  }
+  add_relaxed(stats.actual_partial_shadow_full_fail, 1);
+  const std::string reason =
+      failure_reason.empty() ? "unknown_guard_failure" : failure_reason;
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_partial_shadow_stats_mutex());
+  guard_last_success_partial_shadow_fail_reason_stats()[reason] += 1;
+  auto& path_stats = guard_last_success_partial_shadow_fail_path_stats()[reason];
+  path_stats.count += 1;
+  if (path_stats.reason.empty()) {
+    path_stats.reason = reason;
+  }
+}
 
 class GuardManager;
 class RootGuardManager;
@@ -9726,6 +9847,32 @@ bool run_root_guard_manager_with_last_success_receipt(
       } else {
         record_guard_last_success_actual_partial_residual_fail(
             token_check_ns, residual_ns);
+      }
+      if (residual_result && C10_UNLIKELY(guard_lookup_stats_enabled())) {
+        const uint64_t shadow_full_start_ns = guard_lookup_time_ns();
+        bool shadow_full_result = false;
+        {
+          std::vector<GuardSubtreeEntryToken> shadow_full_tokens;
+          GuardSubtreeMemoRecorderScope shadow_full_recorder(
+              &shadow_full_tokens);
+          shadow_full_result = run_root_guard_manager(root, f_locals);
+        }
+        const uint64_t shadow_full_ns =
+            guard_lookup_time_ns() - shadow_full_start_ns;
+        if (shadow_full_result) {
+          record_guard_last_success_actual_partial_shadow_full(
+              true, shadow_full_ns);
+        } else {
+          std::string failure_reason = "unknown_guard_failure";
+          py::handle f_locals_dict = (PyObject*)f_locals->to_dict();
+          GuardDebugInfo debug_info =
+              root_mgr->check_verbose_nopybind(f_locals_dict.ptr());
+          if (!debug_info.result) {
+            failure_reason = guard_debug_info_first_reason(debug_info);
+          }
+          record_guard_last_success_actual_partial_shadow_full(
+              false, shadow_full_ns, failure_reason);
+        }
       }
       return residual_result;
     }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -122,6 +122,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   TensorMatch,
   DefaultDevice,
   GlobalState,
+  TorchFunctionModeStack,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -162,6 +163,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_tensor_match{0};
   std::atomic<uint64_t> token_default_device{0};
   std::atomic<uint64_t> token_global_state{0};
+  std::atomic<uint64_t> token_torch_function_mode_stack{0};
 };
 
 struct GuardFastPlanStats {
@@ -257,6 +259,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_tensor_match{0};
   uint64_t token_default_device{0};
   uint64_t token_global_state{0};
+  uint64_t token_torch_function_mode_stack{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -502,6 +505,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_tensor_match);
   store_zero(subtree_stats.token_default_device);
   store_zero(subtree_stats.token_global_state);
+  store_zero(subtree_stats.token_torch_function_mode_stack);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -639,6 +643,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_default_device);
   subtree_token_kind_counts["GlobalState"] =
       load_relaxed(subtree_stats.token_global_state);
+  subtree_token_kind_counts["TorchFunctionModeStack"] =
+      load_relaxed(subtree_stats.token_torch_function_mode_stack);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -1006,6 +1012,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::GlobalState:
       add_relaxed(stats.token_global_state, 1);
       break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      add_relaxed(stats.token_torch_function_mode_stack, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1033,6 +1042,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::GlobalState:
       stats.token_global_state += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      stats.token_torch_function_mode_stack += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2166,6 +2178,8 @@ static bool default_device_matches(
   return result == 1;
 }
 
+static bool torch_function_mode_stack_guard_matches(const void* guard);
+
 struct GuardSubtreeEntryToken {
   PyObject* object{nullptr};
   PyTypeObject* type{nullptr};
@@ -2185,6 +2199,7 @@ struct GuardSubtreeEntryToken {
   PyObject* default_device_dict{nullptr};
   PyObject* default_device{nullptr};
   GlobalStateGuard* global_state_guard{nullptr};
+  const void* torch_function_mode_stack_guard{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -2274,6 +2289,14 @@ struct GuardSubtreeEntryToken {
     GuardSubtreeEntryToken token;
     token.kind = GuardSubtreeProbeTokenKind::GlobalState;
     token.global_state_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_torch_function_mode_stack(
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::TorchFunctionModeStack;
+    token.torch_function_mode_stack_guard = guard;
     return token;
   }
 
@@ -2368,6 +2391,10 @@ struct GuardSubtreeEntryToken {
     if (kind == GuardSubtreeProbeTokenKind::GlobalState) {
       return global_state_guard == other.global_state_guard;
     }
+    if (kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      return torch_function_mode_stack_guard ==
+          other.torch_function_mode_stack_guard;
+    }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
   }
@@ -2461,6 +2488,13 @@ static bool guard_subtree_memo_tokens_match(
     }
     if (token.kind == GuardSubtreeProbeTokenKind::GlobalState) {
       if (!token.matches_global_state_current()) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      if (!torch_function_mode_stack_guard_matches(
+              token.torch_function_mode_stack_guard)) {
         return false;
       }
       continue;
@@ -5704,7 +5738,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   }
 
   template <typename T>
-  bool check_nopybind_template(T* value) {
+  bool check_nopybind_template(T* value) const {
     // Ignore value arg, only used to satisfy the interface
     const size_t len = (size_t)at::impl::PythonTorchFunctionTLS::stack_len();
     const size_t ref_stack_size = this->_ref_stack.size();
@@ -5735,15 +5769,50 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   }
 
   bool supports_subtree_memo() const override {
-    return false;
+    return true;
   }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:TORCH_FUNCTION_MODE_STACK";
   }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
 
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    tokens->emplace_back(
+        GuardSubtreeEntryToken::make_torch_function_mode_stack(
+            static_cast<const void*>(this)));
+    return true;
+  }
+
   std::vector<PyTypeObject*> _ref_stack;
 };
+
+static bool torch_function_mode_stack_guard_matches(const void* guard) {
+  return guard != nullptr &&
+      static_cast<const TORCH_FUNCTION_MODE_STACK*>(guard)
+          ->check_nopybind_template(nullptr);
+}
 
 class DISPATCH_KEY_SET_MATCH : public LeafGuard {
  public:

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -123,6 +123,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   DefaultDevice,
   GlobalState,
   TorchFunctionModeStack,
+  NoTensorAliasing,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -164,6 +165,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_default_device{0};
   std::atomic<uint64_t> token_global_state{0};
   std::atomic<uint64_t> token_torch_function_mode_stack{0};
+  std::atomic<uint64_t> token_no_tensor_aliasing{0};
 };
 
 struct GuardFastPlanStats {
@@ -260,6 +262,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_default_device{0};
   uint64_t token_global_state{0};
   uint64_t token_torch_function_mode_stack{0};
+  uint64_t token_no_tensor_aliasing{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -506,6 +509,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_default_device);
   store_zero(subtree_stats.token_global_state);
   store_zero(subtree_stats.token_torch_function_mode_stack);
+  store_zero(subtree_stats.token_no_tensor_aliasing);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -645,6 +649,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_global_state);
   subtree_token_kind_counts["TorchFunctionModeStack"] =
       load_relaxed(subtree_stats.token_torch_function_mode_stack);
+  subtree_token_kind_counts["NoTensorAliasing"] =
+      load_relaxed(subtree_stats.token_no_tensor_aliasing);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -1015,6 +1021,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
       add_relaxed(stats.token_torch_function_mode_stack, 1);
       break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      add_relaxed(stats.token_no_tensor_aliasing, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1045,6 +1054,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
       stats.token_torch_function_mode_stack += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      stats.token_no_tensor_aliasing += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2209,6 +2221,7 @@ struct GuardSubtreeEntryToken {
   PyObject* default_device{nullptr};
   GlobalStateGuard* global_state_guard{nullptr};
   const void* torch_function_mode_stack_guard{nullptr};
+  const void* no_tensor_aliasing_guard{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -2309,6 +2322,17 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_no_tensor_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::NoTensorAliasing;
+    token.no_tensor_aliasing_guard = guard;
+    return token;
+  }
+
   bool matches_tensor_current(
       const LocalState* state,
       GuardFastPlanTensorTokenMissReason& reason) const {
@@ -2403,6 +2427,9 @@ struct GuardSubtreeEntryToken {
     if (kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
       return torch_function_mode_stack_guard ==
           other.torch_function_mode_stack_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+      return no_tensor_aliasing_guard == other.no_tensor_aliasing_guard;
     }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
@@ -2504,6 +2531,12 @@ static bool guard_subtree_memo_tokens_match(
     if (token.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
       if (!torch_function_mode_stack_guard_matches(
               token.torch_function_mode_stack_guard)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+      if (token.object == nullptr || Py_TYPE(token.object) != token.type) {
         return false;
       }
       continue;
@@ -3815,8 +3848,24 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     _unique_tensors.clear();
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:NO_TENSOR_ALIASING";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    tokens->emplace_back(GuardSubtreeEntryToken::make_no_tensor_aliasing(
+        value, static_cast<const void*>(this)));
+    return true;
   }
 
  private:

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -126,6 +126,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   NoTensorAliasing,
   ObjectAliasing,
   BoundMethod,
+  FrameGlobals,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -191,6 +192,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_no_tensor_aliasing{0};
   std::atomic<uint64_t> token_object_aliasing{0};
   std::atomic<uint64_t> token_bound_method{0};
+  std::atomic<uint64_t> token_frame_globals{0};
 };
 
 struct GuardFastPlanStats {
@@ -295,6 +297,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_no_tensor_aliasing{0};
   uint64_t token_object_aliasing{0};
   uint64_t token_bound_method{0};
+  uint64_t token_frame_globals{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -577,6 +580,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_no_tensor_aliasing);
   store_zero(subtree_stats.token_object_aliasing);
   store_zero(subtree_stats.token_bound_method);
+  store_zero(subtree_stats.token_frame_globals);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -734,6 +738,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_object_aliasing);
   subtree_token_kind_counts["BoundMethod"] =
       load_relaxed(subtree_stats.token_bound_method);
+  subtree_token_kind_counts["FrameGlobals"] =
+      load_relaxed(subtree_stats.token_frame_globals);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -1000,6 +1006,7 @@ py::dict get_guard_lookup_stats() {
           items[i].second.token_no_tensor_aliasing;
       token_counts["ObjectAliasing"] = items[i].second.token_object_aliasing;
       token_counts["BoundMethod"] = items[i].second.token_bound_method;
+      token_counts["FrameGlobals"] = items[i].second.token_frame_globals;
       item_stats["token_kind_counts"] = token_counts;
       path_stats[py::str(items[i].first)] = item_stats;
     }
@@ -1126,6 +1133,8 @@ static const char* guard_subtree_token_kind_name(
       return "ObjectAliasing";
     case GuardSubtreeProbeTokenKind::BoundMethod:
       return "BoundMethod";
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      return "FrameGlobals";
   }
   return "Unknown";
 }
@@ -1243,6 +1252,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::BoundMethod:
       add_relaxed(stats.token_bound_method, 1);
       break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      add_relaxed(stats.token_frame_globals, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1282,6 +1294,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::BoundMethod:
       stats.token_bound_method += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      stats.token_frame_globals += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2550,6 +2565,19 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_for_source(
+      PyObject* obj,
+      const std::string& source) {
+    if (source == "G" && PyDict_CheckExact(obj)) {
+      GuardSubtreeEntryToken token;
+      token.object = obj;
+      token.type = Py_TYPE(obj);
+      token.kind = GuardSubtreeProbeTokenKind::FrameGlobals;
+      return token;
+    }
+    return make(obj);
+  }
+
   static bool make_tensor_match(
       PyObject* obj,
       TensorCheck& tensor_check,
@@ -2731,6 +2759,9 @@ struct GuardSubtreeEntryToken {
     }
     if (object != other.object) {
       return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      return true;
     }
     if (kind == GuardSubtreeProbeTokenKind::TensorMatch) {
       return tensor_dispatch_key == other.tensor_dispatch_key &&
@@ -3017,6 +3048,13 @@ static bool guard_subtree_memo_tokens_match(
          token.kind == GuardSubtreeProbeTokenKind::BoundMethod)) {
       // Parent tokens prove whether this non-root object is still reachable.
       continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      // FrameGlobals is only safe for full slow-guard receipt comparison,
+      // where every run records a fresh child token vector. Existing hot
+      // memo checks rely on exact parent container tokens to prove non-root
+      // ObjectOnly tokens are still reachable.
+      return false;
     }
     GuardSubtreeEntryToken current =
         GuardSubtreeEntryToken::make(i == 0 ? root_value : token.object);
@@ -4935,7 +4973,9 @@ class GuardManager {
       if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
         append_guard_subtree_memo_token(
             active_guard_subtree_memo_recorder,
-            GuardSubtreeEntryToken::make(value),
+            active_guard_subtree_memo_debug_paths != nullptr
+                ? GuardSubtreeEntryToken::make_for_source(value, _source)
+                : GuardSubtreeEntryToken::make(value),
             _source);
       }
     }
@@ -5108,7 +5148,9 @@ class GuardManager {
       const GuardSubtreeMemoState& memo,
       std::vector<GuardSubtreeEntryToken>* tokens) {
     append_guard_subtree_memo_token(
-        tokens, GuardSubtreeEntryToken::make(value), _source);
+        tokens,
+        GuardSubtreeEntryToken::make(value),
+        _source);
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
     }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -37,7 +37,6 @@
 #include <mutex>
 #include <optional>
 #include <sstream>
-#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -214,6 +213,7 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> shadow_max_passes{0};
   std::atomic<uint64_t> token_count_sum{0};
   std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> support_check_ns{0};
   std::atomic<uint64_t> receipt_update_ns{0};
   std::atomic<uint64_t> receipt_compare_ns{0};
 };
@@ -543,6 +543,7 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.shadow_max_passes);
   store_zero(last_success_stats.token_count_sum);
   store_zero(last_success_stats.token_cap_disabled);
+  store_zero(last_success_stats.support_check_ns);
   store_zero(last_success_stats.receipt_update_ns);
   store_zero(last_success_stats.receipt_compare_ns);
   {
@@ -759,6 +760,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.token_count_sum);
   result["guard_last_success_token_cap_disabled"] =
       load_relaxed(last_success_stats.token_cap_disabled);
+  result["guard_last_success_support_check_ns"] =
+      load_relaxed(last_success_stats.support_check_ns);
   result["guard_last_success_receipt_update_ns"] =
       load_relaxed(last_success_stats.receipt_update_ns);
   result["guard_last_success_receipt_compare_ns"] =
@@ -1237,15 +1240,25 @@ static void record_guard_last_success_shadow_reset() {
   add_relaxed(guard_last_success_stats().shadow_reset, 1);
 }
 
+static void record_guard_last_success_support_check(uint64_t check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().support_check_ns, check_ns);
+}
+
 static void record_guard_last_success_incomplete(
     const char* reason,
     const std::string& path = "") {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
+  if (reason == nullptr) {
+    reason = "unsupported:unknown";
+  }
   auto& stats = guard_last_success_stats();
   add_relaxed(stats.shadow_incomplete, 1);
-  if (std::string_view(reason) == "token_cap_exceeded") {
+  if (std::strcmp(reason, "token_cap_exceeded") == 0) {
     add_relaxed(stats.token_cap_disabled, 1);
   }
   std::lock_guard<std::mutex> lock(
@@ -2067,14 +2080,34 @@ static bool tensor_layout_does_not_support_stride(const at::Tensor& tensor) {
       tensor.layout() == c10::kSparseBsr;
 }
 
-static std::vector<c10::SymInt> tensor_strides_for_guard_check(
-    const at::Tensor& tensor) {
-  if (tensor_layout_does_not_support_stride(tensor)) {
-    return std::vector<c10::SymInt>(
-        tensor.ndimension(), c10::SymInt(static_cast<int64_t>(-1)));
+static bool tensor_strides_match_guard_check(
+    const at::Tensor& tensor,
+    const std::vector<int64_t>& stride_indices,
+    const std::vector<c10::SymInt>& stride_values) {
+  if (stride_indices.size() != stride_values.size()) {
+    return false;
   }
-  auto strides = tensor.sym_strides();
-  return std::vector<c10::SymInt>(strides.begin(), strides.end());
+  if (tensor_layout_does_not_support_stride(tensor)) {
+    const int64_t ndim = tensor.ndimension();
+    const c10::SymInt unsupported_stride(static_cast<int64_t>(-1));
+    for (auto i : c10::irange(stride_indices.size())) {
+      const int64_t index = stride_indices[i];
+      if (index < 0 || index >= ndim ||
+          stride_values[i] != unsupported_stride) {
+        return false;
+      }
+    }
+    return true;
+  }
+  const auto current_strides = tensor.sym_strides();
+  for (auto i : c10::irange(stride_indices.size())) {
+    const int64_t index = stride_indices[i];
+    if (index < 0 || index >= static_cast<int64_t>(current_strides.size()) ||
+        stride_values[i] != current_strides[index]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 struct GuardSubtreeEntryToken {
@@ -2219,16 +2252,10 @@ struct GuardSubtreeEntryToken {
       }
     }
 
-    const std::vector<c10::SymInt> current_strides =
-        tensor_strides_for_guard_check(tensor);
-    for (auto i : c10::irange(tensor_stride_indices.size())) {
-      const int64_t index = tensor_stride_indices[i];
-      if (index < 0 ||
-          index >= static_cast<int64_t>(current_strides.size()) ||
-          tensor_stride_values[i] != current_strides[index]) {
-        reason = GuardFastPlanTensorTokenMissReason::Stride;
-        return false;
-      }
+    if (!tensor_strides_match_guard_check(
+            tensor, tensor_stride_indices, tensor_stride_values)) {
+      reason = GuardFastPlanTensorTokenMissReason::Stride;
+      return false;
     }
     return true;
   }
@@ -7760,7 +7787,11 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
   GuardSubtreeMemoSupportAnalysis analysis;
-  if (!root_mgr->supports_subtree_memo_recursive(&analysis)) {
+  const uint64_t support_start_ns = guard_lookup_time_ns();
+  const bool supported = root_mgr->supports_subtree_memo_recursive(&analysis);
+  record_guard_last_success_support_check(
+      guard_lookup_time_ns() - support_start_ns);
+  if (!supported) {
     record_guard_last_success_incomplete(
         analysis.reason.empty() ? "unsupported:unknown"
                                 : analysis.reason.c_str(),
@@ -7771,6 +7802,8 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   std::vector<GuardSubtreeEntryToken> tokens;
   {
+    // This receipt is shadow-only diagnostics. The recorder deliberately
+    // disables nested manager fastplan so it can observe the full guard tree.
     GuardSubtreeMemoRecorderScope recorder(&tokens);
     const bool result = run_root_guard_manager(root, f_locals);
     if (!result) {
@@ -7785,7 +7818,7 @@ bool run_root_guard_manager_with_last_success_receipt(
     return true;
   }
   if (tokens.size() > kGuardFastPlanMaxTokens) {
-    record_guard_last_success_incomplete("token_cap_exceeded");
+    record_guard_last_success_incomplete("token_cap_exceeded", "L");
     state->reset();
     return true;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1396,10 +1396,19 @@ static GuardFastPlanCandidateKind compute_guard_fastplan_candidate_kind(
   return GuardFastPlanCandidateKind::NestedModules;
 }
 
+static bool source_ends_with(
+    const std::string& source,
+    const char* suffix) {
+  const size_t suffix_len = std::strlen(suffix);
+  return source.size() >= suffix_len &&
+      source.compare(source.size() - suffix_len, suffix_len, suffix) == 0;
+}
+
 static bool tensor_match_source_supports_subtree_memo(
     const std::string& source) {
   return source.find("._parameters[") != std::string::npos ||
-      source.find("._buffers[") != std::string::npos;
+      source.find("._buffers[") != std::string::npos ||
+      source_ends_with(source, "._cached_tensor");
 }
 
 std::string guard_accessor_stats_key(PyObject* key) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -223,6 +223,8 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> shadow_max_passes{0};
   std::atomic<uint64_t> token_count_sum{0};
   std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> token_cap_count_sum{0};
+  std::atomic<uint64_t> token_cap_count_max{0};
   std::atomic<uint64_t> support_check_ns{0};
   std::atomic<uint64_t> receipt_update_ns{0};
   std::atomic<uint64_t> receipt_compare_ns{0};
@@ -272,6 +274,7 @@ constexpr size_t kGuardAccessorDetailStatsTopK = 64;
 constexpr size_t kGuardSubtreeProbeTopK = 64;
 constexpr size_t kGuardFastPlanDisabledTopK = 64;
 constexpr size_t kGuardFastPlanMaxTokens = 1024;
+constexpr size_t kGuardLastSuccessShadowMaxTokens = 65536;
 constexpr size_t kGuardSubtreeMemoSupportAnalysisMaxItems = 1024;
 
 struct GuardSubtreeMemoSupportAnalysis {
@@ -572,6 +575,8 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.shadow_max_passes);
   store_zero(last_success_stats.token_count_sum);
   store_zero(last_success_stats.token_cap_disabled);
+  store_zero(last_success_stats.token_cap_count_sum);
+  store_zero(last_success_stats.token_cap_count_max);
   store_zero(last_success_stats.support_check_ns);
   store_zero(last_success_stats.receipt_update_ns);
   store_zero(last_success_stats.receipt_compare_ns);
@@ -799,6 +804,10 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.token_count_sum);
   result["guard_last_success_token_cap_disabled"] =
       load_relaxed(last_success_stats.token_cap_disabled);
+  result["guard_last_success_token_cap_count_sum"] =
+      load_relaxed(last_success_stats.token_cap_count_sum);
+  result["guard_last_success_token_cap_count_max"] =
+      load_relaxed(last_success_stats.token_cap_count_max);
   result["guard_last_success_support_check_ns"] =
       load_relaxed(last_success_stats.support_check_ns);
   result["guard_last_success_receipt_update_ns"] =
@@ -1334,7 +1343,8 @@ static void record_guard_last_success_disabled_item_locked(
 
 static void record_guard_last_success_incomplete(
     const char* reason,
-    const std::string& path = "") {
+    const std::string& path = "",
+    size_t token_count = 0) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
@@ -1345,6 +1355,8 @@ static void record_guard_last_success_incomplete(
   add_relaxed(stats.shadow_incomplete, 1);
   if (std::strcmp(reason, "token_cap_exceeded") == 0) {
     add_relaxed(stats.token_cap_disabled, 1);
+    add_relaxed(stats.token_cap_count_sum, token_count);
+    max_relaxed(stats.token_cap_count_max, token_count);
   }
   std::lock_guard<std::mutex> lock(
       guard_last_success_disabled_stats_mutex());
@@ -8229,8 +8241,9 @@ bool run_root_guard_manager_with_last_success_receipt(
     state->reset();
     return true;
   }
-  if (tokens.size() > kGuardFastPlanMaxTokens) {
-    record_guard_last_success_incomplete("token_cap_exceeded", "L");
+  if (tokens.size() > kGuardLastSuccessShadowMaxTokens) {
+    record_guard_last_success_incomplete(
+        "token_cap_exceeded", "L", tokens.size());
     state->reset();
     return true;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -149,6 +149,26 @@ enum class GuardFastPlanTensorTokenMissReason : uint8_t {
   Stride,
 };
 
+enum class GuardLastSuccessCompareMismatchReason : uint8_t {
+  EntryKey,
+  RootKey,
+  EmptyPrevious,
+  Size,
+  Kind,
+  Object,
+  Type,
+  TensorMeta,
+  DefaultDevice,
+  GlobalState,
+  TorchFunctionModeStack,
+  NoTensorAliasing,
+  ObjectAliasing,
+  Version,
+  DictSize,
+  ListItems,
+  Unknown,
+};
+
 struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> attempt{0};
   std::atomic<uint64_t> entry_match{0};
@@ -228,6 +248,9 @@ struct GuardLastSuccessStats {
   std::atomic<uint64_t> support_check_ns{0};
   std::atomic<uint64_t> receipt_update_ns{0};
   std::atomic<uint64_t> receipt_compare_ns{0};
+  std::atomic<uint64_t> compare_mismatch{0};
+  std::atomic<uint64_t> compare_mismatch_index_sum{0};
+  std::atomic<uint64_t> compare_mismatch_index_max{0};
 };
 
 struct GuardFastPlanDisabledPathStats {
@@ -413,6 +436,23 @@ guard_last_success_disabled_path_stats() {
   return stats;
 }
 
+std::mutex& guard_last_success_mismatch_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_mismatch_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_mismatch_kind_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
 } // namespace
 
 bool guard_lookup_stats_enabled() {
@@ -580,6 +620,9 @@ void reset_guard_lookup_stats() {
   store_zero(last_success_stats.support_check_ns);
   store_zero(last_success_stats.receipt_update_ns);
   store_zero(last_success_stats.receipt_compare_ns);
+  store_zero(last_success_stats.compare_mismatch);
+  store_zero(last_success_stats.compare_mismatch_index_sum);
+  store_zero(last_success_stats.compare_mismatch_index_max);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -602,6 +645,12 @@ void reset_guard_lookup_stats() {
         guard_last_success_disabled_stats_mutex());
     guard_last_success_disabled_reason_stats().clear();
     guard_last_success_disabled_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_mismatch_stats_mutex());
+    guard_last_success_mismatch_reason_stats().clear();
+    guard_last_success_mismatch_kind_stats().clear();
   }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
@@ -814,6 +863,12 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(last_success_stats.receipt_update_ns);
   result["guard_last_success_receipt_compare_ns"] =
       load_relaxed(last_success_stats.receipt_compare_ns);
+  result["guard_last_success_compare_mismatch"] =
+      load_relaxed(last_success_stats.compare_mismatch);
+  result["guard_last_success_compare_mismatch_index_sum"] =
+      load_relaxed(last_success_stats.compare_mismatch_index_sum);
+  result["guard_last_success_compare_mismatch_index_max"] =
+      load_relaxed(last_success_stats.compare_mismatch_index_max);
   py::dict last_success_disabled_reasons;
   py::dict last_success_disabled_top_paths;
   {
@@ -850,6 +905,22 @@ py::dict get_guard_lookup_stats() {
       last_success_disabled_reasons;
   result["guard_last_success_disabled_top_paths"] =
       last_success_disabled_top_paths;
+  py::dict last_success_mismatch_reasons;
+  py::dict last_success_mismatch_token_kinds;
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_mismatch_stats_mutex());
+    for (const auto& item : guard_last_success_mismatch_reason_stats()) {
+      last_success_mismatch_reasons[py::str(item.first)] = item.second;
+    }
+    for (const auto& item : guard_last_success_mismatch_kind_stats()) {
+      last_success_mismatch_token_kinds[py::str(item.first)] = item.second;
+    }
+  }
+  result["guard_last_success_mismatch_reasons"] =
+      last_success_mismatch_reasons;
+  result["guard_last_success_mismatch_token_kinds"] =
+      last_success_mismatch_token_kinds;
   if (guard_subtree_probe_detail_enabled()) {
     py::dict path_stats;
     std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
@@ -982,6 +1053,74 @@ void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index) {
   add_relaxed(stats.unsafe_mock_guard_bypass_count, 1);
   add_relaxed(
       stats.unsafe_mock_guard_bypass_hit_index_sum, cache_entry_hit_index);
+}
+
+static const char* guard_subtree_token_kind_name(
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      return "ObjectOnly";
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      return "ExactDict";
+    case GuardSubtreeProbeTokenKind::ExactList:
+      return "ExactList";
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      return "ExactTuple";
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      return "TensorMatch";
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      return "DefaultDevice";
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      return "GlobalState";
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      return "TorchFunctionModeStack";
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      return "NoTensorAliasing";
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      return "ObjectAliasing";
+  }
+  return "Unknown";
+}
+
+static const char* guard_last_success_mismatch_reason_name(
+    GuardLastSuccessCompareMismatchReason reason) {
+  switch (reason) {
+    case GuardLastSuccessCompareMismatchReason::EntryKey:
+      return "entry_key";
+    case GuardLastSuccessCompareMismatchReason::RootKey:
+      return "root_key";
+    case GuardLastSuccessCompareMismatchReason::EmptyPrevious:
+      return "empty_previous";
+    case GuardLastSuccessCompareMismatchReason::Size:
+      return "size";
+    case GuardLastSuccessCompareMismatchReason::Kind:
+      return "kind";
+    case GuardLastSuccessCompareMismatchReason::Object:
+      return "object";
+    case GuardLastSuccessCompareMismatchReason::Type:
+      return "type";
+    case GuardLastSuccessCompareMismatchReason::TensorMeta:
+      return "tensor_meta";
+    case GuardLastSuccessCompareMismatchReason::DefaultDevice:
+      return "default_device";
+    case GuardLastSuccessCompareMismatchReason::GlobalState:
+      return "global_state";
+    case GuardLastSuccessCompareMismatchReason::TorchFunctionModeStack:
+      return "torch_function_mode_stack";
+    case GuardLastSuccessCompareMismatchReason::NoTensorAliasing:
+      return "no_tensor_aliasing";
+    case GuardLastSuccessCompareMismatchReason::ObjectAliasing:
+      return "object_aliasing";
+    case GuardLastSuccessCompareMismatchReason::Version:
+      return "version";
+    case GuardLastSuccessCompareMismatchReason::DictSize:
+      return "dict_size";
+    case GuardLastSuccessCompareMismatchReason::ListItems:
+      return "list_items";
+    case GuardLastSuccessCompareMismatchReason::Unknown:
+      return "unknown";
+  }
+  return "unknown";
 }
 
 void record_guard_accessor_type_stats(
@@ -1316,6 +1455,25 @@ static void record_guard_last_success_shadow_reset() {
     return;
   }
   add_relaxed(guard_last_success_stats().shadow_reset, 1);
+}
+
+static void record_guard_last_success_compare_mismatch(
+    GuardLastSuccessCompareMismatchReason reason,
+    GuardSubtreeProbeTokenKind token_kind,
+    size_t index) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.compare_mismatch, 1);
+  add_relaxed(stats.compare_mismatch_index_sum, index);
+  max_relaxed(stats.compare_mismatch_index_max, index);
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_mismatch_stats_mutex());
+  guard_last_success_mismatch_reason_stats()
+      [guard_last_success_mismatch_reason_name(reason)] += 1;
+  guard_last_success_mismatch_kind_stats()
+      [guard_subtree_token_kind_name(token_kind)] += 1;
 }
 
 static void record_guard_last_success_support_check(uint64_t check_ns) {
@@ -2516,6 +2674,73 @@ struct GuardSubtreeEntryToken {
   }
 };
 
+static GuardLastSuccessCompareMismatchReason
+guard_subtree_token_mismatch_reason(
+    const GuardSubtreeEntryToken& lhs,
+    const GuardSubtreeEntryToken& rhs) {
+  if (lhs.kind != rhs.kind) {
+    return GuardLastSuccessCompareMismatchReason::Kind;
+  }
+  if (lhs.object != rhs.object) {
+    return GuardLastSuccessCompareMismatchReason::Object;
+  }
+  if (lhs.type != rhs.type) {
+    return GuardLastSuccessCompareMismatchReason::Type;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+    if (lhs.tensor_dispatch_key != rhs.tensor_dispatch_key ||
+        lhs.tensor_dtype != rhs.tensor_dtype ||
+        lhs.tensor_device_index != rhs.tensor_device_index ||
+        lhs.tensor_requires_grad != rhs.tensor_requires_grad ||
+        lhs.tensor_dim != rhs.tensor_dim ||
+        lhs.tensor_size_indices != rhs.tensor_size_indices ||
+        lhs.tensor_size_values != rhs.tensor_size_values ||
+        lhs.tensor_stride_indices != rhs.tensor_stride_indices ||
+        lhs.tensor_stride_values != rhs.tensor_stride_values) {
+      return GuardLastSuccessCompareMismatchReason::TensorMeta;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+    if (lhs.default_device_dict != rhs.default_device_dict ||
+        lhs.default_device != rhs.default_device) {
+      return GuardLastSuccessCompareMismatchReason::DefaultDevice;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::GlobalState) {
+    return lhs.global_state_guard == rhs.global_state_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::GlobalState;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+    return lhs.torch_function_mode_stack_guard ==
+            rhs.torch_function_mode_stack_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::TorchFunctionModeStack;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+    return lhs.no_tensor_aliasing_guard == rhs.no_tensor_aliasing_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::NoTensorAliasing;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+    return lhs.object_aliasing_guard == rhs.object_aliasing_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::ObjectAliasing;
+  }
+  if (lhs.version != rhs.version) {
+    return GuardLastSuccessCompareMismatchReason::Version;
+  }
+  if (lhs.size != rhs.size) {
+    return GuardLastSuccessCompareMismatchReason::DictSize;
+  }
+  if (lhs.list_items != rhs.list_items) {
+    return GuardLastSuccessCompareMismatchReason::ListItems;
+  }
+  return GuardLastSuccessCompareMismatchReason::Unknown;
+}
+
 static bool guard_subtree_token_vectors_match(
     const std::vector<GuardSubtreeEntryToken>& lhs,
     const std::vector<GuardSubtreeEntryToken>& rhs) {
@@ -2524,6 +2749,32 @@ static bool guard_subtree_token_vectors_match(
   }
   for (size_t i = 0; i < lhs.size(); ++i) {
     if (!lhs[i].matches(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_subtree_token_vectors_match(
+    const std::vector<GuardSubtreeEntryToken>& lhs,
+    const std::vector<GuardSubtreeEntryToken>& rhs,
+    GuardLastSuccessCompareMismatchReason& reason,
+    GuardSubtreeProbeTokenKind& token_kind,
+    size_t& index) {
+  reason = GuardLastSuccessCompareMismatchReason::Unknown;
+  token_kind = GuardSubtreeProbeTokenKind::ObjectOnly;
+  index = 0;
+  if (lhs.size() != rhs.size()) {
+    reason = GuardLastSuccessCompareMismatchReason::Size;
+    index = std::min(lhs.size(), rhs.size());
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!lhs[i].matches(rhs[i])) {
+      reason = guard_subtree_token_mismatch_reason(lhs[i], rhs[i]);
+      token_kind = lhs[i].kind == rhs[i].kind ? lhs[i].kind
+                                              : GuardSubtreeProbeTokenKind::ObjectOnly;
+      index = i;
       return false;
     }
   }
@@ -2546,10 +2797,30 @@ struct GuardLastSuccessReceipt {
       bool& reset_state,
       uint64_t& compare_ns) {
     const uint64_t compare_start_ns = guard_lookup_time_ns();
-    stable = entry_key == new_entry_key && root_key == new_root_key &&
-        !tokens.empty() && guard_subtree_token_vectors_match(tokens, new_tokens);
+    GuardLastSuccessCompareMismatchReason mismatch_reason =
+        GuardLastSuccessCompareMismatchReason::Unknown;
+    GuardSubtreeProbeTokenKind mismatch_kind =
+        GuardSubtreeProbeTokenKind::ObjectOnly;
+    size_t mismatch_index = 0;
+    if (entry_key != new_entry_key) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::EntryKey;
+    } else if (root_key != new_root_key) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::RootKey;
+    } else if (tokens.empty()) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::EmptyPrevious;
+    } else {
+      stable = guard_subtree_token_vectors_match(
+          tokens, new_tokens, mismatch_reason, mismatch_kind, mismatch_index);
+    }
     compare_ns = guard_lookup_time_ns() - compare_start_ns;
     reset_state = !stable && !tokens.empty();
+    if (!stable) {
+      record_guard_last_success_compare_mismatch(
+          mismatch_reason, mismatch_kind, mismatch_index);
+    }
 
     if (stable) {
       shadow_passes += 1;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -148,6 +148,11 @@ struct GuardFastPlanStats {
   std::atomic<uint64_t> slow_check_ns{0};
 };
 
+struct GuardFastPlanDisabledPathStats {
+  uint64_t count{0};
+  std::string reason;
+};
+
 struct GuardAccessorTypeStats {
   uint64_t count{0};
   uint64_t fail_count{0};
@@ -179,6 +184,20 @@ struct GuardSubtreeProbePathStats {
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
 constexpr size_t kGuardSubtreeProbeTopK = 64;
+constexpr size_t kGuardFastPlanDisabledTopK = 64;
+
+struct GuardSubtreeMemoSupportAnalysis {
+  std::string reason;
+  std::string path;
+
+  void set_if_empty(const char* new_reason, const std::string& new_path) {
+    if (!reason.empty()) {
+      return;
+    }
+    reason = new_reason == nullptr ? "unsupported:unknown" : new_reason;
+    path = new_path;
+  }
+};
 
 GuardLookupStats& guard_lookup_stats() {
   static GuardLookupStats stats;
@@ -242,6 +261,23 @@ std::mutex& guard_subtree_probe_path_stats_mutex() {
 std::unordered_map<std::string, GuardSubtreeProbePathStats>&
 guard_subtree_probe_path_stats() {
   static std::unordered_map<std::string, GuardSubtreeProbePathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_fastplan_disabled_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_fastplan_disabled_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_fastplan_disabled_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
   return stats;
 }
 
@@ -372,6 +408,11 @@ void reset_guard_lookup_stats() {
     std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
     guard_subtree_probe_path_stats().clear();
   }
+  {
+    std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+    guard_fastplan_disabled_reason_stats().clear();
+    guard_fastplan_disabled_path_stats().clear();
+  }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
 
@@ -447,6 +488,38 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(fastplan_stats.token_check_ns);
   result["guard_fastplan_slow_check_ns"] =
       load_relaxed(fastplan_stats.slow_check_ns);
+  py::dict fastplan_disabled_reasons;
+  py::dict fastplan_disabled_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+      for (const auto& item : guard_fastplan_disabled_reason_stats()) {
+        fastplan_disabled_reasons[py::str(item.first)] = item.second;
+      }
+      path_items.reserve(guard_fastplan_disabled_path_stats().size());
+      for (const auto& item : guard_fastplan_disabled_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      fastplan_disabled_top_paths[py::str(path_items[i].first)] = item_stats;
+    }
+  }
+  result["guard_fastplan_disabled_reasons"] = fastplan_disabled_reasons;
+  result["guard_fastplan_disabled_top_paths"] = fastplan_disabled_top_paths;
   if (guard_subtree_probe_detail_enabled()) {
     py::dict path_stats;
     std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
@@ -735,11 +808,25 @@ static void record_guard_fastplan_enable() {
   add_relaxed(guard_fastplan_stats().enable, 1);
 }
 
-static void record_guard_fastplan_disabled() {
+static void record_guard_fastplan_disabled(
+    const GuardSubtreeMemoSupportAnalysis& analysis) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
   add_relaxed(guard_fastplan_stats().disabled, 1);
+  if (analysis.reason.empty()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+  guard_fastplan_disabled_reason_stats()[analysis.reason] += 1;
+  if (!analysis.path.empty()) {
+    auto& path_stats = guard_fastplan_disabled_path_stats()[analysis.path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = analysis.reason;
+    }
+  }
 }
 
 static void record_guard_fastplan_hit(
@@ -2220,6 +2307,9 @@ class LeafGuard {
   virtual bool supports_subtree_memo() const {
     return true;
   }
+  virtual const char* subtree_memo_unsupported_reason() const {
+    return "unsupported_leaf:LeafGuard";
+  }
 
   virtual ~LeafGuard() = default;
 
@@ -2286,6 +2376,9 @@ class LAMBDA_GUARD : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:LAMBDA_GUARD";
   }
 
  private:
@@ -2544,6 +2637,9 @@ class DEFAULT_DEVICE : public LeafGuard {
   bool supports_subtree_memo() const override {
     return false;
   }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DEFAULT_DEVICE";
+  }
 
  private:
   // Save the current device and the module dict during the guard construction.
@@ -2580,6 +2676,9 @@ class GLOBAL_STATE : public LeafGuard {
   bool supports_subtree_memo() const override {
     return false;
   }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:GLOBAL_STATE";
+  }
 
  private:
   std::unique_ptr<GlobalStateGuard> _guard;
@@ -2606,6 +2705,9 @@ class DATA_PTR_MATCH : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DATA_PTR_MATCH";
   }
 
  private:
@@ -2678,6 +2780,9 @@ class RelationalGuard : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:RelationalGuard";
   }
 
   // reset the relational guard state on guard failure. This is called by the
@@ -2941,6 +3046,9 @@ class DYNAMIC_INDICES : public LeafGuard {
   bool supports_subtree_memo() const override {
     return false;
   }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DYNAMIC_INDICES";
+  }
 
  private:
   py::set _dynamic_indices;
@@ -3031,6 +3139,9 @@ class GuardAccessor {
   bool check_child_manager_nopybind(PyObject* obj);
   virtual bool supports_subtree_memo() const {
     return true;
+  }
+  virtual const char* subtree_memo_unsupported_reason() const {
+    return "unsupported_accessor:GuardAccessor";
   }
   virtual const char* stats_name() const {
     return "GuardAccessor";
@@ -3302,17 +3413,31 @@ class GuardManager {
     return _source.find("._modules[") == std::string::npos;
   }
 
-  virtual bool supports_subtree_memo_recursive() const {
+  virtual bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const {
     for (const auto& guard : _leaf_guards) {
       if (!guard->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), _source);
+        }
         return false;
       }
     }
     for (const auto& accessor : _accessors) {
       if (!accessor->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        }
         return false;
       }
-      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive()) {
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              analysis)) {
+        if (analysis != nullptr && analysis->path.empty()) {
+          analysis->path = accessor->get_source();
+        }
         return false;
       }
     }
@@ -3330,10 +3455,14 @@ class GuardManager {
     if (collect_stats) {
       record_guard_fastplan_candidate();
     }
-    if (memo.tokens.empty() && !supports_subtree_memo_recursive()) {
+    GuardSubtreeMemoSupportAnalysis analysis;
+    GuardSubtreeMemoSupportAnalysis* analysis_ptr =
+        collect_stats ? &analysis : nullptr;
+    if (memo.tokens.empty() &&
+        !supports_subtree_memo_recursive(analysis_ptr)) {
       memo.disabled = true;
       if (collect_stats) {
-        record_guard_fastplan_disabled();
+        record_guard_fastplan_disabled(analysis);
       }
       return check_nopybind(value);
     }
@@ -4261,17 +4390,20 @@ class DictGuardManager : public GuardManager {
     return _is_exact_dict_type;
   }
 
-  bool supports_subtree_memo_recursive() const override {
-    if (!GuardManager::supports_subtree_memo_recursive()) {
+  bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const override {
+    if (!GuardManager::supports_subtree_memo_recursive(analysis)) {
       return false;
     }
     for (const auto& item : _key_value_managers) {
       const auto& key_manager = item.second.first;
-      if (key_manager && !key_manager->supports_subtree_memo_recursive()) {
+      if (key_manager && !key_manager->supports_subtree_memo_recursive(
+                             analysis)) {
         return false;
       }
       const auto& value_manager = item.second.second;
-      if (value_manager && !value_manager->supports_subtree_memo_recursive()) {
+      if (value_manager && !value_manager->supports_subtree_memo_recursive(
+                               analysis)) {
         return false;
       }
     }
@@ -4479,6 +4611,9 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   bool supports_subtree_memo() const override {
     return false;
   }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:TORCH_FUNCTION_MODE_STACK";
+  }
 
  private:
   std::vector<PyTypeObject*> _ref_stack;
@@ -4505,6 +4640,9 @@ class DISPATCH_KEY_SET_MATCH : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DISPATCH_KEY_SET_MATCH";
   }
 
  private:
@@ -4593,6 +4731,9 @@ class TENSOR_MATCH : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:TENSOR_MATCH";
   }
 
  private:
@@ -6333,6 +6474,9 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
   bool supports_subtree_memo() const override {
     return false;
   }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_accessor:CallFunctionNoArgsGuardAccessor";
+  }
 
  public: // cloning functions
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
@@ -6410,6 +6554,9 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_accessor:PythonLambdaGuardAccessor";
   }
 
  public: // cloning functions

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -453,6 +453,12 @@ guard_last_success_mismatch_kind_stats() {
   return stats;
 }
 
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_mismatch_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
 } // namespace
 
 bool guard_lookup_stats_enabled() {
@@ -651,6 +657,7 @@ void reset_guard_lookup_stats() {
         guard_last_success_mismatch_stats_mutex());
     guard_last_success_mismatch_reason_stats().clear();
     guard_last_success_mismatch_kind_stats().clear();
+    guard_last_success_mismatch_path_stats().clear();
   }
   guard_lookup_stats_force_enabled().store(true, std::memory_order_relaxed);
 }
@@ -907,6 +914,7 @@ py::dict get_guard_lookup_stats() {
       last_success_disabled_top_paths;
   py::dict last_success_mismatch_reasons;
   py::dict last_success_mismatch_token_kinds;
+  py::dict last_success_mismatch_top_paths;
   {
     std::lock_guard<std::mutex> lock(
         guard_last_success_mismatch_stats_mutex());
@@ -916,11 +924,34 @@ py::dict get_guard_lookup_stats() {
     for (const auto& item : guard_last_success_mismatch_kind_stats()) {
       last_success_mismatch_token_kinds[py::str(item.first)] = item.second;
     }
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    path_items.reserve(guard_last_success_mismatch_path_stats().size());
+    for (const auto& item : guard_last_success_mismatch_path_stats()) {
+      path_items.emplace_back(item.first, item.second);
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      last_success_mismatch_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
   }
   result["guard_last_success_mismatch_reasons"] =
       last_success_mismatch_reasons;
   result["guard_last_success_mismatch_token_kinds"] =
       last_success_mismatch_token_kinds;
+  result["guard_last_success_mismatch_top_paths"] =
+      last_success_mismatch_top_paths;
   if (guard_subtree_probe_detail_enabled()) {
     py::dict path_stats;
     std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
@@ -1460,7 +1491,8 @@ static void record_guard_last_success_shadow_reset() {
 static void record_guard_last_success_compare_mismatch(
     GuardLastSuccessCompareMismatchReason reason,
     GuardSubtreeProbeTokenKind token_kind,
-    size_t index) {
+    size_t index,
+    const std::string& path) {
   if (!guard_lookup_stats_enabled()) {
     return;
   }
@@ -1474,6 +1506,13 @@ static void record_guard_last_success_compare_mismatch(
       [guard_last_success_mismatch_reason_name(reason)] += 1;
   guard_last_success_mismatch_kind_stats()
       [guard_subtree_token_kind_name(token_kind)] += 1;
+  if (!path.empty()) {
+    auto& path_stats = guard_last_success_mismatch_path_stats()[path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = guard_last_success_mismatch_reason_name(reason);
+    }
+  }
 }
 
 static void record_guard_last_success_support_check(uint64_t check_ns) {
@@ -2787,12 +2826,14 @@ struct GuardLastSuccessReceipt {
     root_key = nullptr;
     shadow_passes = 0;
     tokens.clear();
+    debug_paths.clear();
   }
 
   uint64_t update(
       void* new_entry_key,
       void* new_root_key,
       std::vector<GuardSubtreeEntryToken>&& new_tokens,
+      std::vector<std::string>&& new_debug_paths,
       bool& stable,
       bool& reset_state,
       uint64_t& compare_ns) {
@@ -2818,8 +2859,17 @@ struct GuardLastSuccessReceipt {
     compare_ns = guard_lookup_time_ns() - compare_start_ns;
     reset_state = !stable && !tokens.empty();
     if (!stable) {
+      const std::string* mismatch_path = nullptr;
+      if (mismatch_index < new_debug_paths.size()) {
+        mismatch_path = &new_debug_paths[mismatch_index];
+      } else if (mismatch_index < debug_paths.size()) {
+        mismatch_path = &debug_paths[mismatch_index];
+      }
       record_guard_last_success_compare_mismatch(
-          mismatch_reason, mismatch_kind, mismatch_index);
+          mismatch_reason,
+          mismatch_kind,
+          mismatch_index,
+          mismatch_path == nullptr ? std::string() : *mismatch_path);
     }
 
     if (stable) {
@@ -2828,6 +2878,7 @@ struct GuardLastSuccessReceipt {
       entry_key = new_entry_key;
       root_key = new_root_key;
       tokens = std::move(new_tokens);
+      debug_paths = std::move(new_debug_paths);
       shadow_passes = 1;
     }
     return shadow_passes;
@@ -2837,6 +2888,7 @@ struct GuardLastSuccessReceipt {
   void* root_key{nullptr};
   uint64_t shadow_passes{0};
   std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<std::string> debug_paths;
 };
 
 extern thread_local const LocalState* active_guard_local_state;
@@ -2929,21 +2981,38 @@ struct GuardSubtreeProbeState {
 
 thread_local std::vector<GuardSubtreeEntryToken>*
     active_guard_subtree_memo_recorder = nullptr;
+thread_local std::vector<std::string>*
+    active_guard_subtree_memo_debug_paths = nullptr;
 thread_local const LocalState* active_guard_local_state = nullptr;
 
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
-      std::vector<GuardSubtreeEntryToken>* tokens)
-      : previous(active_guard_subtree_memo_recorder) {
+      std::vector<GuardSubtreeEntryToken>* tokens,
+      std::vector<std::string>* debug_paths = nullptr)
+      : previous(active_guard_subtree_memo_recorder),
+        previous_debug_paths(active_guard_subtree_memo_debug_paths) {
     active_guard_subtree_memo_recorder = tokens;
+    active_guard_subtree_memo_debug_paths = debug_paths;
   }
 
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
+    active_guard_subtree_memo_debug_paths = previous_debug_paths;
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
+  std::vector<std::string>* previous_debug_paths{nullptr};
 };
+
+static void append_guard_subtree_memo_token(
+    std::vector<GuardSubtreeEntryToken>* tokens,
+    GuardSubtreeEntryToken&& token,
+    const std::string& debug_path) {
+  tokens->emplace_back(std::move(token));
+  if (active_guard_subtree_memo_debug_paths != nullptr) {
+    active_guard_subtree_memo_debug_paths->push_back(debug_path);
+  }
+}
 
 struct GuardLocalStateScope {
   explicit GuardLocalStateScope(const LocalState* state)
@@ -3957,8 +4026,11 @@ class DEFAULT_DEVICE : public LeafGuard {
     if (!check_nopybind_template(value)) {
       return false;
     }
-    tokens->emplace_back(GuardSubtreeEntryToken::make_default_device(
-        _utils_device_dict.ptr(), _device.ptr()));
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_default_device(
+            _utils_device_dict.ptr(), _device.ptr()),
+        "<DEFAULT_DEVICE>");
     return true;
   }
 
@@ -4024,8 +4096,10 @@ class GLOBAL_STATE : public LeafGuard {
     if (!check_nopybind(value)) {
       return false;
     }
-    tokens->emplace_back(
-        GuardSubtreeEntryToken::make_global_state(_guard.get()));
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_global_state(_guard.get()),
+        "<GLOBAL_STATE>");
     return true;
   }
 
@@ -4174,8 +4248,11 @@ class OBJECT_ALIASING : public RelationalGuard {
     if (!check_nopybind(value)) {
       return false;
     }
-    tokens->emplace_back(GuardSubtreeEntryToken::make_object_aliasing(
-        value, static_cast<const void*>(this)));
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_object_aliasing(
+            value, static_cast<const void*>(this)),
+        "<OBJECT_ALIASING>");
     return true;
   }
 
@@ -4236,8 +4313,11 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     if (!check_nopybind(value)) {
       return false;
     }
-    tokens->emplace_back(GuardSubtreeEntryToken::make_no_tensor_aliasing(
-        value, static_cast<const void*>(this)));
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_no_tensor_aliasing(
+            value, static_cast<const void*>(this)),
+        "<NO_TENSOR_ALIASING>");
     return true;
   }
 
@@ -4789,8 +4869,10 @@ class GuardManager {
   bool check_nopybind_template(T* value) { // borrowed ref
     if constexpr (std::is_same_v<T, PyObject>) {
       if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
-        active_guard_subtree_memo_recorder->emplace_back(
-            GuardSubtreeEntryToken::make(value));
+        append_guard_subtree_memo_token(
+            active_guard_subtree_memo_recorder,
+            GuardSubtreeEntryToken::make(value),
+            _source);
       }
     }
 
@@ -4961,7 +5043,8 @@ class GuardManager {
       PyObject* value,
       const GuardSubtreeMemoState& memo,
       std::vector<GuardSubtreeEntryToken>* tokens) {
-    tokens->emplace_back(GuardSubtreeEntryToken::make(value));
+    append_guard_subtree_memo_token(
+        tokens, GuardSubtreeEntryToken::make(value), _source);
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
     }
@@ -6269,9 +6352,11 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     if (!check_nopybind_template(value)) {
       return false;
     }
-    tokens->emplace_back(
+    append_guard_subtree_memo_token(
+        tokens,
         GuardSubtreeEntryToken::make_torch_function_mode_stack(
-            static_cast<const void*>(this)));
+            static_cast<const void*>(this)),
+        "<TORCH_FUNCTION_MODE_STACK>");
     return true;
   }
 
@@ -6413,7 +6498,8 @@ class TENSOR_MATCH : public LeafGuard {
             value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
       return false;
     }
-    tokens->emplace_back(std::move(token));
+    append_guard_subtree_memo_token(
+        tokens, std::move(token), _tensor_name);
     record_guard_fastplan_tensor_token_shadow();
     return true;
   }
@@ -8496,15 +8582,19 @@ bool run_root_guard_manager_with_last_success_receipt(
   }
 
   std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<std::string> debug_paths;
   {
     // This receipt is shadow-only diagnostics. The recorder deliberately
     // disables nested manager fastplan so it can observe the full guard tree.
-    GuardSubtreeMemoRecorderScope recorder(&tokens);
+    GuardSubtreeMemoRecorderScope recorder(&tokens, &debug_paths);
     const bool result = run_root_guard_manager(root, f_locals);
     if (!result) {
       state->reset();
       return false;
     }
+  }
+  if (debug_paths.size() != tokens.size()) {
+    debug_paths.clear();
   }
 
   if (tokens.empty()) {
@@ -8524,7 +8614,13 @@ bool run_root_guard_manager_with_last_success_receipt(
   bool reset_state = false;
   uint64_t compare_ns = 0;
   const uint64_t shadow_passes = state->update(
-      entry_key, root, std::move(tokens), stable, reset_state, compare_ns);
+      entry_key,
+      root,
+      std::move(tokens),
+      std::move(debug_paths),
+      stable,
+      reset_state,
+      compare_ns);
   const uint64_t update_ns = guard_lookup_time_ns() - update_start_ns;
   if (stable) {
     record_guard_last_success_shadow_stable();

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -120,6 +120,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   ExactList,
   ExactTuple,
   TensorMatch,
+  DefaultDevice,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -158,6 +159,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_exact_list{0};
   std::atomic<uint64_t> token_exact_tuple{0};
   std::atomic<uint64_t> token_tensor_match{0};
+  std::atomic<uint64_t> token_default_device{0};
 };
 
 struct GuardFastPlanStats {
@@ -251,6 +253,7 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_exact_list{0};
   uint64_t token_exact_tuple{0};
   uint64_t token_tensor_match{0};
+  uint64_t token_default_device{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
@@ -494,6 +497,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_exact_list);
   store_zero(subtree_stats.token_exact_tuple);
   store_zero(subtree_stats.token_tensor_match);
+  store_zero(subtree_stats.token_default_device);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -627,6 +631,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_exact_tuple);
   subtree_token_kind_counts["TensorMatch"] =
       load_relaxed(subtree_stats.token_tensor_match);
+  subtree_token_kind_counts["DefaultDevice"] =
+      load_relaxed(subtree_stats.token_default_device);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -988,6 +994,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::TensorMatch:
       add_relaxed(stats.token_tensor_match, 1);
       break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      add_relaxed(stats.token_default_device, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -1009,6 +1018,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::TensorMatch:
       stats.token_tensor_match += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      stats.token_default_device += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -2110,6 +2122,38 @@ static bool tensor_strides_match_guard_check(
   return true;
 }
 
+static PyObject* current_device_key() {
+  static PyObject* key = PyUnicode_InternFromString("CURRENT_DEVICE");
+  return key;
+}
+
+static bool default_device_matches(
+    PyObject* utils_device_dict,
+    PyObject* expected) {
+  if (utils_device_dict == nullptr || expected == nullptr) {
+    return false;
+  }
+  PyObject* key = current_device_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  PyObject* device = PyDict_GetItem(utils_device_dict, key);
+  if (device == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  if (device == expected) {
+    return true;
+  }
+  const int result = PyObject_RichCompareBool(device, expected, Py_EQ);
+  if (result == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  return result == 1;
+}
+
 struct GuardSubtreeEntryToken {
   PyObject* object{nullptr};
   PyTypeObject* type{nullptr};
@@ -2126,6 +2170,8 @@ struct GuardSubtreeEntryToken {
   std::vector<c10::SymInt> tensor_size_values;
   std::vector<int64_t> tensor_stride_indices;
   std::vector<c10::SymInt> tensor_stride_values;
+  PyObject* default_device_dict{nullptr};
+  PyObject* default_device{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -2199,6 +2245,18 @@ struct GuardSubtreeEntryToken {
     return true;
   }
 
+  static GuardSubtreeEntryToken make_default_device(
+      PyObject* utils_device_dict,
+      PyObject* device) {
+    GuardSubtreeEntryToken token;
+    token.object = utils_device_dict;
+    token.type = Py_TYPE(utils_device_dict);
+    token.kind = GuardSubtreeProbeTokenKind::DefaultDevice;
+    token.default_device_dict = utils_device_dict;
+    token.default_device = device;
+    return token;
+  }
+
   bool matches_tensor_current(
       const LocalState* state,
       GuardFastPlanTensorTokenMissReason& reason) const {
@@ -2260,6 +2318,10 @@ struct GuardSubtreeEntryToken {
     return true;
   }
 
+  bool matches_default_device_current() const {
+    return default_device_matches(default_device_dict, default_device);
+  }
+
   bool matches(const GuardSubtreeEntryToken& other) const {
     if (kind != other.kind || object != other.object || type != other.type) {
       return false;
@@ -2274,6 +2336,10 @@ struct GuardSubtreeEntryToken {
           tensor_size_values == other.tensor_size_values &&
           tensor_stride_indices == other.tensor_stride_indices &&
           tensor_stride_values == other.tensor_stride_values;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+      return default_device_dict == other.default_device_dict &&
+          default_device == other.default_device;
     }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
@@ -2356,6 +2422,12 @@ static bool guard_subtree_memo_tokens_match(
         }
       }
       if (!matches) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+      if (!token.matches_default_device_current()) {
         return false;
       }
       continue;
@@ -3067,8 +3139,16 @@ class LeafGuard {
   virtual bool emits_subtree_memo_token() const {
     return false;
   }
+  virtual bool emits_subtree_memo_token_for_frame_locals() const {
+    return false;
+  }
   virtual bool append_subtree_memo_token(
       PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
+  }
+  virtual bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
       std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
     return check_nopybind(value);
   }
@@ -3369,23 +3449,7 @@ class DEFAULT_DEVICE : public LeafGuard {
 
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
-    // Create a static interned string. Interned string is faster than creating
-    // a new string every time. Even though its a new reference, we don't dec
-    // ref it. Interned strings are used for things like variable names and are
-    // leaked by design.
-    static PyObject* current_device_str =
-        PyUnicode_InternFromString("CURRENT_DEVICE");
-    PyObject* device = PyDict_GetItem(
-        _utils_device_dict.ptr(), current_device_str); // borrowed ref
-    if (device != _device.ptr()) {
-      int result = PyObject_RichCompareBool(device, _device.ptr(), Py_EQ);
-      if (result == -1) {
-        PyErr_Clear();
-        return false;
-      }
-      return result;
-    }
-    return true;
+    return default_device_matches(_utils_device_dict.ptr(), _device.ptr());
   }
 
   bool check_nopybind(PyObject* value) override {
@@ -3397,13 +3461,41 @@ class DEFAULT_DEVICE : public LeafGuard {
   }
 
   bool supports_subtree_memo() const override {
-    return false;
+    return true;
   }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:DEFAULT_DEVICE";
   }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
 
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    tokens->emplace_back(GuardSubtreeEntryToken::make_default_device(
+        _utils_device_dict.ptr(), _device.ptr()));
+    return true;
+  }
+
   // Save the current device and the module dict during the guard construction.
   py::object _utils_device_dict;
   py::object _device;
@@ -4534,15 +4626,14 @@ class GuardManager {
     // Iterate over leaf guards
     for (const auto& guard : _leaf_guards) {
       bool result = false;
-      if constexpr (std::is_same_v<T, PyObject>) {
-        if (C10_UNLIKELY(
-                active_guard_subtree_memo_recorder != nullptr &&
-                guard->emits_subtree_memo_token())) {
-          result = guard->append_subtree_memo_token(
-              value, active_guard_subtree_memo_recorder);
-        } else {
-          result = guard->check_nopybind(value);
-        }
+      const bool emit_subtree_memo_token =
+          std::is_same_v<T, PyObject>
+          ? guard->emits_subtree_memo_token()
+          : guard->emits_subtree_memo_token_for_frame_locals();
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr &&
+                       emit_subtree_memo_token)) {
+        result = guard->append_subtree_memo_token(
+            value, active_guard_subtree_memo_recorder);
       } else {
         result = guard->check_nopybind(value);
       }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -135,6 +136,18 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_exact_tuple{0};
 };
 
+struct GuardFastPlanStats {
+  std::atomic<uint64_t> candidate{0};
+  std::atomic<uint64_t> shadow_pass{0};
+  std::atomic<uint64_t> enable{0};
+  std::atomic<uint64_t> hit{0};
+  std::atomic<uint64_t> miss{0};
+  std::atomic<uint64_t> disabled{0};
+  std::atomic<uint64_t> token_count_sum{0};
+  std::atomic<uint64_t> token_check_ns{0};
+  std::atomic<uint64_t> slow_check_ns{0};
+};
+
 struct GuardAccessorTypeStats {
   uint64_t count{0};
   uint64_t fail_count{0};
@@ -174,6 +187,11 @@ GuardLookupStats& guard_lookup_stats() {
 
 GuardSubtreeProbeStats& guard_subtree_probe_stats() {
   static GuardSubtreeProbeStats stats;
+  return stats;
+}
+
+GuardFastPlanStats& guard_fastplan_stats() {
+  static GuardFastPlanStats stats;
   return stats;
 }
 
@@ -287,6 +305,12 @@ bool unsafe_mock_guard_bypass_enabled() {
   return C10_UNLIKELY(env_enabled);
 }
 
+static bool guard_fast_plan_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_GUARD_FAST_PLAN") == true;
+  return C10_UNLIKELY(env_enabled);
+}
+
 uint64_t guard_lookup_time_ns() {
   return static_cast<uint64_t>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -297,6 +321,7 @@ uint64_t guard_lookup_time_ns() {
 void reset_guard_lookup_stats() {
   auto& stats = guard_lookup_stats();
   auto& subtree_stats = guard_subtree_probe_stats();
+  auto& fastplan_stats = guard_fastplan_stats();
   store_zero(stats.lookup_count);
   store_zero(stats.lookup_total_ns);
   store_zero(stats.backend_match_ns);
@@ -326,6 +351,15 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_exact_dict);
   store_zero(subtree_stats.token_exact_list);
   store_zero(subtree_stats.token_exact_tuple);
+  store_zero(fastplan_stats.candidate);
+  store_zero(fastplan_stats.shadow_pass);
+  store_zero(fastplan_stats.enable);
+  store_zero(fastplan_stats.hit);
+  store_zero(fastplan_stats.miss);
+  store_zero(fastplan_stats.disabled);
+  store_zero(fastplan_stats.token_count_sum);
+  store_zero(fastplan_stats.token_check_ns);
+  store_zero(fastplan_stats.slow_check_ns);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -396,6 +430,23 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_exact_tuple);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
+  auto& fastplan_stats = guard_fastplan_stats();
+  result["guard_fastplan_enabled"] = guard_fast_plan_enabled();
+  result["guard_fastplan_candidate"] =
+      load_relaxed(fastplan_stats.candidate);
+  result["guard_fastplan_shadow_pass"] =
+      load_relaxed(fastplan_stats.shadow_pass);
+  result["guard_fastplan_enable"] = load_relaxed(fastplan_stats.enable);
+  result["guard_fastplan_hit"] = load_relaxed(fastplan_stats.hit);
+  result["guard_fastplan_miss"] = load_relaxed(fastplan_stats.miss);
+  result["guard_fastplan_disabled"] =
+      load_relaxed(fastplan_stats.disabled);
+  result["guard_fastplan_token_count_sum"] =
+      load_relaxed(fastplan_stats.token_count_sum);
+  result["guard_fastplan_token_check_ns"] =
+      load_relaxed(fastplan_stats.token_check_ns);
+  result["guard_fastplan_slow_check_ns"] =
+      load_relaxed(fastplan_stats.slow_check_ns);
   if (guard_subtree_probe_detail_enabled()) {
     py::dict path_stats;
     std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
@@ -654,6 +705,52 @@ static void record_guard_subtree_probe_stats(
   }
   if (disabled_now) {
     path_stats.disabled += 1;
+  }
+}
+
+static void record_guard_fastplan_candidate() {
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.candidate, 1);
+}
+
+static void record_guard_fastplan_shadow_pass(
+    size_t token_count,
+    uint64_t slow_check_ns) {
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.shadow_pass, 1);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.slow_check_ns, slow_check_ns);
+}
+
+static void record_guard_fastplan_enable() {
+  add_relaxed(guard_fastplan_stats().enable, 1);
+}
+
+static void record_guard_fastplan_disabled() {
+  add_relaxed(guard_fastplan_stats().disabled, 1);
+}
+
+static void record_guard_fastplan_hit(
+    size_t token_count,
+    uint64_t token_check_ns) {
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.hit, 1);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.token_check_ns, token_check_ns);
+}
+
+static void record_guard_fastplan_miss(
+    size_t token_count,
+    uint64_t token_check_ns,
+    uint64_t slow_check_ns,
+    bool disabled_now) {
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.miss, 1);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.token_check_ns, token_check_ns);
+  add_relaxed(stats.slow_check_ns, slow_check_ns);
+  if (disabled_now) {
+    add_relaxed(stats.disabled, 1);
   }
 }
 
@@ -1395,11 +1492,69 @@ struct GuardSubtreeEntryToken {
   }
 };
 
+static bool guard_subtree_token_vectors_match(
+    const std::vector<GuardSubtreeEntryToken>& lhs,
+    const std::vector<GuardSubtreeEntryToken>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!lhs[i].matches(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_subtree_memo_tokens_match(
+    const std::vector<GuardSubtreeEntryToken>& tokens) {
+  for (const auto& token : tokens) {
+    GuardSubtreeEntryToken current =
+        GuardSubtreeEntryToken::make(token.object);
+    if (!current.matches(token)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+struct GuardSubtreeMemoState {
+  bool enabled{false};
+  bool disabled{false};
+  uint8_t shadow_passes{0};
+  std::vector<GuardSubtreeEntryToken> tokens;
+};
+
 struct GuardSubtreeProbeState {
   bool has_last_token{false};
   bool disabled{false};
   GuardSubtreeEntryToken last_token;
+  GuardSubtreeMemoState memo;
 };
+
+thread_local std::vector<GuardSubtreeEntryToken>*
+    active_guard_subtree_memo_recorder = nullptr;
+
+struct GuardSubtreeMemoRecorderScope {
+  explicit GuardSubtreeMemoRecorderScope(
+      std::vector<GuardSubtreeEntryToken>* tokens)
+      : previous(active_guard_subtree_memo_recorder) {
+    active_guard_subtree_memo_recorder = tokens;
+  }
+
+  ~GuardSubtreeMemoRecorderScope() {
+    active_guard_subtree_memo_recorder = previous;
+  }
+
+  std::vector<GuardSubtreeEntryToken>* previous{nullptr};
+};
+
+static void record_guard_subtree_memo_token(PyObject* obj) {
+  if (active_guard_subtree_memo_recorder != nullptr) {
+    active_guard_subtree_memo_recorder->emplace_back(
+        GuardSubtreeEntryToken::make(obj));
+  }
+}
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   // Retrieves the version of a dictionary.
@@ -2039,6 +2194,9 @@ class LeafGuard {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict());
   }
+  virtual bool supports_subtree_memo() const {
+    return true;
+  }
 
   virtual ~LeafGuard() = default;
 
@@ -2101,6 +2259,10 @@ class LAMBDA_GUARD : public LeafGuard {
       return GuardDebugInfo(true, 0);
     }
     return GuardDebugInfo(false, verbose_code_parts(), 0);
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
   }
 
  private:
@@ -2356,6 +2518,10 @@ class DEFAULT_DEVICE : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   // Save the current device and the module dict during the guard construction.
   py::object _utils_device_dict;
@@ -2388,6 +2554,10 @@ class GLOBAL_STATE : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   std::unique_ptr<GlobalStateGuard> _guard;
 };
@@ -2409,6 +2579,10 @@ class DATA_PTR_MATCH : public LeafGuard {
     }
     void* data_ptr = THPVariable_Unpack(value).data_ptr();
     return data_ptr == _data_ptr;
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
   }
 
  private:
@@ -2478,6 +2652,10 @@ class RelationalGuard : public LeafGuard {
  public:
   RelationalGuard(py::object verbose_code_parts)
       : LeafGuard(std::move(verbose_code_parts)) {}
+
+  bool supports_subtree_memo() const override {
+    return false;
+  }
 
   // reset the relational guard state on guard failure. This is called by the
   // guard manager.
@@ -2737,6 +2915,10 @@ class DYNAMIC_INDICES : public LeafGuard {
     return result;
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   py::set _dynamic_indices;
 };
@@ -2824,6 +3006,9 @@ class GuardAccessor {
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
   }
   bool check_child_manager_nopybind(PyObject* obj);
+  virtual bool supports_subtree_memo() const {
+    return true;
+  }
   virtual const char* stats_name() const {
     return "GuardAccessor";
   }
@@ -3063,6 +3248,9 @@ class GuardManager {
   // the code here.
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
+    if constexpr (std::is_same_v<T, PyObject>) {
+      record_guard_subtree_memo_token(value);
+    }
 
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
@@ -3075,9 +3263,105 @@ class GuardManager {
     return check_nopybind_template(value);
   }
 
+  bool is_guard_fastplan_candidate() const {
+    static constexpr const char* kModulesSuffix = "._modules";
+    const size_t suffix_len = std::strlen(kModulesSuffix);
+    if (_source.size() < suffix_len ||
+        _source.compare(
+            _source.size() - suffix_len, suffix_len, kModulesSuffix) != 0) {
+      return false;
+    }
+    // P1a only targets the top module registry, e.g. L['self']._modules.
+    // Nested module registries are left to P1 candidate selection.
+    return _source.find("._modules[") == std::string::npos;
+  }
+
+  virtual bool supports_subtree_memo_recursive() const {
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->supports_subtree_memo()) {
+        return false;
+      }
+    }
+    for (const auto& accessor : _accessors) {
+      if (!accessor->supports_subtree_memo()) {
+        return false;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool check_nopybind_with_fastplan(PyObject* value) {
+    GuardSubtreeMemoState& memo = _subtree_probe_state.memo;
+    if (!guard_fast_plan_enabled() || memo.disabled ||
+        !is_guard_fastplan_candidate()) {
+      return check_nopybind(value);
+    }
+
+    record_guard_fastplan_candidate();
+    if (memo.tokens.empty() && !supports_subtree_memo_recursive()) {
+      memo.disabled = true;
+      record_guard_fastplan_disabled();
+      return check_nopybind(value);
+    }
+
+    if (memo.enabled) {
+      const uint64_t token_start_ns = guard_lookup_time_ns();
+      const bool token_match = guard_subtree_memo_tokens_match(memo.tokens);
+      const uint64_t token_check_ns = guard_lookup_time_ns() - token_start_ns;
+      if (token_match) {
+        record_guard_fastplan_hit(memo.tokens.size(), token_check_ns);
+        return true;
+      }
+
+      memo.disabled = true;
+      const uint64_t slow_start_ns = guard_lookup_time_ns();
+      const bool result = check_nopybind(value);
+      const uint64_t slow_check_ns = guard_lookup_time_ns() - slow_start_ns;
+      record_guard_fastplan_miss(
+          memo.tokens.size(), token_check_ns, slow_check_ns, true);
+      return result;
+    }
+
+    std::vector<GuardSubtreeEntryToken> tokens;
+    const uint64_t slow_start_ns = guard_lookup_time_ns();
+    bool result = false;
+    {
+      GuardSubtreeMemoRecorderScope recorder(&tokens);
+      result = check_nopybind(value);
+    }
+    const uint64_t slow_check_ns = guard_lookup_time_ns() - slow_start_ns;
+
+    if (!result) {
+      memo.shadow_passes = 0;
+      memo.tokens.clear();
+      return false;
+    }
+
+    if (!memo.tokens.empty() &&
+        guard_subtree_token_vectors_match(tokens, memo.tokens)) {
+      memo.shadow_passes += 1;
+    } else {
+      memo.tokens = std::move(tokens);
+      memo.shadow_passes = 1;
+    }
+
+    record_guard_fastplan_shadow_pass(memo.tokens.size(), slow_check_ns);
+    if (memo.shadow_passes >= 3) {
+      memo.enabled = true;
+      record_guard_fastplan_enable();
+    }
+    return true;
+  }
+
   bool check_nopybind_with_subtree_probe(
       PyObject* value,
       const std::string& path) {
+    if (guard_fast_plan_enabled() && is_guard_fastplan_candidate()) {
+      return check_nopybind_with_fastplan(value);
+    }
     if (!guard_subtree_probe_enabled() || _subtree_probe_state.disabled) {
       return check_nopybind(value);
     }
@@ -3369,7 +3653,8 @@ GuardAccessor::GuardAccessor(GuardManager* guard_manager, GuardAccessor* from)
 }
 
 inline bool GuardAccessor::check_child_manager_nopybind(PyObject* obj) {
-  if (C10_LIKELY(!guard_subtree_probe_enabled())) {
+  if (C10_LIKELY(
+          !guard_subtree_probe_enabled() && !guard_fast_plan_enabled())) {
     return _guard_manager->check_nopybind(obj);
   }
   static const std::string empty_path = "";
@@ -3930,6 +4215,23 @@ class DictGuardManager : public GuardManager {
     return _is_exact_dict_type;
   }
 
+  bool supports_subtree_memo_recursive() const override {
+    if (!GuardManager::supports_subtree_memo_recursive()) {
+      return false;
+    }
+    for (const auto& item : _key_value_managers) {
+      const auto& key_manager = item.second.first;
+      if (key_manager && !key_manager->supports_subtree_memo_recursive()) {
+        return false;
+      }
+      const auto& value_manager = item.second.second;
+      if (value_manager && !value_manager->supports_subtree_memo_recursive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  public: // cloning functions
   DictGuardManager(
       RootGuardManager* cloned_root,
@@ -4128,6 +4430,10 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   std::vector<PyTypeObject*> _ref_stack;
 };
@@ -4149,6 +4455,10 @@ class DISPATCH_KEY_SET_MATCH : public LeafGuard {
     c10::DispatchKeySet value_ = handle.cast<c10::DispatchKeySet>();
     return raw_repr ==
         _root_guard_manager->_local_state.apply(value_).raw_repr();
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
   }
 
  private:
@@ -4233,6 +4543,10 @@ class TENSOR_MATCH : public LeafGuard {
       return GuardDebugInfo(false, fail_reason, 0);
     }
     return GuardDebugInfo(true, 1);
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
   }
 
  private:
@@ -5970,6 +6284,10 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
     return "CallFunctionNoArgsGuardAccessor()";
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  public: // cloning functions
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CallFunctionNoArgsGuardAccessor(
@@ -6042,6 +6360,10 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
 
   std::string repr() const override {
     return "PythonLambdaGuardAccessor";
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
   }
 
  public: // cloning functions

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1471,7 +1471,9 @@ static bool tensor_match_source_supports_subtree_memo(
     const std::string& source) {
   return source.find("._parameters[") != std::string::npos ||
       source.find("._buffers[") != std::string::npos ||
-      source_ends_with(source, "._cached_tensor");
+      source_ends_with(source, "._cached_tensor") ||
+      (source.find("L['self']._modules[") != std::string::npos &&
+       source_ends_with(source, ".scale"));
 }
 
 std::string guard_accessor_stats_key(PyObject* key) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -119,6 +119,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   ExactDict,
   ExactList,
   ExactTuple,
+  TensorMatch,
 };
 
 enum class GuardFastPlanCandidateKind : uint8_t {
@@ -126,6 +127,21 @@ enum class GuardFastPlanCandidateKind : uint8_t {
   None,
   TopModules,
   NestedModules,
+};
+
+enum class GuardFastPlanTensorTokenMissReason : uint8_t {
+  None,
+  MissingLocalState,
+  Object,
+  Type,
+  NotTensor,
+  DispatchKey,
+  DType,
+  Device,
+  RequiresGrad,
+  Dim,
+  Size,
+  Stride,
 };
 
 struct GuardSubtreeProbeStats {
@@ -141,6 +157,7 @@ struct GuardSubtreeProbeStats {
   std::atomic<uint64_t> token_exact_dict{0};
   std::atomic<uint64_t> token_exact_list{0};
   std::atomic<uint64_t> token_exact_tuple{0};
+  std::atomic<uint64_t> token_tensor_match{0};
 };
 
 struct GuardFastPlanStats {
@@ -168,6 +185,23 @@ struct GuardFastPlanStats {
   std::atomic<uint64_t> token_count_sum{0};
   std::atomic<uint64_t> token_check_ns{0};
   std::atomic<uint64_t> slow_check_ns{0};
+  std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> tensor_token_shadow{0};
+  std::atomic<uint64_t> tensor_token_hit{0};
+  std::atomic<uint64_t> tensor_token_miss{0};
+  std::atomic<uint64_t> tensor_token_check_ns{0};
+  std::atomic<uint64_t> tensor_token_count_sum{0};
+  std::atomic<uint64_t> tensor_token_miss_missing_local_state{0};
+  std::atomic<uint64_t> tensor_token_miss_object{0};
+  std::atomic<uint64_t> tensor_token_miss_type{0};
+  std::atomic<uint64_t> tensor_token_miss_not_tensor{0};
+  std::atomic<uint64_t> tensor_token_miss_dispatch_key{0};
+  std::atomic<uint64_t> tensor_token_miss_dtype{0};
+  std::atomic<uint64_t> tensor_token_miss_device{0};
+  std::atomic<uint64_t> tensor_token_miss_requires_grad{0};
+  std::atomic<uint64_t> tensor_token_miss_dim{0};
+  std::atomic<uint64_t> tensor_token_miss_size{0};
+  std::atomic<uint64_t> tensor_token_miss_stride{0};
 };
 
 struct GuardFastPlanDisabledPathStats {
@@ -202,11 +236,13 @@ struct GuardSubtreeProbePathStats {
   uint64_t token_exact_dict{0};
   uint64_t token_exact_list{0};
   uint64_t token_exact_tuple{0};
+  uint64_t token_tensor_match{0};
 };
 
 constexpr size_t kGuardAccessorDetailStatsTopK = 64;
 constexpr size_t kGuardSubtreeProbeTopK = 64;
 constexpr size_t kGuardFastPlanDisabledTopK = 64;
+constexpr size_t kGuardFastPlanMaxTokens = 1024;
 
 struct GuardSubtreeMemoSupportAnalysis {
   std::string reason;
@@ -409,6 +445,7 @@ void reset_guard_lookup_stats() {
   store_zero(subtree_stats.token_exact_dict);
   store_zero(subtree_stats.token_exact_list);
   store_zero(subtree_stats.token_exact_tuple);
+  store_zero(subtree_stats.token_tensor_match);
   store_zero(fastplan_stats.candidate);
   store_zero(fastplan_stats.candidate_top);
   store_zero(fastplan_stats.candidate_nested);
@@ -433,6 +470,23 @@ void reset_guard_lookup_stats() {
   store_zero(fastplan_stats.token_count_sum);
   store_zero(fastplan_stats.token_check_ns);
   store_zero(fastplan_stats.slow_check_ns);
+  store_zero(fastplan_stats.token_cap_disabled);
+  store_zero(fastplan_stats.tensor_token_shadow);
+  store_zero(fastplan_stats.tensor_token_hit);
+  store_zero(fastplan_stats.tensor_token_miss);
+  store_zero(fastplan_stats.tensor_token_check_ns);
+  store_zero(fastplan_stats.tensor_token_count_sum);
+  store_zero(fastplan_stats.tensor_token_miss_missing_local_state);
+  store_zero(fastplan_stats.tensor_token_miss_object);
+  store_zero(fastplan_stats.tensor_token_miss_type);
+  store_zero(fastplan_stats.tensor_token_miss_not_tensor);
+  store_zero(fastplan_stats.tensor_token_miss_dispatch_key);
+  store_zero(fastplan_stats.tensor_token_miss_dtype);
+  store_zero(fastplan_stats.tensor_token_miss_device);
+  store_zero(fastplan_stats.tensor_token_miss_requires_grad);
+  store_zero(fastplan_stats.tensor_token_miss_dim);
+  store_zero(fastplan_stats.tensor_token_miss_size);
+  store_zero(fastplan_stats.tensor_token_miss_stride);
   {
     std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
     guard_accessor_type_stats().clear();
@@ -506,6 +560,8 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(subtree_stats.token_exact_list);
   subtree_token_kind_counts["ExactTuple"] =
       load_relaxed(subtree_stats.token_exact_tuple);
+  subtree_token_kind_counts["TensorMatch"] =
+      load_relaxed(subtree_stats.token_tensor_match);
   result["guard_subtree_probe_token_kind_counts"] =
       subtree_token_kind_counts;
   auto& fastplan_stats = guard_fastplan_stats();
@@ -553,6 +609,43 @@ py::dict get_guard_lookup_stats() {
       load_relaxed(fastplan_stats.token_check_ns);
   result["guard_fastplan_slow_check_ns"] =
       load_relaxed(fastplan_stats.slow_check_ns);
+  result["guard_fastplan_token_cap_disabled"] =
+      load_relaxed(fastplan_stats.token_cap_disabled);
+  result["guard_fastplan_tensor_token_shadow"] =
+      load_relaxed(fastplan_stats.tensor_token_shadow);
+  result["guard_fastplan_tensor_token_hit"] =
+      load_relaxed(fastplan_stats.tensor_token_hit);
+  result["guard_fastplan_tensor_token_miss"] =
+      load_relaxed(fastplan_stats.tensor_token_miss);
+  result["guard_fastplan_tensor_token_check_ns"] =
+      load_relaxed(fastplan_stats.tensor_token_check_ns);
+  result["guard_fastplan_tensor_token_count_sum"] =
+      load_relaxed(fastplan_stats.tensor_token_count_sum);
+  py::dict tensor_token_miss_reasons;
+  tensor_token_miss_reasons["missing_local_state"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_missing_local_state);
+  tensor_token_miss_reasons["object"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_object);
+  tensor_token_miss_reasons["type"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_type);
+  tensor_token_miss_reasons["not_tensor"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_not_tensor);
+  tensor_token_miss_reasons["dispatch_key"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dispatch_key);
+  tensor_token_miss_reasons["dtype"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dtype);
+  tensor_token_miss_reasons["device"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_device);
+  tensor_token_miss_reasons["requires_grad"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_requires_grad);
+  tensor_token_miss_reasons["dim"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dim);
+  tensor_token_miss_reasons["size"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_size);
+  tensor_token_miss_reasons["stride"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_stride);
+  result["guard_fastplan_tensor_token_miss_reasons"] =
+      tensor_token_miss_reasons;
   py::dict fastplan_disabled_reasons;
   py::dict fastplan_disabled_top_paths;
   {
@@ -617,6 +710,7 @@ py::dict get_guard_lookup_stats() {
       token_counts["ExactDict"] = items[i].second.token_exact_dict;
       token_counts["ExactList"] = items[i].second.token_exact_list;
       token_counts["ExactTuple"] = items[i].second.token_exact_tuple;
+      token_counts["TensorMatch"] = items[i].second.token_tensor_match;
       item_stats["token_kind_counts"] = token_counts;
       path_stats[py::str(items[i].first)] = item_stats;
     }
@@ -767,6 +861,9 @@ static void add_guard_subtree_probe_token_kind(
     case GuardSubtreeProbeTokenKind::ExactTuple:
       add_relaxed(stats.token_exact_tuple, 1);
       break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      add_relaxed(stats.token_tensor_match, 1);
+      break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       add_relaxed(stats.token_object_only, 1);
       break;
@@ -785,6 +882,9 @@ static void add_guard_subtree_probe_token_kind(
       break;
     case GuardSubtreeProbeTokenKind::ExactTuple:
       stats.token_exact_tuple += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      stats.token_tensor_match += 1;
       break;
     case GuardSubtreeProbeTokenKind::ObjectOnly:
       stats.token_object_only += 1;
@@ -972,6 +1072,81 @@ static void record_guard_fastplan_miss(
   }
 }
 
+static void record_guard_fastplan_token_cap_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_fastplan_stats().token_cap_disabled, 1);
+}
+
+static void record_guard_fastplan_tensor_token_shadow() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_shadow, 1);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+}
+
+static void record_guard_fastplan_tensor_token_hit(uint64_t check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_hit, 1);
+  add_relaxed(stats.tensor_token_check_ns, check_ns);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+}
+
+static void record_guard_fastplan_tensor_token_miss(
+    GuardFastPlanTensorTokenMissReason reason,
+    uint64_t check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_miss, 1);
+  add_relaxed(stats.tensor_token_check_ns, check_ns);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+  switch (reason) {
+    case GuardFastPlanTensorTokenMissReason::MissingLocalState:
+      add_relaxed(stats.tensor_token_miss_missing_local_state, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Object:
+      add_relaxed(stats.tensor_token_miss_object, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Type:
+      add_relaxed(stats.tensor_token_miss_type, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::NotTensor:
+      add_relaxed(stats.tensor_token_miss_not_tensor, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::DispatchKey:
+      add_relaxed(stats.tensor_token_miss_dispatch_key, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::DType:
+      add_relaxed(stats.tensor_token_miss_dtype, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Device:
+      add_relaxed(stats.tensor_token_miss_device, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::RequiresGrad:
+      add_relaxed(stats.tensor_token_miss_requires_grad, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Dim:
+      add_relaxed(stats.tensor_token_miss_dim, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Size:
+      add_relaxed(stats.tensor_token_miss_size, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Stride:
+      add_relaxed(stats.tensor_token_miss_stride, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::None:
+      break;
+  }
+}
+
 static GuardFastPlanCandidateKind compute_guard_fastplan_candidate_kind(
     const std::string& source) {
   static constexpr const char* kModulesSuffix = "._modules";
@@ -989,6 +1164,12 @@ static GuardFastPlanCandidateKind compute_guard_fastplan_candidate_kind(
     return GuardFastPlanCandidateKind::TopModules;
   }
   return GuardFastPlanCandidateKind::NestedModules;
+}
+
+static bool tensor_match_source_supports_subtree_memo(
+    const std::string& source) {
+  return source.find("._parameters[") != std::string::npos ||
+      source.find("._buffers[") != std::string::npos;
 }
 
 std::string guard_accessor_stats_key(PyObject* key) {
@@ -1698,6 +1879,23 @@ static uint64_t get_dict_version_unchecked(PyObject* dict) {
 #endif
 }
 
+static bool tensor_layout_does_not_support_stride(const at::Tensor& tensor) {
+  return tensor.layout() == c10::kSparseCsr ||
+      tensor.layout() == c10::kSparseCsc ||
+      tensor.layout() == c10::kSparseBsc ||
+      tensor.layout() == c10::kSparseBsr;
+}
+
+static std::vector<c10::SymInt> tensor_strides_for_guard_check(
+    const at::Tensor& tensor) {
+  if (tensor_layout_does_not_support_stride(tensor)) {
+    return std::vector<c10::SymInt>(
+        tensor.ndimension(), c10::SymInt(static_cast<int64_t>(-1)));
+  }
+  auto strides = tensor.sym_strides();
+  return std::vector<c10::SymInt>(strides.begin(), strides.end());
+}
+
 struct GuardSubtreeEntryToken {
   PyObject* object{nullptr};
   PyTypeObject* type{nullptr};
@@ -1705,6 +1903,15 @@ struct GuardSubtreeEntryToken {
   uint64_t version{0};
   Py_ssize_t size{0};
   std::vector<PyObject*> list_items;
+  uint64_t tensor_dispatch_key{0};
+  at::ScalarType tensor_dtype{at::ScalarType::Undefined};
+  c10::DeviceIndex tensor_device_index{-1};
+  bool tensor_requires_grad{false};
+  int64_t tensor_dim{0};
+  std::vector<int64_t> tensor_size_indices;
+  std::vector<c10::SymInt> tensor_size_values;
+  std::vector<int64_t> tensor_stride_indices;
+  std::vector<c10::SymInt> tensor_stride_values;
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -1728,9 +1935,139 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static bool make_tensor_match(
+      PyObject* obj,
+      TensorCheck& tensor_check,
+      const LocalState& state,
+      GuardSubtreeEntryToken* token) {
+    if (Py_TYPE(obj) != tensor_check.pytype) {
+      return false;
+    }
+    if (!THPVariable_CheckExact(obj) && !THPVariable_Check(obj)) {
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(obj);
+    if (!tensor_check.check(state, tensor)) {
+      return false;
+    }
+
+    token->object = obj;
+    token->type = Py_TYPE(obj);
+    token->kind = GuardSubtreeProbeTokenKind::TensorMatch;
+    token->tensor_dispatch_key = state.apply(tensor.key_set()).raw_repr();
+    token->tensor_dtype = tensor.dtype().toScalarType();
+    token->tensor_device_index = tensor.device().index();
+    token->tensor_requires_grad = tensor.requires_grad();
+    token->tensor_dim = tensor.ndimension();
+
+    const auto& expected_sizes = tensor_check.sizes();
+    token->tensor_size_indices.reserve(expected_sizes.size());
+    token->tensor_size_values.reserve(expected_sizes.size());
+    for (auto i : c10::irange(expected_sizes.size())) {
+      const auto& expected_size = expected_sizes[i];
+      if (expected_size.has_value()) {
+        token->tensor_size_indices.push_back(static_cast<int64_t>(i));
+        token->tensor_size_values.push_back(expected_size.value());
+      }
+    }
+
+    const auto& expected_strides = tensor_check.strides();
+    token->tensor_stride_indices.reserve(expected_strides.size());
+    token->tensor_stride_values.reserve(expected_strides.size());
+    for (auto i : c10::irange(expected_strides.size())) {
+      const auto& expected_stride = expected_strides[i];
+      if (expected_stride.has_value()) {
+        token->tensor_stride_indices.push_back(static_cast<int64_t>(i));
+        token->tensor_stride_values.push_back(expected_stride.value());
+      }
+    }
+    return true;
+  }
+
+  bool matches_tensor_current(
+      const LocalState* state,
+      GuardFastPlanTensorTokenMissReason& reason) const {
+    reason = GuardFastPlanTensorTokenMissReason::None;
+    if (state == nullptr) {
+      reason = GuardFastPlanTensorTokenMissReason::MissingLocalState;
+      return false;
+    }
+    if (object == nullptr) {
+      reason = GuardFastPlanTensorTokenMissReason::Object;
+      return false;
+    }
+    if (Py_TYPE(object) != type) {
+      reason = GuardFastPlanTensorTokenMissReason::Type;
+      return false;
+    }
+    if (!THPVariable_CheckExact(object) && !THPVariable_Check(object)) {
+      reason = GuardFastPlanTensorTokenMissReason::NotTensor;
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(object);
+    if (state->apply(tensor.key_set()).raw_repr() != tensor_dispatch_key) {
+      reason = GuardFastPlanTensorTokenMissReason::DispatchKey;
+      return false;
+    }
+    if (tensor.dtype().toScalarType() != tensor_dtype) {
+      reason = GuardFastPlanTensorTokenMissReason::DType;
+      return false;
+    }
+    if (tensor.device().index() != tensor_device_index) {
+      reason = GuardFastPlanTensorTokenMissReason::Device;
+      return false;
+    }
+    if (tensor.requires_grad() != tensor_requires_grad) {
+      reason = GuardFastPlanTensorTokenMissReason::RequiresGrad;
+      return false;
+    }
+    if (tensor.ndimension() != tensor_dim) {
+      reason = GuardFastPlanTensorTokenMissReason::Dim;
+      return false;
+    }
+
+    const auto current_sizes = tensor.sym_sizes();
+    for (auto i : c10::irange(tensor_size_indices.size())) {
+      const int64_t index = tensor_size_indices[i];
+      if (index < 0 || index >= static_cast<int64_t>(current_sizes.size()) ||
+          tensor_size_values[i] != current_sizes[index]) {
+        reason = GuardFastPlanTensorTokenMissReason::Size;
+        return false;
+      }
+    }
+
+    const std::vector<c10::SymInt> current_strides =
+        tensor_strides_for_guard_check(tensor);
+    for (auto i : c10::irange(tensor_stride_indices.size())) {
+      const int64_t index = tensor_stride_indices[i];
+      if (index < 0 ||
+          index >= static_cast<int64_t>(current_strides.size()) ||
+          tensor_stride_values[i] != current_strides[index]) {
+        reason = GuardFastPlanTensorTokenMissReason::Stride;
+        return false;
+      }
+    }
+    return true;
+  }
+
   bool matches(const GuardSubtreeEntryToken& other) const {
-    return object == other.object && type == other.type && kind == other.kind &&
-        version == other.version && size == other.size &&
+    if (kind != other.kind || object != other.object || type != other.type) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      return tensor_dispatch_key == other.tensor_dispatch_key &&
+          tensor_dtype == other.tensor_dtype &&
+          tensor_device_index == other.tensor_device_index &&
+          tensor_requires_grad == other.tensor_requires_grad &&
+          tensor_dim == other.tensor_dim &&
+          tensor_size_indices == other.tensor_size_indices &&
+          tensor_size_values == other.tensor_size_values &&
+          tensor_stride_indices == other.tensor_stride_indices &&
+          tensor_stride_values == other.tensor_stride_values;
+    }
+    return version == other.version && size == other.size &&
         list_items == other.list_items;
   }
 };
@@ -1749,11 +2086,34 @@ static bool guard_subtree_token_vectors_match(
   return true;
 }
 
+extern thread_local const LocalState* active_guard_local_state;
+
 static bool guard_subtree_memo_tokens_match(
     const std::vector<GuardSubtreeEntryToken>& tokens,
     PyObject* root_value) {
   for (size_t i = 0; i < tokens.size(); ++i) {
     const auto& token = tokens[i];
+    if (token.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      const bool collect_stats = guard_lookup_stats_enabled();
+      const uint64_t tensor_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      GuardFastPlanTensorTokenMissReason reason =
+          GuardFastPlanTensorTokenMissReason::None;
+      const bool matches =
+          token.matches_tensor_current(active_guard_local_state, reason);
+      if (collect_stats) {
+        const uint64_t check_ns = guard_lookup_time_ns() - tensor_start_ns;
+        if (matches) {
+          record_guard_fastplan_tensor_token_hit(check_ns);
+        } else {
+          record_guard_fastplan_tensor_token_miss(reason, check_ns);
+        }
+      }
+      if (!matches) {
+        return false;
+      }
+      continue;
+    }
     if (i != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly) {
       // Parent dict/list tokens prove whether this object is still reachable.
       continue;
@@ -1785,6 +2145,7 @@ struct GuardSubtreeProbeState {
 
 thread_local std::vector<GuardSubtreeEntryToken>*
     active_guard_subtree_memo_recorder = nullptr;
+thread_local const LocalState* active_guard_local_state = nullptr;
 
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
@@ -1798,6 +2159,19 @@ struct GuardSubtreeMemoRecorderScope {
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
+};
+
+struct GuardLocalStateScope {
+  explicit GuardLocalStateScope(const LocalState* state)
+      : previous(active_guard_local_state) {
+    active_guard_local_state = state;
+  }
+
+  ~GuardLocalStateScope() {
+    active_guard_local_state = previous;
+  }
+
+  const LocalState* previous{nullptr};
 };
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
@@ -2443,6 +2817,14 @@ class LeafGuard {
   }
   virtual const char* subtree_memo_unsupported_reason() const {
     return "unsupported_leaf:LeafGuard";
+  }
+  virtual bool emits_subtree_memo_token() const {
+    return false;
+  }
+  virtual bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
   }
 
   virtual ~LeafGuard() = default;
@@ -3823,6 +4205,15 @@ class GuardManager {
       return false;
     }
 
+    if (tokens.size() > kGuardFastPlanMaxTokens) {
+      memo.disabled = true;
+      memo.partial = false;
+      memo.shadow_passes = 0;
+      memo.tokens.clear();
+      record_guard_fastplan_token_cap_disabled();
+      return true;
+    }
+
     if (!memo.tokens.empty() &&
         guard_subtree_token_vectors_match(tokens, memo.tokens)) {
       memo.shadow_passes += 1;
@@ -3896,7 +4287,20 @@ class GuardManager {
   bool check_leaf_guards_nopybind(T* value) {
     // Iterate over leaf guards
     for (const auto& guard : _leaf_guards) {
-      if (!guard->check_nopybind(value)) { // early exit
+      bool result = false;
+      if constexpr (std::is_same_v<T, PyObject>) {
+        if (C10_UNLIKELY(
+                active_guard_subtree_memo_recorder != nullptr &&
+                guard->emits_subtree_memo_token())) {
+          result = guard->append_subtree_memo_token(
+              value, active_guard_subtree_memo_recorder);
+        } else {
+          result = guard->check_nopybind(value);
+        }
+      } else {
+        result = guard->check_nopybind(value);
+      }
+      if (!result) { // early exit
         _fail_count += 1;
         // no need of sorting, just return.
         return false;
@@ -4248,6 +4652,7 @@ class RootGuardManager : public GuardManager {
     if (collect_stats) {
       local_state_ns += guard_lookup_time_ns() - local_state_start_ns;
     }
+    GuardLocalStateScope local_state_scope(&_local_state);
 
     const uint64_t leaf_start_ns =
         collect_stats ? guard_lookup_time_ns() : 0;
@@ -4976,7 +5381,9 @@ class TENSOR_MATCH : public LeafGuard {
       py::object tensor_name,
       py::object verbose_code_parts)
       : LeafGuard(root_guard_manager, std::move(verbose_code_parts)),
-        _tensor_name(py::cast<std::string>(std::move(tensor_name))) {
+        _tensor_name(py::cast<std::string>(std::move(tensor_name))),
+        _supports_subtree_memo_token(
+            tensor_match_source_supports_subtree_memo(_tensor_name)) {
     root_guard_manager->set_init_local_state_flag();
     PyObject* item = value.ptr();
     if (!THPVariable_CheckExact(item) && !THPVariable_Check(item)) {
@@ -5047,14 +5454,30 @@ class TENSOR_MATCH : public LeafGuard {
   }
 
   bool supports_subtree_memo() const override {
-    return false;
+    return _supports_subtree_memo_token;
   }
   const char* subtree_memo_unsupported_reason() const override {
     return "unsupported_leaf:TENSOR_MATCH";
   }
+  bool emits_subtree_memo_token() const override {
+    return _supports_subtree_memo_token;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    GuardSubtreeEntryToken token;
+    if (!GuardSubtreeEntryToken::make_tensor_match(
+            value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
+      return false;
+    }
+    tokens->emplace_back(std::move(token));
+    record_guard_fastplan_tensor_token_shadow();
+    return true;
+  }
 
  private:
   std::string _tensor_name;
+  bool _supports_subtree_memo_token;
   std::unique_ptr<TensorCheck> _tensor_check;
 };
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -600,10 +600,7 @@ static bool guard_subtree_probe_detail_enabled() {
 bool unsafe_mock_guard_bypass_enabled() {
   static const bool env_enabled =
       c10::utils::check_env("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == true;
-  // This bypass is an unsafe measurement aid. Keep it tied to the guard lookup
-  // stats path so accidentally exporting the env var does not skip guards in a
-  // normal performance run.
-  return C10_UNLIKELY(env_enabled) && C10_UNLIKELY(guard_lookup_stats_enabled());
+  return C10_UNLIKELY(env_enabled);
 }
 
 static bool guard_fast_plan_enabled() {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <mutex>
 #include <optional>
@@ -268,6 +269,17 @@ struct GuardLastSuccessStats {
 struct GuardFastPlanDisabledPathStats {
   uint64_t count{0};
   std::string reason;
+  bool has_mismatch_detail{false};
+  std::string old_kind;
+  std::string new_kind;
+  std::string old_type;
+  std::string new_type;
+  uint64_t old_object_id{0};
+  uint64_t new_object_id{0};
+  uint64_t old_version{0};
+  uint64_t new_version{0};
+  Py_ssize_t old_size{0};
+  Py_ssize_t new_size{0};
 };
 
 struct GuardAccessorTypeStats {
@@ -985,6 +997,18 @@ py::dict get_guard_lookup_stats() {
       py::dict item_stats;
       item_stats["count"] = path_items[i].second.count;
       item_stats["reason"] = path_items[i].second.reason;
+      if (path_items[i].second.has_mismatch_detail) {
+        item_stats["old_kind"] = path_items[i].second.old_kind;
+        item_stats["new_kind"] = path_items[i].second.new_kind;
+        item_stats["old_type"] = path_items[i].second.old_type;
+        item_stats["new_type"] = path_items[i].second.new_type;
+        item_stats["old_object_id"] = path_items[i].second.old_object_id;
+        item_stats["new_object_id"] = path_items[i].second.new_object_id;
+        item_stats["old_version"] = path_items[i].second.old_version;
+        item_stats["new_version"] = path_items[i].second.new_version;
+        item_stats["old_size"] = path_items[i].second.old_size;
+        item_stats["new_size"] = path_items[i].second.new_size;
+      }
       last_success_mismatch_top_paths[py::str(path_items[i].first)] =
           item_stats;
     }
@@ -2995,6 +3019,50 @@ static bool guard_subtree_token_vectors_match(
   return true;
 }
 
+static std::string guard_subtree_token_type_name(
+    const GuardSubtreeEntryToken* token) {
+  if (token == nullptr || token->type == nullptr) {
+    return std::string();
+  }
+  return token->type->tp_name == nullptr ? std::string()
+                                         : std::string(token->type->tp_name);
+}
+
+static uint64_t guard_subtree_token_object_id(
+    const GuardSubtreeEntryToken* token) {
+  if (token == nullptr || token->object == nullptr) {
+    return 0;
+  }
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(token->object));
+}
+
+static void record_guard_last_success_compare_mismatch_detail(
+    const std::string& path,
+    const GuardSubtreeEntryToken* old_token,
+    const GuardSubtreeEntryToken* new_token) {
+  if (!guard_lookup_stats_enabled() || path.empty()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_mismatch_stats_mutex());
+  auto& path_stats = guard_last_success_mismatch_path_stats()[path];
+  path_stats.has_mismatch_detail = true;
+  path_stats.old_kind = old_token == nullptr
+      ? std::string()
+      : guard_subtree_token_kind_name(old_token->kind);
+  path_stats.new_kind = new_token == nullptr
+      ? std::string()
+      : guard_subtree_token_kind_name(new_token->kind);
+  path_stats.old_type = guard_subtree_token_type_name(old_token);
+  path_stats.new_type = guard_subtree_token_type_name(new_token);
+  path_stats.old_object_id = guard_subtree_token_object_id(old_token);
+  path_stats.new_object_id = guard_subtree_token_object_id(new_token);
+  path_stats.old_version = old_token == nullptr ? 0 : old_token->version;
+  path_stats.new_version = new_token == nullptr ? 0 : new_token->version;
+  path_stats.old_size = old_token == nullptr ? 0 : old_token->size;
+  path_stats.new_size = new_token == nullptr ? 0 : new_token->size;
+}
+
 struct GuardLastSuccessReceipt {
   void reset() {
     entry_key = nullptr;
@@ -3058,6 +3126,15 @@ struct GuardLastSuccessReceipt {
           mismatch_kind,
           mismatch_index,
           mismatch_path == nullptr ? std::string() : *mismatch_path);
+      if (mismatch_path != nullptr) {
+        const GuardSubtreeEntryToken* old_token =
+            mismatch_index < tokens.size() ? &tokens[mismatch_index] : nullptr;
+        const GuardSubtreeEntryToken* new_token =
+            mismatch_index < new_tokens.size() ? &new_tokens[mismatch_index]
+                                               : nullptr;
+        record_guard_last_success_compare_mismatch_detail(
+            *mismatch_path, old_token, new_token);
+      }
     }
 
     if (stable) {

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -14,6 +14,12 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe);
 
 bool guard_lookup_stats_enabled();
 bool unsafe_mock_guard_bypass_enabled();
@@ -36,6 +42,9 @@ void record_root_guard_stats(
     uint64_t epilogue_ns,
     uint64_t tls_ns);
 void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index);
+void* create_guard_last_success_receipt();
+void destroy_guard_last_success_receipt(void* receipt);
+void reset_guard_last_success_receipt(void* receipt);
 
 struct LocalState {
   // TLS state that changes operators

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -94,6 +94,14 @@ class TensorCheck {
       const at::Tensor& v,
       const std::string& tensor_name);
 
+  const std::vector<std::optional<c10::SymInt>>& sizes() const {
+    return sizes_;
+  }
+
+  const std::vector<std::optional<c10::SymInt>>& strides() const {
+    return strides_;
+  }
+
   PyTypeObject* pytype;
 
  private:

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -4,6 +4,8 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 
+#include <cstdint>
+
 namespace torch::dynamo {
 
 PyObject* torch_c_dynamo_guards_init();
@@ -12,6 +14,28 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+
+bool guard_lookup_stats_enabled();
+bool unsafe_mock_guard_bypass_enabled();
+uint64_t guard_lookup_time_ns();
+void reset_guard_lookup_stats();
+py::dict get_guard_lookup_stats();
+void record_guard_lookup_stats(
+    uint64_t total_ns,
+    uint64_t backend_match_ns,
+    uint64_t slow_guard_ns,
+    uint64_t move_to_front_ns,
+    uint64_t cache_entry_count,
+    uint64_t cache_entry_hit_index);
+void record_root_guard_stats(
+    uint64_t total_ns,
+    uint64_t lock_ns,
+    uint64_t local_state_ns,
+    uint64_t leaf_ns,
+    uint64_t accessor_ns,
+    uint64_t epilogue_ns,
+    uint64_t tls_ns);
+void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index);
 
 struct LocalState {
   // TLS state that changes operators


### PR DESCRIPTION
## 背景

在大模型/推荐模型的 `torch.compile` 推理场景中，单次 step 进入 compiled region 前会经过 TorchDynamo cache lookup。这个 lookup 需要执行 guard 检查，用来判断当前输入、模块状态、全局状态是否仍然匹配已编译 graph。

现场 profile 发现，部分模型的耗时并不只在算子下发和 NPU kernel 上，step 边界处的 `TorchDynamo Cache Lookup` 也会成为明显瓶颈。进一步统计显示，主要开销集中在 guard tree 遍历，尤其是从 `L['self']` 开始递归检查大型 `nn.Module` 树：

- `L['self']`
- `L['self'].__dict__`
- `L['self']._modules`
- 大量子 module / parameter / buffer guard

这些 guard 大多数每轮都 pass，并不是因为频繁失败导致慢，而是稳定场景下仍然重复完整遍历一棵很大的 guard 子树。

## 核心问题

原始路径的行为是：

1. 每次进入 compiled graph 前执行 Dynamo cache lookup。
2. 对 cache entry 执行完整 guard tree。
3. 大型模型中，`self._modules` 子树很深，guard accessor traversal 成本很高。
4. 即使模型结构和 tensor metadata 完全稳定，每次仍然重复做完整检查。

这会造成 CPU 侧 step 边界开销偏大，并间接影响端到端 latency。

## 核心优化

本 PR 增加一套 guard lookup fast path，用于稳定模型场景下减少重复 guard tree 遍历。

主要包括：

1. **Guard lookup stats**
   - 增加 guard lookup 统计能力。
   - 可以看到 lookup 总耗时、slow guard 耗时、root guard 耗时、accessor traversal 耗时、fast path hit/miss、disabled reason 等。
   - 用于定位 guard 开销来源和判断 fast path 是否生效。

2. **Guard fastplan token**
   - 在可证明安全的 guard 子树上，把原来的递归 guard 检查压缩成一组轻量 token。
   - 后续 lookup 先检查 token，如果 token 全部稳定，则跳过对应 guard 子树。
   - token 覆盖对象 identity、dict/list/tuple 结构、tensor metadata、default device、global state、torch function mode stack、aliasing 等稳定性信息。

3. **Last Successful Guard Memo**
   - 记录上一次成功通过 guard 的 cache entry 和部分稳定子树。
   - 下一次 lookup 如果命中同一个稳定场景，优先走 memo fast path。
   - 对可完整证明稳定的部分直接跳过 slow guard；对不完全可证明的部分仍然回退 slow guard。

4. **Partial memo fast path**
   - 对大型 module tree，不要求整棵树一次性完全覆盖。
   - 能证明稳定的子树先走 fast path，不能证明的子树继续走原始 slow guard。
   - 这样可以渐进式吃掉最大热点，同时保持语义安全。

5. **Shadow validation / diagnostics**
   - 增加 shadow 检查与 mismatch 统计。
   - 可以验证 fast path 判断和原 slow guard 结果是否一致。
   - 昂贵的 full shadow 检查通过 `TORCHDYNAMO_GUARD_LAST_SUCCESS_SHADOW_FULL` 单独控制，默认不影响性能路径。

6. **Unsafe mock bypass**
   - 增加 `TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS`，用于性能上限实验。
   - 该开关会绕过 guard，只用于验证 guard lookup 理论最大收益，不用于生产。
   - 已与 stats 解耦，单独打开 mock bypass 即可测试极限性能。

## 安全设计

该优化遵循保守原则：

- fast path 只在 token 能证明 guard 依赖未变化时生效。
- 任何 token mismatch、缺失、不支持的 guard 类型，都会回退原始 slow guard。
- 不改变原始 guard 的失败语义。
- 不支持的 leaf guard 不强行覆盖，先记录 reason，再按需扩展。
- mock bypass 明确标记为 unsafe，仅用于实验，不参与正常安全路径。

## 约束

当前优化主要面向以下场景收益最大：

- compiled graph 被反复调用。
- 模型结构稳定。
- `self._modules` / parameter / buffer / tensor metadata 大部分不变。
- Dynamo cache entry 稳定命中。
- step 边界 guard lookup 在 profile 中占比较高。

以下场景收益有限或会回退：

- 模型结构频繁变化。
- 参数、buffer、tensor metadata 每轮变化。
- guard 中包含暂不支持 token 化的复杂 Python 语义。
- cache entry 不稳定命中。
- 首次 warmup / 首次建立 memo 时仍需走 slow guard。

## 诊断方式

常用环境变量：

```bash
export TORCHDYNAMO_GUARD_FAST_PLAN=1
export TORCHDYNAMO_GUARD_LOOKUP_STATS=1

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98