### PR TITLE
[c10d] Add Gloo process group fault tolerance support

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -517,6 +517,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/FlightRecorder.cpp",
     "torch/csrc/distributed/c10d/Functional.cpp",
     "torch/csrc/distributed/c10d/gloo/GlooDeviceFactory.cpp",
+    "torch/csrc/distributed/c10d/gloo/ProcessGroupGlooReconfigure.cpp",
     "torch/csrc/distributed/c10d/GroupRegistry.cpp",
     "torch/csrc/distributed/c10d/NanCheck.cpp",
     "torch/csrc/distributed/c10d/Ops.cpp",

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -1,0 +1,261 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import sys
+import unittest
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+
+
+if not dist.is_available():
+    print("distributed package not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+FAULT_TOLERANCE_BACKENDS = [
+    ("gloo", "cpu"),
+]
+
+
+class AbstractFaultToleranceTest:
+    @property
+    def world_size(self):
+        return 3
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    def _create_store(self):
+        return dist.FileStore(self.file_name, self.world_size)
+
+    def _init_reconfigurable_pg(self):
+        self.store = self._create_store()
+        dist.init_process_group(
+            self.backend_name,
+            world_size=self.world_size,
+            rank=self.rank,
+            store=self.store,
+            timeout=timedelta(seconds=30),
+            enable_reconfigure=True,
+        )
+        self.pg = c10d._get_default_group()
+        self.backend = self.pg._get_backend(torch.device(self.device))
+        self.assertTrue(dist._supports_reconfigure())
+        self.assertTrue(self.backend.supports_reconfigure)
+
+    def _collect_handles(self, key_prefix):
+        handle = dist._get_reconfigure_handle()
+        self.store.set(f"{key_prefix}_{self.rank}", handle)
+        return [
+            self.store.get(f"{key_prefix}_{rank}").decode("utf-8")
+            for rank in range(self.world_size)
+        ]
+
+    def _store_barrier(self, key_prefix):
+        self.store.set(f"{key_prefix}_{self.rank}", "1")
+        for rank in range(self.world_size):
+            self.store.get(f"{key_prefix}_{rank}")
+
+    def _reconfigure(self, uuid, handles):
+        work = dist._reconfigure(
+            uuid,
+            handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+    def _create_reconfigured_pg(self, name, uuid):
+        self._init_reconfigurable_pg()
+        handles = self._collect_handles(f"{name}_init")
+        self._reconfigure(uuid, handles)
+        self.assertEqual(dist.get_world_size(), self.world_size)
+        self.assertEqual(dist.get_rank(), self.rank)
+        return self._collect_handles(f"{name}_post")
+
+    def _assert_all_reduce_sum(self, expected_value):
+        tensor = torch.full((4,), dist.get_rank() + 1.0, device=self.device)
+        dist.all_reduce(tensor)
+        expected = torch.full((4,), expected_value, dtype=tensor.dtype)
+        self.assertEqual(tensor.cpu(), expected)
+
+    def test_reconfigure_basic(self):
+        self._create_reconfigured_pg("ft_basic", 100)
+
+    def test_reconfigure_then_all_reduce(self):
+        self._create_reconfigured_pg("ft_all_reduce", 200)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_then_send_recv(self):
+        self._create_reconfigured_pg("ft_send_recv", 300)
+
+        rank = dist.get_rank()
+        send_rank = (rank + 1) % self.world_size
+        recv_rank = (rank - 1 + self.world_size) % self.world_size
+        send_tensor = torch.full((4,), rank + 1.0, device=self.device)
+        recv_tensor = torch.zeros(4, device=self.device)
+
+        if rank % 2 == 0:
+            send_work = self.backend.send([send_tensor], send_rank, 0)
+            recv_work = self.backend.recv([recv_tensor], recv_rank, 0)
+        else:
+            recv_work = self.backend.recv([recv_tensor], recv_rank, 0)
+            send_work = self.backend.send([send_tensor], send_rank, 0)
+
+        send_work.wait()
+        recv_work.wait()
+        self.assertEqual(recv_tensor.cpu(), torch.full((4,), recv_rank + 1.0))
+
+    def test_shrink_exclude_last_rank(self):
+        handles = self._create_reconfigured_pg("ft_shrink_last", 400)
+        excluded_rank = self.world_size - 1
+        if self.rank == excluded_rank:
+            self._store_barrier("ft_shrink_last_done")
+            return
+
+        self._reconfigure(401, handles[:excluded_rank])
+        self.assertEqual(dist.get_world_size(), self.world_size - 1)
+        self.assertEqual(dist.get_rank(), self.rank)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size)))
+
+        tensor = torch.zeros(4, device=self.device)
+        if dist.get_rank() == 0:
+            tensor.fill_(42.0)
+        dist.broadcast(tensor, group_src=0)
+        self.assertEqual(tensor.cpu(), torch.full((4,), 42.0))
+        self._store_barrier("ft_shrink_last_done")
+
+    def test_shrink_exclude_middle_rank(self):
+        handles = self._create_reconfigured_pg("ft_shrink_middle", 500)
+        excluded_rank = self.world_size // 2
+        if self.rank == excluded_rank:
+            self._store_barrier("ft_shrink_middle_done")
+            return
+
+        surviving_handles = [
+            handle for rank, handle in enumerate(handles) if rank != excluded_rank
+        ]
+        self._reconfigure(501, surviving_handles)
+
+        expected_rank = self.rank if self.rank < excluded_rank else self.rank - 1
+        self.assertEqual(dist.get_world_size(), self.world_size - 1)
+        self.assertEqual(dist.get_rank(), expected_rank)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size)))
+        self._store_barrier("ft_shrink_middle_done")
+
+    def test_reconfigure_scale_down_up(self):
+        self._init_reconfigurable_pg()
+        # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
+        self._reconfigure(600 + self.rank, [dist._get_reconfigure_handle()])
+        self.assertEqual(dist.get_world_size(), 1)
+        self.assertEqual(dist.get_rank(), 0)
+
+        handles = self._collect_handles("ft_scale_down_up")
+        self._reconfigure(603, handles)
+        self.assertEqual(dist.get_world_size(), self.world_size)
+        self.assertEqual(dist.get_rank(), self.rank)
+
+        self._reconfigure(604 + self.rank, [dist._get_reconfigure_handle()])
+        self.assertEqual(dist.get_world_size(), 1)
+        self.assertEqual(dist.get_rank(), 0)
+        self._store_barrier("ft_scale_down_up_done")
+
+    def test_reconfigure_single_to_all(self):
+        self._init_reconfigurable_pg()
+        # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
+        self._reconfigure(700 + self.rank, [dist._get_reconfigure_handle()])
+
+        handles = self._collect_handles("ft_single_to_all")
+        self._reconfigure(703, handles)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_identity(self):
+        self._create_reconfigured_pg("ft_identity", 800)
+        handles = self._collect_handles("ft_identity_again")
+        self._reconfigure(801, handles)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_late_join(self):
+        self._init_reconfigurable_pg()
+        handles = self._collect_handles("ft_late_join_initial")
+        initial_world_size = self.world_size // 2
+        if self.rank < initial_world_size:
+            self._reconfigure(900, handles[:initial_world_size])
+
+        handles = self._collect_handles("ft_late_join_all")
+        self._reconfigure(901, handles)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_merge_split(self):
+        self._init_reconfigurable_pg()
+        handles = self._collect_handles("ft_merge_split_initial")
+        split = self.world_size // 2
+        if self.rank < split:
+            self._reconfigure(1000, handles[:split])
+        else:
+            self._reconfigure(1001, handles[split:])
+
+        handles = self._collect_handles("ft_merge_split_all")
+        self._reconfigure(1002, handles)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_rejects_reused_uuid(self):
+        self._init_reconfigurable_pg()
+        uuid = 1100 + self.rank
+        self._reconfigure(uuid, [dist._get_reconfigure_handle()])
+        with self.assertRaisesRegex(RuntimeError, "already used"):
+            self._reconfigure(uuid, [dist._get_reconfigure_handle()])
+
+
+def _make_fault_tolerance_test_class(backend_name, device):
+    class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
+        pass
+
+    FaultToleranceTest.backend_name = backend_name
+    FaultToleranceTest.device = device
+    FaultToleranceTest.__name__ = f"{backend_name.capitalize()}FaultToleranceTest"
+    FaultToleranceTest.__qualname__ = FaultToleranceTest.__name__
+    return unittest.skipIf(
+        not dist.is_backend_available(backend_name),
+        f"{backend_name} backend is not available",
+    )(FaultToleranceTest)
+
+
+for backend_name, device in FAULT_TOLERANCE_BACKENDS:
+    globals()[f"{backend_name.capitalize()}FaultToleranceTest"] = (
+        _make_fault_tolerance_test_class(backend_name, device)
+    )
+
+
+class ReconfigureContractTest(TestCase):
+    def test_reconfigure_rejects_multiple_backends(self) -> None:
+        pg = dist.ProcessGroup(0, 1)
+        pg._register_backend(torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO)
+        pg._register_backend(torch.device("cuda"), dist.ProcessGroup.BackendType.NCCL)
+
+        msg = "multiple backends"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.supports_reconfigure
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.get_reconfigure_handle()
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.reconfigure(c10d.ReconfigureOptions())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -9,6 +9,7 @@
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/gloo/GlooDeviceFactory.hpp>
 #include <torch/csrc/distributed/c10d/gloo/ProcessGroupGlooDetail.hpp>
+#include <algorithm>
 #include <chrono>
 #include <exception>
 
@@ -272,6 +273,7 @@ void returnFutureWithOutput(
 }
 } // namespace
 
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
 inline void ProcessGroupGloo::AsyncWork::recordAsyncWorkProfilingInfo(
     const char* profilingTitle,
     const std::optional<std::vector<at::Tensor>>& inputTensors) {
@@ -301,6 +303,7 @@ inline void ProcessGroupGloo::AsyncWork::recordAsyncWorkProfilingInfo(
     recordFunctionEndCallback_ = at::wrapPropagateTLSState(end_handler);
   }
 }
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 ProcessGroupGloo::AsyncWork::AsyncWork(
     std::shared_ptr<gloo::Context> context,
@@ -593,58 +596,16 @@ ProcessGroupGloo::ProcessGroupGloo(
     : Backend(rank, size),
       store_(new GlooStore(store)),
       options_(std::move(options)),
-
+      c10dStore_(store),
       local_id_(process_group_id++) {
-  TORCH_CHECK(
-      !options_->enable_reconfigure,
-      "ProcessGroupGloo does not support enable_reconfigure "
-      "(reconfigure-based fault tolerance).");
   auto& devices = options_->devices;
   if (devices.empty()) {
     TORCH_CHECK(false, "No device(s) specified");
   }
 
-  // Create and connect a context for every device.
-  //
-  // Note that the same device can be specified multiple times, either
-  // the same object, or the same logical device as different objects.
-  // Either mode is fine and only has performance implications.
-  //
-  // Using the same object multiple times means all contexts share a
-  // single I/O thread. If you use different objects for the same
-  // logical device they will have independent I/O threads. The latter
-  // option is needed if you have a fast NIC that cannot be saturated
-  // by a single I/O thread.
-  //
-  contexts_.reserve(options_->devices.size());
-  for (const auto i : c10::irange(options_->devices.size())) {
-    auto context = std::make_shared<::gloo::rendezvous::Context>(rank_, size_);
-
-#ifdef GLOO_SHARED_STORE
-    auto underlyingStore = store_;
-#else
-    auto& underlyingStore = *store_;
-#endif
-
-    auto store = std::make_shared<::gloo::rendezvous::PrefixStore>(
-        std::to_string(i), underlyingStore);
-
-#ifdef GLOO_SHARED_STORE
-    auto connectStore = store;
-#else
-    auto& connectStore = *store;
-#endif
-
-    context->setTimeout(options_->timeout);
-    try {
-      context->connectFullMesh(connectStore, options_->devices[i]);
-    } catch (const std::runtime_error& e) {
-      auto err = e.what();
-      // TORCH_CHECK to print the cpp stacktrace.
-      auto msg = c10::str("Gloo connectFullMesh failed with ", err);
-      logAndThrow(msg, msg);
-    }
-    contexts_.push_back(std::move(context));
+  if (!options_->enable_reconfigure) {
+    connectContexts(rank_, size_, c10dStore_);
+    initialized_ = true;
   }
 
   // Every worker thread stores the AsyncWork object it's currently
@@ -685,11 +646,75 @@ ProcessGroupGloo::~ProcessGroupGloo() {
   }
 }
 
+void ProcessGroupGloo::checkInitialized() const {
+  TORCH_CHECK(
+      initialized_ && !contexts_.empty(),
+      "ProcessGroupGloo has not been initialized. "
+      "Call reconfigure() before issuing collectives when "
+      "enable_reconfigure=True.");
+}
+
+void ProcessGroupGloo::connectContexts(
+    int rank,
+    int size,
+    const c10::intrusive_ptr<Store>& store) {
+  std::shared_ptr<::gloo::rendezvous::Store> glooStore =
+      std::make_shared<GlooStore>(store);
+  std::vector<std::shared_ptr<::gloo::Context>> contexts;
+
+  // Create and connect a context for every device.
+  //
+  // Note that the same device can be specified multiple times, either
+  // the same object, or the same logical device as different objects.
+  // Either mode is fine and only has performance implications.
+  //
+  // Using the same object multiple times means all contexts share a
+  // single I/O thread. If you use different objects for the same
+  // logical device they will have independent I/O threads. The latter
+  // option is needed if you have a fast NIC that cannot be saturated
+  // by a single I/O thread.
+  contexts.reserve(options_->devices.size());
+  for (const auto i : c10::irange(options_->devices.size())) {
+    auto context = std::make_shared<::gloo::rendezvous::Context>(rank, size);
+
+#ifdef GLOO_SHARED_STORE
+    auto underlyingStore = glooStore;
+#else
+    auto& underlyingStore = *glooStore;
+#endif
+
+    auto prefixedStore = std::make_shared<::gloo::rendezvous::PrefixStore>(
+        std::to_string(i), underlyingStore);
+
+#ifdef GLOO_SHARED_STORE
+    const auto& connectStore = prefixedStore;
+#else
+    auto& connectStore = *prefixedStore;
+#endif
+
+    context->setTimeout(options_->timeout);
+    try {
+      context->connectFullMesh(connectStore, options_->devices[i]);
+    } catch (const std::runtime_error& e) {
+      auto err = e.what();
+      // TORCH_CHECK to print the cpp stacktrace.
+      auto msg = c10::str("Gloo connectFullMesh failed with ", err);
+      logAndThrow(msg, msg);
+    }
+    contexts.push_back(std::move(context));
+  }
+
+  store_ = std::move(glooStore);
+  contexts_ = std::move(contexts);
+}
+
 uint32_t ProcessGroupGloo::nextTag() {
+  checkInitialized();
   return collectiveCounter_++;
 }
 
 std::shared_ptr<::gloo::Context> ProcessGroupGloo::getContext(uint32_t tag) {
+  checkInitialized();
   return contexts_[tag % contexts_.size()];
 }
 
@@ -729,9 +754,11 @@ void ProcessGroupGloo::runLoop(int workerIndex) {
 
 const std::vector<uint64_t>& ProcessGroupGloo::groupRanks() const {
   if (options_->global_ranks_in_group.empty() && local_id_ == 0) {
-    static std::vector<uint64_t> globalRanks(size_);
-    std::iota(globalRanks.begin(), globalRanks.end(), 0);
-    return globalRanks;
+    if (defaultRanks_.size() != static_cast<size_t>(size_)) {
+      defaultRanks_.resize(size_);
+      std::iota(defaultRanks_.begin(), defaultRanks_.end(), 0);
+    }
+    return defaultRanks_;
   }
   return options_->global_ranks_in_group;
 }
@@ -740,13 +767,11 @@ c10::intrusive_ptr<Backend> ProcessGroupGloo::split(
     const c10::intrusive_ptr<Store>& store,
     const std::vector<int>& ranks,
     const c10::intrusive_ptr<Backend::Options>& opts) {
-  auto it = std::find(ranks.begin(), ranks.end(), rank_);
-  int groupRank;
+  auto it = std::ranges::find(ranks, rank_);
   if (it == ranks.end()) {
     return nullptr;
-  } else {
-    groupRank = std::distance(ranks.begin(), it);
   }
+  auto groupRank = static_cast<int>(std::distance(ranks.begin(), it));
 
   auto glooOpts = c10::dynamic_intrusive_pointer_cast<Options>(opts);
   if (glooOpts == nullptr) {
@@ -758,6 +783,7 @@ c10::intrusive_ptr<Backend> ProcessGroupGloo::split(
 
   // TODO: we need to get rid of globalRanksInGroup eventually.
   std::vector<uint64_t> globalRanksInGroup;
+  globalRanksInGroup.reserve(ranks.size());
   for (auto rank : ranks) {
     globalRanksInGroup.emplace_back(groupRanks()[rank]);
   }
@@ -1045,7 +1071,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce(
 static c10::intrusive_ptr<ProcessGroupGloo::AsyncWork> makeAllreduceCPUWork(
     std::shared_ptr<gloo::Context> context,
     std::vector<at::Tensor>& inputs,
-    ReduceOp reduceOp,
+    ReduceOp reduceOp, // NOLINT(performance-unnecessary-value-param)
     uint32_t tag,
     uint64_t seq,
     std::chrono::milliseconds timeout) {
@@ -1100,11 +1126,13 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce_coalesced(
   // input
   // tensors must have the same device, layout and type.
   assertLayoutMatch(invalidArgument, tensors);
+  // NOLINTNEXTLINE(modernize-use-ranges)
   if (!std::all_of(tensors.begin(), tensors.end(), [&](at::Tensor& t) {
         return t.options().type_equal(tensors[0].options());
       })) {
     invalidArgument("tensors must all have the same type");
   }
+  // NOLINTNEXTLINE(modernize-use-ranges)
   if (!std::all_of(tensors.begin(), tensors.end(), [&](at::Tensor& t) {
         return t.device() == tensors[0].device();
       })) {
@@ -1220,6 +1248,7 @@ class AsyncReduceWork : public ProcessGroupGloo::AsyncWork {
 
  protected:
   template <typename T>
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   void getFunction(gloo::ReduceOptions::Func& fn, const ReduceOp op) {
     fn = toFunction<T>(op);
   }
@@ -2742,7 +2771,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::recvAnysource(
   // bindings we don't differentiate between ranks and can receive
   // from any other process in the group.
   std::vector<int> srcRanks;
-  srcRanks.resize(size_);
+  srcRanks.reserve(size_);
   for (const auto i : c10::irange(size_)) {
     srcRanks.push_back(i);
   }
@@ -2921,6 +2950,7 @@ void ProcessGroupGloo::monitoredBarrier(
     if (waitAllRanks && rankFailure) {
       std::vector<int> failedRanks;
       for (const auto i : c10::irange(1, size_)) {
+        // NOLINTNEXTLINE(modernize-use-ranges)
         if (std::find(processedRanks.begin(), processedRanks.end(), i) ==
             processedRanks.end()) {
           failedRanks.push_back(i);

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -271,6 +271,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
     return true;
   }
 
+  bool supportsReconfigure() const override {
+    return true;
+  }
+
   // Helper functions to create a new device object.
   // They are static functions on this class to keep them logically
   // separate from the rest of the code base (e.g. torch/csrc/distributed).
@@ -325,6 +329,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
       const c10::intrusive_ptr<Backend::Options>& opts,
       const int& rank,
       const int& size) override;
+
+  ReconfigureHandle get_reconfigure_handle() const override;
+
+  c10::intrusive_ptr<Work> reconfigure(const ReconfigureOptions& opts) override;
 
   const std::vector<uint64_t>& groupRanks() const;
 
@@ -453,6 +461,10 @@ class TORCH_API ProcessGroupGloo : public Backend {
  protected:
   std::shared_ptr<::gloo::rendezvous::Store> store_;
   const c10::intrusive_ptr<Options> options_;
+  c10::intrusive_ptr<Store> c10dStore_;
+
+  bool initialized_{false};
+  int64_t reconfigureUuid_{-1};
 
   // Every Gloo context represents a set of connections to its peers.
   // In order to use more than one device (or allow for parallelism on
@@ -475,6 +487,13 @@ class TORCH_API ProcessGroupGloo : public Backend {
   // to contexts being used in a round-robin fashion.
   std::shared_ptr<::gloo::Context> getContext(uint32_t tag);
 
+  void checkInitialized() const;
+
+  void connectContexts(
+      int rank,
+      int size,
+      const c10::intrusive_ptr<Store>& store);
+
   // Entrypoint for worker threads.
   void runLoop(int workerIndex);
 
@@ -494,6 +513,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
   std::condition_variable workConsumeCV_;
   uint64_t seq_{0};
   size_t local_id_;
+  mutable std::vector<uint64_t> defaultRanks_;
   std::shared_ptr<ProcessGroupStatus> pgStatus_ =
       std::make_shared<ProcessGroupStatus>();
 };

--- a/torch/csrc/distributed/c10d/gloo/ProcessGroupGlooReconfigure.cpp
+++ b/torch/csrc/distributed/c10d/gloo/ProcessGroupGlooReconfigure.cpp
@@ -1,0 +1,187 @@
+// Reconfigure (fault tolerance) implementation for ProcessGroupGloo. The rest
+// of the backend lives in ProcessGroupGloo.cpp; this file holds the handle
+// encoding and the reconfigure() entry point so the membership-change logic is
+// isolated from the collective implementations.
+#include <c10/util/Exception.h>
+#include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
+
+#ifdef USE_C10D_GLOO
+
+#include <torch/csrc/distributed/c10d/FlightRecorder.hpp>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp>
+#include <torch/csrc/distributed/c10d/TCPStore.hpp>
+
+#include <algorithm>
+#include <unordered_set>
+#include <variant>
+
+namespace c10d {
+
+namespace {
+
+std::string getStoreAddress(const c10::intrusive_ptr<Store>& store) {
+  auto* tcpStore = dynamic_cast<TCPStore*>(store.get());
+  if (tcpStore == nullptr) {
+    auto* prefixStore = dynamic_cast<PrefixStore*>(store.get());
+    if (prefixStore != nullptr) {
+      tcpStore = dynamic_cast<TCPStore*>(
+          prefixStore->getUnderlyingNonPrefixStore().get());
+    }
+  }
+  if (tcpStore == nullptr) {
+    return "";
+  }
+  return c10::str(tcpStore->getHost(), ":", tcpStore->getPort());
+}
+
+struct GlooReconfigureHandle {
+  int rank;
+  int64_t uuid;
+  uint64_t stableRank;
+  std::string storeAddress;
+};
+
+GlooReconfigureHandle parseGlooReconfigureHandle(
+    const ReconfigureHandle& handle) {
+  auto first = handle.find(':');
+  TORCH_CHECK(
+      first != std::string::npos &&
+          handle.substr(0, first) == GLOO_BACKEND_NAME,
+      "Invalid Gloo reconfigure handle: ",
+      handle);
+  auto second = handle.find(':', first + 1);
+  TORCH_CHECK(
+      second != std::string::npos, "Invalid Gloo reconfigure handle: ", handle);
+  auto third = handle.find(':', second + 1);
+  TORCH_CHECK(
+      third != std::string::npos, "Invalid Gloo reconfigure handle: ", handle);
+  auto fourth = handle.find(':', third + 1);
+  TORCH_CHECK(
+      fourth != std::string::npos, "Invalid Gloo reconfigure handle: ", handle);
+  return {
+      .rank = std::stoi(handle.substr(first + 1, second - first - 1)),
+      .uuid = std::stoll(handle.substr(second + 1, third - second - 1)),
+      .stableRank = std::stoull(handle.substr(third + 1, fourth - third - 1)),
+      .storeAddress = handle.substr(fourth + 1)};
+}
+
+std::vector<ReconfigureHandle> getOrderedReconfigureHandles(
+    const ReconfigureOptions& opts) {
+  std::vector<ReconfigureHandle> handles;
+  std::visit(
+      [&](const auto& inputHandles) {
+        handles.assign(inputHandles.begin(), inputHandles.end());
+      },
+      opts.handles);
+  if (std::holds_alternative<std::unordered_set<ReconfigureHandle>>(
+          opts.handles)) {
+    std::ranges::sort(handles);
+  }
+  TORCH_CHECK(!handles.empty(), "Reconfigure requires at least one handle");
+  std::unordered_set<ReconfigureHandle> uniqueHandles(
+      handles.begin(), handles.end());
+  TORCH_CHECK(
+      uniqueHandles.size() == handles.size(),
+      "Reconfigure handles must be unique");
+  for (const auto& handle : handles) {
+    parseGlooReconfigureHandle(handle);
+  }
+  return handles;
+}
+
+c10::intrusive_ptr<Work> makeCompletedWork() {
+  auto future = c10::make_intrusive<c10::ivalue::Future>(
+      c10::ListType::create(c10::TensorType::get()), std::vector<at::Device>{});
+  future->markCompleted(c10::IValue(std::vector<at::Tensor>()));
+  return Work::create_from_future(future);
+}
+
+} // namespace
+
+ReconfigureHandle ProcessGroupGloo::get_reconfigure_handle() const {
+  const auto& ranks = groupRanks();
+  uint64_t stableRank = rank_;
+  if (rank_ >= 0 && static_cast<size_t>(rank_) < ranks.size()) {
+    stableRank = ranks[rank_];
+  }
+  return c10::str(
+      GLOO_BACKEND_NAME,
+      ":",
+      rank_,
+      ":",
+      reconfigureUuid_,
+      ":",
+      stableRank,
+      ":",
+      getStoreAddress(c10dStore_));
+}
+
+c10::intrusive_ptr<Work> ProcessGroupGloo::reconfigure(
+    const ReconfigureOptions& opts) {
+  auto handles = getOrderedReconfigureHandles(opts);
+  std::vector<uint64_t> globalRanks;
+  globalRanks.reserve(handles.size());
+  for (const auto& handle : handles) {
+    globalRanks.push_back(parseGlooReconfigureHandle(handle).stableRank);
+  }
+  auto localHandle = get_reconfigure_handle();
+  auto localIt = std::ranges::find(handles, localHandle);
+  TORCH_CHECK(
+      localIt != handles.end(),
+      "Local Gloo reconfigure handle is not part of the new communicator");
+
+  auto newRank = static_cast<int>(std::distance(handles.begin(), localIt));
+  auto newSize = static_cast<int>(handles.size());
+  auto timeout = opts.timeout.value_or(options_->timeout);
+  auto oldTimeout = options_->timeout;
+  auto oldRank = rank_;
+  auto oldSize = size_;
+  auto oldInitialized = initialized_;
+  auto oldDefaultRanks = defaultRanks_;
+  auto prefixedStore = c10::make_intrusive<PrefixStore>(
+      c10::str("reconfigure/", opts.uuid), c10dStore_);
+
+  // The uuid namespaces this reconfigure's rendezvous keys; reusing it would
+  // read stale rendezvous state. New rank 0 atomically claims the uuid: the
+  // compareSet writes our handle only while "claimed" is unset, so a reused
+  // uuid returns the prior claimant's handle, which differs from ours.
+  if (newRank == 0) {
+    auto claimedBy = prefixedStore->compareSet("claimed", "", localHandle);
+    TORCH_CHECK(
+        claimedBy == localHandle,
+        "Gloo reconfigure uuid ",
+        opts.uuid,
+        " was already used; each reconfigure() requires a unique uuid");
+  }
+
+  rank_ = newRank;
+  size_ = newSize;
+  defaultRanks_ = std::move(globalRanks);
+  collectiveCounter_ = 0;
+  seq_ = 0;
+  options_->timeout = timeout;
+  try {
+    connectContexts(rank_, size_, prefixedStore);
+  } catch (...) {
+    options_->timeout = oldTimeout;
+    rank_ = oldRank;
+    size_ = oldSize;
+    initialized_ = oldInitialized;
+    defaultRanks_ = std::move(oldDefaultRanks);
+    throw;
+  }
+  options_->timeout = oldTimeout;
+  for (auto& context : contexts_) {
+    context->setTimeout(oldTimeout);
+  }
+  initialized_ = true;
+  reconfigureUuid_ = opts.uuid;
+
+  FlightRecorder<c10::Event>::get()->record_pg_ranks(
+      std::make_tuple(pg_uid_, pg_desc_), groupRanks());
+  return makeCompletedWork();
+}
+
+} // namespace c10d
+
+#endif // USE_C10D_GLOO


### PR DESCRIPTION
## Summary

Add `ProcessGroupGloo` support for the c10d backend fault-tolerance reconfigure API.

The implementation defers Gloo context creation when `enable_reconfigure=True`, reconnects contexts during `reconfigure()`, and updates the canonical `Backend` rank/size fields so `ProcessGroup` and Python rank/world-size APIs observe the active membership. It also adds a standalone, allowlisted fault-tolerance test file that Gloo opts into and other backends can reuse.

## Test Plan

```bash
uv run lintrunner -a test/distributed/test_c10d_fault_tolerance.py torch/csrc/distributed/c10d/Backend.hpp torch/csrc/distributed/c10d/ProcessGroup.cpp torch/csrc/distributed/c10d/ProcessGroup.hpp torch/csrc/distributed/c10d/ProcessGroupGloo.cpp torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
```

```bash
uv run spin quicklint test/distributed/test_c10d_fault_tolerance.py torch/csrc/distributed/c10d/Backend.hpp torch/csrc/distributed/c10d/ProcessGroup.cpp torch/csrc/distributed/c10d/ProcessGroup.hpp torch/csrc/distributed/c10d/ProcessGroupGloo.cpp torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
```

```bash
pip install -e . -v --no-build-isolation
```

```bash
python test/distributed/test_c10d_fault_tolerance.py
```

```bash
git diff --check
```

Authored with assistance from an AI assistant.
