### PR TITLE
[inductor] Skip slow Triton CPU tests

### DIFF
--- a/test/inductor/test_triton_cpu_backend.py
+++ b/test/inductor/test_triton_cpu_backend.py
@@ -1,7 +1,8 @@
 # Owner(s): ["module: inductor"]
+import unittest
+
 from torch._inductor import config
 from torch._inductor.test_case import run_tests
-from torch.testing._internal.common_utils import slowTest
 from torch.testing._internal.inductor_utils import HAS_CPU, TRITON_HAS_CPU
 
 
@@ -53,7 +54,11 @@ if HAS_CPU and TRITON_HAS_CPU:
     )
 
     for name in TRITON_CPU_SLOW_TESTS:
-        setattr(CpuTritonTests, name, slowTest(getattr(CpuTritonTests, name)))
+        setattr(
+            CpuTritonTests,
+            name,
+            unittest.skip("Triton CPU: slow test")(getattr(CpuTritonTests, name)),
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_cpu_backend.py
+++ b/test/inductor/test_triton_cpu_backend.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 from torch._inductor import config
 from torch._inductor.test_case import run_tests
+from torch.testing._internal.common_utils import slowTest
 from torch.testing._internal.inductor_utils import HAS_CPU, TRITON_HAS_CPU
 
 
@@ -9,6 +10,17 @@ try:
 except ImportError:
     import test_torchinductor
 
+TRITON_CPU_SLOW_TESTS = (
+    # ~1000s
+    "test_sort_stable_cpu",
+    # ~300-400s
+    "test_sort_bool_cpu",
+    "test_sort_transpose_cpu",
+    # ~100-300s
+    "test_avg_pool3d_backward2_cpu",
+    "test_pattern_matcher_multi_user_cpu",
+    "test_split_cumsum_cpu",
+)
 
 if HAS_CPU and TRITON_HAS_CPU:
 
@@ -39,6 +51,9 @@ if HAS_CPU and TRITON_HAS_CPU:
         "cpu",
         xfail_prop="_expected_failure_triton_cpu",
     )
+
+    for name in TRITON_CPU_SLOW_TESTS:
+        setattr(CpuTritonTests, name, slowTest(getattr(CpuTritonTests, name)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These tests are frequently added and removed from slow_tests.json. Just skip them for now

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo