### PR TITLE
[Inductor][Blackwell] Fix unregistered range symbol in `test_blackwell_max_autotune_addmm_persistent_tma*`

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1533,6 +1533,12 @@ class TritonTemplateKernel(TritonKernel):
                         range_val = range_tree.var_ranges[old_name]
                         del range_tree.var_ranges[old_name]
                         range_tree.var_ranges[symbol] = range_val
+                        # Keep block-shape inference metadata in sync with the
+                        # renamed epilogue range symbols used below.
+                        if self.range_tree_nodes.get(old_name) is lookup_output:
+                            del self.range_tree_nodes[old_name]
+                        if self.range_tree_nodes.get(symbol) is None:
+                            self.range_tree_nodes[symbol] = lookup_output
                         intermediate_lines.extend(
                             self._generate_index_from_tma_index(
                                 name,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1524,21 +1524,20 @@ class TritonTemplateKernel(TritonKernel):
                         symbol = range_tree.symbol()
                         epilogue_index_symbols.append(symbol)
                         lookup_output = range_tree.lookup(sympy.S.One, lengths[i])
-                        old_name = lookup_output.symbol()
+                        old_symbol = lookup_output.symbol()
                         lookup_output.set_name(name)
                         # Update var_list and var_range
-                        range_tree.var_list[range_tree.var_list.index(old_name)] = (
+                        range_tree.var_list[range_tree.var_list.index(old_symbol)] = (
                             symbol
                         )
-                        range_val = range_tree.var_ranges[old_name]
-                        del range_tree.var_ranges[old_name]
+                        range_val = range_tree.var_ranges[old_symbol]
+                        del range_tree.var_ranges[old_symbol]
                         range_tree.var_ranges[symbol] = range_val
                         # Keep block-shape inference metadata in sync with the
                         # renamed epilogue range symbols used below.
-                        if self.range_tree_nodes.get(old_name) is lookup_output:
-                            del self.range_tree_nodes[old_name]
-                        if self.range_tree_nodes.get(symbol) is None:
-                            self.range_tree_nodes[symbol] = lookup_output
+                        if self.range_tree_nodes.get(old_symbol) is lookup_output:
+                            del self.range_tree_nodes[old_symbol]
+                        self.range_tree_nodes[symbol] = lookup_output
                         intermediate_lines.extend(
                             self._generate_index_from_tma_index(
                                 name,


### PR DESCRIPTION
authored with codex

otherwise fails with e.g., 
```2026-06-13T07:57:33.477900Z 01E     raise AssertionError(f"Unregistered range symbol: {var.name}")
2026-06-13T07:57:33.477900Z 01E torch._inductor.exc.InductorError: LoweringException: AssertionError: Unregistered range symbol: yindex
2026-06-13T07:57:33.478000Z 01E   target: aten.addmm.default
2026-06-13T07:57:33.478000Z 01E   args[0]: TensorBox(StorageBox(
2026-06-13T07:57:33.478400Z 01E     ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float16, size=[248], stride=[1]), data=Pointwise(
2026-06-13T07:57:33.478400Z 01E       'cuda',
2026-06-13T07:57:33.478500Z 01E       torch.float16,
2026-06-13T07:57:33.478500Z 01E       def inner_fn(index):
2026-06-13T07:57:33.478800Z 01E           i0 = index
2026-06-13T07:57:33.478800Z 01E           tmp0 = ops.load(arg0_1, ModularIndexing(i0, 1, 31))
2026-06-13T07:57:33.478900Z 01E           return tmp0
2026-06-13T07:57:33.478900Z 01E       ,
2026-06-13T07:57:33.478900Z 01E       ranges=[248],
2026-06-13T07:57:33.479000Z 01E       origin_node=repeat,
2026-06-13T07:57:33.479000Z 01E       origins=OrderedSet([repeat]),
2026-06-13T07:57:33.479100Z 01E       stack_traces = {,
2026-06-13T07:57:33.479100Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 253, in addmm,
2026-06-13T07:57:33.479200Z 01E           x = x.repeat(8),
2026-06-13T07:57:33.479200Z 01E               ^^^^^^^^^^^,
2026-06-13T07:57:33.479900Z 01E       ,
2026-06-13T07:57:33.480000Z 01E       }
2026-06-13T07:57:33.483500Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.483600Z 01E   ))
2026-06-13T07:57:33.483700Z 01E   args[1]: TensorBox(StorageBox(
2026-06-13T07:57:33.483700Z 01E     ComputedBuffer(name='buf0', layout=FlexibleLayout('cuda:0', torch.float16, size=[168, 88], stride=[88, 1]), data=Pointwise(
2026-06-13T07:57:33.483800Z 01E       'cuda',
2026-06-13T07:57:33.483800Z 01E       torch.float16,
2026-06-13T07:57:33.483900Z 01E       def inner_fn(index):
2026-06-13T07:57:33.483900Z 01E           i0, i1 = index
2026-06-13T07:57:33.484000Z 01E           tmp0 = ops.load(arg1_1, 11 * ModularIndexing(i0, 1, 21) + ModularIndexing(i1, 1, 11))
2026-06-13T07:57:33.484000Z 01E           return tmp0
2026-06-13T07:57:33.484100Z 01E       ,
2026-06-13T07:57:33.484100Z 01E       ranges=[168, 88],
2026-06-13T07:57:33.484100Z 01E       origin_node=repeat_1,
2026-06-13T07:57:33.484200Z 01E       origins=OrderedSet([repeat_1]),
2026-06-13T07:57:33.484200Z 01E       stack_traces = {,
2026-06-13T07:57:33.484300Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 254, in addmm,
2026-06-13T07:57:33.484600Z 01E           a = a.repeat(8, 8),
2026-06-13T07:57:33.484600Z 01E               ^^^^^^^^^^^^^^,
2026-06-13T07:57:33.484700Z 01E       ,
2026-06-13T07:57:33.485000Z 01E       }
2026-06-13T07:57:33.485000Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.485100Z 01E   ))
2026-06-13T07:57:33.485100Z 01E   args[2]: TensorBox(StorageBox(
2026-06-13T07:57:33.485300Z 01E     ComputedBuffer(name='buf1', layout=FlexibleLayout('cuda:0', torch.float16, size=[88, 248], stride=[248, 1]), data=Pointwise(
2026-06-13T07:57:33.485400Z 01E       'cuda',
2026-06-13T07:57:33.485400Z 01E       torch.float16,
2026-06-13T07:57:33.485500Z 01E       def inner_fn(index):
2026-06-13T07:57:33.485800Z 01E           i0, i1 = index
2026-06-13T07:57:33.485800Z 01E           tmp0 = ops.load(arg2_1, 31 * ModularIndexing(i0, 1, 11) + ModularIndexing(i1, 1, 31))
2026-06-13T07:57:33.485900Z 01E           return tmp0
2026-06-13T07:57:33.485900Z 01E       ,
2026-06-13T07:57:33.485900Z 01E       ranges=[88, 248],
2026-06-13T07:57:33.486000Z 01E       origin_node=repeat_2,
2026-06-13T07:57:33.486000Z 01E       origins=OrderedSet([repeat_2]),
2026-06-13T07:57:33.486100Z 01E       stack_traces = {,
2026-06-13T07:57:33.486100Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 255, in addmm,
2026-06-13T07:57:33.486200Z 01E           b = b.repeat(8, 8),
2026-06-13T07:57:33.486600Z 01E               ^^^^^^^^^^^^^^,
2026-06-13T07:57:33.486600Z 01E       ,
2026-06-13T07:57:33.486700Z 01E       }
2026-06-13T07:57:33.486700Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.486800Z 01E   ))AssertionError: Unregistered range symbol: yindex
2026-06-13T07:57:33.486800Z 01E   target: aten.addmm.default
2026-06-13T07:57:33.486900Z 01E   args[0]: TensorBox(StorageBox(
2026-06-13T07:57:33.486900Z 01E     ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float16, size=[248], stride=[1]), data=Pointwise(
2026-06-13T07:57:33.487000Z 01E       'cuda',
2026-06-13T07:57:33.487000Z 01E       torch.float16,
2026-06-13T07:57:33.489400Z 01E       def inner_fn(index):
2026-06-13T07:57:33.489400Z 01E           i0 = index
2026-06-13T07:57:33.489500Z 01E           tmp0 = ops.load(arg0_1, ModularIndexing(i0, 1, 31))
2026-06-13T07:57:33.489600Z 01E           return tmp0
2026-06-13T07:57:33.489600Z 01E       ,
2026-06-13T07:57:33.489600Z 01E       ranges=[248],
2026-06-13T07:57:33.489700Z 01E       origin_node=repeat,
2026-06-13T07:57:33.489700Z 01E       origins=OrderedSet([repeat]),
2026-06-13T07:57:33.489800Z 01E       stack_traces = {,
2026-06-13T07:57:33.489800Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 253, in addmm,
2026-06-13T07:57:33.489900Z 01E           x = x.repeat(8),
2026-06-13T07:57:33.489900Z 01E               ^^^^^^^^^^^,
2026-06-13T07:57:33.489900Z 01E       ,
2026-06-13T07:57:33.490000Z 01E       }
2026-06-13T07:57:33.490000Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.490100Z 01E   ))
2026-06-13T07:57:33.490100Z 01E   args[1]: TensorBox(StorageBox(
2026-06-13T07:57:33.490200Z 01E     ComputedBuffer(name='buf0', layout=FlexibleLayout('cuda:0', torch.float16, size=[168, 88], stride=[88, 1]), data=Pointwise(
2026-06-13T07:57:33.490200Z 01E       'cuda',
2026-06-13T07:57:33.490600Z 01E       torch.float16,
2026-06-13T07:57:33.490600Z 01E       def inner_fn(index):
2026-06-13T07:57:33.490700Z 01E           i0, i1 = index
2026-06-13T07:57:33.490700Z 01E           tmp0 = ops.load(arg1_1, 11 * ModularIndexing(i0, 1, 21) + ModularIndexing(i1, 1, 11))
2026-06-13T07:57:33.490800Z 01E           return tmp0
2026-06-13T07:57:33.490800Z 01E       ,
2026-06-13T07:57:33.490800Z 01E       ranges=[168, 88],
2026-06-13T07:57:33.490900Z 01E       origin_node=repeat_1,
2026-06-13T07:57:33.490900Z 01E       origins=OrderedSet([repeat_1]),
2026-06-13T07:57:33.491200Z 01E       stack_traces = {,
2026-06-13T07:57:33.491600Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 254, in addmm,
2026-06-13T07:57:33.491700Z 01E           a = a.repeat(8, 8),
2026-06-13T07:57:33.491700Z 01E               ^^^^^^^^^^^^^^,
2026-06-13T07:57:33.491800Z 01E       ,
2026-06-13T07:57:33.491800Z 01E       }
2026-06-13T07:57:33.491900Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.491900Z 01E   ))
2026-06-13T07:57:33.492000Z 01E   args[2]: TensorBox(StorageBox(
2026-06-13T07:57:33.492000Z 01E     ComputedBuffer(name='buf1', layout=FlexibleLayout('cuda:0', torch.float16, size=[88, 248], stride=[248, 1]), data=Pointwise(
2026-06-13T07:57:33.492100Z 01E       'cuda',
2026-06-13T07:57:33.492100Z 01E       torch.float16,
2026-06-13T07:57:33.492100Z 01E       def inner_fn(index):
2026-06-13T07:57:33.492200Z 01E           i0, i1 = index
2026-06-13T07:57:33.492200Z 01E           tmp0 = ops.load(arg2_1, 31 * ModularIndexing(i0, 1, 11) + ModularIndexing(i1, 1, 31))
2026-06-13T07:57:33.492500Z 01E           return tmp0
2026-06-13T07:57:33.492500Z 01E       ,
2026-06-13T07:57:33.492600Z 01E       ranges=[88, 248],
2026-06-13T07:57:33.492600Z 01E       origin_node=repeat_2,
2026-06-13T07:57:33.492600Z 01E       origins=OrderedSet([repeat_2]),
2026-06-13T07:57:33.492700Z 01E       stack_traces = {,
2026-06-13T07:57:33.492700Z 01E         File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 255, in addmm,
2026-06-13T07:57:33.492800Z 01E           b = b.repeat(8, 8),
2026-06-13T07:57:33.492800Z 01E               ^^^^^^^^^^^^^^,
2026-06-13T07:57:33.492900Z 01E       ,
2026-06-13T07:57:33.492900Z 01E       }
2026-06-13T07:57:33.494900Z 01E     ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
2026-06-13T07:57:33.494900Z 01E   ))
2026-06-13T07:57:33.495000Z 01E Found from : 
2026-06-13T07:57:33.499800Z 01E    File "/opt/pytorch/pytorch/test/inductor/test_max_autotune_blackwell.py", line 262, in addmm
2026-06-13T07:57:33.499900Z 01E     return torch.addmm(x, a, b)
```

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo