### PR TITLE
[xpu][3/3] inductor: route MX scaled_mm_v2 fallback through v2 aten kernel

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -2634,7 +2634,6 @@ class TestFP8Matmul(TestCase):
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
-    @skipXPU
     def test_blockwise_mxfp8_compile(self, device) -> None:
 
         M, K, N = 128, 128, 128
@@ -2664,7 +2663,6 @@ class TestFP8Matmul(TestCase):
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
-    @skipXPU
     def test_blockwise_nvfp4_compile(self, device) -> None:
 
         M, K, N = 128, 128, 128

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -165,6 +165,19 @@ aten__fp8_mm = ExternKernelChoice(
     torch._scaled_mm, "at::_scaled_mm_out", op_overload=aten._scaled_mm.out
 )
 
+# Fallback choice for the _scaled_mm_v2 API. Used for recipes that have no Triton
+# template yet (e.g. the MX variants BlockWise1x32/BlockWise1x16). Routed through
+# ir.FallbackKernel so the v2 op is called directly with its native scale
+# convention, instead of being lowered to the v1 _scaled_mm kernel which uses a
+# different scale_b orientation.
+aten__scaled_mm_v2 = ExternKernelChoice(
+    aten._scaled_mm_v2.default,
+    name="_scaled_mm_v2",
+    has_out_variant=False,
+    op_overload=aten._scaled_mm_v2.default,
+    use_fallback_kernel=True,
+)
+
 
 def _is_int8_mat(mat):
     return mat.get_dtype() in (torch.int8, torch.uint8)
@@ -1032,7 +1045,16 @@ def tuned_scaled_mm_v2(
         recipe_b
     )
 
-    # Only handle single-level scales (no MX/NV)
+    # MX variants (BlockWise1x32/BlockWise1x16) and multi-level scales have no
+    # Triton template; they fall back to an aten kernel. The v1 _scaled_mm kernel
+    # uses a different scale_b orientation than v2, so route these through the
+    # _scaled_mm_v2 fallback below instead of the v1 aten__fp8_mm choice.
+    is_mx_fallback = (
+        scale_a[0].dtype != torch.float32
+        or (not supported_recipe)
+        or (not is_single_level_scale)
+    )
+
     scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
 
     input_nodes: list[Any]
@@ -1055,10 +1077,29 @@ def tuned_scaled_mm_v2(
     kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
-        templates_to_use.append(aten__fp8_mm)
-        kwarg_overrides[aten__fp8_mm.uid] = dict(
-            out_dtype=out_dtype, use_fast_accum=use_fast_accum
-        )
+        if is_mx_fallback:
+            # Call _scaled_mm_v2 directly so the scales keep their v2 convention.
+            bias_node = realize_inputs(bias) if bias else None
+            aten__scaled_mm_v2.maybe_append_choice(
+                choices,
+                input_nodes=[mat_a, mat_b],
+                layout=layout,
+                scale_a=[realize_inputs(s) for s in scale_a],
+                recipe_a=list(recipe_a),
+                swizzle_a=list(swizzle_a),
+                scale_b=[realize_inputs(s) for s in scale_b],
+                recipe_b=list(recipe_b),
+                swizzle_b=list(swizzle_b),
+                bias=bias_node,
+                out_dtype=out_dtype,
+                contraction_dim=list(contraction_dim) if contraction_dim else [],
+                use_fast_accum=use_fast_accum,
+            )
+        else:
+            templates_to_use.append(aten__fp8_mm)
+            kwarg_overrides[aten__fp8_mm.uid] = dict(
+                out_dtype=out_dtype, use_fast_accum=use_fast_accum
+            )
 
     _, is_nonzero = _is_static_problem(layout)
 
@@ -1150,11 +1191,7 @@ def tuned_scaled_mm_v2(
         )
 
     # Early return for MX variants
-    if (
-        scale_a[0].dtype != torch.float32
-        or (not supported_recipe)
-        or (not is_single_level_scale)
-    ):
+    if is_mx_fallback:
         node, _ = autotune_select_algorithm(name, choices, input_nodes, layout)
         return node
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -979,6 +979,7 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+
     # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
     # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,
     # RowWise, and DeepSeek BlockWise1x128/128x128). Everything else has no

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -165,19 +165,6 @@ aten__fp8_mm = ExternKernelChoice(
     torch._scaled_mm, "at::_scaled_mm_out", op_overload=aten._scaled_mm.out
 )
 
-# Fallback choice for the _scaled_mm_v2 API. Used for recipes that have no Triton
-# template yet (e.g. the MX variants BlockWise1x32/BlockWise1x16). Routed through
-# ir.FallbackKernel so the v2 op is called directly with its native scale
-# convention, instead of being lowered to the v1 _scaled_mm kernel which uses a
-# different scale_b orientation.
-aten__scaled_mm_v2 = ExternKernelChoice(
-    aten._scaled_mm_v2.default,
-    name="_scaled_mm_v2",
-    has_out_variant=False,
-    op_overload=aten._scaled_mm_v2.default,
-    use_fallback_kernel=True,
-)
-
 
 def _is_int8_mat(mat):
     return mat.get_dtype() in (torch.int8, torch.uint8)
@@ -992,11 +979,32 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
-    # Swizzling is not yet wired into any Inductor template or extern choice
-    # here. Rather than failing compilation, defer swizzled scale layouts
-    # (e.g. blockwise MXFP8/NVFP4 on Blackwell) to the eager op so they still
-    # produce correct results.
-    if any(s != 0 for s in swizzle_a) or any(s != 0 for s in swizzle_b):
+    # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
+    # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,
+    # RowWise, and DeepSeek BlockWise1x128/128x128). Everything else has no
+    # template or extern choice here, so defer to the eager _scaled_mm_v2 op:
+    #   - swizzled scale layouts (e.g. CUDA/Blackwell MXFP8/NVFP4)
+    #   - the blockwise MX/NVFP4 recipes BlockWise1x32/1x16 (also how XPU
+    #     expresses MX/NVFP4, with NO_SWIZZLE)
+    #   - multi-level scales (two-level NVFP4)
+    #   - any non-fp32 block scale
+    # The eager op is called directly so it keeps its native v2 scale_b
+    # convention, unlike the v1 aten__fp8_mm choice used on the supported path.
+    def check_supported_recipe(recipe: list[int]) -> bool:
+        disallowed = OrderedSet([ScalingType.BlockWise1x16, ScalingType.BlockWise1x32])
+        return all(ScalingType(r) not in disallowed for r in recipe)
+
+    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
+    supported_recipe = check_supported_recipe(recipe_a) and check_supported_recipe(
+        recipe_b
+    )
+    if (
+        any(s != 0 for s in swizzle_a)
+        or any(s != 0 for s in swizzle_b)
+        or not supported_recipe
+        or not is_single_level_scale
+        or scale_a[0].dtype != torch.float32
+    ):
         # contraction_dim is a non-optional int[] in the schema (default []);
         # this lowering defaults it to None, so coerce before the eager call.
         fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
@@ -1032,29 +1040,6 @@ def tuned_scaled_mm_v2(
     name = "scaled_mm"
     check_supported_striding(mat_a, mat_b)
 
-    if not (len(scale_a) >= 1 and len(scale_b) >= 1):
-        raise AssertionError("scale_a and scale_b must each have at least one entry")
-
-    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
-
-    def check_supported_recipe(recipe: list[int]) -> bool:
-        disallowed = OrderedSet([ScalingType.BlockWise1x16, ScalingType.BlockWise1x32])
-        return all(ScalingType(r) not in disallowed for r in recipe)
-
-    supported_recipe = check_supported_recipe(recipe_a) and check_supported_recipe(
-        recipe_b
-    )
-
-    # MX variants (BlockWise1x32/BlockWise1x16) and multi-level scales have no
-    # Triton template; they fall back to an aten kernel. The v1 _scaled_mm kernel
-    # uses a different scale_b orientation than v2, so route these through the
-    # _scaled_mm_v2 fallback below instead of the v1 aten__fp8_mm choice.
-    is_mx_fallback = (
-        scale_a[0].dtype != torch.float32
-        or (not supported_recipe)
-        or (not is_single_level_scale)
-    )
-
     scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
 
     input_nodes: list[Any]
@@ -1077,29 +1062,10 @@ def tuned_scaled_mm_v2(
     kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
-        if is_mx_fallback:
-            # Call _scaled_mm_v2 directly so the scales keep their v2 convention.
-            bias_node = realize_inputs(bias) if bias else None
-            aten__scaled_mm_v2.maybe_append_choice(
-                choices,
-                input_nodes=[mat_a, mat_b],
-                layout=layout,
-                scale_a=[realize_inputs(s) for s in scale_a],
-                recipe_a=list(recipe_a),
-                swizzle_a=list(swizzle_a),
-                scale_b=[realize_inputs(s) for s in scale_b],
-                recipe_b=list(recipe_b),
-                swizzle_b=list(swizzle_b),
-                bias=bias_node,
-                out_dtype=out_dtype,
-                contraction_dim=list(contraction_dim) if contraction_dim else [],
-                use_fast_accum=use_fast_accum,
-            )
-        else:
-            templates_to_use.append(aten__fp8_mm)
-            kwarg_overrides[aten__fp8_mm.uid] = dict(
-                out_dtype=out_dtype, use_fast_accum=use_fast_accum
-            )
+        templates_to_use.append(aten__fp8_mm)
+        kwarg_overrides[aten__fp8_mm.uid] = dict(
+            out_dtype=out_dtype, use_fast_accum=use_fast_accum
+        )
 
     _, is_nonzero = _is_static_problem(layout)
 
@@ -1189,11 +1155,6 @@ def tuned_scaled_mm_v2(
             input_nodes,
             kernel_inputs=kernel_inputs,
         )
-
-    # Early return for MX variants
-    if is_mx_fallback:
-        node, _ = autotune_select_algorithm(name, choices, input_nodes, layout)
-        return node
 
     if (
         is_nonzero


### PR DESCRIPTION
The Inductor lowering for  _scaled_mm_v2  ( tuned_scaled_mm_v2 ) has no Triton/extern template for the MX/NVFP4 recipes ( BlockWise1x32 / BlockWise1x16 ), multi-level (two-level NVFP4) scales, or any non-fp32 block scale. For these, it previously fell back to the v1  aten__fp8_mm  choice, which expects a different  scale_b  orientation than v2 — so the scales were misinterpreted and results were wrong.

This surfaced on XPU, which expresses MX/NVFP4 with  NO_SWIZZLE . The existing swizzle-based fallback from #186384 only diverts swizzled layouts (CUDA/Blackwell MXFP8/NVFP4) to the eager  _scaled_mm_v2  op, so the non-swizzled XPU recipes slipped through to the incorrect v1 path.

Fold the recipe / multi-level / scale-dtype conditions into the existing early-return  scaled_mm_v2_fallback  (the  fallback_handler  for  aten._scaled_mm_v2 ). Every layout with no Inductor template now defers to the eager v2 op through one unified path.

This is backend-agnostic, not XPU-specific.

### PR Stack:
Since I don't have ghstack permission, I manually created the following stacked PRs for review. 

#181726 [xpu][1/3]Implement scaled_mm_v2 for MXFP8/MXFP4/NVFP4 on XPU
#181727 [xpu][2/3]Implement scaled_mm_v1 for MXFP8/MXFP4/NVFP4 on XPU
#187315 [xpu][3/3] inductor: route MX scaled_mm_v2 fallback through v2 aten kernel


Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo