### PR TITLE
[Metal][ops] propagate NaN in argmax/argmin to match CPU semantics (#130295)

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -781,6 +781,25 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
         argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
       }
 
+      // MPSGraph's argmax/argmin ignore NaN. CPU returns the index of the first NaN
+      // (NaN propagates through max/min). Detect NaNs and override the result.
+      if (isFloatingType(inputScalarType)) {
+        MPSGraphTensor* nanMask = [mpsGraph isNaNWithTensor:castInputTensor name:@"is_nan"];
+        MPSGraphTensor* nanCast = [mpsGraph castTensor:nanMask toType:MPSDataTypeInt32 name:@"nan_to_int"];
+        MPSGraphTensor* nanIdx = [mpsGraph reductionArgMaximumWithTensor:nanCast axis:(NSInteger)dim_ name:@"nan_idx"];
+        // hasNan = nanMask gathered at nanIdx along the reduced axis. If any NaN
+        // exists, nanIdx points at it and the gather returns true; otherwise the
+        // mask is all-zero and the gather returns false.
+        MPSGraphTensor* hasNan = [mpsGraph gatherAlongAxis:(NSInteger)dim_
+                                          withUpdatesTensor:nanMask
+                                              indicesTensor:nanIdx
+                                                       name:@"has_nan"];
+        argreduceOutTensor = [mpsGraph selectWithPredicateTensor:hasNan
+                                              truePredicateTensor:nanIdx
+                                             falsePredicateTensor:argreduceOutTensor
+                                                             name:@"select_nan_idx"];
+      }
+
       MPSGraphTensor* outputTensor = argreduceOutTensor;
       if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
         outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5392,6 +5392,29 @@ class TestMPS(TestCaseMPS):
         helper(2, 8, 4, 4, "min", torch.float16)
         helper(2, 8, 4, 4, "min", torch.int64)
 
+    # https://github.com/pytorch/pytorch/issues/130295
+    # argmax/argmin must return the index of the first NaN to match CPU
+    # semantics (NaN propagates through max/min).
+    @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+    def test_argmax_argmin_with_nan(self, dtype):
+        # 1-D, scalar arg-reduction
+        x = torch.tensor([1.0, float("nan"), 3.0], device="mps", dtype=dtype)
+        self.assertEqual(torch.argmax(x), torch.argmax(x.cpu()))
+        self.assertEqual(torch.argmin(x), torch.argmin(x.cpu()))
+
+        # 2-D, per-dim arg-reduction
+        x = torch.tensor(
+            [[1.0, float("nan"), 3.0], [float("nan"), 2.0, 1.0], [4.0, 5.0, 6.0]],
+            device="mps", dtype=dtype,
+        )
+        for d in (0, 1):
+            self.assertEqual(torch.argmax(x, dim=d), torch.argmax(x.cpu(), dim=d))
+            self.assertEqual(torch.argmin(x, dim=d), torch.argmin(x.cpu(), dim=d))
+
+        # All NaN
+        x = torch.tensor([float("nan")] * 3, device="mps", dtype=dtype)
+        self.assertEqual(torch.argmax(x), torch.argmax(x.cpu()))
+
     def test_reduction_sum_max_long_val(self):
         x_mps = torch.tensor([sys.maxsize, sys.maxsize - 10, sys.maxsize - 5, sys.maxsize - 18], device="mps")
         x_cpu = x_mps.detach().clone().cpu()


### PR DESCRIPTION
## Problem

`torch.argmax` / `torch.argmin` on MPS ignore `NaN` values. CPU returns the index of the first `NaN` (NaN propagates through max/min); MPS returns the index of the largest finite value. The `max` / `min` half of #130295 was fixed in #130445; this PR completes #130295 by handling `argmax` / `argmin`.

## Reproducer (from the issue)

```python
import torch
torch.manual_seed(0)
x = torch.rand(32, device="mps"); x[5] = torch.nan
print(x.argmin(), x.argmax())
```

| | before | after | CPU |
|---|---|---|---|
| `argmin` | `tensor(13)` | `tensor(5)` | `tensor(5)` |
| `argmax` | `tensor(3)`  | `tensor(5)` | `tensor(5)` |

## How

In `argmax_argmin_out_mps`, when input is floating-point: build a 0/1 NaN mask, run argmax on the mask to get the first-NaN index, and `select` between that index and the regular argmax result based on whether any NaN was present. Stays in the MPSGraph path; the added reductions over the NaN-mask are dominated by the existing argmax reduction in typical workloads.

A shader-based version (folding NaN detection and argmax into a single pass) remains a viable follow-up if performance ever motivates it.

## Test

```
python test/test_mps_issue_130295.py -v
```

5 cases pass on Apple M4 Pro: scalar with NaN, per-dim with NaN, no-NaN regression, all-NaN, fp16 with NaN.

Happy to relocate the test into `test/test_mps.py` if preferred.

Fixes #130295.