### PR TITLE
Preserve CPU memory format in max_unpool2d decomposition

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5516,6 +5516,25 @@ for dtype in (torch.int32, torch.int64):
         with config.patch({"triton.use_block_ptr": use_block_ptr}):
             self.common(fn, (torch.randn(1, 3, *[10] * dim),))
 
+    def test_max_unpool2d_channels_last(self):
+        # https://github.com/pytorch/pytorch/issues/187173
+        if self.device != "cpu":
+            raise unittest.SkipTest(
+                "only the native CPU kernel preserves the input memory format"
+            )
+
+        def fn(p, i):
+            return torch.nn.functional.max_unpool2d(p, i, (8, 8))
+
+        x = torch.randn(2, 4, 8, 8, device=self.device).to(
+            memory_format=torch.channels_last
+        )
+        pooled, indices = torch.nn.functional.max_pool2d(x, 2, return_indices=True)
+        expected = fn(pooled, indices)
+        actual = torch.compile(fn)(pooled, indices)
+        self.assertEqual(expected.stride(), actual.stride())
+        self.assertEqual(expected, actual)
+
     def test_max_unpool_empty_output(self):
         class Unpool1d(nn.Module):
             def __init__(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3190,9 +3190,20 @@ def _max_unpoolnd(
                 f"spatial dimensions, but got output_size[{i}]={size}"
             ),
         )
+
+    # The native CPU kernel preserves the input's memory format
+    # (aten/src/ATen/native/MaxUnpooling.cpp uses suggest_memory_format),
+    # while the CUDA kernel and the 3d kernels always return contiguous output.
+    def _restride(t: TensorLike) -> TensorLike:
+        if dim == 2 and self.device.type == "cpu":
+            return t.contiguous(memory_format=utils.suggest_memory_format(self))
+        return t
+
     output_shape = list(self.shape[:-dim]) + list(output_size)
     if any(s == 0 for s in output_shape):
-        return self.new_zeros(output_shape)
+        # The native CPU kernel still applies the memory format to the empty
+        # output (resize_ runs before the numel()==0 guard); mirror it here.
+        return _restride(self.new_zeros(output_shape))
     nc = reduce(operator.mul, self.shape[:-dim])
     hw = reduce(operator.mul, output_size)
     indices_nc_shape = [1] * self.ndim
@@ -3205,13 +3216,7 @@ def _max_unpoolnd(
     result = aten._unsafe_index_put(
         output.reshape(-1), [indices_flat], self.reshape(-1), accumulate=False
     ).view(output.shape)
-    if dim == 2 and self.device.type == "cpu":
-        # The native CPU kernel preserves the input's memory format
-        # (aten/src/ATen/native/MaxUnpooling.cpp uses suggest_memory_format),
-        # while the CUDA kernel and the 3d kernels always return contiguous
-        # output.
-        result = result.contiguous(memory_format=utils.suggest_memory_format(self))
-    return result
+    return _restride(result)
 
 
 @register_decomposition(aten.max_unpool2d)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3202,9 +3202,16 @@ def _max_unpoolnd(
     ).reshape(-1)
 
     output = self.new_zeros(output_shape)
-    return aten._unsafe_index_put(
+    result = aten._unsafe_index_put(
         output.reshape(-1), [indices_flat], self.reshape(-1), accumulate=False
     ).view(output.shape)
+    if dim == 2 and self.device.type == "cpu":
+        # The native CPU kernel preserves the input's memory format
+        # (aten/src/ATen/native/MaxUnpooling.cpp uses suggest_memory_format),
+        # while the CUDA kernel and the 3d kernels always return contiguous
+        # output.
+        result = result.contiguous(memory_format=utils.suggest_memory_format(self))
+    return result
 
 
 @register_decomposition(aten.max_unpool2d)


### PR DESCRIPTION
Fixes #187173

## Root cause

The `_max_unpoolnd` decomposition computes the result through flat indexing and always produces contiguous output. The native CPU `max_unpooling2d` kernel preserves the input's memory format via `suggest_memory_format` (aten/src/ATen/native/MaxUnpooling.cpp), so for channels-last input, compiled `max_unpool2d` on CPU returns contiguous strides where eager returns channels-last strides, failing the opinfo exact-stride checks with `Significant strides mismatch`.

## Approach

Match eager per device: restride the decomposition output to `suggest_memory_format(input)` for the 2d case on CPU only. Eager is device-dependent here, so the scoping mirrors it: the CUDA 2d kernel calls plain `.contiguous()` and returns contiguous output, and both 3d kernels resize without a memory format, so those paths are intentionally unchanged. Values were already correct (the flat-index math is layout-agnostic); only the output strides change.

Standalone verification (channels-last input, CPU):

```
eager strides:    (4096, 1, 128, 4) channels_last: True
before: compiled  (4096, 1024, 32, 1) channels_last: False
after:  compiled  (4096, 1, 128, 4) channels_last: True, values equal
```

## Test plan

```
python test/inductor/test_torchinductor.py -k max_unpool
Ran 4 tests ... OK (skipped=1)
```

New `test_max_unpool2d_channels_last` asserts compiled strides equal eager strides for channels-last input on CPU; it fails without the fix and passes with it. The two opinfo tests named in the issue require a GPU+triton environment (`@requires_gpu_and_triton` gates the CPU instantiations too) and will be exercised by CI.

Authored with the help of an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison @jansel @shunting314