### PR TITLE
[dynamo] remove redundant call_obj_hasattr overrides

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -104,6 +104,58 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, x + 1)
 
+    def test_hasattr_user_function_true(self):
+        def bar():
+            pass
+
+        def fn():
+            return hasattr(bar, "__name__")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertTrue(result)
+
+    def test_hasattr_user_function_false(self):
+        def bar():
+            pass
+
+        def fn():
+            return hasattr(bar, "nonexistent")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertFalse(result)
+
+    def test_hasattr_skip_function_true(self):
+        def fn():
+            return hasattr(print, "__name__")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertTrue(result)
+
+    def test_hasattr_skip_function_false(self):
+        def fn():
+            return hasattr(print, "nonexistent")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertFalse(result)
+
+    def test_hasattr_python_module_true(self):
+        import math
+
+        def fn():
+            return hasattr(math, "sqrt")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertTrue(result)
+
+    def test_hasattr_python_module_false(self):
+        import math
+
+        def fn():
+            return hasattr(math, "nonexistent")
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertFalse(result)
+
     # --- Tensor attributes ---
 
     def test_tensor_shape(self):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -742,12 +742,6 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         source = self.get_source()
         return fn_getattro_impl(tx, self.fn, source, name)
 
-    def call_obj_hasattr(
-        self, tx: "InstructionTranslatorBase", name: str
-    ) -> ConstantVariable:
-        result = hasattr(self.fn, name)
-        return VariableTracker.build(tx, result)
-
     def tp_descr_get_impl(
         self,
         tx: "InstructionTranslatorBase",
@@ -2458,11 +2452,6 @@ class SkipFunctionVariable(VariableTracker):
         raise NotImplementedError(
             "Python codegen not implemented for sourceless SkipFunctionVariable"
         )
-
-    def call_obj_hasattr(
-        self, tx: "InstructionTranslatorBase", name: str
-    ) -> ConstantVariable:
-        return VariableTracker.build(tx, hasattr(self.value, name))
 
     def getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1613,12 +1613,6 @@ class PythonModuleVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"PythonModuleVariable({self.value})"
 
-    def call_obj_hasattr(
-        self, tx: "InstructionTranslatorBase", name: str
-    ) -> "ConstantVariable":
-        result = hasattr(self.value, name)
-        return VariableTracker.build(tx, result)
-
     def getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187708
* #187707
* #187532
* #187531
* #187474
* #187469
* #187468
* __->__ #187398
* #187226
* #187200
* #187196
* #187113
* #186013

Remove call_obj_hasattr overrides from UserFunctionVariable,
SkipFunctionVariable, and PythonModuleVariable. These are redundant
now that the base call_obj_hasattr calls getattro_impl (which properly
raises ObservedAttributeError for missing attrs on all three types).

Audited all 22 remaining overrides. The other 19 must stay because
their getattro_impl either raises the wrong exception type for missing
attrs (NotImplementedError instead of ObservedAttributeError), installs
HASATTR guards, or can graph-break on existing-but-untraceable attrs.

Test Plan:
```
python test/dynamo/test_tp_getattro.py -v  # 63 OK
python test/dynamo/test_misc.py MiscTests -v  # 743 OK
python test/dynamo/test_functions.py -v  # 516 OK
```

Co-authored-by: Claude <noreply@anthropic.com>