### PR TITLE
Fix GCC15 AArch64 enablement issues

### DIFF
--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -41,9 +41,10 @@ struct OperatorName final {
       const auto old_name_size = name.size();
       name.resize(ns_len + 2 + old_name_size);
       // Shift current value of name to the end of the new space.
-      name.replace(
-          name.size() - old_name_size, old_name_size, name, 0, old_name_size);
-      name.replace(0, ns_len, ns, ns_len);
+      auto name_data = name.data();
+      std::char_traits<char>::move(
+          name_data + ns_len + 2, name_data, old_name_size);
+      std::char_traits<char>::copy(name_data, ns, ns_len);
       name[ns_len] = ':';
       name[ns_len + 1] = ':';
       return true;

--- a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
@@ -621,7 +621,7 @@ void inline transpose_mxn<BFloat16>(
     }
     // Works for any count<= vector lanes
     svbool_t pg = svwhilelt_b16((uint64_t)0, (uint64_t)count);
-    const uint16_t* pu16 = reinterpret_cast<const uint16_t*>(p);
+    const uint16_t* pu16 = &p->x;
     svuint16_t v = svld1_u16(pg, pu16);
     return svsel_u16(pg, v, z);
   };
@@ -632,7 +632,7 @@ void inline transpose_mxn<BFloat16>(
       return;
     }
     svbool_t pg = svwhilelt_b16((uint64_t)0, (uint64_t)count);
-    uint16_t* pu16 = reinterpret_cast<uint16_t*>(p);
+    uint16_t* pu16 = &p->x;
     svst1_u16(pg, pu16, v);
   };
 
@@ -645,7 +645,7 @@ void inline transpose_mxn<BFloat16>(
       // Use SVE load+store(from the helpers above) into each row
       for (int r = 0; r < TILE; r++) {
         for (int c = 0; c < TILE; c++) {
-          tile_in[r * TILE + c] = BFloat16(0);
+          tile_in[r * TILE + c].x = 0;
         }
         if (r < m_blk) {
           const BFloat16* srow = src + (i0 + r) * ld_src + j0;
@@ -657,12 +657,12 @@ void inline transpose_mxn<BFloat16>(
       // Transpose tile_in to tile_out (scalar on tiny tile)
       for (int r = 0; r < TILE; r++) {
         for (int c = 0; c < TILE; c++) {
-          tile_out[r * TILE + c] = BFloat16(0);
+          tile_out[r * TILE + c].x = 0;
         }
       }
       for (int r = 0; r < m_blk; r++) {
         for (int c = 0; c < n_blk; c++) {
-          tile_out[c * TILE + r] = tile_in[r * TILE + c];
+          tile_out[c * TILE + r].x = tile_in[r * TILE + c].x;
         }
       }
 

--- a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
@@ -242,9 +242,18 @@ convert_bfloat16_float(const Vectorized<c10::BFloat16>& a) {
   return {Vectorized<float>(x1), Vectorized<float>(x2)};
 }
 
-inline Vectorized<c10::BFloat16> convert_float_bfloat16(
-    const Vectorized<float>& a,
-    const Vectorized<float>& b) {
+#if defined(TORCH_INDUCTOR_PRECOMPILE_HEADERS) && defined(__GNUC__) && \
+    !defined(__clang__) &&                                             \
+    ((__GNUC__ == 14 && __GNUC_MINOR__ < 4) ||                         \
+     (__GNUC__ == 15 && __GNUC_MINOR__ < 3))
+// GCC 14/15 can ICE when compiling AArch64 SVE intrinsics with PCH enabled
+// (GCC PR target/123457). The fix is expected in GCC 14.4 and 15.3, and is
+// backported to only some 14.3 and 15.2 packages, so conservatively guard by
+// upstream minor version.
+__attribute__((optimize("O0")))
+#endif
+inline Vectorized<c10::BFloat16>
+convert_float_bfloat16(const Vectorized<float>& a, const Vectorized<float>& b) {
   static_assert(
       Vectorized<c10::BFloat16>::size() == 2 * Vectorized<float>::size());
   svbfloat16_t x1 = svcvt_bf16_f32_z(ptrue, a);

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -470,7 +470,18 @@ class Vectorized<float> {
   }
   // Implementation is picked from
   // https://github.com/ARM-software/ComputeLibrary/blob/v25.01/src/core/NEON/SVEMath.inl#L179
-  Vectorized<float> tanh() const {
+#if defined(TORCH_INDUCTOR_PRECOMPILE_HEADERS) && defined(__GNUC__) && \
+    !defined(__clang__) &&                                             \
+    ((__GNUC__ == 14 && __GNUC_MINOR__ < 4) ||                         \
+     (__GNUC__ == 15 && __GNUC_MINOR__ < 3))
+  // GCC 14/15 can ICE when compiling AArch64 SVE intrinsics with PCH enabled
+  // (GCC PR target/123457). The fix is expected in GCC 14.4 and 15.3, and is
+  // backported to only some 14.3 and 15.2 packages, so conservatively guard by
+  // upstream minor version.
+  __attribute__((optimize("O0")))
+#endif
+  Vectorized<float>
+  tanh() const {
     // Constants used for the tanh calculation.
     const svfloat32_t CONST_1 =
         svdup_n_f32(1.f); // Constant 1.0f for the tanh formula.

--- a/aten/src/ATen/cpu/vec/sve/vec_int.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_int.h
@@ -17,6 +17,19 @@ inline namespace CPU_CAPABILITY {
 
 #if defined(CPU_CAPABILITY_SVE256)
 
+#if defined(TORCH_INDUCTOR_PRECOMPILE_HEADERS) && defined(__GNUC__) && \
+    !defined(__clang__) &&                                             \
+    ((__GNUC__ == 14 && __GNUC_MINOR__ < 4) ||                         \
+     (__GNUC__ == 15 && __GNUC_MINOR__ < 3))
+// GCC 14/15 can ICE when compiling AArch64 SVE intrinsics with PCH enabled
+// (GCC PR target/123457). The fix is expected in GCC 14.4 and 15.3, and is
+// backported to only some 14.3 and 15.2 packages, so conservatively guard by
+// upstream minor version.
+#define VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND __attribute__((optimize("O0")))
+#else
+#define VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND
+#endif
+
 #define VEC_INT_SVE_TEMPLATE(vl, bit)                                         \
   template <>                                                                 \
   struct is_vec_specialized_for<int##bit##_t> : std::bool_constant<true> {};  \
@@ -181,7 +194,8 @@ inline namespace CPU_CAPABILITY {
     return svsub_s##bit##_x(ptrue, a, b);                                     \
   }                                                                           \
   template <>                                                                 \
-  Vectorized<int##bit##_t> inline operator*(                                  \
+  VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND Vectorized<int##bit##_t> inline          \
+  operator*(                                                                  \
       const Vectorized<int##bit##_t>& a, const Vectorized<int##bit##_t>& b) { \
     return svmul_s##bit##_x(ptrue, a, b);                                     \
   }                                                                           \
@@ -279,14 +293,14 @@ Vectorized<T> inline intdiv_nosve(
 }
 
 template <>
-Vectorized<int64_t> inline operator/(
+VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND Vectorized<int64_t> inline operator/(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
   return svdiv_s64_x(ptrue, a, b);
 }
 
 template <>
-Vectorized<int32_t> inline operator/(
+VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND Vectorized<int32_t> inline operator/(
     const Vectorized<int32_t>& a,
     const Vectorized<int32_t>& b) {
   return svdiv_s32_x(ptrue, a, b);
@@ -492,6 +506,8 @@ Vectorized<int8_t> inline operator>>(
     const Vectorized<int8_t>& b) {
   return svasr_s8_x(ptrue, a, svreinterpret_u8_s8(b));
 }
+
+#undef VEC_INT_SVE_GCC_PCH_ICE_WORKAROUND
 
 #endif // defined(CPU_CAPABILITY_SVE256)
 

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -237,6 +237,9 @@ class HeaderOnlyArrayRef {
   /// @name Expensive Operations
   /// @{
   std::vector<T> vec() const {
+    if (this->empty()) {
+      return {};
+    }
     return std::vector<T>(this->Data, this->Data + this->Length);
   }
 


### PR DESCRIPTION
Ahead of updating the AArch64 CI toolchains to GCC15 (#182016), this PR fixes issues that arise on the newer compiler version.

## Fixes included

### 1. HeaderOnlyArrayRef empty vector construction

GCC 15 reports `-Werror=free-nonheap-object` from inlined `HeaderOnlyArrayRef<T>::vec()` while constructing an `std::vector<T>` from `Data` to `Data + Length`. For empty refs, `Data` may be null, and forming `Data + Length` still performs pointer arithmetic on that null pointer. The fix returns `{}` immediately for empty refs to avoid that.

Failure message:

```text
    inlined from 'std::vector<T> c10::HeaderOnlyArrayRef<T>::vec() const [with T = long int]' at /pytorch/torch/headeronly/util/HeaderOnlyArrayRef.h:237:64,
    inlined from 'at::TensorIterator at::native::{anonymous}::_make_unfold_backward_iter_over_grad_out(at::Tensor&, const at::Tensor&, int64_t, int64_t, int64_t)' at /pytorch/aten/src/ATen/native/UnfoldBackward.h:52:65,
    inlined from 'void at::native::{anonymous}::unfold_backward_cpu_kernel(at::Tensor&, const at::Tensor&, int64_t, int64_t, int64_t)' at /pytorch/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp:129:41:
/usr/include/c++/15/bits/new_allocator.h:172:66: error: 'void operator delete(void*, std::size_t)' called on pointer '<unknown>' with nonzero offset [8, 9223372036854775800] [-Werror=free-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                                                  ^
cc1plus: some warnings being treated as errors
```

Files changed:

- `torch/headeronly/util/HeaderOnlyArrayRef.h`

### 2. OperatorName namespace string insertion overlap

`OperatorName::setNamespaceIfNotSet()` used `std::string::replace()` to copy from `name` back into an overlapping region of the same `name` buffer. GCC 15 inlines that path down to `memcpy` and reports `-Werror=restrict`. The fix uses `std::char_traits<char>::move()` for the overlapping move and `std::char_traits<char>::copy()` for the non-overlapping namespace prefix.

Failure message:

```text
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/15/bits/basic_string.h:2434:29,
    inlined from 'bool c10::OperatorName::setNamespaceIfNotSet(const char*)' at /pytorch/aten/src/ATen/core/operator_name.h:44:19,
    inlined from 'bool c10::OperatorName::setNamespaceIfNotSet(const char*)' at /pytorch/aten/src/ATen/core/operator_name.h:38:8,
    inlined from 'virtual void OperatorNameTest_SetNamespaceIfNotSetWithExistingNamespace_Test::TestBody()' at /pytorch/aten/src/ATen/test/operator_name_test.cpp:17:58:
/usr/include/c++/15/bits/char_traits.h:429:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' accessing 28 bytes at offsets 11 and 0 overlaps 17 bytes at offset 11 [-Werror=restrict]
  429 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
```

Files changed:

- `aten/src/ATen/core/operator_name.h`

### 3. SVE PCH internal compiler errors

GCC reports an internal compiler error while compiling AArch64 SVE vector helpers through the Inductor precompiled-header path, matching [GCC PR target/123457](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123457).

The affected code is valid, but GCC 14/15 can ICE when those SVE intrinsics are compiled with `TORCH_INDUCTOR_PRECOMPILE_HEADERS` enabled. The workaround adds narrow `__attribute__((optimize("O0")))` guards around the specific helper functions that trigger the compiler bug for the affected GCC versions.

Representative failure:

```text
torch._inductor.exc.InductorError: CppCompileError: C++ compile error

Output:
during GIMPLE pass: ccp
... In member function 'at::vec::CPU_CAPABILITY::Vectorized<float> at::vec::CPU_CAPABILITY::Vectorized<float>::tanh() const':
... internal compiler error: Segmentation fault
```

Files changed:

- `aten/src/ATen/cpu/vec/sve/vec_bfloat16.h`
- `aten/src/ATen/cpu/vec/sve/vec_float.h`
- `aten/src/ATen/cpu/vec/sve/vec_int.h`

### 4. SVE BF16 transpose tile aliasing

The SVE BF16 transpose helper used `BFloat16` scratch tiles while also loading and storing those tiles through raw `uint16_t` SVE accesses. This keeps the existing tile representation and `uint16_t` helper path, but makes the scalar tile zero/copy operations access the raw `BFloat16::x` member. That avoids the mixed whole-object `BFloat16` / raw `uint16_t` access pattern that caused stale tile values with GCC15.

Failure message:

```text
======================================================================
FAIL: test_transpose_copy (__main__.CPUReproTests)
----------------------------------------------------------------------
...
AssertionError: Tensor-likes are not close!

Mismatched elements: 8 / 289 (2.8%)
Greatest absolute difference: 2.0625 at index (16, 15) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (16, 8) (up to 0.016 allowed)
```

Files changed:

- `aten/src/ATen/cpu/vec/sve/vec_bfloat16.h`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @robert-hardwick 