### PR TITLE
[inductor] Preserve backend compiler options in user defined triton kernels 

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -2569,7 +2569,7 @@ class GraphModule(torch.nn.Module):
         def forward(self, x: "f32[5]", y: "f32[5]"):
             o: "f32[5]" = torch.zeros_like(x)
 
-            triton_kernel_wrapper_mutation = torch.ops.higher_order.triton_kernel_wrapper_mutation(kernel_idx = 0, constant_args_idx = 0, grid = [(5, 1, 1)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x, 'in_ptr1': y, 'out_ptr': o});  x = y = triton_kernel_wrapper_mutation = None
+            triton_kernel_wrapper_mutation = torch.ops.higher_order.triton_kernel_wrapper_mutation(kernel_idx = 0, constant_args_idx = 0, grid = [(5, 1, 1)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x, 'in_ptr1': y, 'out_ptr': o}, launch_kwargs = ('BLOCK_SIZE',));  x = y = triton_kernel_wrapper_mutation = None
 
             sin: "f32[5]" = o.sin();  o = None
             return (sin,)

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -153,6 +153,19 @@ class FxirTestCase(InductorTestCase):
         args = [torch.randn(8, device=self.device) for _ in range(2)]
         self._compile_and_check(torch.add, args)
 
+    def test_standard_kernel_omits_empty_launch_kwargs(self):
+        args = [torch.randn(8, device=self.device) for _ in range(2)]
+        (gm,) = self._compile_and_check(torch.add, args)
+        (triton_node,) = gm.graph.find_nodes(
+            op="call_function", target=triton_kernel_wrapper_mutation
+        )
+
+        # launch_kwargs is only needed when user Triton backend options must be
+        # replayed. Omitting the empty case keeps standard FXIR HOP calls
+        # compatible with downstream py_impls that have fixed keyword-only
+        # signatures matching the original HOP payload.
+        self.assertNotIn("launch_kwargs", triton_node.kwargs)
+
     def test_device_type(self):
         """
         Test that we allocate on a device type instead of a specific index.

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -42,7 +42,6 @@ from torch.testing._internal.inductor_utils import (
     HAS_GPU,
     patch_custom_fallback_pass,
     requires_gpu,
-    TRITON_HAS_CPU,
 )
 from torch.utils._sympy.functions import FloorDiv
 
@@ -1478,5 +1477,5 @@ class TestReplaceFloorDiv(InductorTestCase):
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU or TRITON_HAS_CPU:
+    if HAS_GPU:
         run_tests(needs="filelock")

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2873,6 +2873,50 @@ def forward(self, arg0_1, arg1_1):
         self._assert_triton_compile_option(options, "enable_fp_fusion", False)
 
     @requires_gpu
+    def test_triton_kernel_backend_options_preserved_in_fx_wrapper_hop(self):
+        add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=False)
+        f = _get_backend_options_fn(add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False)
+
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+        from torch._inductor.codegen.wrapper_fxir import FxConverter
+
+        captured_gms = []
+        orig_generate = FxConverter.generate
+
+        def record_generate(self):
+            gm = orig_generate(self)
+            captured_gms.append(gm)
+            return gm
+
+        x = torch.randn(4, device=GPU_TYPE)
+        with (
+            inductor_config.patch({"fx_wrapper": True, "compile_threads": 1}),
+            mock.patch.object(FxConverter, "generate", record_generate),
+        ):
+            out = torch.compile(f, fullgraph=True)(x, x)
+
+        self.assertEqual(out, x + x)
+        self.assertTrue(captured_gms)
+        hop_node = next(
+            node
+            for node in captured_gms[0].graph.nodes
+            if node.op == "call_function"
+            and node.target is triton_kernel_wrapper_mutation
+            and "enable_fp_fusion" in node.kwargs["launch_kwargs"]
+        )
+        constant_args = kernel_side_table.get_constant_args(
+            hop_node.kwargs["constant_args_idx"]
+        )
+        hop_kwargs = {**hop_node.kwargs["kwargs"], **constant_args}
+
+        # The FX wrapper runs the HOP directly, so names alone are not enough:
+        # non-signature backend options also need their values in the HOP
+        # payload. Otherwise the direct FXIR run re-enters Triton JIT with
+        # default compiler options and may compile a different kernel.
+        self.assertEqual(hop_node.kwargs["launch_kwargs"], ("enable_fp_fusion",))
+        self.assertEqual(hop_kwargs["enable_fp_fusion"], False)
+
+    @requires_gpu
     def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):
         # SPECIAL_CONFIG_NAMES keep the existing behavior: they update Triton
         # configs instead of being preserved as generic backend options.

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -4666,6 +4666,96 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         expected = torch.empty_like(x)
         self.assertEqual(out, expected)
 
+    @unittest.skipIf(not has_triton_package(), "requires triton")
+    def test_capture_triton_backend_options_exclude_kernel_args(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pass
+
+        def f(x, y):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                in_ptr0=x,
+                in_ptr1=y,
+                out_ptr=output,
+                n_elements=n_elements,
+                BLOCK_SIZE=16,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        x = torch.randn(4)
+        y = torch.randn(4)
+        gm = make_fx(f, tracing_mode="symbolic")(x, y)
+        hop_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is triton_kernel_wrapper_mutation
+        )
+
+        # capture_triton sees the original launch kwargs, including tensor and
+        # symbolic kernel args. Those names must remain in kwargs, not in
+        # backend_options, because backend_options are later parsed as compiler
+        # options.
+        self.assertEqual(
+            set(hop_node.kwargs["kwargs"]),
+            {"in_ptr0", "in_ptr1", "out_ptr", "n_elements", "BLOCK_SIZE"},
+        )
+        self.assertEqual(
+            hop_node.kwargs["backend_options"], {"enable_fp_fusion": False}
+        )
+
+    @unittest.skipIf(not has_triton_package(), "requires triton")
+    def test_capture_triton_dynamic_backend_options_error(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pass
+
+        def f(x):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                in_ptr0=x,
+                out_ptr=output,
+                n_elements=n_elements,
+                BLOCK_SIZE=16,
+                grid_launch_partition=(n_elements,),
+            )
+            return output
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        # Unlike n_elements above, grid_launch_partition is not a kernel
+        # parameter. If it contains a symbolic value, it cannot be represented
+        # as a concrete compile-time backend option.
+        with self.assertRaisesRegex(
+            RuntimeError, "Triton backend options must be concrete values"
+        ):
+            make_fx(f, tracing_mode="symbolic")(torch.randn(4))
+
     @requires_gpu
     def test_wrap_triton_disabled_in_triton_op(self):
         import triton  # @manual

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -434,7 +434,7 @@ class KernelTests(torch._inductor.test_case.TestCase):
             gm.code.strip(),
             """\
 def forward(self, x_1, output_1):
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr']);  x_1 = output_1 = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr'], backend_options = {});  x_1 = output_1 = None
     getitem = triton_kernel_wrapper_functional_proxy['in_ptr0'];  getitem = None
     getitem_1 = triton_kernel_wrapper_functional_proxy['out_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return getitem_1""",
@@ -2288,7 +2288,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256;  arg0_1 = None
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  floordiv = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  floordiv = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2301,7 +2301,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2312,7 +2312,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2322,7 +2322,7 @@ def forward(self, arg0_1, arg1_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2669,6 +2669,168 @@ def forward(self, arg0_1, arg1_1):
 
         x = torch.randn(4, device=GPU_TYPE)
         f(x, x)
+
+    @requires_gpu
+    def test_triton_kernel_backend_options_without_signature(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                BLOCK_SIZE=128,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
+        self.assertEqual(out, x + x)
+        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+
+    @requires_gpu
+    def test_triton_kernel_backend_options_also_used_as_kernel_kwarg(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+            enable_fp_fusion: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            if enable_fp_fusion:
+                result = x + y
+            else:
+                result = x * y
+            tl.store(out_ptr + offsets, result, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                BLOCK_SIZE=128,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        y = torch.randn(4, device=GPU_TYPE)
+        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, y)
+        self.assertEqual(out, x * y)
+        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+
+    @requires_gpu
+    def test_triton_kernel_backend_options_with_autotune(self):
+        @triton.autotune(
+            configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
+            key=[],
+        )
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
+        self.assertEqual(out, x + x)
+        self.assertIn("@triton_heuristics.user_autotune", code)
+        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+
+    @requires_gpu
+    def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):
+        @triton.autotune(
+            configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
+            key=[],
+        )
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                num_warps=8,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
+        self.assertEqual(out, x + x)
+        self.assertIn("'num_warps': 8", code)
+        self.assertNotIn("backend_options", code)
 
     @requires_gpu
     @common_utils.parametrize("backend", ["eager", "aot_eager", "inductor"])

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -215,6 +215,30 @@ class KernelTests(torch._inductor.test_case.TestCase):
             return f"launchKernel({kernel_name}" in code
         return f"{kernel_name}.run(" in code
 
+    def _run_and_get_triton_compile_options(self, fn, *args):
+        # TestCase already gives each test a fresh compile cache. This patch
+        # only keeps compilation in-process while the triton.compile mock is
+        # installed, so we can assert on the actual options passed to Triton.
+        with (
+            inductor_config.patch("compile_threads", 1),
+            mock.patch.object(triton, "compile", wraps=triton.compile) as compile_mock,
+        ):
+            out, codes = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+        compile_options = [
+            dict(call.kwargs["options"])
+            for call in compile_mock.call_args_list
+            if "options" in call.kwargs
+        ]
+        self.assertTrue(compile_options)
+        return out, codes, compile_options
+
+    def _assert_triton_compile_option(self, options, name, expected_value):
+        self.assertTrue(
+            any(option.get(name) == expected_value for option in options),
+            f"expected triton.compile options to include "
+            f"{name}={expected_value!r}, got {options!r}",
+        )
+
     @requires_gpu
     def test_triton_kernel_with_kernel_param(self):
         @triton.jit
@@ -498,7 +522,7 @@ class KernelTests(torch._inductor.test_case.TestCase):
             gm.code.strip(),
             """\
 def forward(self, x_1, output_1):
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr'], backend_options = {});  x_1 = output_1 = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr'], launch_kwargs = ());  x_1 = output_1 = None
     getitem = triton_kernel_wrapper_functional_proxy['in_ptr0'];  getitem = None
     getitem_1 = triton_kernel_wrapper_functional_proxy['out_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return getitem_1""",
@@ -2352,7 +2376,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256;  arg0_1 = None
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  floordiv = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  floordiv = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2365,7 +2389,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2376,7 +2400,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2386,7 +2410,7 @@ def forward(self, arg0_1, arg1_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], backend_options = {});  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2742,10 +2766,28 @@ def forward(self, arg0_1, arg1_1):
         f = _get_backend_options_fn(add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
-        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
+        out, _, options = self._run_and_get_triton_compile_options(f, x, x)
         self.assertEqual(out, x + x)
-        self.assertIn("'backend_options':", code)
-        self.assertIn("'enable_fp_fusion': False", code)
+        self._assert_triton_compile_option(options, "enable_fp_fusion", False)
+
+    @requires_gpu
+    def test_triton_kernel_invalid_backend_options_error(self):
+        # Dynamo leaves the determination of the target triton backend to
+        # inductor, so it will accept constant non-kernel arguments provided
+        # to a user defined triton kernels launch. Inductor will then validate
+        # backend compiler options once the target is known:
+        # every launch kwarg must be either a kernel parameter or a
+        # backend option accepted by backend.parse_options(), matching direct
+        # Triton's _pack_args check.
+        add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=False)
+        f = _get_backend_options_fn(
+            add_kernel, BLOCK_SIZE=128, not_a_backend_option=False
+        )
+
+        x = torch.randn(4, device=GPU_TYPE)
+        msg = "Triton launch kwargs must be kernel parameters or valid backend options"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.compile(f, fullgraph=True)(x, x)
 
     @requires_gpu
     def test_triton_kernel_backend_options_also_used_as_kernel_kwarg(self):
@@ -2765,10 +2807,9 @@ def forward(self, arg0_1, arg1_1):
         eager_backend_out = torch.compile(f, backend="eager", fullgraph=True)(x, y)
         self.assertEqual(eager_backend_out, x * y)
 
-        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, y)
+        out, _, options = self._run_and_get_triton_compile_options(f, x, y)
         self.assertEqual(out, x * y)
-        self.assertIn("'backend_options':", code)
-        self.assertIn("'enable_fp_fusion': False", code)
+        self._assert_triton_compile_option(options, "enable_fp_fusion", False)
 
     @requires_gpu
     def test_triton_kernel_backend_options_also_kernel_kwarg_with_autotune(self):
@@ -2786,11 +2827,10 @@ def forward(self, arg0_1, arg1_1):
         eager_backend_out = torch.compile(f, backend="eager", fullgraph=True)(x, y)
         self.assertEqual(eager_backend_out, x * y)
 
-        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, y)
+        out, (code,), options = self._run_and_get_triton_compile_options(f, x, y)
         self.assertEqual(out, x * y)
         self.assertIn("@triton_heuristics.user_autotune", code)
-        self.assertIn("'backend_options':", code)
-        self.assertIn("'enable_fp_fusion': False", code)
+        self._assert_triton_compile_option(options, "enable_fp_fusion", False)
 
     @requires_gpu
     def test_triton_kernel_autotune_config_conflicts_with_launch_kwarg(self):
@@ -2827,11 +2867,10 @@ def forward(self, arg0_1, arg1_1):
         f = _get_backend_options_fn(add_kernel, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
-        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
+        out, (code,), options = self._run_and_get_triton_compile_options(f, x, x)
         self.assertEqual(out, x + x)
         self.assertIn("@triton_heuristics.user_autotune", code)
-        self.assertIn("'backend_options':", code)
-        self.assertIn("'enable_fp_fusion': False", code)
+        self._assert_triton_compile_option(options, "enable_fp_fusion", False)
 
     @requires_gpu
     def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):
@@ -2850,7 +2889,7 @@ def forward(self, arg0_1, arg1_1):
         self.assertNotIn("backend_options", code)
 
     @requires_gpu
-    def test_capture_triton_backend_options_exclude_kernel_args(self):
+    def test_capture_triton_backend_options_preserve_launch_kwarg_names(self):
         @triton.jit
         def add_kernel(
             in_ptr0,
@@ -2866,9 +2905,9 @@ def forward(self, arg0_1, arg1_1):
             n_elements = output.numel()
             grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
             capture_triton(add_kernel)[grid](
-                in_ptr0=x,
-                in_ptr1=y,
-                out_ptr=output,
+                x,
+                y,
+                output,
                 n_elements=n_elements,
                 BLOCK_SIZE=16,
                 enable_fp_fusion=False,
@@ -2887,17 +2926,19 @@ def forward(self, arg0_1, arg1_1):
             and node.target is triton_kernel_wrapper_mutation
         )
 
-        # capture_triton sees the original launch kwargs, including tensor and
-        # symbolic kernel args. Dynamic kernel args must remain only in kwargs,
-        # not backend_options, while concrete launch kwargs such as BLOCK_SIZE
-        # and enable_fp_fusion stay visible to backend.parse_options().
+        # capture_triton preserves the original launch kwarg names separately
+        # from the normalized argument values. Kernel args are present here too
+        # because names such as enable_fp_fusion may have direct Triton dual
+        # meaning as both a kernel parameter and a compiler option. Inductor
+        # later recovers values by name and filters them with the target
+        # backend before serializing triton_meta.
         self.assertEqual(
-            set(hop_node.kwargs["kwargs"]),
-            {"in_ptr0", "in_ptr1", "out_ptr", "n_elements", "BLOCK_SIZE"},
-        )
-        self.assertEqual(
-            hop_node.kwargs["backend_options"],
-            {"BLOCK_SIZE": 16, "enable_fp_fusion": False},
+            set(hop_node.kwargs["launch_kwargs"]),
+            {
+                "n_elements",
+                "BLOCK_SIZE",
+                "enable_fp_fusion",
+            },
         )
 
     @requires_gpu
@@ -2938,11 +2979,11 @@ def forward(self, arg0_1, arg1_1):
         # Direct Triton gives a kwarg such as enable_fp_fusion two meanings
         # when the kernel also has a parameter with that name: it binds the
         # tl.constexpr parameter and backend.parse_options() still sees it as
-        # a backend option. The tracing path should preserve that concrete
-        # kwarg instead of dropping it just because it is also a kernel arg.
+        # a backend option. The tracing path should preserve the launch-site
+        # name instead of dropping it just because it is also a kernel arg.
         self.assertEqual(
-            hop_node.kwargs["backend_options"],
-            {"BLOCK_SIZE": 16, "enable_fp_fusion": False},
+            hop_node.kwargs["launch_kwargs"],
+            ("BLOCK_SIZE", "enable_fp_fusion"),
         )
 
     @requires_gpu
@@ -2996,7 +3037,7 @@ def forward(self, arg0_1, arg1_1):
         self.assertNotIn("BLOCK_SIZE", hop_node.kwargs["kwargs"])
         self.assertNotIn("BLOCK_SIZE", constant_args)
         self.assertEqual(hop_node.kwargs["grid"], [(1, 1, 1)])
-        self.assertEqual(hop_node.kwargs["backend_options"], {})
+        self.assertEqual(hop_node.kwargs["launch_kwargs"], ())
 
     @requires_gpu
     def test_capture_triton_dynamic_backend_options_error(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -145,6 +145,10 @@ if HAS_GPU:
         tl.store(out_ptr + offsets, output, mask=mask)
 
     def _get_backend_options_kernel(*, with_enable_fp_fusion):
+        # These kernels are intentionally illustrative. `enable_fp_fusion` is a
+        # real backend option name, but the branch below only makes the kwarg's
+        # kernel-argument binding observable; it is not modeling the compiler
+        # option's normal optimization behavior.
         if with_enable_fp_fusion:
 
             @triton.jit

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -144,6 +144,50 @@ if HAS_GPU:
         output = x + y
         tl.store(out_ptr + offsets, output, mask=mask)
 
+    def _get_backend_options_kernel(*, with_enable_fp_fusion):
+        if with_enable_fp_fusion:
+
+            @triton.jit
+            def add_kernel(
+                in_ptr0,
+                in_ptr1,
+                out_ptr,
+                n_elements,
+                BLOCK_SIZE: "tl.constexpr",
+                enable_fp_fusion: "tl.constexpr",
+            ):
+                pid = tl.program_id(axis=0)
+                block_start = pid * BLOCK_SIZE
+                offsets = block_start + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < n_elements
+                x = tl.load(in_ptr0 + offsets, mask=mask)
+                y = tl.load(in_ptr1 + offsets, mask=mask)
+                if enable_fp_fusion:
+                    result = x + y
+                else:
+                    result = x * y
+                tl.store(out_ptr + offsets, result, mask=mask)
+
+        else:
+
+            @triton.jit
+            def add_kernel(
+                in_ptr0,
+                in_ptr1,
+                out_ptr,
+                n_elements,
+                BLOCK_SIZE: "tl.constexpr",
+            ):
+                pid = tl.program_id(axis=0)
+                block_start = pid * BLOCK_SIZE
+                offsets = block_start + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < n_elements
+                x = tl.load(in_ptr0 + offsets, mask=mask)
+                y = tl.load(in_ptr1 + offsets, mask=mask)
+                tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        return add_kernel
+
 
 class KernelTests(torch._inductor.test_case.TestCase):
     def _kernel_launched_in_code(self, kernel_name: str, code: str) -> bool:
@@ -2674,21 +2718,7 @@ def forward(self, arg0_1, arg1_1):
     def test_triton_kernel_backend_options_without_signature(self):
         # A launch kwarg that is not in the kernel signature should be kept as
         # a backend option and emitted in the generated Triton metadata.
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            tl.store(out_ptr + offsets, x + y, mask=mask)
+        add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=False)
 
         def f(x, y):
             output = torch.zeros_like(x)
@@ -2720,26 +2750,7 @@ def forward(self, arg0_1, arg1_1):
         # replaying it as the illegal form
         # `kernel[grid](..., False, enable_fp_fusion=False)`, which passes the
         # same kernel parameter both positionally and by keyword.
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-            enable_fp_fusion: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            if enable_fp_fusion:
-                result = x + y
-            else:
-                result = x * y
-            tl.store(out_ptr + offsets, result, mask=mask)
+        add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=True)
 
         def f(x, y):
             output = torch.zeros_like(x)
@@ -2770,30 +2781,10 @@ def forward(self, arg0_1, arg1_1):
         # Same dual-meaning kwarg case as above, but through a user-provided
         # triton.Config. The launch kwarg should remain both a kernel
         # parameter and a backend option after the autotune wrapper is applied.
-        @triton.autotune(
+        add_kernel = triton.autotune(
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
-        )
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-            enable_fp_fusion: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            if enable_fp_fusion:
-                result = x + y
-            else:
-                result = x * y
-            tl.store(out_ptr + offsets, result, mask=mask)
+        )(_get_backend_options_kernel(with_enable_fp_fusion=True))
 
         def f(x, y):
             output = torch.zeros_like(x)
@@ -2824,34 +2815,14 @@ def forward(self, arg0_1, arg1_1):
         # Direct Triton errors when a generic autotune config kwarg is also
         # passed as a launch kwarg. The config does not override the launch
         # kwarg; it would create duplicate keyword arguments at launch.
-        @triton.autotune(
+        add_kernel = triton.autotune(
             configs=[
                 triton.Config(
                     {"BLOCK_SIZE": 128, "enable_fp_fusion": True}, num_warps=4
                 )
             ],
             key=[],
-        )
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-            enable_fp_fusion: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            if enable_fp_fusion:
-                result = x + y
-            else:
-                result = x * y
-            tl.store(out_ptr + offsets, result, mask=mask)
+        )(_get_backend_options_kernel(with_enable_fp_fusion=True))
 
         def f(x, y):
             output = torch.zeros_like(x)
@@ -2878,25 +2849,10 @@ def forward(self, arg0_1, arg1_1):
     def test_triton_kernel_backend_options_with_autotune(self):
         # Backend options passed at launch should survive through the
         # user-defined Triton autotune wrapper as compile metadata.
-        @triton.autotune(
+        add_kernel = triton.autotune(
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
-        )
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            tl.store(out_ptr + offsets, x + y, mask=mask)
+        )(_get_backend_options_kernel(with_enable_fp_fusion=False))
 
         def f(x, y):
             output = torch.zeros_like(x)
@@ -2922,25 +2878,10 @@ def forward(self, arg0_1, arg1_1):
     def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):
         # SPECIAL_CONFIG_NAMES keep the existing behavior: they update Triton
         # configs instead of being preserved as generic backend options.
-        @triton.autotune(
+        add_kernel = triton.autotune(
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
-        )
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            tl.store(out_ptr + offsets, x + y, mask=mask)
+        )(_get_backend_options_kernel(with_enable_fp_fusion=False))
 
         def f(x, y):
             output = torch.zeros_like(x)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2850,6 +2850,189 @@ def forward(self, arg0_1, arg1_1):
         self.assertNotIn("backend_options", code)
 
     @requires_gpu
+    def test_capture_triton_backend_options_exclude_kernel_args(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pass
+
+        def f(x, y):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                in_ptr0=x,
+                in_ptr1=y,
+                out_ptr=output,
+                n_elements=n_elements,
+                BLOCK_SIZE=16,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        x = torch.randn(4, device=GPU_TYPE)
+        y = torch.randn(4, device=GPU_TYPE)
+        gm = make_fx(f, tracing_mode="symbolic")(x, y)
+        hop_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is triton_kernel_wrapper_mutation
+        )
+
+        # capture_triton sees the original launch kwargs, including tensor and
+        # symbolic kernel args. Dynamic kernel args must remain only in kwargs,
+        # not backend_options, while concrete launch kwargs such as BLOCK_SIZE
+        # and enable_fp_fusion stay visible to backend.parse_options().
+        self.assertEqual(
+            set(hop_node.kwargs["kwargs"]),
+            {"in_ptr0", "in_ptr1", "out_ptr", "n_elements", "BLOCK_SIZE"},
+        )
+        self.assertEqual(
+            hop_node.kwargs["backend_options"],
+            {"BLOCK_SIZE": 16, "enable_fp_fusion": False},
+        )
+
+    @requires_gpu
+    def test_capture_triton_backend_options_also_kernel_kwarg(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+            enable_fp_fusion: "tl.constexpr",
+        ):
+            pass
+
+        def f(x):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                x,
+                output,
+                n_elements,
+                BLOCK_SIZE=16,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        gm = make_fx(f)(torch.randn(4, device=GPU_TYPE))
+        hop_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is triton_kernel_wrapper_mutation
+        )
+
+        # Direct Triton gives a kwarg such as enable_fp_fusion two meanings
+        # when the kernel also has a parameter with that name: it binds the
+        # tl.constexpr parameter and backend.parse_options() still sees it as
+        # a backend option. The tracing path should preserve that concrete
+        # kwarg instead of dropping it just because it is also a kernel arg.
+        self.assertEqual(
+            hop_node.kwargs["backend_options"],
+            {"BLOCK_SIZE": 16, "enable_fp_fusion": False},
+        )
+
+    @requires_gpu
+    def test_capture_triton_autotune_config_does_not_materialize_default_args(self):
+        @triton.autotune(
+            configs=[triton.Config({"BLOCK_SIZE": 16}, num_warps=4)],
+            key=[],
+        )
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr" = 2,
+        ):
+            pass
+
+        def f(x):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                x,
+                output,
+                n_elements,
+            )
+            return output
+
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        gm = make_fx(f)(torch.randn(4, device=GPU_TYPE))
+        hop_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is triton_kernel_wrapper_mutation
+        )
+
+        # Omitted Python defaults should stay omitted from the HOP payload.
+        # The autotune config still provides BLOCK_SIZE to grid(meta), giving a
+        # single-program grid for four elements. This prevents the default
+        # BLOCK_SIZE=2 from being recorded as an explicit constant argument and
+        # competing with the config's BLOCK_SIZE=16 downstream.
+        constant_args = kernel_side_table.get_constant_args(
+            hop_node.kwargs["constant_args_idx"]
+        )
+        self.assertEqual(
+            set(hop_node.kwargs["kwargs"]), {"in_ptr0", "out_ptr", "n_elements"}
+        )
+        self.assertNotIn("BLOCK_SIZE", hop_node.kwargs["kwargs"])
+        self.assertNotIn("BLOCK_SIZE", constant_args)
+        self.assertEqual(hop_node.kwargs["grid"], [(1, 1, 1)])
+        self.assertEqual(hop_node.kwargs["backend_options"], {})
+
+    @requires_gpu
+    def test_capture_triton_dynamic_backend_options_error(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pass
+
+        def f(x):
+            output = torch.empty_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            capture_triton(add_kernel)[grid](
+                in_ptr0=x,
+                out_ptr=output,
+                n_elements=n_elements,
+                BLOCK_SIZE=16,
+                maxnreg=n_elements,
+            )
+            return output
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        # Unlike n_elements above, maxnreg is not a kernel parameter. If it
+        # contains a symbolic value, it cannot be represented as a concrete
+        # compile-time backend option.
+        with self.assertRaisesRegex(
+            RuntimeError, "Triton backend options must be concrete values"
+        ):
+            make_fx(f, tracing_mode="symbolic")(torch.randn(4, device=GPU_TYPE))
+
+    @requires_gpu
     @common_utils.parametrize("backend", ["eager", "aot_eager", "inductor"])
     @common_utils.parametrize("autotune_at_compile_time", [True, False])
     def test_triton_kernel_restore_value(self, backend, autotune_at_compile_time):
@@ -4665,96 +4848,6 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         out = f(x, y)
         expected = torch.empty_like(x)
         self.assertEqual(out, expected)
-
-    @unittest.skipIf(not has_triton_package(), "requires triton")
-    def test_capture_triton_backend_options_exclude_kernel_args(self):
-        import triton
-        import triton.language as tl
-
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pass
-
-        def f(x, y):
-            output = torch.empty_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            capture_triton(add_kernel)[grid](
-                in_ptr0=x,
-                in_ptr1=y,
-                out_ptr=output,
-                n_elements=n_elements,
-                BLOCK_SIZE=16,
-                enable_fp_fusion=False,
-            )
-            return output
-
-        from torch.fx.experimental.proxy_tensor import make_fx
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-        gm = make_fx(f, tracing_mode="symbolic")(x, y)
-        hop_node = next(
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function"
-            and node.target is triton_kernel_wrapper_mutation
-        )
-
-        # capture_triton sees the original launch kwargs, including tensor and
-        # symbolic kernel args. Those names must remain in kwargs, not in
-        # backend_options, because backend_options are later parsed as compiler
-        # options.
-        self.assertEqual(
-            set(hop_node.kwargs["kwargs"]),
-            {"in_ptr0", "in_ptr1", "out_ptr", "n_elements", "BLOCK_SIZE"},
-        )
-        self.assertEqual(
-            hop_node.kwargs["backend_options"], {"enable_fp_fusion": False}
-        )
-
-    @unittest.skipIf(not has_triton_package(), "requires triton")
-    def test_capture_triton_dynamic_backend_options_error(self):
-        import triton
-        import triton.language as tl
-
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pass
-
-        def f(x):
-            output = torch.empty_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            capture_triton(add_kernel)[grid](
-                in_ptr0=x,
-                out_ptr=output,
-                n_elements=n_elements,
-                BLOCK_SIZE=16,
-                grid_launch_partition=(n_elements,),
-            )
-            return output
-
-        from torch.fx.experimental.proxy_tensor import make_fx
-
-        # Unlike n_elements above, grid_launch_partition is not a kernel
-        # parameter. If it contains a symbolic value, it cannot be represented
-        # as a concrete compile-time backend option.
-        with self.assertRaisesRegex(
-            RuntimeError, "Triton backend options must be concrete values"
-        ):
-            make_fx(f, tracing_mode="symbolic")(torch.randn(4))
 
     @requires_gpu
     def test_wrap_triton_disabled_in_triton_op(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2672,6 +2672,8 @@ def forward(self, arg0_1, arg1_1):
 
     @requires_gpu
     def test_triton_kernel_backend_options_without_signature(self):
+        # A launch kwarg that is not in the kernel signature should be kept as
+        # a backend option and emitted in the generated Triton metadata.
         @triton.jit
         def add_kernel(
             in_ptr0,
@@ -2709,6 +2711,8 @@ def forward(self, arg0_1, arg1_1):
 
     @requires_gpu
     def test_triton_kernel_backend_options_also_used_as_kernel_kwarg(self):
+        # Triton exposes keyword args to backend option parsing even when the
+        # same name also binds a kernel parameter; preserve both meanings.
         @triton.jit
         def add_kernel(
             in_ptr0,
@@ -2752,6 +2756,8 @@ def forward(self, arg0_1, arg1_1):
 
     @requires_gpu
     def test_triton_kernel_backend_options_with_autotune(self):
+        # Backend options passed at launch should survive through the
+        # user-defined Triton autotune wrapper as compile metadata.
         @triton.autotune(
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
@@ -2793,6 +2799,8 @@ def forward(self, arg0_1, arg1_1):
 
     @requires_gpu
     def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):
+        # SPECIAL_CONFIG_NAMES keep the existing behavior: they update Triton
+        # configs instead of being preserved as generic backend options.
         @triton.autotune(
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -522,7 +522,7 @@ class KernelTests(torch._inductor.test_case.TestCase):
             gm.code.strip(),
             """\
 def forward(self, x_1, output_1):
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr'], launch_kwargs = ());  x_1 = output_1 = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 3, grid = [(5,)], tma_descriptor_metadata = {}, kwargs = {'in_ptr0': x_1, 'out_ptr': output_1}, tensors_to_clone = ['in_ptr0', 'out_ptr']);  x_1 = output_1 = None
     getitem = triton_kernel_wrapper_functional_proxy['in_ptr0'];  getitem = None
     getitem_1 = triton_kernel_wrapper_functional_proxy['out_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return getitem_1""",
@@ -2376,7 +2376,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256;  arg0_1 = None
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  floordiv = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  floordiv = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2389,7 +2389,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     add_2 = arg0_1 + 256
     sub_1 = add_2 - 1;  add_2 = None
     floordiv = sub_1 // 256;  sub_1 = None
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(floordiv, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([arg0_1], [256], 4)), 'in_desc_ptr1': ('experimental', ([arg0_1], [256], 4)), 'out_desc_ptr': ('experimental', ([arg0_1], [256], 4))}, kwargs = {'in_desc_ptr0': arg1_1, 'in_desc_ptr1': arg2_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  floordiv = arg0_1 = arg1_1 = arg2_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2400,7 +2400,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('stable', ([256],)), 'in_desc_ptr1': ('stable', ([256],)), 'out_desc_ptr': ('stable', ([256],))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2410,7 +2410,7 @@ def forward(self, arg0_1, arg1_1):
                     """\
 def forward(self, arg0_1, arg1_1):
     zeros_like = torch.ops.aten.zeros_like.default(arg0_1, pin_memory = False)
-    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr'], launch_kwargs = ());  arg0_1 = arg1_1 = zeros_like = None
+    triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(2, 1, 1)], tma_descriptor_metadata = {'in_desc_ptr0': ('experimental', ([301], [256], 4)), 'in_desc_ptr1': ('experimental', ([301], [256], 4)), 'out_desc_ptr': ('experimental', ([301], [256], 4))}, kwargs = {'in_desc_ptr0': arg0_1, 'in_desc_ptr1': arg1_1, 'out_desc_ptr': zeros_like}, tensors_to_clone = ['out_desc_ptr']);  arg0_1 = arg1_1 = zeros_like = None
     getitem = triton_kernel_wrapper_functional_proxy['out_desc_ptr'];  triton_kernel_wrapper_functional_proxy = None
     return (getitem,)""",
                 )
@@ -2902,7 +2902,7 @@ def forward(self, arg0_1, arg1_1):
             for node in captured_gms[0].graph.nodes
             if node.op == "call_function"
             and node.target is triton_kernel_wrapper_mutation
-            and "enable_fp_fusion" in node.kwargs["launch_kwargs"]
+            and "enable_fp_fusion" in node.kwargs.get("launch_kwargs", ())
         )
         constant_args = kernel_side_table.get_constant_args(
             hop_node.kwargs["constant_args_idx"]
@@ -3081,7 +3081,7 @@ def forward(self, arg0_1, arg1_1):
         self.assertNotIn("BLOCK_SIZE", hop_node.kwargs["kwargs"])
         self.assertNotIn("BLOCK_SIZE", constant_args)
         self.assertEqual(hop_node.kwargs["grid"], [(1, 1, 1)])
-        self.assertEqual(hop_node.kwargs["launch_kwargs"], ())
+        self.assertNotIn("launch_kwargs", hop_node.kwargs)
 
     @requires_gpu
     def test_capture_triton_dynamic_backend_options_error(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2707,12 +2707,19 @@ def forward(self, arg0_1, arg1_1):
         x = torch.randn(4, device=GPU_TYPE)
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
         self.assertEqual(out, x + x)
-        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+        self.assertIn("'backend_options':", code)
+        self.assertIn("'enable_fp_fusion': False", code)
 
     @requires_gpu
     def test_triton_kernel_backend_options_also_used_as_kernel_kwarg(self):
-        # Triton exposes keyword args to backend option parsing even when the
-        # same name also binds a kernel parameter; preserve both meanings.
+        # For `def kernel(..., enable_fp_fusion: tl.constexpr)`, the call
+        # `kernel[grid](..., enable_fp_fusion=False)` has two meanings in
+        # direct Triton: the binder uses it as a kernel parameter, and
+        # _pack_args still exposes it to backend.parse_options(), so Triton
+        # also parses it as a compiler option. Preserve both meanings without
+        # replaying it as the illegal form
+        # `kernel[grid](..., False, enable_fp_fusion=False)`, which passes the
+        # same kernel parameter both positionally and by keyword.
         @triton.jit
         def add_kernel(
             in_ptr0,
@@ -2750,9 +2757,122 @@ def forward(self, arg0_1, arg1_1):
 
         x = torch.randn(4, device=GPU_TYPE)
         y = torch.randn(4, device=GPU_TYPE)
+        eager_backend_out = torch.compile(f, backend="eager", fullgraph=True)(x, y)
+        self.assertEqual(eager_backend_out, x * y)
+
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, y)
         self.assertEqual(out, x * y)
-        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+        self.assertIn("'backend_options':", code)
+        self.assertIn("'enable_fp_fusion': False", code)
+
+    @requires_gpu
+    def test_triton_kernel_backend_options_also_kernel_kwarg_with_autotune(self):
+        # Same dual-meaning kwarg case as above, but through a user-provided
+        # triton.Config. The launch kwarg should remain both a kernel
+        # parameter and a backend option after the autotune wrapper is applied.
+        @triton.autotune(
+            configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
+            key=[],
+        )
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+            enable_fp_fusion: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            if enable_fp_fusion:
+                result = x + y
+            else:
+                result = x * y
+            tl.store(out_ptr + offsets, result, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        y = torch.randn(4, device=GPU_TYPE)
+        eager_backend_out = torch.compile(f, backend="eager", fullgraph=True)(x, y)
+        self.assertEqual(eager_backend_out, x * y)
+
+        out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, y)
+        self.assertEqual(out, x * y)
+        self.assertIn("@triton_heuristics.user_autotune", code)
+        self.assertIn("'backend_options':", code)
+        self.assertIn("'enable_fp_fusion': False", code)
+
+    @requires_gpu
+    def test_triton_kernel_autotune_config_conflicts_with_launch_kwarg(self):
+        # Direct Triton errors when a generic autotune config kwarg is also
+        # passed as a launch kwarg. The config does not override the launch
+        # kwarg; it would create duplicate keyword arguments at launch.
+        @triton.autotune(
+            configs=[
+                triton.Config(
+                    {"BLOCK_SIZE": 128, "enable_fp_fusion": True}, num_warps=4
+                )
+            ],
+            key=[],
+        )
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+            enable_fp_fusion: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            if enable_fp_fusion:
+                result = x + y
+            else:
+                result = x * y
+            tl.store(out_ptr + offsets, result, mask=mask)
+
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                enable_fp_fusion=False,
+            )
+            return output
+
+        x = torch.randn(4, device=GPU_TYPE)
+        y = torch.randn(4, device=GPU_TYPE)
+        msg = "Triton launch kwargs conflict with autotune config kwargs"
+        with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
+            torch.compile(f, backend="eager", fullgraph=True)(x, y)
+        with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
+            torch.compile(f, fullgraph=True)(x, y)
 
     @requires_gpu
     def test_triton_kernel_backend_options_with_autotune(self):
@@ -2795,7 +2915,8 @@ def forward(self, arg0_1, arg1_1):
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
         self.assertEqual(out, x + x)
         self.assertIn("@triton_heuristics.user_autotune", code)
-        self.assertIn("'backend_options': {'enable_fp_fusion': False}", code)
+        self.assertIn("'backend_options':", code)
+        self.assertIn("'enable_fp_fusion': False", code)
 
     @requires_gpu
     def test_triton_kernel_special_kwargs_with_autotune_use_configs(self):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -188,6 +188,22 @@ if HAS_GPU:
 
         return add_kernel
 
+    def _get_backend_options_fn(add_kernel, **launch_kwargs):
+        def f(x, y):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel[grid](
+                x,
+                y,
+                output,
+                n_elements,
+                **launch_kwargs,
+            )
+            return output
+
+        return f
+
 
 class KernelTests(torch._inductor.test_case.TestCase):
     def _kernel_launched_in_code(self, kernel_name: str, code: str) -> bool:
@@ -2719,20 +2735,9 @@ def forward(self, arg0_1, arg1_1):
         # A launch kwarg that is not in the kernel signature should be kept as
         # a backend option and emitted in the generated Triton metadata.
         add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=False)
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                BLOCK_SIZE=128,
-                enable_fp_fusion=False,
-            )
-            return output
+        f = _get_backend_options_fn(
+            add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False
+        )
 
         x = torch.randn(4, device=GPU_TYPE)
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
@@ -2751,20 +2756,9 @@ def forward(self, arg0_1, arg1_1):
         # `kernel[grid](..., False, enable_fp_fusion=False)`, which passes the
         # same kernel parameter both positionally and by keyword.
         add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=True)
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                BLOCK_SIZE=128,
-                enable_fp_fusion=False,
-            )
-            return output
+        f = _get_backend_options_fn(
+            add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False
+        )
 
         x = torch.randn(4, device=GPU_TYPE)
         y = torch.randn(4, device=GPU_TYPE)
@@ -2785,19 +2779,7 @@ def forward(self, arg0_1, arg1_1):
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
         )(_get_backend_options_kernel(with_enable_fp_fusion=True))
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                enable_fp_fusion=False,
-            )
-            return output
+        f = _get_backend_options_fn(add_kernel, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
         y = torch.randn(4, device=GPU_TYPE)
@@ -2823,19 +2805,7 @@ def forward(self, arg0_1, arg1_1):
             ],
             key=[],
         )(_get_backend_options_kernel(with_enable_fp_fusion=True))
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                enable_fp_fusion=False,
-            )
-            return output
+        f = _get_backend_options_fn(add_kernel, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
         y = torch.randn(4, device=GPU_TYPE)
@@ -2853,19 +2823,7 @@ def forward(self, arg0_1, arg1_1):
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
         )(_get_backend_options_kernel(with_enable_fp_fusion=False))
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                enable_fp_fusion=False,
-            )
-            return output
+        f = _get_backend_options_fn(add_kernel, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
@@ -2882,19 +2840,7 @@ def forward(self, arg0_1, arg1_1):
             configs=[triton.Config({"BLOCK_SIZE": 128}, num_warps=4)],
             key=[],
         )(_get_backend_options_kernel(with_enable_fp_fusion=False))
-
-        def f(x, y):
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-            add_kernel[grid](
-                x,
-                y,
-                output,
-                n_elements,
-                num_warps=8,
-            )
-            return output
+        f = _get_backend_options_fn(add_kernel, num_warps=8)
 
         x = torch.randn(4, device=GPU_TYPE)
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2799,9 +2799,10 @@ def forward(self, arg0_1, arg1_1):
         # kwarg; it would create duplicate keyword arguments at launch.
         add_kernel = triton.autotune(
             configs=[
+                triton.Config({"BLOCK_SIZE": 128}, num_warps=4),
                 triton.Config(
                     {"BLOCK_SIZE": 128, "enable_fp_fusion": True}, num_warps=4
-                )
+                ),
             ],
             key=[],
         )(_get_backend_options_kernel(with_enable_fp_fusion=True))

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2739,9 +2739,7 @@ def forward(self, arg0_1, arg1_1):
         # A launch kwarg that is not in the kernel signature should be kept as
         # a backend option and emitted in the generated Triton metadata.
         add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=False)
-        f = _get_backend_options_fn(
-            add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False
-        )
+        f = _get_backend_options_fn(add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
         out, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), x, x)
@@ -2760,9 +2758,7 @@ def forward(self, arg0_1, arg1_1):
         # `kernel[grid](..., False, enable_fp_fusion=False)`, which passes the
         # same kernel parameter both positionally and by keyword.
         add_kernel = _get_backend_options_kernel(with_enable_fp_fusion=True)
-        f = _get_backend_options_fn(
-            add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False
-        )
+        f = _get_backend_options_fn(add_kernel, BLOCK_SIZE=128, enable_fp_fusion=False)
 
         x = torch.randn(4, device=GPU_TYPE)
         y = torch.randn(4, device=GPU_TYPE)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3368,7 +3368,8 @@ class DynamoTritonHOPifier(TritonHOPifier):
         variable: "TritonKernelVariable",
         grids: Any,
         combined_args: dict[str, Any],
-        backend_option_kwargs: dict[str, Any],
+        launch_kwargs: tuple[str, ...],
+        kernel_arg_names: set[str],
         tx: "InstructionTranslatorBase",
     ) -> ConstantVariable | None:
         from .dicts import ConstDictVariable
@@ -3410,24 +3411,23 @@ class DynamoTritonHOPifier(TritonHOPifier):
             for k, v in combined_args_vt.items()
             if not (isinstance(v, VariableTracker) and v.is_python_constant())
         }
-        backend_options = {
-            k: v.as_python_constant()
-            for k, v in backend_option_kwargs.items()
-            if isinstance(v, VariableTracker) and v.is_python_constant()
-        }
-        # backend_option_kwargs starts as the original Triton launch kwargs
-        # because direct Triton exposes that full kwargs dict to
-        # backend.parse_options(). This is an over-approximation: tensor and
-        # symbolic kwargs that bind real kernel parameters are not backend
-        # options, even though their names were included in the original
-        # launch kwargs. Only reject non-constant values that are not also
-        # legitimate non-constant kernel args.
-        missing_options = set(backend_option_kwargs) - set(backend_options)
-        missing_options -= {k.as_python_constant() for k in non_constant_args}
-        if missing_options:
+        # launch_kwargs records the names passed as kwargs at the Triton launch
+        # site. A non-kernel launch kwarg can only be a compiler option, so it
+        # must be a Python constant before entering the graph. Kernel launch
+        # kwargs may also be compiler options, but that target-specific check
+        # happens in Inductor after the triton backend is determined and
+        # backend.parse_options() is called.
+        non_const_options: list[str] = []
+        for k in launch_kwargs:
+            if k in kernel_arg_names:
+                continue
+            v = combined_args[k]
+            if not (isinstance(v, VariableTracker) and v.is_python_constant()):
+                non_const_options.append(k)
+        if non_const_options:
             self.raise_unsupported(
                 "Triton backend options must be Python constants: "
-                f"{sorted(missing_options)!r}."
+                f"{sorted(non_const_options)!r}."
             )
 
         for v in non_constant_args.values():
@@ -3449,7 +3449,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
                 "grid": grids,
                 "tma_descriptor_metadata": tma_descriptor_metadata,
                 "kwargs": meta.as_proxy(),
-                "backend_options": backend_options,
+                "launch_kwargs": launch_kwargs,
             },
         )
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3371,7 +3371,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
         backend_option_kwargs: dict[str, Any],
         default_args: dict[str, Any],
         tx: "InstructionTranslatorBase",
-    ) -> Optional[ConstantVariable]:
+    ) -> ConstantVariable | None:
         from .dicts import ConstDictVariable
 
         # as we can only pass tensors as non-const args in fx graph,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3369,7 +3369,6 @@ class DynamoTritonHOPifier(TritonHOPifier):
         grids: Any,
         combined_args: dict[str, Any],
         backend_option_kwargs: dict[str, Any],
-        default_args: dict[str, Any],
         tx: "InstructionTranslatorBase",
     ) -> ConstantVariable | None:
         from .dicts import ConstDictVariable
@@ -3406,12 +3405,10 @@ class DynamoTritonHOPifier(TritonHOPifier):
             for k, v in combined_args.items()
             if isinstance(v, VariableTracker) and v.is_python_constant()
         }
-        constant_args.update(default_args)
         non_constant_args = {
             k: v
             for k, v in combined_args_vt.items()
             if not (isinstance(v, VariableTracker) and v.is_python_constant())
-            and k.as_python_constant() not in default_args
         }
         backend_options = {
             k: v.as_python_constant()

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3371,7 +3371,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
         backend_option_kwargs: dict[str, Any],
         default_args: dict[str, Any],
         tx: "InstructionTranslatorBase",
-    ) -> "variables.ConstantVariable":
+    ) -> Optional[ConstantVariable]:
         from .dicts import ConstDictVariable
 
         # as we can only pass tensors as non-const args in fx graph,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3368,6 +3368,8 @@ class DynamoTritonHOPifier(TritonHOPifier):
         variable: "TritonKernelVariable",
         grids: Any,
         combined_args: dict[str, Any],
+        backend_option_kwargs: dict[str, Any],
+        default_args: dict[str, Any],
         tx: "InstructionTranslatorBase",
     ) -> "variables.ConstantVariable":
         from .dicts import ConstDictVariable
@@ -3404,11 +3406,32 @@ class DynamoTritonHOPifier(TritonHOPifier):
             for k, v in combined_args.items()
             if isinstance(v, VariableTracker) and v.is_python_constant()
         }
+        constant_args.update(default_args)
         non_constant_args = {
             k: v
             for k, v in combined_args_vt.items()
             if not (isinstance(v, VariableTracker) and v.is_python_constant())
+            and k.as_python_constant() not in default_args
         }
+        backend_options = {
+            k: v.as_python_constant()
+            for k, v in backend_option_kwargs.items()
+            if isinstance(v, VariableTracker) and v.is_python_constant()
+        }
+        # backend_option_kwargs starts as the original Triton launch kwargs
+        # because direct Triton exposes that full kwargs dict to
+        # backend.parse_options(). This is an over-approximation: tensor and
+        # symbolic kwargs that bind real kernel parameters are not backend
+        # options, even though their names were included in the original
+        # launch kwargs. Only reject non-constant values that are not also
+        # legitimate non-constant kernel args.
+        missing_options = set(backend_option_kwargs) - set(backend_options)
+        missing_options -= {k.as_python_constant() for k in non_constant_args}
+        if missing_options:
+            self.raise_unsupported(
+                "Triton backend options must be Python constants: "
+                f"{sorted(missing_options)!r}."
+            )
 
         for v in non_constant_args.values():
             v = v.realize()
@@ -3429,6 +3452,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
                 "grid": grids,
                 "tma_descriptor_metadata": tma_descriptor_metadata,
                 "kwargs": meta.as_proxy(),
+                "backend_options": backend_options,
             },
         )
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1274,15 +1274,18 @@ class TritonKernelWrapperMutation(_TritonKernelWrapper):
         kwargs: dict[str, Any],
         launch_kwargs: tuple[str, ...] | None = None,
     ) -> Any:
+        hop_kwargs: dict[str, Any] = {
+            "kernel_idx": kernel_idx,
+            "constant_args_idx": constant_args_idx,
+            "grid": grid,
+            "tma_descriptor_metadata": tma_descriptor_metadata,
+            "kwargs": kwargs,
+        }
+        if launch_kwargs:
+            hop_kwargs["launch_kwargs"] = launch_kwargs
+
         # pyrefly: ignore [missing-attribute]
-        return super().__call__(
-            kernel_idx=kernel_idx,
-            constant_args_idx=constant_args_idx,
-            grid=grid,
-            tma_descriptor_metadata=tma_descriptor_metadata,
-            kwargs=kwargs,
-            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
-        )
+        return super().__call__(**hop_kwargs)
 
 
 triton_kernel_wrapper_mutation = TritonKernelWrapperMutation()
@@ -1303,16 +1306,19 @@ class TritonKernelWrapperFunctional(_TritonKernelWrapper):
         tensors_to_clone: list[str],
         launch_kwargs: tuple[str, ...] | None = None,
     ) -> dict[str, Any]:
+        hop_kwargs: dict[str, Any] = {
+            "kernel_idx": kernel_idx,
+            "constant_args_idx": constant_args_idx,
+            "grid": grid,
+            "tma_descriptor_metadata": tma_descriptor_metadata,
+            "kwargs": kwargs,
+            "tensors_to_clone": tensors_to_clone,
+        }
+        if launch_kwargs:
+            hop_kwargs["launch_kwargs"] = launch_kwargs
+
         # pyrefly: ignore [missing-attribute]
-        return super().__call__(
-            kernel_idx=kernel_idx,
-            constant_args_idx=constant_args_idx,
-            grid=grid,
-            tma_descriptor_metadata=tma_descriptor_metadata,
-            kwargs=kwargs,
-            tensors_to_clone=tensors_to_clone,
-            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
-        )
+        return super().__call__(**hop_kwargs)
 
 
 triton_kernel_wrapper_functional = TritonKernelWrapperFunctional()
@@ -1487,17 +1493,20 @@ def triton_kernel_wrapper_mutation_proxy_torch_dispatch_mode(
     kwargs: dict[str, Any],
     launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
+    node_args: dict[str, Any] = {
+        "kernel_idx": kernel_idx,
+        "constant_args_idx": constant_args_idx,
+        "grid": grid,
+        "tma_descriptor_metadata": tma_descriptor_metadata,
+        "kwargs": kwargs,
+    }
+    if launch_kwargs:
+        node_args["launch_kwargs"] = launch_kwargs
+
     trace_triton_kernel_wrapper(
         mode,
         triton_kernel_wrapper_mutation,
-        {
-            "kernel_idx": kernel_idx,
-            "constant_args_idx": constant_args_idx,
-            "grid": grid,
-            "tma_descriptor_metadata": tma_descriptor_metadata,
-            "kwargs": kwargs,
-            "launch_kwargs": () if launch_kwargs is None else launch_kwargs,
-        },
+        node_args,
     )
 
     return None
@@ -1542,15 +1551,17 @@ def triton_kernel_wrapper_mutation_functionalize(
         kernel_idx, constant_args_idx, unwrapped_kwargs, tma_descriptor_metadata
     )
     with ctx.redispatch_to_next():
-        unwrapped_outputs = triton_kernel_wrapper_functional(
-            kernel_idx=kernel_idx,
-            constant_args_idx=constant_args_idx,
-            grid=grid,
-            tma_descriptor_metadata=tma_descriptor_metadata,
-            kwargs=unwrapped_kwargs,
-            tensors_to_clone=tensors_to_clone,
-            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
-        )
+        functional_kwargs: dict[str, Any] = {
+            "kernel_idx": kernel_idx,
+            "constant_args_idx": constant_args_idx,
+            "grid": grid,
+            "tma_descriptor_metadata": tma_descriptor_metadata,
+            "kwargs": unwrapped_kwargs,
+            "tensors_to_clone": tensors_to_clone,
+        }
+        if launch_kwargs:
+            functional_kwargs["launch_kwargs"] = launch_kwargs
+        unwrapped_outputs = triton_kernel_wrapper_functional(**functional_kwargs)
 
     if not set(unwrapped_outputs.keys()).issubset(set(kwargs.keys())):
         raise AssertionError(
@@ -1592,14 +1603,16 @@ def triton_kernel_wrapper_functional_dense(
         key: (clone_preserve_strides(val) if key in tensors_to_clone else val)
         for key, val in kwargs.items()
     }
-    triton_kernel_wrapper_mutation(
-        kernel_idx=kernel_idx,
-        constant_args_idx=constant_args_idx,
-        grid=grid,
-        tma_descriptor_metadata=tma_descriptor_metadata,
-        kwargs=kwargs,
-        launch_kwargs=() if launch_kwargs is None else launch_kwargs,
-    )
+    mutation_kwargs: dict[str, Any] = {
+        "kernel_idx": kernel_idx,
+        "constant_args_idx": constant_args_idx,
+        "grid": grid,
+        "tma_descriptor_metadata": tma_descriptor_metadata,
+        "kwargs": kwargs,
+    }
+    if launch_kwargs:
+        mutation_kwargs["launch_kwargs"] = launch_kwargs
+    triton_kernel_wrapper_mutation(**mutation_kwargs)
     return {key: val for key, val in kwargs.items() if key in tensors_to_clone}
 
 
@@ -1637,18 +1650,21 @@ def triton_kernel_wrapper_functional_proxy_torch_dispatch_mode(
     tensors_to_clone: list[str],
     launch_kwargs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
+    node_args: dict[str, Any] = {
+        "kernel_idx": kernel_idx,
+        "constant_args_idx": constant_args_idx,
+        "grid": grid,
+        "tma_descriptor_metadata": tma_descriptor_metadata,
+        "kwargs": kwargs,
+        "tensors_to_clone": tensors_to_clone,
+    }
+    if launch_kwargs:
+        node_args["launch_kwargs"] = launch_kwargs
+
     ret = trace_triton_kernel_wrapper(
         mode,
         triton_kernel_wrapper_functional,
-        {
-            "kernel_idx": kernel_idx,
-            "constant_args_idx": constant_args_idx,
-            "grid": grid,
-            "tma_descriptor_metadata": tma_descriptor_metadata,
-            "kwargs": kwargs,
-            "tensors_to_clone": tensors_to_clone,
-            "launch_kwargs": () if launch_kwargs is None else launch_kwargs,
-        },
+        node_args,
     )
     if ret is None:
         raise AssertionError("trace_triton_kernel_wrapper returned None")
@@ -1668,15 +1684,17 @@ def triton_kernel_wrapper_functional_functionalize(
 ) -> dict[str, Any]:
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     with ctx.redispatch_to_next():
-        outputs = triton_kernel_wrapper_functional(
-            kernel_idx=kernel_idx,
-            constant_args_idx=constant_args_idx,
-            grid=grid,
-            tma_descriptor_metadata=tma_descriptor_metadata,
-            kwargs=unwrapped_kwargs,
-            tensors_to_clone=tensors_to_clone,
-            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
-        )
+        functional_kwargs: dict[str, Any] = {
+            "kernel_idx": kernel_idx,
+            "constant_args_idx": constant_args_idx,
+            "grid": grid,
+            "tma_descriptor_metadata": tma_descriptor_metadata,
+            "kwargs": unwrapped_kwargs,
+            "tensors_to_clone": tensors_to_clone,
+        }
+        if launch_kwargs:
+            functional_kwargs["launch_kwargs"] = launch_kwargs
+        outputs = triton_kernel_wrapper_functional(**functional_kwargs)
         return ctx.wrap_tensors(outputs)  # type: ignore[return-value,arg-type]
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1272,6 +1272,7 @@ class TritonKernelWrapperMutation(_TritonKernelWrapper):
         grid: list["TritonGridType"],
         tma_descriptor_metadata: TMADescriptorMetadata,
         kwargs: dict[str, Any],
+        backend_options: dict[str, Any] | None = None,
     ) -> Any:
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
@@ -1280,6 +1281,7 @@ class TritonKernelWrapperMutation(_TritonKernelWrapper):
             grid=grid,
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=kwargs,
+            backend_options={} if backend_options is None else backend_options,
         )
 
 
@@ -1299,6 +1301,7 @@ class TritonKernelWrapperFunctional(_TritonKernelWrapper):
         tma_descriptor_metadata: TMADescriptorMetadata,
         kwargs: dict[str, Any],
         tensors_to_clone: list[str],
+        backend_options: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
@@ -1308,6 +1311,7 @@ class TritonKernelWrapperFunctional(_TritonKernelWrapper):
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=kwargs,
             tensors_to_clone=tensors_to_clone,
+            backend_options={} if backend_options is None else backend_options,
         )
 
 
@@ -1326,6 +1330,7 @@ def triton_kernel_wrapper_mutation_dense(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    backend_options: dict[str, Any] | None = None,
 ) -> None:
     from torch._inductor.codegen.wrapper import user_defined_kernel_grid_fn_code
 
@@ -1402,8 +1407,15 @@ def triton_kernel_wrapper_mutation_dense(
         else:
             break
 
+    backend_options = {} if backend_options is None else backend_options
+    launch_backend_options = {
+        k: v
+        for k, v in backend_options.items()
+        if k not in kwargs and k not in constant_args
+    }
+
     # pyrefly: ignore [bad-index, index-error]
-    kernel[grid_fn](*args, **kwargs, **constant_args)
+    kernel[grid_fn](*args, **kwargs, **constant_args, **launch_backend_options)
 
 
 @register_fake(triton_kernel_wrapper_mutation, skip_cache=True)
@@ -1414,6 +1426,7 @@ def triton_kernel_wrapper_mutation_fake_tensor_mode(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    backend_options: dict[str, Any] | None = None,
 ) -> None:
     return None
 
@@ -1426,6 +1439,7 @@ def _(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    backend_options: dict[str, Any] | None = None,
 ) -> None:
     return None
 
@@ -1463,6 +1477,7 @@ def triton_kernel_wrapper_mutation_proxy_torch_dispatch_mode(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    backend_options: dict[str, Any] | None = None,
 ) -> None:
     trace_triton_kernel_wrapper(
         mode,
@@ -1473,6 +1488,7 @@ def triton_kernel_wrapper_mutation_proxy_torch_dispatch_mode(
             "grid": grid,
             "tma_descriptor_metadata": tma_descriptor_metadata,
             "kwargs": kwargs,
+            "backend_options": {} if backend_options is None else backend_options,
         },
     )
 
@@ -1507,6 +1523,7 @@ def triton_kernel_wrapper_mutation_functionalize(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    backend_options: dict[str, Any] | None = None,
 ) -> None:
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     # TODO(oulgen): Preexisting bug, if two kernel inputs are views of each
@@ -1524,6 +1541,7 @@ def triton_kernel_wrapper_mutation_functionalize(
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=unwrapped_kwargs,
             tensors_to_clone=tensors_to_clone,
+            backend_options={} if backend_options is None else backend_options,
         )
 
     if not set(unwrapped_outputs.keys()).issubset(set(kwargs.keys())):
@@ -1556,6 +1574,7 @@ def triton_kernel_wrapper_functional_dense(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
+    backend_options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
     # `clone_preserve_strides` calls are never executed at runtime
@@ -1571,6 +1590,7 @@ def triton_kernel_wrapper_functional_dense(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kwargs=kwargs,
+        backend_options={} if backend_options is None else backend_options,
     )
     return {key: val for key, val in kwargs.items() if key in tensors_to_clone}
 
@@ -1584,6 +1604,7 @@ def triton_kernel_wrapper_functional_fake_tensor_mode(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
+    backend_options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
     # `clone_preserve_strides` calls are never executed at runtime
@@ -1606,6 +1627,7 @@ def triton_kernel_wrapper_functional_proxy_torch_dispatch_mode(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
+    backend_options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     ret = trace_triton_kernel_wrapper(
         mode,
@@ -1617,6 +1639,7 @@ def triton_kernel_wrapper_functional_proxy_torch_dispatch_mode(
             "tma_descriptor_metadata": tma_descriptor_metadata,
             "kwargs": kwargs,
             "tensors_to_clone": tensors_to_clone,
+            "backend_options": {} if backend_options is None else backend_options,
         },
     )
     if ret is None:
@@ -1633,6 +1656,7 @@ def triton_kernel_wrapper_functional_functionalize(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
+    backend_options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     with ctx.redispatch_to_next():
@@ -1643,6 +1667,7 @@ def triton_kernel_wrapper_functional_functionalize(
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=unwrapped_kwargs,
             tensors_to_clone=tensors_to_clone,
+            backend_options={} if backend_options is None else backend_options,
         )
         return ctx.wrap_tensors(outputs)  # type: ignore[return-value,arg-type]
 
@@ -1789,6 +1814,8 @@ class TritonHOPifier:
         variable,
         grids,
         combined_args: dict[str, Any],
+        backend_option_kwargs: dict[str, Any],
+        default_args: dict[str, Any],
         tx,
     ) -> Optional["ConstantVariable"]:
         raise NotImplementedError("abstract method")
@@ -1979,6 +2006,8 @@ class TritonHOPifier:
 
             iter_kernel = iter_kernel.fn
 
+        jit_arg_names = set(iter_kernel.arg_names)
+
         # Process the @triton.heuristics decorator:
         # - We know there is only 1 autotuner decorator here
         # - We can apply the heuristic to all triton.Configs in the order that the decorators appear
@@ -2103,7 +2132,7 @@ class TritonHOPifier:
         if isinstance(variable.kernel, Autotuner):
             special_param_names = []
             for name in SPECIAL_CONFIG_NAMES:
-                if name in variable.kernel.fn.arg_names:
+                if name in jit_arg_names:
                     special_param_names.append(name)
 
             if special_param_names:
@@ -2210,10 +2239,40 @@ class TritonHOPifier:
             )
             return self.call_triton_kernel(new_var, args, kwargs, tx)
 
-        # Both for grid's meta as well as for the kernel, we need combined
-        # args and kwargs combined and normalized
+        # Triton passes the full launch kwargs dict to backend.parse_options(),
+        # even when a kwarg also binds a kernel parameter. Preserve those
+        # concrete candidates separately from the normalized kernel arguments.
+        backend_option_kwargs = dict(kwargs)
 
-        combined_args_raw = {**dict(zip(variable.kernel.arg_names, args)), **kwargs}
+        for name in list(kwargs):
+            if name not in jit_arg_names:
+                kwargs.pop(name)
+
+        positional_arg_names = iter_kernel.arg_names[: len(args)]
+        if len(args) > len(iter_kernel.arg_names):
+            self.raise_unsupported(
+                f"{iter_kernel.__name__}() takes {len(iter_kernel.arg_names)} "
+                f"positional arguments but {len(args)} were given"
+            )
+
+        duplicate_kwargs = sorted(set(positional_arg_names) & set(kwargs))
+        if duplicate_kwargs:
+            self.raise_unsupported(
+                f"{iter_kernel.__name__}() got multiple values for argument "
+                f"{duplicate_kwargs[0]!r}"
+            )
+
+        # Both for grid's meta as well as for the kernel, we need combined
+        # args and kwargs combined and normalized. Backend options are excluded:
+        # direct Triton leaves non-signature kwargs in **options instead of
+        # adding them to the bound argument map.
+
+        combined_args_raw = {**dict(zip(iter_kernel.arg_names, args)), **kwargs}
+        default_args = {}
+        for name, param in iter_kernel.signature.parameters.items():
+            if name not in combined_args_raw and param.default is not inspect.Parameter.empty:
+                default_args[name] = param.default
+                combined_args_raw[name] = param.default
 
         # precompute the grid for the kernel
         configs = (
@@ -2276,7 +2335,9 @@ class TritonHOPifier:
                     combined_args_raw[arg_name] = variable.specialize_symbolic(
                         combined_args_raw[arg_name]
                     )
-        return self.call_HOP(variable, grids, combined_args_raw, tx)
+        return self.call_HOP(
+            variable, grids, combined_args_raw, backend_option_kwargs, default_args, tx
+        )
 
 
 ###############################################################################
@@ -2382,6 +2443,8 @@ class TracingTritonHOPifier(TritonHOPifier):
         variable: "TraceableTritonKernelWrapper",
         grids: list["TritonGridTupleType"],
         combined_args: dict[str, Any],
+        backend_option_kwargs: dict[str, Any],
+        default_args: dict[str, Any],
         tx: None,
     ) -> None:
         if tx is not None:
@@ -2392,6 +2455,14 @@ class TracingTritonHOPifier(TritonHOPifier):
             )
 
         graphable_args, constant_args_idx = self.store_non_graphable_args(combined_args)
+        dynamic_backend_options = [
+            k for k, v in backend_option_kwargs.items() if isinstance(v, fx.Node)
+        ]
+        if dynamic_backend_options:
+            self.raise_unsupported(
+                "Triton backend options must be concrete values: "
+                f"{sorted(dynamic_backend_options)!r}."
+            )
 
         if not isinstance(variable.kernel_idx, int):
             raise AssertionError(
@@ -2405,6 +2476,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             # supported in non-dynamo tracing
             tma_descriptor_metadata={},
             kwargs=graphable_args,
+            backend_options=dict(backend_option_kwargs),
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1272,7 +1272,7 @@ class TritonKernelWrapperMutation(_TritonKernelWrapper):
         grid: list["TritonGridType"],
         tma_descriptor_metadata: TMADescriptorMetadata,
         kwargs: dict[str, Any],
-        backend_options: dict[str, Any] | None = None,
+        launch_kwargs: tuple[str, ...] | None = None,
     ) -> Any:
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
@@ -1281,7 +1281,7 @@ class TritonKernelWrapperMutation(_TritonKernelWrapper):
             grid=grid,
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=kwargs,
-            backend_options={} if backend_options is None else backend_options,
+            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
         )
 
 
@@ -1301,7 +1301,7 @@ class TritonKernelWrapperFunctional(_TritonKernelWrapper):
         tma_descriptor_metadata: TMADescriptorMetadata,
         kwargs: dict[str, Any],
         tensors_to_clone: list[str],
-        backend_options: dict[str, Any] | None = None,
+        launch_kwargs: tuple[str, ...] | None = None,
     ) -> dict[str, Any]:
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
@@ -1311,7 +1311,7 @@ class TritonKernelWrapperFunctional(_TritonKernelWrapper):
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=kwargs,
             tensors_to_clone=tensors_to_clone,
-            backend_options={} if backend_options is None else backend_options,
+            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
         )
 
 
@@ -1330,7 +1330,7 @@ def triton_kernel_wrapper_mutation_dense(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
     from torch._inductor.codegen.wrapper import user_defined_kernel_grid_fn_code
 
@@ -1398,16 +1398,14 @@ def triton_kernel_wrapper_mutation_dense(
     # avoid mutating the original inputs
     kwargs = kwargs.copy()
     constant_args = constant_args.copy()
-    backend_options = {} if backend_options is None else backend_options
+    launch_kwargs = () if launch_kwargs is None else launch_kwargs
     # pyrefly: ignore [missing-attribute]
     for name in kernel.arg_names:
-        if name in backend_options:
-            # Preserve the single-kwarg form for names that are both kernel
-            # parameters and backend options. Triton's binder uses that kwarg
-            # to bind the kernel parameter, and _pack_args still exposes it to
-            # backend.parse_options(). Moving this parameter into positional
-            # args would reconstruct the invalid duplicate form:
-            # kernel(..., False, enable_fp_fusion=False).
+        if name in launch_kwargs:
+            # Preserve the original kwarg form for launch kwargs. Triton's
+            # binder uses the kwarg to bind the kernel parameter, and
+            # _pack_args still exposes launch kwargs to backend.parse_options()
+            # so the same name may also be parsed as a compiler option.
             #
             # Stop positional packing entirely at this point. A later kernel
             # parameter cannot be safely packed positionally after an earlier
@@ -1424,17 +1422,8 @@ def triton_kernel_wrapper_mutation_dense(
         else:
             break
 
-    # This path directly calls the original Triton kernel. If a backend option
-    # name also binds a kernel argument, it remains in kwargs/constant_args
-    # above, so do not pass the same name again as an extra launch kwarg.
-    launch_backend_options = {
-        k: v
-        for k, v in backend_options.items()
-        if k not in kwargs and k not in constant_args
-    }
-
     # pyrefly: ignore [bad-index, index-error]
-    kernel[grid_fn](*args, **kwargs, **constant_args, **launch_backend_options)
+    kernel[grid_fn](*args, **kwargs, **constant_args)
 
 
 @register_fake(triton_kernel_wrapper_mutation, skip_cache=True)
@@ -1445,7 +1434,7 @@ def triton_kernel_wrapper_mutation_fake_tensor_mode(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
     return None
 
@@ -1458,7 +1447,7 @@ def _(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
     return None
 
@@ -1496,7 +1485,7 @@ def triton_kernel_wrapper_mutation_proxy_torch_dispatch_mode(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
     trace_triton_kernel_wrapper(
         mode,
@@ -1507,7 +1496,7 @@ def triton_kernel_wrapper_mutation_proxy_torch_dispatch_mode(
             "grid": grid,
             "tma_descriptor_metadata": tma_descriptor_metadata,
             "kwargs": kwargs,
-            "backend_options": {} if backend_options is None else backend_options,
+            "launch_kwargs": () if launch_kwargs is None else launch_kwargs,
         },
     )
 
@@ -1542,7 +1531,7 @@ def triton_kernel_wrapper_mutation_functionalize(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> None:
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     # TODO(oulgen): Preexisting bug, if two kernel inputs are views of each
@@ -1560,7 +1549,7 @@ def triton_kernel_wrapper_mutation_functionalize(
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=unwrapped_kwargs,
             tensors_to_clone=tensors_to_clone,
-            backend_options={} if backend_options is None else backend_options,
+            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
         )
 
     if not set(unwrapped_outputs.keys()).issubset(set(kwargs.keys())):
@@ -1593,7 +1582,7 @@ def triton_kernel_wrapper_functional_dense(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
     # `clone_preserve_strides` calls are never executed at runtime
@@ -1609,7 +1598,7 @@ def triton_kernel_wrapper_functional_dense(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kwargs=kwargs,
-        backend_options={} if backend_options is None else backend_options,
+        launch_kwargs=() if launch_kwargs is None else launch_kwargs,
     )
     return {key: val for key, val in kwargs.items() if key in tensors_to_clone}
 
@@ -1623,7 +1612,7 @@ def triton_kernel_wrapper_functional_fake_tensor_mode(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
     # `clone_preserve_strides` calls are never executed at runtime
@@ -1646,7 +1635,7 @@ def triton_kernel_wrapper_functional_proxy_torch_dispatch_mode(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     ret = trace_triton_kernel_wrapper(
         mode,
@@ -1658,7 +1647,7 @@ def triton_kernel_wrapper_functional_proxy_torch_dispatch_mode(
             "tma_descriptor_metadata": tma_descriptor_metadata,
             "kwargs": kwargs,
             "tensors_to_clone": tensors_to_clone,
-            "backend_options": {} if backend_options is None else backend_options,
+            "launch_kwargs": () if launch_kwargs is None else launch_kwargs,
         },
     )
     if ret is None:
@@ -1675,7 +1664,7 @@ def triton_kernel_wrapper_functional_functionalize(
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
     tensors_to_clone: list[str],
-    backend_options: dict[str, Any] | None = None,
+    launch_kwargs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
     with ctx.redispatch_to_next():
@@ -1686,7 +1675,7 @@ def triton_kernel_wrapper_functional_functionalize(
             tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=unwrapped_kwargs,
             tensors_to_clone=tensors_to_clone,
-            backend_options={} if backend_options is None else backend_options,
+            launch_kwargs=() if launch_kwargs is None else launch_kwargs,
         )
         return ctx.wrap_tensors(outputs)  # type: ignore[return-value,arg-type]
 
@@ -1833,7 +1822,8 @@ class TritonHOPifier:
         variable,
         grids,
         combined_args: dict[str, Any],
-        backend_option_kwargs: dict[str, Any],
+        launch_kwargs: tuple[str, ...],
+        kernel_arg_names: set[str],
         tx,
     ) -> Optional["ConstantVariable"]:
         raise NotImplementedError("abstract method")
@@ -2257,25 +2247,22 @@ class TritonHOPifier:
             )
             return self.call_triton_kernel(new_var, args, kwargs, tx)
 
-        # Triton passes the full launch kwargs dict to backend.parse_options(),
-        # even when a kwarg also binds a kernel parameter. Preserve those
-        # concrete candidates separately from the normalized kernel arguments.
-        backend_option_kwargs = dict(kwargs)
+        # Triton passes launch kwargs to backend.parse_options(), even when a
+        # kwarg also binds a kernel parameter. Preserve the launch-site names;
+        # values stay in combined_args_raw so Inductor materializes backend
+        # options only after the target backend is known.
+        launch_kwargs = tuple(kwargs)
 
         if isinstance(variable.kernel, Autotuner):
             config_kwarg_names = set().union(
                 *(set(config.kwargs) for config in variable.kernel.configs)
             )
-            config_conflicts = sorted(set(backend_option_kwargs) & config_kwarg_names)
+            config_conflicts = sorted(set(launch_kwargs) & config_kwarg_names)
             if config_conflicts:
                 self.raise_unsupported(
                     "Triton launch kwargs conflict with autotune config kwargs: "
                     f"{config_conflicts!r}."
                 )
-
-        for name in list(kwargs):
-            if name not in jit_arg_names:
-                kwargs.pop(name)
 
         positional_arg_names = iter_kernel.arg_names[: len(args)]
         if len(args) > len(iter_kernel.arg_names):
@@ -2292,9 +2279,9 @@ class TritonHOPifier:
             )
 
         # Both for grid's meta as well as for the kernel, we need combined
-        # args and kwargs combined and normalized. Backend options are excluded:
-        # direct Triton leaves non-signature kwargs in **options instead of
-        # adding them to the bound argument map.
+        # args and launch kwargs combined and normalized. Non-signature launch
+        # kwargs are included here so Inductor can later recover their values
+        # when materializing target-specific backend options.
 
         combined_args_raw = {**dict(zip(iter_kernel.arg_names, args)), **kwargs}
 
@@ -2360,7 +2347,7 @@ class TritonHOPifier:
                         combined_args_raw[arg_name]
                     )
         return self.call_HOP(
-            variable, grids, combined_args_raw, backend_option_kwargs, tx
+            variable, grids, combined_args_raw, launch_kwargs, jit_arg_names, tx
         )
 
 
@@ -2488,7 +2475,8 @@ class TracingTritonHOPifier(TritonHOPifier):
         variable: "TraceableTritonKernelWrapper",
         grids: list["TritonGridTupleType"],
         combined_args: dict[str, Any],
-        backend_option_kwargs: dict[str, Any],
+        launch_kwargs: tuple[str, ...],
+        kernel_arg_names: set[str],
         tx: None,
     ) -> None:
         if tx is not None:
@@ -2499,25 +2487,21 @@ class TracingTritonHOPifier(TritonHOPifier):
             )
 
         graphable_args, constant_args_idx = self.store_non_graphable_args(combined_args)
-        # backend_option_kwargs starts as the original launch kwargs because
-        # direct Triton exposes that dict to backend.parse_options(). In the
-        # tracing HOP, tensor/proxy kernel arguments already live in
-        # combined_args and must be carried through kwargs/constant_args
-        # instead. Drop only those dynamic bound kernel parameters. Keep
-        # concrete kwargs, including the dual-meaning case where a kwarg both
-        # binds a tl.constexpr kernel parameter and is parsed as a backend
-        # option, to match Dynamo and direct Triton.
-        backend_options = dict(backend_option_kwargs)
-        for name, value in combined_args.items():
-            if name in backend_options and self.is_dynamic_backend_option(value):
-                backend_options.pop(name)
-        dynamic_backend_options = [
-            k for k, v in backend_options.items() if self.is_dynamic_backend_option(v)
+        # launch_kwargs records the names passed as kwargs at the Triton launch
+        # site. A non-kernel launch kwarg can only be a compiler option, so it
+        # must be concrete before entering the graph. Kernel launch kwargs may
+        # also be compiler options, but that target-specific check happens in
+        # Inductor after backend.parse_options().
+        non_const_options = [
+            k
+            for k in launch_kwargs
+            if k not in kernel_arg_names
+            and self.is_dynamic_backend_option(combined_args[k])
         ]
-        if dynamic_backend_options:
+        if non_const_options:
             self.raise_unsupported(
                 "Triton backend options must be concrete values: "
-                f"{sorted(dynamic_backend_options)!r}."
+                f"{sorted(non_const_options)!r}."
             )
 
         if not isinstance(variable.kernel_idx, int):
@@ -2532,7 +2516,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             # supported in non-dynamo tracing
             tma_descriptor_metadata={},
             kwargs=graphable_args,
-            backend_options=backend_options,
+            launch_kwargs=launch_kwargs,
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1398,8 +1398,17 @@ def triton_kernel_wrapper_mutation_dense(
     # avoid mutating the original inputs
     kwargs = kwargs.copy()
     constant_args = constant_args.copy()
+    backend_options = {} if backend_options is None else backend_options
     # pyrefly: ignore [missing-attribute]
     for name in kernel.arg_names:
+        if name in backend_options:
+            # Preserve the single-kwarg form for names that are both kernel
+            # parameters and backend options. Triton's binder uses that kwarg
+            # to bind the kernel parameter, and _pack_args still exposes it to
+            # backend.parse_options(). Moving it into positional args here
+            # would reconstruct the invalid duplicate form:
+            # kernel(..., False, enable_fp_fusion=False).
+            break
         if name in kwargs:
             args.append(kwargs.pop(name))
         elif name in constant_args:
@@ -1407,10 +1416,9 @@ def triton_kernel_wrapper_mutation_dense(
         else:
             break
 
-    backend_options = {} if backend_options is None else backend_options
     # This path directly calls the original Triton kernel. If a backend option
-    # name also binds a kernel argument, it is already in kwargs/constant_args,
-    # so do not pass the same name again as an extra launch kwarg.
+    # name also binds a kernel argument, it remains in kwargs/constant_args
+    # above, so do not pass the same name again as an extra launch kwarg.
     launch_backend_options = {
         k: v
         for k, v in backend_options.items()
@@ -2246,6 +2254,18 @@ class TritonHOPifier:
         # even when a kwarg also binds a kernel parameter. Preserve those
         # concrete candidates separately from the normalized kernel arguments.
         backend_option_kwargs = dict(kwargs)
+
+        if isinstance(variable.kernel, Autotuner):
+            config_conflicts = sorted(
+                set(backend_option_kwargs).intersection(
+                    *(set(config.kwargs) for config in variable.kernel.configs)
+                )
+            )
+            if config_conflicts:
+                self.raise_unsupported(
+                    "Triton launch kwargs conflict with autotune config kwargs: "
+                    f"{config_conflicts!r}."
+                )
 
         for name in list(kwargs):
             if name not in jit_arg_names:

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1408,6 +1408,9 @@ def triton_kernel_wrapper_mutation_dense(
             break
 
     backend_options = {} if backend_options is None else backend_options
+    # This path directly calls the original Triton kernel. If a backend option
+    # name also binds a kernel argument, it is already in kwargs/constant_args,
+    # so do not pass the same name again as an extra launch kwarg.
     launch_backend_options = {
         k: v
         for k, v in backend_options.items()

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -2293,7 +2293,10 @@ class TritonHOPifier:
         combined_args_raw = {**dict(zip(iter_kernel.arg_names, args)), **kwargs}
         default_args = {}
         for name, param in iter_kernel.signature.parameters.items():
-            if name not in combined_args_raw and param.default is not inspect.Parameter.empty:
+            if (
+                name not in combined_args_raw
+                and param.default is not inspect.Parameter.empty
+            ):
                 default_args[name] = param.default
                 combined_args_raw[name] = param.default
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -18,7 +18,7 @@ import sympy
 
 import torch.fx as fx
 import torch.utils._pytree as pytree
-from torch import SymInt, Tensor
+from torch import SymBool, SymFloat, SymInt, Tensor
 from torch._C import _dispatch_keys, DispatchKey
 from torch._higher_order_ops.utils import redirect_to_mode, register_fake
 from torch._ops import HigherOrderOperator
@@ -2463,6 +2463,27 @@ class TracingTritonHOPifier(TritonHOPifier):
 
         return graphable_args, constant_args_idx
 
+    def is_dynamic_backend_option(self, value: Any) -> bool:
+        # Backend options are compile-time values. In proxy tracing, a value can
+        # be a Proxy/Node directly or be nested inside a tuple/list option such
+        # as grid_launch_partition=(sym_size,). Reject those unless the name is
+        # later identified as a real kernel parameter.
+        leaves, _ = pytree.tree_flatten(value)
+        return any(
+            isinstance(
+                leaf,
+                (
+                    fx.Node,
+                    fx.Proxy,
+                    Tensor,
+                    SymInt,
+                    SymBool,
+                    SymFloat,
+                ),
+            )
+            for leaf in leaves
+        )
+
     def call_HOP(
         self,
         variable: "TraceableTritonKernelWrapper",
@@ -2480,8 +2501,18 @@ class TracingTritonHOPifier(TritonHOPifier):
             )
 
         graphable_args, constant_args_idx = self.store_non_graphable_args(combined_args)
+        # backend_option_kwargs starts as the original launch kwargs because
+        # direct Triton exposes that dict to backend.parse_options(). In the
+        # tracing HOP, real kernel arguments already live in combined_args and
+        # must be carried through kwargs/constant_args instead. Drop every
+        # bound kernel parameter, including tensor/proxy args and Python
+        # constants, then validate that the remaining backend options are
+        # concrete compile-time values.
+        backend_options = dict(backend_option_kwargs)
+        for name in combined_args:
+            backend_options.pop(name, None)
         dynamic_backend_options = [
-            k for k, v in backend_option_kwargs.items() if isinstance(v, fx.Node)
+            k for k, v in backend_options.items() if self.is_dynamic_backend_option(v)
         ]
         if dynamic_backend_options:
             self.raise_unsupported(
@@ -2501,7 +2532,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             # supported in non-dynamo tracing
             tma_descriptor_metadata={},
             kwargs=graphable_args,
-            backend_options=dict(backend_option_kwargs),
+            backend_options=backend_options,
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -2256,11 +2256,10 @@ class TritonHOPifier:
         backend_option_kwargs = dict(kwargs)
 
         if isinstance(variable.kernel, Autotuner):
-            config_conflicts = sorted(
-                set(backend_option_kwargs).intersection(
-                    *(set(config.kwargs) for config in variable.kernel.configs)
-                )
+            config_kwarg_names = set().union(
+                *(set(config.kwargs) for config in variable.kernel.configs)
             )
+            config_conflicts = sorted(set(backend_option_kwargs) & config_kwarg_names)
             if config_conflicts:
                 self.raise_unsupported(
                     "Triton launch kwargs conflict with autotune config kwargs: "

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1405,9 +1405,17 @@ def triton_kernel_wrapper_mutation_dense(
             # Preserve the single-kwarg form for names that are both kernel
             # parameters and backend options. Triton's binder uses that kwarg
             # to bind the kernel parameter, and _pack_args still exposes it to
-            # backend.parse_options(). Moving it into positional args here
-            # would reconstruct the invalid duplicate form:
+            # backend.parse_options(). Moving this parameter into positional
+            # args would reconstruct the invalid duplicate form:
             # kernel(..., False, enable_fp_fusion=False).
+            #
+            # Stop positional packing entirely at this point. A later kernel
+            # parameter cannot be safely packed positionally after an earlier
+            # parameter is intentionally left in kwargs/constant_args; doing so
+            # would shift it into the wrong argument slot. Triton accepts the
+            # remaining parameters by keyword, so the only trade-off is that
+            # the triton#5082 workaround no longer applies after this first
+            # backend-option/kernel-parameter overlap.
             break
         if name in kwargs:
             args.append(kwargs.pop(name))
@@ -1826,7 +1834,6 @@ class TritonHOPifier:
         grids,
         combined_args: dict[str, Any],
         backend_option_kwargs: dict[str, Any],
-        default_args: dict[str, Any],
         tx,
     ) -> Optional["ConstantVariable"]:
         raise NotImplementedError("abstract method")
@@ -2290,14 +2297,6 @@ class TritonHOPifier:
         # adding them to the bound argument map.
 
         combined_args_raw = {**dict(zip(iter_kernel.arg_names, args)), **kwargs}
-        default_args = {}
-        for name, param in iter_kernel.signature.parameters.items():
-            if (
-                name not in combined_args_raw
-                and param.default is not inspect.Parameter.empty
-            ):
-                default_args[name] = param.default
-                combined_args_raw[name] = param.default
 
         # precompute the grid for the kernel
         configs = (
@@ -2361,7 +2360,7 @@ class TritonHOPifier:
                         combined_args_raw[arg_name]
                     )
         return self.call_HOP(
-            variable, grids, combined_args_raw, backend_option_kwargs, default_args, tx
+            variable, grids, combined_args_raw, backend_option_kwargs, tx
         )
 
 
@@ -2466,8 +2465,8 @@ class TracingTritonHOPifier(TritonHOPifier):
     def is_dynamic_backend_option(self, value: Any) -> bool:
         # Backend options are compile-time values. In proxy tracing, a value can
         # be a Proxy/Node directly or be nested inside a tuple/list option such
-        # as grid_launch_partition=(sym_size,). Reject those unless the name is
-        # later identified as a real kernel parameter.
+        # as backend_option=(sym_size,). Reject those unless the name is later
+        # identified as a real kernel parameter.
         leaves, _ = pytree.tree_flatten(value)
         return any(
             isinstance(
@@ -2490,7 +2489,6 @@ class TracingTritonHOPifier(TritonHOPifier):
         grids: list["TritonGridTupleType"],
         combined_args: dict[str, Any],
         backend_option_kwargs: dict[str, Any],
-        default_args: dict[str, Any],
         tx: None,
     ) -> None:
         if tx is not None:
@@ -2503,14 +2501,16 @@ class TracingTritonHOPifier(TritonHOPifier):
         graphable_args, constant_args_idx = self.store_non_graphable_args(combined_args)
         # backend_option_kwargs starts as the original launch kwargs because
         # direct Triton exposes that dict to backend.parse_options(). In the
-        # tracing HOP, real kernel arguments already live in combined_args and
-        # must be carried through kwargs/constant_args instead. Drop every
-        # bound kernel parameter, including tensor/proxy args and Python
-        # constants, then validate that the remaining backend options are
-        # concrete compile-time values.
+        # tracing HOP, tensor/proxy kernel arguments already live in
+        # combined_args and must be carried through kwargs/constant_args
+        # instead. Drop only those dynamic bound kernel parameters. Keep
+        # concrete kwargs, including the dual-meaning case where a kwarg both
+        # binds a tl.constexpr kernel parameter and is parsed as a backend
+        # option, to match Dynamo and direct Triton.
         backend_options = dict(backend_option_kwargs)
-        for name in combined_args:
-            backend_options.pop(name, None)
+        for name, value in combined_args.items():
+            if name in backend_options and self.is_dynamic_backend_option(value):
+                backend_options.pop(name)
         dynamic_backend_options = [
             k for k, v in backend_options.items() if self.is_dynamic_backend_option(v)
         ]

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2996,6 +2996,7 @@ class PythonWrapperCodegen(CodeGen):
         reset_to_zero_args,
         grids: list[list[int | sympy.Expr]],
         epilogue_fusion: tuple[ir.ComputedBuffer, str] | None,
+        backend_options: dict[str, Any],
     ):
         """Codegen a user-defined Triton kernel and return its cache entry.
 
@@ -3161,6 +3162,9 @@ class PythonWrapperCodegen(CodeGen):
 
         if reset_to_zero_args:
             triton_meta["reset_to_zero"] = tuple(reset_to_zero_args)
+
+        if backend_options:
+            triton_meta["backend_options"] = backend_options
 
         if len(grids) == 1:
             # compute the grid in the wrapper and pass it in as an arg

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2996,7 +2996,7 @@ class PythonWrapperCodegen(CodeGen):
         reset_to_zero_args,
         grids: list[list[int | sympy.Expr]],
         epilogue_fusion: tuple[ir.ComputedBuffer, str] | None,
-        backend_options: dict[str, Any],
+        launch_kwargs: tuple[str, ...],
     ):
         """Codegen a user-defined Triton kernel and return its cache entry.
 
@@ -3007,6 +3007,10 @@ class PythonWrapperCodegen(CodeGen):
         inductor_meta, extra_launcher_call_args)``; subsequent calls with the
         same ``cache_key`` reuse the previously assigned name.
         """
+        from torch._dynamo.device_interface import get_interface_for_device
+
+        from ..runtime.triton_compat import GPUTarget
+        from ..runtime.triton_helpers import try_filter_backend_options_for_target
         from ..runtime.triton_heuristics import (
             config_to_dict,
             FixedGrid,
@@ -3134,9 +3138,11 @@ class PythonWrapperCodegen(CodeGen):
             indices=arg_indices,
             argdefs=[ArgName(x) for x in kernel.arg_names],
         )
+        device = V.graph.get_current_device_or_throw()
+        device_props = DeviceProperties.create(device)
         triton_meta: dict[str, Any] = {
             "signature": triton_signature,
-            "device": DeviceProperties.create(V.graph.get_current_device_or_throw()),
+            "device": device_props,
             # Triton compiler includes equal_to_1 args into constants even
             # when they are not constexpr. otherwise there may be a segfault
             # during launching the Inductor-compiled Triton kernel.
@@ -3163,8 +3169,28 @@ class PythonWrapperCodegen(CodeGen):
         if reset_to_zero_args:
             triton_meta["reset_to_zero"] = tuple(reset_to_zero_args)
 
-        if backend_options:
-            triton_meta["backend_options"] = backend_options
+        backend_option_candidates = {
+            name: kwargs[name] for name in launch_kwargs if name in kwargs
+        }
+        if backend_option_candidates:
+            get_interface_for_device(device).raise_if_triton_unavailable(device)
+            assert GPUTarget is not None  # noqa: S101
+            target = GPUTarget(
+                device_props.type,
+                device_props.cc,
+                device_props.warp_size_or_default,
+            )
+            # HOP capture deliberately keeps an over-approximation of launch kwargs so
+            # a concrete kwarg can still have Triton's direct-call dual meaning:
+            # kernel parameter plus backend option. Once the target backend is known,
+            # only names accepted by parse_options() should be serialized into
+            # triton_meta["backend_options"]. Names that are neither kernel parameters
+            # nor backend options are invalid launch kwargs, matching eager Triton.
+            filtered_backend_options = try_filter_backend_options_for_target(
+                target, backend_option_candidates, kernel.arg_names
+            )
+            if filtered_backend_options:
+                triton_meta["backend_options"] = filtered_backend_options
 
         if len(grids) == 1:
             # compute the grid in the wrapper and pass it in as an arg

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1169,16 +1169,23 @@ class FxConverter:
             constant_args_idx,
         ) = tracing_triton_hopifier_singleton.store_non_graphable_args(call_kwargs)
 
+        hop_kwargs: dict[str, Any] = {
+            "kernel_idx": kernel.wrapped.kernel_idx,
+            "constant_args_idx": constant_args_idx,
+            "grid": wrapper_grid,
+            "tma_descriptor_metadata": {},
+            "kwargs": call_kwargs,
+        }
+        if backend_options:
+            # Keep the FXIR HOP call shape unchanged for normal Inductor
+            # kernels. Some downstream HOP py_impls have fixed keyword-only
+            # signatures and only need launch_kwargs when there are real
+            # Triton backend options to preserve.
+            hop_kwargs["launch_kwargs"] = tuple(backend_options)
+
         triton_node = self.gm.graph.call_function(
             triton_kernel_wrapper_mutation,
-            kwargs={
-                "kernel_idx": kernel.wrapped.kernel_idx,
-                "constant_args_idx": constant_args_idx,
-                "grid": wrapper_grid,
-                "tma_descriptor_metadata": {},
-                "kwargs": call_kwargs,
-                "launch_kwargs": tuple(backend_options),
-            },
+            kwargs=hop_kwargs,
         )
         if extra_options:
             triton_node.meta["extra_options"] = extra_options

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1149,6 +1149,19 @@ class FxConverter:
         call_kwargs = {
             name: self._generate_sym_node(val) for name, val in call_kwargs.items()
         }
+        backend_options = triton_meta.get("backend_options", {})
+        if backend_options:
+            # FXIR executes Triton kernels through the HOP, not the already
+            # materialized CachingAutotuner launcher. Preserve backend option
+            # values in the HOP payload so a direct FXIR run or later Inductor
+            # re-lowering re-enters Triton JIT with the same compiler options
+            # that were used during FXIR precompile/autotune.
+            for name, value in backend_options.items():
+                # If the backend option is also a kernel parameter, call_kwargs
+                # already contains the launch value reconstructed from the Triton
+                # signature/config. Keep that value and only add backend options
+                # that are not otherwise represented in the HOP payload.
+                call_kwargs.setdefault(name, value)
 
         # Store non-graphable kwargs in the side table.
         (
@@ -1164,6 +1177,7 @@ class FxConverter:
                 "grid": wrapper_grid,
                 "tma_descriptor_metadata": {},
                 "kwargs": call_kwargs,
+                "launch_kwargs": tuple(backend_options),
             },
         )
         if extra_options:

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1164,7 +1164,6 @@ class FxConverter:
                 "grid": wrapper_grid,
                 "tma_descriptor_metadata": {},
                 "kwargs": call_kwargs,
-                "backend_options": extra_options or {},
             },
         )
         if extra_options:

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1164,6 +1164,7 @@ class FxConverter:
                 "grid": wrapper_grid,
                 "tma_descriptor_metadata": {},
                 "kwargs": call_kwargs,
+                "backend_options": extra_options or {},
             },
         )
         if extra_options:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8399,6 +8399,7 @@ class UserDefinedTritonKernel(ExternKernel):
             reset_to_zero_args,
             self.grid,
             epilogue_fusion,
+            self.backend_options,
         )
         named_args = {
             k: self.get_kwargs_value(k) for k in self.ordered_kwargs_for_cpp_kernel
@@ -8485,6 +8486,7 @@ class UserDefinedTritonKernel(ExternKernel):
         grid: Any,
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
+        backend_options: dict[str, Any],
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}
@@ -8516,6 +8518,7 @@ class UserDefinedTritonKernel(ExternKernel):
         )
         self.kernel_idx = kernel_idx
         self.grid = grid
+        self.backend_options = backend_options
 
         kernel, configs, _, _ = self.get_kernel_and_metadata()
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8399,7 +8399,7 @@ class UserDefinedTritonKernel(ExternKernel):
             reset_to_zero_args,
             self.grid,
             epilogue_fusion,
-            self.backend_options,
+            self.launch_kwargs,
         )
         named_args = {
             k: self.get_kwargs_value(k) for k in self.ordered_kwargs_for_cpp_kernel
@@ -8486,7 +8486,7 @@ class UserDefinedTritonKernel(ExternKernel):
         grid: Any,
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
-        backend_options: dict[str, Any],
+        launch_kwargs: tuple[str, ...],
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}
@@ -8518,7 +8518,7 @@ class UserDefinedTritonKernel(ExternKernel):
         )
         self.kernel_idx = kernel_idx
         self.grid = grid
-        self.backend_options = backend_options
+        self.launch_kwargs = launch_kwargs
 
         kernel, configs, _, _ = self.get_kernel_and_metadata()
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8777,7 +8777,7 @@ def triton_kernel_wrap_(
     grid,
     tma_descriptor_metadata,
     kwargs,
-    launch_kwargs,
+    launch_kwargs=None,
 ):
     from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
@@ -8787,7 +8787,7 @@ def triton_kernel_wrap_(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
-        launch_kwargs=launch_kwargs,
+        launch_kwargs=() if launch_kwargs is None else launch_kwargs,
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8777,6 +8777,7 @@ def triton_kernel_wrap_(
     grid,
     tma_descriptor_metadata,
     kwargs,
+    backend_options,
 ):
     from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
@@ -8786,6 +8787,7 @@ def triton_kernel_wrap_(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
+        backend_options=backend_options,
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8777,7 +8777,7 @@ def triton_kernel_wrap_(
     grid,
     tma_descriptor_metadata,
     kwargs,
-    backend_options,
+    launch_kwargs,
 ):
     from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
@@ -8787,7 +8787,7 @@ def triton_kernel_wrap_(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
-        backend_options=backend_options,
+        launch_kwargs=launch_kwargs,
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -7,8 +7,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, TypeVar
 
-from torch.utils._ordered_set import OrderedSet
-
 from .triton_compat import (
     _log2,
     builtins_use_semantic_kwarg,
@@ -119,7 +117,7 @@ def _is_concrete_backend_option_value(value: Any) -> bool:
         ),
     ):
         return False
-    if isinstance(value, (tuple, list, OrderedSet, frozenset)):
+    if isinstance(value, (tuple, list)):
         return all(_is_concrete_backend_option_value(item) for item in value)
     if isinstance(value, dict):
         return all(
@@ -132,7 +130,7 @@ def _is_concrete_backend_option_value(value: Any) -> bool:
 
 def try_filter_backend_options_for_target(target, options, kernel_arg_names=()):
     parsed_options = get_backend_options_for_target(target)
-    kernel_arg_names = OrderedSet(kernel_arg_names)
+    kernel_arg_names = tuple(kernel_arg_names)
     filtered_options = {
         name: value for name, value in options.items() if name in parsed_options
     }

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -7,6 +7,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, TypeVar
 
+from torch.utils._ordered_set import OrderedSet
+
 from .triton_compat import (
     _log2,
     builtins_use_semantic_kwarg,
@@ -88,13 +90,73 @@ def set_driver_to_gpu():
     raise RuntimeError("Could not find an active GPU backend")
 
 
+def get_backend_options_for_target(target, options=None):
+    options = {} if options is None else dict(options)
+    backend = triton.compiler.compiler.make_backend(target)
+    return backend.parse_options(options).__dict__
+
+
 def get_backend_options():
     from triton.runtime import driver
 
     target = driver.active.get_current_target()
-    backend = triton.compiler.compiler.make_backend(target)
-    options = backend.parse_options(dict())
-    return options.__dict__
+    return get_backend_options_for_target(target)
+
+
+def _is_concrete_backend_option_value(value: Any) -> bool:
+    import sympy
+
+    import torch
+
+    if isinstance(
+        value,
+        (
+            torch.Tensor,
+            torch.SymInt,
+            torch.SymFloat,
+            torch.SymBool,
+            sympy.Expr,
+        ),
+    ):
+        return False
+    if isinstance(value, (tuple, list, OrderedSet, frozenset)):
+        return all(_is_concrete_backend_option_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            _is_concrete_backend_option_value(key)
+            and _is_concrete_backend_option_value(item)
+            for key, item in value.items()
+        )
+    return True
+
+
+def try_filter_backend_options_for_target(target, options, kernel_arg_names=()):
+    parsed_options = get_backend_options_for_target(target)
+    kernel_arg_names = OrderedSet(kernel_arg_names)
+    filtered_options = {
+        name: value for name, value in options.items() if name in parsed_options
+    }
+    invalid_options = [
+        name
+        for name in options
+        if name not in parsed_options and name not in kernel_arg_names
+    ]
+    if invalid_options:
+        raise RuntimeError(
+            "Triton launch kwargs must be kernel parameters or valid backend options: "
+            f"{sorted(invalid_options)!r}."
+        )
+    dynamic_options = [
+        name
+        for name, value in filtered_options.items()
+        if not _is_concrete_backend_option_value(value)
+    ]
+    if dynamic_options:
+        raise RuntimeError(
+            "Triton backend options must be concrete values: "
+            f"{sorted(dynamic_options)!r}."
+        )
+    return filtered_options
 
 
 def get_constexprs(kernel: JITFunction) -> list[int]:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1125,7 +1125,10 @@ class CachingAutotuner(KernelInterface):
             if backend_options:
                 # Stash backend-only options separately so they do not get mixed into
                 # `constants`, which are interpreted as signature-bound constexpr args.
-                compile_meta["backend_options"] = backend_options
+                compile_meta["backend_options"] = {
+                    **compile_meta.get("backend_options", {}),
+                    **backend_options,
+                }
         compile_meta["constants"].update(cfg_kwargs)
 
         for i in get_constexprs(self.fn):
@@ -1190,10 +1193,9 @@ class CachingAutotuner(KernelInterface):
             for k in tlx_only_cuda_options():
                 if v := getattr(cfg, k, None):
                     options[k] = v
-        if self.device_props.type == "hip":
-            # HIP backend options are consumed by Triton out-of-band from the kernel
-            # signature. They are intentionally *not* present in `constants`.
-            options.update(compile_meta.get("backend_options", {}))
+        # Backend options are consumed by Triton out-of-band from the kernel
+        # signature. They are intentionally *not* present in `constants`.
+        options.update(compile_meta.get("backend_options", {}))
 
         if self.device_props.type == "xpu" and XPU_KERNEL_FORMAT == "zebin":
             options["generate_native_code"] = True


### PR DESCRIPTION
Preserve user-passed Triton backend compiler options through Dynamo and Inductor for user-defined Triton kernels.

Given a kernel call such as `my_kernel[grid](a, b, compiler_option=value)`, today only `SPECIAL_CONFIG_NAMES` compiler options are preserved and handled specially. Other backend compiler options can be lost before Inductor reaches Triton compilation. This PR preserves original launch kwarg names so Inductor can validate them against the active Triton backend and pass valid backend options to  `triton.compile`.

This mirrors Triton launch semantics: original launch kwargs are backend option candidates, while kernel arguments are still bound by signature. Existing `SPECIAL_CONFIG_NAMES` handling is preserved exactly: those names continue to update Triton `Config` objects instead of being serialized as generic backend options.

## Details
  - Tracks original Triton launch kwarg names through the Triton kernel wrapper HOP instead of materializing backend options in Dynamo.
  - Keeps Dynamo target-independent:
    - non-kernel launch kwargs must be Python constants because they can only be backend options
    - signature-bound kwargs remain kernel arguments, even if their names may also be valid backend options
  - Defers target-aware backend option filtering to Inductor, where the active device/backend is known.
  - Uses the Triton backend parser to identify valid backend options for the target.
  - Raises if a launch kwarg is neither a kernel parameter nor a valid backend option.
  - Raises before serializing `triton_meta` if a valid backend option has a dynamic value.
  - Preserves Triton’s dual-meaning kwarg behavior, where a launch kwarg can both bind a kernel parameter and be parsed as a backend compiler option.
  - Preserves existing autotune config semantics, including conflict detection between launch kwargs and autotune config kwargs.
  - Threads launch kwarg metadata through:
    - Dynamo Triton HOP lowering
    - tracing/capture Triton HOP lowering
    - Inductor lowering
    - `UserDefinedTritonKernel`
    - wrapper codegen
    - FXIR conversion
    - Triton heuristic compile options

  ## Testing

  Added and updated tests in `test/inductor/test_triton_kernels.py` covering:

  - backend option not in the kernel signature
  - backend option also used as a kernel kwarg
  - autotuned user-defined Triton kernels
  - launch kwarg conflicts with autotune config kwargs
  - `SPECIAL_CONFIG_NAMES` continuing to use config semantics
  - capture/make_fx preserving launch kwarg names
  - omitted default args not being materialized into HOP payloads
  - dynamic backend options being rejected
  - actual `triton.compile(..., options=...)` receiving the expected backend option values

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98