### PR TITLE
[inductor] Avoid Triton driver setup in compile workers

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -5,8 +5,10 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import types
 import unittest
 from threading import Event
+from unittest.mock import patch
 
 import torch._inductor.config as config
 from torch._inductor.compile_worker.subproc_pool import (
@@ -17,7 +19,7 @@ from torch._inductor.compile_worker.subproc_pool import (
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_FBCODE, IS_LINUX, skipIfWindows
-from torch.testing._internal.inductor_utils import HAS_CPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
 class TestCompileWorker(TestCase):
@@ -326,6 +328,70 @@ class TestSetTritonLibdevicePath(TestCase):
         from triton import knobs
 
         self.assertEqual(knobs.nvidia.libdevice_path, expected)
+
+
+class TestTritonCompileWorker(TestCase):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_worker_compile_triton_warm_cache_skips_gpu_driver_setup(self):
+        from torch._inductor.runtime import triton_helpers
+        from torch._inductor.runtime.compile_tasks import _worker_compile_triton
+
+        class RaisingDriver:
+            @staticmethod
+            def is_active():
+                raise RuntimeError("0 active drivers ([]). There should only be one.")
+
+        class FakeKernel:
+            def __init__(self):
+                self.precompile_calls = []
+                self.prepared = False
+
+            def precompile(self, warm_cache_only=False):
+                self.precompile_calls.append(warm_cache_only)
+                triton_helpers.set_driver_to_gpu()
+
+            def prepare_for_pickle(self):
+                self.prepared = True
+
+        kernel = FakeKernel()
+
+        def load_kernel():
+            triton_helpers.set_driver_to_gpu()
+            return kernel
+
+        fake_backends = {"nvidia": types.SimpleNamespace(driver=RaisingDriver)}
+        with patch.object(triton_helpers.triton.backends, "backends", fake_backends):
+            result, _elapsed_us = _worker_compile_triton(load_kernel, {}, {})
+            self.assertIs(result, kernel)
+            self.assertEqual(kernel.precompile_calls, [True])
+            self.assertTrue(kernel.prepared)
+
+            # The skip is scoped to the worker compile call and restored afterward.
+            with self.assertRaisesRegex(RuntimeError, "0 active drivers"):
+                triton_helpers.set_driver_to_gpu()
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_worker_compile_triton_restores_gpu_driver_setup_after_error(self):
+        from torch._inductor.runtime import triton_helpers
+        from torch._inductor.runtime.compile_tasks import _worker_compile_triton
+
+        class RaisingDriver:
+            @staticmethod
+            def is_active():
+                raise RuntimeError("0 active drivers ([]). There should only be one.")
+
+        def load_kernel():
+            triton_helpers.set_driver_to_gpu()
+            raise ValueError("compile failed")
+
+        fake_backends = {"nvidia": types.SimpleNamespace(driver=RaisingDriver)}
+        with patch.object(triton_helpers.triton.backends, "backends", fake_backends):
+            with self.assertRaisesRegex(ValueError, "compile failed"):
+                _worker_compile_triton(load_kernel, {}, {})
+
+            # The skip is restored even if worker compilation raises.
+            with self.assertRaisesRegex(RuntimeError, "0 active drivers"):
+                triton_helpers.set_driver_to_gpu()
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -7,7 +7,7 @@ import tempfile
 import types
 import unittest
 from unittest import skipUnless
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import torch
 from torch._dynamo.testing import rand_strided
@@ -463,6 +463,33 @@ class TestTritonHeuristics(TestCase):
 _PLUGIN_FACTORY_PATH = (
     "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"
 )
+
+
+class TestCachingAutotunerPrecompileDriverSetup(TestCase):
+    @skipIfRocm
+    @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_warm_cache_only_precompile_skips_driver_setup_in_context(self):
+        from torch._inductor.runtime import triton_helpers
+
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        num_configs = len(args["configs"])
+        self.assertGreaterEqual(num_configs, 2)
+        autotuner = CachingAutotuner(**args)
+
+        with (
+            triton_helpers.skip_gpu_driver_setup(),
+            patch.object(
+                type(triton.runtime.driver),
+                "active",
+                new_callable=PropertyMock,
+                side_effect=RuntimeError("driver.active should not be read"),
+            ) as mock_driver_active,
+        ):
+            autotuner.precompile(warm_cache_only=True)
+
+        # Covers every synchronous _precompile_config() iteration.
+        mock_driver_active.assert_not_called()
+        self.assertEqual(len(autotuner.compile_results), num_configs)
 
 
 # Triton's HIP MLIR pipeline raises AttributeError("'NoneType' object has no

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -195,13 +195,17 @@ def _worker_compile_triton(
         except ImportError:
             pass
     from torch._inductor import config
+    from torch._inductor.runtime import triton_helpers
 
     with config.patch(extra_config):
         fail = None
         try:
             start_ns = time.time_ns()
-            kernel = load_kernel()
-            kernel.precompile(warm_cache_only=True)
+            # Generated Triton modules set up the GPU driver at import time,
+            # but compile workers only need to warm the compile cache.
+            with triton_helpers.skip_gpu_driver_setup():
+                kernel = load_kernel()
+                kernel.precompile(warm_cache_only=True)
             elapsed_ns = time.time_ns() - start_ns
             kernel.prepare_for_pickle()
             # We can release this memory in the compile subprocesses:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -3,6 +3,8 @@
 import math as pymath
 import warnings
 from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, TypeVar
 
 from torch.utils._ordered_set import OrderedSet
@@ -20,6 +22,20 @@ from .triton_compat import (
 
 _T = TypeVar("_T")
 _LOG_2_E: tl.constexpr = tl.constexpr(pymath.log2(pymath.e))
+_skip_gpu_driver_setup: ContextVar[bool] = ContextVar(
+    "_skip_gpu_driver_setup", default=False
+)
+
+
+@contextmanager
+def skip_gpu_driver_setup():
+    # Scoped no-op for set_driver_to_gpu(). ContextVar keeps nested/thread-local
+    # uses isolated.
+    token = _skip_gpu_driver_setup.set(True)
+    try:
+        yield
+    finally:
+        _skip_gpu_driver_setup.reset(token)
 
 
 def set_driver_to_cpu():
@@ -54,6 +70,9 @@ def _is_backend_active(name, backend):
 
 
 def set_driver_to_gpu():
+    if _skip_gpu_driver_setup.get():
+        return
+
     driver = triton.runtime.driver
     for name, backend in triton.backends.backends.items():
         if _is_backend_active(name, backend) and name != "cpu":


### PR DESCRIPTION
## Summary

Fixes #184643.

Inductor's async Triton compile workers can be created after CUDA has already been initialized in the worker-manager process. Because CUDA initialization is not fork-safe, those workers can inherit a bad CUDA state. After triton-lang/triton#9578 changed NVIDIA backend detection to use a raw `cuInit(0)` probe, resolving `triton.runtime.driver.active` in one of these workers can fail with:

`RuntimeError: 0 active drivers ([]). There should only be one.`

This happens while the worker is only warming the Triton compile cache. The worker loads Inductor-generated Triton kernel source and runs `precompile(warm_cache_only=True)`. Loading that generated source executes its top-level `triton_helpers.set_driver_to_gpu()` call, which can force Triton runtime driver resolution even though this path is not launching kernels.

A previous mitigation (#185870) avoided the crash by pinning Triton's active CUDA driver in the compile worker before generated kernels ran. That fixed this failure, but the pin mutated Triton's process-global driver state for the rest of the forked worker, including code outside the narrow warm-cache compile step, and was reverted internally after that broader state change caused regressions.

This PR avoids that failure mode by not setting or pinning Triton's active driver. It only skips the unnecessary generated-module `set_driver_to_gpu()` call while the worker loads Triton source and runs `precompile(warm_cache_only=True)`, then restores normal behavior. **We tested this internally on the same set of tests that previously regressed and observed they pass with this new implementation.**

## This Change

Add `skip_gpu_driver_setup()` guard around `_worker_compile_triton`'s generated-kernel load and warm-cache precompile. While the guard is active, `triton_helpers.set_driver_to_gpu()` becomes a no-op and avoids calling problematic `cuInit(0)`. 

This is safe for this path because the path where we enable the guard does need Triton's runtime GPU driver and can avoid calling `triton_helpers.set_driver_to_gpu()` safely. Specifically `warm_cache_only=True` does not create launchers, benchmark, autotune, or launch kernels, and the compile path already passes an explicit `GPUTarget` to `triton.compile(...)` so calling `set_driver_to_gpu()` is not needed.

Normal runtime paths are unchanged. Parent/non-worker execution still runs `set_driver_to_gpu()` normally, and the torch-free backend detection path is untouched.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo