### PR TITLE
[spmd_types] Restore FSDP params from init compute mesh

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -1,0 +1,598 @@
+# Owner(s): ["oncall: distributed"]
+
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import (
+    DataParallelMeshDims,
+    fully_shard,
+    MixedPrecisionPolicy,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_common import (
+    FSDPMeshInfo,
+    ShardPlacementResult,
+)
+from torch.distributed.fsdp._fully_shard._fsdp_init import _get_mesh_info
+from torch.distributed.tensor import init_device_mesh, Replicate, Shard
+from torch.distributed.tensor.debug import CommDebugMode
+from torch.distributed.tensor.placement_types import _StridedShard
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.distributed.fake_pg import FakeStore
+
+
+if dist._is_spmd_types_available():
+    import spmd_types as spmd
+    from spmd_types.checker import typecheck
+
+
+class SpmdLinear(nn.Module):
+    def __init__(self, mesh, seq_parallel: bool):
+        super().__init__()
+        self.mesh = mesh
+        self.tp_pg = mesh.get_group("tp")
+        self.seq_parallel = seq_parallel
+        self.unsharded_weight = nn.Parameter(torch.randn(16, 16))
+        self.sharded_weight = nn.Parameter(torch.randn(16, 16))
+        self.compute_param_types = None
+
+    def forward(self, x):
+        """Simulate the TP collectives around a sharded projection.
+
+        The global computation is x = x @ A; x = x @ B; return x.sum().
+        With sequence parallelism, the activation is all-gathered before the
+        sharded projection. Without it, the output is all-gathered before loss.
+        """
+        self.compute_param_types = (
+            dict(spmd.get_local_type(self.unsharded_weight)),
+            dict(spmd.get_local_type(self.sharded_weight)),
+        )
+        x = x @ self.unsharded_weight
+        x = spmd.redistribute(
+            x,
+            self.tp_pg,
+            src=spmd.S(1) if self.seq_parallel else spmd.I,
+            dst=spmd.R,
+            backward_options={"op_dtype": torch.float32},
+        )
+        x = x @ self.sharded_weight.t()
+        x = spmd.redistribute(
+            x,
+            self.tp_pg,
+            src=spmd.S(2),
+            dst=spmd.I,
+            backward_options={"op_dtype": torch.float32},
+        )
+        return x.sum()
+
+
+class SpmdParamOnly(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(16, 16))
+        self.compute_param_type = None
+
+    def forward(self):
+        self.compute_param_type = dict(spmd.get_local_type(self.weight))
+        return self.weight.sum()
+
+
+@unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
+class TestFullyShardSpmdTypes(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        dist.init_process_group(
+            backend="fake", store=FakeStore(), rank=0, world_size=16
+        )
+        cls.type_mesh = init_device_mesh(
+            "cpu", (4, 2, 2), mesh_dim_names=("dp", "cp", "tp")
+        )
+        cls.fsdp_mesh = init_device_mesh(
+            "cpu", (2, 2, 2, 2), mesh_dim_names=("dpr", "dps", "cp", "tp")
+        )
+        cls.sparse_mesh = init_device_mesh(
+            "cpu", (4, 4), mesh_dim_names=("efsdp", "ep")
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDownClass()
+
+    def test_restores_param_spmd_type_for_compute(self):
+        """FSDP restores user SPMD metadata on params for compute.
+
+        FSDP should preserve the compute-mesh annotations when applied with
+        a different storage-mesh view.
+        """
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        for seq_parallel in (False, True):
+            with self.subTest(seq_parallel=seq_parallel):
+                model = SpmdLinear(self.type_mesh, seq_parallel)
+                spmd.assert_type(
+                    model.unsharded_weight,
+                    {
+                        dp_axis: spmd.R,
+                        cp_axis: spmd.R,
+                        tp_axis: spmd.R if seq_parallel else spmd.I,
+                    },
+                )
+                spmd.assert_type(
+                    model.sharded_weight,
+                    {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.S(0)},
+                )
+
+                # FSDP turns params into DTensor, in this case should contain StridedShard @ dps
+                with spmd.set_current_mesh(self.type_mesh):
+                    fully_shard(
+                        model,
+                        mesh=self.fsdp_mesh,
+                        dp_mesh_dims=DataParallelMeshDims(
+                            shard=("dps", "cp"),
+                            replicate="dpr",
+                        ),
+                        mp_policy=MixedPrecisionPolicy(
+                            param_dtype=torch.bfloat16,
+                            reduce_dtype=torch.float32,
+                            cast_forward_inputs=True,
+                        ),
+                    )
+                self.assertEqual(
+                    model.sharded_weight._spec.placements,
+                    (
+                        Replicate(),
+                        _StridedShard(0, split_factor=self.type_mesh["tp"].size()),
+                        Shard(0),
+                    ),
+                )
+
+                # annotate model inputs as V + PartitionSpec
+                inp = torch.randn(4, 8, 16)
+                input_type = {
+                    dp_axis: spmd.V,
+                    cp_axis: spmd.V,
+                    tp_axis: spmd.V if seq_parallel else spmd.I,
+                }
+                input_partition_spec = spmd.PartitionSpec(
+                    dp_axis,
+                    (cp_axis, tp_axis) if seq_parallel else cp_axis,
+                    None,
+                )
+
+                # check loss output type, check compute-time param annotations are restored.
+                with (
+                    spmd.set_current_mesh(self.type_mesh),
+                    typecheck(strict_mode="strict", local=False),
+                ):
+                    spmd.assert_type(
+                        inp,
+                        input_type,
+                        partition_spec=input_partition_spec,
+                    )
+                    loss = model(inp)
+                    spmd.assert_type(
+                        loss,
+                        {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
+                    )
+                self.assertEqual(
+                    model.compute_param_types,
+                    (
+                        {
+                            dp_axis: spmd.R,
+                            cp_axis: spmd.R,
+                            tp_axis: spmd.R if seq_parallel else spmd.I,
+                        },
+                        {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+                    ),
+                )
+
+                with CommDebugMode() as comm_mode:
+                    loss.backward()
+                comm_counts = comm_mode.get_comm_counts()
+                if seq_parallel:
+                    self.assertEqual(
+                        comm_counts[torch.ops.c10d._reduce_scatter_base_], 2
+                    )
+                else:
+                    self.assertEqual(
+                        comm_counts[torch.ops.c10d._reduce_scatter_base_], 1
+                    )
+                self.assertEqual(
+                    comm_counts[torch.ops.c10d.allreduce_]
+                    + comm_counts[torch.ops.c10d_functional.all_reduce],
+                    2,
+                )
+
+    def test_local_v_param_requires_partition_spec(self):
+        """Local-only V@TP params are ambiguous for FSDP.
+
+        Without PartitionSpec shard info, FSDP cannot choose the matching
+        DTensor Shard(dim), so it rejects the parameter at init time.
+        """
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.I},
+            )
+            spmd.assert_type(
+                model.sharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.V},
+            )
+        with self.assertRaises(ValueError) as cm, spmd.set_current_mesh(self.type_mesh):
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            """Cannot convert plain Varying to a DTensor placement. Use S(dim) to specify which tensor dimension is sharded.""",
+        )
+
+    def test_partial_param_annotations_infer_fsdp_axes_at_compute(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+
+        spmd.assert_type(
+            model.unsharded_weight,
+            {tp_axis: spmd.I},
+        )
+        spmd.assert_type(
+            model.sharded_weight,
+            {tp_axis: spmd.S(0)},
+        )
+        with spmd.set_current_mesh(self.type_mesh):
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+
+        inp = torch.randn(4, 8, 16)
+        with (
+            spmd.set_current_mesh(self.type_mesh),
+            typecheck(strict_mode="strict", local=False),
+        ):
+            spmd.assert_type(
+                inp,
+                {dp_axis: spmd.V, cp_axis: spmd.V, tp_axis: spmd.I},
+                partition_spec=spmd.PartitionSpec(dp_axis, cp_axis, None),
+            )
+            loss = model(inp)
+            spmd.assert_type(
+                loss,
+                {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
+            )
+        self.assertEqual(
+            model.compute_param_types,
+            (
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.I},
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+            ),
+        )
+
+    def test_shard_placement_result_spmd_compute_mesh_infers_fsdp_axes(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        spmd.assert_type(model.unsharded_weight, {tp_axis: spmd.I})
+        spmd.assert_type(model.sharded_weight, {tp_axis: spmd.S(0)})
+
+        mesh_info = _get_mesh_info(
+            self.fsdp_mesh,
+            DataParallelMeshDims(shard=("dps", "cp"), replicate="dpr"),
+        )
+        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+
+        def shard_placement_fn(param):
+            return ShardPlacementResult(
+                placement=Shard(0),
+                mesh_info=mesh_info,
+                spmd_compute_mesh=self.type_mesh,
+            )
+
+        fully_shard(
+            model,
+            mesh=self.fsdp_mesh,
+            dp_mesh_dims=DataParallelMeshDims(
+                shard=("dps", "cp"),
+                replicate="dpr",
+            ),
+            shard_placement_fn=shard_placement_fn,
+        )
+
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        inp = torch.randn(4, 8, 16)
+        with (
+            spmd.set_current_mesh(self.type_mesh),
+            typecheck(strict_mode="strict", local=False),
+        ):
+            spmd.assert_type(
+                inp,
+                {dp_axis: spmd.V, cp_axis: spmd.V, tp_axis: spmd.I},
+                partition_spec=spmd.PartitionSpec(dp_axis, cp_axis, None),
+            )
+            loss = model(inp)
+            spmd.assert_type(
+                loss,
+                {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
+            )
+        self.assertEqual(
+            model.compute_param_types,
+            (
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.I},
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+            ),
+        )
+
+    def test_spmd_compute_mesh_axes_must_match_annotations(self):
+        model = SpmdParamOnly()
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        spmd.assert_type(model.weight, {tp_axis: spmd.I})
+
+        mesh_info = _get_mesh_info(
+            self.fsdp_mesh,
+            DataParallelMeshDims(shard=("dps", "cp"), replicate="dpr"),
+        )
+        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+
+        def shard_placement_fn(param):
+            return ShardPlacementResult(
+                placement=Shard(0),
+                mesh_info=mesh_info,
+                spmd_compute_mesh=self.sparse_mesh,
+            )
+
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+                shard_placement_fn=shard_placement_fn,
+            )
+        self.assertIn(
+            "annotations on axes that are not in the resolved typechecking mesh",
+            str(cm.exception),
+        )
+
+    def test_spmd_compute_mesh_must_span_storage_mesh(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        spmd.assert_type(model.unsharded_weight, {tp_axis: spmd.I})
+
+        mesh_info = _get_mesh_info(
+            self.fsdp_mesh,
+            DataParallelMeshDims(shard=("dps", "cp"), replicate="dpr"),
+        )
+        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+
+        def shard_placement_fn(param):
+            return ShardPlacementResult(
+                placement=Shard(0),
+                mesh_info=mesh_info,
+                spmd_compute_mesh=self.type_mesh["tp"],
+            )
+
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+                shard_placement_fn=shard_placement_fn,
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "Parameter 'unsharded_weight' uses spmd_types annotations on a "
+            "typechecking mesh that does not span the same ranks as its FSDP "
+            "storage mesh. FSDP can fill omitted FSDP-managed axes only when "
+            "these meshes span the same rank set. Typechecking mesh axes: "
+            "(mesh_tp,). Storage mesh axes: (mesh_dpr, mesh_dps, mesh_cp, "
+            "mesh_tp).",
+        )
+
+    def test_spmd_compute_mesh_same_size_different_span_errors(self):
+        model = SpmdParamOnly()
+        compute_mesh = DeviceMesh(
+            "cpu",
+            torch.arange(0, 16, 2),
+            mesh_dim_names=("even",),
+        )
+        compute_axis = spmd.MeshAxis.of(compute_mesh.get_group("even"))
+        spmd.assert_type(model.weight, {compute_axis: spmd.I})
+
+        storage_mesh = DeviceMesh(
+            "cpu",
+            torch.arange(8).reshape(2, 2, 2),
+            mesh_dim_names=("half_dpr", "half_dps", "half_tp"),
+        )
+        mesh_info = _get_mesh_info(
+            storage_mesh,
+            DataParallelMeshDims(shard="half_dps", replicate="half_dpr"),
+        )
+        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+
+        def shard_placement_fn(param):
+            return ShardPlacementResult(
+                placement=Shard(0),
+                mesh_info=mesh_info,
+                spmd_compute_mesh=compute_mesh,
+            )
+
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=storage_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard="half_dps",
+                    replicate="half_dpr",
+                ),
+                shard_placement_fn=shard_placement_fn,
+            )
+        self.assertIn(
+            "FSDP can fill omitted FSDP-managed axes only when these meshes "
+            "span the same rank set.",
+            str(cm.exception),
+        )
+
+    def test_shard_placement_fn_defaults_compute_mesh_to_storage_mesh(self):
+        model = SpmdParamOnly()
+        efsdp_axis = spmd.MeshAxis.of(self.sparse_mesh.get_group("efsdp"))
+        ep_axis = spmd.MeshAxis.of(self.sparse_mesh.get_group("ep"))
+        spmd.assert_type(model.weight, {ep_axis: spmd.S(0)})
+
+        mesh_info = _get_mesh_info(
+            self.sparse_mesh,
+            DataParallelMeshDims(shard="efsdp"),
+        )
+        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+
+        def shard_placement_fn(param):
+            return ShardPlacementResult(
+                placement=Shard(0),
+                mesh_info=mesh_info,
+            )
+
+        fully_shard(
+            model,
+            mesh=self.sparse_mesh,
+            dp_mesh_dims=DataParallelMeshDims(shard="efsdp"),
+            shard_placement_fn=shard_placement_fn,
+        )
+
+        with (
+            spmd.set_current_mesh(self.sparse_mesh),
+            typecheck(strict_mode="strict", local=False),
+        ):
+            out = model()
+            spmd.assert_type(out, {efsdp_axis: spmd.R, ep_axis: spmd.P})
+        self.assertEqual(
+            model.compute_param_type,
+            {efsdp_axis: spmd.R, ep_axis: spmd.V},
+        )
+
+    def test_spmd_params_require_dp_mesh_dims(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.I},
+            )
+        with self.assertRaises(ValueError) as cm, spmd.set_current_mesh(self.type_mesh):
+            fully_shard(model, mesh=self.type_mesh["dp"])
+        self.assertExpectedInline(
+            str(cm.exception),
+            "spmd_types parameters require a named SPMD mesh "
+            "(pass dp_mesh_dims to fully_shard)",
+        )
+
+    def test_partial_param_annotations_require_init_compute_mesh(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        spmd.assert_type(model.unsharded_weight, {tp_axis: spmd.I})
+
+        with self.assertRaises(ValueError) as cm:
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "spmd_types parameters require an init-time compute mesh for FSDP "
+            "annotation restore. If all parameters in the FSDP unit share a "
+            "typechecking mesh, wrap fully_shard() in spmd.set_current_mesh(). "
+            "For mixed parameter groups, set DataParallelMeshInfo.spmd_mesh "
+            "or FSDPMeshInfo.spmd_mesh when the typechecking mesh matches the "
+            "FSDP storage mesh, or set ShardPlacementResult.spmd_compute_mesh "
+            "when the typechecking and storage meshes differ.",
+        )
+
+    def test_partial_param_annotations_missing_non_fsdp_axis_errors(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+
+        spmd.assert_type(
+            model.unsharded_weight,
+            {dp_axis: spmd.R, cp_axis: spmd.R},
+        )
+        spmd.assert_type(
+            model.sharded_weight,
+            {tp_axis: spmd.S(0)},
+        )
+        with self.assertRaises(ValueError) as cm, spmd.set_current_mesh(self.type_mesh):
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "Parameter 'unsharded_weight' has incomplete spmd_types annotations "
+            "for FSDP storage. Annotated axes: (mesh_dp, mesh_cp). Storage "
+            "mesh axes: (mesh_dpr, mesh_dps, mesh_cp, mesh_tp). FSDP mesh "
+            "dims: DataParallelMeshDims(shard=('dps', 'cp'), "
+            "replicate='dpr'). Missing non-FSDP storage axes: "
+            "(mesh_tp,).",
+        )
+
+    def test_fsdp_dp_axes_must_be_r(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+
+        with spmd.set_current_mesh(self.type_mesh):
+            spmd.assert_type(
+                model.unsharded_weight,
+                {"dp": spmd.I, "cp": spmd.R, "tp": spmd.I},
+            )
+        with self.assertRaises(ValueError) as cm, spmd.set_current_mesh(self.type_mesh):
+            fully_shard(
+                model,
+                mesh=self.fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(
+                    shard=("dps", "cp"),
+                    replicate="dpr",
+                ),
+            )
+        self.assertExpectedInline(
+            str(cm.exception),
+            "Expected spmd.R on FSDP DP axis mesh_dp for parameter "
+            "'unsharded_weight' but got PerMeshAxisLocalSpmdType.I. FSDP "
+            "requires DP parameters to be R since it handles the DP gradient "
+            "reduction.",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -79,6 +79,21 @@ class SpmdParamOnly(nn.Module):
         return self.weight.sum()
 
 
+class DenseSparseParams(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense_weight = nn.Parameter(torch.randn(16, 16))
+        self.sparse_weight = nn.Parameter(torch.randn(16, 16))
+        self.compute_param_types = None
+
+    def forward(self):
+        self.compute_param_types = (
+            dict(spmd.get_local_type(self.dense_weight)),
+            dict(spmd.get_local_type(self.sparse_weight)),
+        )
+        return self.dense_weight.sum(), self.sparse_weight.sum()
+
+
 @unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
 class TestFullyShardSpmdTypes(TestCase):
     @classmethod
@@ -97,6 +112,9 @@ class TestFullyShardSpmdTypes(TestCase):
         )
         cls.sparse_mesh = init_device_mesh(
             "cpu", (4, 4), mesh_dim_names=("efsdp", "ep")
+        )
+        cls.sparse_compute_mesh = init_device_mesh(
+            "cpu", (2, 2, 4), mesh_dim_names=("sdp", "scp", "ep")
         )
 
     @classmethod
@@ -211,6 +229,52 @@ class TestFullyShardSpmdTypes(TestCase):
                     2,
                 )
 
+    def test_full_param_annotations_do_not_require_init_compute_mesh(self):
+        model = SpmdLinear(self.type_mesh, seq_parallel=False)
+        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+
+        spmd.assert_type(
+            model.unsharded_weight,
+            {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.I},
+        )
+        spmd.assert_type(
+            model.sharded_weight,
+            {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.S(0)},
+        )
+        fully_shard(
+            model,
+            mesh=self.fsdp_mesh,
+            dp_mesh_dims=DataParallelMeshDims(
+                shard=("dps", "cp"),
+                replicate="dpr",
+            ),
+        )
+
+        inp = torch.randn(4, 8, 16)
+        with (
+            spmd.set_current_mesh(self.type_mesh),
+            typecheck(strict_mode="strict", local=False),
+        ):
+            spmd.assert_type(
+                inp,
+                {dp_axis: spmd.V, cp_axis: spmd.V, tp_axis: spmd.I},
+                partition_spec=spmd.PartitionSpec(dp_axis, cp_axis, None),
+            )
+            loss = model(inp)
+            spmd.assert_type(
+                loss,
+                {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
+            )
+        self.assertEqual(
+            model.compute_param_types,
+            (
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.I},
+                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+            ),
+        )
+
     def test_local_v_param_requires_partition_spec(self):
         """Local-only V@TP params are ambiguous for FSDP.
 
@@ -243,6 +307,10 @@ class TestFullyShardSpmdTypes(TestCase):
         )
 
     def test_partial_param_annotations_infer_fsdp_axes_at_compute(self):
+        """Use init-time current_mesh to restore omitted FSDP axes as R.
+
+        Params annotate only TP; FSDP fills DP/CP axes for module compute.
+        """
         model = SpmdLinear(self.type_mesh, seq_parallel=False)
         dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
         cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
@@ -276,11 +344,8 @@ class TestFullyShardSpmdTypes(TestCase):
                 {dp_axis: spmd.V, cp_axis: spmd.V, tp_axis: spmd.I},
                 partition_spec=spmd.PartitionSpec(dp_axis, cp_axis, None),
             )
-            loss = model(inp)
-            spmd.assert_type(
-                loss,
-                {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
-            )
+            model(inp)
+
         self.assertEqual(
             model.compute_param_types,
             (
@@ -289,57 +354,60 @@ class TestFullyShardSpmdTypes(TestCase):
             ),
         )
 
-    def test_shard_placement_result_spmd_compute_mesh_infers_fsdp_axes(self):
-        model = SpmdLinear(self.type_mesh, seq_parallel=False)
-        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
-        spmd.assert_type(model.unsharded_weight, {tp_axis: spmd.I})
-        spmd.assert_type(model.sharded_weight, {tp_axis: spmd.S(0)})
+    def test_mixed_dense_sparse_params_use_per_param_restore_meshes(self):
+        """Dense uses storage mesh restore; sparse uses explicit compute mesh."""
+        model = DenseSparseParams()
+        dense_dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
+        dense_cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
+        dense_tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
+        sparse_dp_axis = spmd.MeshAxis.of(self.sparse_compute_mesh.get_group("sdp"))
+        sparse_cp_axis = spmd.MeshAxis.of(self.sparse_compute_mesh.get_group("scp"))
+        sparse_ep_axis = spmd.MeshAxis.of(self.sparse_compute_mesh.get_group("ep"))
+        spmd.assert_type(model.dense_weight, {dense_tp_axis: spmd.S(0)})
+        spmd.assert_type(model.sparse_weight, {sparse_ep_axis: spmd.S(0)})
 
-        mesh_info = _get_mesh_info(
-            self.fsdp_mesh,
-            DataParallelMeshDims(shard=("dps", "cp"), replicate="dpr"),
+        dense_mesh_info = _get_mesh_info(
+            self.type_mesh,
+            DataParallelMeshDims(shard=("dp", "cp")),
         )
-        self.assertIsInstance(mesh_info, FSDPMeshInfo)
+        sparse_mesh_info = _get_mesh_info(
+            self.sparse_mesh,
+            DataParallelMeshDims(shard="efsdp"),
+        )
+        self.assertIsInstance(dense_mesh_info, FSDPMeshInfo)
+        self.assertIsInstance(sparse_mesh_info, FSDPMeshInfo)
+        sparse_param = model.sparse_weight
 
         def shard_placement_fn(param):
+            if param is sparse_param:
+                return ShardPlacementResult(
+                    placement=Shard(0),
+                    mesh_info=sparse_mesh_info,
+                    spmd_compute_mesh=self.sparse_compute_mesh,
+                )
             return ShardPlacementResult(
                 placement=Shard(0),
-                mesh_info=mesh_info,
-                spmd_compute_mesh=self.type_mesh,
+                mesh_info=dense_mesh_info,
             )
 
         fully_shard(
             model,
-            mesh=self.fsdp_mesh,
-            dp_mesh_dims=DataParallelMeshDims(
-                shard=("dps", "cp"),
-                replicate="dpr",
-            ),
+            mesh=self.type_mesh,
+            dp_mesh_dims=DataParallelMeshDims(shard=("dp", "cp")),
             shard_placement_fn=shard_placement_fn,
         )
 
-        dp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("dp"))
-        cp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("cp"))
-        inp = torch.randn(4, 8, 16)
-        with (
-            spmd.set_current_mesh(self.type_mesh),
-            typecheck(strict_mode="strict", local=False),
-        ):
-            spmd.assert_type(
-                inp,
-                {dp_axis: spmd.V, cp_axis: spmd.V, tp_axis: spmd.I},
-                partition_spec=spmd.PartitionSpec(dp_axis, cp_axis, None),
-            )
-            loss = model(inp)
-            spmd.assert_type(
-                loss,
-                {dp_axis: spmd.P, cp_axis: spmd.P, tp_axis: spmd.I},
-            )
+        with typecheck(strict_mode="strict", local=False):
+            model()
         self.assertEqual(
             model.compute_param_types,
             (
-                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.I},
-                {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.V},
+                {dense_dp_axis: spmd.R, dense_cp_axis: spmd.R, dense_tp_axis: spmd.V},
+                {
+                    sparse_dp_axis: spmd.R,
+                    sparse_cp_axis: spmd.R,
+                    sparse_ep_axis: spmd.V,
+                },
             ),
         )
 
@@ -374,44 +442,6 @@ class TestFullyShardSpmdTypes(TestCase):
         self.assertIn(
             "annotations on axes that are not in the resolved typechecking mesh",
             str(cm.exception),
-        )
-
-    def test_spmd_compute_mesh_must_span_storage_mesh(self):
-        model = SpmdLinear(self.type_mesh, seq_parallel=False)
-        tp_axis = spmd.MeshAxis.of(self.type_mesh.get_group("tp"))
-        spmd.assert_type(model.unsharded_weight, {tp_axis: spmd.I})
-
-        mesh_info = _get_mesh_info(
-            self.fsdp_mesh,
-            DataParallelMeshDims(shard=("dps", "cp"), replicate="dpr"),
-        )
-        self.assertIsInstance(mesh_info, FSDPMeshInfo)
-
-        def shard_placement_fn(param):
-            return ShardPlacementResult(
-                placement=Shard(0),
-                mesh_info=mesh_info,
-                spmd_compute_mesh=self.type_mesh["tp"],
-            )
-
-        with self.assertRaises(ValueError) as cm:
-            fully_shard(
-                model,
-                mesh=self.fsdp_mesh,
-                dp_mesh_dims=DataParallelMeshDims(
-                    shard=("dps", "cp"),
-                    replicate="dpr",
-                ),
-                shard_placement_fn=shard_placement_fn,
-            )
-        self.assertExpectedInline(
-            str(cm.exception),
-            "Parameter 'unsharded_weight' uses spmd_types annotations on a "
-            "typechecking mesh that does not span the same ranks as its FSDP "
-            "storage mesh. FSDP can fill omitted FSDP-managed axes only when "
-            "these meshes span the same rank set. Typechecking mesh axes: "
-            "(mesh_tp,). Storage mesh axes: (mesh_dpr, mesh_dps, mesh_cp, "
-            "mesh_tp).",
         )
 
     def test_spmd_compute_mesh_same_size_different_span_errors(self):
@@ -458,42 +488,6 @@ class TestFullyShardSpmdTypes(TestCase):
             str(cm.exception),
         )
 
-    def test_shard_placement_fn_defaults_compute_mesh_to_storage_mesh(self):
-        model = SpmdParamOnly()
-        efsdp_axis = spmd.MeshAxis.of(self.sparse_mesh.get_group("efsdp"))
-        ep_axis = spmd.MeshAxis.of(self.sparse_mesh.get_group("ep"))
-        spmd.assert_type(model.weight, {ep_axis: spmd.S(0)})
-
-        mesh_info = _get_mesh_info(
-            self.sparse_mesh,
-            DataParallelMeshDims(shard="efsdp"),
-        )
-        self.assertIsInstance(mesh_info, FSDPMeshInfo)
-
-        def shard_placement_fn(param):
-            return ShardPlacementResult(
-                placement=Shard(0),
-                mesh_info=mesh_info,
-            )
-
-        fully_shard(
-            model,
-            mesh=self.sparse_mesh,
-            dp_mesh_dims=DataParallelMeshDims(shard="efsdp"),
-            shard_placement_fn=shard_placement_fn,
-        )
-
-        with (
-            spmd.set_current_mesh(self.sparse_mesh),
-            typecheck(strict_mode="strict", local=False),
-        ):
-            out = model()
-            spmd.assert_type(out, {efsdp_axis: spmd.R, ep_axis: spmd.P})
-        self.assertEqual(
-            model.compute_param_type,
-            {efsdp_axis: spmd.R, ep_axis: spmd.V},
-        )
-
     def test_spmd_params_require_dp_mesh_dims(self):
         model = SpmdLinear(self.type_mesh, seq_parallel=False)
 
@@ -526,13 +520,14 @@ class TestFullyShardSpmdTypes(TestCase):
             )
         self.assertExpectedInline(
             str(cm.exception),
-            "spmd_types parameters require an init-time compute mesh for FSDP "
-            "annotation restore. If all parameters in the FSDP unit share a "
-            "typechecking mesh, wrap fully_shard() in spmd.set_current_mesh(). "
-            "For mixed parameter groups, set DataParallelMeshInfo.spmd_mesh "
-            "or FSDPMeshInfo.spmd_mesh when the typechecking mesh matches the "
-            "FSDP storage mesh, or set ShardPlacementResult.spmd_compute_mesh "
-            "when the typechecking and storage meshes differ.",
+            "Parameter 'unsharded_weight' has partial spmd_types annotations "
+            "that do not span the full FSDP storage mesh. Wrap fully_shard() "
+            "in spmd.set_current_mesh() if all parameters in the FSDP unit "
+            "share a typechecking mesh, set ShardPlacementResult.spmd_compute_mesh "
+            "when the typechecking and storage meshes differ, or set "
+            "ShardPlacementResult.mesh_info.spmd_mesh when they match. "
+            "Annotated axes: (mesh_tp,). Storage mesh axes: (mesh_dpr, "
+            "mesh_dps, mesh_cp, mesh_tp).",
         )
 
     def test_partial_param_annotations_missing_non_fsdp_axis_errors(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -196,6 +196,9 @@ def is_bw() -> bool:
 class ShardPlacementResult:
     placement: Shard | None
     mesh_info: FSDPMeshInfo
+    # Optional compute mesh for restoring partial spmd_types annotations when it
+    # differs from the per-param FSDP storage mesh.
+    spmd_compute_mesh: DeviceMesh | None = None
 
 
 ShardPlacementFnResult = Shard | ShardPlacementResult | None

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -11,7 +11,16 @@ if TYPE_CHECKING:
     from ._fsdp_api import DataParallelMeshDims
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
+
+
+if dist._is_spmd_types_available():
+    import spmd_types as spmd
+    from spmd_types._mesh_axis import flatten_axes
+    from spmd_types.runtime import get_partition_spec
+    from spmd_types.types import partition_spec_to_shard_types
+
 from torch._prims_common import make_contiguous_strides_for
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.device_mesh import DeviceMesh
@@ -32,6 +41,7 @@ from ._fsdp_common import (
     HSDPMeshInfo,
     resolve_shard_placement,
     ShardPlacementFnResult,
+    ShardPlacementResult,
 )
 
 
@@ -43,6 +53,14 @@ def _get_orig_param_uid(param: nn.Parameter) -> int:
         uid = next(_orig_param_uid_counter)
         param._fsdp_orig_uid = uid  # pyrefly: ignore[missing-attribute]
     return param._fsdp_orig_uid  # pyrefly: ignore[missing-attribute]
+
+
+def _spans_same_mesh(lhs_axes: tuple[Any, ...], rhs_axes: tuple[Any, ...]) -> bool:
+    lhs_mesh = spmd.normalize_mesh(frozenset(lhs_axes))
+    rhs_mesh = spmd.normalize_mesh(frozenset(rhs_axes))
+    if not lhs_mesh or not rhs_mesh:
+        return lhs_mesh == rhs_mesh
+    return flatten_axes(tuple(lhs_mesh)) == flatten_axes(tuple(rhs_mesh))
 
 
 """
@@ -80,6 +98,9 @@ This implies that we construct the unsharded parameter object once and write to
 it in-place thereafter. For the default ``torch.Tensor` original parameter
 case, the all-gather output and unsharded parameter share the same
 data, so we use storage resizing on the all-gather output.
+
+[Note: FSDP and spmd_types]
+Refer to https://github.com/meta-pytorch/spmd_types/blob/main/docs/local_spmd_types.md
 """
 
 lib = torch.library.Library("fsdp", "FRAGMENT")
@@ -232,13 +253,14 @@ class FSDPParam:
         shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None,
         mesh_info: DataParallelMeshInfo,
     ):
+        shard_placement_result = None
         if callable(shard_placement_fn):
-            shard_result = resolve_shard_placement(
+            shard_placement_result = resolve_shard_placement(
                 shard_placement_fn(param),
                 cast(FSDPMeshInfo, mesh_info),
             )
-            self.mesh_info = shard_result.mesh_info
-            fsdp_placement = shard_result.placement
+            self.mesh_info = shard_placement_result.mesh_info
+            fsdp_placement = shard_placement_result.placement
         else:
             self.mesh_info = mesh_info  # pyrefly: ignore[bad-assignment]
             fsdp_placement = None
@@ -265,6 +287,21 @@ class FSDPParam:
         # `distribute_tensor` after https://github.com/pytorch/pytorch/issues/116101
         # TODO: Simplify the following sharded parameter padding logic after
         # https://github.com/pytorch/pytorch/issues/113045
+        # Tracks that this parameter contained FSDP-init-time spmd_types annotations;
+        # this remains true even if spmd typechecking is disabled at runtime.
+        self.is_spmd_types = (
+            dist._is_spmd_types_available()
+            and bool(spmd.get_local_type(param))
+            and not isinstance(param, DTensor)
+        )
+        if self.is_spmd_types:
+            self._spmd_partition_spec = get_partition_spec(param)
+            self._spmd_init_local_type = spmd.get_local_type(param)
+            self._resolve_spmd_restore_mesh(shard_placement_result)
+            param = self._spmd_types_to_dtensor(
+                param,
+                self.mesh_info,
+            )
         self.is_dtensor = isinstance(param, DTensor)
         self._orig_param_uid = _get_orig_param_uid(param)
         param_data = self._init_sharding_spec(param, fsdp_placement, shard_dim)
@@ -330,6 +367,236 @@ class FSDPParam:
         # the `fully_shard` call returns to allow provided parameters to alias
         self._setattr_on_modules(self.sharded_param)
         self.sharded_state = ShardedState.SHARDED
+
+    def _spmd_types_to_dtensor(
+        self,
+        param: nn.Parameter,
+        mesh_info: DataParallelMeshInfo,
+    ) -> nn.Parameter:
+        """
+        Translate spmd_types annotations into DTensor placements for FSDP
+        storage.
+
+        The original parameter is a plain tensor annotated for module compute
+        on the typechecking mesh. FSDP stores parameters as DTensors on
+        ``mesh_info.spmd_mesh``, so init time only needs enough type information
+        to translate into DTensor placements on the storage mesh axes. Axes
+        named by ``dp_mesh_dims`` are FSDP-managed DP axes and are treated as
+        ``spmd.R``; non-FSDP storage axes must have a direct spmd_types
+        annotation.
+
+        The original compute annotations and PartitionSpec are saved. At
+        compute time, FSDP all-gathers the DTensor storage, exposes a plain
+        tensor parameter, and restores spmd_types metadata on the init-time
+        compute mesh. Missing compute axes are filled in as ``spmd.R``.
+
+        Gradients use spmd_types backward typing to choose DTensor placements:
+        for example, ``R`` becomes ``P``, while ``I`` and ``S(dim)`` stay as
+        ``I`` and ``S(dim)``. This lets FSDP handle pending non-FSDP
+        redistributions after wrapping incoming gradients as DTensors.
+        """
+        spmd_mesh = mesh_info.spmd_mesh
+        if spmd_mesh is None or spmd_mesh.mesh_dim_names is None:
+            raise AssertionError(
+                "spmd_types storage mesh should have been validated before "
+                "_spmd_types_to_dtensor"
+            )
+
+        # Infer types on the FSDP storage mesh from saved compute metadata.
+        self._spmd_restore_type = {
+            axis: self._spmd_init_local_type.get(axis, spmd.R)
+            for axis in self._spmd_restore_mesh
+        }
+        storage_axis_types = self._get_storage_mesh_axes_types(spmd_mesh, mesh_info)
+
+        # Expand storage-mesh SPMD types into per-mesh-dim DTensor placements.
+        placements = []
+        self._spmd_grad_placements = []
+        for axis_type in storage_axis_types.values():
+            placements.append(spmd.spmd_type_to_dtensor_placement(axis_type))
+            self._spmd_grad_placements.append(
+                spmd.spmd_type_to_dtensor_placement(axis_type.backward_type())
+            )
+
+        dtensor_param = nn.Parameter(
+            DTensor.from_local(param.data, spmd_mesh, placements, run_check=False),
+            requires_grad=param.requires_grad,
+        )
+        return dtensor_param
+
+    def _resolve_spmd_restore_mesh(
+        self,
+        shard_placement_result: ShardPlacementResult | None,
+    ) -> None:
+        """Resolve the compute mesh used to restore spmd_types metadata.
+
+        The restore mesh is the spmd_types typechecking mesh used during
+        module compute. FSDP uses it to fill omitted FSDP-managed axes as
+        ``spmd.R`` when restoring annotations on the unsharded parameter. It
+        must contain every axis in the initial parameter annotation, and it
+        must span the same ranks as the named FSDP storage mesh, although the
+        mesh view may differ.
+
+        Precedence:
+        1. Use ``ShardPlacementResult.spmd_compute_mesh`` when per-parameter
+           sharding explicitly says that module compute/typechecking uses a
+           different mesh from FSDP storage.
+        2. For per-parameter sharding without an explicit compute mesh, use
+           the named FSDP SPMD storage mesh from ``ShardPlacementResult``.
+           This covers mixed parameter groups where typechecking and storage
+           use the same mesh.
+        3. Otherwise, use the ambient init-time ``spmd.current_mesh()``. This
+           covers the single typechecking mesh case for the whole FSDP unit.
+        4. Otherwise, error because FSDP cannot fill omitted DP annotations
+           without knowing the compute/typechecking mesh.
+        """
+        spmd_mesh = self.mesh_info.spmd_mesh
+        if spmd_mesh is None or spmd_mesh.mesh_dim_names is None:
+            raise ValueError(
+                "spmd_types parameters require a named SPMD mesh "
+                "(pass dp_mesh_dims to fully_shard)"
+            )
+
+        if (
+            shard_placement_result is not None
+            and shard_placement_result.spmd_compute_mesh is not None
+        ):
+            restore_mesh = tuple(
+                spmd.MeshAxis.of(
+                    shard_placement_result.spmd_compute_mesh.get_group(name)
+                )
+                for name in shard_placement_result.spmd_compute_mesh.mesh_dim_names
+            )
+        elif (
+            shard_placement_result is not None
+            and shard_placement_result.mesh_info.spmd_mesh is not None
+        ):
+            restore_mesh = tuple(
+                spmd.MeshAxis.of(
+                    shard_placement_result.mesh_info.spmd_mesh.get_group(name)
+                )
+                for name in shard_placement_result.mesh_info.spmd_mesh.mesh_dim_names
+            )
+        elif (current_mesh := spmd.current_mesh()) is not None:
+            restore_mesh = tuple(current_mesh)
+        else:
+            raise ValueError(
+                "spmd_types parameters require an init-time compute mesh for "
+                "FSDP annotation restore. If all parameters in the FSDP unit "
+                "share a typechecking mesh, wrap fully_shard() in "
+                "spmd.set_current_mesh(). For mixed parameter groups, set "
+                "DataParallelMeshInfo.spmd_mesh or FSDPMeshInfo.spmd_mesh "
+                "when the typechecking mesh matches the FSDP storage mesh, "
+                "or set ShardPlacementResult.spmd_compute_mesh when the "
+                "typechecking and storage meshes differ."
+            )
+        unknown_axes = tuple(
+            axis for axis in self._spmd_init_local_type if axis not in restore_mesh
+        )
+        if unknown_axes:
+            raise ValueError(
+                f"Parameter '{self._module_info.param_name}' has spmd_types "
+                "annotations on axes that are not in the resolved "
+                f"typechecking mesh. Annotated axes: {unknown_axes}. "
+                f"Typechecking mesh axes: {restore_mesh}."
+            )
+        storage_mesh_axes = tuple(
+            spmd.MeshAxis.of(spmd_mesh.get_group(name))
+            for name in spmd_mesh.mesh_dim_names
+        )
+        # The restore mesh may have different logical axes than the FSDP
+        # storage mesh, but it must describe the same rank set.
+        if not _spans_same_mesh(restore_mesh, storage_mesh_axes):
+            raise ValueError(
+                f"Parameter '{self._module_info.param_name}' uses spmd_types "
+                "annotations on a typechecking mesh that does not span the "
+                "same ranks as its FSDP storage mesh. FSDP can fill omitted "
+                "FSDP-managed axes only when these meshes span the same "
+                f"rank set. Typechecking mesh axes: {restore_mesh}. "
+                f"Storage mesh axes: {storage_mesh_axes}."
+            )
+        self._spmd_restore_mesh = restore_mesh
+
+    def _get_storage_mesh_axes_types(
+        self,
+        spmd_mesh: DeviceMesh,
+        mesh_info: DataParallelMeshInfo,
+    ) -> dict[Any, Any]:
+        """Return spmd_types for each FSDP storage mesh axis.
+
+        ``dp_mesh_dims`` defines the FSDP-managed submesh, whose axes have
+        ``spmd.R`` semantics because FSDP handles their gradient reduction.
+        User annotations may either be contained in this FSDP submesh, in which
+        case they must be ``spmd.R``, or map 1:1 to a non-FSDP storage-mesh
+        axis, in which case placement is flexible. Together, FSDP-managed axes
+        plus directly annotated non-FSDP axes must cover the full storage mesh;
+        otherwise the full DTensor placement cannot be inferred.
+
+        FSDP-axis annotations are optional because they are restricted to
+        ``spmd.R``. Non-FSDP storage axes must be annotated. ``PartitionSpec``
+        metadata may refine ``spmd.V`` annotations into ``spmd.S(dim)`` for
+        DTensor placement translation.
+        """
+        dp_names = set(
+            itertools.chain(
+                mesh_info.dp_mesh_dims.shard_names,
+                mesh_info.dp_mesh_dims.replicate_names,
+            )
+        )
+        fsdp_axis = spmd.MeshAxis.of(mesh_info.mesh._flatten().get_group(0))
+        spmd_mesh_axes = tuple(
+            (name, spmd.MeshAxis.of(spmd_mesh.get_group(name)))
+            for name in spmd_mesh.mesh_dim_names
+        )
+        non_fsdp_spmd_mesh_axes = {
+            axis for name, axis in spmd_mesh_axes if name not in dp_names
+        }
+        storage_axis_types = {
+            axis: spmd.R for name, axis in spmd_mesh_axes if name in dp_names
+        }
+        local_type = dict(self._spmd_init_local_type)
+        if self._spmd_partition_spec is not None:
+            local_type.update(partition_spec_to_shard_types(self._spmd_partition_spec))
+        for axis, axis_type in local_type.items():
+            if axis <= fsdp_axis:
+                if axis_type is not spmd.R:
+                    raise ValueError(
+                        f"Expected spmd.R on FSDP DP axis {axis} for parameter "
+                        f"'{self._module_info.param_name}' but got {axis_type}. "
+                        "FSDP requires DP parameters to be R since it handles "
+                        "the DP gradient reduction."
+                    )
+            else:
+                if axis not in non_fsdp_spmd_mesh_axes:
+                    raise ValueError(
+                        f"Parameter '{self._module_info.param_name}' has spmd_types "
+                        f"annotation on axis {axis}, which is neither a non-FSDP "
+                        "storage-mesh axis nor contained in the FSDP DP mesh."
+                    )
+                storage_axis_types[axis] = axis_type
+
+        if {axis for _, axis in spmd_mesh_axes} != set(storage_axis_types.keys()):
+            raise ValueError(
+                f"Parameter '{self._module_info.param_name}' has incomplete "
+                "spmd_types annotations for FSDP storage. "
+                f"Annotated axes: {tuple(local_type.keys())}. "
+                f"Storage mesh axes: {tuple(axis for _, axis in spmd_mesh_axes)}. "
+                f"FSDP mesh dims: {mesh_info.dp_mesh_dims}. "
+                "Missing non-FSDP storage axes: "
+                f"{tuple(axis for _, axis in spmd_mesh_axes if axis not in storage_axis_types)}."
+            )
+        return storage_axis_types
+
+    def _restore_spmd_types(self, tensor: torch.Tensor) -> None:
+        """Restore the saved spmd_types annotation onto a tensor."""
+        if not self.is_spmd_types or not spmd.is_type_checking():
+            return
+        if self._spmd_restore_type:
+            spmd.assert_type(
+                tensor,
+                self._spmd_restore_type,
+                partition_spec=self._spmd_partition_spec,
+            )
 
     def _init_sharding_spec(
         self,
@@ -669,7 +936,9 @@ class FSDPParam:
             self._contiguous_orig_stride,
             storage_offset=0,
         )
-        if self._unsharded_dtensor_spec is not None:
+        if self.is_spmd_types:
+            pass  # keep as plain tensor; spmd_types restored in to_unsharded()
+        elif self._unsharded_dtensor_spec is not None:
             unsharded_dtensor_spec = self._get_unsharded_dtensor_spec(unsharded_param)
             unsharded_param = _from_local_no_grad(
                 unsharded_param, unsharded_dtensor_spec
@@ -748,6 +1017,8 @@ class FSDPParam:
     def to_unsharded(self) -> None:
         # Assume that the data has been allocated and all-gathered
         set_requires_grad_if_needed(self.sharded_param, self._unsharded_param)
+        if self.is_spmd_types:
+            self._restore_spmd_types(self._unsharded_param)
         self._setattr_on_modules(self._unsharded_param)
         if self.sharded_state == ShardedState.SHARDED_POST_FORWARD:
             # The data is allocated in the default stream via the post-forward
@@ -932,6 +1203,23 @@ class FSDPParam:
         return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
+        if self.is_spmd_types:
+            if self._unsharded_dtensor_spec is None:
+                raise AssertionError(
+                    "Expected _unsharded_dtensor_spec for spmd_types param"
+                )
+            grad = DTensor.from_local(
+                grad,
+                self._unsharded_dtensor_spec.mesh,
+                tuple(self._spmd_grad_placements),
+                run_check=False,
+            )
+            if not self.is_dtensor:
+                raise AssertionError(
+                    "Expected spmd_types -> DTensor wrapping to use the DTensor gradient "
+                    "path for correct gradient redistribution."
+                )
+
         if self.is_dtensor:
             if isinstance(grad, AsyncCollectiveTensor):
                 grad = grad.wait()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -431,23 +431,24 @@ class FSDPParam:
         """Resolve the compute mesh used to restore spmd_types metadata.
 
         The restore mesh is the spmd_types typechecking mesh used during
-        module compute. FSDP uses it to fill omitted FSDP-managed axes as
-        ``spmd.R`` when restoring annotations on the unsharded parameter. It
-        must contain every axis in the initial parameter annotation, and it
-        must span the same ranks as the named FSDP storage mesh, although the
-        mesh view may differ.
+        module compute. If the parameter annotation already spans the full FSDP
+        storage mesh, it is self-contained and can be used directly. Otherwise,
+        FSDP needs an external compute/typechecking mesh to fill omitted axes as
+        ``spmd.R`` when restoring annotations on the unsharded parameter.
 
         Precedence:
-        1. Use ``ShardPlacementResult.spmd_compute_mesh`` when per-parameter
+        1. Use the parameter's annotated axes when they span the same ranks as
+           the FSDP storage mesh.
+        2. Use ``ShardPlacementResult.spmd_compute_mesh`` when per-parameter
            sharding explicitly says that module compute/typechecking uses a
            different mesh from FSDP storage.
-        2. For per-parameter sharding without an explicit compute mesh, use
+        3. For per-parameter sharding without an explicit compute mesh, use
            the named FSDP SPMD storage mesh from ``ShardPlacementResult``.
            This covers mixed parameter groups where typechecking and storage
            use the same mesh.
-        3. Otherwise, use the ambient init-time ``spmd.current_mesh()``. This
+        4. Otherwise, use the ambient init-time ``spmd.current_mesh()``. This
            covers the single typechecking mesh case for the whole FSDP unit.
-        4. Otherwise, error because FSDP cannot fill omitted DP annotations
+        5. Otherwise, error because FSDP cannot fill omitted DP annotations
            without knowing the compute/typechecking mesh.
         """
         spmd_mesh = self.mesh_info.spmd_mesh
@@ -456,40 +457,57 @@ class FSDPParam:
                 "spmd_types parameters require a named SPMD mesh "
                 "(pass dp_mesh_dims to fully_shard)"
             )
+        spmd_mesh_dim_names = spmd_mesh.mesh_dim_names
+        storage_mesh_axes = tuple(
+            spmd.MeshAxis.of(spmd_mesh.get_group(name)) for name in spmd_mesh_dim_names
+        )
+        local_type: dict[Any, Any] = dict(self._spmd_init_local_type)
+        if self._spmd_partition_spec is not None:
+            local_type.update(partition_spec_to_shard_types(self._spmd_partition_spec))
+        annotated_axes = tuple(local_type.keys())
 
-        if (
+        if _spans_same_mesh(annotated_axes, storage_mesh_axes):
+            # 1. Read the restore mesh from the parameter's annotated axes.
+            self._spmd_restore_mesh = annotated_axes
+            return
+        elif (
             shard_placement_result is not None
-            and shard_placement_result.spmd_compute_mesh is not None
+            and (compute_mesh := shard_placement_result.spmd_compute_mesh) is not None
         ):
+            # 2. Read the restore mesh from ShardPlacementResult.spmd_compute_mesh.
+            if compute_mesh.mesh_dim_names is None:
+                raise AssertionError("spmd_compute_mesh.mesh_dim_names cannot be None")
             restore_mesh = tuple(
-                spmd.MeshAxis.of(
-                    shard_placement_result.spmd_compute_mesh.get_group(name)
-                )
-                for name in shard_placement_result.spmd_compute_mesh.mesh_dim_names
+                spmd.MeshAxis.of(compute_mesh.get_group(name))
+                for name in compute_mesh.mesh_dim_names
             )
         elif (
             shard_placement_result is not None
-            and shard_placement_result.mesh_info.spmd_mesh is not None
+            and (storage_mesh := shard_placement_result.mesh_info.spmd_mesh) is not None
         ):
+            # 3. Read the restore mesh from ShardPlacementResult.mesh_info.spmd_mesh.
+            if storage_mesh.mesh_dim_names is None:
+                raise AssertionError("spmd_mesh.mesh_dim_names cannot be None")
             restore_mesh = tuple(
-                spmd.MeshAxis.of(
-                    shard_placement_result.mesh_info.spmd_mesh.get_group(name)
-                )
-                for name in shard_placement_result.mesh_info.spmd_mesh.mesh_dim_names
+                spmd.MeshAxis.of(storage_mesh.get_group(name))
+                for name in storage_mesh.mesh_dim_names
             )
         elif (current_mesh := spmd.current_mesh()) is not None:
+            # 4. Read the restore mesh from the ambient spmd.current_mesh().
             restore_mesh = tuple(current_mesh)
         else:
             raise ValueError(
-                "spmd_types parameters require an init-time compute mesh for "
-                "FSDP annotation restore. If all parameters in the FSDP unit "
-                "share a typechecking mesh, wrap fully_shard() in "
-                "spmd.set_current_mesh(). For mixed parameter groups, set "
-                "DataParallelMeshInfo.spmd_mesh or FSDPMeshInfo.spmd_mesh "
-                "when the typechecking mesh matches the FSDP storage mesh, "
-                "or set ShardPlacementResult.spmd_compute_mesh when the "
-                "typechecking and storage meshes differ."
+                f"Parameter '{self._module_info.param_name}' has partial "
+                "spmd_types annotations that do not span the full FSDP "
+                "storage mesh. Wrap fully_shard() in spmd.set_current_mesh() "
+                "if all parameters in the FSDP unit share a typechecking mesh, "
+                "set ShardPlacementResult.spmd_compute_mesh when the "
+                "typechecking and storage meshes differ, or set "
+                "ShardPlacementResult.mesh_info.spmd_mesh when they match. "
+                f"Annotated axes: {annotated_axes}. "
+                f"Storage mesh axes: {storage_mesh_axes}."
             )
+
         unknown_axes = tuple(
             axis for axis in self._spmd_init_local_type if axis not in restore_mesh
         )
@@ -500,10 +518,6 @@ class FSDPParam:
                 f"typechecking mesh. Annotated axes: {unknown_axes}. "
                 f"Typechecking mesh axes: {restore_mesh}."
             )
-        storage_mesh_axes = tuple(
-            spmd.MeshAxis.of(spmd_mesh.get_group(name))
-            for name in spmd_mesh.mesh_dim_names
-        )
         # The restore mesh may have different logical axes than the FSDP
         # storage mesh, but it must describe the same rank set.
         if not _spans_same_mesh(restore_mesh, storage_mesh_axes):
@@ -537,6 +551,10 @@ class FSDPParam:
         metadata may refine ``spmd.V`` annotations into ``spmd.S(dim)`` for
         DTensor placement translation.
         """
+        if mesh_info.dp_mesh_dims is None:
+            raise AssertionError("dp_mesh_dims cannot be None")
+        if spmd_mesh.mesh_dim_names is None:
+            raise AssertionError("spmd_mesh.mesh_dim_names cannot be None")
         dp_names = set(
             itertools.chain(
                 mesh_info.dp_mesh_dims.shard_names,
@@ -554,7 +572,7 @@ class FSDPParam:
         storage_axis_types = {
             axis: spmd.R for name, axis in spmd_mesh_axes if name in dp_names
         }
-        local_type = dict(self._spmd_init_local_type)
+        local_type: dict[Any, Any] = dict(self._spmd_init_local_type)
         if self._spmd_partition_spec is not None:
             local_type.update(partition_spec_to_shard_types(self._spmd_partition_spec))
         for axis, axis_type in local_type.items():

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -552,6 +552,8 @@ class FSDPParamGroup:
                 self._training_state = TrainingState.FORWARD
                 self.unshard(self.unshard_async_op)
                 self.wait_for_unshard()
+            for fsdp_param in self.fsdp_params:
+                fsdp_param._restore_spmd_types(fsdp_param.unsharded_param)
             if entering_forward_pass:
                 args, kwargs = self._register_post_backward_hook(args, kwargs)
             return args, kwargs
@@ -1151,3 +1153,9 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
         # Drop the non-tensor param_group tangent. The output pre-backward hook
         # queues final post-backward after all primal/tangent paths finish.
         return grad_inputs
+
+
+if dist._is_spmd_types_available():
+    import spmd_types
+
+    spmd_types.register_local_autograd_function(RegisterPostBackwardFunction)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -290,10 +290,10 @@ class FSDPState(_State):
     def _pre_forward(
         self, module: nn.Module, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        with _spmd_no_typecheck():
-            # When composing with module-hook-based activation checkpointing, the
-            # pre-backward hook is responsible for the unshard
-            if self._training_state == TrainingState.PRE_BACKWARD:
+        # When composing with module-hook-based activation checkpointing, the
+        # pre-backward hook is responsible for the unshard
+        if self._training_state == TrainingState.PRE_BACKWARD:
+            with _spmd_no_typecheck():
                 # With nested FSDP and multiple forward passes before backward,
                 # the params might have been resharded by a previous post_backward.
                 # We need to ensure params are unsharded for AC recomputation.
@@ -301,18 +301,24 @@ class FSDPState(_State):
                     if not fsdp_param_group.is_unsharded:
                         fsdp_param_group.unshard()
                         fsdp_param_group.wait_for_unshard()
-                return self._cast_forward_inputs(args, kwargs)
-            # With grouped ``fully_shard([a, b, ...])`` the pre-hook fires per
-            # module (so ``cast_forward_inputs`` and ``fsdp_param_group.pre_forward``
-            # run for each). Root setup and forward prefetch are one-shot, gated
-            # on the first module's entry.
+            for fsdp_param_group in self._fsdp_param_groups:
+                for fsdp_param in fsdp_param_group.fsdp_params:
+                    fsdp_param._restore_spmd_types(fsdp_param.unsharded_param)
+            return self._cast_forward_inputs(args, kwargs)
+
+        # With grouped ``fully_shard([a, b, ...])`` the pre-hook fires per
+        # module (so ``cast_forward_inputs`` and ``fsdp_param_group.pre_forward``
+        # run for each). Root setup and forward prefetch are one-shot, gated
+        # on the first module's entry.
+        with _spmd_no_typecheck():
             state_first_in_pass = self._training_state != TrainingState.FORWARD
             self._training_state = TrainingState.FORWARD
             if state_first_in_pass:
                 args, kwargs = self._root_pre_forward(module, args, kwargs)
-            args, kwargs = self._cast_forward_inputs(args, kwargs)
-            for fsdp_param_group in self._fsdp_param_groups:
-                args, kwargs = fsdp_param_group.pre_forward(module, args, kwargs)
+        args, kwargs = self._cast_forward_inputs(args, kwargs)
+        for fsdp_param_group in self._fsdp_param_groups:
+            args, kwargs = fsdp_param_group.pre_forward(module, args, kwargs)
+        with _spmd_no_typecheck():
             if state_first_in_pass:
                 for fsdp_state in self._states_to_forward_prefetch:
                     # Forward order (not reversed) to match forward execution

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -213,7 +213,9 @@ def fully_shard(
               and a custom :class:`FSDPMeshInfo`. This allows different
               parameters to be sharded across different process groups, enabling
               use cases like Mixture of Experts where expert params use a
-              different mesh than regular params.
+              different mesh than regular params. When using ``spmd_types``,
+              this may also specify the compute mesh used to restore partial
+              parameter annotations.
 
             If sharding on a nonzero dim, we currently require even sharding,
             i.e. the tensor dim size on that dim must be divisible by the FSDP


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187394

 ## Summary

  This PR lets FSDP initialize from plain parameters carrying `spmd_types` annotations, convert those annotations into DTensor storage placements, and restore the original compute-time `spmd_types` metadata on the unsharded parameter before module compute.

  Fully annotated parameters are self-contained: if the annotated axes already span the full FSDP storage mesh, `fully_shard()` does not require an ambient `spmd.set_current_mesh()` context or an explicit per-parameter compute mesh.

  This also supports partial parameter annotations: FSDP-managed axes may be omitted from the parameter annotation and are restored as `spmd.R` when FSDP can resolve the init-time compute/typechecking mesh. This is needed for dense/sparse composition where, for example, dense params annotate only TP while sparse params annotate only EP, but FSDP still owns the DP-style storage axes.

  ## Typechecking Mesh Resolution

  For each `spmd_types`-annotated plain parameter, FSDP resolves a restore/typechecking mesh. This mesh is used later to restore local `spmd_types` metadata on the plain unsharded parameter.

  Precedence:

  1. Annotated axes already span the full FSDP storage mesh

     Use the parameter's annotated axes directly. This covers fully annotated parameters and does not require any ambient current mesh or explicit mesh passing.

  2. `ShardPlacementResult.spmd_compute_mesh`

     Use this when a parameter has per-parameter FSDP storage placement, and its module-compute/typechecking mesh differs from its FSDP storage mesh.

  3. `ShardPlacementResult.mesh_info.spmd_mesh`

     Use this for mixed parameter groups where the parameter-specific typechecking mesh is the same mesh as its FSDP storage mesh.

  4. Ambient init-time `spmd.current_mesh()`

     Use this when every parameter in the FSDP unit shares one typechecking mesh.

  5. Error

     If the parameter is partially annotated and none of the above is available, FSDP cannot safely fill omitted FSDP-managed axes.

  FSDP validates that the resolved typechecking mesh contains every initially annotated axis and spans the same rank set as the named FSDP storage mesh. Logical axis decompositions may differ.

  ## Calling Conventions

  Fully annotated parameters:

  ```python
  spmd.assert_type(
      param,
      {dp_axis: spmd.R, cp_axis: spmd.R, tp_axis: spmd.S(0)},  # param has dp/cp/tp
  )

  fully_shard(
      module,
      mesh=storage_mesh,
      dp_mesh_dims=DataParallelMeshDims(
          shard=("dps", "cp"),
          replicate="dpr",
      ),
  )
```

  Single typechecking mesh, inferred from ambient `spmd.current_mesh` context ("data" axes implicitly added by FSDP):

  ```python
  with spmd.set_current_mesh(type_mesh):
      spmd.assert_type(param, {tp_axis: spmd.S(0)})  # R@dp/cp inferred from type_mesh
      fully_shard(
          module,
          mesh=storage_mesh,
          dp_mesh_dims=DataParallelMeshDims(
              shard=("dps", "cp"),
              replicate="dpr",
          ),
      )
```

  Mixed dense/sparse parameter groups in one FSDP unit (e.g. `torchtitan/fsdp.py` example, where one fully_shard calls mixes dense-mesh & sparse-mesh params, but dense mesh params are on dp/cp/tp typechecking mesh):

```python
  dense_mesh_info = _get_fsdp_mesh_info(
      dense_spmd_mesh,  # [dp, cp, tp]
      dp_mesh_dims=DataParallelMeshDims(shard=("dp", "cp")),
      spmd_mesh=dense_spmd_mesh,  # [dp, cp, tp]
  )
  sparse_mesh_info = _get_fsdp_mesh_info(
      edp_mesh,
      dp_mesh_dims=DataParallelMeshDims(
          shard="efsdp",
          replicate="dp_replicate" if edp_mesh.ndim == 2 else None,
      ),
      spmd_mesh=sparse_spmd_mesh,  # [efsdp, ep]
  )

  def _shard_placement_fn(
      param: nn.Parameter,
      _sparse_params: set[nn.Parameter] = sparse_params,
      _sparse_placement: Shard = sparse_shard_placement,
      _sparse_mesh_info: FSDPMeshInfo = sparse_mesh_info,
      _dense_mesh_info: FSDPMeshInfo = dense_mesh_info,
      _sparse_compute_mesh: DeviceMesh = sparse_compute_mesh,
  ) -> ShardPlacementResult:
      if param in _sparse_params:
          return ShardPlacementResult(
              placement=_sparse_placement,
              mesh_info=_sparse_mesh_info,
              spmd_compute_mesh=_sparse_compute_mesh,  # R@dp_replicate/efsdp can be inferred from this mesh
          )
      return ShardPlacementResult(
          placement=Shard(0),
          mesh_info=_dense_mesh_info,
      )

  fully_shard(
      transformer_block,
      **fsdp_config,
      reshard_after_forward=reshard_after_forward,
      shard_placement_fn=_shard_placement_fn,
  )
```

  In the above example, dense params use `ShardPlacementResult.mesh_info.spmd_mesh` because their storage and compute/typechecking mesh is the same `[dp, cp, tp]` mesh. Sparse params use `ShardPlacementResult.spmd_compute_mesh` because their FSDP storage mesh differs from their module-compute/typechecking mesh.

  ## Invalid Cases

  1. Partial annotations with no reference mesh

```python
  spmd.assert_type(param, {tp_axis: spmd.S(0)})

  fully_shard(
      module,
      mesh=dense_storage_mesh,
      dp_mesh_dims=DataParallelMeshDims(
          shard=("dp_shard", "cp"),
          replicate="dp_replicate",
      ),
  )
```
  This errors because FSDP sees omitted dense DP/CP axes but has no `[dp, cp, tp]` mesh to restore them against.

  2. Non-FSDP axis mismatch

```python
  spmd.assert_type(param, {tp_axis: spmd.S(0)})
  fully_shard(
      module,
      mesh=sparse_mesh,
      dp_mesh_dims=DataParallelMeshDims(
          shard="efsdp",
          replicate="dp_replicate",
      ),
  )
```
  This errors because annotated axes not under the FSDP submesh (e.g. TP) must map 1-1 to the FSDP storage mesh.

  3. Non-FSDP-managed axis omitted, or not annotated as `spmd.R`

```python
  # dense_storage_mesh is [dp_replicate, dp_shard, cp, tp].
  # FSDP owns dp_replicate/dp_shard/cp, but not tp.
  spmd.assert_type(param, {dp_axis: spmd.R, cp_axis: spmd.R})

  with spmd.set_current_mesh(dense_typecheck_mesh):
      fully_shard(
          module,
          mesh=dense_storage_mesh,
          dp_mesh_dims=DataParallelMeshDims(
              shard=("dp_shard", "cp"),
              replicate="dp_replicate",
          ),
      )
```
  This errors because FSDP can infer omitted FSDP-managed axes as `spmd.R`, but non-FSDP storage axes like TP must be annotated.

4. FSDP-managed axis not annotated as `spmd.R`

```python
  # dense_storage_mesh is [dp_replicate, dp_shard, cp, tp].
  spmd.assert_type(param, {dp_axis: spmd.I, tp_axis: spmd.I})

  with spmd.set_current_mesh(dense_typecheck_mesh):
      fully_shard(
          module,
          mesh=dense_storage_mesh,
          dp_mesh_dims=DataParallelMeshDims(
              shard=("dp_shard", "cp"),
              replicate="dp_replicate",
          ),
      )
```
This errors as FSDP owns "DP" axes BWD allreduce, implying partial gradients