### PR TITLE
Fix try_convert_fake_to_real for tensors with unhinted symints

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -614,6 +614,22 @@ class FakeTensorTest(TestCase):
 
         self.assertEqual(torch.ones([10]), out[0])
 
+    def test_convert_fake_to_real_unhinted(self):
+        # A FakeTensor with an unhinted (unbacked) symint dimension whose
+        # storage maps to a real storage must be returned unchanged rather than
+        # reconstructed: there is no concrete hint to build a real size from, so
+        # try_convert_fake_to_real should leave it alone instead of raising.
+        x = torch.ones([20])
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+        with fake_mode:
+            fx = fake_mode.from_tensor(x)
+            u = shape_env.create_unbacked_symint()  # no hint set
+            v = torch.as_strided(fx, (u,), (1,))
+
+        out = torch._subclasses.fake_utils.try_convert_fake_to_real([v])
+        self.assertIs(out[0], v)
+
     def test_conv_nhwc(self):
         x = torch.randn([1, 1024, 16, 16]).to(memory_format=torch.channels_last)
         w = torch.randn([256, 1024, 4, 4]).to(memory_format=torch.channels_last)

--- a/torch/_subclasses/fake_utils.py
+++ b/torch/_subclasses/fake_utils.py
@@ -148,20 +148,23 @@ def try_convert_fake_to_real(
             out.append(t)
             continue
 
-        unhinted = False
+        contains_unhinted = False
 
         def map_symint(s: torch.SymInt | int) -> int:
-            nonlocal unhinted
+            nonlocal contains_unhinted
             if not isinstance(s, torch.SymInt):
                 return s
-            unhinted = unhinted if not unhinted else s.node.has_hint()
-            return s.node.hint
+            hint = s.node.hint
+            if hint is None:
+                contains_unhinted = True
+                return 0  # unused: caller bails (contains_unhinted) and discards this
+            return hint
 
         stor_offset = map_symint(t.storage_offset())
         size = [map_symint(s) for s in t.shape]
         stride = [map_symint(s) for s in t.stride()]
 
-        if unhinted:
+        if contains_unhinted:
             out.append(t)
             continue
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187214

`map_symint()` is typed `-> int` but returned `s.node.hint`, which is `None` for an unhinted (unbacked) symint. The guard meant to skip such tensors never fired: `unhinted = unhinted if not unhinted else s.node.has_hint()` starts `False` and can only ever evaluate back to `unhinted` (the `else` branch is dead), so it stays `False`. As a result a tensor with an unhinted symint dimension reached `new_tensor.set_(size=[None, ...])` and raised `TypeError` instead of being left unchanged.

Replace it with a correctly-updated `contains_unhinted` flag (set when a hint is missing) and return a placeholder `0` for the unhinted element (discarded once the caller bails), so such tensors are returned as-is.

Test Plan:
`python test/test_fake_tensor.py FakeTensorTest.test_convert_fake_to_real_unhinted` fails before this change (`set_()` TypeError from `size=[None]`) and passes after; existing `FakeTensorTest.test_convert_fake_to_real` still passes; `lintrunner` is clean.

Authored with Claude.