### PR TITLE
Revert XPU device-wide synchronization

### DIFF
--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -1,4 +1,3 @@
-#include <c10/core/impl/GPUTrace.h>
 #include <c10/util/Exception.h>
 #include <c10/xpu/XPUFunctions.h>
 
@@ -280,29 +279,6 @@ c10::DeviceIndex exchange_device(c10::DeviceIndex to_device) {
 
 c10::DeviceIndex maybe_exchange_device(c10::DeviceIndex to_device) {
   return exchange_device(to_device);
-}
-
-// TODO: Currently only used by syncStreamsOnDevice. Once a driver supporting
-// `ext_oneapi_device_wait` is widely deployed across all supported platforms,
-// deprecate syncStreamsOnDevice and route callers to device_synchronize.
-void device_synchronize(c10::DeviceIndex device) {
-#if SYCL_COMPILER_VERSION >= 20260000
-  initDevicePoolCallOnce();
-  if (device == -1) {
-    device = c10::xpu::current_device();
-  }
-  check_device_index(device);
-  get_raw_device(device).ext_oneapi_wait_and_throw();
-  const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
-  if (C10_UNLIKELY(interp)) {
-    (*interp)->trace_gpu_device_synchronization(c10::kXPU);
-  }
-#else
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      false,
-      "device_synchronize is not supported for the current SYCL compiler version. ",
-      "Please upgrade to SYCL compiler version 2026.0 or newer.");
-#endif
 }
 
 } // namespace c10::xpu

--- a/c10/xpu/XPUFunctions.h
+++ b/c10/xpu/XPUFunctions.h
@@ -26,8 +26,6 @@ C10_XPU_API sycl::device& get_raw_device(DeviceIndex device);
 
 C10_XPU_API sycl::context& get_device_context();
 
-C10_XPU_API void device_synchronize(c10::DeviceIndex device = -1);
-
 C10_XPU_API void get_device_properties(
     DeviceProp* device_prop,
     DeviceIndex device);

--- a/c10/xpu/XPUStream.cpp
+++ b/c10/xpu/XPUStream.cpp
@@ -362,18 +362,17 @@ std::ostream& operator<<(std::ostream& stream, const XPUStream& s) {
  * Note [Synchronize Streams on Device]
  *
  * syncStreamsOnDevice waits for all work previously submitted to the SYCL
- * queues we manage on `device`. Two paths exist:
+ * queues we manage on `device`. It walks every reserved queue in each priority
+ * pool and calls `wait()` on it; only queues we own are drained, SYCL queues
+ * created outside our pools are unaffected.
  *
- *  1. Fast path (SYCL >= 2026.0 and device exposes `ext_oneapi_device_wait`):
- *     delegate to `device_synchronize`, which issues a single
- *     `ext_oneapi_wait_and_throw()` -- a true device-wide wait.
- *  2. Legacy path (otherwise): walk every reserved queue in each priority
- *     pool and `wait()` on it. This only drains queues we own; SYCL queues
- *     outside our pools are unaffected.
+ * A true device-wide wait via `ext_oneapi_wait_and_throw()` (available with
+ * SYCL >= 2026.0 on devices exposing `ext_oneapi_device_wait`) would be more
+ * efficient, but it does not currently interoperate with XPUGraph. We will
+ * switch to that path once the XPUGraph interaction is resolved.
  */
 
-// Note: The stream pools are lazily initialized on the legacy path; the fast
-// path bypasses our pools entirely.
+// Note: The stream pools are lazily initialized on first call.
 void syncStreamsOnDevice(DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
@@ -396,18 +395,7 @@ void syncStreamsOnDevice(DeviceIndex device) {
     }
   };
 
-#if SYCL_COMPILER_VERSION < 20260000
   legacy_sync();
-#else
-  // TODO: drop the legacy fallback once a driver supporting
-  // `ext_oneapi_device_wait` is widely deployed across all supported platforms.
-  if (c10::xpu::get_raw_device(device).has(
-          sycl::aspect::ext_oneapi_device_wait)) {
-    c10::xpu::device_synchronize(device);
-  } else {
-    legacy_sync();
-  }
-#endif
 }
 
 } // namespace c10::xpu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #187314
* __->__ #187306
* #187232
* #187137

# Motivation
This PR reverts https://github.com/pytorch/pytorch/pull/182630 to fix https://github.com/pytorch/pytorch/issues/187277

Root cause is `ext_oneapi_wait_and_throw` will introduce SYCL Graph to sync an invalid queue.

# Additional Context

This needs to be cherry-picked to the release branch.

Why isn't it captured on CI?
This issue is only found on BMG (Xe2), and the current CI is on Data Center GPU (Xe). We will enable a BMG-specific CI soon.