### PR TITLE
Followup - Full git fetch on tag pushes so release manywheel builds detect the tag

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -173,10 +173,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -74,10 +74,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -164,10 +163,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -254,10 +252,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -344,10 +341,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -75,10 +75,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -165,10 +164,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -255,10 +253,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
@@ -345,10 +342,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is present for
-          # `git describe --tags --exact`; a shallow fetch of a pinned SHA drops
-          # tag refs even with fetch-tags. Nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type == 'tag' && 0 || 2 }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
           fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false


### PR DESCRIPTION
## Problem

The unified inline manywheel build jobs (`cpu` / `cpu-aarch64` / `cuda` / `cuda-aarch64`) check out a pinned commit SHA with a shallow `fetch-depth: 2`. On a release tag push (e.g. `v2.13.0-rc1`) the tag ref is never written into that shallow checkout, so `tagged_version()` in `.ci/pytorch/binary_populate_env.sh` (`git describe --tags --exact`) fails. The build then falls through to the `<version>.dev<DATE>` default, producing wheels versioned `2.13.0.devYYYYMMDD` and pinning triton to a `+git<hash>` version that does not exist on the test index.

## Root cause

#187001 added `fetch-tags: true` but kept `fetch-depth: 2`. `fetch-tags` is ineffective when `ref` is a bare SHA and the fetch is shallow -- git does not write the tag ref locally. The proven path (the `checkout-pytorch` action) works because it uses `fetch-depth: 0`, where a full fetch brings all tags regardless.

## Fix

Do a full fetch (`fetch-depth: 0`) on tag pushes and keep the shallow `fetch-depth: 2` for nightlies:

```yaml
fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
fetch-tags: ${{ github.ref_type == 'tag' }}
```

### Why the expression is written this way

GitHub Actions has no ternary, so the `A && B || C` idiom is used -- but it only works when `B` is **truthy**. The naive `github.ref_type == 'tag' && 0 || 2` is broken because `0` is falsy: on a real tag push it evaluates `true && 0` -> `0`, then `0 || 2` -> `2`, so it **always** yields `2` and the full-fetch branch is unreachable. An earlier revision shipped this broken form, which is why tag builds kept getting `fetch-depth: 2`.

Negating the condition keeps the truthy literal (`2`) as the `&&` operand so the value is never swallowed:

| trigger | expression | result |
|---|---|---|
| tag | `false && 2` -> false -> `false \|\| 0` | **0** (full fetch) |
| branch / nightly | `true && 2` -> 2 | **2** (shallow) |

With a full fetch the tag is present, `git describe --tags --exact` succeeds, and the build resolves to the release version with a clean triton requirement.

> Needs to be cherry-picked onto `release/2.13` (superseding the broken expression) for the RC builds to pick it up.

## Test Plan

Regenerated the workflows from the template and confirmed only the two linux manywheel workflows change, each of the 4 unified build jobs getting the conditional `fetch-depth` and `fetch-tags`:

```
python3 .github/scripts/generate_ci_workflows.py
git diff --stat .github/workflows
grep -c "github.ref_type != 'tag' && 2 || 0" \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

Validated the regenerated YAML parses and passes actionlint (the only reported shellcheck warnings are pre-existing `SC1090` on `source "${BINARY_ENV_FILE}"`):

```
python3 -c "import yaml,sys;[yaml.safe_load(open(f)) for f in sys.argv[1:]]" \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
lintrunner --take ACTIONLINT \
  .github/workflows/generated-linux-binary-manywheel-nightly.yml \
  .github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
```

This PR was authored with the assistance of an AI coding assistant.
