### PR TITLE
Fix profiler_kineto.cpp build with USE_KINETO=0 and clean up clang-tidy

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
 #include <c10/util/overloaded.h>
+#include <fmt/format.h>
 #include <torch/csrc/profiler/api.h>
 #include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/containers.h>
@@ -99,11 +100,11 @@ inline bool isExternalTracerState(ProfilerState state) {
 
 inline bool hasRequestedDeviceActivity(
     const std::set<torch::profiler::impl::ActivityType>& activities) {
-  return activities.count(ActivityType::CUDA) ||
-      activities.count(ActivityType::XPU) ||
-      activities.count(ActivityType::MTIA) ||
-      activities.count(ActivityType::HPU) ||
-      activities.count(ActivityType::PrivateUse1);
+  return activities.contains(ActivityType::CUDA) ||
+      activities.contains(ActivityType::XPU) ||
+      activities.contains(ActivityType::MTIA) ||
+      activities.contains(ActivityType::HPU) ||
+      activities.contains(ActivityType::PrivateUse1);
 }
 
 struct OpArgData {
@@ -119,7 +120,7 @@ auto parseArgData(
     const std::vector<op_input_t>& input_shapes,
     const std::vector<op_input_t>& concreteInputs) {
   if (input_shapes.empty()) {
-    return OpArgData{false, {}, {}, {}, {}, {}};
+    return OpArgData{.hasData = false};
   }
 
   std::vector<shape> shapes(input_shapes.size());
@@ -178,12 +179,12 @@ auto parseArgData(
   }
 
   return OpArgData{
-      true,
-      shapes,
-      dtypes,
-      concrete_inputs_list,
-      shapesForKinetoEvent,
-      strides};
+      .hasData = true,
+      .shapes = shapes,
+      .dtypes = dtypes,
+      .concreteInputs = concrete_inputs_list,
+      .shapesForKinetoEvent = shapesForKinetoEvent,
+      .strides = strides};
 }
 
 struct MetadataBase {
@@ -316,10 +317,8 @@ struct AddGenericMetadata : public MetadataBase {
       if (!isValidType && val.isList()) {
         // Check if it's a list of strings
         auto list = val.toListRef();
-        isStringList =
-            std::all_of(list.begin(), list.end(), [](const c10::IValue& item) {
-              return item.isString();
-            });
+        isStringList = std::ranges::all_of(
+            list, [](const c10::IValue& item) { return item.isString(); });
       }
 
       if (!isValidType && !isStringList) {
@@ -868,15 +867,15 @@ static void toggleCPUCollectionDynamic(bool enable) {
 void toggleCollectionDynamic(
     const bool enable,
     const std::set<torch::profiler::impl::ActivityType>& activities) {
-  if (activities.count(torch::autograd::profiler::ActivityType::CPU) > 0 &&
-      (activities.count(torch::autograd::profiler::ActivityType::CUDA) == 0 ||
-       activities.count(torch::autograd::profiler::ActivityType::XPU) == 0)) {
+  if (activities.contains(torch::autograd::profiler::ActivityType::CPU) &&
+      (!activities.contains(torch::autograd::profiler::ActivityType::CUDA) ||
+       !activities.contains(torch::autograd::profiler::ActivityType::XPU))) {
     LOG(WARNING)
         << "Toggling CPU activity with GPU activity on may result in traces with GPU events on arbitrary tracks";
   } else if (
-      (activities.count(torch::autograd::profiler::ActivityType::CUDA) > 0 ||
-       activities.count(torch::autograd::profiler::ActivityType::XPU) > 0) &&
-      activities.count(torch::autograd::profiler::ActivityType::CPU) == 0) {
+      (activities.contains(torch::autograd::profiler::ActivityType::CUDA) ||
+       activities.contains(torch::autograd::profiler::ActivityType::XPU)) &&
+      !activities.contains(torch::autograd::profiler::ActivityType::CPU)) {
     LOG(WARNING)
         << "Toggling GPU activity with CPU activity on may result in traces with incorrect correlation between CPU and GPU events";
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187281

profiler_kineto.cpp calls fmt::format (in AddTensorboardFields) but never
includes a fmt header itself. It only compiled because fmt was pulled in
transitively through the libkineto headers, which are gated behind the
USE_KINETO macro. When building with USE_KINETO=0 that include block is
skipped, the transitive fmt/format.h disappears, and the file fails to
compile. The fix adds an explicit #include <fmt/format.h>, matching sibling
profiler files such as collection.cpp and util.cpp. fmt is always a libtorch
build dependency (third_party/fmt), so this is correct regardless of the
USE_KINETO value and removes the fragile reliance on a transitive include.

Modifying the file caused lintrunner to run clang-tidy over it (it only lints
changed files), surfacing pre-existing warnings that are treated as errors.
These are cleaned up so lint passes: std::set::count() membership checks are
replaced with contains() (count() is 0 or 1 on a set, so the behavior is
unchanged) per readability-container-contains; the two OpArgData aggregate
initializers now use designated initializers per
modernize-use-designated-initializers; and std::all_of(begin, end, ...) is
replaced with std::ranges::all_of(range, ...) per modernize-use-ranges.

Test Plan:
Lint passes clean on the file:

```
lintrunner torch/csrc/autograd/profiler_kineto.cpp
```

Authored with Claude.