### PR TITLE
Add spectral_unclamped scaling option to adjust_lr_fn in Muon

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1392,8 +1392,6 @@ class TestOptimRenewed(TestCase):
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
-        param = torch.randn((5, 1), device=device, dtype=dtype, requires_grad=True)
-        old_param = param.detach().clone()
 
         def closure():
             return torch.tensor([1], device=device, dtype=dtype)
@@ -1406,13 +1404,13 @@ class TestOptimRenewed(TestCase):
             if kwargs.get("weight_decay", 0) != 0:
                 continue
 
-            # AdamW/Muon params will be updated regardless of grads due to lr, so make lr smaller
-            if optim_cls.__name__ == "AdamW" or optim_cls.__name__ == "Muon":
-                kwargs["lr"] = (
-                    torch.tensor(1e-5)
-                    if isinstance(kwargs.get("lr", 1e-5), torch.Tensor)
-                    else 1e-5
-                )
+            # AdamW and Muon have a nonzero default weight_decay, which decays
+            # params even with zero grads; override it so the step is a true no-op.
+            if optim_cls.__name__ in ("AdamW", "Muon"):
+                kwargs["weight_decay"] = 0
+
+            param = torch.randn((5, 1), device=device, dtype=dtype, requires_grad=True)
+            old_param = param.detach().clone()
 
             if kwargs.get("differentiable", False):
                 params = [param.detach()]

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -255,7 +255,7 @@ Muon.__doc__ = (
     and weight decay tuned for AdamW.
 
     Jeremy Bernstein in `Deriving Muon`_ proposes a scaling condition on the spectral norm, which
-    scales the update by :math:`\sqrt{\frac{A}{B}}`. This is similar to the "original" Keller's
+    scales the update by :math:`\sqrt{\frac{A}{B}}`. This is similar to the Keller's "original"
     implementation but removes clamping down to 1.
 
     We provide these options for the learning rate adjustment: "original", which follows Keller's

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -242,23 +242,25 @@ Muon.__doc__ = (
     with numerical stabilization :math:`\varepsilon`.
 
     The purpose for :math:`\mathrm{AdjustLR}\!\big(\gamma;\ \mathrm{shape}\!\big(\theta_t \big) \big)`
-    is to make the orthogonalized update have a consistent :math:`RMS` across rectangular matrices.
+    is to make the orthogonalized update scale consistently across rectangular matrices.
 
     Keller's original implementation scales the update by :math:`\sqrt{\max\!\left(1, \frac{A}{B}\right)}`,
-    where :math:`A` and :math:`B` are dimension of the matrix being optimized.
+    where :math:`A` and :math:`B` are dimensions of the matrix being optimized, which represent fan-out
+    and fan-in for a Linear weight matrix.
 
-    Moonshot's implementation also focuses on matching :math:`RMS` of AdamW. The adjustment is computed as:
+    Moonshot's implementation focuses on matching :math:`RMS` of AdamW. The adjustment is computed as:
     :math:`\gamma \leftarrow {0.2}\gamma\,\sqrt{\max\!\left({A}, {B}\right)}`
     The method is adopted from `Muon is Scalable for LLM Training`_. Research
     results show that with this adjustment Muon can directly reuse the learning rate
     and weight decay tuned for AdamW.
 
-    Jeremy Bernstein and co in `Deriving Muon`_ proposed yet another implementation that they expect
-    to scale better, which scales the update by :math:`\sqrt{\frac{A}{B}}`.
+    Jeremy Bernstein in `Deriving Muon`_ proposes a scaling condition on the spectral norm, which
+    scales the update by :math:`\sqrt{\frac{A}{B}}`. This is similar to the "original" implementation
+    but removes clamping down to 1.
 
-    We provide three options for the learning rate adjustment: "original", which follows Keller's
+    We provide these options for the learning rate adjustment: "original", which follows Keller's
     implementation, "match_rms_adamw", which refers to Moonshot's implementation, and "spectral",
-    which matches Bernstein and co's implementation. If `adjust_lr_fn` is not specified, the default is "original".
+    which matches Bernstein's implementation. If `adjust_lr_fn` is not specified, the default is "original".
 
     For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_,
     `Muon is Scalable for LLM Training`_, and `Deriving Muon`_.

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -79,6 +79,8 @@ def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> 
         adjusted_ratio = math.sqrt(max(1, A / B))
     elif adjust_lr_fn == "match_rms_adamw":
         adjusted_ratio = 0.2 * math.sqrt(max(A, B))
+    elif adjust_lr_fn == "spectral":
+        adjusted_ratio = math.sqrt(A / B)
     else:
         adjusted_ratio = 1.0
     return lr * adjusted_ratio
@@ -108,6 +110,7 @@ class Muon(Optimizer):
         if adjust_lr_fn is not None and adjust_lr_fn not in [
             "original",
             "match_rms_adamw",
+            "spectral",
         ]:
             raise ValueError(
                 f"Adjust learning rate function {adjust_lr_fn} is not supported"
@@ -250,12 +253,15 @@ Muon.__doc__ = (
     results show that with this adjustment Muon can directly reuse the learning rate
     and weight decay tuned for AdamW.
 
-    We provide two options for the learning rate adjustment: "original", which follows Keller's
-    implementation, and "match_rms_adamw", which refers to Moonshot's implementation. This gives users the
-    flexibility to choose between the two. If `adjust_lr_fn` is not specified, the default is "original".
+    Jeremy Bernstein and co in `Deriving Muon`_ proposed yet another implementation that they expect
+    to scale better, which scales the update by :math:`\sqrt{\frac{A}{B}}`.
 
-    For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_
-    and `Muon is Scalable for LLM Training`_.
+    We provide three options for the learning rate adjustment: "original", which follows Keller's
+    implementation, "match_rms_adamw", which refers to Moonshot's implementation, and "spectral",
+    which matches Bernstein and co's implementation. If `adjust_lr_fn` is not specified, the default is "original".
+
+    For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_,
+    `Muon is Scalable for LLM Training`_, and `Deriving Muon`_.
     """
     + rf"""
     Args:
@@ -270,7 +276,7 @@ Muon.__doc__ = (
             Newton–Schulz orthogonalization polynomial (default: ({DEFAULT_A}, {DEFAULT_B}, {DEFAULT_C}))
         eps (float, optional): term added to the denominator for numerical stability. (default: {EPS})
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
-        adjust_lr_fn (str, optional): function to adjust learning rate. One of "original" and "match_rms_adamw".
+        adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral".
             If not specified, we will default to use "original". (default: None)
 
     Example:
@@ -300,6 +306,8 @@ Muon.__doc__ = (
         https://kellerjordan.github.io/posts/muon/
     .. _Muon is Scalable for LLM Training:
         https://arxiv.org/pdf/2502.16982
+    .. _Deriving Muon:
+        https://jeremybernste.in/writing/deriving-muon
 
     """
 )

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -79,7 +79,7 @@ def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> 
         adjusted_ratio = math.sqrt(max(1, A / B))
     elif adjust_lr_fn == "match_rms_adamw":
         adjusted_ratio = 0.2 * math.sqrt(max(A, B))
-    elif adjust_lr_fn == "spectral":
+    elif adjust_lr_fn == "spectral_unclamped":
         adjusted_ratio = math.sqrt(A / B)
     else:
         adjusted_ratio = 1.0
@@ -110,7 +110,7 @@ class Muon(Optimizer):
         if adjust_lr_fn is not None and adjust_lr_fn not in [
             "original",
             "match_rms_adamw",
-            "spectral",
+            "spectral_unclamped",
         ]:
             raise ValueError(
                 f"Adjust learning rate function {adjust_lr_fn} is not supported"
@@ -255,11 +255,11 @@ Muon.__doc__ = (
     and weight decay tuned for AdamW.
 
     Jeremy Bernstein in `Deriving Muon`_ proposes a scaling condition on the spectral norm, which
-    scales the update by :math:`\sqrt{\frac{A}{B}}`. This is similar to the "original" implementation
-    but removes clamping down to 1.
+    scales the update by :math:`\sqrt{\frac{A}{B}}`. This is similar to the "original" Keller's
+    implementation but removes clamping down to 1.
 
     We provide these options for the learning rate adjustment: "original", which follows Keller's
-    implementation, "match_rms_adamw", which refers to Moonshot's implementation, and "spectral",
+    implementation, "match_rms_adamw", which refers to Moonshot's implementation, and "spectral_unclamped",
     which matches Bernstein's implementation. If `adjust_lr_fn` is not specified, the default is "original".
 
     For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_,
@@ -278,7 +278,7 @@ Muon.__doc__ = (
             Newton–Schulz orthogonalization polynomial (default: ({DEFAULT_A}, {DEFAULT_B}, {DEFAULT_C}))
         eps (float, optional): term added to the denominator for numerical stability. (default: {EPS})
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
-        adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral".
+        adjust_lr_fn (str, optional): function to adjust learning rate. One of "original", "match_rms_adamw", and "spectral_unclamped".
             If not specified, we will default to use "original". (default: None)
 
     Example:

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -917,6 +917,7 @@ def optim_error_inputs_func_muon(device, dtype):
                 params=[param],
                 kwargs={"adjust_lr_fn": "arbitrary"},
                 desc="unsupported adjust_lr_fn",
+            ),
             error_type=ValueError,
             error_regex="Adjust learning rate function arbitrary is not supported",
             error_on=OptimizerErrorEnum.CONSTRUCTION_ERROR,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -890,6 +890,16 @@ def optim_inputs_func_muon(device, dtype=None):
             },
             desc="passing alternative ns_coefficients",
         ),
+        OptimizerInput(
+            params=None,
+            kwargs={"adjust_lr_fn": "match_rms_adamw"},
+            desc="match_rms_adamw lr adjustment",
+        ),
+        OptimizerInput(
+            params=None,
+            kwargs={"adjust_lr_fn": "spectral_unclamped"},
+            desc="spectral_unclamped lr adjustment",
+        ),
     ]
 
 

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -916,8 +916,7 @@ def optim_error_inputs_func_muon(device, dtype):
             OptimizerInput(
                 params=[param],
                 kwargs={"adjust_lr_fn": "arbitrary"},
-                desc="only support `original` and `match_rms_adamw`",
-            ),
+                desc="unsupported adjust_lr_fn",
             error_type=ValueError,
             error_regex="Adjust learning rate function arbitrary is not supported",
             error_on=OptimizerErrorEnum.CONSTRUCTION_ERROR,


### PR DESCRIPTION
Inspired by Jeremy Bernstein and co: https://jeremybernste.in/writing/deriving-muon, https://x.com/jxbz/status/1846188906733044029, and https://x.com/ArdaGoreci/status/2064797197338857801

I tried my best with the naming given what I understood from the paper as shifting from keeping the Frobenius norm/entrywise RMS consistent vs the new idea of keeping the spectral norm consistent. And then the difference between original and new impl is just that the new impl doesn't clamp....so we are calling it spectral_unclamped.

But I observe that Megatron/NVIDIA adopts the opposite naming which is confusing...

https://github.com/NVIDIA-NeMo/Emerging-Optimizers/blob/06ff4c68cda0d41a7a40580644a47f61ea4a59b0/emerging_optimizers/orthogonalized_optimizers/muon.py#L136-L162

I tested locally with a Claude-written script that I reviewed:

<details>

```
"""Scratch: verify Muon adjust_lr_fn math, including the new "spectral_unclamped"."""

import math

import torch
from torch.optim._muon import _adjust_lr, Muon


def expected(adjust_lr_fn, lr, A, B):
    if adjust_lr_fn in (None, "original"):
        ratio = math.sqrt(max(1, A / B))
    elif adjust_lr_fn == "match_rms_adamw":
        ratio = 0.2 * math.sqrt(max(A, B))
    elif adjust_lr_fn == "spectral_unclamped":
        ratio = math.sqrt(A / B)
    else:
        ratio = 1.0
    return lr * ratio


# 1) Pure-function check over a sweep of shapes (wide, tall, square).
lr = 0.02
shapes = [(8, 32), (32, 8), (16, 16), (1, 100), (100, 1), (3, 7)]
fns = [None, "original", "match_rms_adamw", "spectral_unclamped"]
for fn in fns:
    for A, B in shapes:
        got = _adjust_lr(lr, fn, torch.Size((A, B)))
        exp = expected(fn, lr, A, B)
        assert math.isclose(got, exp, rel_tol=1e-12), (fn, A, B, got, exp)
print("[ok] _adjust_lr matches expected formula for all fns/shapes")

# Show the spectral_unclamped differs from original exactly when A < B (factor < 1).
for A, B in shapes:
    orig = _adjust_lr(lr, "original", torch.Size((A, B)))
    spec = _adjust_lr(lr, "spectral_unclamped", torch.Size((A, B)))
    print(f"  shape=({A:>3},{B:>3})  original={orig:.5f}  spectral_unclamped={spec:.5f}")

# 2) End-to-end: one step's param delta == -adjusted_lr * orthogonalized_update
#    with weight_decay=0 and momentum=0 (so update == grad orthogonalized).
torch.manual_seed(0)
A, B = 8, 32
for fn in ["original", "match_rms_adamw", "spectral_unclamped"]:
    p = torch.randn(A, B, dtype=torch.float64)
    p0 = p.clone()
    g = torch.randn(A, B, dtype=torch.float64)
    p.grad = g.clone()

    opt = Muon([p], lr=lr, weight_decay=0.0, momentum=0.0, nesterov=False,
               adjust_lr_fn=fn)
    opt.step()

    # Recompute the orthogonalized update the same way the optimizer does.
    from torch.optim._muon import _zeropower_via_newtonschulz, DEFAULT_A, DEFAULT_B, DEFAULT_C, EPS, DEFAULT_NS_STEPS
    ortho = _zeropower_via_newtonschulz(g, (DEFAULT_A, DEFAULT_B, DEFAULT_C), DEFAULT_NS_STEPS, EPS)
    adj = expected(fn, lr, A, B)
    expected_p = p0 - adj * ortho.to(p0.dtype)
    max_err = (p - expected_p).abs().max().item()
    print(f"[{fn}] adjusted_lr={adj:.5f}  max|delta err|={max_err:.2e}")
    assert max_err < 1e-6, fn

print("[ok] end-to-end step matches expected adjusted-lr scaling")

```

</details>

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187402

