### PR TITLE
Fix NumPy 2 DeprecationWarning in Tensor.__array_wrap__ (#187190)

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -3,6 +3,7 @@
 # Owner(s): ["module: numpy"]
 
 import sys
+import warnings
 from itertools import product
 from unittest import skipIf
 
@@ -484,6 +485,22 @@ class TestNumPyInterop(TestCase):
             self.assertIsInstance(geq2_x, torch.ByteTensor)
             for i in range(len(x)):
                 self.assertEqual(geq2_x[i], geq2_array[i])
+
+    @onlyCPU
+    def test_array_wrap_no_deprecation_warning(self, device):
+        # NumPy 2 calls __array_wrap__ with extra `context` and
+        # `return_scalar` arguments and emits a DeprecationWarning when they
+        # are not accepted. See https://github.com/pytorch/pytorch/issues/180657
+        x = torch.arange(10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # np.delete dispatches through __array_wrap__ on the result.
+            result = np.delete(x, 0)
+        self.assertIsInstance(result, torch.Tensor)
+        self.assertEqual(result, torch.arange(1, 10))
+        # Calling directly with the NumPy 2 signature must also be accepted.
+        wrapped = x.__array_wrap__(np.arange(10), None, False)
+        self.assertIsInstance(wrapped, torch.Tensor)
 
     @onlyCPU
     def test_multiplication_numpy_scalar(self, device) -> None:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1253,7 +1253,10 @@ class Tensor(torch._C.TensorBase):
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`
-    def __array_wrap__(self, array):
+    # NumPy 2 passes `context` and `return_scalar`; torch has no scalars and
+    # does not need the context, so both are accepted and ignored. Declaring
+    # them avoids a NumPy 2 DeprecationWarning about the old call signature.
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.__array_wrap__, (self,), self, array=array

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1341,7 +1341,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         Tensor.__mod__: lambda self, other: -1,
         Tensor.__rmod__: lambda self, other: -1,
         Tensor.__imod__: lambda self, other: -1,
-        Tensor.__array_wrap__: lambda self, array: -1,
+        Tensor.__array_wrap__: lambda self, array, context=None, return_scalar=False: -1,
         Tensor.__getitem__: lambda self, idx: -1,
         Tensor.__deepcopy__: lambda self, memo: -1,
         Tensor.__int__: lambda self: -1,


### PR DESCRIPTION
Summary:

NumPy 2 changed how it invokes the `__array_wrap__` protocol: it now passes two extra positional arguments, `context` and `return_scalar`, and emits a `DeprecationWarning` (through an internal try/except fallback) when the override only accepts `(self, array)`. `torch.Tensor.__array_wrap__` still had the old two-argument signature, so any NumPy ufunc/protocol path that wraps a tensor result (for example `np.delete(torch.arange(10), 0)`) tripped the warning. End users rarely see it because of how `DeprecationWarning` is filtered by default, which is why it went unnoticed.

The fix accepts and ignores the two new arguments. Torch has no scalars and does not need the call `context`, so `context` and `return_scalar` are simply absorbed. Defaults keep the legacy single-argument call working for backward compatibility. The matching lambda in `torch/overrides.py` (used by the override-table/testing machinery) is updated to the same signature to stay consistent. This is the root-cause fix recommended by the issue reporter, a NumPy maintainer, not a warning suppression.

Fixes https://github.com/pytorch/pytorch/issues/180657

This change was authored with the assistance of an AI coding agent.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Claude Code](https://www.internalfb.com/wiki/Confucius/Analect/Dev/Assistant/Claude_Code/)
Trajectory: https://www.internalfb.com/devai/trajectory/e6e4165a-6556-4dd0-a94a-1b7578d53acc
Inspector: https://www.internalfb.com/intern/devai/devmate/inspector/e6e4165a-6556-4dd0-a94a-1b7578d53acc
Agent Home: https://www.internalfb.com/agent-home?session_id=e6e4165a-6556-4dd0-a94a-1b7578d53acc

Test Plan:
Added a regression test `test_array_wrap_no_deprecation_warning` in `test/test_numpy_interop.py` that escalates `DeprecationWarning` to an error around `np.delete(torch.arange(10), 0)` and also exercises the direct NumPy 2 call signature.

Run on a host with a built PyTorch and NumPy 2:

```
python test/test_numpy_interop.py -k test_array_wrap_no_deprecation_warning
```

Validation performed in this environment (no built torch/numpy available here):

```
python3 -m py_compile torch/_tensor.py torch/overrides.py test/test_numpy_interop.py   # SYNTAX OK
arc lint -a fbcode/caffe2/torch/_tensor.py fbcode/caffe2/torch/overrides.py fbcode/caffe2/test/test_numpy_interop.py   # ok No lint issues.
```

A stdlib-only simulation of NumPy 2's calling convention confirmed the old two-argument signature raises `TypeError` on the three-positional-argument call while the patched signature accepts both the new and legacy call forms.

Differential Revision: D107484919


