### PR TITLE
Validate LocalResponseNorm parameters to prevent silent inf output

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10165,6 +10165,30 @@ class TestNNDeviceType(NNTestCase):
         inp = torch.ones(0, 5, 24, 24, device=device)
         _test_module_empty_input(self, mod, inp, check_size=False)
 
+    @onlyNativeDeviceTypes
+    def test_LocalResponseNorm_zero_denominator(self, device):
+        with self.assertRaisesRegex(ValueError, "cannot both be non-positive"):
+            torch.nn.LocalResponseNorm(size=1, alpha=0.0, beta=0.2, k=0.0)
+        with self.assertRaisesRegex(ValueError, "cannot both be non-positive"):
+            torch.nn.LocalResponseNorm(size=1, alpha=-1.0, beta=0.5, k=-0.5)
+        with self.assertRaisesRegex(ValueError, "cannot both be non-positive"):
+            F.local_response_norm(
+                torch.randn(2, 8, 4, 4, device=device),
+                size=1, alpha=0.0, beta=0.2, k=0.0,
+            )
+        # k=0 with positive alpha is safe
+        mod = torch.nn.LocalResponseNorm(size=1, alpha=1e-4, beta=0.75, k=0.0)
+        out = mod(torch.randn(2, 8, 4, 4, device=device))
+        self.assertFalse(torch.isinf(out).any())
+        # alpha=0 with positive k is safe
+        mod = torch.nn.LocalResponseNorm(size=1, alpha=0.0, beta=0.75, k=1.0)
+        out = mod(torch.randn(2, 8, 4, 4, device=device))
+        self.assertFalse(torch.isinf(out).any())
+        # beta=0 makes LRN a no-op, so k=0 alpha=0 is safe
+        mod = torch.nn.LocalResponseNorm(size=1, alpha=0.0, beta=0.0, k=0.0)
+        out = mod(torch.randn(2, 8, 4, 4, device=device))
+        self.assertFalse(torch.isinf(out).any())
+
     @onlyCUDA   # Test if CPU and GPU results match
     def test_ReflectionPad3d_large(self, device):
         shapes = ([2, 1000, 7, 7, 7], [1000, 2, 7, 7, 7])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3067,6 +3067,12 @@ def local_response_norm(
         raise ValueError(
             f"Expected 3D or higher dimensionality                          input (got {dim} dimensions)"
         )
+    if k <= 0 and alpha <= 0 and beta != 0:
+        raise ValueError(
+            f"k ({k}) and alpha ({alpha}) cannot both be non-positive "
+            f"when beta ({beta}) is non-zero, "
+            "as this would make the normalization denominator zero"
+        )
 
     if input.numel() == 0:
         return input

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -53,6 +53,12 @@ class LocalResponseNorm(Module):
         self, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1.0
     ) -> None:
         super().__init__()
+        if k <= 0 and alpha <= 0 and beta != 0:
+            raise ValueError(
+                f"k ({k}) and alpha ({alpha}) cannot both be non-positive "
+                f"when beta ({beta}) is non-zero, "
+                "as this would make the normalization denominator zero"
+            )
         self.size = size
         self.alpha = alpha
         self.beta = beta


### PR DESCRIPTION
## Summary

`LocalResponseNorm` silently produces `+/-inf` when both `k` and `alpha` are set to non-positive values. The denominator `(k + alpha/size * sum(x^2))` becomes zero in this case, and `0^(-beta)` evaluates to infinity for any positive `beta`.

This adds a `ValueError` in both `LocalResponseNorm.__init__` and `F.local_response_norm` to reject this combination upfront, instead of silently returning garbage.

The default parameters (`alpha=1e-4, beta=0.75, k=1.0`) are not affected. Only the joint zero/negative case is rejected. Setting `k=0` with positive `alpha`, or `alpha=0` with positive `k`, remains valid.

**Note:** Reproduced the issue and verified the fix locally on torch 2.12.0+cpu.

## Test plan

Added `test_LocalResponseNorm_zero_denominator` covering:
  - `k=0, alpha=0` raises `ValueError` (module path)
  - `k<0, alpha<0` raises `ValueError` (module path)
  - `k=0, alpha=0` raises `ValueError` (functional path)
  - `k=0, alpha>0` works without inf
  - `alpha=0, k>0` works without inf
  - `beta=0` with `k=0, alpha=0` is allowed (no op identity)

```
python test/test_nn.py TestNNDeviceType.test_LocalResponseNorm_zero_denominator_cpu
python test/test_nn.py TestNNDeviceType.test_LocalResponseNorm_empty_cpu
```

Fixes #187177