### PR TITLE
Apply libnop clang warning suppression to TensorPipe subtargets

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1200,10 +1200,22 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
 
     # Tensorpipe uses cuda_add_library
     torch_update_find_cuda_flags()
+    # Suppress warning to unblock libnop compilation by clang-17.
+    # Apply it while creating TensorPipe targets so nested libnop users such as
+    # tensorpipe_cuda also inherit it.
+    set(_tensorpipe_libnop_compile_options "")
+    append_cxx_flag_if_supported(
+      "-Wno-missing-template-arg-list-after-template-kw"
+      _tensorpipe_libnop_compile_options)
+    get_directory_property(_caffe2_compile_options COMPILE_OPTIONS)
+    if(NOT "${_tensorpipe_libnop_compile_options}" STREQUAL "")
+      add_compile_options(
+        "$<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-template-arg-list-after-template-kw>")
+    endif()
     add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/tensorpipe)
-    # Suppress warning to unblock libnop compilation by clang-17
-    # See https://github.com/pytorch/pytorch/issues/151316
-    target_compile_options_if_supported(tensorpipe -Wno-missing-template-arg-list-after-template-kw)
+    set_directory_properties(PROPERTIES COMPILE_OPTIONS "${_caffe2_compile_options}")
+    unset(_caffe2_compile_options)
+    unset(_tensorpipe_libnop_compile_options)
     # Workaround for relocation truncated to fit: R_AARCH64_CALL26 against symbol __aarch64_swp4_relax'
     # When compiling for ARMv8.0, build uv with embedded atomics, which are slightly slower
     # But are used only once during shutdown


### PR DESCRIPTION
## Summary

This PR broadens the existing TensorPipe/libnop Clang warning workaround so it also applies to TensorPipe subtargets created during `add_subdirectory(third_party/tensorpipe)`.

PyTorch already suppresses `-Wmissing-template-arg-list-after-template-kw` on the main `tensorpipe` target because vendored libnop triggers newer Clang diagnostics. That target-level suppression does not cover nested TensorPipe targets such as `tensorpipe_cuda`, which are created inside TensorPipe's CMake subdirectory and can include the same libnop headers.

The concrete failure looks like:

```text
third_party/tensorpipe/third_party/libnop/include/nop/types/variant.h:265:26: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  if (!value_.template Assign(index_, std::forward<T>(value))) {
                         ^
```

This keeps the workaround scoped to TensorPipe by temporarily adding a checked CXX-only compile option while TensorPipe creates its targets, then restoring the parent directory compile options afterward.

Longer term, the cleaner fix is probably in libnop itself: calls such as `value_.template Assign(...)` can be written as `value_.template Assign<>(...)`, preserving template argument deduction while satisfying newer Clang. I tested that source-level fix locally, but `google/libnop` is archived/read-only, so I am opening this PyTorch PR to make the issue visible and discuss the preferred path.

## Testing

```bash
git diff --check
```

```bash
lintrunner -a
```

Not run: `lintrunner` is not installed in this environment, and no `.venv` exists in `/tmp/pytorch-tensorpipe-libnop-pr` or its parent directories.

For the underlying libnop source issue, I also tested a source-level fix in `/tmp/libnop-clang-template-fix`:

```bash
clang++ -std=c++17 -Iinclude -Werror=missing-template-arg-list-after-template-kw -fsyntax-only /tmp/libnop-repro_variant.cpp
make clean
make all CXX=clang++ HOST_CXXFLAGS='-std=c++14 -Werror=missing-template-arg-list-after-template-kw'
```

The libnop Makefile reported that gtest was not installed, so the gtest-based test binary was not built. The example targets built successfully with the warning promoted to an error.
