### PR TITLE
Add targeted SDPA coverage to H100 CI

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -428,6 +428,25 @@ test_python_smoke() {
   assert_git_not_dirty
 }
 
+test_h100_sdpa() {
+  # Bounded SDPA subset; the full fused attention and transformers files are too broad for H100 CI.
+  local sdpa_tests
+  sdpa_tests="test_sdpa_rewriter_1_gpu or "
+  sdpa_tests+="test_sdpa_rewriter_16_inference_gpu or "
+  sdpa_tests+="test_cache_sdpa_constraint_shared_kv_gpu or "
+  sdpa_tests+="test_math_backend_high_precision or "
+  sdpa_tests+="test_is_causal_gpu or "
+  sdpa_tests+="(test_fused_sdp_choice and cuda) or "
+  sdpa_tests+="test_fused_kernels_seq_len_1_inputs"
+
+  time python test/run_test.py \
+    --include inductor/test_fused_attention test_transformers \
+    -k "$sdpa_tests" \
+    $PYTHON_TEST_EXTRA_OPTION \
+    --upload-artifacts-while-running
+  assert_git_not_dirty
+}
+
 test_python_smoke_b200() {
   # Targeted smoke tests for B200 including FlashAttention CuTe coverage
   install_flash_attn_cute
@@ -2417,6 +2436,8 @@ elif [[ "${TEST_CONFIG}" = docs_test ]]; then
   test_docs_test
 elif [[ "${TEST_CONFIG}" == smoke ]]; then
   test_python_smoke
+elif [[ "${TEST_CONFIG}" == h100_sdpa ]]; then
+  test_h100_sdpa
 elif [[ "${TEST_CONFIG}" == smoke_b200 ]]; then
   test_python_smoke_b200
 elif [[ "${TEST_CONFIG}" == smoke_xpu ]]; then

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -162,7 +162,10 @@
 - aten/src/ATen/native/cuda/*Blas.cpp
 - aten/src/ATen/cuda/CUDA*Blas.*
 - torch/**/*cublas*
+- torch/_inductor/fx_passes/fuse_attention.py
 - torch/_inductor/kernel/mm.py
+- test/inductor/test_fused_attention.py
+- test/test_transformers.py
 - test/inductor/test_max_autotune.py
 - third_party/fbgemm
 

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -5,7 +5,10 @@ on:
   pull_request:
     paths:
       - .github/workflows/test-h100.yml
+      - test/inductor/test_fused_attention.py
+      - test/test_transformers.py
       - test/inductor/test_max_autotune.py
+      - torch/_inductor/fx_passes/fuse_attention.py
       - torch/_inductor/kernel/mm.py
       - torch/_inductor/kernel/mm_grouped.py
 
@@ -51,6 +54,7 @@ jobs:
       test-matrix: |
         { include: [
           { config: "smoke", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
+          { config: "h100_sdpa", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
         ]}
       python-version: "3.10"
       compiler: gcc11


### PR DESCRIPTION
Add a separate h100_sdpa config to the H100 limited CI workflow so the existing smoke run remains unchanged while SDPA gets targeted coverage. The new config runs a bounded subset of inductor/test_fused_attention, and the H100 label/path routing now includes the SDPA fused-attention test and fuse pass so edits trigger the flow automatically.

Test Plan:
```
git diff --check
bash -n .ci/pytorch/test.sh
ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/test-h100.yml .github/labeler.yml\n```\n\nNote: `lintrunner -a` was attempted but is not installed in this checkout.\n\nAuthored with assistance from an AI assistant.