### PR TITLE
[release/2.13] Revert "Skip cudagraphs for kernel-free inductor graphs (#185760)"

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3897,31 +3897,6 @@ if HAS_CUDA_AND_TRITON:
                 _out = f_compiled(x, y)
             self.assertEqual(self.get_manager() is None, True)
 
-        @torch._inductor.config.patch("graph_partition", False)
-        def test_view_only_cuda_graph_skips_cudagraphs(self):
-            counters.clear()
-
-            def fn(x):
-                return x.reshape(1, -1, 4)
-
-            x = torch.randn(6, 4, device="cuda")
-            compiled_fn = torch.compile(fn, fullgraph=True)
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                for _ in range(3):
-                    actual = compiled_fn(x)
-                    torch.cuda.synchronize()
-
-            self.assertEqual(actual, fn(x))
-            self.assertFalse(
-                any("CUDA Graph is empty" in str(w.message) for w in caught)
-            )
-            self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
-            self.assertEqual(
-                counters["inductor"]["cudagraph_recorded_non_static_inputs"], 0
-            )
-            self.assertIsNone(self.get_manager())
-
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_forward_backward(self):
             class Mod(torch.nn.Module):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1742,14 +1742,6 @@ class _InProcessFxCompile(FxCompile):
                             )
                         )
 
-                    if (
-                        cudagraphs
-                        and not V.graph.disable_cudagraphs_reason
-                        and graph.scheduler.count_kernel_nodes(graph.scheduler.nodes)
-                        == 0
-                    ):
-                        V.graph.disable_cudagraphs_reason = "no CUDA kernel invocations"
-
                     self._compile_stats[type(self)].codegen_and_compile += 1
 
                     if (

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4035,10 +4035,6 @@ class Scheduler:
         with dynamo_timed("Scheduler.__init__"):
             self._init(nodes)
 
-    @staticmethod
-    def count_kernel_nodes(nodes: Sequence[BaseSchedulerNode]) -> int:
-        return sum(1 for node in nodes if not isinstance(node, NopKernelSchedulerNode))
-
     def _init(self, nodes: list[ir.Operation]) -> None:
         super().__init__()
         V.graph.scheduler = self
@@ -9120,7 +9116,12 @@ class Scheduler:
         if min_size > 0:
             for i, (partition, skip) in enumerate(zip(partitions, skip_cudagraphs)):
                 if not skip:
-                    kernel_count = self.count_kernel_nodes(partition)
+                    # Count kernels excluding NopKernelSchedulerNode
+                    kernel_count = sum(
+                        1
+                        for n in partition
+                        if not isinstance(n, NopKernelSchedulerNode)
+                    )
                     if kernel_count < min_size:
                         skip_cudagraphs[i] = True
                         cudagraphs_log.debug(


### PR DESCRIPTION
Cherry-pick of the main-branch revert 82a2694abd3f7a58aee9c72d109dc88855b9e513 onto release/2.13.

The reverted commit b1e3edd7b8abad8ffff8614c2090e109087d8f7f (#185760) shipped in a release candidate (v2.13.0-rcN) and is present in release/2.13, but the revert only landed on main. This cherry-picks the revert so release/2.13 matches main.

Detected by tools/analytics/github_analyze.py --analyze-missing-reverts-from-branch (GitHub Analytics Daily run 27555527571). Cherry-pick (-x): (cherry picked from commit 82a2694abd3f7a58aee9c72d109dc88855b9e513).

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo