### PR TITLE
Fix caching of DeviceMesh.get_coordinate results in LocalTensorMode

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,9 +1261,7 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Cache for get_coordinate results, keyed by mesh id
-        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
-        self._coordinate_cache: dict[int, list[SymInt]] = {}
+        # Shared lock for LocalDeviceMesh coordinate caching for thread safety in MPMD contexts
         self._coordinate_cache_lock = threading.Lock()
 
     def __enter__(self) -> "LocalTensorMode":
@@ -1632,22 +1630,25 @@ class _LocalDeviceMesh:
         if lm is None:
             raise AssertionError("Unexpectedly not in LocalTensorMode")
 
+        ranks = lm.ranks
         # Check cache first (fast path without lock)
-        mesh_id = id(self)
-        if mesh_id in lm._coordinate_cache:
-            return lm._coordinate_cache[mesh_id]
-
+        # Note that we are caching the result based on the set of ranks,
+        # so that different LocalTensorModes with different ranks will not interfere with each other's cache.
+        with contextlib.suppress(AttributeError, KeyError):
+            return self._local_coordinates_cache[ranks]
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
-            # Double-check after acquiring lock
-            if mesh_id in lm._coordinate_cache:
-                return lm._coordinate_cache[mesh_id]
-
+            try:
+                return self._local_coordinates_cache[ranks]
+            except AttributeError:
+                self._local_coordinates_cache = {}
+            except KeyError:
+                pass
             coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
             # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
             # error when running under torch.inference_mode()
             rank_map = self._rank_map.clone()
-            for r in lm.ranks:
+            for r in ranks:
                 rank_tensor = self._layout.remap_to_tensor(rank_map)
                 rank_coords = (rank_tensor == r).nonzero().tolist()
                 if len(rank_coords) != 1:
@@ -1656,8 +1657,7 @@ class _LocalDeviceMesh:
                     coords[d][r] = c
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
-            # Cache the result
-            lm._coordinate_cache[mesh_id] = out
+            self._local_coordinates_cache[ranks] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions
             # as the current mesh.

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1635,12 +1635,15 @@ class _LocalDeviceMesh:
         # Note that we are caching the result based on the set of ranks,
         # so that different LocalTensorModes with different ranks will not interfere with each other's cache.
         with contextlib.suppress(AttributeError, KeyError):
+            # pyrefly: ignore [missing-attribute]
             return self._local_coordinates_cache[ranks]
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
             try:
+                # pyrefly: ignore [missing-attribute]
                 return self._local_coordinates_cache[ranks]
             except AttributeError:
+                # pyrefly: ignore [missing-attribute]
                 self._local_coordinates_cache = {}
             except KeyError:
                 pass
@@ -1657,6 +1660,7 @@ class _LocalDeviceMesh:
                     coords[d][r] = c
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
+            # pyrefly: ignore [missing-attribute]
             self._local_coordinates_cache[ranks] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions


### PR DESCRIPTION
Alternative to https://github.com/pytorch/pytorch/pull/184534 after discussion.

Move coordinate cache to LocalDeviceMesh.

The cache used the `id` of the Mesh as the key which is not unique over the lifetime of the `LocalTensorMode` instance:
When the mesh is destroyed its slot may be reused leading to silently wrong, indeterministic results.
E.g.:
        mesh_dim0_local_rank = mesh_2d["dim0"].get_local_rank(mesh_dim=0)
        mesh_dim1_local_rank = mesh_2d["dim1"].get_local_rank(mesh_dim=0)
The values for both might be the same as the 2nd could use the cached coords from the first submesh, which is a temporary that gets immediately destroyed.

Caching the result directly in LocalDeviceMesh, as it is a property of that, is safer.
It might be possible that during the lifetime of a LocalDeviceMesh the LocalTensorMode is changed which affects the coordinate calculation through the `ranks` value, so use that as a key of a dict instead of storing the value directly in a property.

Fixes #184526
Fixes 8e65dfa6f2c451dc3c71d76d68796d1271c72772.


Possible issue: I accounted for a changing `LocalTensorMode` as that is where the cache lived previously. I'm not sure if that could happen in practice but assumed it may. If different threads are in different local tensor modes but working with the same local mesh the lock will not be the same leading to a race condition. The only solution would be to move the lock to `DeviceMesh` but it [was argued](https://github.com/pytorch/pytorch/pull/184534#issuecomment-4625547906) that `LocalDeviceMesh`-specific stuff shouldn't go into `DeviceMesh`.
I don't see how that situation might happen though: Can different `LocalTensorMode`s be active across threads using the same `DeviceMesh`?


The alternative is to keep caching in `LocalTensorMode` but using `(self._flatten_rank_map, self._layout)` as the key, which is what the result depends on, so should be fine but might be a bit more costly as it is larger.
Additionally the cached value should be a property of `LocalDeviceMesh` because it is caching the return value of a function of it. So that seems cleaner.
Implemented that in https://github.com/pytorch/pytorch/pull/187052 for comparison