### PR TITLE
Issue-106571: Lint Fixes - Rule B007 - gb_registry_linter  - Replace …

### DIFF
--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -165,7 +165,7 @@ def _update_registry_with_changes(
     # Collect new entries separately to insert them all at once
     new_entries: list[tuple[str, list[dict[str, Any]]]] = []
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 
@@ -244,7 +244,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     for gb_type, call_list in all_calls.items():
         if len(call_list) > 1:
             first_call = call_list[0][0]
-            for call, file_path in call_list[1:]:
+            for call, _file_path in call_list[1:]:
                 if (
                     call["context"] != first_call["context"]
                     or call["explanation"] != first_call["explanation"]
@@ -321,7 +321,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     renames: dict[str, str] = {}
     remaining_calls = dict(calls)
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type not in latest_entry:
             for existing_gb_type, existing_entry in latest_entry.items():
                 if (
@@ -335,7 +335,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
 
     needs_update = bool(renames)
 
-    for gb_type, (call, file_path) in remaining_calls.items():
+    for gb_type, (call, _file_path) in remaining_calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 


### PR DESCRIPTION
### Description
- This is part of the ongoing bugbear-flak8 linting fixes that are tracked under this issue [issue-106571](https://github.com/pytorch/pytorch/issues/106571)
- This PR deals with `B007 lint` violations in the `gb_registry_linter.py` file

### Testing
To test for `B007` lint violations:
- Remove `B007` ignore flag from `pyproject.toml` (line 171)
- Run lint on the file `gb_registry_linter.py` via command: `spin quicklint -- --take RUFF tools/linter/adapters/gb_registry_linter.py`

Test cases:
- [x] On main - repro'ing the lint errors
<img width="865" height="766" alt="pytorch - lint fix - error repro" src="https://github.com/user-attachments/assets/7d215cac-a10f-4a76-b982-53e9ab1f7b7f" />

- [x] On bugfix branch - confirming the lint errors are fixed
<img width="865" height="766" alt="pytorch - lint fix - success" src="https://github.com/user-attachments/assets/193c81dc-a1b1-4058-8de1-8154fb2a2b43" />
