### PR TITLE
Use abs() in lp_pool to avoid NaN for non-integer norm_type

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -917,6 +917,21 @@ torch.cuda.synchronize()
         with self.assertRaisesRegex(RuntimeError, "integer out of range"):
             avgpool(inp)
 
+    @onlyCPU
+    def test_lp_pool_noninteger_norm_no_nan(self, device):
+        torch.manual_seed(0)
+        x = torch.randn(2, 3, 8, device=device)
+        out1d = F.lp_pool1d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out1d).any())
+
+        x = torch.randn(2, 3, 8, 8, device=device)
+        out2d = F.lp_pool2d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out2d).any())
+
+        x = torch.randn(2, 3, 8, 8, 8, device=device)
+        out3d = F.lp_pool3d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out3d).any())
+
     @onlyNativeDeviceTypes
     def test_AvgPool2d_empty(self, device):
         avgpool = torch.nn.AvgPool2d(3, stride=2).to(device)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -963,6 +963,22 @@ torch.cuda.synchronize()
         with self.assertRaisesRegex(ValueError, err):
             torch.nn.LPPool3d(norm_type=0, kernel_size=3)
 
+    @onlyNativeDeviceTypes
+    def test_lp_pool_noninteger_norm_no_nan(self, device):
+        torch.manual_seed(0)
+        x = torch.randn(2, 3, 8, device=device)
+        out1d = F.lp_pool1d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out1d).any())
+
+        x = torch.randn(2, 3, 8, 8, device=device)
+        out2d = F.lp_pool2d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out2d).any())
+
+        x = torch.randn(2, 3, 8, 8, 8, device=device)
+        out3d = F.lp_pool3d(x, norm_type=2.5, kernel_size=2)
+        self.assertFalse(torch.isnan(out3d).any())
+
+    @onlyNativeDeviceTypes
     def test_AvgPool2d_empty(self, device):
         avgpool = torch.nn.AvgPool2d(3, stride=2).to(device)
         inp = torch.randn(0, 16, 20, 32, device=device)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -917,7 +917,7 @@ torch.cuda.synchronize()
         with self.assertRaisesRegex(RuntimeError, "integer out of range"):
             avgpool(inp)
 
-    @onlyCPU
+    @onlyNativeDeviceTypes
     def test_lp_pool_noninteger_norm_no_nan(self, device):
         torch.manual_seed(0)
         x = torch.randn(2, 3, 8, device=device)

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -1010,7 +1010,7 @@ inline Tensor lp_pool1d(
     ExpandingArray<1> stride,
     bool ceil_mode) {
   Tensor out = detail::avg_pool1d(
-      input.abs().pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1058,7 +1058,7 @@ inline Tensor lp_pool2d(
   auto kw = (*kernel_size)[0];
   auto kh = (*kernel_size)[1];
   Tensor out = detail::avg_pool2d(
-      input.abs().pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1108,7 +1108,7 @@ inline Tensor lp_pool3d(
   auto kw = (*kernel_size)[1];
   auto kh = (*kernel_size)[2];
   Tensor out = detail::avg_pool3d(
-      input.abs().pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -1010,14 +1010,14 @@ inline Tensor lp_pool1d(
     ExpandingArray<1> stride,
     bool ceil_mode) {
   Tensor out = detail::avg_pool1d(
-      input.pow(norm_type),
+      input.abs().pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
       ceil_mode,
       /*count_include_pad=*/true);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul((*kernel_size)[0])
       .pow(1. / norm_type);
 }
@@ -1058,7 +1058,7 @@ inline Tensor lp_pool2d(
   auto kw = (*kernel_size)[0];
   auto kh = (*kernel_size)[1];
   Tensor out = detail::avg_pool2d(
-      input.pow(norm_type),
+      input.abs().pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1066,7 +1066,7 @@ inline Tensor lp_pool2d(
       /*count_include_pad=*/true,
       /*divisor_override=*/std::nullopt);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul(kw * kh)
       .pow(1. / norm_type);
 }
@@ -1108,7 +1108,7 @@ inline Tensor lp_pool3d(
   auto kw = (*kernel_size)[1];
   auto kh = (*kernel_size)[2];
   Tensor out = detail::avg_pool3d(
-      input.pow(norm_type),
+      input.abs().pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1116,7 +1116,7 @@ inline Tensor lp_pool3d(
       /*count_include_pad=*/true,
       /*divisor_override=*/std::nullopt);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul(kd * kw * kh)
       .pow(1. / norm_type);
 }

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -1010,14 +1010,14 @@ inline Tensor lp_pool1d(
     ExpandingArray<1> stride,
     bool ceil_mode) {
   Tensor out = detail::avg_pool1d(
-      input.pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
       ceil_mode,
       /*count_include_pad=*/true);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul((*kernel_size)[0])
       .pow(1. / norm_type);
 }
@@ -1058,7 +1058,7 @@ inline Tensor lp_pool2d(
   auto kw = (*kernel_size)[0];
   auto kh = (*kernel_size)[1];
   Tensor out = detail::avg_pool2d(
-      input.pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1066,7 +1066,7 @@ inline Tensor lp_pool2d(
       /*count_include_pad=*/true,
       /*divisor_override=*/std::nullopt);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul(kw * kh)
       .pow(1. / norm_type);
 }
@@ -1108,7 +1108,7 @@ inline Tensor lp_pool3d(
   auto kw = (*kernel_size)[1];
   auto kh = (*kernel_size)[2];
   Tensor out = detail::avg_pool3d(
-      input.pow(norm_type),
+      input.abs().pow_(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1116,7 +1116,7 @@ inline Tensor lp_pool3d(
       /*count_include_pad=*/true,
       /*divisor_override=*/std::nullopt);
 
-  return (torch::sign(out) * relu(torch::abs(out)))
+  return relu(out)
       .mul(kd * kw * kh)
       .pow(1. / norm_type);
 }

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1114,10 +1114,10 @@ def lp_pool3d(
         )
     kd, kw, kh = _triple(kernel_size)
     if stride is not None:
-        out = avg_pool3d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool3d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool3d(
-            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return relu(out).mul(kd * kw * kh).pow(1.0 / norm_type)
@@ -1153,10 +1153,10 @@ def lp_pool2d(
         )
     kw, kh = _pair(kernel_size)
     if stride is not None:
-        out = avg_pool2d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool2d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool2d(
-            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return relu(out).mul(kw * kh).pow(1.0 / norm_type)
@@ -1190,10 +1190,10 @@ def lp_pool1d(
             ceil_mode=ceil_mode,
         )
     if stride is not None:
-        out = avg_pool1d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool1d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool1d(
-            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return relu(out).mul(kernel_size).pow(1.0 / norm_type)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1114,15 +1114,13 @@ def lp_pool3d(
         )
     kd, kw, kh = _triple(kernel_size)
     if stride is not None:
-        out = avg_pool3d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool3d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool3d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (
-        (torch.sign(out) * relu(torch.abs(out))).mul(kd * kw * kh).pow(1.0 / norm_type)
-    )
+    return relu(out).mul(kd * kw * kh).pow(1.0 / norm_type)
 
 
 def lp_pool2d(
@@ -1155,13 +1153,13 @@ def lp_pool2d(
         )
     kw, kh = _pair(kernel_size)
     if stride is not None:
-        out = avg_pool2d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool2d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool2d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (torch.sign(out) * relu(torch.abs(out))).mul(kw * kh).pow(1.0 / norm_type)
+    return relu(out).mul(kw * kh).pow(1.0 / norm_type)
 
 
 def lp_pool1d(
@@ -1192,15 +1190,13 @@ def lp_pool1d(
             ceil_mode=ceil_mode,
         )
     if stride is not None:
-        out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool1d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool1d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (
-        (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1.0 / norm_type)
-    )
+    return relu(out).mul(kernel_size).pow(1.0 / norm_type)
 
 
 def adaptive_max_pool1d_with_indices(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1146,15 +1146,13 @@ def lp_pool3d(
             return -max_pool3d(-input.abs(), kernel_size, stride, 0, 1, ceil_mode)
 
     if stride is not None:
-        out = avg_pool3d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool3d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool3d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (
-        (torch.sign(out) * relu(torch.abs(out))).mul(kd * kw * kh).pow(1.0 / norm_type)
-    )
+    return relu(out).mul(kd * kw * kh).pow(1.0 / norm_type)
 
 
 def lp_pool2d(
@@ -1195,13 +1193,13 @@ def lp_pool2d(
             return -max_pool2d(-input.abs(), kernel_size, stride, 0, 1, ceil_mode)
 
     if stride is not None:
-        out = avg_pool2d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool2d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool2d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (torch.sign(out) * relu(torch.abs(out))).mul(kw * kh).pow(1.0 / norm_type)
+    return relu(out).mul(kw * kh).pow(1.0 / norm_type)
 
 
 def lp_pool1d(
@@ -1240,15 +1238,13 @@ def lp_pool1d(
             return -max_pool1d(-input.abs(), kernel_size, stride, 0, 1, ceil_mode)
 
     if stride is not None:
-        out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool1d(input.abs().pow_(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool1d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow_(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
-    return (
-        (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1.0 / norm_type)
-    )
+    return relu(out).mul(kernel_size).pow(1.0 / norm_type)
 
 
 def adaptive_max_pool1d_with_indices(

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1126,7 +1126,7 @@ class LPPool1d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to Average Pooling)
@@ -1173,7 +1173,7 @@ class LPPool2d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)
@@ -1233,7 +1233,7 @@ class LPPool3d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1130,7 +1130,7 @@ class LPPool1d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling over absolute values
     - At p = 1, one gets Sum Pooling (which is proportional to Average Pooling)
@@ -1177,7 +1177,7 @@ class LPPool2d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling over absolute values
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)
@@ -1237,7 +1237,7 @@ class LPPool3d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling over absolute values
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)


### PR DESCRIPTION
Fixes #184037

`lp_pool{1,2,3}d` compute `input.pow(norm_type)` directly. For non-integer `norm_type` (e.g. 2.3) and negative input values, `(-x)^p` is undefined in IEEE floating point and produces NaN:

```python
m = nn.LPPool2d(norm_type=2.3, kernel_size=1)
m(torch.randn(2, 8, 8, 8))  # NaN everywhere negatives appear
```

The standard Lp norm is defined as `(sum |x_i|^p)^(1/p)`. The current code omits the absolute value. The docstring also claims "At p = infinity, one gets Max Pooling" which only holds for `|x|^p`.

**Fix:** Change `input.pow(norm_type)` to `input.abs().pow(norm_type)` consistently across:
- `torch/nn/functional.py` — all three `lp_pool{1,2,3}d` Python implementations
- `torch/csrc/api/include/torch/nn/functional/pooling.h` — C++ API parity
- `torch/nn/modules/pooling.py` — docstrings: `x^p` to `|x|^p` in all three LPPool classes

Since intermediate values are now always non-negative, the `sign(out) * relu(abs(out))` output formula simplifies to `relu(out)`.

**Note:** A prior PR (#184511) attempted the same fix but was closed due to a bad rebase accumulating unrelated files. This is a clean re-submission of that approach.

**Test:** `test_lp_pool_noninteger_norm_no_nan` in `test/nn/test_pooling.py` verifying all three variants produce no NaN with signed input.

cc @jbschlosser @albanD @zou3519