### PR TITLE
[dynamo] Support member access on protobuf enums

### DIFF
--- a/test/dynamo/test_protobuf.py
+++ b/test/dynamo/test_protobuf.py
@@ -1,0 +1,109 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+import torch._dynamo
+import torch._dynamo.testing
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+TEST_PROTOBUF = True
+try:
+    from google.protobuf import descriptor_pool as _descriptor_pool
+    from google.protobuf.internal import enum_type_wrapper
+except ImportError:
+    TEST_PROTOBUF = False
+
+
+def _make_test_enum():
+    """Create a minimal protobuf enum from a serialized descriptor."""
+    descriptor = _descriptor_pool.Default().AddSerializedFile(
+        b"\n\x0csample.proto*Z\n\x0f\x45goFeatureIndex"
+        b"\x12\x10\n\x0c\x45GO_IS_VALID\x10\x00"
+        b"\x12\x12\n\x0e\x45GO_POSITION_X\x10\x01"
+        b"\x12\x12\n\x0e\x45GO_POSITION_Y\x10\x02"
+        b"\x12\r\n\tEGO_SPEED\x10\x03\x62\x06proto3"
+    )
+    enum_desc = descriptor.enum_types_by_name["EgoFeatureIndex"]
+    return enum_type_wrapper.EnumTypeWrapper(enum_desc)
+
+
+if TEST_PROTOBUF:
+    EgoFeatureIndex = _make_test_enum()
+
+
+@unittest.skipIf(not TEST_PROTOBUF, "Missing protobuf")
+class ProtobufTests(TestCase):
+    def test_enum_member_access(self):
+        """Access a protobuf enum member inside torch.compile (fullgraph)."""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            idx = EgoFeatureIndex.EGO_SPEED
+            return x[:, idx : idx + 1]
+
+        x = torch.randn(4, 5)
+        result = f(x)
+        self.assertEqual(result, x[:, 3:4])
+
+    def test_enum_member_as_constant(self):
+        """Protobuf enum value should be treated as a constant int."""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f():
+            return EgoFeatureIndex.EGO_SPEED
+
+        self.assertEqual(f(), 3)
+
+    def test_enum_multiple_members(self):
+        """Access multiple protobuf enum members in a single compiled function."""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            px = EgoFeatureIndex.EGO_POSITION_X
+            py = EgoFeatureIndex.EGO_POSITION_Y
+            return x[:, px] + x[:, py]
+
+        x = torch.randn(4, 5)
+        result = f(x)
+        self.assertEqual(result, x[:, 1] + x[:, 2])
+
+    def test_enum_no_graph_break(self):
+        """Verify protobuf enum access does not cause a graph break."""
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            idx = EgoFeatureIndex.EGO_SPEED
+            return x[:, idx : idx + 1]
+
+        f(torch.randn(4, 5))
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_enum_invalid_member(self):
+        """Accessing a nonexistent member should raise an error at trace time."""
+
+        @torch.compile(backend="eager")
+        def f():
+            return EgoFeatureIndex.NONEXISTENT
+
+        with self.assertRaises(AttributeError):
+            f()
+
+    def test_enum_member_in_arithmetic(self):
+        """Use protobuf enum value in tensor arithmetic."""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            speed = EgoFeatureIndex.EGO_SPEED
+            valid = EgoFeatureIndex.EGO_IS_VALID
+            return x * speed + valid
+
+        x = torch.tensor([1.0, 2.0, 3.0])
+        result = f(x)
+        expected = x * 3 + 0
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -315,6 +315,7 @@ from .user_defined import (
     KeyedJaggedTensorVariable,
     MutableMappingVariable,
     OrderedDictVariable,
+    ProtobufEnumWrapperVariable,
     SourcelessGraphModuleVariable,
     UserDefinedClassVariable,
     UserDefinedConstantVariable,
@@ -1294,6 +1295,9 @@ class VariableBuilder:
             items = [SourcelessBuilder.create(self.tx, v) for v in value]
             self.install_guards(GuardBuilder.EQUALS_MATCH)
             return FrozensetVariable(items, source=self.source)
+        elif ProtobufEnumWrapperVariable.is_matching_object(value):
+            self.install_guards(GuardBuilder.ID_MATCH)
+            return ProtobufEnumWrapperVariable(value, source=self.source)
         elif isinstance(
             value,
             (enum.Enum, torch.DispatchKey, torch._C._functorch.TransformType),
@@ -5168,6 +5172,8 @@ class SourcelessBuilder:
         elif is_function_or_wrapper(value):
             # pyrefly: ignore[not-callable, bad-argument-count]
             return trace_rules.lookup(value)(value)
+        elif ProtobufEnumWrapperVariable.is_matching_object(value):
+            return ProtobufEnumWrapperVariable(value)
         elif isinstance(
             value,
             (enum.Enum, torch.DispatchKey, torch._C._functorch.TransformType),

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -4300,6 +4300,37 @@ _constant_base_methods: dict[type, set[Any]] = {
 }
 
 
+class ProtobufEnumWrapperVariable(UserDefinedObjectVariable):
+    """Protobuf EnumTypeWrapper instances -- immutable name-to-int mappings.
+
+    Attribute access (e.g. MyEnum.MEMBER) resolves through __getattr__
+    which calls into C extension code (_ByNameMap) that Dynamo cannot
+    trace.  Since the wrapper is immutable once constructed, we resolve
+    all attribute access eagerly at trace time.
+    """
+
+    @staticmethod
+    def is_matching_object(obj: object) -> bool:
+        mod = sys.modules.get("google.protobuf.internal.enum_type_wrapper")
+        return mod is not None and isinstance(obj, mod.EnumTypeWrapper)
+
+    def var_getattr(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        source = AttrSource(self.source, name) if self.source else None
+        try:
+            result = getattr(self.value, name)
+        except AttributeError:
+            raise_observed_exception(
+                AttributeError,
+                tx,
+                args=[
+                    f"'{type(self.value).__name__}' object has no attribute '{name}'"
+                ],
+            )
+        return VariableTracker.build(tx, result, source)
+
+
 class UserDefinedConstantVariable(UserDefinedObjectVariable):
     """
     Represents user-defined objects that subclass immutable constant types


### PR DESCRIPTION
Fixes #161765
Supersedes #174336

Adds Dynamo support for accessing protobuf enum members (e.g. `EgoFeatureIndex.EGO_SPEED`) inside `torch.compile` without graph breaks.

**Root cause:** `EnumTypeWrapper.__getattr__` traces into `self._enum_type.values_by_name[name].number`, which hits two C extension barriers in protobuf's UPB backend (`google._upb._message`):
1. `_ByNameMap.__getitem__` : a `wrapper_descriptor` that `mp_subscript_impl` can't handle (line 2127 in `user_defined.py` checks `isinstance(method, types.FunctionType)` which fails for C slots)
2. `EnumValueDescriptor.number` : a `getset_descriptor`

**Fix:** New `ProtobufEnumWrapperVariable(UserDefinedObjectVariable)` that intercepts at the public API boundary. Follows the `KeyedJaggedTensorVariable` pattern `is_matching_object()` via `sys.modules.get()`, detection in both builders with `ID_MATCH` guard, `var_getattr` override that eagerly resolves attributes since protobuf enum wrappers are immutable.

## Test plan

```bash
python test/dynamo/test_protobuf.py -v                     # 6 new tests
python test/dynamo/test_misc.py -v                         # 808 tests, 0 failures
python test/dynamo/test_user_defined_object.py -v          # 66 tests, 0 failures
python test/dynamo/test_iterators.py TestEnumIteration -v  # 7 tests, 0 failures
```

## Question for reviewers
Enabling Dynamo to trace `_ByNameMap.__getitem__` in `mp_subscript_impl` and `EnumValueDescriptor.number` via `getset_descriptor` handling. This would fix the underlying C extension tracing gap but requires two separate fixes coupled to protobuf C internals. Would appreciate guidance from maintainers on whether that approach is preferred ?

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @anijain2305 @rtimpe @Lucaskabela 