### PR TITLE
Dynamically link NCCL EP for USE_SYSTEM_NCCL=ON (wheel) builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
                        OFF)
 # Builds NCCL-EP if true.
 cmake_dependent_option(USE_NCCL_EP "Build NCCL EP contrib library" OFF
-                       "USE_NCCL;USE_CUDA;NOT USE_SYSTEM_NCCL" OFF)
+                       "USE_NCCL;USE_CUDA" OFF)
 cmake_dependent_option(USE_NVSHMEM "Use NVSHMEM" ON
                        "USE_DISTRIBUTED;USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
 option(USE_NNAPI "Use NNAPI" OFF)

--- a/cmake/External/nccl_ep.cmake
+++ b/cmake/External/nccl_ep.cmake
@@ -37,7 +37,29 @@ if(NOT __NCCL_EP_INCLUDED)
     set(__NCCL_EP_ARCH_ARG "-DCMAKE_CUDA_ARCHITECTURES=${__NCCL_EP_ARCHS}")
   endif()
 
-  message(STATUS "Configuring NCCL EP as third-party dependency (__caffe2_nccl_ep)")
+  # Branch on how torch links NCCL (USE_NCCL_EP supports both):
+  #  - USE_SYSTEM_NCCL=OFF (source/dev): torch statically embeds the submodule
+  #    NCCL, so build libnccl_ep.a against it and have the extension statically
+  #    link it -- self-contained, no nccl4py, no runtime libnccl_ep.so.
+  #  - USE_SYSTEM_NCCL=ON (wheel/CI): torch dynamically links the system NCCL, so
+  #    build libnccl_ep.so against that same NCCL; the extension NEEDED-links it
+  #    and resolves it (and its JIT headers) from the nccl4py wheel at runtime.
+  if(USE_SYSTEM_NCCL)
+    if(DEFINED ENV{NCCL_INCLUDE_DIR})
+      get_filename_component(__NCCL_EP_NCCL_HOME "$ENV{NCCL_INCLUDE_DIR}" DIRECTORY)
+    else()
+      list(GET NCCL_INCLUDE_DIRS 0 __nccl_inc)
+      get_filename_component(__NCCL_EP_NCCL_HOME "${__nccl_inc}" DIRECTORY)
+    endif()
+    set(__NCCL_EP_LIB "libnccl_ep.so")
+    set(__NCCL_EP_DEPENDS "")
+  else()
+    set(__NCCL_EP_NCCL_HOME "${__NCCL_BUILD_DIR}")
+    set(__NCCL_EP_LIB "libnccl_ep.a")
+    set(__NCCL_EP_DEPENDS nccl_external)
+  endif()
+
+  message(STATUS "Configuring NCCL EP (__caffe2_nccl_ep): ${__NCCL_EP_LIB} against NCCL at ${__NCCL_EP_NCCL_HOME}")
   ExternalProject_Add(nccl_ep_external
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nccl_ep_build
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/nccl_ep
@@ -51,25 +73,26 @@ if(NOT __NCCL_EP_INCLUDED)
       # libcudart does, matching how libtorch_cuda links it.
       -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared
       ${__NCCL_EP_ARCH_ARG}
-      -DNCCL_HOME=${__NCCL_BUILD_DIR}
+      -DNCCL_HOME=${__NCCL_EP_NCCL_HOME}
       -DNCCL_EP_BUILDDIR=${__NCCL_BUILD_DIR}
       -DNCCL_EP_SOURCE_DIR=${PROJECT_SOURCE_DIR}/third_party/nccl/contrib/nccl_ep
-    # Build the static lib; the _nccl_ep extension statically links it, so its
-    # ncclEp* symbols are embedded in the extension and its nccl* references
-    # resolve against torch_cuda's own (statically-linked) NCCL. No runtime
-    # libnccl_ep.so and no nccl4py dependency.
-    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a"
+    BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}"
     INSTALL_COMMAND ""
-    # NCCL (Makefile) must finish first: nccl_ep links -lnccl and includes its headers.
-    DEPENDS nccl_external
+    # In the static path NCCL (Makefile) must finish first; in the system path
+    # NCCL is already present so there is no in-tree dependency.
+    DEPENDS ${__NCCL_EP_DEPENDS}
   )
 
-  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/libnccl_ep.a")
+  set(NCCL_EP_LIBRARIES "${__NCCL_BUILD_DIR}/lib/${__NCCL_EP_LIB}")
   set(NCCL_EP_INCLUDE_DIRS "${__NCCL_BUILD_DIR}/include")
-  # The runtime JIT resolves NCCL_EP_HOME -> include/nccl_ep and NCCL_HOME ->
-  # include/nccl.h; the submodule build installs both under this one dir, which
-  # the extension bakes in as the default (see torch/CMakeLists.txt).
-  set(NCCL_EP_JIT_HOME "${__NCCL_BUILD_DIR}" CACHE INTERNAL "nccl-ep JIT header home")
+
+  if(NOT USE_SYSTEM_NCCL)
+    # Static path only: bake the in-tree JIT header dir so the extension
+    # self-configures NCCL_EP_HOME / NCCL_HOME (both resolve under this one dir:
+    # include/nccl_ep and include/nccl.h). The dynamic path instead gets these
+    # from nccl4py at runtime, so leave NCCL_EP_JIT_HOME unset there.
+    set(NCCL_EP_JIT_HOME "${__NCCL_BUILD_DIR}" CACHE INTERNAL "nccl-ep JIT header home")
+  endif()
 
   add_library(__caffe2_nccl_ep INTERFACE)
   add_dependencies(__caffe2_nccl_ep nccl_ep_external)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -472,27 +472,38 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
   # ---[ NCCL EP extension (torch._nccl_ep)
   # Optional standalone extension holding the NCCL EP bindings, imported lazily
   # by torch/distributed/_token_switch.py so libtorch_cuda never references
-  # ncclEp*. It statically links libnccl_ep.a (from the same submodule build as
-  # torch's NCCL), so the extension is self-contained: its nccl* references bind
-  # to torch_cuda's embedded NCCL, and there is no runtime libnccl_ep.so or
-  # nccl4py dependency. The runtime JIT headers come from the submodule build
-  # dir, baked in below.
+  # ncclEp*. How it links libnccl_ep follows how torch links NCCL:
+  #  - USE_SYSTEM_NCCL=OFF: __caffe2_nccl_ep is libnccl_ep.a, statically linked
+  #    here -- self-contained (nccl* bind to torch_cuda's embedded NCCL; JIT
+  #    headers baked from the submodule build dir; no nccl4py).
+  #  - USE_SYSTEM_NCCL=ON: __caffe2_nccl_ep is libnccl_ep.so, NEEDED-linked here
+  #    and resolved from the nccl4py wheel at runtime (RPATH to nccl/ep/lib; JIT
+  #    headers also from nccl4py, so nothing is baked).
   if(USE_NCCL_EP)
     Python_add_library(_nccl_ep MODULE WITH_SOABI
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep.cu"
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp")
-    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL
-      # Default NCCL_EP_HOME / NCCL_HOME for nccl-ep's runtime JIT; the extension
-      # sets these at import (without overriding a user-provided value).
-      "NCCL_EP_JIT_HOME=\"${NCCL_EP_JIT_HOME}\"")
+    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL)
     # torch_python: pybind + Tensor/ProcessGroup casters; torch_cuda:
     # ProcessGroupNCCL::getCommPtr, getNcclDataType, CUDA stream, embedded NCCL;
-    # __caffe2_nccl_ep: libnccl_ep.a (static) + nccl_ep headers.
+    # __caffe2_nccl_ep: libnccl_ep (static .a or shared .so) + nccl_ep headers.
     target_link_libraries(_nccl_ep PRIVATE
       torch_python torch_cuda __caffe2_nccl_ep pybind::pybind11)
     set_target_properties(_nccl_ep PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/torch"
-      INSTALL_RPATH "${_rpath_portable_origin}/lib")
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/torch")
+    if(USE_SYSTEM_NCCL)
+      # Dynamic: resolve nccl4py's libnccl_ep.so (site-packages/nccl/ep/lib, one
+      # dir up from torch/ via $ORIGIN/..) at import.
+      set_target_properties(_nccl_ep PROPERTIES
+        INSTALL_RPATH "${_rpath_portable_origin}/lib:${_rpath_portable_origin}/../nccl/ep/lib")
+    else()
+      # Static: only torch's own libs needed; bake the in-tree JIT header dir so
+      # the extension self-configures NCCL_EP_HOME / NCCL_HOME at import.
+      target_compile_definitions(_nccl_ep PRIVATE
+        "NCCL_EP_JIT_HOME=\"${NCCL_EP_JIT_HOME}\"")
+      set_target_properties(_nccl_ep PROPERTIES
+        INSTALL_RPATH "${_rpath_portable_origin}/lib")
+    endif()
     if(NOT WIN32)
       set_target_properties(_nccl_ep PROPERTIES C_VISIBILITY_PRESET "default")
     endif()

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -495,7 +495,7 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
       # Dynamic: resolve nccl4py's libnccl_ep.so (site-packages/nccl/ep/lib, one
       # dir up from torch/ via $ORIGIN/..) at import.
       set_target_properties(_nccl_ep PROPERTIES
-        INSTALL_RPATH "${_rpath_portable_origin}/lib:${_rpath_portable_origin}/../nccl/ep/lib")
+        INSTALL_RPATH "${_rpath_portable_origin}/lib;${_rpath_portable_origin}/../nccl/ep/lib")
     else()
       # Static: only torch's own libs needed; bake the in-tree JIT header dir so
       # the extension self-configures NCCL_EP_HOME / NCCL_HOME at import.

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -47,8 +47,14 @@ def _prepare_nccl4py() -> None:
             "`pip install nccl4py==0.3.1`."
         )
     ep_dir = os.path.join(nccl_pkg, "ep")
-    if os.path.isdir(os.path.join(ep_dir, "include", "nccl_ep")):
-        os.environ.setdefault("NCCL_EP_HOME", ep_dir)
+    if "NCCL_EP_HOME" not in os.environ:
+        ep_headers = os.path.join(ep_dir, "include", "nccl_ep")
+        if not os.path.isdir(ep_headers):
+            raise ImportError(
+                f"nccl4py at {nccl_pkg} is missing the EP JIT headers expected "
+                f"at {ep_headers}; reinstall nccl4py or set NCCL_EP_HOME."
+            )
+        os.environ["NCCL_EP_HOME"] = ep_dir
 
     # Point the JIT at NCCL headers. libnccl.so itself needs no preload here: a
     # USE_SYSTEM_NCCL=ON torch (the only build that reaches this path) already

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import abc
+import ctypes
+import importlib.util
+import os
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -12,18 +15,81 @@ if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup
 
 
+# Keeps preloaded shared libraries resident for the process lifetime.
+_NCCL_EP_KEEPALIVE: list[ctypes.CDLL] = []
+
+
+def _find_pkg_dir(name: str) -> str | None:
+    # Locate an installed package's directory without importing it. find_spec
+    # raises (rather than returning None) when a dotted name's parent namespace
+    # is absent, so guard that.
+    try:
+        spec = importlib.util.find_spec(name)
+    except ModuleNotFoundError:
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    return spec.submodule_search_locations[0]
+
+
+def _prepare_nccl4py() -> None:
+    # Dynamic (USE_SYSTEM_NCCL=ON / wheel) build only: the extension NEEDED-links
+    # libnccl_ep.so, which the nccl4py wheel provides at runtime. Point nccl-ep's
+    # JIT at nccl4py's EP headers (NCCL_EP_HOME) and the nvidia.nccl wheel's NCCL
+    # headers (NCCL_HOME), and make libnccl_ep resolvable, before importing the
+    # extension (its libnccl dependency is already loaded by torch). The static
+    # build bakes all of this in and never reaches here.
+    nccl_pkg = _find_pkg_dir("nccl")
+    if nccl_pkg is None:
+        raise ImportError(
+            "TokenSwitchNCCL needs the 'nccl4py' package for this build's "
+            "libnccl_ep.so and runtime JIT headers. Install it with "
+            "`pip install nccl4py==0.3.1`."
+        )
+    ep_dir = os.path.join(nccl_pkg, "ep")
+    if os.path.isdir(os.path.join(ep_dir, "include", "nccl_ep")):
+        os.environ.setdefault("NCCL_EP_HOME", ep_dir)
+
+    # Point the JIT at NCCL headers. libnccl.so itself needs no preload here: a
+    # USE_SYSTEM_NCCL=ON torch (the only build that reaches this path) already
+    # dynamically loaded the system libnccl, so libnccl_ep.so's NEEDED
+    # libnccl.so.2 resolves to that already-loaded copy.
+    nvidia_nccl = _find_pkg_dir("nvidia.nccl")
+    if nvidia_nccl is not None and os.path.isdir(os.path.join(nvidia_nccl, "include")):
+        os.environ.setdefault("NCCL_HOME", nvidia_nccl)
+
+    # nccl4py ships libnccl_ep unversioned (libnccl_ep.so) while the extension's
+    # NEEDED entry is its SONAME libnccl_ep.so.0; load it by path to register
+    # that SONAME for the import below.
+    lib = os.path.join(ep_dir, "lib", "libnccl_ep.so")
+    if os.path.isfile(lib):
+        _NCCL_EP_KEEPALIVE.append(ctypes.CDLL(lib, mode=ctypes.RTLD_LOCAL))
+
+
 def _import_nccl_ep() -> Any:
-    # The EP bindings live in the optional torch._nccl_ep extension, built only
-    # with USE_NCCL_EP. It statically links libnccl_ep (its nccl* symbols bind to
-    # torch's own NCCL) and bakes in the JIT header paths, so it is fully
-    # self-contained -- no libnccl_ep.so to preload and no nccl4py dependency.
+    # The EP bindings live in the optional torch._nccl_ep extension (USE_NCCL_EP).
+    # A USE_SYSTEM_NCCL=OFF build links libnccl_ep statically and bakes its JIT
+    # header paths, so the extension imports directly -- self-contained, no
+    # nccl4py. A USE_SYSTEM_NCCL=ON build NEEDED-links libnccl_ep from the nccl4py
+    # wheel, so the first import fails until nccl4py is set up; fall back to that
+    # and retry.
+    try:
+        # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
+        import torch._nccl_ep as _ep
+
+        return _ep
+    except ImportError:
+        pass
+
+    _prepare_nccl4py()
     try:
         # pyrefly: ignore [missing-import]  # built only with USE_NCCL_EP
         import torch._nccl_ep as _ep
     except ImportError as e:
         raise ImportError(
             "torch._nccl_ep is unavailable; this PyTorch was not built with "
-            "USE_NCCL_EP."
+            "USE_NCCL_EP (or, for a USE_SYSTEM_NCCL=ON build, the nccl4py wheel "
+            "is missing)."
         ) from e
 
     return _ep


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #187385

Allow `USE_NCCL_EP` with `USE_SYSTEM_NCCL=ON` (drop the `NOT USE_SYSTEM_NCCL` gate) and branch the
extension's libnccl_ep linkage to **follow torch's NCCL linkage**:

- `USE_SYSTEM_NCCL=OFF` (source / dev build): static libnccl_ep.a, self-contained (as the previous commit).
- `USE_SYSTEM_NCCL=ON` (wheel / CI): torch dynamically links the system NCCL, so libnccl_ep.so is built
  against that same NCCL and the extension NEEDED-links it, resolved from the nccl4py wheel at runtime
  (JIT headers from nccl4py). 

Review order:
1. CMakeLists.txt: drop the `NOT USE_SYSTEM_NCCL` gate for NCCL EP.
2. cmake/External/nccl_ep.cmake: branch shared `.so` (system NCCL) vs static `.a`; bake `NCCL_EP_JIT_HOME`
   only on the static path.
3. torch/CMakeLists.txt: dynamic path NEEDED-links libnccl_ep + uses the nccl4py RPATH.
4. `_token_switch.py`: `_prepare_nccl4py` locate nccl4py, set `NCCL_EP_HOME/NCCL_HOME`, load
   libnccl_ep.

Test Plan:
`USE_SYSTEM_NCCL=ON` on 4xH100, using the nvidia.nccl wheel as the system NCCL: the extension NEEDED-links
libnccl_ep.so.0, libtorch_cuda NEEDED-links libnccl.so.2, and the suite passes through the
_prepare_nccl4py fallback (Ran 7 tests ... OK).