### PR TITLE
xpu: fix CUTLASS cpp_wrapper crash when XPU support is unavailable

### DIFF
--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -316,9 +316,13 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                 manifest, args.toolkit_version, arch=int(arch)
             )
         else:
-            raise NotImplementedError(
-                "Arch " + arch + " is not supported by current cutlass lib."
+            log.warning(
+                "GenerateIntelXe not available in CUTLASS library. "
+                "Skipping CUTLASS gemm ops for XPU arch %s. "
+                "Set TORCHINDUCTOR_CUTLASS_DIR to a CUTLASS with Intel Xe support.",
+                arch,
             )
+            return {}
 
     elif arch == "100":
         if hasattr(cutlass_generator, "GenerateSM100"):

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -342,10 +342,8 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                 # Clear cached modules imported from the tmp symlink paths
                 saved_modules = {}
                 for mod_name in list(_sys.modules):
-                    if (
-                        mod_name.startswith("cutlass_library")
-                        or mod_name.startswith("cutlass_cppgen")
-                        or mod_name.startswith("pycute")
+                    if mod_name.startswith(
+                        ("cutlass_library", "cutlass_cppgen", "pycute")
                     ):
                         saved_modules[mod_name] = _sys.modules.pop(mod_name)
                 import cutlass_library.generator as sys_gen  # type: ignore[no-redef]

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -185,6 +185,17 @@ def try_import_cutlass() -> bool:
             "Failed to import CUTLASS packages: CUTLASS repo does not exist: %s",
             cutlass_python_path,
         )
+    # On XPU, try system-installed cutlass_library (e.g., SYCL-TLA pip package)
+    # which provides GenerateIntelXe even when TORCHINDUCTOR_CUTLASS_DIR is
+    # not set or points to NVIDIA CUTLASS.
+    if torch.xpu._is_compiled():
+        try:
+            import cutlass_library.generator as _sys_gen  # type: ignore[import-not-found]
+
+            if hasattr(_sys_gen, "GenerateIntelXe"):
+                return True
+        except ImportError:
+            pass
     return False
 
 
@@ -316,13 +327,51 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                 manifest, args.toolkit_version, arch=int(arch)
             )
         else:
-            log.warning(
-                "GenerateIntelXe not available in CUTLASS library. "
-                "Skipping CUTLASS gemm ops for XPU arch %s. "
-                "Set TORCHINDUCTOR_CUTLASS_DIR to a CUTLASS with Intel Xe support.",
-                arch,
-            )
-            return {}
+            # The CUTLASS at TORCHINDUCTOR_CUTLASS_DIR (or default) may be
+            # NVIDIA CUTLASS without Intel Xe support. Try to find the
+            # system-installed cutlass_library (e.g., SYCL-TLA pip package)
+            # which provides GenerateIntelXe for XPU.
+            try:
+                import sys as _sys
+
+                # Temporarily remove tmp symlink paths so importlib finds
+                # the system-installed cutlass_library instead
+                saved_paths = [p for p in _sys.path if "torch_cutlass" in p]
+                for p in saved_paths:
+                    _sys.path.remove(p)
+                # Clear cached modules imported from the tmp symlink paths
+                saved_modules = {}
+                for mod_name in list(_sys.modules):
+                    if (
+                        mod_name.startswith("cutlass_library")
+                        or mod_name.startswith("cutlass_cppgen")
+                        or mod_name.startswith("pycute")
+                    ):
+                        saved_modules[mod_name] = _sys.modules.pop(mod_name)
+                import cutlass_library.generator as sys_gen  # type: ignore[no-redef]
+
+                if hasattr(sys_gen, "GenerateIntelXe"):
+                    sys_gen.GenerateIntelXe(
+                        manifest, args.toolkit_version, arch=int(arch)
+                    )
+                    log.debug(
+                        "Using system-installed CUTLASS library (SYCL-TLA) "
+                        "for XPU ops generation."
+                    )
+                else:
+                    raise ImportError("System cutlass_library lacks GenerateIntelXe")
+            except ImportError:
+                log.warning(
+                    "GenerateIntelXe not available in CUTLASS library. "
+                    "Skipping CUTLASS gemm ops for XPU arch %s. "
+                    "Set TORCHINDUCTOR_CUTLASS_DIR to a CUTLASS with "
+                    "Intel Xe support.",
+                    arch,
+                )
+                return {}
+            finally:
+                _sys.path.extend(saved_paths)
+                _sys.modules.update(saved_modules)
 
     elif arch == "100":
         if hasattr(cutlass_generator, "GenerateSM100"):

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -171,7 +171,7 @@ def try_import_cutlass() -> bool:
             import cutlass_cppgen  # type: ignore[import-not-found]  # noqa: F401
             import cutlass_library.generator
             import cutlass_library.library
-            import cutlass_library.manifest  # noqa: F401
+            import cutlass_library.manifest
             import pycute  # type: ignore[import-not-found]  # noqa: F401
 
             # On XPU, the CUTLASS at TORCHINDUCTOR_CUTLASS_DIR may be
@@ -241,8 +241,7 @@ def _try_swap_sycl_tla() -> None:
 
             if hasattr(_sys_gen, "GenerateIntelXe"):
                 log.debug(
-                    "Using system-installed CUTLASS library "
-                    "(SYCL-TLA) for XPU ops."
+                    "Using system-installed CUTLASS library (SYCL-TLA) for XPU ops."
                 )
                 found = True
         except ImportError:
@@ -250,7 +249,7 @@ def _try_swap_sycl_tla() -> None:
 
         if not found:
             # Try 2: sibling sycl-tla/python directory
-            import torch  # noqa: F811
+            import torch
 
             torch_root = os.path.abspath(os.path.dirname(torch.__file__))
             sycl_tla_python = os.path.abspath(
@@ -437,9 +436,11 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                         saved_modules[mod_name] = _sys.modules.pop(mod_name)
 
                 _found = False
+                sys_gen = None
                 try:
                     # Try 1: system pip-installed SYCL-TLA
                     import cutlass_library.generator as sys_gen  # type: ignore[no-redef]
+
                     if hasattr(sys_gen, "GenerateIntelXe"):
                         _found = True
                 except ImportError:
@@ -447,9 +448,7 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
 
                 if not _found:
                     # Try 2: sibling sycl-tla/python directory
-                    _torch_root = os.path.abspath(
-                        os.path.dirname(torch.__file__)
-                    )
+                    _torch_root = os.path.abspath(os.path.dirname(torch.__file__))
                     _sycl_tla_python = os.path.abspath(
                         os.path.join(
                             _torch_root,
@@ -464,6 +463,7 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                         _sys.path.insert(0, _sycl_tla_python)
                         try:
                             import cutlass_library.generator as sib_gen  # type: ignore[no-redef]
+
                             if hasattr(sib_gen, "GenerateIntelXe"):
                                 _found = True
                                 sys_gen = sib_gen
@@ -471,24 +471,26 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                             pass
 
                 if _found:
-                    sys_gen.GenerateIntelXe(
+                    sys_gen.GenerateIntelXe(  # type: ignore[union-attr]
                         manifest, args.toolkit_version, arch=int(arch)
                     )
                     log.debug(
-                        "Using %s CUTLASS library (SYCL-TLA) "
-                        "for XPU ops generation.",
-                        "system-installed" if not os.path.isdir(
+                        "Using %s CUTLASS library (SYCL-TLA) for XPU ops generation.",
+                        "system-installed"
+                        if not os.path.isdir(
                             os.path.join(
                                 os.path.abspath(os.path.dirname(torch.__file__)),
-                                os.pardir, os.pardir, os.pardir,
-                                "sycl-tla", "python",
+                                os.pardir,
+                                os.pardir,
+                                os.pardir,
+                                "sycl-tla",
+                                "python",
                             )
-                        ) else "sibling sycl-tla",
+                        )
+                        else "sibling sycl-tla",
                     )
                 else:
-                    raise ImportError(
-                        "System cutlass_library lacks GenerateIntelXe"
-                    )
+                    raise ImportError("System cutlass_library lacks GenerateIntelXe")
             except ImportError:
                 log.warning(
                     "GenerateIntelXe not available in CUTLASS library. "

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -249,8 +249,6 @@ def _try_swap_sycl_tla() -> None:
 
         if not found:
             # Try 2: sibling sycl-tla/python directory
-            import torch
-
             torch_root = os.path.abspath(os.path.dirname(torch.__file__))
             sycl_tla_python = os.path.abspath(
                 os.path.join(
@@ -415,94 +413,17 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                 manifest, args.toolkit_version, arch=int(arch)
             )
         else:
-            # The CUTLASS at TORCHINDUCTOR_CUTLASS_DIR (or default) may be
-            # NVIDIA CUTLASS without Intel Xe support. Try to find the
-            # system-installed cutlass_library (e.g., SYCL-TLA pip package)
-            # which provides GenerateIntelXe for XPU.
-            try:
-                import sys as _sys
-
-                # Temporarily remove tmp symlink paths so importlib finds
-                # the system-installed cutlass_library instead
-                saved_paths = [p for p in _sys.path if "torch_cutlass" in p]
-                for p in saved_paths:
-                    _sys.path.remove(p)
-                # Clear cached modules imported from the tmp symlink paths
-                saved_modules = {}
-                for mod_name in list(_sys.modules):
-                    if mod_name.startswith(
-                        ("cutlass_library", "cutlass_cppgen", "pycute")
-                    ):
-                        saved_modules[mod_name] = _sys.modules.pop(mod_name)
-
-                _found = False
-                sys_gen = None
-                try:
-                    # Try 1: system pip-installed SYCL-TLA
-                    import cutlass_library.generator as sys_gen  # type: ignore[no-redef]
-
-                    if hasattr(sys_gen, "GenerateIntelXe"):
-                        _found = True
-                except ImportError:
-                    pass
-
-                if not _found:
-                    # Try 2: sibling sycl-tla/python directory
-                    _torch_root = os.path.abspath(os.path.dirname(torch.__file__))
-                    _sycl_tla_python = os.path.abspath(
-                        os.path.join(
-                            _torch_root,
-                            os.pardir,
-                            os.pardir,
-                            os.pardir,
-                            "sycl-tla",
-                            "python",
-                        )
-                    )
-                    if os.path.isdir(_sycl_tla_python):
-                        _sys.path.insert(0, _sycl_tla_python)
-                        try:
-                            import cutlass_library.generator as sib_gen  # type: ignore[no-redef]
-
-                            if hasattr(sib_gen, "GenerateIntelXe"):
-                                _found = True
-                                sys_gen = sib_gen
-                        except ImportError:
-                            pass
-
-                if _found:
-                    sys_gen.GenerateIntelXe(  # type: ignore[union-attr]
-                        manifest, args.toolkit_version, arch=int(arch)
-                    )
-                    log.debug(
-                        "Using %s CUTLASS library (SYCL-TLA) for XPU ops generation.",
-                        "system-installed"
-                        if not os.path.isdir(
-                            os.path.join(
-                                os.path.abspath(os.path.dirname(torch.__file__)),
-                                os.pardir,
-                                os.pardir,
-                                os.pardir,
-                                "sycl-tla",
-                                "python",
-                            )
-                        )
-                        else "sibling sycl-tla",
-                    )
-                else:
-                    raise ImportError("System cutlass_library lacks GenerateIntelXe")
-            except ImportError:
-                log.warning(
-                    "GenerateIntelXe not available in CUTLASS library. "
-                    "Skipping CUTLASS gemm ops for XPU arch %s. "
-                    "Set TORCHINDUCTOR_CUTLASS_DIR to a CUTLASS with "
-                    "Intel Xe support.",
-                    arch,
-                )
-                return {}
-            finally:
-                _sys.path.extend(saved_paths)
-                _sys.modules.update(saved_modules)
+            # `try_import_cutlass()` already attempts a SYCL-TLA swap on XPU.
+            # If we're still here, neither the CUTLASS at CUTLASS_DIR nor any
+            # system-installed SYCL-TLA provides GenerateIntelXe.
+            log.warning(
+                "GenerateIntelXe not available in CUTLASS library. "
+                "Skipping CUTLASS gemm ops for XPU arch %s. "
+                "Set TORCHINDUCTOR_CUTLASS_DIR to a CUTLASS with "
+                "Intel Xe support.",
+                arch,
+            )
+            return {}
 
     elif arch == "100":
         if hasattr(cutlass_generator, "GenerateSM100"):

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -174,6 +174,13 @@ def try_import_cutlass() -> bool:
             import cutlass_library.manifest  # noqa: F401
             import pycute  # type: ignore[import-not-found]  # noqa: F401
 
+            # On XPU, the CUTLASS at TORCHINDUCTOR_CUTLASS_DIR may be
+            # NVIDIA CUTLASS without Intel Xe support.  Try to find
+            # SYCL-TLA (which has GenerateIntelXe) and swap it in.
+            if torch.xpu._is_compiled() and not hasattr(
+                cutlass_library.generator, "GenerateIntelXe"
+            ):
+                _try_swap_sycl_tla()
             return True
         except ImportError as e:
             log.debug(
@@ -197,6 +204,88 @@ def try_import_cutlass() -> bool:
         except ImportError:
             pass
     return False
+
+
+def _try_swap_sycl_tla() -> None:
+    """On XPU, try to find SYCL-TLA (with GenerateIntelXe) and swap sys.modules.
+
+    Called when ``try_import_cutlass()`` successfully imported CUTLASS from
+    ``TORCHINDUCTOR_CUTLASS_DIR`` but the imported ``cutlass_library.generator``
+    lacks ``GenerateIntelXe`` (NVIDIA CUTLASS on XPU).
+
+    Searches, in order:
+    1. System pip-installed SYCL-TLA (site-packages)
+    2. Sibling ``sycl-tla/python`` directory relative to pytorch root
+
+    If SYCL-TLA is found, its modules replace the NVIDIA CUTLASS entries in
+    ``sys.modules`` so subsequent imports in ``_gen_ops_cached()`` use the
+    SYCL-TLA versions.  If not found, the original (NVIDIA CUTLASS) modules
+    are restored unchanged.
+    """
+    # Remove the tmp symlink paths so importlib searches system site-packages.
+    saved_paths = [p for p in sys.path if "torch_cutlass" in p]
+    for p in saved_paths:
+        sys.path.remove(p)
+
+    # Clear cached cutlass modules imported from the symlink paths.
+    saved_modules = {}
+    for mod_name in list(sys.modules):
+        if mod_name.startswith(("cutlass_library", "cutlass_cppgen", "pycute")):
+            saved_modules[mod_name] = sys.modules.pop(mod_name)
+
+    found = False
+    try:
+        # Try 1: system pip-installed SYCL-TLA
+        try:
+            import cutlass_library.generator as _sys_gen  # type: ignore[no-redef]
+
+            if hasattr(_sys_gen, "GenerateIntelXe"):
+                log.debug(
+                    "Using system-installed CUTLASS library "
+                    "(SYCL-TLA) for XPU ops."
+                )
+                found = True
+        except ImportError:
+            pass
+
+        if not found:
+            # Try 2: sibling sycl-tla/python directory
+            import torch  # noqa: F811
+
+            torch_root = os.path.abspath(os.path.dirname(torch.__file__))
+            sycl_tla_python = os.path.abspath(
+                os.path.join(
+                    torch_root,
+                    os.pardir,
+                    os.pardir,
+                    os.pardir,
+                    "sycl-tla",
+                    "python",
+                )
+            )
+            if os.path.isdir(sycl_tla_python):
+                sys.path.insert(0, sycl_tla_python)
+                try:
+                    import cutlass_library.generator as _sib_gen  # type: ignore[no-redef]
+
+                    if hasattr(_sib_gen, "GenerateIntelXe"):
+                        log.debug(
+                            "Using sibling sycl-tla (%s) for XPU CUTLASS ops.",
+                            sycl_tla_python,
+                        )
+                        found = True
+                except ImportError:
+                    pass
+
+        if found:
+            # Success: the new module versions stay in sys.modules.
+            log.debug("SYCL-TLA swap succeeded for XPU CUTLASS.")
+            return
+    finally:
+        if not found:
+            # Restore the original (NVIDIA CUTLASS) modules and paths.
+            sys.modules.update(saved_modules)
+        sys.path.extend(saved_paths)
 
 
 def _normalize_xpu_arch(arch: str) -> str:
@@ -346,18 +435,60 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
                         ("cutlass_library", "cutlass_cppgen", "pycute")
                     ):
                         saved_modules[mod_name] = _sys.modules.pop(mod_name)
-                import cutlass_library.generator as sys_gen  # type: ignore[no-redef]
 
-                if hasattr(sys_gen, "GenerateIntelXe"):
+                _found = False
+                try:
+                    # Try 1: system pip-installed SYCL-TLA
+                    import cutlass_library.generator as sys_gen  # type: ignore[no-redef]
+                    if hasattr(sys_gen, "GenerateIntelXe"):
+                        _found = True
+                except ImportError:
+                    pass
+
+                if not _found:
+                    # Try 2: sibling sycl-tla/python directory
+                    _torch_root = os.path.abspath(
+                        os.path.dirname(torch.__file__)
+                    )
+                    _sycl_tla_python = os.path.abspath(
+                        os.path.join(
+                            _torch_root,
+                            os.pardir,
+                            os.pardir,
+                            os.pardir,
+                            "sycl-tla",
+                            "python",
+                        )
+                    )
+                    if os.path.isdir(_sycl_tla_python):
+                        _sys.path.insert(0, _sycl_tla_python)
+                        try:
+                            import cutlass_library.generator as sib_gen  # type: ignore[no-redef]
+                            if hasattr(sib_gen, "GenerateIntelXe"):
+                                _found = True
+                                sys_gen = sib_gen
+                        except ImportError:
+                            pass
+
+                if _found:
                     sys_gen.GenerateIntelXe(
                         manifest, args.toolkit_version, arch=int(arch)
                     )
                     log.debug(
-                        "Using system-installed CUTLASS library (SYCL-TLA) "
-                        "for XPU ops generation."
+                        "Using %s CUTLASS library (SYCL-TLA) "
+                        "for XPU ops generation.",
+                        "system-installed" if not os.path.isdir(
+                            os.path.join(
+                                os.path.abspath(os.path.dirname(torch.__file__)),
+                                os.pardir, os.pardir, os.pardir,
+                                "sycl-tla", "python",
+                            )
+                        ) else "sibling sycl-tla",
                     )
                 else:
-                    raise ImportError("System cutlass_library lacks GenerateIntelXe")
+                    raise ImportError(
+                        "System cutlass_library lacks GenerateIntelXe"
+                    )
             except ImportError:
                 log.warning(
                     "GenerateIntelXe not available in CUTLASS library. "

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -543,16 +543,17 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         best_config_future = gen_best_config(mat1, mat2)
 
     # Safety net: fall back to ATEN when configured backends produce no choices
-    # (e.g., CUTLASS-only config on XPU where CUTLASS XPU ops aren't available)
-    if len(choices) == 0:
+    # (e.g., CUTLASS-only config on XPU where CUTLASS XPU ops aren't available).
+    # Only trigger when max_autotune_gemm_backends is non-empty — an empty
+    # backends string (deliberately set by test_no_valid_choices) should still
+    # raise NoValidChoicesError upstream.
+    if len(choices) == 0 and inductor_config.max_autotune_gemm_backends:
         log.warning(
             "No gemm choices found for backend(s) %s. Falling back to ATEN.",
             inductor_config.max_autotune_gemm_backends,
         )
         choices.append(
-            aten_handler.bind(
-                kernel_inputs.nodes(), layout, **aten_extra_kwargs
-            )
+            aten_handler.bind(kernel_inputs.nodes(), layout, **aten_extra_kwargs)
         )
 
     if box := distributed_autotune.maybe_autotune_remote(

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -542,6 +542,19 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         # The future will be awaited at scheduling time in select_algorithm.py
         best_config_future = gen_best_config(mat1, mat2)
 
+    # Safety net: fall back to ATEN when configured backends produce no choices
+    # (e.g., CUTLASS-only config on XPU where CUTLASS XPU ops aren't available)
+    if len(choices) == 0:
+        log.warning(
+            "No gemm choices found for backend(s) %s. Falling back to ATEN.",
+            inductor_config.max_autotune_gemm_backends,
+        )
+        choices.append(
+            aten_handler.bind(
+                kernel_inputs.nodes(), layout, **aten_extra_kwargs
+            )
+        )
+
     if box := distributed_autotune.maybe_autotune_remote(
         name, choices, kernel_inputs.nodes(), layout
     ):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -544,7 +544,7 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
 
     # Safety net: fall back to ATEN when configured backends produce no choices
     # (e.g., CUTLASS-only config on XPU where CUTLASS XPU ops aren't available).
-    # Only trigger when max_autotune_gemm_backends is non-empty — an empty
+    # Only trigger when max_autotune_gemm_backends is non-empty -- an empty
     # backends string (deliberately set by test_no_valid_choices) should still
     # raise NoValidChoicesError upstream.
     if len(choices) == 0 and inductor_config.max_autotune_gemm_backends:


### PR DESCRIPTION
Fixes #186781

When `max_autotune_gemm_backends="CUTLASS"` is set on XPU and the installed
CUTLASS library doesn't have Intel Xe support (e.g., standard NVIDIA CUTLASS),
`_gen_ops_cached()` raises `NotImplementedError`, crashing the entire inductor
lowering with:

```
NotImplementedError: Arch 12 is not supported by current cutlass lib.
```

This affects `test_max_autotune_cutlass_backend_cpp_wrapper_*` in CI.

### Changes

1. **Gracefully handle missing GenerateIntelXe** — return `{}` + warning instead of raising, so inductor falls back to Triton templates
2. **Add ATEN fallback** when no gemm choices exist for configured backends — prevents NoValidChoicesError when all backends produce empty ops
3. **Fallback to system-installed SYCL-TLA cutlass_library** — when file-based CUTLASS lacks Intel Xe support, try importing from system path (e.g., SYCL-TLA pip package) to actually enable CUTLASS on XPU
4. **Guard ATEN safety net** on non-empty backends — preserves deliberate NoValidChoicesError when backends are explicitly empty
5. **RUFF PIE810** lint fix

### Test commands

```bash
# The failing test (should now pass with graceful fallback)
python test/inductor/test_cutlass_backend.py TestCutlassBackend.test_max_autotune_cutlass_backend_cpp_wrapper_bfloat16_num_gemms_1

# Regression guard: empty backends should still raise
python test/inductor/test_max_autotune.py TestMaxAutotune.test_no_valid_choices
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo