### PR TITLE
[DTensor] Avoid guarding on unbacked transpose shardability

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -308,6 +308,58 @@ class TestCostModel(DTensorOpTestBase):
             )
             self.assertFalse(output_sharding.needs_redistribute)
 
+    def test_t_prunes_unproven_unbacked_strided_shard_candidates(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.distributed.tensor._ops.utils import is_tensor_shardable
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        mesh = DeviceMesh("cpu", torch.arange(2), _init_backend=False, _rank=0)
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        strategy_info = (
+            DTensor._op_dispatcher.sharding_propagator.op_single_dim_strategy_funcs[
+                torch.ops.aten.t.default
+            ]
+        )
+        self.assertFalse(strategy_info.allow_unbacked_sharding)
+
+        with fake_mode:
+            split_factor = fake_mode.shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(split_factor, 8)
+            input_meta = TensorMeta(
+                torch.Size([2048 * split_factor, 8]),
+                (8, 1),
+                torch.float32,
+            )
+
+            unproven_input_spec = DTensorSpec(
+                mesh,
+                (_StridedShard(1, split_factor=split_factor),),
+                input_meta,
+            )
+            self.assertFalse(
+                is_tensor_shardable(
+                    input_meta.shape,
+                    unproven_input_spec,
+                    allow_unbacked_sharding=strategy_info.allow_unbacked_sharding,
+                )
+            )
+
+            input_spec = DTensorSpec(
+                mesh,
+                (_StridedShard(0, split_factor=split_factor),),
+                input_meta,
+            )
+            op_schema = OpSchema(torch.ops.aten.t.default, (input_spec,), {})
+            output_sharding = DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding_non_cached(
+                op_schema
+            )
+
+        self.assertFalse(output_sharding.needs_redistribute)
+        self.assertEqual(
+            output_sharding.output_spec.placements,
+            (_StridedShard(1, split_factor=split_factor),),
+        )
+
     def test_bmm_strategies(self):
         mesh = self.build_device_mesh()
         lhs_tensor = torch.randn(8, 6, 8)

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -37,7 +37,7 @@ from torch.fx.experimental.symbolic_shapes import guard_or_false
 aten = torch.ops.aten
 
 
-@register_single_dim_strategy(aten.t.default)
+@register_single_dim_strategy(aten.t.default, allow_unbacked_sharding=False)
 def transpose_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:


### PR DESCRIPTION

The `aten.t` single-dim strategy can enumerate candidate placements that move a
symbolic `_StridedShard` split factor onto the other tensor dimension. When that
candidate is not provably shardable, strategy expansion must reject it instead
of evaluating a Python bool on an unbacked expression such as `8 < 2*u0`.

Register transpose with `allow_unbacked_sharding=False` so shardability checks
use data-dependent-safe rejection for unproven candidates. Candidates that are
statically valid are still kept, so the valid `_StridedShard(0, u0)` input case
continues to propagate to `_StridedShard(1, u0)` on the transposed output.

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python -m pytest test/distributed/tensor/test_op_strategy.py::TestCostModel::test_t_prunes_unproven_unbacked_strided_shard_candidates -q -s
```

```bash
python -m pytest test/distributed/tensor/test_op_strategy.py::TestCostModel::test_mm_strategies test/distributed/tensor/test_op_strategy.py::TestCostModel::test_t_prunes_unproven_unbacked_strided_shard_candidates -q -s
```

```bash
python -m pytest test/distributed/tensor/test_dtensor_compile.py::TestDTensorCompile::test_to_local_backward_unbacked_symbolic_stride -q -s
```

```bash
lintrunner -a
```