### PR TITLE
Fix Windows libtorch debug packaging when runner reports OSTYPE=cygwin

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -136,7 +136,7 @@ export DESIRED_PYTHON="${DESIRED_PYTHON:-}"
 export DESIRED_CUDA="$DESIRED_CUDA"
 export LIBTORCH_VARIANT="${LIBTORCH_VARIANT:-}"
 export BUILD_PYTHONLESS="${BUILD_PYTHONLESS:-}"
-if [[ "${OSTYPE}" == "msys" ]]; then
+if [[ "${OSTYPE}" == "msys" || "${OSTYPE}" == "cygwin" ]]; then
   export LIBTORCH_CONFIG="${LIBTORCH_CONFIG:-}"
   if [[ "${LIBTORCH_CONFIG:-}" == 'debug' ]]; then
     export DEBUG=1


### PR DESCRIPTION
## Summary

The Windows libtorch **debug** binaries stopped being uploaded to S3 (e.g. `libtorch-win-shared-with-deps-debug-latest.zip` / `...-debug-<ver>.zip` is missing for 2.12.1, present for 2.12.0).

Root cause: the "Populate binary env" step of the Windows binary build job runs `.ci/pytorch/binary_populate_env.sh`, which generates the in-build env file via an **unquoted heredoc**, so `${OSTYPE}` is expanded at generation time on the runner. The Windows-only block that exports `DEBUG=1` / `LIBTORCH_CONFIG=debug` was gated on:

```bash
if [[ "${OSTYPE}" == "msys" ]]; then
```

The Windows binary runner image changed so `$OSTYPE` is now reported as **`cygwin`** instead of `msys`. The guard evaluated false, `DEBUG` was never exported, and `.ci/pytorch/windows/internal/setup.bat` (`IF "%DEBUG%"==""`) took its **release** branch — packaging the debug build as `libtorch-win-shared-with-deps-<ver>.zip` instead of `...-debug-<ver>.zip`. The debug artifact thus overwrote the release-named object and the `-debug-` files were never produced/uploaded.

Fix: accept `cygwin` in addition to `msys`.

## Evidence

Rendered guard in the libtorch debug **build** jobs (same script, same release branch):

| Build | Rendered guard | Result |
| --- | --- | --- |
| 2.12.0-rc9 (run 25344769027) | `if [[ "msys" == "msys" ]]` ✅ | `DEBUG=1` set -> `libtorch-win-shared-with-deps-debug-2.12.0+cu130.zip` |
| 2.12.1-rc1 (run 27232737669) | `if [[ "cygwin" == "msys" ]]` ❌ | `DEBUG` unset -> `libtorch-win-shared-with-deps-2.12.1+cu130.zip` |

S3 confirms the outcome:

```
libtorch-win-shared-with-deps-debug-2.12.0+cu130.zip -> 200 (exists)
libtorch-win-shared-with-deps-debug-2.12.1+cu130.zip -> 404 (missing)
```

## Note

The same `[[ "$OSTYPE" == "msys" ]]` Windows detection also exists in `.ci/pytorch/check_binary.sh` and `.ci/pytorch/run_tests.sh` and is likely broken on the cygwin runner; left as a follow-up to keep this fix focused on restoring the debug uploads.

*This PR was authored with the assistance of an AI coding agent.*