### PR TITLE
Add _single c10d::Backend methods and migrate backends to them (#187140)

### DIFF
--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -461,7 +461,7 @@ void testAlltoall(const std::string& path, const at::DeviceType b) {
   enableProfilerLegacy(ProfilerConfig(
       ProfilerState::CPU, /* report_input_shapes */ true, false));
   for (const auto rank : c10::irange(size)) {
-    work[rank] = tests[rank].getProcessGroup().alltoall_base(
+    work[rank] = tests[rank].getProcessGroup().all_to_all_single(
         outputs[rank], inputs[rank], outputSplits[rank], inputSplits[rank]);
   }
 

--- a/test/cpp/c10d/ProcessGroupMPITest.cpp
+++ b/test/cpp/c10d/ProcessGroupMPITest.cpp
@@ -199,7 +199,8 @@ void testAllgatherBase(int iter = 10000) {
     auto output = at::zeros({worldSize, 16, 16});
 
     // Queue the work.
-    c10::intrusive_ptr<::c10d::Work> work = pg->_allgather_base(output, tensor);
+    c10::intrusive_ptr<::c10d::Work> work =
+        pg->all_gather_single(output, tensor);
     works.push_back(std::move(work));
   }
 
@@ -274,7 +275,7 @@ void testReduceScatterBase(int iter = 10000) {
 
     // Queue the work.
     c10::intrusive_ptr<::c10d::Work> work =
-        pg->_reduce_scatter_base(output, tensor);
+        pg->reduce_scatter_single(output, tensor);
     works.push_back(std::move(work));
   }
 

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -326,7 +326,7 @@ class AllgatherBaseNCCLTest : public NCCLTest {
     // contains at least one element otherwise wouldn't run.
     // this is a flattened allgather, hence one rank contributes
     // only 1 tensor, regardless of number of devices
-    return pg_->_allgather_base(output_tensor_, tensors_[0]);
+    return pg_->all_gather_single(output_tensor_, tensors_[0]);
   }
 
   at::Tensor getOutputTensor() {
@@ -381,7 +381,7 @@ class ReduceScatterBaseNCCLTest : public NCCLTest {
     at::cuda::CUDAMultiStreamGuard guard(streams_);
 
     launchDeviceSleep();
-    return pg_->_reduce_scatter_base(output_tensor_, input_tensor_);
+    return pg_->reduce_scatter_single(output_tensor_, input_tensor_);
   }
 
   at::Tensor getOutputTensor() {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -236,7 +236,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce(
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
-c10::intrusive_ptr<Work> ProcessGroupOCCL::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& /* opts */) {
@@ -245,7 +245,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::_reduce_scatter_base(
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
-c10::intrusive_ptr<Work> ProcessGroupOCCL::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupOCCL::all_gather_single(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& /* opts */) {
@@ -272,7 +272,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_coalesced(
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
-c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_into_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupOCCL::all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& /* opts */) {
@@ -308,7 +308,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter(
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
-c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ReduceScatterOptions& /* opts */) {
@@ -317,7 +317,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_tensor_coalesced(
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
-c10::intrusive_ptr<Work> ProcessGroupOCCL::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupOCCL::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& /* outputCounts */,

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -88,12 +88,12 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts = ReduceOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -108,7 +108,7 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     std::vector<at::Tensor>& input_list,
     const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -128,12 +128,12 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     std::vector<std::vector<at::Tensor>>& inputs,
     const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputCounts,

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -42,6 +42,37 @@ enum class ErrorType {
   REMOTE_ERROR = 3
 };
 
+namespace {
+// RAII helper for C10D_BACKEND_FORWARDING_GUARD (below): sets the re-entry flag
+// while a canonical `_single` collective forwards to its deprecated alias, and
+// clears it on scope exit (including exceptions).
+struct ForwardingGuard {
+  bool& flag_;
+  explicit ForwardingGuard(bool& flag) : flag_(flag) {
+    flag_ = true;
+  }
+  ~ForwardingGuard() {
+    flag_ = false;
+  }
+};
+} // namespace
+
+// Guards a canonical `_single` collective method against infinite recursion.
+// Each `_single` method and its deprecated alias forward to each other so that
+// a Backend subclass may override (and a caller may call) either name. Placed
+// at the top of each canonical method, this macro declares a thread-local
+// re-entry flag and -- if neither name is overridden -- reports "Backend <name>
+// does not support <method>" (using __func__) instead of looping forever.
+#define C10D_BACKEND_FORWARDING_GUARD()                 \
+  static thread_local bool forwardingGuardFlag = false; \
+  TORCH_CHECK(                                          \
+      !forwardingGuardFlag,                             \
+      "Backend ",                                       \
+      getBackendName(),                                 \
+      " does not support ",                             \
+      __func__);                                        \
+  ForwardingGuard forwardingGuard(forwardingGuardFlag)
+
 class TORCH_API Backend : public torch::CustomClassHolder {
  public:
   // Backend Options is a base struct that defines the basic options
@@ -273,15 +304,23 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   // Gathers a single tensor inputBuffer into a single buffer outputBuffer that
   // is interpreted as a contiguous collection of size inputBuffer * WORLD_SIZE.
   // For implementers of ProcessGroup API and advanced users only.
-  // Note: this function will be deprecated in near future.
+  // Named after the torchcomms backend naming scheme.
+  virtual c10::intrusive_ptr<Work> all_gather_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    C10D_BACKEND_FORWARDING_GUARD();
+    return _allgather_base(outputBuffer, inputBuffer, opts);
+  }
+
+  // Deprecated: use all_gather_single instead. Kept as an overridable,
+  // forwarding alias for backward compatibility with existing backends and
+  // callers.
   virtual c10::intrusive_ptr<Work> _allgather_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "Backend ", getBackendName(), " does not support _allgather_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    return all_gather_single(outputBuffer, inputBuffer, opts);
   }
 
   // This function is deprecated and will be moved out of Backend to comms:
@@ -300,19 +339,25 @@ class TORCH_API Backend : public torch::CustomClassHolder {
             " does not support allgather_coalesced"));
   }
 
-  // This function is a coalesced version of `allgather_into_tensor` (currently
-  // still named as `_allgather_base`). Each tensor in the vector corresponds to
-  // an input/output of one `allgather_into_tensor` operation.
+  // This function is a coalesced version of `all_gather_single`. Each tensor in
+  // the vector corresponds to an input/output of one `all_gather_single`
+  // operation. Named after the torchcomms backend naming scheme.
+  virtual c10::intrusive_ptr<Work> all_gather_single_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    C10D_BACKEND_FORWARDING_GUARD();
+    return allgather_into_tensor_coalesced(outputs, inputs, opts);
+  }
+
+  // Deprecated: use all_gather_single_coalesced instead. Kept as an
+  // overridable, forwarding alias for backward compatibility with existing
+  // backends and callers.
   virtual c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
-      std::vector<at::Tensor>& /* outputs */,
-      std::vector<at::Tensor>& /* inputs */,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "Backend ",
-            getBackendName(),
-            " does not support allgather_into_tensor_coalesced"));
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    return all_gather_single_coalesced(outputs, inputs, opts);
   }
 
   virtual c10::intrusive_ptr<Work> gather(
@@ -343,43 +388,70 @@ class TORCH_API Backend : public torch::CustomClassHolder {
             "Backend ", getBackendName(), " does not support reduce_scatter"));
   }
 
+  // Named after the torchcomms backend naming scheme.
+  virtual c10::intrusive_ptr<Work> reduce_scatter_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    C10D_BACKEND_FORWARDING_GUARD();
+    return _reduce_scatter_base(outputBuffer, inputBuffer, opts);
+  }
+
+  // Deprecated: use reduce_scatter_single instead. Kept as an overridable,
+  // forwarding alias for backward compatibility with existing backends and
+  // callers.
   virtual c10::intrusive_ptr<Work> _reduce_scatter_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      const ReduceScatterOptions& /* opts */ = ReduceScatterOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "Backend ",
-            getBackendName(),
-            " does not support _reduce_scatter_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    return reduce_scatter_single(outputBuffer, inputBuffer, opts);
   }
 
-  // This function is a coalesced version of `reduce_scatter_tensor` (currently
-  // still named as `_reduce_scatter_base`). Each tensor in the vector
-  // corresponds to an input/output of one `reduce_scatter_tensor` operation.
+  // This function is a coalesced version of `reduce_scatter_single`. Each
+  // tensor in the vector corresponds to an input/output of one
+  // `reduce_scatter_single` operation. Named after the torchcomms backend
+  // naming scheme.
+  virtual c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    C10D_BACKEND_FORWARDING_GUARD();
+    return reduce_scatter_tensor_coalesced(outputs, inputs, opts);
+  }
+
+  // Deprecated: use reduce_scatter_single_coalesced instead. Kept as an
+  // overridable, forwarding alias for backward compatibility with existing
+  // backends and callers.
   virtual c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
-      std::vector<at::Tensor>& /* outputs */,
-      std::vector<at::Tensor>& /* inputs */,
-      const ReduceScatterOptions& /* opts */ = ReduceScatterOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "Backend ",
-            getBackendName(),
-            " does not support reduce_scatter_tensor_coalesced"));
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    return reduce_scatter_single_coalesced(outputs, inputs, opts);
   }
 
+  // Named after the torchcomms backend naming scheme.
+  virtual c10::intrusive_ptr<Work> all_to_all_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) {
+    C10D_BACKEND_FORWARDING_GUARD();
+    return alltoall_base(
+        outputBuffer, inputBuffer, outputSplitSizes, inputSplitSizes, opts);
+  }
+
+  // Deprecated: use all_to_all_single instead. Kept as an overridable,
+  // forwarding alias for backward compatibility with existing backends and
+  // callers.
   virtual c10::intrusive_ptr<Work> alltoall_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      std::vector<int64_t>& /* outputSplitSizes */,
-      std::vector<int64_t>& /* inputSplitSizes */,
-      const AllToAllOptions& /* opts */ = AllToAllOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "Backend ", getBackendName(), " does not support alltoall_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) {
+    return all_to_all_single(
+        outputBuffer, inputBuffer, outputSplitSizes, inputSplitSizes, opts);
   }
 
   virtual c10::intrusive_ptr<Work> alltoall(
@@ -630,3 +702,5 @@ class TORCH_API Backend : public torch::CustomClassHolder {
 };
 
 } // namespace c10d
+
+#undef C10D_BACKEND_FORWARDING_GUARD

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -102,7 +102,7 @@ class FakeProcessGroup : public Backend {
     return c10::make_intrusive<FakeWork>();
   }
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
@@ -140,7 +140,7 @@ class FakeProcessGroup : public Backend {
     return c10::make_intrusive<FakeWork>();
   }
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
@@ -223,7 +223,7 @@ class FakeProcessGroup : public Backend {
     return c10::make_intrusive<FakeWork>();
   }
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const ReduceScatterOptions& /* opts */ =
@@ -239,7 +239,7 @@ class FakeProcessGroup : public Backend {
     return c10::make_intrusive<FakeWork>();
   }
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const ReduceScatterOptions& /* opts */ =
@@ -263,7 +263,7 @@ class FakeProcessGroup : public Backend {
     return c10::make_intrusive<FakeWork>();
   }
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       std::vector<int64_t>& outputSplitSizes,

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -250,7 +250,7 @@ IMPL_ALLGATHER(PrivateUse1)
       bool asyncOp,                                                        \
       int64_t timeout) {                                                   \
     auto work = process_group->getBackend(c10::DeviceType::DEV)            \
-                    ->_allgather_base(                                     \
+                    ->all_gather_single(                                   \
                         output_tensor,                                     \
                         input_tensor,                                      \
                         AllgatherOptions{                                  \
@@ -294,7 +294,7 @@ IMPL_ALLGATHER_COALESCED(PrivateUse1)
     auto opts = AllgatherOptions{};                                     \
     opts.asyncOp = asyncOp;                                             \
     return process_group->getBackend(c10::DeviceType::DEV)              \
-        ->allgather_into_tensor_coalesced(output_vec, input_vec, opts); \
+        ->all_gather_single_coalesced(output_vec, input_vec, opts);     \
   }
 
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CPU)
@@ -337,7 +337,7 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
       bool asyncOp,                                                            \
       int64_t timeout) {                                                       \
     auto work = process_group->getBackend(c10::DeviceType::DEV)                \
-                    ->_reduce_scatter_base(                                    \
+                    ->reduce_scatter_single(                                   \
                         output_tensor,                                         \
                         input_tensor,                                          \
                         ReduceScatterOptions{                                  \
@@ -363,7 +363,7 @@ IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
     auto output_vec = outputs.vec();                                    \
     auto input_vec = inputs.vec();                                      \
     return process_group->getBackend(c10::DeviceType::DEV)              \
-        ->reduce_scatter_tensor_coalesced(                              \
+        ->reduce_scatter_single_coalesced(                              \
             output_vec,                                                 \
             input_vec,                                                  \
             ReduceScatterOptions{                                       \
@@ -456,7 +456,7 @@ IMPL_ALLTOALL(PrivateUse1)
       bool asyncOp,                                                        \
       int64_t timeout) {                                                   \
     return process_group->getBackend(c10::DeviceType::DEV)                 \
-        ->alltoall_base(                                                   \
+        ->all_to_all_single(                                               \
             output,                                                        \
             input,                                                         \
             output_split_sizes,                                            \

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -1513,16 +1513,16 @@ class LambdaWork : public Work {
 
 } // namespace
 
-c10::intrusive_ptr<Work> ProcessGroupGloo::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts) {
   std::vector<at::Tensor> outputTensors = {outputTensor};
   std::vector<at::Tensor> inputTensors = {inputTensor};
-  return reduce_scatter_tensor_coalesced(outputTensors, inputTensors, opts);
+  return reduce_scatter_single_coalesced(outputTensors, inputTensors, opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ReduceScatterOptions& opts) {
@@ -1561,7 +1561,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_tensor_coalesced(
       });
 }
 
-c10::intrusive_ptr<Work> ProcessGroupGloo::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupGloo::all_gather_single(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& opts) {
@@ -1766,7 +1766,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allgather_coalesced(
   return work;
 }
 
-c10::intrusive_ptr<Work> ProcessGroupGloo::allgather_into_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupGloo::all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts) {
@@ -2385,7 +2385,7 @@ class AsyncAlltoallCUDAWork : public AsyncAlltoallWork {
 
 } // namespace
 
-c10::intrusive_ptr<Work> ProcessGroupGloo::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupGloo::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputCounts,

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -349,12 +349,12 @@ class TORCH_API ProcessGroupGloo : public Backend {
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& output_tensor,
       at::Tensor& input_tensor,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -369,7 +369,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
       std::vector<at::Tensor>& input_list,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -389,12 +389,12 @@ class TORCH_API ProcessGroupGloo : public Backend {
       std::vector<std::vector<at::Tensor>>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputCounts,

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -757,7 +757,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::reduce_scatter(
       std::optional<std::vector<at::Tensor>>(inputTensors[0]));
 }
 
-c10::intrusive_ptr<Work> ProcessGroupMPI::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupMPI::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -999,7 +999,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::barrier(const BarrierOptions& opts) {
   return enqueue(std::move(entry), "mpi:barrier", std::nullopt);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupMPI::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupMPI::all_gather_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const AllgatherOptions& opts) {
@@ -1033,7 +1033,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::_allgather_base(
       std::optional<std::vector<at::Tensor>>(inputTensors));
 }
 
-c10::intrusive_ptr<Work> ProcessGroupMPI::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupMPI::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts) {

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -172,7 +172,7 @@ class TORCH_API ProcessGroupMPI : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputbuffer,
       at::Tensor& inputbuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -197,12 +197,12 @@ class TORCH_API ProcessGroupMPI : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -4966,7 +4966,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather_coalesced(
       "ProcessGroupNCCL does not support allgather_coalesced");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather_into_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupNCCL::all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts) {
@@ -5116,7 +5116,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter(
   }
 }
 
-c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts) {
@@ -5196,7 +5196,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
       "nccl:_reduce_scatter_base");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const ReduceScatterOptions& opts) {
@@ -5353,7 +5353,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::barrier(const BarrierOptions& opts) {
   return nullptr;
 }
 
-c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupNCCL::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -5799,7 +5799,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recvAnysource(
       NotImplementedError, "ProcessGroupNCCL does not support recvAnysource");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupNCCL::all_gather_single(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& opts) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -861,7 +861,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputbuffer,
       at::Tensor& inputbuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -871,7 +871,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -881,12 +881,12 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
@@ -894,7 +894,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -962,7 +962,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::allgather(
   }
 }
 
-c10::intrusive_ptr<Work> ProcessGroupUCC::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupUCC::all_gather_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const AllgatherOptions& opts) {
@@ -1107,7 +1107,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::alltoall(
       "ucc:alltoall");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupUCC::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupUCC::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -1457,7 +1457,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::reduce_scatter(
       "ucc:reduce_scatter");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupUCC::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupUCC::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts) {

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
@@ -209,7 +209,7 @@ class TORCH_API ProcessGroupUCC : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -232,12 +232,12 @@ class TORCH_API ProcessGroupUCC : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -442,13 +442,13 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather(
   return backend_->allgather(outputTensors, inputTensors, opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupWrapper::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupWrapper::all_gather_single(
     at::Tensor& outputBuffer,
     at::Tensor& inputBuffer,
     const AllgatherOptions& opts) {
   std::vector<at::Tensor> inputTensors({inputBuffer});
   runCollectiveChecks(OpType::_ALLGATHER_BASE, inputTensors);
-  return backend_->_allgather_base(outputBuffer, inputBuffer, opts);
+  return backend_->all_gather_single(outputBuffer, inputBuffer, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather_coalesced(
@@ -463,11 +463,11 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather_coalesced(
   return backend_->allgather_coalesced(outputTensorLists, inputTensors, opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather_into_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupWrapper::all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts) {
-  return backend_->allgather_into_tensor_coalesced(outputs, inputs, opts);
+  return backend_->all_gather_single_coalesced(outputs, inputs, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::gather(
@@ -498,7 +498,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter(
   return backend_->reduce_scatter(outputTensors, inputTensors, opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupWrapper::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupWrapper::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -506,7 +506,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::alltoall_base(
     const AllToAllOptions& opts) {
   // alltoall supports uneven split, so don't enforce shape checking.
   runCollectiveChecks(OpType::ALLTOALL_BASE, {});
-  return backend_->alltoall_base(
+  return backend_->all_to_all_single(
       outputTensor, inputTensor, outputSplitSizes, inputSplitSizes, opts);
 }
 
@@ -563,16 +563,16 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::barrier(
   return backend_->barrier(opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupWrapper::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter_single(
     at::Tensor& outputBuffer,
     at::Tensor& inputBuffer,
     const ReduceScatterOptions& opts) {
   runCollectiveChecks(
       OpType::_REDUCE_SCATTER_BASE, {inputBuffer, outputBuffer});
-  return backend_->_reduce_scatter_base(outputBuffer, inputBuffer, opts);
+  return backend_->reduce_scatter_single(outputBuffer, inputBuffer, opts);
 }
 
-c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const ReduceScatterOptions& opts) {
@@ -581,7 +581,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter_tensor_coalesced(
   // use inconsistent shapes, see python implementation in distributed_c10d for
   // details.
   runCollectiveChecks(OpType::REDUCE_SCATTER_TENSOR_COALESCED, {});
-  return backend_->reduce_scatter_tensor_coalesced(outputs, inputs, opts);
+  return backend_->reduce_scatter_single_coalesced(outputs, inputs, opts);
 }
 
 void ProcessGroupWrapper::startCoalescing() {

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -49,7 +49,7 @@ class TORCH_API ProcessGroupWrapper : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -63,7 +63,7 @@ class TORCH_API ProcessGroupWrapper : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -83,17 +83,17 @@ class TORCH_API ProcessGroupWrapper : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& inputBuffer,
       at::Tensor& outputBuffer,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3301,8 +3301,18 @@ Arguments:
               py::arg("opts") = ::c10d::AllgatherOptions(),
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "all_gather_single",
+              &::c10d::Backend::all_gather_single,
+              py::arg("output"),
+              py::arg("input"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          // Deprecated alias of all_gather_single, kept for backward
+          // compatibility. Bound to all_gather_single to avoid referencing the
+          // deprecated C++ method.
+          .def(
               "_allgather_base",
-              &::c10d::Backend::_allgather_base,
+              &::c10d::Backend::all_gather_single,
               py::arg("output"),
               py::arg("input"),
               py::arg("opts") = ::c10d::AllgatherOptions(),
@@ -3415,15 +3425,37 @@ Arguments:
               py::arg("timeout") = ::c10d::kUnsetTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "reduce_scatter_single",
+              &::c10d::Backend::reduce_scatter_single,
+              py::arg("outputTensor"),
+              py::arg("inputTensor"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          // Deprecated alias of reduce_scatter_single, kept for backward
+          // compatibility. Bound to reduce_scatter_single to avoid referencing
+          // the deprecated C++ method.
+          .def(
               "_reduce_scatter_base",
-              &::c10d::Backend::_reduce_scatter_base,
+              &::c10d::Backend::reduce_scatter_single,
               py::arg("outputTensor"),
               py::arg("inputTensor"),
               py::arg("opts") = ::c10d::ReduceScatterOptions(),
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "all_to_all_single",
+              &::c10d::Backend::all_to_all_single,
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          // Deprecated alias of all_to_all_single, kept for backward
+          // compatibility. Bound to all_to_all_single to avoid referencing the
+          // deprecated C++ method.
+          .def(
               "alltoall_base",
-              &::c10d::Backend::alltoall_base,
+              &::c10d::Backend::all_to_all_single,
               py::arg("output_tensor"),
               py::arg("input_tensor"),
               py::arg("output_split_sizes"),
@@ -3440,7 +3472,7 @@ Arguments:
                  std::chrono::milliseconds timeout) {
                 ::c10d::AllToAllOptions opts;
                 opts.timeout = timeout;
-                return self.alltoall_base(
+                return self.all_to_all_single(
                     output, input, outputSplitSizes, inputSplitSizes, opts);
               },
               py::arg("output"),

--- a/torch/csrc/distributed/c10d/nccl/NCCLXStub.hpp
+++ b/torch/csrc/distributed/c10d/nccl/NCCLXStub.hpp
@@ -50,11 +50,11 @@ class NCCLXStub : public Backend {
     return nccl_->allgather(outputTensors, inputTensors, opts);
   }
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override {
-    return nccl_->_allgather_base(outputBuffer, inputBuffer, opts);
+    return nccl_->all_gather_single(outputBuffer, inputBuffer, opts);
   }
 
   c10::intrusive_ptr<Work> barrier(


### PR DESCRIPTION
Summary:

Introduce the torchcomms `_single` collective names on the C++ `c10d::Backend` and migrate the in-tree backends to define them, while keeping the old names fully working for backward compatibility.

`Backend` now declares `all_gather_single`, `all_gather_single_coalesced`, `reduce_scatter_single`, `reduce_scatter_single_coalesced`, and `all_to_all_single` alongside the existing `_allgather_base`, `allgather_into_tensor_coalesced`, `_reduce_scatter_base`, `reduce_scatter_tensor_coalesced`, and `alltoall_base`, which are kept as overridable, forwarding aliases.

Backward compatibility is preserved in both directions: each new method and its old-name alias forward to each other, so a `Backend` subclass may override EITHER name and a caller may invoke EITHER name. The old aliases simply forward to the canonical `_single` method; each canonical method opens with the `C10D_BACKEND_FORWARDING_GUARD()` macro, which installs a function-local thread-local re-entry flag using `__func__` for the message. If a backend overrides neither name the mutual forwarding re-enters the canonical method, the flag trips, and it reports "does not support <method>" instead of recursing forever. As a result, existing callers of the old names (first-party and out-of-tree) and existing out-of-tree backends that override the old names both keep working unchanged. Removing the old overrides outright would have broken out-of-tree backends on the dispatch path, and dropping the old caller-facing names would have broken direct callers; the bidirectional forwarding avoids both.

The old names are intentionally NOT marked `C10_DEPRECATED_MESSAGE` in this change. PyTorch's open-source build compiles the bundled `third_party/torch-xpu-ops` submodule with `-Werror -Wdeprecated`, and its XPU collective op registration (`xccl/Register.cpp`) still calls the old `Backend` names, so a compile-time deprecation turns into a hard build error there. The deprecation will be reintroduced in a follow-up once those callers (and any other out-of-tree backends that are built in-tree) are migrated to the `_single` names and the submodule pin is bumped.

The in-tree backends are migrated to define the new names: `ProcessGroupNCCL`, `ProcessGroupGloo`, `ProcessGroupMPI`, `ProcessGroupUCC`, `ProcessGroupWrapper`, `FakeProcessGroup`, `NCCLXStub`, and the `torch_openreg` (`ProcessGroupOCCL`) test backend. The dispatcher op implementations in `Ops.cpp`, `ProcessGroupWrapper`'s forwarders, and the `Backend` pybind bindings in `init.cpp` use the new names.

The underlying aten / c10d dispatcher op names (`c10d::_allgather_base_`, `c10d::alltoall_base_`, etc.), their schema strings, the `IMPL_*` macro names in `Ops.cpp`, and the `OpType` enum values are intentionally left unchanged for backward compatibility.

Suggested review order: `Backend.hpp` (the new/old method pairs and the bidirectional forwarding + `ForwardingGuard`), then the per-backend subclass renames, then the `Ops.cpp` / `ProcessGroupWrapper` / `init.cpp` call sites.

This diff was authored with the assistance of an AI coding agent (Claude).

Test Plan:
This revision only removes the compile-time deprecation annotations (`C10_DEPRECATED_MESSAGE`), their `-Wdeprecated-declarations` suppressions, and the now-unused `<c10/util/Deprecated.h>` include. The `_single` rename and the bidirectional forwarding/recursion guard are unchanged, so there is no runtime or codegen change -- dropping the annotations only removes deprecation warnings.

Verified by open-source CI on the exported commit: the full libtorch build across platforms, the `linux-noble-xpu-n-py3.10 / build-osdc` job (which compiles the bundled `torch-xpu-ops` `xccl/Register.cpp` with `-Werror -Wdeprecated` and previously failed on `-Werror=deprecated-declarations`), and the `lintrunner-clang` format jobs.

Reviewed By: kapilsh

Differential Revision: D108364288


