### PR TITLE
[dynamo] add exception fetch/restore to ExceptionStack, unify base call_obj_hasattr

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -56,6 +56,54 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)()
         self.assertFalse(result)
 
+    def test_hasattr_constant_true(self):
+        def fn():
+            return hasattr("hello", "upper")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertTrue(result)
+
+    def test_hasattr_false_then_access(self):
+        """hasattr returning False must not leak exception state."""
+
+        def fn(x):
+            _ = hasattr(42, "nonexistent")
+            return x.shape[0]
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(5))
+        self.assertEqual(result, 5)
+
+    def test_hasattr_sequence(self):
+        """Multiple hasattr calls must each restore exception state."""
+
+        def fn():
+            a = hasattr(42, "__add__")
+            b = hasattr(42, "nonexistent")
+            c = hasattr("hi", "upper")
+            d = hasattr("hi", "nonexistent")
+            return (a, b, c, d)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertEqual(result, (True, False, True, False))
+
+    def test_hasattr_false_in_except(self):
+        """hasattr inside an except block must preserve the active exception."""
+        import sys
+
+        def fn(x):
+            try:
+                raise ValueError("test")
+            except ValueError:
+                has = hasattr(42, "nonexistent")
+                exc_type = sys.exc_info()[0]
+                if not has and exc_type is ValueError:
+                    return x + 1
+            return x
+
+        x = torch.randn(3)
+        result = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(result, x + 1)
+
     # --- Tensor attributes ---
 
     def test_tensor_shape(self):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1258,6 +1258,16 @@ class ExceptionStack:
     def clear_current_exception(self) -> None:
         self._current_exception = None
 
+    def fetch_current_exception(self) -> ExceptionVals | None:
+        # PyErr_Fetch: atomically read and clear the error indicator.
+        saved = self._current_exception
+        self._current_exception = None
+        return saved
+
+    def restore_current_exception(self, saved: ExceptionVals | None) -> None:
+        # PyErr_Restore: set the error indicator to a previously fetched value.
+        self._current_exception = saved
+
     def set_current_exception(
         self, val: ExceptionVals, set_context: bool = True
     ) -> None:

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -693,15 +693,35 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def call_obj_hasattr(
         self, tx: InstructionTranslatorBase, name: str
     ) -> ConstantVariable:
-        unimplemented(
-            gb_type="Unsupported hasattr call",
-            context=f"call_obj_hasattr {self} {name}",
-            explanation=f"Dynamo does not know how to trace the function `{self.debug_repr()}`",
-            hints=[
-                f"Avoid calling `hasattr({self.__class__.__name__}, {name})` in your code.",
-                *graph_break_hints.SUPPORTABLE,
-            ],
-        )
+        """Dynamo's hasattr(): try getattro_impl, catch AttributeError.
+
+        Mirrors CPython's PyObject_HasAttr: call PyObject_GetAttr (full
+        attribute access including descriptors/__getattr__), suppress
+        AttributeError, return True/False.
+        """
+        from ..exc import ObservedAttributeError, Unsupported
+
+        saved_exc = tx.exn_vt_stack.fetch_current_exception()
+        try:
+            try:
+                self.getattro_impl(tx, name)
+                return variables.ConstantVariable.create(True)
+            except ObservedAttributeError:
+                return variables.ConstantVariable.create(False)
+            except (NotImplementedError, Unsupported):
+                pass
+
+            unimplemented(
+                gb_type="Unsupported hasattr call",
+                context=f"call_obj_hasattr {self} {name}",
+                explanation=f"Dynamo does not know how to trace the function `{self.debug_repr()}`",
+                hints=[
+                    f"Avoid calling `hasattr({self.__class__.__name__}, {name})` in your code.",
+                    *graph_break_hints.SUPPORTABLE,
+                ],
+            )
+        finally:
+            tx.exn_vt_stack.restore_current_exception(saved_exc)
 
     def tp_iter_impl(self, tx: InstructionTranslatorBase) -> VariableTracker:
         """

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -12,7 +12,6 @@ import enum
 import operator
 from collections.abc import Iterable
 from typing import Any, Literal, overload, TYPE_CHECKING
-from typing_extensions import override
 
 import torch
 from torch._dynamo.source import GetItemSource
@@ -448,13 +447,6 @@ class ConstantVariable(VariableTracker):
 
     def reconstruct_pycode(self, codegen) -> str:
         return repr(self.value)
-
-    @override
-    def call_obj_hasattr(
-        self, tx: InstructionTranslatorBase, name: str
-    ) -> ConstantVariable:
-        result = hasattr(self.value, name)
-        return variables.ConstantVariable.create(result)
 
     def is_python_equal(self, other: object) -> bool:
         from .tensor import SymNodeVariable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187226
* __->__ #187392
* #187200
* #187196
* #187113
* #186013

Add fetch_current_exception/restore_current_exception to ExceptionStack,
mirroring CPython's PyErr_Fetch/PyErr_Restore. fetch atomically reads and
clears the error indicator; restore sets it back. These are the C-level
exception save/restore primitives, complementing the bytecode-level
PUSH_EXC_INFO/POP_EXCEPT that operate on the exception stack.

Use this to rewrite the base call_obj_hasattr to mirror CPython's
PyObject_HasAttr: call getattro_impl (the Dynamo equivalent of
PyObject_GetAttr), catch ObservedAttributeError and return False,
return True on success. A try/finally ensures the error indicator is
always restored regardless of the outcome.

Remove ConstantVariable.call_obj_hasattr since the base now handles it
via object_generic_getattr's MRO walk.

Test Plan:
```
python test/dynamo/test_tp_getattro.py -v  # 57 OK
python test/dynamo/test_misc.py MiscTests -v  # 743 OK
python test/dynamo/test_functions.py -v  # 516 OK
```

Co-authored-by: Claude <noreply@anthropic.com>