### PR TITLE
Add docs pages for torch.e and torch.pi

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2372,6 +2372,20 @@ def coverage_post_process(app, exception):
                 f.write(o)
 
 
+TORCH_CONSTANT_DOCSTRINGS = {
+    "torch.e": [
+        "Euler's number, the base of natural logarithms.",
+        "",
+        "This constant is an alias for :data:`math.e`.",
+    ],
+    "torch.pi": [
+        "The ratio of a circle's circumference to its diameter.",
+        "",
+        "This constant is an alias for :data:`math.pi`.",
+    ],
+}
+
+
 def process_docstring(app, what_, name, obj, options, lines):
     """
     Custom process to transform docstring lines Remove "Ignore" blocks
@@ -2398,6 +2412,10 @@ def process_docstring(app, what_, name, obj, options, lines):
         https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
     """
     import re
+
+    if name in TORCH_CONSTANT_DOCSTRINGS:
+        lines[:] = TORCH_CONSTANT_DOCSTRINGS[name] + [""]
+        return
 
     remove_directives = [
         # Remove all xdoctest directives

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -409,11 +409,18 @@ False
 ### Constants
 
 ```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    e
+    pi
+```
+
+```{eval-rst}
 ======================================= ===========================================
-``e``                                       Euler's number, the base of natural logarithms (~2.7183). Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
-``pi``                                      The ratio of a circle's circumference to its diameter (~3.1416). Alias for :attr:`math.pi`.
 ======================================= ===========================================
 ```
 


### PR DESCRIPTION
Fixes #134964

Problem:
- `torch.e` and `torch.pi` are public constants, but the docs only listed them in the constants table and did not generate dedicated API pages for them.

Fix:
- Add `e` and `pi` to the `torch.md` constants autosummary so Sphinx generates `generated/torch.e` and `generated/torch.pi` pages.
- Override the autodoc docstrings for these two float constants so the generated pages describe the constants instead of inheriting Python `float`'s generic docstring.

Test:
- Syntax-compiled `docs/source/conf.py`.
- Verified a Sphinx/MyST autosummary sandbox matching the `torch.md` constants section generated pages for `e` and `pi` with the expected descriptions.