### PR TITLE
[Inductor][Triton] Add host-side tensor descriptors for point-wise TMA 

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -40,6 +40,7 @@ from torch.testing._internal.inductor_utils import (
     skip_windows_ci,
     TRITON_HAS_CPU,
 )
+from torch.utils._triton import has_triton_stable_tma_api
 
 
 try:
@@ -1671,6 +1672,27 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         compiled_fn = torch.compile(fn)
         actual = compiled_fn(t)
         self.assertTrue((actual == 4).all())
+
+    @unittest.skipIf(
+        not has_triton_stable_tma_api(),
+        "Host-side TMA requires the Triton stable tensor-descriptor API (triton>=3.4)",
+    )
+    @config.patch({"triton.use_host_side_tma_descriptor": True})
+    def test_silu_host_side_tma_descriptor(self):
+        def fn(x):
+            return torch.nn.functional.silu(x)
+
+        # Contiguous bf16, large enough to be TMA-eligible and a multiple of the
+        # pinned block size so the flattened 1D view tiles evenly.
+        x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=self.device)
+        result, (code,) = run_and_get_code(torch.compile(fn), x)
+
+        self.assertEqual(result, fn(x))
+        # No per-CTA descriptor construction.
+        self.assertNotIn("tl.make_tensor_descriptor", code)
+        # Host builds the descriptor and the kernel arg is a tensordesc<>.
+        self.assertIn("TensorDescriptor.from_tensor", code)
+        self.assertIn("tensordesc<", code)
 
     def test_slice_constant_offset_disables_tma(self):
         """TMA requires 16-byte aligned base; x[1:] with float32 yields 4-byte offset."""

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -107,6 +107,7 @@ from .common import (
     RemovedArg,
     SizeArg,
     TensorArg,
+    TMADescriptorArg,
     WorkspaceArg,
     WorkspaceZeroMode,
 )
@@ -761,15 +762,20 @@ class BlockDescriptorOptions:
 class TensorDescriptorOptions(BlockDescriptorOptions):
     def format(self, name: str, roffset=True) -> str:
         """
-        Codegen a call to tl.make_tensor_descriptor()
+        Codegen a call to tl.make_tensor_descriptor(), or, when host-side TMA is
+        enabled, the kernel-arg reference itself: the descriptor is built once
+        on the host and passed in as `name` (typed tensordesc<>), so the kernel
+        references the argument directly instead of constructing one per CTA.
 
         Args:
             name: variable name for pointer
             roffset: unused, but kept for compatibility with BlockPtrOptions.format()
 
         Returns:
-            "tl.make_tensor_descriptor(...)"
+            "tl.make_tensor_descriptor(...)", or `name` for the host-side path.
         """
+        if V.kernel.register_host_tma_descriptor(self, name):
+            return name
 
         f = V.kernel.index_to_str
         args = [
@@ -3181,6 +3187,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
+        self.host_tma_descriptor_inputs: dict[str, list[int]] = {}
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3880,6 +3887,26 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index,
             expand_shape=expand_shape,
         )
+
+    def register_host_tma_descriptor(
+        self, indexing: TensorDescriptorOptions, name: str
+    ) -> bool:
+        """
+        To support host-side TMA tensor descriptors, record the
+        pinned block shape for kernel arg `name`, so the launcher builds the
+        TensorDescriptor on the host and the signature is upgraded to
+        tensordesc<> and returns True; the caller then references `name`
+        directly instead of emitting a per-CTA tl.make_tensor_descriptor().
+        Returns False to fall back to device-side creation.
+        """
+        if not (
+            config.triton.use_host_side_tma_descriptor and has_triton_stable_tma_api()
+        ):
+            return False
+        if self.inside_reduction or len(indexing.block_shape) != 1:
+            return False
+        self.host_tma_descriptor_inputs[name] = [config.triton.host_side_tma_block_size]
+        return True
 
     def codegen_block_ptr(
         self,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6406,6 +6406,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             )
         if self.tma_min_block_sizes:
             out["tma_min_block_sizes"] = self.tma_min_block_sizes
+        if self.host_tma_descriptor_inputs:
+            out["host_tma_descriptor_block_size"] = (
+                config.triton.host_side_tma_block_size
+            )
         if self.tiling_scores:
             out["tiling_scores"] = self.tiling_scores
         if self.min_xblock is not None:
@@ -6522,6 +6526,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if symbol in V.graph.sizevars.inv_precomputed_replacements:
                     signature[i] = SizeArg(
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
+                    )
+
+        if self.host_tma_descriptor_inputs:
+            for i, arg in enumerate(signature):
+                if (
+                    isinstance(arg, TensorArg)
+                    and arg.name in self.host_tma_descriptor_inputs
+                ):
+                    signature[i] = TMADescriptorArg(
+                        name=arg.name,
+                        api_type="stable",
+                        block_shape=self.host_tma_descriptor_inputs[arg.name],
+                        dtype=arg.dtype,
                     )
 
         mutated_args: OrderedSet[str] = OrderedSet()
@@ -6856,7 +6873,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     ):
         wrapper = V.graph.wrapper_code
         wrapper.write_triton_header_once()
-        _, call_args, _, arg_types = self.args.python_argdefs()
+        argdefs, call_args, _, arg_types = self.args.python_argdefs()
+
+        if self.host_tma_descriptor_inputs:
+            call_args = list(call_args)
+            for i, argdef in enumerate(argdefs):
+                block = self.host_tma_descriptor_inputs.get(argdef.name)
+                if block is None:
+                    continue
+                desc_var = f"{argdef.name}_host_tma_desc"
+                wrapper.writeline(
+                    f"{desc_var} = triton.tools.tensor_descriptor.TensorDescriptor"
+                    f".from_tensor({call_args[i]}.reshape(-1), {block})"
+                )
+                call_args[i] = desc_var
+
         self.add_numel_to_call_args(name, call_args, arg_types)
 
         for ws in self.args.workspace_args:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2072,6 +2072,30 @@ class triton:
     use_tensor_descriptor = False
 
     # (Experimental)
+    # When generating tl.make_tensor_descriptor() loads/stores (use_tensor_descriptor),
+    # build the TensorDescriptor once on the host and pass it in as a kernel argument
+    # instead of reconstructing it inside every CTA. This removes the per-CTA descriptor
+    # construction overhead that makes the device-side TMA path slower than the no-TMA
+    # baseline for memory-bound pointwise/reduction kernels (issue #185819).
+    #
+    # Requires a fixed (pinned) block shape, so kernels using this path are not autotuned
+    # over the TMA'd block dimension. Only the JIT/Python wrapper path is currently
+    # supported; cpp_wrapper/AOTI is a follow-up.
+    use_host_side_tma_descriptor = (
+        os.environ.get("TORCHINDUCTOR_HOST_SIDE_TMA", "0") == "1"
+    )
+
+    # Pinned block size (innermost dim) for host-side TMA descriptors. Used both
+    # for the descriptor's block_shape and to pin the kernel's XBLOCK, so the one
+    # host-created descriptor is valid for the (single) kernel config.
+    #
+    # 4096 is a safe default: on GB200 SiLU it removes the device-side regression
+    # at every size and beats the no-TMA baseline at large sizes, while keeping
+    # XBLOCK moderate enough to avoid register pressure on heavier pointwise
+    # kernels. A size-aware heuristic (scale with numel) is a follow-up.
+    host_side_tma_block_size = 4096
+
+    # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending
     # strides, at the expense of transposing values after load / before store.
     transpose_discontiguous_tensor_descriptor = True

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -199,8 +199,8 @@ class StaticallyLaunchedTritonKernel:
         """
         if ty[0] == "*":
             return "O"
-        elif ty == "nvTmaDesc":
-            raise NotImplementedError("nvTmaDesc kernels are not yet supported")
+        elif ty == "nvTmaDesc" or ty.startswith("tensordesc<"):
+            raise NotImplementedError("TMA descriptor kernels are not yet supported")
         return StaticallyLaunchedTritonKernel.type_mappings()[ty]
 
     def arg_ty_from_signature(self, src: ASTSource) -> str:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3073,6 +3073,15 @@ def cached_autotune(
     has additional debugging, error handling, and on-disk caching.
     """
     inductor_meta = {} if inductor_meta is None else inductor_meta
+
+    # The host builds one TensorDescriptor with a fixed block, so the kernel must
+    # run with XBLOCK pinned to that block for the descriptor to stay valid.
+    host_tma_block = inductor_meta.get("host_tma_descriptor_block_size")
+    if host_tma_block is not None:
+        for tconfig in configs:
+            if "XBLOCK" in tconfig.kwargs:
+                tconfig.kwargs["XBLOCK"] = host_tma_block
+
     if size_hints is not None and heuristic_type in (
         HeuristicType.REDUCTION,
         HeuristicType.PERSISTENT_REDUCTION,


### PR DESCRIPTION
Since #185825 was abandoned, this takes over and is part of fixing #185819. In particular the point-wise split of #186752 which instead takes care of the same issue on the GEMM side.

@jananisriram let me know what you think and let's coordinate further for #186752

cc. @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo