### PR TITLE
Add missing dispatch for bf16 in tensor_cpu

### DIFF
--- a/aten/src/ATen/Utils.cpp
+++ b/aten/src/ATen/Utils.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Functions.h>
 #include <ATen/Utils.h>
+#include <c10/core/ScalarType.h>
 #include <c10/util/accumulate.h>
 
 
@@ -22,9 +23,13 @@ template <typename T>
 Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
   auto result = at::empty(values.size(), options);
   AT_ASSERT(result.is_contiguous());
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(result.scalar_type(), "tensor_cpu", [&] {
-    std::copy(
-        values.begin(), values.end(), result.template data_ptr<scalar_t>());
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16,
+      result.scalar_type(), "tensor_cpu", [&] {
+    auto* dest = result.template data_ptr<scalar_t>();
+    for (size_t i = 0; i < values.size(); ++i) {
+      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+      dest[i] = static_cast<scalar_t>(values[i]);
+    }
   });
   return result;
 }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -399,6 +399,32 @@ TEST(TensorTest, TorchTensorCtorScalarFloatingType) {
       /*default_dtype=*/torch::kDouble);
 }
 
+TEST(TensorTest, TorchTensorCtorScalarBFloat16Type) {
+  AutoDefaultDtypeMode dtype_mode(torch::kBFloat16);
+
+  auto tensor = at::tensor(
+      at::ArrayRef<c10::BFloat16>{c10::BFloat16(1.0f), c10::BFloat16(2.0f)},
+      at::dtype(at::kBFloat16));
+  ASSERT_EQ(tensor.numel(), 2);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2}));
+  ASSERT_EQ(tensor.dtype(), torch::kBFloat16);
+  ASSERT_TRUE(almost_equal(tensor[0], 1.0f));
+  ASSERT_TRUE(almost_equal(tensor[1], 2.0f));
+}
+
+TEST(TensorTest, TorchTensorCtorScalarHalfType) {
+  AutoDefaultDtypeMode dtype_mode(torch::kHalf);
+
+  auto tensor = at::tensor(
+      at::ArrayRef<c10::Half>{c10::Half(1.0f), c10::Half(2.0f)},
+      at::dtype(at::kHalf));
+  ASSERT_EQ(tensor.numel(), 2);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2}));
+  ASSERT_EQ(tensor.dtype(), torch::kHalf);
+  ASSERT_TRUE(almost_equal(tensor[0], 1.0f));
+  ASSERT_TRUE(almost_equal(tensor[1], 2.0f));
+}
+
 TEST(TensorTest, TorchTensorCtorScalarBoolType) {
   auto tensor = torch::tensor(true);
   ASSERT_EQ(tensor.numel(), 1);


### PR DESCRIPTION
The [`ctc_loss`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/LossCTC.cpp) implementation currently has a bug when backend is PrivateUse1 and dtype is bf16. Specifically, when `get_clamped_target_length` is called for the bf16 dtype, it crashes because [`tensor_cpu`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/Utils.cpp#L22) is missing dispatch support for that type. This change adds support for that as well as the half dtype which was also broken through an updated macro. See linked issue for full repro.

Fixes #187089