### PR TITLE
handle foreign unbacked symint in wrap literal

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9508,7 +9508,6 @@ class GraphModule(torch.nn.Module):
 
     # unbacked symint inputs are created during non-strict export,
     # which causes a graph break
-    @unittest.expectedFailure
     def test_cond_unbacked_symint_closure(self):
         from torch.export import Dim
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6680,6 +6680,45 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
             f"Expected at least 4 unbacked dims but found {unbacked_count}",
         )
 
+    def test_flex_attention_with_unbacked_seq_len(self):
+        """
+        Regression test: flex_attention over fake tensors whose seq_len is an
+        unbacked symint must not raise GuardOnDataDependentSymNode during the
+        shape guard self-check when fed unbacked fake input.
+
+        The contiguous-stride shape guard contains expressions like
+        ``stride[0] == 8 * Max(1, size[2])``. If the python ShapeGuardPrinter
+        lowers ``Max`` to the builtin ``max``, evaluating the guard against
+        fake-tensor inputs triggers ``__bool__`` on a SymBool (``1 < u0``),
+        which raises ``GuardOnDataDependentSymNode``. Lowering to
+        ``torch.sym_max`` keeps the result as a SymInt and avoids the DDE.
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.nn.attention.flex_attention import BlockMask, flex_attention
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint()
+
+        with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True):
+            q = torch.empty((1, 1, seq, 8), device="cpu")
+            k = torch.empty((1, 1, seq, 8), device="cpu")
+            v = torch.empty((1, 1, seq, 8), device="cpu")
+            kv_num_blocks = torch.ones((1, 1, 1), dtype=torch.int32)
+            kv_indices = torch.zeros((1, 1, 1, 1), dtype=torch.int32)
+            block_mask = BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                BLOCK_SIZE=128,
+                seq_lengths=(seq, seq),
+            )
+
+            # Must not raise GuardOnDataDependentSymNode.
+            with (
+                torch.compiler._non_strict_tracing_context(),
+                torch._dynamo.config.patch(force_compile_during_fx_trace=True),
+            ):
+                flex_attention(q, k, v, block_mask=block_mask)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1591,21 +1591,14 @@ class VariableBuilder:
                     )
                 )
             else:
-                if isinstance(value, torch.SymBool):
-                    # We need to create an unbacked symint to replace the unbacked symbool.
-                    new_symint = self.tx.output.shape_env.create_unbacked_symint()
-                else:
-                    # TODO (yidi): we need to figure out a way to propagate the guards
-                    # we accumulated when tracing the subggraph to outer shape_env. For normal symints,
-                    # this is automatically done by evaluating the guards once but this
-                    # will cause data-dependent error when we evaluate the outer unbacked symints.
-                    # The test case that triggers this graph break is test_cond_unbacked_symint_closure
-                    unimplemented(
-                        gb_type="Attempted to wrap unbacked SymInt",
-                        context="",
-                        explanation="Unbacked SymInt input is not supported yet.",
-                        hints=[*graph_break_hints.SUPPORTABLE],
-                    )
+                new_symint = self.tx.output.shape_env.create_unbacked_symint()
+                foreign_env = value.node.shape_env
+                if foreign_env is not None:
+                    opt_hint = foreign_env.var_to_hint_override.get(value.node.expr)
+                    if opt_hint is not None:
+                        self.tx.output.shape_env.var_to_hint_override[
+                            new_symint.node.expr
+                        ] = opt_hint
             if new_symint is None:
                 raise AssertionError("new_symint must not be None after wrapping")
             if not isinstance(new_symint, SymInt):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2918,6 +2918,33 @@ class ShapeGuardPythonPrinter(_ShapeGuardPrinter, PythonPrinter):
             self._print_cache[expr] = res
             return res
 
+    # Override Max/Min to emit torch.sym_max / torch.sym_min instead of the
+    # builtin max/min. The builtins call __bool__ on a SymBool internally
+    # (e.g. `if a < b:`), which raises GuardOnDataDependentSymNode when an
+    # arg is an unbacked SymInt. torch.sym_max / torch.sym_min dispatch
+    # through __sym_max__ / __sym_min__ on the SymInt and return a SymInt
+    # without going through __bool__. On real tensors at runtime the args
+    # are concrete ints and torch.sym_max falls back to builtins.max.
+    def _print_Max(self, expr: sympy.Expr) -> str:
+        if len(expr.args) < 2:
+            raise AssertionError("Max expects at least two arguments")
+        # pyrefly: ignore [missing-attribute]
+        out = self._print(expr.args[-1])
+        for arg in reversed(expr.args[:-1]):
+            # pyrefly: ignore [missing-attribute]
+            out = f"torch.sym_max({self._print(arg)}, {out})"
+        return out
+
+    def _print_Min(self, expr: sympy.Expr) -> str:
+        if len(expr.args) < 2:
+            raise AssertionError("Min expects at least two arguments")
+        # pyrefly: ignore [missing-attribute]
+        out = self._print(expr.args[-1])
+        for arg in reversed(expr.args[:-1]):
+            # pyrefly: ignore [missing-attribute]
+            out = f"torch.sym_min({self._print(arg)}, {out})"
+        return out
+
 
 @deprecated(
     "`torch.fx.experimental.symbolic_shapes.ShapeGuardPrinter` is deprecated, "
@@ -4888,6 +4915,12 @@ class ShapeEnv:
         # doesn't appear as a dim itself (e.g., size=[u0//2, u0//4]), the
         # relationship between dims is lost — each gets an independent symbol.
         # This is acceptable as this case is rare in practice.
+        # TODO: make `old_to_new` a tracer-global cache (instead of per-call)
+        # so a foreign symbol shared across wraps maps to the same outer
+        # symbol, preserving cross-input and derived-expression relations
+        # (e.g. `t1.shape[0] == t2.shape[0]`, size=[u0//2, u0//4]).
+        # TODO: transfer value ranges from old to new shapeenv, do that also
+        # in wrap literal.
         old_to_new: dict[sympy.Expr, sympy.Expr] = {}
         new_size_exprs: list[sympy.Expr] = []
         for i, old_sz in enumerate(sizes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187393

1. Use torch.sym_max / torch.sym_min in shape-guard codegen to avoid DDE. ShapeGuardPythonPrinter previously emitted builtin max(1, _var6), which calls SymBool.__bool__ on unbacked SymInts when the input to the compile region is fake tensor with unbacked symbols. 


2. Handle foreign unbacked literals when wrapping into the current ShapeEnv. When a user-provided unbacked SymInt/SymBool from a foreign ShapeEnv is wrapped as a literal in dynamo's builder, mint a fresh unbacked symint in the current env and carry over the foreign env's var_to_hint_override so the new symbol keeps the user-supplied hint.