### PR TITLE
Fix combo kernel crash with dynamic persistent reduction dimensions

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1515,17 +1515,28 @@ class ComboKernelDynamicShapesTests(TestCase):
 
     @requires_gpu_and_triton
     def test_dynamic_shapes_persistent_reduction_dynamic_rdim(self):
-        @torch.compile(dynamic=True)
         def fn(a, b):
             torch._check(a.shape[0] <= 32)
             torch._check(b.shape[0] <= 32)
             return a.sum(), b.sum()
 
-        a = torch.randn(16, device=GPU_TYPE)
-        b = torch.randn(16, device=GPU_TYPE)
-        result = fn(a, b)
-        self.assertEqual(result[0], a.sum())
-        self.assertEqual(result[1], b.sum())
+        for benchmark in (False, True):
+            torch._dynamo.reset()
+            torch._inductor.metrics.reset()
+            a = torch.randn(16, device=GPU_TYPE)
+            b = torch.randn(16, device=GPU_TYPE)
+            with torch._inductor.config.patch("benchmark_combo_kernel", benchmark):
+                fn_c = torch.compile(fn, dynamic=True)
+                result, code = run_and_get_code(fn_c, a, b)
+                self.assertEqual(result[0], a.sum())
+                self.assertEqual(result[1], b.sum())
+                self.assertEqual(
+                    torch._inductor.metrics.generated_kernel_count,
+                    4 if benchmark else 1,
+                )
+                FileCheck().check("R0_BLOCK_0: tl.constexpr = 32").check(
+                    "R0_BLOCK_1: tl.constexpr = 32"
+                ).run(code[0])
 
 
 class ComboKernelTestsPerSubkernelBlocks(ComboKernelTests):

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1513,6 +1513,20 @@ class ComboKernelDynamicShapesTests(TestCase):
         self.assertEqual(out_eager, out_compiled)
         self.assertEqual(code.count("def _triton_helper_fn_add0(arg0_0, arg1_0):"), 1)
 
+    @requires_gpu_and_triton
+    def test_dynamic_shapes_persistent_reduction_dynamic_rdim(self):
+        @torch.compile(dynamic=True)
+        def fn(a, b):
+            torch._check(a.shape[0] <= 32)
+            torch._check(b.shape[0] <= 32)
+            return a.sum(), b.sum()
+
+        a = torch.randn(16, device=GPU_TYPE)
+        b = torch.randn(16, device=GPU_TYPE)
+        result = fn(a, b)
+        self.assertEqual(result[0], a.sum())
+        self.assertEqual(result[1], b.sum())
+
 
 class ComboKernelTestsPerSubkernelBlocks(ComboKernelTests):
     combo_kernel_per_subkernel_blocks = True

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -578,13 +578,7 @@ class ComboKernel(Kernel):
                     grid.append(f"{tree.prefix}numel_{num}")
 
             if tree.is_reduction and sub_kernel.persistent_reduction:
-                if isinstance(simplified_tree_numel, (Integer, int)):
-                    val = int(simplified_tree_numel)
-                else:
-                    raise RuntimeError(
-                        "Dynamic shape on reduction dimension is not supported"
-                    )
-                val = next_power_of_2(val)
+                val = TritonKernel._get_persistent_RBLOCK(tree.numel)
                 code.writeline(
                     f"{tree.prefix.upper()}BLOCK_{num}: tl.constexpr = {val}"
                 )
@@ -790,13 +784,11 @@ class ComboKernel(Kernel):
         if not self.per_subkernel_blocks:
             max_persistent_rblock = max(
                 (
-                    next_power_of_2(int(simplified))
+                    TritonKernel._get_persistent_RBLOCK(tree.numel)
                     for sub in self.sub_kernels
                     if sub.persistent_reduction
                     for tree in sub.range_trees
                     if tree.is_reduction
-                    for simplified in [V.graph.sizevars.simplify(tree.numel)]
-                    if isinstance(simplified, (Integer, int))
                 ),
                 default=0,
             )


### PR DESCRIPTION
Fixes: #187269

Summary:

- Fix combo kernel crash on persistent reductions with dynamic reduction numels by reusing `TritonKernel._get_persistent_RBLOCK()`

Test added: `test_dynamic_shapes_persistent_reduction_dynamic_rdim`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo