### PR TITLE
Add 2.13 to Release Compatibility Matrix and CUDA Support Matrix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,7 +51,7 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 
 | PyTorch version | Python | C++ | Stable CUDA | Experimental CUDA | Stable ROCm |
 | --- | --- | --- | --- | --- | --- |
-| 2.13 | >=3.10, <=(3.15, 3.15t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.29.3), CUDA 13.0 (CUDNN 9.20.0.48) (NCCL 2.29.7) | CUDA 13.2 (CUDNN 9.20.0.48) (NCCL 2.29.7) | ROCm 7.2 |
+| 2.13 | >=3.10, <=(3.15, 3.15t experimental) | C++20 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.29.3), CUDA 13.0 (CUDNN 9.20.0.48) (NCCL 2.29.7) | CUDA 13.2 (CUDNN 9.20.0.48) (NCCL 2.29.7) | ROCm 7.2 |
 | 2.12 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 13.0 (CUDNN 9.20.0.48) | CUDA 13.2 (CUDNN 9.20.0.48) | ROCm 7.2 |
 | 2.11 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.17.1.4), CUDA 13.0 (CUDNN 9.17.1.4) | -- | ROCm 7.2 |
 | 2.10 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.10.2.21) | CUDA 13.0 (CUDNN 9.15.1.9) | ROCm 7.1 |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,7 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 
 | PyTorch version | Python | C++ | Stable CUDA | Experimental CUDA | Stable ROCm |
 | --- | --- | --- | --- | --- | --- |
+| 2.13 | >=3.10, <=(3.15, 3.15t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.29.3), CUDA 13.0 (CUDNN 9.20.0.48) (NCCL 2.29.7) | CUDA 13.2 (CUDNN 9.20.0.48) (NCCL 2.29.7) | ROCm 7.2 |
 | 2.12 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 13.0 (CUDNN 9.20.0.48) | CUDA 13.2 (CUDNN 9.20.0.48) | ROCm 7.2 |
 | 2.11 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.17.1.4), CUDA 13.0 (CUDNN 9.17.1.4) | -- | ROCm 7.2 |
 | 2.10 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.10.2.21) | CUDA 13.0 (CUDNN 9.15.1.9) | ROCm 7.1 |
@@ -69,7 +70,7 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 
 ### PyTorch CUDA Support Matrix
 
-For Release 2.12 PyTorch Supports following CUDA Architectures:
+For Release 2.12 and 2.13 PyTorch Supports following CUDA Architectures:
 
 | CUDA | architectures supported for Linux x86 and Windows builds | notes |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- Add the PyTorch **2.13** row to the Release Compatibility Matrix (Python `>=3.10, <=3.15` with 3.15t experimental, C++17, stable CUDA 12.6/13.0, experimental CUDA 13.2, ROCm 7.2, including NCCL versions).
- Extend the **PyTorch CUDA Support Matrix** heading to cover both 2.12 and 2.13.

The CUDA versions in the new row match the existing CUDA Support Matrix rows (12.6.3 / 13.0.2 / 13.2.1).

## Test Plan

Docs-only change. Verified by inspection that the new matrix row is consistent with the CUDA Support Matrix.

*This PR was authored with the assistance of an AI coding agent.*