### PR TITLE
[SymmMem] Allocate symmetric memory through the `CUDACachingAllocator`

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -402,7 +402,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         with torch.cuda.graph(graph_all_reduce):
             c10d.all_reduce(out)
         graph_all_reduce.replay()
-        torch.cuda.synchronize()
         self.assertEqual(
             out, torch.full_like(out, (self.world_size - 1) * self.world_size / 2)
         )
@@ -427,6 +426,74 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
             graph_one_shot_all_reduce.replay()
             self.assertEqual(out, torch.full_like(out, expected_sum))
             self.assertEqual(res, out)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_nccl_symmem_tensor_creation_and_collective_cuda_graph(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        dtype = torch.float
+        numel = 1024
+        capture_offset = torch.tensor(1, dtype=dtype, device=self.device)
+        capture_stream = torch.cuda.Stream(device=self.device)
+
+        # Warm up on the same stream that will be captured. This establishes
+        # NCCL window metadata for the symmetric block that capture reuses.
+        with torch.cuda.stream(capture_stream):
+            inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+            out = torch.empty(numel, dtype=dtype, device=self.device)
+            for warmup_idx in range(3):
+                offset = 1 + warmup_idx
+                capture_offset.fill_(self.rank + offset)
+                inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+                out = torch.empty(numel, dtype=dtype, device=self.device)
+                inp.fill_(capture_offset)
+                out.fill_(0.0)
+                torch.ops.symm_mem.one_shot_all_reduce_out(
+                    inp, "sum", group_name, out
+                )
+                expected_sum = float(
+                    self.world_size * offset
+                    + self.world_size * (self.world_size - 1) / 2
+                )
+                self.assertEqual(out, torch.full_like(out, expected_sum))
+            del inp, out
+        capture_stream.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        offset = 13
+        capture_offset.fill_(self.rank + offset)
+        with torch.cuda.graph(graph, stream=capture_stream):
+            inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+            out = torch.empty(numel, dtype=dtype, device=self.device)
+            inp.fill_(capture_offset)
+            out.fill_(0.0)
+            torch.ops.symm_mem.one_shot_all_reduce_out(
+                inp, "sum", group_name, out
+            )
+
+        graph.replay()
+        expected_sum = float(
+            self.world_size * offset + self.world_size * (self.world_size - 1) / 2
+        )
+        self.assertEqual(out, torch.full_like(out, expected_sum))
+
+        for repeat in range(3):
+            offset = 20 + repeat
+            capture_offset.fill_(self.rank + offset)
+            graph.replay()
+            expected_sum = float(
+                self.world_size * offset
+                + self.world_size * (self.world_size - 1) / 2
+            )
+            self.assertEqual(out, torch.full_like(out, expected_sum))
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -456,9 +456,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
                 out = torch.empty(numel, dtype=dtype, device=self.device)
                 inp.fill_(capture_offset)
                 out.fill_(0.0)
-                torch.ops.symm_mem.one_shot_all_reduce_out(
-                    inp, "sum", group_name, out
-                )
+                torch.ops.symm_mem.one_shot_all_reduce_out(inp, "sum", group_name, out)
                 expected_sum = float(
                     self.world_size * offset
                     + self.world_size * (self.world_size - 1) / 2
@@ -475,9 +473,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
             out = torch.empty(numel, dtype=dtype, device=self.device)
             inp.fill_(capture_offset)
             out.fill_(0.0)
-            torch.ops.symm_mem.one_shot_all_reduce_out(
-                inp, "sum", group_name, out
-            )
+            torch.ops.symm_mem.one_shot_all_reduce_out(inp, "sum", group_name, out)
 
         graph.replay()
         expected_sum = float(
@@ -490,8 +486,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
             capture_offset.fill_(self.rank + offset)
             graph.replay()
             expected_sum = float(
-                self.world_size * offset
-                + self.world_size * (self.world_size - 1) / 2
+                self.world_size * offset + self.world_size * (self.world_size - 1) / 2
             )
             self.assertEqual(out, torch.full_like(out, expected_sum))
 

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1945,6 +1945,55 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         expected = torch.mm(x, w) * self.world_size
         self.assertEqual(y, expected)
 
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_mempool_storage_reuse(self):
+        """MemPool with no_split=True returns the same VA for same-size allocs."""
+        self._init_process()
+
+        mempool = symm_mem.get_mem_pool(self.device)
+        numel = 1024
+        dtype = torch.float
+
+        with torch.cuda.use_mem_pool(mempool):
+            t1 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        with torch.cuda.use_mem_pool(mempool):
+            t2 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1, ptr2, "MemPool should return the same storage block for same-size re-allocation"
+        )
+
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_symm_mem_empty_storage_reuse(self):
+        """symm_mem.empty() reuses storage across alloc/free cycles via the MemPool."""
+        self._init_process()
+
+        numel = 1024
+        dtype = torch.float
+
+        t1 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        t2 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1, ptr2, "symm_mem.empty() should reuse the same storage block via the implicit MemPool"
+        )
+
 
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1968,7 +1968,9 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         ptr2 = t2.data_ptr()
 
         self.assertEqual(
-            ptr1, ptr2, "MemPool should return the same storage block for same-size re-allocation"
+            ptr1,
+            ptr2,
+            "MemPool should return the same storage block for same-size re-allocation",
         )
 
     @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
@@ -1991,7 +1993,9 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         ptr2 = t2.data_ptr()
 
         self.assertEqual(
-            ptr1, ptr2, "symm_mem.empty() should reuse the same storage block via the implicit MemPool"
+            ptr1,
+            ptr2,
+            "symm_mem.empty() should reuse the same storage block via the implicit MemPool",
         )
 
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -503,6 +503,14 @@ struct RendezvousRequest {
   char hostname[HOST_NAME_MAX + 1];
 };
 
+static void reset_signal_pad(const c10::intrusive_ptr<Block>& block) {
+  c10::cuda::CUDAGuard guard(block->device_idx);
+  auto base_addr = reinterpret_cast<uintptr_t>(block->alloc_ref->ptr);
+  auto* signal_pad =
+      reinterpret_cast<void*>(base_addr + block->signal_pad_offset);
+  AT_CUDA_CHECK(cudaMemset(signal_pad, 0, get_signal_pad_size()));
+}
+
 static std::string import_err_msg(
     int rank,
     int peer,
@@ -930,9 +938,25 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     group_name_ = *block->default_group_name;
   }
 
-  // If found, this block has been rendezvous by the given group
-  auto it = block->symm_mems.find(group_name_);
-  if (it == block->symm_mems.end()) {
+  reset_signal_pad(block);
+
+  // MemPool reuse can leave the per-block rendezvous cache populated on only a
+  // subset of ranks. Make the cached-vs-new decision collective so all ranks
+  // either enter make_peer_alloc_info() or all ranks reuse the cached metadata.
+  auto group = resolve_process_group(group_name_);
+  bool use_pg = group->hasBackendForDeviceType(c10::DeviceType::CUDA) &&
+      group->getBackend(c10::DeviceType::CUDA)->getUsePgForSymmMemRendezvous();
+  auto cache_key = group_name_ + (use_pg ? "#pg" : "#store");
+  auto it = block->symm_mems.find(cache_key);
+  uint8_t need_rendezvous = it == block->symm_mems.end();
+  auto peer_needs = storeExchange.all_gather(
+      group->getStore(), group->getRank(), group->getSize(), need_rendezvous);
+  bool should_rendezvous = false;
+  for (auto peer_need : peer_needs) {
+    should_rendezvous |= peer_need != 0;
+  }
+
+  if (should_rendezvous) {
     // Create PeerAllocInfo for this block (this is the costly part)
     TORCH_INTERNAL_ASSERT(
         handle_type_ != Expandable_Segments_Handle_Type::UNSPECIFIED)
@@ -941,8 +965,8 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     // PeerAllocInfo captures this block's rendezvous info
     auto pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_name_)
                           : make_peer_alloc_info<false>(ptr, block, group_name_);
-    // Cache it with the group name
-    it = block->symm_mems.emplace(group_name_, pai).first;
+    // Cache it with the group name and rendezvous transport.
+    it = block->symm_mems.insert_or_assign(cache_key, pai).first;
   }
 
   // Create symm mem handle for this tensor, specified by its offset

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1966,12 +1966,13 @@ def empty(  # type: ignore[misc]
     stride = torch._prims_common.make_contiguous_strides_for(size)
 
     if _should_use_implicit_mempool() and device.type == "cuda":
-        # Allocate tensor from an implicit memory pool
+        # Allocate through the CUDACachingAllocator so symmetric allocations
+        # can participate in MemPool and CUDAGraph private-pool reuse.
         mempool = get_mem_pool(device)
         # TODO: this path can be made device-agnostic if `use_mem_pool` is
         # elevated from torch.cuda to torch accelerator.
-        with torch.cuda.use_mem_pool(mempool):
-            return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
+        with torch.cuda.use_mem_pool(mempool, device=device):
+            return torch.empty_strided(size, stride, dtype=dtype, device=device)
     else:
         return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1971,7 +1971,7 @@ def empty(  # type: ignore[misc]
         mempool = get_mem_pool(device)
         # TODO: this path can be made device-agnostic if `use_mem_pool` is
         # elevated from torch.cuda to torch accelerator.
-        with torch.cuda.use_mem_pool(mempool, device=device):
+        with torch.cuda.use_mem_pool(mempool):
             return torch.empty_strided(size, stride, dtype=dtype, device=device)
     else:
         return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)


### PR DESCRIPTION
This PR makes `symm_mem.empty()` allocate through the `CUDACachingAllocator` when using the implicit symmetric memory pool. This lets symmetric-memory allocations participate in CUDAGraph private-pool reuse, enabling `symm_mem.empty()` inside CUDAGraph capture region.

cc @kwen2501 