### PR TITLE
Fix embedding_bag CPU segfault when offsets is empty and indices is not

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1132,6 +1132,20 @@ void _embedding_bag_cpu_impl_out(Tensor& output, Tensor& offset2bag,
                             const Tensor &offsets, const int64_t mode,
                             const std::optional<Tensor>& per_sample_weights,
                             bool include_last_offset, int64_t padding_idx, _EmbeddingBagKernelCache* fbgemm_kernel_cache) {
+  // With no bags, offset2bag maps every index to bag -1 and the reduction
+  // kernels would read out of bounds on the empty output. bag_size still
+  // needs zeroing: the no-gradient SUM path sizes it like offsets, which is
+  // non-empty when include_last_offset is set.
+  // See https://github.com/pytorch/pytorch/issues/175370 for more details.
+  if (output.size(0) == 0) {
+    if (mode == EmbeddingBagMode::SUM) {
+      at::native::zero_(bag_size);
+      if (max_indices) {
+        max_indices->copy_(bag_size);
+      }
+    }
+    return;
+  }
   if (mode == EmbeddingBagMode::MEAN || mode == EmbeddingBagMode::SUM) {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "embedding_bag_no_grad_cpu_out",
       [&indices, &offset2bag, &per_sample_weights, &weight, &output, &offsets, &include_last_offset, &mode, &bag_size, &padding_idx, &fbgemm_kernel_cache]() {

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1060,6 +1060,37 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             )
             self.assertEqual(output, torch.zeros_like(output))
 
+    @onlyOn("cpu")
+    @dtypes(torch.float32, torch.float64, torch.float16, torch.bfloat16)
+    @parametrize_test("mode", ["sum", "mean", "max"])
+    def test_embedding_bag_empty_offsets(self, device, dtype, mode):
+        # used to segfault, see https://github.com/pytorch/pytorch/issues/175370
+        weight = torch.randn(3, 5, device=device, dtype=dtype)
+        indices = torch.tensor([0, 1, 2, 1], device=device)
+        offsets = torch.zeros(0, device=device, dtype=torch.long)
+        expected = torch.zeros(0, 5, device=device, dtype=dtype)
+        output = F.embedding_bag(indices, weight, offsets, mode=mode)
+        self.assertEqual(output, expected)
+        # offsets=[0] with include_last_offset=True also yields zero bags
+        output = F.embedding_bag(
+            indices,
+            weight,
+            torch.zeros(1, device=device, dtype=torch.long),
+            mode=mode,
+            include_last_offset=True,
+        )
+        self.assertEqual(output, expected)
+        if mode == "sum":
+            per_sample_weights = torch.randn(4, device=device, dtype=dtype)
+            output = F.embedding_bag(
+                indices,
+                weight,
+                offsets,
+                mode=mode,
+                per_sample_weights=per_sample_weights,
+            )
+            self.assertEqual(output, expected)
+
     @skipCUDAIf(True, "no out-of-bounds check on CUDA for perf.")
     @skipXPUIf(True, "no out-of-bounds check on XPU for perf.")
     @dtypes(*itertools.product((torch.float, torch.double), (torch.int, torch.long)))


### PR DESCRIPTION
Fixes #175370

`F.embedding_bag` on CPU segfaults when `offsets` is empty and `indices` is not.

### Root cause

With zero bags, `make_offset2bag` fills `offset2bag` with -1: the `index_add_` over empty offsets is a no-op, so the initial `offset2bag[0] -= 1` propagates through the cumsum. The slow-path kernels (`index_select_add`, `index_select_scale_add`, `embedding_bag_cpu_max_out`) use those entries as output row indices, accessing one row before the empty `(0, D)` output whose 0-byte allocation is null (the `0xffffffffffffffb0` READ in the issue's UBSan trace).

This is wider than float64: max mode has no fast path and crashed for every dtype, and `include_last_offset=True` with `offsets=[0]` crashed the same way. float32/half/bfloat16 sum/mean survive only because their fbgemm fast path iterates over zero bags and never touches `offset2bag`; float64 always takes the slow path.

### Fix

Return early from `_embedding_bag_cpu_impl_out` when `output.size(0) == 0`, the choke point shared by `_embedding_bag`, `_embedding_bag_forward_only` and `_embedding_bag_cpu_out`. The early return still zeroes SUM-mode `bag_size` and copies `max_indices`, which matters because with `include_last_offset=True` and `offsets=[0]` `bag_size` is non-empty and would otherwise be returned uninitialized. All dtypes now return `(0, D)`, matching the existing float32 behavior.

Unlike #175487, which added a blanket `TORCH_CHECK` rejecting empty offsets, this keeps the input accepted: erroring would be backward incompatible since float32/half/bfloat16 already return `(0, D)`. Backward with empty offsets has a separate pre-existing problem (affecting float32 too) that is unchanged here.

### Verification

Using `weight=zeros(1, 10)`, `indices=zeros(6, int64)`, `offsets=zeros(0, int64)`, each probe in its own subprocess:

| dtype, mode | before | after |
|---|---|---|
| float64 sum / mean / max | SIGSEGV (exit 139) | `(0, 10)` |
| float32 / float16 / bfloat16 max | SIGSEGV (exit 139) | `(0, 10)` |
| float32 / float16 / bfloat16 sum / mean | `(0, 10)` | `(0, 10)`, unchanged |

New test `test_embedding_bag_empty_offsets` covers 4 dtypes x 3 modes, plus `per_sample_weights` and the `include_last_offset` zero-bag variant. `python test/nn/test_embedding.py` passes (186 tests, 12 pre-existing skips).
