### PR TITLE
[xpu]Implement scaled_mm for XPU - combined

### DIFF
--- a/aten/src/ATen/native/ScaledBlasUtils.cpp
+++ b/aten/src/ATen/native/ScaledBlasUtils.cpp
@@ -326,6 +326,9 @@ void validate_scaled_mm_v2_inputs(
   const auto N = mat_b.sym_size(1);
   const bool both_fp4 = is_fp4_type(mat_a.scalar_type()) && is_fp4_type(mat_b.scalar_type());
   const auto K_unpacked = both_fp4 ? mat_a.sym_size(1) * 2 : mat_a.sym_size(1);
+  // XPU (oneDNN) uses unswizzled, unpadded blockwise scale shapes, unlike the
+  // L4-padded SWIZZLE_32_4_4 layout that CUDA expects.
+  const bool is_xpu = mat_a.is_xpu();
 
   auto sym_ceil_div = [](const c10::SymInt& a, int64_t b) {
     return (a + b - 1) / b;
@@ -386,7 +389,11 @@ void validate_scaled_mm_v2_inputs(
     // ROCm and NVIDIA use different blockwise scale shapes; detect at runtime
     // to keep aten-cpu free of GPU-conditional compilation. Formulas mirror
     // _scaled_mxfp8_mxfp8 and _scaled_mxfp4_mxfp4 in cuda/ScaledBlas.cpp.
-    if (at::globalContext().hasROCM()) {
+    if (is_xpu) {
+      // XPU: unpadded [M, ceil_div(K, 32)] / [N, ceil_div(K, 32)], NO_SWIZZLE.
+      expected_a_elems = M * sym_ceil_div(K_unpacked, 32);
+      expected_b_elems = N * sym_ceil_div(K_unpacked, 32);
+    } else if (at::globalContext().hasROCM()) {
       // ROCm: K_multiplier=2 doubles M and N (the non-contraction dims) for
       // packed fp4; K (= mat_a.sym_size(1)) is used raw on both sides.
       const auto K = mat_a.sym_size(1);
@@ -412,13 +419,20 @@ void validate_scaled_mm_v2_inputs(
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b.empty() ? c10::SymInt(0) : scale_b[0].sym_numel());
     TORCH_CHECK_VALUE(
-        scale_a[0].is_contiguous() && scale_b[0].is_contiguous(),
+        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
         "For Blockwise scaling both scales should be contiguous");
   } else if (is_nv_1x16) {
-    const auto expected_a_elems = sym_round_up(M, 128) *
-        sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-    const auto expected_b_elems = sym_round_up(N, 128) *
-        sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+    c10::SymInt expected_a_elems;
+    c10::SymInt expected_b_elems;
+    if (is_xpu) {
+      expected_a_elems = M * sym_ceil_div(K_unpacked, 16);
+      expected_b_elems = N * sym_ceil_div(K_unpacked, 16);
+    } else {
+      expected_a_elems = sym_round_up(M, 128) *
+          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+      expected_b_elems = sym_round_up(N, 128) *
+          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+    }
     TORCH_CHECK_VALUE(
         scale_a.size() == 1 && scale_a[0].sym_numel() == expected_a_elems &&
             scale_a[0].scalar_type() == ScalarType::Float8_e4m3fn,
@@ -430,13 +444,20 @@ void validate_scaled_mm_v2_inputs(
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b.empty() ? c10::SymInt(0) : scale_b[0].sym_numel());
     TORCH_CHECK_VALUE(
-        scale_a[0].is_contiguous() && scale_b[0].is_contiguous(),
+        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
         "For Blockwise scaling both scales should be contiguous");
   } else if (is_nv_2lvl) {
-    const auto expected_a_elems = sym_round_up(M, 128) *
-        sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-    const auto expected_b_elems = sym_round_up(N, 128) *
-        sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+    c10::SymInt expected_a_elems;
+    c10::SymInt expected_b_elems;
+    if (is_xpu) {
+      expected_a_elems = M * sym_ceil_div(K_unpacked, 16);
+      expected_b_elems = N * sym_ceil_div(K_unpacked, 16);
+    } else {
+      expected_a_elems = sym_round_up(M, 128) *
+          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+      expected_b_elems = sym_round_up(N, 128) *
+          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+    }
     // Split the count check from the per-element check so the error
     // message points at the actual mismatch.
     TORCH_CHECK_VALUE(
@@ -458,7 +479,7 @@ void validate_scaled_mm_v2_inputs(
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b[0].sym_numel());
     TORCH_CHECK_VALUE(
-        scale_a[0].is_contiguous() && scale_b[0].is_contiguous(),
+        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
         "For Blockwise scaling both scales should be contiguous");
   } else if (!is_deepseek) {
     // Match the kernel's `find_scaled_gemm_impl` fall-through so unrecognized
@@ -481,7 +502,17 @@ void validate_scaled_mm_v2_inputs(
     const auto num_args_a = recipe_a.size();
     const auto num_args_b = recipe_b.size();
     const bool is_rocm = at::globalContext().hasROCM();
-    if (!is_rocm) {
+    if (is_xpu) {
+      // XPU consumes unswizzled scales for all MX/NVFP4 recipes.
+      TORCH_CHECK_VALUE(
+          swizzle_a.size() == num_args_a && swizzle_b.size() == num_args_b,
+          "swizzle_a/swizzle_b must match the number of scale recipes, got ",
+          swizzle_a.size(), " and ", swizzle_b.size());
+      TORCH_CHECK_VALUE(
+          swizzle_a[0] == SwizzleType::NO_SWIZZLE &&
+              swizzle_b[0] == SwizzleType::NO_SWIZZLE,
+          "For XPU MX/NVFP4 gemm, scale_a and scale_b must both be NO_SWIZZLE");
+    } else if (!is_rocm) {
       TORCH_CHECK_VALUE(
           swizzle_a.size() == num_args_a,
           "swizzle_a must have ", num_args_a, " value",

--- a/aten/src/ATen/native/ScaledBlasUtils.cpp
+++ b/aten/src/ATen/native/ScaledBlasUtils.cpp
@@ -340,7 +340,7 @@ void validate_scaled_mm_v2_inputs(
   // XPU (oneDNN) also accepts a column-major (transpose-contiguous) layout
   // because it calls .contiguous() internally; CUDA/ROCm require a plain
   // contiguous scale.
-  auto scale_layout_ok = [is_xpu](const Tensor& s) {
+  auto is_scale_contiguous = [is_xpu](const Tensor& s) {
     return is_xpu ? (s.is_contiguous() || s.t().is_contiguous())
                   : s.is_contiguous();
   };
@@ -494,7 +494,7 @@ void validate_scaled_mm_v2_inputs(
     // recipes). scale_a[0]/scale_b[0] are the blockwise scales and were
     // size-validated in the per-recipe branches above.
     TORCH_CHECK_VALUE(
-        scale_layout_ok(scale_a[0]) && scale_layout_ok(scale_b[0]),
+        is_scale_contiguous(scale_a[0]) && is_scale_contiguous(scale_b[0]),
         is_xpu
             ? "For Blockwise scaling both scales should be contiguous (row-major or column-major)"
             : "For Blockwise scaling both scales should be contiguous");

--- a/aten/src/ATen/native/ScaledBlasUtils.cpp
+++ b/aten/src/ATen/native/ScaledBlasUtils.cpp
@@ -337,6 +337,24 @@ void validate_scaled_mm_v2_inputs(
     return sym_ceil_div(a, b) * b;
   };
 
+  // XPU (oneDNN) also accepts a column-major (transpose-contiguous) layout
+  // because it calls .contiguous() internally; CUDA/ROCm require a plain
+  // contiguous scale.
+  auto scale_layout_ok = [is_xpu](const Tensor& s) {
+    return is_xpu ? (s.is_contiguous() || s.t().is_contiguous())
+                  : s.is_contiguous();
+  };
+
+  // NVFP4 (BlockWise1x16) blockwise scale element count for a given outer
+  // dim, shared by the single- and two-level NVFP4 recipes. XPU uses the
+  // unpadded shape; NVIDIA the L4-padded SWIZZLE_32_4_4 shape. ROCm doesn't
+  // support NVFP4, so only these two cases arise.
+  auto nvfp4_scale_elems = [&](const c10::SymInt& dim) {
+    return is_xpu ? dim * sym_ceil_div(K_unpacked, 16)
+                  : sym_round_up(dim, 128) *
+            sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
+  };
+
   // Per-recipe scale checks. Shapes and dtypes mirror the per-recipe
   // acceptance functions in aten/src/ATen/native/cuda/ScaledBlas.cpp so a
   // configuration that survives the meta also survives the kernel
@@ -418,21 +436,9 @@ void validate_scaled_mm_v2_inputs(
             scale_b[0].scalar_type() == ScalarType::Float8_e8m0fnu,
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b.empty() ? c10::SymInt(0) : scale_b[0].sym_numel());
-    TORCH_CHECK_VALUE(
-        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
-        "For Blockwise scaling both scales should be contiguous");
   } else if (is_nv_1x16) {
-    c10::SymInt expected_a_elems;
-    c10::SymInt expected_b_elems;
-    if (is_xpu) {
-      expected_a_elems = M * sym_ceil_div(K_unpacked, 16);
-      expected_b_elems = N * sym_ceil_div(K_unpacked, 16);
-    } else {
-      expected_a_elems = sym_round_up(M, 128) *
-          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-      expected_b_elems = sym_round_up(N, 128) *
-          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-    }
+    const auto expected_a_elems = nvfp4_scale_elems(M);
+    const auto expected_b_elems = nvfp4_scale_elems(N);
     TORCH_CHECK_VALUE(
         scale_a.size() == 1 && scale_a[0].sym_numel() == expected_a_elems &&
             scale_a[0].scalar_type() == ScalarType::Float8_e4m3fn,
@@ -443,21 +449,9 @@ void validate_scaled_mm_v2_inputs(
             scale_b[0].scalar_type() == ScalarType::Float8_e4m3fn,
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b.empty() ? c10::SymInt(0) : scale_b[0].sym_numel());
-    TORCH_CHECK_VALUE(
-        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
-        "For Blockwise scaling both scales should be contiguous");
   } else if (is_nv_2lvl) {
-    c10::SymInt expected_a_elems;
-    c10::SymInt expected_b_elems;
-    if (is_xpu) {
-      expected_a_elems = M * sym_ceil_div(K_unpacked, 16);
-      expected_b_elems = N * sym_ceil_div(K_unpacked, 16);
-    } else {
-      expected_a_elems = sym_round_up(M, 128) *
-          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-      expected_b_elems = sym_round_up(N, 128) *
-          sym_round_up(sym_ceil_div(K_unpacked, 16), 4);
-    }
+    const auto expected_a_elems = nvfp4_scale_elems(M);
+    const auto expected_b_elems = nvfp4_scale_elems(N);
     // Split the count check from the per-element check so the error
     // message points at the actual mismatch.
     TORCH_CHECK_VALUE(
@@ -478,9 +472,6 @@ void validate_scaled_mm_v2_inputs(
             scale_b[1].scalar_type() == ScalarType::Float,
         "For Blockwise scaling scale_b should have ", expected_b_elems,
         " elements, got: ", scale_b[0].sym_numel());
-    TORCH_CHECK_VALUE(
-        is_xpu || (scale_a[0].is_contiguous() && scale_b[0].is_contiguous()),
-        "For Blockwise scaling both scales should be contiguous");
   } else if (!is_deepseek) {
     // Match the kernel's `find_scaled_gemm_impl` fall-through so unrecognized
     // recipe combinations fail at trace time rather than at kernel dispatch.
@@ -499,6 +490,14 @@ void validate_scaled_mm_v2_inputs(
   // swizzle; tensorwise/rowwise/deepseek paths don't.
   const bool is_mx_or_nvfp = is_mx_1x32 || is_nv_1x16 || is_nv_2lvl;
   if (is_mx_or_nvfp) {
+    // Blockwise scales must be contiguous (checked once for all MX/NVFP4
+    // recipes). scale_a[0]/scale_b[0] are the blockwise scales and were
+    // size-validated in the per-recipe branches above.
+    TORCH_CHECK_VALUE(
+        scale_layout_ok(scale_a[0]) && scale_layout_ok(scale_b[0]),
+        is_xpu
+            ? "For Blockwise scaling both scales should be contiguous (row-major or column-major)"
+            : "For Blockwise scaling both scales should be contiguous");
     const auto num_args_a = recipe_a.size();
     const auto num_args_b = recipe_b.size();
     const bool is_rocm = at::globalContext().hasROCM();

--- a/aten/src/ATen/native/ScaledBlasUtils.cpp
+++ b/aten/src/ATen/native/ScaledBlasUtils.cpp
@@ -502,14 +502,13 @@ void validate_scaled_mm_v2_inputs(
     const auto num_args_b = recipe_b.size();
     const bool is_rocm = at::globalContext().hasROCM();
     if (is_xpu) {
-      // XPU consumes unswizzled scales for all MX/NVFP4 recipes.
+      // XPU consumes unswizzled scales for all MX/NVFP4 recipes. The public
+      // API (F.scaled_mm) defaults swizzle to None, which becomes an empty
+      // list, so accept an empty list (treated as NO_SWIZZLE) and only require
+      // NO_SWIZZLE when entries are present, mirroring the XPU kernel.
       TORCH_CHECK_VALUE(
-          swizzle_a.size() == num_args_a && swizzle_b.size() == num_args_b,
-          "swizzle_a/swizzle_b must match the number of scale recipes, got ",
-          swizzle_a.size(), " and ", swizzle_b.size());
-      TORCH_CHECK_VALUE(
-          swizzle_a[0] == SwizzleType::NO_SWIZZLE &&
-              swizzle_b[0] == SwizzleType::NO_SWIZZLE,
+          (swizzle_a.empty() || swizzle_a[0] == SwizzleType::NO_SWIZZLE) &&
+              (swizzle_b.empty() || swizzle_b[0] == SwizzleType::NO_SWIZZLE),
           "For XPU MX/NVFP4 gemm, scale_a and scale_b must both be NO_SWIZZLE");
     } else if (!is_rocm) {
       TORCH_CHECK_VALUE(

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -47,7 +47,8 @@ namespace {
 /*
  * Scaling Type Determination (XPU):
  * -------------------------------------------
- * All scale tensors must be float32.
+ * Most scale tensors are float32. The exception is BlockWise1x32
+ * (MXFP8/MXFP4 microscaling), whose scales are Float8_e8m0fnu.
  * API shapes match CUDA for portability (Same shape [n, k], but strides may
  * differ). CUDA uses col-major because of swizzling purpose, but XPU expects
  * row-major order for oneDNN.
@@ -56,12 +57,14 @@ namespace {
  *   - TensorWise:      scale_a is a singleton (numel==1)
  *   - RowWise:         scale_a has shape [M, 1]
  *   - BlockWise1x128:  scale_a has shape [M, K//128]
+ *   - BlockWise1x32:   scale_a has shape [M, K//32]   (MXFP8/MXFP4)
  *   - BlockWise128x128: scale_a has shape [M//128, K//128]
  *
  * For matrix B [K, N] and scale_b:
  *   - TensorWise:      scale_b is a singleton (numel==1)
  *   - RowWise:         scale_b has shape [1, N]
  *   - BlockWise1x128:  scale_b has shape [K//128, N]
+ *   - BlockWise1x32:   scale_b has shape [K//32, N]   (MXFP8/MXFP4)
  *   - BlockWise128x128: scale_b has shape [K//128, N//128]
  *
  * Supported (A, B) scaling combinations:
@@ -70,6 +73,7 @@ namespace {
  *   - (BlockWise128x128, BlockWise1x128)  -- DeepSeek-style
  *   - (BlockWise1x128, BlockWise128x128)
  *   - (BlockWise1x128, BlockWise1x128)
+ *   - (BlockWise1x32, BlockWise1x32)      -- MXFP8/MXFP4 microscaling
  */
 
 bool is_tensorwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
@@ -247,11 +251,13 @@ Tensor& _scaled_gemm(
 //        TensorWise: scalar tensor;
 //        RowWise: [M, 1];
 //        BlockWise1x128: [M, K//128];
+//        BlockWise1x32: [M, K//32] (MXFP8/MXFP4, Float8_e8m0fnu);
 //        BlockWise128x128: [M//128, K//128]
 //    - `scale_b`: inverse scale of `mat2`; shape depends on scaling scheme:
 //        TensorWise: scalar tensor;
 //        RowWise: [1, N];
 //        BlockWise1x128: [K//128, N];
+//        BlockWise1x32: [K//32, N] (MXFP8/MXFP4, Float8_e8m0fnu);
 //        BlockWise128x128: [K//128, N//128]
 //    - `scale_result`: a scalar tensor with the scale of the output (not
 //    currently supported on XPU)
@@ -454,7 +460,7 @@ using scaled_blas::convert_int_to_enum;
 using scaled_blas::ScaledGemmImplementation;
 using scaled_blas::ScaleKernelDispatchEntry;
 
-std::array<ScaleKernelDispatchEntry, 5> scale_kernel_dispatch = {{
+std::array<ScaleKernelDispatchEntry, 7> scale_kernel_dispatch = {{
     {"tensorwise_tensorwise",
      scaled_blas::check_tensorwise_recipe,
      ScaledGemmImplementation::TENSORWISE_TENSORWISE},
@@ -497,6 +503,12 @@ std::array<ScaleKernelDispatchEntry, 5> scale_kernel_dispatch = {{
          _5,
          _6),
      ScaledGemmImplementation::BLOCK_1x128_1x128},
+    {"mxfp8_mxfp8",
+     scaled_blas::check_mxfp8_recipe,
+     ScaledGemmImplementation::MXFP8_MXFP8},
+    {"mxfp4_mxfp4",
+     scaled_blas::check_mxfp4_recipe,
+     ScaledGemmImplementation::MXFP4_MXFP4},
 }};
 
 Tensor& _scaled_tensorwise_tensorwise(
@@ -515,6 +527,7 @@ Tensor& _scaled_tensorwise_tensorwise(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
       mat_a.scalar_type(),
+      ", ",
       mat_b.scalar_type());
   TORCH_CHECK_VALUE(
       scale_a.numel() == 1 && scale_a.scalar_type() == kFloat,
@@ -555,6 +568,7 @@ Tensor& _scaled_rowwise_rowwise(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
       mat_a.scalar_type(),
+      ", ",
       mat_b.scalar_type());
   TORCH_CHECK_VALUE(
       scale_a.size(0) == mat_a.size(0) && scale_a.size(1) == 1,
@@ -618,6 +632,7 @@ Tensor& _scaled_block1x128_block1x128(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
       mat_a.scalar_type(),
+      ", ",
       mat_b.scalar_type());
 
   const int64_t M = mat_a.sizes()[0];
@@ -683,6 +698,7 @@ Tensor& _scaled_block128x128_block1x128(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
       mat_a.scalar_type(),
+      ", ",
       mat_b.scalar_type());
 
   const int64_t M = mat_a.sizes()[0];
@@ -750,6 +766,7 @@ Tensor& _scaled_block1x128_block128x128(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
       mat_a.scalar_type(),
+      ", ",
       mat_b.scalar_type());
 
   int64_t M = mat_a.size(0);
@@ -800,10 +817,150 @@ Tensor& _scaled_block1x128_block128x128(
   return out;
 }
 
+Tensor& _scaled_mxfp8_mxfp8(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A, B are FP8, scales are e8m0, scale_a: [M, K//32], scale_b: [N, K//32].
+  // Unlike CUDA, oneDNN does not swizzle scales; it needs real row-major 2D
+  // data, so scale_b is transposed to [K//32, N] below.
+  TORCH_CHECK_VALUE(
+      isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
+      "mat_a and mat_b must be fp8 types, got: ",
+      mat_a.scalar_type(),
+      ", ",
+      mat_b.scalar_type());
+
+  const int64_t M = mat_a.sizes()[0];
+  const int64_t K = mat_a.sizes()[1];
+  const int64_t N = mat_b.sizes()[1];
+
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 32) &&
+          scale_a.scalar_type() == kFloat8_e8m0fnu,
+      "scale_a must have shape ",
+      M,
+      " x ",
+      ceil_div<int64_t>(K, 32),
+      " Float8_e8m0fnu elements, got ",
+      scale_a.sizes());
+
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 32) &&
+          scale_b.scalar_type() == kFloat8_e8m0fnu,
+      "scale_b must have shape ",
+      N,
+      " x ",
+      ceil_div<int64_t>(K, 32),
+      " Float8_e8m0fnu elements, got ",
+      scale_b.sizes());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [M, K//32] -> no transpose, just contiguous
+  //   scale_b [N, K//32] -> transpose to [K//32, N], then contiguous
+  auto sa = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
+  auto sb_t = scale_b.t();
+  auto sb = sb_t.is_contiguous() ? sb_t : sb_t.contiguous();
+
+  auto scaling_choice_a = ScalingType::BlockWise1x32;
+  auto scaling_choice_b = ScalingType::BlockWise1x32;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      sa,
+      sb,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
+Tensor& _scaled_mxfp4_mxfp4(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A, B are FP4, scales are e8m0, scale_a: [M, K//32], scale_b: [N, K//32].
+  // Unlike CUDA, oneDNN does not swizzle scales; it needs real row-major 2D
+  // data, so scale_b is transposed to [K//32, N] below.
+  TORCH_CHECK_VALUE(
+      mat_a.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+          mat_b.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "mat_a and mat_b must be Float4_e2m1fn_x2 types, got: ",
+      mat_a.scalar_type(),
+      ", ",
+      mat_b.scalar_type());
+
+  // Packed FP4 format means actual-K = 2 * reported-K -- adjust
+  constexpr int64_t K_multiplier = 2;
+  const int64_t M = mat_a.sizes()[0];
+  const int64_t K = mat_a.sizes()[1] * K_multiplier;
+  const int64_t N = mat_b.sizes()[1];
+
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 32) &&
+          scale_a.scalar_type() == kFloat8_e8m0fnu,
+      "scale_a must have shape ",
+      M,
+      " x ",
+      ceil_div<int64_t>(K, 32),
+      " Float8_e8m0fnu elements, got ",
+      scale_a.sizes());
+
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 32) &&
+          scale_b.scalar_type() == kFloat8_e8m0fnu,
+      "scale_b must have shape ",
+      N,
+      " x ",
+      ceil_div<int64_t>(K, 32),
+      " Float8_e8m0fnu elements, got ",
+      scale_b.sizes());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [M, K//32] -> no transpose, just contiguous
+  //   scale_b [N, K//32] -> transpose to [K//32, N], then contiguous
+  auto sa = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
+  auto sb_t = scale_b.t();
+  auto sb = sb_t.is_contiguous() ? sb_t : sb_t.contiguous();
+
+  auto scaling_choice_a = ScalingType::BlockWise1x32;
+  auto scaling_choice_b = ScalingType::BlockWise1x32;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      sa,
+      sb,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
 // V2: Computes matrix multiply + bias while applying scaling to input and
-// output matrices Scales are only applicable when matrices are of Float8 type
-// and assumed to be equal to 1.0 by default. If output matrix type is 16 or
-// 32-bit type, scale_result is not applied. Known limitations:
+// output matrices. Scales are applicable when matrices are of Float8 or
+// Float4 (packed) type and assumed to be equal to 1.0 by default. If output
+// matrix type is 16 or 32-bit type, scale_result is not applied.
+// Known limitations:
 //  - Only works if mat1 is row-major and mat2 is column-major
 //  - Only works if matrices sizes are divisible by 32
 //  - If 1-dimensional tensors are used then scale_a should be size =
@@ -811,9 +968,9 @@ Tensor& _scaled_block1x128_block128x128(
 //    and scale_b should have size = to mat2.size(1)
 //  Arguments:
 //    - `mat_a`: the first operand of the matrix multiply, can be type
-//    `torch.float8_e4m3fn` or `torch.float8_e5m2`
+//    `torch.float8_e4m3fn`, `torch.float8_e5m2`, or `torch.float4_e2m1fn_x2`
 //    - `mat_b`: the second operand of the matrix multiply, can be type
-//    `torch.float8_e4m3fn` or `torch.float8_e5m2`
+//    `torch.float8_e4m3fn`, `torch.float8_e5m2`, or `torch.float4_e2m1fn_x2`
 //    - `scale_a`: a tensor with the inverse scale of `mat1`, whose
 //    shape/strides/dtype depend on the scaling scheme
 //    - `scale_recipe_a`: An integer corresponding to an enum describing the
@@ -951,6 +1108,24 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
       ", ",
       ceil_div<int64_t>(mat_b.size(1), 128),
       ").\n"
+      "- For MXFP8 BlockWise 1x32 scaling, a and b should be float8, scales should be float8_e8m0fnu, scale_a should be (",
+      mat_a.size(0),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(1), 32),
+      ") and scale_b should be (",
+      mat_b.size(1),
+      ", ",
+      ceil_div<int64_t>(mat_b.size(0), 32),
+      ").\n"
+      "- For MXFP4 BlockWise 1x32 scaling, a and b should be float4 (packed 2x), scales should be float8_e8m0fnu, scale_a should be (",
+      mat_a.size(0),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(1) * 2, 32),
+      ") and scale_b should be (",
+      mat_b.size(1),
+      ", ",
+      ceil_div<int64_t>(mat_b.size(0) * 2, 32),
+      ").\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -1011,6 +1186,26 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
         out_mut);
   } else if (gemm_impl == ScaledGemmImplementation::BLOCK_1x128_1x128) {
     _scaled_block1x128_block1x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias_opt,
+        out_dtype_,
+        use_fast_accum,
+        out_mut);
+  } else if (gemm_impl == ScaledGemmImplementation::MXFP8_MXFP8) {
+    _scaled_mxfp8_mxfp8(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias_opt,
+        out_dtype_,
+        use_fast_accum,
+        out_mut);
+  } else if (gemm_impl == ScaledGemmImplementation::MXFP4_MXFP4) {
+    _scaled_mxfp4_mxfp4(
         mat_a,
         mat_b,
         scale_a[0],

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -278,7 +278,7 @@ Tensor& _scaled_gemm(
     TORCH_WARN(
         "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
-  // TODO: scale_result and alpha is not defined or used!
+  // TODO: scale_result is not defined or used!
   std::optional<Tensor> scaled_result = std::nullopt;
   at::native::onednn::scaled_matmul(
       mat1,
@@ -290,7 +290,8 @@ Tensor& _scaled_gemm(
       scaling_choice_b,
       bias,
       scaled_result,
-      false /* use_fast_accum */);
+      false /* use_fast_accum */,
+      alpha);
 
   return out;
 }
@@ -536,7 +537,7 @@ using scaled_blas::convert_int_to_enum;
 using scaled_blas::ScaledGemmImplementation;
 using scaled_blas::ScaleKernelDispatchEntry;
 
-std::array<ScaleKernelDispatchEntry, 8> scale_kernel_dispatch = {{
+std::array<ScaleKernelDispatchEntry, 9> scale_kernel_dispatch = {{
     {"tensorwise_tensorwise",
      scaled_blas::check_tensorwise_recipe,
      ScaledGemmImplementation::TENSORWISE_TENSORWISE},
@@ -585,6 +586,9 @@ std::array<ScaleKernelDispatchEntry, 8> scale_kernel_dispatch = {{
     {"mxfp4_mxfp4",
      scaled_blas::check_mxfp4_recipe,
      ScaledGemmImplementation::MXFP4_MXFP4},
+    {"nvfp4_nvfp4",
+     scaled_blas::check_nvfp4_recipe,
+     ScaledGemmImplementation::NVFP4_NVFP4},
     {"nvfp4_nvfp4_single_scale",
      scaled_blas::check_nvfp4_recipe_single_scale,
      ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE},
@@ -1043,12 +1047,16 @@ Tensor& _scaled_nvfp4_nvfp4(
     const std::optional<Tensor>& bias,
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
-    Tensor& out) {
+    Tensor& out,
+    const std::optional<Tensor>& global_scale_a = std::nullopt,
+    const std::optional<Tensor>& global_scale_b = std::nullopt) {
   // Restrictions:
-  // A, B are FP4, scales are float8_e4m3fn, scale_a: [M, K//16],
-  // scale_b: [N, K//16]. Single-level scaling (no global scale). Unlike CUDA,
-  // oneDNN does not swizzle scales; it needs real row-major 2D data, so scale_b
-  // is transposed to [K//16, N] below.
+  // A, B are FP4, block scales are float8_e4m3fn, scale_a: [M, K//16],
+  // scale_b: [N, K//16]. Two-level scaling additionally takes per-tensor fp32
+  // global scales; the product alpha = global_scale_a * global_scale_b is
+  // applied to the matmul output (matching CUDA). Single-level scaling omits
+  // the global scales. Unlike CUDA, oneDNN does not swizzle scales; it needs
+  // real row-major 2D data, so scale_b is transposed to [K//16, N] below.
   TORCH_CHECK_VALUE(
       mat_a.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
           mat_b.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
@@ -1056,6 +1064,31 @@ Tensor& _scaled_nvfp4_nvfp4(
       mat_a.scalar_type(),
       ", ",
       mat_b.scalar_type());
+
+  // Note: "Or" here means that if only one global scale is passed, we still
+  // require the other; otherwise we would silently ignore a provided scale.
+  std::optional<Tensor> alpha = std::nullopt;
+  if (global_scale_a.has_value() || global_scale_b.has_value()) {
+    TORCH_CHECK_VALUE(
+        global_scale_a.has_value(),
+        "For two-level-scaled NVFP4, global_scale_a must have a value");
+    TORCH_CHECK_VALUE(
+        global_scale_b.has_value(),
+        "For two-level-scaled NVFP4, global_scale_b must have a value");
+    TORCH_CHECK_VALUE(
+        global_scale_a->numel() == 1 && global_scale_a->scalar_type() == kFloat,
+        "global_scale_a must be a single fp32 element, got ",
+        global_scale_a->sizes(),
+        " ",
+        global_scale_a->scalar_type());
+    TORCH_CHECK_VALUE(
+        global_scale_b->numel() == 1 && global_scale_b->scalar_type() == kFloat,
+        "global_scale_b must be a single fp32 element, got ",
+        global_scale_b->sizes(),
+        " ",
+        global_scale_b->scalar_type());
+    alpha = global_scale_a->mul(global_scale_b.value());
+  }
 
   // Packed FP4 format means actual-K = 2 * reported-K -- adjust
   constexpr int64_t K_multiplier = 2;
@@ -1102,7 +1135,8 @@ Tensor& _scaled_nvfp4_nvfp4(
       scaling_choice_b,
       bias,
       use_fast_accum,
-      out);
+      out,
+      alpha);
 
   return out;
 }
@@ -1286,6 +1320,7 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
       ", ",
       ceil_div<int64_t>(mat_b.size(0) * 2, 16),
       ").\n"
+      "  For two-level NVFP4, additionally pass per-tensor fp32 global scales as scale_a[1] and scale_b[1] with recipe TensorWise.\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -1374,6 +1409,18 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
         out_dtype_,
         use_fast_accum,
         out_mut);
+  } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4) {
+    _scaled_nvfp4_nvfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias_opt,
+        out_dtype_,
+        use_fast_accum,
+        out_mut,
+        scale_a[1],
+        scale_b[1]);
   } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE) {
     _scaled_nvfp4_nvfp4(
         mat_a,

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -474,8 +474,8 @@ Tensor& _scaled_mm_out_xpu(
 
   // TODO: Scale_result is not supported by now!!
   // API shapes match CUDA v1. oneDNN needs row-major contiguous.
-  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32]
-  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N]
+  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32] or [M, K//16]
+  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N] or [K//16, N]
   // Because the user might passed in the CUDA's stride (col-major because of
   // swizzling)
   // call a contiguous() to ensure row-major for oneDNN

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -47,8 +47,9 @@ namespace {
 /*
  * Scaling Type Determination (XPU):
  * -------------------------------------------
- * Most scale tensors are float32. The exception is BlockWise1x32
- * (MXFP8/MXFP4 microscaling), whose scales are Float8_e8m0fnu.
+ * Most scale tensors are float32. The exceptions are BlockWise1x32
+ * (MXFP8/MXFP4 microscaling), whose scales are Float8_e8m0fnu, and
+ * BlockWise1x16 (NVFP4), whose scales are Float8_e4m3fn.
  * API shapes match CUDA for portability (Same shape [n, k], but strides may
  * differ). CUDA uses col-major because of swizzling purpose, but XPU expects
  * row-major order for oneDNN.
@@ -58,6 +59,7 @@ namespace {
  *   - RowWise:         scale_a has shape [M, 1]
  *   - BlockWise1x128:  scale_a has shape [M, K//128]
  *   - BlockWise1x32:   scale_a has shape [M, K//32]   (MXFP8/MXFP4)
+ *   - BlockWise1x16:   scale_a has shape [M, K//16]   (NVFP4)
  *   - BlockWise128x128: scale_a has shape [M//128, K//128]
  *
  * For matrix B [K, N] and scale_b:
@@ -65,6 +67,7 @@ namespace {
  *   - RowWise:         scale_b has shape [1, N]
  *   - BlockWise1x128:  scale_b has shape [K//128, N]
  *   - BlockWise1x32:   scale_b has shape [K//32, N]   (MXFP8/MXFP4)
+ *   - BlockWise1x16:   scale_b has shape [K//16, N]   (NVFP4)
  *   - BlockWise128x128: scale_b has shape [K//128, N//128]
  *
  * Supported (A, B) scaling combinations:
@@ -74,6 +77,7 @@ namespace {
  *   - (BlockWise1x128, BlockWise128x128)
  *   - (BlockWise1x128, BlockWise1x128)
  *   - (BlockWise1x32, BlockWise1x32)      -- MXFP8/MXFP4 microscaling
+ *   - (BlockWise1x16, BlockWise1x16)      -- NVFP4
  */
 
 bool is_tensorwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
@@ -133,6 +137,18 @@ bool is_blockwise_1x32_scaling(const at::Tensor& t, const at::Tensor& scale) {
   return (is_fp8_path || is_packed_fp4_path);
 }
 
+// 1x16 blocks for packed nvfp4 data and float8_e4m3fn scales
+bool is_blockwise_1x16_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  // Packed FP4 stores 2 elements per byte, so the logical column count is
+  // size(1) * 2.
+  return (
+      t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+      scale.scalar_type() == at::kFloat8_e4m3fn && scale.dim() == 2 &&
+      scale.size(0) == t.size(0) &&
+      scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 16) &&
+      (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -148,6 +164,8 @@ bool is_desired_scaling(
       return is_blockwise_128x128_scaling(t, scale);
     case ScalingType::BlockWise1x32:
       return is_blockwise_1x32_scaling(t, scale);
+    case ScalingType::BlockWise1x16:
+      return is_blockwise_1x16_scaling(t, scale);
     default:
       return false;
   }
@@ -212,6 +230,15 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ceil_div<int64_t>(a.size(1) * 2, 32),
       ") and scale_b should be (",
       ceil_div<int64_t>(b.size(0) * 2, 32),
+      ", ",
+      b.size(1),
+      ").\n"
+      "- For NVFP4 1x16 scaling, a and b should be float4_e2m1fn_x2, scales should be float8_e4m3fn, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1) * 2, 16),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0) * 2, 16),
       ", ",
       b.size(1),
       ").\n"
@@ -289,12 +316,14 @@ Tensor& _scaled_gemm(
 //        RowWise: [M, 1];
 //        BlockWise1x128: [M, K//128];
 //        BlockWise1x32: [M, K//32] (MXFP8/MXFP4, Float8_e8m0fnu);
+//        BlockWise1x16: [M, K//16] (NVFP4, Float8_e4m3fn);
 //        BlockWise128x128: [M//128, K//128]
 //    - `scale_b`: inverse scale of `mat2`; shape depends on scaling scheme:
 //        TensorWise: scalar tensor;
 //        RowWise: [1, N];
 //        BlockWise1x128: [K//128, N];
 //        BlockWise1x32: [K//32, N] (MXFP8/MXFP4, Float8_e8m0fnu);
+//        BlockWise1x16: [K//16, N] (NVFP4, Float8_e4m3fn);
 //        BlockWise128x128: [K//128, N//128]
 //    - `scale_result`: a scalar tensor with the scale of the output (not
 //    currently supported on XPU)
@@ -350,6 +379,8 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
           std::make_pair(
               ScalingType::BlockWise1x32, ScalingType::BlockWise1x32),
+          std::make_pair(
+              ScalingType::BlockWise1x16, ScalingType::BlockWise1x16),
       },
       mat1,
       mat2,
@@ -451,14 +482,16 @@ Tensor& _scaled_mm_out_xpu(
   Tensor scale_b_internal = scale_b;
   if (scaling_choice_a == ScalingType::BlockWise128x128 ||
       scaling_choice_a == ScalingType::BlockWise1x128 ||
-      scaling_choice_a == ScalingType::BlockWise1x32) {
+      scaling_choice_a == ScalingType::BlockWise1x32 ||
+      scaling_choice_a == ScalingType::BlockWise1x16) {
     scale_a_internal = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
   }
   if (scaling_choice_b == ScalingType::BlockWise1x128 ||
       scaling_choice_b == ScalingType::BlockWise128x128 ||
-      scaling_choice_b == ScalingType::BlockWise1x32) {
-    // CUDA v1 shapes [K//128, N], [K//128, N//128], or [K//32, N] already
-    // match oneDNN's expected row-major layout. Just ensure contiguous.
+      scaling_choice_b == ScalingType::BlockWise1x32 ||
+      scaling_choice_b == ScalingType::BlockWise1x16) {
+    // CUDA v1 shapes [K//128, N], [K//128, N//128], [K//32, N], or [K//16, N]
+    // already match oneDNN's expected row-major layout. Just ensure contiguous.
     scale_b_internal = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
   }
   return _scaled_gemm(
@@ -503,7 +536,7 @@ using scaled_blas::convert_int_to_enum;
 using scaled_blas::ScaledGemmImplementation;
 using scaled_blas::ScaleKernelDispatchEntry;
 
-std::array<ScaleKernelDispatchEntry, 7> scale_kernel_dispatch = {{
+std::array<ScaleKernelDispatchEntry, 8> scale_kernel_dispatch = {{
     {"tensorwise_tensorwise",
      scaled_blas::check_tensorwise_recipe,
      ScaledGemmImplementation::TENSORWISE_TENSORWISE},
@@ -552,6 +585,9 @@ std::array<ScaleKernelDispatchEntry, 7> scale_kernel_dispatch = {{
     {"mxfp4_mxfp4",
      scaled_blas::check_mxfp4_recipe,
      ScaledGemmImplementation::MXFP4_MXFP4},
+    {"nvfp4_nvfp4_single_scale",
+     scaled_blas::check_nvfp4_recipe_single_scale,
+     ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE},
 }};
 
 Tensor& _scaled_tensorwise_tensorwise(
@@ -999,6 +1035,78 @@ Tensor& _scaled_mxfp4_mxfp4(
   return out;
 }
 
+Tensor& _scaled_nvfp4_nvfp4(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A, B are FP4, scales are float8_e4m3fn, scale_a: [M, K//16],
+  // scale_b: [N, K//16]. Single-level scaling (no global scale). Unlike CUDA,
+  // oneDNN does not swizzle scales; it needs real row-major 2D data, so scale_b
+  // is transposed to [K//16, N] below.
+  TORCH_CHECK_VALUE(
+      mat_a.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+          mat_b.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "mat_a and mat_b must be Float4_e2m1fn_x2 types, got: ",
+      mat_a.scalar_type(),
+      ", ",
+      mat_b.scalar_type());
+
+  // Packed FP4 format means actual-K = 2 * reported-K -- adjust
+  constexpr int64_t K_multiplier = 2;
+  const int64_t M = mat_a.sizes()[0];
+  const int64_t K = mat_a.sizes()[1] * K_multiplier;
+  const int64_t N = mat_b.sizes()[1];
+
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 16) &&
+          scale_a.scalar_type() == kFloat8_e4m3fn,
+      "scale_a must have shape ",
+      M,
+      " x ",
+      ceil_div<int64_t>(K, 16),
+      " Float8_e4m3fn elements, got ",
+      scale_a.sizes());
+
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 16) &&
+          scale_b.scalar_type() == kFloat8_e4m3fn,
+      "scale_b must have shape ",
+      N,
+      " x ",
+      ceil_div<int64_t>(K, 16),
+      " Float8_e4m3fn elements, got ",
+      scale_b.sizes());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [M, K//16] -> no transpose, just contiguous
+  //   scale_b [N, K//16] -> transpose to [K//16, N], then contiguous
+  auto sa = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
+  auto sb_t = scale_b.t();
+  auto sb = sb_t.is_contiguous() ? sb_t : sb_t.contiguous();
+
+  auto scaling_choice_a = ScalingType::BlockWise1x16;
+  auto scaling_choice_b = ScalingType::BlockWise1x16;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      sa,
+      sb,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
 // V2: Computes matrix multiply + bias while applying scaling to input and
 // output matrices. Scales are applicable when matrices are of Float8 or
 // Float4 (packed) type and assumed to be equal to 1.0 by default. If output
@@ -1169,6 +1277,15 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
       ", ",
       ceil_div<int64_t>(mat_b.size(0) * 2, 32),
       ").\n"
+      "- For NVFP4 BlockWise 1x16 scaling, a and b should be float4 (packed 2x), scales should be float8_e4m3fn, scale_a should be (",
+      mat_a.size(0),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(1) * 2, 16),
+      ") and scale_b should be (",
+      mat_b.size(1),
+      ", ",
+      ceil_div<int64_t>(mat_b.size(0) * 2, 16),
+      ").\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -1249,6 +1366,16 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
         out_mut);
   } else if (gemm_impl == ScaledGemmImplementation::MXFP4_MXFP4) {
     _scaled_mxfp4_mxfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias_opt,
+        out_dtype_,
+        use_fast_accum,
+        out_mut);
+  } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE) {
+    _scaled_nvfp4_nvfp4(
         mat_a,
         mat_b,
         scale_a[0],

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -116,6 +116,23 @@ bool is_blockwise_128x128_scaling(
       (scale.is_contiguous() || scale.t().is_contiguous()));
 }
 
+// 1x32 blocks for microscaled fp8 data and fp8_e8m0fnu scales
+bool is_blockwise_1x32_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  bool is_fp8_path =
+      (isFloat8Type(t.scalar_type()) &&
+       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
+       scale.size(0) == t.size(0) &&
+       scale.size(1) == ceil_div<int64_t>(t.size(1), 32) &&
+       (scale.is_contiguous() || scale.t().is_contiguous()));
+  bool is_packed_fp4_path =
+      (t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
+       scale.size(0) == t.size(0) &&
+       scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 32) &&
+       (scale.is_contiguous() || scale.t().is_contiguous()));
+  return (is_fp8_path || is_packed_fp4_path);
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -129,6 +146,8 @@ bool is_desired_scaling(
       return is_blockwise_1x128_scaling(t, scale);
     case ScalingType::BlockWise128x128:
       return is_blockwise_128x128_scaling(t, scale);
+    case ScalingType::BlockWise1x32:
+      return is_blockwise_1x32_scaling(t, scale);
     default:
       return false;
   }
@@ -177,6 +196,24 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ceil_div<int64_t>(b.size(0), 128),
       ", ",
       ceil_div<int64_t>(b.size(1), 128),
+      ").\n"
+      "- For MXFP8 1x32 scaling, a and b should be float8, scales should be float8_e8m0fnu, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 32),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 32),
+      ", ",
+      b.size(1),
+      ").\n"
+      "- For MXFP4 1x32 scaling, a and b should be float4_e2m1fn_x2, scales should be float8_e8m0fnu, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1) * 2, 32),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0) * 2, 32),
+      ", ",
+      b.size(1),
       ").\n"
       "Got a.dtype()=",
       a.scalar_type(),
@@ -311,6 +348,8 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
           std::make_pair(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
+          std::make_pair(
+              ScalingType::BlockWise1x32, ScalingType::BlockWise1x32),
       },
       mat1,
       mat2,
@@ -346,12 +385,14 @@ Tensor& _scaled_mm_out_xpu(
       !out_dtype || *out_dtype == out.scalar_type(),
       "out_dtype must match output matrix type");
   TORCH_CHECK(
-      at::isFloat8Type(mat1.scalar_type()),
-      "Expected mat1 to be Float8 matrix got ",
+      at::isFloat8Type(mat1.scalar_type()) ||
+          mat1.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat1 to be Float8 or Float4_e2m1fn_x2 matrix got ",
       mat1.scalar_type());
   TORCH_CHECK(
-      at::isFloat8Type(mat2.scalar_type()),
-      "Expected mat2 to be Float8 matrix got ",
+      at::isFloat8Type(mat2.scalar_type()) ||
+          mat2.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat2 to be Float8 or Float4_e2m1fn_x2 matrix got ",
       mat2.scalar_type());
   // TODO: oneDNN Currently only supports e4m3 with group scales on BMG. Not
   // support 2D scales, only 1D. Needs to add more checks there.
@@ -401,21 +442,23 @@ Tensor& _scaled_mm_out_xpu(
 
   // TODO: Scale_result is not supported by now!!
   // API shapes match CUDA v1. oneDNN needs row-major contiguous.
-  // scale_a: [M, K//128] or [M//128, K//128]
-  // scale_b: [K//128, N] or [K//128, N//128]
+  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32]
+  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N]
   // Because the user might passed in the CUDA's stride (col-major because of
   // swizzling)
   // call a contiguous() to ensure row-major for oneDNN
   Tensor scale_a_internal = scale_a;
   Tensor scale_b_internal = scale_b;
   if (scaling_choice_a == ScalingType::BlockWise128x128 ||
-      scaling_choice_a == ScalingType::BlockWise1x128) {
+      scaling_choice_a == ScalingType::BlockWise1x128 ||
+      scaling_choice_a == ScalingType::BlockWise1x32) {
     scale_a_internal = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
   }
   if (scaling_choice_b == ScalingType::BlockWise1x128 ||
-      scaling_choice_b == ScalingType::BlockWise128x128) {
-    // CUDA v1 shapes [K//128, N] and [K//128, N//128] already match oneDNN's
-    // expected row-major layout. Just ensure contiguous.
+      scaling_choice_b == ScalingType::BlockWise128x128 ||
+      scaling_choice_b == ScalingType::BlockWise1x32) {
+    // CUDA v1 shapes [K//128, N], [K//128, N//128], or [K//32, N] already
+    // match oneDNN's expected row-major layout. Just ensure contiguous.
     scale_b_internal = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
   }
   return _scaled_gemm(

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -279,7 +279,7 @@ Tensor& _scaled_gemm(
         "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
   // TODO: scale_result is not defined or used!
-  std::optional<Tensor> scaled_result = std::nullopt;
+  std::optional<Tensor> scale_result = std::nullopt;
   at::native::onednn::scaled_matmul(
       mat1,
       mat2,
@@ -289,7 +289,7 @@ Tensor& _scaled_gemm(
       scaling_choice_a,
       scaling_choice_b,
       bias,
-      scaled_result,
+      scale_result,
       false /* use_fast_accum */,
       alpha);
 

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -1221,14 +1221,21 @@ TORCH_IMPL_FUNC(_scaled_mm_xpu_v2_out)
   }
   {
     auto bias_ = bias.has_value() ? *bias : Tensor();
-    // NOLINTNEXTLINE(*c-array*)
-    TensorArg targs[]{
+    std::vector<TensorArg> targs{
         {out, "out", 0},
         {mat_a, "mat_a", 1},
         {mat_b, "mat_b", 2},
         {bias_, "bias", 3},
         {scale_a[0], "scale_a", 4},
         {scale_b[0], "scale_b", 5}};
+    // Two-level NVFP4 additionally passes per-tensor fp32 global scales as
+    // scale_a[1]/scale_b[1].
+    if (scale_a.size() > 1) {
+      targs.emplace_back(scale_a[1], "scale_a_global", 6);
+    }
+    if (scale_b.size() > 1) {
+      targs.emplace_back(scale_b[1], "scale_b_global", 7);
+    }
     checkAllSameGPU(__func__, targs);
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -365,6 +365,8 @@ struct ScaleSpec {
     //     This gives outer_dim scales (M for SRC, N for WEI)
     // For blockwise 1x128: groups = {1, 128} for SRC, {128, 1} for WEI
     //     scale shape: [outer_dim, ceil_div(inner_dim, 128)]
+    // For blockwise 1x32 (MXFP8/MXFP4): groups = {1, 32} for SRC, {32, 1} for WEI
+    //     scale shape: [outer_dim, ceil_div(inner_dim, 32)]
     if (group_m == 1 && group_k > 1) {
       return outer_dim * at::ceil_div(inner_dim, group_k);
     } else if (group_m > 1 && group_k == 1) {
@@ -459,12 +461,24 @@ inline ScaleSpec make_scale_spec(
           dnnl::memory::data_type::f32};
     }
 
+    case at::blas::ScalingType::BlockWise1x32: {
+      // Blockwise 1x32 scaling (MXFP8/MXFP4 microscaling)
+      // For SRC (A): scale shape [M, ceil_div(K, 32)], groups = {1, 32}
+      // For WEI (B): scale shape [ceil_div(K, 32), N], groups = {32, 1}
+      // mask={(1 << 0) | (1 << 1)}: Scale on both dim0 and dim1
+      // Scale dtype is e8m0
+      return {
+          (1 << 0) | (1 << 1),
+          is_src ? dnnl::memory::dims{1, 32} : dnnl::memory::dims{32, 1},
+          dnnl::memory::data_type::e8m0};
+    }
+
     default:
       TORCH_INTERNAL_ASSERT(
           false,
           "Unsupported scaling_type: ",
           static_cast<int>(scaling_type),
-          ". Currently only support TensorWise, RowWise, BlockWise1x128, and BlockWise128x128");
+          ". Currently only support TensorWise, RowWise, BlockWise1x128, BlockWise128x128, and BlockWise1x32");
   }
 }
 
@@ -488,12 +502,34 @@ sycl::event scaled_matmul(
   // 3. execute
 
   const int64_t M = mat1.size(0);
-  const int64_t K = mat1.size(1);
+  bool is_fp4 = (mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2);
+  if (is_fp4) {
+    TORCH_INTERNAL_ASSERT(
+        mat2.scalar_type() == at::ScalarType::Float4_e2m1fn_x2,
+        "Both mat1 and mat2 must be Float4_e2m1fn_x2 when FP4 path is used");
+  }
+  // Packed FP4 format means actual-K = 2 * reported-K -- adjust
+  const int64_t K_multiplier = is_fp4 ? 2 : 1;
+  const int64_t K = mat1.size(1) * K_multiplier;
   const int64_t N = mat2.size(1);
 
   // 1.1 Create memory descriptors
-  dnnl::memory::desc src_md = get_onednn_md(mat1);
-  dnnl::memory::desc weights_md = get_onednn_md(mat2);
+  // For FP4 types, the logical K dimension differs from the tensor dimension
+  // due to 2-element packing, so we must use format tags with the logical
+  // shape. For all other types, use get_onednn_md() to respect actual tensor
+  // strides (fixes stride mismatch for non-contiguous inputs).
+  dnnl::memory::desc src_md, weights_md;
+  if (is_fp4) {
+    src_md = dnnl::memory::desc(
+        {M, K}, get_onednn_dtype_include_double(mat1),
+        dnnl::memory::format_tag::ab);
+    weights_md = dnnl::memory::desc(
+        {K, N}, get_onednn_dtype_include_double(mat2),
+        dnnl::memory::format_tag::ba);
+  } else {
+    src_md = get_onednn_md(mat1);
+    weights_md = get_onednn_md(mat2);
+  }
   dnnl::memory::desc dst_md = get_onednn_md(result);
 
   dnnl::memory::desc bias_md;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -365,8 +365,11 @@ struct ScaleSpec {
     //     This gives outer_dim scales (M for SRC, N for WEI)
     // For blockwise 1x128: groups = {1, 128} for SRC, {128, 1} for WEI
     //     scale shape: [outer_dim, ceil_div(inner_dim, 128)]
-    // For blockwise 1x32 (MXFP8/MXFP4): groups = {1, 32} for SRC, {32, 1} for WEI
+    // For blockwise 1x32 (MXFP8/MXFP4): groups = {1, 32} for SRC, {32, 1} for
+    // WEI
     //     scale shape: [outer_dim, ceil_div(inner_dim, 32)]
+    // For blockwise 1x16 (NVFP4): groups = {1, 16} for SRC, {16, 1} for WEI
+    //     scale shape: [outer_dim, ceil_div(inner_dim, 16)]
     if (group_m == 1 && group_k > 1) {
       return outer_dim * at::ceil_div(inner_dim, group_k);
     } else if (group_m > 1 && group_k == 1) {
@@ -473,12 +476,24 @@ inline ScaleSpec make_scale_spec(
           dnnl::memory::data_type::e8m0};
     }
 
+    case at::blas::ScalingType::BlockWise1x16: {
+      // Blockwise 1x16 scaling (NVFP4)
+      // For SRC (A): scale shape [M, ceil_div(K, 16)], groups = {1, 16}
+      // For WEI (B): scale shape [ceil_div(K, 16), N], groups = {16, 1}
+      // mask={(1 << 0) | (1 << 1)}: Scale on both dim0 and dim1
+      // Scale dtype is float8_e4m3fn -> oneDNN f8_e4m3
+      return {
+          (1 << 0) | (1 << 1),
+          is_src ? dnnl::memory::dims{1, 16} : dnnl::memory::dims{16, 1},
+          dnnl::memory::data_type::f8_e4m3};
+    }
+
     default:
       TORCH_INTERNAL_ASSERT(
           false,
           "Unsupported scaling_type: ",
           static_cast<int>(scaling_type),
-          ". Currently only support TensorWise, RowWise, BlockWise1x128, BlockWise128x128, and BlockWise1x32");
+          ". Currently only support TensorWise, RowWise, BlockWise1x128, BlockWise128x128, BlockWise1x32, and BlockWise1x16");
   }
 }
 
@@ -521,10 +536,12 @@ sycl::event scaled_matmul(
   dnnl::memory::desc src_md, weights_md;
   if (is_fp4) {
     src_md = dnnl::memory::desc(
-        {M, K}, get_onednn_dtype_include_double(mat1),
+        {M, K},
+        get_onednn_dtype_include_double(mat1),
         dnnl::memory::format_tag::ab);
     weights_md = dnnl::memory::desc(
-        {K, N}, get_onednn_dtype_include_double(mat2),
+        {K, N},
+        get_onednn_dtype_include_double(mat2),
         dnnl::memory::format_tag::ba);
   } else {
     src_md = get_onednn_md(mat1);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -507,7 +507,8 @@ sycl::event scaled_matmul(
     at::blas::ScalingType scaling_choice_b,
     const std::optional<at::Tensor>& bias,
     const std::optional<at::Tensor>& scale_result,
-    bool use_fast_accum) {
+    bool use_fast_accum,
+    const std::optional<at::Tensor>& alpha) {
   auto& engine = GpuEngineManager::Instance().get_engine();
   auto& stream = GpuStreamManager::Instance().get_stream();
 
@@ -562,6 +563,16 @@ sycl::event scaled_matmul(
     }
   }
 
+  // alpha applies a per-tensor multiplier to the matmul product (used by
+  // two-level NVFP4 global scaling: alpha = global_scale_a * global_scale_b).
+  // CUDA computes alpha*(A@B)+bias. oneDNN applies DNNL_ARG_BIAS *before*
+  // post-ops, so when alpha is present we apply bias as a binary_add post-op
+  // *after* the alpha multiply to preserve the same math. Without alpha, bias
+  // stays on the native DNNL_ARG_BIAS path.
+  bool with_alpha = alpha.has_value() && alpha->defined();
+  bool bias_as_arg = with_bias && !with_alpha;
+  bool bias_as_post_op = with_bias && with_alpha;
+
   // 1.2 Create primitive descriptor and set scales mask
   const ScaleSpec src_spec = make_scale_spec(scaling_choice_a, M, K, N, "src");
   const ScaleSpec wei_spec = make_scale_spec(scaling_choice_b, M, K, N, "wei");
@@ -585,10 +596,27 @@ sycl::event scaled_matmul(
     op_attr.set_scales(DNNL_ARG_DST, 0, {}, dnnl::memory::data_type::f32);
   }
 
+  // Assemble post-ops: optional alpha (binary_mul) followed by optional bias
+  // (binary_add). Order matters -- alpha must be applied to the product before
+  // bias is added.
+  dnnl::memory::desc alpha_md;
+  dnnl::post_ops po;
+  if (with_alpha) {
+    alpha_md = dnnl::memory::desc(
+        {1, 1}, dnnl::memory::data_type::f32, dnnl::memory::format_tag::ab);
+    po.append_binary(dnnl::algorithm::binary_mul, alpha_md);
+  }
+  if (bias_as_post_op) {
+    po.append_binary(dnnl::algorithm::binary_add, bias_md);
+  }
+  if (po.len() > 0) {
+    op_attr.set_post_ops(po);
+  }
+
   op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
   // 1.3 Create the matmul primitive descriptor
-  dnnl::matmul::primitive_desc matmul_pd = with_bias
+  dnnl::matmul::primitive_desc matmul_pd = bias_as_arg
       ? dnnl::matmul::primitive_desc(
             engine, src_md, weights_md, bias_md, dst_md, op_attr)
       : dnnl::matmul::primitive_desc(
@@ -610,7 +638,6 @@ sycl::event scaled_matmul(
     b_usr_m =
         make_onednn_memory(bias_md, engine, possible_reshaped_bias.data_ptr());
   }
-
   // Prepare scale memory for oneDNN.
   auto make_scale_mem_from_spec =
       [&](const ScaleSpec& spec,
@@ -636,7 +663,7 @@ sycl::event scaled_matmul(
   args.insert({DNNL_ARG_WEIGHTS, weights_usr_m});
   args.insert({DNNL_ARG_DST, dst_usr_m});
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
-  if (with_bias) {
+  if (bias_as_arg) {
     args.insert({DNNL_ARG_BIAS, b_usr_m});
   }
 
@@ -648,6 +675,24 @@ sycl::event scaled_matmul(
 
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, src_sc_mem});
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_sc_mem});
+
+  // Bind post-op operands in the same order they were appended above.
+  at::Tensor alpha_f32;
+  int post_op_idx = 0;
+  if (with_alpha) {
+    alpha_f32 = alpha->to(at::kFloat).contiguous();
+    auto alpha_mem = make_onednn_memory(alpha_md, engine, alpha_f32.data_ptr());
+    args.insert(
+        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_op_idx) | DNNL_ARG_SRC_1,
+         alpha_mem});
+    post_op_idx++;
+  }
+  if (bias_as_post_op) {
+    args.insert(
+        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_op_idx) | DNNL_ARG_SRC_1,
+         b_usr_m});
+    post_op_idx++;
+  }
 
   at::Tensor dst_scale_tensor;
   if (with_dst_scale) {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -518,7 +518,7 @@ sycl::event scaled_matmul(
   // 3. execute
 
   const int64_t M = mat1.size(0);
-  bool is_fp4 = (mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2);
+  const bool is_fp4 = (mat1.scalar_type() == at::ScalarType::Float4_e2m1fn_x2);
   if (is_fp4) {
     TORCH_INTERNAL_ASSERT(
         mat2.scalar_type() == at::ScalarType::Float4_e2m1fn_x2,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -529,25 +529,11 @@ sycl::event scaled_matmul(
   const int64_t K = mat1.size(1) * K_multiplier;
   const int64_t N = mat2.size(1);
 
-  // 1.1 Create memory descriptors
-  // For FP4 types, the logical K dimension differs from the tensor dimension
-  // due to 2-element packing, so we must use format tags with the logical
-  // shape. For all other types, use get_onednn_md() to respect actual tensor
-  // strides (fixes stride mismatch for non-contiguous inputs).
-  dnnl::memory::desc src_md, weights_md;
-  if (is_fp4) {
-    src_md = dnnl::memory::desc(
-        {M, K},
-        get_onednn_dtype_include_double(mat1),
-        dnnl::memory::format_tag::ab);
-    weights_md = dnnl::memory::desc(
-        {K, N},
-        get_onednn_dtype_include_double(mat2),
-        dnnl::memory::format_tag::ba);
-  } else {
-    src_md = get_onednn_md(mat1);
-    weights_md = get_onednn_md(mat2);
-  }
+  // 1.1 Create memory descriptors. get_onednn_md() respects the tensor's real
+  // strides and unpacks Float4_e2m1fn_x2 (2 logical elements per byte) into the
+  // logical shape oneDNN's f4_e2m1 descriptor expects.
+  dnnl::memory::desc src_md = get_onednn_md(mat1);
+  dnnl::memory::desc weights_md = get_onednn_md(mat2);
   dnnl::memory::desc dst_md = get_onednn_md(result);
 
   dnnl::memory::desc bias_md;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -89,6 +89,10 @@ dnnl::memory::data_type get_onednn_dtype(
       return dnnl::memory::data_type::f8_e4m3;
     case at::ScalarType::Float8_e5m2:
       return dnnl::memory::data_type::f8_e5m2;
+    case at::ScalarType::Float8_e8m0fnu:
+      return dnnl::memory::data_type::e8m0;
+    case at::ScalarType::Float4_e2m1fn_x2:
+      return dnnl::memory::data_type::f4_e2m1;
     default:
       if (!allow_undef) {
         TORCH_CHECK(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -133,10 +133,36 @@ dnnl::memory::dims get_onednn_strides(const at::Tensor& tensor) {
 
 dnnl::memory::desc get_onednn_md(const at::Tensor& tensor) {
   Tensor t = tensor.sizes().empty() ? tensor.unsqueeze(0) : tensor;
-  return {
-      get_onednn_dims(t),
-      get_onednn_dtype_include_double(t),
-      get_onednn_strides(t)};
+  auto dims = get_onednn_dims(t);
+  auto strides = get_onednn_strides(t);
+
+  // Float4_e2m1fn_x2 packs 2 logical elements into one byte along the
+  // contiguous (stride-1) dimension, so the tensor reports packed sizes and
+  // strides. oneDNN's sub-byte f4_e2m1 descriptor expects the logical
+  // (unpacked) shape with element-unit strides: double the packed dim's extent
+  // and scale every other dim's stride by 2 (the packed dim stays stride 1).
+  if (t.scalar_type() == at::ScalarType::Float4_e2m1fn_x2) {
+    int packed_dim = -1;
+    for (size_t i = 0; i < strides.size(); ++i) {
+      if (strides[i] == 1) {
+        packed_dim = static_cast<int>(i);
+        break;
+      }
+    }
+    TORCH_CHECK(
+        packed_dim >= 0,
+        "oneDNN FP4 matmul requires a contiguous (stride-1) packed dimension, got strides ",
+        t.strides());
+    for (size_t i = 0; i < strides.size(); ++i) {
+      if (static_cast<int>(i) == packed_dim) {
+        dims[i] *= 2;
+      } else {
+        strides[i] *= 2;
+      }
+    }
+  }
+
+  return {dims, get_onednn_dtype_include_double(t), strides};
 }
 
 bool onednn_strides_check(const Tensor& src) {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
@@ -216,5 +216,6 @@ sycl::event scaled_matmul(
     at::blas::ScalingType scaling_choice_b,
     const std::optional<at::Tensor>& bias,
     const std::optional<at::Tensor>& scale_result,
-    bool use_fast_accum);
+    bool use_fast_accum,
+    const std::optional<at::Tensor>& alpha = std::nullopt);
 } // namespace at::native::onednn

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1615,8 +1615,11 @@ class TestFP8Lowering(TestCase):
         B_scale = torch.full(
             (N, ceil_div(K, BLOCK_SIZE)), 1.0, device=device, dtype=torch.float8_e8m0fnu
         )
-        A_scale = to_blocked(A_scale)
-        B_scale = to_blocked(B_scale)
+        if "cuda" in device:
+            A_scale = to_blocked(A_scale)
+            B_scale = to_blocked(B_scale)
+        elif "xpu" in device:
+            B_scale = B_scale.t()
 
         def linear(A, B, A_scale, B_scale):
             y = torch._scaled_mm(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1602,7 +1602,11 @@ class TestFP8Lowering(TestCase):
     @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, "Not supported on non B200")
     def test_mx_fp8_max_autotune(self, device):
-        M, K, N = 128, 32, 128
+        # K must match the operands, which are eye(M)/eye(N) (i.e. 128 wide);
+        # using a smaller K would size the MX 1x32 scales for fewer K-blocks
+        # than the data has (XPU rejects this; CUDA only masks it via the
+        # to_blocked() zero-padding below).
+        M, K, N = 128, 128, 128
         BLOCK_SIZE = 32
         dtype = torch.bfloat16
         A_ref = torch.eye(M, device=device, dtype=torch.bfloat16)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -711,7 +711,7 @@ class TestFP8Matmul(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_float8_basics_invalid_out_dtype(self, device) -> None:
         with self.assertRaises(
-            AssertionError if (torch.version.hip or "xpu" in device)
+            AssertionError if (torch.version.hip or "xpu" in device or "cpu" in device)
             else RuntimeError
         ):
             self._test_tautological_mm(device, out_dtype=e5m2_type)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1965,8 +1965,6 @@ class TestFP8Matmul(TestCase):
         if "xpu" in device:
             if fast_accum:
                 raise unittest.SkipTest("fast_accum not supported on XPU, skipping")
-            if recipe == "nvfp4":
-                raise unittest.SkipTest("nvfp4 not supported on XPU, skipping")
         M, K, N = mkn
         if recipe == "nvfp4" and K % 32 != 0:
             raise unittest.SkipTest("K must be divisible by 32 for nvfp4 cublas gemm, skipping")
@@ -2587,7 +2585,7 @@ class TestFP8Matmul(TestCase):
 
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
-    @skipXPU
+    @onlyOn(["cuda", "xpu"])
     def test_blockwise_nvfp4_compile(self, device) -> None:
 
         M, K, N = 128, 128, 128

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -711,7 +711,7 @@ class TestFP8Matmul(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_float8_basics_invalid_out_dtype(self, device) -> None:
         with self.assertRaises(
-            AssertionError if (torch.version.hip or "xpu" in device or "cpu" in device)
+            AssertionError if (torch.version.hip or "xpu" in device)
             else RuntimeError
         ):
             self._test_tautological_mm(device, out_dtype=e5m2_type)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1918,6 +1918,7 @@ class TestFP8Matmul(TestCase):
             raise AssertionError(f"sqnr {sqnr.item()} should be > {approx_match_sqnr_target}")
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    @onlyOn(["cuda", "xpu"])
     @parametrize("test_case_name", [
         "a_eye_b_eye",
         "a_ones_b_ones",
@@ -1961,6 +1962,11 @@ class TestFP8Matmul(TestCase):
             raise unittest.SkipTest("fast_accum not supported in nvfp4/mxfp4 cublas gemm, skipping")
         if recipe == "mxfp4" and SM120OrLater:
             raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
+        if "xpu" in device:
+            if fast_accum:
+                raise unittest.SkipTest("fast_accum not supported on XPU, skipping")
+            if recipe == "nvfp4":
+                raise unittest.SkipTest("nvfp4 not supported on XPU, skipping")
         M, K, N = mkn
         if recipe == "nvfp4" and K % 32 != 0:
             raise unittest.SkipTest("K must be divisible by 32 for nvfp4 cublas gemm, skipping")
@@ -2157,7 +2163,7 @@ class TestFP8Matmul(TestCase):
         C_ref = A_ref @ B_ref.t()
 
         # convert to swizzled format
-        if not torch.version.hip:
+        if not torch.version.hip and "xpu" not in device:
             A_scale = to_blocked(A_scale)
             B_scale = to_blocked(B_scale)
 
@@ -2301,6 +2307,8 @@ class TestFP8Matmul(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM or IS_WINDOWS, mx_skip_msg)
     @parametrize("recipe", ["mxfp8", "mxfp4" if torch.version.hip else "nvfp4"])
     def test_blockwise_mxfp8_nvfp4_error_messages(self, device, recipe) -> None:
+        if "xpu" in device:
+            raise unittest.SkipTest("Error messages test not supported on XPU, skipping")
         if recipe == "mxfp4" and SM120OrLater:
             raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
         M, K, N = (1024, 512, 2048)
@@ -2550,6 +2558,7 @@ class TestFP8Matmul(TestCase):
 
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    @onlyOn(["cuda", "xpu"])
     def test_blockwise_mxfp8_compile(self, device) -> None:
 
         M, K, N = 128, 128, 128
@@ -2578,6 +2587,7 @@ class TestFP8Matmul(TestCase):
 
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    @skipXPU
     def test_blockwise_nvfp4_compile(self, device) -> None:
 
         M, K, N = 128, 128, 128

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1860,7 +1860,7 @@ class TestFP8Matmul(TestCase):
         torch.testing.assert_close(lp_data_actual, lp_data_expected, atol=0, rtol=0)
 
     @skipIfRocm
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     @parametrize("mkn", [
         # Nice shapes

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -2181,6 +2181,7 @@ class TestFP8Matmul(TestCase):
             if sqnr.item() <= approx_match_sqnr_target:
                 raise AssertionError(f"sqnr {sqnr.item()} should be > {approx_match_sqnr_target}")
 
+    @skipXPU
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM or IS_WINDOWS, mx_skip_msg)
     def test_passed_swizzle_arrays(self, device) -> None:
         # Ensure that incorrectly-sized swizzle arrays are caught

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -25,7 +25,7 @@ from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemm
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
-from ..ir import Buffer, ChoiceCaller, is_triton, Layout
+from ..ir import Buffer, ChoiceCaller, is_triton, Layout, PermuteView, TensorBox
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import (
     fallback_handler,
@@ -982,6 +982,14 @@ def tuned_scaled_mm_v2(
 
     # Only handle single-level scales (no MX/NV)
     scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
+
+    # When falling back to aten._scaled_mm (v1) for MX types (BlockWise1x32,
+    # BlockWise1x16), transpose scale_b from v2 convention [N, K//32] to v1
+    # convention [K//32, N]. The v1 kernel checks scale_b shape against
+    # b.t()/scale_b.t(), so the shape must match.
+    if not supported_recipe and len(scale_b_real.get_size()) == 2:
+        scale_b_real = TensorBox(PermuteView.create(scale_b_real.data, (1, 0)))
+        scale_b_real = realize_inputs(scale_b_real)
 
     input_nodes: list[Any]
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -25,7 +25,7 @@ from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemm
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
-from ..ir import Buffer, ChoiceCaller, is_triton, Layout, PermuteView, TensorBox
+from ..ir import Buffer, ChoiceCaller, is_triton, Layout
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import (
     fallback_handler,
@@ -162,6 +162,19 @@ aten__sparse_semi_structured_mm = ExternKernelChoice(
 
 aten__fp8_mm = ExternKernelChoice(
     torch._scaled_mm, "at::_scaled_mm_out", op_overload=aten._scaled_mm.out
+)
+
+# Fallback choice for the _scaled_mm_v2 API. Used for recipes that have no Triton
+# template yet (e.g. the MX variants BlockWise1x32/BlockWise1x16). Routed through
+# ir.FallbackKernel so the v2 op is called directly with its native scale
+# convention, instead of being lowered to the v1 _scaled_mm kernel which uses a
+# different scale_b orientation.
+aten__scaled_mm_v2 = ExternKernelChoice(
+    aten._scaled_mm_v2.default,
+    name="_scaled_mm_v2",
+    has_out_variant=False,
+    op_overload=aten._scaled_mm_v2.default,
+    use_fallback_kernel=True,
 )
 
 
@@ -980,16 +993,17 @@ def tuned_scaled_mm_v2(
         recipe_b
     )
 
-    # Only handle single-level scales (no MX/NV)
-    scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
+    # MX variants (BlockWise1x32/BlockWise1x16) and multi-level scales have no
+    # Triton template; they fall back to an aten kernel. The v1 _scaled_mm kernel
+    # uses a different scale_b orientation than v2, so route these through the
+    # _scaled_mm_v2 fallback below instead of the v1 aten__fp8_mm choice.
+    is_mx_fallback = (
+        scale_a[0].dtype != torch.float32
+        or (not supported_recipe)
+        or (not is_single_level_scale)
+    )
 
-    # When falling back to aten._scaled_mm (v1) for MX types (BlockWise1x32,
-    # BlockWise1x16), transpose scale_b from v2 convention [N, K//32] to v1
-    # convention [K//32, N]. The v1 kernel checks scale_b shape against
-    # b.t()/scale_b.t(), so the shape must match.
-    if not supported_recipe and len(scale_b_real.get_size()) == 2:
-        scale_b_real = TensorBox(PermuteView.create(scale_b_real.data, (1, 0)))
-        scale_b_real = realize_inputs(scale_b_real)
+    scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
 
     input_nodes: list[Any]
 
@@ -1011,10 +1025,29 @@ def tuned_scaled_mm_v2(
     kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
-        templates_to_use.append(aten__fp8_mm)
-        kwarg_overrides[aten__fp8_mm.uid] = dict(
-            out_dtype=out_dtype, use_fast_accum=use_fast_accum
-        )
+        if is_mx_fallback:
+            # Call _scaled_mm_v2 directly so the scales keep their v2 convention.
+            bias_node = realize_inputs(bias) if bias else None
+            aten__scaled_mm_v2.maybe_append_choice(
+                choices,
+                input_nodes=[mat_a, mat_b],
+                layout=layout,
+                scale_a=[realize_inputs(s) for s in scale_a],
+                recipe_a=list(recipe_a),
+                swizzle_a=list(swizzle_a),
+                scale_b=[realize_inputs(s) for s in scale_b],
+                recipe_b=list(recipe_b),
+                swizzle_b=list(swizzle_b),
+                bias=bias_node,
+                out_dtype=out_dtype,
+                contraction_dim=list(contraction_dim) if contraction_dim else [],
+                use_fast_accum=use_fast_accum,
+            )
+        else:
+            templates_to_use.append(aten__fp8_mm)
+            kwarg_overrides[aten__fp8_mm.uid] = dict(
+                out_dtype=out_dtype, use_fast_accum=use_fast_accum
+            )
 
     _, is_nonzero = _is_static_problem(layout)
 
@@ -1106,11 +1139,7 @@ def tuned_scaled_mm_v2(
         )
 
     # Early return for MX variants
-    if (
-        scale_a[0].dtype != torch.float32
-        or (not supported_recipe)
-        or (not is_single_level_scale)
-    ):
+    if is_mx_fallback:
         node, _ = autotune_select_algorithm(name, choices, input_nodes, layout)
         return node
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -927,6 +927,7 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+
     # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
     # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,
     # RowWise, and DeepSeek BlockWise1x128/128x128). Everything else has no

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -164,19 +164,6 @@ aten__fp8_mm = ExternKernelChoice(
     torch._scaled_mm, "at::_scaled_mm_out", op_overload=aten._scaled_mm.out
 )
 
-# Fallback choice for the _scaled_mm_v2 API. Used for recipes that have no Triton
-# template yet (e.g. the MX variants BlockWise1x32/BlockWise1x16). Routed through
-# ir.FallbackKernel so the v2 op is called directly with its native scale
-# convention, instead of being lowered to the v1 _scaled_mm kernel which uses a
-# different scale_b orientation.
-aten__scaled_mm_v2 = ExternKernelChoice(
-    aten._scaled_mm_v2.default,
-    name="_scaled_mm_v2",
-    has_out_variant=False,
-    op_overload=aten._scaled_mm_v2.default,
-    use_fallback_kernel=True,
-)
-
 
 def _is_int8_mat(mat):
     return mat.get_dtype() in (torch.int8, torch.uint8)
@@ -940,11 +927,32 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
-    # Swizzling is not yet wired into any Inductor template or extern choice
-    # here. Rather than failing compilation, defer swizzled scale layouts
-    # (e.g. blockwise MXFP8/NVFP4 on Blackwell) to the eager op so they still
-    # produce correct results.
-    if any(s != 0 for s in swizzle_a) or any(s != 0 for s in swizzle_b):
+    # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
+    # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,
+    # RowWise, and DeepSeek BlockWise1x128/128x128). Everything else has no
+    # template or extern choice here, so defer to the eager _scaled_mm_v2 op:
+    #   - swizzled scale layouts (e.g. CUDA/Blackwell MXFP8/NVFP4)
+    #   - the blockwise MX/NVFP4 recipes BlockWise1x32/1x16 (also how XPU
+    #     expresses MX/NVFP4, with NO_SWIZZLE)
+    #   - multi-level scales (two-level NVFP4)
+    #   - any non-fp32 block scale
+    # The eager op is called directly so it keeps its native v2 scale_b
+    # convention, unlike the v1 aten__fp8_mm choice used on the supported path.
+    def check_supported_recipe(recipe: list[int]) -> bool:
+        disallowed = OrderedSet([ScalingType.BlockWise1x16, ScalingType.BlockWise1x32])
+        return all(ScalingType(r) not in disallowed for r in recipe)
+
+    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
+    supported_recipe = check_supported_recipe(recipe_a) and check_supported_recipe(
+        recipe_b
+    )
+    if (
+        any(s != 0 for s in swizzle_a)
+        or any(s != 0 for s in swizzle_b)
+        or not supported_recipe
+        or not is_single_level_scale
+        or scale_a[0].dtype != torch.float32
+    ):
         # contraction_dim is a non-optional int[] in the schema (default []);
         # this lowering defaults it to None, so coerce before the eager call.
         fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
@@ -980,29 +988,6 @@ def tuned_scaled_mm_v2(
     name = "scaled_mm"
     check_supported_striding(mat_a, mat_b)
 
-    if not (len(scale_a) >= 1 and len(scale_b) >= 1):
-        raise AssertionError("scale_a and scale_b must each have at least one entry")
-
-    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
-
-    def check_supported_recipe(recipe: list[int]) -> bool:
-        disallowed = OrderedSet([ScalingType.BlockWise1x16, ScalingType.BlockWise1x32])
-        return all(ScalingType(r) not in disallowed for r in recipe)
-
-    supported_recipe = check_supported_recipe(recipe_a) and check_supported_recipe(
-        recipe_b
-    )
-
-    # MX variants (BlockWise1x32/BlockWise1x16) and multi-level scales have no
-    # Triton template; they fall back to an aten kernel. The v1 _scaled_mm kernel
-    # uses a different scale_b orientation than v2, so route these through the
-    # _scaled_mm_v2 fallback below instead of the v1 aten__fp8_mm choice.
-    is_mx_fallback = (
-        scale_a[0].dtype != torch.float32
-        or (not supported_recipe)
-        or (not is_single_level_scale)
-    )
-
     scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
 
     input_nodes: list[Any]
@@ -1025,29 +1010,10 @@ def tuned_scaled_mm_v2(
     kwarg_overrides = {}
 
     if use_aten_gemm_kernels():
-        if is_mx_fallback:
-            # Call _scaled_mm_v2 directly so the scales keep their v2 convention.
-            bias_node = realize_inputs(bias) if bias else None
-            aten__scaled_mm_v2.maybe_append_choice(
-                choices,
-                input_nodes=[mat_a, mat_b],
-                layout=layout,
-                scale_a=[realize_inputs(s) for s in scale_a],
-                recipe_a=list(recipe_a),
-                swizzle_a=list(swizzle_a),
-                scale_b=[realize_inputs(s) for s in scale_b],
-                recipe_b=list(recipe_b),
-                swizzle_b=list(swizzle_b),
-                bias=bias_node,
-                out_dtype=out_dtype,
-                contraction_dim=list(contraction_dim) if contraction_dim else [],
-                use_fast_accum=use_fast_accum,
-            )
-        else:
-            templates_to_use.append(aten__fp8_mm)
-            kwarg_overrides[aten__fp8_mm.uid] = dict(
-                out_dtype=out_dtype, use_fast_accum=use_fast_accum
-            )
+        templates_to_use.append(aten__fp8_mm)
+        kwarg_overrides[aten__fp8_mm.uid] = dict(
+            out_dtype=out_dtype, use_fast_accum=use_fast_accum
+        )
 
     _, is_nonzero = _is_static_problem(layout)
 
@@ -1137,11 +1103,6 @@ def tuned_scaled_mm_v2(
             input_nodes,
             kernel_inputs=kernel_inputs,
         )
-
-    # Early return for MX variants
-    if is_mx_fallback:
-        node, _ = autotune_select_algorithm(name, choices, input_nodes, layout)
-        return node
 
     if (
         is_nonzero

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4942,14 +4942,26 @@ def _infer_scale_swizzle_impl(
 
     # NVFP4: BlockWise1x16 with float8_e4m3fn scales
     if mat_dtype == torch.float4_e2m1fn_x2 and scale_dtype == torch.float8_e4m3fn:
-        expected_numel_a = _round_up(mat_size[0], 128) * _round_up(
-            ceildiv(K_multiplier * mat_size[1], 16), 4
-        )
-        expected_numel_b = _round_up(mat_size[1], 128) * _round_up(
-            ceildiv(K_multiplier * mat_size[0], 16), 4
-        )
-        if eq_fn(scale_numel, expected_numel_a) or eq_fn(scale_numel, expected_numel_b):
-            return ScalingType.BlockWise1x16, SwizzleType.SWIZZLE_32_4_4
+        if torch.xpu._is_compiled():
+            # XPU: no swizzle
+            expected_numel_a = ceildiv(mat_size[0], 16) * K_multiplier * mat_size[1]
+            expected_numel_b = ceildiv(K_multiplier * mat_size[1], 16) * mat_size[0]
+            if eq_fn(scale_numel, expected_numel_a) or eq_fn(
+                scale_numel, expected_numel_b
+            ):
+                return ScalingType.BlockWise1x16, SwizzleType.NO_SWIZZLE
+        else:
+            # NVIDIA: uses swizzled 32x4x4 layout
+            expected_numel_a = _round_up(mat_size[0], 128) * _round_up(
+                ceildiv(K_multiplier * mat_size[1], 16), 4
+            )
+            expected_numel_b = _round_up(mat_size[1], 128) * _round_up(
+                ceildiv(K_multiplier * mat_size[0], 16), 4
+            )
+            if eq_fn(scale_numel, expected_numel_a) or eq_fn(
+                scale_numel, expected_numel_b
+            ):
+                return ScalingType.BlockWise1x16, SwizzleType.SWIZZLE_32_4_4
 
     # MXFP8: BlockWise1x32 with float8_e8m0fnu scales
     if scale_dtype == torch.float8_e8m0fnu:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4953,7 +4953,7 @@ def _infer_scale_swizzle_impl(
 
     # MXFP8: BlockWise1x32 with float8_e8m0fnu scales
     if scale_dtype == torch.float8_e8m0fnu:
-        if not torch.version.hip:
+        if not torch.version.hip and not torch.xpu._is_compiled():
             # NVIDIA: uses swizzled 32x4x4 layout
             expected_numel_a = _round_up(mat_size[0], 128) * _round_up(
                 ceildiv(K_multiplier * mat_size[1], 32), 4
@@ -4966,7 +4966,7 @@ def _infer_scale_swizzle_impl(
             ):
                 return ScalingType.BlockWise1x32, SwizzleType.SWIZZLE_32_4_4
         else:
-            # AMD: no swizzle
+            # AMD/XPU: no swizzle
             expected_numel_a = ceildiv(mat_size[0], 32) * K_multiplier * mat_size[1]
             expected_numel_b = ceildiv(K_multiplier * mat_size[1], 32) * mat_size[0]
             if eq_fn(scale_numel, expected_numel_a) or eq_fn(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7067,14 +7067,24 @@ def _check_scaled_mm_sizes(
                 scale_a.numel() == expected_a_size
                 and scale_b.numel() == expected_b_size
             ):
-                torch._check(
-                    scale_a.is_contiguous(),
-                    lambda: "scale_a must be contiguous",
-                )
-                torch._check(
-                    scale_b.is_contiguous(),
-                    lambda: "scale_b must be contiguous",
-                )
+                if device_hint(self) == "xpu":
+                    torch._check(
+                        scale_a.is_contiguous() or scale_a.t().is_contiguous(),
+                        lambda: "scale_a must be contiguous or column-major contiguous",
+                    )
+                    torch._check(
+                        scale_b.is_contiguous() or scale_b.t().is_contiguous(),
+                        lambda: "scale_b must be contiguous or column-major contiguous",
+                    )
+                else:
+                    torch._check(
+                        scale_a.is_contiguous(),
+                        lambda: "scale_a must be contiguous",
+                    )
+                    torch._check(
+                        scale_b.is_contiguous(),
+                        lambda: "scale_b must be contiguous",
+                    )
             else:
                 torch._check(
                     False,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7054,14 +7054,21 @@ def _check_scaled_mm_sizes(
             block_size_mn = 128
 
             num_k_blocks = ceil_div(_k, block_size_k)
-            padded_num_k_blocks = ceil_div(num_k_blocks, 4) * 4
 
-            expected_a_size = (
-                block_size_mn * ceil_div(m, block_size_mn) * padded_num_k_blocks
-            )
-            expected_b_size = (
-                block_size_mn * ceil_div(n, block_size_mn) * padded_num_k_blocks
-            )
+            if device_hint(self) == "xpu":
+                # XPU (oneDNN) uses unswizzled, unpadded blockwise scale shapes,
+                # unlike the L4-padded SWIZZLE_32_4_4 layout CUDA expects.
+                expected_a_size = num_k_blocks * m
+                expected_b_size = num_k_blocks * n
+            else:
+                padded_num_k_blocks = ceil_div(num_k_blocks, 4) * 4
+
+                expected_a_size = (
+                    block_size_mn * ceil_div(m, block_size_mn) * padded_num_k_blocks
+                )
+                expected_b_size = (
+                    block_size_mn * ceil_div(n, block_size_mn) * padded_num_k_blocks
+                )
 
             if (
                 scale_a.numel() == expected_a_size

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -207,6 +207,8 @@ def evaluate_platform_supports_mx_gemm():
                 return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
         else:
             return SM100OrLater
+    if torch.xpu.is_available():
+        return True
     return False
 
 def evaluate_platform_supports_mxfp8_grouped_gemm():


### PR DESCRIPTION
The purpose of this PR is to test on CI only.  I have split the code into the following 4 PRs for review: 

#181726 [xpu][1/4]Implement scaled_mm_v2 for MXFP8/MXFP4/NVFP4 on XPU
#181727 [xpu][2/4]Implement scaled_mm_v1 for MXFP8/MXFP4/NVFP4 on XPU
#187315 [xpu][3/4] inductor: route MX scaled_mm_v2 fallback through v2 aten kernel
#181728 [xpu][4/4]Enable MXFP8/MXFP4/NVFP4 tests for XPU

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo