### PR TITLE
[BE][Ez]: Use CPP20 rvalue overload for ostringstream

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -138,7 +138,7 @@ inline std::string _all_equal_numel_error(at::ArrayRef<Tensor> tensors) {
   }
   oss << "and " << tensors[tensors.size() - 1].numel()
       << " elements respectively";
-  return oss.str();
+  return std::move(oss).str();
 }
 
 inline bool _apply_preamble(ArrayRef<Tensor> tensors) {

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -138,7 +138,7 @@ inline std::string _all_equal_numel_error(at::ArrayRef<Tensor> tensors) {
   }
   oss << "and " << tensors[tensors.size() - 1].numel()
       << " elements respectively";
-  return std::move(oss).str();
+  return oss.str();
 }
 
 inline bool _apply_preamble(ArrayRef<Tensor> tensors) {

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
 #include <c10/util/irange.h>
+#include <algorithm>
 #include <cstring>
 #include <limits>
 
@@ -46,7 +47,7 @@ inline Tensor sort_strides(Tensor& tensor_) {
   for (const auto i : c10::irange(tensor_.ndimension())) {
     indices.push_back(i);
   }
-  std::sort(indices.begin(), indices.end(), [&strides](int64_t i1, int64_t i2) {
+  std::ranges::sort(indices, [&strides](int64_t i1, int64_t i2) {
     return strides[i1] > strides[i2];
   });
   Tensor tensor = tensor_.permute(indices);

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -4,7 +4,6 @@
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
 #include <c10/util/irange.h>
-#include <algorithm>
 #include <cstring>
 #include <limits>
 
@@ -47,7 +46,7 @@ inline Tensor sort_strides(Tensor& tensor_) {
   for (const auto i : c10::irange(tensor_.ndimension())) {
     indices.push_back(i);
   }
-  std::ranges::sort(indices, [&strides](int64_t i1, int64_t i2) {
+  std::sort(indices.begin(), indices.end(), [&strides](int64_t i1, int64_t i2) {
     return strides[i1] > strides[i2];
   });
   Tensor tensor = tensor_.permute(indices);

--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -41,7 +41,7 @@ size_t get_env_num_threads(const char* var_name, size_t def_value = 0) {
   } catch (const std::exception& e) {
     std::ostringstream oss;
     oss << "Invalid " << var_name << " variable value, " << e.what();
-    TORCH_WARN(oss.str());
+    TORCH_WARN(std::move(oss).str());
   }
   return def_value;
 }
@@ -97,7 +97,7 @@ std::string get_parallel_info() {
   ss << "Experimental: single thread pool" << std::endl;
   #endif
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 int intraop_default_num_threads() {

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -152,7 +152,7 @@ void checkSameGPU(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
     }
     oss << "but expected " << ((!t1->is_cpu() && !t2->is_cpu()) ? "them" : "it")
         << " to be on GPU (while checking arguments for " << c << ')';
-    TORCH_CHECK(false, oss.str());
+    TORCH_CHECK(false, std::move(oss).str());
   }
   TORCH_CHECK(
     t1->get_device() == t2->get_device(),
@@ -197,7 +197,7 @@ void checkScalarTypes(CheckedFrom c, const TensorArg& t,
       }
       oss << "; but got " << t->toString()
           << " instead (while checking arguments for " << c << ')';
-      TORCH_CHECK(false, oss.str());
+      TORCH_CHECK(false, std::move(oss).str());
     }
 }
 

--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -48,7 +48,7 @@ std::string get_mkldnn_version() {
   #else
     ss << "MKLDNN not found";
   #endif
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string get_openmp_version() {
@@ -86,7 +86,7 @@ std::string get_openmp_version() {
   #else
     ss << "OpenMP not found";
   #endif
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string get_cpu_capability() {
@@ -124,7 +124,7 @@ static std::string used_cpu_capability() {
   // environment variable
   std::ostringstream ss;
   ss << "CPU capability usage: " << get_cpu_capability();
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string show_config() {
@@ -210,7 +210,7 @@ std::string show_config() {
   // TODO: do XLA
   // TODO: do MPS
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string get_cxx_flags() {

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -45,7 +45,7 @@ std::string KernelFunction::dumpState() const {
   if (unboxed_kernel_func_) {
     oss << "unboxed ";
   }
-  return oss.str();
+  return std::move(oss).str();
 }
 
 bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -64,7 +64,7 @@ std::string DispatchKeyExtractor::dumpState() const {
     }
   }
   oss << ' ' << nonFallthroughKeys_ << '\n';
-  return oss.str();
+  return std::move(oss).str();
 }
 
 void DispatchKeyExtractor::checkInvariants(const FunctionSchema& schema) const {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -585,7 +585,7 @@ std::string OperatorEntry::listAllDispatchKeys() const {
     has_kernels = true;
   }
   str << ']';
-  return str.str();
+  return std::move(str).str();
 }
 
 void OperatorEntry::reportSignatureError(const CppSignature& call_signature, const CppSignatureWithDebug& saved_signature) const {
@@ -669,7 +669,7 @@ std::string OperatorEntry::dumpComputedTable() const {
           << kernel_prov.first.debug << " [" << kernel_prov.second << "]\n";
     }
   }
-  return oss.str();
+  return std::move(oss).str();
 }
 
 void OperatorEntry::setReportErrorCallback_(std::unique_ptr<c10::SafePyObject> callback) {
@@ -715,7 +715,7 @@ std::string OperatorEntry::dumpState() const {
       print_kernel(toString(k), it->second, c10::isAliasDispatchKey(k));
     }
   }
-  return oss.str();
+  return std::move(oss).str();
 }
 
 }

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -628,7 +628,7 @@ TORCH_API std::ostream& operator<<(std::ostream& out, const FunctionSchema& sche
 inline std::string toString(const FunctionSchema& schema) {
   std::ostringstream str;
   str << schema;
-  return str.str();
+  return std::move(str).str();
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -1189,7 +1189,7 @@ std::string formatSetOfDevices(const std::vector<c10::Device>& devices) {
       devices.begin(),
       devices.end(),
       std::ostream_iterator<c10::Device>(oss, ", "));
-  return oss.str();
+  return std::move(oss).str();
 }
 #endif
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1303,7 +1303,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
       }
       oss << devices[idx];
     }
-    return oss.str();
+    return std::move(oss).str();
   }
 
   static c10::DeviceType getTypeOfDevices(

--- a/aten/src/ATen/core/operator_name.cpp
+++ b/aten/src/ATen/core/operator_name.cpp
@@ -5,7 +5,7 @@ namespace c10 {
 std::string toString(const OperatorName& opName) {
   std::ostringstream oss;
   oss << opName;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 std::ostream& operator<<(std::ostream& os, const OperatorName& opName) {

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -485,7 +485,7 @@ std::string CUDAHooks::showConfig() const {
   oss << "  - Magma " << MAGMA_VERSION_MAJOR << '.' << MAGMA_VERSION_MINOR << '.' << MAGMA_VERSION_MICRO << '\n';
 #endif
 
-  return oss.str();
+  return std::move(oss).str();
 }
 
 double CUDAHooks::batchnormMinEpsilonCuDNN() const {

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -93,7 +93,7 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
     default:
       std::ostringstream oss;
       oss << "(unknown data-type " << static_cast<int>(dtype) << ')';
-      return oss.str();
+      return std::move(oss).str();
   }
 }
 
@@ -168,7 +168,7 @@ std::string cudnnMemoryFormatToString(cudnnTensorFormat_t tformat) {
     default:
       std::ostringstream oss;
       oss << "(unknown cudnn tensor format " << static_cast<int>(tformat) << ')';
-      return oss.str();
+      return std::move(oss).str();
   }
 }
 

--- a/aten/src/ATen/miopen/Descriptors.cpp
+++ b/aten/src/ATen/miopen/Descriptors.cpp
@@ -75,7 +75,7 @@ std::string miopenTypeToString(miopenDataType_t dtype) {
     default:
       std::ostringstream oss;
       oss << "(unknown data-type " << static_cast<int>(dtype) << ')';
-      return oss.str();
+      return std::move(oss).str();
   }
 }
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -767,8 +767,8 @@ static void check_shape_forward(const at::Tensor& input,
         separator = " x ";
       }
 
-      TORCH_CHECK(false, "Calculated padded input size per channel: (", input_ss.str(), "). "
-               "Kernel size: (", kernel_ss.str(), "). Kernel size can't be greater than actual input size");
+      TORCH_CHECK(false, "Calculated padded input size per channel: (", std::move(input_ss).str(), "). "
+               "Kernel size: (", std::move(kernel_ss).str(), "). Kernel size can't be greater than actual input size");
     }
   } else { // transposed
     for (const auto i : c10::irange(2, k)) {

--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -248,7 +248,7 @@ Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mod
   error_msg << "  - 3D or 4D input: padding size = 4 (pads last 2 dimensions)\n";
   error_msg << "  - 4D or 5D input: padding size = 6 (pads last 3 dimensions)";
 
-  C10_THROW_ERROR(NotImplementedError, error_msg.str());
+  C10_THROW_ERROR(NotImplementedError, std::move(error_msg).str());
 }
 
 Tensor pad_symint(const Tensor &self, c10::SymIntArrayRef pad, std::string_view mode, std::optional<double> value) {

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -901,12 +901,12 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const std::optional<int64_t
   if (!at::isFloatingType(self.scalar_type()) && !at::isComplexType(self.scalar_type())) {
     std::ostringstream ss;
     REPR(ss) << ": expected a tensor of floating point or complex values";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (self.dim() > 2 || self.dim() < 1) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D or 2D tensor";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   Tensor input = self;
   if (self.dim() == 1) {
@@ -931,24 +931,24 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const std::optional<int64_t
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < n_fft < " << len
              << ", but got n_fft=" << win_length;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (hop_length <= 0) {
     std::ostringstream ss;
     REPR(ss) << ": expected hop_length > 0, but got hop_length=" << hop_length;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (win_length <= 0 || win_length > n_fft) {
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
              << win_length;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (window.defined() && (window.dim() != 1 || window.size(0) != win_length)) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D window tensor of size equal to win_length="
              << win_length << ", but got window with size " << window.sizes();
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   #undef REPR
   auto window_ = window;
@@ -1094,17 +1094,17 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const std::optional<int64_
   if (input.numel() == 0) {
     std::ostringstream ss;
     REPR(ss) << ": input tensor cannot be empty.";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (input_dim != 3 && input_dim != 4) {
     std::ostringstream ss;
     REPR(ss) << ": expected a tensor with 3 or 4 dimensions, but got " << input_dim;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (input.size(-1) != 2) {
     std::ostringstream ss;
     REPR(ss) << ": expected the last dimension to be 2 (corresponding to real and imaginary parts), but got " << self.size(-1);
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 
   const bool onesided = onesidedOpt.value_or(fft_size != n_fft);
@@ -1112,32 +1112,32 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const std::optional<int64_
     if (n_fft / 2 + 1 != fft_size) {
       std::ostringstream ss;
       REPR(ss) << ": expected the frequency dimension (3rd to the last) of the input tensor to match n_fft / 2 + 1 when onesided=True, but got " << fft_size;
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   } else {
     if (n_fft != fft_size) {
       std::ostringstream ss;
       REPR(ss) << ": expected the frequency dimension (3rd to the last) of the input tensor to match n_fft when onesided=False, but got " << fft_size;
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   }
 
   if (!(0 < hop_length && hop_length <= win_length)) {
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < hop_length <= win_length";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 
   if (!(0 < win_length && win_length <= n_fft)) {
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < win_length <= n_fft";
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   if (window.defined()) {
     if (window.dim() != 1 || window.size(0) != win_length) {
       std::ostringstream ss;
       REPR(ss) << ": Invalid window shape. window has to be 1D and length of `win_length`";
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   }
 
@@ -1206,7 +1206,7 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const std::optional<int64_
   if (at::is_scalar_tensor_true(window_envelop_lowest)) {
     std::ostringstream ss;
     REPR(ss) << "window overlap add min: " << window_envelop_lowest;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 
   y = (y / window_envelop);  // size: (channel, expected_output_signal_len)

--- a/aten/src/ATen/native/SpectralOpsUtils.h
+++ b/aten/src/ATen/native/SpectralOpsUtils.h
@@ -63,7 +63,7 @@ inline int64_t infer_ft_complex_to_real_onesided_size(int64_t complex_size,
     std::ostringstream ss;
     ss << "expected real signal size " << expected_size << " is incompatible "
        << "with onesided complex frequency size " << complex_size;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -18,7 +18,7 @@ inline std::string shapes_as_str(TensorList tensors) {
       first = false;
     }
   }
-  return os.str();
+  return std::move(os).str();
 }
 #endif
 } // anonymous namespace

--- a/aten/src/ATen/native/cuda/CuFFTUtils.h
+++ b/aten/src/ATen/native/cuda/CuFFTUtils.h
@@ -59,7 +59,7 @@ static inline std::string _cudaGetErrorEnum(cufftResult error)
     default:
       std::ostringstream ss;
       ss << "unknown error " << error;
-      return ss.str();
+      return std::move(ss).str();
   }
 }
 
@@ -68,7 +68,7 @@ static inline void CUFFT_CHECK(cufftResult error)
   if (error != CUFFT_SUCCESS) {
     std::ostringstream ss;
     ss << "cuFFT error: " << _cudaGetErrorEnum(error);
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 }
 

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -841,7 +841,7 @@ static void replace_all(std::string& s, const std::string& to_replace, const std
   }
 
   oss << s.substr(prev_pos);
-  s = oss.str();
+  s = std::move(oss).str();
 }
 
 // hipify replaces certain device math functions, e.g., std::max -> ::max

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -196,7 +196,7 @@ std::string repro_from_args(const ConvolutionParams& params) {
   ss << "out.backward(torch.randn_like(out))\n";
   ss << "torch.cuda.synchronize()\n\n";
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 // ---------------------------------------------------------------------

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -180,7 +180,7 @@ struct RNNDescriptorParams {
       default: {
         std::ostringstream oss;
         oss << "unrecognized cuDNN RNN mode " << fn_mode;
-        TORCH_CHECK(false, oss.str());
+        TORCH_CHECK(false, std::move(oss).str());
       }
     }
   }

--- a/aten/src/ATen/native/metal/MetalTensorImplStorage.mm
+++ b/aten/src/ATen/native/metal/MetalTensorImplStorage.mm
@@ -115,7 +115,7 @@ std::ostream& operator<<(
   std::copy(
       strides.begin(), strides.end() - 1, std::ostream_iterator<int>(oss, ","));
   oss << sizes.back();
-  output << oss.str() << '}';
+  output << std::move(oss).str() << '}';
   return output;
 }
 

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -136,7 +136,7 @@ struct RNNDescriptorParams {
                 {
                     std::ostringstream oss;
                     oss << "unrecognized miopen RNN mode " << fn_mode;
-                    TORCH_CHECK(false, oss.str());
+                    TORCH_CHECK(false, std::move(oss).str());
                 }
         }
     }

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -116,8 +116,8 @@ static void check_shape_forward(const Tensor& input,
       separator = " x ";
     }
 
-    TORCH_CHECK(false, "Calculated padded input size per channel: (", input_ss.str(), "). "
-                "Kernel size: (", kernel_ss.str(), "). Kernel size can't be greater than actual input size");
+    TORCH_CHECK(false, "Calculated padded input size per channel: (", std::move(input_ss).str(), "). "
+                "Kernel size: (", std::move(kernel_ss).str(), "). Kernel size can't be greater than actual input size");
   }
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -197,10 +197,10 @@ static void check_shape_forward(
       TORCH_CHECK(
           0,
           "Calculated padded input size per channel: (",
-          input_ss.str(),
+          std::move(input_ss).str(),
           "). "
           "Kernel size: (",
-          kernel_ss.str(),
+          std::move(kernel_ss).str(),
           "). Kernel size can't be greater than actual input size");
     }
   } else {

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -543,7 +543,7 @@ inline bool check_last_dim_stride_equals_1_dense(sdp_params const& params, bool 
             << params.attn_mask.value().sym_stride(-1)
             << " (GPU backends require attn_mask's last dimension to have stride 1 while the CPU does not).";
       }
-      TORCH_WARN(message.str());
+      TORCH_WARN(std::move(message).str());
     }
 
     return false;

--- a/aten/src/ATen/native/utils/ParamUtils.h
+++ b/aten/src/ATen/native/utils/ParamUtils.h
@@ -18,7 +18,7 @@ inline std::vector<T> _expand_param_if_needed(
     ss << "expected " << param_name << " to be a single integer value or a "
        << "list of " << expected_dim << " values to match the convolution "
        << "dimensions, but got " << param_name << '=' << list_param;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   } else {
     return list_param.vec();
   }

--- a/aten/src/ATen/native/vulkan/api/Exception.cpp
+++ b/aten/src/ATen/native/vulkan/api/Exception.cpp
@@ -59,7 +59,7 @@ Error::Error(SourceLocation source_location, std::string msg)
   std::ostringstream oss;
   oss << "Exception raised from " << source_location_ << ": ";
   oss << msg_;
-  what_ = oss.str();
+  what_ = std::move(oss).str();
 }
 
 Error::Error(SourceLocation source_location, const char* cond, std::string msg)
@@ -68,7 +68,7 @@ Error::Error(SourceLocation source_location, const char* cond, std::string msg)
   oss << "Exception raised from " << source_location_ << ": ";
   oss << '(' << cond << ") is false! ";
   oss << msg_;
-  what_ = oss.str();
+  what_ = std::move(oss).str();
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/StringUtil.h
+++ b/aten/src/ATen/native/vulkan/api/StringUtil.h
@@ -62,7 +62,7 @@ struct _str_wrapper final {
   static std::string call(const Args&... args) {
     std::ostringstream ss;
     _str(ss, args...);
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -181,7 +181,7 @@ TEST(TestScalar, TestFormatting) {
   auto format = [] (Scalar a) {
     std::ostringstream str;
     str << a;
-    return str.str();
+    return std::move(str).str();
   };
   ASSERT_EQ("3", format(Scalar(3)));
   ASSERT_EQ("3.1", format(Scalar(3.1)));

--- a/binaries/parallel_info.cc
+++ b/binaries/parallel_info.cc
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
   cmd << "lsof -p " << getpid() << " | grep .so";
   std::cout << "Loaded .so:" << std::endl;
   std::cout << cmd.str() << std::endl;
-  std::system(std::move(cmd).str().c_str());
+  std::system(cmd.str().c_str());
 # endif
 
   return 0;

--- a/binaries/parallel_info.cc
+++ b/binaries/parallel_info.cc
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
   cmd << "lsof -p " << getpid() << " | grep .so";
   std::cout << "Loaded .so:" << std::endl;
   std::cout << cmd.str() << std::endl;
-  std::system(cmd.str().c_str());
+  std::system(std::move(cmd).str().c_str());
 # endif
 
   return 0;

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -444,7 +444,7 @@ inline std::string format_size(uint64_t size) {
     os << static_cast<double>(size) / 1073741824.0;
     os << " GiB";
   }
-  return os.str();
+  return std::move(os).str();
 }
 
 } // namespace CachingAllocator

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -144,9 +144,8 @@ struct C10_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given device.
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
-  template <
-      typename T,
-      typename = std::enable_if_t<std::is_same_v<std::decay_t<T>, Device>>>
+  template <typename T>
+  requires std::is_same_v<std::decay_t<T>, Device>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -159,9 +158,8 @@ struct C10_API TensorOptions {
   /// NB: Ideally we only allow implicit constructors here. But there is no easy
   ///     way to detect them. So we have this one that allows explicit
   ///     constructors too.
-  template <
-      typename... Args,
-      typename = std::enable_if_t<std::is_constructible_v<Device, Args&&...>>>
+  template <typename... Args>
+  requires std::is_constructible_v<Device, Args&&...>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -616,7 +616,7 @@ inline TensorOptions dtype() {
 inline std::string toString(const TensorOptions& options) {
   std::ostringstream stream;
   stream << options;
-  return stream.str();
+  return std::move(stream).str();
 }
 
 // This is intended to be a centralized location by which we can determine

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -144,10 +144,8 @@ struct C10_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given device.
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
-  template <
-      typename T,
-      typename = std::enable_if_t< // NOLINT(modernize-use-constraints)
-          std::is_same_v<std::decay_t<T>, Device>>>
+  template <typename T>
+  requires std::is_same_v<std::decay_t<T>, Device>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -160,10 +158,8 @@ struct C10_API TensorOptions {
   /// NB: Ideally we only allow implicit constructors here. But there is no easy
   ///     way to detect them. So we have this one that allows explicit
   ///     constructors too.
-  template <
-      typename... Args,
-      typename = std::enable_if_t< // NOLINT(modernize-use-constraints)
-          std::is_constructible_v<Device, Args&&...>>>
+  template <typename... Args>
+  requires std::is_constructible_v<Device, Args&&...>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -144,8 +144,10 @@ struct C10_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given device.
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
-  template <typename T>
-  requires std::is_same_v<std::decay_t<T>, Device>
+  template <
+      typename T,
+      typename = std::enable_if_t< // NOLINT(modernize-use-constraints)
+          std::is_same_v<std::decay_t<T>, Device>>>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -158,8 +160,10 @@ struct C10_API TensorOptions {
   /// NB: Ideally we only allow implicit constructors here. But there is no easy
   ///     way to detect them. So we have this one that allows explicit
   ///     constructors too.
-  template <typename... Args>
-  requires std::is_constructible_v<Device, Args&&...>
+  template <
+      typename... Args,
+      typename = std::enable_if_t< // NOLINT(modernize-use-constraints)
+          std::is_constructible_v<Device, Args&&...>>>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -616,7 +616,7 @@ inline TensorOptions dtype() {
 inline std::string toString(const TensorOptions& options) {
   std::ostringstream stream;
   stream << options;
-  return std::move(stream).str();
+  return stream.str();
 }
 
 // This is intended to be a centralized location by which we can determine

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -144,8 +144,9 @@ struct C10_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given device.
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
-  template <typename T>
-  requires std::is_same_v<std::decay_t<T>, Device>
+  template <
+      typename T,
+      typename = std::enable_if_t<std::is_same_v<std::decay_t<T>, Device>>>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -158,8 +159,9 @@ struct C10_API TensorOptions {
   /// NB: Ideally we only allow implicit constructors here. But there is no easy
   ///     way to detect them. So we have this one that allows explicit
   ///     constructors too.
-  template <typename... Args>
-  requires std::is_constructible_v<Device, Args&&...>
+  template <
+      typename... Args,
+      typename = std::enable_if_t<std::is_constructible_v<Device, Args&&...>>>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2475,7 +2475,7 @@ class DeviceCachingAllocator {
           SegmentRange(block->ptr, block->size), ss);
       offset = static_cast<const char*>(block->ptr) - full_range.ptr;
     }
-    return ShareableHandle{.offset = offset, .handle = ss.str()};
+    return ShareableHandle{.offset = offset, .handle = std::move(ss).str()};
   }
 
   void recordStream(Block* block, cuda::CUDAStream stream) {

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -288,7 +288,7 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
         << static_cast<int>(info.healthSummary);
   }
 #endif
-  return oss.str();
+  return std::move(oss).str();
 #else
   return "fabric info unsupported (requires CUDA >= 12.4)";
 #endif

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -288,7 +288,7 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
         << static_cast<int>(info.healthSummary);
   }
 #endif
-  return std::move(oss).str();
+  return oss.str();
 #else
   return "fabric info unsupported (requires CUDA >= 12.4)";
 #endif

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -10,6 +10,7 @@
 #include <c10/util/Logging.h>
 #include <c10/util/irange.h>
 
+#include <array>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -88,12 +89,10 @@ nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
   cudaDeviceProp prop{};
   C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
-  char
-      pci_id // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-          [NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+  std::array<char, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE> pci_id{};
   snprintf(
-      pci_id,
-      sizeof(pci_id),
+      pci_id.data(),
+      pci_id.size(),
       NVML_DEVICE_PCI_BUS_ID_FMT,
       prop.pciDomainID,
       prop.pciBusID,
@@ -103,7 +102,7 @@ nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
   TORCH_INTERNAL_ASSERT(
       NVML_SUCCESS ==
       DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
-          pci_id, &nvml_device));
+          pci_id.data(), &nvml_device));
   return nvml_device;
 }
 
@@ -256,12 +255,13 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
     }
   }
 
-  char uuid_hex[33];
-  for (int i = 0; i < 16; ++i) {
-    snprintf(uuid_hex + i * 2, 3, "%02x", info.clusterUuid[i]);
+  std::array<char, 33> uuid_hex{};
+  for (size_t i = 0; i < 16; ++i) {
+    snprintf(uuid_hex.data() + i * 2, 3, "%02x", info.clusterUuid[i]);
   }
 
   const char* state_str = "unknown";
+  // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (info.state) {
     case NVML_GPU_FABRIC_STATE_NOT_SUPPORTED:
       state_str = "not_supported";
@@ -278,7 +278,7 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
   }
 
   std::ostringstream oss;
-  oss << "clique_id=" << info.cliqueId << ", cluster_uuid=" << uuid_hex
+  oss << "clique_id=" << info.cliqueId << ", cluster_uuid=" << uuid_hex.data()
       << ", state=" << state_str << ", status=" << info.status
       << ", health_mask=0x" << std::hex << std::setfill('0') << std::setw(8)
       << info.healthMask;

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -10,7 +10,6 @@
 #include <c10/util/Logging.h>
 #include <c10/util/irange.h>
 
-#include <array>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -89,10 +88,12 @@ nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
   cudaDeviceProp prop{};
   C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
 
-  std::array<char, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE> pci_id{};
+  char
+      pci_id // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+          [NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
   snprintf(
-      pci_id.data(),
-      pci_id.size(),
+      pci_id,
+      sizeof(pci_id),
       NVML_DEVICE_PCI_BUS_ID_FMT,
       prop.pciDomainID,
       prop.pciBusID,
@@ -102,7 +103,7 @@ nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
   TORCH_INTERNAL_ASSERT(
       NVML_SUCCESS ==
       DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
-          pci_id.data(), &nvml_device));
+          pci_id, &nvml_device));
   return nvml_device;
 }
 
@@ -255,13 +256,12 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
     }
   }
 
-  std::array<char, 33> uuid_hex{};
-  for (size_t i = 0; i < 16; ++i) {
-    snprintf(uuid_hex.data() + i * 2, 3, "%02x", info.clusterUuid[i]);
+  char uuid_hex[33];
+  for (int i = 0; i < 16; ++i) {
+    snprintf(uuid_hex + i * 2, 3, "%02x", info.clusterUuid[i]);
   }
 
   const char* state_str = "unknown";
-  // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (info.state) {
     case NVML_GPU_FABRIC_STATE_NOT_SUPPORTED:
       state_str = "not_supported";
@@ -278,7 +278,7 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
   }
 
   std::ostringstream oss;
-  oss << "clique_id=" << info.cliqueId << ", cluster_uuid=" << uuid_hex.data()
+  oss << "clique_id=" << info.cliqueId << ", cluster_uuid=" << uuid_hex
       << ", state=" << state_str << ", status=" << info.status
       << ", health_mask=0x" << std::hex << std::setfill('0') << std::setw(8)
       << info.healthMask;

--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -111,7 +111,7 @@ class GetBacktraceImpl {
          << addr << "]\t" << std::endl;
     }
     free(demangled);
-    return os.str();
+    return std::move(os).str();
   }
 
  private:
@@ -278,7 +278,7 @@ class GetBacktraceImpl {
       }
     }
 
-    return stream.str();
+    return std::move(stream).str();
   }
 
  private:
@@ -427,7 +427,7 @@ class GetBacktraceImpl {
       stream << ']' << std::endl;
     }
 
-    return stream.str();
+    return std::move(stream).str();
   }
 
  private:

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -70,7 +70,7 @@ std::string Error::compute_what(bool include_backtrace) const {
     oss << '\n' << backtrace_->get();
   }
 
-  return oss.str();
+  return std::move(oss).str();
 }
 
 const Backtrace& Error::backtrace() const {

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -101,7 +101,7 @@ struct _str_wrapper final {
   static std::string call(const Args&... args) {
     std::ostringstream ss;
     _str(ss, args...);
-    return ss.str();
+    return std::move(ss).str();
   }
 };
 

--- a/c10/util/TypeCast.cpp
+++ b/c10/util/TypeCast.cpp
@@ -5,7 +5,8 @@ namespace c10 {
 [[noreturn]] void report_overflow(const char* name) {
   std::ostringstream oss;
   oss << "value cannot be converted to type " << name << " without overflow";
-  throw std::runtime_error(oss.str()); // rather than domain_error (issue 33562)
+  throw std::runtime_error(
+      std::move(oss).str()); // rather than domain_error (issue 33562)
 }
 
 } // namespace c10

--- a/c10/util/hash.h
+++ b/c10/util/hash.h
@@ -87,7 +87,7 @@ struct sha1 {
       buf << std::hex << std::setfill('0') << std::setw(8) << i;
     }
 
-    return buf.str();
+    return std::move(buf).str();
   }
 
  private:

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -167,7 +167,7 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
     os << std::noshowbase << std::setfill('0') << std::setw(div_base_log);
   }
   os << low.lo_;
-  std::string rep = os.str();
+  std::string rep = std::move(os).str();
 
   // Add the requisite padding.
   std::streamsize width = o.width(0);

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -39,8 +39,9 @@
 namespace c10 {
 
 const uint128_pod kuint128max = {
-    uint64_t{0xFFFFFFFFFFFFFFFFu},
-    uint64_t{0xFFFFFFFFFFFFFFFFu}};
+    .hi = uint64_t{0xFFFFFFFFFFFFFFFFu},
+    .lo = uint64_t{0xFFFFFFFFFFFFFFFFu},
+};
 
 // Returns the 0-based position of the last set bit (i.e., most significant bit)
 // in the given uint64. The argument may not be 0.

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -167,7 +167,7 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
     os << std::noshowbase << std::setfill('0') << std::setw(div_base_log);
   }
   os << low.lo_;
-  std::string rep = std::move(os).str();
+  std::string rep = os.str();
 
   // Add the requisite padding.
   std::streamsize width = o.width(0);

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -39,9 +39,8 @@
 namespace c10 {
 
 const uint128_pod kuint128max = {
-    .hi = uint64_t{0xFFFFFFFFFFFFFFFFu},
-    .lo = uint64_t{0xFFFFFFFFFFFFFFFFu},
-};
+    uint64_t{0xFFFFFFFFFFFFFFFFu},
+    uint64_t{0xFFFFFFFFFFFFFFFFu}};
 
 // Returns the 0-based position of the last set bit (i.e., most significant bit)
 // in the given uint64. The argument may not be 0.

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -918,7 +918,7 @@ void PyTorchStreamWriter::writeSerializationId() {
     serialization_id_oss << std::setfill('0') << std::setw(20)
                          << combined_record_name_hash << std::setfill('0')
                          << std::setw(20) << combined_uncomp_crc32_;
-    serialization_id_ = serialization_id_oss.str();
+    serialization_id_ = std::move(serialization_id_oss).str();
     writeRecord(
         kSerializationIdRecordName,
         serialization_id_.c_str(),

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -50,7 +50,7 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoad) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -145,7 +145,7 @@ TEST(PyTorchStreamWriterAndReader, LoadWithMultiThreads) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -232,7 +232,7 @@ TEST(PytorchStreamWriterAndReader, GetNonexistentRecordThrows) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output2.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -293,7 +293,7 @@ TEST(PytorchStreamWriterAndReader, SkipDebugRecords) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output3.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -385,7 +385,7 @@ TEST(PytorchStreamWriterAndReader, SkipDuplicateSerializationIdRecords) {
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
   auto writer_serialization_id = writer.serializationId();
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output4.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -426,7 +426,7 @@ TEST(PytorchStreamWriterAndReader, LogAPIUsageMetadata) {
       {"pytorch.stream.writer.metadata",
        {{"serialization_id", writer.serializationId()},
         {"file_name", "archive"},
-        {"file_size", str(oss.str().length())}}},
+        {"file_size", str(std::move(oss).str().length())}}},
       {"pytorch.stream.reader.metadata",
        {{"serialization_id", writer.serializationId()},
         {"file_name", "archive"},
@@ -503,7 +503,7 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoadWithAllocator) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -578,7 +578,7 @@ TEST(PyTorchStreamWriterAndReader, LoadWithMultiThreadsWithAllocator) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   const char* file_name = "output.zip";
   std::ofstream foo(file_name);
   foo.write(the_file.c_str(), the_file.size());
@@ -668,7 +668,7 @@ TEST_P(ChunkRecordIteratorTest, ChunkRead) {
   writer.writeEndOfFile();
   ASSERT_EQ(written_records.count(kSerializationIdRecordName), 1);
 
-  std::string the_file = oss.str();
+  std::string the_file = std::move(oss).str();
   std::ofstream foo(fileName, std::ios::binary);
   foo.write(the_file.c_str(), the_file.size());
   foo.close();

--- a/test/cpp/api/printing.cpp
+++ b/test/cpp/api/printing.cpp
@@ -10,7 +10,7 @@ TEST(PrintSciModeTest, ToggleScientificNotation) {
   torch::set_printoption_sci_mode(true);
   std::ostringstream oss1;
   oss1 << t;
-  auto out1 = oss1.str();
+  auto out1 = std::move(oss1).str();
   std::cout << "With sci_mode=true: '" << out1 << '\'' << std::endl;
   EXPECT_TRUE(
       out1.find("e-") != std::string::npos ||
@@ -20,7 +20,7 @@ TEST(PrintSciModeTest, ToggleScientificNotation) {
   torch::set_printoption_sci_mode(false);
   std::ostringstream oss2;
   oss2 << t;
-  auto out2 = oss2.str();
+  auto out2 = std::move(oss2).str();
   std::cout << "With sci_mode=false: '" << out2 << '\'' << std::endl;
   EXPECT_TRUE(
       out2.find("e-") == std::string::npos &&

--- a/test/cpp/jit/test_custom_class.cpp
+++ b/test/cpp/jit/test_custom_class.cpp
@@ -54,7 +54,7 @@ TEST(CustomClassTest, ScalarTypeClass) {
 
   std::ostringstream oss;
   m.save(oss);
-  std::istringstream iss(oss.str());
+  std::istringstream iss(std::move(oss).str());
   caffe2::serialize::IStreamAdapter adapter{&iss};
   auto loaded_module = torch::jit::load(iss, torch::kCPU);
 }
@@ -135,13 +135,13 @@ TEST(CustomClassTest, Serialization) {
 
   std::ostringstream oss;
   m.save(oss);
-  std::istringstream iss(oss.str());
+  std::istringstream iss(std::move(oss).str());
   caffe2::serialize::IStreamAdapter adapter{&iss};
   auto loaded_module = torch::jit::load(iss, torch::kCPU);
 
   std::ostringstream oss_frozen;
   frozen_m.save(oss_frozen);
-  std::istringstream iss_frozen(oss_frozen.str());
+  std::istringstream iss_frozen(std::move(oss_frozen).str());
   caffe2::serialize::IStreamAdapter adapter_frozen{&iss_frozen};
   auto loaded_frozen_module = torch::jit::load(iss_frozen, torch::kCPU);
 }

--- a/test/cpp/jit/test_irparser.cpp
+++ b/test/cpp/jit/test_irparser.cpp
@@ -21,7 +21,7 @@ static void checkRoundtrip(const std::string& s) {
   parseIR(s, &*graph);
   std::ostringstream ss;
   ss << *graph;
-  std::string parsed = ss.str();
+  std::string parsed = std::move(ss).str();
 
   // Skip whitespace in the beginning of the input string.
   int i = 0;

--- a/test/cpp/jit/test_jit_logging_levels.cpp
+++ b/test/cpp/jit/test_jit_logging_levels.cpp
@@ -50,7 +50,7 @@ TEST(JitLoggingTest, CheckOutputStreamSetting) {
       __FILE__,
       __LINE__,
       ::c10::str("Message"));
-  ASSERT_TRUE(test_stream.str().size() > 0);
+  ASSERT_TRUE(std::move(test_stream).str().size() > 0);
 }
 
 } // namespace jit

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -993,7 +993,7 @@ TEST(LiteInterpreterTest, ExtraFiles) {
   extra_files["mobile_info.json"] = "{\"key\": 23}";
   module->_save_for_mobile(oss, extra_files);
 
-  std::istringstream iss(oss.str());
+  std::istringstream iss(std::move(oss).str());
   std::unordered_map<std::string, std::string> loaded_extra_files;
   loaded_extra_files["metadata.json"] = "";
   torch::jit::_load_for_mobile(iss, torch::kCPU, loaded_extra_files);

--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -69,7 +69,7 @@ TEST(SerializationTest, ExtraFilesHookPreference) {
   module->save(oss, extra_files);
   SetExportModuleExtraFilesHook(nullptr);
 
-  std::istringstream iss(oss.str());
+  std::istringstream iss(std::move(oss).str());
   caffe2::serialize::IStreamAdapter adapter{&iss};
   std::unordered_map<std::string, std::string> loaded_extra_files;
   loaded_extra_files["metadata.json"] = "";

--- a/test/cpp/nativert/test_placement.cpp
+++ b/test/cpp/nativert/test_placement.cpp
@@ -31,7 +31,7 @@ TEST(PlacementTest, PlacementDefaultOnly) {
 
   std::ostringstream os;
   os << placement;
-  EXPECT_EQ(os.str(), "|cuda:0");
+  EXPECT_EQ(std::move(os).str(), "|cuda:0");
 
   c10::Device cuda0 = c10::Device(c10::DeviceType::CUDA, 0);
   c10::Device cuda1 = c10::Device(c10::DeviceType::CUDA, 1);
@@ -53,7 +53,7 @@ TEST(PlacementTest, PlacementBasic) {
 
   std::ostringstream os;
   os << placement;
-  EXPECT_EQ(os.str(), "cpu|cpu,cuda:0|cuda:1,cuda:1|cuda:2,|cuda:0");
+  EXPECT_EQ(std::move(os).str(), "cpu|cpu,cuda:0|cuda:1,cuda:1|cuda:2,|cuda:0");
 
   c10::Device cpu = c10::Device(c10::DeviceType::CPU);
   c10::Device cuda0 = c10::Device(c10::DeviceType::CUDA, 0);

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -62,7 +62,7 @@ static void setSignalHandler(
     std::ostringstream oss;
     oss << "An error occurred while setting handler for " << strsignal(signal)
         << '.';
-    TORCH_CHECK(false, oss.str());
+    TORCH_CHECK(false, std::move(oss).str());
   }
 }
 

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -34,13 +34,13 @@ static PyObject* THPDevice_repr(THPDevice* self) {
     oss << ", index=" << static_cast<uint16_t>(self->device.index());
   }
   oss << ')';
-  return THPUtils_packString(oss.str().c_str());
+  return THPUtils_packString(std::move(oss).str().c_str());
 }
 
 static PyObject* THPDevice_str(THPDevice* self) {
   std::ostringstream oss;
   oss << self->device;
-  return THPUtils_packString(oss.str().c_str());
+  return THPUtils_packString(std::move(oss).str().c_str());
 }
 
 static PyObject* THPDevice_pynew(
@@ -89,7 +89,7 @@ static PyObject* THPDevice_type(THPDevice* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   std::ostringstream oss;
   oss << self->device.type();
-  return THPUtils_packString(oss.str().c_str());
+  return THPUtils_packString(std::move(oss).str().c_str());
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -162,7 +162,7 @@ static PyObject* THPDevice_reduce(PyObject* _self, PyObject* noargs) {
     args = THPObjectPtr{Py_BuildValue(
         "(si)", oss.str().c_str(), static_cast<int>(self->device.index()))};
   } else {
-    args = THPObjectPtr{Py_BuildValue("(s)", oss.str().c_str())};
+    args = THPObjectPtr{Py_BuildValue("(s)", std::move(oss).str().c_str())};
   }
   if (!args)
     throw python_error();

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -254,7 +254,8 @@ static PyObject* THPFInfo_str(THPFInfo* self) {
   if (dtypeStr != nullptr) {
     oss << ", dtype=" << PyUnicode_AsUTF8(dtypeStr) << ')';
   }
-  return !PyErr_Occurred() ? THPUtils_packString(oss.str().c_str()) : nullptr;
+  return !PyErr_Occurred() ? THPUtils_packString(std::move(oss).str().c_str())
+                           : nullptr;
 }
 
 static PyObject* THPIInfo_str(THPIInfo* self) {
@@ -267,7 +268,8 @@ static PyObject* THPIInfo_str(THPIInfo* self) {
     oss << ", dtype=" << PyUnicode_AsUTF8(dtypeStr) << ')';
   }
 
-  return !PyErr_Occurred() ? THPUtils_packString(oss.str().c_str()) : nullptr;
+  return !PyErr_Occurred() ? THPUtils_packString(std::move(oss).str().c_str())
+                           : nullptr;
 }
 
 static const std::initializer_list<PyGetSetDef> THPFInfo_properties = {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1054,7 +1054,7 @@ static variable_list call_function(
   validate_outputs(fn.next_edges(), outputs, [&](const std::string& msg) {
     std::ostringstream ss;
     ss << "Function " << fn.name() << " returned an " << msg;
-    return ss.str();
+    return std::move(ss).str();
   });
 
   // NOLINTNEXTLINE(bugprone-use-after-move)

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1166,7 +1166,7 @@ class NativeOpSchema {
       }
     }
     ss << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
 
  private:
@@ -1230,7 +1230,7 @@ void log_sharding_prop_cache_hit(
   if (!output_spec.is_none()) {
     ss << " -> " << py::str(output_spec).cast<std::string>();
   }
-  dtensor_dispatch_logger.attr("debug")(ss.str());
+  dtensor_dispatch_logger.attr("debug")(std::move(ss).str());
 }
 } // namespace
 

--- a/torch/csrc/autograd/utils/error_messages.h
+++ b/torch/csrc/autograd/utils/error_messages.h
@@ -12,7 +12,7 @@ inline std::string requires_grad_leaf_error(bool requires_grad) {
            "that doesn't require differentiation use "
            "var_no_grad = var.detach().";
   }
-  return oss.str();
+  return std::move(oss).str();
 }
 
 } // namespace torch::autograd::utils

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1213,7 +1213,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
                << ", pci_domain_id=" << prop.pciDomainID
                << ", L2_cache_size=" << prop.l2CacheSize / (1024ull * 1024)
                << "MB)";
-        return stream.str();
+        return std::move(stream).str();
       });
 
   m.def(

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -226,7 +226,7 @@ void throw_nccl_error(torch::cuda::nccl::ncclResult status) {
   std::ostringstream err;
   err << "NCCL Error " << static_cast<int>(status) << ": "
       << ncclGetErrorString(to_nccl_result(status));
-  TORCH_CHECK(false, err.str());
+  TORCH_CHECK(false, std::move(err).str());
 }
 
 struct NcclCommList {

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -638,7 +638,7 @@ void Reducer::delay_all_reduce() {
     if (!unused_parameters_.empty()) {
       LOG(INFO) << "[Rank " << process_group_->getRank() << "]: "
                 << "Parameter(s) (in the format of {param_name, index}): "
-                << unused_params_stream.str()
+                << std::move(unused_params_stream).str()
                 << " is(are) unused during first iteration. Since"
                 << " static_graph=True is enabled for DDP, we expect"
                 << " this set of unused parameters to remain consistent"

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -459,7 +459,7 @@ static std::string import_err_msg(
       << " (host: " << reqs[peer].hostname
       << ", device: " << reqs[peer].device_idx << ", NCCL_MNNVL_CLIQUE_ID: "
       << c10::utils::get_env("NCCL_MNNVL_CLIQUE_ID").value_or("unset") << ").";
-  return oss.str();
+  return std::move(oss).str();
 }
 
 void validate_rendezvous_requests(
@@ -516,7 +516,7 @@ static void validate_nvlink_fabric_support(
           << ", device: " << reqs[r].device_idx
           << ", clique_id: " << reqs[r].clique_id << ')';
     }
-    TORCH_CHECK(false, oss.str());
+    TORCH_CHECK(false, std::move(oss).str());
   }
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -259,7 +259,7 @@ std::string IpcChannel::get_socket_name(int pid) {
   }
   std::ostringstream oss;
   oss << tmp_dir << "/symm_mem-" << pid;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 void map_block(

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -105,7 +105,7 @@ class StoreExchange {
     for (int r = 0; r < world_size; ++r) {
       std::ostringstream oss;
       oss << store_prefix_ << '/' << seq_id_ << '/' << r;
-      peer_keys.push_back(oss.str());
+      peer_keys.push_back(std::move(oss).str());
     }
     ++seq_id_;
 
@@ -137,7 +137,7 @@ class StoreExchange {
     std::ostringstream oss;
     oss << store_prefix_ << '/' << seq_id_;
     ++seq_id_;
-    store->barrier(oss.str(), world_size);
+    store->barrier(std::move(oss).str(), world_size);
   }
 
  private:

--- a/torch/csrc/distributed/c10d/symm_mem/DMAConnectivity.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/DMAConnectivity.cpp
@@ -8,7 +8,7 @@ std::string get_detector_key(
     const std::string& connection_type) {
   std::ostringstream oss;
   oss << device_type << '/' << connection_type;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 class DetectorMap {

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
@@ -230,7 +230,7 @@ static std::vector<T> storeAllGather(
   for (size_t r = 0; r < worldSize; ++r) {
     std::ostringstream oss;
     oss << prefix << '-' << r;
-    peerKeys.push_back(oss.str());
+    peerKeys.push_back(std::move(oss).str());
   }
 
   {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -117,7 +117,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
               [](const WorkerInfo& workerInfo) {
                 std::ostringstream os;
                 os << workerInfo;
-                return os.str();
+                return std::move(os).str();
               })
           .def(py::pickle(
               /* __getstate__ */

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -75,7 +75,7 @@ TypePtr tryInferTypeWithTypeHint(
         " is not a subtype of the type hint: ",
         type_qualified_name.qualifiedName(),
         ", did you pass a valid interface type?\n",
-        subtype_check_msg.str());
+        std::move(subtype_check_msg).str());
     return type_hint_ptr;
   } else {
     TORCH_CHECK(

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -656,7 +656,7 @@ void TensorPipeAgent::sendCompletedResponseMessage(
                   "RPC detected that a user-function output tensor on device ",
                   device,
                   ". This device is not one of the input tensor devices: ",
-                  oss.str(),
+                  std::move(oss).str(),
                   "which is not yet supported. Please file a feature request "
                   "issue in PyTorch GitHub repo."),
               static_cast<int64_t>(messageId));

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -652,7 +652,7 @@ struct AutocastState {
     if (cache_enabled != o.cache_enabled) {
       os << "autocast_cache_enabled ";
     }
-    return os.str();
+    return std::move(os).str();
   }
 
   template <typename T>
@@ -745,7 +745,7 @@ struct GlobalStateGuard {
       os << "num_threads ";
     if (_default_dtype != at::get_default_dtype())
       os << "default_dtype ";
-    return os.str();
+    return std::move(os).str();
   }
 
   template <typename T>

--- a/torch/csrc/export/upgrader.cpp
+++ b/torch/csrc/export/upgrader.cpp
@@ -81,7 +81,7 @@ void registerUpgrader(
             error_stream << '.';
           error_stream << keypath[i];
         }
-        TORCH_CHECK(false, error_stream.str());
+        TORCH_CHECK(false, std::move(error_stream).str());
       }
     }
   }
@@ -172,7 +172,7 @@ void throwUpgraderError(
     error_stream << "\nProblematic object: " << problematic_object.dump(2);
   }
 
-  TORCH_CHECK(false, error_stream.str());
+  TORCH_CHECK(false, std::move(error_stream).str());
 }
 
 nlohmann::json upgrade(nlohmann::json artifact, int target_version) {
@@ -226,7 +226,7 @@ nlohmann::json upgrade(nlohmann::json artifact, int target_version) {
         << "Failed to upgrade to target version " << target_version
         << ". Final version reached: " << current_version
         << ". This may indicate missing upgraders for intermediate versions.";
-    TORCH_CHECK(false, error_stream.str());
+    TORCH_CHECK(false, std::move(error_stream).str());
   }
 
   return artifact;

--- a/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/sycl_runtime_wrappers.h
@@ -99,7 +99,7 @@ static std::unique_ptr<sycl::kernel> _createKernel(
   std::ifstream IFS(filePath.c_str(), std::ios::binary);
   std::ostringstream OSS;
   OSS << IFS.rdbuf();
-  std::string data(OSS.str());
+  std::string data(std::move(OSS).str());
 
   bool isSpirv = filePath.size() >= 4 &&
       filePath.compare(filePath.size() - 4, 4, ".spv") == 0;

--- a/torch/csrc/inductor/static_launcher/xpu.cpp
+++ b/torch/csrc/inductor/static_launcher/xpu.cpp
@@ -267,7 +267,7 @@ sycl::kernel* loadKernel(
   std::ifstream IFS(filePath, std::ios::binary);
   std::ostringstream OSS;
   OSS << IFS.rdbuf();
-  std::string data(OSS.str());
+  std::string data(std::move(OSS).str());
   auto mod = _createModule(
       reinterpret_cast<const uint8_t*>(data.c_str()), data.size(), device_idx);
 

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -656,7 +656,7 @@ struct NamedPolicy {
         }
         ss << nameFragment(cursors[i]);
       }
-      name = ss.str();
+      name = std::move(ss).str();
     }
     return value_type{std::move(name), Policy::create(cursors, std::move(v))};
   }

--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -51,7 +51,7 @@ static std::string scalarValue(const double v) {
   } else {
     out << std::setprecision(16) << v;
   }
-  return out.str();
+  return std::move(out).str();
 }
 
 // Note: Half is special-cased to avoid returning at::Half

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -1096,7 +1096,7 @@ void _do_warn(const char* _reason, const char* _kind) {
   std::string kind{_kind ? _kind : ""};
   std::ostringstream s;
   s << reason << kind;
-  warn_callback.load()(s.str());
+  warn_callback.load()(std::move(s).str());
 }
 
 void setWarn(warn_fn_type fn) {

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -426,7 +426,7 @@ std::string AliasDb::getElementName(const Element* e) const {
       ss << '%' << v->debugName() << ", ";
     }
     ss << ')';
-    return ss.str();
+    return std::move(ss).str();
   }
 }
 
@@ -518,7 +518,7 @@ std::string AliasDb::toGraphviz() const {
         ss << "\\%" << v->debugName() << ", ";
       }
       ss << ")\"";
-      return ss.str();
+      return std::move(ss).str();
     }
   };
 
@@ -626,7 +626,7 @@ void AliasDb::analyzeImpl(Node* node) {
           node->kind().toDisplayString(),
           " but it isn't a special case.  ",
           "Argument types: ",
-          oss.str());
+          std::move(oss).str());
     }
   }
 

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -170,7 +170,7 @@ static void printAttribute(std::ostream& out, const at::Tensor& tensor) {
     // TODO: This is awful code.  Also it doesn't work on Windows.
     std::ostringstream tensor_ss;
     tensor_ss << tensor;
-    std::string tensor_s{tensor_ss.str()};
+    std::string tensor_s{std::move(tensor_ss).str()};
     // Remove newlines
     std::replace(tensor_s.begin(), tensor_s.end(), '\n', ' ');
     out << tensor_s;
@@ -1975,7 +1975,7 @@ Value* Graph::insertConstant(
 std::string Graph::toString(bool print_source_locations) const {
   std::ostringstream oss;
   print(oss, print_source_locations);
-  return oss.str();
+  return std::move(oss).str();
 }
 
 Graph::~Graph() {

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -343,7 +343,7 @@ ModelCompatCheckResult is_compatible(
     s << "model bytecode version " << model_info.bytecode_version
       << "is greater than the max supported bytecode version in runtimes "
       << runtime_info.min_max_supported_bytecode_version.second;
-    result.errors.emplace_back(s.str());
+    result.errors.emplace_back(std::move(s).str());
   } else if (
       model_info.bytecode_version <
       runtime_info.min_max_supported_bytecode_version.first) {
@@ -352,7 +352,7 @@ ModelCompatCheckResult is_compatible(
     s << "model bytecode version " << model_info.bytecode_version
       << "is less than the minimum supported bytecode version in runtime "
       << runtime_info.min_max_supported_bytecode_version.first;
-    result.errors.emplace_back(s.str());
+    result.errors.emplace_back(std::move(s).str());
   }
 
   std::unordered_set<std::string> supported_type = runtime_info.supported_types;
@@ -364,7 +364,7 @@ ModelCompatCheckResult is_compatible(
       std::ostringstream s;
       s << "Primitive type: '" << type_name
         << "' is not supported in current runtime";
-      result.errors.push_back(s.str());
+      result.errors.push_back(std::move(s).str());
     }
   }
 
@@ -381,7 +381,7 @@ ModelCompatCheckResult is_compatible(
       result.status = ModelCompatibilityStatus::ERROR;
       std::ostringstream s;
       s << "Operator '" << op_name << "' missing from runtime (not found)";
-      result.errors.push_back(s.str());
+      result.errors.push_back(std::move(s).str());
     } else {
       OperatorInfo runtime_op_info = runtime_info.operator_info.at(op_name);
 
@@ -392,7 +392,7 @@ ModelCompatCheckResult is_compatible(
         std::ostringstream s;
         s << "Operator '" << op_name
           << "' missing from runtime (missing schema)";
-        result.errors.push_back(s.str());
+        result.errors.push_back(std::move(s).str());
       } else {
         // Check if the model operator has schema information. If it doesn't
         // then the model is from a bytecode version < 6 and we are done. If the
@@ -408,7 +408,7 @@ ModelCompatCheckResult is_compatible(
             << model_op_info.num_schema_args.value()
             << " args in model but only "
             << runtime_op_info.num_schema_args.value() << " in the runtime";
-          result.errors.push_back(s.str());
+          result.errors.push_back(std::move(s).str());
         }
       }
     }
@@ -425,7 +425,7 @@ ModelCompatCheckResult is_compatible(
       << "is not within supported version range of the runtime "
       << runtime_info.min_max_supported_operator_versions.first << " to "
       << runtime_info.min_max_supported_operator_versions.second;
-    result.errors.push_back(s.str());
+    result.errors.push_back(std::move(s).str());
   }
 
   return result;

--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -105,7 +105,7 @@ std::pair<std::string, std::string> getStackTraceWithModuleHierarchy(
   std::ostringstream ss;
   ss << "Module hierarchy:" << module_info << '\n';
   format_stack_trace(ss, stack_entries);
-  return {ss.str(), std::move(module_info)};
+  return {std::move(ss).str(), std::move(module_info)};
 }
 
 } // namespace

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -290,7 +290,7 @@ void NodeToONNX(
       ss << "symbolic for " << op_name
          << " produced an incorrect number of outputs (expected ";
       ss << num_old_outputs << ", but got " << outputs.size() << ')';
-      throw std::runtime_error(ss.str());
+      throw std::runtime_error(std::move(ss).str());
     }
     // For const node, it does not need params_dict info, so set it to {}.
     const ParamMap empty_params_dict = {};
@@ -390,7 +390,7 @@ void NodeToONNX(
           ss << " (indicating conversion for that particular output is not supported), ";
           ss << "but the network uses this output later";
           // TODO: Say what actually used it
-          throw std::runtime_error(ss.str());
+          throw std::runtime_error(std::move(ss).str());
         }
       }
     }
@@ -449,7 +449,7 @@ void NodeToONNX(
          << ": expected to return list of op nodes, instead received type ''"
          << py::str(py::type::handle_of(raw_output))
          << "': " << py::str(raw_output);
-      throw std::runtime_error(ss.str());
+      throw std::runtime_error(std::move(ss).str());
     }
 
     setOutputs(op_name, n, outputs);

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1336,7 +1336,7 @@ void initJITBindings(PyObject* module) {
       .def("__repr__", [](CompleteArgumentSpec& self) {
         std::ostringstream s;
         s << self;
-        return s.str();
+        return std::move(s).str();
       });
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ArgumentSpec>(m, "ArgumentSpec");
@@ -1833,7 +1833,7 @@ void initJITBindings(PyObject* module) {
                     sortedOps, symbol, args, kwargs, false);
               },
               py::name(symbol.toUnqualString()),
-              py::doc(docstring.str().c_str()));
+              py::doc(std::move(docstring).str().c_str()));
           return py::make_tuple(func, overload_names);
         } catch (const c10::Error& e) {
           auto msg = torch::get_cpp_stacktraces_enabled()
@@ -1901,7 +1901,7 @@ void initJITBindings(PyObject* module) {
     std::ostringstream s;
     auto type = unifyTypeList(types, s);
     if (!type) {
-      throw std::runtime_error(s.str());
+      throw std::runtime_error(std::move(s).str());
     }
     return type.value();
   });
@@ -2019,7 +2019,7 @@ void initJITBindings(PyObject* module) {
           [](const FunctionSchema& self, const FunctionSchema& old_schema) {
             std::ostringstream out;
             auto result = self.isForwardCompatibleWith(old_schema, out);
-            return std::make_pair(result, out.str());
+            return std::make_pair(result, std::move(out).str());
           })
       .def(
           "__eq__",

--- a/torch/csrc/jit/python/python_dict.h
+++ b/torch/csrc/jit/python/python_dict.h
@@ -71,7 +71,7 @@ class ScriptDict final {
       f = true;
     }
     s << '}';
-    return s.str();
+    return std::move(s).str();
   }
 
   // Return an iterator over the keys of the dictionary.

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -812,7 +812,7 @@ void initPythonIRBindings(PyObject* module_) {
           [](Type& t) {
             std::ostringstream s;
             s << t;
-            return s.str();
+            return std::move(s).str();
           })
       .def(
           "containedTypes",

--- a/torch/csrc/jit/python/python_list.h
+++ b/torch/csrc/jit/python/python_list.h
@@ -72,7 +72,7 @@ class ScriptList final {
       f = true;
     }
     s << ']';
-    return s.str();
+    return std::move(s).str();
   }
 
   // Return an iterator over the elements of the list.

--- a/torch/csrc/jit/python/python_tracer.cpp
+++ b/torch/csrc/jit/python/python_tracer.cpp
@@ -218,14 +218,14 @@ void initPythonTracerBindings(PyObject* module) {
           [](const TracingState& s) {
             std::ostringstream ss;
             ss << "<TracingState " << (const void*)&s << '>';
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(
           "__str__",
           [](const TracingState& s) -> std::string {
             std::ostringstream ss;
             ss << *s.graph;
-            return ss.str();
+            return std::move(ss).str();
           })
       .def(
           "push_scope",

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -82,7 +82,7 @@ void initTreeViewBindings(PyObject* module) {
           [](const SourceRange& self) {
             std::ostringstream stream;
             self.highlight(stream);
-            return stream.str();
+            return std::move(stream).str();
           })
       .def("__repr__", [](const SourceRange& self) { return self.str(); })
       .def(
@@ -112,7 +112,7 @@ void initTreeViewBindings(PyObject* module) {
           [](const TreeView& tree) {
             std::ostringstream stream;
             stream << tree.get();
-            return stream.str();
+            return std::move(stream).str();
           })
       .def("dump", [](const TreeView& tree) { tree.dump(); });
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1256,7 +1256,7 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& m, const ExtraFilesMap& _extra_files = ExtraFilesMap()) {
             std::ostringstream buf;
             m.save(buf, _extra_files);
-            return py::bytes(buf.str());
+            return py::bytes(std::move(buf).str());
           },
           py::arg("_extra_files") = ExtraFilesMap())
       .def(
@@ -1285,7 +1285,7 @@ void initJitScriptBindings(PyObject* module) {
             std::ostringstream buf;
             m._save_for_mobile(
                 buf, _extra_files, _save_mobile_debug_info, _use_flatbuffer);
-            return py::bytes(buf.str());
+            return py::bytes(std::move(buf).str());
           },
           py::arg("_extra_files") = ExtraFilesMap(),
           py::arg("_save_mobile_debug_info") = false,
@@ -1688,7 +1688,7 @@ void initJitScriptBindings(PyObject* module) {
             module.register_attribute("training", BoolType::get(), true);
             addFunctionToModule(module, self);
             module.save(buf, _extra_files);
-            return py::bytes(buf.str());
+            return py::bytes(std::move(buf).str());
           },
           py::arg("_extra_files") = ExtraFilesMap())
       .def_property_readonly(
@@ -2183,7 +2183,8 @@ void initJitScriptBindings(PyObject* module) {
         std::ostringstream buffer_output;
         bool success =
             _backport_for_mobile(filename_input, buffer_output, version);
-        return success ? py::bytes(buffer_output.str()) : py::bytes("");
+        return success ? py::bytes(std::move(buffer_output).str())
+                       : py::bytes("");
       });
   m.def(
       "_backport_for_mobile_from_buffer_to_buffer",
@@ -2191,7 +2192,8 @@ void initJitScriptBindings(PyObject* module) {
         std::istringstream in(buffer_input);
         std::ostringstream buffer_output;
         bool success = _backport_for_mobile(in, buffer_output, version);
-        return success ? py::bytes(buffer_output.str()) : py::bytes("");
+        return success ? py::bytes(std::move(buffer_output).str())
+                       : py::bytes("");
       });
   m.def("_get_model_bytecode_version", [](const std::string& filename) {
     return _get_model_bytecode_version(filename);

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -934,7 +934,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       if (get_cpp_stacktraces_enabled()) {
         ss << e.what() << '\n';
       }
-      throw std::runtime_error(ss.str());
+      throw std::runtime_error(std::move(ss).str());
     }
   }
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -57,7 +57,7 @@ namespace {
 std::string iValueToString(const c10::IValue& val) {
   std::ostringstream oss;
   oss << val;
-  return oss.str();
+  return std::move(oss).str();
 }
 #endif
 
@@ -182,7 +182,7 @@ std::string dumpValueSet(
     oss << '%' << val->debugName() << ", ";
   }
   oss << '}';
-  return oss.str();
+  return std::move(oss).str();
 }
 
 namespace {

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -158,7 +158,7 @@ bool hasVarArgs(Node* n);
 inline std::string PrintNode(const Node* node) {
   std::ostringstream ss;
   node->print(ss, 0, nullptr, false);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 inline void LogAndDumpSchema(const Node* node) {

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -495,7 +495,7 @@ static onnx::AttributeProto_AttributeType ATenAttributeKindToOnnxAttributeType(
       std::ostringstream err_msg;
       err_msg << "attribute \"" << name.toDisplayString()
               << "\" has unexpected kind: " << toString(at_kind);
-      throw std::runtime_error(err_msg.str());
+      throw std::runtime_error(std::move(err_msg).str());
   }
 }
 
@@ -1162,7 +1162,7 @@ void GraphEncoder::AddAttribute(
       std::ostringstream err_msg;
       err_msg << "attribute \"" << name.toDisplayString()
               << "\" has unexpected kind: " << toString(node->kindOf(name));
-      throw std::runtime_error(err_msg.str());
+      throw std::runtime_error(std::move(err_msg).str());
   }
 }
 

--- a/torch/csrc/jit/serialization/onnx.cpp
+++ b/torch/csrc/jit/serialization/onnx.cpp
@@ -235,7 +235,7 @@ void dump(const onnx::ModelProto& model, std::ostream& stream, size_t indent) {
 std::string prettyPrint(const ::ONNX_NAMESPACE::ModelProto& model) {
   std::ostringstream ss;
   dump(model, ss, 0);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -52,7 +52,7 @@ RegisterCodeGenList::StmtFactoryMethod RegisterCodeGenList::
       index++;
     }
     oss << ']';
-    throw std::runtime_error(oss.str());
+    throw std::runtime_error(std::move(oss).str());
   }
   return iter->second;
 }

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -679,13 +679,13 @@ namespace std {
 std::string to_string(const ExprPtr& expr) {
   std::ostringstream oss;
   oss << *expr;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 std::string to_string(const StmtPtr& stmt) {
   std::ostringstream oss;
   oss << *stmt;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 std::string to_string(const Tensor& t) {
@@ -699,6 +699,6 @@ std::string to_string(const Tensor& t) {
     oss << *t.buf()->dim(i);
   }
   oss << "]:\n" << *t.stmt() << '\n';
-  return oss.str();
+  return std::move(oss).str();
 }
 } // namespace std

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -124,13 +124,13 @@ namespace std {
 std::string to_string(const Dtype& dtype) {
   std::ostringstream oss;
   oss << dtype;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 std::string to_string(const ScalarType& type) {
   std::ostringstream oss;
   oss << type;
-  return oss.str();
+  return std::move(oss).str();
 }
 
 } // namespace std

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -327,7 +327,7 @@ struct FileCheckImpl {
         SourceRange(source, start, start + 1).highlight(ss);
         ss << "Check for bad input.";
         has_run = true;
-        throw std::runtime_error(ss.str());
+        throw std::runtime_error(std::move(ss).str());
       }
       start = findNextStart(source, start);
     }

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -86,7 +86,7 @@ static std::vector<int64_t> expand_param_if_needed(
     ss << "expected " << param_name << " to be a single integer value or a "
        << "list of " << expected_dim << " values to match the convolution "
        << "dimensions, but got " << param_name << '=' << list_param;
-    TORCH_CHECK(false, ss.str());
+    TORCH_CHECK(false, std::move(ss).str());
   } else {
     return list_param.vec();
   }

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -45,7 +45,7 @@ class TORCH_API TSComputation : public Computation {
   const std::string to_string() const override {
     std::ostringstream oss;
     oss << *graph_;
-    return oss.str();
+    return std::move(oss).str();
   }
 
   std::shared_ptr<torch::jit::Graph> graph() const {

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -316,7 +316,7 @@ static void writeJsonNode(
 static std::string timeString(const std::time_t timepoint) {
   std::ostringstream oss;
   oss << std::put_time(std::localtime(&timepoint), "%Y-%m-%d %X"); // NOLINT
-  return oss.str();
+  return std::move(oss).str();
 }
 
 static bool initExecutionTraceStart(ExecutionTraceObserver& ob) {
@@ -806,7 +806,7 @@ static std::string json_str_escape(const std::string& str) {
       ostream << ch;
     }
   }
-  return ostream.str();
+  return std::move(ostream).str();
 }
 
 static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -168,7 +168,7 @@ std::string stacksToStr(
 #endif
         return s;
       });
-  auto rc = oss.str();
+  auto rc = std::move(oss).str();
   return "\"" + rc + "\"";
 }
 
@@ -300,7 +300,7 @@ std::string strListToStr(const std::vector<std::string>& types) {
         types.end(),
         std::ostream_iterator<std::string>(oss, ", "),
         [](const std::string& s) -> std::string { return "\"" + s + "\""; });
-    auto rc = oss.str();
+    auto rc = std::move(oss).str();
     rc.erase(rc.length() - 2); // remove last ", "
     return "[" + rc + "]";
   }

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -220,7 +220,7 @@ static std::string get_name(Backend backend, ScalarType scalarType) {
   std::ostringstream ss;
   ss << torch::utils::backend_to_string(backend) << '.' << toString(scalarType)
      << "Tensor";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 static THPObjectPtr get_storage_obj(Backend backend, ScalarType dtype) {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -203,7 +203,7 @@ bool maybeThrowBackCompatKeepdimWarn(char* func) {
     std::ostringstream ss;
     ss << "backwards compatibility: call to \"" << func
        << "\" uses default value for keepdim which has changed default to False.  Consider passing as kwarg.",
-        PyErr_WarnEx(PyExc_UserWarning, ss.str().c_str(), 1);
+        PyErr_WarnEx(PyExc_UserWarning, std::move(ss).str().c_str(), 1);
   }
   return true;
 }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1545,7 +1545,7 @@ std::string FunctionSignature::toString() const {
     i++;
   }
   ss << ')';
-  return ss.str();
+  return std::move(ss).str();
 }
 
 [[noreturn]] static void extra_args(

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -65,14 +65,14 @@ std::string options_to_string(const at::TensorOptions& options) {
   std::ostringstream ss;
   ss << backend_to_string(options.backend()) << '.'
      << toString(at::typeMetaToScalarType(options.dtype())) << "Tensor";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string type_to_string(const at::DeprecatedTypeProperties& type) {
   std::ostringstream ss;
   ss << backend_to_string(type.backend()) << '.' << toString(type.scalarType())
      << "Tensor";
-  return ss.str();
+  return std::move(ss).str();
 }
 
 using TypeMap = std::unordered_map<std::string, at::DeprecatedTypeProperties*>;

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -294,7 +294,7 @@ static void registerXpuDeviceProperties(PyObject* module) {
                       prop.device_type);
         break;
     }
-    return stream.str();
+    return std::move(stream).str();
   };
   auto gpu_subslice_count = [](const DeviceProp& prop) {
     return (prop.gpu_eu_count / prop.gpu_eu_count_per_subslice);
@@ -390,7 +390,7 @@ static void registerXpuDeviceProperties(PyObject* module) {
                    << ", is_integrated_gpu=" << prop.is_integrated_gpu
 #endif
                    << ')';
-            return stream.str();
+            return std::move(stream).str();
           });
 }
 

--- a/torch/headeronly/util/Exception.h
+++ b/torch/headeronly/util/Exception.h
@@ -47,7 +47,7 @@ std::string stdTorchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
   // in the headeronly world.
   std::ostringstream oss;
   ((oss << args), ...);
-  return oss.str();
+  return std::move(oss).str();
 }
 
 inline const char* stdTorchCheckMsgImpl(const char* msg) {

--- a/torch/nativert/executor/memory/AliasAnalyzer.cpp
+++ b/torch/nativert/executor/memory/AliasAnalyzer.cpp
@@ -232,7 +232,7 @@ void AliasAnalyzer::log_state() const {
 
     ss << '\n';
 
-    return ss.str();
+    return std::move(ss).str();
   }() << std::flush;
 }
 


### PR DESCRIPTION
Followup to #186552 . Uses the rvalue overload of ostringstream newly introduced in CPP20 to reduce the amount of string copy allowing us to steal the internal string buffer.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @EikanWang @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98