### PR TITLE
[DTensor] preserve None SDPA philox output specs

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -22,7 +22,10 @@ from torch.distributed.tensor._op_schema import (
     RuntimeSchemaInfo,
     TupleStrategy,
 )
-from torch.distributed.tensor._ops._matrix_ops import mm_single_dim_strategy
+from torch.distributed.tensor._ops._matrix_ops import (
+    mm_single_dim_strategy,
+    scaled_dot_product_efficient_attention_single_dim_strategy,
+)
 from torch.distributed.tensor._ops._pointwise_ops import (
     _BINARY_ADDITIVE_RULES,
     _common_pointwise_single_dim_strategy,
@@ -992,6 +995,72 @@ class TestExpandPlaceholder(TestCase):
                 self.assertIsInstance(out_spec, DTensorSpec)
 
             self.assertEqual(len(op_spec.input_specs), 1, "Should have 1 input tensor")
+
+    def test_sdpa_efficient_attention_preserves_none_scalar_outputs(self):
+        mesh = DeviceMesh("cpu", mesh=torch.arange(4).reshape(2, 2))
+
+        op = torch.ops.aten._scaled_dot_product_efficient_attention.default
+        q = torch.empty((4, 4, 8, 16), device="meta")
+        outputs = op(q, q, q, None, True)
+        output_metas = tuple(TensorMeta(t.shape, t.stride(), t.dtype) for t in outputs)
+
+        input_meta = TensorMeta(q.shape, q.stride(), q.dtype)
+        input_spec = DTensorSpec(
+            mesh,
+            (Replicate(), Shard(1)),
+            tensor_meta=input_meta,
+        )
+        input_strategy = OpStrategy([OpSpec(input_spec)])
+        op_schema = OpSchema(
+            op=op,
+            args_schema=(input_strategy,) * 3 + (None, True),
+            kwargs_schema={},
+        )
+
+        expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
+            mesh,
+            op_schema,
+            _SingleDimStrategyInfo(
+                scaled_dot_product_efficient_attention_single_dim_strategy
+            ),
+            output_metas,
+        )
+        strategy = expanded_strategy_fn(
+            op_schema.op,
+            op_schema.args_meta,
+            op_schema.kwargs_meta,
+        )
+
+        for op_spec in strategy.strategies:
+            output_specs = op_spec.output_specs
+            self.assertIsInstance(output_specs, tuple)
+            self.assertEqual(output_specs[2:4], (None, None))
+
+    def test_expand_rejects_mixed_none_output_placements(self):
+        mesh = DeviceMesh("cpu", mesh=torch.arange(4).reshape(2, 2))
+        meta = TensorMeta(torch.Size([8, 8]), (8, 1), torch.float32)
+        input_spec = DTensorSpec(
+            mesh,
+            (Replicate(), Replicate()),
+            tensor_meta=meta,
+        )
+        op_schema = OpSchema(
+            op=torch.ops.aten.add.Tensor,
+            args_schema=(OpStrategy([OpSpec(input_spec)]),),
+            kwargs_schema={},
+        )
+
+        with self.assertRaisesRegex(AssertionError, "mixes None with placements"):
+            expand_to_full_mesh_op_strategy(
+                mesh,
+                op_schema,
+                [
+                    [Replicate(), Replicate()],
+                    [None, Replicate()],
+                ],
+                output_tensor_meta=meta,
+                input_index=1,
+            )
 
     def test_inplace_op_partial_input_raises_clear_error(self):
         """Test that inplace ops with Partial input raise a clear error.

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -108,6 +108,8 @@ def _insert_single_dim_replication_strategy(
     Inserts the [Replicate(), Replicate(), ...] strategy after asserting that such strategy does not yet exist.
     For ops with masked-off outputs (e.g. backward ops with output_mask), output positions
     where output_tensor_meta is None are set to None in the all-Replicate rule.
+    Output positions that are explicitly None in every strategy are also preserved
+    as None in the inserted rule.
     """
     for strategy in single_dim_strategies_with_placeholders:
         if all(isinstance(p, Replicate) or p is None for p in strategy):
@@ -117,10 +119,17 @@ def _insert_single_dim_replication_strategy(
         Replicate()
     ] * total_len
     # Set None for masked-off output positions based on output_tensor_meta
-    if isinstance(output_tensor_meta, Sequence):
+    if isinstance(output_tensor_meta, Sequence) and not isinstance(
+        output_tensor_meta, TensorMeta
+    ):
         for i, meta in enumerate(output_tensor_meta):
             if meta is None and i < num_outputs:
                 replicate_rule[i] = None
+    for i in range(num_outputs):
+        if single_dim_strategies_with_placeholders and all(
+            strategy[i] is None for strategy in single_dim_strategies_with_placeholders
+        ):
+            replicate_rule[i] = None
     single_dim_strategies_with_placeholders.insert(0, replicate_rule)
     return single_dim_strategies_with_placeholders
 
@@ -253,11 +262,19 @@ def _build_output_specs(
         )
 
     def _spec_for_output(out_idx: int) -> DTensorSpec | None:
+        maybe_placements = tuple(out[out_idx] for out in per_mesh_dim_placements)
+        # All mesh dims agreeing on None means the whole output has no
+        # DTensorSpec, e.g. local scalar SDPA philox outputs.
+        if all(placement is None for placement in maybe_placements):
+            return None
+        if any(placement is None for placement in maybe_placements):
+            raise AssertionError(
+                f"Output {out_idx} mixes None with placements across mesh dims: "
+                f"{maybe_placements}"
+            )
         if output_metas[out_idx] is None:
             return None
-        placements = tuple(
-            cast(Placement, out[out_idx]) for out in per_mesh_dim_placements
-        )
+        placements = tuple(cast(Placement, placement) for placement in maybe_placements)
         return DTensorSpec(mesh, placements, tensor_meta=output_metas[out_idx])
 
     if num_outputs > 1:

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -466,7 +466,14 @@ def expand_to_full_mesh_op_strategy(
         # (e.g., philox_seed/offset in SDPA are scalar tensors without OpStrategy)
         input_strategy_counter = 0
         for position, specs in enumerate(zip(*strategy_comb, strict=True)):
-            if specs[0] is not None:
+            if any(spec is None for spec in specs):
+                if any(spec is not None for spec in specs):
+                    raise AssertionError(
+                        f"{op_schema.op}: strategy position {position} mixes None "
+                        f"with placements across mesh dims: {specs}"
+                    )
+                spec_list.append(None)
+            else:
                 # Populate tensor_meta field for both output and input specs,
                 # including for tuple output cases
                 tensor_meta = None
@@ -505,8 +512,6 @@ def expand_to_full_mesh_op_strategy(
                         use_strided_shard_as_shard_order=use_strided,
                     )
                 )
-            else:
-                spec_list.append(None)
 
         # Skip strategy combinations that would create mixed partial types
         # (except sum+avg which commute with each other).


### PR DESCRIPTION
The single-dim strategy path inserts an implicit all-Replicate rule. SDPA efficient attention intentionally uses None output specs for philox_seed and philox_offset so those scalar tensor outputs remain local tensors, matching the previous op-strategy behavior. The inserted rule used Replicate for those outputs because meta propagation returns real scalar TensorMeta, so combining it with explicit SDPA rules on a 2D mesh could build a DTensorSpec with placements=(Replicate(), None).

This addresses a regression from #186667, which migrated matrix ops to single-dim strategies and introduced the mixed per-mesh-dim behavior for these outputs.

Preserve output positions that are None in every explicit single-dim strategy when inserting the implicit replicate rule. Also make full-mesh expansion reject mixed None/Placement entries instead of constructing invalid DTensorSpec objects.

Test Plan: Added regression tests for SDPA efficient-attention philox scalar outputs and mixed None/Placement output rejection. Ran the affected tests and lintrunner.

Authored with the assistance of an AI coding assistant.