### PR TITLE
Protect GraphPassRegistry map with shared_mutex against concurrent access (#187192)

### DIFF
--- a/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
+++ b/torch/nativert/graph/passes/pass_manager/GraphPassRegistry.h
@@ -2,6 +2,8 @@
 
 #include <functional>
 #include <map>
+#include <mutex>
+#include <shared_mutex>
 
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
@@ -42,26 +44,40 @@ class GraphPassRegistry {
   }
 
   void add_pass(GraphPass&& pass) {
-    if (auto it = registry_.find(pass.name()); it != registry_.end()) {
-      LOG(WARNING) << "Pass " << pass.name() << " already registered";
-      return;
-    }
-
     GraphPassIdentifier name = pass.name();
-
-    LOG(INFO) << "Pass " << name << " registered";
-    registry_.insert({std::move(name), std::move(pass)});
+    bool already_registered = false;
+    {
+      std::unique_lock lock(mutex_);
+      if (registry_.find(name) != registry_.end()) {
+        already_registered = true;
+      } else {
+        registry_.insert({name, std::move(pass)});
+      }
+    }
+    if (already_registered) {
+      LOG(WARNING) << "Pass " << name << " already registered";
+    } else {
+      LOG(INFO) << "Pass " << name << " registered";
+    }
   }
 
   void remove_pass(const GraphPassIdentifier& name) {
-    if (!registry_.erase(name)) {
-      LOG(WARNING) << "Pass " << name << " not registered but tried to remove";
-      return;
+    bool removed = false;
+    {
+      std::unique_lock lock(mutex_);
+      removed = registry_.erase(name) > 0;
     }
-    LOG(INFO) << "Pass " << name << " unregistered";
+    if (removed) {
+      LOG(INFO) << "Pass " << name << " unregistered";
+    } else {
+      LOG(WARNING) << "Pass " << name << " not registered but tried to remove";
+    }
   }
 
-  const GraphPass& get_pass(const GraphPassIdentifier& name) {
+  // Returns by value: a reference into registry_ would be invalidated by a
+  // concurrent remove_pass once the shared_lock is released.
+  GraphPass get_pass(const GraphPassIdentifier& name) {
+    std::shared_lock lock(mutex_);
     auto it = registry_.find(name);
     TORCH_CHECK(it != registry_.end(), "Pass ", name, " not registered to get");
     return it->second;
@@ -73,6 +89,7 @@ class GraphPassRegistry {
   }
 
   std::map<std::string, GraphPass> registry_;
+  mutable std::shared_mutex mutex_;
 
  public:
   GraphPassRegistry(GraphPassRegistry const&) = delete;


### PR DESCRIPTION
Summary:

Making GraphPassRegistry thread-safe

Test Plan: CI

Differential Revision: D108432093


