### PR TITLE
Fix CPU fallback returning tensors on wrong device for reverse binary ops with scalar promotion

### DIFF
--- a/aten/src/ATen/native/CPUFallback.cpp
+++ b/aten/src/ATen/native/CPUFallback.cpp
@@ -62,7 +62,14 @@ static std::optional<c10::Device> compute_target_device(std::vector<at::Tensor>&
   // Decide what device to move the output tensor(s) to.
   // The current convention is that we use the first tensor arg to pick the device
   // Barring that, we take the first tensor from a TensorList arg.
+  // Prefer a non-CPU device to handle cases like scalar op (e.g. 2 // privateuseone_tensor)
+  // where the first tensor arg is a CPU scalar tensor promoted from a Python int.
   if (!t_args.empty()) {
+    for (const auto& t : t_args) {
+        if (t.device().type() != c10::DeviceType::CPU) {
+            return t.device();
+        }
+    }
     return t_args[0].device();
   } else {
     // We need to loop through all of the (potentially multiple) TensorList arguments


### PR DESCRIPTION
#### Problem

When a custom backend (e.g. `PrivateUse1`) relies on `cpu_fallback` for operators it hasn't implemented, reverse binary operations against a Python scalar can produce results on the wrong device.

**Example with floor division:**

```python
b = torch.rand(2, 3).to("txda")
result = 2 // b # Expect result on txda, but it ends up on CPU
```

Root cause: `compute_target_device` unconditionally returns `t_args[0].device()`. For reverse ops, Python calls `torch.floor_divide(2, b)`, where the Python int `2` is promoted to a CPU scalar tensor and becomes `t_args[0]`. Since `t_args[0].device()` is CPU, the result is never moved back to the custom device.

#### Why this only affects some reverse ops

Not all reverse ops hit this bug. For example, `2 / b` works correctly because `__rtruediv__` is implemented as `b.reciprocal() * 2` — the TXDA tensor remains the first argument. However, `__rfloordiv__` directly calls `torch.floor_divide(other, self)`, making the scalar the first tensor argument.

#### Fix

Modify `compute_target_device` to iterate through all tensor arguments and prefer the first non-CPU device. If all tensor arguments are on CPU, fall back to `t_args[0].device()` as before, preserving backward compatibility.

This aligns with the existing design principle stated in `DispatchKey.h`:

> "private use keys should have higher precedence than all built-in keys"

The CPU fallback should similarly prioritize returning results to the custom backend's device over CPU, matching the dispatch priority.