### PR TITLE
[MPS] Matmul for strided out errors on mac OS 14/15

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -304,10 +304,10 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
   if (always_use_metal || c10::isIntegralType(self.scalar_type(), true)) {
     return true;
   }
-  // MPSGraph mis-writes a non-contiguous output before macOS 26 (strided
-  // matmul-output bug, same family as #180201); metal honors the output strides.
-  static const bool is_macos_26_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_4_PLUS);
-  if (!output.is_contiguous() && !is_macos_26_4_or_newer) {
+  // MPSGraph mis-writes a non-contiguous output before macOS 26; the metal
+  // kernels honor the output strides.
+  static const bool is_macos_26_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_0_PLUS);
+  if (!output.is_contiguous() && !is_macos_26_0_or_newer) {
     return true;
   }
   // multiplicationWithPrimaryTensor: returns incorrect results if inner size exceeds 2048

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -304,6 +304,12 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
   if (always_use_metal || c10::isIntegralType(self.scalar_type(), true)) {
     return true;
   }
+  // MPSGraph mis-writes a non-contiguous output before macOS 26 (strided
+  // matmul-output bug, same family as #180201); metal honors the output strides.
+  static const bool is_macos_26_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_4_PLUS);
+  if (!output.is_contiguous() && !is_macos_26_4_or_newer) {
+    return true;
+  }
   // multiplicationWithPrimaryTensor: returns incorrect results if inner size exceeds 2048
   // See https://github.com/pytorch/pytorch/issues/167727#issuecomment-3529308548
   if (c10::isComplexType(self.scalar_type()) && self.size(1) > max_complex_inner_size) {

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1129,6 +1129,13 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     return do_metal_bmm(batch1, batch2, result);
   }
 
+  // MPSGraph mis-writes a non-contiguous output before macOS 26; the metal
+  // kernel honors the output strides.
+  static const bool is_macos_26_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_0_PLUS);
+  if (!result.is_contiguous() && !is_macos_26_0_or_newer) {
+    return do_metal_bmm(batch1, batch2, result);
+  }
+
   static const bool is_macOS_15_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
   MPSShape* shape = nil;
   bool doTranspose = false;

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8175,24 +8175,18 @@ for dtype in (torch.int32, torch.int64):
             atol = 5e-4
             rtol = 3e-4
 
-        # MPS has correctness problem before MacOS15
-        with (
-            contextlib.nullcontext()
-            if self.device != "mps" or MACOS_VERSION >= 15.0
-            else self.assertRaises(AssertionError)
-        ):
-            self.common(
-                fn,
-                (
-                    torch.randn(256, 256),
-                    torch.randn(256, 1024),
-                    torch.randn(1024, 1600),
-                    torch.randn(100, 256),
-                ),
-                atol=atol,
-                rtol=rtol,
-                check_lowp=False,  # accuracy issues with relatively large matmuls
-            )
+        self.common(
+            fn,
+            (
+                torch.randn(256, 256),
+                torch.randn(256, 1024),
+                torch.randn(1024, 1600),
+                torch.randn(100, 256),
+            ),
+            atol=atol,
+            rtol=rtol,
+            check_lowp=False,  # accuracy issues with relatively large matmuls
+        )
 
     @skip_if_gpu_halide
     # Constant folding was explicitly turned off due to issue #108388

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1300,14 +1300,6 @@ class TestMPS(TestCaseMPS):
         result_cpu = torch.addmm(bias.cpu().conj(), a.cpu(), b.cpu())
         self.assertEqual(result_cpu, result_mps)
 
-    def _noncontig_out(self, M, N, layout, dtype):
-        # transposed: column-major out; outer: unit inner stride but row-gapped.
-        if layout == "transposed":
-            return torch.empty(N, M, device="mps", dtype=dtype).t()
-        if layout == "outer":
-            return torch.empty(2 * M, N, device="mps", dtype=dtype)[::2]
-        return torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
-
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
         ((1, 64, 12), "inner"),
@@ -1324,7 +1316,12 @@ class TestMPS(TestCaseMPS):
         (M, K, N), layout = case
         a = torch.randn(M, K, device="mps", dtype=dtype)
         b = torch.randn(K, N, device="mps", dtype=dtype)
-        out = self._noncontig_out(M, N, layout, dtype)
+        if layout == "transposed":
+            out = torch.empty(N, M, device="mps", dtype=dtype).t()
+        elif layout == "outer":
+            out = torch.empty(2 * M, N, device="mps", dtype=dtype)[::2]
+        else:
+            out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
         self.assertFalse(out.is_contiguous())
         torch.mm(a, b, out=out)
         ref = torch.mm(a.cpu(), b.cpu())
@@ -1348,7 +1345,12 @@ class TestMPS(TestCaseMPS):
         bias = torch.randn(M, N, device="mps", dtype=dtype)
         a = torch.randn(M, K, device="mps", dtype=dtype)
         b = torch.randn(K, N, device="mps", dtype=dtype)
-        out = self._noncontig_out(M, N, layout, dtype)
+        if layout == "transposed":
+            out = torch.empty(N, M, device="mps", dtype=dtype).t()
+        elif layout == "outer":
+            out = torch.empty(2 * M, N, device="mps", dtype=dtype)[::2]
+        else:
+            out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
         self.assertFalse(out.is_contiguous())
         torch.addmm(bias, a, b, out=out)
         ref = torch.addmm(bias.cpu(), a.cpu(), b.cpu())

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1310,8 +1310,14 @@ class TestMPS(TestCaseMPS):
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
-        ((33, 17, 49), "transposed"),
+        ((1, 64, 12), "inner"),
+        ((12, 64, 1), "inner"),
+        ((8, 64, 12), "inner"),
         ((8, 64, 12), "transposed"),
+        ((8, 64, 12), "outer"),
+        ((33, 17, 49), "inner"),
+        ((33, 17, 49), "transposed"),
+        ((33, 17, 49), "outer"),
     ])
     def test_mm_strided_output(self, case, dtype):
         # Non-contiguous out= is mis-written by the MPSGraph matmul before macOS 26.4.
@@ -1327,8 +1333,14 @@ class TestMPS(TestCaseMPS):
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
-        ((33, 17, 49), "transposed"),
+        ((1, 64, 12), "inner"),
+        ((12, 64, 1), "inner"),
+        ((8, 64, 12), "inner"),
         ((8, 64, 12), "transposed"),
+        ((8, 64, 12), "outer"),
+        ((33, 17, 49), "inner"),
+        ((33, 17, 49), "transposed"),
+        ((33, 17, 49), "outer"),
     ])
     def test_addmm_strided_output(self, case, dtype):
         # addmm shares mm's strided-output fallback; same contract.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1300,12 +1300,29 @@ class TestMPS(TestCaseMPS):
         result_cpu = torch.addmm(bias.cpu().conj(), a.cpu(), b.cpu())
         self.assertEqual(result_cpu, result_mps)
 
+    def _noncontig_out(self, M, N, layout, dtype):
+        # transposed: column-major out; outer: unit inner stride but row-gapped.
+        if layout == "transposed":
+            return torch.empty(N, M, device="mps", dtype=dtype).t()
+        if layout == "outer":
+            return torch.empty(2 * M, N, device="mps", dtype=dtype)[::2]
+        return torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
+
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_mm_strided_output(self, dtype):
-        M, K, N = 8, 64, 12
+    @parametrize("case", [
+        ((1, 64, 12), "inner"),
+        ((12, 64, 1), "inner"),
+        ((8, 64, 12), "transposed"),
+        ((33, 17, 49), "inner"),
+        ((33, 17, 49), "transposed"),
+        ((16, 24, 20), "outer"),
+    ])
+    def test_mm_strided_output(self, case, dtype):
+        # Non-contiguous out= is mis-written by the MPSGraph matmul before macOS 26.4.
+        (M, K, N), layout = case
         a = torch.randn(M, K, device="mps", dtype=dtype)
         b = torch.randn(K, N, device="mps", dtype=dtype)
-        out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
+        out = self._noncontig_out(M, N, layout, dtype)
         self.assertFalse(out.is_contiguous())
         torch.mm(a, b, out=out)
         ref = torch.mm(a.cpu(), b.cpu())
@@ -1313,13 +1330,21 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_addmm_strided_output(self, dtype):
+    @parametrize("case", [
+        ((1, 64, 12), "inner"),
+        ((12, 64, 1), "inner"),
+        ((8, 64, 12), "transposed"),
+        ((33, 17, 49), "inner"),
+        ((33, 17, 49), "transposed"),
+        ((16, 24, 20), "outer"),
+    ])
+    def test_addmm_strided_output(self, case, dtype):
         # addmm shares mm's strided-output fallback; same contract.
-        M, K, N = 8, 64, 12
+        (M, K, N), layout = case
         bias = torch.randn(M, N, device="mps", dtype=dtype)
         a = torch.randn(M, K, device="mps", dtype=dtype)
         b = torch.randn(K, N, device="mps", dtype=dtype)
-        out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
+        out = self._noncontig_out(M, N, layout, dtype)
         self.assertFalse(out.is_contiguous())
         torch.addmm(bias, a, b, out=out)
         ref = torch.addmm(bias.cpu(), a.cpu(), b.cpu())

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1300,6 +1300,32 @@ class TestMPS(TestCaseMPS):
         result_cpu = torch.addmm(bias.cpu().conj(), a.cpu(), b.cpu())
         self.assertEqual(result_cpu, result_mps)
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_mm_strided_output(self, dtype):
+        M, K, N = 8, 64, 12
+        a = torch.randn(M, K, device="mps", dtype=dtype)
+        b = torch.randn(K, N, device="mps", dtype=dtype)
+        out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
+        self.assertFalse(out.is_contiguous())
+        torch.mm(a, b, out=out)
+        ref = torch.mm(a.cpu(), b.cpu())
+        tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
+        self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
+
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_addmm_strided_output(self, dtype):
+        # addmm shares mm's strided-output fallback; same contract.
+        M, K, N = 8, 64, 12
+        bias = torch.randn(M, N, device="mps", dtype=dtype)
+        a = torch.randn(M, K, device="mps", dtype=dtype)
+        b = torch.randn(K, N, device="mps", dtype=dtype)
+        out = torch.empty(M, N, 2, device="mps", dtype=dtype)[..., 0]
+        self.assertFalse(out.is_contiguous())
+        torch.addmm(bias, a, b, out=out)
+        ref = torch.addmm(bias.cpu(), a.cpu(), b.cpu())
+        tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
+        self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
+
     @xfailIf(MACOS_VERSION < 15.0)
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_large_bmm(self, dtype):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1310,12 +1310,8 @@ class TestMPS(TestCaseMPS):
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
-        ((1, 64, 12), "inner"),
-        ((12, 64, 1), "inner"),
-        ((8, 64, 12), "transposed"),
-        ((33, 17, 49), "inner"),
         ((33, 17, 49), "transposed"),
-        ((16, 24, 20), "outer"),
+        ((8, 64, 12), "transposed"),
     ])
     def test_mm_strided_output(self, case, dtype):
         # Non-contiguous out= is mis-written by the MPSGraph matmul before macOS 26.4.
@@ -1331,12 +1327,8 @@ class TestMPS(TestCaseMPS):
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
-        ((1, 64, 12), "inner"),
-        ((12, 64, 1), "inner"),
-        ((8, 64, 12), "transposed"),
-        ((33, 17, 49), "inner"),
         ((33, 17, 49), "transposed"),
-        ((16, 24, 20), "outer"),
+        ((8, 64, 12), "transposed"),
     ])
     def test_addmm_strided_output(self, case, dtype):
         # addmm shares mm's strided-output fallback; same contract.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1357,6 +1357,34 @@ class TestMPS(TestCaseMPS):
         tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
         self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("case", [
+        ((2, 2, 2, 2), "inner"),
+        ((2, 2, 2, 2), "transposed"),
+        ((2, 2, 2, 2), "outer"),
+        ((4, 8, 64, 12), "inner"),
+        ((4, 8, 64, 12), "transposed"),
+        ((4, 8, 64, 12), "outer"),
+        ((3, 33, 17, 49), "inner"),
+        ((3, 33, 17, 49), "transposed"),
+        ((3, 33, 17, 49), "outer"),
+    ])
+    def test_bmm_strided_output(self, case, dtype):
+        (B, M, K, N), layout = case
+        a = torch.randn(B, M, K, device="mps", dtype=dtype)
+        b = torch.randn(B, K, N, device="mps", dtype=dtype)
+        if layout == "transposed":
+            out = torch.empty(B, N, M, device="mps", dtype=dtype).transpose(-1, -2)
+        elif layout == "outer":
+            out = torch.empty(2 * B, M, N, device="mps", dtype=dtype)[::2]
+        else:
+            out = torch.empty(B, M, N, 2, device="mps", dtype=dtype)[..., 0]
+        self.assertFalse(out.is_contiguous())
+        torch.bmm(a, b, out=out)
+        ref = torch.bmm(a.cpu(), b.cpu())
+        tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
+        self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
+
     @xfailIf(MACOS_VERSION < 15.0)
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_large_bmm(self, dtype):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18760,12 +18760,6 @@ op_db: list[OpInfo] = [
                    'TestSchemaCheckModeOpInfo',
                    'test_schema_correctness',
                    dtypes=(torch.complex64, torch.complex128)),
-               # AssertionError: Tensor-likes are not close!
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestCommon', 'test_out',
-                   device_type='mps', dtypes=(torch.float32,),
-                   active_if=MACOS_VERSION < 26.0,
-               ),
            )),
     OpInfo('mode',
            op=torch.mode,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13342,12 +13342,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-5, rtol=1e-5)}),
                             "TestCommon", "test_out"),
-               # AssertionError: Tensor-likes are not close!
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestCommon', 'test_out',
-                   device_type='mps', dtypes=(torch.float32,),
-                   active_if=MACOS_VERSION < 26.0,
-               ),
            ),
            sample_inputs_func=sample_inputs_bmm),
     OpInfo('mv',

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -36,7 +36,6 @@ from torch.testing._internal.common_utils import (
     IS_ARM64,
     IS_LINUX,
     IS_WINDOWS,
-    MACOS_VERSION,
     make_fullrank_matrices_with_distinct_singular_values,
     skipIfSlowGradcheckEnv,
     slowTest,
@@ -1708,15 +1707,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=(torch.complex64,),
             ),
-            # AssertionError: Tensor-likes are not close!
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out",
-                device_type="mps",
-                dtypes=(torch.float32,),
-                active_if=MACOS_VERSION < 26.0,
-            ),
         ),
         sample_inputs_func=sample_inputs_linalg_matrix_power,
     ),
@@ -1756,15 +1746,6 @@ op_db: list[OpInfo] = [
                 "test_nnc_correctness",
                 device_type="cpu",
                 dtypes=(torch.long,),
-            ),
-            # AssertionError: Tensor-likes are not close!
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_out",
-                device_type="mps",
-                dtypes=(torch.float32,),
-                active_if=MACOS_VERSION < 26.0,
             ),
         ),
         decorators=[


### PR DESCRIPTION
Putting strided out in torch mm/addmm leads to error on mac OS 14/15. First discovered in gemv PR:
https://github.com/pytorch/pytorch/pull/186927


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo