### PR TITLE
Add nondeterministic alert for kthvalue on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/Sorting.cpp
+++ b/aten/src/ATen/native/cuda/Sorting.cpp
@@ -35,6 +35,10 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cuda(
     int64_t k,
     int64_t dim_,
     bool keepdim) {
+  // See note [Writing Nondeterministic Operations]
+  // The selection algorithm may return different indices for duplicate values
+  // depending on CUDA thread scheduling.
+  at::globalContext().alertNotDeterministic("kthvalue CUDA");
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   int64_t slicesize = self.dim() == 0 ? 1 : self.size(dim);
   zero_numel_check_dims(self, dim, "kthvalue()");

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1951,6 +1951,31 @@ class TestTorchDeviceType(TestCase):
         test_func_expect_error('method with indices', is_cuda)
         test_func_expect_error('out with indices', is_cuda)
 
+    @dtypes(torch.double)
+    def test_nondeterministic_alert_kthvalue(self, device, dtype):
+        def test_func(call_type):
+            S = 10
+            a = torch.randn(S, device=device)
+            if call_type == 'function':
+                torch.kthvalue(a, 3)
+            elif call_type == 'method':
+                a.kthvalue(3)
+            elif call_type == 'out':
+                values = torch.empty_like(a)
+                indices = torch.empty((), dtype=torch.long, device=device)
+                torch.kthvalue(a, 3, out=(values, indices))
+            else:
+                self.fail(f"'{call_type}' is not a valid call type")
+
+        is_cuda = torch.device(device).type == 'cuda'
+
+        self.check_nondeterministic_alert(
+            lambda: test_func('function'), 'kthvalue CUDA', is_cuda)
+        self.check_nondeterministic_alert(
+            lambda: test_func('method'), 'kthvalue CUDA', is_cuda)
+        self.check_nondeterministic_alert(
+            lambda: test_func('out'), 'kthvalue CUDA', is_cuda)
+
     # FIXME: move to test_scatter_gather_ops
     def _test_gather_backward_one_dim(self, device, deterministic: bool = False) -> None:
         with DeterministicGuard(deterministic):


### PR DESCRIPTION
## Summary

The CUDA kthvalue kernel uses a selection algorithm where duplicate values may return different indices depending on thread scheduling. This is the same nondeterminism that median already alerts about (in the same file, Sorting.cpp), but kthvalue was missing the check.

This adds an `alertNotDeterministic` call so that `torch.use_deterministic_algorithms(True)` raises a clear error instead of silently returning nondeterministic indices.

**Note:** This is a C++ change so reproduction and full verification require a CUDA build. The fix follows the exact same pattern as `median` in the same file (Sorting.cpp line 90). CPU side of the test was verified locally.

## Test plan

Added `test_nondeterministic_alert_kthvalue` following the same pattern as the existing `test_nondeterministic_alert_median` test. It checks that `torch.kthvalue`, `Tensor.kthvalue`, and the `out=` variant all raise when deterministic mode is on and device is CUDA, and do not raise on CPU.

```
python test/test_torch.py TestTorchDeviceTypeCPU.test_nondeterministic_alert_kthvalue_cpu
python test/test_torch.py TestTorchDeviceTypeCUDA.test_nondeterministic_alert_kthvalue_cuda
```
