### PR TITLE
[benchmarks/dynamo] Enable emulate_precision_casts for mobilenetv2_100.

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -287,10 +287,10 @@ class TimmRunner(BenchmarkRunner):
             self.compute_loss = self.scaled_compute_loss
 
         # See yaml note for emulate_precision_casts. This preserves the
-        # bf16 downcast-upcast pairs (fp16 untested) that inductor would
-        # otherwise elide when fusing across mixed-precision boundaries
-        # (e.g. bf16 conv-bias-add fused into an fp32 cat-prep store),
-        # which is what eager autocast actually does.
+        # autocast downcast-upcast pairs (bf16 and fp16; mobilenetv2_100 is
+        # the fp16 case) that inductor would otherwise elide when fusing
+        # across mixed-precision boundaries (e.g. bf16 conv-bias-add fused
+        # into an fp32 cat-prep store), which is what eager autocast does.
         #
         # Baseline is captured on the FIRST load_model call so that any
         # --inductor-config emulate_precision_casts=... CLI override (applied

--- a/benchmarks/dynamo/timm_models.yaml
+++ b/benchmarks/dynamo/timm_models.yaml
@@ -64,13 +64,17 @@ require_larger_multiplier_for_smaller_tensor:
 
 
 # Models that need torch._inductor.config.emulate_precision_casts=True to match
-# eager bf16 rounding semantics (fp16 untested). Without this, inductor
-# pointwise fusion can elide a bf16 round-trip that eager performs (e.g.
-# conv-bias-add fused across a bf16->fp32 cat boundary), producing a ~1 bf16
-# ULP forward divergence that amplifies through gradients in models with very
-# small natural gradient magnitudes (e.g. LayerScale init=1e-5).
+# eager autocast rounding semantics (bf16 and fp16; e.g. mobilenetv2_100
+# fails only under fp16). Without this, inductor
+# pointwise fusion can elide a low-precision round-trip that eager performs
+# (e.g. conv-bias-add fused across a bf16->fp32 cat boundary), producing a
+# ~1 ULP forward divergence that amplifies through gradients in models with
+# very small natural gradient magnitudes (e.g. vit LayerScale init=1e-5; the
+# fp16 mobilenetv2_100 case is BatchNorm-gradient driven, its near-zero BN
+# weight/bias grads).
 emulate_precision_casts:
   - vit_base_patch14_dinov2.lvd142m
+  - mobilenetv2_100
 
 
 dtype:

--- a/test/inductor/test_timm_emulate_precision_casts.py
+++ b/test/inductor/test_timm_emulate_precision_casts.py
@@ -28,6 +28,7 @@ BENCHMARKS_DYNAMO = (
 @unittest.skipUnless(BENCHMARKS_DYNAMO.is_dir(), "benchmarks/dynamo not present")
 class TimmEmulatePrecisionCastsTest(TestCase):
     LISTED = "vit_base_patch14_dinov2.lvd142m"
+    LISTED_FP16 = "mobilenetv2_100"
     UNLISTED = "vit_base_patch16_siglip_256"
 
     @classmethod
@@ -83,12 +84,15 @@ class TimmEmulatePrecisionCastsTest(TestCase):
             pass
 
     def test_flag_toggles_per_model_no_carryover(self):
-        """Listed model flips flag True; subsequent unlisted model resets it."""
-        inductor_config.emulate_precision_casts = False
-        self._load(self.LISTED)
-        self.assertTrue(inductor_config.emulate_precision_casts)
-        self._load(self.UNLISTED)
-        self.assertFalse(inductor_config.emulate_precision_casts)
+        """Each listed model (bf16: LISTED, fp16: LISTED_FP16) flips the flag
+        True; a subsequent unlisted model resets it (no carryover)."""
+        for listed in (self.LISTED, self.LISTED_FP16):
+            with self.subTest(model=listed):
+                inductor_config.emulate_precision_casts = False
+                self._load(listed)
+                self.assertTrue(inductor_config.emulate_precision_casts)
+                self._load(self.UNLISTED)
+                self.assertFalse(inductor_config.emulate_precision_casts)
 
     def test_user_override_preserved_in_production_order(self):
         """Mirrors timm_main(): TimmRunner() runs in setUp, BEFORE the CLI


### PR DESCRIPTION
  Fixes `mobilenetv2_100 --training --amp` inductor `fail_accuracy` on MI350X (near-zero BatchNorm grads, e.g. `blocks.5.2.bn1.bias.grad`). Same class as #185676 (vit), but the **fp16** case that PR left untested — passes under bf16/fp32, fails only fp16; `emulate_precision_casts=1` fixes it (verified 2x).                                                                         
                                                                                                                                                          
  Also fixes the stale "(fp16 untested)" comment and extends the toggle test. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98