### PR TITLE
Warn that register_post_accumulate_grad_hook receives the param, not the grad

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -710,6 +710,15 @@ class Tensor(torch._C.TensorBase):
         accumulate grad hook is ONLY applicable for leaf tensors (tensors without a
         .grad_fn field). Registering this hook on a non-leaf tensor will error!
 
+        .. warning::
+            Unlike :meth:`~torch.Tensor.register_hook`, the hook registered here is
+            passed the **tensor itself** (the leaf parameter), not its gradient. The
+            method name and the phrase "after grad accumulation" are easy to misread as
+            implying the hook receives the gradient -- it does not. To read the gradient
+            inside the hook, access the tensor's ``.grad`` field (for example
+            ``param.grad``). Treating the argument as the gradient is a silent error
+            that can corrupt training without raising any exception.
+
         The hook should have the following signature::
 
             hook(param: Tensor) -> None


### PR DESCRIPTION
Tensor.register_post_accumulate_grad_hook passes the leaf tensor itself to the registered hook, not its gradient. The method name and the 'after grad accumulation' phrasing read as though the hook is handed the gradient -- the same convention as register_hook -- so it is easy to treat the argument as the gradient, cast/offload it, and silently corrupt training. The gradient actually lives in param.grad.

The docstring already mentioned this, but only in a plain paragraph below the signature where it is easy to miss. Promote it to a prominent warning admonition that contrasts with register_hook and points users to param.grad. Documentation only; no behavior change.

Fixes #187268

Test Plan:
Documentation-only change; no runtime behavior is affected. Verified the module still byte-compiles and the existing doctest example is unchanged:

`
python -m py_compile torch/_tensor.py
`

This change was authored with the assistance of an AI coding assistant.