### PR TITLE
Add get_device_name and memory snapshot accelerator APIs

### DIFF
--- a/docs/source/accelerator.md
+++ b/docs/source/accelerator.md
@@ -50,6 +50,7 @@ per-backend modules, the following APIs are delegated to each backend:
     current_device_index
     current_device_idx
     get_device_capability
+    get_device_name
     set_stream
     current_stream
     synchronize

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: tests"]
 
 import gc
+import os
 import sys
+import tempfile
 import unittest
 from contextlib import nullcontext
 
@@ -269,6 +271,40 @@ class TestAccelerator(TestCase):
         free_bytes, total_bytes = torch.accelerator.get_memory_info()
         self.assertGreaterEqual(free_bytes, 0)
         self.assertGreaterEqual(total_bytes, 0)
+
+    def test_get_device_name(self):
+        device_name = torch.accelerator.get_device_name()
+        self.assertIsInstance(device_name, str)
+
+        acc = torch.accelerator.current_accelerator()
+        mod = torch.get_device_module(acc)
+        if hasattr(mod, "get_device_name"):
+            self.assertGreater(len(device_name), 0)
+
+    @unittest.skipIf(TEST_MPS, "MPS doesn't support torch.accelerator memory API!")
+    def test_memory_snapshot(self):
+        acc = torch.accelerator.current_accelerator()
+        mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+        if (
+            mem_mod is None
+            or not hasattr(mem_mod, "_dump_snapshot")
+            or not hasattr(mem_mod, "_snapshot")
+        ):
+            self.skipTest("Backend doesn't support memory snapshots")
+        snapshot_path = os.path.join(tempfile.gettempdir(), "test_snapshot.pickle")
+        torch.accelerator.memory._record_memory_history(max_entries=100)
+        try:
+            _ = torch.ones(64, device=acc)
+            snapshot = torch.accelerator.memory._snapshot()
+            self.assertIsInstance(snapshot, dict)
+            self.assertIn("segments", snapshot)
+            self.assertIn("device_traces", snapshot)
+            torch.accelerator.memory._dump_snapshot(snapshot_path)
+            self.assertTrue(os.path.exists(snapshot_path))
+        finally:
+            torch.accelerator.memory._record_memory_history(enabled=None)
+            if os.path.exists(snapshot_path):
+                os.remove(snapshot_path)
 
     @unittest.skipIf(
         TEST_XPU,

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -303,11 +303,7 @@ class TestAccelerator(TestCase):
     def test_memory_snapshot(self):
         acc = torch.accelerator.current_accelerator()
         mem_mod = getattr(torch.get_device_module(acc), "memory", None)
-        if (
-            mem_mod is None
-            or not hasattr(mem_mod, "_dump_snapshot")
-            or not hasattr(mem_mod, "_snapshot")
-        ):
+        if mem_mod is None or not hasattr(mem_mod, "_snapshot"):
             self.skipTest("Backend doesn't support memory snapshots")
         snapshot_path = os.path.join(tempfile.gettempdir(), "test_snapshot.pickle")
         torch.accelerator.memory._record_memory_history(max_entries=100)

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -2,7 +2,9 @@
 
 import gc
 import operator
+import os
 import sys
+import tempfile
 import unittest
 from contextlib import nullcontext
 
@@ -287,6 +289,40 @@ class TestAccelerator(TestCase):
         free_bytes, total_bytes = torch.accelerator.get_memory_info()
         self.assertGreaterEqual(free_bytes, 0)
         self.assertGreaterEqual(total_bytes, 0)
+
+    def test_get_device_name(self):
+        device_name = torch.accelerator.get_device_name()
+        self.assertIsInstance(device_name, str)
+
+        acc = torch.accelerator.current_accelerator()
+        mod = torch.get_device_module(acc)
+        if hasattr(mod, "get_device_name"):
+            self.assertGreater(len(device_name), 0)
+
+    @unittest.skipIf(TEST_MPS, "MPS doesn't support torch.accelerator memory API!")
+    def test_memory_snapshot(self):
+        acc = torch.accelerator.current_accelerator()
+        mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+        if (
+            mem_mod is None
+            or not hasattr(mem_mod, "_dump_snapshot")
+            or not hasattr(mem_mod, "_snapshot")
+        ):
+            self.skipTest("Backend doesn't support memory snapshots")
+        snapshot_path = os.path.join(tempfile.gettempdir(), "test_snapshot.pickle")
+        torch.accelerator.memory._record_memory_history(max_entries=100)
+        try:
+            _ = torch.ones(64, device=acc)
+            snapshot = torch.accelerator.memory._snapshot()
+            self.assertIsInstance(snapshot, dict)
+            self.assertIn("segments", snapshot)
+            self.assertIn("device_traces", snapshot)
+            torch.accelerator.memory._dump_snapshot(snapshot_path)
+            self.assertTrue(os.path.exists(snapshot_path))
+        finally:
+            torch.accelerator.memory._record_memory_history(enabled=None)
+            if os.path.exists(snapshot_path):
+                os.remove(snapshot_path)
 
     @unittest.skipIf(
         TEST_XPU,

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "current_device_idx",  # deprecated
     "current_device_index",
     "get_device_capability",
+    "get_device_name",
     "current_stream",
     "device_count",
     "device_index",
@@ -69,6 +70,27 @@ def device_count() -> int:
 
     mod = torch.get_device_module(acc)
     return mod.device_count()
+
+
+def get_device_name(device: _device_t = None, /) -> str:
+    r"""Return the name of the current :ref:`accelerator<accelerators>` device.
+
+    Args:
+        device (:class:`torch.device`, str, int, optional): The device to query the name for.
+            If not given, use :func:`torch.accelerator.current_device_index` by default.
+
+    Returns:
+        str: the name of the device, or an empty string if no accelerator is
+            available or the backend does not implement device name querying.
+    """
+    acc = current_accelerator()
+    if acc is None:
+        return ""
+
+    mod = torch.get_device_module(acc)
+    if not hasattr(mod, "get_device_name"):
+        return ""
+    return mod.get_device_name(device)
 
 
 def is_available() -> bool:

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 from typing import Any
 
@@ -253,11 +254,10 @@ def get_memory_info(device_index: _device_t = None, /) -> tuple[int, int]:
     return torch._C._accelerator_getMemoryInfo(device_index)
 
 
-def _snapshot(device=None, augment_with_fx_traces: bool = False):
+def _snapshot(device=None, augment_with_fx_traces: bool = False) -> dict[str, Any]:
     r"""Return a snapshot of the current :ref:`accelerator<accelerators>` memory allocator state.
 
-    Requires :func:`_record_memory_history` on the appropriate device module
-    (e.g., :func:`torch.cuda.memory._record_memory_history`) to have been called.
+    Requires :func:`torch.accelerator.memory._record_memory_history` to have been called.
 
     Args:
         device: the device to snapshot. If not given, uses the current device.
@@ -265,13 +265,63 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
             with FX graph information. Default: ``False``.
 
     Returns:
-        dict: a dictionary containing memory allocator state information.
+        dict: a dictionary containing memory allocator state information,
+            or an empty dict if no accelerator is available or the backend
+            does not support memory snapshots.
     """
     acc = torch.accelerator.current_accelerator()
-    if acc is not None and acc.type == "xpu":
-        return torch.xpu.memory._snapshot(
-            device, augment_with_fx_traces=augment_with_fx_traces
-        )
-    return torch.cuda.memory._snapshot(
-        device, augment_with_fx_traces=augment_with_fx_traces
-    )
+    if acc is None:
+        return {}
+    mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+    if mem_mod is None or not hasattr(mem_mod, "_snapshot"):
+        return {}
+    return mem_mod._snapshot(device, augment_with_fx_traces=augment_with_fx_traces)
+
+
+def _record_memory_history(
+    enabled: str | None = "all",
+    *,
+    max_entries: int = sys.maxsize,
+    **kwargs,
+) -> None:
+    r"""Enable recording of stack traces associated with memory allocations for
+    the current :ref:`accelerator<accelerators>`.
+
+    This is a no-op if the current accelerator does not support memory history recording.
+
+    Args:
+        enabled (str or None): ``"all"`` records all events, ``"state"`` records
+            only current allocations, ``None`` disables recording.
+            Default: ``"all"``.
+        max_entries (int, optional): Maximum number of trace entries to store.
+            Default: ``sys.maxsize``.
+    """
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
+        return
+    mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+    if mem_mod is None or not hasattr(mem_mod, "_record_memory_history"):
+        return
+    mem_mod._record_memory_history(enabled=enabled, max_entries=max_entries, **kwargs)
+
+
+def _dump_snapshot(
+    filename: str = "dump_snapshot.pickle", augment_with_fx_traces: bool = False
+) -> None:
+    r"""Save a pickled snapshot of the current :ref:`accelerator<accelerators>` memory state.
+
+    This is a no-op if the current accelerator does not support memory snapshots.
+
+    Args:
+        filename (str, optional): Path to write the snapshot to.
+            Default: ``"dump_snapshot.pickle"``.
+        augment_with_fx_traces (bool, optional): if True, augment stack traces
+            with FX graph information. Default: ``False``.
+    """
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
+        return
+    mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+    if mem_mod is None or not hasattr(mem_mod, "_dump_snapshot"):
+        return
+    mem_mod._dump_snapshot(filename, augment_with_fx_traces=augment_with_fx_traces)

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 from collections import OrderedDict
 from typing import Any
@@ -309,19 +310,15 @@ def _dump_snapshot(
     filename: str = "dump_snapshot.pickle", augment_with_fx_traces: bool = False
 ) -> None:
     r"""Save a pickled snapshot of the current :ref:`accelerator<accelerators>` memory state.
-
     This is a no-op if the current accelerator does not support memory snapshots.
-
     Args:
         filename (str, optional): Path to write the snapshot to.
             Default: ``"dump_snapshot.pickle"``.
         augment_with_fx_traces (bool, optional): if True, augment stack traces
             with FX graph information. Default: ``False``.
     """
-    acc = torch.accelerator.current_accelerator()
-    if acc is None:
+    snapshot = _snapshot(augment_with_fx_traces=augment_with_fx_traces)
+    if not snapshot:
         return
-    mem_mod = getattr(torch.get_device_module(acc), "memory", None)
-    if mem_mod is None or not hasattr(mem_mod, "_dump_snapshot"):
-        return
-    mem_mod._dump_snapshot(filename, augment_with_fx_traces=augment_with_fx_traces)
+    with open(filename, "wb") as f:
+        pickle.dump(snapshot, f)


### PR DESCRIPTION
## Summary
Adds `torch.accelerator.get_device_name()` and three memory diagnostic
APIs (`_record_memory_history`, `_dump_snapshot`, `_snapshot`) to the
generic accelerator module to replace CUDA-specific calls in Inductor's
diagnostic and instrumentation code.

These APIs follow the accelerator interface design principle: the
accelerator module serves as a reference interface for all device
backends, and no backend is required to implement every feature. For
backends that do not implement a given feature, the default implementation
returns a sentinel value (`""` for `get_device_name`, `{}` for
`_snapshot`, no-op for `_record_memory_history` and `_dump_snapshot`) to
indicate that the functionality is unavailable. This allows generic
diagnostic and instrumentation code to run consistently across all
hardware without branching on device type.

Also fixes the pre-existing `_snapshot` implementation which hardcoded
CUDA/XPU dispatch instead of using the generic device module pattern.

cc @albanD @guangyey @EikanWang