### PR TITLE
Fix torch.special.zeta returning NaN for q=+inf

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -272,6 +272,10 @@ C10_HOST_DEVICE inline scalar_t zeta(scalar_t x, scalar_t q) __ubsan_ignore_floa
     }
   }
 
+  if (std::isinf(q)) {
+    return zero;
+  }
+
   s = std::pow(q, -x);
   a = q;
   int i = 0;

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -342,6 +342,11 @@ const auto zeta_string = jiterator_stringify(
       }
     }
 
+    // Short-circuits q -> +infty: every term 1/(n+q)^x vanishes
+    if (isinf(q)) {
+      return zero;
+    }
+
     s = pow(q, -x);
     a = q;
     i = 0;

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -4583,6 +4583,25 @@ class TestBinaryUfuncsDevice(TestCase):
             x = make_tensor((2, 3, 4), dtype=x_dtype, device=device)
             test_helper(x, q)
 
+    @dtypes(torch.float32, torch.float64)
+    def test_zeta_with_inf_q(self, device, dtype):
+        # zeta(s, +inf) should be 0 for s > 1, not NaN
+        # (the old code hit 0 * inf in the tail expansion)
+        s = torch.tensor([2.0, 3.0], dtype=dtype, device=device)
+        q_inf = torch.full_like(s, float("inf"))
+        self.assertEqual(
+            torch.special.zeta(s, q_inf),
+            torch.zeros_like(s),
+        )
+
+        # finite and inf mixed in the same tensor
+        q_mix = torch.tensor([1.0, float("inf")], dtype=dtype, device=device)
+        out = torch.special.zeta(
+            torch.tensor([2.0, 2.0], dtype=dtype, device=device), q_mix
+        )
+        self.assertGreater(out[0].item(), 0)
+        self.assertEqual(out[1].item(), 0.0)
+
     @onlyOn(["cuda", "xpu"])
     @dtypes(torch.chalf)
     def test_mul_chalf_tensor_and_cpu_scalar(self, device, dtype):

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -4583,25 +4583,6 @@ class TestBinaryUfuncsDevice(TestCase):
             x = make_tensor((2, 3, 4), dtype=x_dtype, device=device)
             test_helper(x, q)
 
-    @dtypes(torch.float32, torch.float64)
-    def test_zeta_with_inf_q(self, device, dtype):
-        # zeta(s, +inf) should be 0 for s > 1, not NaN
-        # (the old code hit 0 * inf in the tail expansion)
-        s = torch.tensor([2.0, 3.0], dtype=dtype, device=device)
-        q_inf = torch.full_like(s, float("inf"))
-        self.assertEqual(
-            torch.special.zeta(s, q_inf),
-            torch.zeros_like(s),
-        )
-
-        # finite and inf mixed in the same tensor
-        q_mix = torch.tensor([1.0, float("inf")], dtype=dtype, device=device)
-        out = torch.special.zeta(
-            torch.tensor([2.0, 2.0], dtype=dtype, device=device), q_mix
-        )
-        self.assertGreater(out[0].item(), 0)
-        self.assertEqual(out[1].item(), 0.0)
-
     @onlyOn(["cuda", "xpu"])
     @dtypes(torch.chalf)
     def test_mul_chalf_tensor_and_cpu_scalar(self, device, dtype):

--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -24,6 +24,7 @@ from torch.testing._internal.opinfo.core import (
     S,
     SampleInput,
     UnaryUfuncInfo,
+    reference_inputs_elementwise_binary,
 )
 from torch.testing._internal.opinfo.refs import (
     ElementwiseBinaryPythonRefInfo,
@@ -90,6 +91,23 @@ def reference_polygamma(x, n):
     if x.dtype == np.double:
         result_dtype = np.double
     return scipy.special.polygamma(n, x).astype(result_dtype)
+
+
+def reference_inputs_zeta(op, device, dtype, requires_grad, **kwargs):
+    yield from reference_inputs_elementwise_binary(
+        op, device, dtype, requires_grad, **kwargs
+    )
+    if dtype.is_floating_point:
+        # zeta(s, +inf) == 0 for s > 1; exercises the early-return guard
+        # against the 0 * inf NaN in the tail expansion.
+        s = torch.tensor([2.0, 3.0, 10.0], device=device, dtype=dtype)
+        q_inf = torch.full_like(s, float("inf"))
+        yield SampleInput(s, args=(q_inf,))
+
+        # mixed finite / +inf q
+        s_mix = torch.tensor([2.0, 2.0], device=device, dtype=dtype)
+        q_mix = torch.tensor([1.0, float("inf")], device=device, dtype=dtype)
+        yield SampleInput(s_mix, args=(q_mix,))
 
 
 def sample_inputs_entr(op_info, device, dtype, requires_grad, **kwargs):
@@ -252,6 +270,7 @@ op_db: list[OpInfo] = [
         promotes_int_to_float=True,
         supports_autograd=False,
         supports_one_python_scalar=True,
+        reference_inputs_func=reference_inputs_zeta,
         skips=(
             # Reference reference_inputs nans and infs on cuda and nan, inf, 0., -inf for cpu
             DecorateInfo(unittest.expectedFailure, "TestCommon", "test_compare_cpu"),


### PR DESCRIPTION
zeta(s, +inf) returned NaN instead of 0 for s > 1. The tail expansion computes b * w where b = 0 and w = inf, producing NaN. Added isinf(q) early return in both CPU (Math.h) and CUDA jiterator (Math.cuh) paths. Added test_zeta_with_inf_q covering all-inf and mixed finite/inf inputs. Fixes #187294