### PR TITLE
[inductor] Expose compile_worker_malloc_conf to tune the compile-worker allocator (#187062)

### DIFF
--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -177,15 +177,18 @@ class SubprocPool:
             # pyrefly: ignore [bad-assignment]
             self.log_file = open(log_path, "w")  # noqa:SIM115
 
+        subproc_env = {
+            **python_subprocess_env(),
+            # Safeguard against creating a SubprocPool in the subprocess.
+            "TORCH_WARM_POOL": "0",
+            # Some internal usages need a modified LD_LIBRARY_PATH.
+            "LD_LIBRARY_PATH": get_ld_library_path(),
+        }
+        if config.compile_worker_malloc_conf:
+            subproc_env["MALLOC_CONF"] = config.compile_worker_malloc_conf
         self.process = subprocess.Popen(
             cmd,
-            env={
-                **python_subprocess_env(),
-                # Safeguard against creating a SubprocPool in the subprocess.
-                "TORCH_WARM_POOL": "0",
-                # Some internal usages need a modified LD_LIBRARY_PATH.
-                "LD_LIBRARY_PATH": get_ld_library_path(),
-            },
+            env=subproc_env,
             pass_fds=(subproc_read_fd, subproc_write_fd),
             stdout=self.log_file,
             stderr=self.log_file,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1143,6 +1143,16 @@ worker_suppress_logging: bool = Config(
     default=True,
 )
 
+
+def _compile_worker_malloc_conf_default() -> str:
+    env = os.environ.get("TORCHINDUCTOR_COMPILE_WORKER_MALLOC_CONF")
+    if env is not None:
+        return env
+    return "dirty_decay_ms:0,narenas:4"
+
+
+compile_worker_malloc_conf: str = _compile_worker_malloc_conf_default()
+
 # Log per-operation runtime estimates for TLParse analysis.
 log_tlparse: bool = Config(
     env_name_force="LOG_TLPARSE",


### PR DESCRIPTION
Summary:

Adds an Inductor config (env TORCHINDUCTOR_COMPILE_WORKER_MALLOC_CONF / config.compile_worker_malloc_conf)

Test Plan:
```
buck2 build fbcode//mode/opt -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=h100a -c fbcode.enable_gpu_sections=true fbsource//users/sa/sashko/inductor:compile_worker_memory_repro
python -c "import os; os.environ['TORCHINDUCTOR_COMPILE_WORKER_MALLOC_CONF']='dirty_decay_ms:0,narenas:4'; import torch._inductor.config as c; assert c.compile_worker_malloc_conf=='dirty_decay_ms:0,narenas:4'"
```

Reviewed By: PaulZhang12

Differential Revision: D108298791




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo