### PR TITLE
Remove setuptools upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1137,7 +1137,7 @@ def main() -> None:
     install_requires = [
         "filelock",
         "typing-extensions>=4.10.0",
-        "setuptools>=49.4.0",
+        "setuptools>=77.0.3",
         "sympy>=1.13.3",
         "networkx>=2.5.1",
         "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -1137,7 +1137,7 @@ def main() -> None:
     install_requires = [
         "filelock",
         "typing-extensions>=4.10.0",
-        "setuptools<82",
+        "setuptools>=49.4.0",
         "sympy>=1.13.3",
         "networkx>=2.5.1",
         "jinja2",


### PR DESCRIPTION
Upper bound was originally introduced by https://github.com/pytorch/pytorch/pull/174631, but `pkg_resources` is not used by `torch.utils.cpp_extensions`

Test Plan: Install latest setuptools and all `cpp_extensions` test still work

Fixes https://github.com/pytorch/pytorch/issues/187188
