### PR TITLE
linear_cross_entropy: do not materialize gradients for unused chunked-op outputs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15529,6 +15529,35 @@ if __name__ == '__main__':
         self.assertEqual(inp.grad, g1_inp)
         self.assertEqual(weight.grad, g1_w)
 
+    @onlyCUDA
+    def test_linear_cross_entropy_chunked_backward_no_grad_materialization(
+        self, device
+    ):
+        """The chunked scalar op returns its precomputed gradients as op
+        outputs; backward must not let the engine materialize zero-filled
+        gradients for those unused outputs (set_materialize_grads(False)
+        in setup_context). The materialized zeros would be (N, F) + (C, F)
+        at input dtype -- asserted here as a peak-memory regression
+        trip-wire: backward's allocations must stay well below that.
+        """
+        torch.manual_seed(0)
+        N, F_, C = 1024, 1024, 4096
+        inp = torch.randn(N, F_, device=device, dtype=torch.float16,
+                          requires_grad=True)
+        lw = torch.randn(C, F_, device=device, dtype=torch.float16,
+                         requires_grad=True)
+        target = torch.randint(0, C, (N,), device=device)
+        options = nn.LinearCrossEntropyOptions(batch_chunk_size=256)
+        loss = nn.functional.linear_cross_entropy(inp, lw, target, options=options)
+        torch.cuda.synchronize(device)
+        torch.cuda.reset_peak_memory_stats(device)
+        pre = torch.cuda.memory_allocated(device)
+        loss.backward()
+        torch.cuda.synchronize(device)
+        backward_extra = torch.cuda.max_memory_allocated(device) - pre
+        materialized = (N * F_ + C * F_) * 2  # the zeros the engine would fill
+        self.assertLess(backward_extra, materialized // 2)
+
     @parametrize_test("bias", [False, True])
     @parametrize_test("dtype", [torch.float16, torch.bfloat16])
     @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])

--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -34,6 +34,11 @@ def _linear_cross_entropy_batch_chunked_setup_context(ctx, inputs, output):
         compute_linear_weight_grad,
         compute_linear_bias_grad,
     ) = inputs
+    # Without this, backward through the loss materializes zero-filled
+    # gradients for the three unused grad outputs -- (N, F) + (C, F) + (C,)
+    # at input dtype -- silently adding an input+weight-sized transient to
+    # every backward peak. The backward only consumes the loss gradient.
+    ctx.set_materialize_grads(False)
     ctx.allow_retain_graph = allow_retain_graph
     ctx.compute_input_grad = compute_input_grad
     ctx.compute_linear_weight_grad = compute_linear_weight_grad
@@ -1077,6 +1082,11 @@ def _linear_cross_entropy_batch_chunked_backward(
     ctx, grad_output, _gi_grad, _gw_grad, _gb_grad
 ):
     result = [None] * _NUM_OP_INPUTS
+    # set_materialize_grads(False): grad_output is None when backward is
+    # driven only through the (unsupported) grad outputs -- no gradient
+    # flows through the loss, so none flow to the inputs.
+    if grad_output is None:
+        return tuple(result)
     if ctx.compute_input_grad:
         if ctx.allow_retain_graph:
             result[0] = ctx._gi * grad_output


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #187053
* __->__ #187219

The chunked scalar-reduction custom op returns (loss, grad_input,
grad_linear_weight, grad_linear_bias) with the gradients precomputed in
forward; its backward consumes only the loss gradient and scales the
precomputed tensors. Because the autograd registration left
materialize_grads at its default, every backward through the loss made
the engine materialize zero-filled gradients for the three unused
outputs -- (N, F) + (C, F) + (C,) at the input dtype -- silently adding
an input+weight-sized transient to the backward peak of every chunked
mean/sum call. The overhead is chunk-size independent, which is what
distinguished it from the tunable chunk-buffer overhead during
diagnosis: on an fp16 N=4096, F=8192, C=32000 sweep point the chunked
peak exceeded even the unchunked reference (1.66 vs 1.61 GiB) and drops
to 1.16 GiB with the fix, restoring the expected ordering along the
in_features axis.

The fix is ctx.set_materialize_grads(False) in the op's setup_context,
plus a backward guard returning no input gradients when grad_output is
None (a backward driven only through the unsupported gradient outputs
means no gradient flows through the loss). The reduction='none' op is
unchanged: its unused outputs are rank-empty placeholders, so their
materialized zeros were already byte-free. A CUDA peak-memory
regression test asserts backward allocates well below the
would-be-materialized size; it fails before this fix and passes after.

This PR was authored with the assistance of an AI tool (Claude).