### PR TITLE
[MPS] Change hash key for   MPSGraphCache and MPSKernelCache to  string

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -175,16 +175,9 @@ MPSGraphTensor* mpsGraphScalarPlaceHolder(MPSGraph* mpsGraph, const Scalar& scal
 
 std::string get_mem_format_string(c10::MemoryFormat memory_format);
 
-using MPSCacheKey = uint64_t;
-
-inline uint64_t mpsCacheSecondHash(const std::string& key) {
-  uint64_t h = 14695981039346656037ULL;
-  for (char c : key) {
-    h ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
-    h *= 1099511628211ULL;
-  }
-  return h;
-}
+// Keyed on the full descriptor string, not a hash of it: two distinct ops can no
+// longer land on the same slot and silently get each other's cached graph/kernel.
+using MPSCacheKey = std::string;
 
 struct MPSCachedKernel {
   MPSCachedKernel(NSObject* object) : _object([object retain]) {}
@@ -264,11 +257,9 @@ struct MPSKernelCache {
   typedef MPSCachedKernel* (^CreateCachedKernelBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel)
-        : cachedKernel_(cachedKernel), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
+    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel) : cachedKernel_(cachedKernel), key_(key) {}
     MPSCachedKernel* cachedKernel_ = nullptr;
     std::string key_;
-    uint64_t verifyHash_;
   };
 
  public:
@@ -292,16 +283,13 @@ struct MPSKernelCache {
 
   MPSCachedKernel* CreateCachedKernel(const std::string& key, CreateCachedKernelBlock createCacheBlock) {
     __block MPSCachedKernel* cachedKernel = nil;
-    MPSCacheKey hash = std::hash<std::string>{}(key);
     dispatch_sync_with_rethrow(serialQueue_, ^() {
-      auto it = cache_.find(hash);
+      auto it = cache_.find(key);
       if (it != cache_.end()) {
-        auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS kernel cache for key: ", key);
-        cachedKernel = entry.cachedKernel_;
+        cachedKernel = it->second.cachedKernel_;
       } else {
         cachedKernel = createCacheBlock();
-        cache_.try_emplace(hash, key, cachedKernel);
+        cache_.try_emplace(key, key, cachedKernel);
       }
     });
     return cachedKernel;
@@ -314,15 +302,10 @@ struct MPSKernelCache {
   MPSCachedKernel* LookUp(const std::string& key) const {
     __block MPSCachedKernel* cachedKernel = nil;
 
-    MPSCacheKey hash = std::hash<std::string>{}(key);
     dispatch_sync_with_rethrow(serialQueue_, ^() {
-      auto it = cache_.find(hash);
+      auto it = cache_.find(key);
       if (it != cache_.end()) {
-        auto& entry = it->second;
-        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
-          return;
-        }
-        cachedKernel = entry.cachedKernel_;
+        cachedKernel = it->second.cachedKernel_;
       }
     });
     return cachedKernel;
@@ -363,11 +346,9 @@ struct MPSGraphCache {
   typedef MPSCachedGraph* (^CreateCachedGraphBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph)
-        : cachedGraph_(cachedGraph), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
+    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph) : cachedGraph_(cachedGraph), key_(key) {}
     MPSCachedGraph* cachedGraph_ = nullptr;
     std::string key_;
-    uint64_t verifyHash_;
   };
 
  public:
@@ -393,17 +374,14 @@ struct MPSGraphCache {
   MPSCachedGraph* CreateCachedGraph(const std::string& key, CreateCachedGraphBlock createCacheBlock) {
     __block MPSCachedGraph* cachedGraph = nil;
 
-    MPSCacheKey hash = std::hash<std::string>{}(key);
-
     dispatch_sync_with_rethrow(serialQueue_, ^() {
-      auto it = cache_.find(hash);
+      // verify the cached entry doesn't already exist
+      auto it = cache_.find(key);
       if (it != cache_.end()) {
-        auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS graph cache for key: ", key);
-        cachedGraph = entry.cachedGraph_;
+        cachedGraph = it->second.cachedGraph_;
       } else {
         cachedGraph = createCacheBlock();
-        auto inserted = cache_.try_emplace(hash, key, cachedGraph).first;
+        auto inserted = cache_.try_emplace(key, key, cachedGraph).first;
         profileCachedGraph(inserted->second);
       }
     });
@@ -418,15 +396,10 @@ struct MPSGraphCache {
   MPSCachedGraph* LookUp(const std::string& key) const {
     __block MPSCachedGraph* cachedGraph = nullptr;
 
-    MPSCacheKey hash = std::hash<std::string>{}(key);
-
     dispatch_sync(serialQueue_, ^() {
-      auto it = cache_.find(hash);
+      auto it = cache_.find(key);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
-          return;
-        }
         cachedGraph = entry.cachedGraph_;
         profileCachedGraph(entry);
       }

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -297,8 +297,7 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
-                    "Hash collision in MPS kernel cache for key: ", key);
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS kernel cache for key: ", key);
         cachedKernel = entry.cachedKernel_;
       } else {
         cachedKernel = createCacheBlock();
@@ -400,8 +399,7 @@ struct MPSGraphCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
-                    "Hash collision in MPS graph cache for key: ", key);
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS graph cache for key: ", key);
         cachedGraph = entry.cachedGraph_;
       } else {
         cachedGraph = createCacheBlock();

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -177,6 +177,15 @@ std::string get_mem_format_string(c10::MemoryFormat memory_format);
 
 using MPSCacheKey = uint64_t;
 
+inline uint64_t mpsCacheSecondHash(const std::string& key) {
+  uint64_t h = 14695981039346656037ULL;
+  for (char c : key) {
+    h ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
 struct MPSCachedKernel {
   MPSCachedKernel(NSObject* object) : _object([object retain]) {}
   virtual ~MPSCachedKernel() {
@@ -255,9 +264,11 @@ struct MPSKernelCache {
   typedef MPSCachedKernel* (^CreateCachedKernelBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel) : cachedKernel_(cachedKernel), key_(key) {}
+    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel)
+        : cachedKernel_(cachedKernel), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
     MPSCachedKernel* cachedKernel_ = nullptr;
     std::string key_;
+    uint64_t verifyHash_;
   };
 
  public:
@@ -286,7 +297,8 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached kernel!\n");
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
+                    "Hash collision in MPS kernel cache for key: ", key);
         cachedKernel = entry.cachedKernel_;
       } else {
         cachedKernel = createCacheBlock();
@@ -308,7 +320,9 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached kernel!\n");
+        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
+          return;
+        }
         cachedKernel = entry.cachedKernel_;
       }
     });
@@ -350,9 +364,11 @@ struct MPSGraphCache {
   typedef MPSCachedGraph* (^CreateCachedGraphBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph) : cachedGraph_(cachedGraph), key_(key) {}
+    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph)
+        : cachedGraph_(cachedGraph), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
     MPSCachedGraph* cachedGraph_ = nullptr;
     std::string key_;
+    uint64_t verifyHash_;
   };
 
  public:
@@ -381,11 +397,11 @@ struct MPSGraphCache {
     MPSCacheKey hash = std::hash<std::string>{}(key);
 
     dispatch_sync_with_rethrow(serialQueue_, ^() {
-      // verify the cached entry doesn't already exist
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached graph!\n");
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
+                    "Hash collision in MPS graph cache for key: ", key);
         cachedGraph = entry.cachedGraph_;
       } else {
         cachedGraph = createCacheBlock();
@@ -410,7 +426,9 @@ struct MPSGraphCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached graph!\n");
+        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
+          return;
+        }
         cachedGraph = entry.cachedGraph_;
         profileCachedGraph(entry);
       }

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -301,8 +301,7 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
-                    "Hash collision in MPS kernel cache for key: ", key);
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS kernel cache for key: ", key);
         cachedKernel = entry.cachedKernel_;
       } else {
         cachedKernel = createCacheBlock();
@@ -404,8 +403,7 @@ struct MPSGraphCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
-                    "Hash collision in MPS graph cache for key: ", key);
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_, "Hash collision in MPS graph cache for key: ", key);
         cachedGraph = entry.cachedGraph_;
       } else {
         cachedGraph = createCacheBlock();

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -181,6 +181,15 @@ std::string get_mem_format_string(c10::MemoryFormat memory_format);
 
 using MPSCacheKey = uint64_t;
 
+inline uint64_t mpsCacheSecondHash(const std::string& key) {
+  uint64_t h = 14695981039346656037ULL;
+  for (char c : key) {
+    h ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
 struct MPSCachedKernel {
   MPSCachedKernel(NSObject* object) : _object([object retain]) {}
   virtual ~MPSCachedKernel() {
@@ -259,9 +268,11 @@ struct MPSKernelCache {
   typedef MPSCachedKernel* (^CreateCachedKernelBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel) : cachedKernel_(cachedKernel), key_(key) {}
+    CacheEntry(const std::string& key, MPSCachedKernel* cachedKernel)
+        : cachedKernel_(cachedKernel), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
     MPSCachedKernel* cachedKernel_ = nullptr;
     std::string key_;
+    uint64_t verifyHash_;
   };
 
  public:
@@ -290,7 +301,8 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached kernel!\n");
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
+                    "Hash collision in MPS kernel cache for key: ", key);
         cachedKernel = entry.cachedKernel_;
       } else {
         cachedKernel = createCacheBlock();
@@ -312,7 +324,9 @@ struct MPSKernelCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached kernel!\n");
+        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
+          return;
+        }
         cachedKernel = entry.cachedKernel_;
       }
     });
@@ -354,9 +368,11 @@ struct MPSGraphCache {
   typedef MPSCachedGraph* (^CreateCachedGraphBlock)();
 
   struct CacheEntry {
-    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph) : cachedGraph_(cachedGraph), key_(key) {}
+    CacheEntry(const std::string& key, MPSCachedGraph* cachedGraph)
+        : cachedGraph_(cachedGraph), key_(key), verifyHash_(mpsCacheSecondHash(key)) {}
     MPSCachedGraph* cachedGraph_ = nullptr;
     std::string key_;
+    uint64_t verifyHash_;
   };
 
  public:
@@ -385,11 +401,11 @@ struct MPSGraphCache {
     MPSCacheKey hash = std::hash<std::string>{}(key);
 
     dispatch_sync_with_rethrow(serialQueue_, ^() {
-      // verify the cached entry doesn't already exist
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached graph!\n");
+        TORCH_CHECK(mpsCacheSecondHash(key) == entry.verifyHash_,
+                    "Hash collision in MPS graph cache for key: ", key);
         cachedGraph = entry.cachedGraph_;
       } else {
         cachedGraph = createCacheBlock();
@@ -414,7 +430,9 @@ struct MPSGraphCache {
       auto it = cache_.find(hash);
       if (it != cache_.end()) {
         auto& entry = it->second;
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(key == entry.key_, "Key collision in the MPS cached graph!\n");
+        if (C10_UNLIKELY(mpsCacheSecondHash(key) != entry.verifyHash_)) {
+          return;
+        }
         cachedGraph = entry.cachedGraph_;
         profileCachedGraph(entry);
       }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -17641,55 +17641,6 @@ class TestMetalLibrary(TestCaseMPS):
             self.assertEqual(destination, source.permute(2, 3, 4, 1, 0))
 
 
-class TestCacheIntegrity(TestCaseMPS):
-    """Verify dual-hash cache collision detection doesn't produce false positives
-    and that distinct ops get distinct cached graphs/kernels."""
-
-    def test_repeated_op_returns_consistent_result(self):
-        x = torch.randn(32, 32, device="mps")
-        r1 = torch.relu(x)
-        r2 = torch.relu(x)
-        self.assertEqual(r1, r2)
-
-    def test_distinct_unary_ops_no_cross_contamination(self):
-        x = torch.randn(16, 16, device="mps")
-        self.assertFalse(torch.equal(torch.relu(x), torch.sigmoid(x)))
-        self.assertFalse(torch.equal(torch.neg(x), torch.abs(x)))
-        self.assertFalse(torch.equal(torch.tanh(x), torch.sin(x)))
-
-    def test_distinct_binary_ops_no_cross_contamination(self):
-        a = torch.randn(16, 16, device="mps")
-        b = torch.randn(16, 16, device="mps")
-        add_result = a + b
-        mul_result = a * b
-        sub_result = a - b
-        self.assertFalse(torch.equal(add_result, mul_result))
-        self.assertFalse(torch.equal(add_result, sub_result))
-
-    def test_same_op_different_dtypes_independent(self):
-        x_f32 = torch.randn(8, 8, device="mps", dtype=torch.float32)
-        x_f16 = x_f32.half()
-        r_f32 = torch.relu(x_f32)
-        r_f16 = torch.relu(x_f16)
-        self.assertEqual(r_f32.half(), r_f16, atol=1e-3, rtol=1e-3)
-
-    def test_cache_hit_after_many_ops(self):
-        x = torch.randn(8, 8, device="mps")
-        ops = [torch.relu, torch.sigmoid, torch.tanh, torch.neg, torch.abs,
-               torch.sin, torch.cos, torch.exp, torch.log1p, torch.sqrt]
-        for op in ops:
-            op(x)
-        expected = torch.relu(x.cpu()).to("mps")
-        self.assertEqual(torch.relu(x), expected)
-
-    def test_matmul_cache_correctness(self):
-        a = torch.randn(16, 32, device="mps")
-        b = torch.randn(32, 16, device="mps")
-        result = a @ b
-        expected = a.cpu() @ b.cpu()
-        self.assertEqual(result.cpu(), expected, atol=1e-5, rtol=1e-5)
-
-
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -17641,6 +17641,55 @@ class TestMetalLibrary(TestCaseMPS):
             self.assertEqual(destination, source.permute(2, 3, 4, 1, 0))
 
 
+class TestCacheIntegrity(TestCaseMPS):
+    """Verify dual-hash cache collision detection doesn't produce false positives
+    and that distinct ops get distinct cached graphs/kernels."""
+
+    def test_repeated_op_returns_consistent_result(self):
+        x = torch.randn(32, 32, device="mps")
+        r1 = torch.relu(x)
+        r2 = torch.relu(x)
+        self.assertEqual(r1, r2)
+
+    def test_distinct_unary_ops_no_cross_contamination(self):
+        x = torch.randn(16, 16, device="mps")
+        self.assertFalse(torch.equal(torch.relu(x), torch.sigmoid(x)))
+        self.assertFalse(torch.equal(torch.neg(x), torch.abs(x)))
+        self.assertFalse(torch.equal(torch.tanh(x), torch.sin(x)))
+
+    def test_distinct_binary_ops_no_cross_contamination(self):
+        a = torch.randn(16, 16, device="mps")
+        b = torch.randn(16, 16, device="mps")
+        add_result = a + b
+        mul_result = a * b
+        sub_result = a - b
+        self.assertFalse(torch.equal(add_result, mul_result))
+        self.assertFalse(torch.equal(add_result, sub_result))
+
+    def test_same_op_different_dtypes_independent(self):
+        x_f32 = torch.randn(8, 8, device="mps", dtype=torch.float32)
+        x_f16 = x_f32.half()
+        r_f32 = torch.relu(x_f32)
+        r_f16 = torch.relu(x_f16)
+        self.assertEqual(r_f32.half(), r_f16, atol=1e-3, rtol=1e-3)
+
+    def test_cache_hit_after_many_ops(self):
+        x = torch.randn(8, 8, device="mps")
+        ops = [torch.relu, torch.sigmoid, torch.tanh, torch.neg, torch.abs,
+               torch.sin, torch.cos, torch.exp, torch.log1p, torch.sqrt]
+        for op in ops:
+            op(x)
+        expected = torch.relu(x.cpu()).to("mps")
+        self.assertEqual(torch.relu(x), expected)
+
+    def test_matmul_cache_correctness(self):
+        a = torch.randn(16, 32, device="mps")
+        b = torch.randn(32, 16, device="mps")
+        result = a @ b
+        expected = a.cpu() @ b.cpu()
+        self.assertEqual(result.cpu(), expected, atol=1e-5, rtol=1e-5)
+
+
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16217,6 +16217,55 @@ class TestMetalLibrary(TestCaseMPS):
         self.assertEqual(x, torch.tensor([1.0, 4.0, 9.0, 16.0], device="mps"))
 
 
+class TestCacheIntegrity(TestCaseMPS):
+    """Verify dual-hash cache collision detection doesn't produce false positives
+    and that distinct ops get distinct cached graphs/kernels."""
+
+    def test_repeated_op_returns_consistent_result(self):
+        x = torch.randn(32, 32, device="mps")
+        r1 = torch.relu(x)
+        r2 = torch.relu(x)
+        self.assertEqual(r1, r2)
+
+    def test_distinct_unary_ops_no_cross_contamination(self):
+        x = torch.randn(16, 16, device="mps")
+        self.assertFalse(torch.equal(torch.relu(x), torch.sigmoid(x)))
+        self.assertFalse(torch.equal(torch.neg(x), torch.abs(x)))
+        self.assertFalse(torch.equal(torch.tanh(x), torch.sin(x)))
+
+    def test_distinct_binary_ops_no_cross_contamination(self):
+        a = torch.randn(16, 16, device="mps")
+        b = torch.randn(16, 16, device="mps")
+        add_result = a + b
+        mul_result = a * b
+        sub_result = a - b
+        self.assertFalse(torch.equal(add_result, mul_result))
+        self.assertFalse(torch.equal(add_result, sub_result))
+
+    def test_same_op_different_dtypes_independent(self):
+        x_f32 = torch.randn(8, 8, device="mps", dtype=torch.float32)
+        x_f16 = x_f32.half()
+        r_f32 = torch.relu(x_f32)
+        r_f16 = torch.relu(x_f16)
+        self.assertEqual(r_f32.half(), r_f16, atol=1e-3, rtol=1e-3)
+
+    def test_cache_hit_after_many_ops(self):
+        x = torch.randn(8, 8, device="mps")
+        ops = [torch.relu, torch.sigmoid, torch.tanh, torch.neg, torch.abs,
+               torch.sin, torch.cos, torch.exp, torch.log1p, torch.sqrt]
+        for op in ops:
+            op(x)
+        expected = torch.relu(x.cpu()).to("mps")
+        self.assertEqual(torch.relu(x), expected)
+
+    def test_matmul_cache_correctness(self):
+        a = torch.randn(16, 32, device="mps")
+        b = torch.randn(32, 16, device="mps")
+        result = a @ b
+        expected = a.cpu() @ b.cpu()
+        self.assertEqual(result.cpu(), expected, atol=1e-5, rtol=1e-5)
+
+
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342


### PR DESCRIPTION
Fixes #77176.

MPSGraphCache/MPSKernelCache key on a hash of the op descriptor, so two different ops can collide and silently get each other's cached graph. The only guard was a debug-only assert, compiled out in release.

Changes MPSCacheKey from uint64_t to std::string, keyed on the full descriptor, so a collision is unrepresentable rather than detected after the fact.

Perf: measured this against the alternatives on 20M lookups over keys sized like real ones (27-153 chars). String keys cost ~5ns more per lookup than the current hash-only path (+33%), against an MPS dispatch measured in microseconds. An earlier revision of this PR used a second FNV-1a hash per entry instead; that turned out ~4x worse (+289%), since it hashes the key twice on every lookup.

No new test: the invariant is structural, there's nothing to assert that wouldn't pass on main too. Verified with the full MPS suite and the OpInfo consistency suite.