### PR TITLE
[MPS] Fix linear backward reshape->matmul->reshape > 4D issue

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -27,6 +27,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_15_2_PLUS,
   MACOS_VER_26_0_PLUS,
   MACOS_VER_26_4_PLUS,
+  MACOS_VER_27_0_PLUS,
 };
 
 // Helper enum for GPU-family-gated workarounds

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -66,6 +66,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_15_2_plus = is_os_version_at_least(15, 2);
   static bool _macos_26_0_plus = is_os_version_at_least(26, 0);
   static bool _macos_26_4_plus = is_os_version_at_least(26, 4);
+  static bool _macos_27_0_plus = is_os_version_at_least(27, 0);
 
   switch (version) {
     case MacOSVersion::MACOS_VER_14_4_PLUS:
@@ -80,6 +81,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_26_0_plus;
     case MacOSVersion::MACOS_VER_26_4_PLUS:
       return _macos_26_4_plus;
+    case MacOSVersion::MACOS_VER_27_0_PLUS:
+      return _macos_27_0_plus;
     default:
       return false;
   }

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -234,34 +234,30 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
     return output;
   }
 
+  // For >4D inputs, flatten to 2D outside the graph. The 2D flattening is required to avoid an older
+  // matmul bug (https://github.com/pytorch/pytorch/issues/114942), but doing it inside the graph
+  // (reshape -> matmul -> reshape) crashes the MLIR pass manager on macOS 26+
+  // (https://github.com/pytorch/pytorch/issues/187201). <=4D keeps the direct N-D matmul as before.
+  const bool needs_reshape = grad_output.dim() > 4;
+  auto grad_output_reshaped = needs_reshape ? grad_output.reshape({-1, grad_output.size(-1)}) : grad_output;
+  auto output_reshaped = needs_reshape ? output.view({-1, output.size(-1)}) : output;
+
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output, weight_reshaped});
+    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output_reshaped, weight_reshaped});
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       newCachedGraph->weightTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, weight_reshaped);
-      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_reshaped);
 
-      // MPS matrixMultiplication crashes for 5D+ tensors on 14.2.1 with `New volume should match old volume`
-      // See https://github.com/pytorch/pytorch/issues/114942 for more details
-      bool needReshape = grad_output.dim() > 4;
-      auto gradOutputTensor = needReshape
-          ? [mpsGraph flatten2DTensor:newCachedGraph->gradOutputTensor_ axis:-1 name:nil]
-          : newCachedGraph->gradOutputTensor_;
-
-      auto outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:gradOutputTensor
-                                                          secondaryTensor:newCachedGraph->weightTensor_
-                                                                     name:nil];
-      if (needReshape) {
-        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:getMPSShape(output) name:nil];
-      }
-
-      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->outputTensor_ = [mpsGraph matrixMultiplicationWithPrimaryTensor:newCachedGraph->gradOutputTensor_
+                                                                      secondaryTensor:newCachedGraph->weightTensor_
+                                                                                 name:nil];
     });
 
     Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_reshaped);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
+    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_reshaped);
+    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_reshaped);
 
     auto feeds = dictionaryFromPlaceholders(weightPlaceholder, gradOutputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -234,30 +234,36 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
     return output;
   }
 
-  // For >4D inputs, flatten to 2D outside the graph. The 2D flattening is required to avoid an older
-  // matmul bug (https://github.com/pytorch/pytorch/issues/114942), but doing it inside the graph
-  // (reshape -> matmul -> reshape) crashes the MLIR pass manager on macOS 26+
-  // (https://github.com/pytorch/pytorch/issues/187201). <=4D keeps the direct N-D matmul as before.
-  const bool needs_reshape = grad_output.dim() > 4;
-  auto grad_output_reshaped = needs_reshape ? grad_output.reshape({-1, grad_output.size(-1)}) : grad_output;
-  auto output_reshaped = needs_reshape ? output.view({-1, output.size(-1)}) : output;
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output_reshaped, weight_reshaped});
+    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output, weight_reshaped});
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       newCachedGraph->weightTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, weight_reshaped);
-      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_reshaped);
+      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-      newCachedGraph->outputTensor_ = [mpsGraph matrixMultiplicationWithPrimaryTensor:newCachedGraph->gradOutputTensor_
-                                                                      secondaryTensor:newCachedGraph->weightTensor_
-                                                                                 name:nil];
+      // MPS matrixMultiplication crashes for 5D+ tensors on 14.2.1 with `New volume should match old volume`
+      // (https://github.com/pytorch/pytorch/issues/114942), so flatten >4D to 2D first. macOS 27 handles N-D
+      // matmul directly and instead crashes the MLIR pass manager on the in-graph reshape -> matmul -> reshape
+      // (https://github.com/pytorch/pytorch/issues/187201), so skip the reshape there.
+      bool needReshape = grad_output.dim() > 4 && !is_macos_13_or_newer(MacOSVersion::MACOS_VER_27_0_PLUS);
+      auto gradOutputTensor = needReshape
+          ? [mpsGraph flatten2DTensor:newCachedGraph->gradOutputTensor_ axis:-1 name:nil]
+          : newCachedGraph->gradOutputTensor_;
+
+      auto outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:gradOutputTensor
+                                                          secondaryTensor:newCachedGraph->weightTensor_
+                                                                     name:nil];
+      if (needReshape) {
+        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:getMPSShape(output) name:nil];
+      }
+
+      newCachedGraph->outputTensor_ = outputTensor;
     });
 
     Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_reshaped);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_reshaped);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_reshaped);
+    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
+    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
 
     auto feeds = dictionaryFromPlaceholders(weightPlaceholder, gradOutputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/187201

The issue stems from MPSGraph optimizing pass over the reshape->matmul->reshape which seems to misbehave when there are more than one singleton dimension in the original shape. 

EDIT: It was actually enough to just gate the macos27 to use matmul directly without reshaping. The newer OS can handle the > 4D matmul directly and avoiding the reshape+matmul+reshape pattern prevents the error on the beta 1 seed of macos27.

Once https://github.com/pytorch/pytorch/pull/186541 lands I think we'll regardless move the linear ops to use the metal kernels so we'll skip this issue