### PR TITLE
[ROCm] Split CK SDPA vs CK GEMM arch gating

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -558,7 +558,7 @@ at::BlasBackend Context::blasPreferredBackend() {
   return blas_preferred_backend;
 }
 
-bool Context::ckSPDASupported() {
+bool Context::ckSDPASupported() {
 #ifdef USE_ROCM
   // CK SDPA is only built for a subset of architectures to limit compile time.
   static const std::vector<std::string> supported_archs = {
@@ -640,11 +640,11 @@ at::ROCmFABackend Context::getROCmFAPreferredBackend() {
     // which initialize the backend without calling the setter
     // Perform validity checking
     static const bool hasCKSDPAFlag = hasCKSDPA();
-    static const bool ckSPDASupportedFlag = ckSPDASupported();
-    if (!(hasCKSDPAFlag && ckSPDASupportedFlag)) {
+    static const bool ckSDPASupportedFlag = ckSDPASupported();
+    if (!(hasCKSDPAFlag && ckSDPASupportedFlag)) {
       TORCH_WARN_ONCE(
           "Cannot set preferred SDPA backend to CK since following conditions are not true: ",
-          "architecture supported for CK SDPA: ", ckSPDASupportedFlag,
+          "architecture supported for CK SDPA: ", ckSDPASupportedFlag,
           ", PyTorch built with CK SDPA support: ", hasCKSDPAFlag);
       rocm_fa_preferred_backend = at::ROCmFABackend::AOTriton;
     }
@@ -657,10 +657,10 @@ at::ROCmFABackend Context::getROCmFAPreferredBackend() {
 void Context::setROCmFAPreferredBackend(at::ROCmFABackend b) {
 #ifdef USE_ROCM
   static const bool hasCKSDPAFlag = hasCKSDPA();
-  static const bool ckSPDASupportedFlag = ckSPDASupported();
-  TORCH_CHECK((b != at::ROCmFABackend::Ck) || (hasCKSDPAFlag && ckSPDASupportedFlag),
+  static const bool ckSDPASupportedFlag = ckSDPASupported();
+  TORCH_CHECK((b != at::ROCmFABackend::Ck) || (hasCKSDPAFlag && ckSDPASupportedFlag),
       "Cannot set preferred SDPA backend to CK since following conditions are not true: ",
-      "architecture supported for CK SDPA: ", ckSPDASupportedFlag,
+      "architecture supported for CK SDPA: ", ckSDPASupportedFlag,
       ", PyTorch built with CK SDPA support: ", hasCKSDPAFlag);
 #endif
   rocm_fa_preferred_backend = b;

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -558,15 +558,39 @@ at::BlasBackend Context::blasPreferredBackend() {
   return blas_preferred_backend;
 }
 
-bool Context::ckSupported() {
+bool Context::ckSPDASupported() {
 #ifdef USE_ROCM
+  // CK SDPA is only built for a subset of architectures to limit compile time.
   static const std::vector<std::string> supported_archs = {
-    "gfx942", "gfx950"
+      "gfx942", "gfx950",
   };
   for (auto index : c10::irange(detail::getCUDAHooks().deviceCount())) {
-    if(!detail::getCUDAHooks().isGPUArch(supported_archs, index)) {
+    if (!detail::getCUDAHooks().isGPUArch(supported_archs, index)) {
       TORCH_WARN_ONCE(
-        "Attempting to use CK on an unsupported architecture! Cannot set backend to CK");
+          "Attempting to use CK SDPA on an unsupported architecture! Cannot set "
+          "SDPA backend to CK");
+      return false;
+    }
+  }
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool Context::ckGemmSupported() {
+#ifdef USE_ROCM
+  // CK GEMM support is broader than CK SDPA.
+  static const std::vector<std::string> supported_archs = {
+      "gfx90a",
+      "gfx942",
+      "gfx950",
+  };
+  for (auto index : c10::irange(detail::getCUDAHooks().deviceCount())) {
+    if (!detail::getCUDAHooks().isGPUArch(supported_archs, index)) {
+      TORCH_WARN_ONCE(
+          "Attempting to use CK GEMM on an unsupported architecture! Cannot set "
+          "blas backend to CK");
       return false;
     }
   }
@@ -586,11 +610,11 @@ void Context::setBlasPreferredBackend(at::BlasBackend b) {
   TORCH_CHECK((b != at::BlasBackend::Cublaslt) || hasCuBLASLt(),
       "Cannot set preferred backend to cuBLASLt if PyTorch has not been compiled with cuBLASLt.");
 #ifdef USE_ROCM
-  static const bool ckSupportedFlag = ckSupported();
+  static const bool ckGemmSupportedFlag = ckGemmSupported();
   static const bool hasCKGEMMFlag = hasCKGEMM();
-  TORCH_CHECK((b != at::BlasBackend::Ck) || (ckSupportedFlag && hasCKGEMMFlag),
+  TORCH_CHECK((b != at::BlasBackend::Ck) || (ckGemmSupportedFlag && hasCKGEMMFlag),
       "Cannot set preferred blas backend to CK since following conditions are not true: ",
-      "architecture supported for CK: ", ckSupportedFlag,
+      "architecture supported for CK GEMM: ", ckGemmSupportedFlag,
       ", PyTorch built with CK GEMM support: ", hasCKGEMMFlag);
 #endif
   if (b != at::BlasBackend::Default && b != at::BlasBackend::Cublas) {
@@ -616,12 +640,12 @@ at::ROCmFABackend Context::getROCmFAPreferredBackend() {
     // which initialize the backend without calling the setter
     // Perform validity checking
     static const bool hasCKSDPAFlag = hasCKSDPA();
-    static const bool ckSupportedFlag = ckSupported();
-    if(!(hasCKSDPAFlag && ckSupportedFlag)){
+    static const bool ckSPDASupportedFlag = ckSPDASupported();
+    if (!(hasCKSDPAFlag && ckSPDASupportedFlag)) {
       TORCH_WARN_ONCE(
-        "Cannot set preferred SDPA backend to CK since following conditions are not true: ",
-        "architecture supported for CK: ", ckSupportedFlag,
-        ", PyTorch built with CK SDPA support: ", hasCKSDPAFlag);
+          "Cannot set preferred SDPA backend to CK since following conditions are not true: ",
+          "architecture supported for CK SDPA: ", ckSPDASupportedFlag,
+          ", PyTorch built with CK SDPA support: ", hasCKSDPAFlag);
       rocm_fa_preferred_backend = at::ROCmFABackend::AOTriton;
     }
   }
@@ -633,10 +657,10 @@ at::ROCmFABackend Context::getROCmFAPreferredBackend() {
 void Context::setROCmFAPreferredBackend(at::ROCmFABackend b) {
 #ifdef USE_ROCM
   static const bool hasCKSDPAFlag = hasCKSDPA();
-  static const bool ckSupportedFlag = ckSupported();
-  TORCH_CHECK((b != at::ROCmFABackend::Ck) || (hasCKSDPAFlag && ckSupportedFlag),
+  static const bool ckSPDASupportedFlag = ckSPDASupported();
+  TORCH_CHECK((b != at::ROCmFABackend::Ck) || (hasCKSDPAFlag && ckSPDASupportedFlag),
       "Cannot set preferred SDPA backend to CK since following conditions are not true: ",
-      "architecture supported for CK: ", ckSupportedFlag,
+      "architecture supported for CK SDPA: ", ckSPDASupportedFlag,
       ", PyTorch built with CK SDPA support: ", hasCKSDPAFlag);
 #endif
   rocm_fa_preferred_backend = b;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -158,7 +158,7 @@ class TORCH_API Context {
   static bool hasKleidiAI();
   static bool hasLAPACK();
   static bool hasMKLDNN();
-  static bool ckSPDASupported();
+  static bool ckSDPASupported();
   static bool ckGemmSupported();
   static bool hasEigenSparse();
   static bool hasMAGMA() {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -158,7 +158,8 @@ class TORCH_API Context {
   static bool hasKleidiAI();
   static bool hasLAPACK();
   static bool hasMKLDNN();
-  static bool ckSupported();
+  static bool ckSPDASupported();
+  static bool ckGemmSupported();
   static bool hasEigenSparse();
   static bool hasMAGMA() {
     return detail::getCUDAHooks().hasMAGMA();

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10578,6 +10578,8 @@ class TestLinalgCudaOnly(TestCase):
     @setBlasBackendsToDefaultFinally
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_ck_blas_library_mm(self, dtype):
+        if dtype == torch.bfloat16 and isRocmArchAnyOf(MI200_ARCH):
+            self.skipTest("bfloat16 case skipped on gfx90a")
         device = 'cuda'
         shapes = [(7168, 8192, 1280), (1280, 8192, 7168), (8192, 8192, 1280)]
         for M, K, N in shapes:

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2918,7 +2918,8 @@ Call this whenever a new thread is created in order to propagate values from
 
   py_module.def("_is_ck_sdpa_available", []() {
 #ifdef USE_ROCM
-    return at::globalContext().ckSPDASupported() && at::globalContext().hasCKSDPA();
+    return at::globalContext().ckSPDASupported() &&
+        at::globalContext().hasCKSDPA();
 #else
     return false;
 #endif

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2918,7 +2918,7 @@ Call this whenever a new thread is created in order to propagate values from
 
   py_module.def("_is_ck_sdpa_available", []() {
 #ifdef USE_ROCM
-    return at::globalContext().ckSPDASupported() &&
+    return at::globalContext().ckSDPASupported() &&
         at::globalContext().hasCKSDPA();
 #else
     return false;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2918,7 +2918,7 @@ Call this whenever a new thread is created in order to propagate values from
 
   py_module.def("_is_ck_sdpa_available", []() {
 #ifdef USE_ROCM
-    return at::globalContext().ckSupported() && at::globalContext().hasCKSDPA();
+    return at::globalContext().ckSPDASupported() && at::globalContext().hasCKSDPA();
 #else
     return false;
 #endif


### PR DESCRIPTION
Gate preferred_blas_library CK on ckGemmSupported (includes gfx90a) and keep SDPA/ROCm FA on ckSPDASupported. Update _is_ck_sdpa_available accordingly.

Skip test_ck_blas_library_mm bfloat16 on MI200 (gfx90a).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang