### PR TITLE
Fix slow test updater churn

### DIFF
--- a/tools/test/test_update_slow_tests.py
+++ b/tools/test/test_update_slow_tests.py
@@ -1,0 +1,28 @@
+import unittest
+
+from tools.testing.update_slow_tests import merge_slow_tests
+
+
+class TestUpdateSlowTests(unittest.TestCase):
+    def test_merge_slow_tests_preserves_existing_unmeasured_entries(self) -> None:
+        existing = {
+            "test_still_slow (__main__.FooTests)": 95.0,
+            "test_recently_measured (__main__.FooTests)": 61.0,
+        }
+        measured = {
+            "test_recently_measured (__main__.FooTests)": 70.0,
+            "test_new_slow (__main__.BarTests)": 80.0,
+        }
+
+        self.assertEqual(
+            merge_slow_tests(existing, measured),
+            {
+                "test_new_slow (__main__.BarTests)": 80.0,
+                "test_recently_measured (__main__.FooTests)": 70.0,
+                "test_still_slow (__main__.FooTests)": 95.0,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testing/update_slow_tests.py
+++ b/tools/testing/update_slow_tests.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import requests
-from clickhouse import query_clickhouse  # type: ignore[import]
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -91,13 +90,14 @@ ORDER BY
 """
 
 
-UPDATEBOT_TOKEN = os.environ["UPDATEBOT_TOKEN"]
-PYTORCHBOT_TOKEN = os.environ["PYTORCHBOT_TOKEN"]
+SLOW_TESTS_FILE = REPO_ROOT / "test" / "slow_tests.json"
 
 
 def git_api(
-    url: str, params: dict[str, Any], type: str = "get", token: str = UPDATEBOT_TOKEN
+    url: str, params: dict[str, Any], type: str = "get", token: str | None = None
 ) -> Any:
+    if token is None:
+        token = os.environ["UPDATEBOT_TOKEN"]
     headers = {
         "Accept": "application/vnd.github.v3+json",
         "Authorization": f"token {token}",
@@ -135,7 +135,7 @@ def approve_pr(source_repo: str, pr_number: int) -> None:
         f"/repos/{source_repo}/pulls/{pr_number}/reviews",
         params,
         type="post",
-        token=PYTORCHBOT_TOKEN,
+        token=os.environ["PYTORCHBOT_TOKEN"],
     )
 
 
@@ -146,7 +146,7 @@ def make_comment(source_repo: str, pr_number: int, msg: str) -> None:
         f"/repos/{source_repo}/issues/{pr_number}/comments",
         params,
         type="post",
-        token=PYTORCHBOT_TOKEN,
+        token=os.environ["PYTORCHBOT_TOKEN"],
     )
 
 
@@ -178,11 +178,31 @@ def search_for_open_pr(source_repo: str, search_string: str) -> tuple[int, str] 
     return None
 
 
-if __name__ == "__main__":
-    results = query_clickhouse(QUERY, {})
-    slow_tests = {row["test_name"]: row["avg_duration_sec"] for row in results}
+def read_existing_slow_tests() -> dict[str, float]:
+    if not SLOW_TESTS_FILE.exists():
+        return {}
+    with open(SLOW_TESTS_FILE) as f:
+        return cast(dict[str, float], json.load(f))
 
-    with open(REPO_ROOT / "test" / "slow_tests.json", "w") as f:
+
+def merge_slow_tests(
+    existing_slow_tests: dict[str, float], measured_slow_tests: dict[str, float]
+) -> dict[str, float]:
+    # Existing slow tests are skipped by viable/strict, so absence from the
+    # fresh ClickHouse sample is not evidence that they became fast.
+    return dict(sorted({**existing_slow_tests, **measured_slow_tests}.items()))
+
+
+if __name__ == "__main__":
+    from clickhouse import query_clickhouse  # type: ignore[import]
+
+    results = query_clickhouse(QUERY, {})
+    measured_slow_tests = {
+        row["test_name"]: row["avg_duration_sec"] for row in results
+    }
+    slow_tests = merge_slow_tests(read_existing_slow_tests(), measured_slow_tests)
+
+    with open(SLOW_TESTS_FILE, "w") as f:
         json.dump(slow_tests, f, indent=2)
 
     branch_name = f"update_slow_tests_{int(time.time())}"

--- a/tools/testing/update_slow_tests.py
+++ b/tools/testing/update_slow_tests.py
@@ -197,9 +197,7 @@ if __name__ == "__main__":
     from clickhouse import query_clickhouse  # type: ignore[import]
 
     results = query_clickhouse(QUERY, {})
-    measured_slow_tests = {
-        row["test_name"]: row["avg_duration_sec"] for row in results
-    }
+    measured_slow_tests = {row["test_name"]: row["avg_duration_sec"] for row in results}
     slow_tests = merge_slow_tests(read_existing_slow_tests(), measured_slow_tests)
 
     with open(SLOW_TESTS_FILE, "w") as f:


### PR DESCRIPTION
## Summary
- keep existing entries from `test/slow_tests.json` when the weekly updater writes the next generated file
- let newly measured slow tests override stale durations for the same test name
- add a small regression test for the merge behavior

## Why
The updater only sees tests that ran on recent `viable/strict` commits. Tests already listed as slow can be skipped there, so overwriting the file with only the fresh ClickHouse sample can remove tests that are still slow and make them churn back in later weeks.

## To verify
- `python -m unittest tools.test.test_update_slow_tests`
- `python -m py_compile tools/testing/update_slow_tests.py tools/test/test_update_slow_tests.py`
