### PR TITLE
[BE] Fix B007 unused loop variables

### DIFF
--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -220,7 +220,7 @@ def create_libtorch_zip(
 ) -> Path:
     zip_path = output_dir / f"{zip_prefix}-{version}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for root, dirs, files in os.walk(libtorch_dir):
+        for root, _dirs, files in os.walk(libtorch_dir):
             for f in files:
                 filepath = Path(root) / f
                 arcname = filepath.relative_to(libtorch_dir.parent)

--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -119,7 +119,7 @@ def find_missing_redirects(
         List of (old_key, new_url) tuples. new_url is None for deletions.
     """
     missing = []
-    for status, old_path, new_path in changes:
+    for _status, old_path, new_path in changes:
         old_key = path_to_key(old_path)
         if old_key not in existing:
             new_url = path_to_url(new_path) if new_path else None

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -29,7 +29,7 @@ class TestPeekableIterator(TestCase):
 
     def test_peek(self, input_: str = "abcdef") -> None:
         iter_ = PeekableIterator(input_)
-        for idx, c in enumerate(iter_):
+        for idx, _c in enumerate(iter_):
             if idx + 1 < len(input_):
                 self.assertEqual(iter_.peek(), input_[idx + 1])
             else:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2108,7 +2108,7 @@ def get_ghstack_dependent_prs(
     if skip_len > 0:
         rev_list = rev_list[:-skip_len]
     rc: list[tuple[str, GitHubPR]] = []
-    for pr_, sha in _revlist_to_prs(repo, pr, rev_list):
+    for pr_, _sha in _revlist_to_prs(repo, pr, rev_list):
         if not pr_.is_closed():
             if not only_closed:
                 rc.append(("", pr_))


### PR DESCRIPTION
Fixes a small set of B007 lint violations by renaming intentionally unused loop variables with a leading underscore.

This addresses the B007 slice I mentioned in #106571.

Test:
- `./venv/bin/python -m ruff check --no-cache --select B007 .github/scripts .ci/libtorch`