### PR TITLE
Validate quantile arguments in Distribution.icdf

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4240,6 +4240,25 @@ class TestDistributions(DistributionsTestCase):
                         self.assertEqual(expanded.event_shape, indep_dist.event_shape)
                         self.assertEqual(expanded.batch_shape, expanded_shape)
 
+    def test_icdf_validates_quantile(self):
+        distributions_to_test = [
+            Uniform(0.0, 1.0),
+            Normal(0.0, 1.0),
+            Cauchy(0.0, 1.0),
+            Exponential(1.0),
+            Laplace(0.0, 1.0),
+            HalfCauchy(1.0),
+            HalfNormal(1.0),
+            ContinuousBernoulli(0.3),
+            GeneralizedPareto(0.0, 1.0, 0.5),
+        ]
+        invalid_quantiles = [torch.tensor(-0.1), torch.tensor(1.5)]
+        for dist in distributions_to_test:
+            for q in invalid_quantiles:
+                with self.assertRaises(ValueError, msg=f"{dist} icdf({q})"):
+                    dist.icdf(q)
+            dist.icdf(torch.tensor(0.5))
+
     @expectedFailureMPS
     @set_default_dtype_if_supported(torch.double)
     def test_cdf_icdf_inverse(self):

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -93,6 +93,8 @@ class Cauchy(Distribution):
         return torch.atan((value - self.loc) / self.scale) / math.pi + 0.5
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         return torch.tan(math.pi * (value - 0.5)) * self.scale + self.loc
 
     def entropy(self):

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -210,6 +210,8 @@ class ContinuousBernoulli(ExponentialFamily):
         )
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         cut_probs = self._cut_probs()
         return torch.where(
             self._outside_unstable_region(),

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -329,6 +329,17 @@ class Distribution:
                 f"but found invalid values:\n{value}"
             )
 
+    def _validate_quantile(self, value: Tensor) -> None:
+        if not isinstance(value, torch.Tensor):
+            raise ValueError("The value argument to icdf must be a Tensor")
+        if not torch._is_all_true(constraints.unit_interval.check(value)):
+            raise ValueError(
+                f"Expected value argument "
+                f"({type(value).__name__} of shape {tuple(value.shape)}) "
+                f"to be within the unit interval [0, 1], "
+                f"but found invalid values:\n{value}"
+            )
+
     def _get_checked_instance(self, cls, _instance=None):
         if _instance is None and type(self).__init__ != cls.__init__:
             raise NotImplementedError(

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -80,6 +80,8 @@ class Exponential(ExponentialFamily):
         return 1 - torch.exp(-self.rate * value)
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         return -torch.log1p(-value) / self.rate
 
     def entropy(self):

--- a/torch/distributions/generalized_pareto.py
+++ b/torch/distributions/generalized_pareto.py
@@ -105,6 +105,8 @@ class GeneralizedPareto(Distribution):
         return torch.exp(self.log_cdf(value))
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         loc = self.loc
         scale = self.scale
         concentration = self.concentration

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -86,6 +86,8 @@ class HalfCauchy(TransformedDistribution):
         return 2 * self.base_dist.cdf(value) - 1
 
     def icdf(self, prob):
+        if self._validate_args:
+            self._validate_quantile(prob)
         return self.base_dist.icdf((prob + 1) / 2)
 
     def entropy(self):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -78,6 +78,8 @@ class HalfNormal(TransformedDistribution):
         return 2 * self.base_dist.cdf(value) - 1
 
     def icdf(self, prob):
+        if self._validate_args:
+            self._validate_quantile(prob)
         return self.base_dist.icdf((prob + 1) / 2)
 
     def entropy(self):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -97,6 +97,8 @@ class Laplace(Distribution):
         )
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         term = value - 0.5
         return self.loc - self.scale * (term).sign() * torch.log1p(-2 * term.abs())
 

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -108,6 +108,8 @@ class Normal(ExponentialFamily):
         )
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         return self.loc + self.scale * torch.erfinv(2 * value - 1) * math.sqrt(2)
 
     def entropy(self):

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -219,6 +219,8 @@ class TransformedDistribution(Distribution):
         Computes the inverse cumulative distribution function using
         transform(s) and computing the score of the base distribution.
         """
+        if self._validate_args:
+            self._validate_quantile(value)
         value = self._monotonize_cdf(value)
         value = self.base_dist.icdf(value)
         for transform in self.transforms:

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -101,6 +101,8 @@ class Uniform(Distribution):
         return result.clamp(min=0, max=1)
 
     def icdf(self, value):
+        if self._validate_args:
+            self._validate_quantile(value)
         result = value * (self.high - self.low) + self.low
         return result
 


### PR DESCRIPTION
## Summary

`Distribution.icdf()` silently accepts quantiles outside `[0, 1]` and returns nonsensical values. For example, `Uniform(0, 1).icdf(tensor(2.0))` returns `tensor(2.0)`, `Cauchy(0, 1).icdf(tensor(-1.0))` returns `tensor(83858288.0)`, and `Exponential(1.0).icdf(tensor(-2.0))` returns `tensor(-1.0986)`.

Meanwhile `cdf()` and `log_prob()` both validate their inputs via `_validate_sample` when `validate_args` is set. scipy returns NaN for all of the above.

This adds a `_validate_quantile` helper in the base `Distribution` class that checks values lie within `[0, 1]` using the existing `constraints.unit_interval`, and calls it from every subclass that implements `icdf`: Uniform, Cauchy, Exponential, Laplace, Normal, HalfCauchy, HalfNormal, ContinuousBernoulli, GeneralizedPareto, and TransformedDistribution.

The validation only runs when `validate_args=True` (the default), matching the existing `_validate_sample` pattern.

**Note:** Reproduced the issue and verified the fix locally on torch 2.12.0+cpu.

## Test plan

Added `test_icdf_validates_quantile` that tests all 9 distributions reject `q < 0` and `q > 1` with `ValueError`, and accept `q = 0.5`

```
python test/distributions/test_distributions.py \
    TestDistributions.test_icdf_validates_quantile
python test/distributions/test_distributions.py \
    TestDistributions.test_cdf_icdf_inverse
```

Fixes #186826