### PR TITLE
[fmha_fwd][rocm] Pad CK ck_tile FMHA seqlen allocations to fix gfx950 OOB fault on tile-unaligned shapes (#187152)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -413,6 +413,45 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     {
       attn_bias = attn_bias_;
     }
+    // === [stopgap] gfx950 CK FMHA tile-tail OOB guard ===
+    // The generated no-seqlen-pad fwd instances issue unpredicated tile loads/
+    // stores of round_up(seqlen, tile) rows. For tile-unaligned seqlens this
+    // over-reads Q/K/V and over-writes O/LSE past the tensor end, which faults
+    // ("Memory access fault by GPU node-N ... Reason: Unknown") when the buffer
+    // ends on an unmapped page (observed on MI350X AOTT lowering, fwd pass).
+    // Hand the kernel seqlen-padded *allocations* (the extra rows are mapped
+    // scratch) while leaving seqlen_q/seqlen_k unchanged, so the kernel's logical
+    // masking is identical and numerics are unchanged; the real rows are copied
+    // back into the caller-visible tensors below. Engages only for tile-unaligned
+    // seqlens on the non-swapped path; skipped when seqlenq_ngroups_swapped is
+    // active (that fast path reshapes seqlen_q into the batch/group dim, so the
+    // tile-tail over-read does not apply).
+    // Scope: covers Q/K/V (read) and O/LSE (write) only. attn_bias (bias_ptr,
+    // seqlen_q x seqlen_k) and the dropout randval buffer (p / rand_val_ptr) are
+    // touched by the same round_up(seqlen, tile) pattern but are left unpadded
+    // here -- out of scope for this stopgap (pre-existing, not in the observed
+    // fault repro; whether CK issues full-tile loads on them is upstream-
+    // dependent). The proper fix is upstream CK kPadSeqLen fwd instances.
+    // TODO: remove once CK generates/selects kPadSeqLen fwd instances upstream.
+    at::Tensor q_arg = q_padded, k_arg = k_padded, v_arg = v_padded;
+    at::Tensor out_arg = out, lse_arg = softmax_lse;
+    constexpr int kCkSeqTileLCM = 256; // >= every fwd kM0/kN0 in the generated set
+    const int seqlen_q_pad = round_multiple(seqlen_q, kCkSeqTileLCM);
+    const int seqlen_k_pad = round_multiple(seqlen_k, kCkSeqTileLCM);
+    const bool ck_oob_guard = !seqlenq_ngroups_swapped &&
+        ((seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k));
+    if (ck_oob_guard) {
+        if (seqlen_q_pad != seqlen_q) {
+            q_arg   = at::pad(q_padded, {0, 0, 0, 0, 0, seqlen_q_pad - seqlen_q});
+            out_arg = at::empty({out.size(0), seqlen_q_pad, out.size(2), out.size(3)}, out.options());
+            lse_arg = at::empty({batch_size, num_heads, seqlen_q_pad}, softmax_lse.options());
+        }
+        if (seqlen_k_pad != seqlen_k) {
+            k_arg = at::pad(k_padded, {0, 0, 0, 0, 0, seqlen_k_pad - seqlen_k});
+            v_arg = at::pad(v_padded, {0, 0, 0, 0, 0, seqlen_k_pad - seqlen_k});
+        }
+    }
+
     if (seqlen_k > 0) {
         drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
         drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
@@ -439,18 +478,23 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
                 num_heads,
                 num_heads_k,
                 head_size_8x,
-                q_padded,
-                k_padded,
-                v_padded,
+                q_arg,
+                k_arg,
+                v_arg,
                 attn_bias,
-                out,
-                softmax_lse,
+                out_arg,
+                lse_arg,
                 p,
                 softmax_scale,
                 p_dropout,
                 drop_seed_offset);
         float t = fmha_fwd(traits, args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
+        if (ck_oob_guard && seqlen_q_pad != seqlen_q) {
+            // copy the real rows out of the padded scratch into the caller tensors
+            out.copy_(out_arg.narrow(1, 0, seqlen_q));
+            softmax_lse.copy_(lse_arg.narrow(2, 0, seqlen_q));
+        }
     }
     else {
         // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.


### PR DESCRIPTION
Summary:

PROBLEM & REPRODUCE

GPU lowering of models on AMD MI350X (gfx950)
crashes deterministically with "Memory access fault by GPU node-N ... Reason:
Unknown" (SIGABRT) during the autotune forward passes. Reproduced exact crash as reported by an internal document.

ROOT CAUSE
 
on ROCm, F.scaled_dot_product_attention's flash path dispatches to
the CK ck_tile::FmhaFwd kernel. For tile-unaligned attention shapes (here
seqlen_q=4, not a multiple of kM0=16; seqlen_k=656, not a multiple of kN0=32) the
CK forward dispatcher selects a no-seqlen-pad instance (kPadSeqLenQ=
kPadSeqLenK=false). That kernel issues unpredicated full-tile loads/stores of
round_up(seqlen, tile) rows, reading past the end of Q/K/V (and writing past
O/LSE). The over-read is numerically harmless (the tail is masked out in
softmax), but it faults when the tensor's allocation ends on an unmapped page.
Decoded from the faulting kernel's kernarg: bf16, b=5, h=2, seqlen_q=4,
seqlen_k=656, head_dim=128, bias_ptr=NULL -- i.e. NOT the attention-bias path. 

FIX

3 orthogonal candidates: app layer, host stopgap, device fix. This is the host stopgap.  

(app layer): A non-bug-exposer app could have its input data checked to be tile-aligned. 

(host-side stopgap): when seqlens are tile-unaligned, hand the kernel
seqlen-padded allocations of Q/K/V (read) and O/LSE (write) -- the extra rows are
mapped scratch -- while leaving seqlen_q/seqlen_k passed to the kernel unchanged,
so the kernel's logical masking and numerics are identical. The real rows are
copied back into the caller-visible output/LSE. Engages only on unaligned shapes;
padding LCM (256) >= every fwd kM0/kN0 in the generated instance set.

(Device side): CK should generate/select kPadSeqLen
forward instances for unaligned seqlens upstream, after which this host guard can
be removed. I will upstream this fix with a separate diff and PR.

Test Plan:
Repro: deterministic "Memory access fault by GPU node-N ... Reason: Unknown"
(SIGABRT) during AOTT GPU lowering on MI350X (gfx950) for tile-unaligned
attention shapes (e.g. seqlen_q=4 not a multiple of kM0=16; seqlen_k=656 not a
multiple of kN0=32). Decoded faulting kernel: bf16 ck_tile::FmhaFwd, no bias
(bias_ptr=NULL), kPadSeqLenQ=kPadSeqLenK=false, head_dim=128 -- an unpredicated
tile tail over-read that faults only when the buffer is page-terminal.

Fix verification (MI350X / gfx950):
- Built the lowering binary with this fix and re-ran the exact failing lowering
  job: all autotune forward passes complete, 0 memory faults, scripted-model
  validation forward pass completed successfully, all lowered .so packed. CK fast
  path stays ENABLED (not disabled).
- Standalone CK-backend SDPA at the faulting shape: outputs finite, max|abs-diff|
  vs fp32 math ~7e-4 (numerically unchanged before/after the fix).
- arc lint: clean (fbcode + xplat copies).

Reverse-repro (ablation, MI350X/gfx950): rebuilt the lowering pkg from the same
base with ONLY the seqlen-pad guard removed -> the "Memory access fault ... Reason:
Unknown" SIGABRT returns on autotune forward pass 5/5, while the with-guard build
is clean. The guard is the sole variable that flips crash<->pass, confirming
causality in both directions.

Reviewed By: liangbeixu

Differential Revision: D108370469




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang