### PR TITLE
[inductor] Fix GroupNorm eval-mode precision loss after BatchNorm

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3998,6 +3998,20 @@ class CommonTemplate:
                 b = torch.full((8,), b_val, dtype=dtype, device=self.device)
                 self.common(fn, (a, b))
 
+    def test_batchnorm_groupnorm_eval_folding(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/181696
+        # BN+GN in eval mode must produce correct output under compile.
+        bn = torch.nn.BatchNorm1d(10).eval()
+        gn = torch.nn.GroupNorm(10, 10).eval()
+
+        def fn(x):
+            t = bn(x)
+            t = gn(t)
+            return t
+
+        x = torch.ones([6, 10, 12], device=self.device)
+        self.common(fn, (x,))
+
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3385,9 +3385,8 @@ def native_group_norm(
         [batch_size, num_groups, num_channels // num_groups, flattened_inner_size],
     )
     reduction_dims = utils.canonicalize_dims(input_reshaped.ndim, reduction_dims)
-    biased_var, mean = torch.var_mean(
-        input_reshaped, dim=reduction_dims, unbiased=False, keepdim=True
-    )
+    mean = input_reshaped.mean(dim=reduction_dims, keepdim=True)
+    biased_var = ((input_reshaped - mean) ** 2).mean(dim=reduction_dims, keepdim=True)
     rstd = torch.rsqrt(biased_var + eps)
     if input.device.type == "cpu" and weight is not None:
         weight_reshaped = torch.reshape(


### PR DESCRIPTION
Fixes #181696

The GN decomposition used `torch.var_mean` which lowers to a Welford reduction. Welford loses precision with nearly-identical values (e.g. after BN in eval mode where all elements are ~0.999995), producing `m2=0` and zeroed GN output.

Use separate `mean` and `var` operations which lower to simple sum reductions that preserve numerical accuracy.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo