### PR TITLE
[Test] Add test hardware classification for test_complex.py and test_kernel_launch_checks.py

### DIFF
--- a/test/autograd/test_complex.py
+++ b/test/autograd/test_complex.py
@@ -1,10 +1,17 @@
 # Owner(s): ["module: autograd"]
 
 import torch
-from torch.testing._internal.common_utils import gradcheck, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    gradcheck,
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestAutogradComplex(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_view_func_for_complex_views(self):
         # case 1: both parent and child have view_func
         x = torch.randn(2, 2, 2, dtype=torch.double, requires_grad=True)

--- a/test/test_kernel_launch_checks.py
+++ b/test/test_kernel_launch_checks.py
@@ -1,12 +1,14 @@
 # Owner(s): ["module: cuda"]
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import HardwareClassification, TestCase, run_tests
 from torch.testing._internal.check_kernel_launches import (
     check_cuda_kernel_launches, check_code_for_cuda_kernel_launches
 )
 
 
 class AlwaysCheckCudaLaunchTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_check_code(self):
         """Verifies that the regex works for a few different situations"""
 


### PR DESCRIPTION
…kernel_launch_checks.py

Classify test classes in test/autograd/test_complex.py and test/test_kernel_launch_checks.py by hardware scope per the test classification RFC (#185142, #185590).

Both files contain tests that exercise pure CPU-side logic with no accelerator dependency,  autograd complex view mechanics and CUDA kernel launch regex checking respectively, so both are classified as GENERIC.

Test Plan:

Verified tests pass:
  python test/autograd/test_complex.py -v
  python test/test_kernel_launch_checks.py -v

Depends on: #186918