### PR TITLE
[CUDA] linalg: overlap looped cuSOLVER LU (getrf) across auxiliary   streams

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -8,7 +8,13 @@
 #include <ATen/cuda/CUDABlas.h>
 #include <ATen/cuda/CUDAEvent.h>
 #include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/util/irange.h>
+#include <c10/util/SmallVector.h>
+
+#include <unordered_map>
 
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/TransposeType.h>
@@ -39,6 +45,13 @@
 #define ROCSOLVER_SYEVD_BATCHED_ENABLED 0
 #endif
 #endif // defined(USE_ROCM)
+
+namespace at::cuda {
+// Declared here rather than in the widely-included CUDAContextLight.h: this is
+// an internal helper for the looped multi-stream paths, unlike
+// getCurrentCUDASolverDnHandle, which is public API.
+cusolverDnHandle_t getCUDASolverDnHandleForStream(cudaStream_t stream);
+} // namespace at::cuda
 
 namespace at::native {
 
@@ -1644,6 +1657,80 @@ void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvec
 // The 'apply_' word is used for templated by dtype functions that call an API routine
 // underneath. Since the cusolver API has a slightly different structure we do not prepend
 // apply_ to this function.
+
+namespace {
+
+// Keep storage alive until work queued on `stream` completes.
+void record_tensor_on_stream(const Tensor& t, c10::cuda::CUDAStream stream) {
+  if (t.defined() && t.numel() > 0) {
+    c10::cuda::CUDACachingAllocator::recordStream(t.storage().data_ptr(), stream);
+  }
+}
+
+void record_dataptr_on_stream(const c10::DataPtr& ptr, c10::cuda::CUDAStream stream) {
+  if (ptr.get() != nullptr) {
+    c10::cuda::CUDACachingAllocator::recordStream(ptr, stream);
+  }
+}
+
+// Run independent cuSOLVER calls round-robin over auxiliary streams and join
+// back to the original stream. `launch` receives is_first_use_of_stream so it
+// can record shared storages once per auxiliary stream without re-deriving the
+// scheduling. Falls back to serial execution during CUDA graph capture.
+template <typename launch_t>
+void looped_cusolver_multistream(
+    int64_t batch_size,
+    int64_t n_streams,
+    const launch_t& launch) {
+  auto main_stream = c10::cuda::getCurrentCUDAStream();
+  // Do not grab more pooled streams than there is work for.
+  n_streams = std::min<int64_t>(n_streams, batch_size);
+  // Avoid introducing auxiliary-stream execution while capturing CUDA graphs:
+  // fall back to serial execution during capture.
+  if (n_streams <= 1 ||
+      c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+          c10::cuda::CaptureStatus::None) {
+    auto handle = at::cuda::getCurrentCUDASolverDnHandle();
+    for (const auto i : c10::irange(batch_size)) {
+      launch(i, /*stream_id=*/static_cast<int64_t>(0),
+             /*is_first_use_of_stream=*/false, handle, main_stream);
+    }
+    return;
+  }
+
+  at::cuda::CUDAEvent fork_event;
+  fork_event.record(main_stream);
+
+  c10::SmallVector<c10::cuda::CUDAStream, 8> streams;
+  streams.reserve(n_streams);
+  for (int64_t s = 0; s < n_streams; ++s) {
+    auto stream = c10::cuda::getStreamFromPool();
+    fork_event.block(stream);
+    streams.push_back(stream);
+  }
+
+  // Track first use of each auxiliary stream here, where the scheduling is
+  // owned, so the callback does not have to re-derive it.
+  c10::SmallVector<uint8_t, 8> used(n_streams, 0);
+  for (const auto i : c10::irange(batch_size)) {
+    const auto stream_id = i % n_streams;
+    auto stream = streams[stream_id];
+    const bool is_first_use_of_stream = used[stream_id] == 0;
+    used[stream_id] = 1;
+    c10::cuda::CUDAStreamGuard guard(stream);
+    auto handle = at::cuda::getCUDASolverDnHandleForStream(stream.stream());
+    launch(i, stream_id, is_first_use_of_stream, handle, stream);
+  }
+
+  for (auto& stream : streams) {
+    at::cuda::CUDAEvent join_event;
+    join_event.record(stream);
+    join_event.block(main_stream);
+  }
+}
+
+} // anonymous namespace
+
 void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const Tensor& infos, bool get_pivots) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
     self.scalar_type(),
@@ -1669,19 +1756,59 @@ void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const T
     at::cuda::solver::getrf_bufferSize<scalar_t>(
       handle, m, n, self_data, lda, &lwork);
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-    auto workspace = allocator.allocate(sizeof(scalar_t) * lwork);
-    auto workspace_ptr = static_cast<scalar_t*>(workspace.get());
 
-    for (auto batch = decltype(batch_size){0}; batch < batch_size; ++batch) {
+    // Overlap independent factorizations across a few auxiliary streams.
+    // Larger factorizations naturally show less overlap as a single getrf occupies
+    // more of the GPU, so this path is bounded by the batch threshold, stream-count
+    // cap, and workspace budget rather than by a fixed size cutoff.
+    constexpr int64_t kMultiStreamMinBatch = 8;
+    constexpr int64_t kMaxStreams = 8;
+    int64_t n_streams = 1;
+    if (batch_size >= kMultiStreamMinBatch) {
+      n_streams = std::min<int64_t>(batch_size, kMaxStreams);
+      // Bound extra memory from per-stream workspaces; clamping to 1 falls back to
+      // serial execution.
+      const int64_t workspace_bytes =
+          static_cast<int64_t>(sizeof(scalar_t)) * static_cast<int64_t>(lwork);
+      if (workspace_bytes > 0) {
+        constexpr int64_t kMaxAuxWorkspaceBytes = 256LL << 20;
+        n_streams = std::min<int64_t>(
+            n_streams,
+            std::max<int64_t>(1, kMaxAuxWorkspaceBytes / workspace_bytes));
+      }
+    }
+
+    // Allocate before launching auxiliary work so OOM cannot bypass the join.
+    c10::SmallVector<c10::DataPtr, 8> workspaces;
+    workspaces.reserve(n_streams);
+    for (int64_t k = 0; k < n_streams; ++k) {
+      workspaces.push_back(allocator.allocate(sizeof(scalar_t) * lwork));
+    }
+
+    auto launch = [&](int64_t i,
+                      int64_t stream_id,
+                      bool is_first_use_of_stream,
+                      cusolverDnHandle_t h,
+                      c10::cuda::CUDAStream stream) {
+      if (is_first_use_of_stream) {
+        // Record shared storages once per auxiliary stream.
+        record_tensor_on_stream(self, stream);
+        if (get_pivots) {
+          record_tensor_on_stream(pivots, stream);
+        }
+        record_tensor_on_stream(infos, stream);
+        record_dataptr_on_stream(workspaces[stream_id], stream);
+      }
+      auto* workspace_ptr = static_cast<scalar_t*>(workspaces[stream_id].get());
       at::cuda::solver::getrf<scalar_t>(
-        handle, m, n,
-        self_data + batch * self_stride,
+        h, m, n,
+        self_data + i * self_stride,
         lda,
         workspace_ptr,
-        get_pivots ? pivots_data + batch * pivots_stride : nullptr,
-        infos_data + batch
-      );
-    }
+        get_pivots ? pivots_data + i * pivots_stride : nullptr,
+        infos_data + i);
+    };
+    looped_cusolver_multistream(batch_size, n_streams, launch);
   });
 
   // Necessary because cuSOLVER uses nan for outputs that correspond to 0 in MAGMA for non-pivoted LU.

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -6,7 +6,13 @@
 #include <ATen/cuda/PinnedMemoryAllocator.h>
 #include <ATen/cuda/CUDABlas.h>
 #include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/util/irange.h>
+#include <c10/util/SmallVector.h>
+
+#include <unordered_map>
 
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/TransposeType.h>
@@ -37,6 +43,13 @@
 #define ROCSOLVER_SYEVD_BATCHED_ENABLED 0
 #endif
 #endif // defined(USE_ROCM)
+
+namespace at::cuda {
+// Declared here rather than in the widely-included CUDAContextLight.h: this is
+// an internal helper for the looped multi-stream paths, unlike
+// getCurrentCUDASolverDnHandle, which is public API.
+cusolverDnHandle_t getCUDASolverDnHandleForStream(cudaStream_t stream);
+} // namespace at::cuda
 
 namespace at::native {
 
@@ -1663,6 +1676,80 @@ void linalg_eig_cusolver_xgeev(const Tensor& eigenvalues, const Tensor& eigenvec
 // The 'apply_' word is used for templated by dtype functions that call an API routine
 // underneath. Since the cusolver API has a slightly different structure we do not prepend
 // apply_ to this function.
+
+namespace {
+
+// Keep storage alive until work queued on `stream` completes.
+void record_tensor_on_stream(const Tensor& t, c10::cuda::CUDAStream stream) {
+  if (t.defined() && t.numel() > 0) {
+    c10::cuda::CUDACachingAllocator::recordStream(t.storage().data_ptr(), stream);
+  }
+}
+
+void record_dataptr_on_stream(const c10::DataPtr& ptr, c10::cuda::CUDAStream stream) {
+  if (ptr.get() != nullptr) {
+    c10::cuda::CUDACachingAllocator::recordStream(ptr, stream);
+  }
+}
+
+// Run independent cuSOLVER calls round-robin over auxiliary streams and join
+// back to the original stream. `launch` receives is_first_use_of_stream so it
+// can record shared storages once per auxiliary stream without re-deriving the
+// scheduling. Falls back to serial execution during CUDA graph capture.
+template <typename launch_t>
+void looped_cusolver_multistream(
+    int64_t batch_size,
+    int64_t n_streams,
+    const launch_t& launch) {
+  auto main_stream = c10::cuda::getCurrentCUDAStream();
+  // Do not grab more pooled streams than there is work for.
+  n_streams = std::min<int64_t>(n_streams, batch_size);
+  // Avoid introducing auxiliary-stream execution while capturing CUDA graphs:
+  // fall back to serial execution during capture.
+  if (n_streams <= 1 ||
+      c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+          c10::cuda::CaptureStatus::None) {
+    auto handle = at::cuda::getCurrentCUDASolverDnHandle();
+    for (const auto i : c10::irange(batch_size)) {
+      launch(i, /*stream_id=*/static_cast<int64_t>(0),
+             /*is_first_use_of_stream=*/false, handle, main_stream);
+    }
+    return;
+  }
+
+  at::cuda::CUDAEvent fork_event;
+  fork_event.record(main_stream);
+
+  c10::SmallVector<c10::cuda::CUDAStream, 8> streams;
+  streams.reserve(n_streams);
+  for (int64_t s = 0; s < n_streams; ++s) {
+    auto stream = c10::cuda::getStreamFromPool();
+    fork_event.block(stream);
+    streams.push_back(stream);
+  }
+
+  // Track first use of each auxiliary stream here, where the scheduling is
+  // owned, so the callback does not have to re-derive it.
+  c10::SmallVector<uint8_t, 8> used(n_streams, 0);
+  for (const auto i : c10::irange(batch_size)) {
+    const auto stream_id = i % n_streams;
+    auto stream = streams[stream_id];
+    const bool is_first_use_of_stream = used[stream_id] == 0;
+    used[stream_id] = 1;
+    c10::cuda::CUDAStreamGuard guard(stream);
+    auto handle = at::cuda::getCUDASolverDnHandleForStream(stream.stream());
+    launch(i, stream_id, is_first_use_of_stream, handle, stream);
+  }
+
+  for (auto& stream : streams) {
+    at::cuda::CUDAEvent join_event;
+    join_event.record(stream);
+    join_event.block(main_stream);
+  }
+}
+
+} // anonymous namespace
+
 void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const Tensor& infos, bool get_pivots) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
     self.scalar_type(),
@@ -1688,19 +1775,59 @@ void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const T
     at::cuda::solver::getrf_bufferSize<scalar_t>(
       handle, m, n, self_data, lda, &lwork);
     auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-    auto workspace = allocator.allocate(sizeof(scalar_t) * lwork);
-    auto workspace_ptr = static_cast<scalar_t*>(workspace.get());
 
-    for (auto batch = decltype(batch_size){0}; batch < batch_size; ++batch) {
+    // Overlap independent factorizations across a few auxiliary streams.
+    // Larger factorizations naturally show less overlap as a single getrf occupies
+    // more of the GPU, so this path is bounded by the batch threshold, stream-count
+    // cap, and workspace budget rather than by a fixed size cutoff.
+    constexpr int64_t kMultiStreamMinBatch = 8;
+    constexpr int64_t kMaxStreams = 8;
+    int64_t n_streams = 1;
+    if (batch_size >= kMultiStreamMinBatch) {
+      n_streams = std::min<int64_t>(batch_size, kMaxStreams);
+      // Bound extra memory from per-stream workspaces; clamping to 1 falls back to
+      // serial execution.
+      const int64_t workspace_bytes =
+          static_cast<int64_t>(sizeof(scalar_t)) * static_cast<int64_t>(lwork);
+      if (workspace_bytes > 0) {
+        constexpr int64_t kMaxAuxWorkspaceBytes = 256LL << 20;
+        n_streams = std::min<int64_t>(
+            n_streams,
+            std::max<int64_t>(1, kMaxAuxWorkspaceBytes / workspace_bytes));
+      }
+    }
+
+    // Allocate before launching auxiliary work so OOM cannot bypass the join.
+    c10::SmallVector<c10::DataPtr, 8> workspaces;
+    workspaces.reserve(n_streams);
+    for (int64_t k = 0; k < n_streams; ++k) {
+      workspaces.push_back(allocator.allocate(sizeof(scalar_t) * lwork));
+    }
+
+    auto launch = [&](int64_t i,
+                      int64_t stream_id,
+                      bool is_first_use_of_stream,
+                      cusolverDnHandle_t h,
+                      c10::cuda::CUDAStream stream) {
+      if (is_first_use_of_stream) {
+        // Record shared storages once per auxiliary stream.
+        record_tensor_on_stream(self, stream);
+        if (get_pivots) {
+          record_tensor_on_stream(pivots, stream);
+        }
+        record_tensor_on_stream(infos, stream);
+        record_dataptr_on_stream(workspaces[stream_id], stream);
+      }
+      auto* workspace_ptr = static_cast<scalar_t*>(workspaces[stream_id].get());
       at::cuda::solver::getrf<scalar_t>(
-        handle, m, n,
-        self_data + batch * self_stride,
+        h, m, n,
+        self_data + i * self_stride,
         lda,
         workspace_ptr,
-        get_pivots ? pivots_data + batch * pivots_stride : nullptr,
-        infos_data + batch
-      );
-    }
+        get_pivots ? pivots_data + i * pivots_stride : nullptr,
+        infos_data + i);
+    };
+    looped_cusolver_multistream(batch_size, n_streams, launch);
   });
 
   // Necessary because cuSOLVER uses nan for outputs that correspond to 0 in MAGMA for non-pivoted LU.

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -2,6 +2,11 @@
 #include <ATen/cuda/detail/DeviceThreadHandles.h>
 #include <c10/macros/Export.h>
 
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
+
 namespace at::cuda {
 namespace {
 
@@ -25,6 +30,67 @@ void destroyCusolverDnHandle(cusolverDnHandle_t handle) {
 
 using CuSolverDnPoolType = DeviceThreadHandlePool<cusolverDnHandle_t, createCusolverDnHandle, destroyCusolverDnHandle>;
 
+// Per-(device, stream) cuSOLVER handles for the looped multi-stream path.
+// A handle is kept on its original stream to avoid rebinding it while work may
+// still be in flight. Handles are thread-local while owned, and returned on
+// thread exit to a process-lifetime free list keyed by the same (device, stream)
+// instead of being destroyed during teardown.
+using AuxCusolverHandleKey = std::pair<c10::DeviceIndex, cudaStream_t>;
+
+struct AuxCusolverHandlePool {
+  std::mutex mutex;
+  std::map<AuxCusolverHandleKey, std::vector<cusolverDnHandle_t>> free_handles;
+};
+
+AuxCusolverHandlePool& auxCusolverHandlePool() {
+  static auto* pool = new AuxCusolverHandlePool();
+  return *pool;
+}
+
+// Thread-local cache keyed by the actual CUDA stream. Reusing a handle on the
+// same stream is ordered by stream FIFO; reusing it on a different stream could
+// conflict with in-flight handle-local state.
+class AuxCusolverHandleWindow {
+ public:
+  cusolverDnHandle_t reserve(c10::DeviceIndex device, cudaStream_t stream) {
+    AuxCusolverHandleKey key = std::make_pair(device, stream);
+    auto it = my_handles_.find(key);
+    if (it != my_handles_.end()) {
+      return it->second;
+    }
+
+    cusolverDnHandle_t handle = nullptr;
+    auto& pool = auxCusolverHandlePool();
+    {
+      std::lock_guard<std::mutex> lock(pool.mutex);
+      auto& free_handles = pool.free_handles[key];
+      if (!free_handles.empty()) {
+        handle = free_handles.back();
+        free_handles.pop_back();
+      }
+    }
+    if (handle == nullptr) {
+      createCusolverDnHandle(&handle);
+    }
+    my_handles_[key] = handle;
+    return handle;
+  }
+
+  ~AuxCusolverHandleWindow() {
+    if (my_handles_.empty()) {
+      return;
+    }
+    auto& pool = auxCusolverHandlePool();
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    for (const auto& [key, handle] : my_handles_) {
+      pool.free_handles[key].push_back(handle);
+    }
+  }
+
+ private:
+  std::map<AuxCusolverHandleKey, cusolverDnHandle_t> my_handles_;
+};
+
 } // namespace
 
 cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
@@ -42,6 +108,22 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
 
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
+  TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
+  return handle;
+}
+
+// Return a cuSOLVER handle dedicated to a specific stream, keyed by
+// (device, stream). Used by the looped multi-stream path, which launches
+// independent factorizations on several auxiliary streams concurrently and
+// therefore cannot share one handle across them. These per-stream handles do
+// not clone state from torch.cuda.current_solver_handle(); PyTorch only sets the
+// stream.
+cusolverDnHandle_t getCUDASolverDnHandleForStream(cudaStream_t stream) {
+  c10::DeviceIndex device = 0;
+  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
+
+  thread_local AuxCusolverHandleWindow window;
+  auto handle = window.reserve(device, stream);
   TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
   return handle;
 }

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5620,6 +5620,41 @@ class TestLinalg(TestCase):
                 with self.assertRaisesRegex(RuntimeError, 'LU without pivoting is not implemented on the CPU'):
                     f(torch.empty(1, 2, 2), pivot=False)
 
+    @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3})
+    @skipCUDAIfNoCusolver
+    @setLinalgBackendsToDefaultFinally
+    @onlyCUDA
+    @dtypes(*floating_and_complex_types())
+    def test_lu_factor_looped_cusolver_multistream(self, device, dtype):
+        # The looped cuSOLVER getrf path overlaps independent factorizations
+        # across auxiliary streams. It is only taken when the cuSOLVER backend is
+        # selected (batched cuBLAS is the default for small matrices) and
+        # batch_size >= kMultiStreamMinBatch (=8). Force it so the fork/join,
+        # recordStream, and per-stream handle logic is exercised in CI.
+        torch.backends.cuda.preferred_linalg_library('cusolver')
+        for batch in (8, 16):  # >= kMultiStreamMinBatch, covers the trigger boundary
+            for pivot in (True, False):
+                # Rectangular [B, M, M-1] guarantees the looped (non-batched) path.
+                # Bounded off-diagonals + a strongly dominant diagonal keep both the
+                # pivoted and non-pivoted LU stable and accurate (incl. fp32), so the
+                # reconstruction check stays tight.
+                A = make_tensor((batch, 64, 63), device=device, dtype=dtype, low=-1, high=1)
+                eye = torch.eye(64, 63, device=device, dtype=dtype).expand(batch, -1, -1)
+                A = A + 100 * eye
+                LU, pivots, info = torch.linalg.lu_factor_ex(A, pivot=pivot)
+                self.assertEqual(info, torch.zeros_like(info))
+                # Pivot choice is not unique, so validate by reconstruction.
+                if pivot:
+                    P, L, U = torch.lu_unpack(LU, pivots)
+                    self.assertEqual(P @ L @ U, A)
+                else:
+                    m, n = A.shape[-2:]
+                    k = min(m, n)
+                    L = torch.tril(LU[..., :, :k], diagonal=-1)
+                    L = L + torch.eye(m, k, device=device, dtype=dtype)
+                    U = torch.triu(LU[..., :k, :])
+                    self.assertEqual(L @ U, A)
+
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2})
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5861,6 +5861,41 @@ class TestLinalg(TestCase):
                 with self.assertRaisesRegex(RuntimeError, 'LU without pivoting is not implemented on the CPU'):
                     f(torch.empty(1, 2, 2), pivot=False)
 
+    @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3})
+    @skipCUDAIfNoCusolver
+    @setLinalgBackendsToDefaultFinally
+    @onlyCUDA
+    @dtypes(*floating_and_complex_types())
+    def test_lu_factor_looped_cusolver_multistream(self, device, dtype):
+        # The looped cuSOLVER getrf path overlaps independent factorizations
+        # across auxiliary streams. It is only taken when the cuSOLVER backend is
+        # selected (batched cuBLAS is the default for small matrices) and
+        # batch_size >= kMultiStreamMinBatch (=8). Force it so the fork/join,
+        # recordStream, and per-stream handle logic is exercised in CI.
+        torch.backends.cuda.preferred_linalg_library('cusolver')
+        for batch in (8, 16):  # >= kMultiStreamMinBatch, covers the trigger boundary
+            for pivot in (True, False):
+                # Rectangular [B, M, M-1] guarantees the looped (non-batched) path.
+                # Bounded off-diagonals + a strongly dominant diagonal keep both the
+                # pivoted and non-pivoted LU stable and accurate (incl. fp32), so the
+                # reconstruction check stays tight.
+                A = make_tensor((batch, 64, 63), device=device, dtype=dtype, low=-1, high=1)
+                eye = torch.eye(64, 63, device=device, dtype=dtype).expand(batch, -1, -1)
+                A = A + 100 * eye
+                LU, pivots, info = torch.linalg.lu_factor_ex(A, pivot=pivot)
+                self.assertEqual(info, torch.zeros_like(info))
+                # Pivot choice is not unique, so validate by reconstruction.
+                if pivot:
+                    P, L, U = torch.lu_unpack(LU, pivots)
+                    self.assertEqual(P @ L @ U, A)
+                else:
+                    m, n = A.shape[-2:]
+                    k = min(m, n)
+                    L = torch.tril(LU[..., :, :k], diagonal=-1)
+                    L = L + torch.eye(m, k, device=device, dtype=dtype)
+                    U = torch.triu(LU[..., :k, :])
+                    self.assertEqual(L @ U, A)
+
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2})
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack


### PR DESCRIPTION

## Summary

`lu_factor_looped_cusolver` issues one cuSOLVER `getrf` call per batch item serially on the current CUDA stream. For small/medium matrices, these independent per-item calls cannot overlap, which can underutilize the GPU.

This PR overlaps those independent GETRF calls across a small number of auxiliary CUDA streams. It follows #181998, which hoisted GETRF workspace allocation out of the per-batch loop, and keeps that explicit-workspace model while using one workspace per auxiliary stream so concurrent calls do not share scratch.

This partially addresses #182001 for the LU/getrf path.

## Scope

This first version only changes `lu_factor_looped_cusolver`. The existing dispatcher still decides whether LU should use the looped cuSOLVER backend or a batched cuBLAS path; this PR only applies after the looped cuSOLVER backend has already been selected.

The helper is file-local for now, but is intended to be reusable by follow-up looped cuSOLVER paths such as `geqrf`, `orgqr` / `ormqr`, `lu_solve`, `cholesky_solve` / POTRS, and `xgeev`.

## Approach

* Distribute independent batch items round-robin over auxiliary streams from the CUDA stream pool.
* Use CUDA events so auxiliary streams wait on the current stream before starting, and the current stream waits for all auxiliary streams before the post-loop fixup.
* Use one cuSOLVER workspace per auxiliary stream.
* Record every storage touched by auxiliary streams with the CUDA caching allocator: `self`, `pivots`, `infos`, and the per-stream workspaces.
* Use a thread-local cuSOLVER handle cache keyed by physical `cudaStream_t`, so each physical CUDA stream has its own cuSOLVER handle.

The handle cache is keyed by physical stream rather than by per-call slot because `getStreamFromPool()` can return different physical streams for the same slot across calls. Stress testing showed that reusing one cuSOLVER handle across concurrent auxiliary streams is not safe for this path; a per-physical-stream handle cache removed the run-to-run nondeterminism.

## Heuristic

The multi-stream path is enabled inside `lu_factor_looped_cusolver` when:

```cpp
batch_size >= 8
```

with at most 8 auxiliary streams, and the stream count is further capped by a workspace-byte budget so the multi-stream path does not allocate excessive scratch memory compared with the original single-workspace path.

There is no matrix-size cutoff: larger factorizations naturally overlap less (a single `getrf` already occupies more of the GPU), so the path is bounded by the batch threshold, the stream-count cap, and the workspace budget rather than by a fixed size gate. This does not change the existing cuBLAS-vs-cuSOLVER dispatch heuristic. The stream count is kept automatic for this first version; local scaling saturated at 8 streams, while backend selection remains controlled by the existing linalg dispatcher.

## Validation

Validated on RTX PRO 6000 Blackwell, CUDA 13.0.

Correctness and determinism stress coverage:

```text
dtypes: fp32, fp64, complex64, complex128
shapes: [8,512,511], [64,512,511], [64,768,767], [64,1024,1023]
pivot:  true / false
runs:   100 iterations per config
```

Results:

* 0 run-to-run differences after switching to per-physical-stream cuSOLVER handles.
* 31/32 configurations are bit-identical against the serial reference.
* The only raw-output mismatch is `complex64 [64,1024,1023]` with pivoting. It differs only in pivot choice for 3/64 batch items. Both serial and multi-stream results are valid factorizations: `||P L U - A|| / ||A||` is `1.2e-5` for both, matching the residual scale of the passing cases.
* The corresponding complex128 case is bit-exact, which supports that the remaining complex64 raw LU mismatch is pivot non-uniqueness in single precision rather than a stream/workspace/handle bug.

compute-sanitizer:

* `memcheck`: 0 errors
* `initcheck`: 0 errors
* `synccheck`: 0 errors
* `racecheck`: only reports warnings inside cuSOLVER's internal `getrf_wo_pivot` kernel. The same warnings reproduce on the batch=1 serial path, so they are unrelated to this change.

## Performance

Measured on RTX PRO 6000 Blackwell, CUDA 13.0, fp32, CUDA-event timing after warmup. Rectangular near-square inputs `[B, M, M-1]` are used to isolate the looped cuSOLVER path; high-batch square inputs may dispatch to cuBLAS batched and therefore not exercise this change.

Serial vs multi-stream, `[B, M, M-1]`:

```text
  B     M   serial(ms)  multi(ms)  speedup   serial(MB)  multi(MB)
  8   512       7.48       2.70      2.8x        48.0       48.1
  8   768      11.28       2.56      4.4x        68.0       68.1
  8  1024      15.86       5.08      3.1x        96.0       96.1
  8  1536      25.33       7.36      3.4x       176.1      176.2
  8  2048      36.59       9.56      3.8x       288.1      288.5
 16   512      14.93       5.28      2.8x        64.0       64.0
 16   768      22.53       4.85      4.6x       104.0      104.0
 16  1024      31.75       9.82      3.2x       160.1      160.2
 16  1536      50.72      14.13      3.6x       320.1      320.3
 16  2048      73.29      18.69      3.9x       544.2      544.5
 64   512      59.60      20.45      2.9x       159.9      159.9
 64   768      90.01      18.34      4.9x       320.0      320.1
 64  1024     126.89      36.67      3.5x       544.3      544.3
 64  1536     202.99      55.31      3.7x      1184.4     1184.5
 64  2048     292.61      74.74      3.9x      2080.6     2080.9
```

Per-stream workspaces add less than 0.5 MB in these cases, so peak memory is effectively unchanged.

Stream-count scaling saturates at 8 streams:

```text
streams   [64,768]ms  [64,1024]ms
      1       86.3       121.0
      2       45.2        70.2
      4       26.1        45.5
      8       17.8        36.6
     16       17.8        36.5
```

Square dispatch sanity check: high-batch low-n square inputs continue to route to cuBLAS batched and are unchanged within noise, for example `B=64, n=1024` is 88.9 ms vs 89.1 ms. Larger square inputs that dispatch to looped cuSOLVER get the multi-stream speedup, for example `B=64, n=1536` improves from 203 ms to 55 ms.

## BC

No public API or behavior change. `torch.linalg.lu_factor` / `lu_factor_ex` still return a valid LU factorization as before; only the internal scheduling of the per-batch cuSOLVER calls changes.

## Test 

Build:

```bash
TORCH_CUDA_ARCH_LIST=12.0 USE_CUDA=1 python -m pip install -e . -v --no-build-isolation
```

Existing linalg tests:

```bash
python -m pytest test/test_linalg.py -k "linalg_lu_family and cuda" -v
```

Result:

```text
4 passed
```

This covers the CUDA LU family tests for `float32`, `float64`, `complex64`, and `complex128`.

Additional local validation:

* custom correctness / determinism stress test over `fp32`, `fp64`, `complex64`, and `complex128`
* forced looped cuSOLVER multi-stream validation with rectangular batched inputs and relative reconstruction residual checks
* compute-sanitizer `memcheck`, `initcheck`, `synccheck`, and `racecheck`
* local performance benchmarks on RTX PRO 6000 Blackwell


cc @IvanYashchuk

