### PR TITLE
[MPS] Faster reductions on non-contiguous inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -10,7 +10,6 @@
 #include <c10/util/irange.h>
 #include <algorithm>
 #include <numeric>
-#include <vector>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -840,7 +839,7 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
   TORCH_INTERNAL_ASSERT(input_orig.numel() > 0 && output.numel() > 0);
   TORCH_INTERNAL_ASSERT(output.dim() == input_orig.dim());
   if (!input_orig.is_contiguous()) {
-    std::vector<int64_t> perm(input_orig.dim());
+    c10::DimVector perm(input_orig.dim());
     std::iota(perm.begin(), perm.end(), 0);
     std::stable_sort(
         perm.begin(), perm.end(), [&](int64_t a, int64_t b) { return input_orig.stride(a) > input_orig.stride(b); });

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -8,6 +8,9 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/ReduceOps.h>
 #include <c10/util/irange.h>
+#include <algorithm>
+#include <numeric>
+#include <vector>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -832,10 +835,21 @@ struct ReductionDispatch {
 };
 
 static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch& opts) {
-  const Tensor& output = iter.output(0);
-  const Tensor& input_orig = iter.input(0);
+  Tensor output = iter.output(0);
+  Tensor input_orig = iter.input(0);
   TORCH_INTERNAL_ASSERT(input_orig.numel() > 0 && output.numel() > 0);
   TORCH_INTERNAL_ASSERT(output.dim() == input_orig.dim());
+  if (!input_orig.is_contiguous()) {
+    std::vector<int64_t> perm(input_orig.dim());
+    std::iota(perm.begin(), perm.end(), 0);
+    std::stable_sort(
+        perm.begin(), perm.end(), [&](int64_t a, int64_t b) { return input_orig.stride(a) > input_orig.stride(b); });
+    auto permuted = input_orig.permute(perm);
+    if (permuted.is_contiguous()) {
+      input_orig = permuted;
+      output = output.permute(perm);
+    }
+  }
 
   const uint32_t reduction_size = input_orig.numel() / output.numel();
   constexpr uint32_t NCHAINS = SUM_NCHAINS;

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -841,11 +841,10 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
   if (!input_orig.is_contiguous()) {
     c10::DimVector perm(input_orig.dim());
     std::iota(perm.begin(), perm.end(), 0);
-    std::stable_sort(
-        perm.begin(), perm.end(), [&](int64_t a, int64_t b) { return input_orig.stride(a) > input_orig.stride(b); });
+     std::ranges::stable_sort(perm, std::greater{}, [&](int64_t d) { return input_orig.stride(d); });
     auto permuted = input_orig.permute(perm);
     if (permuted.is_contiguous()) {
-      input_orig = permuted;
+      input_orig = std::move(permuted);
       output = output.permute(perm);
     }
   }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -841,7 +841,7 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
   if (!input_orig.is_contiguous()) {
     c10::DimVector perm(input_orig.dim());
     std::iota(perm.begin(), perm.end(), 0);
-     std::ranges::stable_sort(perm, std::greater{}, [&](int64_t d) { return input_orig.stride(d); });
+    std::ranges::stable_sort(perm, std::greater{}, [&](int64_t d) { return input_orig.stride(d); });
     auto permuted = input_orig.permute(perm);
     if (permuted.is_contiguous()) {
       input_orig = std::move(permuted);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5361,6 +5361,13 @@ class TestMPS(TestCaseMPS):
             for _ in range(4):
                 self.assertEqual(x.sum().item(), ref, msg=f"unstable sum for N={N}")
 
+    def test_sum_reduction_non_contiguous(self):
+        x = torch.randn(64, 96, dtype=torch.bfloat16, device="mps")
+        for dim, keepdim in itertools.product((0, -1), [False, True]):
+            kw = {"dim": dim, "keepdim": keepdim}
+            for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
+                self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
+
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497
         torch.manual_seed(42)


### PR DESCRIPTION
`sum/mean/amax/amin/count_nonzero/nansum/all/any` copied or slow-pathed transposed inputs. 
Relabel a permuted-contiguous input's dims (and the output) so the fast contiguous kernels fire.
Shape (4096, 4096), dtype bf16 (didn't test other shapes since there is no way this will regress the non contiguous shapes)

| op | trans |
|---|---|
| `sum` | 9.0x |
| `mean` | 9.0x |
| `amax` | 8.6x |
| `amin` | 8.6x |
| `count_nonzero` | 9.1x |
| `nansum` | 8.0x |
| `all` | 14.2x |
| `any` | 14.3x |
| `aminmax` | 8.0x |
| `logsumexp` | 2.0x |