### PR TITLE
[CUDA] Add cuDNN heuristic fast path

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -265,6 +265,12 @@ std::vector<perf_t> getValidAlgorithms(
   return result;
 }
 
+template <typename perf_t>
+struct AlgorithmSearchResult {
+  std::vector<perf_t> perfResults;
+  int perf_count;
+};
+
 template <>
 struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
   using perf_t = cudnnConvolutionFwdAlgoPerf_t;
@@ -276,7 +282,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
     return fwd_algos;
   }
 
-  static std::vector<perf_t> findAlgorithms(
+  static AlgorithmSearchResult<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
       bool benchmark,
       bool get_all_algorithms = false) {
@@ -335,11 +341,13 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(
-        perf_results.data(),
-        args,
-        perf_count,
-        !benchmark && !get_all_algorithms);
+    return AlgorithmSearchResult<perf_t>{
+        getValidAlgorithms<perf_t>(
+            perf_results.data(),
+            args,
+            perf_count,
+            !benchmark && !get_all_algorithms),
+        perf_count};
   }
 
   static void getWorkspaceSize(
@@ -369,7 +377,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
     return bwd_data_algos;
   }
 
-  static std::vector<perf_t> findAlgorithms(
+  static AlgorithmSearchResult<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
       bool benchmark,
       bool get_all_algorithms = false) {
@@ -426,11 +434,13 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(
-        perf_results.data(),
-        args,
-        perf_count,
-        !benchmark && !get_all_algorithms);
+    return AlgorithmSearchResult<perf_t>{
+        getValidAlgorithms<perf_t>(
+            perf_results.data(),
+            args,
+            perf_count,
+            !benchmark && !get_all_algorithms),
+        perf_count};
   }
 
   static void getWorkspaceSize(
@@ -461,7 +471,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
     return bwd_filter_algos;
   }
 
-  static std::vector<perf_t> findAlgorithms(
+  static AlgorithmSearchResult<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
       bool benchmark,
       bool get_all_algorithms = false) {
@@ -521,11 +531,13 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(
-        perf_results.data(),
-        args,
-        perf_count,
-        !benchmark && !get_all_algorithms);
+    return AlgorithmSearchResult<perf_t>{
+        getValidAlgorithms<perf_t>(
+            perf_results.data(),
+            args,
+            perf_count,
+            !benchmark && !get_all_algorithms),
+        perf_count};
   }
 
   static void getWorkspaceSize(
@@ -600,18 +612,22 @@ class AlgoIterator {
       return false;
     };
 
-    auto perfResults = only_use_default
-        ? onlyDefaultAlgorithm(args)
+    auto searchResult = only_use_default
+        ? AlgorithmSearchResult<perf_t>{onlyDefaultAlgorithm(args), 1}
         : search::findAlgorithms(args, benchmark);
+    auto& perfResults = searchResult.perfResults;
 
-    if (try_perf_results(perfResults.begin(), perfResults.end())) {
-      return;
+    if (!perfResults.empty()) {
+      if (try_perf_results(perfResults.begin(), perfResults.end())) {
+        return;
+      }
     }
 
-    if (!only_use_default && !benchmark && !perfResults.empty()) {
-      auto fallbackPerfResults = search::findAlgorithms(args, benchmark, true);
+    if (!only_use_default && !benchmark && searchResult.perf_count > 0) {
+      auto fallbackSearchResult = search::findAlgorithms(args, benchmark, true);
+      auto& fallbackPerfResults = fallbackSearchResult.perfResults;
       auto perf_begin = fallbackPerfResults.begin();
-      if (perf_begin != fallbackPerfResults.end()) {
+      if (!perfResults.empty() && perf_begin != fallbackPerfResults.end()) {
         perf_begin = std::next(perf_begin);
       }
       if (try_perf_results(perf_begin, fallbackPerfResults.end())) {

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -585,15 +585,11 @@ class AlgoIterator {
       }
     }
 
-    auto perfResults = only_use_default
-        ? onlyDefaultAlgorithm(args)
-        : search::findAlgorithms(args, benchmark);
-
-    auto try_perf_results = [&](std::vector<perf_t>& perfResults) {
-      for (auto& algoPerf : perfResults) {
+    auto try_perf_results = [&](auto perf_begin, auto perf_end) {
+      for (auto perf_iter = perf_begin; perf_iter != perf_end; ++perf_iter) {
         try {
-          f(algoPerf);
-          cache.insert(args.params, algoPerf);
+          f(*perf_iter);
+          cache.insert(args.params, *perf_iter);
           return true;
         } catch (c10::OutOfMemoryError&) {
           std::ignore = cudaGetLastError(); // clear CUDA error
@@ -604,13 +600,21 @@ class AlgoIterator {
       return false;
     };
 
-    if (try_perf_results(perfResults)) {
+    auto perfResults = only_use_default
+        ? onlyDefaultAlgorithm(args)
+        : search::findAlgorithms(args, benchmark);
+
+    if (try_perf_results(perfResults.begin(), perfResults.end())) {
       return;
     }
 
-    if (!only_use_default && !benchmark) {
+    if (!only_use_default && !benchmark && !perfResults.empty()) {
       auto fallbackPerfResults = search::findAlgorithms(args, benchmark, true);
-      if (try_perf_results(fallbackPerfResults)) {
+      auto perf_begin = fallbackPerfResults.begin();
+      if (perf_begin != fallbackPerfResults.end()) {
+        perf_begin = std::next(perf_begin);
+      }
+      if (try_perf_results(perf_begin, fallbackPerfResults.end())) {
         return;
       }
     }

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -241,7 +241,8 @@ template <typename perf_t>
 std::vector<perf_t> getValidAlgorithms(
     perf_t* perfResults,
     const ConvolutionArgs& args,
-    int n_algo) {
+    int n_algo,
+    bool allow_empty = false) {
   std::vector<perf_t> result;
   result.reserve(n_algo);
   for (const auto i : c10::irange(n_algo)) {
@@ -255,6 +256,9 @@ std::vector<perf_t> getValidAlgorithms(
         result.push_back(perf);
       }
     }
+  }
+  if (allow_empty && result.empty()) {
+    return result;
   }
   TORCH_CHECK(
       result.size() > 0, "no valid convolution algorithms available in CuDNN");
@@ -274,7 +278,8 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
 
   static std::vector<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
-      bool benchmark) {
+      bool benchmark,
+      bool get_all_algorithms = false) {
     static const algo_t algos[] = {
         CUDNN_CONVOLUTION_FWD_ALGO_GEMM,
         CUDNN_CONVOLUTION_FWD_ALGO_FFT,
@@ -292,6 +297,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
     int perf_count;
     c10::SmallVector<perf_t, CUDNN_CONVOLUTION_FWD_ALGO_COUNT> perf_results;
     if (!benchmark) {
+      const auto requested_algo_count = get_all_algorithms ? num_algos : 1;
       AT_CUDNN_CHECK_WITH_SHAPES(
           cudnnGetConvolutionForwardAlgorithm_v7(
               args.handle,
@@ -299,7 +305,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
               args.wdesc.desc(),
               args.cdesc.desc(),
               args.odesc.desc(),
-              num_algos,
+              requested_algo_count,
               &perf_count,
               perf_results.data()),
           args);
@@ -329,7 +335,11 @@ struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(perf_results.data(), args, perf_count);
+    return getValidAlgorithms<perf_t>(
+        perf_results.data(),
+        args,
+        perf_count,
+        !benchmark && !get_all_algorithms);
   }
 
   static void getWorkspaceSize(
@@ -361,7 +371,8 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
 
   static std::vector<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
-      bool benchmark) {
+      bool benchmark,
+      bool get_all_algorithms = false) {
     static const algo_t algos[] = {
         CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
         CUDNN_CONVOLUTION_BWD_DATA_ALGO_1,
@@ -377,6 +388,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
     c10::SmallVector<perf_t, CUDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT>
         perf_results;
     if (!benchmark) {
+      const auto requested_algo_count = get_all_algorithms ? num_algos : 1;
       AT_CUDNN_CHECK_WITH_SHAPES(
           cudnnGetConvolutionBackwardDataAlgorithm_v7(
               args.handle,
@@ -384,7 +396,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
               args.odesc.desc(),
               args.cdesc.desc(),
               args.idesc.desc(),
-              num_algos,
+              requested_algo_count,
               &perf_count,
               perf_results.data()),
           args);
@@ -414,7 +426,11 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(perf_results.data(), args, perf_count);
+    return getValidAlgorithms<perf_t>(
+        perf_results.data(),
+        args,
+        perf_count,
+        !benchmark && !get_all_algorithms);
   }
 
   static void getWorkspaceSize(
@@ -447,7 +463,8 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
 
   static std::vector<perf_t> findAlgorithms(
       const ConvolutionArgs& args,
-      bool benchmark) {
+      bool benchmark,
+      bool get_all_algorithms = false) {
     static const algo_t algos[] = {
         CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
         CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1,
@@ -466,6 +483,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
         perf_results;
     int perf_count;
     if (!benchmark) {
+      const auto requested_algo_count = get_all_algorithms ? num_algos : 1;
       AT_CUDNN_CHECK_WITH_SHAPES(
           cudnnGetConvolutionBackwardFilterAlgorithm_v7(
               args.handle,
@@ -473,7 +491,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
               args.odesc.desc(),
               args.cdesc.desc(),
               args.wdesc.desc(),
-              num_algos,
+              requested_algo_count,
               &perf_count,
               perf_results.data()),
           args);
@@ -503,7 +521,11 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
       // memory, e.g. a few GBs.
       c10::cuda::CUDACachingAllocator::emptyCache();
     }
-    return getValidAlgorithms<perf_t>(perf_results.data(), args, perf_count);
+    return getValidAlgorithms<perf_t>(
+        perf_results.data(),
+        args,
+        perf_count,
+        !benchmark && !get_all_algorithms);
   }
 
   static void getWorkspaceSize(
@@ -566,15 +588,30 @@ class AlgoIterator {
     auto perfResults = only_use_default
         ? onlyDefaultAlgorithm(args)
         : search::findAlgorithms(args, benchmark);
-    for (auto& algoPerf : perfResults) {
-      try {
-        f(algoPerf);
-        cache.insert(args.params, algoPerf);
+
+    auto try_perf_results = [&](std::vector<perf_t>& perfResults) {
+      for (auto& algoPerf : perfResults) {
+        try {
+          f(algoPerf);
+          cache.insert(args.params, algoPerf);
+          return true;
+        } catch (c10::OutOfMemoryError&) {
+          std::ignore = cudaGetLastError(); // clear CUDA error
+        } catch (c10::CuDNNError&) {
+          std::ignore = cudaGetLastError(); // clear CUDA error
+        }
+      }
+      return false;
+    };
+
+    if (try_perf_results(perfResults)) {
+      return;
+    }
+
+    if (!only_use_default && !benchmark) {
+      auto fallbackPerfResults = search::findAlgorithms(args, benchmark, true);
+      if (try_perf_results(fallbackPerfResults)) {
         return;
-      } catch (c10::OutOfMemoryError&) {
-        std::ignore = cudaGetLastError(); // clear CUDA error
-      } catch (c10::CuDNNError&) {
-        std::ignore = cudaGetLastError(); // clear CUDA error
       }
     }
     TORCH_CHECK(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -583,14 +583,16 @@ auto get_generator_sources(
     const cudnnBackendHeurMode_t heur_mode,
     const bool heuristic,
     const bool fallback,
-    const bool get_all_heuristic_configs = false) {
+    const bool get_all_heuristic_configs = false,
+    int64_t* heuristic_config_count = nullptr) {
   // Method for engine config generator based on heuristics
   const auto heurgen_method =
       [/*&desc,*/ &x,
        deterministic,
        allow_tf32,
        heur_mode,
-       get_all_heuristic_configs](cudnn_frontend::OperationGraph& opGraph)
+       get_all_heuristic_configs,
+       heuristic_config_count](cudnn_frontend::OperationGraph& opGraph)
       -> cudnn_frontend::EngineConfigList {
     auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
                           .setOperationGraph(opGraph)
@@ -598,6 +600,9 @@ auto get_generator_sources(
                           .build();
     auto& engine_configs = heuristics.getEngineConfig(
         get_all_heuristic_configs ? heuristics.getEngineConfigCount() : 1);
+    if (heuristic_config_count != nullptr) {
+      *heuristic_config_count = engine_configs.size();
+    }
     cudnn_frontend::EngineConfigList filtered_configs;
     filterEngineConfigs(
         engine_configs,
@@ -637,6 +642,11 @@ auto get_generator_sources(
     return sources;
   }
 }
+
+struct EngineConfigResult {
+  cudnn_frontend::EngineConfigList configs;
+  int64_t heuristic_config_count;
+};
 
 int64_t get_available_workspace() {
   c10::DeviceIndex device = 0;
@@ -872,6 +882,7 @@ auto get_configs_from_heuristics(
   auto heuristic_mode = at::native::cudnnv8_use_heur_mode_b()
       ? CUDNN_HEUR_MODE_B
       : CUDNN_HEUR_MODE_INSTANT;
+  int64_t heuristic_config_count = -1;
   auto sources = get_generator_sources(
       desc,
       x,
@@ -880,11 +891,13 @@ auto get_configs_from_heuristics(
       heuristic_mode,
       !fallback,
       fallback,
-      get_all_heuristic_configs);
+      get_all_heuristic_configs,
+      &heuristic_config_count);
 
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
-  return generator.generate_engine_config(opGraph);
+  auto configs = generator.generate_engine_config(opGraph);
+  return EngineConfigResult{std::move(configs), heuristic_config_count};
 }
 
 auto get_configs_from_heuristics_fused(
@@ -910,6 +923,7 @@ auto get_configs_from_heuristics_fused(
   auto heuristic_mode = at::native::cudnnv8_use_heur_mode_b()
       ? CUDNN_HEUR_MODE_B
       : CUDNN_HEUR_MODE_INSTANT;
+  int64_t heuristic_config_count = -1;
   auto sources = get_generator_sources(
       CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR,
       x,
@@ -918,12 +932,13 @@ auto get_configs_from_heuristics_fused(
       heuristic_mode,
       !fallback,
       fallback,
-      get_all_heuristic_configs);
+      get_all_heuristic_configs,
+      &heuristic_config_count);
 
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
   auto configs = generator.generate_engine_config(opGraph);
-  return configs;
+  return EngineConfigResult{std::move(configs), heuristic_config_count};
 }
 
 void try_plans(
@@ -1112,7 +1127,7 @@ void run_single_conv(
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter
     // top config from heuristic
-    cudnn_frontend::EngineConfigList configs = get_configs_from_heuristics(
+    auto engine_config_result = get_configs_from_heuristics(
         handle,
         operation,
         opgraph_tag,
@@ -1126,12 +1141,23 @@ void run_single_conv(
         deterministic,
         allow_tf32,
         false);
-    if (!configs.empty()) {
-      if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
+    const bool tried_top_config = !engine_config_result.configs.empty();
+    if (tried_top_config) {
+      if (try_configs(
+              engine_config_result.configs,
+              opgraph_tag,
+              key,
+              handle,
+              x,
+              y,
+              w,
+              operation)) {
         return;
       }
+    }
+    if (engine_config_result.heuristic_config_count > 0) {
       // all heuristic configs
-      configs = get_configs_from_heuristics(
+      engine_config_result = get_configs_from_heuristics(
           handle,
           operation,
           opgraph_tag,
@@ -1146,14 +1172,15 @@ void run_single_conv(
           allow_tf32,
           false,
           true);
-      auto configs_begin = configs.begin();
+      auto configs_begin = engine_config_result.configs.begin();
       // The top-config path already tried the first filtered heuristic config.
-      if (configs_begin != configs.end()) {
+      if (tried_top_config &&
+          configs_begin != engine_config_result.configs.end()) {
         configs_begin += 1;
       }
       if (try_configs(
               configs_begin,
-              configs.end(),
+              engine_config_result.configs.end(),
               opgraph_tag,
               key,
               handle,
@@ -1165,7 +1192,7 @@ void run_single_conv(
       }
     }
     // fallback configs
-    configs = get_configs_from_heuristics(
+    engine_config_result = get_configs_from_heuristics(
         handle,
         operation,
         opgraph_tag,
@@ -1179,7 +1206,15 @@ void run_single_conv(
         deterministic,
         allow_tf32,
         true);
-    if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
+    if (try_configs(
+            engine_config_result.configs,
+            opgraph_tag,
+            key,
+            handle,
+            x,
+            y,
+            w,
+            operation)) {
       return;
     }
     TORCH_CHECK(
@@ -1247,29 +1282,40 @@ void run_fused_conv(
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter
     // top heuristic config
-    cudnn_frontend::EngineConfigList configs =
-        get_configs_from_heuristics_fused(
-            handle,
-            opgraph_tag,
-            x,
-            y,
-            w,
-            z,
-            b,
-            alpha,
-            key,
-            padding,
-            stride,
-            dilation,
-            deterministic,
-            allow_tf32,
-            false);
-    if (!configs.empty()) {
-      if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
+    auto engine_config_result = get_configs_from_heuristics_fused(
+        handle,
+        opgraph_tag,
+        x,
+        y,
+        w,
+        z,
+        b,
+        alpha,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32,
+        false);
+    const bool tried_top_config = !engine_config_result.configs.empty();
+    if (tried_top_config) {
+      if (try_configs_fused(
+              engine_config_result.configs,
+              opgraph_tag,
+              key,
+              handle,
+              x,
+              y,
+              w,
+              z,
+              b)) {
         return;
       }
+    }
+    if (engine_config_result.heuristic_config_count > 0) {
       // all heuristic configs
-      configs = get_configs_from_heuristics_fused(
+      engine_config_result = get_configs_from_heuristics_fused(
           handle,
           opgraph_tag,
           x,
@@ -1286,14 +1332,15 @@ void run_fused_conv(
           allow_tf32,
           false,
           true);
-      auto configs_begin = configs.begin();
+      auto configs_begin = engine_config_result.configs.begin();
       // The top-config path already tried the first filtered heuristic config.
-      if (configs_begin != configs.end()) {
+      if (tried_top_config &&
+          configs_begin != engine_config_result.configs.end()) {
         configs_begin += 1;
       }
       if (try_configs_fused(
               configs_begin,
-              configs.end(),
+              engine_config_result.configs.end(),
               opgraph_tag,
               key,
               handle,
@@ -1306,7 +1353,7 @@ void run_fused_conv(
       }
     }
     // fallback configs
-    configs = get_configs_from_heuristics_fused(
+    engine_config_result = get_configs_from_heuristics_fused(
         handle,
         opgraph_tag,
         x,
@@ -1322,7 +1369,16 @@ void run_fused_conv(
         deterministic,
         allow_tf32,
         true);
-    if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
+    if (try_configs_fused(
+            engine_config_result.configs,
+            opgraph_tag,
+            key,
+            handle,
+            x,
+            y,
+            w,
+            z,
+            b)) {
       return;
     }
     TORCH_CHECK(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -974,7 +974,8 @@ void try_plans_fused(
 }
 
 bool try_configs(
-    cudnn_frontend::EngineConfigList& configs,
+    cudnn_frontend::EngineConfigList::iterator configs_begin,
+    cudnn_frontend::EngineConfigList::iterator configs_end,
     const std::string& opgraph_tag,
     const CacheKeyWrapper& key,
     const cudnnHandle_t handle,
@@ -982,8 +983,10 @@ bool try_configs(
     const Tensor& y,
     const Tensor& w,
     const cudnnBackendDescriptorType_t operation) {
-  for (auto& config : configs) {
+  for (auto config_iter = configs_begin; config_iter != configs_end;
+       ++config_iter) {
     try {
+      auto& config = *config_iter;
       auto plan = cudnn_frontend::ExecutionPlanBuilder()
                       .setHandle(handle)
                       .setEngineConfig(config, opgraph_tag)
@@ -1004,7 +1007,8 @@ bool try_configs(
 }
 
 bool try_configs_fused(
-    cudnn_frontend::EngineConfigList& configs,
+    cudnn_frontend::EngineConfigList::iterator configs_begin,
+    cudnn_frontend::EngineConfigList::iterator configs_end,
     const std::string& opgraph_tag,
     const CacheKeyFusedWrapper& key,
     const cudnnHandle_t handle,
@@ -1013,8 +1017,10 @@ bool try_configs_fused(
     const Tensor& w,
     const Tensor& z,
     const Tensor& b) {
-  for (auto& config : configs) {
+  for (auto config_iter = configs_begin; config_iter != configs_end;
+       ++config_iter) {
     try {
+      auto& config = *config_iter;
       auto plan = cudnn_frontend::ExecutionPlanBuilder()
                       .setHandle(handle)
                       .setEngineConfig(config, opgraph_tag)
@@ -1032,6 +1038,41 @@ bool try_configs_fused(
     }
   }
   return false;
+}
+
+bool try_configs(
+    cudnn_frontend::EngineConfigList& configs,
+    const std::string& opgraph_tag,
+    const CacheKeyWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const cudnnBackendDescriptorType_t operation) {
+  return try_configs(
+      configs.begin(),
+      configs.end(),
+      opgraph_tag,
+      key,
+      handle,
+      x,
+      y,
+      w,
+      operation);
+}
+
+bool try_configs_fused(
+    cudnn_frontend::EngineConfigList& configs,
+    const std::string& opgraph_tag,
+    const CacheKeyFusedWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& z,
+    const Tensor& b) {
+  return try_configs_fused(
+      configs.begin(), configs.end(), opgraph_tag, key, handle, x, y, w, z, b);
 }
 
 void run_single_conv(
@@ -1085,27 +1126,43 @@ void run_single_conv(
         deterministic,
         allow_tf32,
         false);
-    if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
-      return;
-    }
-    // all heuristic configs
-    configs = get_configs_from_heuristics(
-        handle,
-        operation,
-        opgraph_tag,
-        x,
-        y,
-        w,
-        key,
-        padding,
-        stride,
-        dilation,
-        deterministic,
-        allow_tf32,
-        false,
-        true);
-    if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
-      return;
+    if (!configs.empty()) {
+      if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
+        return;
+      }
+      // all heuristic configs
+      configs = get_configs_from_heuristics(
+          handle,
+          operation,
+          opgraph_tag,
+          x,
+          y,
+          w,
+          key,
+          padding,
+          stride,
+          dilation,
+          deterministic,
+          allow_tf32,
+          false,
+          true);
+      auto configs_begin = configs.begin();
+      // The top-config path already tried the first filtered heuristic config.
+      if (configs_begin != configs.end()) {
+        configs_begin += 1;
+      }
+      if (try_configs(
+              configs_begin,
+              configs.end(),
+              opgraph_tag,
+              key,
+              handle,
+              x,
+              y,
+              w,
+              operation)) {
+        return;
+      }
     }
     // fallback configs
     configs = get_configs_from_heuristics(
@@ -1207,29 +1264,46 @@ void run_fused_conv(
             deterministic,
             allow_tf32,
             false);
-    if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
-      return;
-    }
-    // all heuristic configs
-    configs = get_configs_from_heuristics_fused(
-        handle,
-        opgraph_tag,
-        x,
-        y,
-        w,
-        z,
-        b,
-        alpha,
-        key,
-        padding,
-        stride,
-        dilation,
-        deterministic,
-        allow_tf32,
-        false,
-        true);
-    if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
-      return;
+    if (!configs.empty()) {
+      if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
+        return;
+      }
+      // all heuristic configs
+      configs = get_configs_from_heuristics_fused(
+          handle,
+          opgraph_tag,
+          x,
+          y,
+          w,
+          z,
+          b,
+          alpha,
+          key,
+          padding,
+          stride,
+          dilation,
+          deterministic,
+          allow_tf32,
+          false,
+          true);
+      auto configs_begin = configs.begin();
+      // The top-config path already tried the first filtered heuristic config.
+      if (configs_begin != configs.end()) {
+        configs_begin += 1;
+      }
+      if (try_configs_fused(
+              configs_begin,
+              configs.end(),
+              opgraph_tag,
+              key,
+              handle,
+              x,
+              y,
+              w,
+              z,
+              b)) {
+        return;
+      }
     }
     // fallback configs
     configs = get_configs_from_heuristics_fused(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -582,18 +582,22 @@ auto get_generator_sources(
     const bool allow_tf32,
     const cudnnBackendHeurMode_t heur_mode,
     const bool heuristic,
-    const bool fallback) {
+    const bool fallback,
+    const bool get_all_heuristic_configs = false) {
   // Method for engine config generator based on heuristics
   const auto heurgen_method =
-      [/*&desc,*/ &x, deterministic, allow_tf32, heur_mode](
-          cudnn_frontend::OperationGraph& opGraph)
+      [/*&desc,*/ &x,
+       deterministic,
+       allow_tf32,
+       heur_mode,
+       get_all_heuristic_configs](cudnn_frontend::OperationGraph& opGraph)
       -> cudnn_frontend::EngineConfigList {
     auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
                           .setOperationGraph(opGraph)
                           .setHeurMode(heur_mode)
                           .build();
-    auto& engine_configs =
-        heuristics.getEngineConfig(heuristics.getEngineConfigCount());
+    auto& engine_configs = heuristics.getEngineConfig(
+        get_all_heuristic_configs ? heuristics.getEngineConfigCount() : 1);
     cudnn_frontend::EngineConfigList filtered_configs;
     filterEngineConfigs(
         engine_configs,
@@ -754,7 +758,14 @@ auto get_plans_from_find(
   // We don't care about getting the best ordering of algos if we're roing to
   // run all of them
   auto sources = get_generator_sources(
-      desc, x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT, true, true);
+      desc,
+      x,
+      deterministic,
+      allow_tf32,
+      CUDNN_HEUR_MODE_INSTANT,
+      true,
+      true,
+      true);
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
   cudnn_frontend::executionPlans_t valid_plans;
@@ -809,6 +820,7 @@ auto get_plans_from_find_fused(
       allow_tf32,
       CUDNN_HEUR_MODE_INSTANT,
       true,
+      true,
       true);
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
@@ -852,7 +864,8 @@ auto get_configs_from_heuristics(
     const IntArrayRef dilation,
     const bool deterministic,
     const bool allow_tf32,
-    const bool fallback) {
+    const bool fallback,
+    const bool get_all_heuristic_configs = false) {
   auto opGraph =
       build_opgraph(handle, desc, x, y, w, key, padding, stride, dilation);
   opgraph_tag = opGraph.getTag();
@@ -860,12 +873,18 @@ auto get_configs_from_heuristics(
       ? CUDNN_HEUR_MODE_B
       : CUDNN_HEUR_MODE_INSTANT;
   auto sources = get_generator_sources(
-      desc, x, deterministic, allow_tf32, heuristic_mode, !fallback, fallback);
+      desc,
+      x,
+      deterministic,
+      allow_tf32,
+      heuristic_mode,
+      !fallback,
+      fallback,
+      get_all_heuristic_configs);
 
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
-  auto configs = generator.generate_engine_config(opGraph);
-  return configs;
+  return generator.generate_engine_config(opGraph);
 }
 
 auto get_configs_from_heuristics_fused(
@@ -883,7 +902,8 @@ auto get_configs_from_heuristics_fused(
     const IntArrayRef dilation,
     const bool deterministic,
     const bool allow_tf32,
-    const bool fallback) {
+    const bool fallback,
+    const bool get_all_heuristic_configs = false) {
   auto opGraph = build_opgraph_fused(
       handle, x, y, w, z, b, alpha, key, padding, stride, dilation);
   opgraph_tag = opGraph.getTag();
@@ -897,7 +917,8 @@ auto get_configs_from_heuristics_fused(
       allow_tf32,
       heuristic_mode,
       !fallback,
-      fallback);
+      fallback,
+      get_all_heuristic_configs);
 
   cudnn_frontend::EngineConfigGenerator generator(
       sources.size(), sources.data());
@@ -1049,7 +1070,7 @@ void run_single_conv(
   }
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter
-    // heuristic configs
+    // top config from heuristic
     cudnn_frontend::EngineConfigList configs = get_configs_from_heuristics(
         handle,
         operation,
@@ -1064,6 +1085,25 @@ void run_single_conv(
         deterministic,
         allow_tf32,
         false);
+    if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
+      return;
+    }
+    // all heuristic configs
+    configs = get_configs_from_heuristics(
+        handle,
+        operation,
+        opgraph_tag,
+        x,
+        y,
+        w,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32,
+        false,
+        true);
     if (try_configs(configs, opgraph_tag, key, handle, x, y, w, operation)) {
       return;
     }
@@ -1149,7 +1189,7 @@ void run_fused_conv(
   }
   if (!benchmark) {
     std::string opgraph_tag; // extra data needed for errata filter
-    // heuristic configs
+    // top heuristic config
     cudnn_frontend::EngineConfigList configs =
         get_configs_from_heuristics_fused(
             handle,
@@ -1167,6 +1207,27 @@ void run_fused_conv(
             deterministic,
             allow_tf32,
             false);
+    if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
+      return;
+    }
+    // all heuristic configs
+    configs = get_configs_from_heuristics_fused(
+        handle,
+        opgraph_tag,
+        x,
+        y,
+        w,
+        z,
+        b,
+        alpha,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32,
+        false,
+        true);
     if (try_configs_fused(configs, opgraph_tag, key, handle, x, y, w, z, b)) {
       return;
     }


### PR DESCRIPTION
Cold starts of cuDNN convolution have excessive CPU overhead on both v7 and v8 APIs because calls to get algorithms/engine configs (`cudnnGetConvolutionForwardAlgorithm_v7` on the v7 API and `heuristics.getEngineConfig` on the v8 API) request as many algos/configs as possible, even though most cases only end up using the top recommendation from the heuristic.

This PR changes the existing control flow from two stages (try all heuristic configs -> fallback) to three stages (try top heuristic config -> try all heuristic configs -> fallback). Though this introduces some additional overhead for cases which need the fallback or a config other than the top recommendation, on average cold start CPU time is considerably reduced.

I've included timing results before and after the change to show the overhead difference on each API for identified cases that were adding 1ms or more of CPU overhead. I've also included fuzzer results to give a general sense of how many cases use the top config, a different config from all configs, or the fallback.

## v8 timing results (float32)
Before speedup:
| scope | calls | total ms | avg us |
|---|---:|---:|---:|
| run_single_conv | 1741 | 2206.98 | 1267.7 |
| top_engine | 0 | 0.00 | 0.0 |
| all_engine | 1741 | 1811.32 | 1040.4 |
| fallback_engine | 0 | 0.00 | 0.0 |

After speedup:
| scope | calls | total ms | avg us |
|---|---:|---:|---:|
| run_single_conv | 1741 | 511.50 | 293.8 |
| top_engine | 1741 | 237.89 | 136.6 |
| all_engine | 0 | 0.00 | 0.0 |
| fallback_engine | 0 | 0.00 | 0.0 |

## v8 fuzzer results
Overall:
| Successful Path | Count | Rate |
|---|---:|---:|
| top config | 8,167 | 83.13% |
| all configs | 1,406 | 14.31% |
| fallback | 251 | 2.55% |

By dtype:
| Dtype | Count | Top % | All % | Fallback % |
|---|---:|---:|---:|---:|
| float16 | 3,469 | 96.7 | 0.0 | 3.3 |
| bfloat16 | 3,267 | 96.7 | 0.0 | 3.3 |
| float32 | 3,088 | 53.5 | 45.5 | 1.0 |

## v7 timing results (float32)
Before speedup:
| scope | calls | total ms | avg us |
|---|---:|---:|---:|
| cudnnv7_raw_total | 1741 | 721.62 | 414.5 |
| cudnnv7_find_top | 0 | 0.00 | 0.0 |
| cudnnv7_find_all | 1741 | 470.12 | 270.0 |

After speedup:
| scope | calls | total ms | avg us |
|---|---:|---:|---:|
| cudnnv7_raw_total | 1741 | 532.54 | 305.9 |
| cudnnv7_find_top | 1741 | 309.11 | 177.5 |
| cudnnv7_find_all | 0 | 0.00 | 0.0 |

## v7 fuzzer results
Overall:
| Successful Path | Count | Rate |
|---|---:|---:|
| top config | 6,504 | 99.19% |
| all configs | 0 | 0% |
| fallback | 53 | 0.81% |

By dtype:
| Dtype | Count | Top % | All % | Fallback % |
|---|---:|---:|---:|---:|
| float16 | 3,469 | 98.5 | 0.0 | 1.5 |
| float32 | 3,088 | 100.0 | 0.0 | 0.0 |

Authored with Codex

cc @eqy