### PR TITLE
[CUDA][NCCL] Fix nccl.broadcast dropping the root argument

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -85,6 +85,20 @@ class TestNCCL(TestCase):
         for i in range(torch.cuda.device_count()):
             self.assertEqual(tensors[i], expected)
 
+        # Test with a non-zero root (regression test for #179908)
+        root = nGPUs - 1
+        expected = torch.zeros(128).uniform_().to(dtype=dtype)
+        tensors = [
+            expected.cuda(device)
+            if device == root
+            else torch.zeros(128, dtype=dtype, device=device)
+            for device in range(nGPUs)
+        ]
+
+        nccl.broadcast(tensors, root=root)
+        for i in range(nGPUs):
+            self.assertEqual(tensors[i], expected)
+
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "only one GPU detected")
     @dtypes(*datatypes)

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -525,10 +525,13 @@ size_t get_max_count() {
 
 void broadcast(
     TensorList tensors,
+    int32_t root,
     const stream_list& streams,
     const comm_list& user_comms) {
 #ifdef USE_NCCL
   using namespace torch::cuda::nccl::detail;
+  TORCH_CHECK(
+      root >= 0 && static_cast<size_t>(root) < tensors.size(), "invalid root");
   check_inputs(tensors, tensors, 1, 1);
   auto data_type = to_nccl_data_type(tensors[0]);
   int64_t numel = tensors[0].numel();
@@ -558,7 +561,7 @@ void broadcast(
         tensors[i].mutable_data_ptr(),
         numel,
         data_type,
-        0,
+        root,
         to_nccl_comm(comm),
         stream));
   }

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -125,6 +125,7 @@ TORCH_CUDA_CPP_API void comm_destroy(ncclComm_t comm);
 
 TORCH_CUDA_CPP_API void broadcast(
     at::TensorList tensors,
+    int32_t root = 0,
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -216,7 +216,7 @@ PyObject* THCPModule_nccl_broadcast(PyObject* self, PyObject* args) {
 
   {
     pybind11::gil_scoped_release no_gil;
-    torch::cuda::nccl::broadcast(inputs, streams, user_comms);
+    torch::cuda::nccl::broadcast(inputs, root, streams, user_comms);
   }
 
   Py_RETURN_NONE;


### PR DESCRIPTION
Fixes #179908

## Summary

`torch.cuda.nccl.broadcast(tensors, root=N)` silently ignores `root` and always broadcasts from `tensors[0]`, while `nccl.reduce` honors `root` — full root-cause chain in [my issue comment](https://github.com/pytorch/pytorch/issues/179908#issuecomment-4685032224):

1. `torch/cuda/nccl.py::broadcast` passes `root` to `torch._C._nccl_broadcast` correctly.
2. `THCPModule_nccl_broadcast` (`torch/csrc/cuda/python_nccl.cpp`) parses and validates `root`, then calls `torch::cuda::nccl::broadcast(inputs, streams, user_comms)` **without it**.
3. `torch::cuda::nccl::broadcast` (`torch/csrc/cuda/nccl.cpp`) has no root parameter and hardcodes `0` in the `ncclBcast` call.

The bug is old: v0.3.0 passed `root` through to `ncclBcast`; commit de5f7b7251f ("Base for pure C++ NCCL interface", Dec 2017) dropped it when the C++ helper was extracted, so the binding has been wrong since v0.4.0 (~8.5 years).

## Fix

- `torch/csrc/cuda/nccl.h` / `nccl.cpp`: add `int32_t root = 0` to `torch::cuda::nccl::broadcast`, mirroring the existing `reduce` signature (defaulted, so the internal caller in `torch/csrc/cuda/comm.cpp::broadcast_coalesced` is unaffected); validate it in-range exactly like `reduce` does; pass it to `ncclBcast`.
- `torch/csrc/cuda/python_nccl.cpp`: forward the already-parsed `root`.
- `test/distributed/test_nccl.py`: extend `test_broadcast` with a non-zero-root regression block (`root = nGPUs - 1`; the root device holds a `uniform_()` tensor, all other devices hold zeros; assert every device ends up with the root's values). Before this fix the broadcast originates from the zeros at index 0, so the new assertions fail; after the fix they pass. It runs under the existing `TEST_MULTIGPU` skip and `@dtypes(*broadcast_dtypes)` (incl. float8) conventions.

## Test plan

- New regression assertions in `test/distributed/test_nccl.py::TestNCCL::test_broadcast` (multi-GPU).
- `lintrunner -a` on the four touched files: no lint issues (CLANGTIDY skipped locally — requires a build dir).
- Compile-verified the touched translation units (`nccl.cpp`, `python_nccl.cpp`) plus the unmodified internal caller (`comm.cpp`) with `g++ -fsyntax-only` against the modified header: all clean.
- **Validation gap, stated honestly:** my box has a single GPU, so I could not run the multi-GPU broadcast path locally; `python test/distributed/test_nccl.py -k broadcast` collects and skip-passes here (`OK (skipped=2)`). The behavioral coverage relies on PyTorch's multi-GPU CI exercising the extended `test_broadcast`.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @xmfan

 Generated with [Claude Code](https://claude.com/claude-code)