### PR TITLE
Reject p < 1 in triplet_margin_loss to prevent NaN from p-norm overflow

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5654,6 +5654,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(F.triplet_margin_loss(input1, input2, input3, swap=True, reduction='none'),
                          loss_reference_fns['TripletMarginLoss'](input1, input2, input3, swap=True, reduction='none'))
 
+    def test_triplet_margin_loss_invalid_p(self):
+        anchor = torch.randn(4, 8)
+        positive = torch.randn(4, 8)
+        negative = torch.randn(4, 8)
+        with self.assertRaisesRegex(ValueError, "expected p to be >= 1"):
+            F.triplet_margin_loss(anchor, positive, negative, p=0.5)
+        with self.assertRaisesRegex(ValueError, "expected p to be >= 1"):
+            F.triplet_margin_loss(anchor, positive, negative, p=1e-6)
+        with self.assertRaisesRegex(ValueError, "expected p to be >= 1"):
+            torch.nn.TripletMarginLoss(p=0.5)
+        with self.assertRaisesRegex(ValueError, "expected p to be >= 1"):
+            torch.nn.TripletMarginLoss(p=-1.0)
+        loss = F.triplet_margin_loss(anchor, positive, negative, p=1)
+        self.assertFalse(torch.isnan(loss).any())
+        loss = F.triplet_margin_loss(anchor, positive, negative, p=2)
+        self.assertFalse(torch.isnan(loss).any())
+
     def test_pointwise_loss_target_grad_none_reduction(self):
         i = torch.randn(5, 10)
         t = torch.randn(5, 10, requires_grad=True)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5985,6 +5985,8 @@ def triplet_margin_loss(
         reduction_enum = _Reduction.get_enum(reduction)
     if margin <= 0:
         raise ValueError(f"margin must be greater than 0, got {margin}")
+    if p < 1:
+        raise ValueError(f"triplet_margin_loss: expected p to be >= 1, got {p}")
     return torch.triplet_margin_loss(
         anchor, positive, negative, margin, p, eps, swap, reduction_enum
     )

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1994,6 +1994,10 @@ class TripletMarginLoss(_Loss):
             raise ValueError(
                 f"TripletMarginLoss: expected margin to be greater than 0, got {margin} instead"
             )
+        if p < 1:
+            raise ValueError(
+                f"TripletMarginLoss: expected p to be >= 1, got {p} instead"
+            )
         self.margin = margin
         self.p = p
         self.eps = eps


### PR DESCRIPTION
## Summary

`F.triplet_margin_loss` silently returns NaN when `p < 1` because the p-norm computation overflows. For very small p, each `(|a - b| + eps)^p` is close to 1, so the sum across the feature dimension is roughly N, and `N^(1/p)` blows past fp32 range. The loss then becomes `inf - inf + margin = NaN` with no error.

The docstring already says `p (int, optional)` implying p >= 1, but nothing enforced it. This adds a `ValueError` for `p < 1` in both `F.triplet_margin_loss` and `nn.TripletMarginLoss`, matching the existing `margin > 0` validation pattern.

**Note:** Reproduced the issue and verified the fix locally on torch 2.12.0+cpu.

## Test plan

Added `test_triplet_margin_loss_invalid_p` covering:
  - `p=0.5` raises ValueError (functional)
  - `p=1e-6` raises ValueError (functional)
  - `p=0.5` raises ValueError (module)
  - `p=-1.0` raises ValueError (module)
  - `p=1` and `p=2` still produce valid (non NaN) loss

```
python test/test_nn.py TestNN.test_triplet_margin_loss_invalid_p
python test/test_nn.py TestNN.test_triplet_margin_loss
```

Fixes #187178