### PR TITLE
[Inductor][XPU] Fix combo kernel no-bench carve-out gate for XPU

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -888,11 +888,11 @@ class ComboKernelTests(TestCase):
         }
     )
     def test_combo_kernel_no_bench_carve_out(self):
-        # torch.bucketize triggers carve-out under both gate variants:
+        # torch.bucketize triggers carve-out under all gate variants:
         #   CUDA: pointwise heuristic returns 3 configs (>2) -> carve out
-        #   ROCm: lowering sets AutotuneHint.ONE_ELEMENT_PER_THREAD -> carve out
-        # Simple pointwise (b*2.0, c+1.0) passes both gates -> fuses into combo.
-        # Expect 1 combo + 1 standalone on both backends.
+        #   ROCm/XPU: lowering sets AutotuneHint.ONE_ELEMENT_PER_THREAD -> carve out
+        # Simple pointwise (b*2.0, c+1.0) passes all gates -> fuses into combo.
+        # Expect 1 combo + 1 standalone on all backends.
         def fn(a, b, c, boundaries):
             return torch.bucketize(a, boundaries), b * 2.0, c + 1.0
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3732,7 +3732,7 @@ class SIMDScheduling(BaseScheduling):
                         configs, probe_kernel = self._probe_subkernel_heuristic(
                             node_schedule_map[pn]
                         )
-                        if torch.version.hip:
+                        if torch.version.hip or torch.xpu.is_available():
                             fuse_ok = configs and not probe_kernel.autotune_hints
                         else:
                             fuse_ok = configs and len(configs) <= 2


### PR DESCRIPTION
## Summary

The no-bench per-subkernel combo kernel gate in `simd.py` decides whether to fuse a subkernel into the combo or carve it out to a standalone kernel based on how many autotune configs its heuristic produces:

- **CUDA**: `fuse_ok = configs and len(configs) <= 2`
- **HIP**: `fuse_ok = configs and not probe_kernel.autotune_hints`

XPU's `pointwise()` heuristic appends extra device-specific configs beyond the CUDA baseline (+1 for 1D, +2 for 2D SQUARE), making `len(configs) > 2` even for simple ops like relu/sigmoid/tanh. This caused all pointwise subkernels — including ones that should fuse — to be carved out, generating N standalone kernels instead of 1 combo kernel.

**Root cause:** the `len(configs) <= 2` gate was written for CUDA's fixed config count and does not account for XPU's extra heuristic configs. The HIP gate (`not probe_kernel.autotune_hints`) avoids this problem because it tests for operator-level constraints rather than counting backend-specific config candidates.

**Fix:** extend the `autotune_hints` gate to XPU, same as HIP:

```python
if torch.version.hip or torch.xpu.is_available():
    fuse_ok = configs and not probe_kernel.autotune_hints
else:
    fuse_ok = configs and len(configs) <= 2
```

This correctly handles all cases on XPU:
- Simple pointwise (relu/sigmoid/tanh): `autotune_hints` empty → fuse ✓
- Persistent reduction (`a.sum(-1)`): `autotune_hints` empty → fuse ✓
- `bucketize`: lowering sets `ONE_ELEMENT_PER_THREAD` hint → `autotune_hints` non-empty → carve out ✓

Fixes:
- Fixes #187031 DISABLED `test_combo_kernel_no_bench_stitched_config` (xpu)
- Fixes #187019 DISABLED `test_combo_kernel_no_bench_persistent_reduction` (xpu)
- Fixes #186782 DISABLED `test_combo_kernel_no_bench_carve_out` (xpu)
- Fixes #187120 DISABLED `test_dynamic_shapes_activations_no_autotune` (ComboKernelDynamicShapesTestsPerSubkernelBlocks, xpu)
- Fixes #187122 DISABLED `test_dynamic_shapes_activations_no_autotune` (ComboKernelDynamicShapesTestsPerSubkernelBlocks, xpu)

## Test Plan

```
pytest test/inductor/test_combo_kernels.py -v -k \
  'test_combo_kernel_no_bench_stitched_config or \
   test_combo_kernel_no_bench_persistent_reduction or \
   test_combo_kernel_no_bench_carve_out or \
   test_dynamic_shapes_activations_no_autotune'
```

To be verified on XPU CI once the DISABLED issues are re-enabled.

cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey @xuhancn

Authored with the assistance of Claude.