### PR TITLE
[torch][autograd] Fix Python refcount leaks in autograd C++ glue (#187069)

### DIFF
--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -32,24 +32,29 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
   if (!PyDict_Check(dict())) {
     TORCH_CHECK(false, "Anomaly metadata is not a python dictionary.");
   }
-  PyObject* trace_stack = nullptr;
-  if (PyDict_GetItemStringRef(dict(), ANOMALY_TRACE_KEY, &trace_stack) < 0) {
+  PyObject* trace_stack_ptr = nullptr;
+  if (PyDict_GetItemStringRef(dict(), ANOMALY_TRACE_KEY, &trace_stack_ptr) <
+      0) {
     throw python_error();
   }
-  _print_stack(trace_stack, current_node_name, false);
-  PyObject* pyparent = nullptr;
-  if (PyDict_GetItemStringRef(dict(), ANOMALY_PARENT_KEY, &pyparent) < 0) {
+  THPObjectPtr trace_stack(trace_stack_ptr);
+  _print_stack(trace_stack.get(), current_node_name, false);
+  PyObject* pyparent_ptr = nullptr;
+  if (PyDict_GetItemStringRef(dict(), ANOMALY_PARENT_KEY, &pyparent_ptr) < 0) {
     throw python_error();
   }
+  THPObjectPtr pyparent(pyparent_ptr);
 
   // if there is no "parent_" in metadata, then it means this metadata's node
   // is the root and stop printing the traceback
   while (pyparent) {
-    THPObjectPtr parent_metadata(PyObject_GetAttrString(pyparent, "metadata"));
+    THPObjectPtr parent_metadata(
+        PyObject_GetAttrString(pyparent.get(), "metadata"));
     if (!parent_metadata) {
       throw python_error();
     }
-    THPObjectPtr parent_name_pyobj(PyObject_CallMethod(pyparent, "name", ""));
+    THPObjectPtr parent_name_pyobj(
+        PyObject_CallMethod(pyparent.get(), "name", ""));
     if (!parent_name_pyobj) {
       throw python_error();
     }
@@ -58,18 +63,21 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
       throw python_error();
     }
     const std::string parent_name(parent_name_char);
-    PyObject* parent_stack = nullptr;
+    PyObject* parent_stack_ptr = nullptr;
     if (PyDict_GetItemStringRef(
-            parent_metadata.get(), ANOMALY_TRACE_KEY, &parent_stack) < 0) {
+            parent_metadata.get(), ANOMALY_TRACE_KEY, &parent_stack_ptr) < 0) {
       throw python_error();
     }
-    _print_stack(parent_stack, parent_name, true);
+    THPObjectPtr parent_stack(parent_stack_ptr);
+    _print_stack(parent_stack.get(), parent_name, true);
     // get the parent of this node, if this node is a root, pyparent is simply
     // null
+    PyObject* next_parent_ptr = nullptr;
     if (PyDict_GetItemStringRef(
-            parent_metadata.get(), ANOMALY_PARENT_KEY, &pyparent) < 0) {
+            parent_metadata.get(), ANOMALY_PARENT_KEY, &next_parent_ptr) < 0) {
       throw python_error();
     }
+    pyparent = THPObjectPtr(next_parent_ptr);
   }
 }
 

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -254,12 +254,15 @@ void PyFunctionTensorPostAccGradHooks::apply_with_saved(
     torch::dynamo::autograd::SwapSavedVariables& saved) {
   for (const auto hook : saved.get_curr_node_call().post_acc_grad_hooks) {
     THPObjectPtr py_var(THPVariable_Wrap(tensor));
-    PyObject_CallMethod(
+    THPObjectPtr res(PyObject_CallMethod(
         saved.get_py_compiler(),
         "post_acc_grad_hook",
         "Oi",
         py_var.get(),
-        hook);
+        hook));
+    if (!res) {
+      throw python_error();
+    }
   }
 }
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1999,7 +1999,8 @@ static PyObject* DTensor_compute_global_tensor_info_impl(
     } else if (!cpp_placement.is_replicate() && !cpp_placement.is_partial()) {
 #if IS_PYTHON_3_11_PLUS
       const auto placement_type_name =
-          py::str(py::handle(PyType_GetName(Py_TYPE(placement.ptr()))));
+          py::str(py::reinterpret_steal<py::object>(
+              PyType_GetName(Py_TYPE(placement.ptr()))));
 #else
       const auto placement_type_name =
           py::str(py::handle((PyObject*)Py_TYPE(placement.ptr()))


### PR DESCRIPTION
Summary:

Autograd's Python bindings were leaking references in several places, causing memory issues. This diff fixes these leaks by properly adopting owned references in the autograd C++ glue code, ensuring they are released correctly.

Test Plan: arc lint + buck build of affected targets (see stack).

Reviewed By: atalman

Differential Revision: D108306635


