### PR TITLE
Add TorchElastic signal-failure enrichment hook (#187098)

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -125,6 +125,34 @@ class ApiTest(unittest.TestCase):
             f"Signal {signal.SIGSEGV} (SIGSEGV) received by PID {pf.pid}", pf.message
         )
 
+    def test_format_msg_enriches_root_signal_failure(self):
+        # The root signal failure's rendered message is passed through the
+        # handler's enrichment seam at format time (no-op base; a build-swapped
+        # handler may append device-fault context). The seam works on the local
+        # rendered string, so the failure's stored message is not mutated.
+        with open(self.test_error_file, "w") as fp:
+            json.dump({"message": "Fatal signal received", "timestamp": 10}, fp)
+        handler = mock.MagicMock()
+        handler.maybe_enrich_signal_failure_message.side_effect = (
+            lambda message, error_file: message + "\n[device fault context]"
+        )
+        with mock.patch(
+            "torch.distributed.elastic.multiprocessing.errors.get_error_handler",
+            return_value=handler,
+        ):
+            pf = ProcessFailure(
+                local_rank=0,
+                pid=997,
+                exitcode=-signal.SIGABRT,
+                error_file=self.test_error_file,
+            )
+            rendered = str(ChildFailedError("trainer", {0: pf}))
+        self.assertIn("[device fault context]", rendered)
+        self.assertNotIn("[device fault context]", pf.message)
+        handler.maybe_enrich_signal_failure_message.assert_called_once_with(
+            mock.ANY, self.test_error_file
+        )
+
     def test_process_failure_no_error_file(self):
         pf = self.failure_without_error_file(exitcode=138)
         self.assertEqual("<N/A>", pf.signal_name())

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -294,6 +294,19 @@ class ChildFailedError(Exception):
                 .replace("\n", "\n  ")  # to properly indent the traceback
             )
 
+        # For signal failures, let the (build-swapped) handler append
+        # device-fault context (e.g. ROCm GPU faults) to the rendered message.
+        # Works on the local string, so error_file_data is never mutated, and it
+        # is a no-op in OSS (the base handler returns the message unchanged).
+        # Best-effort: never let a handler override break failure rendering.
+        if failure.exitcode < 0:
+            try:
+                msg = get_error_handler().maybe_enrich_signal_failure_message(
+                    msg, failure.error_file
+                )
+            except Exception:
+                logger.warning("Failed to enrich signal failure message", exc_info=True)
+
         signal_name = failure.signal_name()
         signal_name_str = f" ({signal_name})" if signal_name != _NOT_AVAILABLE else ""
 

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -87,6 +87,18 @@ class ErrorHandler:
             with open(file, "w") as fp:
                 json.dump(data, fp)
 
+    def maybe_enrich_signal_failure_message(self, message: str, error_file: str) -> str:
+        """Hook to enrich a signal (no-traceback) failure message.
+
+        Called from ``ProcessFailure`` when a worker fails by signal (negative
+        exitcode). Subclasses may override this to append device-specific fault
+        context (e.g. GPU memory faults) scanned from the worker logs near
+        ``error_file``, so it surfaces in the propagated failure regardless of
+        how the failure is later handled. The base implementation is a no-op
+        that returns ``message`` unchanged.
+        """
+        return message
+
     def override_error_code_in_rootcause_data(
         self,
         rootcause_error_file: str,


### PR DESCRIPTION
Summary:

A worker killed by a signal has no Python traceback, so ChildFailedError normally renders only the signal line. Add a generic ErrorHandler.maybe_enrich_signal_failure_message hook and call it while rendering signal failures.

The base handler is a no-op, so OSS behavior is unchanged. Build-swapped handlers can append platform-specific context using the existing worker error_file without mutating ProcessFailure or error_file_data.

Test Plan:
buck2 test fbcode//caffe2/test/distributed/elastic/multiprocessing/errors:api_test -- --timeout=300
arc lint --take AUTODEPS2

Reviewed By: d4l3k

Differential Revision: D108324871


