### PR TITLE
Fix accuracy degradation for baddbmm on CPU for float tensors

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/AccumulateType.h>
 #include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
@@ -1638,9 +1639,9 @@ static inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, 
   int64_t js = result.size(2);
   int64_t ks = self.size(2);
 
-  using opmath_t = at::opmath_type<scalar_t>;
-  opmath_t alpha = alpha_.to<opmath_t>();
-  opmath_t beta = beta_.to<opmath_t>();
+  using accscalar_t = at::acc_type<scalar_t, false>;
+  accscalar_t alpha = alpha_.to<accscalar_t>();
+  accscalar_t beta = beta_.to<accscalar_t>();
 
   auto r0 = result.accessor<scalar_t, 3>();
   auto s0 = self.accessor<const scalar_t, 3>();
@@ -1657,19 +1658,19 @@ static inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, 
           auto r2 = r1[i];
           auto s2 = s1[i];
           for (const auto j : c10::irange(js)) {
-            opmath_t acc_value = 0;//is_bmm ? opmath_t(0) : opmath_t(r2[j]);
+            accscalar_t acc_value = 0;//is_bmm ? opmath_t(0) : opmath_t(r2[j]);
             for (const auto k : c10::irange(ks)) {
-              acc_value += static_cast<opmath_t>(s2[k]) *
-                  static_cast<opmath_t>(m1[k][j]);
+              acc_value += static_cast<accscalar_t>(static_cast<opmath_t>(s2[k]) *
+                  static_cast<opmath_t>(m1[k][j]));
             }
             if (is_bmm) {
               r2[j] = acc_value;
             } else {
               // For beta == 0, the r's value will be ignored, especially for nan value.
-              if (beta == opmath_t{0}) {
+              if (beta == accscalar_t{0}) {
                 r2[j] = alpha * acc_value;
               } else {
-                r2[j] = static_cast<opmath_t>(r2[j]) * beta + alpha * acc_value;
+                r2[j] = static_cast<accscalar_t>(r2[j]) * beta + alpha * acc_value;
               }
             }
           }

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/AccumulateType.h>
 #include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
@@ -1630,9 +1631,9 @@ static inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, 
   int64_t js = result.size(2);
   int64_t ks = self.size(2);
 
-  using opmath_t = at::opmath_type<scalar_t>;
-  opmath_t alpha = alpha_.to<opmath_t>();
-  opmath_t beta = beta_.to<opmath_t>();
+  using accscalar_t = at::acc_type<scalar_t, false>;
+  accscalar_t alpha = alpha_.to<accscalar_t>();
+  accscalar_t beta = beta_.to<accscalar_t>();
 
   auto r0 = result.accessor<scalar_t, 3>();
   auto s0 = self.accessor<const scalar_t, 3>();
@@ -1649,19 +1650,19 @@ static inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, 
           auto r2 = r1[i];
           auto s2 = s1[i];
           for (const auto j : c10::irange(js)) {
-            opmath_t acc_value = 0;//is_bmm ? opmath_t(0) : opmath_t(r2[j]);
+            accscalar_t acc_value = 0;//is_bmm ? opmath_t(0) : opmath_t(r2[j]);
             for (const auto k : c10::irange(ks)) {
-              acc_value += static_cast<opmath_t>(s2[k]) *
-                  static_cast<opmath_t>(m1[k][j]);
+              acc_value += static_cast<accscalar_t>(static_cast<opmath_t>(s2[k]) *
+                  static_cast<opmath_t>(m1[k][j]));
             }
             if (is_bmm) {
               r2[j] = acc_value;
             } else {
               // For beta == 0, the r's value will be ignored, especially for nan value.
-              if (beta == opmath_t{0}) {
+              if (beta == accscalar_t{0}) {
                 r2[j] = alpha * acc_value;
               } else {
-                r2[j] = static_cast<opmath_t>(r2[j]) * beta + alpha * acc_value;
+                r2[j] = static_cast<accscalar_t>(r2[j]) * beta + alpha * acc_value;
               }
             }
           }


### PR DESCRIPTION
Use `acc_type` instead of `opmath_type` to avoid loosing precision leading to different results depending on tensor strides and compiler optimizations.

The basic loop over `ks` gets conditionally vectorized by `-O3` depending on the stride (Option `-fversion-loops-for-strides`).
This leads to slightly different values for non-contiguous tensors that get amplified by further calculations especially during gradient calculation.

`TestOperatorsCPU.test_grad_linalg_lstsq_cpu_float32` fails for this reason:

```
Mismatched elements: 1 / 36 (2.8%)
Greatest absolute difference: 1.1444091796875e-05 at index (0, 2, 0) (up to 1e-05 allowed)
Greatest relative difference: 1.9410221284488216e-05 at index (0, 2, 0) (up to 1.3e-06 allowed)
```

Debugging showed that the output of baddbmm differs by ~1 ULP, so it isn't a compiler issue but (kind of) expected

It looks like `at::acc_type` is exactly for such calculations.