### PR TITLE
[AutoGenEager] Support `int[]` / `SymInt[]` / `int[]?` params in cache key (#187360)

### DIFF
--- a/torch/_inductor/aoti_eager.py
+++ b/torch/_inductor/aoti_eager.py
@@ -197,6 +197,17 @@ def extract_layout_metadata(input: torch.layout) -> dict[str, Any]:
     return metadata
 
 
+def extract_int_list_metadata(input: list[int]) -> dict[str, Any]:
+    if not (
+        isinstance(input, (list, tuple))
+        and all(isinstance(item, int) and not isinstance(item, bool) for item in input)
+    ):
+        raise AssertionError(f"expected a list/tuple of int, got {input!r}")
+    metadata: dict[str, Any] = {}
+    metadata["int_list_value"] = list(input)
+    return metadata
+
+
 def aoti_compile_with_persistent_cache(
     ns: str,
     op_func_name_with_overload: str,
@@ -293,14 +304,31 @@ def aoti_compile_with_persistent_cache(
             kernel_metadata_items = []
 
             for idx, input in enumerate(flattened_inputs):
+                # Skip explicit-None args (e.g. an optional `int[1]? dim`) so the
+                # written metadata vector matches the cache reader, which also
+                # drops None entries.
+                if input is None:
+                    continue
                 if isinstance(input, torch.Tensor):
                     metadata = extract_tensor_metadata(dynamic, input)
-                elif isinstance(input, list):
-                    if not all(isinstance(item, torch.Tensor) for item in input):
-                        raise AssertionError(
-                            "expected all items in list to be torch.Tensor"
-                        )
-                    metadata = extract_tensor_list_metadata(dynamic, input)
+                elif isinstance(input, (list, tuple)) and all(
+                    isinstance(item, int) and not isinstance(item, bool)
+                    for item in input
+                ):
+                    # `int[]` / `SymInt[]` params. Checked before the Tensor-list
+                    # branch so an empty list/tuple is tagged INT_LIST, matching
+                    # the cache reader and C++ unpack_input_parameters for an
+                    # empty `int[]`. An empty `Tensor[]` is the converse case:
+                    # C++ tags it TENSOR_LIST (isTensorList() is checked before
+                    # isIntList()) while this tags it INT_LIST -- only a cache
+                    # miss/recompile (per-op cache, fixed schema type per slot ->
+                    # no aliasing), and it does not arise for real ops
+                    # (`cat([])`/`stack([])` raise in eager).
+                    metadata = extract_int_list_metadata(list(input))
+                elif isinstance(input, (list, tuple)) and all(
+                    isinstance(item, torch.Tensor) for item in input
+                ):
+                    metadata = extract_tensor_list_metadata(dynamic, list(input))
                 elif isinstance(input, supported_scalar_types()):
                     metadata = extract_scalar_metadata(device_type, input)
                 elif isinstance(input, str):

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -191,12 +191,22 @@ std::vector<ParameterMetadata> unpack_input_parameters(
       inputs_metadata.emplace_back(c10::Scalar(stack[idx].toBool()), arg_order);
     } else if (stack[idx].isDevice()) {
       inputs_metadata.emplace_back(stack[idx].toDevice(), arg_order);
+    } else if (stack[idx].isIntList()) {
+      // Covers schema params declared `int[]` and `SymInt[]` (the latter
+      // materializes as IntList when dynamic shapes are off).
+      inputs_metadata.emplace_back(stack[idx].toIntList().vec(), arg_order);
+    } else if (stack[idx].isNone()) {
+      // Optional parameter explicitly passed as None (e.g.,
+      // `aten.mean.dim`'s `int[1]? dim`). Emit no metadata entry; the
+      // resulting shorter metadata vector differentiates None from a
+      // concrete value, mirroring the optional-tensor branch above.
     } else {
       TORCH_CHECK_NOT_IMPLEMENTED(
           false,
           "Not implemented for operations that contain a parameter which is ",
           "not one of the following types: at::Tensor, at::TensorList, ",
-          "std::optional<at::Tensor>, std::vector<std::optional<at::Tensor>> and c10::Scalar.",
+          "std::optional<at::Tensor>, std::vector<std::optional<at::Tensor>>, "
+          "c10::Scalar, std::string, c10::Device and IntList.",
           "The input type is ",
           stack[idx].type()->str());
     }
@@ -375,6 +385,7 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
       bool is_device = metadata.contains("device_type_value");
       bool is_dtype = metadata.contains("dtype_value");
       bool is_layout = metadata.contains("layout_value");
+      bool is_int_list = metadata.contains("int_list_value");
 
       if (is_tensor_list) {
         // Tensor List
@@ -448,6 +459,12 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
             reinterpret_cast<THPLayout*>(layout_value_obj.ptr())->layout;
         parameter_metadata_list.emplace_back(
             c10::Scalar(static_cast<int>(layout_value)), arg_idx);
+      } else if (is_int_list) {
+        auto metadata = item_metadata.cast<py::dict>();
+        auto int_list_value =
+            metadata["int_list_value"].cast<std::vector<int64_t>>();
+        parameter_metadata_list.emplace_back(
+            std::move(int_list_value), arg_idx);
       } else {
         // Tensor
         auto metadata = item_metadata.cast<py::dict>();

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
@@ -168,6 +168,11 @@ ParameterMetadata::ParameterMetadata(
     uint64_t input_order)
     : tag_(DEVICE), value_(device), order_(input_order) {}
 
+ParameterMetadata::ParameterMetadata(
+    std::vector<int64_t> int_list,
+    uint64_t input_order)
+    : tag_(INT_LIST), value_(std::move(int_list)), order_(input_order) {}
+
 bool ParameterMetadata::operator==(const ParameterMetadata& other) const {
   // Same type
   if (tag_ != other.tag_) {
@@ -197,6 +202,9 @@ bool ParameterMetadata::operator==(const ParameterMetadata& other) const {
     case DEVICE:
       return std::get<c10::Device>(value_) ==
           std::get<c10::Device>(other.value_);
+    case INT_LIST:
+      return std::get<std::vector<int64_t>>(value_) ==
+          std::get<std::vector<int64_t>>(other.value_);
     default:
       return false;
   }
@@ -252,6 +260,9 @@ bool ParameterMetadata::dynamic_check(const ParameterMetadata& other) const {
     case DEVICE:
       return std::get<c10::Device>(value_) ==
           std::get<c10::Device>(other.value_);
+    case INT_LIST:
+      return std::get<std::vector<int64_t>>(value_) ==
+          std::get<std::vector<int64_t>>(other.value_);
     default:
       return false;
   }

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -94,6 +94,12 @@ enum ParameterTag {
   SCALAR,
   STRING,
   DEVICE,
+  // List of int64_t. Covers schema params declared `int[]` and `SymInt[]`
+  // (the latter materializes as IntList when dynamic shapes are off, e.g.
+  // for `aten.new_zeros(Tensor self, SymInt[] size, ...)` /
+  // `aten.mean.dim(Tensor self, int[1]? dim, ...)` /
+  // `aten.count_nonzero.dim_IntList(Tensor self, int[] dim)`).
+  INT_LIST,
   INVALID,
 };
 
@@ -104,7 +110,8 @@ using ParameterMetadataValue = std::variant<
     std::vector<TensorMetadata>,
     c10::Scalar,
     std::string,
-    c10::Device>;
+    c10::Device,
+    std::vector<int64_t>>;
 
 // ParameterMetadata is to represent the metadata of the input parameters of a
 // aten operation. It includes the tag of the parameter, the value of the
@@ -133,6 +140,7 @@ struct ParameterMetadata {
   ParameterMetadata(const c10::Scalar& scalar, uint64_t input_order);
   ParameterMetadata(std::string string_value, uint64_t input_order);
   ParameterMetadata(const c10::Device& device, uint64_t input_order);
+  ParameterMetadata(std::vector<int64_t> int_list, uint64_t input_order);
 
   bool operator==(const ParameterMetadata& other) const;
 


### PR DESCRIPTION
Summary:

AOTI eager dispatch (`AOTIPythonKernelHolder`) did not support caching or compiling an op whose schema declares an `int[]` / `SymInt[]` parameter. Both the C++ `unpack_input_parameters` and the Python `_extract_metadata_from_args_kwargs` paths raised `NotImplementedError` on those types, affecting ops like `aten.new_zeros` (`SymInt[] size`), `aten.mean.dim` (`int[1]? dim`), `aten.count_nonzero.dim_IntList` (`int[] dim`), and `aten.new_ones` (`SymInt[] size`).

This change plumbs `int[]` / `SymInt[]` end-to-end through the AOTI eager cache plus an explicit `None` skip for the optional case:

- `ParameterTag::INT_LIST` and a `std::vector<int64_t>` arm in `ParameterMetadataValue`, plus a matching ctor, `operator==` arm, and `dynamic_check` arm on `ParameterMetadata`.
- `unpack_input_parameters` now emits `INT_LIST` from `isIntList()` and silently drops `isNone()` entries (matching the existing optional-tensor convention of recording no entry while still advancing `arg_order`, so cache keys differentiate present vs absent positions by metadata-vector length).
- `init_aoti_kernel_cache` learns the `int_list_value` JSON field so cache-load matches cache-write.
- Python side: `extract_int_list_metadata` is added to `torch/_inductor/aoti_eager.py`, and MTIA's `_extract_metadata_from_args_kwargs` now (a) skips `None` leaves so they don't crash on the catch-all `NotImplementedError`, and (b) recognises Python `list[int]` / `tuple[int]` separately from `list[Tensor]` so the existing `assert all(isinstance(item, torch.Tensor))` doesn't fire on a dim list.

The cache-write/cache-read sides agree: both skip `None` and both emit/consume `int_list_value`, so the `AOTIKernelMetadata::check` size+pairwise comparison continues to work.

`_specialize_int_list_shapes` pins Dynamo to static specialization (`automatic_dynamic_shapes=False`) whenever an `int[]` / `SymInt[]` arg is present. AOTI eager bakes such a non-tensor arg (e.g. a `SymInt[] size`) into the graph as a constant — the compiled kernel takes only the tensor inputs and `create_afg` is handed only those tensors — so each distinct int-list value must stay a baked-in constant keyed by its per-value cache entry. Dynamo's automatic-dynamic heuristic would otherwise lift the list elements into unbacked symbolic int graph inputs (`L_size_0_`, ...) that the `torch.export` re-trace inside `create_afg` cannot bind; disabling it keeps Dynamo re-specializing per value.

On-diff unit coverage is added in `mtia/host_runtime/aoti_eager/tests/test_aoti_eager_dispatch.py`: `test_sym_int_list_param_new_zeros` (`SymInt[] size` via `new_zeros`, issuing two distinct size lists to confirm the int-list participates in the kernel cache key) and `test_int_list_param_count_nonzero_dim` (`int[] dim` via `count_nonzero.dim_IntList`).

Authored by Claude.

Test Plan:
Verified via the operator-coverage harness on the device simulator (`GLOBE_EXECUTION_MODE=inductor_autogen_eager`, `suite=opinfo_specialized`), per-run cap lifted (`GLOBE_MAX_TESTS=0`). The affected ops compile and dispatch:

| op | pass |
|---|---|
| `new_zeros` (`SymInt[] size`) | 54 |
| `count_nonzero` (`int[] dim`) | 171 |
| `mean` (`int[1]? dim`) | 76 |

```
GLOBE_MAX_TESTS=0 buck2 run fbcode//mode/dev fbcode//mtia/coverage/scripts:run_op_tests -- --op new_zeros --suite opinfo_specialized --version 1 --mode inductor_autogen_eager
```

On-diff unit coverage: `buck2 test fbcode//mtia/host_runtime/aoti_eager:test_aoti_eager_dispatch` -- `test_sym_int_list_param_new_zeros` and `test_int_list_param_count_nonzero_dim` exercise the `SymInt[]` / `int[]` cache-key paths through MTIA AOTI dispatch.

https://www.internalfb.com/intern/testinfra/testrun/29836347545462401

Reviewed By: StellarrZ

Differential Revision: D106219536




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo