### PR TITLE
[dynamo] Split list/tuple-specific behavior out of BaseListVariable

### DIFF
--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -186,25 +186,6 @@ class BaseListVariable(VariableTracker):
         """Sequence length for lists, tuples, and range objects."""
         return VariableTracker.build(tx, len(self.items))
 
-    def tp_iteritem_impl(
-        self, tx: "InstructionTranslatorBase", index: VariableTracker
-    ) -> tuple[VariableTracker, VariableTracker]:
-        # 3.15 _tp_iteritem slot.  list/tuple (and tuple subclasses like
-        # torch.Size) all share the same algorithm: index into self.items,
-        # bump the index, signal exhaustion with StopIteration.  Subclasses
-        # whose Python type does NOT install _tp_iteritem (range, deque)
-        # override this to fall back to the base "missing" behavior.
-        # ref: https://github.com/python/cpython/blob/f31a89bb9010/Objects/listobject.c#L3916-L3921 (list_iteritem)
-        # ref: https://github.com/python/cpython/blob/f31a89bb9010/Objects/tupleobject.c#L876-L885 (tuple_iteritem)
-        if not isinstance(self, (ListVariable, TupleVariable)):
-            return super().tp_iteritem_impl(tx, index)
-        i = index.as_python_constant()
-        if i < 0:
-            raise AssertionError(f"Invalid index {i}")
-        if i >= len(self.items):
-            raise_observed_exception(IndexError, tx)
-        return self.items[i], ConstantVariable.create(i + 1)
-
     def sq_contains(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
@@ -212,50 +193,6 @@ class BaseListVariable(VariableTracker):
         # TODO(dynamo-team): Replace iter_contains by a proper impl. once we
         # implement PyObject_RichCompare
         return iter_contains(unpack_iterable(tx, self), item, tx)
-
-    def call_tree_map_branch(
-        self,
-        tx: "InstructionTranslatorBase",
-        tree_map_fn: UserFunctionVariable,
-        map_fn: VariableTracker,
-        rest: list[VariableTracker],
-        tree_map_kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if not isinstance(self, (ListVariable, TupleVariable)):
-            return self._tree_map_fallback(
-                tx, tree_map_fn, map_fn, rest, tree_map_kwargs
-            )
-
-        other_lists: list[BaseListVariable] = []
-        for candidate in rest:
-            if (
-                not isinstance(candidate, BaseListVariable)
-                or len(candidate.items) != len(self.items)
-                or self.python_type() != candidate.python_type()
-            ):
-                return self._tree_map_fallback(
-                    tx, tree_map_fn, map_fn, rest, tree_map_kwargs
-                )
-            other_lists.append(candidate)
-
-        new_items: list[VariableTracker] = []
-        for idx, item in enumerate(self.items):
-            sibling_leaves = [candidate.items[idx] for candidate in other_lists]
-            new_items.append(
-                item.call_tree_map(
-                    tx,
-                    tree_map_fn,
-                    map_fn,
-                    sibling_leaves,
-                    tree_map_kwargs,
-                )
-            )
-
-        return self.clone(
-            items=new_items,
-            source=None,
-            mutation_type=ValueMutationNew(),
-        )
 
     def call_tree_map_with_path_branch(
         self,
@@ -266,42 +203,14 @@ class BaseListVariable(VariableTracker):
         tree_map_kwargs: dict[str, VariableTracker],
         keypath: tuple[Any, ...],
     ) -> VariableTracker:
-        if not isinstance(self, (ListVariable, TupleVariable)):
-            return self._tree_map_with_path_fallback(
-                tx, tree_map_fn, map_fn, rest, tree_map_kwargs, keypath
-            )
-
-        other_lists: list[BaseListVariable] = []
-        for candidate in rest:
-            if (
-                not isinstance(candidate, BaseListVariable)
-                or len(candidate.items) != len(self.items)
-                or self.python_type() != candidate.python_type()
-            ):
-                return self._tree_map_with_path_fallback(
-                    tx, tree_map_fn, map_fn, rest, tree_map_kwargs, keypath
-                )
-            other_lists.append(candidate)
-
-        new_items: list[VariableTracker] = []
-        for idx, item in enumerate(self.items):
-            sibling_leaves = [candidate.items[idx] for candidate in other_lists]
-            child_keypath = keypath + (SequenceKey(idx),)
-            new_items.append(
-                item.call_tree_map_with_path(
-                    tx,
-                    tree_map_fn,
-                    map_fn,
-                    sibling_leaves,
-                    tree_map_kwargs,
-                    child_keypath,
-                )
-            )
-
-        return self.clone(
-            items=new_items,
-            source=None,
-            mutation_type=ValueMutationNew(),
+        # list/tuple override this with element-wise recursion (see
+        # _listtuple_tree_map_with_path_branch).  Other list-likes (range,
+        # deque) trace through the fallback rather than being treated as a
+        # single leaf (VariableTracker's default).  call_tree_map_branch is
+        # not overridden here because VariableTracker's default already routes
+        # to _tree_map_fallback.
+        return self._tree_map_with_path_fallback(
+            tx, tree_map_fn, map_fn, rest, tree_map_kwargs, keypath
         )
 
     def mp_subscript_impl(
@@ -525,6 +434,112 @@ class BaseListVariable(VariableTracker):
                 mutation_type=ValueMutationNew(),
             )
         return super().call_method(tx, name, args, kwargs)
+
+
+# list/tuple-specific sequence behaviors.  These are assigned onto
+# ListVariable and TupleVariable (torch.Size inherits them via TupleVariable)
+# rather than living on BaseListVariable, because range/deque must NOT inherit
+# them: range/deque do not install the 3.15 _tp_iteritem slot, and their
+# tree_map must trace through the fallback instead of recursing element-wise.
+def _listtuple_tp_iteritem_impl(
+    self: "BaseListVariable",
+    tx: "InstructionTranslatorBase",
+    index: VariableTracker,
+) -> tuple[VariableTracker, VariableTracker]:
+    # 3.15 _tp_iteritem slot.  list/tuple (and tuple subclasses like
+    # torch.Size) share one algorithm: index into self.items, bump the index,
+    # signal exhaustion with StopIteration.
+    # ref: https://github.com/python/cpython/blob/f31a89bb9010/Objects/listobject.c#L3916-L3921 (list_iteritem)
+    # ref: https://github.com/python/cpython/blob/f31a89bb9010/Objects/tupleobject.c#L876-L885 (tuple_iteritem)
+    i = index.as_python_constant()
+    if i < 0:
+        raise AssertionError(f"Invalid index {i}")
+    if i >= len(self.items):
+        raise_observed_exception(IndexError, tx)
+    return self.items[i], ConstantVariable.create(i + 1)
+
+
+def _listtuple_tree_map_branch(
+    self: "BaseListVariable",
+    tx: "InstructionTranslatorBase",
+    tree_map_fn: UserFunctionVariable,
+    map_fn: VariableTracker,
+    rest: list[VariableTracker],
+    tree_map_kwargs: dict[str, VariableTracker],
+) -> VariableTracker:
+    other_lists: list[BaseListVariable] = []
+    for candidate in rest:
+        if (
+            not isinstance(candidate, BaseListVariable)
+            or len(candidate.items) != len(self.items)
+            or self.python_type() != candidate.python_type()
+        ):
+            return self._tree_map_fallback(
+                tx, tree_map_fn, map_fn, rest, tree_map_kwargs
+            )
+        other_lists.append(candidate)
+
+    new_items: list[VariableTracker] = []
+    for idx, item in enumerate(self.items):
+        sibling_leaves = [candidate.items[idx] for candidate in other_lists]
+        new_items.append(
+            item.call_tree_map(
+                tx,
+                tree_map_fn,
+                map_fn,
+                sibling_leaves,
+                tree_map_kwargs,
+            )
+        )
+
+    return self.clone(
+        items=new_items,
+        source=None,
+        mutation_type=ValueMutationNew(),
+    )
+
+
+def _listtuple_tree_map_with_path_branch(
+    self: "BaseListVariable",
+    tx: "InstructionTranslatorBase",
+    tree_map_fn: UserFunctionVariable,
+    map_fn: VariableTracker,
+    rest: list[VariableTracker],
+    tree_map_kwargs: dict[str, VariableTracker],
+    keypath: tuple[Any, ...],
+) -> VariableTracker:
+    other_lists: list[BaseListVariable] = []
+    for candidate in rest:
+        if (
+            not isinstance(candidate, BaseListVariable)
+            or len(candidate.items) != len(self.items)
+            or self.python_type() != candidate.python_type()
+        ):
+            return self._tree_map_with_path_fallback(
+                tx, tree_map_fn, map_fn, rest, tree_map_kwargs, keypath
+            )
+        other_lists.append(candidate)
+
+    new_items: list[VariableTracker] = []
+    for idx, item in enumerate(self.items):
+        sibling_leaves = [candidate.items[idx] for candidate in other_lists]
+        child_keypath = keypath + (SequenceKey(idx),)
+        new_items.append(
+            item.call_tree_map_with_path(
+                tx,
+                tree_map_fn,
+                map_fn,
+                sibling_leaves,
+                tree_map_kwargs,
+                child_keypath,
+            )
+        )
+
+    return self.clone(
+        items=new_items,
+        source=None,
+        mutation_type=ValueMutationNew(),
+    )
 
 
 class RangeVariable(BaseListVariable):
@@ -1050,6 +1065,10 @@ class ListVariable(CommonListMethodsVariable):
     # PyList_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3776
     _cpython_type = list
     _has_instance_dict = False
+
+    tp_iteritem_impl = _listtuple_tp_iteritem_impl
+    call_tree_map_branch = _listtuple_tree_map_branch
+    call_tree_map_with_path_branch = _listtuple_tree_map_with_path_branch
 
     def richcompare_impl(
         self,
@@ -1597,6 +1616,10 @@ class DequeVariable(CommonListMethodsVariable):
 class TupleVariable(BaseListVariable):
     # PyTuple_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L846
     _cpython_type = tuple
+
+    tp_iteritem_impl = _listtuple_tp_iteritem_impl
+    call_tree_map_branch = _listtuple_tree_map_branch
+    call_tree_map_with_path_branch = _listtuple_tree_map_with_path_branch
 
     def richcompare_impl(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

BaseListVariable held three methods that branched on
`isinstance(self, (ListVariable, TupleVariable))`: `tp_iteritem_impl`,
`call_tree_map_branch`, and `call_tree_map_with_path_branch`. A base class
inspecting its own subclasses is backwards, mirrors nothing in CPython (where
list and tuple share only the abstract sequence protocol, not implementation),
and made the list/tuple-only fast paths hard to follow.

This moves those bodies into module-level helpers (`_listtuple_*`) assigned
onto ListVariable and TupleVariable directly; torch.Size keeps them by
inheriting TupleVariable. RangeVariable and DequeVariable no longer carry the
list/tuple algorithms at all and fall back to VariableTracker's defaults, which
are behavior-equivalent to the old `else` branches:

- `tp_iteritem_impl`: VariableTracker raises "Missing tp_iteritem", matching the
  old `super()` call for non-list/tuple.
- `call_tree_map_branch`: VariableTracker's default already routes to
  `_tree_map_fallback`, identical to the old `else`, so the override is dropped
  from the base entirely.
- `call_tree_map_with_path_branch`: VariableTracker's default treats self as a
  single leaf, which is NOT what range/deque want, so BaseListVariable keeps a
  simplified override that routes to `_tree_map_with_path_fallback`.

BaseListVariable and its public surface are otherwise unchanged, so the ~30
external `isinstance(BaseListVariable)` / `cls_for` call sites need no edits.

A fuller "no shared ancestor" split (each type inheriting VariableTracker
directly) was considered and rejected: it cargo-cults a C-language limitation,
forces external isinstance sites onto a hand-maintained type tuple, and carries
large blast radius for little gain. The CPython fidelity that matters already
lives in the per-type slot `_impl` methods, which this change leaves intact.

Test Plan:

CPython sequence suites under Dynamo (counts unchanged from baseline):

```
pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_list.py
pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_tuple.py
pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_range.py
pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_deque.py
pixi run -w pytorch -e pytorch313-copy python test/cpython/v3_13/test_slice.py
```

Dynamo suites covering the relocated paths:

```
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_tree_map.py
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_getitem.py
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_tp_richcompare.py
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_functions.py
pixi run -w pytorch -e pytorch313-copy python test/dynamo/test_misc.py
```

Authored with an AI assistant.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98