### PR TITLE
Support save_on_cpu offloading under first-order torch.func transforms

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import copy
 import math
 import os
@@ -3829,52 +3830,121 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "must override the setup_context"):
             transform(MySin.apply)(x)
 
-    # Some of these pass, some of these don't
     @parametrize(
         "transform",
         [
             "grad",
             "jacrev",
             "grad_and_value",
-            "hessian",
+            "vjp",
         ],
     )
-    def test_transforms_dont_support_saved_tensor_hooks(self, device, transform):
+    def test_first_order_transforms_support_saved_tensor_hooks(self, device, transform):
+        # A single first-order reverse-mode transform supports saved-tensor
+        # hooks (e.g. save_on_cpu). Results must match the same transform with
+        # no offloading, whether the hook is set inside the function or as an
+        # enclosing context.
         def f(x):
-            return torch.sin(x).sum()
+            return (torch.sin(x) * x).sum()
 
-        def g(x):
+        def f_offload(x):
             with torch.autograd.graph.save_on_cpu():
-                return f(x)
+                return (torch.sin(x) * x).sum()
 
         x = torch.randn(3, device=device)
 
-        if transform == "functionalize":
-            transform = functorch.experimental.functionalize
-        else:
-            transform = getattr(functorch, transform)
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            with torch.autograd.graph.save_on_cpu():
-                transform(f)(x)
+        def apply(fn):
+            if transform == "vjp":
+                value, vjp_fn = vjp(fn, x)
+                return value, vjp_fn(torch.ones((), device=device))[0]
+            return getattr(functorch, transform)(fn)(x)
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            transform(g)(x)
+        expected = apply(f)
+        self.assertEqual(apply(f_offload), expected)
+        with torch.autograd.graph.save_on_cpu():
+            self.assertEqual(apply(f), expected)
 
-    def test_vjp_doesnt_support_saved_tensor_hooks(self, device):
+    def test_higher_order_transforms_dont_support_saved_tensor_hooks(self, device):
+        # Nested / higher-order differentiation over a saved-tensor-hooks region
+        # must raise rather than silently miscompute: the offload device
+        # round-trip severs the higher-order autograd graph.
         def f(x):
-            return torch.sin(x).sum()
+            with torch.autograd.graph.save_on_cpu():
+                return (torch.sin(x) * x).sum()
 
         def g(x):
+            return (torch.sin(x) * x).sum()
+
+        def enclosed(thunk):
             with torch.autograd.graph.save_on_cpu():
-                return f(x)
+                return thunk()
 
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            with torch.autograd.graph.save_on_cpu():
-                vjp(f, x)
+        t = torch.randn(3, device=device)
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            vjp(g, x)
+        # The hooks region may be inside the differentiated function or an
+        # enclosing context around the higher-order call; both must raise.
+        higher_order = [
+            lambda: grad(lambda z: grad(f)(z).sum())(x),
+            lambda: jacrev(jacrev(f))(x),
+            lambda: hessian(f)(x),
+            lambda: jvp(grad(f), (x,), (t,)),
+            lambda: enclosed(lambda: grad(lambda z: grad(g)(z).sum())(x)),
+            lambda: enclosed(lambda: hessian(g)(x)),
+        ]
+        for call in higher_order:
+            with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
+                call()
+
+    @parametrize(
+        "pin_memory",
+        [subtest(False, name="nopin"), subtest(True, name="pin")],
+    )
+    def test_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
+        if pin_memory and self.device_type != "cuda":
+            self.skipTest("pin_memory offloading requires CUDA")
+
+        def f(x, offload):
+            ctx = (
+                torch.autograd.graph.save_on_cpu(pin_memory=pin_memory)
+                if offload
+                else contextlib.nullcontext()
+            )
+            with ctx:
+                y = (x * x).sin()
+                z = (y * y).cos()
+            return (z * x).sum()
+
+        x = torch.randn(16, device=device, dtype=torch.double)
+        self.assertEqual(
+            grad(partial(f, offload=True))(x),
+            grad(partial(f, offload=False))(x),
+        )
+
+    @parametrize(
+        "pin_memory",
+        [subtest(False, name="nopin"), subtest(True, name="pin")],
+    )
+    def test_vmap_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
+        if pin_memory and self.device_type != "cuda":
+            self.skipTest("pin_memory offloading requires CUDA")
+
+        def f(x, offload):
+            ctx = (
+                torch.autograd.graph.save_on_cpu(pin_memory=pin_memory)
+                if offload
+                else contextlib.nullcontext()
+            )
+            with ctx:
+                y = (x * x).sin()
+                z = (y * y).cos()
+            return (z * x).sum()
+
+        x = torch.randn(5, 16, device=device, dtype=torch.double)
+        self.assertEqual(
+            vmap(grad(partial(f, offload=True)))(x),
+            vmap(grad(partial(f, offload=False)))(x),
+        )
 
     def test_jvp_supports_saved_tensor_hooks(self, device):
         def f(x):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3830,6 +3830,11 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "must override the setup_context"):
             transform(MySin.apply)(x)
 
+    _SAVED_TENSOR_HOOKS_EAGER_ONLY = (
+        "saved-tensor hooks (save_on_cpu) with torch.func are eager only; "
+        "under torch.compile they are handled by AOTAutograd"
+    )
+
     @parametrize(
         "transform",
         [
@@ -3839,6 +3844,7 @@ class TestComposability(TestCase):
             "vjp",
         ],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_first_order_transforms_support_saved_tensor_hooks(self, device, transform):
         # A single first-order reverse-mode transform supports saved-tensor
         # hooks (e.g. save_on_cpu). Results must match the same transform with
@@ -3864,6 +3870,7 @@ class TestComposability(TestCase):
         with torch.autograd.graph.save_on_cpu():
             self.assertEqual(apply(f), expected)
 
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_higher_order_transforms_dont_support_saved_tensor_hooks(self, device):
         # Nested / higher-order differentiation over a saved-tensor-hooks region
         # must raise rather than silently miscompute: the offload device
@@ -3900,6 +3907,7 @@ class TestComposability(TestCase):
         "pin_memory",
         [subtest(False, name="nopin"), subtest(True, name="pin")],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
         if pin_memory and self.device_type != "cuda":
             self.skipTest("pin_memory offloading requires CUDA")
@@ -3925,6 +3933,7 @@ class TestComposability(TestCase):
         "pin_memory",
         [subtest(False, name="nopin"), subtest(True, name="pin")],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_vmap_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
         if pin_memory and self.device_type != "cuda":
             self.skipTest("pin_memory offloading requires CUDA")
@@ -3946,6 +3955,7 @@ class TestComposability(TestCase):
             vmap(grad(partial(f, offload=False)))(x),
         )
 
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_jvp_supports_saved_tensor_hooks(self, device):
         def f(x):
             return torch.sin(x).sum()

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3896,6 +3896,7 @@ class TestComposability(TestCase):
             lambda: jacrev(jacrev(f))(x),
             lambda: hessian(f)(x),
             lambda: jvp(grad(f), (x,), (t,)),
+            lambda: grad(lambda z: vmap(grad(f))(z).sum())(x),
             lambda: enclosed(lambda: grad(lambda z: grad(g)(z).sum())(x)),
             lambda: enclosed(lambda: hessian(g)(x)),
         ]

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import copy
 import math
 import os
@@ -3874,52 +3875,121 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "must override the setup_context"):
             transform(MySin.apply)(x)
 
-    # Some of these pass, some of these don't
     @parametrize(
         "transform",
         [
             "grad",
             "jacrev",
             "grad_and_value",
-            "hessian",
+            "vjp",
         ],
     )
-    def test_transforms_dont_support_saved_tensor_hooks(self, device, transform):
+    def test_first_order_transforms_support_saved_tensor_hooks(self, device, transform):
+        # A single first-order reverse-mode transform supports saved-tensor
+        # hooks (e.g. save_on_cpu). Results must match the same transform with
+        # no offloading, whether the hook is set inside the function or as an
+        # enclosing context.
         def f(x):
-            return torch.sin(x).sum()
+            return (torch.sin(x) * x).sum()
 
-        def g(x):
+        def f_offload(x):
             with torch.autograd.graph.save_on_cpu():
-                return f(x)
+                return (torch.sin(x) * x).sum()
 
         x = torch.randn(3, device=device)
 
-        if transform == "functionalize":
-            transform = functorch.experimental.functionalize
-        else:
-            transform = getattr(functorch, transform)
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            with torch.autograd.graph.save_on_cpu():
-                transform(f)(x)
+        def apply(fn):
+            if transform == "vjp":
+                value, vjp_fn = vjp(fn, x)
+                return value, vjp_fn(torch.ones((), device=device))[0]
+            return getattr(functorch, transform)(fn)(x)
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            transform(g)(x)
+        expected = apply(f)
+        self.assertEqual(apply(f_offload), expected)
+        with torch.autograd.graph.save_on_cpu():
+            self.assertEqual(apply(f), expected)
 
-    def test_vjp_doesnt_support_saved_tensor_hooks(self, device):
+    def test_higher_order_transforms_dont_support_saved_tensor_hooks(self, device):
+        # Nested / higher-order differentiation over a saved-tensor-hooks region
+        # must raise rather than silently miscompute: the offload device
+        # round-trip severs the higher-order autograd graph.
         def f(x):
-            return torch.sin(x).sum()
+            with torch.autograd.graph.save_on_cpu():
+                return (torch.sin(x) * x).sum()
 
         def g(x):
+            return (torch.sin(x) * x).sum()
+
+        def enclosed(thunk):
             with torch.autograd.graph.save_on_cpu():
-                return f(x)
+                return thunk()
 
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            with torch.autograd.graph.save_on_cpu():
-                vjp(f, x)
+        t = torch.randn(3, device=device)
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            vjp(g, x)
+        # The hooks region may be inside the differentiated function or an
+        # enclosing context around the higher-order call; both must raise.
+        higher_order = [
+            lambda: grad(lambda z: grad(f)(z).sum())(x),
+            lambda: jacrev(jacrev(f))(x),
+            lambda: hessian(f)(x),
+            lambda: jvp(grad(f), (x,), (t,)),
+            lambda: enclosed(lambda: grad(lambda z: grad(g)(z).sum())(x)),
+            lambda: enclosed(lambda: hessian(g)(x)),
+        ]
+        for call in higher_order:
+            with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
+                call()
+
+    @parametrize(
+        "pin_memory",
+        [subtest(False, name="nopin"), subtest(True, name="pin")],
+    )
+    def test_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
+        if pin_memory and self.device_type != "cuda":
+            self.skipTest("pin_memory offloading requires CUDA")
+
+        def f(x, offload):
+            ctx = (
+                torch.autograd.graph.save_on_cpu(pin_memory=pin_memory)
+                if offload
+                else contextlib.nullcontext()
+            )
+            with ctx:
+                y = (x * x).sin()
+                z = (y * y).cos()
+            return (z * x).sum()
+
+        x = torch.randn(16, device=device, dtype=torch.double)
+        self.assertEqual(
+            grad(partial(f, offload=True))(x),
+            grad(partial(f, offload=False))(x),
+        )
+
+    @parametrize(
+        "pin_memory",
+        [subtest(False, name="nopin"), subtest(True, name="pin")],
+    )
+    def test_vmap_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
+        if pin_memory and self.device_type != "cuda":
+            self.skipTest("pin_memory offloading requires CUDA")
+
+        def f(x, offload):
+            ctx = (
+                torch.autograd.graph.save_on_cpu(pin_memory=pin_memory)
+                if offload
+                else contextlib.nullcontext()
+            )
+            with ctx:
+                y = (x * x).sin()
+                z = (y * y).cos()
+            return (z * x).sum()
+
+        x = torch.randn(5, 16, device=device, dtype=torch.double)
+        self.assertEqual(
+            vmap(grad(partial(f, offload=True)))(x),
+            vmap(grad(partial(f, offload=False)))(x),
+        )
 
     def test_jvp_supports_saved_tensor_hooks(self, device):
         def f(x):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -79,6 +79,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
+from torch.utils.checkpoint import checkpoint
 
 
 USE_TORCHVISION = False
@@ -3948,6 +3949,22 @@ class TestComposability(TestCase):
         for call in higher_order:
             with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
                 call()
+
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
+    def test_failed_compile_does_not_leak_saved_tensor_hook_state(self, device):
+        def f(x):
+            return checkpoint(
+                lambda x: (torch.sin(x) * x).sum(), x, use_reentrant=False
+            )
+
+        x = torch.randn(5, 3, device=device)
+        expected = vmap(grad(lambda x: (torch.sin(x) * x).sum()))(x)
+        compiled = torch.compile(vmap(grad(f)), backend="aot_eager", fullgraph=True)
+
+        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks.*torch.compile"):
+            compiled(x)
+
+        self.assertEqual(vmap(grad(f))(x), expected)
 
     @parametrize(
         "pin_memory",

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3875,6 +3875,11 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "must override the setup_context"):
             transform(MySin.apply)(x)
 
+    _SAVED_TENSOR_HOOKS_EAGER_ONLY = (
+        "saved-tensor hooks (save_on_cpu) with torch.func are eager only; "
+        "under torch.compile they are handled by AOTAutograd"
+    )
+
     @parametrize(
         "transform",
         [
@@ -3884,6 +3889,7 @@ class TestComposability(TestCase):
             "vjp",
         ],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_first_order_transforms_support_saved_tensor_hooks(self, device, transform):
         # A single first-order reverse-mode transform supports saved-tensor
         # hooks (e.g. save_on_cpu). Results must match the same transform with
@@ -3909,6 +3915,7 @@ class TestComposability(TestCase):
         with torch.autograd.graph.save_on_cpu():
             self.assertEqual(apply(f), expected)
 
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_higher_order_transforms_dont_support_saved_tensor_hooks(self, device):
         # Nested / higher-order differentiation over a saved-tensor-hooks region
         # must raise rather than silently miscompute: the offload device
@@ -3945,6 +3952,7 @@ class TestComposability(TestCase):
         "pin_memory",
         [subtest(False, name="nopin"), subtest(True, name="pin")],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
         if pin_memory and self.device_type != "cuda":
             self.skipTest("pin_memory offloading requires CUDA")
@@ -3970,6 +3978,7 @@ class TestComposability(TestCase):
         "pin_memory",
         [subtest(False, name="nopin"), subtest(True, name="pin")],
     )
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_vmap_grad_save_on_cpu_matches_no_offload(self, device, pin_memory):
         if pin_memory and self.device_type != "cuda":
             self.skipTest("pin_memory offloading requires CUDA")
@@ -3991,6 +4000,7 @@ class TestComposability(TestCase):
             vmap(grad(partial(f, offload=False)))(x),
         )
 
+    @skipIfTorchDynamo(_SAVED_TENSOR_HOOKS_EAGER_ONLY)
     def test_jvp_supports_saved_tensor_hooks(self, device):
         def f(x):
             return torch.sin(x).sum()

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3941,6 +3941,7 @@ class TestComposability(TestCase):
             lambda: jacrev(jacrev(f))(x),
             lambda: hessian(f)(x),
             lambda: jvp(grad(f), (x,), (t,)),
+            lambda: grad(lambda z: vmap(grad(f))(z).sum())(x),
             lambda: enclosed(lambda: grad(lambda z: grad(g)(z).sum())(x)),
             lambda: enclosed(lambda: hessian(g)(x)),
         ]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2649,6 +2649,9 @@ class OutputGraph(OutputGraphCommon):
         prior_global_state = self.tracing_context.global_context.copy_graphstate()
         current_global_state: dict[str, tuple[Any, bool]] = {}
         self.save_global_state(out=current_global_state)
+        prior_saved_tensors_hooks_error_message = (
+            torch._C._autograd._saved_tensors_hooks_get_disabled_error_message()
+        )
         try:
             # Set to state prior to tracing the graph
             self.tracing_context.global_context.restore_graphstate(prior_global_state)
@@ -2658,6 +2661,12 @@ class OutputGraph(OutputGraphCommon):
             self.tracing_context.global_context.restore_graphstate(
                 GlobalContextCheckpointState(current_global_state)
             )
+            if prior_saved_tensors_hooks_error_message is None:
+                torch._C._autograd._saved_tensors_hooks_enable()
+            else:
+                torch._C._autograd._saved_tensors_hooks_disable(
+                    prior_saved_tensors_hooks_error_message
+                )
 
     def run_compiler_collective(self) -> None:
         tx = self.root_tx

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -290,7 +290,7 @@ manual_torch_name_rule_map: dict[
     "torch._functorch.vmap._process_batched_inputs": UserFunctionVariable,
     "torch._functorch.vmap._unwrap_batched": UserFunctionVariable,
     "torch._functorch.vmap._validate_and_get_batch_size": UserFunctionVariable,
-    "torch._functorch.vmap.doesnt_support_saved_tensors_hooks": UserFunctionVariable,
+    "torch._functorch.vmap.disable_saved_tensors_hooks_for_higher_order": UserFunctionVariable,
     "torch._functorch.vmap.get_chunk_sizes": UserFunctionVariable,
     # lazy_load_decompositions uses a lock that is not supported yet in dynamo
     # "torch._functorch.vmap.lazy_load_decompositions": UserFunctionVariable,

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -299,7 +299,7 @@ manual_torch_name_rule_map: dict[
     "torch._functorch.vmap._process_batched_inputs": UserFunctionVariable,
     "torch._functorch.vmap._unwrap_batched": UserFunctionVariable,
     "torch._functorch.vmap._validate_and_get_batch_size": UserFunctionVariable,
-    "torch._functorch.vmap.doesnt_support_saved_tensors_hooks": UserFunctionVariable,
+    "torch._functorch.vmap.disable_saved_tensors_hooks_for_higher_order": UserFunctionVariable,
     "torch._functorch.vmap.get_chunk_sizes": UserFunctionVariable,
     # lazy_load_decompositions uses a lock that is not supported yet in dynamo
     # "torch._functorch.vmap.lazy_load_decompositions": UserFunctionVariable,

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -48,7 +48,7 @@ from torch.utils._pytree import (
 )
 
 from .apis import _wraps_without_dynamo_attrs, vmap
-from .vmap import doesnt_support_saved_tensors_hooks, get_chunk_sizes
+from .vmap import disable_saved_tensors_hooks_for_higher_order, get_chunk_sizes
 
 
 if TYPE_CHECKING:
@@ -384,7 +384,7 @@ def jvp_increment_nesting() -> Generator[int, None, None]:
         exit_jvp_nesting()
 
 
-@doesnt_support_saved_tensors_hooks
+@disable_saved_tensors_hooks_for_higher_order
 def _vjp_with_argnums(
     func: Callable[..., Any],
     *primals: Any,
@@ -1469,7 +1469,7 @@ def hessian(func: Callable[..., Any], argnums: argnums_t = 0) -> Callable[..., A
     return jacfwd(jacrev(func, argnums), argnums)
 
 
-@doesnt_support_saved_tensors_hooks
+@disable_saved_tensors_hooks_for_higher_order
 def grad_and_value_impl(
     func: Callable[..., Any],
     argnums: argnums_t,

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -48,7 +48,7 @@ from torch.utils._pytree import (
 )
 
 from .apis import _wraps_without_dynamo_attrs, vmap
-from .vmap import doesnt_support_saved_tensors_hooks, get_chunk_sizes
+from .vmap import disable_saved_tensors_hooks_for_higher_order, get_chunk_sizes
 
 
 if TYPE_CHECKING:
@@ -384,7 +384,7 @@ def jvp_increment_nesting() -> Generator[int, None, None]:
         exit_jvp_nesting()
 
 
-@doesnt_support_saved_tensors_hooks
+@disable_saved_tensors_hooks_for_higher_order
 def _vjp_with_argnums(
     func: Callable[..., Any],
     *primals: Any,
@@ -1472,7 +1472,7 @@ def hessian(func: Callable[..., Any], argnums: argnums_t = 0) -> Callable[..., A
     return jacfwd(jacrev(func, argnums), argnums)
 
 
-@doesnt_support_saved_tensors_hooks
+@disable_saved_tensors_hooks_for_higher_order
 def grad_and_value_impl(
     func: Callable[..., Any],
     argnums: argnums_t,

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -16,7 +16,7 @@ from typing_extensions import ParamSpec, TypeVar
 
 import torch
 from torch import Tensor
-from torch._C._functorch import is_batchedtensor
+from torch._C._functorch import get_interpreter_stack, is_batchedtensor, TransformType
 from torch._functorch.predispatch import (
     _add_batch_dim,
     _remove_batch_dim,
@@ -44,16 +44,31 @@ in_dims_t = int | tuple[Any, ...]
 out_dims_t = int | tuple[int, ...] | None
 
 
-def doesnt_support_saved_tensors_hooks(f: Callable[_P, _R]) -> Callable[_P, _R]:
+def disable_saved_tensors_hooks_for_higher_order(
+    f: Callable[_P, _R],
+) -> Callable[_P, _R]:
     message = (
-        "torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. "
-        "Please open an issue with your use case."
+        "torch.func transforms (grad, vjp, jacrev, hessian) don't support saved "
+        "tensor hooks (e.g. torch.autograd.graph.save_on_cpu) under higher-order "
+        "differentiation such as grad(grad) or hessian: the saved-tensor "
+        "round-trip severs the higher-order graph and would silently produce "
+        "incorrect gradients. First-order use is supported."
     )
 
     @functools.wraps(f)
     def fn(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        with torch.autograd.graph.disable_saved_tensors_hooks(message):
-            return f(*args, **kwargs)
+        # An enclosing Grad/Jvp layer (checked before this transform pushes its
+        # own) means higher-order differentiation, where saved-tensor hooks
+        # miscompute. vmap layers don't differentiate and are ignored.
+        stack = get_interpreter_stack()
+        higher_order = bool(stack) and any(
+            interpreter.key() in (TransformType.Grad, TransformType.Jvp)
+            for interpreter in stack
+        )
+        if higher_order:
+            with torch.autograd.graph.disable_saved_tensors_hooks(message):
+                return f(*args, **kwargs)
+        return f(*args, **kwargs)
 
     return fn
 

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -54,9 +54,21 @@ def disable_saved_tensors_hooks_for_higher_order(
         "round-trip severs the higher-order graph and would silently produce "
         "incorrect gradients. First-order use is supported."
     )
+    compile_message = (
+        "torch.func transforms (grad, vjp, jacrev, hessian) don't support saved "
+        "tensor hooks (e.g. torch.autograd.graph.save_on_cpu) under torch.compile, "
+        "where saved-tensor hooks are managed by AOTAutograd. Use eager execution "
+        "for saved-tensor hooks with torch.func."
+    )
 
     @functools.wraps(f)
     def fn(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        # Under torch.compile the interpreter stack below is not traceable;
+        # disable hooks unconditionally, matching the pre-existing compiled
+        # behavior. Saved-tensor hook support with torch.func is eager only.
+        if torch.compiler.is_compiling():
+            with torch.autograd.graph.disable_saved_tensors_hooks(compile_message):
+                return f(*args, **kwargs)
         # An enclosing Grad/Jvp layer (checked before this transform pushes its
         # own) means higher-order differentiation, where saved-tensor hooks
         # miscompute. vmap layers don't differentiate and are ignored.

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -404,11 +404,14 @@ class save_on_cpu(saved_tensors_hooks):
             if not pin_memory:
                 return (tensor.device, tensor.cpu())
             is_pinnable = device_module.is_available() and not tensor.is_sparse
-            packed = torch.empty(
-                tensor.size(),
-                dtype=tensor.dtype,
-                layout=tensor.layout,
+            # Under vmap the source is a BatchedTensor whose size() is the
+            # unbatched shape; empty_like carries the batch dim. contiguous_format
+            # gives a contiguous pinned buffer for non-contiguous sources.
+            packed = torch.empty_like(
+                tensor,
+                device="cpu",
                 pin_memory=is_pinnable,
+                memory_format=torch.contiguous_format,
             )
             packed.copy_(tensor, non_blocking=is_pinnable)
             return (tensor.device, packed)

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -405,14 +405,18 @@ class save_on_cpu(saved_tensors_hooks):
                 return (tensor.device, tensor.cpu())
             is_pinnable = device_module.is_available() and not tensor.is_sparse
             # Under vmap the source is a BatchedTensor whose size() is the
-            # unbatched shape; empty_like carries the batch dim. contiguous_format
-            # gives a contiguous pinned buffer for non-contiguous sources.
-            packed = torch.empty_like(
-                tensor,
-                device="cpu",
-                pin_memory=is_pinnable,
-                memory_format=torch.contiguous_format,
-            )
+            # unbatched shape; empty_like carries the batch dim. Request
+            # contiguous_format for a contiguous pinned buffer, but only for
+            # strided tensors -- memory_format is rejected for other layouts.
+            if tensor.layout == torch.strided:
+                packed = torch.empty_like(
+                    tensor,
+                    device="cpu",
+                    pin_memory=is_pinnable,
+                    memory_format=torch.contiguous_format,
+                )
+            else:
+                packed = torch.empty_like(tensor, device="cpu", pin_memory=is_pinnable)
             packed.copy_(tensor, non_blocking=is_pinnable)
             return (tensor.device, packed)
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -412,14 +412,18 @@ class save_on_cpu(saved_tensors_hooks):
                 return (tensor.device, tensor.cpu())
             is_pinnable = device_module.is_available() and not tensor.is_sparse
             # Under vmap the source is a BatchedTensor whose size() is the
-            # unbatched shape; empty_like carries the batch dim. contiguous_format
-            # gives a contiguous pinned buffer for non-contiguous sources.
-            packed = torch.empty_like(
-                tensor,
-                device="cpu",
-                pin_memory=is_pinnable,
-                memory_format=torch.contiguous_format,
-            )
+            # unbatched shape; empty_like carries the batch dim. Request
+            # contiguous_format for a contiguous pinned buffer, but only for
+            # strided tensors -- memory_format is rejected for other layouts.
+            if tensor.layout == torch.strided:
+                packed = torch.empty_like(
+                    tensor,
+                    device="cpu",
+                    pin_memory=is_pinnable,
+                    memory_format=torch.contiguous_format,
+                )
+            else:
+                packed = torch.empty_like(tensor, device="cpu", pin_memory=is_pinnable)
             packed.copy_(tensor, non_blocking=is_pinnable)
             return (tensor.device, packed)
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -411,11 +411,14 @@ class save_on_cpu(saved_tensors_hooks):
             if not pin_memory:
                 return (tensor.device, tensor.cpu())
             is_pinnable = device_module.is_available() and not tensor.is_sparse
-            packed = torch.empty(
-                tensor.size(),
-                dtype=tensor.dtype,
-                layout=tensor.layout,
+            # Under vmap the source is a BatchedTensor whose size() is the
+            # unbatched shape; empty_like carries the batch dim. contiguous_format
+            # gives a contiguous pinned buffer for non-contiguous sources.
+            packed = torch.empty_like(
+                tensor,
+                device="cpu",
                 pin_memory=is_pinnable,
+                memory_format=torch.contiguous_format,
             )
             packed.copy_(tensor, non_blocking=is_pinnable)
             return (tensor.device, packed)


### PR DESCRIPTION
## Issue

Fixes #122729 (also #146036, #141845)

## Summary

`torch.func` (grad/vjp/jacrev/vmap-over-them) disabled saved-tensor hooks for all
transforms via a 2022 blanket guard, so `save_on_cpu` raised under any of them.
This scopes the guard to higher-order only: a single first-order transform now
allows the hooks; nested diff (grad(grad), hessian, jvp(grad), ...) still raises.
Also makes `save_on_cpu`'s pinned buffer use `empty_like` so it carries the vmap
batch dim.

The 2022 attempts (#89166, #89159, #88976) stalled because they tried to support
higher-order too, which needs unwrapping/re-wrapping functorch tensors and
stashing autograd metadata by hand. We only enable the hooks for one first-order
layer (which round-trips correctly) and keep raising for nested diff, so none of
that is needed.

Follow-up: non-reentrant gradient checkpointing builds on this — JetBrains-Research/pytorch#3.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
