### PR TITLE
Move NCCL EP bindings into an optional extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
                        OFF)
 # Builds NCCL-EP if true.
 cmake_dependent_option(USE_NCCL_EP "Build NCCL EP contrib library" OFF
-                       "USE_NCCL;USE_CUDA;NOT USE_SYSTEM_NCCL" OFF)
+                       "USE_NCCL;USE_CUDA" OFF)
 cmake_dependent_option(USE_NVSHMEM "Use NVSHMEM" ON
                        "USE_DISTRIBUTED;USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
 option(USE_NNAPI "Use NNAPI" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
                        OFF)
 # Builds NCCL-EP if true.
 cmake_dependent_option(USE_NCCL_EP "Build NCCL EP contrib library" OFF
-                       "USE_NCCL;USE_CUDA" OFF)
+                       "USE_NCCL;USE_CUDA;NOT USE_SYSTEM_NCCL" OFF)
 cmake_dependent_option(USE_NVSHMEM "Use NVSHMEM" ON
                        "USE_DISTRIBUTED;USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
 option(USE_NNAPI "Use NNAPI" OFF)

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -789,7 +789,6 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp",
     "torch/csrc/distributed/c10d/symm_mem/CudaDMAConnectivity.cpp",
     "torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu",
-    "torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu",
     "torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu",
     "torch/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu",
     "torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -579,7 +579,6 @@ if(USE_CUDA)
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
-        ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_extension.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/cuda_mem_pool.cpp

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1159,15 +1159,13 @@ if(USE_NCCL)
 endif()
 
 # ---[ NCCL EP
-# Static-link libnccl_ep.a into libtorch_cuda.so. This is interim: once nccl-ep
-# ships in a release wheel we'll switch to dynamic linking. Static linking is
-# fine in the meantime because libnccl_ep.a is small -- the actual EP CUDA
-# kernels are JIT-compiled at runtime, so the archive is mostly host-side and
-# launcher logic.
+# Defines the __caffe2_nccl_ep interface target (libnccl_ep.so + headers). It is
+# NOT added to Caffe2_CUDA_DEPENDENCY_LIBS: the EP code lives in its own optional
+# extension (torch._nccl_ep, see torch/CMakeLists.txt), which links it, so
+# libtorch_cuda does not depend on libnccl_ep and torch imports without nccl4py.
 if(USE_NCCL_EP)
   message(STATUS "USE_NCCL_EP is ON")
   include(${CMAKE_CURRENT_LIST_DIR}/External/nccl_ep.cmake)
-  list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS __caffe2_nccl_ep)
 endif()
 
 # ---[ XCCL

--- a/cmake/External/nccl_ep.cmake
+++ b/cmake/External/nccl_ep.cmake
@@ -37,7 +37,29 @@ if(NOT __NCCL_EP_INCLUDED)
     set(__NCCL_EP_ARCH_ARG "-DCMAKE_CUDA_ARCHITECTURES=${__NCCL_EP_ARCHS}")
   endif()
 
-  message(STATUS "Configuring NCCL EP as third-party dependency (__caffe2_nccl_ep)")
+  # Branch on how torch links NCCL (USE_NCCL_EP supports both):
+  #  - USE_SYSTEM_NCCL=OFF (source/dev): torch statically embeds the submodule
+  #    NCCL, so build libnccl_ep.a against it and have the extension statically
+  #    link it -- self-contained, no nccl4py, no runtime libnccl_ep.so.
+  #  - USE_SYSTEM_NCCL=ON (wheel/CI): torch dynamically links the system NCCL, so
+  #    build libnccl_ep.so against that same NCCL; the extension NEEDED-links it
+  #    and resolves it (and its JIT headers) from the nccl4py wheel at runtime.
+  if(USE_SYSTEM_NCCL)
+    if(DEFINED ENV{NCCL_INCLUDE_DIR})
+      get_filename_component(__NCCL_EP_NCCL_HOME "$ENV{NCCL_INCLUDE_DIR}" DIRECTORY)
+    else()
+      list(GET NCCL_INCLUDE_DIRS 0 __nccl_inc)
+      get_filename_component(__NCCL_EP_NCCL_HOME "${__nccl_inc}" DIRECTORY)
+    endif()
+    set(__NCCL_EP_LIB "libnccl_ep.so")
+    set(__NCCL_EP_DEPENDS "")
+  else()
+    set(__NCCL_EP_NCCL_HOME "${__NCCL_BUILD_DIR}")
+    set(__NCCL_EP_LIB "libnccl_ep.a")
+    set(__NCCL_EP_DEPENDS nccl_external)
+  endif()
+
+  message(STATUS "Configuring NCCL EP (__caffe2_nccl_ep): ${__NCCL_EP_LIB} against NCCL at ${__NCCL_EP_NCCL_HOME}")
   ExternalProject_Add(nccl_ep_external
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nccl_ep_build
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/nccl_ep
@@ -45,24 +67,38 @@ if(NOT __NCCL_EP_INCLUDED)
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}
+      # Link the CUDA runtime dynamically (CMake defaults to static). The static
+      # cudart does not support CUDA minor-version (enhanced) compatibility, so a
+      # static-cudart libnccl_ep cannot run on a minor-older driver; the shared
+      # libcudart does, matching how libtorch_cuda links it.
+      -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared
       ${__NCCL_EP_ARCH_ARG}
-      -DNCCL_HOME=${__NCCL_BUILD_DIR}
+      -DNCCL_HOME=${__NCCL_EP_NCCL_HOME}
       -DNCCL_EP_BUILDDIR=${__NCCL_BUILD_DIR}
       -DNCCL_EP_SOURCE_DIR=${PROJECT_SOURCE_DIR}/third_party/nccl/contrib/nccl_ep
-    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a"
+    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}"
     INSTALL_COMMAND ""
-    # NCCL (Makefile) must finish first: nccl_ep links -lnccl and includes its headers.
-    DEPENDS nccl_external
+    # In the static path NCCL (Makefile) must finish first; in the system path
+    # NCCL is already present so there is no in-tree dependency.
+    DEPENDS ${__NCCL_EP_DEPENDS}
   )
 
-  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a")
+  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}")
   set(NCCL_EP_INCLUDE_DIRS "${__NCCL_BUILD_DIR}/include")
+
+  if(NOT USE_SYSTEM_NCCL)
+    # Static path only: bake the in-tree JIT header dir so the extension
+    # self-configures NCCL_EP_HOME / NCCL_HOME (both resolve under this one dir:
+    # include/nccl_ep and include/nccl.h). The dynamic path instead gets these
+    # from nccl4py at runtime, so leave NCCL_EP_JIT_HOME unset there.
+    set(NCCL_EP_JIT_HOME "${__NCCL_BUILD_DIR}" CACHE INTERNAL "nccl-ep JIT header home")
+  endif()
 
   add_library(__caffe2_nccl_ep INTERFACE)
   add_dependencies(__caffe2_nccl_ep nccl_ep_external)
   target_link_libraries(__caffe2_nccl_ep INTERFACE ${NCCL_EP_LIBRARIES})
   target_include_directories(__caffe2_nccl_ep INTERFACE ${NCCL_EP_INCLUDE_DIRS})
-  # libnccl_ep.a's JIT calls CUDA Driver APIs; pull in libcuda.so.
+  # libnccl_ep's JIT calls CUDA Driver APIs; pull in libcuda.so.
   if(TARGET CUDA::cuda_driver)
     target_link_libraries(__caffe2_nccl_ep INTERFACE CUDA::cuda_driver)
   endif()

--- a/cmake/External/nccl_ep.cmake
+++ b/cmake/External/nccl_ep.cmake
@@ -37,29 +37,7 @@ if(NOT __NCCL_EP_INCLUDED)
     set(__NCCL_EP_ARCH_ARG "-DCMAKE_CUDA_ARCHITECTURES=${__NCCL_EP_ARCHS}")
   endif()
 
-  # Branch on how torch links NCCL (USE_NCCL_EP supports both):
-  #  - USE_SYSTEM_NCCL=OFF (source/dev): torch statically embeds the submodule
-  #    NCCL, so build libnccl_ep.a against it and have the extension statically
-  #    link it -- self-contained, no nccl4py, no runtime libnccl_ep.so.
-  #  - USE_SYSTEM_NCCL=ON (wheel/CI): torch dynamically links the system NCCL, so
-  #    build libnccl_ep.so against that same NCCL; the extension NEEDED-links it
-  #    and resolves it (and its JIT headers) from the nccl4py wheel at runtime.
-  if(USE_SYSTEM_NCCL)
-    if(DEFINED ENV{NCCL_INCLUDE_DIR})
-      get_filename_component(__NCCL_EP_NCCL_HOME "$ENV{NCCL_INCLUDE_DIR}" DIRECTORY)
-    else()
-      list(GET NCCL_INCLUDE_DIRS 0 __nccl_inc)
-      get_filename_component(__NCCL_EP_NCCL_HOME "${__nccl_inc}" DIRECTORY)
-    endif()
-    set(__NCCL_EP_LIB "libnccl_ep.so")
-    set(__NCCL_EP_DEPENDS "")
-  else()
-    set(__NCCL_EP_NCCL_HOME "${__NCCL_BUILD_DIR}")
-    set(__NCCL_EP_LIB "libnccl_ep.a")
-    set(__NCCL_EP_DEPENDS nccl_external)
-  endif()
-
-  message(STATUS "Configuring NCCL EP (__caffe2_nccl_ep): ${__NCCL_EP_LIB} against NCCL at ${__NCCL_EP_NCCL_HOME}")
+  message(STATUS "Configuring NCCL EP as third-party dependency (__caffe2_nccl_ep)")
   ExternalProject_Add(nccl_ep_external
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nccl_ep_build
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/nccl_ep
@@ -73,26 +51,25 @@ if(NOT __NCCL_EP_INCLUDED)
       # libcudart does, matching how libtorch_cuda links it.
       -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared
       ${__NCCL_EP_ARCH_ARG}
-      -DNCCL_HOME=${__NCCL_EP_NCCL_HOME}
+      -DNCCL_HOME=${__NCCL_BUILD_DIR}
       -DNCCL_EP_BUILDDIR=${__NCCL_BUILD_DIR}
       -DNCCL_EP_SOURCE_DIR=${PROJECT_SOURCE_DIR}/third_party/nccl/contrib/nccl_ep
-    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}"
+    # Build the static lib; the _nccl_ep extension statically links it, so its
+    # ncclEp* symbols are embedded in the extension and its nccl* references
+    # resolve against torch_cuda's own (statically-linked) NCCL. No runtime
+    # libnccl_ep.so and no nccl4py dependency.
+    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a"
     INSTALL_COMMAND ""
-    # In the static path NCCL (Makefile) must finish first; in the system path
-    # NCCL is already present so there is no in-tree dependency.
-    DEPENDS ${__NCCL_EP_DEPENDS}
+    # NCCL (Makefile) must finish first: nccl_ep links -lnccl and includes its headers.
+    DEPENDS nccl_external
   )
 
-  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}")
+  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a")
   set(NCCL_EP_INCLUDE_DIRS "${__NCCL_BUILD_DIR}/include")
-
-  if(NOT USE_SYSTEM_NCCL)
-    # Static path only: bake the in-tree JIT header dir so the extension
-    # self-configures NCCL_EP_HOME / NCCL_HOME (both resolve under this one dir:
-    # include/nccl_ep and include/nccl.h). The dynamic path instead gets these
-    # from nccl4py at runtime, so leave NCCL_EP_JIT_HOME unset there.
-    set(NCCL_EP_JIT_HOME "${__NCCL_BUILD_DIR}" CACHE INTERNAL "nccl-ep JIT header home")
-  endif()
+  # The runtime JIT resolves NCCL_EP_HOME -> include/nccl_ep and NCCL_HOME ->
+  # include/nccl.h; the submodule build installs both under this one dir, which
+  # the extension bakes in as the default (see torch/CMakeLists.txt).
+  set(NCCL_EP_JIT_HOME "${__NCCL_BUILD_DIR}" CACHE INTERNAL "nccl-ep JIT header home")
 
   add_library(__caffe2_nccl_ep INTERFACE)
   add_dependencies(__caffe2_nccl_ep nccl_ep_external)

--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -3,7 +3,7 @@
 
 import torch
 import torch.distributed as dist
-from torch.distributed._token_switch import TokenSwitchNCCL
+from torch.distributed._token_switch import _import_nccl_ep, TokenSwitchNCCL
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     skip_if_lt_x_gpu,
@@ -14,13 +14,24 @@ from torch.testing._internal.common_utils import (
 )
 
 
+def _nccl_ep_available() -> bool:
+    # The torch._nccl_ep extension is built only with USE_NCCL_EP, and a
+    # USE_SYSTEM_NCCL=ON build additionally needs the nccl4py wheel at runtime.
+    # Actually importing it is the real check: find_spec would only locate the
+    # extension without dlopening it, so it would miss a missing libnccl_ep.so.
+    if not torch.cuda.is_available():
+        return False
+    try:
+        _import_nccl_ep()
+    except Exception:
+        return False
+    return True
+
+
 def requires_nccl_ep():
-    # The NCCL EP bindings are not_supported() stubs unless torch is built with
-    # USE_NCCL_EP, and there is no reliable availability signal yet. A later
-    # change adds the torch._nccl_ep extension and flips this to a real check;
-    # until then these tests cannot run, so skip unconditionally.
     return skip_but_pass_in_sandcastle_if(
-        True, "NCCL EP tests are enabled with the torch._nccl_ep extension"
+        not _nccl_ep_available(),
+        "Test requires a USE_NCCL_EP build (plus nccl4py for USE_SYSTEM_NCCL=ON)",
     )
 
 

--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -1,6 +1,8 @@
 # Owner(s): ["oncall: distributed"]
 
 
+import logging
+
 import torch
 import torch.distributed as dist
 from torch.distributed._token_switch import _import_nccl_ep, TokenSwitchNCCL
@@ -14,6 +16,9 @@ from torch.testing._internal.common_utils import (
 )
 
 
+log = logging.getLogger(__name__)
+
+
 def _nccl_ep_available() -> bool:
     # The torch._nccl_ep extension is built only with USE_NCCL_EP, and a
     # USE_SYSTEM_NCCL=ON build additionally needs the nccl4py wheel at runtime.
@@ -24,6 +29,7 @@ def _nccl_ep_available() -> bool:
     try:
         _import_nccl_ep()
     except Exception:
+        log.debug("torch._nccl_ep unavailable; skipping EP tests", exc_info=True)
         return False
     return True
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -468,6 +468,47 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
     LIBRARY DESTINATION "."
     ARCHIVE DESTINATION "lib"
   )
+
+  # ---[ NCCL EP extension (torch._nccl_ep)
+  # Optional standalone extension holding the NCCL EP bindings, imported lazily
+  # by torch/distributed/_token_switch.py so libtorch_cuda never references
+  # ncclEp*. How it links libnccl_ep follows how torch links NCCL:
+  #  - USE_SYSTEM_NCCL=OFF: __caffe2_nccl_ep is libnccl_ep.a, statically linked
+  #    here -- self-contained (nccl* bind to torch_cuda's embedded NCCL; JIT
+  #    headers baked from the submodule build dir; no nccl4py).
+  #  - USE_SYSTEM_NCCL=ON: __caffe2_nccl_ep is libnccl_ep.so, NEEDED-linked here
+  #    and resolved from the nccl4py wheel at runtime (RPATH to nccl/ep/lib; JIT
+  #    headers also from nccl4py, so nothing is baked).
+  if(USE_NCCL_EP)
+    Python_add_library(_nccl_ep MODULE WITH_SOABI
+      "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep.cu"
+      "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp")
+    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL)
+    # torch_python: pybind + Tensor/ProcessGroup casters; torch_cuda:
+    # ProcessGroupNCCL::getCommPtr, getNcclDataType, CUDA stream, embedded NCCL;
+    # __caffe2_nccl_ep: libnccl_ep (static .a or shared .so) + nccl_ep headers.
+    target_link_libraries(_nccl_ep PRIVATE
+      torch_python torch_cuda __caffe2_nccl_ep pybind::pybind11)
+    set_target_properties(_nccl_ep PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/torch")
+    if(USE_SYSTEM_NCCL)
+      # Dynamic: resolve nccl4py's libnccl_ep.so (site-packages/nccl/ep/lib, one
+      # dir up from torch/ via $ORIGIN/..) at import.
+      set_target_properties(_nccl_ep PROPERTIES
+        INSTALL_RPATH "${_rpath_portable_origin}/lib:${_rpath_portable_origin}/../nccl/ep/lib")
+    else()
+      # Static: only torch's own libs needed; bake the in-tree JIT header dir so
+      # the extension self-configures NCCL_EP_HOME / NCCL_HOME at import.
+      target_compile_definitions(_nccl_ep PRIVATE
+        "NCCL_EP_JIT_HOME=\"${NCCL_EP_JIT_HOME}\"")
+      set_target_properties(_nccl_ep PROPERTIES
+        INSTALL_RPATH "${_rpath_portable_origin}/lib")
+    endif()
+    if(NOT WIN32)
+      set_target_properties(_nccl_ep PROPERTIES C_VISIBILITY_PRESET "default")
+    endif()
+    install(TARGETS _nccl_ep RUNTIME DESTINATION "." LIBRARY DESTINATION ".")
+  endif()
 endif()
 
 # Generate torch/version.py from the appropriate CMake cache variables.

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -472,38 +472,27 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
   # ---[ NCCL EP extension (torch._nccl_ep)
   # Optional standalone extension holding the NCCL EP bindings, imported lazily
   # by torch/distributed/_token_switch.py so libtorch_cuda never references
-  # ncclEp*. How it links libnccl_ep follows how torch links NCCL:
-  #  - USE_SYSTEM_NCCL=OFF: __caffe2_nccl_ep is libnccl_ep.a, statically linked
-  #    here -- self-contained (nccl* bind to torch_cuda's embedded NCCL; JIT
-  #    headers baked from the submodule build dir; no nccl4py).
-  #  - USE_SYSTEM_NCCL=ON: __caffe2_nccl_ep is libnccl_ep.so, NEEDED-linked here
-  #    and resolved from the nccl4py wheel at runtime (RPATH to nccl/ep/lib; JIT
-  #    headers also from nccl4py, so nothing is baked).
+  # ncclEp*. It statically links libnccl_ep.a (from the same submodule build as
+  # torch's NCCL), so the extension is self-contained: its nccl* references bind
+  # to torch_cuda's embedded NCCL, and there is no runtime libnccl_ep.so or
+  # nccl4py dependency. The runtime JIT headers come from the submodule build
+  # dir, baked in below.
   if(USE_NCCL_EP)
     Python_add_library(_nccl_ep MODULE WITH_SOABI
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep.cu"
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp")
-    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL)
+    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL
+      # Default NCCL_EP_HOME / NCCL_HOME for nccl-ep's runtime JIT; the extension
+      # sets these at import (without overriding a user-provided value).
+      "NCCL_EP_JIT_HOME=\"${NCCL_EP_JIT_HOME}\"")
     # torch_python: pybind + Tensor/ProcessGroup casters; torch_cuda:
     # ProcessGroupNCCL::getCommPtr, getNcclDataType, CUDA stream, embedded NCCL;
-    # __caffe2_nccl_ep: libnccl_ep (static .a or shared .so) + nccl_ep headers.
+    # __caffe2_nccl_ep: libnccl_ep.a (static) + nccl_ep headers.
     target_link_libraries(_nccl_ep PRIVATE
       torch_python torch_cuda __caffe2_nccl_ep pybind::pybind11)
     set_target_properties(_nccl_ep PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/torch")
-    if(USE_SYSTEM_NCCL)
-      # Dynamic: resolve nccl4py's libnccl_ep.so (site-packages/nccl/ep/lib, one
-      # dir up from torch/ via $ORIGIN/..) at import.
-      set_target_properties(_nccl_ep PROPERTIES
-        INSTALL_RPATH "${_rpath_portable_origin}/lib:${_rpath_portable_origin}/../nccl/ep/lib")
-    else()
-      # Static: only torch's own libs needed; bake the in-tree JIT header dir so
-      # the extension self-configures NCCL_EP_HOME / NCCL_HOME at import.
-      target_compile_definitions(_nccl_ep PRIVATE
-        "NCCL_EP_JIT_HOME=\"${NCCL_EP_JIT_HOME}\"")
-      set_target_properties(_nccl_ep PROPERTIES
-        INSTALL_RPATH "${_rpath_portable_origin}/lib")
-    endif()
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/torch"
+      INSTALL_RPATH "${_rpath_portable_origin}/lib")
     if(NOT WIN32)
       set_target_properties(_nccl_ep PROPERTIES C_VISIBILITY_PRESET "default")
     endif()

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -217,7 +217,7 @@ TORCH_API std::string getNcclErrorDetailStr(
     std::optional<std::string> processGroupFailureReason = std::nullopt);
 
 // Helper function that gets the data type and issues error if not supported
-ncclDataType_t getNcclDataType(at::ScalarType type);
+TORCH_API ncclDataType_t getNcclDataType(at::ScalarType type);
 
 // RAII wrapper for NCCL communicator
 class NCCLComm {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -57,10 +57,6 @@
 #include <torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp>
 #endif
 
-#ifdef USE_C10D_NCCL
-#include <torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp>
-#endif
-
 #include <torch/csrc/distributed/c10d/comm.hpp>
 #include <torch/csrc/distributed/c10d/debug.h>
 #include <torch/csrc/distributed/c10d/logger.hpp>
@@ -1452,53 +1448,6 @@ Example:
       py::arg("group_name"),
       py::arg("device"));
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
-
-  // nccl_ep.cu (which defines these symbols) is only compiled into torch_cuda
-  // for CUDA + NCCL distributed builds; guard the registration with the same
-  // condition so non-NCCL builds of libtorch_python don't reference undefined
-  // symbols (e.g. typeinfo for c10d::nccl_ep::NcclEpGroup).
-  using NcclEpGroup = ::c10d::nccl_ep::NcclEpGroup;
-  using NcclEpHandle = ::c10d::nccl_ep::NcclEpHandle;
-
-  py::class_<NcclEpGroup, c10::intrusive_ptr<NcclEpGroup>>(
-      module, "_NcclEpGroup")
-      .def_static(
-          "create",
-          &::c10d::nccl_ep::nccl_ep_create_group,
-          py::arg("pg"),
-          py::arg("num_experts"),
-          py::arg("max_dispatch_tokens_per_rank"),
-          py::arg("max_recv_tokens_per_rank"),
-          py::arg("max_token_bytes"));
-
-  py::class_<NcclEpHandle, c10::intrusive_ptr<NcclEpHandle>>(
-      module, "_NcclEpHandle")
-      .def_static(
-          "create",
-          &::c10d::nccl_ep::nccl_ep_create_handle,
-          py::arg("group"),
-          py::arg("topk_idx"),
-          py::arg("recv_expert_counter") = py::none())
-      .def(
-          "get_num_recv_tokens",
-          &::c10d::nccl_ep::nccl_ep_handle_get_num_recv_tokens);
-
-  module.def(
-      "_nccl_ep_dispatch",
-      &::c10d::nccl_ep::nccl_ep_dispatch,
-      py::arg("handle"),
-      py::arg("tokens"),
-      py::arg("topk_weights"),
-      py::arg("out_tokens"),
-      py::arg("out_topk_weights"),
-      py::arg("out_topk_idx"));
-
-  module.def(
-      "_nccl_ep_combine",
-      &::c10d::nccl_ep::nccl_ep_combine,
-      py::arg("handle"),
-      py::arg("expert_tokens"),
-      py::arg("out_tokens"));
 #endif // USE_C10D_NCCL
 
   auto store =

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp
@@ -1,0 +1,64 @@
+// Standalone Python extension (torch._nccl_ep) for the NCCL EP bindings.
+//
+// The EP code lives in this optional extension -- which NEEDED-links libnccl_ep
+// -- rather than in libtorch_cuda / libtorch_python's init.cpp. It is imported
+// lazily by torch/distributed/_token_switch.py, so the normal Python
+// extension-import machinery loads libnccl_ep (and raises ImportError if the
+// optional nccl4py wheel that provides it is absent). libtorch_cuda therefore
+// never references ncclEp* and torch imports with or without nccl4py.
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp>
+#include <torch/csrc/utils/pybind.h>
+
+#include <pybind11/pybind11.h>
+
+#include <cstdlib>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_nccl_ep, m) {
+  using namespace c10d::nccl_ep;
+
+#ifdef NCCL_EP_JIT_HOME
+  // Point nccl-ep's runtime JIT at the in-tree headers baked at build time
+  // (NCCL_EP_HOME -> include/nccl_ep, NCCL_HOME -> include/nccl.h, both under
+  // this dir). overwrite=0 so an explicit user setting wins.
+  setenv("NCCL_EP_HOME", NCCL_EP_JIT_HOME, /*overwrite=*/0);
+  setenv("NCCL_HOME", NCCL_EP_JIT_HOME, /*overwrite=*/0);
+#endif
+
+  py::class_<NcclEpGroup, c10::intrusive_ptr<NcclEpGroup>>(m, "_NcclEpGroup")
+      .def_static(
+          "create",
+          &nccl_ep_create_group,
+          py::arg("pg"),
+          py::arg("num_experts"),
+          py::arg("max_dispatch_tokens_per_rank"),
+          py::arg("max_recv_tokens_per_rank"),
+          py::arg("max_token_bytes"));
+
+  py::class_<NcclEpHandle, c10::intrusive_ptr<NcclEpHandle>>(m, "_NcclEpHandle")
+      .def_static(
+          "create",
+          &nccl_ep_create_handle,
+          py::arg("group"),
+          py::arg("topk_idx"),
+          py::arg("recv_expert_counter") = py::none())
+      .def("get_num_recv_tokens", &nccl_ep_handle_get_num_recv_tokens);
+
+  m.def(
+      "_nccl_ep_dispatch",
+      &nccl_ep_dispatch,
+      py::arg("handle"),
+      py::arg("tokens"),
+      py::arg("topk_weights"),
+      py::arg("out_tokens"),
+      py::arg("out_topk_weights"),
+      py::arg("out_topk_idx"));
+
+  m.def(
+      "_nccl_ep_combine",
+      &nccl_ep_combine,
+      py::arg("handle"),
+      py::arg("expert_tokens"),
+      py::arg("out_tokens"));
+}

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -2,9 +2,6 @@
 from __future__ import annotations
 
 import abc
-import ctypes
-import importlib.util
-import os
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -15,81 +12,18 @@ if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
 
 
-# Keeps preloaded shared libraries resident for the process lifetime.
-_NCCL_EP_KEEPALIVE: list[ctypes.CDLL] = []
-
-
-def _find_pkg_dir(name: str) -> str | None:
-    # Locate an installed package's directory without importing it. find_spec
-    # raises (rather than returning None) when a dotted name's parent namespace
-    # is absent, so guard that.
-    try:
-        spec = importlib.util.find_spec(name)
-    except ModuleNotFoundError:
-        return None
-    if spec is None or not spec.submodule_search_locations:
-        return None
-    return spec.submodule_search_locations[0]
-
-
-def _prepare_nccl4py() -> None:
-    # Dynamic (USE_SYSTEM_NCCL=ON / wheel) build only: the extension NEEDED-links
-    # libnccl_ep.so, which the nccl4py wheel provides at runtime. Point nccl-ep's
-    # JIT at nccl4py's EP headers (NCCL_EP_HOME) and the nvidia.nccl wheel's NCCL
-    # headers (NCCL_HOME), and make libnccl_ep resolvable, before importing the
-    # extension (its libnccl dependency is already loaded by torch). The static
-    # build bakes all of this in and never reaches here.
-    nccl_pkg = _find_pkg_dir("nccl")
-    if nccl_pkg is None:
-        raise ImportError(
-            "TokenSwitchNCCL needs the 'nccl4py' package for this build's "
-            "libnccl_ep.so and runtime JIT headers. Install it with "
-            "`pip install nccl4py==0.3.1`."
-        )
-    ep_dir = os.path.join(nccl_pkg, "ep")
-    if os.path.isdir(os.path.join(ep_dir, "include", "nccl_ep")):
-        os.environ.setdefault("NCCL_EP_HOME", ep_dir)
-
-    # Point the JIT at NCCL headers. libnccl.so itself needs no preload here: a
-    # USE_SYSTEM_NCCL=ON torch (the only build that reaches this path) already
-    # dynamically loaded the system libnccl, so libnccl_ep.so's NEEDED
-    # libnccl.so.2 resolves to that already-loaded copy.
-    nvidia_nccl = _find_pkg_dir("nvidia.nccl")
-    if nvidia_nccl is not None and os.path.isdir(os.path.join(nvidia_nccl, "include")):
-        os.environ.setdefault("NCCL_HOME", nvidia_nccl)
-
-    # nccl4py ships libnccl_ep unversioned (libnccl_ep.so) while the extension's
-    # NEEDED entry is its SONAME libnccl_ep.so.0; load it by path to register
-    # that SONAME for the import below.
-    lib = os.path.join(ep_dir, "lib", "libnccl_ep.so")
-    if os.path.isfile(lib):
-        _NCCL_EP_KEEPALIVE.append(ctypes.CDLL(lib, mode=ctypes.RTLD_LOCAL))
-
-
 def _import_nccl_ep() -> Any:
-    # The EP bindings live in the optional torch._nccl_ep extension (USE_NCCL_EP).
-    # A USE_SYSTEM_NCCL=OFF build links libnccl_ep statically and bakes its JIT
-    # header paths, so the extension imports directly -- self-contained, no
-    # nccl4py. A USE_SYSTEM_NCCL=ON build NEEDED-links libnccl_ep from the nccl4py
-    # wheel, so the first import fails until nccl4py is set up; fall back to that
-    # and retry.
-    try:
-        # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
-        import torch._nccl_ep as _ep
-
-        return _ep
-    except ImportError:
-        pass
-
-    _prepare_nccl4py()
+    # The EP bindings live in the optional torch._nccl_ep extension, built only
+    # with USE_NCCL_EP. It statically links libnccl_ep (its nccl* symbols bind to
+    # torch's own NCCL) and bakes in the JIT header paths, so it is fully
+    # self-contained -- no libnccl_ep.so to preload and no nccl4py dependency.
     try:
         # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
         import torch._nccl_ep as _ep
     except ImportError as e:
         raise ImportError(
             "torch._nccl_ep is unavailable; this PyTorch was not built with "
-            "USE_NCCL_EP (or, for a USE_SYSTEM_NCCL=ON build, the nccl4py wheel "
-            "is missing)."
+            "USE_NCCL_EP."
         ) from e
 
     return _ep

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import abc
+import ctypes
+import importlib.util
+import os
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -10,6 +13,86 @@ import torch
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
+
+
+# Keeps preloaded shared libraries resident for the process lifetime.
+_NCCL_EP_KEEPALIVE: list[ctypes.CDLL] = []
+
+
+def _find_pkg_dir(name: str) -> str | None:
+    # Locate an installed package's directory without importing it. find_spec
+    # raises (rather than returning None) when a dotted name's parent namespace
+    # is absent, so guard that.
+    try:
+        spec = importlib.util.find_spec(name)
+    except ModuleNotFoundError:
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    return spec.submodule_search_locations[0]
+
+
+def _prepare_nccl4py() -> None:
+    # Dynamic (USE_SYSTEM_NCCL=ON / wheel) build only: the extension NEEDED-links
+    # libnccl_ep.so, which the nccl4py wheel provides at runtime. Point nccl-ep's
+    # JIT at nccl4py's EP headers (NCCL_EP_HOME) and the nvidia.nccl wheel's NCCL
+    # headers (NCCL_HOME), and make libnccl_ep resolvable, before importing the
+    # extension (its libnccl dependency is already loaded by torch). The static
+    # build bakes all of this in and never reaches here.
+    nccl_pkg = _find_pkg_dir("nccl")
+    if nccl_pkg is None:
+        raise ImportError(
+            "TokenSwitchNCCL needs the 'nccl4py' package for this build's "
+            "libnccl_ep.so and runtime JIT headers. Install it with "
+            "`pip install nccl4py==0.3.1`."
+        )
+    ep_dir = os.path.join(nccl_pkg, "ep")
+    if os.path.isdir(os.path.join(ep_dir, "include", "nccl_ep")):
+        os.environ.setdefault("NCCL_EP_HOME", ep_dir)
+
+    # Point the JIT at NCCL headers. libnccl.so itself needs no preload here: a
+    # USE_SYSTEM_NCCL=ON torch (the only build that reaches this path) already
+    # dynamically loaded the system libnccl, so libnccl_ep.so's NEEDED
+    # libnccl.so.2 resolves to that already-loaded copy.
+    nvidia_nccl = _find_pkg_dir("nvidia.nccl")
+    if nvidia_nccl is not None and os.path.isdir(os.path.join(nvidia_nccl, "include")):
+        os.environ.setdefault("NCCL_HOME", nvidia_nccl)
+
+    # nccl4py ships libnccl_ep unversioned (libnccl_ep.so) while the extension's
+    # NEEDED entry is its SONAME libnccl_ep.so.0; load it by path to register
+    # that SONAME for the import below.
+    lib = os.path.join(ep_dir, "lib", "libnccl_ep.so")
+    if os.path.isfile(lib):
+        _NCCL_EP_KEEPALIVE.append(ctypes.CDLL(lib, mode=ctypes.RTLD_LOCAL))
+
+
+def _import_nccl_ep() -> Any:
+    # The EP bindings live in the optional torch._nccl_ep extension (USE_NCCL_EP).
+    # A USE_SYSTEM_NCCL=OFF build links libnccl_ep statically and bakes its JIT
+    # header paths, so the extension imports directly -- self-contained, no
+    # nccl4py. A USE_SYSTEM_NCCL=ON build NEEDED-links libnccl_ep from the nccl4py
+    # wheel, so the first import fails until nccl4py is set up; fall back to that
+    # and retry.
+    try:
+        # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
+        import torch._nccl_ep as _ep
+
+        return _ep
+    except ImportError:
+        pass
+
+    _prepare_nccl4py()
+    try:
+        # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
+        import torch._nccl_ep as _ep
+    except ImportError as e:
+        raise ImportError(
+            "torch._nccl_ep is unavailable; this PyTorch was not built with "
+            "USE_NCCL_EP (or, for a USE_SYSTEM_NCCL=ON build, the nccl4py wheel "
+            "is missing)."
+        ) from e
+
+    return _ep
 
 
 @dataclass(frozen=True, slots=True)
@@ -200,13 +283,9 @@ class TokenSwitchNCCL(TokenSwitch):
         max_recv_tokens_per_rank: int,
         max_token_bytes: int,
     ) -> None:
-        c10d = torch._C._distributed_c10d
-        if not hasattr(c10d, "_NcclEpGroup"):
-            raise RuntimeError(
-                "TokenSwitchNCCL requires a build with NCCL EP (USE_NCCL_EP)."
-            )
+        self._ep = _import_nccl_ep()
         self._max_recv_tokens_per_rank = max_recv_tokens_per_rank
-        self._group = c10d._NcclEpGroup.create(
+        self._group = self._ep._NcclEpGroup.create(
             process_group,
             num_experts,
             max_dispatch_tokens_per_rank,
@@ -220,8 +299,7 @@ class TokenSwitchNCCL(TokenSwitch):
         per_expert_token_counts: torch.Tensor | None = None,
     ) -> Routing:
         """Create expert routing for this phase; pass to :meth:`dispatch` / :meth:`combine`."""
-        c10d = torch._C._distributed_c10d
-        handle = c10d._NcclEpHandle.create(
+        handle = self._ep._NcclEpHandle.create(
             self._group,
             topk_idx,
             per_expert_token_counts,
@@ -237,7 +315,7 @@ class TokenSwitchNCCL(TokenSwitch):
         out_topk_weights: torch.Tensor,
         out_topk_idx: torch.Tensor,
     ) -> None:
-        torch._C._distributed_c10d._nccl_ep_dispatch(
+        self._ep._nccl_ep_dispatch(
             routing.handle,
             tokens,
             topk_weights,
@@ -252,7 +330,7 @@ class TokenSwitchNCCL(TokenSwitch):
         expert_tokens: torch.Tensor,
         out_tokens: torch.Tensor,
     ) -> None:
-        torch._C._distributed_c10d._nccl_ep_combine(
+        self._ep._nccl_ep_combine(
             routing.handle,
             expert_tokens,
             out_tokens,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187385
* __->__ #187366
* #181314

The NCCL EP bindings move out of libtorch_cuda / libtorch_python into their own optional Python
extension, torch._nccl_ep, imported lazily by torch/distributed/_token_switch.py. libtorch_cuda no
longer references ncclEp*, so torch imports with or without EP, and a missing EP build is a clean
ImportError rather than a core-torch load failure.

The extension follows how torch links its (statically embedded, submodule) NCCL: libnccl_ep.a is built
from source and statically linked into the extension, so its ncclEp* are embedded and its nccl* bind to
torch's own NCCL. The runtime JIT header paths are baked in from the submodule build dir. The extension
is fully self-contained -- no libnccl_ep.so, no preload, no nccl4py. (USE_NCCL_EP keeps requiring
NOT USE_SYSTEM_NCCL here; a follow-up enables the USE_SYSTEM_NCCL=ON / wheel path via nccl4py.)

Review order:
1. nccl_ep_pybind.cpp (new): the PYBIND11_MODULE(_nccl_ep) bindings, moved from init.cpp; sets
   NCCL_EP_HOME/NCCL_HOME from the baked JIT home at import.
2. init.cpp / build_variables.bzl / caffe2/CMakeLists.txt / Dependencies.cmake: remove the bindings,
   drop nccl_ep.cu from torch_cuda, stop linking __caffe2_nccl_ep into torch_cuda.
3. cmake/External/nccl_ep.cmake: build libnccl_ep.a against the submodule NCCL; bake NCCL_EP_JIT_HOME.
4. torch/CMakeLists.txt: the Python_add_library(_nccl_ep) target -- static-link + bake JIT home +
   $ORIGIN/lib RPATH.
5. NCCLUtils.hpp: export getNcclDataType (TORCH_API) -- the extension uses it.
6. _token_switch.py: import torch._nccl_ep (self-contained).
7. test_token_switch.py: gate on the extension being importable.

Test Plan:
USE_SYSTEM_NCCL=OFF on 4xH100, with NO nccl4py and NO LD_PRELOAD -- only the CUDA toolkit (nccl-ep JITs
kernels at runtime):

    USE_NCCL_EP=1 TORCH_CUDA_ARCH_LIST="9.0" pip install --no-build-isolation -v -e .
    CUDA_VISIBLE_DEVICES=0,1,2,3 python test/distributed/test_token_switch.py -v
    # Ran 7 tests ... OK; the extension has no libnccl_ep.so NEEDED (statically embedded ncclEp*).