### PR TITLE
Skip TestMultiprocessingDeviceType on XPU due to lack of IPC support

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -557,7 +557,7 @@ class TestMultiprocessingDeviceType(_MultiprocessingTestMixin, TestCase):
         self.assertTrue(t.is_shared())
 
 
-instantiate_device_type_tests(TestMultiprocessingDeviceType, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestMultiprocessingDeviceType, globals())
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187314
* #187306
* #187232
* #187137

# Motivation
When https://github.com/pytorch/pytorch/pull/184737 generalize `test_multiprocess.py`, it helps enable `TestMultiprocessingDeviceType` test on XPU. However, XPU doesn't support this test suite because lack of IPC support currently. So we would like to skip this test case and restore XPU CI to green.

Fixes https://github.com/pytorch/pytorch/issues/186585

Code originates from https://github.com/pytorch/pytorch/pull/186793
Co-authored-by: @xuhancn 