### PR TITLE
Add target range validation in binary_cross_entropy_with_logits

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -15,6 +15,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_assert_async.h>
 #include <ATen/ops/binary_cross_entropy_backward_native.h>
 #include <ATen/ops/binary_cross_entropy_native.h>
 #include <ATen/ops/binary_cross_entropy_with_logits_native.h>
@@ -347,6 +348,10 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
+  at::_assert_async(
+      (target >= 0).logical_and_(target <= 1).all(),
+      "all elements of target should be between 0 and 1");
+
   auto log_sigmoid_input = at::log_sigmoid(input);
   if (pos_weight_opt.has_value() && pos_weight_opt->defined()) {
       // pos_weight need to be broadcasted, thus mul(target) is not inplace.

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -16,6 +16,8 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_assert_async.h>
+#include <ATen/ops/amax.h>
+#include <ATen/ops/amin.h>
 #include <ATen/ops/binary_cross_entropy_backward_native.h>
 #include <ATen/ops/binary_cross_entropy_native.h>
 #include <ATen/ops/binary_cross_entropy_with_logits_native.h>
@@ -348,9 +350,12 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
-  at::_assert_async(
-      (target >= 0).logical_and_(target <= 1).all(),
-      "all elements of target should be between 0 and 1");
+  if (target.numel() > 0) {
+    // Use amin/amax rather than aminmax because DTensor has no sharding strategy for aminmax.
+    at::_assert_async(
+        (at::amin(target) >= 0).logical_and_(at::amax(target) <= 1),
+        "all elements of target should be between 0 and 1");
+  }
 
   auto log_sigmoid_input = at::log_sigmoid(input);
   if (pos_weight_opt.has_value() && pos_weight_opt->defined()) {

--- a/test/distributed/tensor/test_decompositions.py
+++ b/test/distributed/tensor/test_decompositions.py
@@ -148,7 +148,7 @@ class TestDecompSharding(TestCase):
         # binary_cross_entropy_with_logits
         check_no_strategy(aten.binary_cross_entropy_with_logits.default)
         input = d_empty(16, device_mesh=mesh, placements=[Shard(0)])
-        target = d_empty(16, device_mesh=mesh, placements=[Shard(0)])
+        target = d_empty(16, device_mesh=mesh, placements=[Shard(0)]).fill_(0.5)
         weight = d_empty(16, device_mesh=mesh, placements=[Shard(0)])
         out = aten.binary_cross_entropy_with_logits.default(input, target, weight)
         self.assertEqual(out.placements, (Partial("avg"),))

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -876,24 +876,24 @@ class TestMemoryProfilerE2E(TestCase):
             aten::mul.Tensor                         1 (INPUT), 3 (INPUT)                          -> 4 (INPUT)
             aten::mul.Tensor                         1 (INPUT), 5 (INPUT)                          -> 6 (INPUT)
             aten::cat                                4 (INPUT), 6 (INPUT)                          -> 7 (INPUT)
-            aten::binary_cross_entropy_with_logits   7 (INPUT), 2 (INPUT)                          -> 18 (INPUT)
+            aten::binary_cross_entropy_with_logits   7 (INPUT), 2 (INPUT)                          -> 19 (INPUT)
 
             -- Backward ---------------------------------------------------------------------------------------------
-            aten::ones_like                          18 (INPUT)                                    -> 21 (INPUT)
-            aten::sigmoid                            7 (INPUT)                                     -> 22 (TEMPORARY)
-            aten::sub.Tensor                         22 (TEMPORARY), 2 (INPUT)                     -> 23 (TEMPORARY)
-            aten::mul.Tensor                         23 (TEMPORARY), 21 (INPUT)                    -> 24 (AUTOGRAD_DETAIL)
-            aten::div_.Scalar                        24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 27 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    27 (AUTOGRAD_DETAIL)                          -> 28 (GRADIENT)
-            aten::view                               28 (GRADIENT)                                 -> 28 (GRADIENT)
-            aten::detach                             28 (GRADIENT)                                 -> ???
-            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 29 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    29 (AUTOGRAD_DETAIL)                          -> 30 (GRADIENT)
-            aten::view                               30 (GRADIENT)                                 -> 30 (GRADIENT)
-            aten::detach                             30 (GRADIENT)                                 -> ???""",
+            aten::ones_like                          19 (INPUT)                                    -> 22 (INPUT)
+            aten::sigmoid                            7 (INPUT)                                     -> 23 (TEMPORARY)
+            aten::sub.Tensor                         23 (TEMPORARY), 2 (INPUT)                     -> 24 (TEMPORARY)
+            aten::mul.Tensor                         24 (TEMPORARY), 22 (INPUT)                    -> 25 (AUTOGRAD_DETAIL)
+            aten::div_.Scalar                        25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::mul.Tensor                         25 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 28 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    28 (AUTOGRAD_DETAIL)                          -> 29 (GRADIENT)
+            aten::view                               29 (GRADIENT)                                 -> 29 (GRADIENT)
+            aten::detach                             29 (GRADIENT)                                 -> ???
+            aten::mul.Tensor                         25 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 30 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    30 (AUTOGRAD_DETAIL)                          -> 31 (GRADIENT)
+            aten::view                               31 (GRADIENT)                                 -> 31 (GRADIENT)
+            aten::detach                             31 (GRADIENT)                                 -> ???""",
         )
 
     def test_categories_e2e_simple_fwd_bwd_step(self) -> None:
@@ -926,28 +926,28 @@ class TestMemoryProfilerE2E(TestCase):
             aten::mul.Tensor                         1 (INPUT), 3 (PARAMETER)                      -> 4 (ACTIVATION)
             aten::mul.Tensor                         1 (INPUT), 5 (PARAMETER)                      -> 6 (ACTIVATION)
             aten::cat                                4 (ACTIVATION), 6 (ACTIVATION)                -> 7 (ACTIVATION)
-            aten::binary_cross_entropy_with_logits   7 (ACTIVATION), 2 (INPUT)                     -> 18 (ACTIVATION)
+            aten::binary_cross_entropy_with_logits   7 (ACTIVATION), 2 (INPUT)                     -> 19 (ACTIVATION)
 
             -- Backward ---------------------------------------------------------------------------------------------
-            aten::ones_like                          18 (ACTIVATION)                               -> 21 (ACTIVATION)
-            aten::sigmoid                            7 (ACTIVATION)                                -> 22 (TEMPORARY)
-            aten::sub.Tensor                         22 (TEMPORARY), 2 (INPUT)                     -> 23 (TEMPORARY)
-            aten::mul.Tensor                         23 (TEMPORARY), 21 (ACTIVATION)               -> 24 (AUTOGRAD_DETAIL)
-            aten::div_.Scalar                        24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
-            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 27 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    27 (AUTOGRAD_DETAIL)                          -> 28 (GRADIENT)
-            aten::view                               28 (GRADIENT)                                 -> 28 (GRADIENT)
-            aten::detach                             28 (GRADIENT)                                 -> 28 (GRADIENT)
-            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 29 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    29 (AUTOGRAD_DETAIL)                          -> 30 (GRADIENT)
-            aten::view                               30 (GRADIENT)                                 -> 30 (GRADIENT)
-            aten::detach                             30 (GRADIENT)                                 -> 30 (GRADIENT)
+            aten::ones_like                          19 (ACTIVATION)                               -> 22 (ACTIVATION)
+            aten::sigmoid                            7 (ACTIVATION)                                -> 23 (TEMPORARY)
+            aten::sub.Tensor                         23 (TEMPORARY), 2 (INPUT)                     -> 24 (TEMPORARY)
+            aten::mul.Tensor                         24 (TEMPORARY), 22 (ACTIVATION)               -> 25 (AUTOGRAD_DETAIL)
+            aten::div_.Scalar                        25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       25 (AUTOGRAD_DETAIL)                          -> 25 (AUTOGRAD_DETAIL)
+            aten::mul.Tensor                         25 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 28 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    28 (AUTOGRAD_DETAIL)                          -> 29 (GRADIENT)
+            aten::view                               29 (GRADIENT)                                 -> 29 (GRADIENT)
+            aten::detach                             29 (GRADIENT)                                 -> 29 (GRADIENT)
+            aten::mul.Tensor                         25 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 30 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    30 (AUTOGRAD_DETAIL)                          -> 31 (GRADIENT)
+            aten::view                               31 (GRADIENT)                                 -> 31 (GRADIENT)
+            aten::detach                             31 (GRADIENT)                                 -> 31 (GRADIENT)
 
             -- Optimizer --------------------------------------------------------------------------------------------
-            aten::add_.Tensor                        3 (PARAMETER), 30 (GRADIENT)                  -> 3 (PARAMETER)
-            aten::add_.Tensor                        5 (PARAMETER), 28 (GRADIENT)                  -> 5 (PARAMETER)""",
+            aten::add_.Tensor                        3 (PARAMETER), 31 (GRADIENT)                  -> 3 (PARAMETER)
+            aten::add_.Tensor                        5 (PARAMETER), 29 (GRADIENT)                  -> 5 (PARAMETER)""",
         )
 
     def test_categories_e2e_simple_module_fwd(self) -> None:

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -876,24 +876,24 @@ class TestMemoryProfilerE2E(TestCase):
             aten::mul.Tensor                         1 (INPUT), 3 (INPUT)                          -> 4 (INPUT)
             aten::mul.Tensor                         1 (INPUT), 5 (INPUT)                          -> 6 (INPUT)
             aten::cat                                4 (INPUT), 6 (INPUT)                          -> 7 (INPUT)
-            aten::binary_cross_entropy_with_logits   7 (INPUT), 2 (INPUT)                          -> 11 (INPUT)
+            aten::binary_cross_entropy_with_logits   7 (INPUT), 2 (INPUT)                          -> 18 (INPUT)
 
             -- Backward ---------------------------------------------------------------------------------------------
-            aten::ones_like                          11 (INPUT)                                    -> 14 (INPUT)
-            aten::sigmoid                            7 (INPUT)                                     -> 15 (TEMPORARY)
-            aten::sub.Tensor                         15 (TEMPORARY), 2 (INPUT)                     -> 16 (TEMPORARY)
-            aten::mul.Tensor                         16 (TEMPORARY), 14 (INPUT)                    -> 17 (AUTOGRAD_DETAIL)
-            aten::div_.Scalar                        17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::mul.Tensor                         17 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 20 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    20 (AUTOGRAD_DETAIL)                          -> 21 (GRADIENT)
-            aten::view                               21 (GRADIENT)                                 -> 21 (GRADIENT)
-            aten::detach                             21 (GRADIENT)                                 -> ???
-            aten::mul.Tensor                         17 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 22 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    22 (AUTOGRAD_DETAIL)                          -> 23 (GRADIENT)
-            aten::view                               23 (GRADIENT)                                 -> 23 (GRADIENT)
-            aten::detach                             23 (GRADIENT)                                 -> ???""",
+            aten::ones_like                          18 (INPUT)                                    -> 21 (INPUT)
+            aten::sigmoid                            7 (INPUT)                                     -> 22 (TEMPORARY)
+            aten::sub.Tensor                         22 (TEMPORARY), 2 (INPUT)                     -> 23 (TEMPORARY)
+            aten::mul.Tensor                         23 (TEMPORARY), 21 (INPUT)                    -> 24 (AUTOGRAD_DETAIL)
+            aten::div_.Scalar                        24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 27 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    27 (AUTOGRAD_DETAIL)                          -> 28 (GRADIENT)
+            aten::view                               28 (GRADIENT)                                 -> 28 (GRADIENT)
+            aten::detach                             28 (GRADIENT)                                 -> ???
+            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 29 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    29 (AUTOGRAD_DETAIL)                          -> 30 (GRADIENT)
+            aten::view                               30 (GRADIENT)                                 -> 30 (GRADIENT)
+            aten::detach                             30 (GRADIENT)                                 -> ???""",
         )
 
     def test_categories_e2e_simple_fwd_bwd_step(self) -> None:
@@ -926,28 +926,28 @@ class TestMemoryProfilerE2E(TestCase):
             aten::mul.Tensor                         1 (INPUT), 3 (PARAMETER)                      -> 4 (ACTIVATION)
             aten::mul.Tensor                         1 (INPUT), 5 (PARAMETER)                      -> 6 (ACTIVATION)
             aten::cat                                4 (ACTIVATION), 6 (ACTIVATION)                -> 7 (ACTIVATION)
-            aten::binary_cross_entropy_with_logits   7 (ACTIVATION), 2 (INPUT)                     -> 11 (ACTIVATION)
+            aten::binary_cross_entropy_with_logits   7 (ACTIVATION), 2 (INPUT)                     -> 18 (ACTIVATION)
 
             -- Backward ---------------------------------------------------------------------------------------------
-            aten::ones_like                          11 (ACTIVATION)                               -> 14 (ACTIVATION)
-            aten::sigmoid                            7 (ACTIVATION)                                -> 15 (TEMPORARY)
-            aten::sub.Tensor                         15 (TEMPORARY), 2 (INPUT)                     -> 16 (TEMPORARY)
-            aten::mul.Tensor                         16 (TEMPORARY), 14 (ACTIVATION)               -> 17 (AUTOGRAD_DETAIL)
-            aten::div_.Scalar                        17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::slice.Tensor                       17 (AUTOGRAD_DETAIL)                          -> 17 (AUTOGRAD_DETAIL)
-            aten::mul.Tensor                         17 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 20 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    20 (AUTOGRAD_DETAIL)                          -> 21 (GRADIENT)
-            aten::view                               21 (GRADIENT)                                 -> 21 (GRADIENT)
-            aten::detach                             21 (GRADIENT)                                 -> 21 (GRADIENT)
-            aten::mul.Tensor                         17 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 22 (AUTOGRAD_DETAIL)
-            aten::sum.dim_IntList                    22 (AUTOGRAD_DETAIL)                          -> 23 (GRADIENT)
-            aten::view                               23 (GRADIENT)                                 -> 23 (GRADIENT)
-            aten::detach                             23 (GRADIENT)                                 -> 23 (GRADIENT)
+            aten::ones_like                          18 (ACTIVATION)                               -> 21 (ACTIVATION)
+            aten::sigmoid                            7 (ACTIVATION)                                -> 22 (TEMPORARY)
+            aten::sub.Tensor                         22 (TEMPORARY), 2 (INPUT)                     -> 23 (TEMPORARY)
+            aten::mul.Tensor                         23 (TEMPORARY), 21 (ACTIVATION)               -> 24 (AUTOGRAD_DETAIL)
+            aten::div_.Scalar                        24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::slice.Tensor                       24 (AUTOGRAD_DETAIL)                          -> 24 (AUTOGRAD_DETAIL)
+            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 27 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    27 (AUTOGRAD_DETAIL)                          -> 28 (GRADIENT)
+            aten::view                               28 (GRADIENT)                                 -> 28 (GRADIENT)
+            aten::detach                             28 (GRADIENT)                                 -> 28 (GRADIENT)
+            aten::mul.Tensor                         24 (AUTOGRAD_DETAIL), 1 (INPUT)               -> 29 (AUTOGRAD_DETAIL)
+            aten::sum.dim_IntList                    29 (AUTOGRAD_DETAIL)                          -> 30 (GRADIENT)
+            aten::view                               30 (GRADIENT)                                 -> 30 (GRADIENT)
+            aten::detach                             30 (GRADIENT)                                 -> 30 (GRADIENT)
 
             -- Optimizer --------------------------------------------------------------------------------------------
-            aten::add_.Tensor                        3 (PARAMETER), 23 (GRADIENT)                  -> 3 (PARAMETER)
-            aten::add_.Tensor                        5 (PARAMETER), 21 (GRADIENT)                  -> 5 (PARAMETER)""",
+            aten::add_.Tensor                        3 (PARAMETER), 30 (GRADIENT)                  -> 3 (PARAMETER)
+            aten::add_.Tensor                        5 (PARAMETER), 28 (GRADIENT)                  -> 5 (PARAMETER)""",
         )
 
     def test_categories_e2e_simple_module_fwd(self) -> None:

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1155,7 +1155,7 @@ def forward(self, scores_1, mask_1, value_1):
     def test_binary_cross_entropy_with_logits_decomp(self, device):
         op_config = {
             "self": torch.randn([4, 5, 6], dtype=torch.bfloat16, device=device),
-            "target": torch.randn([4, 5, 6], dtype=torch.bfloat16, device=device),
+            "target": torch.rand([4, 5, 6], dtype=torch.bfloat16, device=device),
             "weight": torch.randn([6], dtype=torch.float32, device=device),
             "reduction": 2,
         }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4100,6 +4100,20 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
             loss_too_positive = bceloss(output_too_positive, target)
 
+    def test_bce_with_logits_target_range(self):
+        bcelogitsloss = nn.BCEWithLogitsLoss()
+
+        output = torch.randn(25, 25)
+        target_valid = torch.rand(25, 25)
+        target_too_negative = target_valid - 1.0
+        target_too_positive = target_valid + 1.0
+
+        bcelogitsloss(output, target_valid)
+        with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+            bcelogitsloss(output, target_too_negative)
+        with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+            bcelogitsloss(output, target_too_positive)
+
     def test_bce_loss_size_mismatch(self):
         bceloss = nn.BCELoss()
         a = torch.rand(25)
@@ -4141,7 +4155,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_bce_with_logits_has_correct_forward_grad(self):
         output = torch.randn(3, 5, requires_grad=True, dtype=torch.double)
-        target = torch.randn(3, 5, dtype=torch.double)
+        target = torch.rand(3, 5, dtype=torch.double)
         for reduction in ('sum', 'mean', 'none'):
             gradcheck(lambda self, target: nn.BCEWithLogitsLoss(reduction=reduction)(self, target),
                       (output, target), check_forward_ad=True)
@@ -9705,7 +9719,7 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.poisson_nll_loss(input, input, reduction=reduction))
             v(lambda: F.gaussian_nll_loss(input, input, var, reduction=reduction))
             v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
-            v(lambda: F.binary_cross_entropy_with_logits(input, input, reduction=reduction))
+            v(lambda: F.binary_cross_entropy_with_logits(input, input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
 
             zeros = torch.zeros_like(input).to(torch.int64)
             v(lambda: F.multilabel_soft_margin_loss(input, zeros, reduction=reduction))

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3192,7 +3192,11 @@ classification_criterion_no_batch = [
         lambda: torch.sigmoid(torch.randn(9, dtype=torch.double)),
         lambda: torch.randn(9, dtype=torch.double).gt(0).to(torch.double)
     ),
-    ('BCEWithLogitsLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.randn(9, dtype=torch.double)),
+    (
+        'BCEWithLogitsLoss',
+        lambda: torch.randn(9, dtype=torch.double),
+        lambda: torch.randn(9, dtype=torch.double).gt(0).to(torch.double)
+    ),
     ('HingeEmbeddingLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.tensor([-1, 1, 1] * 3)),
     ('MultiLabelMarginLoss', lambda: torch.randn(4, dtype=torch.double), lambda: torch.tensor([3, 0, -1, 1])),
     ('SoftMarginLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.tensor([-1, 1, 1] * 3)),


### PR DESCRIPTION
#### Fixes:
 - #123339 

`BCELoss` raises `RuntimeError: all elements of target should be between 0 and 1` for out-of-range targets, but `BCEWithLogitsLoss` silently accepts them and returns a meaningless (possibly negative) loss, even though the documentation of both losses requires targets in [0, 1]:

```python
>>> torch.nn.BCELoss()(torch.FloatTensor([.5]), torch.FloatTensor([2]))
RuntimeError: all elements of target should be between 0 and 1
>>> torch.nn.BCEWithLogitsLoss()(torch.FloatTensor([.5]), torch.FloatTensor([2]))
tensor(-0.0259)
```

### Fix description
Validate the target range in `binary_cross_entropy_with_logits` with `at::_assert_async`. Compared to an eager `TORCH_CHECK(...item())` check (attempted in #123582 and abandoned after CI fallout), `_assert_async`:
- throws a regular `RuntimeError` with the same message as `BCELoss` on CPU;
- performs a sync-free device-side assert on CUDA, matching `BCELoss`'s CUDA failure mode without blocking the hot path;
- is a no-op for meta/fake tensors, so tracing and export are unaffected.

The `torch.compile` decomposition (`torch/_decomp/decompositions.py`) is deliberately left unchanged, so compiled programs keep identical behavior and performance. This matches `BCELoss`, whose in-kernel asserts also do not run under compile.

Several test fixtures generated targets with `randn` (unbounded) in violation of the documented contract; they now generate in-range targets. A regression test `test_bce_with_logits_target_range` is added alongside the existing `test_bce_loss_input_range`.

## Test Plan
```
python test/test_nn.py -k bce -v
python test/test_modules.py -k BCEWithLogits -v
python test/test_ops.py -k binary_cross_entropy_with_logits -v
python test/test_decomp.py -k binary_cross_entropy_with_logits -v
```