### PR TITLE
docs: fix quantization typo

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -6,7 +6,7 @@ Quantization
 .. automodule:: torch.ao.quantization
 .. automodule:: torch.ao.quantization.fx
 
-We are cetralizing all quantization related development to `torchao <https://github.com/pytorch/ao>`__, please checkout our new doc page: https://docs.pytorch.org/ao/stable/index.html
+We are centralizing all quantization related development to `torchao <https://github.com/pytorch/ao>`__, please checkout our new doc page: https://docs.pytorch.org/ao/stable/index.html
 
 Plan for the existing quantization flows:
 1. Eager mode quantization (torch.ao.quantization.quantize,


### PR DESCRIPTION
Closes #186496.

## Summary
- Fix `cetralizing` to `centralizing` in the PyTorch 2.12 quantization docs.

## Verification
- Checked `docs/source/quantization.rst` on `release/2.12` no longer contains `cetralizing`.