### PR TITLE
[dtensor][math_ops] fixing math_ops single dim strategies to consider output_mask

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,8 @@ When asked to review a PR, always use the /pr-review skill.
 
 If any tool you're trying to use (pip, python, spin, etc) is missing, check for
 a `.venv` directory in the project root or its parent directory. If found,
-activate it and retry. If no `.venv` is found, try `conda activate pytorch-3.12`
-and retry. If that environment is unavailable or the tool is still missing, stop
-and ask the user if an environment is needed. Do NOT try to find other
-alternatives or install these tools.
+activate it and retry. If no `.venv` is found, stop and ask the user if an
+environment is needed. Do NOT try to find alternatives or install these tools.
 
 # CI Docker Images
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,10 @@ When asked to review a PR, always use the /pr-review skill.
 
 If any tool you're trying to use (pip, python, spin, etc) is missing, check for
 a `.venv` directory in the project root or its parent directory. If found,
-activate it and retry. If no `.venv` is found, stop and ask the user if an
-environment is needed. Do NOT try to find alternatives or install these tools.
+activate it and retry. If no `.venv` is found, try `conda activate pytorch-3.12`
+and retry. If that environment is unavailable or the tool is still missing, stop
+and ask the user if an environment is needed. Do NOT try to find other
+alternatives or install these tools.
 
 # CI Docker Images
 

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1057,6 +1057,7 @@ class TestOpSchemaMetaProperties(TestCase):
                 [8],  # normalized_shape
                 stat_meta,  # rstd
                 weight_meta,  # weight
+                [True, True],  # output_mask
             ),
             {},
         )
@@ -1071,7 +1072,7 @@ class TestOpSchemaMetaProperties(TestCase):
         # Without weight: d_weight=None
         strategies = rms_norm_bwd_single_dim_strategy(
             torch.ops.aten._fused_rms_norm_backward.default,
-            (input_meta, input_meta, [8], stat_meta, None),
+            (input_meta, input_meta, [8], stat_meta, None, [True, True]),
             {},
         )
         self.assertEqual(len(strategies), 1)

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -990,6 +990,50 @@ class TestOpSchemaMetaProperties(TestCase):
         self.assertIsNone(rule[1])  # d_weight
         self.assertIsNone(rule[2])  # d_bias
 
+        # With weight/bias inputs but masked-off weight/bias outputs
+        strategies = layer_norm_bwd_single_dim_strategy(
+            torch.ops.aten.native_layer_norm_backward.default,
+            (
+                input_meta,
+                input_meta,
+                [8],
+                stat_meta,
+                stat_meta,
+                weight_meta,
+                weight_meta,
+                [True, False, False],
+            ),
+            {},
+        )
+        self.assertEqual(len(strategies), 1)
+        rule = strategies[0]
+        self.assertEqual(len(rule), 9)
+        self.assertEqual(rule[0].dim, 0)  # d_input sharded
+        self.assertIsNone(rule[1])  # d_weight masked off
+        self.assertIsNone(rule[2])  # d_bias masked off
+        self.assertIsInstance(rule[7], Replicate)  # weight input still present
+        self.assertIsInstance(rule[8], Replicate)  # bias input still present
+
+        # d_input can also be masked independently of d_weight/d_bias
+        strategies = layer_norm_bwd_single_dim_strategy(
+            torch.ops.aten.native_layer_norm_backward.default,
+            (
+                input_meta,
+                input_meta,
+                [8],
+                stat_meta,
+                stat_meta,
+                weight_meta,
+                weight_meta,
+                [False, True, False],
+            ),
+            {},
+        )
+        rule = strategies[0]
+        self.assertIsNone(rule[0])  # d_input masked off
+        self.assertIsInstance(rule[1], Partial)  # d_weight reduced
+        self.assertIsNone(rule[2])  # d_bias masked off
+
     def test_rms_norm_bwd_single_dim_strategy(self):
         """rms_norm backward produces correct output/input placements."""
         from torch.distributed.tensor._ops._math_ops import (
@@ -1035,6 +1079,141 @@ class TestOpSchemaMetaProperties(TestCase):
         # outputs: [d_input, None] + inputs: [grad_out, input, rstd]
         self.assertEqual(len(rule), 5)
         self.assertIsNone(rule[1])  # d_weight
+
+        # With weight input but masked-off d_weight output
+        strategies = rms_norm_bwd_single_dim_strategy(
+            torch.ops.aten._fused_rms_norm_backward.default,
+            (
+                input_meta,  # grad_out
+                input_meta,  # input
+                [8],  # normalized_shape
+                stat_meta,  # rstd
+                weight_meta,  # weight
+                [True, False],  # output_mask
+            ),
+            {},
+        )
+        self.assertEqual(len(strategies), 1)
+        rule = strategies[0]
+        self.assertEqual(len(rule), 6)
+        self.assertEqual(rule[0].dim, 0)  # d_input sharded
+        self.assertIsNone(rule[1])  # d_weight masked off
+        self.assertIsInstance(rule[5], Replicate)  # weight input still present
+
+        # d_input can be masked independently of d_weight
+        strategies = rms_norm_bwd_single_dim_strategy(
+            torch.ops.aten._fused_rms_norm_backward.default,
+            (
+                input_meta,
+                input_meta,
+                [8],
+                stat_meta,
+                weight_meta,
+                [False, True],
+            ),
+            {},
+        )
+        rule = strategies[0]
+        self.assertIsNone(rule[0])  # d_input masked off
+        self.assertIsInstance(rule[1], Partial)  # d_weight reduced
+
+    def test_grid_sampler_bwd_single_dim_strategy(self):
+        """grid_sampler backward respects output_mask."""
+        from torch.distributed.tensor._ops._math_ops import (
+            grid_sampler_backward_strategy,
+        )
+
+        grad_output_meta = TensorMeta(
+            shape=torch.Size([2, 3, 4, 4]), stride=(48, 16, 4, 1), dtype=torch.float32
+        )
+        input_meta = TensorMeta(
+            shape=torch.Size([2, 3, 8, 8]), stride=(192, 64, 8, 1), dtype=torch.float32
+        )
+        grid_meta = TensorMeta(
+            shape=torch.Size([2, 4, 4, 2]), stride=(32, 8, 2, 1), dtype=torch.float32
+        )
+
+        strategies = grid_sampler_backward_strategy(
+            torch.ops.aten.grid_sampler_2d_backward.default,
+            (grad_output_meta, input_meta, grid_meta, 0, 0, False, [True, False]),
+            {},
+        )
+        self.assertEqual(len(strategies), 1)
+        rule = strategies[0]
+        self.assertEqual(len(rule), 5)
+        self.assertEqual(rule[0].dim, 0)  # grad_input sharded
+        self.assertIsNone(rule[1])  # grad_grid masked off
+        self.assertEqual(rule[2].dim, 0)  # grad_output sharded
+        self.assertEqual(rule[3].dim, 0)  # input sharded
+        self.assertEqual(rule[4].dim, 0)  # grid sharded
+
+        strategies = grid_sampler_backward_strategy(
+            torch.ops.aten.grid_sampler_2d_backward.default,
+            (grad_output_meta, input_meta, grid_meta, 0, 0, False, [False, True]),
+            {},
+        )
+        rule = strategies[0]
+        self.assertIsNone(rule[0])  # grad_input masked off
+        self.assertEqual(rule[1].dim, 0)  # grad_grid sharded
+
+    def test_batch_norm_bwd_single_dim_strategy(self):
+        """batch_norm backward respects output_mask."""
+        from torch.distributed.tensor._ops._math_ops import batch_norm_backward_strategy
+
+        input_meta = TensorMeta(
+            shape=torch.Size([4, 8, 16, 16]),
+            stride=(2048, 256, 16, 1),
+            dtype=torch.float32,
+        )
+        channel_meta = TensorMeta(
+            shape=torch.Size([8]), stride=(1,), dtype=torch.float32
+        )
+
+        strategies = batch_norm_backward_strategy(
+            torch.ops.aten.native_batch_norm_backward.default,
+            (
+                input_meta,  # grad_out
+                input_meta,  # input
+                channel_meta,  # weight
+                channel_meta,  # running_mean
+                channel_meta,  # running_var
+                channel_meta,  # save_mean
+                channel_meta,  # save_invstd
+                True,  # train
+                1e-5,  # eps
+                [True, False, True],  # output_mask
+            ),
+            {},
+        )
+        self.assertEqual(len(strategies), 1)
+        rule = strategies[0]
+        self.assertEqual(len(rule), 10)
+        self.assertEqual(rule[0].dim, 1)  # grad_input sharded on channel
+        self.assertIsNone(rule[1])  # grad_weight masked off
+        self.assertEqual(rule[2].dim, 0)  # grad_bias sharded
+        self.assertEqual(rule[3].dim, 1)  # grad_out sharded on channel
+        self.assertEqual(rule[4].dim, 1)  # input sharded on channel
+
+        strategies = batch_norm_backward_strategy(
+            torch.ops.aten.native_batch_norm_backward.default,
+            (
+                input_meta,
+                input_meta,
+                channel_meta,
+                channel_meta,
+                channel_meta,
+                channel_meta,
+                channel_meta,
+                True,
+                1e-5,
+                [False, True, False],
+            ),
+            {},
+        )
+        rule = strategies[0]
+        self.assertIsNone(rule[0])  # grad_input masked off
+        self.assertEqual(rule[1].dim, 0)  # grad_weight sharded
+        self.assertIsNone(rule[2])  # grad_bias masked off
 
     def test_constant_pad_nd_allows_shard_on_non_padded_dim(self):
         """constant_pad_nd should allow sharding on non-padded dims."""

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1119,7 +1119,7 @@ class TestOpSchemaMetaProperties(TestCase):
         self.assertIsInstance(rule[1], Partial)  # d_weight reduced
 
     def test_grid_sampler_bwd_single_dim_strategy(self):
-        """grid_sampler backward respects output_mask."""
+        """grid_sampler backward respects the native output_mask contract."""
         from torch.distributed.tensor._ops._math_ops import (
             grid_sampler_backward_strategy,
         )
@@ -1143,7 +1143,7 @@ class TestOpSchemaMetaProperties(TestCase):
         rule = strategies[0]
         self.assertEqual(len(rule), 5)
         self.assertEqual(rule[0].dim, 0)  # grad_input sharded
-        self.assertIsNone(rule[1])  # grad_grid masked off
+        self.assertEqual(rule[1].dim, 0)  # grad_grid is always computed
         self.assertEqual(rule[2].dim, 0)  # grad_output sharded
         self.assertEqual(rule[3].dim, 0)  # input sharded
         self.assertEqual(rule[4].dim, 0)  # grid sharded
@@ -1156,6 +1156,15 @@ class TestOpSchemaMetaProperties(TestCase):
         rule = strategies[0]
         self.assertIsNone(rule[0])  # grad_input masked off
         self.assertEqual(rule[1].dim, 0)  # grad_grid sharded
+
+        strategies = grid_sampler_backward_strategy(
+            torch.ops.aten.grid_sampler_2d_backward.default,
+            (grad_output_meta, input_meta, grid_meta, 0, 0, False, [False, False]),
+            {},
+        )
+        rule = strategies[0]
+        self.assertIsNone(rule[0])  # grad_input masked off
+        self.assertEqual(rule[1].dim, 0)  # grad_grid ignores output_mask[1]
 
     def test_batch_norm_bwd_single_dim_strategy(self):
         """batch_norm backward respects output_mask."""

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1269,7 +1269,7 @@ def layer_norm_bwd_single_dim_strategy(
     # mean = args_schema[3], rstd = args_schema[4]
     weight_meta = args_schema[5]
     bias_meta = args_schema[6]
-    output_mask = args_schema[7] if len(args_schema) > 7 else (True, True, True)
+    output_mask = args_schema[7]
     compute_d_input = output_mask[0]
     compute_d_weight = weight_meta is not None and output_mask[1]
     compute_d_bias = bias_meta is not None and output_mask[2]
@@ -1316,7 +1316,7 @@ def rms_norm_bwd_single_dim_strategy(
     normalized_shape = args_schema[2]
     # rstd = args_schema[3]
     weight_meta = args_schema[4]
-    output_mask = args_schema[5] if len(args_schema) > 5 else (True, True)
+    output_mask = args_schema[5]
     compute_d_input = output_mask[0]
     compute_d_weight = weight_meta is not None and output_mask[1]
 

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1772,11 +1772,12 @@ def grid_sampler_backward_strategy(
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder | None]]:
     # grid_sampler_{2,3}d_backward: 2 outputs (grad_input, grad_grid) + 3 inputs = 5 placements, batch-only
+    # The native implementation only honors output_mask[0]; grad_grid is always computed.
     output_mask = args_schema[6]
     return [
         [
             _ShardingPlaceholder(0) if output_mask[0] else None,
-            _ShardingPlaceholder(0) if output_mask[1] else None,
+            _ShardingPlaceholder(0),
             _ShardingPlaceholder(0),  # grad_output
             _ShardingPlaceholder(0),  # input
             _ShardingPlaceholder(0),  # grid

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1269,17 +1269,21 @@ def layer_norm_bwd_single_dim_strategy(
     # mean = args_schema[3], rstd = args_schema[4]
     weight_meta = args_schema[5]
     bias_meta = args_schema[6]
+    output_mask = args_schema[7] if len(args_schema) > 7 else (True, True, True)
+    compute_d_input = output_mask[0]
+    compute_d_weight = weight_meta is not None and output_mask[1]
+    compute_d_bias = bias_meta is not None and output_mask[2]
 
     axis = len(input_meta.shape) - len(normalize_to_torch_size(normalized_shape))
 
     strategies: list[list[Placement | _ShardingPlaceholder | None]] = []
     for dim in range(axis):
         # outputs: [d_input, d_weight, d_bias] — always 3 per schema
-        # d_weight/d_bias use None when weight/bias are None
+        # Masked-off outputs use None even if the corresponding input exists.
         rule: list[Placement | _ShardingPlaceholder | None] = [
-            _ShardingPlaceholder(dim),  # d_input
-            Partial("sum") if weight_meta is not None else None,  # d_weight
-            Partial("sum") if bias_meta is not None else None,  # d_bias
+            _ShardingPlaceholder(dim) if compute_d_input else None,
+            Partial("sum") if compute_d_weight else None,
+            Partial("sum") if compute_d_bias else None,
         ]
         # inputs: [grad_out, input, mean, rstd, weight?, bias?]
         rule.extend(
@@ -1312,17 +1316,20 @@ def rms_norm_bwd_single_dim_strategy(
     normalized_shape = args_schema[2]
     # rstd = args_schema[3]
     weight_meta = args_schema[4]
+    output_mask = args_schema[5] if len(args_schema) > 5 else (True, True)
+    compute_d_input = output_mask[0]
+    compute_d_weight = weight_meta is not None and output_mask[1]
 
     axis = len(input_meta.shape) - len(normalize_to_torch_size(normalized_shape))
 
     strategies: list[list[Placement | _ShardingPlaceholder | None]] = []
     for dim in range(axis):
         # outputs: [d_input, d_weight] — always 2 per schema
-        # d_weight uses None when weight is None
+        # Masked-off outputs use None even if the corresponding input exists.
         # inputs: [grad_out, input, rstd, weight?]
         rule: list[Placement | _ShardingPlaceholder | None] = [
-            _ShardingPlaceholder(dim),  # d_input
-            Partial("sum") if weight_meta is not None else None,  # d_weight
+            _ShardingPlaceholder(dim) if compute_d_input else None,
+            Partial("sum") if compute_d_weight else None,
             _ShardingPlaceholder(dim),  # grad_out
             _ShardingPlaceholder(dim),  # input
             _ShardingPlaceholder(dim),  # rstd
@@ -1763,9 +1770,18 @@ def grid_sampler_backward_strategy(
     op: torch._ops.OpOverload,
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
-) -> list[list[Placement | _ShardingPlaceholder]]:
+) -> list[list[Placement | _ShardingPlaceholder | None]]:
     # grid_sampler_{2,3}d_backward: 2 outputs (grad_input, grad_grid) + 3 inputs = 5 placements, batch-only
-    return [[_ShardingPlaceholder(0)] * 5]
+    output_mask = args_schema[6]
+    return [
+        [
+            _ShardingPlaceholder(0) if output_mask[0] else None,
+            _ShardingPlaceholder(0) if output_mask[1] else None,
+            _ShardingPlaceholder(0),  # grad_output
+            _ShardingPlaceholder(0),  # input
+            _ShardingPlaceholder(0),  # grid
+        ]
+    ]
 
 
 def _adjust_group_norm_scalars(
@@ -1858,15 +1874,16 @@ def batch_norm_backward_strategy(
     op: torch._ops.OpOverload,
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
-) -> list[list[Placement | _ShardingPlaceholder]]:
+) -> list[list[Placement | _ShardingPlaceholder | None]]:
     # Backward reduces over batch + spatial dims, orthogonal to the channel dim,
     # so channel sharding commutes with the op (same principle as forward).
     # Tensors are [N,C,*] -> Shard(1) or [C] -> Shard(0).
+    output_mask = args_schema[9]
     num_tensor_inputs = sum(isinstance(a, TensorMeta) for a in args_schema)
-    rule: list[Placement | _ShardingPlaceholder] = [
-        _ShardingPlaceholder(1),  # grad_input [N,C,*]
-        _ShardingPlaceholder(0),  # grad_weight [C]
-        _ShardingPlaceholder(0),  # grad_bias [C]
+    rule: list[Placement | _ShardingPlaceholder | None] = [
+        _ShardingPlaceholder(1) if output_mask[0] else None,  # grad_input [N,C,*]
+        _ShardingPlaceholder(0) if output_mask[1] else None,  # grad_weight [C]
+        _ShardingPlaceholder(0) if output_mask[2] else None,  # grad_bias [C]
         _ShardingPlaceholder(1),  # grad_out [N,C,*]
         _ShardingPlaceholder(1),  # input [N,C,*]
     ]


### PR DESCRIPTION
**Summary:**  PR #187199 tightened single-dim strategy handling for `None` output specs, which exposed latent bugs in several `math_ops` single-dim backward strategies. These strategies were emitting placements for outputs that were disabled by `output_mask`, causing invalid mixed`None`/placement specs on multi-dimensional meshes, as reported in #187373.

Update the affected single-dim strategies to respect `output_mask`:
  - `native_layer_norm_backward`
  - `_fused_rms_norm_backward`
  - `grid_sampler_{2,3}d_backward`
  - `native_batch_norm_backward`

For masked-off outputs, the strategies now emit `None` even when the corresponding input tensor still exists. Input placements are preserved separately, so cases like “weight input exists but d_weight output is masked off” are handled correctly.

**Test Cases**
1. pytest /data/users/anshulsi/pytorch/test/distributed/tensor/test_op_strategy.py -k test_layer_norm_bwd_single_dim_strategy
2. pytest /data/users/anshulsi/pytorch/test/distributed/tensor/test_op_strategy.py -k test_rms_norm_bwd_single_dim_strategy

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187383

