### PR TITLE
Add missing <fmt/format.h> include in profiler_kineto.cpp

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1,5 +1,5 @@
-#include <cstring>
 #include <fmt/format.h>
+#include <cstring>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <torch/csrc/autograd/profiler_kineto.h>
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <fmt/format.h>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <torch/csrc/autograd/profiler_kineto.h>
 


### PR DESCRIPTION
Building with USE_KINETO=0 fails to compile `torch/csrc/autograd/profiler_kineto.cpp`:
```
torch/csrc/autograd/profiler_kineto.cpp:254:13: error: 'fmt' has not been declared
```

PR #186230 (d74dff0) added the first fmt::format call to this file. With USE_KINETO=0 the transitive include is absent and the build fails. This PR adds the missing direct include so the file includes what it uses, independent of USE_KINETO.

Repro:
```
USE_KINETO=0 python -m pip install --no-build-isolation -v -e .
```