### PR TITLE
[Inductor][cond] Allow output-input aliasing in torch.cond branches (re-land D106106380 + dev-nosan test fix)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -6480,18 +6480,10 @@ def forward(self, x_1):
     return view""",
         )
 
-        # torch.cond triggers the check of the branches because the predicate
-        # is a SymBool.
-        with self.assertRaisesRegex(
-            # Should be
-            # torch._dynamo.exc.Unsupported,
-            # "Encountered aliasing during higher order op tracing for HOP.*"
-            torch._dynamo.exc.UncapturedHigherOrderOpError,
-            r"Higher Order Operator: torch\.cond",
-        ):
-            make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(
-                *example_inputs
-            )
+        # With the SymBool predicate, cond checks the branches; output-input
+        # aliasing is now allowed, so symbolic tracing succeeds instead of
+        # raising.
+        make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
 
     def test_cond_functionalized_nested_input_mutation(self):
         def true_true_fn(x):
@@ -6590,17 +6582,12 @@ def forward(self, x_1):
             return cond(pred, true_fn, false_fn, [x])
 
         example_input = torch.ones(5, 5)
+        # Output-input aliasing is now allowed in torch.cond, so this no
+        # longer raises.
         try:
             example_input_func = to_fun_old(example_input)
             torch._enable_functionalization(reapply_views=False)
-            with self.assertRaisesRegex(
-                # Should be
-                # torch._dynamo.exc.Unsupported,
-                # "Encountered aliasing during higher order op tracing for HOP.*"
-                torch._dynamo.exc.UncapturedHigherOrderOpError,
-                r"Higher Order Operator: torch\.cond",
-            ):
-                f(example_input_func)
+            f(example_input_func)
         finally:
             torch._disable_functionalization()
 
@@ -6627,14 +6614,8 @@ def forward(self, x_1):
 
             return wrapper
 
-        with self.assertRaisesRegex(
-            # Should be
-            # torch._dynamo.exc.Unsupported,
-            # "Encountered aliasing during higher order op tracing for HOP.*"
-            torch._dynamo.exc.UncapturedHigherOrderOpError,
-            r"Higher Order Operator: torch\.cond",
-        ):
-            make_fx(f_wrapper(f), tracing_mode="symbolic")(example_input)
+        # Aliasing no longer raises; symbolic tracing succeeds.
+        make_fx(f_wrapper(f), tracing_mode="symbolic")(example_input)
 
     def test_cond_functionalized_aot_func_check_functional(self):
         def true_fn(x):
@@ -6778,12 +6759,13 @@ def forward(self, arg0_1):
             return cond(y, true_fn, false_fn, [x])
 
         x = torch.randn(4)
+        # true_fn returns a single tensor while false_fn returns a 2-tuple, so
+        # the branches have mismatched output specs. (false_fn also aliases the
+        # input, which is now allowed for cond, so the output-spec mismatch is
+        # the error that surfaces.)
         with self.assertRaisesRegex(
-            # Should be
-            # torch._dynamo.exc.Unsupported,
-            # "Encountered aliasing during higher order op tracing for HOP.*"
-            torch._dynamo.exc.UncapturedHigherOrderOpError,
-            r"Higher Order Operator: torch\.cond",
+            torch._dynamo.exc.TorchRuntimeError,
+            "Unmatched output spec from torch.cond branches",
         ):
             make_fx(f)(x, torch.tensor(False))
 
@@ -6954,12 +6936,13 @@ def forward(self, arg0_1):
             return cond(y, true_fn, false_fn, [x])
 
         x = torch.randn(4)
+        # true_fn returns a single tensor while false_fn returns a 2-tuple, so
+        # the branches have mismatched output specs. (false_fn also aliases the
+        # input, which is now allowed for cond, so the output-spec mismatch is
+        # the error that surfaces.)
         with self.assertRaisesRegex(
-            # Should be
-            # torch._dynamo.exc.Unsupported,
-            # "Encountered aliasing during higher order op tracing for HOP.*"
-            torch._dynamo.exc.UncapturedHigherOrderOpError,
-            r"Higher Order Operator: torch\.cond",
+            torch._dynamo.exc.TorchRuntimeError,
+            "Unmatched output spec from torch.cond branches",
         ):
             make_fx(f, tracing_mode="fake")(x, torch.tensor(False))
 
@@ -9249,39 +9232,75 @@ class GraphModule(torch.nn.Module):
             )
 
     def test_input_output_alias(self):
+        # Output-input aliasing is now allowed in torch.cond: branches are
+        # mutually exclusive and outputs are materialized as fresh tensors, so
+        # returning an operand (or a view of it) is safe.
         def fn(f, *args):
             return torch.cond(args[0].sum() > 0, f, f, args)
 
         x = torch.randn(2, 2)
         for f in ALIAS_FN:
-            with self.assertRaisesRegex(
-                # Should be
-                # torch._dynamo.exc.Unsupported,
-                # "Encountered aliasing during higher order op tracing for HOP.*"
-                torch._dynamo.exc.UncapturedHigherOrderOpError,
-                r"Higher Order Operator: torch\.cond",
-            ):
-                torch.compile(fn)(f, x)
+            self.assertEqual(torch.compile(fn)(f, x), fn(f, x))
+
+    @skipIfTorchDynamo("storage identity is not meaningful under TEST_WITH_DYNAMO")
+    def test_cond_output_input_alias_is_materialized(self):
+        # A branch may return an operand directly (output aliases an input).
+        # Functionalization clones such outputs, so the cond result is a fresh
+        # tensor: mutating it must not corrupt the input. Distinct branches keep
+        # cond from auto-lifting identical branches into a pass-through (which
+        # would legitimately alias the input).
+        def true_fn(x):
+            return x
+
+        def false_fn(x):
+            return x + 1
+
+        def fn(x):
+            return torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
+
+        x = torch.ones(3, 4)  # sum > 0 -> true_fn, which returns the input
+        x_ref = x.clone()
+        out = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(out, x_ref)
+        self.assertNotEqual(out.data_ptr(), x.data_ptr())
+        out.add_(1.0)
+        self.assertEqual(x, x_ref)
+
+    @skipIfTorchDynamo("storage identity is not meaningful under TEST_WITH_DYNAMO")
+    def test_cond_output_input_view_alias_is_materialized(self):
+        # A branch returning a view of an input also aliases its storage and
+        # must be materialized.
+        def true_fn(x):
+            return x.view(-1)
+
+        def false_fn(x):
+            return x.reshape(-1) + 1
+
+        def fn(x):
+            return torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
+
+        x = torch.ones(3, 4)  # sum > 0 -> true_fn, returns a view of the input
+        x_ref = x.clone()
+        out = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(out, x_ref.view(-1))
+        self.assertNotEqual(out.data_ptr(), x.data_ptr())
+        out.add_(1.0)
+        self.assertEqual(x, x_ref)
 
     def test_input_input_alias(self):
+        # Input-input aliasing (two operands sharing storage) is now allowed:
+        # the branches only read their inputs, so read-only aliasing is safe.
         def fn(view_f, arg):
             def f(arg1, arg2):
-                return arg1.cos(), arg2.sin()
+                # Plain arithmetic (no transcendental/Sleef ops) so the test
+                # exercises input aliasing, not vectorized-math codegen.
+                return arg1 + 1, arg2 * 2
 
             return torch.cond(arg.sum() > 0, f, f, (arg, view_f(arg)))
 
         x = torch.randn(2, 2)
-        # ALIAS_FN[0] is an identical function, cond optimizes the duplication
-        # as a result of auto lifting.
         for view_f in ALIAS_FN[1:]:
-            with self.assertRaisesRegex(
-                # Should be
-                # torch._dynamo.exc.Unsupported,
-                # "Encountered aliasing during higher order op tracing for HOP.*"
-                torch._dynamo.exc.UncapturedHigherOrderOpError,
-                r"Higher Order Operator: torch\.cond",
-            ):
-                torch.compile(fn)(view_f, x)
+            self.assertEqual(torch.compile(fn)(view_f, x), fn(view_f, x))
 
     @parametrize("inference_mode", [True, False])
     def test_input_mutation(self, inference_mode):

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -652,7 +652,8 @@ class CondTests(TestCase):
 
     @requires_gpu
     def test_cond_aliasing_outputs(self):
-        # output aliasing in subgraphs: not supported
+        # Output-output aliasing (z and z[1:] share a buffer) is now allowed
+        # in torch.cond; outputs are materialized, so the result matches eager.
         class Model(torch.nn.Module):
             def forward(self, p, a, b):
                 def true_fn(x, y):
@@ -665,11 +666,105 @@ class CondTests(TestCase):
 
                 return torch.cond(p, true_fn, false_fn, [a, b])
 
-        # AssertionError: Output aliasing is currently not supported...
-        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+        m = Model()
+        for p in [torch.tensor(True), torch.tensor(False)]:
+            a = torch.randn(10, 20)
+            b = torch.randn(10, 20)
+            self.assertEqual(torch.compile(m)(p, a, b), m(p, a, b))
+
+    @requires_gpu
+    @parametrize("device", ["cpu", GPU_TYPE])
+    def test_cond_output_input_aliasing(self, device):
+        # torch.cond branches are mutually exclusive, so returning an
+        # operand directly (output-input aliasing) is safe.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(20, 20)
+
+            def forward(self, p, a):
+                def true_fn(x):
+                    return x
+
+                def false_fn(x):
+                    return self.linear(x)
+
+                return torch.cond(p, true_fn, false_fn, [a])
+
+        self._run_test(
+            model=Model().to(device),
+            inputs=(torch.randn(10, 20),),
+            device=device,
+            dynamic=True,
+        )
+
+    @requires_gpu
+    @parametrize("device", ["cpu", GPU_TYPE])
+    def test_cond_output_input_aliasing_multi_output(self, device):
+        # One of multiple outputs aliases the input — compile + numerical check.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(20, 10)
+
+            def forward(self, p, a):
+                def true_fn(x):
+                    return x, self.linear(x)
+
+                def false_fn(x):
+                    return x.new_zeros(x.shape), x.new_zeros(x.shape[0], 10)
+
+                out1, out2 = torch.cond(p, true_fn, false_fn, [a])
+                return out1 + out2.sum(dim=1, keepdim=True).expand_as(out1)
+
+        model = Model().to(device)
+        compiled = torch.compile(model, backend="inductor", fullgraph=True)
+        a = torch.randn(10, 20, device=device)
+        for p_val in [True, False]:
+            p = torch.tensor(p_val, device=device)
+            expected = model(p, a)
+            actual = compiled(p, a)
+            torch.testing.assert_close(actual, expected)
+
+    @requires_gpu
+    @parametrize("device", ["cpu", GPU_TYPE])
+    def test_cond_output_input_aliasing_both_branches(self, device):
+        # Both branches return the input directly (identity cond).
+        class Model(torch.nn.Module):
+            def forward(self, p, a):
+                def true_fn(x):
+                    return x
+
+                def false_fn(x):
+                    return x
+
+                return torch.cond(p, true_fn, false_fn, [a])
+
+        model = Model().to(device)
+        compiled = torch.compile(model, backend="inductor", fullgraph=True)
+        a = torch.randn(10, 20, device=device)
+        for p_val in [True, False]:
+            p = torch.tensor(p_val, device=device)
+            expected = model(p, a)
+            actual = compiled(p, a)
+            torch.testing.assert_close(actual, expected)
+
+    def test_cond_input_mutation_still_rejected(self):
+        # Mutation must still be rejected even though aliasing is allowed.
+        class Model(torch.nn.Module):
+            def forward(self, p, a):
+                def true_fn(x):
+                    x.add_(1)
+                    return x
+
+                def false_fn(x):
+                    return x
+
+                return torch.cond(p, true_fn, false_fn, [a])
+
+        with self.assertRaises(Exception):
             torch.compile(Model())(
                 torch.tensor(True),
-                torch.randn(10, 20),
                 torch.randn(10, 20),
             )
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2395,7 +2395,9 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.cond"
     _ALLOW_FALLBACK_TO_EAGER = False
     supports_input_mutation = False
-    supports_aliasing = False
+    # torch.cond branches are mutually exclusive — only one branch executes,
+    # so output-input aliasing is safe (no concurrent access to aliased buffers).
+    supports_aliasing = True
 
     def _call_function(
         self,
@@ -2406,7 +2408,6 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
         from . import ListVariable
 
         self.supports_input_mutation = not torch.is_grad_enabled()
-        self.supports_aliasing = not torch.is_grad_enabled()
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -713,7 +713,11 @@ def cond_func(ctx, pred, true_fn, false_fn, inputs):
         can_auto_functionalize,
         do_auto_functionalize_v2,
     )
-    from torch._higher_order_ops.utils import _check_alias_and_mutation, HopInstance
+    from torch._higher_order_ops.utils import (
+        _check_mutation,
+        clone_outputs_aliasing_inputs,
+        HopInstance,
+    )
 
     hop_instance = HopInstance.create(cond_op, pred, true_fn, false_fn, inputs)
     # For now, we only support auto-functionalization for cond when using python
@@ -732,13 +736,24 @@ def cond_func(ctx, pred, true_fn, false_fn, inputs):
         functional_true = ctx.functionalize(_maybe_run_with_interpreter(true_fn))
         functional_false = ctx.functionalize(_maybe_run_with_interpreter(false_fn))
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
+        # A branch may return an operand directly; clone outputs that alias an
+        # input so the cond HOP stays functional (outputs must not alias inputs).
+        # Input mutation is still rejected.
         for branch, branch_name in [(true_fn, "cond_true"), (false_fn, "cond_false")]:
-            _check_alias_and_mutation(
-                branch, unwrapped_inputs, branch_name, pre_dispatch
-            )
+            _check_mutation(branch, unwrapped_inputs, branch_name, pre_dispatch)
+
+        def _materialize_aliased_outputs(fn):
+            def wrapped(*operands):
+                maybe_clone = clone_outputs_aliasing_inputs(operands)
+                return pytree.tree_map(maybe_clone, fn(*operands))
+
+            return wrapped
 
         cond_return = cond_op(
-            unwrapped_pred, functional_true, functional_false, unwrapped_inputs
+            unwrapped_pred,
+            _materialize_aliased_outputs(functional_true),
+            _materialize_aliased_outputs(functional_false),
+            unwrapped_inputs,
         )
         return ctx.wrap_tensors(cond_return)
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -501,6 +501,16 @@ def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
         raise RuntimeError(f"{name} might be modifying the input!")
 
 
+def _check_mutation(graph_module, inputs_fake, name, pre_dispatch):
+    # Like _check_alias_and_mutation but only rejects input mutation; aliasing
+    # is permitted (e.g. torch.cond, whose branches are mutually exclusive).
+    _, inp_mutation = has_potential_input_alias_or_mutation(
+        graph_module, inputs_fake, pre_dispatch=pre_dispatch
+    )
+    if inp_mutation:
+        raise RuntimeError(f"{name} might be modifying the input!")
+
+
 def unique_graph_id(proxy_mode, prefix):
     """Returns a unique name and id for a graph to be added to a proxy_mode tracer"""
     # There are probably better ways - I know that create_arg has some self incrementing name


### PR DESCRIPTION
Summary:
Re-land of D106106380 (reverted by D108642140 - "not approved in OSS, needs more discussion"), folded together with its follow-up dev-nosan test fix D108479020.

Allow output-input aliasing in `torch.cond` branches.

torch.cond branches are mutually exclusive — only one branch executes at runtime. When the true branch returns an operand directly (e.g., identity/skip path), the output aliases the input. This is safe because the non-taken branch never runs, so there is no concurrent access to aliased buffers.

Previously, two checks rejected this pattern:
1. **Dynamo** (`higher_order_ops.py`): `CondHigherOrderVariable.supports_aliasing = False` rejected aliasing during tracing with a graph break.
2. **Functionalization** (`cond.py`): `_check_alias_and_mutation` rejected aliasing during AOT functionalization.

Note: Dynamo already allowed aliasing in inference (`supports_aliasing = not torch.is_grad_enabled()`), but `torch.export` traces with grad enabled even for inference models, so the check was ineffective for the AOTI export path.

Fix:
- Set `supports_aliasing = True` unconditionally on `CondHigherOrderVariable`. Aliasing is safe for cond regardless of grad context because branches are exclusive — even with autograd, only the taken branch's gradient flows.
- Skip the alias check in the functionalization impl (keep mutation check).

Motivation: PrismNet's `_clone_layer_outputs` uses `lo.clone()` to break output-input aliasing required by torch.cond. Removing this constraint saves ~0.046ms per inference (2 DHEN layers at B=2048).

Adds `test_cond_output_input_aliasing` regression test.

Note: D106106380 was reverted for OSS-approval reasons - this re-land needs that discussion resolved (Richard Zou) before it can land.

Fixes T275596551.

Test Plan:
torch.cond aliasing tests (Inductor):
```
buck2 test fbcode//mode/opt -c 'fbcode.nvcc_arch=a100,h100' fbcode//caffe2/test/inductor:control_flow -- --exact 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_device_cpu (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_device_cuda (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_multi_output_device_cpu (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_multi_output_device_cuda (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_both_branches_device_cpu (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_output_input_aliasing_both_branches_device_cuda (caffe2.test.inductor.test_control_flow.CondTests)' 'fbcode//caffe2/test/inductor:control_flow - test_cond_input_mutation_still_rejected (caffe2.test.inductor.test_control_flow.CondTests)'
```
Test session: https://www.internalfb.com/intern/testinfra/testrun/10414574313882076

PrismNet repro — all 11 tests pass, including `CondOutputInputAlias: without clone` which previously failed with "Replace return input with return input.clone()". Confirms `lo.clone()` workaround in `_clone_layer_outputs` can be removed.
```
buck2 run fbcode//mode/opt fbcode//aps_models/ads/gmp/models/ads_mtml_prism_net_dedicated_model/experimental/benchmarks:repro_aoti_inductor_bugs
```

dev-nosan input-aliasing test (the folded-in D108479020 Sleef fix):
```
buck test fbcode//mode/dev-nosan fbcode//caffe2/test/functorch:test_control_flow -- --exact 'fbcode//caffe2/test/functorch:test_control_flow - test_input_input_alias (caffe2.test.functorch.test_control_flow.TestControlFlowTraced)'
```

Differential Revision: D108709373




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98