### PR TITLE
fix _split_iteration_ranges error (#187209)

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -1830,6 +1830,26 @@ class TestSplitIterationRanges(MockSchedulerTest):
         # The first getter should return 0 for any input
         self.assertEqual(getters[0][0]([sympy.Integer(99)]), sympy.Integer(0))
 
+    def test_leftover_extent_raises_cant_split(self):
+        """Lengths consume cleanly but leave a non-unit group extent.
+
+        Each size divides cleanly as it is consumed, so none of the add_range
+        divisibility checks trip, but the groups are larger than the lengths and
+        a non-unit extent remains at the end. This is the case a fused epilogue
+        whose iteration domain is a strict sub-multiple of a template's tiling
+        hits (e.g. [s, N] into [K*s, N]); it must surface as CantSplit so callers
+        skip the fusion rather than crashing the compile with an AssertionError.
+        """
+        from torch._inductor.codegen.simd import CantSplit, SIMDKernel
+
+        # groups=[2, 2], lengths=[[2], []]: size 2 maps onto group 0, leaving
+        # group 1 (extent 2) unconsumed -> remaining=[1, 2], not all ones.
+        with self.assertRaises(CantSplit):
+            SIMDKernel._split_iteration_ranges(
+                [sympy.Integer(2), sympy.Integer(2)],
+                [[sympy.Integer(2)], []],
+            )
+
 
 class TestIndexInversion(TestCase):
     @classmethod

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -961,7 +961,14 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             return_getters_groups.append(return_getters)
 
         if not all(V.graph.sizevars.guarding_hint_or_throw(s) == 1 for s in remaining):
-            raise AssertionError(f"failed to set ranges {remaining} {lengths}")
+            # Non-unit leftover extents mean the node's iteration space does not
+            # tile onto the kernel groups -- e.g. fusing an epilogue whose row
+            # count is a strict sub-multiple of a template's tiling ([s, N] into
+            # [K*s, N]). Raise CantSplit (consistent with the divisibility exits
+            # in add_range above) so callers like is_compatible and
+            # Scheduler.speedup_by_fusion skip this fusion and fall back to
+            # unfused codegen instead of hard-failing the whole compile.
+            raise CantSplit(remaining, lengths)
         # pyrefly: ignore [bad-return]
         return new_ranges, return_getters_groups
 


### PR DESCRIPTION
Summary:

`_split_iteration_ranges` in `torch/_inductor/codegen/simd.py` ended with a bare `assert all(... == 1 for s in remaining)` that fired whenever a node's iteration lengths were consumed cleanly but left a non-unit extent in the kernel's tiling groups. This happens when a pointwise epilogue whose iteration domain is a strict sub-multiple of a template's tiling is considered for fusion, e.g. fusing a `[s, N]` epilogue into a `[K*s, N]` matmul template tile. The three divisibility exits earlier in the same function already `raise CantSplit`, and both callers that drive epilogue fusion (`SIMDKernel.is_compatible` and `Scheduler.speedup_by_fusion`) wrap the split in `try/except CantSplit` specifically to skip range-incompatible fusions and fall back to unfused codegen. Because the final invariant raised `AssertionError` instead of `CantSplit`, it escaped those handlers and hard-failed the entire AOTInductor compile with `InductorError: AssertionError: failed to set ranges ...`.

This PR converts the final invariant to `raise CantSplit(remaining, lengths)`, matching the exception contract of the rest of the function so the existing safety nets catch it. The success path is byte-for-byte unchanged (identical trigger condition), so models that compile today are unaffected; models that previously crashed now lower with the incompatible epilogue left unfused (a separate kernel) instead of aborting the compile.

Test Plan:
Unit test (new regression):

```
buck2 test //caffe2/test/inductor:loop_ordering -- -r TestSplitIterationRanges
```

Result: Pass 7, Fail 0. testrun: https://www.internalfb.com/intern/testinfra/testrun/1688850234333388

The new case `test_leftover_extent_raises_cant_split` constructs `groups=[2, 2]`, `lengths=[[2], []]`: every size divides cleanly as it is consumed (so no `add_range` divisibility exit trips), but group 1 is left with extent `2`, producing `remaining=[1, 2]`. It asserts this raises `CantSplit` rather than `AssertionError`, exercising exactly the changed line.

Differential Revision: D108339950




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo