### PR TITLE
[MPS] Migrate sigmoid_backward from MPSGraph to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -303,3 +303,23 @@ REGISTER_BINARY_OP(gelu_backward, bfloat, bfloat);
 REGISTER_BINARY_OP(gelu_tanh_backward, float, float);
 REGISTER_BINARY_OP(gelu_tanh_backward, half, half);
 REGISTER_BINARY_OP(gelu_tanh_backward, bfloat, bfloat);
+
+struct sigmoid_backward_functor {
+  template <typename T, enable_if_t<is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    const float of = float(output);
+    return static_cast<T>(float(grad_output) * (1.0f - of) * of);
+  }
+  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    return c10::metal::mul(
+        grad_output,
+        c10::metal::conj(c10::metal::mul(T(1, 0) - output, output)));
+  }
+};
+
+REGISTER_BINARY_OP(sigmoid_backward, float, float);
+REGISTER_BINARY_OP(sigmoid_backward, half, half);
+REGISTER_BINARY_OP(sigmoid_backward, bfloat, bfloat);
+REGISTER_BINARY_OP(sigmoid_backward, float2, float2);
+REGISTER_BINARY_OP(sigmoid_backward, half2, half2);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -22,7 +22,6 @@
 #include <ATen/ops/mish_backward_native.h>
 #include <ATen/ops/mish_native.h>
 #include <ATen/ops/relu_native.h>
-#include <ATen/ops/sigmoid_backward_native.h>
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
 #include <ATen/ops/tanh_backward_native.h>
@@ -259,48 +258,6 @@ Tensor log_sigmoid_backward_mps(const Tensor& grad_output, const Tensor& self, c
   auto grad_input = at::empty_like(grad_output);
   log_sigmoid_backward_mps_out(grad_output, self, buffer, grad_input);
   return grad_input;
-}
-
-TORCH_IMPL_FUNC(sigmoid_backward_out_mps)(const Tensor& grad_output, const Tensor& output, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(grad_input.is_mps());
-
-  if (grad_output.numel() == 0) {
-    return;
-  }
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "sigmoid_backward_out_mps:" + getMPSTypeString(grad_output);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* oneMinusSigmoidTensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                     secondaryTensor:outputTensor
-                                                                                name:nil];
-      MPSGraphTensor* timesTensor = [mpsGraph multiplicationWithPrimaryTensor:oneMinusSigmoidTensor
-                                                              secondaryTensor:outputTensor
-                                                                         name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                  secondaryTensor:timesTensor
-                                                                             name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, outputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
-  }
 }
 
 TORCH_IMPL_FUNC(tanh_backward_out_mps)(const Tensor& grad_output, const Tensor& output, const Tensor& grad_input) {

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -14,8 +14,10 @@
 #include <ATen/ops/relu_native.h>
 #include <ATen/ops/rsub.h>
 #include <ATen/ops/sigmoid.h>
+#include <ATen/ops/sigmoid_backward_native.h>
 #include <ATen/ops/sigmoid_native.h>
 #endif
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/Gelu.h>
 #include <ATen/native/mps/kernels/Activation.h>
 #include <fmt/format.h>
@@ -141,6 +143,10 @@ static void gelu_backward_kernel(TensorIteratorBase& iter, GeluType approximate)
   lib.exec_binary_kernel(iter, name);
 }
 
+static void sigmoid_backward_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "sigmoid_backward");
+}
+
 REGISTER_DISPATCH(hardshrink_stub, hardshrink_kernel);
 REGISTER_DISPATCH(softshrink_stub, softshrink_kernel);
 REGISTER_DISPATCH(shrink_backward_stub, shrink_backward_kernel);
@@ -156,5 +162,6 @@ REGISTER_DISPATCH(silu_stub, silu_kernel);
 REGISTER_DISPATCH(silu_backward_stub, silu_backward_kernel);
 REGISTER_DISPATCH(GeluKernel, gelu_kernel);
 REGISTER_DISPATCH(GeluBackwardKernel, gelu_backward_kernel);
+REGISTER_DISPATCH(sigmoid_backward_stub, sigmoid_backward_kernel);
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12894,8 +12894,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: sigmoid_backward_out
-    MPS: sigmoid_backward_out_mps
+    CPU, CUDA, MPS: sigmoid_backward_out
   tags: pointwise
 
 - func: sigmoid_backward(Tensor grad_output, Tensor output) -> Tensor

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4861,16 +4861,6 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.Sigmoid,
                module_inputs_func=module_inputs_torch_nn_Sigmoid,
-               skips=None if _macos15_or_newer else (
-                   # Fails on backward check on MPS
-                   # See https://github.com/pytorch/pytorch/issues/107214
-                   DecorateInfo(
-                       unittest.expectedFailure,
-                       'TestModule',
-                       'test_memory_format',
-                       active_if=operator.itemgetter('training'),
-                       device_type='mps',
-                   ),)
                ),
     ModuleInfo(torch.nn.LogSigmoid,
                module_inputs_func=module_inputs_torch_nn_LogSigmoid,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #187151

Replace the MPSGraph-based `sigmoid_backward_out_mps` with a native Metal kernel registered through the shared `sigmoid_backward_stub`.

Complex types are handled via the conjugated derivative (`grad * conj((1 - output) * output)`), matching CUDA's behavior.

Microbenchmark (us per call, A/B from the same script with only the impl
swapped):

```
shape|dtype                      mpsgraph     metal   speedup
1024|float32                        12.81      7.43     1.72x
1024|float16                        14.82      7.10     2.09x
1024|bfloat16                       12.11      7.15     1.69x
1024x1024|float16                   18.56     14.67     1.26x
1024x1024|float32                   45.02     40.06     1.12x
8x1024x1024|float32                382.21    376.67     1.01x
32x1024x1024|float32              1487.84   1493.75     1.00x
```

Metal wins on dispatch overhead at small sizes; parity at large sizes where
the op is memory-bandwidth bound, as expected for ~3 FLOPs/element.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>