### PR TITLE
[inductor] Fix manual bucket placement order

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1941,6 +1941,159 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @torch._inductor.config.patch(
+        {"aten_distributed_optimizations.bucket_mode": "custom_ops"}
+    )
+    def test_manual_bucketing_ag_convert_inputs_before_consumers(self):
+        module_path_key = "module_path"
+
+        def module_stack_fn(node):
+            module_stack = node.meta.get("custom", {}).get(module_path_key, "")
+            return [(module_stack, torch.nn.Module)]
+
+        def func(a, b, *, ranks):
+            with torch.fx.traceback.annotate({module_path_key: "mod"}):
+                ag1 = _functional_collectives.all_gather_tensor(
+                    a.to(torch.bfloat16), 0, ranks
+                )
+            use_ag1 = ag1.float().sum()
+            late = b + 1.0
+            with torch.fx.traceback.annotate({module_path_key: "mod"}):
+                ag2 = _functional_collectives.all_gather_tensor(
+                    late.to(torch.bfloat16), 0, ranks
+                )
+            return use_ag1 + ag2.float().sum()
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            a = torch.ones(8, 8, dtype=torch.float, device=device_type)
+            b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
+            ranks = list(range(self.world_size))
+
+            compiled = torch.compile(functools.partial(func, ranks=ranks))
+            out, aten_graph = run_and_get_manual_aten_graph(
+                compiled,
+                [["mod"]],
+                a,
+                b,
+                custom_module_stack_fn=module_stack_fn,
+            )
+
+            FileCheck().check("_pre_bucket_all_gather").check("wait_tensor").run(
+                str(aten_graph)
+            )
+            self.assertTrue(same(out, func(a, b, ranks=ranks)))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(
+        {"aten_distributed_optimizations.bucket_mode": "custom_ops"}
+    )
+    def test_manual_bucket_insertion_uses_graph_order(self):
+        def func(a, b, *, ranks):
+            ag1 = _functional_collectives.all_gather_tensor(a, 0, ranks)
+            ag2 = _functional_collectives.all_gather_tensor(b, 0, ranks)
+            return ag1[:8, :8].sum() + ag2[:8, :8].sum()
+
+        def reverse_bucket_order(graph, out_li):
+            gm = graph.owning_module
+            from torch._inductor.fx_passes.overlap_manual_scheduling import (
+                ManualOverlapScheduler,
+            )
+
+            scheduler = ManualOverlapScheduler(
+                gm,
+                module_bucket_plans=[],
+                insert_overlap_deps=False,
+            )
+            ag_nodes = [
+                n
+                for n in scheduler.nodes
+                if n.name in ("all_gather_into_tensor", "all_gather_into_tensor_1")
+            ]
+            self.assertEqual(len(ag_nodes), 2)
+            scheduler.bucketer._bucket_group(list(reversed(ag_nodes)))
+            scheduler.graph.lint()
+            out_li.append(scheduler.graph)
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            a = torch.ones(8, 8, dtype=torch.float, device=device_type)
+            b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
+            ranks = list(range(self.world_size))
+
+            li = []
+            apply = functools.partial(reverse_bucket_order, out_li=li)
+            with torch._inductor.config.patch(post_grad_custom_post_pass=apply):
+                compiled = torch.compile(functools.partial(func, ranks=ranks))
+                out = compiled(a, b)
+
+            FileCheck().check("_pre_bucket_all_gather").check("wait_tensor").run(
+                str(li[0])
+            )
+            self.assertTrue(same(out, func(a, b, ranks=ranks)))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(
+        {"aten_distributed_optimizations.bucket_mode": "custom_ops"}
+    )
+    def test_manual_reduce_scatter_bucket_wait_stays_after_inputs(self):
+        def func(a, b):
+            rs1 = _functional_collectives.reduce_scatter_tensor(a, "sum", 0, "0")
+            b = b + 1
+            rs2 = _functional_collectives.reduce_scatter_tensor(b, "sum", 0, "0")
+            return rs1, rs2
+
+        def bucket_reduce_scatters(graph, out_li):
+            gm = graph.owning_module
+            from torch._inductor.fx_passes.overlap_manual_scheduling import (
+                ManualOverlapScheduler,
+            )
+
+            scheduler = ManualOverlapScheduler(
+                gm,
+                module_bucket_plans=[],
+                insert_overlap_deps=False,
+            )
+            rs_nodes = list(
+                scheduler.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops._c10d_functional.reduce_scatter_tensor.default,
+                )
+            )
+            self.assertEqual(len(rs_nodes), 2)
+            scheduler.bucketer._bucket_group(rs_nodes)
+            scheduler.graph.lint()
+            out_li.append(scheduler.graph)
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            a = torch.ones(8, 8, dtype=torch.float, device=device_type)
+            b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
+
+            li = []
+            apply = functools.partial(bucket_reduce_scatters, out_li=li)
+            with torch._inductor.config.patch(post_grad_custom_post_pass=apply):
+                compiled = torch.compile(func)
+                out = compiled(a, b)
+
+            FileCheck().check("add").check("_pre_bucket_reduce_scatter").check(
+                "wait_tensor"
+            ).run(str(li[0]))
+            self.assertTrue(same(out, func(a, b)))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(
         {"aten_distributed_optimizations.bucket_mode": "default"}
     )
     def test_manual_bucketing_ag_with_intermediate_deps(self):

--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1991,6 +1991,121 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
     @torch._inductor.config.patch(
         {"aten_distributed_optimizations.bucket_mode": "custom_ops"}
     )
+    def test_manual_bucketing_ag_late_input_repairs_wait_consumer(self):
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            ManualOverlapPreservingBucketer,
+        )
+        from torch._inductor.fx_passes.overlap_scheduling import CollectiveInfo
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.utils._ordered_set import OrderedSet
+
+        def set_val(node, val):
+            node.meta["val"] = val
+            return node
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            with FakeTensorMode():
+                a_val = torch.empty(8, 8, device=device_type)
+                b_val = torch.empty(8, 8, device=device_type)
+                ag1_val = torch.empty(self.world_size * 8, 8, device=device_type)
+                late_val = torch.empty(8, 8, device=device_type)
+                convert_val = torch.empty(
+                    8, 8, device=device_type, dtype=torch.bfloat16
+                )
+                ag2_val = torch.empty(
+                    self.world_size * 8,
+                    8,
+                    device=device_type,
+                    dtype=torch.bfloat16,
+                )
+                use_ag1_val = torch.empty_like(ag1_val)
+                use_ag1_2_val = torch.empty_like(ag1_val)
+
+            graph = fx.Graph()
+            a = set_val(graph.placeholder("a"), a_val)
+            b = set_val(graph.placeholder("b"), b_val)
+            ag1 = set_val(
+                graph.call_function(
+                    torch.ops._c10d_functional.all_gather_into_tensor.default,
+                    args=(a, self.world_size, "0"),
+                ),
+                ag1_val,
+            )
+            wait1 = set_val(
+                graph.call_function(
+                    torch.ops._c10d_functional.wait_tensor.default,
+                    args=(ag1,),
+                ),
+                ag1_val,
+            )
+            use_ag1 = set_val(
+                graph.call_function(torch.ops.aten.neg.default, args=(wait1,)),
+                use_ag1_val,
+            )
+            use_ag1_2 = set_val(
+                graph.call_function(torch.ops.aten.relu.default, args=(use_ag1,)),
+                use_ag1_2_val,
+            )
+            late = set_val(
+                graph.call_function(torch.ops.aten.add.Tensor, args=(b, 1.0)),
+                late_val,
+            )
+            convert = set_val(
+                graph.call_function(
+                    torch.ops.prims.convert_element_type.default,
+                    args=(late, torch.bfloat16),
+                ),
+                convert_val,
+            )
+            ag2 = set_val(
+                graph.call_function(
+                    torch.ops._c10d_functional.all_gather_into_tensor.default,
+                    args=(convert, self.world_size, "0"),
+                ),
+                ag2_val,
+            )
+            wait2 = set_val(
+                graph.call_function(
+                    torch.ops._c10d_functional.wait_tensor.default,
+                    args=(ag2,),
+                ),
+                ag2_val,
+            )
+            graph.output((use_ag1_2, wait2))
+            gm = fx.GraphModule(torch.nn.Module(), graph)
+            gm.graph.lint()
+
+            bucketer = ManualOverlapPreservingBucketer(
+                gm.graph,
+                {
+                    ag1: CollectiveInfo(ag1, wait1, 0, 0, 0),
+                    ag2: CollectiveInfo(ag2, wait2, 0, 0, 0),
+                },
+                OrderedSet(gm.graph.nodes),
+                bucket_mode="custom_ops",
+            )
+            bucketer._bucket_group([ag1, ag2])
+            gm.graph.lint()
+
+            (
+                FileCheck()
+                .check("add")
+                .check("_pre_bucket_all_gather")
+                .check("wait_tensor")
+                .check("neg")
+                .check("relu")
+                .run(str(gm.graph))
+            )
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(
+        {"aten_distributed_optimizations.bucket_mode": "custom_ops"}
+    )
     def test_manual_bucket_insertion_uses_graph_order(self):
         def func(a, b, *, ranks):
             ag1 = _functional_collectives.all_gather_tensor(a, 0, ranks)

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -72,28 +72,80 @@ def _collect_nodes_must_be_before(
     return sorted(visited, key=lambda n: node_positions[n])
 
 
-def _bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
-    node_in = coll_node.args[0]
+def _bucket_trace_inputs(
+    coll_node: fx.Node, node_in: object, group_name_arg: int
+) -> list[fx.Node]:
+    if not isinstance(node_in, fx.Node):
+        raise AssertionError(f"expected node input to be a Node, got {type(node_in)}")
+    inputs = [node_in]
+
+    group_name = coll_node.args[group_name_arg]
+    if isinstance(group_name, fx.Node):
+        inputs.append(group_name)
+    return inputs
+
+
+def _all_gather_bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
+    node_in: object = coll_node.args[0]
+    # The dtype conversion is erased by the all-gather bucket trace, so anchor
+    # insertion on the tensor that remains as a graph input to the bucket.
     if has_mergeable_all_gather_convert_dtype(coll_node):
         if not isinstance(node_in, fx.Node):
             raise AssertionError(
                 f"expected node input to be a Node, got {type(node_in)}"
             )
         node_in = node_in.args[0]
-    if not isinstance(node_in, fx.Node):
-        raise AssertionError(f"expected node input to be a Node, got {type(node_in)}")
-    inputs = [node_in]
+    return _bucket_trace_inputs(coll_node, node_in, group_name_arg=2)
 
-    if is_all_gather(coll_node):
-        group_name_arg = 2
-    elif is_reduce_scatter(coll_node):
-        group_name_arg = 3
-    else:
-        raise AssertionError(f"expected collective node, got {coll_node}")
-    group_name = coll_node.args[group_name_arg]
-    if isinstance(group_name, fx.Node):
-        inputs.append(group_name)
-    return inputs
+
+def _reduce_scatter_bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
+    return _bucket_trace_inputs(coll_node, coll_node.args[0], group_name_arg=3)
+
+
+def _move_wait_users_after_latest_inputs(
+    graph: fx.Graph,
+    replacements: dict[fx.Node, fx.Node],
+    replaced_users: dict[fx.Node, list[fx.Node]],
+) -> None:
+    node_positions = {n: i for i, n in enumerate(graph.nodes)}
+    initial_users: OrderedSet[fx.Node] = OrderedSet()
+    for old_out, new_out in replacements.items():
+        if new_out not in node_positions:
+            continue
+        for user in replaced_users.get(old_out, []):
+            if (
+                user in node_positions
+                and user.op != "output"
+                and node_positions[user] < node_positions[new_out]
+            ):
+                initial_users.add(user)
+
+    pending = sorted(initial_users, key=lambda n: node_positions[n])
+    queued = OrderedSet(pending)
+    while pending:
+        node = pending.pop(0)
+        queued.discard(node)
+
+        node_positions = {n: i for i, n in enumerate(graph.nodes)}
+        if node not in node_positions:
+            continue
+
+        input_nodes = [inp for inp in node.all_input_nodes if inp in node_positions]
+        if not input_nodes:
+            continue
+
+        latest_input = max(input_nodes, key=lambda n: node_positions[n])
+        if node_positions[node] >= node_positions[latest_input]:
+            continue
+
+        # Replacing old waits can leave existing consumers before the new bucket
+        # outputs. Pull each affected consumer after its latest input.
+        latest_input.append(node)
+        node_positions = {n: i for i, n in enumerate(graph.nodes)}
+        for user in node.users:
+            if user in node_positions and user.op != "output" and user not in queued:
+                queued.add(user)
+                pending.append(user)
 
 
 def _move_overlap_nodes(
@@ -159,13 +211,29 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         if len(coll_nodes) <= 0:
             raise AssertionError("bucketed coll_nodes should have nonzero node")
 
+        # Graph order changes after each bucket, so positions must be fresh.
         node_positions = {n: i for i, n in enumerate(self.graph.nodes)}
         waits = [self.collective_info[n].wait_node for n in coll_nodes]
         first_wait = min(waits, key=lambda w: node_positions[w])
         first = min(coll_nodes, key=lambda n: node_positions[n])
+        replaced_users = {wait: list(wait.users) for wait in waits}
+
+        if is_all_gather(first):
+            bucket_trace_inputs = _all_gather_bucket_trace_inputs
+            merge_bucket = merge_all_gather_bucket
+            node_type = "bucketed_all_gather"
+        elif is_reduce_scatter(first):
+            bucket_trace_inputs = _reduce_scatter_bucket_trace_inputs
+            merge_bucket = merge_reduce_scatter_bucket
+            node_type = "bucketed_reduce_scatter"
+        else:
+            raise ValueError(
+                "bucket non all_gather/reduce_scatter node is not supported"
+            )
+
         # coll_nodes order is used for tensor packing and may differ from
         # graph order. Insert the bucketed collective after its latest input.
-        bucket_inputs = [inp for n in coll_nodes for inp in _bucket_trace_inputs(n)]
+        bucket_inputs = [inp for n in coll_nodes for inp in bucket_trace_inputs(n)]
         anchor = max([first, *bucket_inputs], key=lambda n: node_positions[n])
         next_node = anchor.next
         coll_node_set = OrderedSet(coll_nodes)
@@ -177,26 +245,14 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             (first_wait, next_node), key=lambda n: node_positions[n]
         )
 
-        if is_all_gather(first):
-            new_nodes, replacements = merge_all_gather_bucket(
-                self.graph,
-                coll_nodes,
-                wait_insertion_point=wait_insertion_point,
-                insert_before=next_node,
-                mode=self.bucket_mode,
-            )
-        elif is_reduce_scatter(first):
-            new_nodes, replacements = merge_reduce_scatter_bucket(
-                self.graph,
-                coll_nodes,
-                wait_insertion_point=wait_insertion_point,
-                insert_before=next_node,
-                mode=self.bucket_mode,
-            )
-        else:
-            raise ValueError(
-                "bucket non all_gather/reduce_scatter node is not supported"
-            )
+        new_nodes, replacements = merge_bucket(
+            self.graph,
+            coll_nodes,
+            wait_insertion_point=wait_insertion_point,
+            insert_before=next_node,
+            mode=self.bucket_mode,
+        )
+        _move_wait_users_after_latest_inputs(self.graph, replacements, replaced_users)
 
         logger.debug(f"bucketing nodes: {coll_nodes} into {new_nodes}")  # noqa: G004
 
@@ -218,9 +274,6 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         # Track bucketed node types on this bucketer instance so it doesn't leak
         # when the same graph is processed by multiple ManualOverlapScheduler
         # invocations (e.g. separate forward and backward passes).
-        node_type = (
-            "bucketed_all_gather" if is_all_gather(first) else "bucketed_reduce_scatter"
-        )
         wait_set = OrderedSet(new_waits)
         for n in new_nodes:
             if n in wait_set:

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -4,12 +4,13 @@ import heapq
 from collections import Counter, defaultdict
 from typing import Any, TYPE_CHECKING
 
-import torch  # noqa: TC001
-import torch.fx as fx  # noqa: TC001
+import torch
+import torch.fx as fx
 from torch._inductor.fx_passes.bucketing import (
     _get_collective_node_from_wait,
     _schedulable_wait_node,
     BucketMode,
+    has_mergeable_all_gather_convert_dtype,
     is_all_gather_into_tensor as is_all_gather,
     is_fsdp_all_gather,
     is_fsdp_reduce_scatter,
@@ -69,6 +70,30 @@ def _collect_nodes_must_be_before(
         visited.add(cur)
         queue.extend(cur.all_input_nodes)
     return sorted(visited, key=lambda n: node_positions[n])
+
+
+def _bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
+    node_in = coll_node.args[0]
+    if has_mergeable_all_gather_convert_dtype(coll_node):
+        if not isinstance(node_in, fx.Node):
+            raise AssertionError(
+                f"expected node input to be a Node, got {type(node_in)}"
+            )
+        node_in = node_in.args[0]
+    if not isinstance(node_in, fx.Node):
+        raise AssertionError(f"expected node input to be a Node, got {type(node_in)}")
+    inputs = [node_in]
+
+    if is_all_gather(coll_node):
+        group_name_arg = 2
+    elif is_reduce_scatter(coll_node):
+        group_name_arg = 3
+    else:
+        raise AssertionError(f"expected collective node, got {coll_node}")
+    group_name = coll_node.args[group_name_arg]
+    if isinstance(group_name, fx.Node):
+        inputs.append(group_name)
+    return inputs
 
 
 def _move_overlap_nodes(
@@ -134,30 +159,38 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         if len(coll_nodes) <= 0:
             raise AssertionError("bucketed coll_nodes should have nonzero node")
 
+        node_positions = {n: i for i, n in enumerate(self.graph.nodes)}
         waits = [self.collective_info[n].wait_node for n in coll_nodes]
-        first_wait = min(waits, key=lambda w: self.node_idx[w])
-        first = min(coll_nodes, key=lambda n: self.node_idx[n])
-        last = max(coll_nodes, key=lambda n: self.node_idx[n])
+        first_wait = min(waits, key=lambda w: node_positions[w])
+        first = min(coll_nodes, key=lambda n: node_positions[n])
+        # coll_nodes order is used for tensor packing and may differ from
+        # graph order. Insert the bucketed collective after its latest input.
+        bucket_inputs = [inp for n in coll_nodes for inp in _bucket_trace_inputs(n)]
+        anchor = max([first, *bucket_inputs], key=lambda n: node_positions[n])
+        next_node = anchor.next
+        coll_node_set = OrderedSet(coll_nodes)
+        while next_node in coll_node_set:
+            next_node = next_node.next
+        # Use the earliest old wait unless it precedes the bucket insertion
+        # point; otherwise keep wait/output nodes with the traced bucket.
+        wait_insertion_point = max(
+            (first_wait, next_node), key=lambda n: node_positions[n]
+        )
 
         if is_all_gather(first):
-            # AG: insert early (right after first AG) to start prefetch ASAP.
-            # Move wait+consumers to the earliest original wait position.
             new_nodes, replacements = merge_all_gather_bucket(
                 self.graph,
                 coll_nodes,
-                wait_insertion_point=first_wait,
-                insert_before=first.next,
+                wait_insertion_point=wait_insertion_point,
+                insert_before=next_node,
                 mode=self.bucket_mode,
             )
         elif is_reduce_scatter(first):
-            # RS: pre_bucket_reduce_scatter needs all individual RS inputs,
-            # which are only available after the last RS fires.  Insert
-            # after the last coll_node (by graph position) and leave the
-            # wait in place -- it naturally follows the bucketed RS.
             new_nodes, replacements = merge_reduce_scatter_bucket(
                 self.graph,
                 coll_nodes,
-                insert_before=last.next,
+                wait_insertion_point=wait_insertion_point,
+                insert_before=next_node,
                 mode=self.bucket_mode,
             )
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #187341

Manual bucketing can receive collectives in a tensor-packing order that differs from the FX graph order. The old placement logic used that order to choose where to insert the bucketed collective, which could create a non-topological graph once the post-bucketing topo-sort repair was removed. All-gather could move a new wait before its bucket start, and reduce-scatter could insert _pre_bucket_reduce_scatter before a later gradient input existed.

Fix this by deriving placement from the current graph order. The bucketed collective is inserted after the latest real input it consumes, skipping over collectives that will be erased. The wait/output nodes are moved to the earliest old wait only if that point is not before the bucket insertion point; otherwise they stay with the traced bucket. This keeps the local transform topologically valid without relying on _stable_topological_sort as a repair pass.

For all-gather buckets, the real inputs must match process_collective_bucket: mergeable dtype-convert nodes are erased and the underlying tensor is passed to _pre_bucket_all_gather. Using those soon-to-be-erased convert nodes as placement anchors can move the bucket after consumers of the bucket outputs; this showed up in the Llama3 8B GraphTrainer TP=1 run as an FX graph lint failure.

I chose the local placement rule over reintroducing a topo sort because it preserves the intended manual schedule while making the bucketing transform valid by construction.

### Examples of the old failure
#### 1. Bucket inserted before a later input exists
Manual bucketing can receive collectives in tensor-packing order, which is not
always FX graph order.
Valid pre-bucket graph:
```python
a = placeholder()
b = placeholder()
ag0 = all_gather(a)
w0 = wait(ag0)
late = b + 1
ag1 = all_gather(late)
w1 = wait(ag1)
return w0, w1
```
If the bucket list is ordered as `[ag1, ag0]`, the old placement could insert the
bucket near `ag0`, before `late` is defined:
```python
bucket = _pre_bucket_all_gather([late, a])  # invalid: late is not defined yet
ag_bucket = all_gather_into_tensor_out(bucket)
w_bucket = wait(ag_bucket)
late = b + 1
```
The fix anchors bucket insertion after the latest real input consumed by the
bucket, independent of `coll_nodes` order.
#### 2. Old wait consumer left before the new bucket output
A second issue happens after `replace_all_uses_with`. The bucket may be correctly
inserted after its inputs, but existing users of an old wait can still be earlier
in graph order than the new bucket output they now consume.
Valid pre-bucket graph:
```python
a = placeholder()
b = placeholder()
ag0 = all_gather(a)
w0 = wait(ag0)
u0 = neg(w0)
u1 = relu(u0)
late = b + 1
to_bf16 = convert(late)
ag1 = all_gather(to_bf16)
w1 = wait(ag1)
return u1, w1
```
After bucketing, `w0` is replaced by an output of the bucket. Without the new
repair step, this can become:
```python
u0 = neg(out0)        # invalid: out0 is defined later
u1 = relu(u0)
late = b + 1
bucket = _pre_bucket_all_gather([a, late])
ag_bucket = all_gather_into_tensor_out(bucket)
w_bucket = wait(ag_bucket)
out0, out1 = split(w_bucket)
```
The fix records users of old wait nodes before replacement. If any rewritten user
now appears before its latest input, it is moved after that latest input, and
downstream users are repaired the same way:
```python
late = b + 1
bucket = _pre_bucket_all_gather([a, late])
ag_bucket = all_gather_into_tensor_out(bucket)
w_bucket = wait(ag_bucket)
out0, out1 = split(w_bucket)
u0 = neg(out0)
u1 = relu(u0)
return u1, out1
```
#### 3. Reduce-scatter with a late gradient input
The same placement rule is needed for reduce-scatter buckets.
Valid pre-bucket graph:
```python
g0 = placeholder()
g1_base = placeholder()
rs0 = reduce_scatter(g0)
w0 = wait(rs0)
g1 = g1_base + 1
rs1 = reduce_scatter(g1)
w1 = wait(rs1)
return w0, w1
```
Old placement could create:
```python
pre = _pre_bucket_reduce_scatter([g0, g1])  # invalid: g1 is not defined yet
g1 = g1_base + 1
```
The new placement inserts the bucket after `g1`, so all bucket inputs are already
available before the traced bucket nodes are introduced.

Test Plan:

```bash
lintrunner -a
```

```bash
export TORCH_NATIVE_SKIP_VERSION_CHECK=1
python3 test/distributed/test_aten_comm_compute_reordering.py \
  TestManualOverlapBucketing.test_manual_bucketing_ag_convert_inputs_before_consumers \
  TestManualOverlapBucketing.test_manual_bucket_insertion_uses_graph_order \
  TestManualOverlapBucketing.test_manual_reduce_scatter_bucket_wait_stays_after_inputs \
  TestManualOverlapBucketing.test_manual_bucketing_ag_with_intermediate_deps \
  TestManualOverlapBucketing.test_manual_bucketing_rs_with_intermediate_deps
```

Llama3 8B GraphTrainer regional Inductor was measured locally on 8xH100 with
torch profiler disabled. Metrics below average only post-warmup steps 6-20 from
TensorBoard scalars.

```bash
STEPS=20 agent_space/llama3_mfu_graphtrainer_regional/run_compare.sh
STEPS=20 agent_space/llama3_mfu_graphtrainer_regional/run_after_current.sh
python3 agent_space/llama3_mfu_graphtrainer_regional/summarize_results.py \
  agent_space/llama3_mfu_graphtrainer_regional/20260615_062522 --warmup 5
python3 agent_space/llama3_mfu_graphtrainer_regional/summarize_results.py \
  agent_space/llama3_mfu_graphtrainer_regional/after_f454a77eb06_20260615_063628 \
  --warmup 5
```

| Config | Before MFU | After MFU | Before active | After active | Before reserved | After reserved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TP=1, DP shard=8 | 40.4000% | 40.4459% | 15.1157 GiB | 15.1157 GiB | 41.9688 GiB | 41.9688 GiB |
| TP=8, DP shard=1 | 23.0607% | 23.0564% | 15.1192 GiB | 15.1192 GiB | 16.4180 GiB | 16.4180 GiB |

Authored with assistance from an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo