### PR TITLE
[DTensor] Preserve symbolic local layouts without DDE guards

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -251,6 +251,20 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         res = fn(x)
         res.to_local().sum().backward()
 
+    def test_to_local_backward_unbacked_symbolic_stride(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        local = torch.randn(8, 8, device=self.device_type, requires_grad=True)
+        x = DTensor.from_local(local, mesh, [Shard(0)], run_check=False)
+        torch._dynamo.decorators.mark_unbacked(x, 0, hint_override=x.shape[0])
+        torch._dynamo.decorators.mark_unbacked(x, 1, hint_override=x.shape[1])
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def fn(x):
+            return (x.to_local() * 2).sum()
+
+        fn(x).backward()
+        self.assertEqual(local.grad, torch.full_like(local, 2))
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW or TEST_XPU,
         "https://github.com/pytorch/pytorch/issues/178745",

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -308,6 +308,58 @@ class TestCostModel(DTensorOpTestBase):
             )
             self.assertFalse(output_sharding.needs_redistribute)
 
+    def test_t_prunes_unproven_unbacked_strided_shard_candidates(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.distributed.tensor._ops.utils import is_tensor_shardable
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        mesh = DeviceMesh("cpu", torch.arange(2), _init_backend=False, _rank=0)
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        strategy_info = (
+            DTensor._op_dispatcher.sharding_propagator.op_single_dim_strategy_funcs[
+                torch.ops.aten.t.default
+            ]
+        )
+        self.assertFalse(strategy_info.allow_unbacked_sharding)
+
+        with fake_mode:
+            split_factor = fake_mode.shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(split_factor, 8)
+            input_meta = TensorMeta(
+                torch.Size([2048 * split_factor, 8]),
+                (8, 1),
+                torch.float32,
+            )
+
+            unproven_input_spec = DTensorSpec(
+                mesh,
+                (_StridedShard(1, split_factor=split_factor),),
+                input_meta,
+            )
+            self.assertFalse(
+                is_tensor_shardable(
+                    input_meta.shape,
+                    unproven_input_spec,
+                    allow_unbacked_sharding=strategy_info.allow_unbacked_sharding,
+                )
+            )
+
+            input_spec = DTensorSpec(
+                mesh,
+                (_StridedShard(0, split_factor=split_factor),),
+                input_meta,
+            )
+            op_schema = OpSchema(torch.ops.aten.t.default, (input_spec,), {})
+            output_sharding = DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding_non_cached(
+                op_schema
+            )
+
+        self.assertFalse(output_sharding.needs_redistribute)
+        self.assertEqual(
+            output_sharding.output_spec.placements,
+            (_StridedShard(1, split_factor=split_factor),),
+        )
+
     def test_bmm_strategies(self):
         mesh = self.build_device_mesh()
         lhs_tensor = torch.randn(8, 6, 8)

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -105,6 +105,7 @@ class _ToTorchTensor(torch.autograd.Function):
         ctx.grad_placements = grad_placements
         ctx.set_materialize_grads(False)
         local_tensor = input._local_tensor
+        ctx.local_tensor_stride = local_tensor.stride()
 
         # We need to return a fresh Tensor object there as autograd metadata
         # will be inplaced into it. So we don't want to pollute the Tensor
@@ -121,25 +122,78 @@ class _ToTorchTensor(torch.autograd.Function):
         grad_placements = ctx.grad_placements
         dtensor_meta = dtensor_spec.tensor_meta
 
-        _, tensor_stride = compute_global_tensor_info(
-            grad_output, mesh, dtensor_spec.placements
-        )
-        tensor_stride = tuple(tensor_stride)
-
         # user should provide grad_placements as there's no guarantee on input gradient placement
         # if grad_placement is None, we provide default placement
         if grad_placements is None:
             # See DTensor.from_local docstring for gradient placement guarantees
             grad_placements = _normalize_placements_for_grad(dtensor_spec.placements)
 
+        from torch._prims_common import check_contiguous_sizes_strides
+        from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+        def strides_provably_match(stride, other):
+            return len(stride) == len(other) and all(
+                guard_or_false(a == b) for a, b in zip(stride, other)
+            )
+
+        def strides_provably_differ(stride, other):
+            return len(stride) != len(other) or any(
+                guard_or_false(a != b) for a, b in zip(stride, other)
+            )
+
+        def strides_are_contiguous_for_shape(shape, stride, other):
+            if not (len(shape) == len(stride) == len(other)):
+                return False
+            return check_contiguous_sizes_strides(
+                shape, stride, false_if_dde=True
+            ) and check_contiguous_sizes_strides(shape, other, false_if_dde=True)
+
+        def strides_may_match(shape, stride, other):
+            return (
+                strides_provably_match(stride, other)
+                or strides_are_contiguous_for_shape(shape, stride, other)
+                or not strides_provably_differ(stride, other)
+            )
+
+        def check_stride_matches(shape, stride, other):
+            if strides_provably_match(
+                stride, other
+            ) or strides_are_contiguous_for_shape(shape, stride, other):
+                return
+            for a, b in zip(stride, other):
+                torch._check(
+                    a == b,
+                    lambda: (
+                        f"Expected matching DTensor local strides, got {stride} and {other}"
+                    ),
+                )
+
+        # Same-placement to_local() backward preserves the forward DTensor
+        # layout. With symbolic shapes, the local grad stride can be equivalent
+        # to the saved stride while carrying different symbol provenance.
         if (
-            tensor_stride == dtensor_meta.stride
-            and grad_placements == dtensor_spec.placements
+            grad_placements == dtensor_spec.placements
+            and strides_may_match(
+                grad_output.shape, grad_output.stride(), ctx.local_tensor_stride
+            )
+            and strides_may_match(
+                dtensor_meta.shape, ctx.local_tensor_stride, dtensor_meta.stride
+            )
         ):
+            check_stride_matches(
+                grad_output.shape, grad_output.stride(), ctx.local_tensor_stride
+            )
+            check_stride_matches(
+                dtensor_meta.shape, ctx.local_tensor_stride, dtensor_meta.stride
+            )
             # Avoid actual sharing of specs in case they're modified during (e.g.)
             # sharding propagation.
             grad_spec = copy.copy(dtensor_spec)
         else:
+            _, tensor_stride = compute_global_tensor_info(
+                grad_output, mesh, dtensor_spec.placements
+            )
+            tensor_stride = tuple(tensor_stride)
             grad_spec = DTensorSpec(
                 mesh,
                 grad_placements,

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -37,7 +37,7 @@ from torch.fx.experimental.symbolic_shapes import guard_or_false
 aten = torch.ops.aten
 
 
-@register_single_dim_strategy(aten.t.default)
+@register_single_dim_strategy(aten.t.default, allow_unbacked_sharding=False)
 def transpose_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:


### PR DESCRIPTION

Compiled DTensor paths can see symbolic local layout metadata that is
semantically valid but not syntactically identical to the metadata saved during
forward propagation.

For `to_local()` backward, AOTAutograd can produce a local gradient stride like
`(Max(1, u3), 1)` while the saved DTensor metadata uses `(u1, 1)`. The previous
backward path recomputed the global gradient stride before deciding whether it
could reuse the original DTensor spec. That forced
`compute_global_tensor_info()` to evaluate symbolic stride relations and could
raise a data-dependent guard for the default same-placement backward path.

Reuse the original DTensor spec only for the default same-placement backward
when the local gradient stride, saved forward local stride, and DTensor spec
stride are compatible. Exact/provable stride equality is accepted directly. For
contiguous symbolic stride forms such as `Max(1, u*)`, use the existing
`check_contiguous_sizes_strides(..., false_if_dde=True)` helper so equivalent
contiguous layouts are recognized without requiring a brittle exact symbolic
match. If neither exact nor contiguous equivalence can be proven, emit
`torch._check` assertions for the required stride equalities before taking the
symbolic shortcut.

If the placement changes or the physical local stride cannot justify the
original spec layout, keep the existing recomputation path and build a fresh
spec from the observed gradient stride. This avoids the symbolic guard failure
without lying about memory layout. In particular, uneven channels-last shards
must keep using the recomputation path so autograd can repair the physical local
gradient layout correctly.

The same class of issue also appears in `aten.t` sharding propagation. The
single-dim strategy can enumerate candidate placements that move a symbolic
`_StridedShard` split factor onto the other tensor dimension. When that
candidate is not provably shardable, strategy expansion should reject it instead
of evaluating a Python bool on an unbacked expression such as `8 < 2*u0`.
Register transpose with `allow_unbacked_sharding=False` so unproven candidates
are pruned while statically valid candidates, including `_StridedShard(0, u0)`
propagating to `_StridedShard(1, u0)`, are still kept.

Fixes #187025

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python -m pytest test/distributed/tensor/test_op_strategy.py::TestCostModel::test_t_prunes_unproven_unbacked_strided_shard_candidates test/distributed/tensor/test_op_strategy.py::TestCostModel::test_mm_strategies test/distributed/tensor/test_dtensor_compile.py::TestDTensorCompile::test_to_local_backward_unbacked_symbolic_stride test/distributed/tensor/test_tensor_ops.py::TestNewEmptyStridedUneven::test_backward_channels_last -q -s
```

```bash
lintrunner -a
```
