### PR TITLE
[muon] add multi-tensor (foreach) standard Muon path (#187131)

### DIFF
--- a/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
+++ b/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
@@ -1,0 +1,73 @@
+import operator_benchmark as op_bench
+
+import torch
+import torch.optim as optim
+
+
+"""Microbenchmarks for the Muon optimizer."""
+
+
+muon_impls = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["muon_forloop", False],
+        ["muon_foreach", True],
+    ],
+)
+
+muon_configs = op_bench.config_list(
+    attr_names=["case_name", "num_params", "rows", "cols"],
+    attrs=[
+        ["one_rect_512x1024", 1, 512, 1024],
+        ["one_rect_512x1536", 1, 512, 1536],
+        ["one_rect_512x2048", 1, 512, 2048],
+        ["four_rect_512x1024", 4, 512, 1024],
+        ["four_rect_512x1536", 4, 512, 1536],
+        ["four_rect_512x2048", 4, 512, 2048],
+        ["sixteen_rect_512x1024", 16, 512, 1024],
+        ["sixteen_rect_512x1536", 16, 512, 1536],
+        ["sixteen_rect_512x2048", 16, 512, 2048],
+        ["four_square_1024", 4, 1024, 1024],
+        ["sixteen_square_1024", 16, 1024, 1024],
+    ],
+    cross_product_configs={
+        "device": ["cuda"],
+    },
+    tags=["long"],
+)
+
+
+class MuonOptimizerBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, op_func, device, case_name, num_params, rows, cols):
+        self.params = [
+            torch.nn.Parameter(
+                torch.randn(rows, cols, device=device, dtype=torch.float32)
+            )
+            for _ in range(num_params)
+        ]
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.optimizer = optim.Muon(self.params, lr=0.001, foreach=op_func)
+        # Initialize momentum buffers before benchmarking steady-state step time.
+        self.optimizer.step()
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.inputs = {"dummy": self.params[0]}
+
+    def forward(self, dummy):
+        self.optimizer.step()
+        return dummy
+
+    def get_memory_traffic_bytes(self):
+        return None
+
+
+op_bench.generate_pt_tests_from_op_list(
+    muon_impls, muon_configs, MuonOptimizerBenchmark
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
+++ b/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
@@ -1,0 +1,81 @@
+import operator_benchmark as op_bench
+
+import torch
+import torch.optim as optim
+
+
+"""Microbenchmarks for the Muon optimizer."""
+
+
+muon_impls = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["muon_forloop", False],
+        ["muon_foreach", True],
+    ],
+)
+
+muon_configs = op_bench.config_list(
+    attr_names=["case_name", "num_params", "rows", "cols"],
+    attrs=[
+        ["one_rect_512x1024", 1, 512, 1024],
+        ["one_rect_512x1536", 1, 512, 1536],
+        ["one_rect_512x2048", 1, 512, 2048],
+        ["two_rect_512x1024", 2, 512, 1024],
+        ["two_rect_512x1536", 2, 512, 1536],
+        ["two_rect_512x2048", 2, 512, 2048],
+        ["three_rect_512x1024", 3, 512, 1024],
+        ["three_rect_512x1536", 3, 512, 1536],
+        ["three_rect_512x2048", 3, 512, 2048],
+        ["four_rect_512x1024", 4, 512, 1024],
+        ["four_rect_512x1536", 4, 512, 1536],
+        ["four_rect_512x2048", 4, 512, 2048],
+        ["sixteen_rect_512x1024", 16, 512, 1024],
+        ["sixteen_rect_512x1536", 16, 512, 1536],
+        ["sixteen_rect_512x2048", 16, 512, 2048],
+        ["two_square_1024", 2, 1024, 1024],
+        ["three_square_1024", 3, 1024, 1024],
+        ["four_square_1024", 4, 1024, 1024],
+        ["sixteen_square_1024", 16, 1024, 1024],
+    ],
+    cross_product_configs={
+        "device": ["cuda"],
+    },
+    tags=["long"],
+)
+
+
+class MuonOptimizerBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, op_func, device, case_name, num_params, rows, cols):
+        self.params = [
+            torch.nn.Parameter(
+                torch.randn(rows, cols, device=device, dtype=torch.float32)
+            )
+            for _ in range(num_params)
+        ]
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.optimizer = optim.Muon(self.params, lr=0.001, foreach=op_func)
+        # Initialize momentum buffers before benchmarking steady-state step time.
+        self.optimizer.step()
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.inputs = {"dummy": self.params[0]}
+
+    def forward(self, dummy):
+        self.optimizer.step()
+        return dummy
+
+    def get_memory_traffic_bytes(self):
+        return None
+
+
+op_bench.generate_pt_tests_from_op_list(
+    muon_impls, muon_configs, MuonOptimizerBenchmark
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -850,14 +850,19 @@ class TestOptimRenewed(TestCase):
                 )
                 model.to(dtype=dtype, device=device)
 
-                # foreach/fused optimizers should be tested with a
-                # zero_size tensor as its last param.
-                # ref: https://github.com/pytorch/pytorch/issues/100701
-                empty_param = torch.empty(
-                    (), device=device, dtype=dtype, requires_grad=True
-                )
-                empty_param.grad = torch.rand_like(empty_param)
-                params = list(model.parameters()) + [empty_param]
+                if optim_cls.__name__ == "Muon":
+                    # Muon only accepts 2D parameters, so filter out the 1D
+                    # biases and the empty/0-D scalar.
+                    params = [p for p in model.parameters() if p.ndim == 2]
+                else:
+                    # foreach/fused optimizers should be tested with a
+                    # zero_size tensor as its last param.
+                    # ref: https://github.com/pytorch/pytorch/issues/100701
+                    empty_param = torch.empty(
+                        (), device=device, dtype=dtype, requires_grad=True
+                    )
+                    empty_param.grad = torch.rand_like(empty_param)
+                    params = list(model.parameters()) + [empty_param]
 
                 optimizer = optim_cls(params, **kwargs)
                 models.append(model)
@@ -1090,6 +1095,8 @@ class TestOptimRenewed(TestCase):
                 if optim_cls.__name__ == "Adafactor" and kwargs.get("maximize", False):
                     # When maximize is True, Adafactor also tracks device_grad
                     nintermediates = 3
+            elif optim_cls.__name__ == "Muon":
+                nintermediates = 2
 
             # Dynamo ST uses less mem than eager in the case of Adam/Adagrad/Nadam/RAdam
             # which makes the foreach memory check fail
@@ -1599,8 +1606,11 @@ class TestOptimRenewed(TestCase):
 
         def _get_model_and_input_tensor(device, dtype, optim_cls):
             if optim_cls.__name__ == "Muon":
-                # Muon only accepts 2D parameter.
-                model = torch.nn.Linear(10, 4, bias=False)
+                # Muon only accepts 2D parameters.
+                model = torch.nn.Sequential(
+                    torch.nn.Linear(10, 4, bias=False),
+                    torch.nn.Linear(4, 4, bias=False),
+                )
                 input = torch.rand(10, device=device, dtype=dtype)
             else:
                 model = torch.nn.Sequential(
@@ -1614,7 +1624,10 @@ class TestOptimRenewed(TestCase):
         for optim_input in all_optim_inputs:
             torch.manual_seed(1)
             model, input = _get_model_and_input_tensor(device, dtype, optim_cls)
-            optimizer = optim_cls(model.parameters(), **optim_input.kwargs)
+            params = model.parameters()
+            if optim_cls.__name__ == "Muon":
+                params = [{"params": [p]} for p in model.parameters()]
+            optimizer = optim_cls(params, **optim_input.kwargs)
 
             def fwd_bwd(optim, mod, i):
                 optim.zero_grad()
@@ -1638,6 +1651,9 @@ class TestOptimRenewed(TestCase):
                         del group[flag]
 
             optimizer.load_state_dict(old_state_dict)
+            if optim_cls.__name__ == "Muon":
+                for group in optimizer.param_groups:
+                    self.assertEqual(group["foreach"], None)
 
             # Make sure we can still step
             if optim_info.step_requires_closure:
@@ -2288,13 +2304,17 @@ class TestOptimRenewed(TestCase):
         [
             o
             for o in optim_db
-            if ("foreach" in o.supported_impls and o.optim_cls.__name__ != "Adafactor")
+            if (
+                "foreach" in o.supported_impls
+                and o.optim_cls.__name__ not in ("Adafactor", "Muon")
+            )
         ],
         dtypes=[torch.float32],
     )
     def test_defaults_changed_to_foreach(self, device, dtype, optim_info):
         # Test that the default implementations for optimizers are changed to foreach
-        # except Adafactor, which defaults to the single tensor impl for memory efficiency.
+        # except Adafactor, which defaults to the single tensor impl for memory efficiency,
+        # and Muon, whose foreach path is explicit opt-in for BC.
         from torch.optim import Adam, AdamW
 
         optim_cls = optim_info.optim_cls

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -863,14 +863,19 @@ class TestOptimRenewed(TestCase):
                 )
                 model.to(dtype=dtype, device=device)
 
-                # foreach/fused optimizers should be tested with a
-                # zero_size tensor as its last param.
-                # ref: https://github.com/pytorch/pytorch/issues/100701
-                empty_param = torch.empty(
-                    (), device=device, dtype=dtype, requires_grad=True
-                )
-                empty_param.grad = torch.rand_like(empty_param)
-                params = list(model.parameters()) + [empty_param]
+                if optim_cls.__name__ == "Muon":
+                    # Muon only accepts 2D parameters, so filter out the 1D
+                    # biases.
+                    params = [p for p in model.parameters() if p.ndim == 2]
+                else:
+                    # foreach/fused optimizers should be tested with a
+                    # zero_size tensor as its last param.
+                    # ref: https://github.com/pytorch/pytorch/issues/100701
+                    empty_param = torch.empty(
+                        (), device=device, dtype=dtype, requires_grad=True
+                    )
+                    empty_param.grad = torch.rand_like(empty_param)
+                    params = list(model.parameters()) + [empty_param]
 
                 optimizer = optim_cls(params, **kwargs)
                 models.append(model)
@@ -1054,19 +1059,46 @@ class TestOptimRenewed(TestCase):
         # situation 2 only, but that's better than skipping the test.
         numel = 2**32 - 2**23 if optim_cls.__name__ == "Adafactor" else 2**32
         optim_inputs = optim_info.optim_inputs_func(device=device)
+        if optim_cls.__name__ == "Muon":
+            # Regular OptimInfo tests cover all Muon configurations. This test only
+            # needs one Newton-Schulz step to exercise foreach indexing beyond 2**32
+            # elements; match_rms_adamw keeps the float16 parameter update observable.
+            optim_inputs = [
+                optim_input
+                for optim_input in optim_inputs
+                if optim_input.kwargs.get("adjust_lr_fn") == "match_rms_adamw"
+            ]
         for optim_input in optim_inputs:
-            params = [torch.ones(numel, device=device, dtype=dtype)]
+            shape = (3, (numel + 2) // 3) if optim_cls.__name__ == "Muon" else (numel,)
+            # Muon's per-element update for this extreme shape rounds away at
+            # one in float16, so start from zero when checking for an update.
+            initial_value = 0 if optim_cls.__name__ == "Muon" else 1
+            params = [torch.full(shape, initial_value, device=device, dtype=dtype)]
             params[0].grad = torch.ones_like(params[0])
-            optimizer = optim_cls(params, foreach=True, **optim_input.kwargs)
+            kwargs = optim_input.kwargs
+            if optim_cls.__name__ == "Muon":
+                kwargs = {**kwargs, "ns_steps": 1}
+            optimizer = optim_cls(params, foreach=True, **kwargs)
             optimizer.step()
 
             # Every element saw the same param and grad, so they must all agree.
             # Compare with a size 1 param for reference.
             self.assertEqual(params[0].min(), params[0].max())
+            if optim_cls.__name__ == "Muon":
+                momentum_buffer = optimizer.state[params[0]]["momentum_buffer"]
+                self.assertEqual(momentum_buffer.min(), momentum_buffer.max())
+                self.assertNotEqual(momentum_buffer.flatten()[0], 0)
+                # Only match_rms_adamw scales this extreme shape enough for the
+                # parameter update to remain observable in float16.
+                if kwargs.get("adjust_lr_fn") == "match_rms_adamw":
+                    self.assertNotEqual(params[0].flatten()[0], initial_value)
+                # Muon scales its update by the parameter shape, so a smaller
+                # reference tensor is not numerically comparable.
+                continue
             ref = torch.ones(1, device=device, dtype=dtype)
             ref.grad = torch.ones_like(ref)
             optim_cls([ref], foreach=True, **optim_input.kwargs).step()
-            self.assertEqual(params[0][0], ref[0])
+            self.assertEqual(params[0].flatten()[0], ref.flatten()[0])
 
     @onlyAccelerator
     @skipMPS
@@ -1146,6 +1178,10 @@ class TestOptimRenewed(TestCase):
                 if optim_cls.__name__ == "Adafactor" and kwargs.get("maximize", False):
                     # When maximize is True, Adafactor also tracks device_grad
                     nintermediates = 3
+            elif optim_cls.__name__ == "Muon":
+                # Muon keeps the orthogonalized updates and their full-precision
+                # copies live together before applying the parameter update.
+                nintermediates = 2
 
             # Dynamo ST uses less mem than eager in the case of Adam/Adagrad/Nadam/RAdam
             # which makes the foreach memory check fail
@@ -1707,7 +1743,7 @@ class TestOptimRenewed(TestCase):
 
         def _get_model_and_input_tensor(device, dtype, optim_cls):
             if optim_cls.__name__ == "Muon":
-                # Muon only accepts 2D parameter.
+                # Muon only accepts 2D parameters.
                 model = torch.nn.Linear(10, 4, bias=False)
                 input = torch.rand(10, device=device, dtype=dtype)
             else:
@@ -2463,14 +2499,19 @@ class TestOptimRenewed(TestCase):
         from torch.optim import Adam, AdamW
 
         optim_cls = optim_info.optim_cls
-        model = torch.nn.Linear(5, 5)
+        model = torch.nn.Linear(5, 5, bias=optim_cls.__name__ != "Muon")
         model.to(dtype=dtype, device=device)
         inpt = torch.rand(2, 5, dtype=dtype, device=device)
 
         import inspect
 
         # AdamW dispatches to superclass' adam
-        if optim_cls is AdamW:
+        if optim_cls.__name__ == "Muon":
+            import torch.optim._muon as muon_module
+
+            module = muon_module
+            module_name = "_multi_tensor_muon"
+        elif optim_cls is AdamW:
             module = inspect.getmodule(Adam)
             module_name = "_multi_tensor_adam"
         else:

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -98,6 +98,7 @@ class Muon(Optimizer):
         eps: float = EPS,
         ns_steps: int = DEFAULT_NS_STEPS,
         adjust_lr_fn: str | None = None,
+        foreach: bool | None = None,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -125,6 +126,7 @@ class Muon(Optimizer):
             "eps": eps,
             "ns_steps": ns_steps,
             "adjust_lr_fn": adjust_lr_fn,
+            "foreach": foreach,
         }
         super().__init__(params, defaults)
 
@@ -134,6 +136,13 @@ class Muon(Optimizer):
                     raise ValueError(
                         f"Muon only supports 2D parameters whereas we found a parameter with size: {p.size()}"
                     )
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        # Backfill defaults for flags introduced after the original release so
+        # that state dicts saved by older versions of Muon load cleanly.
+        for group in self.param_groups:
+            group.setdefault("foreach", None)
 
     def _init_group(
         self,
@@ -192,6 +201,7 @@ class Muon(Optimizer):
                 params_with_grad,
                 grads,
                 muon_momentum_bufs,
+                foreach=group["foreach"],
                 lr=lr,
                 weight_decay=weight_decay,
                 momentum=momentum,
@@ -280,6 +290,11 @@ Muon.__doc__ = (
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
         adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral_unclamped".
             If not specified, we will default to use "original". (default: None)
+        foreach (bool, optional): whether to use the multi-tensor (``torch._foreach_*``) implementation. The
+            multi-tensor path fuses the momentum and parameter updates across same-shape 2D params; the
+            Newton-Schulz iteration itself is still performed per-tensor, so numerics match the single-tensor
+            path. If ``None`` (the default), the single-tensor path is used to preserve historical behavior;
+            pass ``foreach=True`` to opt in. (default: None)
 
     Example:
         >>> # xdoctest: +SKIP
@@ -351,6 +366,75 @@ def _single_tensor_muon(
         param.add_(update, alpha=-adjusted_lr)
 
 
+def _multi_tensor_muon(
+    params: list[Tensor],
+    grads: list[Tensor],
+    muon_momentum_bufs: list[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    nesterov: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    adjust_lr_fn: str | None,
+    has_complex: bool,
+) -> None:
+    lr = _to_scalar(lr)
+    if has_complex:
+        raise ValueError("Complex parameters are not supported")
+    if not params:
+        return
+    for g in grads:
+        if g.ndim != 2:
+            raise ValueError("Param gradient must be a 2D matrix")
+
+    # Phase 1: momentum buffer update fused across all params.
+    # buf <- lerp(buf, grad, 1 - momentum) for every param in one call.
+    torch._foreach_lerp_(muon_momentum_bufs, grads, 1 - momentum)
+    if nesterov:
+        updates = list(torch._foreach_lerp(grads, muon_momentum_bufs, momentum))
+    else:
+        updates = list(muon_momentum_bufs)
+
+    # Phase 2: Newton-Schulz per tensor. Standard NS has no natural batching,
+    # so per-tensor preserves bit-for-bit numerics with _single_tensor_muon.
+    updates = [
+        _zeropower_via_newtonschulz(u, ns_coefficients, ns_steps, eps) for u in updates
+    ]
+
+    # Phase 3: weight-decay shrink (uniform scale across all params) followed
+    # by the shape-grouped negative-lr add. Group by shape, dtype, and device
+    # so each _foreach_add_ call preserves per-tensor dtype semantics while
+    # still sharing the shape-specific adjusted_lr.
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
+
+    add_groups: dict[
+        tuple[int, int, torch.dtype, torch.dtype, torch.device, torch.device], list[int]
+    ] = {}
+    for i, (p, update) in enumerate(zip(params, updates, strict=True)):
+        add_groups.setdefault(
+            (p.size(0), p.size(1), p.dtype, update.dtype, p.device, update.device),
+            [],
+        ).append(i)
+    for indices in add_groups.values():
+        group_params = [params[i] for i in indices]
+        group_updates = [updates[i] for i in indices]
+        # _foreach_add_ silently falls back to per-tensor add_ when self/other
+        # dtypes differ. NS outputs bf16; params are typically fp32. Cast once
+        # via a fused _foreach_copy_ so _foreach_add_ stays on the multi-tensor
+        # fast path. The cast is bit-equivalent to the per-tensor add_ that the
+        # single-tensor path performs internally.
+        target_dtype = group_params[0].dtype
+        if group_updates[0].dtype != target_dtype:
+            cast = [torch.empty_like(p) for p in group_params]
+            torch._foreach_copy_(cast, group_updates)
+            group_updates = cast
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, group_params[0].shape)
+        torch._foreach_add_(group_params, group_updates, alpha=-adjusted_lr)
+
+
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_muon)
 def muon(
     params: list[Tensor],
@@ -372,10 +456,9 @@ def muon(
 
     See :class:`~torch.optim.Muon` for details.
     """
-    if foreach is not None and foreach:
-        raise RuntimeError("Foreach is not supported for Muon yet")
-
-    func = _single_tensor_muon
+    # foreach=None preserves the historical single-tensor default; only an
+    # explicit True opts into the multi-tensor (_foreach_*) path.
+    func = _multi_tensor_muon if foreach else _single_tensor_muon
 
     func(
         params,

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -9,6 +9,7 @@ import torch
 from torch import Tensor
 
 from .optimizer import (
+    _default_to_fused_or_foreach,
     _disable_dynamo_if_unsupported,
     _functional_api_doc,
     _params_doc,
@@ -99,6 +100,7 @@ class Muon(Optimizer):
         eps: float = EPS,
         ns_steps: int = DEFAULT_NS_STEPS,
         adjust_lr_fn: str | None = None,
+        foreach: bool | None = None,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -126,6 +128,7 @@ class Muon(Optimizer):
             "eps": eps,
             "ns_steps": ns_steps,
             "adjust_lr_fn": adjust_lr_fn,
+            "foreach": foreach,
         }
         super().__init__(params, defaults)
 
@@ -135,6 +138,13 @@ class Muon(Optimizer):
                     raise ValueError(
                         f"Muon only supports 2D parameters whereas we found a parameter with size: {p.size()}"
                     )
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        # Backfill defaults for flags introduced after the original release so
+        # that state dicts saved by older versions of Muon load cleanly.
+        for group in self.param_groups:
+            group.setdefault("foreach", None)
 
     def _init_group(
         self,
@@ -193,6 +203,7 @@ class Muon(Optimizer):
                 params_with_grad,
                 grads,
                 muon_momentum_bufs,
+                foreach=group["foreach"],
                 lr=lr,
                 weight_decay=weight_decay,
                 momentum=momentum,
@@ -281,6 +292,10 @@ Muon.__doc__ = (
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
         adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral_unclamped".
             If not specified, we will default to use "original". (default: None)
+        foreach (bool, optional): whether to use the multi-tensor (``torch._foreach_*``) implementation. The
+            multi-tensor path fuses the momentum and parameter updates across same-shape 2D params; the
+            Newton-Schulz iteration itself is still performed per-tensor, so numerics match the single-tensor
+            path. If ``None`` (the default), foreach is used on supported devices. (default: None)
 
     Example:
         >>> # xdoctest: +SKIP
@@ -352,6 +367,75 @@ def _single_tensor_muon(
         param.add_(update, alpha=-adjusted_lr)
 
 
+def _multi_tensor_muon(
+    params: list[Tensor],
+    grads: list[Tensor],
+    muon_momentum_bufs: list[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    nesterov: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    adjust_lr_fn: str | None,
+    has_complex: bool,
+) -> None:
+    lr = _to_scalar(lr)
+    if has_complex:
+        raise ValueError("Complex parameters are not supported")
+    if not params:
+        return
+    for g in grads:
+        if g.ndim != 2:
+            raise ValueError("Param gradient must be a 2D matrix")
+
+    # Phase 1: momentum buffer update fused across all params.
+    # buf <- lerp(buf, grad, 1 - momentum) for every param in one call.
+    torch._foreach_lerp_(muon_momentum_bufs, grads, 1 - momentum)
+    if nesterov:
+        updates = list(torch._foreach_lerp(grads, muon_momentum_bufs, momentum))
+    else:
+        updates = list(muon_momentum_bufs)
+
+    # Phase 2: Newton-Schulz per tensor. Standard NS has no natural batching,
+    # so per-tensor preserves bit-for-bit numerics with _single_tensor_muon.
+    updates = [
+        _zeropower_via_newtonschulz(u, ns_coefficients, ns_steps, eps) for u in updates
+    ]
+
+    # Phase 3: weight-decay shrink (uniform scale across all params) followed
+    # by the shape-grouped negative-lr add. Group by shape, dtype, and device
+    # so each _foreach_add_ call preserves per-tensor dtype semantics while
+    # still sharing the shape-specific adjusted_lr.
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
+
+    add_groups: dict[
+        tuple[int, int, torch.dtype, torch.dtype, torch.device, torch.device], list[int]
+    ] = {}
+    for i, (p, update) in enumerate(zip(params, updates, strict=True)):
+        add_groups.setdefault(
+            (p.size(0), p.size(1), p.dtype, update.dtype, p.device, update.device),
+            [],
+        ).append(i)
+    for indices in add_groups.values():
+        group_params = [params[i] for i in indices]
+        group_updates = [updates[i] for i in indices]
+        # _foreach_add_ silently falls back to per-tensor add_ when self/other
+        # dtypes differ. NS outputs bf16; params are typically fp32. Cast once
+        # via a fused _foreach_copy_ so _foreach_add_ stays on the multi-tensor
+        # fast path. The cast is bit-equivalent to the per-tensor add_ that the
+        # single-tensor path performs internally.
+        target_dtype = group_params[0].dtype
+        if group_updates[0].dtype != target_dtype:
+            cast = [torch.empty_like(p) for p in group_params]
+            torch._foreach_copy_(cast, group_updates)
+            group_updates = cast
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, group_params[0].shape)
+        torch._foreach_add_(group_params, group_updates, alpha=-adjusted_lr)
+
+
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_muon)
 def muon(
     params: list[Tensor],
@@ -369,10 +453,15 @@ def muon(
     adjust_lr_fn: str | None,
     has_complex: bool,
 ) -> None:
-    if foreach is not None and foreach:
-        raise RuntimeError("Foreach is not supported for Muon yet")
+    if foreach is None:
+        _, foreach = _default_to_fused_or_foreach(
+            params, differentiable=False, use_fused=False
+        )
 
-    func = _single_tensor_muon
+    if foreach and torch.jit.is_scripting():
+        raise RuntimeError("torch.jit.script not supported with foreach optimizers")
+
+    func = _multi_tensor_muon if foreach else _single_tensor_muon
 
     func(
         params,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1933,8 +1933,10 @@ optim_db: list[OptimizerInfo] = [
         Muon,
         optim_inputs_func=optim_inputs_func_muon,
         optim_error_inputs_func=optim_error_inputs_func_muon,
-        supported_impls=(),
-        not_og_supported_flags=(),
+        supported_impls=("foreach",),
+        # `foreach` was not in the original Muon release; it must be exercised by
+        # the BC tests that compare new impls against the original (single-tensor).
+        not_og_supported_flags=("foreach",),
         supports_complex=False,
         skips=(
             # Note on numerical differences: `compile` applies different matmul tuning,
@@ -1947,6 +1949,13 @@ optim_db: list[OptimizerInfo] = [
                 ),
                 "CompiledOptimizerParityTests",
                 "test_correctness",
+            ),
+            DecorateInfo(
+                unittest.skip(
+                    "Muon only supports 2D params; its Newton-Schulz foreach path is not applicable to the generic 1D large tensor test."
+                ),
+                "TestOptimRenewed",
+                "test_foreach_large_tensor",
             ),
         ),
     ),

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1961,8 +1961,8 @@ optim_db: list[OptimizerInfo] = [
         Muon,
         optim_inputs_func=optim_inputs_func_muon,
         optim_error_inputs_func=optim_error_inputs_func_muon,
-        supported_impls=(),
-        not_og_supported_flags=(),
+        supported_impls=("foreach",),
+        not_og_supported_flags=("foreach",),
         supports_complex=False,
         skips=(
             # Note on numerical differences: `compile` applies different matmul tuning,


### PR DESCRIPTION
Summary:

Adds a foreach implementation for `torch.optim.Muon` and uses PyTorch standard automatic foreach selection when `foreach=None` on supported devices. Users can still pass `foreach=False` to force the single-tensor path.

This change introduces `_multi_tensor_muon` and wires `foreach` through `Muon`, the functional API, and state-dict BC. The foreach path fuses momentum, weight decay, and shape-grouped parameter updates while preserving per-tensor Newton-Schulz computation and numerical parity with the single-tensor path.

It enables generic foreach parity and BC coverage for Muon, adapts generic optimizer tests to valid 2D Muon parameters, extends the generic large-tensor stress test to cover more than `2**32` Muon elements without allowing a silent no-op to pass, and adds CUDA microbenchmarks comparing foreach with the for-loop implementation. The `fbcode/caffe2/...` and `xplat/caffe2/...` mirrors remain synchronized.

Test Plan:
CPU optimizer tests:
`buck2 --isolation-dir codex-muon-bench test fbcode//mode/opt fbcode//caffe2/test:optim -- --regex Muon`
Result: 43 passed, 0 failed, 8 skipped.
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/11821949216168733

Focused CUDA foreach parity, peak-memory, and large-tensor tests:
`buck2 --isolation-dir codex-muon-bench test fbcode//mode/opt fbcode//caffe2/test:test_optim_cuda -- --regex 'test_(foreach_matches_forloop|peak_memory_foreach|foreach_large_tensor).*Muon'`
Result: 4 passed, 0 failed.
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/8162774698303264

CUDA automatic-default dispatch test:
`buck2 --isolation-dir codex-muon-bench test fbcode//mode/opt fbcode//caffe2/test:test_optim_cuda -- --regex 'test_defaults_changed_to_foreach.*Muon'`
Result: 2 passed, 0 failed.
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/6755399814723046

Strengthened CUDA large-tensor test:
`buck2 --isolation-dir codex-muon-bench test fbcode//mode/opt fbcode//caffe2/test:test_optim_cuda -- --regex 'test_foreach_large_tensor.*Muon'`
Result: 2 passed, 0 failed.
TestInfra: https://www.internalfb.com/intern/testinfra/testrun/8725724653117781

Lint: `arc lint` passed for all modified fbcode/xplat files.

H100 steady-state CUDA microbenchmark:
`buck2 --isolation-dir codex-muon-bench run fbcode//mode/opt fbcode//caffe2/benchmarks/operator_benchmark:muon_optimizer_benchmark -- --tag-filter long --device cuda --warmup-iterations 10 --iterations 20 --num-runs 10`

Positive percentages mean foreach is faster than the for-loop implementation; each result is the mean of 10 runs.
- 1 rectangular parameter: foreach was 0.38%-2.03% slower.
- 2 parameters: foreach was 2.99%-6.64% faster.
- 3 parameters: foreach was 4.42%-12.71% faster.
- 4 parameters: foreach was 5.84%-7.87% faster.
- 16 parameters: foreach was 9.61%-13.40% faster.

The benchmark covers rectangular `512x1024`, `512x1536`, and `512x2048` parameters plus square `1024x1024` parameters for multi-parameter cases.

Differential Revision: D105621588


