### PR TITLE
[MPS] Fix CPU scalar storage_offset ignored in binary op fast path

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -499,7 +499,7 @@ static inline void mtl_setBuffer(encoder_t encoder, const TensorBase& t, unsigne
         [encoder setBytes:&val length:sizeof(val) atIndex:idx];
         return;
       }
-      [encoder setBytes:t.storage().data() length:t.element_size() atIndex:idx];
+      [encoder setBytes:t.const_data_ptr() length:t.element_size() atIndex:idx];
     } else {
       TORCH_CHECK(false, "Passed CPU tensor to MPS op");
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3453,6 +3453,25 @@ class TestMPS(TestCaseMPS):
         helper(torch.not_equal)
         helper(torch.eq)
 
+    def test_cpu_scalar_storage_offset_binary(self):
+        # https://github.com/pytorch/pytorch/issues/187117
+        # CPU 0-dim view with storage_offset > 0 was ignored; the kernel read
+        # element 0 of the backing storage instead of the correct element.
+        cpu_vals = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+        mps_tensor = torch.ones(3, device="mps")
+        for i in range(len(cpu_vals)):
+            scalar_cpu = cpu_vals[i]  # 0-dim view, storage_offset = i
+            self.assertEqual((mps_tensor + scalar_cpu).cpu(), torch.full((3,), 1.0 + i))
+            self.assertEqual((scalar_cpu + mps_tensor).cpu(), torch.full((3,), 1.0 + i))
+            self.assertEqual((mps_tensor * scalar_cpu).cpu(), torch.full((3,), float(i)))
+
+        # also verify with integer dtype
+        cpu_ints = torch.tensor([10, 20, 30, 40], dtype=torch.int32)
+        mps_ints = torch.ones(3, dtype=torch.int32, device="mps")
+        for i in range(len(cpu_ints)):
+            scalar_int = cpu_ints[i]
+            self.assertEqual((mps_ints + scalar_int).cpu(), torch.full((3,), 1 + (i + 1) * 10, dtype=torch.int32))
+
     def test_slice_contiguous_view(self):
         # https://github.com/pytorch/pytorch/issues/77750
 


### PR DESCRIPTION
## Summary

Fixes #187117.

`mtl_setBuffer` in `OperationUtils.h` was calling `[encoder setBytes:t.storage().data() ...]` for CPU 0-dim tensor scalars. This passes the raw storage base address, silently ignoring `storage_offset`. A 0-dim view like `s[4]` has `storage_offset=4`, so the Metal kernel was reading element 0 of the backing storage instead of element 4.

**Fix:** use `t.const_data_ptr()` instead, which already incorporates the offset (`storage().data() + storage_offset * element_size`). The double/complex-double branches above it already use `const_data_ptr()` correctly — this brings the fallback path in line.

```python
# Before fix
s = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
a = torch.ones(3, device='mps')
print(a + s[4])  # tensor([1., 1., 1.])  ← wrong, read s[0]

# After fix
print(a + s[4])  # tensor([5., 5., 5.])  ← correct
```

## Test plan

- Added `test_cpu_scalar_storage_offset_binary` to `test/test_mps.py` covering float and integer dtypes, both lhs and rhs scalar positions, for all offsets 0–4.
- Verified the test **fails** on the unfixed code and **passes** after the fix.
- Ran `pytest test/test_mps.py -k "binary or scalar or storage_offset"`: 165 passed, 0 failed.