### PR TITLE
[PT2] Preserve symbolic metadata across tracing

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -314,6 +314,8 @@ class RegionalInductorTests(torch._inductor.test_case.TestCase):
             options = kwargs.get("options", {})
             captured_options.append(options)
 
+            if kwargs.get("donate_graph_module") is not True:
+                raise AssertionError("regional_inductor should donate submodule GMs")
             # Verify config is set as expected from explicit options
             if not inductor_config.max_autotune:
                 raise AssertionError("max_autotune should be True")

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1182,6 +1182,70 @@ def forward(self, x_1, y_1):
         x = torch.randn(2, 3)
         make_fx(f, tracing_mode="symbolic")(x)
 
+    def test_scalar_placeholder_meta(self):
+        def f(x, n, alpha, flag):
+            y = x + n
+            return y * alpha if flag else y
+
+        gm = make_fx(f)(torch.ones(2), 3, 2.0, True)
+        placeholder_meta = {
+            node.target: node.meta.get("val")
+            for node in gm.graph.nodes
+            if node.op == "placeholder"
+        }
+        self.assertEqual(placeholder_meta["n_1"], 3)
+        self.assertEqual(placeholder_meta["alpha_1"], 2.0)
+        self.assertEqual(placeholder_meta["flag_1"], True)
+
+    def test_unbacked_bindings_on_multiple_token_grid_placeholders(self):
+        from torch._dynamo.source import LocalSource
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+        from torch.utils._pytree import keystr
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+
+        def fakeify(t, name):
+            return fake_mode.from_tensor(
+                t,
+                source=LocalSource(name, is_input=True),
+                symbolic_context=StatelessSymbolicContext(
+                    dynamic_sizes=[DimDynamic.UNBACKED, DimDynamic.STATIC],
+                    shape_ids={0: "token_grid_batch"},
+                ),
+            )
+
+        token_ids = fakeify(torch.randint(8, (2, 4)), "token_ids")
+        labels = fakeify(torch.randint(8, (2, 4)), "labels")
+        position_ids = fakeify(torch.arange(4).expand(2, 4), "position_ids")
+        expected_symbols = tuple(shape_env.pending_fresh_unbacked_symbols)
+
+        def fn(token_ids, labels, position_ids):
+            token_features = token_ids.to(torch.float32) + position_ids.to(
+                torch.float32
+            )
+            return torch.where(labels >= 0, token_features, token_features.neg())
+
+        with fake_mode:
+            gm = make_fx(fn)(token_ids, labels, position_ids)
+
+        placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
+        self.assertEqual(len(placeholders), 3)
+        for placeholder, expected_symbol in zip(
+            placeholders, expected_symbols, strict=True
+        ):
+            bindings = placeholder.meta.get("unbacked_bindings")
+            self.assertIsNotNone(bindings)
+            self.assertEqual(len(bindings), 1)
+            self.assertEqual(set(bindings), {expected_symbol})
+            self.assertEqual(
+                [keystr(path) for path in bindings.values()], [".size()[0]"]
+            )
+
     # https://github.com/pytorch/pytorch/issues/108195
     def test_symbolic_repeat_interleave(self):
         def f(y, x):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1007,7 +1007,7 @@ def track_tensor_tree(
             set_meta(proxy, e)
             e.proxy = proxy
         else:
-            # intentionally pass on primitives
+            # intentionally pass on unsupported primitives
             pass
 
     wrap_with_proxy(inner_res, proxy_res, constant)
@@ -1748,6 +1748,14 @@ def wrap_key(
             if not isinstance(m, ProxyTorchDispatchMode):
                 raise AssertionError(f"Expected ProxyTorchDispatchMode, got {type(m)}")
             track_tensor_tree(flat_tensors, flat_proxies, constant=None, tracer=tracer)
+            # `wrap_key` is the make_fx input-placeholder path. Keep scalar
+            # metadata here instead of teaching recursive output tracking to
+            # treat arbitrary primitive leaves as proxy-trackable values.
+            for input_value, proxy in zip(flat_tensors, flat_proxies):
+                if isinstance(input_value, (int, float, bool)) and isinstance(
+                    proxy, fx.Proxy
+                ):
+                    set_meta(proxy, input_value)
 
         if getattr(tracer, "proxy_module_inputs", False):
             tensors = [  # type: ignore[assignment, var-annotated]
@@ -2166,6 +2174,11 @@ class DecompositionInterpreter(fx.Interpreter):
         out = super().placeholder(target, args, kwargs)  # type: ignore[arg-type]
         proxy = fx.Proxy(self.new_graph.placeholder(target), self.tracer)
         track_tensor_tree(out, proxy, constant=None, tracer=self.tracer)
+        # Primitive scalar placeholders are real graph inputs. Record their
+        # value on the placeholder itself without making recursive output
+        # tracking treat all primitive leaves as proxy-trackable values.
+        if isinstance(out, (int, float, bool)):
+            set_meta(proxy, out)
         # TODO handle case where the first character of target is '*'
         return out
 
@@ -3173,6 +3186,39 @@ def _set_unbacked_bindings(out: object, out_proxy: _NestedProxys) -> None:
     fake_mode = torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FAKE)
     if fake_mode and fake_mode.shape_env:
         if symbol_to_path := compute_unbacked_bindings(fake_mode.shape_env, out):
-            if not isinstance(out_proxy, Proxy):
-                raise AssertionError(f"Expected Proxy, got {out_proxy}")
-            out_proxy.node.meta["unbacked_bindings"] = symbol_to_path
+            # `symbol_to_path` is keyed by the fresh unbacked symbol; each path
+            # is relative to the *whole* output pytree (`out`). Route each
+            # binding to the proxy that owns it. If `out_proxy` is already a
+            # Proxy, it owns the whole output and keeps the original path.
+            bindings_by_proxy: dict[Proxy, dict[sympy.Symbol, pytree.KeyPath]] = {}
+            for symbol, path in symbol_to_path.items():
+                proxy: _NestedProxys = out_proxy
+                local_path = path
+                # `out` and `out_proxy` are structurally congruent, so the
+                # leading container keys index identically into both. Consume
+                # them off `out_proxy` until we reach the owning Proxy leaf; the
+                # remaining suffix (e.g. `.size()[0]`, or an InnerTensorKey for
+                # a wrapper subclass) is the tensor-local accessor that the
+                # per-node consumer resolves against that node's own value.
+                while not isinstance(proxy, Proxy) and local_path:
+                    try:
+                        proxy = local_path[0].get(proxy)
+                    except (IndexError, KeyError, AttributeError) as e:
+                        raise AssertionError(
+                            f"unbacked_bindings path {pytree.keystr(path)} does "
+                            f"not index into the proxy pytree {out_proxy}"
+                        ) from e
+                    local_path = local_path[1:]
+
+                if not isinstance(proxy, Proxy):
+                    raise AssertionError(
+                        f"Expected Proxy at binding path {pytree.keystr(path)}, "
+                        f"got {type(proxy)}"
+                    )
+
+                bindings_by_proxy.setdefault(proxy, {})[symbol] = local_path
+
+            # Merge rather than overwrite: multiple symbols (e.g. two unbacked
+            # dims on one tensor) can route to the same node.
+            for proxy, bindings in bindings_by_proxy.items():
+                proxy.node.meta.setdefault("unbacked_bindings", {}).update(bindings)

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -99,6 +99,7 @@ def _compile_submod(gm: torch.fx.GraphModule, prefix: str) -> torch.fx.GraphModu
                     fake_inputs,
                     dynamic_shapes="from_tracing_context",
                     aot=True,
+                    donate_graph_module=True,
                 )
             if not isinstance(compiled_fn, AOTCompiledArtifact):
                 raise AssertionError(


### PR DESCRIPTION
Stacked PRs:
 * #187273
 * #183838
 * __->__#187231


--- --- ---

### [PT2] Preserve symbolic metadata across tracing


EP-overlap graph chunking traces symbolic tensor dimensions and scalar captures through ProxyTensor, make_fx, and Regional Inductor. These paths should preserve metadata at the boundary where values become FX proxies instead of rediscovering it later in FlexAttention or another downstream subsystem.

ProxyTensor records fresh unbacked symbols on FX nodes via node.meta["unbacked_bindings"]. For nested proxy pytrees, route each binding along its full output path to the proxy that owns the tensor leaf; if the output proxy is already a single Proxy, that proxy owns the whole output and keeps the original path. This preserves provenance for multiple inputs that share token-grid dimensions.

ProxyTensor also records meta["val"] for primitive scalar placeholders when those scalars already have FX proxies. This is the scalar analogue of the existing tensor and SymInt placeholder metadata path, and keeps scalar captures visible to subgraph consumers without Flex-specific placeholder patching.

Regional Inductor compiles temporary submodule graph modules with symbolic fake metadata. Passing donate_graph_module=True avoids deepcopying graph modules that Regional Inductor already owns; deepcopying symbolic fake tensor metadata can call numel() on symbolic sizes and strides.

Fixes #187230

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python -m pytest test/test_proxy_tensor.py -q -s -k "scalar_placeholder_meta or unbacked_bindings_on_multiple_token_grid_placeholders"
```

```bash
python -m pytest test/dynamo/test_regional_inductor.py -q -s -k "RegionalInductorTests and test_max_autotune_no_cudagraphs"
```

```bash
lintrunner -a
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98