### PR TITLE
[nativert] fix: selectScalarOverload handles default overload (#187059)

### DIFF
--- a/test/export/test_nativert.py
+++ b/test/export/test_nativert.py
@@ -100,6 +100,9 @@ def run_with_nativert(ep):
         torch.export.pt2_archive._package.package_pt2(
             f, exported_programs={MODEL_NAME: ep_infer}
         )
+        # Flush so PyModelRunner, which reopens the file by name below, sees the
+        # fully written archive (the zip central directory is written last).
+        f.flush()
         filename = f.name
 
         try:
@@ -371,6 +374,38 @@ class TestNativeRT(TestCase):
                     pass
                 else:
                     raise e
+
+
+@unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not is_fbcode(), "FBcode only for now")
+class TestSelectScalarOverload(TestCase):
+    def test_floor_divide_default_scalar(self) -> None:
+        # PT2 export lowers `x // 10` to aten.floor_divide.default with a scalar
+        # Int argument (the #90923 Scalar->Tensor broadcast).  Its default
+        # schema is (Tensor, Tensor), so nativert's boxed C10Kernel dispatch
+        # raises "Expected Tensor but got Int" unless selectScalarOverload
+        # rewrites the node to floor_divide.Scalar during load.  Running the
+        # exported program through nativert exercises that pass end to end.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.floor_divide(x, 10)
+
+        ep = export(M(), (torch.randint(0, 1000, (999,), dtype=torch.long),))
+        # The export must actually produce the .default overload this fixes.
+        self.assertTrue(
+            any(
+                n.op == "call_function"
+                and n.target is torch.ops.aten.floor_divide.default
+                for n in ep.graph.nodes
+            )
+        )
+
+        # Run the exported program through nativert -- which applies
+        # selectScalarOverload on load -- and compare against eager.  Without
+        # the pass, boxed C10Kernel dispatch raises "Expected Tensor but got
+        # Int" on the floor_divide.default node.
+        run_with_nativert(ep)
 
 
 if is_fbcode():

--- a/torch/nativert/graph/GraphPasses.cpp
+++ b/torch/nativert/graph/GraphPasses.cpp
@@ -110,15 +110,18 @@ std::string selectScalarOverloadName(const Node& node) {
   std::string opName = std::string{atoms[atoms.size() - 2]};
   std::string overloadName = std::string{atoms[atoms.size() - 1]};
   if (overloadName != "Tensor" && overloadName != "Tensor_Tensor" &&
-      overloadName != "Tensor_mode") {
+      overloadName != "Tensor_mode" && overloadName != "default") {
     return overloadName;
   }
   if (allowed.find(opName) == allowed.end()) {
     return overloadName;
   }
-  auto op = c10::Dispatcher::singleton().findSchemaOrThrow(
-      fmt::format("{}::{}", ns, opName.c_str()).c_str(), overloadName.c_str());
-  if (schemaTypeMatch(op.schema(), node)) {
+  // The "default" overload is stored with an empty overload name in the
+  // dispatcher, so normalize before looking it up.
+  std::string lookupOverload = overloadName == "default" ? "" : overloadName;
+  auto op = c10::Dispatcher::singleton().findSchema(
+      {fmt::format("{}::{}", ns, opName.c_str()), lookupOverload});
+  if (!op || schemaTypeMatch(op->schema(), node)) {
     return overloadName;
   }
   for (const auto& variant :


### PR DESCRIPTION
Summary:

`selectScalarOverload` only checked nodes with overload names `Tensor`, `Tensor_Tensor`, or `Tensor_mode`. Nodes with the `default` overload were skipped, so ops like `floor_divide.default(Tensor, Int)` were not converted to `floor_divide.Scalar`.

Add `default` to the overload filter. The `default` overload is stored with an empty overload name in the dispatcher, so normalize it (to an empty string) before the schema lookup. Use `findSchema` (returns optional) instead of `findSchemaOrThrow`, since the `default` overload may not have a registered schema for all ops.

Test Plan:
Added `TestSelectScalarOverload.test_floor_divide_default_scalar` in `caffe2/test/export/test_nativert.py`: it exports `torch.floor_divide(x, 10)`, which torch.export lowers to `aten.floor_divide.default(Tensor, Int)` (the pytorch #90923 Scalar-to-Tensor broadcast), asserts the `.default` overload is present, then runs the program through nativert via `PyModelRunner` (which applies `selectScalarOverload` on load) and checks the result matches eager.

```
buck2 test fbcode//caffe2/test:test_export -- TestSelectScalarOverload
```

Pass 1, Fail 0. Without this fix the run raises `RuntimeError: Expected Tensor but got Int` on the `floor_divide.default` node in `SerialGraphExecutor::executeWithPrefilledFrame`.

Also verified end to end on the ads-preproc graph (CMF 830857007) through torchwave: 659/659 outputs match the serial nativert reference.

Reviewed By: georgiaphillips

Differential Revision: D108232513


