### PR TITLE
Fix causal attention mask handling in Transformer layers

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -903,6 +903,271 @@ class TestTransformers(NNTestCase):
 
         self.assertEqual(masked_output, is_causal_output)
 
+    def _causal_and_custom_masks(self, seq_len, batch_size, num_heads, mask_kind):
+        if mask_kind.startswith("bool"):
+            causal_mask = torch.ones(seq_len, seq_len, dtype=torch.bool).triu_(1)
+            custom_mask = causal_mask.clone()
+            custom_mask[-1, :-1] = True
+        else:
+            causal_mask = torch.nn.Transformer.generate_square_subsequent_mask(seq_len)
+            custom_mask = causal_mask.clone()
+            custom_mask[-1, :-1] = float("-inf")
+
+        if mask_kind.endswith("3d"):
+            causal_mask = causal_mask.repeat(batch_size * num_heads, 1, 1)
+            custom_mask = custom_mask.repeat(batch_size * num_heads, 1, 1)
+
+        return causal_mask, custom_mask
+
+    def test_encoder_is_causal_custom_src_mask(self):
+        for mask_kind in ("float2d", "bool2d", "float3d", "bool3d"):
+            with self.subTest(mask_kind=mask_kind):
+                torch.manual_seed(0)
+                d_model = 4
+                seq_len = 5
+                batch_size = 2
+                num_heads = 2
+                layer = torch.nn.TransformerEncoderLayer(
+                    d_model, num_heads, 8, dropout=0.0, batch_first=True
+                )
+                layer.eval()
+                x = torch.randn(batch_size, seq_len, d_model)
+                causal_mask, custom_mask = self._causal_and_custom_masks(
+                    seq_len, batch_size, num_heads, mask_kind
+                )
+
+                causal_output = layer(x, src_mask=causal_mask, is_causal=True)
+                expected_custom_output = layer(x, src_mask=custom_mask)
+                custom_output = layer(x, src_mask=custom_mask, is_causal=True)
+
+                self.assertEqual(expected_custom_output, custom_output)
+                self.assertFalse(torch.allclose(causal_output, custom_output))
+
+    def test_encoder_is_causal_wrong_shape_src_mask_errors(self):
+        torch.manual_seed(0)
+        d_model = 4
+        seq_len = 5
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model, 2, 8, dropout=0.0, batch_first=True
+        )
+        x = torch.randn(2, seq_len, d_model)
+        bad_mask = torch.zeros(seq_len - 1, seq_len)
+
+        with self.assertRaisesRegex(RuntimeError, "The shape of the 2D attn_mask is"):
+            layer(x, src_mask=bad_mask, is_causal=True)
+
+        bad_batched_mask = torch.zeros(4, seq_len - 1, seq_len)
+        with self.assertRaisesRegex(RuntimeError, "The shape of the 3D attn_mask is"):
+            layer(x, src_mask=bad_batched_mask, is_causal=True)
+
+        layer.eval()
+        bad_fastpath_mask = torch.zeros(1, seq_len * seq_len, dtype=torch.bool)
+        with torch.no_grad(), self.assertRaisesRegex(
+            RuntimeError, "The shape of the 2D attn_mask is"
+        ):
+            layer(x, src_mask=bad_fastpath_mask, is_causal=True)
+
+    def test_encoder_is_causal_without_src_mask_matches_causal_mask_in_eval(self):
+        torch.manual_seed(0)
+        d_model = 4
+        seq_len = 5
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model, 2, 8, dropout=0.0, batch_first=True
+        )
+        layer.eval()
+        x = torch.randn(2, seq_len, d_model)
+        mask = torch.nn.Transformer.generate_square_subsequent_mask(seq_len)
+
+        with torch.no_grad():
+            expected = layer(x, src_mask=mask)
+            actual = layer(x, is_causal=True)
+
+        self.assertEqual(expected, actual)
+
+    def test_encoder_is_causal_without_src_mask_keeps_sdpa_hint(self):
+        torch.manual_seed(0)
+        d_model = 4
+        seq_len = 5
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model, 2, 8, dropout=0.0, batch_first=True
+        )
+        layer.train()
+        x = torch.randn(2, seq_len, d_model)
+
+        with patch(
+            "torch.nn.functional.scaled_dot_product_attention",
+            wraps=torch.nn.functional.scaled_dot_product_attention,
+        ) as sdp_mock:
+            layer(x, is_causal=True)
+
+        self.assertTrue(sdp_mock.called)
+        sdp_args, _ = sdp_mock.call_args
+        self.assertIsNone(sdp_args[3])
+        self.assertTrue(sdp_args[5])
+
+    def test_encoder_is_causal_key_padding_mask_errors_before_nested_fastpath(self):
+        torch.manual_seed(0)
+        d_model = 4
+        seq_len = 5
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model, 2, 8, dropout=0.0, batch_first=True
+        )
+        encoder = torch.nn.TransformerEncoder(layer, 1, enable_nested_tensor=True)
+        encoder.eval()
+        x = torch.randn(2, seq_len, d_model)
+        src_key_padding_mask = torch.tensor(
+            [
+                [False, False, False, True, True],
+                [False, False, False, False, True],
+            ]
+        )
+
+        with torch.no_grad(), self.assertRaisesRegex(RuntimeError, "Need attn_mask"):
+            encoder(
+                x,
+                src_key_padding_mask=src_key_padding_mask,
+                is_causal=True,
+            )
+
+    def test_mha_is_causal_without_attn_mask_matches_causal_mask_in_eval(self):
+        torch.manual_seed(0)
+        mha = torch.nn.MultiheadAttention(
+            embed_dim=4, num_heads=2, dropout=0.0, batch_first=True
+        )
+        mha.eval()
+        x = torch.randn(2, 5, 4)
+        mask = torch.nn.Transformer.generate_square_subsequent_mask(x.size(1))
+
+        with torch.no_grad():
+            expected, _ = mha(x, x, x, attn_mask=mask, need_weights=False)
+            actual, _ = mha(x, x, x, need_weights=False, is_causal=True)
+
+        self.assertEqual(expected, actual)
+
+    def test_mha_is_causal_custom_attn_mask(self):
+        for mask_kind in ("float2d", "bool2d", "float3d", "bool3d"):
+            with self.subTest(mask_kind=mask_kind):
+                torch.manual_seed(0)
+                batch_size = 2
+                seq_len = 5
+                num_heads = 2
+                mha = torch.nn.MultiheadAttention(
+                    embed_dim=4, num_heads=num_heads, dropout=0.0, batch_first=True
+                )
+                mha.eval()
+                x = torch.randn(batch_size, seq_len, 4)
+                causal_mask, custom_mask = self._causal_and_custom_masks(
+                    seq_len, batch_size, num_heads, mask_kind
+                )
+
+                causal_output, _ = mha(x, x, x, need_weights=False, is_causal=True)
+                expected_custom_output, _ = mha(
+                    x, x, x, attn_mask=custom_mask, need_weights=False
+                )
+                custom_output, _ = mha(
+                    x,
+                    x,
+                    x,
+                    attn_mask=custom_mask,
+                    need_weights=False,
+                    is_causal=True,
+                )
+
+                self.assertEqual(expected_custom_output, custom_output)
+                self.assertFalse(torch.allclose(causal_output, custom_output))
+
+    def test_mha_is_causal_wrong_shape_attn_mask_errors_in_fastpath(self):
+        torch.manual_seed(0)
+        seq_len = 5
+        mha = torch.nn.MultiheadAttention(
+            embed_dim=4, num_heads=2, dropout=0.0, batch_first=True
+        )
+        mha.eval()
+        x = torch.randn(2, seq_len, 4)
+        bad_mask = torch.zeros(1, seq_len * seq_len, dtype=torch.bool)
+
+        with torch.no_grad(), self.assertRaisesRegex(
+            RuntimeError, "The shape of the 2D attn_mask is"
+        ):
+            mha(x, x, x, attn_mask=bad_mask, need_weights=False, is_causal=True)
+
+    def test_mha_is_causal_without_attn_mask_keeps_sdpa_hint(self):
+        torch.manual_seed(0)
+        mha = torch.nn.MultiheadAttention(
+            embed_dim=4, num_heads=2, dropout=0.0, batch_first=True
+        )
+        mha.train()
+        x = torch.randn(2, 5, 4)
+
+        with patch(
+            "torch.nn.functional.scaled_dot_product_attention",
+            wraps=torch.nn.functional.scaled_dot_product_attention,
+        ) as sdp_mock:
+            mha(x, x, x, need_weights=False, is_causal=True)
+
+        self.assertTrue(sdp_mock.called)
+        sdp_args, _ = sdp_mock.call_args
+        self.assertIsNone(sdp_args[3])
+        self.assertTrue(sdp_args[5])
+
+    def test_decoder_layer_tgt_is_causal_custom_tgt_mask(self):
+        for mask_kind in ("float2d", "bool2d", "float3d", "bool3d"):
+            with self.subTest(mask_kind=mask_kind):
+                torch.manual_seed(0)
+                d_model = 4
+                seq_len = 5
+                batch_size = 2
+                num_heads = 2
+                layer = torch.nn.TransformerDecoderLayer(
+                    d_model, num_heads, 8, dropout=0.0, batch_first=True
+                )
+                layer.eval()
+                tgt = torch.randn(batch_size, seq_len, d_model)
+                memory = torch.randn(batch_size, seq_len, d_model)
+                causal_mask, custom_mask = self._causal_and_custom_masks(
+                    seq_len, batch_size, num_heads, mask_kind
+                )
+
+                causal_output = layer(
+                    tgt, memory, tgt_mask=causal_mask, tgt_is_causal=True
+                )
+                expected_custom_output = layer(tgt, memory, tgt_mask=custom_mask)
+                custom_output = layer(
+                    tgt, memory, tgt_mask=custom_mask, tgt_is_causal=True
+                )
+
+                self.assertEqual(expected_custom_output, custom_output)
+                self.assertFalse(torch.allclose(causal_output, custom_output))
+
+    def test_decoder_layer_memory_is_causal_custom_memory_mask(self):
+        for mask_kind in ("float2d", "bool2d", "float3d", "bool3d"):
+            with self.subTest(mask_kind=mask_kind):
+                torch.manual_seed(0)
+                d_model = 4
+                seq_len = 5
+                batch_size = 2
+                num_heads = 2
+                layer = torch.nn.TransformerDecoderLayer(
+                    d_model, num_heads, 8, dropout=0.0, batch_first=True
+                )
+                layer.eval()
+                tgt = torch.randn(batch_size, seq_len, d_model)
+                memory = torch.randn(batch_size, seq_len, d_model)
+                causal_mask, custom_mask = self._causal_and_custom_masks(
+                    seq_len, batch_size, num_heads, mask_kind
+                )
+
+                causal_output = layer(
+                    tgt, memory, memory_mask=causal_mask, memory_is_causal=True
+                )
+                expected_custom_output = layer(tgt, memory, memory_mask=custom_mask)
+                custom_output = layer(
+                    tgt, memory, memory_mask=custom_mask, memory_is_causal=True
+                )
+
+                self.assertEqual(expected_custom_output, custom_output)
+                self.assertFalse(torch.allclose(causal_output, custom_output))
+
     @onlyCUDA
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Platform does not supposrt pre-SM80 hardware"

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6688,14 +6688,11 @@ def multi_head_attention_forward(
             leads to a significant performance degradation.*
         attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
             the batches while a 3D mask allows to specify a different mask for the entries of each batch.
-        is_causal: If specified, applies a causal mask as attention mask, and ignores
-            attn_mask for computing scaled dot product attention.
+        is_causal: If specified, applies a causal mask as attention mask when
+            ``attn_mask`` is not provided, ``need_weights=False``, and no
+            key padding, bias, zero attention, or static key/value is used.
+            If ``attn_mask`` is provided, it is applied as supplied.
             Default: ``False``.
-            .. warning::
-                is_causal is provides a hint that the attn_mask is the
-                causal mask.Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
         use_separate_proj_weight: the function accept the proj. weights for query, key,
             and value in different forms. If false, in_proj_weight will be used, which is
             a combination of q_proj_weight, k_proj_weight, v_proj_weight.
@@ -6807,19 +6804,28 @@ def multi_head_attention_forward(
         target_type=query.dtype,
     )
 
-    if is_causal and attn_mask is None:
+    if (
+        is_causal
+        and attn_mask is None
+        and (
+            need_weights
+            or key_padding_mask is not None
+            or bias_k is not None
+            or bias_v is not None
+            or add_zero_attn
+            or static_k is not None
+            or static_v is not None
+        )
+    ):
         raise RuntimeError(
             "Need attn_mask if specifying the is_causal hint. "
             "You may use the Transformer module method "
             "`generate_square_subsequent_mask` to create this mask."
         )
 
-    if is_causal and key_padding_mask is None and not need_weights:
-        # when we have a kpm or need weights, we need attn_mask
-        # Otherwise, we use the is_causal hint go as is_causal
-        # indicator to SDPA.
-        attn_mask = None
-    else:
+    if attn_mask is not None:
+        # An explicit mask must be honored as supplied.
+        is_causal = False
         attn_mask = _canonical_mask(
             mask=attn_mask,
             mask_name="attn_mask",
@@ -6829,11 +6835,11 @@ def multi_head_attention_forward(
             check_other=False,
         )
 
-        if key_padding_mask is not None:
-            # We have the attn_mask, and use that to merge kpm into it.
-            # Turn off use of is_causal hint, as the merged mask is no
-            # longer causal.
-            is_causal = False
+    if key_padding_mask is not None:
+        # We have the attn_mask, and use that to merge kpm into it.
+        # Turn off use of is_causal hint, as the merged mask is no
+        # longer causal.
+        is_causal = False
 
     if embed_dim != embed_dim_to_check:
         raise AssertionError(

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1119,6 +1119,7 @@ class MultiheadAttention(Module):
     - ``add_bias_kv`` is ``False``
     - ``add_zero_attn`` is ``False``
     - ``kdim`` and ``vdim`` are equal to ``embed_dim``
+    - if ``is_causal`` is ``True``, an ``attn_mask`` is passed
     - if a `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_ is passed, neither ``key_padding_mask``
       nor ``attn_mask`` is passed
     - autocast is disabled
@@ -1301,13 +1302,11 @@ class MultiheadAttention(Module):
             average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
                 heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
                 effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
-            is_causal: If specified, applies a causal mask as attention mask.
+            is_causal: If specified, applies a causal mask as attention mask
+                when ``attn_mask`` is not provided, ``need_weights=False``,
+                and no key padding mask, bias key/value, or zero attention is
+                used. If ``attn_mask`` is provided, it is applied as supplied.
                 Default: ``False``.
-                Warning:
-                ``is_causal`` provides a hint that ``attn_mask`` is the
-                causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
 
         Outputs:
             - **attn_output** - Attention outputs of shape :math:`(L, E)` when input is unbatched,
@@ -1382,6 +1381,8 @@ class MultiheadAttention(Module):
             why_not_fast_path = "self.bias_v was not None"
         elif self.add_zero_attn:
             why_not_fast_path = "add_zero_attn was enabled"
+        elif is_causal and attn_mask is None:
+            why_not_fast_path = "is_causal was specified without attn_mask"
         elif not self._qkv_same_embed_dim:
             why_not_fast_path = "_qkv_same_embed_dim was not True"
         elif query.is_nested and (
@@ -1555,10 +1556,24 @@ class MultiheadAttention(Module):
 
             # Always expands attn_mask to 4D
             if attn_mask.dim() == 3:
+                correct_3d_size = (batch_size * self.num_heads, seq_len, seq_len)
+                if attn_mask.shape != correct_3d_size:
+                    raise RuntimeError(
+                        f"The shape of the 3D attn_mask is {attn_mask.shape}, but should be {correct_3d_size}."
+                    )
                 attn_mask_expanded = attn_mask.view(batch_size, -1, seq_len, seq_len)
-            else:  # attn_mask.dim() == 2:
+            elif attn_mask.dim() == 2:
+                correct_2d_size = (seq_len, seq_len)
+                if attn_mask.shape != correct_2d_size:
+                    raise RuntimeError(
+                        f"The shape of the 2D attn_mask is {attn_mask.shape}, but should be {correct_2d_size}."
+                    )
                 attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(
                     batch_size, self.num_heads, -1, -1
+                )
+            else:
+                raise RuntimeError(
+                    f"attn_mask's dimension {attn_mask.dim()} is not supported"
                 )
             merged_mask = attn_mask_expanded
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -208,28 +208,20 @@ class Transformer(Module):
             src_key_padding_mask: the Tensor mask for src keys per batch (optional).
             tgt_key_padding_mask: the Tensor mask for tgt keys per batch (optional).
             memory_key_padding_mask: the Tensor mask for memory keys per batch (optional).
-            src_is_causal: If specified, applies a causal mask as ``src_mask``.
-                Default: ``None``; try to detect a causal mask.
-                Warning:
-                ``src_is_causal`` provides a hint that ``src_mask`` is
-                the causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
-            tgt_is_causal: If specified, applies a causal mask as ``tgt_mask``.
-                Default: ``None``; try to detect a causal mask.
-                Warning:
-                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
-                the causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
-            memory_is_causal: If specified, applies a causal mask as
-                ``memory_mask``.
-                Default: ``False``.
-                Warning:
-                ``memory_is_causal`` provides a hint that
-                ``memory_mask`` is the causal mask. Providing incorrect
-                hints can result in incorrect execution, including
-                forward and backward compatibility.
+            src_is_causal: If specified and ``src_mask`` is not provided,
+                applies a causal mask as ``src_mask`` when no
+                ``src_key_padding_mask`` is supplied. If ``src_mask`` is
+                provided, it is applied as supplied. Default: ``None``; try
+                to detect a causal mask from ``src_mask`` when it is provided.
+            tgt_is_causal: If specified and ``tgt_mask`` is not provided,
+                applies a causal mask as ``tgt_mask`` when no
+                ``tgt_key_padding_mask`` is supplied. If ``tgt_mask`` is
+                provided, it is applied as supplied. Default: ``None``; try
+                to detect a causal mask from ``tgt_mask`` when it is provided.
+            memory_is_causal: If specified and ``memory_mask`` is not provided,
+                applies a causal mask as ``memory_mask`` when no
+                ``memory_key_padding_mask`` is supplied. If ``memory_mask`` is
+                provided, it is applied as supplied. Default: ``False``.
 
         Shape:
             - src: :math:`(S, E)` for unbatched input, :math:`(S, N, E)` if `batch_first=False` or
@@ -415,13 +407,11 @@ class TransformerEncoder(Module):
             src: the sequence to the encoder (required).
             mask: the mask for the src sequence (optional).
             src_key_padding_mask: the mask for the src keys per batch (optional).
-            is_causal: If specified, applies a causal mask as ``mask``.
-                Default: ``None``; try to detect a causal mask.
-                Warning:
-                ``is_causal`` provides a hint that ``mask`` is the
-                causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
+            is_causal: If specified and ``mask`` is not provided, applies a
+                causal mask as ``mask`` when no ``src_key_padding_mask`` is
+                supplied. If ``mask`` is provided, it is applied as supplied.
+                Default: ``None``; try to detect a causal mask from ``mask``
+                when it is provided.
 
         Shape:
             see the docs in :class:`~torch.nn.Transformer`.
@@ -471,6 +461,8 @@ class TransformerEncoder(Module):
             )
         elif src_key_padding_mask is None:
             why_not_sparsity_fast_path = "src_key_padding_mask was None"
+        elif is_causal is True and mask is None:
+            why_not_sparsity_fast_path = "is_causal was specified without mask"
         # This check avoids a call to torch._nested_tensor_from_mask_left_aligned() that
         # breaks in torch.compile.
         elif do_mask_check and torch.compiler.is_compiling():
@@ -614,21 +606,15 @@ class TransformerDecoder(Module):
             memory_mask: the mask for the memory sequence (optional).
             tgt_key_padding_mask: the mask for the tgt keys per batch (optional).
             memory_key_padding_mask: the mask for the memory keys per batch (optional).
-            tgt_is_causal: If specified, applies a causal mask as ``tgt mask``.
-                Default: ``None``; try to detect a causal mask.
-                Warning:
-                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
-                the causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
-            memory_is_causal: If specified, applies a causal mask as
-                ``memory mask``.
-                Default: ``False``.
-                Warning:
-                ``memory_is_causal`` provides a hint that
-                ``memory_mask`` is the causal mask. Providing incorrect
-                hints can result in incorrect execution, including
-                forward and backward compatibility.
+            tgt_is_causal: If specified and ``tgt_mask`` is not provided,
+                applies a causal mask as ``tgt_mask`` when no
+                ``tgt_key_padding_mask`` is supplied. If ``tgt_mask`` is
+                provided, it is applied as supplied. Default: ``None``; try
+                to detect a causal mask from ``tgt_mask`` when it is provided.
+            memory_is_causal: If specified and ``memory_mask`` is not provided,
+                applies a causal mask as ``memory_mask`` when no
+                ``memory_key_padding_mask`` is supplied. If ``memory_mask`` is
+                provided, it is applied as supplied. Default: ``False``.
 
         Shape:
             see the docs in :class:`~torch.nn.Transformer`.
@@ -719,6 +705,7 @@ class TransformerEncoderLayer(Module):
         - batch_first is ``True`` and the input is batched (i.e., ``src.dim() == 3``)
         - activation is one of: ``"relu"``, ``"gelu"``, ``torch.functional.relu``, or ``torch.functional.gelu``
         - at most one of ``src_mask`` and ``src_key_padding_mask`` is passed
+        - if ``is_causal`` is ``True``, ``src_mask`` is passed
         - if src is a `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_, neither ``src_mask``
           nor ``src_key_padding_mask`` is passed
         - the two ``LayerNorm`` instances have a consistent ``eps`` value (this will naturally be the case
@@ -805,13 +792,11 @@ class TransformerEncoderLayer(Module):
             src: the sequence to the encoder layer (required).
             src_mask: the mask for the src sequence (optional).
             src_key_padding_mask: the mask for the src keys per batch (optional).
-            is_causal: If specified, applies a causal mask as ``src mask``.
+            is_causal: If specified, applies a causal mask as ``src_mask`` when
+                ``src_mask`` is not provided and no ``src_key_padding_mask`` is
+                supplied. If ``src_mask`` is provided, it is applied as
+                supplied.
                 Default: ``False``.
-                Warning:
-                ``is_causal`` provides a hint that ``src_mask`` is the
-                causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
 
         Shape:
             see the docs in :class:`~torch.nn.Transformer`.
@@ -862,6 +847,8 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "neither src_key_padding_mask nor src_mask are not supported with NestedTensor input"
         elif self.self_attn.num_heads % 2 == 1:
             why_not_sparsity_fast_path = "num_head is odd"
+        elif is_causal and src_mask is None:
+            why_not_sparsity_fast_path = "is_causal was specified without src_mask"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
         elif any(
@@ -1099,21 +1086,14 @@ class TransformerDecoderLayer(Module):
             memory_mask: the mask for the memory sequence (optional).
             tgt_key_padding_mask: the mask for the tgt keys per batch (optional).
             memory_key_padding_mask: the mask for the memory keys per batch (optional).
-            tgt_is_causal: If specified, applies a causal mask as ``tgt mask``.
-                Default: ``False``.
-                Warning:
-                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
-                the causal mask. Providing incorrect hints can result in
-                incorrect execution, including forward and backward
-                compatibility.
+            tgt_is_causal: If specified, applies a causal mask as
+                ``tgt_mask`` when ``tgt_mask`` is not provided and no
+                ``tgt_key_padding_mask`` is supplied. If ``tgt_mask`` is
+                provided, it is applied as supplied. Default: ``False``.
             memory_is_causal: If specified, applies a causal mask as
-                ``memory mask``.
-                Default: ``False``.
-                Warning:
-                ``memory_is_causal`` provides a hint that
-                ``memory_mask`` is the causal mask. Providing incorrect
-                hints can result in incorrect execution, including
-                forward and backward compatibility.
+                ``memory_mask`` when ``memory_mask`` is not provided and no
+                ``memory_key_padding_mask`` is supplied. If ``memory_mask`` is
+                provided, it is applied as supplied. Default: ``False``.
 
         Shape:
             see the docs in :class:`~torch.nn.Transformer`.
@@ -1214,19 +1194,9 @@ def _detect_is_causal_mask(
     """Return whether the given attention mask is causal.
 
     Warning:
-    If ``is_causal`` is not ``None``, its value will be returned as is.  If a
-    user supplies an incorrect ``is_causal`` hint,
-
-    ``is_causal=False`` when the mask is in fact a causal attention.mask
-       may lead to reduced performance relative to what would be achievable
-       with ``is_causal=True``;
-    ``is_causal=True`` when the mask is in fact not a causal attention.mask
-       may lead to incorrect and unpredictable execution - in some scenarios,
-       a causal mask may be applied based on the hint, in other execution
-       scenarios the specified mask may be used.  The choice may not appear
-       to be deterministic, in that a number of factors like alignment,
-       hardware SKU, etc influence the decision whether to use a mask or
-       rely on the hint.
+    If ``is_causal`` is not ``None``, its value will be returned as is. If
+    ``is_causal`` is ``None``, this helper may detect a supplied causal mask
+    for compatibility with callers that omit the hint.
     ``size`` if not None, check whether the mask is a causal mask of the provided size
        Otherwise, checks for any causal mask.
     """


### PR DESCRIPTION
This fixes a case where `is_causal=True` could cause user provided attention masks to be ignored. If a mask is passed in, it is now validated and used. The maskless causal path is still kept for the supported SDPA case, but unsupported combinations now raise instead of silently doing the wrong thing. This also updates the fast path docs and adds regression tests for encoder, MHA, and decoder masks across float, bool, 2D, and 3D masks.

Validation:
- `git diff --check upstream/main..HEAD`
- `python3 -m py_compile torch/nn/functional.py torch/nn/modules/activation.py torch/nn/modules/transformer.py test/test_transformers.py`

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @drisspg @liangel-02 @howardzhang-cv