### PR TITLE
Type _add_docstr so type checkers see spectral ops as callable

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1173,7 +1173,10 @@ class Module: ...
 # Defined in torch/csrc/Module.cpp
 def _initExtension(shm_manager_path: str) -> None: ...  # THPModule_initExtension
 def _autograd_init() -> _bool: ...  # THPAutograd_initExtension
-def _add_docstr(obj: T, doc_obj: str) -> T: ...  # THPModule_addDocStr
+class _AddDocstr(Protocol):
+    def __call__(self, obj: T, doc_obj: str) -> T: ...  # THPModule_addDocStr
+
+_add_docstr: _AddDocstr
 def _init_names(arg: Sequence[type]) -> None: ...  # THPModule_initNames
 def _has_distributed() -> _bool: ...  # THPModule_hasDistributed
 def _set_default_tensor_type(type) -> None: ...  # THPModule_setDefaultTensorType


### PR DESCRIPTION
Pylint reports `E1102: torch.fft.rfft is not callable` (and the same for the other spectral ops) because those names are bound from `_add_docstr(...)` calls, where `_add_docstr` is the C builtin `torch._C._add_docstr`. Its stub in `torch/_C/__init__.pyi.in` was an ellipsis-bodied `def`, and astroid infers the call result of such a stub from the empty body (`None`) while ignoring the return annotation, so each bound name is treated as non-callable.

This types `_add_docstr` in the stub as a callable object (a small `Protocol`) that returns the same type it receives, instead of an ellipsis-bodied `def`. astroid honors the annotated type of a variable, so each `name = _add_docstr(...)` binding resolves as callable and the warning clears at the source for every binding at once. The identity typing (`obj: T -> T`) is preserved, so mypy and pyright are unaffected.

The earlier per-call `Callable` annotations are reverted, so the only change is to `torch/_C/__init__.pyi.in`.

Resolves #162373
