### PR TITLE
[Metal][ops] fix argmax/argmin for non-contiguous inputs (#160740)

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -718,22 +718,23 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
                                   const std::string& func_name) {
   using CachedGraph = MPSUnaryCachedGraph;
 
+  // Contiguous input required: the no-dim path reshapes to 1-D via
+  // apparent_in_shape, and Placeholder cannot view non-contiguous storage.
+  auto input = input_t.contiguous();
+
   int64_t dim_ = -1;
 
   if (dim.has_value()) {
-    dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
-    zero_numel_check_dims(input_t, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
+    dim_ = maybe_wrap_dim(dim.value(), input.dim());
+    zero_numel_check_dims(input, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
   } else {
-    TORCH_CHECK_INDEX(input_t.numel() != 0,
+    TORCH_CHECK_INDEX(input.numel() != 0,
                       reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()",
                       ": Expected reduction dim to be specified for input.numel() == 0.");
-    // Since input will be flattened, take argmax or argmin along 0'th dimension
     dim_ = 0;
   }
 
-  // Calculate the output shape according to keepdim=True
-  // If there is no dim argument, the input shape is flattened
-  IntArrayRef input_shape = input_t.sizes();
+  IntArrayRef input_shape = input.sizes();
   int64_t num_input_dims = input_shape.size();
   NSMutableArray<NSNumber*>* apparent_in_shape = nil;
   NSMutableArray<NSNumber*>* apparent_out_shape = nil;
@@ -757,15 +758,15 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
   }
 
   if (!apparent_in_shape) {
-    apparent_in_shape = [getMPSShape(input_t.sizes()) mutableCopy];
+    apparent_in_shape = [getMPSShape(input.sizes()) mutableCopy];
   }
 
   @autoreleasepool {
     NSString* ns_key = [[apparent_in_shape valueForKey:@"description"] componentsJoinedByString:@","];
-    std::string key = func_name + ":" + std::to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" +
+    std::string key = func_name + ":" + std::to_string(dim_) + ":" + getTensorsStringKey(input) + ":" +
         std::string([ns_key UTF8String]);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto inputScalarType = input_t.scalar_type();
+      auto inputScalarType = input.scalar_type();
       MPSGraphTensor* inputTensor =
           mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(inputScalarType), apparent_in_shape);
       MPSGraphTensor* argreduceOutTensor = nil;
@@ -796,7 +797,7 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
       newCachedGraph->outputTensor_ = outputClampedTensor;
     });
 
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, apparent_in_shape);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
 
     auto feeds = dictionaryFromPlaceholders(inputPlaceholder);

--- a/test/test_mps_issue_160740.py
+++ b/test/test_mps_issue_160740.py
@@ -1,0 +1,66 @@
+"""Reproduce https://github.com/pytorch/pytorch/issues/160740
+
+argmax/argmin fail on non-contiguous (transposed, strided) MPS tensors
+with: "view size is not compatible with input tensor's size and stride"
+"""
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestArgmaxArgminNonContiguous(TestCase):
+    def test_transposed(self):
+        x = torch.randn(5, 5, device="mps")
+        x_cpu = x.cpu()
+        self.assertEqual(torch.argmax(x.t()).item(), torch.argmax(x_cpu.t()).item())
+        self.assertEqual(torch.argmin(x.t()).item(), torch.argmin(x_cpu.t()).item())
+
+    def test_strided(self):
+        x = torch.randn(5, 5, device="mps")
+        x_cpu = x.cpu()
+        self.assertEqual(
+            torch.argmax(x[::2, ::2]).item(), torch.argmax(x_cpu[::2, ::2]).item()
+        )
+        self.assertEqual(
+            torch.argmin(x[::2, ::2]).item(), torch.argmin(x_cpu[::2, ::2]).item()
+        )
+
+    def test_with_dim_on_transposed(self):
+        x = torch.randn(5, 5, device="mps")
+        x_cpu = x.cpu()
+        self.assertEqual(
+            torch.argmax(x.t(), dim=0).cpu(), torch.argmax(x_cpu.t(), dim=0)
+        )
+        self.assertEqual(
+            torch.argmax(x.t(), dim=1).cpu(), torch.argmax(x_cpu.t(), dim=1)
+        )
+        self.assertEqual(
+            torch.argmin(x.t(), dim=0).cpu(), torch.argmin(x_cpu.t(), dim=0)
+        )
+        self.assertEqual(
+            torch.argmin(x.t(), dim=1).cpu(), torch.argmin(x_cpu.t(), dim=1)
+        )
+
+    def test_large_sliced(self):
+        y = torch.randn(100, 100, device="mps")
+        y_cpu = y.cpu()
+        col_slice = y[:, ::3]
+        col_slice_cpu = y_cpu[:, ::3]
+        self.assertEqual(
+            torch.argmax(col_slice).item(), torch.argmax(col_slice_cpu).item()
+        )
+        self.assertEqual(
+            torch.argmin(col_slice).item(), torch.argmin(col_slice_cpu).item()
+        )
+
+    def test_3d_permuted(self):
+        z = torch.randn(4, 8, 16, device="mps")
+        z_cpu = z.cpu()
+        z_nc = z.permute(2, 0, 1)
+        z_nc_cpu = z_cpu.permute(2, 0, 1)
+        self.assertEqual(torch.argmax(z_nc).item(), torch.argmax(z_nc_cpu).item())
+        self.assertEqual(torch.argmin(z_nc).item(), torch.argmin(z_nc_cpu).item())
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Problem

`torch.argmax` / `torch.argmin` on MPS fail on non-contiguous inputs (transposed, strided slices) with: `view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.` CPU works fine on the same inputs.

The no-dim path in `argmax_argmin_out_mps` flattens the input via `apparent_in_shape = [num_elements]`, and the `Placeholder` constructor reshapes via `.view()`, which requires contiguous memory.

## Reproducer (from the issue)

```python
import torch
x = torch.randn(5, 5, device="mps")
torch.argmax(x.t())          # transposed, raises
torch.argmax(x[::2, ::2])    # strided, raises
```

## How

In `argmax_argmin_out_mps` (`aten/src/ATen/native/mps/operations/ReduceOps.mm`), call `.contiguous()` on the input at the top of the function. No-op for already-contiguous tensors; for non-contiguous inputs it materializes a contiguous copy so the downstream `Placeholder` / `.view()` succeeds. Sibling fix to #187039 (argmax/argmin NaN handling) in the same file.

## Test

```
python test/test_mps_issue_160740.py -v
```

Cases: transposed 2D, strided 2D slice, with-dim on transposed, large column-strided slice, 3D permuted. All match CPU output on Apple M4 Pro.

Happy to relocate the test into `test/test_mps.py` if preferred.

Fixes #160740.