### PR TITLE
Add TorchedHat/pytorch-redhat-ci to CRCR allowlist (L2) for testing CRCR outside PyTorch ecosystem

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -44,3 +44,4 @@ L1:
 L2:
   # Canonical test repo for CRCR.
   - pytorch/crcr-test
+  - TorchedHat/pytorch-redhat-ci


### PR DESCRIPTION
Add TorchedHat/pytorch-redhat-ci to CRCR allowlist (L2) for testing CRCR outside PyTorch ecosystem.
The current test repo https://github.com/pytorch/crcr-test is inside the PyTorch org and we need a repo to test the CRCR from outside the PyTorch org.