### PR TITLE
Migrate remaining CUDA 12.8 CI docker images to CUDA 13.0

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -98,14 +98,6 @@ case "$tag" in
     KATEX=yes
     TRITON=yes
     ;;
-  pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11)
-    CUDA_VERSION=12.8.1
-    ANACONDA_PYTHON_VERSION=3.10
-    GCC_VERSION=11
-    KATEX=yes
-    TRITON=yes
-    INSTALL_MINGW=yes
-    ;;
   pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11)
     CUDA_VERSION=13.0.2
     ANACONDA_PYTHON_VERSION=3.10
@@ -204,9 +196,9 @@ case "$tag" in
     DOCS=yes
     INDUCTOR_BENCHMARKS=yes
     ;;
-  pytorch-linux-jammy-cuda12.8-cudnn9-py3.10-clang18)
+  pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-clang18)
     ANACONDA_PYTHON_VERSION=3.10
-    CUDA_VERSION=12.8.1
+    CUDA_VERSION=13.0.2
     CLANG_VERSION=18
     TRITON=yes
     ;;
@@ -227,8 +219,8 @@ case "$tag" in
     GCC_VERSION=11
     PALLAS=yes
     ;;
-  pytorch-linux-jammy-cuda12.8-py3.12-pallas)
-    CUDA_VERSION=12.8.1
+  pytorch-linux-jammy-cuda13.0-py3.12-pallas)
+    CUDA_VERSION=13.0.2
     ANACONDA_PYTHON_VERSION=3.12
     GCC_VERSION=11
     PALLAS=yes

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2215,9 +2215,7 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
     # Derive the nightly wheel channel from BUILD_ENVIRONMENT so baseline matches the PR
     # build's CUDA/ROCm toolchain. Override by setting BASELINE_INDEX_URL in the workflow.
     if [[ -z "${BASELINE_INDEX_URL:-}" ]]; then
-      if [[ "${BUILD_ENVIRONMENT}" == *cuda12.8* ]]; then
-        BASELINE_INDEX_URL="https://download.pytorch.org/whl/nightly/cu128"
-      elif [[ "${BUILD_ENVIRONMENT}" == *cuda13* ]]; then
+      if [[ "${BUILD_ENVIRONMENT}" == *cuda13* ]]; then
         BASELINE_INDEX_URL="https://download.pytorch.org/whl/nightly/cu130"
       elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
         # Keep in sync with the ROCm version in the benchmarks docker image

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -55,8 +55,8 @@ jobs:
     needs: get-label-type
     with:
       runner: linux.12xlarge.memory
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm80
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm80
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
       cuda-arch-list: '8.0 9.0'
       test-matrix: |
         { include: [
@@ -86,8 +86,8 @@ jobs:
     with:
       runner_prefix: "mt-"
       runner: linux.r7i.4xlarge
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm100
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm100
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '10.0'
       test-matrix: |


### PR DESCRIPTION
The CI docker image matrix in `docker-builds.yml` and its consumers (`pull.yml`, `inductor-pallas.yml`) already reference `cuda13.0` variants of the clang18 and pallas images, but `.ci/docker/build.sh` still defined them as `cuda12.8`, leaving those names without a matching build case. This change finishes that migration and moves the last CUDA 12.8 CI images over to 13.0.

The clang18 and pallas image cases are renamed from `cuda12.8` to `cuda13.0` with `CUDA_VERSION` bumped from `12.8.1` to `13.0.2`. The `cuda12.8-cudnn9-py3-gcc11` case is dropped rather than renamed because an identically configured `cuda13.0-cudnn9-py3-gcc11` image already exists; its only remaining consumer, `operator_microbenchmark_compare.yml`, is repointed to that 13.0 image (matching the build-environment naming already used by `operator_microbenchmark.yml`). The now-dead `cuda12.8` branch in the operator_microbenchmark baseline logic in `test.sh` is removed, so those runs fall through to the cu130 nightly via the existing `cuda13` branch.

Changing `.ci/docker/` content rehashes and rebuilds the affected CI images, which is intended here.

## Test Plan

CI. The docker-builds workflow builds the renamed images, and the consuming workflows (`pull.yml` clang18 build-only, `inductor-pallas.yml`, and the operator microbenchmark compare workflow) exercise them. Verified locally that no `cuda12.8` references to these three images remain:

\`\`\`
grep -rn "cuda12.8\|cuda12_8" .ci .github
\`\`\`

The only remaining hits are the separate manywheel/almalinux binary-builder images and a README example, which are out of scope.

_Authored with the assistance of Claude._