### PR TITLE
jit: add bounds checking for textIndex in SourceRangeDeserializer

### DIFF
--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -73,13 +73,16 @@ std::shared_ptr<Source> SourceRangeDeserializer::deserialize_source(
 
     TORCH_CHECK(
         (uint64_t)fnameIndex < text_table_.size(),
-        "Text table index is out of range")
+        "Filename table index ", fnameIndex, " out of range [0, ", text_table_.size(), ")")
     filename = *text_table_[fnameIndex];
 
     std::vector<std::string_view> pieces;
     std::vector<std::shared_ptr<std::string>> strs;
 
     for (int64_t i : textIndex) {
+      TORCH_CHECK(
+          (uint64_t)i < text_table_.size(),
+          "Text table index ", i, " out of range [0, ", text_table_.size(), ")")
       pieces.emplace_back(*text_table_[i]);
       strs.emplace_back(text_table_[i]);
     }


### PR DESCRIPTION
## Summary

Fixes #185441.

`SourceRangeDeserializer::deserialize_source()` reads a serialized `IntList` (`textIndex`) from a `.pt` file and uses each element as a direct index into `text_table_` with no bounds validation.

A crafted `.pt` file with out-of-bounds or negative indices in `textIndex` causes an out-of-bounds dereference and segfault, crashing any service that loads user-provided models.

The `fnameIndex` scalar already had a `TORCH_CHECK` guard, but `textIndex` , an array of arbitrary attacker-controlled values had none.

## Root Cause

```cpp
// BEFORE — no validation on textIndex elements
for (int64_t i : textIndex) {
    pieces.emplace_back(*text_table_[i]);  // OOB dereference if i is invalid
    strs.emplace_back(text_table_[i]);
}
```


## Changes

* `torch/csrc/jit/serialization/source_range_serialization.cpp`

  * Added `TORCH_CHECK((uint64_t)i < text_table_.size(), ...)` inside the `textIndex` loop,  consistent with the existing guard on `fnameIndex`
  * Fixed the existing `fnameIndex` error message: it previously said `"Text table index is out of range"` (incorrect label) and gave no actionable info. Now reports the actual index value and valid range

## Call Chain

The vulnerable path is triggered when a runtime error during model execution causes the JIT to look up a source range for its error message:

```
model(tensor)                               // runtime error fires
  → InterpreterState raises
    → SourceRange::highlight()
      → ConcreteSourceRangeUnpickler::unpickle()   // reads debug.pkl
        → SourceRangeDeserializer::deserialize_source()
          → text_table_[i]                  // SEGV before fix, RuntimeError after
```

## Test Plan

Manually crafted a .pt file with textIndex = [9999] against a text_table of 6 entries, then loaded and ran the model to trigger source range lookup.

Before fix:

```
SIGSEGV at text_table_[9999]
```

After fix:

```
RuntimeError: Text table index 9999 out of range [0, 6)
```
Happy to share the PoC script used for this if helpful. If the reporter or reviewers have the original malicious .pt from the issue, I'm happy to validate the fix against that as well.