### PR TITLE
Propagate local ranges during symbolic simplification

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -29,6 +29,8 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import (
     FloorDiv,
     Identity,
+    Max,
+    Min,
     Mod,
     ModularIndexing,
     PythonMod,
@@ -246,6 +248,18 @@ class TestIndexingSimplification(InductorTestCase):
             sizevars.simplify_with_ranges(FloorDiv(ModularIndexing(i0, 1, 10), 10), {}),
             sympy.S.Zero,
         )
+
+    def test_simplify_with_ranges_forwards_local_ranges_to_shape_env(self):
+        sizevars = SizeVarAllocator()
+        q3 = sympy.Symbol("q3", integer=True, nonnegative=True)
+        base = Min(
+            Min(28, FloorDiv(q3, 2) + 1) - 1,
+            Max(0, FloorDiv(q3 - 1, 2)),
+        )
+        expr = ModularIndexing(base, 1, 14)
+
+        self.assertNotIn(q3, sizevars.shape_env.var_to_range)
+        self.assertEqual(sizevars.simplify_with_ranges(expr, {q3: 28}), base)
 
     def test_remove_zero_terms_generalized(self):
         sizevars = SizeVarAllocator()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7211,7 +7211,12 @@ class ShapeEnv:
         # axioms with compute hint NYE
         if compute_hint and axioms:
             raise AssertionError("compute_hint and axioms cannot both be set")
-        expr = self.simplify(expr, size_oblivious)
+        expr = self.simplify(
+            expr,
+            size_oblivious,
+            axioms=axioms,
+            var_to_range=var_to_range,
+        )
 
         if compute_hint:
             expr = expr.xreplace(self.backed_var_to_val).xreplace(
@@ -7314,7 +7319,14 @@ class ShapeEnv:
         self._update_version_counter()
 
     @_lru_cache
-    def simplify(self, expr: _SympyT, size_oblivious: bool = False) -> _SympyT:
+    def simplify(
+        self,
+        expr: _SympyT,
+        size_oblivious: bool = False,
+        *,
+        axioms: tuple[SympyBoolean] | None = None,
+        var_to_range: tuple[tuple[sympy.Symbol, ValueRanges[sympy.Expr]]] | None = None,
+    ) -> _SympyT:
         """Use known constraints and replacements to simplify the given expr"""
         expr = safe_expand(expr)
         expr = self.replace(expr)
@@ -7330,9 +7342,17 @@ class ShapeEnv:
                 if b == 1 or b == 0:
                     a, b = b, a
 
-                if a == 1 and self._maybe_evaluate_static(sympy.Ge(b, 1)):
+                if a == 1 and self._maybe_evaluate_static(
+                    sympy.Ge(b, 1),
+                    axioms=axioms,
+                    var_to_range=var_to_range,
+                ):
                     min_max_replacements[atom] = b
-                if a == 0 and self._maybe_evaluate_static(sympy.Ge(b, 0)):
+                if a == 0 and self._maybe_evaluate_static(
+                    sympy.Ge(b, 0),
+                    axioms=axioms,
+                    var_to_range=var_to_range,
+                ):
                     min_max_replacements[atom] = b
             if min_max_replacements:
                 expr = expr.xreplace(min_max_replacements)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187350

Inductor can call SizeVarAllocator.simplify_with_ranges with loop-index
symbols whose value ranges are local to that simplification request. Those
ranges are passed to ShapeEnv._maybe_evaluate_static, but the first step in
that method calls ShapeEnv.simplify. simplify has a Max simplification that can
recursively call _maybe_evaluate_static, and those recursive calls were dropping
the caller-provided axioms and local var_to_range context.

When the expression contained an Inductor loop symbol such as q3, the recursive
static evaluation looked only in ShapeEnv.var_to_range, found no global range,
and raised "vr must not be None for symbol q3". Forward the local static-eval
context through simplify and its nested Max checks so loop-local ranges stay
available for recursive symbolic reasoning.

Add a targeted regression test for the ModularIndexing/Min/Max/FloorDiv pattern
from the failing jx_nest_base training benchmark. This keeps the fix in the
symbolic-shape context propagation path instead of special-casing the benchmark
or the q symbol.

Fixes #187337
Generated by my agent

Test Plan:
- python - <<'PY'
  import sympy
  from torch._inductor.sizevars import SizeVarAllocator
  from torch.utils._sympy.functions import FloorDiv, Max, Min, ModularIndexing
  q3 = sympy.Symbol("q3", integer=True, nonnegative=True)
  base = Min(Min(28, FloorDiv(q3, 2) + 1) - 1, Max(0, FloorDiv(q3 - 1, 2)))
  expr = ModularIndexing(base, 1, 14)
  print(SizeVarAllocator().simplify_with_ranges(expr, {q3: 28}))
  PY
- python test/inductor/test_indexing.py -k test_simplify_with_ranges_forwards_local_ranges_to_shape_env
- python test/inductor/test_indexing.py
- python test/test_dynamic_shapes.py TestPySymInt.test_statically_known_true
- wrapped jx_nest_base benchmark equivalent to: python benchmarks/dynamo/timm_models.py --accuracy -d cuda -n1 --backend=inductor --cold-start-latency --training --float32 --only jx_nest_base --batch-size 32
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo