### PR TITLE
test: guard jit tests with SYMBOLICATE_MOBILE_DEBUG_HANDLE

### DIFF
--- a/test/cpp/jit/test_backend.cpp
+++ b/test/cpp/jit/test_backend.cpp
@@ -368,6 +368,8 @@ TEST(BackendTest, TestCompilerNotSupport) {
       "The node of aten::mul is not supported in this compiler. Source code:");
 }
 
+#if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
+
 TEST(BackendTestDebugInfo, TestCompiler) {
   Module m("m");
   m.define(R"(
@@ -856,6 +858,8 @@ Traceback of TorchScript (most recent call last):
   )";
   ASSERT_THROWS_WITH_MESSAGE(c_loaded.forward(inputs), error_pattern);
 }
+
+#endif
 
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_backend.cpp
+++ b/test/cpp/jit/test_backend.cpp
@@ -369,7 +369,6 @@ TEST(BackendTest, TestCompilerNotSupport) {
 }
 
 #if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
-
 TEST(BackendTestDebugInfo, TestCompiler) {
   Module m("m");
   m.define(R"(
@@ -858,8 +857,7 @@ Traceback of TorchScript (most recent call last):
   )";
   ASSERT_THROWS_WITH_MESSAGE(c_loaded.forward(inputs), error_pattern);
 }
-
-#endif
+#endif // defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
 
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -1425,6 +1425,7 @@ TEST(LiteInterpreterTest, DefaultArgsWithOutArg) {
       op->second.num_schema_args.value() == 3);
 }
 
+#if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
 TEST(LiteInterpreterTest, TestExceptionStackWithTwoLevelModuleHierarchy) {
   Module a("A");
   a.define(R"(
@@ -1474,6 +1475,7 @@ Traceback of TorchScript (most recent call last):
   )";
   ASSERT_THROWS_WITH_MESSAGE(lite_m.forward(inputs), error_pattern);
 }
+#endif // defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
 #endif // !defined(FB_XPLAT_BUILD)
 
 namespace {

--- a/test/cpp/jit/test_lite_interpreter_direct.cpp
+++ b/test/cpp/jit/test_lite_interpreter_direct.cpp
@@ -808,6 +808,7 @@ TEST(LiteInterpreterDirectTest, DefaultArgsWithOutArg) {
   AT_ASSERT(input_x.equal(4 * torch::ones({})));
 }
 
+#if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
 TEST(LiteInterpreterDirectTest, TestExceptionStackWithTwoLevelModuleHierarchy) {
   Module a("A");
   a.define(R"(
@@ -856,6 +857,7 @@ Traceback of TorchScript (most recent call last):
   )";
   ASSERT_THROWS_WITH_MESSAGE(lite_m.forward(inputs), error_pattern);
 }
+#endif // defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
 #endif // !defined(FB_XPLAT_BUILD)
 
 namespace {


### PR DESCRIPTION
 The some test cases explicitly verify TorchScript tracebacks and module hierarchy strings, which are only attached to exceptions when PyTorch is compiled with `-DSYMBOLICATE_MOBILE_DEBUG_HANDLE` .

This change wrapped the test cases with `#if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)`. This allows standard backend tests (`BackendTest`) to run and pass unconditionally in all configurations, while correctly enabling the debug info tests only when the mobile debug info flag is active.