### PR TITLE
Validate non-negative input in poisson_nll_loss when log_input=False

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2754,6 +2754,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(F.gaussian_nll_loss(input, target, var_tensor, reduction='none'),
                          F.gaussian_nll_loss(input, target, var, reduction='none'))
 
+    def test_poisson_nll_loss_negative_input(self):
+        target = torch.rand(3, 5)
+        neg_input = torch.randn(3, 5) - 1.0
+        with self.assertRaisesRegex(ValueError, "input must be non-negative"):
+            F.poisson_nll_loss(neg_input, target, log_input=False)
+
+        pos_input = torch.rand(3, 5)
+        F.poisson_nll_loss(pos_input, target, log_input=False)
+
+        any_input = torch.randn(3, 5)
+        F.poisson_nll_loss(any_input, target, log_input=True)
+
     def test_KLDivLoss_batch_mean(self):
         input_shape = (2, 5)
         log_prob1 = F.log_softmax(torch.randn(input_shape), 1)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3250,6 +3250,12 @@ def poisson_nll_loss(
         ret = input
         raise ValueError(reduction + " is not a valid value for reduction")
 
+    if not log_input and isinstance(input, Tensor) and torch.any(input < 0):
+        raise ValueError(
+            "poisson_nll_loss: input must be non-negative when log_input=False, "
+            "since the loss computes log(input + eps). Got negative values in input."
+        )
+
     ret = torch.poisson_nll_loss(
         input, target, log_input, full, eps, _Reduction.get_enum(reduction)
     )


### PR DESCRIPTION
Fixes #184030

`F.poisson_nll_loss(input, target, log_input=False)` computes `input - target * log(input + eps)`. When `input` contains negative values, `log` of a negative number produces NaN, which silently propagates through the reduction. No validation is performed.

```python
loss = nn.PoissonNLLLoss(log_input=False)
loss(torch.randn(2, 8), torch.rand(2, 8))  # silent NaN
```

This follows the same pattern as `gaussian_nll_loss`, which already validates `var >= 0` with `torch.any(var < 0)`. The check only applies when `log_input=False`; with `log_input=True` the loss is `exp(input) - target * input` which is finite for any real input.

**Changes:**
- `torch/nn/functional.py`: Add `ValueError` for negative input when `log_input=False`, with `isinstance(input, Tensor)` guard for FX tracing compatibility
- `test/test_nn.py`: `test_poisson_nll_loss_negative_input` covering the error case, the valid case, and that `log_input=True` accepts any input

cc @jbschlosser @albanD