### PR TITLE
Raise ValueError for non-positive kernel_size/dilation/stride in unfold/fold

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6522,9 +6522,6 @@ class TestMPS(TestCaseMPS):
             # input channels not divisible by kernel product (5 not divisible by 2*3=6)
             ((1, 5, 9), (4, 5), (2, 3), 0, 1,
              r"Expected size of input's dimension 1 to be divisible"),
-            # zero kernel size
-            ((1, 6, 9), (4, 5), (0, 3), 0, 1,
-             r"kernel size should be greater than zero"),
             # negative padding
             ((1, 6, 9), (4, 5), (2, 3), (-1, 0), 1,
              r"padding should be non-negative"),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7300,6 +7300,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, r"calculated shape of the array of sliding blocks as"):
             fold(torch.randn(1, 12, 12))
 
+        # non-positive kernel_size / dilation / stride are rejected at the
+        # Python API boundary with ValueError (see gh-187299).
+        x = torch.randn(1, 12, 12)
+        with self.assertRaisesRegex(
+            ValueError, r"kernel_size must be greater than zero"
+        ):
+            F.fold(x, output_size=(4, 5), kernel_size=(0, 2))
+        with self.assertRaisesRegex(ValueError, r"dilation must be greater than zero"):
+            F.fold(x, output_size=(4, 5), kernel_size=(2, 2), dilation=(0, 1))
+        with self.assertRaisesRegex(ValueError, r"stride must be greater than zero"):
+            F.fold(x, output_size=(4, 5), kernel_size=(2, 2), stride=(0, 1))
+
     def test_softmin(self):
         x = torch.randn(2, 16)
         self.assertEqual(F.softmin(x, 1), F.softmax(-x, 1))
@@ -10278,16 +10290,20 @@ class TestNNDeviceType(NNTestCase):
             unfold = nn.Unfold(kernel_size=(1, 3), padding=(1, 1), dilation=(1, 2))
             unfold(torch.randn(1, 2, 2, 2, device=device))
 
-        # im2col_shape_check invariants
+        # non-positive kernel_size / dilation / stride are rejected at the
+        # Python API boundary with ValueError (see gh-187299).
         x = torch.randn(1, 3, 8, 8, device=device)
-        with self.assertRaisesRegex(RuntimeError, r"kernel size should be greater than zero"):
+        with self.assertRaisesRegex(
+            ValueError, r"kernel_size must be greater than zero"
+        ):
             F.unfold(x, kernel_size=(0, 1))
-        with self.assertRaisesRegex(RuntimeError, r"dilation should be greater than zero"):
+        with self.assertRaisesRegex(ValueError, r"dilation must be greater than zero"):
             F.unfold(x, kernel_size=(3, 3), dilation=(0, 1))
+        with self.assertRaisesRegex(ValueError, r"stride must be greater than zero"):
+            F.unfold(x, kernel_size=(3, 3), stride=(0, 1))
+        # negative padding is a different class of error handled by the kernel.
         with self.assertRaisesRegex(RuntimeError, r"padding should be non-negative"):
             F.unfold(x, kernel_size=(3, 3), padding=(-1, 0))
-        with self.assertRaisesRegex(RuntimeError, r"stride should be greater than zero"):
-            F.unfold(x, kernel_size=(3, 3), stride=(0, 1))
 
         # Host-side overflow guard on kernel_size product.
         with self.assertRaisesRegex(RuntimeError, r"the product of kernel_width and kernel_height overflowed"):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6142,9 +6142,23 @@ def unfold(
             padding=padding,
             stride=stride,
         )
-    return torch._C._nn.im2col(
-        input, _pair(kernel_size), _pair(dilation), _pair(padding), _pair(stride)
-    )
+    kernel_size_ = _pair(kernel_size)
+    dilation_ = _pair(dilation)
+    padding_ = _pair(padding)
+    stride_ = _pair(stride)
+    # Validate at the API boundary so invalid argument values raise ValueError
+    # (Python/NumPy convention) instead of a RuntimeError from the im2col kernel.
+    if kernel_size_[0] <= 0 or kernel_size_[1] <= 0:
+        raise ValueError(
+            f"kernel_size must be greater than zero, but got kernel_size={kernel_size_}"
+        )
+    if dilation_[0] <= 0 or dilation_[1] <= 0:
+        raise ValueError(
+            f"dilation must be greater than zero, but got dilation={dilation_}"
+        )
+    if stride_[0] <= 0 or stride_[1] <= 0:
+        raise ValueError(f"stride must be greater than zero, but got stride={stride_}")
+    return torch._C._nn.im2col(input, kernel_size_, dilation_, padding_, stride_)
 
 
 def fold(
@@ -6173,13 +6187,28 @@ def fold(
             padding=padding,
             stride=stride,
         )
+    kernel_size_ = _pair(kernel_size)
+    dilation_ = _pair(dilation)
+    stride_ = _pair(stride)
+    # Validate at the API boundary so invalid argument values raise ValueError
+    # (Python/NumPy convention) instead of a RuntimeError from the col2im kernel.
+    if kernel_size_[0] <= 0 or kernel_size_[1] <= 0:
+        raise ValueError(
+            f"kernel_size must be greater than zero, but got kernel_size={kernel_size_}"
+        )
+    if dilation_[0] <= 0 or dilation_[1] <= 0:
+        raise ValueError(
+            f"dilation must be greater than zero, but got dilation={dilation_}"
+        )
+    if stride_[0] <= 0 or stride_[1] <= 0:
+        raise ValueError(f"stride must be greater than zero, but got stride={stride_}")
     return torch._C._nn.col2im(
         input,
         _pair(output_size),
-        _pair(kernel_size),
-        _pair(dilation),
+        kernel_size_,
+        dilation_,
         _pair(padding),
-        _pair(stride),
+        stride_,
     )
 
 


### PR DESCRIPTION
Fixes #187299

## Problem
`torch.nn.functional.unfold` / `fold` forward non-positive `kernel_size`, `dilation`, or `stride` straight into the `im2col`/`col2im` kernels, which surface a `RuntimeError` from deep in the implementation:

```python
F.unfold(torch.randn(1, 3, 8, 8), kernel_size=(3, 3), stride=(0, 1))
# RuntimeError: stride should be greater than zero, but got ...
```

Invalid argument *values* should raise `ValueError` at the API boundary (Python/NumPy convention), not a `RuntimeError` leaking from the kernel.

## Change
Validate `kernel_size`, `dilation`, and `stride` in the Python `unfold`/`fold` wrappers and raise `ValueError` for non-positive values. The kernel-level checks stay as a backstop, so `Tensor.unfold` and other entry points are unchanged. `padding` is untouched (negative padding is a separate, valid-shaped error). The added validation is TorchScript-compatible.

## Tests
- `test_unfold_invalid_arg` / `test_fold_invalid_arg`: expect `ValueError` for zero `kernel_size`/`dilation`/`stride`, covering all three.
- `test_mps.py::test_fold_invalid_input_raises`: dropped the zero-kernel case, which is now caught device-agnostically at the Python boundary before MPS dispatch.

Verified locally that valid inputs are unchanged and the three invalid cases raise `ValueError`; lint (pyfmt/flake8) is clean on the changed lines.