### PR TITLE
[serialization] fix torch.save creating/corrupting file when pickling fails

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -5401,5 +5401,113 @@ instantiate_parametrized_tests(TestSubclassSerialization)
 instantiate_parametrized_tests(TestOldSerialization)
 instantiate_parametrized_tests(TestSerialization)
 
+
+class TestSaveAtomicWrite(TestCase):
+    """Regression tests for gh-48243: torch.save must not create or corrupt
+    the target file when serialization fails."""
+
+    class _Unpicklable:
+        def __reduce__(self):
+            raise RuntimeError("intentional pickle failure")
+
+    def test_new_file_not_created_on_pickle_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "out.pt")
+            with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+                torch.save(self._Unpicklable(), path)
+            self.assertFalse(os.path.exists(path))
+
+    def test_existing_file_unchanged_on_pickle_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "out.pt")
+            original = b"original content"
+            with open(path, "wb") as f:
+                f.write(original)
+            with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+                torch.save(self._Unpicklable(), path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), original)
+
+    def test_original_exception_preserved(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+                torch.save(self._Unpicklable(), os.path.join(td, "out.pt"))
+
+    def test_valid_save_after_failed_save(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "out.pt")
+            with self.assertRaises(RuntimeError):
+                torch.save(self._Unpicklable(), path)
+            t = torch.tensor([1, 2, 3])
+            torch.save(t, path)
+            self.assertEqual(torch.load(path, weights_only=True), t)
+
+    def test_pathlib_path_new_file_not_created_on_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "out.pt"
+            with self.assertRaises(RuntimeError):
+                torch.save(self._Unpicklable(), path)
+            self.assertFalse(path.exists())
+
+    def test_legacy_format_new_file_not_created_on_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "out.pt")
+            with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+                torch.save(self._Unpicklable(), path, _use_new_zipfile_serialization=False)
+            self.assertFalse(os.path.exists(path))
+
+    def test_legacy_format_existing_file_unchanged_on_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "out.pt")
+            original = b"original content"
+            with open(path, "wb") as f:
+                f.write(original)
+            with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+                torch.save(self._Unpicklable(), path, _use_new_zipfile_serialization=False)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), original)
+
+    def test_filelike_raises_but_no_path_side_effects(self):
+        buf = io.BytesIO()
+        with self.assertRaisesRegex(RuntimeError, "intentional pickle failure"):
+            torch.save(self._Unpicklable(), buf)
+
+    def test_is_local_path_routing(self):
+        from torch.serialization import _is_local_path
+
+        self.assertTrue(_is_local_path("/home/user/out.pt"))
+        self.assertTrue(_is_local_path("out.pt"))
+        self.assertTrue(_is_local_path("relative/path/out.pt"))
+        self.assertTrue(_is_local_path("C:/Users/foo/bar.pt"))
+        self.assertFalse(_is_local_path("s3://bucket/key.pt"))
+        self.assertFalse(_is_local_path("gcs://bucket/key.pt"))
+        self.assertFalse(_is_local_path("hdfs://namenode/key.pt"))
+        self.assertFalse(_is_local_path("a://host/path"))
+        if sys.platform == "win32":
+            self.assertFalse(_is_local_path("//server/share/file.pt"))
+            self.assertFalse(_is_local_path("\\\\server\\share\\file.pt"))
+        else:
+            # On POSIX, //server/share is a local path (os.path.splitdrive returns "").
+            self.assertTrue(_is_local_path("//server/share/file.pt"))
+
+    def test_remote_path_bypasses_tmp(self):
+        # The save itself will fail (s3:// is not natively supported); we only
+        # verify the routing: _save_via_tmp must not be called for remote URIs.
+        with patch("torch.serialization._save_via_tmp") as mock_tmp:
+            try:
+                torch.save(torch.tensor([1]), "s3://bucket/key.pt")
+            except Exception:
+                pass
+            mock_tmp.assert_not_called()
+
+        # Complementary check: local paths must use _save_via_tmp.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch("torch.serialization._save_via_tmp") as mock_tmp:
+                mock_tmp.side_effect = RuntimeError("intercepted")
+                with self.assertRaises(RuntimeError):
+                    torch.save(torch.tensor([1]), os.path.join(tmp_dir, "out.pt"))
+                mock_tmp.assert_called_once()
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 import tempfile
 import threading
+import urllib.parse
 import warnings
 from collections.abc import Callable
 from contextlib import closing, contextmanager
@@ -830,8 +831,9 @@ class _open_zipfile_writer_file(_opener[torch._C.PyTorchFileWriter]):
                 )
             )
 
-    def __exit__(self, *args) -> None:
-        self.file_like.write_end_of_file()
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if exc_type is None:
+            self.file_like.write_end_of_file()
         if self.file_stream is not None:
             self.file_stream.close()
 
@@ -850,9 +852,10 @@ class _open_zipfile_writer_buffer(_opener[torch._C.PyTorchFileWriter]):
             )
         )
 
-    def __exit__(self, *args) -> None:
-        self.file_like.write_end_of_file()
-        self.buffer.flush()
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if exc_type is None:
+            self.file_like.write_end_of_file()
+            self.buffer.flush()
 
 
 def _open_zipfile_writer(name_or_buffer: str | IO[bytes]) -> _opener:
@@ -941,6 +944,43 @@ def _check_save_filelike(f):
         )
 
 
+def _is_local_path(path: str) -> bool:
+    parsed = urllib.parse.urlparse(path)
+    scheme = parsed.scheme
+    # A Windows drive letter (e.g. "C:/path") is parsed as a single-alpha scheme
+    # with no netloc. Anything with a netloc or a multi-char scheme is a remote URI.
+    if scheme and not (len(scheme) == 1 and scheme.isalpha() and not parsed.netloc):
+        return False
+    # Exclude UNC network paths (//server/share or \\server\share).
+    drive = os.path.splitdrive(path)[0]
+    return not drive.startswith(("/", "\\"))
+
+
+def _save_via_tmp(path: str, opener, writer) -> None:
+    """Write to path via a temp file; atomic on POSIX (rename), best-effort on Windows.
+
+    Prevents creating or corrupting the target file if serialization fails (gh-48243).
+    """
+    dir_name = os.path.dirname(os.path.abspath(path))
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=dir_name)
+    ctx = None
+    try:
+        os.close(tmp_fd)
+        with opener(tmp_path) as ctx:
+            writer(ctx)
+        del ctx  # release last Python ref to C++ file handle; required on Windows before rename
+        os.replace(tmp_path, path)
+        tmp_path = None
+    except BaseException:
+        del ctx  # release C++ file handle so os.unlink can succeed on Windows
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise
+
+
 def save(
     obj: object,
     f: FileLike,
@@ -999,23 +1039,39 @@ def save(
         f = os.fspath(f)
 
     if _use_new_zipfile_serialization:
-        with _open_zipfile_writer(f) as opened_zipfile:
-            _save(
-                obj,
-                opened_zipfile,
-                pickle_module,
-                pickle_protocol,
-                _disable_byteorder_record,
+        if isinstance(f, str) and _is_local_path(f):
+            _save_via_tmp(
+                f,
+                _open_zipfile_writer,
+                lambda zip_file: _save(
+                    obj, zip_file, pickle_module, pickle_protocol, _disable_byteorder_record
+                ),
             )
-            return
+        else:
+            with _open_zipfile_writer(f) as opened_zipfile:
+                _save(
+                    obj,
+                    opened_zipfile,
+                    pickle_module,
+                    pickle_protocol,
+                    _disable_byteorder_record,
+                )
+        return
     else:
         global _serialization_tls
         if _serialization_tls.skip_data:
             raise RuntimeError(
                 "Cannot use skip_data=True with _use_new_zipfile_serialization=False"
             )
-        with _open_file_like(f, "wb") as opened_file:
-            _legacy_save(obj, opened_file, pickle_module, pickle_protocol)
+        if isinstance(f, str) and _is_local_path(f):
+            _save_via_tmp(
+                f,
+                lambda tmp: _open_file_like(tmp, "wb"),
+                lambda fh: _legacy_save(obj, fh, pickle_module, pickle_protocol),
+            )
+        else:
+            with _open_file_like(f, "wb") as opened_file:
+                _legacy_save(obj, opened_file, pickle_module, pickle_protocol)
 
 
 def _legacy_save(obj, f, pickle_module, pickle_protocol) -> None:


### PR DESCRIPTION
`torch.save(obj, path)` currently opens the destination before serialization starts. If pickling fails in this case it can leave a new empty file or truncate/corrupt an existing file.

This PR makes path-based saves atomic by writing to a temporary file in the same directory and replacing the destination only after serialization succeeds. When it fails the temp file is removed and the original destination is left unchanged. File-like objects keep the existing behavior because arbitrary streams cannot generally be rolled back.

It also makes `_open_zipfile_writer_file.__exit__` exception-aware so `write_end_of_file()` is skipped after serialization errors and the original exception is preserved.

Fixes #48243.

## Test Plan

```
python test/test_serialization.py TestSaveAtomicWrite
```

Covers failed saves for new and existing paths, exception preservation, valid save after failure, `pathlib.Path`, legacy serialization, and file-like object behavior.

This PR was authored with the assistance of an AI coding assistant. I have reviewed the changes myself fully.. I take full responsibility for the code.