### PR TITLE
Clarify set_default_device device arguments

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1266,7 +1266,10 @@ def set_default_device(device: "Device") -> None:
         :func:`torch.from_numpy` and :func:`torch.frombuffer`
 
     Args:
-        device (device or string): the device to set as default
+        device (:class:`torch.device`, str, int, or None): the device to set as
+            default, or ``None`` to clear the default device. An integer is
+            interpreted as an index for the current accelerator, which must be
+            available.
 
     Example::
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1267,9 +1267,8 @@ def set_default_device(device: "Device") -> None:
 
     Args:
         device (:class:`torch.device`, str, int, or None): the device to set as
-            default, or ``None`` to clear the default device. An integer is
-            interpreted as an index for the current accelerator, which must be
-            available.
+            default, or ``None`` to clear the override. An integer is
+            interpreted as an index for the current accelerator.
 
     Example::
 


### PR DESCRIPTION
Update `torch.set_default_device` docs to list the supported device-like inputs, including `int` and `None`, and clarify that integer indices refer to the current accelerator.

Fixes https://github.com/pytorch/pytorch/issues/126646