### PR TITLE
[release/2.13] Revert "Make topk deterministic under deterministic algorithms (#186653)"

### DIFF
--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <ATen/Context.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/NumericUtils.h>
 
@@ -29,24 +28,6 @@ void topk_impl_loop(
     return;
   }
   using elem_t = std::pair<accscalar_t, int64_t>;
-  // See Note [Enabling Deterministic Operations]
-  const bool deterministic = at::globalContext().deterministicAlgorithms();
-  // Keep NumPy-compatible NaN ordering: NaNs sort first for largest=True and
-  // last for largest=False.
-  auto topk_comp = [largest, deterministic](const elem_t& x, const elem_t& y) -> bool {
-    const bool x_nan = _isnan<accscalar_t>(x.first);
-    const bool y_nan = _isnan<accscalar_t>(y.first);
-    if (x_nan || y_nan) {
-      if (x_nan != y_nan) {
-        return largest ? x_nan : !x_nan;
-      }
-      return deterministic ? x.second < y.second : false;
-    }
-    if (x.first == y.first) {
-      return deterministic ? x.second < y.second : false;
-    }
-    return largest ? x.first > y.first : x.first < y.first;
-  };
   std::vector<elem_t> queue(dim_size);
   for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(
@@ -67,12 +48,42 @@ void topk_impl_loop(
       queue[j].second = j;
     }
 
+    // we want nan to be sorted as top for numpy compatibility
     if (use_partial_sort) {
-      std::partial_sort(queue.begin(), queue.begin() + k, queue.end(), topk_comp);
+      if (largest) {
+        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
+          [](const elem_t& x, const elem_t& y) -> bool {
+            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
+          });
+      } else {
+        std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
+          [](const elem_t& x, const elem_t& y) -> bool {
+            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
+          });
+      }
     } else {
-      std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(), topk_comp);
-      if (sorted) {
-        std::sort(queue.begin(), queue.begin() + k, topk_comp);
+      if (largest) {
+        std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
+          [](const elem_t& x, const elem_t& y) -> bool {
+            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
+          });
+        if (sorted) {
+          std::sort(queue.begin(), queue.begin() + k - 1,
+            [](const elem_t& x, const elem_t& y) -> bool {
+              return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
+            });
+        }
+      } else {
+        std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
+          [](const elem_t& x, const elem_t& y) -> bool {
+            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
+          });
+        if (sorted) {
+          std::sort(queue.begin(), queue.begin() + k -1,
+            [](const elem_t& x, const elem_t& y) -> bool {
+              return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
+            });
+        }
       }
     }
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -1,7 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/cuda/TensorTopK.h>
 
-#include <ATen/Context.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorUtils.h>
@@ -24,10 +23,9 @@ void topk_out_with_sort(
   const Tensor& self,
   int64_t k, int64_t dim, bool largest,
   const Tensor& values,
-  const Tensor& indices,
-  bool stable
+  const Tensor& indices
 ) {
-  auto [sorted_values, sorted_indices] = at::cuda::sort(self, stable, dim, largest);
+  auto [sorted_values, sorted_indices] = at::cuda::sort(self, /* stable= */false, dim, largest);
   values.copy_(sorted_values.narrow(dim, 0, k));
   indices.copy_(sorted_indices.narrow(dim, 0, k));
 }
@@ -85,20 +83,9 @@ TORCH_IMPL_FUNC(topk_out_cuda)
   checkAllSameGPU(__func__, {topK_arg, indices_arg, input_arg});
 
   dim = at::maybe_wrap_dim(dim, self);
-  // See Note [Enabling Deterministic Operations]
-  const bool deterministic = at::globalContext().deterministicAlgorithms();
-
-#if defined(USE_ROCM)
-  if (deterministic) {
-    // The ROCm top-k gather path can reserve tie slots through atomics.
-    // Use stable full sort in deterministic mode to guarantee index tie-breaking.
-    topk_out_with_sort(self, k, dim, largest, values, indices, /*stable=*/true);
-    return;
-  }
-#endif
 
   if (should_use_sort(self, dim)) {
-    topk_out_with_sort(self, k, dim, largest, values, indices, deterministic);
+    topk_out_with_sort(self, k, dim, largest, values, indices);
     return;
   }
 
@@ -116,7 +103,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
       // This avoids any memory allocations and performs all sorting
       // work inplace along the slice
 
-      sortKeyValueInplace(values, indices, dim, largest, deterministic);
+      sortKeyValueInplace(values, indices, dim, largest);
     } else {
       // Depend upon the backup sort that returns indices, which we
       // can use in conjunction with gather to produce the original
@@ -129,7 +116,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
 
       Tensor sortedIndices = at::empty_like(indices);
       Tensor sortedValues = at::empty_like(values);
-      at::cuda::sort_outf(values, deterministic, dim, largest, sortedValues, sortedIndices);
+      at::cuda::sort_outf(values, /* stable= */ false, dim, largest, sortedValues, sortedIndices);
       indices.copy_(indices.gather(dim, sortedIndices));
       values.copy_(sortedValues);
     }

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_dtype import (
     integral_types,
 )
 from torch.testing._internal.common_utils import (
-    DeterministicGuard,
     parametrize,
     run_tests,
     skipIfTorchDynamo,
@@ -514,77 +513,6 @@ class TestSortAndSelect(TestCase):
         # see https://github.com/pytorch/pytorch/issues/116324
         x = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
         x.topk(1)
-
-    def test_topk_deterministic_tie_breaking(self, device):
-        x = torch.tensor(
-            [
-                [3.0, 3.0, 2.0, 3.0, 1.0],
-                [1.0, 0.0, 0.0, 0.0, 2.0],
-            ],
-            device=device,
-        )
-
-        with DeterministicGuard(True):
-            values, indices = torch.topk(x, 3, dim=-1, largest=True, sorted=True)
-            self.assertEqual(
-                values,
-                torch.tensor([[3.0, 3.0, 3.0], [2.0, 1.0, 0.0]], device=device),
-            )
-            self.assertEqual(
-                indices, torch.tensor([[0, 1, 3], [4, 0, 1]], device=device)
-            )
-
-            values, indices = torch.topk(x, 4, dim=-1, largest=False, sorted=True)
-            self.assertEqual(
-                values,
-                torch.tensor(
-                    [[1.0, 2.0, 3.0, 3.0], [0.0, 0.0, 0.0, 1.0]],
-                    device=device,
-                ),
-            )
-            self.assertEqual(
-                indices, torch.tensor([[4, 2, 0, 1], [1, 2, 3, 0]], device=device)
-            )
-
-            _, indices = torch.topk(x, 3, dim=-1, largest=True, sorted=False)
-            self.assertEqual(
-                indices.sort(dim=-1).values,
-                torch.tensor([[0, 1, 3], [0, 1, 4]], device=device),
-            )
-
-            nan_x = torch.tensor(
-                [[float("nan"), float("nan"), 3.0, 3.0, 2.0]],
-                device=device,
-            )
-            values, indices = torch.topk(nan_x, 4, dim=-1, largest=True, sorted=True)
-            self.assertTrue(values[0, :2].isnan().all())
-            self.assertEqual(values[0, 2:], torch.tensor([3.0, 3.0], device=device))
-            self.assertEqual(indices, torch.tensor([[0, 1, 2, 3]], device=device))
-
-            values, indices = torch.topk(nan_x, 4, dim=-1, largest=False, sorted=True)
-            self.assertEqual(
-                values[0, :3], torch.tensor([2.0, 3.0, 3.0], device=device)
-            )
-            self.assertTrue(values[0, 3].isnan().item())
-            self.assertEqual(indices, torch.tensor([[4, 2, 3, 0]], device=device))
-
-    @onlyCUDA
-    def test_topk_deterministic_tie_breaking_cuda_multiblock(self, device):
-        x = torch.ones(2, 20000, device=device)
-
-        with DeterministicGuard(True):
-            for k in (128, 129, 4096):
-                _, indices = torch.topk(x, k, dim=-1, largest=True, sorted=True)
-                self.assertEqual(
-                    indices,
-                    torch.arange(k, device=device).expand_as(indices),
-                )
-
-                _, indices = torch.topk(x, k, dim=-1, largest=False, sorted=True)
-                self.assertEqual(
-                    indices,
-                    torch.arange(k, device=device).expand_as(indices),
-                )
 
     def test_topk_arguments(self, device):
         q = torch.randn(10, 2, 10, device=device)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1424,7 +1424,6 @@ def use_deterministic_algorithms(
         * :func:`torch.Tensor.put_` with ``accumulate=True`` when called on a CPU
           tensor
         * :func:`torch.Tensor.scatter_add_` when called on a CUDA tensor
-        * :func:`torch.topk` when called on a CPU or CUDA tensor
         * :func:`torch.gather` when called on a CUDA tensor that requires grad
         * :func:`torch.index_add` when called on CUDA tensor
         * :func:`torch.index_select` when attempting to differentiate a CUDA tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11559,11 +11559,7 @@ The boolean option :attr:`sorted` if ``True``, will make sure that the returned
 
 .. note::
     When using `torch.topk`, the indices of tied elements are not guaranteed to be stable
-    and may vary across different invocations unless
-    :func:`torch.use_deterministic_algorithms` is enabled. In deterministic mode,
-    lower indices are selected before higher indices for tied values. If
-    :attr:`sorted` is ``False``, the returned elements are still not guaranteed
-    to appear in sorted order.
+    and may vary across different invocations.
 
 Args:
     {input}


### PR DESCRIPTION
Cherry-pick of the main-branch revert ca8348e4dd0d25cdf6e7336520cbe8f57072c893 onto release/2.13.

The reverted commit 1100802ab6ce07f48d6ad543fa87318d10bbfb49 (#186653) shipped in a release candidate (v2.13.0-rcN) and is present in release/2.13, but the revert only landed on main. This cherry-picks the revert so release/2.13 matches main.

Detected by tools/analytics/github_analyze.py --analyze-missing-reverts-from-branch (GitHub Analytics Daily run 27555527571). Cherry-pick (-x): (cherry picked from commit ca8348e4dd0d25cdf6e7336520cbe8f57072c893).

This PR was authored with the assistance of an AI coding agent.