### PR TITLE
Fix Tensor.to() ignoring memory_format for non-contiguous tensors

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -419,7 +419,9 @@ bool to_will_alias(
       is_null_or_equal_to(layout, self.layout()) &&
       is_null_or_equal_to(device, self.device()) && !copy &&
       (memory_format == MemoryFormat::Preserve ||
-       self.suggest_memory_format() == memory_format);
+       (memory_format == MemoryFormat::Contiguous
+            ? self.is_contiguous()
+            : self.suggest_memory_format() == memory_format));
 }
 
 static inline Tensor to_impl(

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5332,6 +5332,42 @@ class TestTorchDeviceType(TestCase):
             self._test_memory_format_transformations(
                 device, get_generator(mf, shape), transformation_fn, mf, default_is_preserve=True)
 
+    def test_memory_format_to_non_contiguous(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/132020
+        # and https://github.com/pytorch/pytorch/issues/62027
+        # .to(memory_format=...) must force a copy for non-contiguous tensors
+        # even when dtype/device are unchanged.
+
+        # test #1: expand() produces stride-0 tensor (non-contiguous)
+        x = torch.ones(1, device=device).expand(2)
+        self.assertFalse(x.is_contiguous())
+        y = x.to(memory_format=torch.contiguous_format)
+        self.assertTrue(
+            y.is_contiguous(memory_format=torch.contiguous_format),
+            "expand() tensor must be contiguous after .to(memory_format=contiguous_format)"
+        )
+
+        # test #2: transpose() produces permuted-stride tensor (non-contiguous)
+        x = torch.empty(10, 3, 32, 32, device=device).transpose(0, 1)
+        self.assertFalse(x.is_contiguous())
+        y = x.to(memory_format=torch.contiguous_format)
+        self.assertTrue(
+            y.is_contiguous(memory_format=torch.contiguous_format),
+            "transposed tensor must be contiguous after .to(memory_format=contiguous_format)"
+        )
+
+        # sanity: already-contiguous tensor must not trigger a copy
+        x = torch.empty(10, 3, 32, 32, device=device)
+        self.assertTrue(x.is_contiguous())
+        y = x.to(memory_format=torch.contiguous_format)
+        self.assertEqual(x.data_ptr(), y.data_ptr(), msg="no copy expected for already-contiguous tensor")
+
+        # sanity: channels-last tensor requesting channels-last must not copy
+        x = torch.empty(10, 3, 32, 32, device=device).to(memory_format=torch.channels_last)
+        self.assertTrue(x.is_contiguous(memory_format=torch.channels_last))
+        y = x.to(memory_format=torch.channels_last)
+        self.assertEqual(x.data_ptr(), y.data_ptr(), msg="no copy expected for already channels-last tensor")
+
     def test_memory_format_type(self, device):
         def get_generator(memory_format, shape):
             def input_generator_fn(device):


### PR DESCRIPTION
**Root cause:** `to_will_alias()` used `suggest_memory_format()` which returns `Contiguous` as a default for anything not channels-last shaped — incorrectly skipping the copy for stride-0 (`expand`) and
permuted-stride (`transpose`) tensors when `contiguous_format` was requested.

**Fix:** For `contiguous_format`, replace `suggest_memory_format()` with `is_contiguous()` which reads the actual `TensorImpl` contiguity flags. For all other formats (`channels_last`, `channels_last_3d`),
keep `suggest_memory_format()` to preserve existing alias behavior relied upon by conv/inductor code.

```cpp
// Before (buggy for contiguous_format)
self.suggest_memory_format() == memory_format

// After (targeted fix)
memory_format == MemoryFormat::Contiguous
    ? self.is_contiguous()
    : self.suggest_memory_format() == memory_format
```

Co-authored-by: Claude 

Fixes: #132020, 
Fixes: #62027, 
Fixes: #86558