### PR TITLE
Fix nn.Module.to() failure on subclass parameters held by Python weakrefs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10835,6 +10835,8 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             _wr = weakref.ref(t1)
             with self.assertRaisesRegex(RuntimeError, "has weakref"):
                 torch.utils.swap_tensors(t1, t2)
+            torch.utils.swap_tensors(t1, t2, allow_weakrefs=True)
+            self.assertIs(_wr(), t1)
 
 
     @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "Dynamo adds weakrefs")

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -983,7 +983,7 @@ class Module:
                         param_applied,
                         requires_grad=param.requires_grad,
                     )
-                    torch.utils.swap_tensors(param, param_applied)
+                    torch.utils.swap_tensors(param, param_applied, allow_weakrefs=True)
                 except Exception as e:
                     if param_grad is not None:
                         param.grad = param_grad
@@ -1012,7 +1012,7 @@ class Module:
                 if p_should_use_swap_tensors:
                     grad_applied.requires_grad_(param_grad.requires_grad)
                     try:
-                        torch.utils.swap_tensors(param_grad, grad_applied)
+                        torch.utils.swap_tensors(param_grad, grad_applied, allow_weakrefs=True)
                     except Exception as e:
                         raise RuntimeError(
                             f"_apply(): Couldn't swap {self._get_name()}.{key}.grad"
@@ -2479,7 +2479,7 @@ class Module:
                                     )
                                 else:
                                     new_input_param.requires_grad_(param.requires_grad)
-                            torch.utils.swap_tensors(param, new_input_param)
+                            torch.utils.swap_tensors(param, new_input_param, allow_weakrefs=True)
                             del new_input_param
                         elif assign_to_params_buffers:
                             # Shape checks are already done above

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -32,7 +32,7 @@ def set_module(obj, mod):
 cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), "share", "cmake")
 
 
-def swap_tensors(t1, t2):
+def swap_tensors(t1, t2, allow_weakrefs=False):
     """
     This function swaps the content of the two Tensor objects.
     At a high level, this will make t1 have the content of t2 while preserving
@@ -40,11 +40,12 @@ def swap_tensors(t1, t2):
 
     This will not work if t1 and t2 have different slots.
     """
-    # Ensure there are no weakrefs
-    if weakref.getweakrefs(t1):
-        raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
-    if weakref.getweakrefs(t2):
-        raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
+    if not allow_weakrefs:
+        # Ensure there are no weakrefs
+        if weakref.getweakrefs(t1):
+            raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
+        if weakref.getweakrefs(t2):
+            raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
     t1_slots = set(copyreg._slotnames(t1.__class__))  # type: ignore[attr-defined]
     t2_slots = set(copyreg._slotnames(t2.__class__))  # type: ignore[attr-defined]
     if t1_slots != t2_slots:


### PR DESCRIPTION
Fixes #187008

### Summary
This PR resolves an issue where calling `nn.Module.to()`, device/dtype conversions, or `load_state_dict` on modules with tensor subclass parameters fails if any Python-level weak references are held to them (e.g. by EMA trackers, memory profilers, or Dynamo guards). 

### Action & Rationale
We introduce an `allow_weakrefs=False` default parameter to `torch.utils.swap_tensors` and explicitly opt-in inside `nn.Module` internal operations:
1. **Safety & Backward Compatibility:** General callers of `swap_tensors` are still guarded by default (retaining the `RuntimeError` check), preserving existing API contracts and preventing silent cache/guard staleness bugs elsewhere.
2. **In-place Module Moves:** Inside `nn.Module._apply` and `load_state_dict`, we pass `allow_weakrefs=True` to safely perform the swap, preserving Python-level weakrefs (like those held by EMA) pointing to the same PyObject. 
3. **C++ Invariants:** Any unsafe C++-level weak references (`c10::weak_intrusive_ptr` to the C++ `TensorImpl`) are still strictly prevented by the C++ check `weak_use_count() == 1` inside `THPModule_swap_tensor_impl`.

### Test Plan
We update `test_swap_basic` in `test/test_torch.py` to verify both the default error-raising behavior and the opted-in swap behavior.

To run the updated test:
```bash
python test/test_torch.py -k test_swap_basic