### PR TITLE
Fix typos in code comments and docstrings

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -258,7 +258,7 @@ prepare_freezing = os.environ.get("TORCHDYNAMO_PREPARE_FREEZING", "0") == "1"
 # NOTE this has been deprecated, it does nothing now.
 traceable_tensor_subclasses: set[type[Any]] = set()
 
-# If a tensor subclass is put into this set, Dynamo will model its instasnces in
+# If a tensor subclass is put into this set, Dynamo will model its instances in
 # a very conservative and limited way (most likely causing lots of graph breaks
 # if one apply tensor ops on these instances). This is useful if you encounter
 # internal compiler errors from Dynamo which are caused by tensor subclasses,
@@ -882,7 +882,7 @@ run_gc_after_compile = Config(  # type: ignore[var-annotated]
 )
 
 # Does not graph break on torch.autograd._profiler_enabled if set to True. We
-# want this flag to be True by default, but there is an unsolbed bug that causes
+# want this flag to be True by default, but there is an unsolved bug that causes
 # distributed jobs to timeout with Kineto profiler when this is set to True.
 constant_fold_autograd_profiler_enabled = False
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -2550,7 +2550,7 @@ def export(
                     "Failed to produce a graph during tracing as no tensor operations were found and same_signature is False."
                 )
             # If the module does not contain any tensor computation, we would create a graph with inputs and outputs.
-            # To be consistent with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
+            # To be consistent with the graph traced by dynamo, `graph` will have only tensor inputs as placeholders
             # and tensor outputs as output nodes. non-tensor inputs and outputs will be added when rewriting signature.
             # We will also construct the `example_inputs`, `graph_captured_input`, and `graph_captured_result` corresponding
             # to `graph`.

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -15,6 +15,15 @@
       "Context": "{self}.as_subclass({cls})",
       "Explanation": "Currently not supported",
       "Hints": [
+        "Avoid this call or move it outside `torch.compile` region",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Argument of `as_subclass` must be a non-dispatcher-style tensor subclass",
+      "Context": "{self}.as_subclass({cls})",
+      "Explanation": "Currently not supported",
+      "Hints": [
         "Avoid this call or move it outside `torch.compile` regione",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
@@ -325,6 +334,16 @@
     }
   ],
   "GB0026": [
+    {
+      "Gb_type": "Calling subclass default constructor with more than tensor argument",
+      "Context": "{self.value}(args={args}, kwargs={kwargs})",
+      "Explanation": "Currently not supported",
+      "Hints": [
+        "Avoid this constructor call or move it outside ",
+        "`torch.compile` region",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
     {
       "Gb_type": "Calling subclass default constructor with more than tensor argument",
       "Context": "{self.value}(args={args}, kwargs={kwargs})",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1238,7 +1238,7 @@ class TensorVariable(VariableTracker):
             context=f"{self}.as_subclass({cls})",
             explanation="Currently not supported",
             hints=[
-                "Avoid this call or move it outside `torch.compile` regione",
+                "Avoid this call or move it outside `torch.compile` region",
                 *graph_break_hints.SUPPORTABLE,
             ],
         )
@@ -3261,7 +3261,7 @@ class TensorSubclassVariable(UserDefinedClassVariable):
                     explanation="Currently not supported",
                     hints=[
                         "Avoid this constructor call or move it outside "
-                        "`torch.compile` regione",
+                        "`torch.compile` region",
                         *graph_break_hints.SUPPORTABLE,
                     ],
                 )

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -438,7 +438,7 @@ def run_functionalized_fw_and_collect_metadata(
         #     return out
         #
         # In this scenario, 'x' and 'out' have different shapes and are stored at different memory addresses, aka no aliasing.
-        # However, due to how set_() and more specificlaly, set is functionalized, is defined to preserve eager semantics,
+        # However, due to how set_() and more specifically, set is functionalized, is defined to preserve eager semantics,
         # the autograd engine mistakenly assumes that 'x' and 'out' are aliased, treating 'x' as 'out._base'.
         # This misinterpretation leads to an 'alias_of_input' flag, causing an unnecessary as_strided() call to be generated,
         # which could lead to issues later in the code.
@@ -654,7 +654,7 @@ from a multi-output view call"
                 #    (iii) alias_of_intermediate_base_is_user_output.
                 #
                 # No need to worry about in-place view operations here, since
-                # this functionalization step elimitates mutations.
+                # this functionalization step eliminates mutations.
                 #
                 # i.e. we have access to the actual base tensor, before the
                 # in-place operation was applied.

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -317,7 +317,7 @@ def _set_compilation_env():
     # but it exposes some bugs in existing tests so we have to have a temporary flag to control
     # the behavior, which allows dynamo to store an empty graph for a frame without falling back to eager
     try:
-        # We need to turn off the is_fx_tracing_flag. Remove this flag check from dyanmo
+        # We need to turn off the is_fx_tracing_flag. Remove this flag check from dynamo
         # once we are confident fx tracing works with dynamo.
         torch.fx._symbolic_trace._is_fx_tracing_flag = False
         # pyrefly: ignore [bad-assignment]

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1543,7 +1543,7 @@ class FxGraphHashDetails:
             config._fuse_ddp_communication_passes
         )
 
-        # Register indcutor backends and custom passes and get their UUIDs.
+        # Register inductor backends and custom passes and get their UUIDs.
         init_backend_registration()
         self.custom_backend_passes = tuple(
             map(self._get_custom_pass_detail, custom_backend_passes.values())

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1227,7 +1227,7 @@ def _schedule_for_comm(
         The new schedule order.
 
     Some notes on the synergy between different options:
-        - `raise_comms` provides more overlapping oppurtunies for `reorder_compute_for_overlap`.
+        - `raise_comms` provides more overlapping opportunities for `reorder_compute_for_overlap`.
         - When both `raise_comms` and `sink_waits` is `True`, `raise_comms` is prioritized.
     """
     # We assign each node a tuple of scores (score_0, score_1, score_2),

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1293,7 +1293,7 @@ def repeat_interleave_Tensor(
     return torch.clamp(indices, max=repeat.size(0) - 1)
 
 
-# intentionally not regiestered
+# intentionally not registered
 def conv1d_to_conv2d(
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1935,7 +1935,7 @@ class CachingAutotuner(KernelInterface):
         E.g., assuming regular autotune only get one config C1; while max-autotune get 4 configs C1, C2, C3, C4
         and max-autotune figure out C3 is the best.
 
-        Then if coordinate desecnt tuning is run with max-autotune disabled, it will start from C1;
+        Then if coordinate descent tuning is run with max-autotune disabled, it will start from C1;
         while if coordinate descent tuning is run with max-autotune enabled, it will start from C3.
         """
         if not self._should_coordesc_tune:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1082,7 +1082,7 @@ def get_kernel_metadata(
                     continue
                 if hasattr(n.read_writes, "reads") and n.read_writes.reads is not None:
                     for r in n.read_writes.reads:
-                        # Remove the dupricated inputs
+                        # Remove the duplicated inputs
                         if r.name in all_reads:
                             continue
                         all_reads.add(r.name)

--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -170,7 +170,7 @@ class _ExportPackage:
 
     This design allows users to decouple the exported callables from the actual sample inputs which can
     be helpful for use cases where the exported callable is hidden behind helper functions or when sample
-    inpusts are hard to get.
+    inputs are hard to get.
 
     NOTE: This is an experimental API and anything can be changed in the future.
 
@@ -246,7 +246,7 @@ class _ExportPackage:
         A "fallback" is exported when no overload precondition matches a given set of sample
         inputs. Overloads should
         Fallbacks don't have names and are ordered in a list. It's up to a backend to decide
-        which fallback is used amony multiple ones.
+        which fallback is used among multiple ones.
 
         A reference backend implementation of ExportMethod may look like the following:
         ```

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -192,7 +192,7 @@ _BACKEND_KEYS_TO_OVERRIDE = [
 def _override_composite_implicit_decomp(cia_ops_to_callable):
     # This function overrides CompositeImplicitAutograd decomp for
     # functional composite ops that user specified. Ideally we want to not-decompose
-    # ALL composite ops but today's C++ functinalization relies on
+    # ALL composite ops but today's C++ functionalization relies on
     # the fact that it is working with the opset after decomp is run.
     # Hence we can only do it for functional ops. One caveat is that
     # there are some composite ops that lie about their schema (claimed to be
@@ -505,7 +505,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                 new_graph_signature = aten_export_artifact.sig
 
                 # In the previous step, we assume constants as buffers for AOTDispatcher to
-                # functianalize properly, so undo that here
+                # functionalize properly, so undo that here
                 new_graph_signature = (
                     _override_graph_signature_for_temp_registered_constants(
                         new_graph_signature, temp_registered_constants

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -799,7 +799,7 @@ def element_wise_eq(n: Node) -> list[Any]:
     For element-wise operations and handles broadcasting.
     Note that after applying broadcasting to the arguments
     we are able to determine if certain dimensions have not been broadcast
-    if they are symbolicallu equal.
+    if they are symbolically equal.
 
     in this case, we can establish equality between those dimensions and the
     corresponding output dimensions.
@@ -875,7 +875,7 @@ def flatten_refinement_rule(n: Node) -> list[Any]:
 @register_algebraic_expressions_inference_rule(Conv2d)
 def conv_rule(n: Node, module_instance: Any) -> TensorType | None:
     """
-    Represents the output in terms of an algrbraic expression w.r.t
+    Represents the output in terms of an algebraic expression w.r.t
     the input when possible
     """
     if not isinstance(n.args[0], Node):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -604,7 +604,7 @@ def _build_proxy_for_sym_expr(
     To handle this we decompose the sympy.Expr and look for the pieces as
     inputs. But there are problems with this approach:
 
-    - We lose operation provanance: We end up figuring out where to get the
+    - We lose operation provenance: We end up figuring out where to get the
       inputs - but those may not actually be correct. If we have "s1" coming in
       from both tensor1 and tensor2 and we pick the wrong one we could end up
       keeping a tensor alive longer than intended.
@@ -2376,7 +2376,7 @@ class _ModuleStackTracer(PythonKeyTracer):
             self.module_id_cache[id(mod)].append(name)
 
         # Build a wrapper around _AttrProxy to provide the tracer. We can't
-        # store it on _AttrProxy itself beceause we mimic the underlying class
+        # store it on _AttrProxy itself because we mimic the underlying class
         # (including its attributes).
         tracer = self
 

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -50,7 +50,7 @@ def _get_view_type(tgt: object) -> _ViewType:
 
 # Stores a bunch of metadata related to functionalization each node.
 # Relevant metadata:
-# n.meta['fake_result']: FakeTensor (same type as the output of the node, but with FakeTenors instead of Tensors)
+# n.meta['fake_result']: FakeTensor (same type as the output of the node, but with FakeTensors instead of Tensors)
 #   The fake tensor output from running the current node
 # n.meta['view_of']: Node
 #   If the current node n is a view of some base tensor, the 'view_of' field tells us which

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -700,10 +700,10 @@ def scatter_mm_meta(
 
     if SPLIT_N is None:
         # Assume NVIDIA GeForce RTX 2060 SUPER:
-        # With the probality of 92% (99.9% when N > 512), the
+        # With the probability of 92% (99.9% when N > 512), the
         # performance will not be worse more than 2% from the
         # performance when using an optimal value.  Otherwise, when N
-        # <= 512, using the following heuristics may give upto 15%
+        # <= 512, using the following heuristics may give up to 15%
         # lower performance.
         SPLIT_N = {
             16: 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187234

Several misspellings corrected across Dynamo, AOTAutograd, Inductor, FX, export, and sparse Triton ops — including "instasnces", "unsolbed", "dynano", "specificlaly", "elimitates", "indcutor", "oppurtunies", "regiestered", "desecnt", "dupricated", "inpusts", "amony", "functinalization", "functianalize", "symbolicallu", "algrbraic", "provanance", "beceause", "FakeTenors", "probality", and "upto". Also corrects the user-facing graph-break hint "regione" -> "region" in the as_subclass and subclass-constructor paths, and regenerates the graph_break_registry.json entries to match.

Authored-with: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98