### PR TITLE
[inductor] decompose broadcast-bias baddbmm into bmm + pointwise add

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10355,6 +10355,68 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 rtol=0.001,
             )
 
+    def test_baddbmm_broadcast_bias_decompose(self):
+        # baddbmm with a bias broadcast along dim 1 (M) of the output
+        # decomposes to bmm + pointwise add on non-cpu/mps devices so the
+        # bias add can fuse with neighboring pointwise ops; a full-size bias
+        # keeps the fused baddbmm lowering.  See issue #187093.
+        if self.device in ("cpu", "mps"):
+            raise unittest.SkipTest("decomposition does not apply on cpu/mps")
+
+        from torch._dynamo.utils import counters
+
+        def fn(bias, a, b):
+            return torch.nn.functional.relu(torch.baddbmm(bias, a, b))
+
+        a = torch.randn(4, 32, 16, device=self.device)
+        b = torch.randn(4, 16, 24, device=self.device)
+
+        # broadcast bias along M: decomposes to bmm + (fused) pointwise add
+        bias = torch.randn(4, 1, 24, device=self.device)
+        counters.clear()
+        actual, codes = run_and_get_code(torch.compile(fn), bias, a, b)
+        self.assertEqual(actual, fn(bias, a, b), atol=1e-4, rtol=1e-4)
+        self.assertEqual(counters["inductor"]["decompose_baddbmm"], 1)
+        if not config.cpp_wrapper:
+            FileCheck().check("extern_kernels.bmm").check_not(
+                "extern_kernels.baddbmm"
+            ).run(codes[0])
+
+        # full-size bias: no decomposition, the baddbmm lowering is kept
+        torch._dynamo.reset()
+        bias_full = torch.randn(4, 32, 24, device=self.device)
+        counters.clear()
+        actual, codes = run_and_get_code(torch.compile(fn), bias_full, a, b)
+        self.assertEqual(actual, fn(bias_full, a, b), atol=1e-4, rtol=1e-4)
+        self.assertEqual(counters["inductor"]["decompose_baddbmm"], 0)
+        if not config.cpp_wrapper:
+            FileCheck().check("extern_kernels.baddbmm").run(codes[0])
+
+        # beta=0 must ignore the bias entirely (eager semantics: no NaN
+        # propagation), and beta/alpha scaling must be preserved
+        torch._dynamo.reset()
+        bias_nan = torch.full((4, 1, 24), float("nan"), device=self.device)
+        counters.clear()
+        actual = torch.compile(lambda bias, a, b: torch.baddbmm(bias, a, b, beta=0.0))(
+            bias_nan, a, b
+        )
+        self.assertEqual(counters["inductor"]["decompose_baddbmm"], 1)
+        self.assertFalse(actual.isnan().any().item())
+        self.assertEqual(actual, torch.bmm(a, b), atol=1e-4, rtol=1e-4)
+
+        torch._dynamo.reset()
+        counters.clear()
+        actual = torch.compile(
+            lambda bias, a, b: torch.baddbmm(bias, a, b, beta=0.5, alpha=2.0)
+        )(bias, a, b)
+        self.assertEqual(counters["inductor"]["decompose_baddbmm"], 1)
+        self.assertEqual(
+            actual,
+            torch.baddbmm(bias, a, b, beta=0.5, alpha=2.0),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
     @config.patch({"triton.max_tiles": 2})
     def test_fuse_tiled(self):
         def fn(a, b, c):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -130,7 +130,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten.squeeze,  # inductor lowers this directly
     aten.sum,  # inductor lowers this directly
     aten.unbind,  # inductor lowers this directly
-    aten.baddbmm,  # upcasts to fp32, perf issue
+    aten.baddbmm,  # upcasts to fp32, perf issue; conditional decomp registered below
     # FMA ops - we have lowerings that use FMA to match eager CUDA behavior
     aten.addcmul,
     aten.addcmul_,
@@ -420,6 +420,47 @@ def addmm(
             counters["inductor"]["decompose_addmm"] += 1
             out = (mat1.T * mat2).sum(dim=0, keepdim=True)
             return alpha * out + beta * self
+    return NotImplemented
+
+
+@register_decomposition([aten.baddbmm])
+def baddbmm(
+    self: torch.Tensor,
+    batch1: torch.Tensor,
+    batch2: torch.Tensor,
+    out_dtype: torch.dtype | None = None,
+    beta: torch.types.Number = 1,
+    alpha: torch.types.Number = 1,
+) -> torch.Tensor:
+    # When the bias is broadcast along the M dim of the [B, M, N] output,
+    # decompose to bmm + pointwise add.  The extern (cuBLAS) baddbmm choice
+    # is slow here: at::baddbmm_out must first materialize the broadcast
+    # bias into the output buffer (a full [B, M, N]-sized strided copy) and
+    # then run a beta=1 GEMM that re-reads those bytes.  The decomposed form
+    # routes the GEMM to a beta=0 kernel (the output is never pre-filled or
+    # re-read) and turns the bias add into a pointwise op that participates
+    # in normal Inductor fusion, so wherever the GEMM output feeds a
+    # pointwise consumer (e.g. the activation in an MLP/MoE block) the bias
+    # add is free.  Standalone (no pointwise consumer), the two forms are
+    # within a few percent of each other.  See issue #187093 for
+    # measurements.  Unlike the excluded core-ATen decomposition above, the
+    # GEMM is kept in the input dtype (no opmath upcast).
+    if (
+        self.device.type not in ["cpu", "mps"]
+        and out_dtype is None
+        and self.is_floating_point()
+        and (self.dim() < 2 or statically_known_true(self.size(-2) == 1))
+        and statically_known_true(batch1.size(1) != 1)
+    ):
+        counters["inductor"]["decompose_baddbmm"] += 1
+        result = torch.bmm(batch1, batch2)
+        if alpha != 1:
+            result = result * alpha
+        if beta == 0:
+            # eager baddbmm ignores the bias entirely when beta == 0
+            # (NaN/inf in the bias must not propagate).
+            return result
+        return result + (self if beta == 1 else self * beta)
     return NotImplemented
 
 


### PR DESCRIPTION
## Issue

Fixes #187093

## Summary

For `baddbmm` with a bias broadcast along dim 1 (M) of the `[B, M, N]` output, register a conditional Inductor decomposition to `bmm(batch1, batch2) + bias`, following the existing conditional `addmm`/`mm`/`bmm` decomps in `torch/_inductor/decomposition.py` (returns `NotImplemented` when the condition does not hold). Mechanism and design discussion are in the issue: the extern choice pays a full output-sized bias materialization copy plus a beta=1 GEMM re-read; the Triton template that wins the autotune as-written is still slower than extern beta=0 `bmm` + a pointwise bias add that fuses into the neighboring pointwise op (the activation, in MLP/MoE blocks).

Measured on GB300 (sm_103), bf16, `[32, 640, 1024] x [32, 1024, 2048] + bias[32, 1, 2048]`, `max-autotune-no-cudagraphs` (per-call, torch profiler):

| | graph as written (before) | decomposed (after) |
|---|---|---|
| GEMM | `triton_tem_fused_baddbmm_0` 105.9 us | `nvjet_...bz_NNT` (extern beta=0 bmm) 61.7 us |
| pointwise | `triton_poi_fused_gelu_1` 69.3 us | `triton_poi_fused_add_gelu_0` 56.0 us |
| `gelu(baddbmm)` total | 168.1 us | 115.8 us (**1.45x**) |

1.31x end-to-end at the MoE layer this came from (0.407 ms -> 0.311 ms median, verified numerics). Re-validated with this exact patch applied to a GB300 installed torch (2.12.0a0): the as-written `gelu(baddbmm(...))` now fires `decompose_baddbmm`, compiles to the extern beta=0 `nvjet` bmm + a single fused bias-add+gelu pointwise kernel, and matches the manually decomposed formulation's per-call time; max rel err vs fp32 eager ref 5.6e-03 (same as before the patch).

Standalone (no pointwise consumer to fuse into) the two forms are within a few percent (102 vs 105 us at this shape), which is why the decomposition is gated on the broadcast-M condition only; a full `[B, M, N]` bias keeps the tuned baddbmm lowering unchanged (verified: counter stays 0, extern/template choice as before). Semantics: beta=0 ignores the bias entirely (no NaN propagation, matching eager and the existing `test_baddbmm`), beta/alpha scaling preserved, `out_dtype`/cpu/mps/integer inputs fall through to the existing lowering, and unlike the excluded core-ATen baddbmm decomposition the GEMM stays in the input dtype (no opmath upcast).

Validation run on GB300 against the patched installed torch: `test/inductor/test_torchinductor.py -k baddbmm` (3 passed, 1 skipped), `test_torchinductor_dynamic_shapes.py -k baddbmm` (3 passed, 1 skipped), `test_torchinductor_codegen_dynamic_shapes.py -k baddbmm` (1 passed, 2 xfailed as before), `test_max_autotune.py -k baddmm` (4 passed, including the broadcast-bias `triton_tem_fused_baddbmm` FileCheck, whose kernel name is preserved through the decomposition via `original_aten`), and a baddbmm OpInfo sample sweep across fp32/fp16/bf16 (18/18 pass, 12 taking the new path).

## Checklist

- [x] Passes lint (`lintrunner` on the changed files; PYREFLY skipped — not runnable in an unbuilt checkout)
- [x] Added/updated tests (`test_baddbmm_broadcast_bias_decompose`: decomposition fires for broadcast bias, not for full bias, beta=0 NaN semantics, beta/alpha scaling)
- [ ] Updated documentation (not applicable)
- [x] Included benchmark results (table above, from the issue + re-validated with this patch)

## BC-breaking?

No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo