### PR TITLE
Drop Kineto's range profiler source file from compilation

### DIFF
--- a/third_party/kineto.buck.bzl
+++ b/third_party/kineto.buck.bzl
@@ -17,7 +17,6 @@ def define_kineto():
             "kineto/libkineto/src/ActivityProfilerProxy.cpp",
             "kineto/libkineto/src/CuptiActivityApi.cpp",
             "kineto/libkineto/src/CuptiActivityProfiler.cpp",
-            "kineto/libkineto/src/CuptiRangeProfilerApi.cpp",
             "kineto/libkineto/src/Demangle.cpp",
             "kineto/libkineto/src/init.cpp",
             "kineto/libkineto/src/output_csv.cpp",


### PR DESCRIPTION
This should have been in https://github.com/pytorch/pytorch/pull/187204; if we don't drop the reference to the source file here, things won't compile when we remove the source files in Kineto.