### PR TITLE
Full git fetch on tag pushes so macOS release wheel builds detect the tag

### DIFF
--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -74,6 +74,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 1 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Clean PyTorch checkout

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -62,6 +62,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 1 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
           submodules: recursive
           show-progress: false
       - name: Clean PyTorch checkout


### PR DESCRIPTION
## Problem

Same issue as #187058, but for the **macOS arm64 binary wheel** build. The `wheel-build` job checks out a pinned commit SHA with the default shallow `actions/checkout` (depth 1, no tags). On a release tag push (e.g. `v2.13.0-rc1`) the tag ref is never written into that checkout, so `tagged_version()` in `.ci/pytorch/binary_populate_env.sh` (`git describe --tags --exact`, invoked per-iteration by `.ci/wheel/build_all_macos_wheels.sh`) fails. The build then falls through to the `<version>.dev<DATE>` default, producing wheels versioned `2.13.0.devYYYYMMDD` instead of the release version.

## Fix

Do a full fetch (`fetch-depth: 0`) on tag pushes and keep the shallow checkout for nightlies:

```yaml
fetch-depth: ${{ github.ref_type != 'tag' && 1 || 0 }}
fetch-tags: ${{ github.ref_type == 'tag' }}
```

The condition is negated (matching #187058) because GitHub Actions has no ternary and the `A && B || C` idiom only works when `B` is truthy; the naive `github.ref_type == 'tag' && 0 || 2` always yields the shallow value because `0` is falsy.

Only the `wheel-build` checkout is changed; the libtorch `*-extract` job uses a sparse checkout of the already-built wheel artifact and does not need the tag.

> Needs to be cherry-picked onto `release/2.13` for the RC builds to pick it up.

## Test Plan

Regenerated the workflows from the template and confirmed only the macOS wheel workflow changed, with the conditional fetch on the build job's checkout:

```
python3 .github/scripts/generate_ci_workflows.py
git diff --stat .github/workflows
```

Validated the regenerated YAML parses and passes actionlint (the only reported shellcheck warning, `SC2086` on `uv python install $DESIRED_PYTHONS`, is pre-existing and unrelated):

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml'))"
lintrunner --take ACTIONLINT .github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
```

*This PR was authored with the assistance of an AI coding agent.*