### PR TITLE
Make Overlap Runtime Estimation Device Aware

### DIFF
--- a/test/inductor/test_overlap_scheduling.py
+++ b/test/inductor/test_overlap_scheduling.py
@@ -50,7 +50,7 @@ class TestOverlapSchedulingRuntimeEstimation(TestCase):
         device = torch.device("cpu")
         fake_device_info = SimpleNamespace(
             tops={torch.float16: 456.0},
-            tops_sparsity_factor=1.0,
+            tops_sparsity_factor=1,
         )
 
         with (

--- a/test/inductor/test_overlap_scheduling.py
+++ b/test/inductor/test_overlap_scheduling.py
@@ -1,0 +1,218 @@
+# Owner(s): ["module: inductor"]
+
+import operator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.fx as fx
+from torch._inductor.analysis import device_info
+from torch._inductor.fx_passes.overlap_scheduling import gather_node_runtime_estimations
+from torch._inductor.utils import get_device_tflops
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestOverlapSchedulingRuntimeEstimation(TestCase):
+    def setUp(self):
+        super().setUp()
+        if hasattr(get_device_tflops, "cache_clear"):
+            get_device_tflops.cache_clear()
+
+    def tearDown(self):
+        if hasattr(get_device_tflops, "cache_clear"):
+            get_device_tflops.cache_clear()
+        super().tearDown()
+
+    def test_get_device_tflops_forwards_device_to_datasheet_tops(self):
+        device = torch.device("cpu")
+
+        with patch("torch._inductor.utils.datasheet_tops") as mock_datasheet_tops:
+            mock_datasheet_tops.return_value = 123.0
+
+            result = get_device_tflops(torch.float16, device=device)
+
+        self.assertEqual(result, 123.0)
+        mock_datasheet_tops.assert_called_once()
+        self.assertEqual(mock_datasheet_tops.call_args.kwargs["device"], device)
+
+    def test_get_device_tflops_non_cuda_without_datasheet_returns_zero(self):
+        device = torch.device("cpu")
+
+        with (
+            patch("torch._inductor.utils.datasheet_tops", return_value=None),
+            patch("torch.cuda.is_available", return_value=True),
+        ):
+            result = get_device_tflops(torch.float16, device=device)
+
+        self.assertEqual(result, 0.0)
+
+    def test_datasheet_tops_uses_device_name_helper(self):
+        device = torch.device("cpu")
+        fake_device_info = SimpleNamespace(
+            tops={torch.float16: 456.0},
+            tops_sparsity_factor=1.0,
+        )
+
+        with (
+            patch.object(
+                device_info,
+                "_get_device_name",
+                return_value="Fake Device",
+            ) as mock_get_device_name,
+            patch.object(
+                device_info,
+                "lookup_device_info",
+                return_value=fake_device_info,
+            ),
+        ):
+            result = device_info.datasheet_tops(
+                torch.float16,
+                device=device,
+            )
+
+        self.assertEqual(result, 456.0)
+        mock_get_device_name.assert_called_once_with(device)
+
+    def test_datasheet_tops_uses_tf32_key_for_tf32(self):
+        device = torch.device("cpu")
+        fake_device_info = SimpleNamespace(
+            tops={"torch.tf32": 789.0},
+            tops_sparsity_factor=1.0,
+        )
+
+        with (
+            patch.object(device_info, "_get_device_name", return_value="Fake Device"),
+            patch.object(
+                device_info,
+                "lookup_device_info",
+                return_value=fake_device_info,
+            ),
+        ):
+            result = device_info.datasheet_tops(
+                torch.float32,
+                is_tf32=True,
+                device=device,
+            )
+
+        self.assertEqual(result, 789.0)
+
+    def test_flops_to_ns_forwards_device_to_get_device_tflops(self):
+        from torch.utils._runtime_estimation import flops_to_ns
+
+        device = torch.device("cpu")
+
+        with patch(
+            "torch.utils._runtime_estimation.get_device_tflops",
+            return_value=0.0,
+        ) as mock_get_device_tflops:
+            result = flops_to_ns(
+                1000,
+                torch.float16,
+                device=device,
+            )
+
+        self.assertEqual(result, 0.0)
+        mock_get_device_tflops.assert_called_once()
+        self.assertEqual(mock_get_device_tflops.call_args.kwargs["device"], device)
+
+    def test_gather_node_runtime_estimations_prefers_custom_estimation(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.relu, (x,))
+        graph.output(relu)
+        gm = fx.GraphModule({}, graph)
+
+        relu.meta["val"] = torch.empty(4, device="meta")
+
+        def custom_runtime_estimation(
+            node: fx.Node,
+            size: int | None,
+        ) -> float | None:
+            if node is relu:
+                return 7.0
+            return None
+
+        with patch(
+            "torch._inductor.fx_passes.overlap_scheduling._schedulable_wait_node",
+            return_value=False,
+        ):
+            estimations = gather_node_runtime_estimations(
+                gm,
+                custom_runtime_estimation=custom_runtime_estimation,
+                log_estimations=False,
+            )
+
+        self.assertEqual(estimations[relu], 7.0)
+
+    def test_custom_estimator_skips_non_compute_roofline(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        getitem = graph.call_function(operator.getitem, ((x,), 0))
+        graph.output(getitem)
+        gm = fx.GraphModule({}, graph)
+
+        getitem.meta["val"] = torch.empty(4, device="meta")
+
+        def custom_runtime_estimation(
+            node: fx.Node,
+            size: int | None,
+        ) -> float | None:
+            return None
+
+        with (
+            patch(
+                "torch._inductor.fx_passes.overlap_scheduling._schedulable_wait_node",
+                return_value=False,
+            ),
+            patch(
+                "torch._inductor.fx_passes.overlap_scheduling.estimate_roofline_runtime_ms"
+            ) as mock_estimate_roofline,
+        ):
+            estimations = gather_node_runtime_estimations(
+                gm,
+                custom_runtime_estimation=custom_runtime_estimation,
+                log_estimations=False,
+            )
+
+        self.assertNotIn(getitem, estimations)
+        mock_estimate_roofline.assert_not_called()
+
+    def test_manual_overlap_scheduler_uses_noop_default_estimator(self):
+        from torch._inductor.fx_passes import overlap_manual_scheduling
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = fx.GraphModule({}, graph)
+
+        captured_kwargs = {}
+
+        def fake_overlap_scheduler_init(self, *args, **kwargs):
+            captured_kwargs.update(kwargs)
+            self.graph = gm.graph
+            self.collective_info = {}
+
+        with (
+            patch.object(
+                overlap_manual_scheduling.OverlapScheduler,
+                "__init__",
+                fake_overlap_scheduler_init,
+            ),
+            patch.object(
+                overlap_manual_scheduling,
+                "ManualOverlapPreservingBucketer",
+            ),
+        ):
+            overlap_manual_scheduling.ManualOverlapScheduler(
+                gm,
+                module_bucket_plans=[],
+                insert_overlap_deps=False,
+            )
+
+        estimator = captured_kwargs["custom_runtime_estimation"]
+        self.assertIsNotNone(estimator)
+        self.assertEqual(estimator(x, None), 0.0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_overlap_scheduling.py
+++ b/test/inductor/test_overlap_scheduling.py
@@ -177,7 +177,7 @@ class TestOverlapSchedulingRuntimeEstimation(TestCase):
         self.assertNotIn(getitem, estimations)
         mock_estimate_roofline.assert_not_called()
 
-    def test_manual_overlap_scheduler_uses_noop_default_estimator(self):
+    def test_manual_overlap_scheduler_skips_runtime_estimations(self):
         from torch._inductor.fx_passes import overlap_manual_scheduling
 
         graph = fx.Graph()
@@ -185,19 +185,10 @@ class TestOverlapSchedulingRuntimeEstimation(TestCase):
         graph.output(x)
         gm = fx.GraphModule({}, graph)
 
-        captured_kwargs = {}
-
-        def fake_overlap_scheduler_init(self, *args, **kwargs):
-            captured_kwargs.update(kwargs)
-            self.graph = gm.graph
-            self.collective_info = {}
-
         with (
-            patch.object(
-                overlap_manual_scheduling.OverlapScheduler,
-                "__init__",
-                fake_overlap_scheduler_init,
-            ),
+            patch(
+                "torch._inductor.fx_passes.overlap_scheduling.gather_node_runtime_estimations"
+            ) as mock_gather,
             patch.object(
                 overlap_manual_scheduling,
                 "ManualOverlapPreservingBucketer",
@@ -209,9 +200,7 @@ class TestOverlapSchedulingRuntimeEstimation(TestCase):
                 insert_overlap_deps=False,
             )
 
-        estimator = captured_kwargs["custom_runtime_estimation"]
-        self.assertIsNotNone(estimator)
-        self.assertEqual(estimator(x, None), 0.0)
+        mock_gather.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_overlap_scheduling.py
+++ b/test/inductor/test_overlap_scheduling.py
@@ -2,6 +2,7 @@
 
 import operator
 from types import SimpleNamespace
+from unittest import skipUnless
 from unittest.mock import patch
 
 import torch
@@ -10,6 +11,12 @@ from torch._inductor.analysis import device_info
 from torch._inductor.fx_passes.overlap_scheduling import gather_node_runtime_estimations
 from torch._inductor.utils import get_device_tflops
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+_HAS_REDUCE_SCATTER_TENSOR = hasattr(
+    torch.ops._c10d_functional,
+    "reduce_scatter_tensor",
+)
 
 
 class TestOverlapSchedulingRuntimeEstimation(TestCase):
@@ -177,6 +184,10 @@ class TestOverlapSchedulingRuntimeEstimation(TestCase):
         self.assertNotIn(getitem, estimations)
         mock_estimate_roofline.assert_not_called()
 
+    @skipUnless(
+        _HAS_REDUCE_SCATTER_TENSOR,
+        "_c10d_functional.reduce_scatter_tensor is unavailable",
+    )
     def test_manual_overlap_scheduler_skips_runtime_estimations(self):
         from torch._inductor.fx_passes import overlap_manual_scheduling
 

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -177,7 +177,7 @@ _device_mapping: dict[str, DeviceInfo] = {
             torch.int8: 1677.72,
         },
         dram_bw_gbs=3276.8,
-        dram_gb=128,
+        dram_gb=128.0,
     ),
     # Source:
     # @lint-ignore https://www.amd.com/content/dam/amd/\

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -30,7 +30,8 @@ class DeviceInfo:
     tops_sparsity_factor: int = 1
 
 
-# Indexing is based on `torch.cuda.get_device_name()`, normalized to upper-case.
+# Indexing is based on device names returned by torch.cuda.get_device_name()
+# or torch.xpu.get_device_name(), normalized to upper-case.
 # TODO investigate profiler support for tf32 and allow device to report correct number when it's turned on.
 _device_mapping: dict[str, DeviceInfo] = {
     # Source:
@@ -156,6 +157,28 @@ _device_mapping: dict[str, DeviceInfo] = {
         dram_bw_gbs=5300.0,
         dram_gb=192.0,
     ),
+    # Intel Data Center GPU Max 1550 / PVC
+    # Sources:
+    # - Intel ARK lists Max 1550 as Xe-HPC / Ponte Vecchio with:
+    #   128 Xe-cores, 1600 MHz max dynamic clock, 128 GB HBM2e,
+    #   and 3276.8 GB/s memory bandwidth.
+    # - Intel Xe-HPC architecture guide lists Data Center GPU Max 1550
+    #   device-level throughput as:
+    #     FP32 MAD: 16384 * 2 FLOPs/clk
+    #     FP64 MAD: 16384 * 2 FLOPs/clk
+    "INTEL DATA CENTER GPU MAX 1550": DeviceInfo(
+        tops={
+            torch.float64: 52.43,
+            torch.float32: 52.43,
+            # XPU does not use NVIDIA TF32; fall back to FP32 throughput.
+            "torch.tf32": 52.43,
+            torch.bfloat16: 838.86,
+            torch.float16: 838.86,
+            torch.int8: 1677.72,
+        },
+        dram_bw_gbs=3276.8,
+        dram_gb=128,
+    ),
     # Source:
     # @lint-ignore https://www.amd.com/content/dam/amd/\
     # en/documents/instinct-business-docs/product-briefs/instinct-mi210-brochure.pdf
@@ -253,6 +276,9 @@ _device_mapping["AMD INSTINCT MI210X"] = _device_mapping["AMD MI210X"]
 _device_mapping["Intel(R) Arc(TM) B580 Graphics"] = _device_mapping["INTEL B580"]
 _device_mapping["Intel(R) Arc(TM) Pro B70 Graphics"] = _device_mapping["INTEL B70"]
 
+_device_mapping["Intel(R) Data Center GPU Max 1550"] = _device_mapping[
+    "INTEL DATA CENTER GPU MAX 1550"
+]
 # Enforce the upper-case-key invariant so entries cannot silently miss
 # `lookup_device_info` (which upper-cases the query before lookup).
 _device_mapping = {k.upper(): v for k, v in _device_mapping.items()}
@@ -270,8 +296,48 @@ def lookup_device_info(name: str) -> DeviceInfo | None:
     return _device_mapping.get(name.upper())
 
 
+def _get_device_name(device: torch.device | None = None) -> str | None:
+    if device is None:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            device = torch.device("xpu")
+        else:
+            return None
+
+    if device.type == "cuda" and torch.cuda.is_available():
+        return torch.cuda.get_device_name(device)
+
+    if device.type == "xpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
+        get_name = getattr(torch.xpu, "get_device_name", None)
+        if get_name is not None:
+            if device.index is None:
+                return get_name()
+            return get_name(device.index)
+
+    return None
+
+
+def datasheet_dram_bw(device: torch.device | None = None) -> float | None:
+    name = _get_device_name(device)
+    if name is None:
+        log.info("No datasheet device name found for %s, returning None", device)
+        return None
+
+    device_info = lookup_device_info(name)
+    if device_info is None:
+        log.info("Device %s not in datasheet, returning None", name)
+        return None
+
+    return device_info.dram_bw_gbs
+
+
 def datasheet_tops(
-    dtype: torch.dtype, is_tf32: bool = False, device_name: str | None = None
+    dtype: torch.dtype,
+    is_tf32: bool = False,
+    device_name: str | None = None,
+    *,
+    device: torch.device | None = None,
 ) -> float | None:
     """
     Get the theoretical *dense* TFLOPS of the device for a given dtype.
@@ -287,33 +353,28 @@ def datasheet_tops(
     """
     if device_name is not None:
         name: str | None = device_name
-    elif torch.cuda.is_available():
-        name = torch.cuda.get_device_name()
-    elif torch.xpu.is_available():
-        name = torch.xpu.get_device_name()
     else:
-        log.info("No supported device available, skipping datasheet lookup")
+        name = _get_device_name(device)
+    if name is None:
+        log.info("No datasheet device name found for %s, returning None", device)
         return None
 
-    if name is None:
-        log.info("No device found, returning None")
-        return None
     device_info = lookup_device_info(name)
     if device_info is None:
-        log_str = f"Device {name} not in datasheet, returning None"
-        log.info(log_str)
+        log.info("Device %s not in datasheet, returning None", name)
         return None
-    if dtype not in device_info.tops:
+
+    dtype_key = "torch.tf32" if dtype == torch.float32 and is_tf32 else dtype
+
+    if dtype_key not in device_info.tops:
         log.info(
             "Device %s does not have a datasheet entry for %s, returning None",
             name,
-            dtype,
+            dtype_key,
         )
         return None
 
-    tops = device_info.tops[
-        "torch.tf32" if dtype == torch.float32 and is_tf32 else dtype
-    ]
+    tops = device_info.tops[dtype_key]
     return tops / device_info.tops_sparsity_factor
 
 

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -350,6 +350,8 @@ def datasheet_tops(
     If ``device_name`` is given, the datasheet is looked up for that named
     device instead of querying the current device. This lets callers pin a
     device spec for deterministic, hardware-independent estimates.
+
+    If ``device`` is given, the name of that specific torch device is used.
     """
     if device_name is not None:
         name: str | None = device_name

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -43,13 +43,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def default_custom_runtime_estimation(
-    node: fx.Node,
-    size: int | None,
-) -> float | None:
-    return 0.0
-
-
 def _collect_nodes_must_be_after(node: fx.Node) -> list[fx.Node]:
     """BFS forward collecting node and its transitive users with no external inputs."""
     result: list[fx.Node] = [node]
@@ -401,14 +394,8 @@ class ManualOverlapScheduler(OverlapScheduler):
         # Manual overlap historically used "custom_ops" mode for bucketing
         bucket_mode = bucket_mode or "custom_ops"
 
-        # ManualOverlapScheduler is plan-driven rather than estimation-driven.
-        # Keep a no-op estimator by default so the inherited OverlapScheduler
-        # initialization path does not enter analytical NCCL estimation for
-        # compile-on-one-rank graphs where group_name may be an FX Node.
-
-        if custom_runtime_estimation is None:
-            custom_runtime_estimation = default_custom_runtime_estimation
-
+        # ManualOverlapScheduler is plan-driven, so it skips runtime estimation
+        # during OverlapScheduler initialization.
         super().__init__(
             gm,
             max_in_flight_gb=0.0,
@@ -417,8 +404,6 @@ class ManualOverlapScheduler(OverlapScheduler):
             insert_overlap_deps=insert_overlap_deps,
             compute_overlap_multipler=0.0,
             max_coll_distance=0,
-            # ManualOverlapScheduler schedules from module_bucket_plans and
-            # overrides _identify_collectives() to assign zero collective cost.
             custom_runtime_estimation=custom_runtime_estimation,
             collective_estimator=collective_estimator,
             compute_estimator=compute_estimator,
@@ -426,6 +411,7 @@ class ManualOverlapScheduler(OverlapScheduler):
             max_memory_increase_gb=None,
             max_memory_increase_ratio=None,
             bucket_mode=bucket_mode,
+            skip_runtime_estimations=True,
         )
         self.module_bucket_plans = module_bucket_plans
         self.nodes_in_subgraph: list[list[fx.Node]] = []
@@ -658,8 +644,6 @@ def manual_overlap_bucketing(
     """
 
     # decode abbreviated FQNs to actual FQNs
-    if custom_runtime_estimation is None:
-        custom_runtime_estimation = default_custom_runtime_estimation
     overlapped_gm = ManualOverlapScheduler(
         gm,
         module_bucket_plans,

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -394,6 +394,20 @@ class ManualOverlapScheduler(OverlapScheduler):
         # Manual overlap historically used "custom_ops" mode for bucketing
         bucket_mode = bucket_mode or "custom_ops"
 
+        # ManualOverlapScheduler is plan-driven rather than estimation-driven.
+        # Keep a no-op estimator by default so the inherited OverlapScheduler
+        # initialization path does not enter analytical NCCL estimation for
+        # compile-on-one-rank graphs where group_name may be an FX Node.
+        if custom_runtime_estimation is None:
+
+            def default_custom_runtime_estimation(
+                node: fx.Node,
+                size: int | None,
+            ) -> float | None:
+                return 0.0
+
+            custom_runtime_estimation = default_custom_runtime_estimation
+
         super().__init__(
             gm,
             max_in_flight_gb=0.0,

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 from collections import Counter, defaultdict
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 import torch.fx as fx
@@ -385,9 +385,15 @@ class ManualOverlapScheduler(OverlapScheduler):
         insert_overlap_deps: bool,
         module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]] | None = None,
         bucket_mode: BucketMode | None = None,
+        custom_runtime_estimation: Callable[[fx.Node, int | None], float | None]
+        | None = None,
+        collective_estimator: Literal["analytical", "benchmark"] = "analytical",
+        compute_estimator: Literal["analytical", "benchmark"] = "analytical",
+        log_runtime_estimations: bool = False,
     ):
         # Manual overlap historically used "custom_ops" mode for bucketing
         bucket_mode = bucket_mode or "custom_ops"
+
         super().__init__(
             gm,
             max_in_flight_gb=0.0,
@@ -396,14 +402,12 @@ class ManualOverlapScheduler(OverlapScheduler):
             insert_overlap_deps=insert_overlap_deps,
             compute_overlap_multipler=0.0,
             max_coll_distance=0,
-            # ManualOverlapScheduler doesn't use runtime estimates (it
-            # hardcodes estimated_time_ms=0 in _identify_collectives and
-            # schedules purely from module_bucket_plans). Providing a
-            # no-op estimator avoids the analytical NCCL path, which
-            # crashes in compile-on-one-rank graphs where group_name is
-            # an FX Node and the distributed runtime may not be available.
-            custom_runtime_estimation=lambda node, size: 0.0,
-            collective_estimator="analytical",
+            # ManualOverlapScheduler schedules from module_bucket_plans and
+            # overrides _identify_collectives() to assign zero collective cost.
+            custom_runtime_estimation=custom_runtime_estimation,
+            collective_estimator=collective_estimator,
+            compute_estimator=compute_estimator,
+            log_runtime_estimations=log_runtime_estimations,
             max_memory_increase_gb=None,
             max_memory_increase_ratio=None,
             bucket_mode=bucket_mode,
@@ -612,6 +616,11 @@ def manual_overlap_bucketing(
     insert_overlap_deps: bool = False,
     module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]] | None = None,
     bucket_mode: BucketMode | None = None,
+    custom_runtime_estimation: Callable[[fx.Node, int | None], float | None]
+    | None = None,
+    collective_estimator: Literal["analytical", "benchmark"] = "analytical",
+    compute_estimator: Literal["analytical", "benchmark"] = "analytical",
+    log_runtime_estimations: bool = False,
 ) -> torch.fx.GraphModule:
     """Schedule nodes based on user specifications in module_bucket_plans
     The manual overlapping consists of two steps:
@@ -639,6 +648,10 @@ def manual_overlap_bucketing(
         insert_overlap_deps,
         module_stack_fn,
         bucket_mode=bucket_mode,
+        custom_runtime_estimation=custom_runtime_estimation,
+        collective_estimator=collective_estimator,
+        compute_estimator=compute_estimator,
+        log_runtime_estimations=log_runtime_estimations,
     ).run()
     overlapped_gm.recompile()
     return overlapped_gm

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -43,6 +43,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def default_custom_runtime_estimation(
+    node: fx.Node,
+    size: int | None,
+) -> float | None:
+    return 0.0
+
+
 def _collect_nodes_must_be_after(node: fx.Node) -> list[fx.Node]:
     """BFS forward collecting node and its transitive users with no external inputs."""
     result: list[fx.Node] = [node]
@@ -398,14 +405,8 @@ class ManualOverlapScheduler(OverlapScheduler):
         # Keep a no-op estimator by default so the inherited OverlapScheduler
         # initialization path does not enter analytical NCCL estimation for
         # compile-on-one-rank graphs where group_name may be an FX Node.
+
         if custom_runtime_estimation is None:
-
-            def default_custom_runtime_estimation(
-                node: fx.Node,
-                size: int | None,
-            ) -> float | None:
-                return 0.0
-
             custom_runtime_estimation = default_custom_runtime_estimation
 
         super().__init__(
@@ -655,7 +656,10 @@ def manual_overlap_bucketing(
             detailed documentation on signature, return format, and usage examples.
         bucket_mode: Bucket mode for collective bucketing. None uses default.
     """
+
     # decode abbreviated FQNs to actual FQNs
+    if custom_runtime_estimation is None:
+        custom_runtime_estimation = default_custom_runtime_estimation
     overlapped_gm = ManualOverlapScheduler(
         gm,
         module_bucket_plans,

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -415,6 +415,7 @@ class OverlapScheduler:
         max_off_bucket_gb: float | None = 0.5,
         prioritize_bucketing_during_scheduling: bool = True,
         pge_profile_path: str | None = None,
+        skip_runtime_estimations: bool = False,
     ):
         self.gm = gm
         self.graph = gm.graph
@@ -470,12 +471,15 @@ class OverlapScheduler:
         # Compute initial node runtime estimates. Compute nodes use roofline model
         # here; the alignment step in run() replaces them with benchmarked +
         # cross-rank-aligned values.
-        self.node_estimations = gather_node_runtime_estimations(
-            gm,
-            custom_runtime_estimation,
-            enable_fusion_regions=enable_fusion_regions,
-            log_estimations=log_runtime_estimations,
-        )
+        if skip_runtime_estimations:
+            self.node_estimations = {}
+        else:
+            self.node_estimations = gather_node_runtime_estimations(
+                gm,
+                custom_runtime_estimation,
+                enable_fusion_regions=enable_fusion_regions,
+                log_estimations=log_runtime_estimations,
+            )
         # Build structures
         stable_topological_sort(self.graph)
         self.nodes = list(self.graph.nodes)

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -126,18 +126,6 @@ def get_group_name(n: fx.Node) -> str:
     return _resolve_group_name(kwargs["group_name"])
 
 
-def get_custom_estimation(
-    n: fx.Node,
-    custom_runtime_estimation: Callable[[fx.Node, int | None], float | None]
-    | None = None,
-    override_size: int | None = None,
-) -> float | None:
-    if custom_runtime_estimation is None:
-        return None
-
-    return custom_runtime_estimation(n, override_size)
-
-
 def estimate_collective_time(
     n: fx.Node,
     override_size: int | None = None,
@@ -146,10 +134,10 @@ def estimate_collective_time(
     collective_estimator: Literal["analytical", "benchmark"] = "analytical",
 ) -> float:
     """Estimate the runtime of a collective operation, optionally with an overridden size."""
-    if (
-        est := get_custom_estimation(n, custom_runtime_estimation, override_size)
-    ) is not None:
-        return est
+    if custom_runtime_estimation is not None:
+        est = custom_runtime_estimation(n, override_size)
+        if est is not None:
+            return est
 
     if collective_estimator == "benchmark":
         from torch._inductor.fx_passes.node_runtime_estimation import (
@@ -315,11 +303,11 @@ def benchmark_node_with_cache_key(
         if unbacked_tensor:
             return 0, key
 
-        if (
-            est := get_custom_estimation(n, custom_runtime_estimation, None)
-        ) is not None:
-            set_cached_node_time(key, est)
-            return est, key
+        if custom_runtime_estimation is not None:
+            est = custom_runtime_estimation(n, None)
+            if est is not None:
+                set_cached_node_time(key, est)
+                return est, key
 
         bench = get_collective_do_bench()
         out = bench(lambda: n.target(*args, **kwargs))  # type: ignore[operator]
@@ -419,6 +407,7 @@ class OverlapScheduler:
         max_memory_increase_gb: float | None = 1.0,
         max_memory_increase_ratio: float | None = 0.05,
         log_final_collectives_estimations: bool = False,
+        log_runtime_estimations: bool = True,
         bucket_exposed_first: bool | None = None,
         enable_fusion_regions: bool = False,
         bucket_only_internode_comms: bool = False,
@@ -455,6 +444,7 @@ class OverlapScheduler:
             self.collective_estimator = collective_estimator
             self.compute_estimator = compute_estimator
         self.log_final_collectives_estimations = log_final_collectives_estimations
+        self.log_runtime_estimations = log_runtime_estimations
         self.bucket_exposed_first = bucket_exposed_first
         self.bucket_only_internode_comms = bucket_only_internode_comms
         self.bucket_mode = bucket_mode or _default_bucket_mode()
@@ -484,7 +474,7 @@ class OverlapScheduler:
             gm,
             custom_runtime_estimation,
             enable_fusion_regions=enable_fusion_regions,
-            log_estimations=True,
+            log_estimations=log_runtime_estimations,
         )
         # Build structures
         stable_topological_sort(self.graph)
@@ -765,8 +755,12 @@ class OverlapScheduler:
         runtime_estimations_analytical: list[float] = []
 
         for n in self.compute_nodes:
-            # Compute analytical estimation using roofline model
-            val_analytical = estimate_roofline_runtime_ms(n)
+            # Prefer caller-provided estimation before falling back to roofline.
+            val_analytical = None
+            if self.custom_runtime_estimation is not None:
+                val_analytical = self.custom_runtime_estimation(n, None)
+            if val_analytical is None:
+                val_analytical = estimate_roofline_runtime_ms(n)
             runtime_estimations_analytical.append(val_analytical)
 
             if self.compute_estimator == "benchmark":
@@ -782,15 +776,16 @@ class OverlapScheduler:
             compute_key_count += 1
 
         # Log compute estimations
-        from torch._inductor.fx_passes.node_runtime_estimation import (
-            _log_compute_estimations,
-        )
+        if self.log_runtime_estimations:
+            from torch._inductor.fx_passes.node_runtime_estimation import (
+                _log_compute_estimations,
+            )
 
-        _log_compute_estimations(
-            self.compute_nodes,
-            runtime_estimations,
-            runtime_estimations_analytical,
-        )
+            _log_compute_estimations(
+                self.compute_nodes,
+                runtime_estimations,
+                runtime_estimations_analytical,
+            )
 
         # Benchmark collectives if enabled (only CUDA events - others are deterministic)
         # Skip if custom estimation is provided for collectives
@@ -810,11 +805,10 @@ class OverlapScheduler:
             # Benchmark CUDA events (non-deterministic, needs alignment)
             # Skip collectives with custom estimation
             for n in collective_nodes:
-                if (
-                    get_custom_estimation(n, self.custom_runtime_estimation, None)
-                    is not None
-                ):
-                    continue
+                if self.custom_runtime_estimation is not None:
+                    est = self.custom_runtime_estimation(n, None)
+                    if est is not None:
+                        continue
 
                 # Benchmark actual size
                 cuda_val, cuda_key = benchmark_collective_with_cuda_events(n, nruns=5)
@@ -885,7 +879,7 @@ class OverlapScheduler:
                 collective_medians.append(median_runtime_estimation)
 
         # Log benchmarks with analytical comparisons
-        if collective_keys:
+        if self.log_runtime_estimations and collective_keys:
             from torch._inductor.fx_passes.node_runtime_estimation import (
                 _log_collective_benchmarks,
             )
@@ -897,21 +891,6 @@ class OverlapScheduler:
                 world_size,
                 "fx_collectives_node_runtime_estimation",
             )
-        else:
-            # No benchmarking - log analytical estimations for all collectives
-            from torch._inductor.fx_passes.node_runtime_estimation import (
-                _log_collective_benchmarks,
-            )
-
-            all_collective_nodes = [
-                info.start_node for info in self.collective_info.values()
-            ]
-            if all_collective_nodes:
-                _log_collective_benchmarks(
-                    all_collective_nodes,
-                    artifact_name="fx_collectives_analytical_estimation",
-                )
-
         log.info("Overlap scheduling: Runtime estimations aligned")
 
     def _get_next_nodes(self) -> list[fx.Node]:
@@ -1749,20 +1728,25 @@ def gather_node_runtime_estimations(
 
     for node in nodes:
         if is_compute_node(node):
-            est = estimate_roofline_runtime_ms(node)
             if custom_runtime_estimation is not None:
-                custom_est = custom_runtime_estimation(node, None)
-                if custom_est is not None:
-                    est = custom_est
+                est = custom_runtime_estimation(node, None)
+                if est is not None:
+                    estimations[node] = est
+                    compute_nodes.append(node)
+                    compute_analytical.append(est)
+                    continue
+
+            est = estimate_roofline_runtime_ms(node)
             estimations[node] = est
             compute_nodes.append(node)
             compute_analytical.append(est)
+
         elif node.op == "call_function" and node not in estimations:
             if custom_runtime_estimation is not None:
                 est = custom_runtime_estimation(node, None)
                 if est is not None:
                     estimations[node] = est
-            else:
+            elif custom_runtime_estimation is None:
                 est = estimate_roofline_runtime_ms(node)
                 if est > 0:
                     estimations[node] = est

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -51,7 +51,7 @@ import sympy
 
 import torch
 import torch.utils._pytree as pytree
-from torch._inductor.analysis.device_info import datasheet_tops
+from torch._inductor.analysis.device_info import datasheet_dram_bw, datasheet_tops
 from torch._inductor.runtime.hints import DeviceProperties
 from torch.fx.passes.regional_inductor import _needs_inductor_compile
 from torch.utils._dtype_abbrs import dtype_abbrs
@@ -2986,7 +2986,10 @@ def get_backend_num_stages() -> int:
 
 
 @functools.cache
-def get_device_tflops(dtype: torch.dtype) -> float:
+def get_device_tflops(
+    dtype: torch.dtype,
+    device: torch.device | None = None,
+) -> float:
     """
     We don't want to throw errors in this function. First check to see if the device is in device_info.py,
     then fall back to the inaccurate triton estimation.
@@ -2994,15 +2997,25 @@ def get_device_tflops(dtype: torch.dtype) -> float:
     is_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
     if torch.xpu.is_available():
         is_tf32 = torch.backends.mkldnn.allow_tf32
-    ds_tops = datasheet_tops(dtype, is_tf32=is_tf32)
+
+    ds_tops = datasheet_tops(
+        dtype,
+        is_tf32,
+        device=device,
+    )
     if ds_tops is not None:
         return ds_tops
 
-    if not torch.cuda.is_available():
+    if device is not None and device.type != "cuda":
         log.warning(
-            "get_device_tflops: no Triton fallback available for non-CUDA devices. "
-            "Returning 0.0; roofline estimates will use memory bandwidth only."
+            "get_device_tflops: no Triton fallback available for non-CUDA device %s, "
+            "returning 0.0.",
+            device,
         )
+        return 0.0
+
+    if not torch.cuda.is_available():
+        log.warning("get_device_tflops: CUDA is not available, returning 0.0.")
         return 0.0
 
     from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops
@@ -3040,16 +3053,22 @@ def get_device_tflops(dtype: torch.dtype) -> float:
 
 
 @functools.cache
-def get_gpu_dram_gbps() -> float:
-    """
-    We don't want to throw errors in this function. First check to see if the device is in device_info.py,
-    then fall back to the inaccurate triton estimation.
-    """
-    from .analysis.device_info import datasheet_dram_bw_gbs
-
-    ds_bw = datasheet_dram_bw_gbs()
+def get_gpu_dram_gbps(device: torch.device | None = None) -> float:
+    ds_bw = datasheet_dram_bw(device=device)
     if ds_bw is not None:
         return ds_bw
+
+    if device is not None and device.type != "cuda":
+        log.warning(
+            "get_gpu_dram_gbps: no Triton fallback available for non-CUDA device %s, "
+            "returning 0.0.",
+            device,
+        )
+        return 0.0
+
+    if not torch.cuda.is_available():
+        log.warning("get_gpu_dram_gbps: CUDA is not available, returning 0.0.")
+        return 0.0
 
     from triton.testing import get_dram_gbps
 

--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -1,4 +1,5 @@
 import torch
+import torch.utils._pytree as pytree
 from torch._inductor.analysis.device_info import datasheet_dram_bw_gbs, datasheet_tops
 from torch._inductor.utils import get_device_tflops, get_gpu_dram_gbps
 from torch.fx.experimental.symbolic_shapes import (
@@ -75,10 +76,22 @@ _CREATE_OPS = OrderedSet(
 _IGNORE_OPS = _VIEW_OPS | _CREATE_OPS
 
 
+def _get_device_from_value(value) -> torch.device | None:  # type: ignore[no-untyped-def]
+    flat_values, _ = pytree.tree_flatten(value)
+    for item in flat_values:
+        if isinstance(item, torch.Tensor):
+            return item.device
+    return None
+
+
 def flops_to_ns(
-    flops: float | int, dtype: "torch.dtype", gpu_type: str | None = None
+    flops: float | int,
+    dtype: "torch.dtype",
+    gpu_type: str | None = None,
+    *,
+    device: torch.device | None = None,
 ) -> float:
-    """Convert a FLOPs count to estimated nanoseconds on the GPU.
+    """Convert a FLOPs count to estimated nanoseconds on the current GPU.
 
     Uses 75% of theoretical peak and converts FLOPs to MACs (divide by 2).
 
@@ -88,16 +101,22 @@ def flops_to_ns(
     """
     if gpu_type is not None:
         is_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
-        tflops = datasheet_tops(dtype, is_tf32=is_tf32, device_name=gpu_type)
-        if tflops is None:
+        device_tflops = datasheet_tops(
+            dtype,
+            is_tf32=is_tf32,
+            device_name=gpu_type,
+        )
+        if device_tflops is None:
             raise ValueError(
                 f"gpu_type {gpu_type!r} has no datasheet entry for {dtype}"
             )
     else:
-        tflops = get_device_tflops(dtype)
-    peak_gpu_flops = tflops * 1e12
-    if peak_gpu_flops == 0:
+        device_tflops = get_device_tflops(dtype, device=device)
+
+    if device_tflops is None or device_tflops == 0:
         return 0.0
+
+    peak_gpu_flops = device_tflops * 1e12
     macs = flops / 2
     return (macs / (0.75 * peak_gpu_flops)) * 1e9
 
@@ -134,7 +153,14 @@ def get_compute_time(
         if node_meta is not None:
             extra_kwargs["_node_meta"] = node_meta
         flop_count = flop_count_func(*args, **kwargs, out_val=out, **extra_kwargs)
-        return flops_to_ns(flop_count, dtype, gpu_type=gpu_type)
+
+        device = _get_device_from_value(out)
+        return flops_to_ns(
+            flop_count,
+            dtype,
+            gpu_type=gpu_type,
+            device=device,
+        )
     return 0.0
 
 
@@ -175,7 +201,11 @@ def get_transfer_time(flat_args_kwargs, flat_outs, gpu_type=None) -> float:  # t
         if gpu_memory_bandwidth is None:
             raise ValueError(f"gpu_type {gpu_type!r} not found in datasheet")
     else:
-        gpu_memory_bandwidth = get_gpu_dram_gbps()
+        device = _get_device_from_value((flat_args_kwargs, flat_outs))
+        gpu_memory_bandwidth = get_gpu_dram_gbps(device=device)
+    if gpu_memory_bandwidth <= 0:
+        return 0.0
+
     read_bytes = sum(
         get_num_bytes(t) for t in flat_args_kwargs if isinstance(t, torch.Tensor)
     )
@@ -183,6 +213,6 @@ def get_transfer_time(flat_args_kwargs, flat_outs, gpu_type=None) -> float:  # t
         get_num_bytes(t) for t in flat_outs if isinstance(t, torch.Tensor)
     )
     counted_bytes = read_bytes + write_bytes
-    # The GPU memory bandwidth is in GB/s so the transfer time is in nanoseconds
-    transfer_time = counted_bytes / gpu_memory_bandwidth
-    return transfer_time
+
+    # gpu_memory_bandwidth is GB/s. bytes / GB/s gives nanoseconds.
+    return counted_bytes / gpu_memory_bandwidth

--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -77,6 +77,8 @@ _IGNORE_OPS = _VIEW_OPS | _CREATE_OPS
 
 
 def _get_device_from_value(value) -> torch.device | None:  # type: ignore[no-untyped-def]
+    # Runtime estimation assumes a single dominant device per op; use the
+    # first tensor device found in the nested FX metadata values.
     flat_values, _ = pytree.tree_flatten(value)
     for item in flat_values:
         if isinstance(item, torch.Tensor):
@@ -113,7 +115,7 @@ def flops_to_ns(
     else:
         device_tflops = get_device_tflops(dtype, device=device)
 
-    if device_tflops is None or device_tflops == 0:
+    if device_tflops == 0:
         return 0.0
 
     peak_gpu_flops = device_tflops * 1e12

--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -81,8 +81,9 @@ def _get_device_from_value(value) -> torch.device | None:  # type: ignore[no-unt
     # first tensor device found in the nested FX metadata values.
     flat_values, _ = pytree.tree_flatten(value)
     for item in flat_values:
-        if isinstance(item, torch.Tensor):
+        if isinstance(item, torch.Tensor) and item.device.type not in ("meta", "cpu"):
             return item.device
+
     return None
 
 


### PR DESCRIPTION
This PR improves inductor’s overlap scheduling path for xpu and other noncuda accelerators . When analytical estimates are requested, the scheduler now stays on the analytical estimation path instead of falling back to device-specific runtime estimation, allowing overlap scheduling to run on xpu while keeping the existing cuda behavior unchanged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo