### PR TITLE
[Profiler] Reduce wait time for profiler test

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2724,7 +2724,11 @@ class TestProfiler(TestCase):
     def test_profiler_time_scale(self):
         MARGIN_ERROR = 0.5
         SEC_TO_US = 1000 * 1000
-        WAIT_TIME = 10
+        # IMPORTANT: For reasons that are not yet understood, having a long idle
+        # profiling window will make later CUPTI activity records (in other tests)
+        # arrive with invalid timestamps, causing them to be dropped as out-of-range.
+        # Empirically, WAIT_TIME should be kept <= 6.
+        WAIT_TIME = 5
         with profile() as p:
             with torch.profiler.record_function("test_span"):
                 for _ in range(WAIT_TIME):


### PR DESCRIPTION
Reduce the wait time for a long running profiling test that's causing test pollution.

Most of the tests in this file are single-shot, no-warmup profiling tests, which makes them super susceptible to test pollution and other weird behavior. It looks like when we have a long wait/sleep duration where no CUDA events are happening after Kineto has been initialized, some events get filtered out during out-of-range checks. This issue goes away when you add a warmup to the polluted test.

This makes me think that there's something wrong with the timestamp checks in Kineto under this specific scenario that goes away when you allow a warmup -> active transition, but I haven't had time to debug it yet. For now, the simplest thing to do is to reduce the duration we are idle for.