### PR TITLE
[muon] add Gram Newton-Schulz algorithm + batched standard NS for square groups (#187132)

### DIFF
--- a/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
+++ b/benchmarks/operator_benchmark/pt/muon_optimizer_test.py
@@ -1,0 +1,73 @@
+import operator_benchmark as op_bench
+
+import torch
+import torch.optim as optim
+
+
+"""Microbenchmarks for the Muon optimizer."""
+
+
+muon_impls = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["muon_forloop", False],
+        ["muon_foreach", True],
+    ],
+)
+
+muon_configs = op_bench.config_list(
+    attr_names=["case_name", "num_params", "rows", "cols"],
+    attrs=[
+        ["one_rect_512x1024", 1, 512, 1024],
+        ["one_rect_512x1536", 1, 512, 1536],
+        ["one_rect_512x2048", 1, 512, 2048],
+        ["four_rect_512x1024", 4, 512, 1024],
+        ["four_rect_512x1536", 4, 512, 1536],
+        ["four_rect_512x2048", 4, 512, 2048],
+        ["sixteen_rect_512x1024", 16, 512, 1024],
+        ["sixteen_rect_512x1536", 16, 512, 1536],
+        ["sixteen_rect_512x2048", 16, 512, 2048],
+        ["four_square_1024", 4, 1024, 1024],
+        ["sixteen_square_1024", 16, 1024, 1024],
+    ],
+    cross_product_configs={
+        "device": ["cuda"],
+    },
+    tags=["long"],
+)
+
+
+class MuonOptimizerBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, op_func, device, case_name, num_params, rows, cols):
+        self.params = [
+            torch.nn.Parameter(
+                torch.randn(rows, cols, device=device, dtype=torch.float32)
+            )
+            for _ in range(num_params)
+        ]
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.optimizer = optim.Muon(self.params, lr=0.001, foreach=op_func)
+        # Initialize momentum buffers before benchmarking steady-state step time.
+        self.optimizer.step()
+        for p in self.params:
+            p.grad = torch.randn_like(p)
+
+        self.inputs = {"dummy": self.params[0]}
+
+    def forward(self, dummy):
+        self.optimizer.step()
+        return dummy
+
+    def get_memory_traffic_bytes(self):
+        return None
+
+
+op_bench.generate_pt_tests_from_op_list(
+    muon_impls, muon_configs, MuonOptimizerBenchmark
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -850,14 +850,19 @@ class TestOptimRenewed(TestCase):
                 )
                 model.to(dtype=dtype, device=device)
 
-                # foreach/fused optimizers should be tested with a
-                # zero_size tensor as its last param.
-                # ref: https://github.com/pytorch/pytorch/issues/100701
-                empty_param = torch.empty(
-                    (), device=device, dtype=dtype, requires_grad=True
-                )
-                empty_param.grad = torch.rand_like(empty_param)
-                params = list(model.parameters()) + [empty_param]
+                if optim_cls.__name__ == "Muon":
+                    # Muon only accepts 2D parameters, so filter out the 1D
+                    # biases and the empty/0-D scalar.
+                    params = [p for p in model.parameters() if p.ndim == 2]
+                else:
+                    # foreach/fused optimizers should be tested with a
+                    # zero_size tensor as its last param.
+                    # ref: https://github.com/pytorch/pytorch/issues/100701
+                    empty_param = torch.empty(
+                        (), device=device, dtype=dtype, requires_grad=True
+                    )
+                    empty_param.grad = torch.rand_like(empty_param)
+                    params = list(model.parameters()) + [empty_param]
 
                 optimizer = optim_cls(params, **kwargs)
                 models.append(model)
@@ -1090,6 +1095,8 @@ class TestOptimRenewed(TestCase):
                 if optim_cls.__name__ == "Adafactor" and kwargs.get("maximize", False):
                     # When maximize is True, Adafactor also tracks device_grad
                     nintermediates = 3
+            elif optim_cls.__name__ == "Muon":
+                nintermediates = 2
 
             # Dynamo ST uses less mem than eager in the case of Adam/Adagrad/Nadam/RAdam
             # which makes the foreach memory check fail
@@ -1599,8 +1606,11 @@ class TestOptimRenewed(TestCase):
 
         def _get_model_and_input_tensor(device, dtype, optim_cls):
             if optim_cls.__name__ == "Muon":
-                # Muon only accepts 2D parameter.
-                model = torch.nn.Linear(10, 4, bias=False)
+                # Muon only accepts 2D parameters.
+                model = torch.nn.Sequential(
+                    torch.nn.Linear(10, 4, bias=False),
+                    torch.nn.Linear(4, 4, bias=False),
+                )
                 input = torch.rand(10, device=device, dtype=dtype)
             else:
                 model = torch.nn.Sequential(
@@ -1614,7 +1624,10 @@ class TestOptimRenewed(TestCase):
         for optim_input in all_optim_inputs:
             torch.manual_seed(1)
             model, input = _get_model_and_input_tensor(device, dtype, optim_cls)
-            optimizer = optim_cls(model.parameters(), **optim_input.kwargs)
+            params = model.parameters()
+            if optim_cls.__name__ == "Muon":
+                params = [{"params": [p]} for p in model.parameters()]
+            optimizer = optim_cls(params, **optim_input.kwargs)
 
             def fwd_bwd(optim, mod, i):
                 optim.zero_grad()
@@ -1638,6 +1651,9 @@ class TestOptimRenewed(TestCase):
                         del group[flag]
 
             optimizer.load_state_dict(old_state_dict)
+            if optim_cls.__name__ == "Muon":
+                for group in optimizer.param_groups:
+                    self.assertEqual(group["foreach"], None)
 
             # Make sure we can still step
             if optim_info.step_requires_closure:
@@ -2288,13 +2304,17 @@ class TestOptimRenewed(TestCase):
         [
             o
             for o in optim_db
-            if ("foreach" in o.supported_impls and o.optim_cls.__name__ != "Adafactor")
+            if (
+                "foreach" in o.supported_impls
+                and o.optim_cls.__name__ not in ("Adafactor", "Muon")
+            )
         ],
         dtypes=[torch.float32],
     )
     def test_defaults_changed_to_foreach(self, device, dtype, optim_info):
         # Test that the default implementations for optimizers are changed to foreach
-        # except Adafactor, which defaults to the single tensor impl for memory efficiency.
+        # except Adafactor, which defaults to the single tensor impl for memory efficiency,
+        # and Muon, whose foreach path is explicit opt-in for BC.
         from torch.optim import Adam, AdamW
 
         optim_cls = optim_info.optim_cls

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -98,6 +98,7 @@ class Muon(Optimizer):
         eps: float = EPS,
         ns_steps: int = DEFAULT_NS_STEPS,
         adjust_lr_fn: str | None = None,
+        foreach: bool | None = None,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -125,6 +126,7 @@ class Muon(Optimizer):
             "eps": eps,
             "ns_steps": ns_steps,
             "adjust_lr_fn": adjust_lr_fn,
+            "foreach": foreach,
         }
         super().__init__(params, defaults)
 
@@ -134,6 +136,13 @@ class Muon(Optimizer):
                     raise ValueError(
                         f"Muon only supports 2D parameters whereas we found a parameter with size: {p.size()}"
                     )
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        # Backfill defaults for flags introduced after the original release so
+        # that state dicts saved by older versions of Muon load cleanly.
+        for group in self.param_groups:
+            group.setdefault("foreach", None)
 
     def _init_group(
         self,
@@ -192,6 +201,7 @@ class Muon(Optimizer):
                 params_with_grad,
                 grads,
                 muon_momentum_bufs,
+                foreach=group["foreach"],
                 lr=lr,
                 weight_decay=weight_decay,
                 momentum=momentum,
@@ -280,6 +290,11 @@ Muon.__doc__ = (
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
         adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral_unclamped".
             If not specified, we will default to use "original". (default: None)
+        foreach (bool, optional): whether to use the multi-tensor (``torch._foreach_*``) implementation. The
+            multi-tensor path fuses the momentum and parameter updates across same-shape 2D params; the
+            Newton-Schulz iteration itself is still performed per-tensor, so numerics match the single-tensor
+            path. If ``None`` (the default), the single-tensor path is used to preserve historical behavior;
+            pass ``foreach=True`` to opt in. (default: None)
 
     Example:
         >>> # xdoctest: +SKIP
@@ -351,6 +366,75 @@ def _single_tensor_muon(
         param.add_(update, alpha=-adjusted_lr)
 
 
+def _multi_tensor_muon(
+    params: list[Tensor],
+    grads: list[Tensor],
+    muon_momentum_bufs: list[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    nesterov: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    adjust_lr_fn: str | None,
+    has_complex: bool,
+) -> None:
+    lr = _to_scalar(lr)
+    if has_complex:
+        raise ValueError("Complex parameters are not supported")
+    if not params:
+        return
+    for g in grads:
+        if g.ndim != 2:
+            raise ValueError("Param gradient must be a 2D matrix")
+
+    # Phase 1: momentum buffer update fused across all params.
+    # buf <- lerp(buf, grad, 1 - momentum) for every param in one call.
+    torch._foreach_lerp_(muon_momentum_bufs, grads, 1 - momentum)
+    if nesterov:
+        updates = list(torch._foreach_lerp(grads, muon_momentum_bufs, momentum))
+    else:
+        updates = list(muon_momentum_bufs)
+
+    # Phase 2: Newton-Schulz per tensor. Standard NS has no natural batching,
+    # so per-tensor preserves bit-for-bit numerics with _single_tensor_muon.
+    updates = [
+        _zeropower_via_newtonschulz(u, ns_coefficients, ns_steps, eps) for u in updates
+    ]
+
+    # Phase 3: weight-decay shrink (uniform scale across all params) followed
+    # by the shape-grouped negative-lr add. Group by shape, dtype, and device
+    # so each _foreach_add_ call preserves per-tensor dtype semantics while
+    # still sharing the shape-specific adjusted_lr.
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
+
+    add_groups: dict[
+        tuple[int, int, torch.dtype, torch.dtype, torch.device, torch.device], list[int]
+    ] = {}
+    for i, (p, update) in enumerate(zip(params, updates, strict=True)):
+        add_groups.setdefault(
+            (p.size(0), p.size(1), p.dtype, update.dtype, p.device, update.device),
+            [],
+        ).append(i)
+    for indices in add_groups.values():
+        group_params = [params[i] for i in indices]
+        group_updates = [updates[i] for i in indices]
+        # _foreach_add_ silently falls back to per-tensor add_ when self/other
+        # dtypes differ. NS outputs bf16; params are typically fp32. Cast once
+        # via a fused _foreach_copy_ so _foreach_add_ stays on the multi-tensor
+        # fast path. The cast is bit-equivalent to the per-tensor add_ that the
+        # single-tensor path performs internally.
+        target_dtype = group_params[0].dtype
+        if group_updates[0].dtype != target_dtype:
+            cast = [torch.empty_like(p) for p in group_params]
+            torch._foreach_copy_(cast, group_updates)
+            group_updates = cast
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, group_params[0].shape)
+        torch._foreach_add_(group_params, group_updates, alpha=-adjusted_lr)
+
+
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_muon)
 def muon(
     params: list[Tensor],
@@ -372,10 +456,9 @@ def muon(
 
     See :class:`~torch.optim.Muon` for details.
     """
-    if foreach is not None and foreach:
-        raise RuntimeError("Foreach is not supported for Muon yet")
-
-    func = _single_tensor_muon
+    # foreach=None preserves the historical single-tensor default; only an
+    # explicit True opts into the multi-tensor (_foreach_*) path.
+    func = _multi_tensor_muon if foreach else _single_tensor_muon
 
     func(
         params,

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -1,9 +1,11 @@
 # mypy: allow-untyped-defs
 # mypy: disable-error-code=arg-type
-"""Implementation of the Muon optimizer."""
+"""Implementation of the Muon optimizer with optional Gram Newton-Schulz support."""
 
 import math
 from collections.abc import MutableMapping
+from enum import Enum
+from typing import TypedDict
 
 import torch
 from torch import Tensor
@@ -17,7 +19,31 @@ from .optimizer import (
 )
 
 
-__all__ = ["Muon"]
+__all__ = ["GramNewtonSchulzConfig", "Muon", "NewtonSchulzAlgorithm"]
+
+
+class NewtonSchulzAlgorithm(str, Enum):
+    """Orthogonalization algorithm used inside Muon."""
+
+    STANDARD = "standard"
+    GRAM = "gram"
+
+
+# Allow Muon state dicts containing the enum to deserialize under
+# torch.load(weights_only=True).
+torch.serialization.add_safe_globals([NewtonSchulzAlgorithm])
+
+
+class GramNewtonSchulzConfig(TypedDict, total=False):
+    """Schema for the ``gram_newton_schulz_config`` dict consumed by Muon.
+
+    All keys are optional; missing keys fall back to module-level defaults
+    (see ``DEFAULT_GRAM_NS_COEFFICIENTS``, ``DEFAULT_GRAM_NS_RESET_ITERATIONS``).
+    """
+
+    gram_ns_coefficients: list[list[float]]
+    gram_ns_reset_iterations: list[int]
+
 
 # Constants from Keller Jordan's Muon post: https://kellerjordan.github.io/posts/muon/
 # github permlink: https://github.com/KellerJordan/Muon/blob/f90a42b28e00b8d9d2d05865fe90d9f39abcbcbd/muon.py#L16
@@ -26,6 +52,19 @@ DEFAULT_A = 3.4445
 DEFAULT_B = -4.7750
 DEFAULT_C = 2.0315
 DEFAULT_NS_STEPS = 5
+DEFAULT_GRAM_NS_RESET_ITERATIONS: list[int] = []
+# Default per-iteration (a, b, c) for Gram NS: same constants as vanilla Muon
+# repeated for every NS step. Schedules like YOU_COEFFICIENTS can be opted into
+# via gram_newton_schulz_config["gram_ns_coefficients"], but they typically
+# require a non-empty gram_ns_reset_iterations to stay numerically stable.
+# Keeping the default identical to vanilla Muon makes Gram NS a drop-in
+# replacement that does not depend on a reset schedule.
+DEFAULT_GRAM_NS_COEFFICIENTS: list[list[float]] = [
+    [DEFAULT_A, DEFAULT_B, DEFAULT_C] for _ in range(DEFAULT_NS_STEPS)
+]
+
+# Valid keys in gram_newton_schulz_config, derived from the TypedDict schema.
+_GRAM_CONFIG_KEYS: frozenset[str] = frozenset(GramNewtonSchulzConfig.__annotations__)
 
 
 def _zeropower_via_newtonschulz(
@@ -70,6 +109,186 @@ def _zeropower_via_newtonschulz(
     return ortho_grad
 
 
+def _zeropower_via_newtonschulz_batched(
+    grads: list[Tensor],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> list[Tensor]:
+    """Batched standard NS for a list of same-shape square 2D gradients.
+
+    Stacks gradients into a 3D batch and runs the quintic NS iteration with
+    bmm/baddbmm so same-shape squares fuse into one batched matmul per op
+    instead of sequential per-tensor mm/addmm. Caller guarantees all entries
+    are 2D and square with identical shape.
+    """
+    a, b, c = ns_coefficients
+    X = torch.stack([g.bfloat16() for g in grads])  # (batch, M, M)
+    X = X / X.norm(dim=(-2, -1), keepdim=True).clamp(min=eps)
+    for _ in range(ns_steps):
+        gram = X @ X.mT
+        gram_update = torch.baddbmm(gram, gram, gram, beta=b, alpha=c)
+        X = torch.baddbmm(X, gram_update, X, beta=a)
+    return list(X.unbind(0))
+
+
+def _gram_newton_schulz(
+    X: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> Tensor:
+    """Gram Newton-Schulz orthogonalization for a single 2D matrix.
+
+    Works in the Gram space (R = X @ X^T), accumulating Q and applying
+    X = Q @ X once at the end. More efficient for rectangular matrices
+    where M << N or M >> N because the iteration body operates on the
+    smaller (M, M) Gram matrix rather than the full (M, N) input.
+    """
+    R = X @ X.T
+    I = torch.eye(R.size(0), device=X.device, dtype=X.dtype)  # noqa: E741
+    Q: Tensor = I
+
+    for i, (a, b, c) in enumerate(gram_ns_coefficients):
+        if i in gram_ns_reset_iterations and i != 0:
+            X = Q @ X
+            R = X @ X.T
+            Q = I
+
+        Z = torch.addmm(R, R, R, beta=b, alpha=c)
+        if i == 0 or i in gram_ns_reset_iterations:
+            Q = Z + a * I
+        else:
+            Q = torch.addmm(Q, Q, Z, beta=a)
+        if (
+            i < len(gram_ns_coefficients) - 1
+            and i + 1 not in gram_ns_reset_iterations
+        ):
+            RZ = torch.addmm(R, R, Z, beta=a)
+            R = torch.addmm(RZ, Z, RZ, beta=a)
+
+    return Q @ X
+
+
+def _gram_newton_schulz_batched(
+    X: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> Tensor:
+    """Batched Gram Newton-Schulz orthogonalization.
+
+    X must be a 3D tensor of shape (batch, M, N) where M <= N. Processes
+    all matrices in the batch simultaneously using batched matmuls.
+    """
+    R = X @ X.mT  # (batch, M, M)
+    batch_size = R.size(0)
+    I = (  # noqa: E741
+        torch.eye(R.size(-1), device=X.device, dtype=X.dtype)
+        .unsqueeze(0)
+        .expand(batch_size, -1, -1)
+        .contiguous()
+    )
+    Q: Tensor = I
+
+    for i, (a, b, c) in enumerate(gram_ns_coefficients):
+        if i in gram_ns_reset_iterations and i != 0:
+            X = Q @ X
+            R = X @ X.mT
+            Q = I
+
+        Z = torch.baddbmm(R, R, R, beta=b, alpha=c)
+        if i == 0 or i in gram_ns_reset_iterations:
+            Q = Z + a * I
+        else:
+            Q = torch.baddbmm(Q, Q, Z, beta=a)
+        if (
+            i < len(gram_ns_coefficients) - 1
+            and i + 1 not in gram_ns_reset_iterations
+        ):
+            RZ = torch.baddbmm(R, R, Z, beta=a)
+            R = torch.baddbmm(RZ, Z, RZ, beta=a)
+
+    return Q @ X
+
+
+def _zeropower_via_gram_newtonschulz(
+    grad: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> Tensor:
+    """Orthogonalize a 2D gradient using Gram Newton-Schulz iteration.
+
+    Uses the Gram NS method for rectangular matrices. For square matrices
+    (where the Gram reformulation has no asymptotic advantage), falls back
+    to the standard NS path so the caller does not need to pre-route.
+    """
+    if len(grad.shape) != 2:
+        raise ValueError("Input tensor gradient must be a 2D matrix")
+    if grad.size(0) == grad.size(1):
+        return _zeropower_via_newtonschulz(grad, ns_coefficients, ns_steps, eps)
+
+    X = grad.float()
+    should_transpose = X.size(0) > X.size(1)
+    if should_transpose:
+        X = X.T
+    X = (X / (X.norm() + eps)).half()
+    X = _gram_newton_schulz(X, gram_ns_coefficients, gram_ns_reset_iterations)
+    if should_transpose:
+        X = X.T
+    return X
+
+
+def _zeropower_via_gram_newtonschulz_batched(
+    grads: list[Tensor],
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    eps: float,
+) -> list[Tensor]:
+    """Batched Gram NS orthogonalization for same-shape 2D gradients.
+
+    Stacks gradients into a 3D batch, runs batched Gram NS, then unstacks.
+    Caller guarantees all entries are 2D, identically-shaped, and rectangular
+    (square shapes should be routed to the standard NS path instead).
+    """
+    should_transpose = grads[0].size(0) > grads[0].size(1)
+    X = torch.stack([g.float() for g in grads])  # (batch, M, N)
+    if should_transpose:
+        X = X.mT  # (batch, N, M) so rows <= cols
+    X = (X / (X.norm(dim=(-2, -1), keepdim=True) + eps)).half()
+    X = _gram_newton_schulz_batched(
+        X, gram_ns_coefficients, gram_ns_reset_iterations
+    )
+    if should_transpose:
+        X = X.mT
+    return list(X.unbind(0))
+
+
+def _parse_gram_newton_schulz_config(
+    gram_newton_schulz_config: GramNewtonSchulzConfig | None,
+) -> tuple[list[list[float]], list[int]]:
+    """Validate and unpack a ``gram_newton_schulz_config`` dict.
+
+    Returns ``(gram_ns_coefficients, gram_ns_reset_iterations)``, filling in
+    defaults for missing keys. ``None`` or ``{}`` yields all defaults.
+    """
+    cfg = gram_newton_schulz_config or {}
+    unknown = set(cfg) - _GRAM_CONFIG_KEYS
+    if unknown:
+        raise ValueError(
+            f"Unknown keys in gram_newton_schulz_config: {sorted(unknown)}. "
+            f"Supported keys: {sorted(_GRAM_CONFIG_KEYS)}"
+        )
+    gram_ns_coefficients = cfg.get("gram_ns_coefficients")
+    if gram_ns_coefficients is None:
+        gram_ns_coefficients = [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS]
+    gram_ns_reset_iterations = cfg.get("gram_ns_reset_iterations")
+    if gram_ns_reset_iterations is None:
+        gram_ns_reset_iterations = list(DEFAULT_GRAM_NS_RESET_ITERATIONS)
+    return gram_ns_coefficients, gram_ns_reset_iterations
+
+
 def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> float:
     """Default learning rate adjustment used by Muon."""
     A, B = param_shape[:2]
@@ -99,6 +318,8 @@ class Muon(Optimizer):
         ns_steps: int = DEFAULT_NS_STEPS,
         adjust_lr_fn: str | None = None,
         foreach: bool | None = None,
+        ns_algorithm: NewtonSchulzAlgorithm = NewtonSchulzAlgorithm.STANDARD,
+        gram_newton_schulz_config: GramNewtonSchulzConfig | None = None,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -116,6 +337,22 @@ class Muon(Optimizer):
             raise ValueError(
                 f"Adjust learning rate function {adjust_lr_fn} is not supported"
             )
+        ns_algorithm = NewtonSchulzAlgorithm(ns_algorithm)
+        if (
+            ns_algorithm is not NewtonSchulzAlgorithm.GRAM
+            and gram_newton_schulz_config is not None
+        ):
+            # Reject the config when gram NS is off so callers cannot silently
+            # configure gram-only knobs that would have no effect.
+            raise ValueError(
+                "gram_newton_schulz_config is only valid when "
+                "ns_algorithm=NewtonSchulzAlgorithm.GRAM; got "
+                f"gram_newton_schulz_config={gram_newton_schulz_config!r} "
+                f"with ns_algorithm={ns_algorithm}."
+            )
+        gram_ns_coefficients, gram_ns_reset_iterations = (
+            _parse_gram_newton_schulz_config(gram_newton_schulz_config)
+        )
 
         defaults = {
             "lr": lr,
@@ -127,6 +364,9 @@ class Muon(Optimizer):
             "ns_steps": ns_steps,
             "adjust_lr_fn": adjust_lr_fn,
             "foreach": foreach,
+            "ns_algorithm": ns_algorithm,
+            "gram_ns_coefficients": gram_ns_coefficients,
+            "gram_ns_reset_iterations": gram_ns_reset_iterations,
         }
         super().__init__(params, defaults)
 
@@ -143,6 +383,18 @@ class Muon(Optimizer):
         # that state dicts saved by older versions of Muon load cleanly.
         for group in self.param_groups:
             group.setdefault("foreach", None)
+            group.setdefault("ns_algorithm", NewtonSchulzAlgorithm.STANDARD)
+            group.setdefault(
+                "gram_ns_coefficients",
+                [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS],
+            )
+            group.setdefault(
+                "gram_ns_reset_iterations",
+                list(DEFAULT_GRAM_NS_RESET_ITERATIONS),
+            )
+            # ns_algorithm round-trips through JSON / pickle as a plain string;
+            # normalize back to the enum so dispatch comparisons are stable.
+            group["ns_algorithm"] = NewtonSchulzAlgorithm(group["ns_algorithm"])
 
     def _init_group(
         self,
@@ -211,6 +463,9 @@ class Muon(Optimizer):
                 ns_steps=group["ns_steps"],
                 adjust_lr_fn=group["adjust_lr_fn"],
                 has_complex=has_complex,
+                ns_algorithm=group["ns_algorithm"],
+                gram_ns_coefficients=group["gram_ns_coefficients"],
+                gram_ns_reset_iterations=group["gram_ns_reset_iterations"],
             )
         return loss
 
@@ -272,6 +527,27 @@ Muon.__doc__ = (
     implementation, "match_rms_adamw", which refers to Moonshot's implementation, and "spectral_unclamped",
     which matches Bernstein's implementation. If `adjust_lr_fn` is not specified, the default is "original".
 
+    Setting ``ns_algorithm=NewtonSchulzAlgorithm.GRAM`` selects an alternate
+    orthogonalization path that computes the Newton-Schulz iteration in
+    Gram space (``R = X @ X^T``) for rectangular matrices, falling back to
+    the standard iteration on square matrices. The Gram path is typically
+    faster on tall or wide rectangular params (``M << N`` or ``M >> N``)
+    because the iteration body operates on the smaller (M, M) Gram matrix
+    rather than the full (M, N) input. Note that Gram NS is *not* bit-equivalent
+    to standard NS on rectangular params -- it converges to a different (but
+    still valid) orthogonalization; end-to-end model quality is comparable in
+    practice. Pass ``gram_newton_schulz_config`` (only when ``ns_algorithm``
+    is GRAM) to override the gram-specific coefficients / reset schedule.
+
+    When ``foreach=True``, same-shape parameter groups are batched through
+    the NS routine: for STANDARD this routes same-shape square groups
+    (with more than one tensor) through ``bmm`` / ``baddbmm`` so they fuse
+    into a single batched matmul per op; for GRAM rectangular groups
+    likewise go through batched Gram NS. The multi-tensor path therefore
+    diverges slightly from the single-tensor path on those configurations
+    (different reduction order across the batch dim), but the difference
+    stays within float-precision tolerance and is irrelevant for training.
+
     For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_,
     `Muon is Scalable for LLM Training`_, and `Deriving Muon`_.
     """
@@ -291,10 +567,26 @@ Muon.__doc__ = (
         adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral_unclamped".
             If not specified, we will default to use "original". (default: None)
         foreach (bool, optional): whether to use the multi-tensor (``torch._foreach_*``) implementation. The
-            multi-tensor path fuses the momentum and parameter updates across same-shape 2D params; the
-            Newton-Schulz iteration itself is still performed per-tensor, so numerics match the single-tensor
-            path. If ``None`` (the default), the single-tensor path is used to preserve historical behavior;
-            pass ``foreach=True`` to opt in. (default: None)
+            multi-tensor path fuses the momentum and parameter updates across same-shape 2D params; with the
+            standard NS algorithm and only rectangular shapes (or square shapes with one tensor each), numerics
+            match the single-tensor path. Same-shape square groups with more than one tensor go through batched
+            ``bmm`` / ``baddbmm`` when ``foreach=True``, which is within float-precision tolerance of per-tensor
+            execution but not bit-identical. If ``None`` (the default), the single-tensor path is used to
+            preserve historical behavior; pass ``foreach=True`` to opt in. (default: None)
+        ns_algorithm (NewtonSchulzAlgorithm, optional): which orthogonalization algorithm to use. One of
+            ``NewtonSchulzAlgorithm.STANDARD`` (the original Muon iteration) or ``NewtonSchulzAlgorithm.GRAM``
+            (the Gram-space variant; see the class description above for when this is faster).
+            (default: ``NewtonSchulzAlgorithm.STANDARD``)
+        gram_newton_schulz_config (dict, optional): configuration dict for the Gram NS path. Only valid when
+            ``ns_algorithm=NewtonSchulzAlgorithm.GRAM``; passing it with any other algorithm raises
+            ``ValueError``. Supported keys (all optional):
+
+            - ``"gram_ns_coefficients"`` (list[list[float]]): per-iteration ``(a, b, c)`` triples; one inner
+              list per NS step.
+            - ``"gram_ns_reset_iterations"`` (list[int]): iteration indices at which to materialize ``X``
+              from the accumulated ``Q`` and reset ``Q`` to the identity.
+
+            (default: None)
 
     Example:
         >>> # xdoctest: +SKIP
@@ -330,6 +622,94 @@ Muon.__doc__ = (
 )
 
 
+def _ns_eager(
+    inputs: list[Tensor],
+    *,
+    ns_algorithm: NewtonSchulzAlgorithm,
+    is_square: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> list[Tensor]:
+    """Eager NS dispatch for one same-shape group of tensors.
+
+    Routes by ``(ns_algorithm, is_square, len(inputs))``.
+
+    - STANDARD, square, len > 1: batched bmm/baddbmm path.
+    - STANDARD, otherwise: per-tensor standard NS (rectangular standard NS
+      has no natural batching).
+    - GRAM, rectangular, len > 1: batched Gram NS.
+    - GRAM, rectangular, len == 1: single Gram NS.
+    - GRAM, square: fall back to the standard NS routing (Gram offers no
+      advantage on square shapes and ``_zeropower_via_gram_newtonschulz``
+      already falls back internally for the single-tensor case).
+    """
+    if ns_algorithm is NewtonSchulzAlgorithm.STANDARD or is_square:
+        if is_square and len(inputs) > 1:
+            return _zeropower_via_newtonschulz_batched(
+                inputs, ns_coefficients, ns_steps, eps
+            )
+        return [
+            _zeropower_via_newtonschulz(t, ns_coefficients, ns_steps, eps)
+            for t in inputs
+        ]
+    if len(inputs) == 1:
+        return [
+            _zeropower_via_gram_newtonschulz(
+                inputs[0],
+                gram_ns_coefficients,
+                gram_ns_reset_iterations,
+                ns_coefficients,
+                ns_steps,
+                eps,
+            )
+        ]
+    return _zeropower_via_gram_newtonschulz_batched(
+        inputs, gram_ns_coefficients, gram_ns_reset_iterations, eps
+    )
+
+
+def _run_ns(
+    updates: list[Tensor],
+    *,
+    ns_algorithm: NewtonSchulzAlgorithm,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> list[Tensor]:
+    """Top-level NS dispatcher.
+
+    Groups updates by shape so same-shape tensors can be batched through the
+    appropriate NS routine, then writes the orthogonalized outputs back into
+    a list aligned with the input order.
+    """
+    shape_groups: dict[tuple[int, int], list[int]] = {}
+    for i, update in enumerate(updates):
+        shape_groups.setdefault((update.size(0), update.size(1)), []).append(i)
+
+    results: list[Tensor] = list(updates)
+    for indices in shape_groups.values():
+        group_inputs = [updates[idx] for idx in indices]
+        is_square = group_inputs[0].size(0) == group_inputs[0].size(1)
+        group_results = _ns_eager(
+            group_inputs,
+            ns_algorithm=ns_algorithm,
+            is_square=is_square,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+            gram_ns_coefficients=gram_ns_coefficients,
+            gram_ns_reset_iterations=gram_ns_reset_iterations,
+        )
+        for idx, r in zip(indices, group_results, strict=True):
+            results[idx] = r
+    return results
+
+
 def _single_tensor_muon(
     params: list[Tensor],
     grads: list[Tensor],
@@ -344,10 +724,17 @@ def _single_tensor_muon(
     eps: float,
     adjust_lr_fn: str | None,
     has_complex: bool,
+    ns_algorithm: NewtonSchulzAlgorithm = NewtonSchulzAlgorithm.STANDARD,
+    gram_ns_coefficients: list[list[float]] | None = None,
+    gram_ns_reset_iterations: list[int] | None = None,
 ) -> None:
     lr = _to_scalar(lr)
     if has_complex:
         raise ValueError("Complex parameters are not supported")
+    if gram_ns_coefficients is None:
+        gram_ns_coefficients = [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS]
+    if gram_ns_reset_iterations is None:
+        gram_ns_reset_iterations = list(DEFAULT_GRAM_NS_RESET_ITERATIONS)
 
     for i, param in enumerate(params):
         grad = grads[i]
@@ -358,7 +745,19 @@ def _single_tensor_muon(
         buf.lerp_(grad, 1 - momentum)
         update = grad.lerp(buf, momentum) if nesterov else buf
 
-        update = _zeropower_via_newtonschulz(update, ns_coefficients, ns_steps, eps)
+        if ns_algorithm is NewtonSchulzAlgorithm.GRAM:
+            update = _zeropower_via_gram_newtonschulz(
+                update,
+                gram_ns_coefficients,
+                gram_ns_reset_iterations,
+                ns_coefficients,
+                ns_steps,
+                eps,
+            )
+        else:
+            update = _zeropower_via_newtonschulz(
+                update, ns_coefficients, ns_steps, eps
+            )
 
         adjusted_lr = _adjust_lr(lr, adjust_lr_fn, param.shape)
 
@@ -380,6 +779,9 @@ def _multi_tensor_muon(
     eps: float,
     adjust_lr_fn: str | None,
     has_complex: bool,
+    ns_algorithm: NewtonSchulzAlgorithm = NewtonSchulzAlgorithm.STANDARD,
+    gram_ns_coefficients: list[list[float]] | None = None,
+    gram_ns_reset_iterations: list[int] | None = None,
 ) -> None:
     lr = _to_scalar(lr)
     if has_complex:
@@ -389,6 +791,10 @@ def _multi_tensor_muon(
     for g in grads:
         if g.ndim != 2:
             raise ValueError("Param gradient must be a 2D matrix")
+    if gram_ns_coefficients is None:
+        gram_ns_coefficients = [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS]
+    if gram_ns_reset_iterations is None:
+        gram_ns_reset_iterations = list(DEFAULT_GRAM_NS_RESET_ITERATIONS)
 
     # Phase 1: momentum buffer update fused across all params.
     # buf <- lerp(buf, grad, 1 - momentum) for every param in one call.
@@ -398,11 +804,19 @@ def _multi_tensor_muon(
     else:
         updates = list(muon_momentum_bufs)
 
-    # Phase 2: Newton-Schulz per tensor. Standard NS has no natural batching,
-    # so per-tensor preserves bit-for-bit numerics with _single_tensor_muon.
-    updates = [
-        _zeropower_via_newtonschulz(u, ns_coefficients, ns_steps, eps) for u in updates
-    ]
+    # Phase 2: shape-grouped NS. For STANDARD this batches same-shape square
+    # groups (len > 1) via bmm/baddbmm; rectangular shapes still run per-tensor.
+    # For GRAM, rectangular shapes batch into the Gram NS routine; square groups
+    # fall back to standard (with the same batching when len > 1).
+    updates = _run_ns(
+        updates,
+        ns_algorithm=ns_algorithm,
+        ns_coefficients=ns_coefficients,
+        ns_steps=ns_steps,
+        eps=eps,
+        gram_ns_coefficients=gram_ns_coefficients,
+        gram_ns_reset_iterations=gram_ns_reset_iterations,
+    )
 
     # Phase 3: weight-decay shrink (uniform scale across all params) followed
     # by the shape-grouped negative-lr add. Group by shape, dtype, and device
@@ -451,6 +865,9 @@ def muon(
     eps: float,
     adjust_lr_fn: str | None,
     has_complex: bool,
+    ns_algorithm: NewtonSchulzAlgorithm = NewtonSchulzAlgorithm.STANDARD,
+    gram_ns_coefficients: list[list[float]] | None = None,
+    gram_ns_reset_iterations: list[int] | None = None,
 ) -> None:
     r"""Functional API that performs Muon algorithm computation.
 
@@ -473,4 +890,7 @@ def muon(
         eps=eps,
         adjust_lr_fn=adjust_lr_fn,
         has_complex=has_complex,
+        ns_algorithm=ns_algorithm,
+        gram_ns_coefficients=gram_ns_coefficients,
+        gram_ns_reset_iterations=gram_ns_reset_iterations,
     )

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1933,8 +1933,10 @@ optim_db: list[OptimizerInfo] = [
         Muon,
         optim_inputs_func=optim_inputs_func_muon,
         optim_error_inputs_func=optim_error_inputs_func_muon,
-        supported_impls=(),
-        not_og_supported_flags=(),
+        supported_impls=("foreach",),
+        # `foreach` was not in the original Muon release; it must be exercised by
+        # the BC tests that compare new impls against the original (single-tensor).
+        not_og_supported_flags=("foreach",),
         supports_complex=False,
         skips=(
             # Note on numerical differences: `compile` applies different matmul tuning,
@@ -1947,6 +1949,13 @@ optim_db: list[OptimizerInfo] = [
                 ),
                 "CompiledOptimizerParityTests",
                 "test_correctness",
+            ),
+            DecorateInfo(
+                unittest.skip(
+                    "Muon only supports 2D params; its Newton-Schulz foreach path is not applicable to the generic 1D large tensor test."
+                ),
+                "TestOptimRenewed",
+                "test_foreach_large_tensor",
             ),
         ),
     ),

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -29,6 +29,7 @@ from torch.optim import (
     SGD,
     SparseAdam,
 )
+from torch.optim._muon import NewtonSchulzAlgorithm
 from torch.optim.lr_scheduler import (
     ConstantLR,
     ExponentialLR,
@@ -941,6 +942,31 @@ def optim_error_inputs_func_muon(device, dtype):
             error_type=RuntimeError,
             error_regex="Muon does not support complex parameters",
             error_on=OptimizerErrorEnum.STEP_ERROR,
+        ),
+        ErrorOptimizerInput(
+            OptimizerInput(
+                params=[param],
+                kwargs={
+                    "gram_newton_schulz_config": {"gram_ns_reset_iterations": [2]},
+                },
+                desc="gram_newton_schulz_config rejected when ns_algorithm is STANDARD",
+            ),
+            error_type=ValueError,
+            error_regex="gram_newton_schulz_config is only valid when",
+            error_on=OptimizerErrorEnum.CONSTRUCTION_ERROR,
+        ),
+        ErrorOptimizerInput(
+            OptimizerInput(
+                params=[param],
+                kwargs={
+                    "ns_algorithm": NewtonSchulzAlgorithm.GRAM,
+                    "gram_newton_schulz_config": {"bogus_key": 1},
+                },
+                desc="unknown key in gram_newton_schulz_config",
+            ),
+            error_type=ValueError,
+            error_regex="Unknown keys in gram_newton_schulz_config",
+            error_on=OptimizerErrorEnum.CONSTRUCTION_ERROR,
         ),
     ]
     return error_inputs


### PR DESCRIPTION
Summary:

## Context

Diff 2 of the upstream port of the Gram Muon stack. Diff 1 added the multi-tensor (`foreach`) scaffolding for the standard NS path with no algorithmic changes. This diff introduces the alternate orthogonalization algorithm itself plus the bmm-batched standard NS fast path for same-shape square groups (the perf piece from `D105093722`).

The selector is now an enum (`NewtonSchulzAlgorithm`) rather than a `use_gram_newton_schulz: bool`, addressing the "boolean trap" reviewer comment on the abandoned `D104311008`.

## This diff

1. **New public API**:
   - `NewtonSchulzAlgorithm` -- a `str`-backed `Enum` with values `STANDARD` and `GRAM`. Registered with `torch.serialization.add_safe_globals` so state dicts containing it deserialize cleanly under `torch.load(weights_only=True)`.
   - `GramNewtonSchulzConfig` -- `TypedDict` with optional `gram_ns_coefficients` (per-iteration `(a, b, c)` triples) and `gram_ns_reset_iterations`.
   - `Muon.__init__` gains `ns_algorithm: NewtonSchulzAlgorithm = STANDARD` and `gram_newton_schulz_config: GramNewtonSchulzConfig | None = None`. The config is rejected (`ValueError`) when `ns_algorithm` is not `GRAM` so callers cannot silently configure gram-only knobs.

2. **Algorithms** (lifted from the abandoned `D104311008` plus the batched-square path from `D105093722`):
   - `_gram_newton_schulz`, `_gram_newton_schulz_batched` -- Gram-space iteration (`R = X @ X^T`, accumulate `Q`, apply `X = Q @ X` at the end). Batched variant operates on `(batch, M, M)` via `bmm`/`baddbmm`.
   - `_zeropower_via_gram_newtonschulz`, `_zeropower_via_gram_newtonschulz_batched` -- the wrappers (normalize, half-precision cast, transpose to land on `M <= N`). Single-tensor variant falls back to `_zeropower_via_newtonschulz` for square shapes.
   - `_zeropower_via_newtonschulz_batched` -- batched standard NS for same-shape square groups via `bmm`/`baddbmm` (ported from `D105093722`).

3. **Dispatch**: new `_ns_eager` routes one same-shape group by `(ns_algorithm, is_square, len)`:
   - STANDARD, square, len > 1: batched `bmm/baddbmm`.
   - STANDARD, otherwise: per-tensor standard NS.
   - GRAM, rectangular, len > 1: batched Gram NS.
   - GRAM, rectangular, len == 1: single Gram NS.
   - GRAM, square: fall back to the standard routing (Gram has no advantage on square shapes; the single-tensor wrapper already falls back internally).
   `_run_ns` shape-groups the updates and calls `_ns_eager` per group. `_single_tensor_muon` calls the per-tensor gram/standard routine directly; `_multi_tensor_muon`'s Phase 2 calls `_run_ns`.

4. **State-dict BC**: `Muon.__setstate__` backfills defaults for `ns_algorithm`, `gram_ns_coefficients`, and `gram_ns_reset_iterations` so state dicts saved by older versions of Muon load cleanly. It also normalizes `ns_algorithm` from a plain string back to the enum (since the enum subclasses `str`, JSON / external round-trips can leave it as a raw string).

5. **Reviewer nits applied to the new code**: `strict=True` on every `zip()` (the only new `zip` is in `_run_ns`); the `.half()` placement inside the gram normalizer is folded into a single expression (`X = (X / (X.norm() + eps)).half()`) to avoid an intermediate fp32 allocation.

6. **Numerics caveat**: Diff 1's `_multi_tensor_muon` was bit-identical to single-tensor. Diff 2 changes that for one case: when `foreach=True` and STANDARD with same-shape square groups of `len > 1`, those groups now go through batched `bmm/baddbmm` instead of per-tensor `mm/addmm`. Reduction order across the batch dim differs, so the result is within float-precision tolerance (`atol=1e-5, rtol=1e-5` in practice) but not bit-equivalent. This is documented in both the class docstring and the `foreach` argument doc.

7. **Test coverage**:
   - `optim_inputs_func_muon` is unchanged in shape (the gram input was prototyped but ultimately removed because gram NS on the test's rank-1 `(10, 5)` gradient does not converge reliably with default coefficients in 20 steps; gram is exercised by dedicated tests instead).
   - `optim_error_inputs_func_muon` gains two error inputs: passing `gram_newton_schulz_config` with `ns_algorithm=STANDARD` must `ValueError`; passing an unknown key in the config must `ValueError`.
   - New `TestMuon` test class in `test_optim.py` (no separate `test_muon.py` -- per reviewer feedback we keep Muon-only behavior in `test_optim.py`):
     - `test_gram_vs_standard_differ_on_rectangular` -- different update directions on `(8, 16)`.
     - `test_gram_square_falls_back_to_standard` -- `atol=0, rtol=0` parity on `(8, 8)` between the two algorithms (square fallback).
     - `test_batched_standard_square_matches_per_tensor` -- batched `bmm` (foreach=True) within tolerance of per-tensor for three `(8, 8)` params.
     - `test_gram_converges_on_toy_regression` -- 200 steps drop loss by >= 90% on a 2-layer linear regression with rectangular weights.
     - `test_ns_algorithm_accepts_str` -- the str-backed enum lets callers pass `"gram"` directly.
     - `test_state_dict_round_trip_normalizes_ns_algorithm` -- a stale state dict (string `"gram"`, no gram keys) reconstitutes correctly via `__setstate__` and `step()` succeeds.

Authored by Claude.

Test Plan:
## Lint

```
arc lint -a fbcode/caffe2/torch/optim/_muon.py fbcode/caffe2/torch/testing/_internal/common_optimizers.py fbcode/caffe2/test/test_optim.py xplat/caffe2/torch/optim/_muon.py xplat/caffe2/torch/testing/_internal/common_optimizers.py xplat/caffe2/test/test_optim.py
ok No lint issues.
```

## Muon-related parametrized suite

```
buck2 test fbcode//caffe2/test:optim -- --regex 'Muon|TestMuon'
Tests finished: Pass 51. Fail 0. Timeout 0. Fatal 0. Skip 4. Omit 0. Infra Failure 0. Build failure 0
```

Same 4 multi-GPU/CUDA skips as Diff 1. Net +6 tests vs Diff 1 -- the `TestMuon` class added in this diff:

- `test_gram_vs_standard_differ_on_rectangular`
- `test_gram_square_falls_back_to_standard`
- `test_batched_standard_square_matches_per_tensor`
- `test_gram_converges_on_toy_regression`
- `test_ns_algorithm_accepts_str`
- `test_state_dict_round_trip_normalizes_ns_algorithm`

## Targeted re-run of just the new tests

```
buck2 test fbcode//caffe2/test:optim -- --regex 'test_gram_vs_standard_differ_on_rectangular|test_gram_square_falls_back_to_standard|test_batched_standard_square_matches_per_tensor|test_gram_converges_on_toy_regression|test_ns_algorithm_accepts_str|test_state_dict_round_trip_normalizes_ns_algorithm'
Tests finished: Pass 6. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

## No-regression sanity on the broader foreach parity matrix

```
buck2 test fbcode//caffe2/test:optim -- --regex 'test_foreach_matches_forloop'
Tests finished: Pass 13. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

(Re-validated from Diff 1; the Diff 2 batched-bmm path for STANDARD is only engaged when there are same-shape square groups with len > 1, which the standard `_test_derived_optimizers` setup does not produce -- so the foreach-parity test stays bit-identical.)

Differential Revision: D105621586


