### PR TITLE
Prune sm100 ptxas-bad conv bwd weight config

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5979,6 +5979,58 @@ for dtype in (torch.int32, torch.int64):
             check_lowp=False,
         )
 
+    @skip_if_cpu
+    @skipCUDAIf(
+        TEST_WITH_ROCM or not SM100OrLater,
+        "regression is specific to NVIDIA sm100 ptxas",
+    )
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_conv_bwd_weight_backends": "TRITON",
+        }
+    )
+    @with_tf32_off
+    def test_conv2d_backward_weight_sm100_masked_load(self):
+        def fn(grad_output, inp, weight):
+            return torch.ops.aten.convolution_backward.default(
+                grad_output,
+                inp,
+                weight,
+                [out_channels],
+                [stride, stride],
+                [padding, padding],
+                [dilation, dilation],
+                False,
+                [0, 0],
+                groups,
+                [False, True, False],
+            )[1]
+
+        in_channels = 3
+        out_channels = 4
+        groups = 1
+        dilation = 2
+        stride = 1
+        padding = 1
+        kernel = 1
+        input_h = 16
+        input_w = 16
+        output_h = (input_h + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
+        output_w = (input_w + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
+
+        self.common(
+            fn,
+            (
+                torch.randn([2, out_channels, output_h, output_w]),
+                torch.randn([2, in_channels, input_h, input_w]),
+                torch.randn([out_channels, in_channels // groups, kernel, kernel]),
+            ),
+            atol=3e-4,
+            rtol=0.001,
+            check_lowp=False,
+        )
+
     @parametrize(
         "use_block_ptr",
         [subtest(False), subtest(True, decorators=[skip_if_not_triton])],

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -22,6 +22,7 @@ from ..select_algorithm import (
     TritonTemplate,
 )
 from ..utils import (
+    is_nvidia_sm100_or_later,
     is_ones,
     is_zeros,
     pad_listlike,
@@ -961,6 +962,22 @@ conv2d_bwd_input_template = TritonTemplate(
 aten_convolution_backward_fallback = fallback_handler(aten.convolution_backward.default)
 
 
+def _skip_sm100_ptxas_bad_conv_bwd_weight_config(
+    cfg,
+    *,
+    allow_tf32: bool,
+) -> bool:
+    return (
+        not allow_tf32
+        and is_nvidia_sm100_or_later()
+        and cfg.kwargs.get("BLOCK_M") == 256
+        and cfg.kwargs.get("BLOCK_N") == 16
+        and cfg.kwargs.get("BLOCK_K") == 16
+        and cfg.num_warps == 4
+        and cfg.num_stages == 2
+    )
+
+
 @register_lowering(aten.convolution_backward.default)
 def convolution_backward_lowering(
     grad_out: TensorBox,
@@ -1055,6 +1072,12 @@ def convolution_backward_lowering(
                 in_chan,
                 dtype_size=dtype_size,
             ):
+                allow_tf32 = torch.backends.cudnn.allow_tf32
+                if _skip_sm100_ptxas_bad_conv_bwd_weight_config(
+                    cfg, allow_tf32=allow_tf32
+                ):
+                    continue
+
                 if ndim == 2:
                     has_triton_dw_choices = True
                     conv2d_bwd_weight_template.maybe_append_choice(
@@ -1070,7 +1093,7 @@ def convolution_backward_lowering(
                         DILATION_H=dilation[0],
                         DILATION_W=dilation[1],
                         GROUPS=groups,
-                        ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                        ALLOW_TF32=allow_tf32,
                         num_stages=cfg.num_stages,
                         num_warps=cfg.num_warps,
                         **cfg.kwargs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187222

On NVIDIA sm100 with TF32 disabled, ptxas miscompiles the Triton
convolution backward-weight autotune config BLOCK_M=256, BLOCK_N=16,
BLOCK_K=16, num_warps=4, num_stages=2. The generated PTX uses a masked
cp.async where src-size=0 should avoid touching the source address, but
ptxas lowers it to code that can dereference a padding-halo address and
trigger an illegal global read during autotune.

Prune only that exact backward-weight config on NVIDIA sm100+ when
ALLOW_TF32 is false. Other backward-weight Triton configs remain in the
autotune set, including nearby 256x16x16 variants that do not hit the
reported ptxas issue. This keeps the mitigation scoped to the compiler
bug while preserving the normal fallback to other autotuned kernels.

Add a focused sm100 regression test for the issue shape with TF32 off.

Fixes #187081
Generated by my agent

Test Plan:
- Reproduced the original illegal memory access on B200 with a standalone
  TF32-off convolution_backward reproducer before the fix.
- taskset -c 0-3 timeout -s KILL 900s env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 CUDA_VISIBLE_DEVICES=4 PYTHONUNBUFFERED=1 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_187081_pytest2 python - <<'PY' ... pytest exact issue test and new regression test ... PY
  Result: 2 passed in 14.39s.
- taskset -c 0-3 timeout -s KILL 900s env OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 CUDA_VISIBLE_DEVICES=4 CUDA_LAUNCH_BLOCKING=1 PYTHONUNBUFFERED=1 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_187081_sanitizer1 compute-sanitizer --tool memcheck --error-exitcode 99 python - <<'PY' ... standalone fixed reproducer ... PY
  Result: ERROR SUMMARY: 0 errors.
- lintrunner -a
  Result: ok No lint issues. Successfully applied all patches.

Benchmark Results:
Before: the issue shape faults during autotune, so no valid timing is
available.
After: exact issue shape on B200, TF32 off, 200 CUDA-event timed
iterations after warmup: after_ms_per_iter=0.026775. Autotune selected
BLOCK_M=64, BLOCK_N=16, BLOCK_K=16, num_warps=4, num_stages=4 with best
autotune time 0.028511999174952507 ms.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo