### PR TITLE
[spmd_types] Require full FSDP parameter annotations

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -1,0 +1,298 @@
+# Owner(s): ["oncall: distributed"]
+
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.fsdp import (
+    DataParallelMeshDims,
+    fully_shard,
+    MixedPrecisionPolicy,
+)
+from torch.distributed.tensor import init_device_mesh, Replicate, Shard
+from torch.distributed.tensor.debug import CommDebugMode
+from torch.distributed.tensor.placement_types import _StridedShard
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.distributed.fake_pg import FakeStore
+
+
+if dist._is_spmd_types_available():
+    import spmd_types as spmd
+    from spmd_types.checker import typecheck
+
+
+class SpmdLinear(nn.Module):
+    def __init__(self, mesh, seq_parallel: bool):
+        super().__init__()
+        self.mesh = mesh
+        self.tp_pg = mesh.get_group("tp")
+        self.seq_parallel = seq_parallel
+        self.unsharded_weight = nn.Parameter(torch.randn(16, 16))
+        self.sharded_weight = nn.Parameter(torch.randn(16, 16))
+        self.compute_param_types = None
+
+    def forward(self, x):
+        """Simulate the TP collectives around a sharded projection.
+
+        The global computation is x = x @ A; x = x @ B; return x.sum().
+        With sequence parallelism, the activation is all-gathered before the
+        sharded projection. Without it, the output is all-gathered before loss.
+        """
+        self.compute_param_types = (
+            dict(spmd.get_local_type(self.unsharded_weight)),
+            dict(spmd.get_local_type(self.sharded_weight)),
+        )
+        x = x @ self.unsharded_weight
+        x = spmd.redistribute(
+            x,
+            self.tp_pg,
+            src=spmd.S(1) if self.seq_parallel else spmd.I,
+            dst=spmd.R,
+            backward_options={"op_dtype": torch.float32},
+        )
+        x = x @ self.sharded_weight.t()
+        x = spmd.redistribute(
+            x,
+            self.tp_pg,
+            src=spmd.S(2),
+            dst=spmd.I,
+            backward_options={"op_dtype": torch.float32},
+        )
+        return x.sum()
+
+
+@unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
+class TestFullyShardSpmdTypes(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        dist.init_process_group(
+            backend="fake", store=FakeStore(), rank=0, world_size=16
+        )
+        cls.type_mesh = init_device_mesh(
+            "cpu", (4, 2, 2), mesh_dim_names=("dp", "cp", "tp")
+        )
+        cls.fsdp_mesh = init_device_mesh(
+            "cpu", (2, 2, 2, 2), mesh_dim_names=("dpr", "dps", "cp", "tp")
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDownClass()
+
+    def test_restores_param_spmd_type_for_compute(self):
+        """FSDP restores user SPMD metadata on params for compute.
+
+        FSDP should preserve the compute-mesh annotations when applied with
+        a different storage-mesh view. fully_shard() itself does not need a
+        set_current_mesh() scope when all parameter axes are already annotated.
+        """
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        for seq_parallel in (False, True):
+            with self.subTest(seq_parallel=seq_parallel):
+                # init model, annotate params
+                model = SpmdLinear(self.type_mesh, seq_parallel)
+                spmd.assert_type(
+                    model.unsharded_weight,
+                    {
+                        dp_axis: spmd.R,
+                        cp_axis: spmd.R,
+                        tp_axis: spmd.R if seq_parallel else spmd.I,
+                    },
+                )
+                spmd.assert_type(
+                    model.sharded_weight,
+                    {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.S(0)},
+                )
+
+                # FSDP turns params into DTensor, in this case should contain StridedShard @ dps
+                fully_shard(
+                    model,
+                    mesh=self.fsdp_mesh,
+                    dp_mesh_dims=DataParallelMeshDims(
+                        shard=("dps", "cp"),
+                        replicate="dpr",
+                    ),
+                    mp_policy=MixedPrecisionPolicy(
+                        param_dtype=torch.bfloat16,
+                        reduce_dtype=torch.float32,
+                        cast_forward_inputs=True,
+                    ),
+                )
+                self.assertEqual(
+                    model.sharded_weight._spec.placements,
+                    (
+                        Replicate(),
+                        _StridedShard(0, split_factor=self.type_mesh["tp"].size()),
+                        Shard(0),
+                    ),
+                )
+
+                # annotate model inputs as V + PartitionSpec
+                inp = torch.randn(4, 8, 16)
+                input_type = {
+                    dp_axis: spmd.V,
+                    cp_axis: spmd.V,
+                    tp_axis: spmd.V if seq_parallel else spmd.I,
+                }
+                input_partition_spec = spmd.PartitionSpec(
+                    dp_axis,
+                    (cp_axis, tp_axis) if seq_parallel else cp_axis,
+                    None,
+                )
+
+                # check loss output type, check compute-time param annotations are restored.
+                with (
+                    spmd.set_current_mesh(self.type_mesh),
+                    typecheck(strict_mode="strict", local=False),
+                ):
+                    spmd.assert_type(
+                        inp,
+                        input_type,
+                        partition_spec=input_partition_spec,
+                    )
+                    loss = model(inp)
+                    spmd.assert_type(
+                        loss,
+                        {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
+                    )
+                self.assertEqual(
+                    model.compute_param_types,
+                    (
+                        {
+                            dp_axis: spmd.R,
+                            cp_axis: spmd.R,
+                            tp_axis: spmd.R if seq_parallel else spmd.I,
+                        },
+                        {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+                    ),
+                )
+
+                with CommDebugMode() as comm_mode:
+                    loss.backward()
+                comm_counts = comm_mode.get_comm_counts()
+                if seq_parallel:
+                    self.assertEqual(
+                        comm_counts[torch.ops.c10d._reduce_scatter_base_], 2
+                    )
+                else:
+                    self.assertEqual(
+                        comm_counts[torch.ops.c10d._reduce_scatter_base_], 1
+                    )
+                self.assertEqual(
+                    comm_counts[torch.ops.c10d.allreduce_]
+                    + comm_counts[torch.ops.c10d_functional.all_reduce],
+                    2,
+                )
+
+    def test_local_v_param_requires_partition_spec(self):
+        """Local-only V@TP params are ambiguous for FSDP.
+
+        Without PartitionSpec shard info, FSDP cannot choose the matching
+        DTensor Shard(dim), so it rejects the parameter at init time.
+        """
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.I},
+            )
+            spmd.assert_type(
+                model.sharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.V},
+            )
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            """Cannot convert plain Varying to a DTensor placement. Use S(dim) to specify which tensor dimension is sharded.""",
+        )
+
+    def test_partial_param_annotations_error(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+
+        spmd.assert_type(
+            model.unsharded_weight,
+            {tp_axis: spmd.I},
+        )
+        spmd.assert_type(
+            model.sharded_weight,
+            {tp_axis: spmd.S(0)},
+        )
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "Parameter 'unsharded_weight' must have complete spmd_types "
+            "annotations spanning the FSDP storage mesh. Annotated axes: "
+            "(mesh_tp,). Annotated mesh size: 2. Storage mesh axes: "
+            "(mesh_dpr, mesh_dps, mesh_cp, mesh_tp). Storage mesh size: 16.",
+        )
+
+    def test_spmd_params_require_dp_mesh_dims(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.I},
+            )
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(model, mesh=self.type_mesh["dp"])
+        self.assertExpectedInline(
+            str(cm.exception),
+            "spmd_types parameters require a named SPMD mesh "
+            "(pass dp_mesh_dims to fully_shard)",
+        )
+
+    def test_fsdp_dp_axes_must_be_r(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.I, "cp": spmd.R, "tp": spmd.I},
+            )
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "Expected spmd.R on FSDP DP axis mesh_dp for parameter "
+            "'unsharded_weight' but got PerMeshAxisLocalSpmdType.I. FSDP "
+            "requires DP parameters to be R since it handles the DP gradient "
+            "reduction.",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import inspect
 import itertools
+import math
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
 from enum import auto, Enum
@@ -11,7 +12,15 @@ if TYPE_CHECKING:
     from ._fsdp_api import DataParallelMeshDims
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
+
+
+if dist._is_spmd_types_available():
+    import spmd_types as spmd
+    from spmd_types.runtime import get_partition_spec
+    from spmd_types.types import partition_spec_to_shard_types
+
 from torch._prims_common import make_contiguous_strides_for
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.device_mesh import DeviceMesh
@@ -80,6 +89,9 @@ This implies that we construct the unsharded parameter object once and write to
 it in-place thereafter. For the default ``torch.Tensor` original parameter
 case, the all-gather output and unsharded parameter share the same
 data, so we use storage resizing on the all-gather output.
+
+[Note: FSDP and spmd_types]
+Refer to https://github.com/meta-pytorch/spmd_types/blob/main/docs/local_spmd_types.md
 """
 
 lib = torch.library.Library("fsdp", "FRAGMENT")
@@ -265,6 +277,15 @@ class FSDPParam:
         # `distribute_tensor` after https://github.com/pytorch/pytorch/issues/116101
         # TODO: Simplify the following sharded parameter padding logic after
         # https://github.com/pytorch/pytorch/issues/113045
+        # Tracks that this parameter contained FSDP-init-time spmd_types annotations;
+        # this remains true even if spmd typechecking is disabled at runtime.
+        self.is_spmd_types = (
+            dist._is_spmd_types_available()
+            and bool(spmd.get_local_type(param))
+            and not isinstance(param, DTensor)
+        )
+        if self.is_spmd_types:
+            param = self._spmd_types_to_dtensor(param, self.mesh_info)
         self.is_dtensor = isinstance(param, DTensor)
         self._orig_param_uid = _get_orig_param_uid(param)
         param_data = self._init_sharding_spec(param, fsdp_placement, shard_dim)
@@ -330,6 +351,139 @@ class FSDPParam:
         # the `fully_shard` call returns to allow provided parameters to alias
         self._setattr_on_modules(self.sharded_param)
         self.sharded_state = ShardedState.SHARDED
+
+    def _spmd_types_to_dtensor(
+        self,
+        param: nn.Parameter,
+        mesh_info: DataParallelMeshInfo,
+    ) -> nn.Parameter:
+        """
+        Translate spmd_types annotations into DTensor placements for FSDP
+        storage.
+
+        The original parameter is a plain tensor annotated for module compute
+        on the typechecking mesh. FSDP stores parameters as DTensors on
+        ``mesh_info.spmd_mesh``, so init time only needs enough type information
+        to translate into DTensor placements on the storage mesh axes. Axes
+        named by ``dp_mesh_dims`` are FSDP-managed DP axes and must be
+        annotated as ``spmd.R``; non-FSDP storage axes must have a direct
+        spmd_types annotation. The annotated axes must span the same mesh as
+        the FSDP storage mesh.
+
+        The original compute annotations and PartitionSpec are saved. At
+        compute time, FSDP all-gathers the DTensor storage, exposes a plain
+        tensor parameter, and restores the saved spmd_types metadata.
+
+        Gradients use spmd_types backward typing to choose DTensor placements:
+        for example, ``R`` becomes ``P``, while ``I`` and ``S(dim)`` stay as
+        ``I`` and ``S(dim)``. This lets FSDP handle pending non-FSDP
+        redistributions after wrapping incoming gradients as DTensors.
+        """
+        spmd_mesh = mesh_info.spmd_mesh
+        if spmd_mesh is None or spmd_mesh.mesh_dim_names is None:
+            raise ValueError(
+                "spmd_types parameters require a named SPMD mesh "
+                "(pass dp_mesh_dims to fully_shard)"
+            )
+
+        # Save compute-time metadata, then translate types onto the FSDP storage mesh.
+        self._spmd_partition_spec = get_partition_spec(param)
+        self._spmd_init_local_type = spmd.get_local_type(param)
+        storage_axis_types = self._get_storage_axis_types(spmd_mesh, mesh_info)
+
+        # Expand storage-mesh SPMD types into per-mesh-dim DTensor placements.
+        placements = []
+        self._spmd_grad_placements = []
+        for axis_type in storage_axis_types.values():
+            placements.append(spmd.spmd_type_to_dtensor_placement(axis_type))
+            self._spmd_grad_placements.append(
+                spmd.spmd_type_to_dtensor_placement(axis_type.backward_type())
+            )
+
+        dtensor_param = nn.Parameter(
+            DTensor.from_local(param.data, spmd_mesh, placements, run_check=False),
+            requires_grad=param.requires_grad,
+        )
+        return dtensor_param
+
+    def _get_storage_axis_types(
+        self,
+        spmd_mesh: DeviceMesh,
+        mesh_info: DataParallelMeshInfo,
+    ) -> dict[Any, Any]:
+        """Return FSDP storage-mesh spmd_types for DTensor placement translation.
+
+        ``dp_mesh_dims`` defines the FSDP-managed submesh, whose annotated axes
+        must have ``spmd.R`` semantics because FSDP handles their gradient
+        reduction. Annotated non-FSDP axes must map 1:1 to storage mesh axes.
+        The full set of annotated axes must be orthogonal and span the same
+        process set as the storage mesh; FSDP does not infer omitted axes.
+        """
+        dp_names = set(
+            itertools.chain(
+                mesh_info.dp_mesh_dims.shard_names,
+                mesh_info.dp_mesh_dims.replicate_names,
+            )
+        )
+        fsdp_axis = spmd.MeshAxis.of(mesh_info.mesh._flatten().get_group(0))
+        spmd_mesh_axes = tuple(
+            (name, spmd.MeshAxis.of(spmd_mesh.get_group(name)))
+            for name in spmd_mesh.mesh_dim_names
+        )
+        non_fsdp_spmd_mesh_axes = {
+            axis for name, axis in spmd_mesh_axes if name not in dp_names
+        }
+        storage_axis_types = {
+            axis: spmd.R for name, axis in spmd_mesh_axes if name in dp_names
+        }
+        local_type = dict(self._spmd_init_local_type)
+        if self._spmd_partition_spec is not None:
+            local_type.update(partition_spec_to_shard_types(self._spmd_partition_spec))
+        for axis, axis_type in local_type.items():
+            if axis <= fsdp_axis:
+                if axis_type is not spmd.R:
+                    raise ValueError(
+                        f"Expected spmd.R on FSDP DP axis {axis} for parameter "
+                        f"'{self._module_info.param_name}' but got {axis_type}. "
+                        "FSDP requires DP parameters to be R since it handles "
+                        "the DP gradient reduction."
+                    )
+            else:
+                if axis not in non_fsdp_spmd_mesh_axes:
+                    raise ValueError(
+                        f"Parameter '{self._module_info.param_name}' has spmd_types "
+                        f"annotation on axis {axis}, which is neither a non-FSDP "
+                        "storage-mesh axis nor contained in the FSDP DP mesh."
+                    )
+                storage_axis_types[axis] = axis_type
+
+        # After the loop, each annotated axis is either contained in the FSDP
+        # DP submesh or maps 1:1 to a non-FSDP storage axis. Since spmd_types
+        # already enforces orthogonality, matching mesh sizes means the
+        # annotations span the same process set as the storage mesh.
+        annotated_mesh_size = math.prod(axis.size() for axis in local_type)
+        storage_mesh_size = math.prod(axis.size() for _, axis in spmd_mesh_axes)
+        if annotated_mesh_size != storage_mesh_size:
+            raise ValueError(
+                f"Parameter '{self._module_info.param_name}' must have complete "
+                "spmd_types annotations spanning the FSDP storage mesh. "
+                f"Annotated axes: {tuple(local_type.keys())}. "
+                f"Annotated mesh size: {annotated_mesh_size}. "
+                f"Storage mesh axes: {tuple(axis for _, axis in spmd_mesh_axes)}. "
+                f"Storage mesh size: {storage_mesh_size}."
+            )
+        return storage_axis_types
+
+    def _restore_spmd_types(self, tensor: torch.Tensor) -> None:
+        """Restore the saved spmd_types annotation onto a tensor."""
+        if not self.is_spmd_types or not spmd.is_type_checking():
+            return
+        if self._spmd_init_local_type:
+            spmd.assert_type(
+                tensor,
+                self._spmd_init_local_type,
+                partition_spec=self._spmd_partition_spec,
+            )
 
     def _init_sharding_spec(
         self,
@@ -669,7 +823,9 @@ class FSDPParam:
             self._contiguous_orig_stride,
             storage_offset=0,
         )
-        if self._unsharded_dtensor_spec is not None:
+        if self.is_spmd_types:
+            pass  # keep as plain tensor; spmd_types restored in to_unsharded()
+        elif self._unsharded_dtensor_spec is not None:
             unsharded_dtensor_spec = self._get_unsharded_dtensor_spec(unsharded_param)
             unsharded_param = _from_local_no_grad(
                 unsharded_param, unsharded_dtensor_spec
@@ -748,6 +904,8 @@ class FSDPParam:
     def to_unsharded(self) -> None:
         # Assume that the data has been allocated and all-gathered
         set_requires_grad_if_needed(self.sharded_param, self._unsharded_param)
+        if self.is_spmd_types:
+            self._restore_spmd_types(self._unsharded_param)
         self._setattr_on_modules(self._unsharded_param)
         if self.sharded_state == ShardedState.SHARDED_POST_FORWARD:
             # The data is allocated in the default stream via the post-forward
@@ -932,6 +1090,23 @@ class FSDPParam:
         return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
+        if self.is_spmd_types:
+            if self._unsharded_dtensor_spec is None:
+                raise AssertionError(
+                    "Expected _unsharded_dtensor_spec for spmd_types param"
+                )
+            grad = DTensor.from_local(
+                grad,
+                self._unsharded_dtensor_spec.mesh,
+                tuple(self._spmd_grad_placements),
+                run_check=False,
+            )
+            if not self.is_dtensor:
+                raise AssertionError(
+                    "Expected spmd_types -> DTensor wrapping to use the DTensor gradient "
+                    "path for correct gradient redistribution."
+                )
+
         if self.is_dtensor:
             if isinstance(grad, AsyncCollectiveTensor):
                 grad = grad.wait()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -904,8 +904,6 @@ class FSDPParam:
     def to_unsharded(self) -> None:
         # Assume that the data has been allocated and all-gathered
         set_requires_grad_if_needed(self.sharded_param, self._unsharded_param)
-        if self.is_spmd_types:
-            self._restore_spmd_types(self._unsharded_param)
         self._setattr_on_modules(self._unsharded_param)
         if self.sharded_state == ShardedState.SHARDED_POST_FORWARD:
             # The data is allocated in the default stream via the post-forward

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -552,6 +552,8 @@ class FSDPParamGroup:
                 self._training_state = TrainingState.FORWARD
                 self.unshard(self.unshard_async_op)
                 self.wait_for_unshard()
+            for fsdp_param in self.fsdp_params:
+                fsdp_param._restore_spmd_types(fsdp_param.unsharded_param)
             if entering_forward_pass:
                 args, kwargs = self._register_post_backward_hook(args, kwargs)
             return args, kwargs
@@ -1151,3 +1153,9 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
         # Drop the non-tensor param_group tangent. The output pre-backward hook
         # queues final post-backward after all primal/tangent paths finish.
         return grad_inputs
+
+
+if dist._is_spmd_types_available():
+    import spmd_types
+
+    spmd_types.register_local_autograd_function(RegisterPostBackwardFunction)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -290,10 +290,10 @@ class FSDPState(_State):
     def _pre_forward(
         self, module: nn.Module, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        with _spmd_no_typecheck():
-            # When composing with module-hook-based activation checkpointing, the
-            # pre-backward hook is responsible for the unshard
-            if self._training_state == TrainingState.PRE_BACKWARD:
+        # When composing with module-hook-based activation checkpointing, the
+        # pre-backward hook is responsible for the unshard
+        if self._training_state == TrainingState.PRE_BACKWARD:
+            with _spmd_no_typecheck():
                 # With nested FSDP and multiple forward passes before backward,
                 # the params might have been resharded by a previous post_backward.
                 # We need to ensure params are unsharded for AC recomputation.
@@ -301,25 +301,31 @@ class FSDPState(_State):
                     if not fsdp_param_group.is_unsharded:
                         fsdp_param_group.unshard()
                         fsdp_param_group.wait_for_unshard()
-                return self._cast_forward_inputs(args, kwargs)
-            # With grouped ``fully_shard([a, b, ...])`` the pre-hook fires per
-            # module (so ``cast_forward_inputs`` and ``fsdp_param_group.pre_forward``
-            # run for each). Root setup and forward prefetch are one-shot, gated
-            # on the first module's entry.
+            for fsdp_param_group in self._fsdp_param_groups:
+                for fsdp_param in fsdp_param_group.fsdp_params:
+                    fsdp_param._restore_spmd_types(fsdp_param.unsharded_param)
+            return self._cast_forward_inputs(args, kwargs)
+
+        # With grouped ``fully_shard([a, b, ...])`` the pre-hook fires per
+        # module (so ``cast_forward_inputs`` and ``fsdp_param_group.pre_forward``
+        # run for each). Root setup and forward prefetch are one-shot, gated
+        # on the first module's entry.
+        with _spmd_no_typecheck():
             state_first_in_pass = self._training_state != TrainingState.FORWARD
             self._training_state = TrainingState.FORWARD
             if state_first_in_pass:
                 args, kwargs = self._root_pre_forward(module, args, kwargs)
-            args, kwargs = self._cast_forward_inputs(args, kwargs)
-            for fsdp_param_group in self._fsdp_param_groups:
-                args, kwargs = fsdp_param_group.pre_forward(module, args, kwargs)
+        args, kwargs = self._cast_forward_inputs(args, kwargs)
+        for fsdp_param_group in self._fsdp_param_groups:
+            args, kwargs = fsdp_param_group.pre_forward(module, args, kwargs)
+        with _spmd_no_typecheck():
             if state_first_in_pass:
                 for fsdp_state in self._states_to_forward_prefetch:
                     # Forward order (not reversed) to match forward execution
                     # order; contrast with reversed() in _pre_backward.
                     for target_param_group in fsdp_state._fsdp_param_groups:
                         FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
-            return args, kwargs
+        return args, kwargs
 
     @_dynamo_disable
     def _post_forward(self, module: nn.Module, input: Any, output: Any) -> Any:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187386

FSDP now recognizes spmd_types-annotated plain parameters on a named full SPMD mesh, translates their compute-time metadata into DTensor storage placements before sharding, and restores the saved local spmd_types metadata on the unsharded plain parameter for module compute.

This version takes the explicit-annotation path for dense and sparse composition: parameters must already carry annotations whose axes span the same process set as the FSDP storage mesh. FSDP validates that FSDP-managed DP axes are R, maps non-FSDP axes directly to storage mesh axes, and does not infer missing compute axes from spmd.current_mesh. This keeps the calling convention unchanged and avoids coupling parameter restore to the ambient mesh active during pre-forward.

Gradient handling derives backward placements from the saved forward SPMD type, wraps plain gradients as DTensors, and then uses the existing DTensor/FSDP gradient path so non-DP redistributions happen in DTensor form while DP reduction stays with FSDP.

Test Plan:

```bash
lintrunner -a
python -m py_compile torch/distributed/fsdp/_fully_shard/_fsdp_param.py torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py torch/distributed/fsdp/_fully_shard/_fsdp_state.py test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
python test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
```

lintrunner -a applied local patches but did not complete because PYREFLY and FLAKE8 attempted to fetch dependencies from PyPI and DNS resolution failed in this environment.

Authored with the assistance of an AI assistant.