### PR TITLE
[BE] Make linear_cross_entropy compact gradient ULP caps device-independent

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14899,50 +14899,16 @@ if __name__ == '__main__':
                         expected_weight_grad_max_ulp_diff = 4 if bias else 0  # A100
                     expected_linear_bias_grad_max_ulp_diff = 17 if bias else 0  # A100
         elif _resolved_policy == "compact":
-            # Mirrors "balanced" except on CUDA (direct addmm_ skips
-            # weight_grad_chunk). Falls back to "balanced" on non-CUDA
-            # mixed precision.
-            if "cpu" in device:
-                if dtype == torch.float16:
-                    expected_max_ulp_diff = 1
-                    expected_input_grad_max_ulp_diff = 204  # x86_64 119
-                    expected_weight_grad_max_ulp_diff = 229  # was 191, x86_64 101
-                    expected_linear_bias_grad_max_ulp_diff = 1 if bias else 0
-                else:  # bf16
-                    expected_max_ulp_diff = 1
-                    if bias:
-                        expected_input_grad_max_ulp_diff = 10
-                        expected_weight_grad_max_ulp_diff = 13
-                        expected_linear_bias_grad_max_ulp_diff = 1
-                    else:
-                        expected_input_grad_max_ulp_diff = 0
-                        expected_weight_grad_max_ulp_diff = 0
-                        expected_linear_bias_grad_max_ulp_diff = 0
-            else:
-                if dtype == torch.float16:
-                    if "mps" in device:
-                        # MPS + use_acc_dtype: fallback to balanced.
-                        expected_max_ulp_diff = 2
-                        expected_input_grad_max_ulp_diff = 232
-                        expected_weight_grad_max_ulp_diff = 166
-                        expected_linear_bias_grad_max_ulp_diff = 16 if bias else 0
-                    else:  # CUDA
-                        expected_max_ulp_diff = 1
-                        expected_input_grad_max_ulp_diff = 90  # x86_64 68
-                        expected_weight_grad_max_ulp_diff = 118
-                        expected_linear_bias_grad_max_ulp_diff = 16 if bias else 0
-                else:  # bf16
-                    if "mps" in device:
-                        # MPS + use_acc_dtype: fallback to balanced.
-                        expected_max_ulp_diff = 2
-                        expected_input_grad_max_ulp_diff = 90
-                        expected_weight_grad_max_ulp_diff = 22 if bias else 0
-                        expected_linear_bias_grad_max_ulp_diff = 16 if bias else 0
-                    else:  # CUDA
-                        expected_max_ulp_diff = 1
-                        expected_input_grad_max_ulp_diff = 44
-                        expected_weight_grad_max_ulp_diff = 193
-                        expected_linear_bias_grad_max_ulp_diff = 17 if bias else 0  # A100
+            # Loss output is genuinely bounded (O(1), no cancellation); the
+            # +1 on MPS is its lower-precision fp16 matmul.
+            expected_max_ulp_diff = 2 if "mps" in device else 1
+            # The gradient caps are device-independent, RNG-driven drift
+            # trip-wires, not bounds: they do NOT test correctness (the
+            # grad_error Frobenius check does). Sized for the pinned seed
+            # with headroom. See commit message for the seed-sweep evidence.
+            expected_input_grad_max_ulp_diff = 250
+            expected_weight_grad_max_ulp_diff = 250
+            expected_linear_bias_grad_max_ulp_diff = 20 if bias else 0
         else:
             # acc_policy is None (fp32 path; use_acc_dtype is False)
             if "cpu" in device:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #187109
* __->__ #187217

The compact linear_cross_entropy per-element gradient ULP caps in test_linear_cross_entropy_loss were specified per device, but the quantity they bound is device-independent. This collapses them to single values and documents why.

The compact low-precision input/weight/bias grads are cross-entropy gradients that subtract two ~equal-magnitude terms at the target rows (the weight grad is the bulk -logits.T @ input minus an index_add_ of input * weight). The result cancels to a small gradient, so each element's ULP is low-precision rounding amplified by that cancellation -- it scales with the slot's dynamic range Sum|x_i| / |result|, which is unbounded. The per-element ULP is therefore RNG-driven, not a device property: a 25-seed sweep of the exact compact path tops out near the dtype's ULP ceiling on every backend, in the same regime across backends (input/weight ~37-65k, bias ~3k), confirmed on an NVIDIA B200 and an Apple GPU. The old per-device caps (fp16 weight: 229 / 166 / 118 across CPU/MPS/CUDA, etc.) were only what the pinned test seed 1245 happened to hit on each backend, not real device differences -- e.g. CUDA exceeds its own 118 cap in 23 of 25 seeds.

Change three device(in reality RNG)-specific gradient caps into single device-independent values (input 250, weight 250, bias 20) sized for the pinned seed with headroom, and bf16 shares the fp16 value since its pinned-seed max (193) is under 250. Only the loss-output cap stays per-device: the loss is O(1) with no cancellation, so it is genuinely bounded at ~1-2 ULP across seeds, with a +1 on the backend whose fp16 matmul accumulates in fp16 rather than fp32.

These ULP caps do not test correctness -- they are drift trip-wires. Correctness is the grad_error Frobenius relative-error check (<= feps == 3*eps), which stays ~1e-3 (gradients good to ~3 low-precision digits) even on seeds where the ULP hits 65k, because the huge-ULP elements are near-zero cancellation residuals that contribute ~nothing to the norm; and it still binds (it reaches feps on genuinely harder problems). So loosening the ULP caps costs no correctness coverage.

Authored with assistance from Claude.