### PR TITLE
Fix coordinate cache in `LocalDeviceMesh`

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,7 +1261,11 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Shared lock for LocalDeviceMesh coordinate caching for thread safety in MPMD contexts
+        # Cache for get_coordinate results, keyed by mesh id
+        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
+        self._coordinate_cache: dict[
+            tuple[int, tuple, torch.distributed._mesh_layout._MeshLayout], list[SymInt]
+        ] = {}
         self._coordinate_cache_lock = threading.Lock()
 
     def __enter__(self) -> "LocalTensorMode":
@@ -1630,28 +1634,23 @@ class _LocalDeviceMesh:
         if lm is None:
             raise AssertionError("Unexpectedly not in LocalTensorMode")
 
-        ranks = lm.ranks
+        # Include all attributes used below in the cache key
+        cache_key = (self.ndim, self._flatten_rank_map, self._layout)
         # Check cache first (fast path without lock)
-        # Note that we are caching the result based on the set of ranks,
-        # so that different LocalTensorModes with different ranks will not interfere with each other's cache.
-        with contextlib.suppress(AttributeError, KeyError):
-            # pyrefly: ignore [missing-attribute]
-            return self._local_coordinates_cache[ranks]
+        if cache_key in lm._coordinate_cache:
+            return lm._coordinate_cache[cache_key]
+
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
-            try:
-                # pyrefly: ignore [missing-attribute]
-                return self._local_coordinates_cache[ranks]
-            except AttributeError:
-                # pyrefly: ignore [missing-attribute]
-                self._local_coordinates_cache = {}
-            except KeyError:
-                pass
+            # Double-check after acquiring lock
+            if cache_key in lm._coordinate_cache:
+                return lm._coordinate_cache[cache_key]
+
             coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
             # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
             # error when running under torch.inference_mode()
             rank_map = self._rank_map.clone()
-            for r in ranks:
+            for r in lm.ranks:
                 rank_tensor = self._layout.remap_to_tensor(rank_map)
                 rank_coords = (rank_tensor == r).nonzero().tolist()
                 if len(rank_coords) != 1:
@@ -1660,8 +1659,8 @@ class _LocalDeviceMesh:
                     coords[d][r] = c
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
-            # pyrefly: ignore [missing-attribute]
-            self._local_coordinates_cache[ranks] = out
+            # Cache the result
+            lm._coordinate_cache[cache_key] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions
             # as the current mesh.

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,9 +1261,7 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Cache for get_coordinate results, keyed by mesh id
-        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
-        self._coordinate_cache: dict[int, list[SymInt]] = {}
+        # Shared lock for LocalDeviceMesh coordinate caching for thread safety in MPMD contexts
         self._coordinate_cache_lock = threading.Lock()
 
     def __enter__(self) -> "LocalTensorMode":
@@ -1632,22 +1630,25 @@ class _LocalDeviceMesh:
         if lm is None:
             raise AssertionError("Unexpectedly not in LocalTensorMode")
 
+        ranks = lm.ranks
         # Check cache first (fast path without lock)
-        mesh_id = id(self)
-        if mesh_id in lm._coordinate_cache:
-            return lm._coordinate_cache[mesh_id]
-
+        # Note that we are caching the result based on the set of ranks,
+        # so that different LocalTensorModes with different ranks will not interfere with each other's cache.
+        with contextlib.suppress(AttributeError, KeyError):
+            return self._local_coordinates_cache[ranks]
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
-            # Double-check after acquiring lock
-            if mesh_id in lm._coordinate_cache:
-                return lm._coordinate_cache[mesh_id]
-
+            try:
+                return self._local_coordinates_cache[ranks]
+            except AttributeError:
+                self._local_coordinates_cache = {}
+            except KeyError:
+                pass
             coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
             # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
             # error when running under torch.inference_mode()
             rank_map = self._rank_map.clone()
-            for r in lm.ranks:
+            for r in ranks:
                 rank_tensor = self._layout.remap_to_tensor(rank_map)
                 rank_coords = (rank_tensor == r).nonzero().tolist()
                 if len(rank_coords) != 1:
@@ -1656,8 +1657,7 @@ class _LocalDeviceMesh:
                     coords[d][r] = c
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
-            # Cache the result
-            lm._coordinate_cache[mesh_id] = out
+            self._local_coordinates_cache[ranks] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions
             # as the current mesh.

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1635,12 +1635,15 @@ class _LocalDeviceMesh:
         # Note that we are caching the result based on the set of ranks,
         # so that different LocalTensorModes with different ranks will not interfere with each other's cache.
         with contextlib.suppress(AttributeError, KeyError):
+            # pyrefly: ignore [missing-attribute]
             return self._local_coordinates_cache[ranks]
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
             try:
+                # pyrefly: ignore [missing-attribute]
                 return self._local_coordinates_cache[ranks]
             except AttributeError:
+                # pyrefly: ignore [missing-attribute]
                 self._local_coordinates_cache = {}
             except KeyError:
                 pass
@@ -1657,6 +1660,7 @@ class _LocalDeviceMesh:
                     coords[d][r] = c
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
+            # pyrefly: ignore [missing-attribute]
             self._local_coordinates_cache[ranks] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,8 +1261,9 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Cache for get_coordinate results, keyed by mesh id
-        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
+        # Cache for get_coordinate results, keyed by the inputs used to compute them:
+        # (ndim, flattened rank map, layout).
+        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts.
         self._coordinate_cache: dict[
             tuple[int, tuple, torch.distributed._mesh_layout._MeshLayout], list[SymInt]
         ] = {}


### PR DESCRIPTION
Alternative to https://github.com/pytorch/pytorch/pull/184534 after discussion and https://github.com/pytorch/pytorch/pull/187021.

The cache used the `id` of the Mesh as the key which is not unique over the lifetime of the `LocalTensorMode` instance:
When the mesh is destroyed its slot may be reused leading to silently wrong, indeterministic results.
E.g.:
        mesh_dim0_local_rank = mesh_2d["dim0"].get_local_rank(mesh_dim=0)
        mesh_dim1_local_rank = mesh_2d["dim1"].get_local_rank(mesh_dim=0)
The values for both might be the same as the 2nd could use the cached
coords from the first submesh, which is a temporary that gets
immediately destroyed.

Use the attributes used for the calculation as the cache key instead. Those are all tuples or data classes which works fine.

Fixes #184526
Fixes 8e65dfa.

Closes #184534
Closes #187021