### PR TITLE
Fix cpp wrapper fallback outputs and tensor alignment metadata

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1,14 +1,17 @@
 # Owner(s): ["module: inductor"]
 import contextlib
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import sympy
 
 import torch
 import torch._inductor.config as inductor_config
+from torch._inductor import ir
 from torch._inductor.codegen import triton_utils
 from torch._inductor.codegen.common import CSEVariable, SizeArg, TensorArg
+from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch._inductor.codegen.simd import IterationRangesRoot
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import (
@@ -181,6 +184,115 @@ class TestCodegenTriton(InductorTestCase):
         self.assertTrue(
             V.graph.sizevars.statically_known_multiple_of(s2, 16),
         )
+
+    @inductor_config.patch("triton.divisible_by_16", True)
+    def test_config_of_skips_graph_input_tensor_divisibility_for_cpp_wrapper_jit(self):
+        from torch._inductor.utils import (
+            get_triton_attrs_descriptor_version,
+            TritonAttrsDescriptorVersion,
+        )
+
+        def _has_divisibility_16(config, idx):
+            if get_triton_attrs_descriptor_version() in {
+                TritonAttrsDescriptorVersion.V1_COMPILER,
+                TritonAttrsDescriptorVersion.V0_NO_TRITON,
+            }:
+                return idx in config.divisible_by_16
+            if get_triton_attrs_descriptor_version() in {
+                TritonAttrsDescriptorVersion.V2_BACKENDS,
+                TritonAttrsDescriptorVersion.V3_BACKENDS_TUPLE,
+            }:
+                return idx in config.divisibility_16
+            self.assertIsInstance(config, dict)
+            return (idx,) in config and ["tt.divisibility", 16] in config[(idx,)]
+
+        input_arg = TensorArg(name="in_ptr0", buffer="arg0_1", dtype=torch.float32)
+        buffer_arg = TensorArg(name="out_ptr0", buffer="buf0", dtype=torch.float32)
+        V.graph.graph_inputs[input_arg.buffer] = object()
+
+        original_cpp_wrapper = V.graph.cpp_wrapper
+        original_aot_mode = V.graph.aot_mode
+        original_graph_input_names = list(V.graph.graph_input_names)
+        original_inputs_to_check = V.graph.inputs_to_check
+        try:
+            V.graph.graph_input_names = [input_arg.buffer]
+            with patch.object(triton_utils, "is_unaligned_buffer", return_value=False):
+
+                def _check(input_divisible, buffer_divisible, *, skip=False):
+                    triton_config = triton_utils.config_of(
+                        [input_arg, buffer_arg],
+                        skip_cpp_wrapper_input_tensor_alignment=skip,
+                    )
+                    self.assertEqual(
+                        input_divisible, _has_divisibility_16(triton_config, 0)
+                    )
+                    self.assertEqual(
+                        buffer_divisible, _has_divisibility_16(triton_config, 1)
+                    )
+
+                V.graph.cpp_wrapper = False
+                _check(True, True)
+
+                V.graph.cpp_wrapper = True
+                V.graph.aot_mode = False
+                _check(True, True)
+
+                V.graph.inputs_to_check = ()
+                _check(True, True, skip=True)
+
+                V.graph.inputs_to_check = (0,)
+                _check(False, True, skip=True)
+
+                V.graph.aot_mode = True
+                _check(True, True, skip=True)
+        finally:
+            V.graph.cpp_wrapper = original_cpp_wrapper
+            V.graph.aot_mode = original_aot_mode
+            V.graph.graph_input_names = original_graph_input_names
+            V.graph.inputs_to_check = original_inputs_to_check
+            V.graph.graph_inputs.pop(input_arg.buffer, None)
+
+    def test_cpp_wrapper_python_fallback_return_slots_skip_mutation_outputs(self):
+        original_cpp_wrapper = V.graph.cpp_wrapper
+        try:
+            V.graph.cpp_wrapper = True
+            with torch.library._scoped_library(
+                "cpp_wrapper_fallback_test", "FRAGMENT"
+            ) as m:
+                m.define(
+                    "mutate_and_return_(Tensor(a!) out, Tensor x, str tag) -> Tensor"
+                )
+
+                op_overload = (
+                    torch.ops.cpp_wrapper_fallback_test.mutate_and_return_.default
+                )
+                wrapper = CppWrapperCpu()
+                mutation_output = object.__new__(ir.MutationOutput)
+                raw_args = [
+                    SimpleNamespace(codegen_reference=lambda: "out_handle"),
+                    SimpleNamespace(codegen_reference=lambda: "x_handle"),
+                    "tag",
+                ]
+
+                wrapper.generate_fallback_kernel_with_runtime_lookup_python(
+                    "buf",
+                    "test_kernel",
+                    op_overload,
+                    raw_args=raw_args,
+                    output_args=["mutated", "actual"],
+                    raw_outputs=[mutation_output, object()],
+                )
+
+                code = "\n".join(str(line) for line in wrapper.lines)
+                self.assertIn(
+                    "actual = reinterpret_cast<AtenTensorHandle>("
+                    "PyCapsule_GetPointer(py_buf.get(), NULL));",
+                    code,
+                )
+                self.assertNotIn("PyList_GET_ITEM(py_buf.get(), 1)", code)
+                self.assertNotIn("RAIIAtenTensorHandle mutated;", code)
+        finally:
+            V.graph.cpp_wrapper = original_cpp_wrapper
 
     def test_pow_uses_active_override_constant_lowering(self):
         exponent = CSEVariable("ks0", ValueRanges.unknown(), torch.int64)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3601,14 +3601,30 @@ if (!custom_op_wrapper) {
             """
         )
 
-        if len(output_args) == 1 and (output := output_args[0]) is not None:
+        if raw_outputs:
+            num_returned_outputs = 0
+            returned_output_slots = []
+            for output_arg, raw_output_arg in zip(output_args, raw_outputs):
+                if isinstance(raw_output_arg, ir.MutationOutput):
+                    continue
+                if output_arg is not None:
+                    returned_output_slots.append((num_returned_outputs, output_arg))
+                num_returned_outputs += 1
+        else:
+            num_returned_outputs = len(output_args)
+            returned_output_slots = [
+                (idx, output_arg)
+                for idx, output_arg in enumerate(output_args)
+                if output_arg is not None
+            ]
+
+        if num_returned_outputs == 1 and returned_output_slots:
             # result is a single tensor
+            _, output = returned_output_slots[0]
             lines += f"{output} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(py_{buf_name}.get(), NULL));\n"
         else:
             # result is a tuple of tensors
-            for idx, output_arg in enumerate(output_args):
-                if output_arg is None:
-                    continue
+            for idx, output_arg in returned_output_slots:
                 lines += f"{output_arg} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(PyList_GET_ITEM(py_{buf_name}.get(), {idx}), NULL));\n"
 
         if raw_outputs:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6475,9 +6475,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if torch.version.hip is not None and (
             self.atomic_add_found or not config.triton.emit_pointer_range_32
         ):
-            triton_meta["configs"] = [config_of(signature, pointer_range_override=())]
+            triton_meta["configs"] = [
+                config_of(
+                    signature,
+                    pointer_range_override=(),
+                    skip_cpp_wrapper_input_tensor_alignment=True,
+                )
+            ]
         else:
-            triton_meta["configs"] = [config_of(signature)]
+            triton_meta["configs"] = [
+                config_of(signature, skip_cpp_wrapper_input_tensor_alignment=True)
+            ]
 
         for helper in self.helper_functions:
             code.writeline("")

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -739,7 +739,9 @@ class ComboKernel(Kernel):
         for arg_num in equal_1_arg_indices(signature):
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index,union-attr]
 
-        triton_meta["configs"] = [config_of(signature)]
+        triton_meta["configs"] = [
+            config_of(signature, skip_cpp_wrapper_input_tensor_alignment=True)
+        ]
 
         mutated_args = self.get_mutated_args_sub_kernels()
         dispatch = self.dispatch_class

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -276,6 +276,7 @@ def config_of(
     *,
     indices: list[int] | None = None,
     pointer_range_override: tuple[int, ...] | None = None,
+    skip_cpp_wrapper_input_tensor_alignment: bool = False,
 ) -> Any:
     if indices is None:
         indices = list(range(len(args)))
@@ -311,11 +312,31 @@ def config_of(
             return False
         raise NotImplementedError(f"unhandled {type(x)}: {x}")
 
+    def include_tensor_alignment(arg: KernelArgType) -> bool:
+        if (
+            not skip_cpp_wrapper_input_tensor_alignment
+            or not V.graph.cpp_wrapper
+            or V.graph.aot_mode
+            or not isinstance(arg, TensorArg)
+            or arg.buffer not in V.graph.graph_inputs
+        ):
+            return True
+
+        try:
+            input_idx = V.graph.graph_input_names.index(arg.buffer)
+        except ValueError:
+            return True
+        return input_idx not in (V.graph.inputs_to_check or ())
+
     if config.triton.divisible_by_16:
         divisible_by_16 = tuple(
             i
             for i, arg in zip(indices, args)
-            if is_aligned(arg, alignment=16, include_tensor=True)
+            if is_aligned(
+                arg,
+                alignment=16,
+                include_tensor=include_tensor_alignment(arg),
+            )
         )
     else:
         divisible_by_16 = ()


### PR DESCRIPTION
Summary:
This fixes two cpp_wrapper issues that can show up when compiling graphs with fallback custom ops and Triton kernels:

1. Python fallback return unpacking currently indexes outputs by the full IR output list. That list can include MutationOutput entries for mutated inputs, but those entries are not returned by the Python fallback call. When a fallback op both mutates an input and returns a tensor, the returned tensor slot can therefore be shifted and unpacked from the wrong Python result.

2. Triton config generation currently marks TensorArg inputs as 16-byte divisible based on the symbolic TensorArg offset. Under cpp_wrapper, the actual runtime tensor handle may point at a view whose data_ptr is not 16-byte aligned even when the symbolic offset is zero. Emitting that alignment metadata can let Triton generate code with an invalid alignment assumption and fail at runtime for misaligned views.

Changes:
- Skip MutationOutput entries when mapping Python fallback return values back to cpp_wrapper output handles.
- Do not emit tensor-pointer 16-byte divisibility metadata for Triton configs under cpp_wrapper.
- Add coverage for a mutable custom-op fallback schema and a misaligned contiguous CUDA input view with cpp_wrapper.

@jansel Could help review these changes, thanks!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo