### PR TITLE
[dynamo] Reuse ACT-traced graphs for resolved tensor inputs

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1660,6 +1660,24 @@ class ACTCompileTest(TestCase):
         r2 = compiled_fn(plain)
         self.assertEqual(r2, plain * 2)
 
+    def test_act_guard_accepts_resolved_tensor(self):
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled_fn = torch.compile(lambda x: x * 2, backend=cnt)
+
+        elem = torch.randn(4, 4)
+        r1 = compiled_fn(AsyncCollectiveTensor(elem))
+        self.assertEqual(r1, elem * 2)
+        self.assertEqual(cnt.frame_count, 1)
+
+        r2 = compiled_fn(elem)
+        self.assertEqual(r2, elem * 2)
+        self.assertEqual(cnt.frame_count, 1)
+
+        other_dtype = elem.double()
+        r3 = compiled_fn(other_dtype)
+        self.assertEqual(r3, other_dtype * 2)
+        self.assertEqual(cnt.frame_count, 2)
+
     def test_act_guard_recompiles(self):
         """
         Dynamo must recompile when an input switches between plain tensor

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1661,7 +1661,7 @@ class ACTCompileTest(TestCase):
         self.assertEqual(r2, plain * 2)
 
     def test_act_guard_accepts_resolved_tensor(self):
-        cnt = torch._dynamo.testing.CompileCounter()
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
         compiled_fn = torch.compile(lambda x: x * 2, backend=cnt)
 
         elem = torch.randn(4, 4)
@@ -1676,6 +1676,22 @@ class ACTCompileTest(TestCase):
         other_dtype = elem.double()
         r3 = compiled_fn(other_dtype)
         self.assertEqual(r3, other_dtype * 2)
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_act_guard_rejects_unrelated_tensor_subclass(self):
+        class UnrelatedTensor(torch.Tensor):
+            pass
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled_fn = torch.compile(lambda x: x * 2, backend=cnt)
+
+        elem = torch.randn(4, 4)
+        compiled_fn(AsyncCollectiveTensor(elem))
+        self.assertEqual(cnt.frame_count, 1)
+
+        unrelated = elem.as_subclass(UnrelatedTensor)
+        result = compiled_fn(unrelated)
+        self.assertEqual(result, unrelated * 2)
         self.assertEqual(cnt.frame_count, 2)
 
     def test_act_guard_recompiles(self):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -119,6 +119,7 @@ from torch.utils.weak import TensorWeakRef
 from . import config, convert_frame, exc
 from .eval_frame import set_guard_error_hook
 from .source import (
+    AsyncCollectiveTensorSource,
     AttrProxySource,
     AttrSource,
     CallFunctionNoArgsSource,
@@ -778,6 +779,16 @@ def from_numpy(a: Any) -> torch.Tensor:
         return torch.as_tensor(a) if isinstance(a, (np.generic, np.ndarray)) else a
 
 
+def resolve_async_collective_tensor(a: Any) -> torch.Tensor | None:
+    if type(a) is torch.Tensor:
+        return a
+    module = sys.modules.get("torch.distributed._functional_collectives")
+    act_type = getattr(module, "AsyncCollectiveTensor", None)
+    if act_type is not None and type(a) is act_type:
+        return a.elem
+    return None
+
+
 # For user stack printing
 @functools.cache
 def uninteresting_files() -> set[str]:
@@ -824,6 +835,7 @@ def _get_closure_vars() -> dict[str, object]:
             "utils_device": torch.utils._device,
             "device": torch.device,
             "___from_numpy": from_numpy,
+            "___resolve_async_collective_tensor": resolve_async_collective_tensor,
             "___as_tensor": torch._as_tensor_fullprec,
             "torch": torch,
             "inspect": inspect,
@@ -1945,6 +1957,15 @@ class GuardBuilder(GuardBuilderBase):
                 raise AssertionError("base_guard_manager must not be None")
             out = base_guard_manager.lambda_manager(
                 python_lambda=lambda x: x.__tensor_flatten__()[0],
+                source=source_name,
+                example_value=example_value,
+                guard_manager_enum=guard_manager_enum,
+            )
+        elif istype(source, AsyncCollectiveTensorSource):
+            if not base_guard_manager:
+                raise AssertionError("base_guard_manager must not be None")
+            out = base_guard_manager.lambda_manager(
+                python_lambda=resolve_async_collective_tensor,
                 source=source_name,
                 example_value=example_value,
                 guard_manager_enum=guard_manager_enum,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -39,7 +39,7 @@ import weakref
 from contextlib import contextmanager
 from copy import deepcopy
 from inspect import currentframe
-from typing import Any, NamedTuple, NoReturn, TYPE_CHECKING
+from typing import Any, cast, NamedTuple, NoReturn, TYPE_CHECKING
 from typing_extensions import LiteralString, TypeAliasType, TypeVar
 from weakref import ReferenceType
 
@@ -779,13 +779,17 @@ def from_numpy(a: Any) -> torch.Tensor:
         return torch.as_tensor(a) if isinstance(a, (np.generic, np.ndarray)) else a
 
 
-def resolve_async_collective_tensor(a: Any) -> torch.Tensor | None:
+def resolve_async_collective_tensor(a: object) -> torch.Tensor | None:
     if type(a) is torch.Tensor:
         return a
-    module = sys.modules.get("torch.distributed._functional_collectives")
-    act_type = getattr(module, "AsyncCollectiveTensor", None)
+
+    from torch._functorch._aot_autograd.utils import (
+        get_loaded_async_collective_tensor_type,
+    )
+
+    act_type = get_loaded_async_collective_tensor_type()
     if act_type is not None and type(a) is act_type:
-        return a.elem
+        return cast(Any, a).elem
     return None
 
 

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1183,6 +1183,13 @@ class SubclassAttrListSource(ChainedSource):
         return "{0}.__tensor_flatten__()[0]"
 
 
+@dataclass_with_cached_hash(frozen=True)
+class AsyncCollectiveTensorSource(ChainedSource):
+    @property
+    def _name_template(self) -> str:
+        return "___resolve_async_collective_tensor({0})"
+
+
 # NB: We don't expect you to actually ever generate guards against this
 # source, it is ephemeral
 @dataclass_with_cached_hash(frozen=True)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2981,7 +2981,7 @@ class VariableBuilder:
         resolved_act_value = resolve_async_collective_tensor(value)
         is_act = resolved_act_value is not None and resolved_act_value is not value
         subclass_type = infer_subclass_type(value)
-        if subclass_type is not None and not is_act:
+        if subclass_type is not None:
             self.install_guards(GuardBuilder.TYPE_MATCH)
 
         if get_static_address_type(value) == "guarded":

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -119,7 +119,12 @@ from torch.utils.weak import TensorWeakRef
 from .. import config, graph_break_hints, mutation_guard, replay_record, trace_rules
 from ..device_interface import get_registered_device_interfaces
 from ..exc import InternalTorchDynamoError, raise_observed_exception, unimplemented
-from ..guards import GuardBuilder, install_guard, make_dupe_guard
+from ..guards import (
+    GuardBuilder,
+    install_guard,
+    make_dupe_guard,
+    resolve_async_collective_tensor,
+)
 from ..pgo import (
     auto_dynamic,
     auto_unset,
@@ -129,6 +134,7 @@ from ..pgo import (
 )
 from ..side_effects import SideEffects
 from ..source import (
+    AsyncCollectiveTensorSource,
     AttrProxySource,
     AttrSource,
     CallMethodItemSource,
@@ -2972,8 +2978,10 @@ class VariableBuilder:
             return self.tx.output.input_source_to_var[source]
 
         options = {}
+        resolved_act_value = resolve_async_collective_tensor(value)
+        is_act = resolved_act_value is not None and resolved_act_value is not value
         subclass_type = infer_subclass_type(value)
-        if subclass_type is not None:
+        if subclass_type is not None and not is_act:
             self.install_guards(GuardBuilder.TYPE_MATCH)
 
         if get_static_address_type(value) == "guarded":
@@ -3099,7 +3107,24 @@ class VariableBuilder:
         is_dtensor = torch.distributed.is_available() and isinstance(
             value, torch.distributed.tensor.DTensor
         )
-        if not is_dtensor:
+        if is_act:
+            # AOTAutograd resolves ACT inputs before execution, so guard the
+            # resolved tensor and allow an already-resolved Tensor to reuse it.
+            if resolved_act_value is None:
+                raise AssertionError("resolved ACT value must not be None")
+            resolved_source = AsyncCollectiveTensorSource(source)
+            self.tx.output.input_source_to_sizes_strides[resolved_source] = (
+                self.tx.output.input_source_to_sizes_strides[source]
+            )
+            install_guard(
+                resolved_source.make_guard(
+                    functools.partial(
+                        guard_type,
+                        value=TensorWeakRef(resolved_act_value),
+                    )
+                )
+            )
+        elif not is_dtensor:
             # We guard on the _local_tensor and the _spec, and therefore we don't
             # have to guard on the outer DTensor.
             self.install_guards(
@@ -3115,7 +3140,7 @@ class VariableBuilder:
 
         # We install TYPE_MATCH guards for traceable wrapper subclass object,
         # and recursively install corresponding guard for each inner attribute.
-        if is_traceable_wrapper_subclass(value):
+        if is_traceable_wrapper_subclass(value) and not is_act:
             # Tensor subclass guards are very expensive because they are
             # implemented in Python. Since DTensor is PyTorch-maintained class,
             # we can skip a lot of these guards.


### PR DESCRIPTION
## Summary

- Relax Dynamo's AsyncCollectiveTensor guard path so a graph compiled with a top-level ACT input can be reused when the runtime value is the already-resolved plain tensor.
- Guard the resolved tensor through a dedicated `AsyncCollectiveTensorSource`, while still recompiling for unrelated tensor subclasses and for plain Tensor -> ACT transitions.
- Keep this PR downstream of #186442, which has landed and now owns the AOTAutograd runtime ACT wait/unwrapping path. This PR no longer changes `torch/_functorch/_aot_autograd/subclass_codegen.py`.

## Test Plan

- `python -m compileall -q torch/_dynamo/guards.py torch/_dynamo/source.py torch/_dynamo/variables/builder.py test/distributed/test_c10d_functional_native.py`
- `python -m ruff check --config pyproject.toml torch/_dynamo/guards.py torch/_dynamo/source.py torch/_dynamo/variables/builder.py test/distributed/test_c10d_functional_native.py`
- `python tools/linter/adapters/pyfmt_linter.py torch/_dynamo/guards.py torch/_dynamo/source.py torch/_dynamo/variables/builder.py test/distributed/test_c10d_functional_native.py`
- `python -m pyrefly check --config pyrefly.toml torch/_dynamo/guards.py torch/_dynamo/source.py torch/_dynamo/variables/builder.py`
- `python -m pytest -q test/distributed/test_c10d_functional_native.py -k "act_guard_accepts_resolved_tensor or act_guard_rejects_unrelated_tensor_subclass or act_guard_recompiles or direct_aot_top_level_act_path_accepts_plain_runtime_input"` fails to collect locally because this source checkout is missing generated `torch/version.py`; leaving runtime coverage to CI.