### PR TITLE
Update dtensor_dispatch_collectives expected pr_time_benchmark result

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -98,7 +98,7 @@ dtensor_dispatch_to_from_local,instruction_count,228200,0.1
 
 
 
-dtensor_dispatch_collectives,instruction_count,28890000,0.1
+dtensor_dispatch_collectives,instruction_count,31800000,0.1
 
 
 


### PR DESCRIPTION
The `dtensor_dispatch_collectives` / `instruction_count` pr_time_benchmark flaps red on trunk (e.g. [this run](https://github.com/pytorch/pytorch/actions/runs/27568547024/job/81503660525)): it has measured ~31.6-32.1M since June 8, straddling the +10% fail threshold (31.78M) of the stale expected value (28.89M, set in March).

```
REGRESSION: benchmark ('dtensor_dispatch_collectives', 'instruction_count') failed, actual result 31808650 is 10.10% higher than expected 28890000 +-10.00%
```

Bisecting trunk pins the ~12% step-change (28.17M -> 31.62M) to #183545 "[DTensor] Use explicit hints for unbacked sharding", which added symbolic-shape bookkeeping to the `redistribute` hot path this benchmark exercises 5x per iteration (`guard_or_true` checks in `Shard._split_tensor`/`_to_replicate_tensor`, `_redistribute_cost_sort_key` in the Dijkstra planner, `has_free_unbacked_symbols` in `pad_tensor`). The cost leaks into the eager path and may be reducible by gating it behind `_are_we_tracing()`; this PR just rebaselines the expected result to accept it.

New value `31800000` (measured 31,808,650, kept to 4 significant digits per the framework's regeneration rule); the new +/-10% range (28.6M-35.0M) contains the observed band.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @sanketpurandare

Authored with assistance from Claude.