### PR TITLE
[torch][profiler] Fix refcount leaks in _TensorMetadata layout/dtype getters (#187068)

### DIFF
--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -577,15 +577,14 @@ void initPythonBindings(PyObject* module) {
       .def_property_readonly(
           "layout",
           [](const TensorMetadata& metadata) {
-            PyObject* layout_obj =
-                torch::autograd::utils::wrap(metadata.layout_);
-            return py::reinterpret_borrow<py::object>(layout_obj);
+            return py::reinterpret_steal<py::object>(
+                torch::autograd::utils::wrap(metadata.layout_));
           })
       .def_readonly("device", &TensorMetadata::device_)
       .def_property_readonly(
           "dtype",
           [](const TensorMetadata& metadata) {
-            return py::reinterpret_borrow<py::object>(
+            return py::reinterpret_steal<py::object>(
                 torch::autograd::utils::wrap(metadata.dtype_));
           })
       .def_readonly("dim", &TensorMetadata::size_dim_)


### PR DESCRIPTION
Summary:

wrap() returns a new owned reference (Py_NewRef), but the layout and dtype
property getters wrapped it with reinterpret_borrow, which incref's again and
leaks one reference per access. Use reinterpret_steal to adopt the new ref.

Test Plan: arc lint + buck build of affected target (see stack).

Reviewed By: atalman

Differential Revision: D108306634


