### PR TITLE
serialization: fix nondeterministic pickle bytes in _legacy_save (gh#39383)

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -13,6 +13,7 @@ import pickle
 import platform
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -5067,6 +5068,35 @@ class TestSerialization(TestCase, SerializationMixin):
         with torch.sparse.check_sparse_tensor_invariants(True):
             with self.assertRaisesRegex(RuntimeError, "size is inconsistent with indices"):
                 torch.load(bad_buf, weights_only=False)
+
+    def test_serialization_deterministic_across_processes(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/39383
+        env = {**os.environ, "PYTHONHASHSEED": "0"}
+
+        def run(snippet):
+            r = subprocess.run(
+                [sys.executable, "-c", snippet],
+                capture_output=True, text=True, env=env, timeout=60,
+            )
+            self.assertEqual(r.returncode, 0, msg=r.stderr)
+            return r.stdout.strip()
+
+        pickle_snippet = (
+            "import base64, pickle, torch; "
+            "print(base64.b64encode(pickle.dumps(torch.IntTensor([1, 2, 3]))).decode())"
+        )
+        save_snippet = (
+            "import base64, io, torch; "
+            "buf = io.BytesIO(); "
+            "torch.save(torch.IntTensor([1, 2, 3]), buf); "
+            "print(base64.b64encode(buf.getvalue()).decode())"
+        )
+        for label, snippet in (("pickle.dumps", pickle_snippet), ("torch.save", save_snippet)):
+            with self.subTest(method=label):
+                self.assertEqual(
+                    run(snippet), run(snippet),
+                    msg=f"{label} bytes differ across processes (gh#39383)",
+                )
 
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1023,6 +1023,7 @@ def _legacy_save(obj, f, pickle_module, pickle_protocol) -> None:
 
     serialized_container_types = {}
     serialized_storages: dict[str, tuple[torch.UntypedStorage, torch.dtype]] = {}
+    id_map: dict[int, str] = {}
 
     # Since loading storages that view the same data with different dtypes is
     # not supported, we need to keep track of the dtype associated with each
@@ -1095,7 +1096,7 @@ def _legacy_save(obj, f, pickle_module, pickle_protocol) -> None:
             # Offset is always 0, but we keep it for backwards compatibility
             # with the old serialization format (which supported storage views)
             offset = 0
-            storage_key = str(storage._cdata)
+            storage_key = id_map.setdefault(storage._cdata, str(len(id_map)))
             location = location_tag(storage)
 
             # TODO: There's an issue here with FC. It might be impossible to
@@ -1170,7 +1171,7 @@ def _legacy_save(obj, f, pickle_module, pickle_protocol) -> None:
     # The class def keeps the persistent_id closure alive, leaking memory.
     del persistent_id
 
-    serialized_storage_keys = sorted(serialized_storages.keys())
+    serialized_storage_keys = sorted(serialized_storages.keys(), key=int)
     pickle_module.dump(serialized_storage_keys, f, protocol=pickle_protocol)
     f.flush()
     for key in serialized_storage_keys:


### PR DESCRIPTION
Fixes #39383. Supersedes #57536..

## Root cause

`_legacy_save` used `storage._cdata` (a raw C heap pointer) as the storage key written into the pickle stream. ASLR varies this address across processes which makes `pickle.dumps(tensor)` non deterministic. `_save` already carried this fix witdh its own `id_map`. this PR applies the same pattern to `_legacy_save`.

## Changes

- Add `id_map` to `_legacy_save`, identical to the one in `_save`
- Replace `str(storage._cdata)` with `id_map.setdefault(storage._cdata, str(len(id_map)))`
- Fix `sorted(serialized_storage_keys)` → `sorted(..., key=int)` for correct ordering with 10+ storages

Backward compatible: the key is an opaque internal string and `torch.load` treats it as a lookup token regardless of format.

## Test plan

New test `test_serialization_deterministic_across_processes` in `TestSerialization` runs each serialization method in two fresh subprocesses and asserts byte-for-byte identical output. I verified across 10 processess with and without `PYTHONHASHSEED`.