### PR TITLE
update backend parametrization for varlen attn

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -722,10 +722,7 @@ class TestVarlenAttention(NNTestCase):
             (384, 0),  # edge case
         ],
     )
-    @parametrize(
-        "backend",
-        ["fa2"] + (["fa3"] if IS_SM90 else []) + (["fa4"] if SM100OrLater else []),
-    )
+    @parametrize("backend", _varlen_backends(include_fa4_paged_kv=True))
     def test_batch_invariance(
         self, device, dtype, num_splits, window_size, backend, sdpa_backend=None
     ):
@@ -1150,10 +1147,7 @@ class TestVarlenAttention(NNTestCase):
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
     @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @parametrize(
-        "backend",
-        ["fa2"] + (["fa3"] if IS_SM90 else []) + (["fa4"] if SM100OrLater else []),
-    )
+    @parametrize("backend", _varlen_backends(include_fa4_paged_kv=True))
     def test_enable_gqa(self, device, dtype, backend):
         torch.manual_seed(42)
 


### PR DESCRIPTION
This pull request updates the test parameterization logic in `test/test_varlen_attention.py` to use a helper function for backend selection, improving maintainability and consistency. The main changes are:

**Test Parameterization Improvements:**

* Replaced manual construction of the `backend` parameter list in `test_batch_invariance` and `test_enable_gqa` with the `_varlen_backends(include_fa4_paged_kv=True)` helper function, ensuring consistent backend selection logic across tests. [[1]](diffhunk://#diff-0d85d9d89fb11d0cac43164b218d39ca711c7ace58c0c9964f2a965784a2fe77L725-R725) [[2]](diffhunk://#diff-0d85d9d89fb11d0cac43164b218d39ca711c7ace58c0c9964f2a965784a2fe77L1153-R1150)