### PR TITLE
[Dynamo] Trace raw unbacked SymInt inputs

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -552,6 +552,37 @@ class TestShapeVarCompile(TestCase):
             msg=f"expected unbacked symbol (u-prefix), got {sym!r}",
         )
 
+    def test_non_strict_raw_unbacked_symint_input_raises_dde_on_branching(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        def fn(n):
+            if n > 1:
+                return torch.ones(())
+            return torch.zeros(())
+
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        n = ShapeEnv().create_unbacked_symint()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError,
+            "Could not guard on data-dependent expression",
+        ):
+            with torch.compiler._non_strict_tracing_context():
+                compiled(n)
+
+    def test_raw_unbacked_symint_input_graph_breaks_outside_non_strict(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        def fn(n):
+            return torch.ones((n,))
+
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        n = ShapeEnv().create_unbacked_symint()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "Attempted to wrap unbacked SymInt",
+        ):
+            compiled(n)
+
     def test_none_entry_is_static(self):
         """A ``None`` entry is implicit static.
         Each distinct shape at dim 1 triggers a recompile."""

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -59,6 +59,7 @@ from torch._inductor.utils import fresh_cache
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
     AuxRequest,
+    BlockMask,
     create_block_mask,
     flex_attention,
 )
@@ -7318,6 +7319,35 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         # One graph, so no graph breaks
         self.assertEqual(backend_counter.frame_count, 1)
         self.assertEqual(len(backend_counter.graphs), 1)
+
+    def test_flex_attention_non_strict_unbacked_sequence_length(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint()
+        shape_env._set_unbacked_var_to_hint_override(seq, 128)
+
+        with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True):
+            q = torch.empty((1, 1, seq, 8), device="cpu")
+            k = torch.empty((1, 1, seq, 8), device="cpu")
+            v = torch.empty((1, 1, seq, 8), device="cpu")
+            kv_num_blocks = torch.ones((1, 1, 1), dtype=torch.int32)
+            kv_indices = torch.zeros((1, 1, 1, 1), dtype=torch.int32)
+            block_mask = BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                BLOCK_SIZE=128,
+                seq_lengths=(seq, seq),
+            )
+
+            with (
+                torch.compiler._non_strict_tracing_context(),
+                torch._dynamo.config.patch(force_compile_during_fx_trace=True),
+            ):
+                out = flex_attention(q, k, v, block_mask=block_mask)
+
+        self.assertEqual(out.shape, (1, 1, seq, 8))
 
     # https://github.com/pytorch/pytorch/issues/164990
     def test_guard_same_frame_fail_message(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7305,12 +7305,8 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         y2 = torch.arange(9).reshape((3, 3))
         with self.assertRaisesRegex(
             AssertionError,
-            (
-                escape("Guard failed: max(x.size()[1], y.size()[1]) == x.size()[1]")
-                if is_retracebility_test(self._testMethodName)
-                else escape(
-                    "Guard failed: max(1, x.size()[1], y.size()[1]) == x.size()[1]"
-                )
+            escape(
+                "Guard failed: torch.sym_max(1, torch.sym_max(x.size()[1], y.size()[1])) == x.size()[1]"
             ),
         ):
             # TODO: this should not error?

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6279,6 +6279,46 @@ class TestMaybeFastEvalComparison(TestCase):
         result = shape_env._maybe_fast_eval_comparison(expr)
         self.assertIsNone(result)
 
+    def test_sympy_interp_min_max_are_symbol_safe(self):
+        from torch._dynamo.source import LocalSource
+        from torch.fx.experimental.symbolic_shapes import ShapeGuardPythonPrinter
+        from torch.utils._sympy.functions import Max, Min
+
+        shape_env = ShapeEnv()
+        u0 = shape_env.create_unbacked_symint()
+        sym = u0.node.expr
+        source = LocalSource("u0")
+        printer = ShapeGuardPythonPrinter(
+            {sym: [source]}, lambda source: source.name, {sym: [source]}
+        )
+
+        # Printer emits torch.sym_max / torch.sym_min so the printed string is
+        # symbol-safe to eval on unbacked SymInts.
+        max_expr = printer.doprint(sympy.Max(1, sym))
+        min_expr = printer.doprint(sympy.Min(1, sym))
+        self.assertEqual(max_expr, "torch.sym_max(1, L['u0'])")
+        self.assertEqual(min_expr, "torch.sym_min(1, L['u0'])")
+
+        locals_ = {"L": {"u0": u0}}
+        max_result = eval(max_expr, SYMPY_INTERP, locals_).node.expr  # noqa: P204
+        min_result = eval(min_expr, SYMPY_INTERP, locals_).node.expr  # noqa: P204
+        self.assertEqual(max_result, Max(1, sym))
+        self.assertEqual(min_result, Min(1, sym))
+
+        # Three-arg form right-folds into nested binary calls.
+        u1 = shape_env.create_unbacked_symint()
+        sym1 = u1.node.expr
+        printer3 = ShapeGuardPythonPrinter(
+            {sym: [source], sym1: [LocalSource("u1")]},
+            lambda s: s.name,
+            {sym: [source], sym1: [LocalSource("u1")]},
+        )
+        max3 = printer3.doprint(sympy.Max(1, sym, sym1))
+        self.assertIn("torch.sym_max", max3)
+        locals3 = {"L": {"u0": u0, "u1": u1}}
+        max3_result = eval(max3, SYMPY_INTERP, locals3).node.expr  # noqa: P204
+        self.assertEqual(max3_result, Max(1, sym, sym1))
+
     def test_non_zero_rhs_returns_none(self):
         """Test that comparison with non-zero RHS returns None."""
         shape_env = ShapeEnv()
@@ -6371,6 +6411,14 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
 
         return ConstantSource(name)
 
+    @staticmethod
+    def _transfer_symint(env, value, source):
+        """Test helper that mirrors what builder.py does when wrapping a raw
+        foreign unbacked SymInt input: transfer the expression and wrap as a
+        SymInt in the local env."""
+        new_expr = env._transfer_foreign_expr_as_unbacked(value, source=source)
+        return env.create_symintnode(new_expr, hint=None, source=source)
+
     def _create_backed_symbols(self, shape_env, tensor, source_name="foreign"):
         """Create backed symbolic sizes/strides/offset using _create_symbolic_sizes_strides_storage_offset."""
         src = self._make_source(source_name)
@@ -6439,7 +6487,7 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         u0 = foreign_env.create_unbacked_symint()
         u1 = foreign_env.create_unbacked_symint()
 
-        # Use plain int strides — unbacked symbols as strides would need
+        # Use plain int strides; unbacked symbols as strides would need
         # valid positive hints, and INFER_STRIDE handles stride creation.
         sizes = (u0, u1)
         strides = (1, 1)
@@ -6621,6 +6669,211 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertIs(new_sizes[2].node.shape_env, local_env)
         self.assertFalse(local_env.has_guarding_hint(new_sizes[2].node.expr))
         self.assertEqual(local_env.var_to_hint_override[new_sizes[2].node.expr], 99)
+
+    def test_raw_unbacked_symint_transfer_shares_tensor_symbol(self):
+        """Tensor dims and raw SymInts from one foreign ShapeEnv share transfer."""
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        foreign_env.var_to_hint_override[u0.node.expr] = 32
+
+        local_env = ShapeEnv()
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0,),
+            (1,),
+            0,
+            source=self._make_source("tensor"),
+        )
+        raw_u0 = self._transfer_symint(local_env, u0, source=self._make_source("raw"))
+        raw_u0_plus_1 = self._transfer_symint(
+            local_env, u0 + 1, source=self._make_source("raw_plus_1")
+        )
+
+        tensor_symbol = new_sizes[0].node.expr
+        self.assertEqual(raw_u0.node.expr, tensor_symbol)
+        self.assertEqual(raw_u0_plus_1.node.expr, tensor_symbol + 1)
+        self.assertEqual(local_env.var_to_hint_override[tensor_symbol], 32)
+
+    def test_raw_unbacked_symint_transfer_preserves_multi_symbol_expr(self):
+        """Derived raw SymInts are rebuilt from transferred base symbols."""
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        u1 = foreign_env.create_unbacked_symint()
+        foreign_env.var_to_hint_override[u0.node.expr] = 32
+        foreign_env.var_to_hint_override[u1.node.expr] = 16
+
+        local_env = ShapeEnv()
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0, u1, u0 + u1),
+            (1, 1, 1),
+            0,
+            source=self._make_source("tensor"),
+        )
+        raw_sum = self._transfer_symint(
+            local_env, u0 + u1, source=self._make_source("raw_sum")
+        )
+
+        new_u0 = new_sizes[0].node.expr
+        new_u1 = new_sizes[1].node.expr
+        self.assertEqual(new_sizes[2].node.expr, new_u0 + new_u1)
+        self.assertEqual(raw_sum.node.expr, new_u0 + new_u1)
+        self.assertEqual(local_env.var_to_hint_override[new_u0], 32)
+        self.assertEqual(local_env.var_to_hint_override[new_u1], 16)
+
+    def test_raw_unbacked_symint_transfer_falls_back_for_backed_leftover(self):
+        """Mixed backed+unbacked foreign expr falls back to fresh local unbacked."""
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        # Create a backed foreign symbol that this env cannot translate.
+        s0 = foreign_env.create_symbol(
+            8,
+            self._make_source("s0"),
+            DimDynamic.DYNAMIC,
+        )
+        s0_symint = foreign_env.create_symintnode(s0, hint=8)
+        mixed = u0 + s0_symint
+
+        local_env = ShapeEnv()
+        raw = self._transfer_symint(
+            local_env, mixed, source=self._make_source("raw_mixed")
+        )
+
+        # Result is a fresh local unbacked symbol; no foreign symbols leaked.
+        result_expr = raw.node.expr
+        self.assertTrue(local_env.is_unbacked_symint(result_expr))
+        # All free symbols are owned by local_env.
+        for sym in result_expr.free_symbols:
+            self.assertTrue(local_env.is_unbacked_symint(sym))
+
+    def test_transfer_is_self_short_circuit(self):
+        """When the SymInt already belongs to this ShapeEnv,
+        _transfer_foreign_expr_as_unbacked is a no-op (returns the input expr
+        unchanged, no new symbol minted)."""
+        local_env = ShapeEnv()
+        local_u0 = local_env.create_unbacked_symint()
+
+        cache_size_before = len(local_env.foreign_unbacked_symbol_cache)
+        result = local_env._transfer_foreign_expr_as_unbacked(
+            local_u0, source=self._make_source("local")
+        )
+        self.assertEqual(result, local_u0.node.expr)
+        # Nothing should have been added to the cache.
+        self.assertEqual(
+            len(local_env.foreign_unbacked_symbol_cache), cache_size_before
+        )
+
+    def test_transfer_constrains_size_on_cache_hit(self):
+        """When is_size=True and the expression resolves to a single Symbol
+        from the cache (cached via a non-size path earlier),
+        _constrain_range_for_size is still applied; the symbol ends up in
+        size_like."""
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+
+        local_env = ShapeEnv()
+        # First: transfer u0 via the raw SymInt path (is_size=False).
+        raw_symint = self._transfer_symint(
+            local_env, u0, source=self._make_source("raw")
+        )
+        raw = raw_symint.node.expr
+        self.assertNotIn(raw, local_env.size_like)
+
+        # Now: transfer the same u0 as a tensor size dim (is_size=True via
+        # transfer_symbols_from_foreign_shape_env's UNBACKED path).
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0,), (1,), 0, source=self._make_source("tensor")
+        )
+        # Same cached local symbol reused.
+        self.assertEqual(new_sizes[0].node.expr, raw)
+        # And now it carries the size lower-bound constraint.
+        self.assertIn(raw, local_env.size_like)
+
+    def test_foreign_unbacked_transfer_preserves_derived_tensor_expr(self):
+        """Derived tensor dims are minted as opaque symbols; raw SymInt with
+        the same expression reuses that symbol via the (env, expr) cache."""
+        foreign_env = ShapeEnv()
+        global_tokens = foreign_env.create_unbacked_symint()
+        hidden = foreign_env.create_unbacked_symint()
+        foreign_env.var_to_hint_override[global_tokens.node.expr] = 64
+        foreign_env.var_to_hint_override[hidden.node.expr] = 128
+
+        derived_tokens = global_tokens // 2
+        local_env = ShapeEnv()
+        new_sizes, new_strides, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (derived_tokens, hidden),
+            (hidden, 1),
+            0,
+            source=self._make_source("derived_tensor"),
+        )
+        raw_derived_tokens = self._transfer_symint(
+            local_env, derived_tokens, source=self._make_source("raw_derived_tokens")
+        )
+
+        self.assertEqual(raw_derived_tokens.node.expr, new_sizes[0].node.expr)
+        self.assertEqual(new_strides[0].node.expr, new_sizes[1].node.expr)
+        self.assertEqual(len(raw_derived_tokens.node.expr.free_symbols), 1)
+        derived_token_sym = next(iter(raw_derived_tokens.node.expr.free_symbols))
+        # `derived_tokens` (= global_tokens // 2) is minted as one fresh
+        # opaque symbol; its hint is the foreign expression's hint (64 // 2).
+        self.assertEqual(local_env.var_to_hint_override[derived_token_sym], 32)
+        self.assertEqual(local_env.var_to_hint_override[new_sizes[1].node.expr], 128)
+
+    def test_foreign_unbacked_transfer_preserves_shared_token_grid(self):
+        """Separate tensor transfers preserve shared token-grid symbols."""
+        foreign_env = ShapeEnv()
+        batch = foreign_env.create_unbacked_symint()
+        seq = foreign_env.create_unbacked_symint()
+        hidden = foreign_env.create_unbacked_symint()
+        foreign_env.var_to_hint_override[batch.node.expr] = 4
+        foreign_env.var_to_hint_override[seq.node.expr] = 128
+        foreign_env.var_to_hint_override[hidden.node.expr] = 64
+
+        derived_seq = seq // 2
+        local_env = ShapeEnv()
+        token_grid_sizes, token_grid_strides, _ = (
+            local_env.transfer_symbols_from_foreign_shape_env(
+                (batch, seq),
+                (seq, 1),
+                0,
+                source=self._make_source("token_grid"),
+            )
+        )
+        label_sizes, label_strides, _ = (
+            local_env.transfer_symbols_from_foreign_shape_env(
+                (batch, seq),
+                (seq, 1),
+                0,
+                source=self._make_source("labels"),
+            )
+        )
+        derived_sizes, derived_strides, _ = (
+            local_env.transfer_symbols_from_foreign_shape_env(
+                (batch, derived_seq, hidden),
+                (derived_seq * hidden, hidden, 1),
+                0,
+                source=self._make_source("derived_activation"),
+            )
+        )
+        raw_derived_seq = self._transfer_symint(
+            local_env, derived_seq, source=self._make_source("raw_derived_seq")
+        )
+        raw_seq_plus_hidden = self._transfer_symint(
+            local_env, seq + hidden, source=self._make_source("raw_seq_plus_hidden")
+        )
+
+        self.assertEqual(token_grid_sizes[0].node.expr, label_sizes[0].node.expr)
+        self.assertEqual(token_grid_sizes[0].node.expr, derived_sizes[0].node.expr)
+        self.assertEqual(token_grid_sizes[1].node.expr, label_sizes[1].node.expr)
+        self.assertEqual(token_grid_strides[0].node.expr, token_grid_sizes[1].node.expr)
+        self.assertEqual(label_strides[0].node.expr, label_sizes[1].node.expr)
+        self.assertEqual(raw_derived_seq.node.expr, derived_sizes[1].node.expr)
+        self.assertEqual(
+            derived_strides[0].node.expr,
+            derived_sizes[1].node.expr * derived_sizes[2].node.expr,
+        )
+        self.assertEqual(
+            raw_seq_plus_hidden.node.expr,
+            token_grid_sizes[1].node.expr + derived_sizes[2].node.expr,
+        )
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_flex_attention_foreign_fake_e2e(self):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1840,7 +1840,7 @@ def override_optimization_hint(x: Any, val: int) -> None:
             f"override_optimization_hint expects an unbacked symbol, "
             f"but {expr} is backed"
         )
-    shape_env.var_to_hint_override[expr] = val
+    shape_env._set_unbacked_var_to_hint_override(x, val)
 
 
 def is_dynamo_disable_recursive(method: Callable[[Any], Any]) -> bool | None:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4533,7 +4533,14 @@ class CheckFunctionManager:
         # python -s test/dynamo/test_export.py -k test_export_with_symbool_inputs
         latency = 0.0
 
-        if not output_graph.skip_guards_check and not output_graph.export:
+        # Non-strict tracing can compile with fake inputs whose unbacked sizes
+        # cannot be used to evaluate guards eagerly. Keep the runtime guards,
+        # but skip this same-frame sanity check in that tracing context.
+        if (
+            not output_graph.skip_guards_check
+            and not output_graph.export
+            and not torch.compiler._is_non_strict_tracing()
+        ):
             if not self.guard_manager.check(output_graph.local_scope):
                 reasons = get_guard_fail_reason_helper(
                     self.guard_manager,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1666,17 +1666,28 @@ class VariableBuilder:
                     # We need to create an unbacked symint to replace the unbacked symbool.
                     new_symint = self.tx.output.shape_env.create_unbacked_symint()
                 else:
-                    # TODO (yidi): we need to figure out a way to propagate the guards
-                    # we accumulated when tracing the subggraph to outer shape_env. For normal symints,
-                    # this is automatically done by evaluating the guards once but this
-                    # will cause data-dependent error when we evaluate the outer unbacked symints.
-                    # The test case that triggers this graph break is test_cond_unbacked_symint_closure
-                    unimplemented(
-                        gb_type="Attempted to wrap unbacked SymInt",
-                        context="",
-                        explanation="Unbacked SymInt input is not supported yet.",
-                        hints=[*graph_break_hints.SUPPORTABLE],
-                    )
+                    shape_env = self.tx.output.shape_env
+                    if not torch.compiler._is_non_strict_tracing():
+                        # TODO: Need to enable this for Dynamo after broader
+                        # verification. See
+                        # test_raw_unbacked_symint_input_graph_breaks_outside_non_strict.
+                        unimplemented(
+                            gb_type="Attempted to wrap unbacked SymInt",
+                            context="",
+                            explanation="Unbacked SymInt input is not supported yet.",
+                            hints=[*graph_break_hints.SUPPORTABLE],
+                        )
+                    if value.node.shape_env is shape_env:
+                        # SymInt already belongs to this ShapeEnv; no
+                        # transfer needed, reuse it directly.
+                        new_symint = value
+                    else:
+                        new_expr = shape_env._transfer_foreign_expr_as_unbacked(
+                            value, source=source
+                        )
+                        new_symint = shape_env.create_symintnode(
+                            new_expr, hint=None, source=source
+                        )
             if new_symint is None:
                 raise AssertionError("new_symint must not be None after wrapping")
             if not isinstance(new_symint, SymInt):
@@ -1696,11 +1707,11 @@ class VariableBuilder:
                 is_tensor=False,
                 example_strong_ref=new_symint,
             )
-            # We bind the new_symint to graph input.
             sym_expr = new_symint.node.expr
-            if not isinstance(sym_expr, sympy.Symbol):
-                raise AssertionError(f"{sym_expr} is not a basic Symbol.")
-            self.tx.output.tracked_fakes.append(TrackedFake(new_symint, source, None))
+            if isinstance(sym_expr, sympy.Symbol):
+                self.tx.output.tracked_fakes.append(
+                    TrackedFake(new_symint, source, None)
+                )
 
             tracing_symint = (
                 new_symint if isinstance(value, torch.SymInt) else new_symint == 1

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -1145,13 +1145,13 @@ class MetaConverter(Generic[_TensorT]):
                     )
                 else:
                     # FakeTensor from a different ShapeEnv.  Transfer symbols.
+                    # _transfer_foreign_expr picks the hint up via the foreign env.
                     return shape_env.transfer_symbols_from_foreign_shape_env(
                         t.size,
                         t.stride,
                         t.storage_offset,
                         src,
                         symbolic_context=symbolic_context,
-                        hint_overrides=t.dynamo_hint_overrides,
                     )
             else:
                 return (t.size, t.stride, t.storage_offset)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2926,6 +2926,25 @@ class ShapeGuardPythonPrinter(_ShapeGuardPrinter, PythonPrinter):
         super().__init__(*args)
         self._print_cache: dict[sympy.Expr, str] = {}
 
+    # Guards may be eval'd against unbacked SymInts; builtin max/min would
+    # trigger data-dependent errors, so emit torch.sym_max/sym_min instead.
+    def _print_Max(self, expr: sympy.Expr) -> str:
+        if len(expr.args) < 2:
+            raise AssertionError("Max expects at least two arguments")
+        return self._fold_binary_call("torch.sym_max", expr.args)
+
+    def _print_Min(self, expr: sympy.Expr) -> str:
+        if len(expr.args) < 2:
+            raise AssertionError("Min expects at least two arguments")
+        return self._fold_binary_call("torch.sym_min", expr.args)
+
+    def _fold_binary_call(self, fn: str, args: Sequence[sympy.Expr]) -> str:
+        printed = [self.doprint(a) for a in args]
+        result = printed[-1]
+        for arg in reversed(printed[:-1]):
+            result = f"{fn}({arg}, {result})"
+        return result
+
     def print_source(self, source: Source) -> str:
         """
         Convert a source object to its string representation using the source_ref function.
@@ -4025,6 +4044,16 @@ class ShapeEnv:
         # want them to always be stored here, since this dict is used as
         # part of the FxGraphCache key.
         self.var_to_hint_override: dict[sympy.Symbol, int] = {}
+        # When the compiler input is a fake tensor with unbacked symints, we
+        # create new unbacked symints internally in the traced graph.
+        # While doing so, we try to preserve the relations from the original
+        # shape env by avoiding re-emitting new symbols for foreign expressions
+        # that already got bound symbols here. This cache does that by mapping
+        # (foreign_shape_env_id, foreign_expr) -> the local symbol we
+        # already minted for it.
+        self.foreign_unbacked_symbol_cache: dict[
+            tuple[int, sympy.Expr], sympy.Symbol
+        ] = {}
         # Maps a source to the *original* symbol that was assigned to it
         self.source_to_var: dict[str, sympy.Symbol] = {}
         # Maps from sympy ints to expressions representing them
@@ -4331,6 +4360,9 @@ class ShapeEnv:
             # Cached state for optimization_hint unbacked canonicalization
             "_equality_graph",
             "_unbacked_replacements",
+            # Foreign ShapeEnv transfer cache; replay reconstructs equivalent
+            # transferred symbols through recorded registration events.
+            "foreign_unbacked_symbol_cache",
         )
 
         # Mapping of the value of each to-be-compared field into the values that
@@ -4840,6 +4872,105 @@ class ShapeEnv:
             symbolic_context=symbolic_context,
         )
 
+    def _transfer_foreign_expr_as_unbacked(
+        self,
+        value: SymInt,
+        *,
+        source: Source,
+        is_size: bool = False,
+    ) -> sympy.Expr:
+        """Transfer a foreign SymInt expression into this ShapeEnv.
+
+        Algorithm (used uniformly for tensor sizes, strides, storage offsets,
+        and raw SymInt inputs):
+        1. Replace any foreign symbols in ``value.expr`` that are already in
+           the per-symbol cache (cache-only; no minting yet).
+        2. If every free symbol got replaced, return the resulting (possibly
+           derived) expression as-is.
+        3. Otherwise mint ONE fresh local unbacked symbol for the whole
+           foreign expression, attach the caller's ``source`` to it, register
+           its value range / hint from the foreign env, and cache
+           ``(foreign_env, foreign_expr) -> new_symbol`` so a future call
+           with the same expression reuses the symbol.
+
+        Note: this loses fine-grained relationships when a derived expression
+        is minted before its base symbols are seen individually (e.g. minting
+        a symbol for ``u0 + u1`` before any tensor dim carries ``u0`` or
+        ``u1`` alone; later occurrences of those bare symbols cannot share
+        with the minted derived symbol).  This is consistent with the
+        pre-refactor behavior."""
+        src_shape_env = value.node.shape_env
+        if src_shape_env is self:
+            # SymInt already belongs to this ShapeEnv; nothing to transfer.
+            return value.node.expr
+        # All current callers feed in a SymInt that was minted in a foreign
+        # ShapeEnv, so src_shape_env should never be None.  Assert for now;
+        # revisit if a use case for env-less SymInts shows up.
+        if src_shape_env is None:
+            raise AssertionError(
+                f"_transfer_foreign_expr_as_unbacked: expected value to belong "
+                f"to a foreign ShapeEnv, got {value!r} with shape_env=None"
+            )
+        expr = value.node.expr
+
+        # Step 1: cache-only replacement.
+        cache_map = {
+            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
+            for sym in expr.free_symbols
+            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
+        }
+        new_expr = expr.xreplace(cache_map) if cache_map else expr
+
+        # Step 2: all symbols resolved from cache; use the derived expression.
+        if not (new_expr.free_symbols - set(cache_map.values())):
+            if is_size:
+                if isinstance(new_expr, sympy.Symbol):
+                    self._constrain_range_for_size(new_expr)
+                else:
+                    # Derived expr (e.g. u0+u1): constrain the whole sum to be
+                    # a valid size via a deferred runtime assert, not each
+                    # individual base symbol.
+                    torch._check(
+                        self.create_symintnode(new_expr, hint=None, source=source) >= 0
+                    )
+            return new_expr
+
+        # Step 3: at least one symbol could not be resolved.  Mint one fresh
+        # symbol for the whole foreign expression and cache by expression.
+        # TODO we can do better here: we lose all structural info about the
+        # foreign expression (e.g. that it was u0 + u1) by collapsing it to a
+        # single opaque local symbol.
+        expr_key = (id(src_shape_env), expr)
+        cached = self.foreign_unbacked_symbol_cache.get(expr_key)
+        if cached is None:
+            with self.ignore_fresh_unbacked_symbols():
+                new_symint = self.create_unbacked_symint(source)
+            cached = new_symint.node.expr
+            self.foreign_unbacked_symbol_cache[expr_key] = cached
+            # Only carry the foreign optimization hint forward when every
+            # free symbol in expr has an explicit backed value or hint
+            # override; otherwise optimization_hint would return a generic
+            # heuristic fallback that shouldn't be recorded as user
+            # provenance.
+            hint_sources = (
+                src_shape_env.backed_var_to_val.keys()
+                | src_shape_env.var_to_hint_override.keys()
+            )
+            optimization_hint = (
+                src_shape_env.optimization_hint(expr)
+                if not expr.free_symbols - hint_sources
+                else None
+            )
+            self._register_unbacked_symbol_as_input(
+                cached,
+                source=source,
+                value_range=src_shape_env.bound_sympy(expr),
+                optimization_hint=optimization_hint,
+            )
+        if is_size:
+            self._constrain_range_for_size(cached)
+        return cached
+
     def transfer_symbols_from_foreign_shape_env(
         self,
         sizes: Sequence[IntLikeType],
@@ -4848,7 +4979,6 @@ class ShapeEnv:
         source: Source,
         *,
         symbolic_context: SymbolicContext | None = None,
-        hint_overrides: dict[int, int] | None = None,
     ) -> tuple[
         tuple[IntLikeType, ...],
         tuple[IntLikeType, ...],
@@ -4862,10 +4992,9 @@ class ShapeEnv:
         a guarding hint.  If symbolic_context is provided (e.g. from
         _automatic_dynamic), its classification is used instead.
 
-        For unbacked dims, strides are derived by substituting old foreign
-        symbols with the newly created symbols, preserving stride-size
-        relationships.  Hint overrides are read from the foreign ShapeEnv
-        and transferred to the new one."""
+        For unbacked dims, the underlying foreign unbacked symbols (and any
+        user-provided optimization hints registered on the foreign ShapeEnv)
+        are transferred into this env via _transfer_foreign_expr_as_unbacked."""
 
         def _classify(s: IntLikeType) -> DimDynamic:
             if not is_symbolic(s):
@@ -4892,19 +5021,6 @@ class ShapeEnv:
         else:
             dynamic_sizes = symbolic_context.dynamic_sizes  # type: ignore[attr-defined]
 
-        # For unbacked dims, read the optimization hint from the foreign
-        # ShapeEnv and set it as a hint override so the new unbacked symbol
-        # gets a useful hint value.
-        if hint_overrides is None:
-            hint_overrides = {}
-        for i, sz in enumerate(sizes):
-            if dynamic_sizes[i] is DimDynamic.UNBACKED and is_symbolic(sz):
-                foreign_env = sz.node.shape_env  # type: ignore[union-attr]
-                if foreign_env is not None:
-                    opt_hint = foreign_env.var_to_hint_override.get(sz.node.expr)  # type: ignore[union-attr]
-                    if opt_hint is not None:
-                        hint_overrides[i] = opt_hint
-
         import sympy
 
         from torch._dynamo.source import TensorProperty, TensorPropertySource
@@ -4916,7 +5032,7 @@ class ShapeEnv:
         has_unbacked = any(ds is DimDynamic.UNBACKED for ds in dynamic_sizes)
 
         if not has_unbacked:
-            # No unbacked dims — ex_size/ex_stride/ex_storage_offset are all ints.
+            # No unbacked dims; ex_size/ex_stride/ex_storage_offset are all ints.
             return self._create_symbolic_sizes_strides_storage_offset(
                 ex_size,  # type: ignore[arg-type]
                 ex_stride,  # type: ignore[arg-type]
@@ -4924,42 +5040,35 @@ class ShapeEnv:
                 [False] * len(sizes),
                 source,
                 symbolic_context=symbolic_context,
-                hint_overrides=hint_overrides,
             )
 
-        # Unbacked path
-
-        # Unbacked path: create new size symbols with dedup for shared
-        # unbacked symbols, then derive strides by substitution.
-
-        # 1. Create new size symbols, deduplicating shared unbacked symbols.
-        # Try xreplace to substitute known mappings; if foreign symbols remain,
-        # create a fresh unbacked symbol.
-        # NOTE: if all dims are derived expressions from a base symbol that
-        # doesn't appear as a dim itself (e.g., size=[u0//2, u0//4]), the
-        # relationship between dims is lost — each gets an independent symbol.
-        # This is acceptable as this case is rare in practice.
-        old_to_new: dict[sympy.Expr, sympy.Expr] = {}
+        # Transfer unbacked base symbols once, then rebuild every tensor
+        # size/stride/offset expression from that mapping.  The same ShapeEnv
+        # cache is also used for raw foreign SymInt inputs, so a tensor dim
+        # `u0` and a closure-captured SymInt `u0` become the same local symbol.
         new_size_exprs: list[sympy.Expr] = []
         for i, old_sz in enumerate(sizes):
             if is_symbolic(old_sz):
-                old_expr = old_sz.node.expr  # type: ignore[union-attr]
-                new_expr = old_expr.xreplace(old_to_new)
-                if new_expr.free_symbols - set(old_to_new.values()):
-                    # Still has unmapped foreign symbols — create fresh symbol
-                    sym = self.create_symbol(
-                        ex_size[i],  # type: ignore[arg-type]  # None for UNBACKED, ignored
-                        TensorPropertySource(source, TensorProperty.SIZE, i),
+                size_source = TensorPropertySource(source, TensorProperty.SIZE, i)
+                if dynamic_sizes[i] is DimDynamic.UNBACKED:
+                    new_expr = self._transfer_foreign_expr_as_unbacked(
+                        cast(SymInt, old_sz),
+                        source=size_source,
+                        is_size=True,
+                    )
+                else:
+                    # Backed dim through the legacy create_symbol path so the
+                    # standard size machinery handles source/range bookkeeping.
+                    new_expr = self.create_symbol(
+                        ex_size[i],  # type: ignore[arg-type]
+                        size_source,
                         dynamic_sizes[i],
                         symbolic_context.constraint_sizes[i]
                         if hasattr(symbolic_context, "constraint_sizes")
                         else None,  # type: ignore[attr-defined]
                         symbolic_context=symbolic_context,
                     )
-                    old_to_new[old_expr] = sym
-                    new_size_exprs.append(sym)
-                else:
-                    new_size_exprs.append(new_expr)
+                new_size_exprs.append(new_expr)
             else:
                 new_size_exprs.append(sympy.Integer(old_sz))
 
@@ -4967,21 +5076,22 @@ class ShapeEnv:
         # If after substitution a stride still has foreign symbols (e.g. from
         # as_strided), create a fresh unbacked symbol for it.
         new_stride_exprs: list[sympy.Expr] = []
-        for sd in strides:
+        for i, sd in enumerate(strides):
             if is_symbolic(sd):
-                new_expr = sd.node.expr.xreplace(old_to_new)  # type: ignore[union-attr]
-                if new_expr.free_symbols - set(old_to_new.values()):
-                    # Stride references a foreign symbol not in any size dim.
-                    new_expr = self.create_unbacked_symint().node.expr
+                stride_source = TensorPropertySource(source, TensorProperty.STRIDE, i)
+                new_expr = self._transfer_foreign_expr_as_unbacked(
+                    cast(SymInt, sd), source=stride_source
+                )
                 new_stride_exprs.append(new_expr)
             else:
                 new_stride_exprs.append(sympy.Integer(sd))
 
         # 4. Storage offset.
         if is_symbolic(storage_offset):
-            new_offset_expr = storage_offset.node.expr.xreplace(old_to_new)  # type: ignore[union-attr]
-            if new_offset_expr.free_symbols - set(old_to_new.values()):
-                new_offset_expr = self.create_unbacked_symint().node.expr
+            offset_source = TensorPropertySource(source, TensorProperty.STORAGE_OFFSET)
+            new_offset_expr = self._transfer_foreign_expr_as_unbacked(
+                cast(SymInt, storage_offset), source=offset_source
+            )
         else:
             new_offset_expr = sympy.Integer(storage_offset)
 
@@ -4996,13 +5106,6 @@ class ShapeEnv:
                     source=TensorPropertySource(source, TensorProperty.SIZE, i),
                 )
             )
-            if (
-                isinstance(sym_sizes[-1], torch.SymInt)
-                and hint_overrides
-                and i in hint_overrides
-            ):
-                self.var_to_hint_override[sym_sizes[-1].node.expr] = hint_overrides[i]
-
         sym_strides = []
         for i, stride_expr in enumerate(new_stride_exprs):
             hint_stride = ex_stride[i]
@@ -5430,6 +5533,40 @@ class ShapeEnv:
             "create_unbacked_symint", symbol, vr, source, sym_node=sym_node
         )
         return SymInt(sym_node)
+
+    @record_shapeenv_event()
+    def _register_unbacked_symbol_as_input(
+        self,
+        expr: sympy.Symbol,
+        source: Source,
+        value_range: ValueRanges[sympy.Expr] | None = None,
+        optimization_hint: int | None = None,
+    ) -> None:
+        """Mark ``expr`` (a local unbacked Symbol) as an unbacked graph input
+        and seed its metadata.  Used when lifting a symbol minted from a
+        foreign ShapeEnv expression into this env."""
+        self.unbacked_inputs.add(expr)
+        if value_range is not None:
+            self.var_to_range[expr] = value_range
+        if optimization_hint is not None:
+            self.var_to_hint_override[expr] = optimization_hint
+        if source.name in self.source_to_var:
+            raise AssertionError(
+                f"source name {source.name!r} already maps to "
+                f"{self.source_to_var[source.name]!r}"
+            )
+        self.source_to_var[source.name] = expr
+        self.var_to_sources[expr] = [source]
+
+    @record_shapeenv_event()
+    def _set_unbacked_var_to_hint_override(self, symint: SymInt, hint: int) -> None:
+        # Internal-only.  External users should call
+        # torch._dynamo.override_optimization_hint (the public, validated API).
+        # This wrapper exists purely so internal mutations to
+        # var_to_hint_override participate in shape-env event replay via
+        # @record_shapeenv_event().  Callers are responsible for ensuring
+        # symint.node.expr is an unbacked sympy.Symbol.
+        self.var_to_hint_override[symint.node.expr] = hint
 
     def is_unbacked_symint(self, symbol: sympy.Symbol) -> bool:
         """Check if a sympy symbol matches the naming convention for unbacked symbols"""


### PR DESCRIPTION

Non-strict tracing can receive raw SymInt inputs from an outer fake-tensor trace. This happens in the FlexAttention BlockMask path used by graph chunking: tensor sizes and raw SymInt captures can refer to the same outer unbacked sequence length, and nested Dynamo needs to preserve that provenance instead of rejecting the raw scalar.

This change teaches ShapeEnv to transfer a foreign unbacked SymInt expression into the local ShapeEnv. The transfer first rebuilds the expression from any already-transferred foreign symbols. If unresolved foreign symbols remain, it mints one opaque local unbacked symbol for the whole foreign expression and records its source, range, and optimization hint. The same cache is shared by tensor foreign-ShapeEnv transfer and raw SymInt input wrapping, so tensor dimensions and scalar captures preserve sharing when they originate from the same foreign symbols. The cache itself is excluded from ShapeEnv replay equality because the replayed semantic state is the registered symbols, not the memo table.

Raw foreign unbacked SymInt wrapping remains gated to non-strict tracing. General Dynamo still raises the existing unsupported case until the broader guard-propagation behavior is verified. Data-dependent branching on the transferred raw SymInt still fails through the normal data-dependent-symbol path rather than specializing on an optimization hint.

The full non-strict FlexAttention repro also exposed a tracing-only issue: same-frame guard validation eagerly evaluates generated guards against fake inputs whose unbacked sizes cannot be concretized. The runtime guards are still produced, but the same-frame sanity check is skipped while inside the non-strict tracing context.

Guard printing now emits torch.sym_max and torch.sym_min for SymPy Max/Min so generated guards can be evaluated symbolically on unbacked SymInts instead of going through Python builtin truthiness. The export golden is updated to match the new guard text.

Fixes #187272 

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python -m py_compile torch/fx/experimental/symbolic_shapes.py torch/_dynamo/variables/builder.py test/test_dynamic_shapes.py test/dynamo/test_dynamic_spec.py test/dynamo/test_repros.py test/export/test_export.py
```

```bash
python test/test_dynamic_shapes.py TestTransferSymbolsFromForeignShapeEnv
```

```bash
python test/test_dynamic_shapes.py TestMaybeFastEvalComparison
```

```bash
python test/test_dynamic_shapes.py TestMaybeFastEvalComparison.test_negative_constant_returns_none
```

```bash
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_dynamic_shapes.py TestMaybeFastEvalComparison.test_negative_constant_returns_none
```

```bash
python test/dynamo/test_repros.py ReproTests.test_flex_attention_non_strict_unbacked_sequence_length
```

```bash
python test/dynamo/test_dynamic_shapes.py DynamicShapesReproTests.test_flex_attention_non_strict_unbacked_sequence_length_dynamic_shapes
```

```bash
PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/dynamo/test_dynamic_shapes.py DynamicShapesReproTests.test_flex_attention_non_strict_unbacked_sequence_length_dynamic_shapes
```

```bash
python test/dynamo/test_dynamic_spec.py TestShapeVarCompile.test_non_strict_raw_unbacked_symint_input_raises_dde_on_branching
```

```bash
python test/dynamo/test_dynamic_spec.py TestShapeVarCompile.test_raw_unbacked_symint_input_graph_breaks_outside_non_strict
```

```bash
python test/functorch/test_control_flow.py TestControlFlowTraced.test_cond_unbacked_symint_closure
```

```bash
PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/functorch/test_control_flow.py TestControlFlowTraced.test_cond_unbacked_symint_closure
```

```bash
python test/export/test_export.py TestExport.test_export_max_onnx_reported
```

```bash
python test/export/test_retraceability.py RetraceExportTestExport.test_export_max_onnx_reported_retraceability_strict
```

```bash
lintrunner -a
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98