### PR TITLE
Fix silent forward overflow in softplus for reduced precision types

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include <functional>
+#include <limits>
 
 #include <ATen/Dispatch.h>
 #include <ATen/OpMathType.h>
@@ -955,16 +956,40 @@ void softplus_kernel(TensorIteratorBase& iter, const Scalar& beta_, const Scalar
       auto threshold = threshold_.to<float>();
       const Vec beta_vec(beta);
       const Vec threshold_vec(threshold);
+      float max_val = static_cast<float>(std::numeric_limits<scalar_t>::max());
+      const Vec max_vec(max_val); 
       cpu_kernel_vec(
           iter,
-          [beta, threshold](scalar_t a) -> scalar_t {
-            return (float(a) * beta) > threshold ? a
-              : static_cast<scalar_t>((std::log1p(std::exp(float(a) * beta))) / beta);
+          [beta, threshold, max_val](scalar_t a) -> scalar_t {
+            float fa = float(a);
+            if ((fa * beta) > threshold) {
+              return a; 
+            }
+            float result = (std::log1p(std::exp(fa * beta))) / beta;
+            // Clamp to max_val to prevent silent overflow on downcast.
+            // Note: If result is NaN, IEEE 754 rules dictate that (NaN > max_val) 
+            // evaluates to false. The ternary safely falls through and returns NaN.
+            return static_cast<scalar_t>(result > max_val ? max_val : result);
           },
-          [beta_vec, threshold_vec](Vectorized<scalar_t> a) -> Vectorized<scalar_t> {
+          [beta_vec, threshold_vec, max_vec](Vectorized<scalar_t> a) -> Vectorized<scalar_t> {
             auto [a0, a1] = convert_to_float<scalar_t>(a);
-            a0 = Vec::blendv((a0 * beta_vec).exp().log1p() / beta_vec, a0, (a0 * beta_vec) > threshold_vec);
-            a1 = Vec::blendv((a1 * beta_vec).exp().log1p() / beta_vec, a1, (a1 * beta_vec) > threshold_vec);
+
+            auto a0_beta = a0 * beta_vec;
+            auto a1_beta = a1 * beta_vec;
+
+            auto softplus_a0 = a0_beta.exp().log1p() / beta_vec;
+            auto softplus_a1 = a1_beta.exp().log1p() / beta_vec;
+
+            // If the softplus evaluation is NaN, (NaN > max_vec) evaluates to false,
+            // allowing the NaN to safely pass through.
+            auto bounded_a0 = Vec::blendv(softplus_a0, max_vec, softplus_a0 > max_vec);
+            auto bounded_a1 = Vec::blendv(softplus_a1, max_vec, softplus_a1 > max_vec);
+
+            // If a0_beta exceeds the threshold, we select the un-evaluated input (a0/a1).
+            // This preserves +inf inputs. Otherwise, we select the bounded result.
+            a0 = Vec::blendv(bounded_a0, a0, a0_beta > threshold_vec);
+            a1 = Vec::blendv(bounded_a1, a1, a1_beta > threshold_vec);
+
             return convert_from_float<scalar_t>(a0, a1);
           }
       );

--- a/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/Activation.h>
 
 #include <cmath>
+#include <limits>
 
 #include <thrust/tuple.h>
 
@@ -34,9 +35,21 @@ void softplus_kernel(
         auto threshold = threshold_.to<opmath_t>();
         gpu_kernel(iter, [beta, threshold] GPU_LAMBDA(scalar_t a) -> scalar_t {
           opmath_t aop = static_cast<opmath_t>(a);
-          return (aop * beta) > threshold
-              ? aop
-              : (::log1p(std::exp(aop * beta))) / beta;
+          if ((aop * beta) > threshold) {
+            return a; 
+          }
+          opmath_t result = (::log1p(std::exp(aop * beta))) / beta;
+          if constexpr (!std::is_same_v<scalar_t, opmath_t>) {
+            opmath_t max_val = static_cast<opmath_t>(std::numeric_limits<scalar_t>::max());
+            // Clamp to max_val to prevent silent overflow on downcast.
+            // Note: If result is NaN, IEEE 754 rules dictate that (NaN > max_val) 
+            // evaluates to false. The ternary safely falls through and returns NaN.
+            return static_cast<scalar_t>(result > max_val ? max_val : result);
+          } else {
+            // For full-precision types, opmath_t == scalar_t. 
+            // We return result directly to avoid a cast.
+            return result;
+          }
         });
       });
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13815,6 +13815,45 @@ if __name__ == '__main__':
         output = model(input)
         torch.autograd.gradcheck(model, input)
 
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_softplus_small_beta_overflow(self, device, dtype):
+        # Tests that small beta values don't cause silent overflow in reduced precision
+        # See https://github.com/pytorch/pytorch/issues/187180
+        dtype_max = torch.finfo(dtype).max
+
+        x_tiny = torch.tensor([[1.0]], dtype=dtype, device=device, requires_grad=True)
+        res_tiny = torch.nn.functional.softplus(x_tiny, beta=1e-6)
+
+        if dtype == torch.bfloat16:
+            # bfloat16 max (~3.39e38) exceeds the float32 intermediate max. 
+            # The clamp check (result > max_val) is unreachable for finite inputs.
+            # This assertion verifies the clamp allows
+            # the underlying float32 intermediate (~6.9e5) to pass through safely.
+            self.assertTrue(res_tiny.item() < dtype_max)
+            self.assertTrue(res_tiny.item() > 0.0)
+        else:
+            # float16 hits the clamp ceiling (65504.0)
+            self.assertTrue(res_tiny.item() <= dtype_max)
+            self.assertTrue(res_tiny.item() > 0.0)
+
+        x_large = torch.tensor([[60000.0]], dtype=dtype, device=device, requires_grad=True)
+        res_large = torch.nn.functional.softplus(x_large, beta=1e-5)
+        
+        if dtype == torch.bfloat16:
+            self.assertTrue(res_large.item() < dtype_max)
+        else:
+            self.assertTrue(res_large.item() <= dtype_max)
+        self.assertTrue(res_large.item() > 0.0)
+
+        with torch.no_grad():
+            inf_tensor = torch.tensor([[float('inf')]], dtype=dtype, device=device)
+            inf_result = torch.nn.functional.softplus(inf_tensor, beta=1e-6)
+            self.assertTrue(torch.isinf(inf_result).all())
+
+            nan_tensor = torch.tensor([[float('nan')]], dtype=dtype, device=device)
+            nan_result = torch.nn.functional.softplus(nan_tensor, beta=1e-6)
+            self.assertTrue(torch.isnan(nan_result).all())
+
     def test_softshrink_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):


### PR DESCRIPTION
Fixes #187180
# Summary & Motivation
Currently, `torch.nn.functional.softplus` causes silent overflow to +inf when used with reduced precision types (float16, bfloat16) on inputs that bypass the linear threshold. This happens because the intermediate transcendental math is computed in float32 (via opmath_t), and results can easily exceed the float16 maximum (65504.0) before being downcast, breaking the mathematical contract of the activation function and poisoning the autograd graph with NaN gradients on the backward pass.

# Solution
This PR introduces a ceiling clamp in the forward kernel to prevent this downcast overflow, while strictly preserving +inf inputs and IEEE 754 NaN propagation. The fix is impllemented in CPU and CUDA kernels. aa test is added in test/test_nn.py

For the CUDA kernels, the clamp is guarded by if constexpr (!std::is_same_v<scalar_t, opmath_t>). This ensures that for full-precision types (float32, float64), the clamp logic and static_cast are entirely optimized away at compile time, maintaining original performance with no code duplication. For CPU kernels, the floats and reduced floats are already dispatched separately.
The initialization of max_val is localized strictly within the if constexpr block to prevent -Wunused-variable warnings. 

# Backward Compatibility
The only behaviour change caused is that on float16 for large numbers, the computation clamps to tghe max of that dtype instead of returning inf. 

# Testing & Verification
I have expanded the test suite to rigorously cover these boundary conditions:

Added tests with large inputs and small betas (e.g., x=60000.0, beta=1e-5) to prove the clamp catches values that bypass the linear threshold (x * beta > 20) but still mathematically exceed dtype_max.
Added specific assertions and comments for bfloat16. Since bfloat16 shares the float32 exponent range, the math path will hit +inf before producing a finite number large enough to trigger the bfloat16 clamp. The test now explicitly verifies that the clamp acts as an intentional, safe no-op for bfloat16 using strict inequalities.

Code Touched
aten/src/ATen/native/cpu/Activation.cpp
aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
test/test_nn.py

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01