### PR TITLE
[fsdp2][mp] Fix FSDP2 mixed precision reduce dtype after unfreezing params

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -254,6 +254,54 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
             self.assertEqual(fsdp_loss, ref_loss)
             check_sharded_parity(self, ref_model, model)
 
+    @skipIfRocmVersionLessThan((7, 0))
+    @skip_if_lt_x_gpu(2)
+    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
+    def test_reduce_dtype_after_frozen_first_forward(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16))
+                self.non_float = nn.Parameter(
+                    torch.ones(16, dtype=torch.int64), requires_grad=False
+                )
+
+            def forward(self, inp: torch.Tensor) -> torch.Tensor:
+                return self.layers(inp)
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+        )
+        model = Model().to(device_type)
+        fully_shard(model, mp_policy=mp_policy)
+        model.requires_grad_(False)
+
+        inp = torch.randn((4, 16), device=device_type.type)
+        with torch.no_grad():
+            model(inp)
+
+        fsdp_param_group = fully_shard.state(model)._fsdp_param_group
+        if fsdp_param_group is None:
+            raise AssertionError("Expected root FSDP parameter group")
+        self.assertEqual(fsdp_param_group._orig_dtype, torch.float32)
+        self.assertEqual(fsdp_param_group._reduce_dtype, torch.float32)
+
+        model.layers.requires_grad_(True)
+        orig_reduce_scatter = dist.reduce_scatter_single
+
+        def assert_fn(output: torch.Tensor):
+            self.assertEqual(output.dtype, torch.float32)
+
+        reduce_scatter = functools.partial(
+            reduce_scatter_with_assert, self, orig_reduce_scatter, assert_fn
+        )
+        with patch_reduce_scatter(reduce_scatter):
+            model(inp).sum().backward()
+        for param in model.parameters():
+            if param.grad is not None:
+                self.assertEqual(param.grad.dtype, torch.float32)
+
     def _test_reduce_dtype_bf16_reduce(
         self, reshard_after_forward: bool | int, use_shard_placement_fn: bool
     ):

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -256,7 +256,6 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)
-    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
     def test_reduce_dtype_after_frozen_first_forward(self):
         class Model(nn.Module):
             def __init__(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -279,20 +279,18 @@ class FSDPParamGroup:
         ]
         if trainable_params:
             params_for_dtype = trainable_params
-            should_assert_uniform_dtypes = True
         else:
             params_for_dtype = [
                 p for p in self.fsdp_params if p.orig_dtype.is_floating_point
             ]
-            should_assert_uniform_dtypes = False
         orig_dtypes = {p.orig_dtype for p in params_for_dtype}
         reduce_dtypes = {p.reduce_dtype for p in params_for_dtype}
-        if should_assert_uniform_dtypes and len(orig_dtypes) != 1:
+        if len(trainable_params) > 0 and len(orig_dtypes) != 1:
             # Models may have no grad params
             raise AssertionError(
                 f"FSDP expects uniform original parameter dtype but got {orig_dtypes}"
             )
-        if should_assert_uniform_dtypes and len(reduce_dtypes) != 1:
+        if len(trainable_params) > 0 and len(reduce_dtypes) != 1:
             # This can be relaxed if we issue one reduce-scatter per reduce
             # dtype (but we would need a way for users to specify multiple
             # reduce dtypes)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -277,22 +277,33 @@ class FSDPParamGroup:
         trainable_params: list[FSDPParam] = [
             p for p in self.fsdp_params if p.sharded_param.requires_grad
         ]
-        orig_dtypes = {p.orig_dtype for p in trainable_params}
-        reduce_dtypes = {p.reduce_dtype for p in trainable_params}
-        if len(trainable_params) > 0 and len(orig_dtypes) != 1:
+        if trainable_params:
+            params_for_dtype = trainable_params
+            should_assert_uniform_dtypes = True
+        else:
+            params_for_dtype = [
+                p for p in self.fsdp_params if p.orig_dtype.is_floating_point
+            ]
+            should_assert_uniform_dtypes = False
+        orig_dtypes = {p.orig_dtype for p in params_for_dtype}
+        reduce_dtypes = {p.reduce_dtype for p in params_for_dtype}
+        if should_assert_uniform_dtypes and len(orig_dtypes) != 1:
             # Models may have no grad params
             raise AssertionError(
                 f"FSDP expects uniform original parameter dtype but got {orig_dtypes}"
             )
-        self._orig_dtype = next(iter(orig_dtypes)) if trainable_params else None
-        if len(trainable_params) > 0 and len(reduce_dtypes) != 1:
+        if should_assert_uniform_dtypes and len(reduce_dtypes) != 1:
             # This can be relaxed if we issue one reduce-scatter per reduce
             # dtype (but we would need a way for users to specify multiple
             # reduce dtypes)
             raise AssertionError(
                 f"FSDP expects uniform reduce dtype but got {reduce_dtypes}"
             )
-        self._reduce_dtype = next(iter(reduce_dtypes)) if trainable_params else None
+        dtype_sets_are_uniform = len(orig_dtypes) == 1 and len(reduce_dtypes) == 1
+        self._orig_dtype = next(iter(orig_dtypes)) if dtype_sets_are_uniform else None
+        self._reduce_dtype = (
+            next(iter(reduce_dtypes)) if dtype_sets_are_uniform else None
+        )
 
     def lazy_init(self):
         # Lazy init should be idempotent


### PR DESCRIPTION
**Summary:** fixes https://github.com/pytorch/pytorch/issues/186998.  FSDP2 mixed precision initializes a param group’s `_orig_dtype` and `_reduce_dtype` during the first forward. If that first forward happens
  while all params are frozen, there are no trainable params to derive dtype metadata from, so both fields were left as `None`. After later unfreezing, gradient reduction could then fall back to the bf16 compute dtype instead of the requested fp32 reduce dtype.

This updates dtype resolution so that when no params are currently trainable, FSDP2 falls back to the group’s floating-point params if their original and reduce dtypes are uniform. Mixed all-frozen groups still preserve the previous behavior by resolving to `None`.

**Test Case**
1. pytest test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -k test_reduce_dtype_after_frozen_first_forward

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187376

