### PR TITLE
nn: add torch.nn.functional.rotary_embedding and torch.nn.RotaryEmbedding

### DIFF
--- a/docs/source/nn.functional.md
+++ b/docs/source/nn.functional.md
@@ -66,6 +66,7 @@ scaled_dot_product_attention.
     :nosignatures:
 
     scaled_dot_product_attention
+    rotary_embedding
 ```
 
 ## Non-linear activation functions

--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -312,6 +312,17 @@ Global Hooks For Module
     nn.EmbeddingBag
 ```
 
+## Positional Encoding
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    nn.RotaryEmbedding
+```
+
 ## Distance Functions
 
 ```{eval-rst}

--- a/test/nn/test_rope.py
+++ b/test/nn/test_rope.py
@@ -462,6 +462,10 @@ class TestRotaryEmbeddingModule(TestCase):
         x = torch.randn(1, 4, 128, 64, device=device)
         self.assertEqual(rope(x).device.type, torch.device(device).type)
 
+    def test_odd_dim_raises(self, device):
+        with self.assertRaisesRegex(ValueError, "dim must be even"):
+            nn.RotaryEmbedding(dim=63)
+
     def test_output_shape(self, device):
         rope = nn.RotaryEmbedding(dim=64, max_seq_len=128).to(device)
         for B, H, S in [(1, 1, 8), (2, 8, 32), (4, 16, 128)]:

--- a/test/nn/test_rope.py
+++ b/test/nn/test_rope.py
@@ -1,0 +1,485 @@
+# Owner(s): ["module: nn"]
+
+import numpy as np
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+# ---------------------------------------------------------------------------
+# Numpy reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _ref_rope_non_interleaved(x, cos, sin):
+    """Non-interleaved (half-half) RoPE in numpy."""
+    D = x.shape[-1]
+    x1, x2 = x[..., : D // 2], x[..., D // 2 :]
+    return np.concatenate([x1 * cos - x2 * sin, x1 * sin + x2 * cos], axis=-1)
+
+
+def _ref_rope_interleaved(x, cos, sin):
+    """Interleaved (adjacent-pair) RoPE in numpy."""
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    real = x1 * cos - x2 * sin
+    imag = x1 * sin + x2 * cos
+    out = np.stack([real, imag], axis=-1)
+    return out.reshape(x.shape)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cos_sin(S, half_D, dtype=torch.float32, device="cpu"):
+    """Return (cos, sin) caches of shape (S, half_D)."""
+    t = torch.arange(S, device=device, dtype=torch.float32)
+    theta = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, half_D * 2, 2, device=device, dtype=torch.float32)
+            / (half_D * 2)
+        )
+    )
+    freqs = torch.outer(t, theta)
+    return freqs.cos().to(dtype), freqs.sin().to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Functional tests (device-generic)
+# ---------------------------------------------------------------------------
+
+
+class TestRotaryEmbeddingFunctional(TestCase):
+    # -- 5a: correctness vs. numpy reference ----------------------------------
+
+    @dtypes(torch.float32)
+    def test_correctness_non_interleaved(self, device, dtype):
+        B, H, S, D = 2, 4, 8, 16
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+
+        out = F.rotary_embedding(x, cos, sin)
+
+        x_np = x.cpu().float().numpy()
+        cos_np = cos.cpu().float().numpy()
+        sin_np = sin.cpu().float().numpy()
+        expected = _ref_rope_non_interleaved(x_np, cos_np, sin_np)
+        self.assertEqual(out, torch.from_numpy(expected).to(device=device, dtype=dtype))
+
+    @dtypes(torch.float32)
+    def test_correctness_interleaved(self, device, dtype):
+        B, H, S, D = 2, 4, 8, 16
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+
+        out = F.rotary_embedding(x, cos, sin, interleaved=True)
+
+        x_np = x.cpu().float().numpy()
+        cos_np = cos.cpu().float().numpy()
+        sin_np = sin.cpu().float().numpy()
+        expected = _ref_rope_interleaved(x_np, cos_np, sin_np)
+        self.assertEqual(out, torch.from_numpy(expected).to(device=device, dtype=dtype))
+
+    @dtypes(torch.float32)
+    def test_correctness_with_position_ids(self, device, dtype):
+        B, H, S, D = 2, 4, 8, 16
+        cache_len = 32
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos_cache, sin_cache = _make_cos_sin(
+            cache_len, D // 2, dtype=dtype, device=device
+        )
+        position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+        out = F.rotary_embedding(x, cos_cache, sin_cache, position_ids)
+
+        # Reference: index into cache then apply non-interleaved rotation
+        cos_indexed = cos_cache[position_ids]  # (B, S, D//2)
+        sin_indexed = sin_cache[position_ids]
+        x_np = x.cpu().float().numpy()
+        cos_np = cos_indexed.cpu().float().numpy()[:, np.newaxis, :, :]  # add H dim
+        sin_np = sin_indexed.cpu().float().numpy()[:, np.newaxis, :, :]
+        expected = _ref_rope_non_interleaved(x_np, cos_np, sin_np)
+        self.assertEqual(out, torch.from_numpy(expected).to(device=device, dtype=dtype))
+
+    # -- new: mathematical equivalence of the two rotation modes ---------------
+
+    @dtypes(torch.float32)
+    def test_interleaved_noninterleaved_equivalence(self, device, dtype):
+        # Both modes apply identical rotations; they differ only in which
+        # element within each head is paired with which rotation angle.
+        # If we rearrange x so that adjacent-pair mode and half-half mode see
+        # the same pairs, their outputs must be identical up to the inverse
+        # rearrangement.
+        #
+        # For D=8, half-half pairs: (x0,x4),(x1,x5),(x2,x6),(x3,x7)
+        # Adjacent-pair mode pairs:  (x0,x1),(x2,x3),(x4,x5),(x6,x7)
+        #
+        # To make interleaved mode see the same pairs as half-half mode we
+        # interleave the two halves:
+        #   x_il[..., 0::2] = x_ni[..., :D//2]   (first of each half-half pair)
+        #   x_il[..., 1::2] = x_ni[..., D//2:]   (second of each half-half pair)
+        # Then the interleaved output, de-interleaved back to half-half order,
+        # must equal the non-interleaved output.
+        B, H, S, D = 2, 4, 8, 16
+        x_ni = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+
+        # Rearrange x_ni into adjacent-pair layout so interleaved mode pairs
+        # the same elements as non-interleaved mode does on x_ni.
+        x_il = torch.stack([x_ni[..., : D // 2], x_ni[..., D // 2 :]], dim=-1).flatten(
+            -2
+        )
+
+        out_ni = F.rotary_embedding(x_ni, cos, sin, interleaved=False)
+        out_il = F.rotary_embedding(x_il, cos, sin, interleaved=True)
+
+        # De-interleave the interleaved output back to half-half order.
+        out_il_as_ni = torch.cat([out_il[..., 0::2], out_il[..., 1::2]], dim=-1)
+
+        self.assertEqual(out_ni, out_il_as_ni)
+
+    # -- new: position_ids with arbitrary non-sequential positions --------------
+
+    @dtypes(torch.float32)
+    def test_position_ids_arbitrary_positions(self, device, dtype):
+        # position_ids need not be 0..S-1; verify that arbitrary indices
+        # select the correct rows of the cos/sin cache.
+        B, H, S, D = 2, 4, 6, 16
+        cache_len = 64
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos_cache, sin_cache = _make_cos_sin(
+            cache_len, D // 2, dtype=dtype, device=device
+        )
+
+        # Non-monotonic indices with different values per batch element.
+        position_ids = torch.tensor(
+            [[5, 0, 31, 7, 2, 15], [10, 3, 63, 1, 20, 9]], device=device
+        )  # (B, S)
+
+        out = F.rotary_embedding(x, cos_cache, sin_cache, position_ids)
+
+        # Reference: index manually then apply non-interleaved rotation.
+        cos_idx = cos_cache[position_ids].unsqueeze(1)  # (B, 1, S, D//2)
+        sin_idx = sin_cache[position_ids].unsqueeze(1)
+        x1, x2 = x.chunk(2, dim=-1)
+        expected = torch.cat(
+            [x1 * cos_idx - x2 * sin_idx, x1 * sin_idx + x2 * cos_idx], dim=-1
+        )
+        self.assertEqual(out, expected)
+
+    # -- new: sequential mode == position_ids with arange(S) -------------------
+
+    @dtypes(torch.float32)
+    def test_sequential_mode_equals_position_ids_arange(self, device, dtype):
+        # Passing cos_cache[:S] / sin_cache[:S] directly (sequential mode)
+        # must give bit-identical results to passing position_ids=arange(S).
+        B, H, S, D = 2, 4, 8, 32
+        cache_len = 64
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos_cache, sin_cache = _make_cos_sin(
+            cache_len, D // 2, dtype=dtype, device=device
+        )
+
+        out_sequential = F.rotary_embedding(x, cos_cache[:S], sin_cache[:S])
+
+        position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+        out_indexed = F.rotary_embedding(x, cos_cache, sin_cache, position_ids)
+
+        self.assertEqual(out_sequential, out_indexed)
+
+    # -- new: float16/bfloat16 numerical accuracy vs float32 reference ---------
+
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_dtype_numerical_accuracy(self, device, dtype):
+        # Reduced-precision outputs must be close to the float32 reference.
+        B, H, S, D = 2, 4, 8, 32
+        x_fp32 = torch.randn(B, H, S, D, device=device, dtype=torch.float32)
+        cos_fp32, sin_fp32 = _make_cos_sin(
+            S, D // 2, dtype=torch.float32, device=device
+        )
+        ref = F.rotary_embedding(x_fp32, cos_fp32, sin_fp32)
+
+        x_low = x_fp32.to(dtype)
+        cos_low, sin_low = cos_fp32.to(dtype), sin_fp32.to(dtype)
+        out_low = F.rotary_embedding(x_low, cos_low, sin_low)
+
+        # float16 is exact to ~3 decimal places; bfloat16 to ~2.
+        atol = 1e-2 if dtype == torch.float16 else 2e-2
+        rtol = 1e-2 if dtype == torch.float16 else 2e-2
+        self.assertEqual(out_low.float(), ref, atol=atol, rtol=rtol)
+
+    # -- 5b: shape preservation -----------------------------------------------
+
+    @parametrize("shape", [(1, 1, 8, 64), (2, 8, 16, 64), (4, 32, 128, 128)])
+    @dtypes(torch.float32)
+    def test_shape_preservation(self, device, dtype, shape):
+        B, H, S, D = shape
+        x = torch.randn(*shape, device=device, dtype=dtype)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+        out = F.rotary_embedding(x, cos, sin)
+        self.assertEqual(out.shape, x.shape)
+
+    # -- 5c: dtype coverage ---------------------------------------------------
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_dtype_coverage(self, device, dtype):
+        B, H, S, D = 2, 4, 8, 32
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+        out = F.rotary_embedding(x, cos, sin)
+        self.assertEqual(out.dtype, dtype)
+        self.assertEqual(out.shape, x.shape)
+
+    # -- 5d: gradient check ---------------------------------------------------
+
+    @dtypes(torch.float64)
+    def test_gradcheck_non_interleaved(self, device, dtype):
+        B, H, S, D = 1, 2, 4, 8
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+        cos = cos.requires_grad_(False)
+        sin = sin.requires_grad_(False)
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                lambda x_: F.rotary_embedding(x_, cos, sin),
+                (x,),
+            )
+        )
+
+    @dtypes(torch.float64)
+    def test_gradcheck_interleaved(self, device, dtype):
+        B, H, S, D = 1, 2, 4, 8
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)
+        cos, sin = _make_cos_sin(S, D // 2, dtype=dtype, device=device)
+        cos = cos.requires_grad_(False)
+        sin = sin.requires_grad_(False)
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                lambda x_: F.rotary_embedding(x_, cos, sin, interleaved=True),
+                (x,),
+            )
+        )
+
+    # -- 5e: torch.compile - no graph breaks ----------------------------------
+
+    def test_compile_no_graph_break_non_interleaved(self, device):
+        B, H, S, D = 2, 4, 8, 32
+        x = torch.randn(B, H, S, D, device=device)
+        cos, sin = _make_cos_sin(S, D // 2, device=device)
+
+        def f(x, cos, sin):
+            return F.rotary_embedding(x, cos, sin, interleaved=False)
+
+        explanation = torch._dynamo.explain(f)(x, cos, sin)
+        self.assertEqual(
+            explanation.graph_break_count,
+            0,
+            msg=f"Expected 0 graph breaks, got {explanation.graph_break_count}",
+        )
+
+    def test_compile_no_graph_break_interleaved(self, device):
+        B, H, S, D = 2, 4, 8, 32
+        x = torch.randn(B, H, S, D, device=device)
+        cos, sin = _make_cos_sin(S, D // 2, device=device)
+
+        def f(x, cos, sin):
+            return F.rotary_embedding(x, cos, sin, interleaved=True)
+
+        explanation = torch._dynamo.explain(f)(x, cos, sin)
+        self.assertEqual(
+            explanation.graph_break_count,
+            0,
+            msg=f"Expected 0 graph breaks, got {explanation.graph_break_count}",
+        )
+
+    def test_compile_correctness(self, device):
+        B, H, S, D = 2, 8, 16, 64
+        x = torch.randn(B, H, S, D, device=device)
+        cos, sin = _make_cos_sin(S, D // 2, device=device)
+
+        eager = F.rotary_embedding(x, cos, sin)
+        compiled = torch.compile(F.rotary_embedding)(x, cos, sin)
+        self.assertEqual(eager, compiled)
+
+    # -- 5f: torch.export - sequential mode (no position_ids) ----------------
+
+    def test_export_sequential_mode(self, device):
+        if device != "cpu":
+            self.skipTest("export test runs on CPU only")
+
+        B, H, S, D = 2, 4, 8, 32
+
+        class Model(nn.Module):
+            def forward(self, x, cos, sin):
+                return F.rotary_embedding(x, cos, sin)
+
+        model = Model()
+        x = torch.randn(B, H, S, D)
+        cos, sin = _make_cos_sin(S, D // 2)
+
+        B_dim = torch.export.Dim("B")
+        S_dim = torch.export.Dim("S", min=1, max=512)
+        ep = torch.export.export(
+            model,
+            (x, cos, sin),
+            dynamic_shapes={
+                "x": {0: B_dim, 2: S_dim},
+                "cos": {0: S_dim},
+                "sin": {0: S_dim},
+            },
+        )
+
+        # Verify at a different seq_len
+        S2 = 16
+        x2 = torch.randn(B, H, S2, D)
+        cos2, sin2 = _make_cos_sin(S2, D // 2)
+        out = ep.module()(x2, cos2, sin2)
+        self.assertEqual(out.shape, (B, H, S2, D))
+
+    # -- 5g: torch.export - position_ids mode ---------------------------------
+
+    def test_export_position_ids_mode(self, device):
+        if device != "cpu":
+            self.skipTest("export test runs on CPU only")
+
+        B, H, S, D = 2, 4, 8, 32
+        cache_len = 64
+
+        class Model(nn.Module):
+            def forward(self, x, cos, sin, position_ids):
+                return F.rotary_embedding(x, cos, sin, position_ids)
+
+        model = Model()
+        x = torch.randn(B, H, S, D)
+        cos_cache, sin_cache = _make_cos_sin(cache_len, D // 2)
+        position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+
+        B_dim = torch.export.Dim("B")
+        S_dim = torch.export.Dim("S", min=1, max=cache_len)
+        ep = torch.export.export(
+            model,
+            (x, cos_cache, sin_cache, position_ids),
+            dynamic_shapes={
+                "x": {0: B_dim, 2: S_dim},
+                "cos": None,
+                "sin": None,
+                "position_ids": {0: B_dim, 1: S_dim},
+            },
+        )
+
+        # Verify at a different seq_len
+        S2 = 16
+        x2 = torch.randn(B, H, S2, D)
+        pos2 = torch.arange(S2).unsqueeze(0).expand(B, -1)
+        out = ep.module()(x2, cos_cache, sin_cache, pos2)
+        self.assertEqual(out.shape, (B, H, S2, D))
+
+
+# ---------------------------------------------------------------------------
+# Module tests (device-generic)
+# ---------------------------------------------------------------------------
+
+
+class TestRotaryEmbeddingModule(TestCase):
+    # -- 5h: basic module correctness and device transfer ---------------------
+
+    @dtypes(torch.float32)
+    def test_module_matches_functional(self, device, dtype):
+        B, H, S, D = 2, 4, 16, 64
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        rope = nn.RotaryEmbedding(dim=D, max_seq_len=S).to(device=device, dtype=dtype)
+
+        # Sequential mode (no position_ids)
+        cos = rope.cos_cache[:S]
+        sin = rope.sin_cache[:S]
+        expected = F.rotary_embedding(x, cos, sin)
+        self.assertEqual(rope(x), expected)
+
+    @dtypes(torch.float32)
+    def test_module_position_ids_matches_functional(self, device, dtype):
+        B, H, S, D = 2, 4, 8, 32
+        cache_len = 64
+        x = torch.randn(B, H, S, D, device=device, dtype=dtype)
+        rope = nn.RotaryEmbedding(dim=D, max_seq_len=cache_len).to(
+            device=device, dtype=dtype
+        )
+        position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+        # Module passes the full cache + position_ids to the functional
+        out = rope(x, position_ids=position_ids)
+        expected = F.rotary_embedding(x, rope.cos_cache, rope.sin_cache, position_ids)
+        self.assertEqual(out, expected)
+
+    def test_module_buffers_move_to_device(self, device):
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=32).to(device)
+        self.assertEqual(rope.cos_cache.device.type, torch.device(device).type)
+        self.assertEqual(rope.sin_cache.device.type, torch.device(device).type)
+
+    def test_module_buffers_not_in_state_dict(self, device):
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=32)
+        self.assertNotIn("cos_cache", rope.state_dict())
+        self.assertNotIn("sin_cache", rope.state_dict())
+
+    # -- 5i: max_seq_len overflow and rebuild ---------------------------------
+
+    def test_overflow_raises(self, device):
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=128).to(device)
+        x_too_long = torch.randn(1, 8, 256, 64, device=device)
+        with self.assertRaisesRegex(RuntimeError, "exceeds max_seq_len"):
+            rope(x_too_long)
+
+    def test_rebuild_cache_then_forward_succeeds(self, device):
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=128).to(device)
+        x_long = torch.randn(1, 8, 256, 64, device=device)
+
+        rope.build_rope_cache(256)
+        out = rope(x_long)
+        self.assertEqual(out.shape, x_long.shape)
+        self.assertEqual(rope.max_seq_len, 256)
+        self.assertEqual(rope.cos_cache.shape[0], 256)
+
+    def test_rebuild_cache_preserves_device(self, device):
+        # build_rope_cache called after .to(device) must land the new buffers
+        # on the same device as the module, not silently fall back to CPU.
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=64).to(device)
+        self.assertEqual(rope.cos_cache.device.type, torch.device(device).type)
+
+        rope.build_rope_cache(128)
+
+        self.assertEqual(rope.cos_cache.device.type, torch.device(device).type)
+        self.assertEqual(rope.sin_cache.device.type, torch.device(device).type)
+        self.assertEqual(rope.cos_cache.shape[0], 128)
+        # Module must still produce output on the correct device.
+        x = torch.randn(1, 4, 128, 64, device=device)
+        self.assertEqual(rope(x).device.type, torch.device(device).type)
+
+    def test_output_shape(self, device):
+        rope = nn.RotaryEmbedding(dim=64, max_seq_len=128).to(device)
+        for B, H, S in [(1, 1, 8), (2, 8, 32), (4, 16, 128)]:
+            x = torch.randn(B, H, S, 64, device=device)
+            self.assertEqual(rope(x).shape, (B, H, S, 64))
+
+
+# ---------------------------------------------------------------------------
+# Register device-type tests
+# ---------------------------------------------------------------------------
+
+instantiate_device_type_tests(
+    TestRotaryEmbeddingFunctional, globals(), only_for=("cpu", "cuda")
+)
+instantiate_device_type_tests(
+    TestRotaryEmbeddingModule, globals(), only_for=("cpu", "cuda")
+)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6574,7 +6574,7 @@ def rotary_embedding(
             ``(N, D//2)`` where ``N >= max(position_ids) + 1``.  When
             ``position_ids`` is ``None`` this should be broadcastable against
             ``(B, H, S, D//2)``, e.g. shape ``(S, D//2)`` or
-            ``(B, S, D//2)`` or ``(B, 1, S, D//2)``.
+            ``(1, S, D//2)`` or ``(B, 1, S, D//2)``.
         sin (Tensor): Sine values for the rotation, same shape requirements
             as ``cos``.
         position_ids (Tensor, optional): 2-D integer tensor of shape
@@ -6584,15 +6584,15 @@ def rotary_embedding(
             indices (``x[..., 0::2]`` and ``x[..., 1::2]``), matching the
             GPT-NeoX / gpt-fast convention. If ``False`` (default), splits
             the head dimension in half (``x[..., :D//2]`` and
-            ``x[..., D//2:]``), matching the LLaMA / HuggingFace convention.
+            ``x[..., D//2:]``), matching the LLaMA convention.
 
     Returns:
         Tensor: Rotated tensor with the same shape as ``x``.
 
     Shape:
         - ``x``: :math:`(B, H, S, D)`
-        - ``cos``, ``sin``: :math:`(N, D/2)` when ``position_ids`` given,
-          otherwise broadcastable to :math:`(B, H, S, D/2)`
+        - ``cos``, ``sin``: :math:`(N, D//2)` when ``position_ids`` given,
+          otherwise broadcastable to :math:`(B, H, S, D//2)`
         - ``position_ids``: :math:`(B, S)`
         - Output: :math:`(B, H, S, D)`
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6513,6 +6513,140 @@ scaled_dot_product_attention = _add_docstr(
 )
 
 
+def rotary_embedding(
+    x: Tensor,
+    cos: Tensor,
+    sin: Tensor,
+    position_ids: Tensor | None = None,
+    *,
+    interleaved: bool = False,
+) -> Tensor:
+    r"""Apply Rotary Position Embedding (RoPE) to the input tensor.
+
+    RoPE encodes position information by rotating query and key vectors in
+    attention heads. The rotation is applied in the complex plane, where
+    pairs of features are treated as the real and imaginary components. Given
+    input pairs :math:`(x_1, x_2)` and precomputed values
+    :math:`(\cos\theta, \sin\theta)`, the rotation is:
+
+    .. math::
+        \begin{pmatrix} x_1' \\ x_2' \end{pmatrix}
+        =
+        \begin{pmatrix} \cos\theta & -\sin\theta \\ \sin\theta & \cos\theta \end{pmatrix}
+        \begin{pmatrix} x_1 \\ x_2 \end{pmatrix}
+
+    For a head of dimension :math:`D`, the embedding uses :math:`D/2`
+    rotation angles :math:`\theta_i = \text{base}^{-2i/D}` following the
+    original RoPE paper.
+
+    .. note::
+        The ``interleaved`` argument must be a Python ``bool`` literal
+        (``True`` or ``False``) for best ``torch.compile`` performance.
+        Passing a runtime variable causes recompilation on value change
+        but does not error.
+
+    .. note::
+        **HuggingFace cache format:** HuggingFace Transformers precomputes
+        ``cos``/``sin`` caches of shape ``(max_pos, D)`` (values repeated
+        twice across the last dimension). This function expects shape
+        ``(max_pos, D//2)``. To convert, slice:
+        ``cos_hf[..., : head_dim // 2]``.
+
+    .. note::
+        **torchtune layout:** torchtune uses layout ``(B, S, H, D)`` while
+        this function expects ``(B, H, S, D)`` to match
+        :func:`scaled_dot_product_attention`. Permute with
+        ``.transpose(1, 2)`` before and after calling this function.
+
+    .. note::
+        **Frequency scaling / long contexts:** Standard RoPE frequencies
+        (:math:`\theta_i = \text{base}^{-2i/D}`) are used here. For
+        long-context variants (YaRN, NTK, LLaMA3-style scaling) use
+        :class:`~torch.nn.RotaryEmbedding` and override its
+        ``build_rope_cache`` method.
+
+    Args:
+        x (Tensor): Input tensor of shape ``(B, H, S, D)`` where ``B`` is
+            batch size, ``H`` is number of heads, ``S`` is sequence length,
+            and ``D`` is head dimension. ``D`` must be even.
+        cos (Tensor): Cosine values for the rotation.  When ``position_ids``
+            is provided this should be a 2-D tensor of shape
+            ``(N, D//2)`` where ``N >= max(position_ids) + 1``.  When
+            ``position_ids`` is ``None`` this should be broadcastable against
+            ``(B, H, S, D//2)``, e.g. shape ``(S, D//2)`` or
+            ``(B, S, D//2)`` or ``(B, 1, S, D//2)``.
+        sin (Tensor): Sine values for the rotation, same shape requirements
+            as ``cos``.
+        position_ids (Tensor, optional): 2-D integer tensor of shape
+            ``(B, S)`` used to index into ``cos`` and ``sin``. When
+            ``None``, ``cos`` and ``sin`` are used as-is.
+        interleaved (bool): If ``True``, pairs features at even and odd
+            indices (``x[..., 0::2]`` and ``x[..., 1::2]``), matching the
+            GPT-NeoX / gpt-fast convention. If ``False`` (default), splits
+            the head dimension in half (``x[..., :D//2]`` and
+            ``x[..., D//2:]``), matching the LLaMA / HuggingFace convention.
+
+    Returns:
+        Tensor: Rotated tensor with the same shape as ``x``.
+
+    Shape:
+        - ``x``: :math:`(B, H, S, D)`
+        - ``cos``, ``sin``: :math:`(N, D/2)` when ``position_ids`` given,
+          otherwise broadcastable to :math:`(B, H, S, D/2)`
+        - ``position_ids``: :math:`(B, S)`
+        - Output: :math:`(B, H, S, D)`
+
+    Example::
+
+        >>> B, H, S, D = 2, 8, 16, 64
+        >>> x = torch.randn(B, H, S, D)
+        >>> # Sequential mode: cos/sin cover the sequence directly
+        >>> cos = torch.cos(torch.arange(S).unsqueeze(1) * 0.01).expand(S, D // 2)
+        >>> sin = torch.sin(torch.arange(S).unsqueeze(1) * 0.01).expand(S, D // 2)
+        >>> out = torch.nn.functional.rotary_embedding(x, cos, sin)
+        >>> out.shape
+        torch.Size([2, 8, 16, 64])
+
+        >>> # Indexed mode: position_ids select rows from a precomputed cache
+        >>> cache_len = 128
+        >>> cos_cache = torch.randn(cache_len, D // 2)
+        >>> sin_cache = torch.randn(cache_len, D // 2)
+        >>> position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+        >>> out = torch.nn.functional.rotary_embedding(x, cos_cache, sin_cache, position_ids)
+        >>> out.shape
+        torch.Size([2, 8, 16, 64])
+
+    .. _RoPE\: RoFormer\: Enhanced Transformer with Rotary Position Embedding:
+        https://arxiv.org/abs/2104.09864
+    """
+    if has_torch_function_variadic(x, cos, sin):
+        return handle_torch_function(
+            rotary_embedding,
+            (x, cos, sin),
+            x,
+            cos,
+            sin,
+            position_ids,
+            interleaved=interleaved,
+        )
+
+    if position_ids is not None:
+        # cos/sin: (N, D//2) -> index to (B, S, D//2) -> unsqueeze H dim
+        cos = cos[position_ids].unsqueeze(1)  # (B, 1, S, D//2)
+        sin = sin[position_ids].unsqueeze(1)  # (B, 1, S, D//2)
+    # else: cos/sin are passed ready to broadcast against (B, H, S, D//2)
+
+    if interleaved:
+        x1 = x[..., 0::2]
+        x2 = x[..., 1::2]
+        real = x1 * cos - x2 * sin
+        imag = x1 * sin + x2 * cos
+        return torch.stack([real, imag], dim=-1).flatten(-2)
+    else:
+        x1, x2 = x.chunk(2, dim=-1)
+        return torch.cat([x1 * cos - x2 * sin, x1 * sin + x2 * cos], dim=-1)
+
+
 def _mha_shape_check(
     query: Tensor,
     key: Tensor,

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -157,6 +157,7 @@ from .pooling import (
     MaxUnpool3d,
 )
 from .rnn import GRU, GRUCell, LSTM, LSTMCell, RNN, RNNBase, RNNCell, RNNCellBase
+from .rope import RotaryEmbedding
 from .sparse import Embedding, EmbeddingBag
 from .transformer import (
     Transformer,
@@ -301,6 +302,7 @@ __all__ = [
     "ReplicationPad1d",
     "ReplicationPad2d",
     "ReplicationPad3d",
+    "RotaryEmbedding",
     "SELU",
     "Sequential",
     "SiLU",

--- a/torch/nn/modules/rope.py
+++ b/torch/nn/modules/rope.py
@@ -1,0 +1,147 @@
+import torch
+from torch import Tensor
+from torch.nn import functional as F
+
+from .module import Module
+
+
+__all__ = ["RotaryEmbedding"]
+
+
+class RotaryEmbedding(Module):
+    r"""Apply Rotary Position Embedding (RoPE) to query/key tensors.
+
+    Computes and caches cosine/sine tables for standard RoPE frequencies
+    (:math:`\theta_i = \text{base}^{-2i/\text{dim}}`) and applies them
+    via :func:`~torch.nn.functional.rotary_embedding`.
+
+    The ``cos``/``sin`` tables are stored as non-persistent buffers so they
+    travel with the module across devices (``.to("cuda")``) but are not
+    included in ``state_dict`` (they can always be recomputed from
+    ``dim``, ``max_seq_len``, and ``base``).
+
+    **Extending for long-context variants:** Subclasses can override
+    :meth:`build_rope_cache` to apply custom frequency modifications (e.g.,
+    YaRN, NTK-aware, LLaMA3-style scaling) before the buffers are
+    registered::
+
+        class ScaledRotaryEmbedding(nn.RotaryEmbedding):
+            def build_rope_cache(self, max_seq_len: int) -> None:
+                self.max_seq_len = max_seq_len
+                theta = 1.0 / (
+                    self.base ** (torch.arange(0, self.dim, 2).float() / self.dim)
+                )
+                # apply custom scaling to theta here ...
+                t = torch.arange(max_seq_len)
+                freqs = torch.outer(t, theta)
+                self.register_buffer("cos_cache", freqs.cos(), persistent=False)
+                self.register_buffer("sin_cache", freqs.sin(), persistent=False)
+
+    Args:
+        dim (int): Head dimension (number of features per head). Must be even.
+        max_seq_len (int): Maximum sequence length for which to precompute
+            the cos/sin cache. Longer sequences require calling
+            :meth:`build_rope_cache` before the next :meth:`forward` call.
+        base (int): Base for the frequency computation. Default: ``10000``.
+
+    Shape:
+        - Input ``x``: :math:`(B, H, S, D)` where :math:`S \leq \text{max\_seq\_len}`
+        - Output: :math:`(B, H, S, D)`
+
+    Example::
+
+        >>> rope = nn.RotaryEmbedding(dim=64)
+        >>> x = torch.randn(2, 8, 16, 64)
+        >>> out = rope(x)
+        >>> out.shape
+        torch.Size([2, 8, 16, 64])
+
+        >>> # Indexed mode with position_ids
+        >>> position_ids = torch.arange(16).unsqueeze(0).expand(2, -1)
+        >>> out = rope(x, position_ids=position_ids)
+        >>> out.shape
+        torch.Size([2, 8, 16, 64])
+    """
+
+    cos_cache: Tensor
+    sin_cache: Tensor
+
+    def __init__(
+        self,
+        dim: int,
+        max_seq_len: int = 2048,
+        base: int = 10000,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.max_seq_len = max_seq_len
+        self.base = base
+        self.build_rope_cache(max_seq_len)
+
+    def build_rope_cache(self, max_seq_len: int) -> None:
+        """Compute and register ``cos_cache`` and ``sin_cache`` buffers.
+
+        Call this to extend the cache when the model needs to process
+        sequences longer than the current ``max_seq_len``::
+
+            rope = nn.RotaryEmbedding(dim=64, max_seq_len=512)
+            rope.build_rope_cache(1024)  # extend before long-context inference
+
+        Subclasses can override this method to apply custom frequency
+        scaling before registering the buffers.
+
+        Args:
+            max_seq_len (int): New maximum sequence length.
+        """
+        self.max_seq_len = max_seq_len
+        # Infer device from existing buffers so that a rebuild after .to(device)
+        # keeps the new cache on the same device rather than silently falling back to CPU.
+        device = (
+            self.cos_cache.device if hasattr(self, "cos_cache") else torch.device("cpu")
+        )
+        theta = 1.0 / (
+            self.base
+            ** (
+                torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                / self.dim
+            )
+        )
+        t = torch.arange(max_seq_len, dtype=torch.float32, device=device)
+        freqs = torch.outer(t, theta)  # (max_seq_len, dim//2)
+        self.register_buffer("cos_cache", freqs.cos(), persistent=False)
+        self.register_buffer("sin_cache", freqs.sin(), persistent=False)
+
+    def forward(
+        self,
+        x: Tensor,
+        position_ids: Tensor | None = None,
+    ) -> Tensor:
+        """Apply rotary embeddings to ``x``.
+
+        Args:
+            x (Tensor): Shape ``(B, H, S, D)``.
+            position_ids (Tensor, optional): Shape ``(B, S)``, integer indices
+                into the cos/sin cache. When ``None``, positions
+                ``0, 1, ..., S-1`` are used.
+
+        Returns:
+            Tensor: Same shape as ``x``.
+
+        Raises:
+            RuntimeError: If ``x.shape[2] > self.max_seq_len``. Call
+                :meth:`build_rope_cache` with a larger value first.
+        """
+        seq_len = x.shape[2]
+        if seq_len > self.max_seq_len:
+            raise RuntimeError(
+                f"Input sequence length {seq_len} exceeds max_seq_len "
+                f"{self.max_seq_len}. Call build_rope_cache({seq_len}) first."
+            )
+        if position_ids is None:
+            # Sequential positions 0..S-1; (S, dim//2) broadcasts over B and H.
+            cos = self.cos_cache[:seq_len]
+            sin = self.sin_cache[:seq_len]
+            return F.rotary_embedding(x, cos, sin)
+        else:
+            # Pass the full cache so the functional handles the indexing.
+            return F.rotary_embedding(x, self.cos_cache, self.sin_cache, position_ids)

--- a/torch/nn/modules/rope.py
+++ b/torch/nn/modules/rope.py
@@ -73,6 +73,8 @@ class RotaryEmbedding(Module):
         base: int = 10000,
     ) -> None:
         super().__init__()
+        if dim % 2 != 0:
+            raise ValueError(f"dim must be even, got {dim}")
         self.dim = dim
         self.max_seq_len = max_seq_len
         self.base = base
@@ -94,11 +96,11 @@ class RotaryEmbedding(Module):
             max_seq_len (int): New maximum sequence length.
         """
         self.max_seq_len = max_seq_len
-        # Infer device from existing buffers so that a rebuild after .to(device)
-        # keeps the new cache on the same device rather than silently falling back to CPU.
-        device = (
-            self.cos_cache.device if hasattr(self, "cos_cache") else torch.device("cpu")
-        )
+        # Query _buffers directly so we don't go through __getattr__ twice and
+        # so a None-valued buffer (register_buffer("cos_cache", None)) doesn't
+        # trick hasattr() into returning True and then blow up on .device.
+        existing = self._buffers.get("cos_cache")
+        device = existing.device if existing is not None else torch.device("cpu")
         theta = 1.0 / (
             self.base
             ** (


### PR DESCRIPTION
Fixes #149534

## Summary

Rotary Position Embedding (RoPE) is a foundational positional encoding technique widely used across modern large language models. Despite its importance, PyTorch lacked a canonical implementation in core, leading to divergent and incompatible ad-hoc versions across the ecosystem (torchtune, torchao, gpt_fast, torchchat, benchmark, xla). 

This PR resolves that gap by contributing the first official RoPE implementation to PyTorch core - auditing all existing variants for subtle correctness differences, unifying their conventions, and ensuring full compatibility with the complete PyTorch stack (eager, torch.compile, torch.export).

## What is added

**`torch.nn.functional.rotary_embedding(x, cos, sin, position_ids=None, *, interleaved=False)`**
- `x`: `(B, H, S, D)` - matches the layout of `scaled_dot_product_attention`
- `cos`/`sin`: shape `(N, D//2)` when `position_ids` provided; otherwise any shape broadcastable against `(B, H, S, D//2)` (e.g. `(S, D//2)`)
- `position_ids`: `(B, S)` int tensor that indexes into the cos/sin cache
- `interleaved=False` (default): half-half split - LLaMA / HuggingFace convention
- `interleaved=True`: adjacent-pair split - gpt-fast / torchtune convention

**`torch.nn.RotaryEmbedding(dim, max_seq_len=2048, base=10000)`**
- Precomputes cos/sin tables as non-persistent buffers (move with `.to(device)`, absent from `state_dict`)
- `build_rope_cache(max_seq_len)` is public and overridable by subclasses for custom frequency scaling (YaRN, NTK, LLaMA3-style)
- Raises `RuntimeError` with a clear message when `seq_len > max_seq_len`

## Implementation audit

Per the requirements from @mikaylagawarecki, all linked implementations were audited:

| Version | Distinct? | Layout | Interleaved | position\_ids | Complex | Notes |
|---------|-----------|--------|-------------|--------------|---------|-------|
| ONNX `torch/onnx/ops/_impl.py` | YES | 3D `(B,S,hidden)` or 4D `(B,H,S,D)` | Both via flag | Yes — 2D or 3D cache | No | Canonical reference; passes opcheck |
| gpt\_fast `benchmarks/gpt_fast/model.py` | YES | `(B,S,H,D)` | Yes — `reshape(-1,2)`, adjacent pairs | No — packed `freqs_cis` | No | Casts to float32 internally |
| torchtune base `torchtune/modules/position_embeddings.py` | YES | `(B,S,H,D)` | Yes — `reshape(-1,2)`, adjacent pairs | Yes via `input_pos` | No | nn.Module; builds its own cache |
| Llama3ScaledRoPE `torchtune/models/llama3_1/_position_embeddings.py` | YES | `(B,S,H,D)` | Yes | Yes | No | Adds YaRN-style frequency scaling |
| HuggingFace LLaMA | YES | `(B,H,S,D)` | No — `rotate_half`: `cat([-x2, x1])` | Yes — full-dim cache `(max_pos, D)` | No | See equivalence note below |
| Unsloth PR #238 | YES | `(B,H,S,D)` | Same as HF `rotate_half` | Yes | No | Triton kernel; excluded from scope |
| simple\_gpt / torchao / torchchat / mixtral\_moe | NO | Same as gpt\_fast | Same | Same | Same | Literal copies of gpt\_fast |

### Mathematical equivalence note

HuggingFace `rotate_half` is **mathematically equivalent** to the standard non-interleaved approach but uses a **different cos/sin cache format**:

- This API: `cos`/`sin` shape `(max_pos, D//2)` - stores half the angles
- HuggingFace: `cos`/`sin` shape `(max_pos, D)` - values repeated twice across last dim

The math works out identically (`rotate_half([x1,x2]) = [-x2,x1]` expands to the same rotation). The **incompatibility is in the cache format only**. Users migrating from HuggingFace must slice: `cos_hf[..., :D//2]`. This is documented in the docstring.

### Why no complex numbers

`view_as_complex` / `view_as_real` paths were considered and rejected due to known Inductor issues (pytorch/torchtitan#15). The pure real-number implementation compiles cleanly.

### Input layout choice: `(B, H, S, D)`

Chosen to match `scaled_dot_product_attention`. Users coming from torchtune (which uses `(B, S, H, D)`) must call `.transpose(1, 2)` on q/k before and after. This is documented in the docstring.

### torch.compile / `interleaved` flag

The `interleaved` bool drives a Python branch. When passed as a **literal** (`interleaved=True` / `interleaved=False`), torch.compile treats it as a compile-time constant → zero graph breaks. Passing a runtime variable causes recompilation on value change but does not error. Documented in the docstring.

### Frequency scaling

Standard frequencies (`theta_i = base^(-2i/dim)`) are in scope. YaRN, NTK, LLaMA3-style scaling are **out of scope** but supported via subclassing `RotaryEmbedding` and overriding `build_rope_cache`.

### XLA

Uses only standard ATen ops (chunk, mul, sub, add, cat, stack, unsqueeze) - all XLA-supported. Explicit XLA tests are a follow-up.

## Test plan

29 tests covering:
- Correctness vs. numpy reference (non-interleaved, interleaved, position\_ids mode)
- Mathematical equivalence between interleaved and non-interleaved paths
- position\_ids with arbitrary non-sequential positions
- Sequential mode identical to position\_ids=arange(S)
- Numerical accuracy of float16/bfloat16 vs float32
- Shape preservation across multiple input shapes
- dtype coverage: float32, float16, bfloat16
- Gradient check (`gradcheck`) for both interleaved modes
- `torch.compile` - zero graph breaks for both `interleaved=True` and `interleaved=False`
- `torch.export` - dynamic batch + seq dims, both sequential and position\_ids modes
- Module tests: correctness, device transfer, non-persistent buffers, `state_dict`
- `max_seq_len` overflow error + `build_rope_cache` rebuild + rebuild preserves device

```bash
python test/nn/test_rope.py   # 29 tests, all pass
```