### PR TITLE
Add stable tie handling to topk

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -51,7 +51,7 @@ namespace at::meta {
 using namespace ::at::native;
 
 TORCH_META_FUNC(topk)
-(const Tensor& self, int64_t k, int64_t dim_, bool largest, bool sorted) {
+(const Tensor& self, int64_t k, int64_t dim_, bool largest, bool sorted, bool stable) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   TORCH_CHECK(
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
@@ -807,6 +807,7 @@ TORCH_IMPL_FUNC(topk_out_cpu)
     int64_t dim_,
     bool largest,
     bool sorted,
+    bool stable,
     const Tensor& values,
     const Tensor& indices) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
@@ -818,7 +819,7 @@ TORCH_IMPL_FUNC(topk_out_cpu)
     values.copy_(self);
     indices.zero_();
   } else {
-    topk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
+    topk_stub(kCPU, values, indices, self, k, dim, largest, sorted, stable);
   }
 }
 

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -18,7 +18,7 @@ enum class QUANTILE_INTERPOLATION_MODE : uint8_t {
 };
 
 using sort_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, bool, bool);
-using topk_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, int64_t, bool, bool);
+using topk_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, int64_t, bool, bool, bool);
 
 DECLARE_DISPATCH(sort_fn, sort_stub)
 DECLARE_DISPATCH(topk_fn, topk_stub)

--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -20,6 +20,7 @@ void topk_impl_loop(
     const int64_t dim_size,
     const bool largest,
     const bool sorted,
+    const bool stable,
     char** data, const int64_t* strides, const int64_t n) {
 
   // If k is zero, then output values and indices are empty tensors
@@ -48,42 +49,26 @@ void topk_impl_loop(
       queue[j].second = j;
     }
 
-    // we want nan to be sorted as top for numpy compatibility
-    if (use_partial_sort) {
+    auto topk_comp = [largest](const elem_t& x, const elem_t& y) -> bool {
+      // we want nan to be sorted as top for numpy compatibility
       if (largest) {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
-      } else {
-        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
+        return ((_isnan<accscalar_t>(x.first) &&
+                 !_isnan<accscalar_t>(y.first)) ||
+                (x.first > y.first));
       }
+      return ((!_isnan<accscalar_t>(x.first) &&
+               _isnan<accscalar_t>(y.first)) ||
+              (x.first < y.first));
+    };
+
+    if (stable) {
+      std::stable_sort(queue.begin(), queue.end(), topk_comp);
+    } else if (use_partial_sort) {
+      std::partial_sort(queue.begin(), queue.begin() + k, queue.end(), topk_comp);
     } else {
-      if (largest) {
-        std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k - 1,
-            [](const elem_t& x, const elem_t& y) -> bool {
-              return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
-            });
-        }
-      } else {
-        std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
-          [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-          });
-        if (sorted) {
-          std::sort(queue.begin(), queue.begin() + k -1,
-            [](const elem_t& x, const elem_t& y) -> bool {
-              return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
-            });
-        }
+      std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(), topk_comp);
+      if (sorted) {
+        std::sort(queue.begin(), queue.begin() + k - 1, topk_comp);
       }
     }
 

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -229,7 +229,8 @@ void topk_kernel(
     int64_t k,
     int64_t dim,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   auto sizes = self.sizes();
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
@@ -249,11 +250,11 @@ void topk_kernel(
       if (self.scalar_type() == ScalarType::BFloat16) {
         return topk_impl_loop<scalar_t, float>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
-            k, sizes[dim], largest, sorted, data, strides, n);
+            k, sizes[dim], largest, sorted, stable, data, strides, n);
       } else {
         return topk_impl_loop<scalar_t, scalar_t>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
-            k, sizes[dim], largest, sorted, data, strides, n);
+            k, sizes[dim], largest, sorted, stable, data, strides, n);
       }
     };
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -23,9 +23,10 @@ void topk_out_with_sort(
   const Tensor& self,
   int64_t k, int64_t dim, bool largest,
   const Tensor& values,
-  const Tensor& indices
+  const Tensor& indices,
+  bool stable
 ) {
-  auto [sorted_values, sorted_indices] = at::cuda::sort(self, /* stable= */false, dim, largest);
+  auto [sorted_values, sorted_indices] = at::cuda::sort(self, stable, dim, largest);
   values.copy_(sorted_values.narrow(dim, 0, k));
   indices.copy_(sorted_indices.narrow(dim, 0, k));
 }
@@ -77,6 +78,7 @@ bool should_use_sort(const Tensor& self, int64_t dim) {
 TORCH_IMPL_FUNC(topk_out_cuda)
   (const Tensor& self,
    int64_t k, int64_t dim, bool largest, bool sorted,
+   bool stable,
    const Tensor& values,
    const Tensor& indices) {
   TensorArg topK_arg{values, "topK", 1}, indices_arg{indices, "indices", 2}, input_arg{self, "self", 3};
@@ -85,7 +87,12 @@ TORCH_IMPL_FUNC(topk_out_cuda)
   dim = at::maybe_wrap_dim(dim, self);
 
   if (should_use_sort(self, dim)) {
-    topk_out_with_sort(self, k, dim, largest, values, indices);
+    topk_out_with_sort(self, k, dim, largest, values, indices, stable);
+    return;
+  }
+
+  if (stable) {
+    topk_out_with_sort(self, k, dim, largest, values, indices, /*stable=*/true);
     return;
   }
 

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -578,6 +578,7 @@ TORCH_IMPL_FUNC(topk_out_mps)
  int64_t dim_,
  bool largest,
  bool /*sorted*/,
+ bool stable,
  const Tensor& values,
  const Tensor& indices) {
   // `sorted` is ignored: the Metal sort is always sorted, a valid topk result either way.
@@ -597,7 +598,7 @@ TORCH_IMPL_FUNC(topk_out_mps)
   const bool descending = largest;
 
   if (dim == self.dim() - 1) {
-    sort_out_mps_impl(self, /*stable=*/false, dim, descending, values, indices, sel);
+    sort_out_mps_impl(self, stable, dim, descending, values, indices, sel);
     return;
   }
 
@@ -607,7 +608,7 @@ TORCH_IMPL_FUNC(topk_out_mps)
   out_sizes.back() = k;
   Tensor v_tmp = at::empty(out_sizes, values.options());
   Tensor i_tmp = at::empty(out_sizes, indices.options());
-  sort_out_mps_impl(self_l, /*stable=*/false, self_l.dim() - 1, descending, v_tmp, i_tmp, sel);
+  sort_out_mps_impl(self_l, stable, self_l.dim() - 1, descending, v_tmp, i_tmp, sel);
   values.copy_(v_tmp.movedim(-1, dim));
   indices.copy_(i_tmp.movedim(-1, dim));
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9994,14 +9994,14 @@
   device_check: NoCheck   # TensorIterator
   variants: function
 
-- func: topk.values(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
+- func: topk.values(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True, *, bool stable=False, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   structured: True
   dispatch:
     CPU: topk_out_cpu
     CUDA: topk_out_cuda
     MPS: topk_out_mps
 
-- func: topk(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
+- func: topk(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True, *, bool stable=False) -> (Tensor values, Tensor indices)
   variants: method, function
   structured_delegate: topk.values
   dispatch:

--- a/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
@@ -171,7 +171,7 @@ using qcat_nhwc_fn = Tensor (*)(
     int64_t dim,
     double scale,
     int64_t zero_point);
-using qtopk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
+using qtopk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool, bool);
 
 using qbatch_norm_fn = void(*)(int64_t, int64_t, int64_t, int64_t, int64_t, const Tensor&, const Tensor&, const Tensor&, Tensor&);
 

--- a/aten/src/ATen/native/quantized/cpu/Sorting.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Sorting.cpp
@@ -29,14 +29,15 @@ static std::tuple<Tensor&, Tensor&> quantized_topk_out_cpu(
     int64_t k,
     int64_t dim_,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   TORCH_CHECK(
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");
   _allocate_or_resize_output_with_indices(values, indices, self, dim_, k);
 
-  qtopk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
+  qtopk_stub(kCPU, values, indices, self, k, dim, largest, sorted, stable);
 
   return std::forward_as_tuple(values, indices);
 }
@@ -46,7 +47,8 @@ std::tuple<Tensor, Tensor> topk_quantized_cpu(
     int64_t k,
     int64_t dim,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   auto qscheme = self.qscheme();
   TORCH_CHECK(
       qscheme == QScheme::PER_TENSOR_AFFINE ||
@@ -58,7 +60,7 @@ std::tuple<Tensor, Tensor> topk_quantized_cpu(
     self.q_scale(),
     self.q_zero_point());
   Tensor indices = at::empty({0}, self.options().dtype(kLong));
-  return quantized_topk_out_cpu(values, indices, self, k, dim, largest, sorted);
+  return quantized_topk_out_cpu(values, indices, self, k, dim, largest, sorted, stable);
 }
 
 DEFINE_DISPATCH(qtopk_stub);

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2349,7 +2349,8 @@ void qtopk_kernel(Tensor& values,
     int64_t k,
     int64_t dim,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   auto sizes = self.sizes();
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
@@ -2372,7 +2373,7 @@ void qtopk_kernel(Tensor& values,
       static_assert(sizeof(scalar_t) == sizeof(underlying_t), "");
       return topk_impl_loop<underlying_t, underlying_t>(
           mode_values_stride, mode_indices_stride, tmp_values_stride,
-          k, dim_size, largest, sorted, data, strides, n);
+          k, dim_size, largest, sorted, stable, data, strides, n);
     };
 
     int64_t grain_size = internal::GRAIN_SIZE / std::max(int64_t{1}, sizes[dim]);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -508,6 +508,44 @@ class TestSortAndSelect(TestCase):
         compare(t, 2000, 1, True)
         compare(t, 2000, 1, False)
 
+    def test_topk_stable(self, device):
+        x = torch.tensor([[5.0, 5.0, 5.0, 4.0], [0.0, 1.0, 1.0, 1.0]], device=device)
+        expected_values = torch.tensor([[5.0, 5.0], [1.0, 1.0]], device=device)
+        expected_indices = torch.tensor([[0, 1], [1, 2]], device=device)
+
+        values, indices = torch.topk(x, 2, dim=1, stable=True)
+        self.assertEqual(values, expected_values)
+        self.assertEqual(indices, expected_indices)
+
+        method_values, method_indices = x.topk(2, dim=1, stable=True)
+        self.assertEqual(method_values, expected_values)
+        self.assertEqual(method_indices, expected_indices)
+
+        values, indices = torch.topk(x, 2, dim=1, sorted=False, stable=True)
+        self.assertEqual(torch.sort(indices, dim=1).values, expected_indices)
+        self.assertEqual(values, x.gather(1, indices))
+
+        smallest = torch.tensor([[2.0, 0.0, 0.0, 0.0, 1.0]], device=device)
+        values, indices = torch.topk(smallest, 2, largest=False, stable=True)
+        self.assertEqual(values, torch.tensor([[0.0, 0.0]], device=device))
+        self.assertEqual(indices, torch.tensor([[1, 2]], device=device))
+
+        out_values = torch.empty_like(expected_values)
+        out_indices = torch.empty_like(expected_indices)
+        torch.topk(x, 2, dim=1, stable=True, out=(out_values, out_indices))
+        self.assertEqual(out_values, expected_values)
+        self.assertEqual(out_indices, expected_indices)
+
+    def test_topk_stable_nonfinite(self, device):
+        x = torch.tensor([float("nan"), float("nan"), 3.0, 3.0, 2.0], device=device)
+        values, indices = torch.topk(x, 4, stable=True)
+        self.assertEqual(values, torch.tensor([nan, nan, 3.0, 3.0], device=device))
+        self.assertEqual(indices, [0, 1, 2, 3])
+
+        values, indices = torch.topk(x, 4, largest=False, stable=True)
+        self.assertEqual(values, torch.tensor([2.0, 3.0, 3.0, nan], device=device))
+        self.assertEqual(indices, [4, 2, 3, 0])
+
     def test_topk_quantized_scalar_input(self):
         # Calling topk on a quantized scalar input used to segfault,
         # see https://github.com/pytorch/pytorch/issues/116324

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1773,7 +1773,7 @@
   self: tanh_backward(grad, result)
   result: auto_element_wise
 
-- name: topk(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
+- name: topk(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True, *, bool stable=False) -> (Tensor values, Tensor indices)
   self: value_selecting_reduction_backward_symint(grad, dim, indices, self.sym_sizes(), true)
   output_differentiability: [True, False]
   values: gather(self_t, dim, indices)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8094,9 +8094,9 @@ def mode_default(self, dim=-1, keepdim=False):
 
 
 @register_lowering(aten.topk.default, type_promotion_kind=None)
-def topk(self, k, dim=-1, largest=True, sorted=True):
+def topk(self, k, dim=-1, largest=True, sorted=True, *, stable=False):
     if not config.triton.decompose_sort_ops:
-        return topk_fallback(self, k, dim, largest, sorted)
+        return topk_fallback(self, k, dim, largest, sorted, stable=stable)
     shape = self.get_size()
     ndim = len(shape)
     if ndim == 0:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7972,7 +7972,7 @@ def scalar_tensor(s, dtype=None, layout=None, device=None, pin_memory=None):
 
 
 @register_meta(aten.topk.default)
-def topk_meta(self, k, dim=-1, largest=True, sorted=True):
+def topk_meta(self, k, dim=-1, largest=True, sorted=True, *, stable=False):
     # From aten/src/ATen/native/Sorting.cpp
     dim = maybe_wrap_dim(dim, self.dim(), wrap_scalar=True)
     sliceSize = 1 if self.dim() == 0 else self.size(dim)

--- a/torch/_native/ops/topk/cutedsl_impl.py
+++ b/torch/_native/ops/topk/cutedsl_impl.py
@@ -100,8 +100,15 @@ def _min_rows_for_full_wave(device_idx: int) -> int:
 
 
 def _eligible(
-    self: torch.Tensor, k: int, dim: int, largest: bool, sorted_: bool
+    self: torch.Tensor,
+    k: int,
+    dim: int,
+    largest: bool,
+    sorted_: bool,
+    stable: bool,
 ) -> bool:
+    if stable:
+        return False
     if not self.is_cuda or self.dtype != torch.float32:
         return False
     if any_cow(self):
@@ -129,9 +136,14 @@ def _cond(
     largest: bool = True,
     sorted: bool = True,
     *args,
+    stable: bool = False,
     **kwargs,
 ) -> bool:
-    return _eligible(self, int(k), int(dim), bool(largest), bool(sorted))
+    if args:
+        if len(args) != 1:
+            return False
+        stable = bool(args[0])
+    return _eligible(self, int(k), int(dim), bool(largest), bool(sorted), bool(stable))
 
 
 def _out_cond(
@@ -140,11 +152,22 @@ def _out_cond(
     dim: int = -1,
     largest: bool = True,
     sorted: bool = True,
-    *,
-    values: torch.Tensor,
-    indices: torch.Tensor,
+    *args,
+    stable: bool = False,
+    values: torch.Tensor | None = None,
+    indices: torch.Tensor | None = None,
+    **kwargs,
 ) -> bool:
-    if not _cond(self, k, dim, largest, sorted):
+    if args:
+        if len(args) == 3:
+            stable, values, indices = args
+        elif len(args) == 2:
+            values, indices = args
+        else:
+            return False
+    if values is None or indices is None:
+        return False
+    if not _cond(self, k, dim, largest, sorted, stable=stable):
         return False
     if any_cow(values, indices):
         return False
@@ -180,6 +203,7 @@ def _impl(
     largest: bool = True,
     sorted: bool = True,
     *args,
+    stable: bool = False,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return _run(self, int(k))
@@ -191,10 +215,21 @@ def _out_impl(
     dim: int = -1,
     largest: bool = True,
     sorted: bool = True,
-    *,
-    values: torch.Tensor,
-    indices: torch.Tensor,
+    *args,
+    stable: bool = False,
+    values: torch.Tensor | None = None,
+    indices: torch.Tensor | None = None,
+    **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if args:
+        if len(args) == 3:
+            stable, values, indices = args
+        elif len(args) == 2:
+            values, indices = args
+        else:
+            raise TypeError("topk.values expects values and indices outputs")
+    if values is None or indices is None:
+        raise TypeError("topk.values expects values and indices outputs")
     v, i = _run(self, int(k))
     values.copy_(v)
     indices.copy_(i)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5462,7 +5462,7 @@ Examples::
 add_docstr_all(
     "topk",
     r"""
-topk(k, dim=None, largest=True, sorted=True) -> (Tensor, LongTensor)
+topk(k, dim=None, largest=True, sorted=True, *, stable=False) -> (Tensor, LongTensor)
 
 See :func:`torch.topk`
 """,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11459,7 +11459,7 @@ Alias for :func:`torch.nn.functional.softmax`.
 add_docstr(
     torch.topk,
     r"""
-topk(input, k, dim=None, largest=True, sorted=True, *, out=None) -> (Tensor, LongTensor)
+topk(input, k, dim=None, largest=True, sorted=True, *, stable=False, out=None) -> (Tensor, LongTensor)
 
 Returns the :attr:`k` largest elements of the given :attr:`input` tensor along
 a given dimension.
@@ -11472,12 +11472,34 @@ A namedtuple of `(values, indices)` is returned with the `values` and
 `indices` of the largest `k` elements of each row of the `input` tensor in the
 given dimension `dim`.
 
-The boolean option :attr:`sorted` if ``True``, will make sure that the returned
-`k` elements are themselves sorted
+The boolean option :attr:`sorted` if ``True`` will make sure that the returned
+`k` elements are themselves sorted.
 
-.. note::
-    When using `torch.topk`, the indices of tied elements are not guaranteed to be stable
-    and may vary across different invocations.
+The boolean option :attr:`stable` if ``True`` gives stable tie handling. If
+more equivalent elements are eligible at the top-k cutoff than can fit in `k`,
+the earliest input indices are selected first. When :attr:`sorted` is also
+``True``, equivalent returned elements preserve their input order. This option
+may be slower than the default.
+
+.. list-table::
+    :header-rows: 1
+
+    * - ``sorted``
+      - ``stable``
+      - Behavior
+    * - ``False``
+      - ``False``
+      - Output order and selected tied indices are unspecified.
+    * - ``True``
+      - ``False``
+      - Values are sorted, but tied indices are unspecified.
+    * - ``False``
+      - ``True``
+      - Tied elements at the cutoff are selected by input order; output order
+        is not guaranteed.
+    * - ``True``
+      - ``True``
+      - Values are sorted and equal values preserve input order.
 
 Args:
     {input}
@@ -11489,6 +11511,8 @@ Args:
            in sorted order
 
 Keyword args:
+    stable (bool, optional): controls whether ties use stable input-order
+        handling
     out (tuple, optional): the output tuple of (Tensor, LongTensor) that can be
         optionally given to be used as output buffers
 
@@ -11499,6 +11523,9 @@ Example::
     tensor([ 1.,  2.,  3.,  4.,  5.])
     >>> torch.topk(x, 3)
     torch.return_types.topk(values=tensor([5., 4., 3.]), indices=tensor([4, 3, 2]))
+    >>> y = torch.tensor([5., 5., 5., 4.])
+    >>> torch.topk(y, 2, stable=True)
+    torch.return_types.topk(values=tensor([5., 5.]), indices=tensor([0, 1]))
 """.format(**common_args),
 )
 

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_cpu.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_cpu.h
@@ -175,6 +175,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_sort(AtenTensorHandle self, int6
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_sort_stable(AtenTensorHandle self, int32_t* stable, int64_t dim, int32_t descending, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_squeeze_dim(AtenTensorHandle self, int64_t dim, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_to_sparse(AtenTensorHandle self, int32_t* layout, const int64_t** blocksize, int64_t blocksize_len_, int64_t* dense_dim, AtenTensorHandle* ret0);
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_topk_v2(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, int32_t stable, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_topk(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_triangular_solve(AtenTensorHandle self, AtenTensorHandle A, int32_t upper, int32_t transpose, int32_t unitriangular, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu_uniform(AtenTensorHandle self, double from, double to, AtenGeneratorHandle* generator, AtenTensorHandle* ret0);

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.h
@@ -203,6 +203,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_sort(AtenTensorHandle self, int
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_sort_stable(AtenTensorHandle self, int32_t* stable, int64_t dim, int32_t descending, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_squeeze_dim(AtenTensorHandle self, int64_t dim, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_to_sparse(AtenTensorHandle self, int32_t* layout, const int64_t** blocksize, int64_t blocksize_len_, int64_t* dense_dim, AtenTensorHandle* ret0);
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_topk_v2(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, int32_t stable, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_topk(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_triangular_solve(AtenTensorHandle self, AtenTensorHandle A, int32_t upper, int32_t transpose, int32_t unitriangular, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_uniform(AtenTensorHandle self, double from, double to, AtenGeneratorHandle* generator, AtenTensorHandle* ret0);

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -156,6 +156,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_sort(AtenTensorHandle self, int6
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_sort_stable(AtenTensorHandle self, int32_t* stable, int64_t dim, int32_t descending, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_squeeze_dim(AtenTensorHandle self, int64_t dim, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_to_sparse(AtenTensorHandle self, int32_t* layout, const int64_t** blocksize, int64_t blocksize_len_, int64_t* dense_dim, AtenTensorHandle* ret0);
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_topk_v2(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, int32_t stable, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_14_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_topk(AtenTensorHandle self, int64_t k, int64_t dim, int32_t largest, int32_t sorted, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_triangular_solve(AtenTensorHandle self, AtenTensorHandle A, int32_t upper, int32_t transpose, int32_t unitriangular, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_uniform(AtenTensorHandle self, double from, double to, AtenGeneratorHandle* generator, AtenTensorHandle* ret0);

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -27,7 +27,7 @@ using value_set = std::unordered_set<Value*>;
 static bool needTrimGrad(Node* n) {
   static OperatorSet need_trim_grad_ops = {
       "aten::kthvalue(Tensor self, int k, int dim, bool keepdim) -> (Tensor, Tensor)",
-      "aten::topk(Tensor self, int k, int dim, bool largest, bool sorted) -> (Tensor, Tensor)",
+      "aten::topk(Tensor self, int k, int dim, bool largest, bool sorted, *, bool stable) -> (Tensor, Tensor)",
       "aten::max_pool2d(Tensor self, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode) -> Tensor",
       "aten::max_pool2d_with_indices(Tensor self, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode) -> (Tensor, Tensor)"};
   if (n->isMemberOf(need_trim_grad_ops)) {

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -2901,7 +2901,10 @@ def _shape_as_tensor(self: List[int]) -> List[int]:
 )=====")
 + std::string(R"=====(def topk(self: List[int],
     k: int,
-    dim: int=-1) -> Tuple[List[int], List[int]]:
+    dim: int=-1,
+    largest: bool=True,
+    sorted: bool=True,
+    stable: bool=False) -> Tuple[List[int], List[int]]:
   _0 = "k ({}) is too big for dimension {} of size {}"
   if torch.eq(torch.len(self), 0):
     result = annotate(List[int], [])
@@ -3315,7 +3318,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor", "argmax"},
     {"aten::bmm(Tensor self, Tensor mat2) -> Tensor", "bmm"},
     {"aten::_shape_as_tensor(Tensor self) -> Tensor", "_shape_as_tensor"},
-    {"aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)", "topk"},
+    {"aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, bool stable=False) -> (Tensor values, Tensor indices)", "topk"},
     {"aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)", "nll_loss_forward"},
     {"aten::native_layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)", "native_layer_norm"},
     {"aten::native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", "native_batch_norm"},

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -225,12 +225,14 @@ const std::vector<std::string> functions = {
         #          k: int,
         #          dim: int = -1,
         #          largest: bool = True,
-        #          sorted: bool = True):
-        #     result0, result1 = torch.topk(self, k, dim, largest, sorted)
+        #          sorted: bool = True,
+        #          stable: bool = False):
+        #     result0, result1 = torch.topk(
+        #         self, k, dim, largest, sorted, stable=stable)
         #     self_size = self.size()
         #     def backward(grad_output):
         #         grad_self = AD_index_select_backward(grad_output, dim, result1, self_size, True)
-        #         return grad_self, None, None, None, None
+        #         return grad_self, None, None, None, None, None
 
         #     return result0, result1, backward
 

--- a/torch/csrc/stable/c/shim_function_versions.txt
+++ b/torch/csrc/stable/c/shim_function_versions.txt
@@ -116,3 +116,6 @@ torch_library_set_python_module: TORCH_VERSION_2_13_0
 torch_new_generator_handle: TORCH_VERSION_2_13_0
 torch_new_stable_ivalue: TORCH_VERSION_2_13_0
 torch_stream_native_handle: TORCH_VERSION_2_13_0
+aoti_torch_cpu_topk_v2: TORCH_VERSION_2_14_0
+aoti_torch_cuda_topk_v2: TORCH_VERSION_2_14_0
+aoti_torch_mps_topk_v2: TORCH_VERSION_2_14_0

--- a/torch/csrc/stable/version.h
+++ b/torch/csrc/stable/version.h
@@ -30,3 +30,4 @@
 #define TORCH_VERSION_2_11_0 (((0ULL + 2) << 56) | ((0ULL + 11) << 48))
 #define TORCH_VERSION_2_12_0 (((0ULL + 2) << 56) | ((0ULL + 12) << 48))
 #define TORCH_VERSION_2_13_0 (((0ULL + 2) << 56) | ((0ULL + 13) << 48))
+#define TORCH_VERSION_2_14_0 (((0ULL + 2) << 56) | ((0ULL + 14) << 48))

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -1229,7 +1229,14 @@ def _shape_as_tensor(self: list[int]) -> list[int]:
     return [len(self)]
 
 
-def topk(self: list[int], k: int, dim: int = -1) -> tuple[list[int], list[int]]:
+def topk(
+    self: list[int],
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+    stable: bool = False,
+) -> tuple[list[int], list[int]]:
     if len(self) == 0:
         result: list[int] = []
     else:
@@ -1576,7 +1583,7 @@ add_shape_compute_mapping(
     "aten::_shape_as_tensor(Tensor self) -> Tensor", _shape_as_tensor
 )
 add_shape_compute_mapping(
-    "aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)",
+    "aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, bool stable=False) -> (Tensor values, Tensor indices)",
     topk,
 )
 add_shape_compute_mapping(

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset10.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset10.py
@@ -118,8 +118,12 @@ def sort(g: jit_utils.GraphContext, self, dim, descending, out=None):
 
 
 @_onnx_symbolic("aten::topk")
-@symbolic_helper.parse_args("v", "v", "i", "i", "i", "none")
-def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, out=None):
+@symbolic_helper.parse_args("v", "v", "i", "i", "i", "i", "none")
+def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, stable, out=None):
+    if stable:
+        symbolic_helper._unimplemented(
+            "TopK", "stable=True is not supported for topk", self
+        )
     return symbolic_helper._topk_helper(
         g, self, k, dim, largest=largest, sorted=sorted, out=out
     )

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
@@ -559,8 +559,12 @@ def unique_dim(
 
 
 @_onnx_symbolic("aten::topk")
-@symbolic_helper.parse_args("v", "v", "i", "i", "i", "none")
-def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, out=None):
+@symbolic_helper.parse_args("v", "v", "i", "i", "i", "i", "none")
+def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, stable, out=None):
+    if stable:
+        symbolic_helper._unimplemented(
+            "TopK", "stable=True is not supported for topk", self
+        )
     return symbolic_helper._topk_helper(
         g, self, k, dim, largest=largest, sorted=sorted, out=out
     )

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -3866,11 +3866,15 @@ def numel(g: jit_utils.GraphContext, self):
 
 @_onnx_symbolic("aten::topk")
 # TODO(justinchuby): Support multiple quantized args in output
-@symbolic_helper.parse_args("v", "i", "i", "i", "i", "none")
-def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, out=None):
+@symbolic_helper.parse_args("v", "i", "i", "i", "i", "i", "none")
+def topk(g: jit_utils.GraphContext, self, k, dim, largest, sorted, stable, out=None):
     if out is not None:
         symbolic_helper._unimplemented(
             "TopK", "Out parameter is not supported for topk", self
+        )
+    if stable:
+        symbolic_helper._unimplemented(
+            "TopK", "stable=True is not supported for topk", self
         )
     if not largest:
         symbolic_helper._unimplemented("TopK", "Ascending TopK is not supported", self)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5447,7 +5447,7 @@ def _topk_method_deterministic(self, *args, **kwargs):
         torch.use_deterministic_algorithms(prior)
 
 
-def reference_topk(a, k, dim=-1, largest=True, sorted=True):
+def reference_topk(a, k, dim=-1, largest=True, sorted=True, *, stable=False):
     # OpInfo numpy ref hook. NumPy has no direct topk, so we sort the whole
     # axis and take the first k (sample shapes are small enough that this
     # is fine).

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -202,7 +202,9 @@ inductor_fallback_ops: dict[str, dict[str, str | dict[str, list[str] | str]]] = 
     "aten.sort.stable": {},
     "aten.squeeze.dim": {},
     "aten.to_sparse.default": {},
-    "aten.topk.default": {},
+    "aten.topk.default": {
+        "v2": {"new_args": ["stable"], "since": "TORCH_VERSION_2_14_0"}
+    },
     "aten.triangular_solve.default": {},
     "aten.uniform.default": {},
     "aten.upsample_bicubic2d_backward.default": {},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187116

The reverted deterministic-topk change made topk pick stable tie indices when
global deterministic algorithms were enabled. That changed default user-visible
tie behavior for existing deterministic-mode callers, including internal model
checks that had recorded the previous unspecified tie order.

This change makes stable topk an explicit opt-in instead. The default
`stable=False` path keeps the existing topk kernels and their existing tie
semantics. `stable=True` asks topk to preserve the original index order among
equal values, matching the stable-sort convention, and is exposed as a
keyword-only argument so existing positional callsites are not reinterpreted.

The implementation keeps the default fast paths unchanged. CPU and quantized
CPU switch from the existing partial-sort/nth-element selection to stable-sort
only when requested. CUDA and MPS route the requested stable case through their
sort implementations, then narrow to k. The CuTeDSL override declines the stable
case so the canonical implementation handles the stronger tie-order contract.
ONNX export rejects `stable=True` because ONNX TopK does not specify stable tie
semantics. AOTI gets versioned topk v2 shims so existing compiled ABI entry
points remain unchanged.

This change was authored with assistance from an AI assistant.

Test Plan:

```bash
python torchgen/gen.py --update-aoti-c-shim
```

```bash
lintrunner -a
```

```bash
pip install -e . -v --no-build-isolation --no-deps
```

```bash
python test/test_sort_and_select.py -k topk_stable -v
```

```bash
python test/test_sort_and_select.py -k topk -v
```

```bash
python - <<'PY'
import torch
print(torch.ops.aten.topk.default._schema)
x = torch.tensor([[5., 5., 5., 4.], [0., 1., 1., 1.]])
assert torch.topk(x, 2, stable=True).indices.tolist() == [[0, 1], [1, 2]]
try:
    torch.topk(x, 2, -1, True, True, True)
except TypeError:
    pass
else:
    raise AssertionError('stable unexpectedly accepted positionally')
if torch.cuda.is_available():
    y = x.cuda()
    assert torch.topk(y, 2, stable=True).indices.cpu().tolist() == [[0, 1], [1, 2]]
    def f(t):
        return torch.topk(t, 2, stable=True).indices
    compiled_f = torch.compile(f, fullgraph=True)
    assert compiled_f(y[:1]).cpu().tolist() == [[0, 1]]
PY
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo