### PR TITLE
linear_cross_entropy: bound chunked peak memory with the budget chunking method

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7560,7 +7560,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(opts.acc_policy, "auto")
         self.assertEqual(opts.chunking_method, "auto")
 
-        # Known pair: CUDA + bf16 -> ("compact", "aspect_ratio:2").
+        # Known pair: CUDA + bf16 -> ("compact", "aspect_ratio:2"). This
+        # shape is below the crossing region (num_classes >> in_features),
+        # so auto keeps aspect_ratio rather than switching to budget.
         adjusted = opts._adjust(
             128, 4096, 50000, torch.bfloat16, torch.device("cuda"),
         )
@@ -7592,6 +7594,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         )
         self.assertEqual(adjusted.acc_policy, "accurate")
         self.assertEqual(adjusted.chunking_method, "aspect_ratio")
+
+        # Above the crossing region (in_features >= ~num_classes): auto
+        # switches the resolved method to budget to bound the per-chunk
+        # accumulator that aspect_ratio would let grow quadratically.
+        adjusted = opts._adjust(
+            4096, 32768, 16384, torch.float16, torch.device("cuda"),
+        )
+        self.assertEqual(adjusted.acc_policy, "compact")
+        self.assertEqual(adjusted.chunking_method, "budget")
 
         # Unknown pair (cpu + fp32) -> _AUTO_FALLBACK.
         adjusted = opts._adjust(

--- a/torch/nn/modules/linear_cross_entropy_options.py
+++ b/torch/nn/modules/linear_cross_entropy_options.py
@@ -15,7 +15,10 @@ class _AutoDefault(NamedTuple):
 # Defaults for the ``"auto"`` sentinel of ``acc_policy`` / ``chunking_method``,
 # keyed by ``(device_type, input_dtype)`` -- Pareto picks from an fp64-jacobian
 # sweep. CPU picks ``"accurate"`` (only chunked policy with fp32 weight-grad mm
-# on CPU; others hit emulated low-precision matmul, ~20-50x slower).
+# on CPU; others hit emulated low-precision matmul, ~20-50x slower). These are
+# the BELOW-crossing picks; ``_adjust`` automatically switches the resolved
+# method to ``"budget"`` above the crossing region (large ``in_features``),
+# where aspect_ratio's accumulator grows quadratically -- see ``_adjust``.
 _AUTO_DEFAULTS: dict[tuple[str, torch.dtype], _AutoDefault] = {
     ("cuda", torch.bfloat16): _AutoDefault("compact", "aspect_ratio:2"),
     ("cuda", torch.float16): _AutoDefault("compact", "aspect_ratio:2"),
@@ -83,9 +86,22 @@ class LinearCrossEntropyOptions:
     chunking_method: str | None = "auto"
     """Heuristic for picking :attr:`batch_chunk_size`.
 
-    - ``"auto"`` (default) -- resolves to a per-(device, dtype) pick from
-      :data:`_AUTO_DEFAULTS` at call time; falls back to
-      ``"aspect_ratio:2"`` for unlisted pairs.
+    - ``"auto"`` (default) -- resolves at call time to a per-(device, dtype)
+      pick from :data:`_AUTO_DEFAULTS` (an ``aspect_ratio`` variant), then
+      switches to ``"budget"`` above the crossing region (large
+      ``in_features``; see ``_adjust``). Falls back to ``"aspect_ratio:2"``
+      for unlisted pairs.
+    - ``"budget"`` -- sizes each chunk so the per-chunk working buffers
+      occupy about one input footprint
+      (``num_batches * in_features * itemsize`` bytes). Unlike
+      ``aspect_ratio``, this bounds the buffer to a fixed multiple of the
+      input, so peak memory stays close to the reference even when
+      ``in_features`` approaches ``num_classes`` (where ``aspect_ratio``'s
+      ``(batch_chunk_size, in_features)`` accumulator grows quadratically
+      and overtakes the reference). The default for ``"auto"``.
+    - ``"budget:E"`` (``E > 0`` float) -- same, with the buffer budget set
+      to ``E`` input footprints. Smaller ``E`` cuts peak memory at the cost
+      of more chunks (slower); larger ``E`` does the reverse.
     - ``"aspect_ratio"`` -- sizes each chunk so its
       ``(batch_chunk_size, num_classes)`` logits buffer matches the
       ``(num_batches, in_features)`` input in memory:
@@ -148,9 +164,16 @@ class LinearCrossEntropyOptions:
             raise ValueError(f"invalid acc_policy: {self.acc_policy!r}")
         if self.chunking_method is not None and self.chunking_method != "auto":
             name, sep, factor = self.chunking_method.partition(":")
-            if not sep:
-                factor = "1"
-            if not (name == "aspect_ratio" and factor.isdigit() and int(factor) > 0):
+            if name == "aspect_ratio":
+                valid = (not sep) or (factor.isdigit() and int(factor) > 0)
+            elif name == "budget":
+                try:
+                    valid = (not sep) or float(factor) > 0
+                except ValueError:
+                    valid = False
+            else:
+                valid = False
+            if not valid:
                 raise ValueError(f"invalid chunking_method: {self.chunking_method!r}")
         if not (
             self.batch_chunk_size is None
@@ -177,6 +200,20 @@ class LinearCrossEntropyOptions:
     def _ceil_div(a: int, b: int) -> int:
         """ceil(a / b) for non-negative integers."""
         return -(-a // b)
+
+    @staticmethod
+    def _logits_buffer_itemsize(
+        dtype: torch.dtype, acc_dtype: torch.dtype, acc_policy: str
+    ) -> int:
+        """Bytes per element of the per-chunk logits buffer, mirroring
+        ``_ChunkContext.build``'s ``logits_buf_dtype``: input dtype on fp16
+        memory-like policies, else the acc dtype.
+        """
+        if dtype == acc_dtype:
+            return dtype.itemsize
+        if dtype == torch.float16 and acc_policy in ("balanced", "compact"):
+            return dtype.itemsize
+        return acc_dtype.itemsize
 
     @staticmethod
     def _resolve_auto_acc_dtype(
@@ -227,6 +264,44 @@ class LinearCrossEntropyOptions:
         # __post_init__ validates the method, so this is unreachable.
         raise AssertionError(f"unhandled chunking_method: {method!r}")
 
+    def _compute_batch_chunk_size_budget(
+        self,
+        num_batches: int,
+        in_features: int,
+        num_classes: int,
+        dtype: torch.dtype,
+        acc_dtype: torch.dtype,
+        acc_policy: str,
+        eps: float,
+    ) -> int:
+        """Chunk size for the ``budget`` method: size ``B`` so the per-chunk
+        working buffers occupy about ``eps`` times the input tensor's
+        footprint (``num_batches * in_features * dtype.itemsize`` bytes).
+
+        ``aspect_ratio`` scales the logits buffer with the input, which
+        makes the ``(B, in_features)`` accumulator grow as ``B * in_features
+        ~ num_batches * in_features^2 / num_classes`` -- quadratic in
+        ``in_features`` -- so peak memory crosses the reference once
+        ``in_features`` approaches ``num_classes``. ``budget`` instead caps
+        the total per-chunk buffer at a fixed multiple of the input, so peak
+        memory stays parallel to the reference at large ``in_features``.
+
+        Buffer model (mirrors the dominant mixed-precision path in
+        ``_ChunkContext.build``): per chunk row, the logits buffer is
+        ``num_classes * L`` bytes and the input/grad accumulator is
+        ``in_features * a`` bytes, with ``a = acc_dtype.itemsize`` and ``L``
+        the logits-buffer dtype size (input dtype on fp16 memory-like
+        policies, else acc dtype). A bf16 / class-weighted probability
+        target carries one extra ``(B, num_classes)`` buffer not modelled
+        here, so its actual buffer is up to ~2x eps -- still bounded.
+        """
+        s = dtype.itemsize
+        a = acc_dtype.itemsize
+        logits_bytes = self._logits_buffer_itemsize(dtype, acc_dtype, acc_policy)
+        per_row = num_classes * logits_bytes + in_features * a
+        input_bytes = num_batches * in_features * s
+        return max(1, min(int(eps * input_bytes / per_row), num_batches))
+
     def _adjust(self, num_batches, in_features, num_classes, dtype, device=None):
         """Resolve ``"auto"`` sentinels and ``None`` defaults against a
         specific call site; returns a fully concrete options instance.
@@ -243,6 +318,7 @@ class LinearCrossEntropyOptions:
         # unaffected.
         if chunking_method == "auto" and self.batch_chunk_size is not None:
             chunking_method = None
+        auto_chunk = chunking_method == "auto"
         if acc_policy == "auto" or chunking_method == "auto":
             if device is not None:
                 ap, cm = _AUTO_DEFAULTS.get(
@@ -256,29 +332,8 @@ class LinearCrossEntropyOptions:
             if chunking_method == "auto":
                 chunking_method = cm
 
-        if self.batch_chunk_size is None:
-            batch_chunk_size = num_batches
-        else:
-            batch_chunk_size = min(self.batch_chunk_size, num_batches)
-
-        if chunking_method is not None:
-            batch_chunk_size = self._compute_batch_chunk_size(
-                num_batches,
-                in_features,
-                num_classes,
-                chunking_method,
-            )
-            if (
-                self.batch_chunk_size is not None
-                and self.batch_chunk_size != batch_chunk_size
-            ):
-                raise ValueError(
-                    f"batch_chunk_size (={self.batch_chunk_size}) and "
-                    f"chunking_method ('{chunking_method}') give different "
-                    f"chunk sizes ({self.batch_chunk_size} vs {batch_chunk_size}); "
-                    f"pass only one."
-                )
-
+        # Resolve acc_dtype before chunk sizing: the ``budget`` method needs
+        # the acc dtype size to model the per-chunk buffer bytes.
         if self.acc_dtype is None:
             # Under "auto" prefer fp32 on hardware that supports the
             # mixed-precision mm path; otherwise fall back to input dtype.
@@ -290,6 +345,71 @@ class LinearCrossEntropyOptions:
             acc_dtype = auto_acc if auto_acc is not None else dtype
         else:
             acc_dtype = self.acc_dtype
+
+        # Auto switch to ``budget`` above the crossing region. Aspect_ratio
+        # sizes chunks so the logits buffer matches the input, which is the
+        # efficient pick while the logits buffer dominates. Once the per-chunk
+        # (B, in_features) accumulator outgrows the (B, num_classes) logits
+        # buffer (in_features * acc_bytes >= num_classes * logits_bytes), that
+        # accumulator -- which aspect_ratio does not size for -- grows
+        # quadratically in in_features and overtakes the reference; budget
+        # bounds it instead. Only auto-resolved methods switch; an explicit
+        # aspect_ratio is respected.
+        #
+        # budget's default eps=1 ("buffer ~ one input footprint") is fixed by
+        # continuity at this boundary, not by a memory objective: any
+        # memory-only criterion (minimize peak / "don't lose to reference")
+        # is monotonic in eps and degenerates to eps=0 (B=1, slowest). eps=1
+        # makes budget's chunk size meet aspect_ratio's right at the switch,
+        # so the method change is seamless, then budget bounds B above it.
+        if (
+            auto_chunk
+            and chunking_method is not None
+            and chunking_method.startswith("aspect_ratio")
+        ):
+            logits_bytes = self._logits_buffer_itemsize(dtype, acc_dtype, acc_policy)
+            if in_features * acc_dtype.itemsize >= num_classes * logits_bytes:
+                chunking_method = "budget"
+
+        if self.batch_chunk_size is None:
+            batch_chunk_size = num_batches
+        else:
+            batch_chunk_size = min(self.batch_chunk_size, num_batches)
+
+        if chunking_method is not None:
+            if chunking_method.startswith("budget"):
+                eps = (
+                    float(chunking_method.split(":", 1)[1])
+                    if ":" in chunking_method
+                    else 1.0
+                )
+                batch_chunk_size = self._compute_batch_chunk_size_budget(
+                    num_batches,
+                    in_features,
+                    num_classes,
+                    dtype,
+                    acc_dtype,
+                    acc_policy,
+                    eps,
+                )
+            else:
+                batch_chunk_size = self._compute_batch_chunk_size(
+                    num_batches,
+                    in_features,
+                    num_classes,
+                    chunking_method,
+                )
+            if (
+                self.batch_chunk_size is not None
+                and self.batch_chunk_size != batch_chunk_size
+            ):
+                raise ValueError(
+                    f"batch_chunk_size (={self.batch_chunk_size}) and "
+                    f"chunking_method ('{chunking_method}') give different "
+                    f"chunk sizes ({self.batch_chunk_size} vs {batch_chunk_size}); "
+                    f"pass only one."
+                )
+
         return dataclasses.replace(
             self,
             acc_policy=acc_policy,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #187053
* __->__ #187271

The chunked scalar op precomputes grad_input/grad_weight in forward, so at
its peak it holds both inputs and both gradients (2*(N+V)*in_features*
itemsize) plus the per-chunk working buffers. The aspect_ratio heuristic
sizes those buffers so the (chunk, num_classes) logits buffer matches the
input -- the efficient pick while num_classes >> in_features -- but it does
not size the (chunk, in_features) accumulator, which then grows as
chunk*in_features ~ num_batches*in_features^2/num_classes, quadratic in
in_features. So once in_features approaches num_classes the chunked peak
crosses the full-materialization reference.

This adds a 'budget' chunking method that sizes the chunk so the total
per-chunk buffer is about one input footprint, bounding it to a fixed
multiple of the input regardless of in_features; peak memory then stays
parallel to the reference instead of overtaking it. 'auto' keeps the
aspect_ratio pick below the crossing region and switches to budget above it
(in_features*acc_bytes >= num_classes*logits_bytes), so the common
num_classes >> in_features case is unchanged and only the large-in_features
regime gains the bound; an explicit aspect_ratio or budget is respected.

The default budget eps=1 ("buffer ~ one input footprint") is fixed by
continuity at the switch boundary, not by a memory objective: any
memory-only criterion is monotonic in eps and degenerates to eps=0 (one row
per chunk, slowest). eps=1 makes the budget chunk size meet aspect_ratio's
at the boundary, so the auto method change introduces no jump; 'budget:E'
overrides it.

The 2*(N+V) precompute floor is shared with the reference (and liger, which
precomputes likewise), so budget bounds the overage rather than undercutting
the reference -- the chunked path stays more accurate throughout (fp32-acc
logits vs the reference's input-dtype logits), which is why auto switches
method rather than falling back. Target-kind agnostic (index and prob).

This PR was authored with the assistance of an AI tool (Claude).

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki