### PR TITLE
Full git fetch on tag pushes so release manywheel builds detect the tag

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -173,11 +173,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -74,11 +74,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -164,11 +164,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -254,11 +254,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -344,11 +344,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -75,11 +75,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -165,11 +165,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -255,11 +255,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env
@@ -345,11 +345,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-          # Fetch tags so binary_populate_env.sh can detect the release tag via
-          # `git describe --tags --exact`; without this a tag-triggered build is
-          # mistaken for a dev build and pins triton to a +git<hash> version.
-          fetch-tags: true
+          # Full fetch on tag pushes so the release tag is present for
+          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
+          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Populate binary env


### PR DESCRIPTION
The unified inline manywheel build jobs (cpu/cpu-aarch64/cuda/cuda-aarch64) check out a pinned commit SHA with a shallow `fetch-depth: 2`. On a release tag push (e.g. v2.13.0-rc1) the tag ref is never written into that shallow checkout, so `tagged_version()` in .ci/pytorch/binary_populate_env.sh (`git describe --tags --exact`) fails and the build falls through to the `<version>.dev<DATE>` default, producing wheels versioned `2.13.0.devYYYYMMDD` and pinning triton to a `+git<hash>` version that does not exist on the test index.

Root cause: #187001 added `fetch-tags: true` but kept `fetch-depth: 2`. `fetch-tags` is ineffective when `ref` is a bare SHA and the fetch is shallow; git does not write the tag ref locally. The proven path (the checkout-pytorch action) works because it uses `fetch-depth: 0`, where a full fetch brings all tags regardless.

Fix: in the linux binary build template, set `fetch-depth` to 0 on tag pushes (`github.ref_type == 'tag'`) and keep 2 for nightlies so they stay fast. With a full fetch the tag is present, `git describe --tags --exact` succeeds, and the build resolves to the release version with a clean triton requirement.

Needs to be cherry-picked onto release/2.13 for the RC builds to pick it up.

Test Plan:

PR: https://github.com/pytorch/pytorch/pull/187047

Regenerated the workflows from the template and confirmed only the two linux manywheel workflows change, each unified build job getting the conditional fetch-depth and fetch-tags:

```
python3 .github/scripts/generate_ci_workflows.py
git diff --stat .github/workflows
grep -c "github.ref_type == 'tag' && 0 || 2" \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

Validated the regenerated YAML parses and passes actionlint (the only reported shellcheck warnings are pre-existing on the base files):

```
python3 -c "import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
lintrunner --take ACTIONLINT \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

This PR was authored with the assistance of an AI coding assistant.