### PR TITLE
[dynamo] canonicalize output_graph node order (with config flag)

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -1993,6 +1993,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
 
         return backend1.fw_graphs[0].graph, backend2.fw_graphs[0].graph
 
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=False)
     def test_name_based_hash_diverges_on_dict_order(self):
         # Demonstrates the original bug: the name-based hash used in
         # has_same_nodes diverges when different ranks trace with different
@@ -2063,6 +2064,147 @@ class DictTests(torch._dynamo.test_case.TestCase):
             c2[n]: (n.op, str(n.target)) for n in backend2.graphs[0].graph.nodes
         }
         self.assertNotEqual(structure1, structure2)
+
+    def _get_graph_node_names(self, model, inp):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        torch.compile(model, backend=backend)(inp)
+        return [n.name for n in backend.graphs[0].graph.nodes]
+
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=True)
+    def test_dict_order_canonical_graph(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.deep = torch.nn.Sequential(
+                    torch.nn.Linear(8, 16),
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(16, 16),
+                )
+                self.shallow = torch.nn.Linear(8, 16)
+
+            def forward(self, d):
+                results = []
+                for key, val in d.items():
+                    if key == "a":
+                        results.append(self.deep(val))
+                    else:
+                        results.append(self.shallow(val))
+                return torch.cat(results, dim=-1).sum()
+
+        model = Model()
+        d1 = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
+        d2 = {"b": torch.randn(4, 8), "a": torch.randn(4, 8)}
+
+        names1 = self._get_graph_node_names(model, d1)
+        torch._dynamo.reset()
+        names2 = self._get_graph_node_names(model, d2)
+        self.assertEqual(names1, names2)
+
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=True)
+    def test_dict_order_canonical_graph_correctness(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear_a = torch.nn.Linear(8, 16)
+                self.linear_b = torch.nn.Linear(8, 16)
+
+            def forward(self, d):
+                return self.linear_a(d["a"]) + self.linear_b(d["b"])
+
+        model = Model()
+
+        d1 = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
+        d2 = {"b": d1["b"], "a": d1["a"]}
+
+        eager_result = model(d1)
+        compiled_result1 = torch.compile(model, backend="eager")(d1)
+        torch._dynamo.reset()
+        compiled_result2 = torch.compile(model, backend="eager")(d2)
+
+        self.assertEqual(eager_result, compiled_result1)
+        self.assertEqual(eager_result, compiled_result2)
+
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=True)
+    def test_dict_order_canonical_graph_aot_eager(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_a = torch.nn.Linear(8, 16)
+                self.proj_b = torch.nn.Linear(8, 16)
+
+            def forward(self, d):
+                results = []
+                for key, val in d.items():
+                    if key == "a":
+                        results.append(self.proj_a(val))
+                    else:
+                        results.append(self.proj_b(val))
+                return torch.cat(results, dim=-1).sum()
+
+        model = Model()
+        d1 = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
+        d2 = {"b": d1["b"], "a": d1["a"]}
+
+        backend1 = torch._dynamo.testing.AotEagerAndRecordGraphs()
+        loss1 = torch.compile(model, backend=backend1)(d1)
+        loss1.backward()
+
+        torch._dynamo.reset()
+        model.zero_grad()
+
+        backend2 = torch._dynamo.testing.AotEagerAndRecordGraphs()
+        loss2 = torch.compile(model, backend=backend2)(d2)
+        loss2.backward()
+
+        self.assertEqual(loss1, loss2)
+
+        fw_names1 = [n.name for n in backend1.fw_graphs[0].graph.nodes]
+        fw_names2 = [n.name for n in backend2.fw_graphs[0].graph.nodes]
+        self.assertEqual(fw_names1, fw_names2)
+        bw_names1 = [n.name for n in backend1.bw_graphs[0].graph.nodes]
+        bw_names2 = [n.name for n in backend2.bw_graphs[0].graph.nodes]
+        self.assertEqual(bw_names1, bw_names2)
+
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=True)
+    def test_dict_order_canonical_graph_idempotent(self):
+        from torch._dynamo.output_graph import _canonicalize_graph
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(8, 16)
+
+            def forward(self, d):
+                return self.linear(d["a"]) + self.linear(d["b"])
+
+        model = Model()
+        d = {"a": torch.randn(4, 8), "b": torch.randn(4, 8)}
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        torch.compile(model, backend=backend)(d)
+        graph = backend.graphs[0].graph
+
+        names_once = [n.name for n in graph.nodes]
+        graph2 = _canonicalize_graph(graph)
+        names_twice = [n.name for n in graph2.nodes]
+        self.assertEqual(names_once, names_twice)
+
+    @torch._dynamo.config.patch(canonicalize_output_graph_node_order=True)
+    def test_canonical_graph_overlapping_unsqueeze_with_mutation(self):
+        def f(x, y):
+            x.add_(1)
+            y.add_(1)
+            return x
+
+        base = torch.ones(10)
+        inputs = [base.unsqueeze(0), base.unsqueeze(0)]
+        out_eager = f(*inputs)
+
+        optf = torch.compile(backend="aot_eager", dynamic=True)(f)
+        base = torch.ones(10)
+        inputs = [base.unsqueeze(0), base.unsqueeze(0)]
+        out_compiled = optf(*inputs)
+
+        self.assertEqual(out_eager, out_compiled)
 
 
 instantiate_parametrized_tests(DictTests)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -923,6 +923,11 @@ inline_single_use_invoke_subgraph: bool = True
 # - False: never clear regardless of backend
 invalidate_compile_context_weakrefs: bool | None = None
 
+# Reorder and rename output graph nodes into a canonical topological order so
+# that structurally equivalent graphs (e.g., same model traced with different
+# dict iteration orders across distributed ranks) produce identical FX graphs.
+canonicalize_output_graph_node_order: bool = False
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F403
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -542,6 +542,95 @@ class ExportMetaData:
     ] = dc_field(default_factory=dict)
 
 
+_IN_PLACE_OPERATORS = frozenset(
+    {
+        "iadd",
+        "iand",
+        "iconcat",
+        "ifloordiv",
+        "ilshift",
+        "imatmul",
+        "imod",
+        "imul",
+        "ior",
+        "ipow",
+        "irshift",
+        "isub",
+        "itruediv",
+        "ixor",
+    }
+)
+
+
+def _is_safe_to_reorder(node: fx.Node) -> bool:
+    """Check if a node is safe to reorder during graph canonicalization.
+
+    Builds on Node.is_impure() (used by DCE) with two additional checks for
+    cases it doesn't cover: in-place call_method nodes and non-OpOverload
+    state-changing functions detected by a no-node-arguments heuristic.
+    """
+    if node.op == "call_method":
+        return not node.target.endswith("_")  # pyrefly: ignore[missing-attribute]
+    if node.op != "call_function":
+        return True
+    if node.is_impure():
+        return False
+    if not isinstance(node.target, torch._ops.OpOverload):
+        name = getattr(node.target, "__name__", "")
+        if name.endswith("_"):
+            return False
+        if (
+            getattr(node.target, "__module__", "") == "_operator"
+            and name in _IN_PLACE_OPERATORS
+        ):
+            return False
+        if isinstance(node.kwargs.get("out"), fx.Node):
+            return False
+        # Targets with no FX Node arguments are likely state-changing
+        # (e.g., _vmap_increment_nesting, _set_fwd_grad_enabled).
+        if not node.all_input_nodes:
+            return False
+        # functorch batch dim ops modify the vmap interpreter stack.
+        if name in ("_add_batch_dim", "_remove_batch_dim"):
+            return False
+        return True
+    return True
+
+
+def _canonical_key(node: fx.Node, canonical_idx: dict[fx.Node, int]) -> tuple[Any, ...]:
+    """Canonical heap key for Dynamo output graph nodes.
+
+    - Placeholders sorted by grapharg source name
+    - get_attr nodes sorted by target
+    - Computation nodes sorted by (target, canonical indices of inputs)
+    """
+    if node.op == "placeholder":
+        grapharg = node.meta.get("grapharg")
+        if grapharg is not None and grapharg.source is not None:
+            source_name = grapharg.source.name
+        else:
+            source_name = ""
+        return (0, source_name)
+    elif node.op == "get_attr":
+        return (1, str(node.target))
+    elif node.op == "output":
+        return (3,)
+    else:
+        input_indices = tuple(canonical_idx[n] for n in node.all_input_nodes)
+        return (2, str(node.target), input_indices)
+
+
+def _canonicalize_graph(graph: fx.Graph) -> fx.Graph:
+    """Canonicalize a Dynamo output graph's node order and names.
+
+    Delegates to ``torch.fx.passes.canonicalize.canonicalize_graph`` with
+    Dynamo-specific key generation and barrier detection.
+    """
+    from torch.fx.passes.canonicalize import canonicalize_graph
+
+    return canonicalize_graph(graph, _canonical_key, _is_safe_to_reorder)
+
+
 def get_builtins_dict(global_scope: Scope) -> dict[str, Any]:
     # f_globals["__builtins__"] can be a dict or a module. This is an
     # implementation detail -
@@ -2790,6 +2879,12 @@ class OutputGraph(OutputGraphCommon):
 
             # free a bit of memory
             self.real_value_cache.clear()
+
+            if (
+                config.canonicalize_output_graph_node_order
+                and not torch._dynamo.compiled_autograd.in_compiled_autograd_region
+            ):
+                _canonicalize_graph(self.graph)
 
             gm = _make_graph_module(root, self.graph)
 

--- a/torch/fx/passes/canonicalize.py
+++ b/torch/fx/passes/canonicalize.py
@@ -1,0 +1,134 @@
+"""Canonicalize an FX graph's node order and names.
+
+Provides two passes:
+
+- ``canonicalize_graph``: reorders nodes into a deterministic topological order
+  using Kahn's algorithm with a caller-supplied canonical key function and
+  barrier predicate.
+- ``rename_nodes_to_canonical``: renames all nodes to canonical names derived
+  from their target, using the same naming scheme as ``Graph.create_node``.
+"""
+
+import collections
+import heapq
+import itertools
+from typing import Any, Callable
+
+import torch.fx as fx
+
+
+def rename_nodes_to_canonical(graph: fx.Graph) -> None:
+    """Rename all nodes in the graph to canonical names based on their target.
+
+    Uses the same naming scheme as FX ``Graph.create_node`` (auto-generated
+    names from the target string). After renaming, replaces the graph's
+    namespace so future node creation stays consistent.
+    """
+    from torch.fx.graph import _Namespace
+
+    ns = _Namespace()
+    for node in graph.nodes:
+        candidate = graph._target_to_str(node.target)
+        new_name = ns.create_name(candidate, node)
+        node.name = new_name
+    graph._graph_namespace = ns
+
+
+def canonicalize_graph(
+    graph: fx.Graph,
+    canonical_key_fn: Callable[[fx.Node, dict[fx.Node, int]], tuple[Any, ...]],
+    is_safe_to_reorder: Callable[[fx.Node], bool],
+) -> fx.Graph:
+    """Reorder graph nodes into a canonical topological order and rename them.
+
+    This ensures that structurally equivalent graphs produce identical node
+    names and ordering, regardless of the order in which nodes were originally
+    traced.
+
+    Uses Kahn's algorithm with a canonical tiebreaker provided by
+    ``canonical_key_fn``.
+
+    Args:
+        graph: The FX graph to canonicalize. Modified in-place.
+        canonical_key_fn: ``(node, canonical_idx) -> comparable tuple``.
+            Called when a node becomes ready.  ``canonical_idx`` maps already-
+            ordered nodes to their position.  The returned tuple is used as the
+            primary heap key.
+        is_safe_to_reorder: ``(node) -> bool``.  Nodes for which this returns
+            ``False`` act as barriers: they are chained in original order, and
+            pure nodes are confined to their barrier segment.
+
+    Returns:
+        The same ``graph`` object, reordered and renamed in-place.
+    """
+    indeg: dict[fx.Node, int] = {
+        node: len(node.all_input_nodes) for node in graph.nodes
+    }
+
+    # Nodes that aren't provably pure act as barriers. We partition the graph
+    # into segments separated by barrier nodes and add synthetic edges:
+    #   prev_barrier -> reorderable_nodes_in_segment -> next_barrier
+    extra_users: dict[fx.Node, list[fx.Node]] = collections.defaultdict(list)
+    prev_barrier: fx.Node | None = None
+    segment_reorderable: list[fx.Node] = []
+    for node in graph.nodes:
+        if node.op in ("placeholder", "get_attr", "output"):
+            continue
+        is_barrier = not is_safe_to_reorder(node)
+        if is_barrier:
+            for reorderable in segment_reorderable:
+                extra_users[reorderable].append(node)
+                indeg[node] += 1
+            segment_reorderable = []
+        if prev_barrier is not None:
+            extra_users[prev_barrier].append(node)
+            indeg[node] += 1
+        if is_barrier:
+            prev_barrier = node
+        else:
+            segment_reorderable.append(node)
+
+    canonical_idx: dict[fx.Node, int] = {}
+
+    # Counter prevents heapq from comparing fx.Node objects (no __lt__).
+    counter = 0
+    ready: list[tuple[tuple[Any, ...], int, fx.Node]] = []
+    for node in graph.nodes:
+        if indeg[node] == 0:
+            heapq.heappush(
+                ready, (canonical_key_fn(node, canonical_idx), counter, node)
+            )
+            counter += 1
+
+    canonical_order: list[fx.Node] = []
+
+    while ready:
+        _, _, cur = heapq.heappop(ready)
+        canonical_order.append(cur)
+        canonical_idx[cur] = len(canonical_idx)
+
+        for user in itertools.chain(cur.users, extra_users.get(cur, ())):
+            indeg[user] -= 1
+            if indeg[user] == 0:
+                heapq.heappush(
+                    ready,
+                    (canonical_key_fn(user, canonical_idx), counter, user),
+                )
+                counter += 1
+
+    if len(canonical_order) != len(list(graph.nodes)):
+        remaining = [n for n in indeg if indeg[n] != 0]
+        raise RuntimeError(
+            f"Canonicalization failed: processed {len(canonical_order)} of "
+            f"{len(list(graph.nodes))} nodes. Remaining: {remaining}"
+        )
+
+    # Reorder nodes in-place to preserve node object identity.
+    cursor = graph._root  # type: ignore[attr-defined]
+    for node in canonical_order:
+        cursor.append(node)
+        cursor = node
+
+    rename_nodes_to_canonical(graph)
+
+    return graph


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #181781
* #181780
* #181779
* #181778
* #181777
* #181776
* __->__ #187112
* #187111
* #187100
* #181775

Add a canonicalization pass that reorders FX graph nodes using Kahn's
algorithm with canonical tiebreakers, producing a deterministic node
ordering regardless of Python dict iteration order or other
non-deterministic sources. The pass is gated behind the
`canonicalize_output_graph_node_order` config flag (default False).

Co-authored-by: Claude <noreply@anthropic.com>