### PR TITLE
[ROCm] Enable FMA inductor lowering on ROCm

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1393,7 +1393,6 @@ class ForeachTests(TestCase):
         for eager, compiled in zip(eager_result2, compiled_result2):
             self.assertEqual(eager, compiled, atol=atol, rtol=rtol)
 
-    @skipIfRocm
     @requires_cuda_and_triton
     @config.patch({"emulate_precision_casts": True})
     def test_foreach_addcmul_uses_fma_instruction(self):

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1393,6 +1393,9 @@ class ForeachTests(TestCase):
         for eager, compiled in zip(eager_result2, compiled_result2):
             self.assertEqual(eager, compiled, atol=atol, rtol=rtol)
 
+    @skipIfRocm(
+        msg="_foreach_addcmul uses a separate foreach lowering path that does not emit tl.fma"
+    )
     @requires_cuda_and_triton
     @config.patch({"emulate_precision_casts": True})
     def test_foreach_addcmul_uses_fma_instruction(self):

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1393,9 +1393,6 @@ class ForeachTests(TestCase):
         for eager, compiled in zip(eager_result2, compiled_result2):
             self.assertEqual(eager, compiled, atol=atol, rtol=rtol)
 
-    @skipIfRocm(
-        msg="_foreach_addcmul uses a separate foreach lowering path that does not emit tl.fma"
-    )
     @requires_cuda_and_triton
     @config.patch({"emulate_precision_casts": True})
     def test_foreach_addcmul_uses_fma_instruction(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19012,6 +19012,43 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         code = " ".join(code)
         self.assertIn("tl.fma", code, "Expected FMA to be used in generated code")
 
+    @xfail_if_triton_cpu
+    @requires_cuda_and_triton
+    def test_addcdiv_fma_bitwise_equal(self):
+        """Compiled addcdiv matches eager bitwise for both value==1 and value!=1 branches."""
+        s  = torch.randn(64, 64, device=GPU_TYPE)
+        t1 = torch.randn(64, 64, device=GPU_TYPE)
+        t2 = torch.randn(64, 64, device=GPU_TYPE).abs().clamp(min=0.1)
+
+        for value in (1.0, 2.0):
+            @torch.compile(fullgraph=True)
+            def fn(s, t1, t2, v=value):
+                return torch.addcdiv(s, t1, t2, value=v)
+
+            self.assertEqual(fn(s, t1, t2), torch.addcdiv(s, t1, t2, value=value))
+
+    @xfail_if_triton_cpu
+    @requires_cuda_and_triton
+    def test_addcdiv_fma_uses_fma_and_div_rn(self):
+        """Test that addcdiv re-fusion emits tl.fma and triton.language.div_rn."""
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+        self_tensor = torch.randn(64, 64, device=GPU_TYPE)
+        tensor1 = torch.randn(64, 64, device=GPU_TYPE)
+        tensor2 = torch.randn(64, 64, device=GPU_TYPE).abs().clamp(min=0.1)
+
+        @torch.compile(fullgraph=True)
+        def fn(s, t1, t2):
+            return torch.addcdiv(s, t1, t2, value=2.0)
+
+        _, code = run_and_get_code(fn, self_tensor, tensor1, tensor2)
+        code = " ".join(code)
+
+        self.assertEqual(counters["inductor"].get("addcdiv_fma_fused", 0), 1)
+        self.assertIn("tl.fma", code)
+        self.assertIn("triton.language.div_rn", code)
+
     @requires_cuda_and_triton
     @config.patch({"emulate_precision_casts": True})
     def test_addcmul_type_promotion(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19016,11 +19016,12 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @requires_cuda_and_triton
     def test_addcdiv_fma_bitwise_equal(self):
         """Compiled addcdiv matches eager bitwise for both value==1 and value!=1 branches."""
-        s  = torch.randn(64, 64, device=GPU_TYPE)
+        s = torch.randn(64, 64, device=GPU_TYPE)
         t1 = torch.randn(64, 64, device=GPU_TYPE)
         t2 = torch.randn(64, 64, device=GPU_TYPE).abs().clamp(min=0.1)
 
         for value in (1.0, 2.0):
+
             @torch.compile(fullgraph=True)
             def fn(s, t1, t2, v=value):
                 return torch.addcdiv(s, t1, t2, value=v)
@@ -19032,7 +19033,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     def test_addcdiv_fma_uses_fma_and_div_rn(self):
         """Test that addcdiv re-fusion emits tl.fma and triton.language.div_rn."""
         from torch._dynamo.utils import counters
+        from torch._inductor.compile_fx import fx_compile_mode, FxCompileMode
 
+        # Reset the compilation cache so the counter is incremented on a fresh
+        # compile regardless of what ran earlier in the test session.
+        torch._dynamo.reset()
         counters.clear()
         self_tensor = torch.randn(64, 64, device=GPU_TYPE)
         tensor1 = torch.randn(64, 64, device=GPU_TYPE)
@@ -19045,7 +19050,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         _, code = run_and_get_code(fn, self_tensor, tensor1, tensor2)
         code = " ".join(code)
 
-        self.assertEqual(counters["inductor"].get("addcdiv_fma_fused", 0), 1)
+        # The counter increments inside the compilation process. In SUBPROCESS
+        # mode the compile runs in a child process so the counter is not visible
+        # here; skip that assertion and rely on the generated-code checks below.
+        if fx_compile_mode != FxCompileMode.SUBPROCESS:
+            self.assertEqual(counters["inductor"].get("addcdiv_fma_fused", 0), 1)
         self.assertIn("tl.fma", code)
         self.assertIn("triton.language.div_rn", code)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19033,7 +19033,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     def test_addcdiv_fma_uses_fma_and_div_rn(self):
         """Test that addcdiv re-fusion emits tl.fma and triton.language.div_rn."""
         from torch._dynamo.utils import counters
-        from torch._inductor.compile_fx import fx_compile_mode, FxCompileMode
 
         # Reset the compilation cache so the counter is incremented on a fresh
         # compile regardless of what ran earlier in the test session.
@@ -19053,7 +19052,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # The counter increments inside the compilation process. In SUBPROCESS
         # mode the compile runs in a child process so the counter is not visible
         # here; skip that assertion and rely on the generated-code checks below.
-        if fx_compile_mode != FxCompileMode.SUBPROCESS:
+        if torch._inductor.compile_fx.fx_compile_mode != FxCompileMode.SUBPROCESS:
             self.assertEqual(counters["inductor"].get("addcdiv_fma_fused", 0), 1)
         self.assertIn("tl.fma", code)
         self.assertIn("triton.language.div_rn", code)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -4,6 +4,7 @@ import functools
 import itertools
 import logging
 import operator
+import os
 from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
@@ -2027,6 +2028,10 @@ def addmm(match, mat1, mat2, *, inp):
 
 def _is_addcdiv_fma_eligible(match: Match) -> bool:
     """Guards for the addcdiv FMA re-fusion pass."""
+    # Set PYTORCH_DISABLE_ROCM_FMA=1 to skip this pass (restores pre-PR behavior).
+    if torch.version.hip and os.environ.get("PYTORCH_DISABLE_ROCM_FMA", "0") != "0":
+        return False
+
     # aten.addcdiv requires floating-point self; check inp, not output, because
     # aten.div promotes integers to float so the output is float even for int inp.
     inp_val = match.kwargs["inp"].meta.get("val")
@@ -2034,8 +2039,17 @@ def _is_addcdiv_fma_eligible(match: Match) -> bool:
         return False
     # tl.fma / div_rn are Triton GPU-only
     out_val = match.output_node().meta.get("val")
-    if not (isinstance(out_val, torch.Tensor) and out_val.device.type in ("cuda", "xpu")):
+    if not (
+        isinstance(out_val, torch.Tensor) and out_val.device.type in ("cuda", "xpu")
+    ):
         return False
+    # aten.addcdiv requires all tensor args to be floating-point; integer
+    # constants and SymInts can appear as t1/t2 in decomposed graphs.
+    for key in ("t1", "t2"):
+        node = match.kwargs.get(key)
+        val = node.meta.get("val") if isinstance(node, torch.fx.Node) else node
+        if not (isinstance(val, torch.Tensor) and val.dtype.is_floating_point):
+            return False
     # aten.addcdiv requires a scalar value, not a tensor
     return not isinstance(match.kwargs.get("value"), torch.fx.Node)
 
@@ -2063,7 +2077,9 @@ def _fuse_addcdiv_to_fma(match: Match, inp, t1, t2, value) -> None:
     aten.addcdiv node lets that lowering fire (tl.fma + triton.language.div_rn).
     """
 
-    def repl(inp: torch.Tensor, t1: torch.Tensor, t2: torch.Tensor, value) -> torch.Tensor:
+    def repl(
+        inp: torch.Tensor, t1: torch.Tensor, t2: torch.Tensor, value
+    ) -> torch.Tensor:
         return torch.ops.aten.addcdiv(inp, t1, t2, value=value)
 
     counters["inductor"]["addcdiv_fma_fused"] += 1

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -2025,6 +2025,51 @@ def addmm(match, mat1, mat2, *, inp):
     match.replace_by_example(repl, [inp, mat1, mat2])
 
 
+def _is_addcdiv_fma_eligible(match: Match) -> bool:
+    """Guards for the addcdiv FMA re-fusion pass."""
+    # aten.addcdiv requires floating-point self; check inp, not output, because
+    # aten.div promotes integers to float so the output is float even for int inp.
+    inp_val = match.kwargs["inp"].meta.get("val")
+    if not (isinstance(inp_val, torch.Tensor) and inp_val.dtype.is_floating_point):
+        return False
+    # tl.fma / div_rn are Triton GPU-only
+    out_val = match.output_node().meta.get("val")
+    if not (isinstance(out_val, torch.Tensor) and out_val.device.type in ("cuda", "xpu")):
+        return False
+    # aten.addcdiv requires a scalar value, not a tensor
+    return not isinstance(match.kwargs.get("value"), torch.fx.Node)
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.add.Tensor,
+        KeywordArg("inp"),
+        CallFunction(
+            aten.mul.Tensor,
+            CallFunction(aten.div.Tensor, KeywordArg("t1"), KeywordArg("t2")),
+            KeywordArg("value"),
+        ),
+    ),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[2],
+    extra_check=_is_addcdiv_fma_eligible,
+)
+def _fuse_addcdiv_to_fma(match: Match, inp, t1, t2, value) -> None:
+    """Re-fuse ``inp + (t1/t2)*value`` back into ``aten.addcdiv``.
+
+    torch.addcdiv is CompositeImplicitAutograd: it decomposes into
+    aten.div + aten.mul + aten.add before Inductor sees the graph, making the
+    FMA-aware lowering in lowering.py unreachable.  Re-inserting a single
+    aten.addcdiv node lets that lowering fire (tl.fma + triton.language.div_rn).
+    """
+
+    def repl(inp: torch.Tensor, t1: torch.Tensor, t2: torch.Tensor, value) -> torch.Tensor:
+        return torch.ops.aten.addcdiv(inp, t1, t2, value=value)
+
+    counters["inductor"]["addcdiv_fma_fused"] += 1
+    match.replace_by_example(repl, [inp, t1, t2, value])
+
+
 def register_partial_reduction_pattern():
     "Reuse partial reductions in complete reductions"
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -4,7 +4,6 @@ import functools
 import itertools
 import logging
 import operator
-import os
 from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
@@ -2028,10 +2027,6 @@ def addmm(match, mat1, mat2, *, inp):
 
 def _is_addcdiv_fma_eligible(match: Match) -> bool:
     """Guards for the addcdiv FMA re-fusion pass."""
-    # Set PYTORCH_DISABLE_ROCM_FMA=1 to skip this pass (restores pre-PR behavior).
-    if torch.version.hip and os.environ.get("PYTORCH_DISABLE_ROCM_FMA", "0") != "0":
-        return False
-
     # aten.addcdiv requires floating-point self; check inp, not output, because
     # aten.div promotes integers to float so the output is float even for int inp.
     inp_val = match.kwargs["inp"].meta.get("val")

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -670,18 +670,6 @@ def promote_constants(
     return out
 
 
-def _rocm_fma_disabled() -> bool:
-    """Return True when ROCm FMA lowering should be skipped.
-
-    Set PYTORCH_DISABLE_ROCM_FMA=1 to restore pre-PR behavior (no FMA on ROCm).
-    This is used to bisect which test failures are caused by the ROCm FMA change.
-    Has no effect on CUDA (non-ROCm) builds.
-    """
-    return bool(
-        torch.version.hip and os.environ.get("PYTORCH_DISABLE_ROCM_FMA", "0") != "0"
-    )
-
-
 def _add_with_alpha_fma(a, b, alpha):
     """Compute a + alpha * b using FMA for CUDA floating-point precision."""
     dtype = get_promoted_dtype(
@@ -777,7 +765,6 @@ def make_pointwise(
                         inputs[0].get_dtype().is_floating_point
                         and inp_device is not None
                         and inp_device.type == "cuda"
-                        and not _rocm_fma_disabled()
                     ):
                         return _add_with_alpha_fma(inputs[0], inputs[1], alpha)
 
@@ -8416,7 +8403,6 @@ def addcmul(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and device is not None
         and device.type in ["cuda", "xpu"]
-        and not _rocm_fma_disabled()
     )
 
     def inner_fn(idx):
@@ -8492,7 +8478,6 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and device is not None
         and device.type in ["cuda", "xpu"]
-        and not _rocm_fma_disabled()
     )
 
     def inner_fn(idx):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -757,13 +757,12 @@ def make_pointwise(
         )
         if allow_alpha:
             if alpha is not None and alpha != 1:
-                # Use FMA for add-with-alpha on CUDA floating-point.
-                # Eager CUDA computes a + alpha * b as fma(b, alpha, a).
+                # Use FMA for add-with-alpha on Triton GPU floating-point.
+                # Eager CUDA/ROCm computes a + alpha * b as fma(b, alpha, a).
                 if use_fma_for_alpha and isinstance(inputs[0], IRNode):
                     inp_device = inputs[0].get_device()
                     if (
                         inputs[0].get_dtype().is_floating_point
-                        and not torch.version.hip
                         and inp_device is not None
                         and inp_device.type == "cuda"
                     ):
@@ -8398,7 +8397,9 @@ def addcmul(self, tensor1, tensor2, *, value=1):
     t1_loader = tensor1.make_loader()
     t2_loader = tensor2.make_loader()
 
-    # FMA/mul_rn/div_rn are only available for floating-point types on CUDA (non-AMD)
+    # FMA is available for floating-point types on Triton GPU backends.
+    # On ROCm, mul_rn falls back to regular multiplication in the backend
+    # override, but we can still use tl.fma for the final multiply-add.
     device = self.get_device()
     use_fma = (
         dtype.is_floating_point
@@ -8472,11 +8473,12 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
     t1_loader = tensor1.make_loader()
     t2_loader = tensor2.make_loader()
 
-    # FMA/mul_rn/div_rn are only available for floating-point types on CUDA (non-AMD)
+    # FMA is available for floating-point types on Triton GPU backends.
+    # On ROCm, div_rn falls back to regular division in the backend
+    # override, but we can still use tl.fma for the final multiply-add.
     device = self.get_device()
     use_fma = (
         dtype.is_floating_point
-        and not torch.version.hip
         and device is not None
         and device.type in ["cuda", "xpu"]
     )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8378,13 +8378,14 @@ def addcmul(self, tensor1, tensor2, *, value=1):
     Matches eager CUDA kernel order: self + value * (tensor1 * tensor2)
     This is computed as: fma(value, tensor1 * tensor2, self)
 
-    Note: FMA is only used for floating-point types on non-AMD GPUs. For integer types,
-    we fall back to regular arithmetic since FMA doesn't support integers.
+    Note: FMA is used for floating-point types on CUDA and ROCm (via tl.fma). For
+    integer types we fall back to regular arithmetic since FMA doesn't support integers.
 
     For floating-point types, we use mul_rn (round-to-nearest multiplication)
     to force rounding of the product before the FMA. This prevents Triton's
     compiler from fusing the multiplication with the FMA, matching eager's
-    rounding behavior.
+    rounding behavior. On ROCm, mul_rn falls back to regular multiplication since
+    libdevice.mul_rn is not available; the FMA itself (tl.fma) is still used.
     """
     dtype = get_promoted_dtype(
         self,
@@ -8397,9 +8398,6 @@ def addcmul(self, tensor1, tensor2, *, value=1):
     t1_loader = tensor1.make_loader()
     t2_loader = tensor2.make_loader()
 
-    # FMA is available for floating-point types on Triton GPU backends.
-    # On ROCm, mul_rn falls back to regular multiplication in the backend
-    # override, but we can still use tl.fma for the final multiply-add.
     device = self.get_device()
     use_fma = (
         dtype.is_floating_point
@@ -8456,11 +8454,13 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
     For value=1: self + tensor1 / tensor2 (no FMA needed, just add the division)
     For value!=1: fma(value, div_rn(tensor1, tensor2), self)
 
-    Note: FMA is only used for floating-point types on non-AMD GPUs. For integer types,
-    we fall back to regular arithmetic since FMA doesn't support integers.
+    Note: FMA is used for floating-point types on CUDA and ROCm (via tl.fma). For
+    integer types we fall back to regular arithmetic since FMA doesn't support integers.
 
     We use div_rn (round-to-nearest division) to force proper rounding, preventing
     Triton from fusing operations in ways that change the rounding behavior.
+    div_rn emits triton.language.div_rn on both CUDA and ROCm (unlike mul_rn, which
+    falls back to regular multiplication on ROCm where libdevice.mul_rn is unavailable).
     """
     dtype = get_promoted_dtype(
         self,
@@ -8473,9 +8473,6 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
     t1_loader = tensor1.make_loader()
     t2_loader = tensor2.make_loader()
 
-    # FMA is available for floating-point types on Triton GPU backends.
-    # On ROCm, div_rn falls back to regular division in the backend
-    # override, but we can still use tl.fma for the final multiply-add.
     device = self.get_device()
     use_fma = (
         dtype.is_floating_point
@@ -8488,15 +8485,12 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
         t1_val = t1_loader(idx)
         t2_val = t2_loader(idx)
 
-        # Compute tensor1 / tensor2 first
-        # Use div_rn for round-to-nearest division on CUDA to match eager behavior
         if use_fma:
             t1_div_t2 = ops.div_rn(t1_val, t2_val)
         else:
             t1_div_t2 = ops.truediv(t1_val, t2_val)
 
         if value == 1:
-            # For value=1, just add the division result (no FMA needed)
             return ops.add(self_val, t1_div_t2)
 
         # Use index_expr for sympy expressions (e.g., from .item()), constant otherwise
@@ -8506,10 +8500,8 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
             value_expr = ops.constant(value, dtype)
 
         if use_fma:
-            # Use FMA for floating-point types for better precision
             return ops.fma(value_expr, t1_div_t2, self_val)
         else:
-            # Fall back to regular arithmetic for integer types
             return ops.add(self_val, ops.mul(value_expr, t1_div_t2))
 
     return Pointwise.create(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -670,6 +670,18 @@ def promote_constants(
     return out
 
 
+def _rocm_fma_disabled() -> bool:
+    """Return True when ROCm FMA lowering should be skipped.
+
+    Set PYTORCH_DISABLE_ROCM_FMA=1 to restore pre-PR behavior (no FMA on ROCm).
+    This is used to bisect which test failures are caused by the ROCm FMA change.
+    Has no effect on CUDA (non-ROCm) builds.
+    """
+    return bool(
+        torch.version.hip and os.environ.get("PYTORCH_DISABLE_ROCM_FMA", "0") != "0"
+    )
+
+
 def _add_with_alpha_fma(a, b, alpha):
     """Compute a + alpha * b using FMA for CUDA floating-point precision."""
     dtype = get_promoted_dtype(
@@ -765,6 +777,7 @@ def make_pointwise(
                         inputs[0].get_dtype().is_floating_point
                         and inp_device is not None
                         and inp_device.type == "cuda"
+                        and not _rocm_fma_disabled()
                     ):
                         return _add_with_alpha_fma(inputs[0], inputs[1], alpha)
 
@@ -8403,6 +8416,7 @@ def addcmul(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and device is not None
         and device.type in ["cuda", "xpu"]
+        and not _rocm_fma_disabled()
     )
 
     def inner_fn(idx):
@@ -8478,6 +8492,7 @@ def addcdiv(self, tensor1, tensor2, *, value=1):
         dtype.is_floating_point
         and device is not None
         and device.type in ["cuda", "xpu"]
+        and not _rocm_fma_disabled()
     )
 
     def inner_fn(idx):


### PR DESCRIPTION
Enable FMA lowering on ROCm and also fixes an issue related to addcdiv lowering in lowering.py was dead code for the compiled path. Fixed by adding a post-grad pattern pass in fx_passes/post_grad.py that detects the inp + (t1/t2)*value triplet and re-fuses it to a single aten.addcdiv node, which then routes to the FMA lowering

See https://github.com/pytorch/pytorch/pull/187165#issuecomment-4799239557 for more details

Co-authored by Claude

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben