### PR TITLE
[export][serde] Serialize SymBoolArgument in graph input/output specs (#187391)

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -34,7 +34,7 @@ inception_v3,pass,6
 
 
 
-mobilenetv2_100,pass,7
+mobilenetv2_100,pass,0
 
 
 
@@ -58,7 +58,7 @@ swin_base_patch4_window7_224,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -90,11 +90,11 @@ microbench_unbacked_tolist_sum,pass,9
 
 
 
-mnasnet1_0,pass,7
+mnasnet1_0,pass,0
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,0
 
 
 
@@ -162,7 +162,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -1605,6 +1605,21 @@ class TestDeserialize(TestCase):
         f = Module()
         self.check_graph(f, (torch.ones(1), torch.ones(3)))
 
+    def test_sym_bool_output_spec(self):
+        # A SymBool returned as a graph output is recorded as a SymBoolArgument in
+        # the output spec, which exercises (de)serialize_argument_spec. Before the
+        # SymBoolArgument branch was added there, this raised AssertionError("TODO").
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return x + 1, x.shape[0] > 4
+
+        dim0 = torch.export.Dim("dim0")
+        self.check_graph(
+            Module(),
+            (torch.ones(6),),
+            dynamic_shapes={"x": {0: dim0}},
+        )
+
     def test_sym_bool_torch_check_equal(self):
         class Module(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1839,6 +1839,8 @@ class GraphModuleSerializer(metaclass=Final):
             return Argument.create(as_sym_int=SymIntArgument.create(as_name=x.name))
         elif isinstance(x, ep.SymFloatArgument):
             return Argument.create(as_sym_float=SymFloatArgument.create(as_name=x.name))
+        elif isinstance(x, ep.SymBoolArgument):
+            return Argument.create(as_sym_bool=SymBoolArgument.create(as_name=x.name))
         elif isinstance(x, ep.ConstantArgument):
             return self.serialize_input(x.value)
         elif isinstance(x, ep.CustomObjArgument):
@@ -3498,6 +3500,8 @@ class GraphModuleDeserializer(metaclass=Final):
             return ep.SymIntArgument(name=x.as_sym_int.as_name)
         elif x.type == "as_sym_float":
             return ep.SymFloatArgument(name=x.as_sym_float.as_name)
+        elif x.type == "as_sym_bool":
+            return ep.SymBoolArgument(name=x.as_sym_bool.as_name)
         elif x.type == "as_custom_obj":
             return ep.ConstantArgument(
                 name=x.as_custom_obj.name, value=self.deserialize_input(x)
@@ -4250,6 +4254,14 @@ def canonicalize(
                     pass
                 else:
                     raise AssertionError(f"Unknown sym_float type: {f}")
+            elif arg.type == "as_sym_bool":
+                b = arg.as_sym_bool
+                if b.type == "as_name":
+                    b.as_name = replace_table[b.as_name]
+                elif b.type == "as_bool":
+                    pass
+                else:
+                    raise AssertionError(f"Unknown sym_bool type: {b}")
             elif arg.type in (
                 "as_none",
                 "as_bool",
@@ -4306,6 +4318,14 @@ def canonicalize(
                     pass
                 else:
                     raise AssertionError(f"Unknown sym_float type: {f}")
+            elif arg.type == "as_sym_bool":
+                b = arg.as_sym_bool
+                if b.type == "as_name":
+                    b.as_name = replace_table[b.as_name]
+                elif b.type == "as_bool":
+                    pass
+                else:
+                    raise AssertionError(f"Unknown sym_bool type: {b}")
             elif arg.type in ("as_none", "as_bool", "as_int", "as_float", "as_string"):
                 return
             else:


### PR DESCRIPTION
Summary:

`GraphModuleSerializer.serialize_argument_spec` and its `deserialize_argument_spec` counterpart handled `TensorArgument`, `SymIntArgument`, `SymFloatArgument`, `ConstantArgument`, and `CustomObjArgument`, but not `SymBoolArgument`. When an exported program has a `SymBool` graph input/output (e.g. a module that returns `x.shape[0] > 4`), serialization fell through to `raise AssertionError("TODO")`, and deserialization silently degraded the spec to a `ConstantArgument`.

This surfaced during a Sigmoid IR re-export of an Ads model submodule whose graph output was a `SymBool`, where it appeared only as the opaque `AssertionError: TODO`.

Add the missing `SymBoolArgument` branch to both `serialize_argument_spec` and `deserialize_argument_spec`, mirroring the existing `SymIntArgument`/`SymFloatArgument` handling. The serde schema already defines the `as_sym_bool` / `SymBoolArgument` variant (used by `serialize_argument` for node arguments), so this only closes the input/output-spec gap.

Test Plan:
buck2 test //caffe2/test:test_export -- --regex 'test_sym_bool_output_spec'

Added `TestDeserialize.test_sym_bool_output_spec`, which round-trips (serialize then deserialize) an exported program whose output is a `SymBool` and asserts the outputs match. It fails on trunk with `AssertionError: TODO` and passes with this change.

Authored with assistance from Claude Code.

Reviewed By: angelayi

Differential Revision: D108673098




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98