### PR TITLE
[MPS] logical not metal kernel

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1025,6 +1025,13 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   // outputs lose because the wide per-thread state spills out of registers.
   const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type());
   bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype && length >= ILP_DISPATCH_THRESHOLD;
+  // Opt-in ILP for non-floating (bool/int) output: such ops are excluded from
+  // the auto-ILP above, but a bandwidth-bound copy-style op (e.g. logical_not)
+  // can pass an ilp_threshold to use the wide per-thread tile above that size.
+  // Small tensors stay on the scalar path (gated by the threshold).
+  if (is_contiguous && !alpha.has_value() && ilp_threshold.has_value() && length >= ilp_threshold.value()) {
+    dense_ilp = true;
+  }
   // Bench-only override: force ILP or scalar dispatch.
   if (is_contiguous && !alpha.has_value()) {
     if (auto force = c10::utils::get_env("PYTORCH_UNARY_FORCE_FLAVOR")) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1024,8 +1024,9 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   // from the wider per-thread tile regresses real-world sizes, and complex
   // outputs lose because the wide per-thread state spills out of registers.
   // Opt-in ILP for non-floating (bool/int) output if ilp_threshold_specified
-const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type()) || ilp_threshold.has_value();
-bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype && length >= ilp_threshold.value_or(ILP_DISPATCH_THRESHOLD);
+  const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type()) || ilp_threshold.has_value();
+  bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype &&
+      length >= ilp_threshold.value_or(ILP_DISPATCH_THRESHOLD);
   // Bench-only override: force ILP or scalar dispatch.
   if (is_contiguous && !alpha.has_value()) {
     if (auto force = c10::utils::get_env("PYTORCH_UNARY_FORCE_FLAVOR")) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1023,15 +1023,9 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   // cheap ops (neg/abs/sqr/bitwise_not) where the smaller threadgroup count
   // from the wider per-thread tile regresses real-world sizes, and complex
   // outputs lose because the wide per-thread state spills out of registers.
-  const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type());
-  bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype && length >= ILP_DISPATCH_THRESHOLD;
-  // Opt-in ILP for non-floating (bool/int) output: such ops are excluded from
-  // the auto-ILP above, but a bandwidth-bound copy-style op (e.g. logical_not)
-  // can pass an ilp_threshold to use the wide per-thread tile above that size.
-  // Small tensors stay on the scalar path (gated by the threshold).
-  if (is_contiguous && !alpha.has_value() && ilp_threshold.has_value() && length >= ilp_threshold.value()) {
-    dense_ilp = true;
-  }
+  // Opt-in ILP for non-floating (bool/int) output if ilp_threshold_specified
+const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type()) || ilp_threshold.has_value();
+bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype && length >= ilp_threshold.value_or(ILP_DISPATCH_THRESHOLD);
   // Bench-only override: force ILP or scalar dispatch.
   if (is_contiguous && !alpha.has_value()) {
     if (auto force = c10::utils::get_env("PYTORCH_UNARY_FORCE_FLAVOR")) {

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -665,6 +665,29 @@ REGISTER_UNARY_OP(bitwise_not, char, char);
 REGISTER_UNARY_OP(bitwise_not, uchar, uchar);
 REGISTER_UNARY_OP(bitwise_not, bool, bool);
 
+struct logical_not_functor {
+  template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
+  inline bool operator()(const T x) {
+    return x == T(0);
+  }
+  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+  inline bool operator()(const T x) {
+    return x.x == 0 && x.y == 0;
+  }
+};
+
+REGISTER_UNARY_OP(logical_not, bool, bool);
+REGISTER_UNARY_OP(logical_not, uchar, bool);
+REGISTER_UNARY_OP(logical_not, char, bool);
+REGISTER_UNARY_OP(logical_not, short, bool);
+REGISTER_UNARY_OP(logical_not, int, bool);
+REGISTER_UNARY_OP(logical_not, long, bool);
+REGISTER_UNARY_OP(logical_not, half, bool);
+REGISTER_UNARY_OP(logical_not, float, bool);
+REGISTER_UNARY_OP(logical_not, bfloat, bool);
+REGISTER_UNARY_OP(logical_not, float2, bool);
+REGISTER_UNARY_OP(logical_not, half2, bool);
+
 REGISTER_UNARY_OP(abs, int, int);
 REGISTER_UNARY_OP(abs, long, long);
 REGISTER_UNARY_OP(abs, short, short);

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -52,6 +52,10 @@ static void erfcx_kernel(TensorIteratorBase& iter) {
   lib.exec_unary_kernel(iter, "erfcx");
 }
 
+static void logical_not_kernel(TensorIteratorBase& iter) {
+  lib.exec_unary_kernel(iter, "logical_not", std::nullopt, std::nullopt, /*ilp_threshold=*/1u << 18);
+}
+
 static void polygamma_kernel(TensorIteratorBase& iter, int64_t order) {
   if (order == 0) {
     return lib.exec_unary_kernel(iter, "digamma");
@@ -93,7 +97,7 @@ REGISTER_UNARY_TI_DISPATCH(digamma);
 REGISTER_UNARY_TI_DISPATCH(bitwise_not);
 REGISTER_UNARY_TI_DISPATCH(round);
 REGISTER_UNARY_TI_DISPATCH(sigmoid);
-REGISTER_UNARY_TI_DISPATCH(logical_not);
+REGISTER_DISPATCH(logical_not_stub, logical_not_kernel);
 REGISTER_DISPATCH(special_erfcx_stub, erfcx_kernel);
 REGISTER_DISPATCH(round_decimals_stub, round_decimals_kernel);
 REGISTER_DISPATCH(pow_tensor_scalar_stub, pow_tensor_scalar_kernel);

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -93,6 +93,7 @@ REGISTER_UNARY_TI_DISPATCH(digamma);
 REGISTER_UNARY_TI_DISPATCH(bitwise_not);
 REGISTER_UNARY_TI_DISPATCH(round);
 REGISTER_UNARY_TI_DISPATCH(sigmoid);
+REGISTER_UNARY_TI_DISPATCH(logical_not);
 REGISTER_DISPATCH(special_erfcx_stub, erfcx_kernel);
 REGISTER_DISPATCH(round_decimals_stub, round_decimals_kernel);
 REGISTER_DISPATCH(pow_tensor_scalar_stub, pow_tensor_scalar_kernel);

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -193,14 +193,6 @@ CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(asinh_out_mps, asinh)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(acosh_out_mps, acosh)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(atanh_out_mps, atanh)
 
-Tensor& logical_not_out_mps(const Tensor& self, Tensor& output) {
-  auto bool_self = self.to(ScalarType::Bool);
-  mps::unary_op(bool_self, output, "logical_not_out_mps", [](MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
-    return [mpsGraph notWithTensor:inputTensor name:nil];
-  });
-  return output;
-}
-
 TORCH_IMPL_FUNC(frac_out_mps)(const Tensor& self, const Tensor& output) {
   TORCH_CHECK(isFloatingType(self.scalar_type()), "frac_out_mps is only implemented for floating types");
   mps::unary_op(self, output, "frac_out_mps", ^MPSGraphTensor*(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1276,8 +1276,7 @@
 - func: logical_not.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: logical_not_out
-    MPS: logical_not_out_mps
+    CPU, CUDA, MPS, MTIA, XPU: logical_not_out
   tags: pointwise
 
 - func: logical_xor(Tensor self, Tensor other) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15196,9 +15196,6 @@ op_db: list[OpInfo] = [
                                     dtypes=all_types_and_complex_and(torch.half, torch.bfloat16)),
                        DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_variant_consistency_eager',
                                     dtypes=all_types_and_complex_and(torch.half, torch.bfloat16)),
-                       # AssertionError: RuntimeError not raised : Expected RuntimeError when calling with
-                       # input.device=mps:0 and out.device=cpu.
-                       DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
                    )),
     BinaryUfuncInfo('lt',
                     ref=np.less,


### PR DESCRIPTION
Migrate logical not to metal kernels. Perf:
| dtype | shape | contig | trans |
|---|---|---|---|
| bf16 | (100,) | 5.35x | - |
| bf16 | (256, 256) | 4.44x | 4.90x |
| bf16 | (512, 512) | 3.92x | 7.90x |
| bf16 | (1024, 1024) | 4.90x | 21.42x |
| bf16 | (1000000,) | 5.21x | - |
| bf16 | (4096, 4096) | 1.97x | 10.34x |
| fp16 | (100,) | 5.19x | - |
| fp16 | (256, 256) | 4.46x | 5.04x |
| fp16 | (512, 512) | 3.97x | 9.20x |
| fp16 | (1024, 1024) | 5.30x | 20.95x |
| fp16 | (1000000,) | 5.13x | - |
| fp16 | (4096, 4096) | 2.01x | 9.94x |
| fp32 | (100,) | 5.33x | - |
| fp32 | (256, 256) | 4.37x | 5.31x |
| fp32 | (512, 512) | 3.83x | 8.76x |
| fp32 | (1024, 1024) | 2.26x | 11.02x |
| fp32 | (1000000,) | 2.48x | - |
| fp32 | (4096, 4096) | 1.50x | 9.36x |
| int32 | (100,) | 5.65x | - |
| int32 | (256, 256) | 4.69x | 4.26x |
| int32 | (512, 512) | 3.76x | 9.29x |
| int32 | (1024, 1024) | 2.40x | 11.34x |
| int32 | (1000000,) | 2.28x | - |
| int32 | (4096, 4096) | 1.54x | 9.26x |
| bool | (100,) | 3.72x | - |
| bool | (256, 256) | 3.33x | 3.71x |
| bool | (512, 512) | 3.03x | 2.80x |
| bool | (1024, 1024) | 2.42x | 2.81x |
| bool | (1000000,) | 2.30x | - |
| bool | (4096, 4096) | 1.49x | 2.72x |