### PR TITLE
Add numerics-debugging skill

### DIFF
--- a/.claude/skills/numerics-debugging/SKILL.md
+++ b/.claude/skills/numerics-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: numerics-debugging
-description: Debug numeric / bitwise divergence between two PyTorch runs that should agree (eager vs torch.compile, eager vs aot_fx_trace, distributed vs single-process, TF32 vs fp32, before vs after a refactor) by capturing per-op activations with torch.utils._debug_mode.DebugMode and diffing them to localize the first diverging op. Use when the user reports loss drift, mismatched outputs, "numerics don't match", "bitwise divergence", "find which op diverges", or invokes /numerics-debugging.
+description: Debug numeric / bitwise divergence between two PyTorch runs that should agree (eager vs torch.compile, eager vs aot_fx_trace, distributed vs single-process, TF32 vs fp32, before vs after a refactor) by capturing plain torch.utils._debug_mode.DebugMode string dumps with tensor hashes and comparing them to localize the first diverging op. Use when the user reports loss drift, mismatched outputs, "numerics don't match", "bitwise divergence", "find which op diverges", or invokes /numerics-debugging.
 ---
 
 # Numerics Debugging (DebugMode-based)
@@ -8,32 +8,31 @@ description: Debug numeric / bitwise divergence between two PyTorch runs that sh
 When two runs that *should* produce the same numbers don't, the goal is to
 find the **first op where they diverge**, then decide whether that op is the
 cause (its inputs matched but its output didn't) or just a carrier (its inputs
-already differed). This skill captures a per-op fingerprint of one step from
-each run with `torch.utils._debug_mode.DebugMode`, then diffs the two.
+already differed). This skill captures `torch.utils._debug_mode.DebugMode`
+string dumps from one step of each run, with tensor hashes enabled, then
+compares the two dumps.
 
 There is no bundled tooling. You author a small throwaway capture script in
-`agent_space/` from the verified recipe in
+`agent_space/` from the recipe in
 [references/capture-recipe.md](references/capture-recipe.md), run it once per
-side, and compare the two logs.
+side, and compare the plain `debug_string()` text dumps.
 
-## IMPORTANT: probe before you trust the recipe
+## DebugMode Settings
 
-`torch.utils._debug_mode` is **private and version-dependent**. The recipe was
-verified on torch 2.10 and 2.13, but the operator-stream structure (in
-particular how module boundaries are represented) changes across versions:
+Use DebugMode's own string dump as the debugging artifact. Turn on:
 
-- torch ~2.10: module markers are `_NNModuleCall` with a `.module_name` attr.
-- torch ~2.13: module markers are `_AnnotateCall` with `header == "nn.Mod"`
-  and the FQN in `.tag`.
-- `DebugMode.current_nn_module_stack` is **empty at dispatch time** in these
-  versions, so you cannot read the FQN from inside the dispatch hook.
+- `record_realtensor=True`
+- `record_nn_module=True`
+- `record_ids=True`
+- `record_stack_trace=True` when source context is useful
+- `record_profiler_context=True`
+- `run_compile_with_interpreter=True` for AOT/eager compiled regions when
+  module metadata matters
+- `DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True)`
 
-So the first step is always to run the ~15-line probe in the recipe against
-the *actual* environment, confirm the marker class / attribute names, and
-adapt the capture to match. Do not assume. If the probe does not show usable
-layer/module markers for the target model, enable the recipe's generic
-`annotate_modules=True` fallback before capturing; do not rely on framework- or
-model-specific layer-name markers.
+Use `record_nn_module=True` for layer names. Do not monkey-patch modules or add
+framework-specific layer markers; if module names are weak, rely on stack traces,
+profiler scopes, and the surrounding op sequence in the plain dump.
 
 ## Workflow
 
@@ -42,31 +41,33 @@ model-specific layer-name markers.
    diverge and the diff is useless. Set the same `torch.manual_seed(...)`
    before model init and before the step, use the same batch, and enable
    `torch.use_deterministic_algorithms(True)` where possible.
-2. **Probe** the operator stream (recipe, step 1) to confirm the module-marker
-   class for this torch version and whether `record_nn_module=True` produces
-   useful names for this model.
+   For training, first do a one-step scalar check: compare the loss and a
+   deterministic grad norm. If the loss matches bitwise but the grad norm
+   diverges, focus the dump comparison on backward.
+2. **Probe** a tiny `DebugMode.debug_string()` dump (recipe, step 1) to confirm
+   hashes, tensor IDs, stack traces, and module names appear in this
+   environment.
 3. **Capture one step per run** with the capture function (recipe, step 2),
-   writing each run's fingerprints to its own log (`run_A.log`, `run_B.log`).
-   Pass `annotate_modules=True` when the model needs generic layer annotations.
-   The step can be inference-only or forward+backward; capture on a warmed-up
-   step if step 0 has legitimate one-time init/compile differences.
-4. **Diff the two logs** (recipe, step 3 + [references/comparing-runs.md](references/comparing-runs.md)):
-   pair ops by key, parse the hashes as floats, and report the first op whose
-   output hash differs beyond a relative tolerance.
+   writing each run's plain dump to its own file (`run_A_debug.txt`,
+   `run_B_debug.txt`). The step can be inference-only or forward+backward;
+   capture on a warmed-up step if step 0 has legitimate one-time init/compile
+   differences.
+4. **Diff the two dumps** ([references/comparing-runs.md](references/comparing-runs.md)):
+   inspect the plain text and report the first op whose output hash differs.
 
 ## What gets captured per op
 
-For each non-excluded op producing a float tensor:
+For each recorded op in the plain dump:
 
-- **Key** `module_fqn/op_N_opname` (e.g. `features.0.proj/op_0_addmm`) — FQN +
-  per-module op counter + ATen op name.
-- **Phase** — forward or backward (from `torch._C._current_autograd_node()`).
-- **Output hash** — DebugMode's `norm` hash (~L1, float64) of the result.
+- **Module/profiler context** — from `record_nn_module=True` and
+  `record_profiler_context=True`.
+- **Tensor IDs** — from `record_ids=True`.
+- **Source summaries** — from `record_stack_trace=True` and
+  `debug_string(show_stack_trace=True)`.
+- **Output hash** — DebugMode's `norm` hash of the result.
 - **Input hashes** — `norm` hash of each input *before* the op ran. This is
   what catches in-place mutations (e.g. `_fused_adam_` returns `None`, so it
   has no output hash, but its input hashes still move).
-- **Stats** — shape/dtype + L2/min/max/mean, with L2 and mean in **float64**
-  so they don't wobble with reduction order.
 
 ## Interpreting the diff
 
@@ -78,9 +79,9 @@ For each non-excluded op producing a float tensor:
   differs**. That op is the root cause.
 - **Everything diverges from the very first op** -> almost always a dtype or
   seed/determinism mismatch, not a real bug. Fix setup (step 1) and recapture.
-- **A tiny last-digit difference that doesn't propagate** -> reduction-order
-  noise, not a bug. Compare the float64 L2/mean and the `norm` hash with a
-  relative tolerance rather than requiring exact string equality.
+- **A tiny last-digit difference that doesn't propagate** -> often
+  reduction-order noise, not a bug. Use `hash_fn="hash_tensor"` if strict
+  bitwise equality is required.
 
 This was validated on a real divergence: fp32 vs TF32 matmul on the same model
 matched on every forward op but first diverged on a **backward** `mm`, whose
@@ -90,16 +91,13 @@ source. Divergence often first crosses the hash's precision floor in backward
 
 ## Cost
 
-Capture adds roughly 10-40% time/memory on the single captured step only
-(stats reduced inline in float64; no tensor clones held). Because the context
+Capture adds overhead on the single captured step only. Because the context
 wraps just one step, steady-state training is untouched.
 
 ## References
 
 - [references/capture-recipe.md](references/capture-recipe.md) — the probe,
-  generic module annotation fallback, the verified `DebugMode` capture function
-  (forward FQN via the marker/depth stream, backward FQN via a grad_fn map), op
-  filtering, and the compiled/traced-graph caveat.
-- [references/comparing-runs.md](references/comparing-runs.md) — the real log
-  format, tolerance-based pairing/diffing, and the common eager-vs-traced
-  key-drift patterns.
+  relevant DebugMode flags, example dump snippets, single-step training checks,
+  and plain `debug_string()` capture.
+- [references/comparing-runs.md](references/comparing-runs.md) — how to compare
+  the plain dumps and handle common key/order drift.

--- a/.claude/skills/numerics-debugging/SKILL.md
+++ b/.claude/skills/numerics-debugging/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: numerics-debugging
+description: Debug numeric / bitwise divergence between two PyTorch runs that should agree (eager vs torch.compile, eager vs aot_fx_trace, FSDP vs single-GPU, TF32 vs fp32, before vs after a refactor) by capturing per-op activations with torch.utils._debug_mode.DebugMode and diffing them to localize the first diverging op. Use when the user reports loss drift, mismatched outputs, "numerics don't match", "bitwise divergence", "find which op diverges", or invokes /numerics-debugging.
+---
+
+# Numerics Debugging (DebugMode-based)
+
+When two runs that *should* produce the same numbers don't, the goal is to
+find the **first op where they diverge**, then decide whether that op is the
+cause (its inputs matched but its output didn't) or just a carrier (its inputs
+already differed). This skill captures a per-op fingerprint of one step from
+each run with `torch.utils._debug_mode.DebugMode`, then diffs the two.
+
+There is no bundled tooling. You author a small throwaway capture script in
+`agent_space/` from the verified recipe in
+[references/capture-recipe.md](references/capture-recipe.md), run it once per
+side, and compare the two logs.
+
+## IMPORTANT: probe before you trust the recipe
+
+`torch.utils._debug_mode` is **private and version-dependent**. The recipe was
+verified on torch 2.10 and 2.13, but the operator-stream structure (in
+particular how module boundaries are represented) changes across versions:
+
+- torch ~2.10: module markers are `_NNModuleCall` with a `.module_name` attr.
+- torch ~2.13: module markers are `_AnnotateCall` with `header == "nn.Mod"`
+  and the FQN in `.tag`.
+- `DebugMode.current_nn_module_stack` is **empty at dispatch time** in these
+  versions, so you cannot read the FQN from inside the dispatch hook.
+
+So the first step is always to run the ~15-line probe in the recipe against
+the *actual* environment, confirm the marker class / attribute names, and
+adapt the capture to match. Do not assume.
+
+## Workflow
+
+1. **Make the two runs comparable.** They MUST share dtype, seed, and inputs,
+   and run deterministically. A precision change (bf16 vs fp32) makes every op
+   diverge and the diff is useless. Set the same `torch.manual_seed(...)`
+   before model init and before the step, use the same batch, and enable
+   `torch.use_deterministic_algorithms(True)` where possible.
+2. **Probe** the operator stream (recipe, step 1) to confirm the module-marker
+   class for this torch version.
+3. **Capture one step per run** with the capture function (recipe, step 2),
+   writing each run's fingerprints to its own log (`run_A.log`, `run_B.log`).
+   Capture on a warmed-up step if step 0 has legitimate one-time init/compile
+   differences.
+4. **Diff the two logs** (recipe, step 3 + [references/comparing-runs.md](references/comparing-runs.md)):
+   pair ops by key, parse the hashes as floats, and report the first op whose
+   output hash differs beyond a relative tolerance.
+
+## What gets captured per op
+
+For each non-excluded op producing a float tensor:
+
+- **Key** `module_fqn/op_N_opname` (e.g. `blocks.0.fc1/op_0_addmm`) — FQN +
+  per-module op counter + ATen op name.
+- **Phase** — forward or backward (from `torch._C._current_autograd_node()`).
+- **Output hash** — DebugMode's `norm` hash (~L1, float64) of the result.
+- **Input hashes** — `norm` hash of each input *before* the op ran. This is
+  what catches in-place mutations (e.g. `_fused_adam_` returns `None`, so it
+  has no output hash, but its input hashes still move).
+- **Stats** — shape/dtype + L2/min/max/mean, with L2 and mean in **float64**
+  so they don't wobble with reduction order.
+
+## Interpreting the diff
+
+- **All hashes identical** -> the runs are bitwise equal; the bug is elsewhere
+  (data loading, loss, optimizer state, RNG consumption order).
+- **First divergence at op K, and K's input hashes already differ** -> the
+  real divergence is upstream; follow the inputs back to their producing op
+  and keep walking until you find an op whose **inputs match but output
+  differs**. That op is the root cause.
+- **Everything diverges from the very first op** -> almost always a dtype or
+  seed/determinism mismatch, not a real bug. Fix setup (step 1) and recapture.
+- **A tiny last-digit difference that doesn't propagate** -> reduction-order
+  noise, not a bug. Compare the float64 L2/mean and the `norm` hash with a
+  relative tolerance rather than requiring exact string equality.
+
+This was validated on a real divergence: fp32 vs TF32 matmul on the same model
+matched on every forward op but first diverged on a **backward** `mm`, whose
+inputs matched -> correctly fingering the TF32 matmul kernel itself as the
+source. Divergence often first crosses the hash's precision floor in backward
+(larger reductions) even when forward already differs in lower digits.
+
+## Cost
+
+Capture adds roughly 10-40% time/memory on the single captured step only
+(stats reduced inline in float64; no tensor clones held). Because the context
+wraps just one step, steady-state training is untouched.
+
+## References
+
+- [references/capture-recipe.md](references/capture-recipe.md) — the probe,
+  the verified `DebugMode` capture function (forward FQN via the marker/depth
+  stream, backward FQN via a grad_fn map), op filtering, and the
+  compiled/traced-graph caveat.
+- [references/comparing-runs.md](references/comparing-runs.md) — the real log
+  format, tolerance-based pairing/diffing, and the common eager-vs-traced
+  key-drift patterns.

--- a/.claude/skills/numerics-debugging/SKILL.md
+++ b/.claude/skills/numerics-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: numerics-debugging
-description: Debug numeric / bitwise divergence between two PyTorch runs that should agree (eager vs torch.compile, eager vs aot_fx_trace, FSDP vs single-GPU, TF32 vs fp32, before vs after a refactor) by capturing per-op activations with torch.utils._debug_mode.DebugMode and diffing them to localize the first diverging op. Use when the user reports loss drift, mismatched outputs, "numerics don't match", "bitwise divergence", "find which op diverges", or invokes /numerics-debugging.
+description: Debug numeric / bitwise divergence between two PyTorch runs that should agree (eager vs torch.compile, eager vs aot_fx_trace, distributed vs single-process, TF32 vs fp32, before vs after a refactor) by capturing per-op activations with torch.utils._debug_mode.DebugMode and diffing them to localize the first diverging op. Use when the user reports loss drift, mismatched outputs, "numerics don't match", "bitwise divergence", "find which op diverges", or invokes /numerics-debugging.
 ---
 
 # Numerics Debugging (DebugMode-based)
@@ -30,7 +30,10 @@ particular how module boundaries are represented) changes across versions:
 
 So the first step is always to run the ~15-line probe in the recipe against
 the *actual* environment, confirm the marker class / attribute names, and
-adapt the capture to match. Do not assume.
+adapt the capture to match. Do not assume. If the probe does not show usable
+layer/module markers for the target model, enable the recipe's generic
+`annotate_modules=True` fallback before capturing; do not rely on framework- or
+model-specific layer-name markers.
 
 ## Workflow
 
@@ -40,11 +43,13 @@ adapt the capture to match. Do not assume.
    before model init and before the step, use the same batch, and enable
    `torch.use_deterministic_algorithms(True)` where possible.
 2. **Probe** the operator stream (recipe, step 1) to confirm the module-marker
-   class for this torch version.
+   class for this torch version and whether `record_nn_module=True` produces
+   useful names for this model.
 3. **Capture one step per run** with the capture function (recipe, step 2),
    writing each run's fingerprints to its own log (`run_A.log`, `run_B.log`).
-   Capture on a warmed-up step if step 0 has legitimate one-time init/compile
-   differences.
+   Pass `annotate_modules=True` when the model needs generic layer annotations.
+   The step can be inference-only or forward+backward; capture on a warmed-up
+   step if step 0 has legitimate one-time init/compile differences.
 4. **Diff the two logs** (recipe, step 3 + [references/comparing-runs.md](references/comparing-runs.md)):
    pair ops by key, parse the hashes as floats, and report the first op whose
    output hash differs beyond a relative tolerance.
@@ -53,7 +58,7 @@ adapt the capture to match. Do not assume.
 
 For each non-excluded op producing a float tensor:
 
-- **Key** `module_fqn/op_N_opname` (e.g. `blocks.0.fc1/op_0_addmm`) — FQN +
+- **Key** `module_fqn/op_N_opname` (e.g. `features.0.proj/op_0_addmm`) — FQN +
   per-module op counter + ATen op name.
 - **Phase** — forward or backward (from `torch._C._current_autograd_node()`).
 - **Output hash** — DebugMode's `norm` hash (~L1, float64) of the result.
@@ -92,9 +97,9 @@ wraps just one step, steady-state training is untouched.
 ## References
 
 - [references/capture-recipe.md](references/capture-recipe.md) — the probe,
-  the verified `DebugMode` capture function (forward FQN via the marker/depth
-  stream, backward FQN via a grad_fn map), op filtering, and the
-  compiled/traced-graph caveat.
+  generic module annotation fallback, the verified `DebugMode` capture function
+  (forward FQN via the marker/depth stream, backward FQN via a grad_fn map), op
+  filtering, and the compiled/traced-graph caveat.
 - [references/comparing-runs.md](references/comparing-runs.md) — the real log
   format, tolerance-based pairing/diffing, and the common eager-vs-traced
   key-drift patterns.

--- a/.claude/skills/numerics-debugging/references/capture-recipe.md
+++ b/.claude/skills/numerics-debugging/references/capture-recipe.md
@@ -1,237 +1,106 @@
 # Capture recipe
 
-Author a throwaway capture script in `agent_space/` that wraps one step in
-`DebugMode` and writes a per-op fingerprint log. Adapt it to the model and
-the exact computation being compared: inference, forward+backward, an optimizer
-step, or a larger training-loop step. Nothing here is committed.
+Author a throwaway capture script in `agent_space/` that wraps the exact step
+being compared in `DebugMode` and writes `dm.debug_string()` to a text file.
+Do not build a separate log format unless the plain dump is too large to inspect.
 
-Everything below was verified end-to-end on torch 2.10 (CUDA) and the API
-points re-checked on torch 2.13. `torch.utils._debug_mode` is private and
-version-dependent, so **start with the probe**.
+The useful DebugMode settings are:
 
-## Step 1: probe the operator stream (do this first, every time)
+- `record_realtensor=True` — record real tensor ops.
+- `record_nn_module=True` — add `nn.Module` enter markers from the module
+  tracker.
+- `record_ids=True` — give tensors stable IDs in the dump, so input/output
+  flow is easier to follow.
+- `record_stack_trace=True` — include source summaries with
+  `debug_string(show_stack_trace=True)`. Turn this off if the dump is too noisy.
+- `record_profiler_context=True` — keep profiler/record_function context
+  markers. This is the default, but pass it explicitly in the recipe.
+- `run_compile_with_interpreter=True` — use when debugging an aot/eager compiled
+  region and you need FX node/module metadata in the dump.
+- `DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True)` — add output
+  hashes and pre-op input hashes to each op line.
 
-The capture hinges on how `dm.operators` represents module boundaries, which
-changes across torch versions. Confirm it before writing the capture, and check
-whether the target model gets usable layer names without any framework-specific
-setup:
+`log_tensor_hashes` is the key numerics signal. The output `hash` tells you
+whether this op produced the same value in both runs. `input_hash` is computed
+before the op executes, so if an output hash differs while the input hashes
+match, that op is the likely source. If the input hashes already differ, the
+op is only carrying an upstream divergence.
+
+## Step 1: probe the dump shape
+
+`DebugMode` is an internal debugging tool, so first run a tiny probe in the
+same checkout/environment. Confirm that module markers and tensor hashes show
+up in the plain string dump before adapting the recipe to the real model:
 
 ```python
-import torch, torch.nn as nn
+import torch
+import torch.nn as nn
 from torch.utils._debug_mode import DebugMode
 
-class Blk(nn.Module):
-    def __init__(s): super().__init__(); s.fc = nn.Linear(64, 64)
-    def forward(s, x): return torch.relu(s.fc(x))
+class Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(64, 64)
 
-m = nn.Sequential(Blk(), Blk())
-dm = DebugMode(record_realtensor=True, record_nn_module=True, record_ids=True)
+    def forward(self, x):
+        return torch.relu(self.proj(x))
+
+m = nn.Sequential(Block(), Block())
+dm = DebugMode(
+    record_realtensor=True,
+    record_nn_module=True,
+    record_ids=True,
+    record_stack_trace=True,
+    record_profiler_context=True,
+)
 with dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True):
     m(torch.randn(8, 64)).sum().backward()
 
-for o in dm.operators:
-    t = type(o).__name__
-    if t == "_OpCall":
-        print("op  d=%s %s | log=%s" % (o.call_depth, o.op, o.log))
-    else:
-        attrs = {a: getattr(o, a, None) for a in dir(o)
-                 if not a.startswith("__") and not callable(getattr(o, a, None))}
-        print(t, attrs)
+print(dm.debug_string(show_stack_trace=True))
 ```
 
-What this tells you:
+Look for:
 
-- The op-call class is `_OpCall` (import: `from torch.utils._debug_mode import
-  _OpCall`). Each has `.op` (the `OpOverload`), `.call_depth`, `.record` (your
-  dispatch-hook dict), and `.log` (the hash dict, e.g.
-  `{'hash': 446.47, 'input_hash': ((7.69, 377.1, 508.4), {})}`).
-- The **module-marker class and its FQN attribute vary by version**. Observed:
-  - torch ~2.10: class `_NNModuleCall`, FQN in `.module_name`
-    (e.g. `Net.features.0.proj`), with `.call_depth`.
-  - torch ~2.13: class `_AnnotateCall` with `header == "nn.Mod"`, FQN in
-    `.tag` (e.g. `Sequential.0.fc`), with `.call_depth`.
-  Set `MODULE_MARKER` / the FQN getter in the capture below to whatever the
-  probe shows.
-- Module ops appear at `call_depth = marker_depth + 1`, right after their
-  marker. Backward ops all sit at `call_depth == 1` with **no** module markers
-  -> they need the grad_fn map (below).
-- If the probe or target model has no useful `nn.Mod` / module markers, do not
-  add one-off model-specific labels. Use `annotate_modules=True` in the capture
-  function below to temporarily annotate every `named_modules()` entry with its
-  FQN for this one debug step.
+- `[nn.Mod] ...` lines around module execution.
+- Tensor IDs like `$0`, `$1`, etc. on op inputs/outputs.
+- Per-op hash comments containing `hash` and `input_hash`.
+- Useful source summaries when `show_stack_trace=True`.
 
-## Step 2: the capture function (verified working)
+If `record_nn_module=True` does not give useful layer names for the target
+model, keep the dump generic: use stack traces, profiler scopes, tensor IDs, and
+nearby op order. Do not monkey-patch modules just to manufacture layer names.
+
+## Step 2: capture the real step
+
+Use this as the starting point for each side of the comparison. The only output
+is DebugMode's own text dump.
 
 ```python
-import contextlib
 import torch
-import torch.nn as nn
-import torch.utils._pytree as pytree
-from torch.utils._debug_mode import DebugMode, _OpCall, get_active_debug_mode
+from torch.utils._debug_mode import DebugMode
 
-# --- set these from the probe output ---
-def is_module_marker(o):
-    t = type(o).__name__
-    return t == "_NNModuleCall" or (t == "_AnnotateCall" and getattr(o, "header", None) == "nn.Mod")
-
-def marker_fqn(o):
-    return getattr(o, "module_name", None) or getattr(o, "tag", None)
-# ----------------------------------------
-
-EXCLUDED = frozenset({
-    # no real compute / just rewrap storage -> drop so the diff isn't polluted
-    "t", "transpose", "view", "_unsafe_view", "reshape", "permute", "expand",
-    "squeeze", "unsqueeze", "detach", "clone", "_to_copy", "to", "contiguous",
-    "ones_like", "zeros_like", "empty_like", "slice", "select", "as_strided",
-})
-FLOAT = {torch.float32, torch.float16, torch.bfloat16}
-
-def _op_name(func):
-    return func._schema.name.split("::")[-1] if hasattr(func, "_schema") else str(func).split(".")[-1]
-
-def _float_leaves(result, min_numel):
-    out = []
-    for leaf in pytree.tree_leaves(result):
-        if isinstance(leaf, torch.Tensor) and not isinstance(leaf, torch._subclasses.FakeTensor):
-            if leaf.numel() >= min_numel and leaf.dtype in FLOAT:
-                out.append(leaf)
-    return out
-
-def _stats(t):
-    t = t.detach(); t64 = t.to(torch.float64)
-    return {
-        "Shape": f"{tuple(t.shape)} {t.dtype}",
-        "L2": f"{t64.norm(2).item():.6e}",
-        "Min": f"{t.float().min().item():.6e}",
-        "Max": f"{t.float().max().item():.6e}",
-        "Mean": f"{t64.mean().item():.6e}",
-    }
-
-def _hashstr(h):
-    vals = [v for v in pytree.tree_leaves(h) if v is not None]
-    return ", ".join(f"{v:.6e}" if isinstance(v, float) else str(v) for v in vals)
-
-@contextlib.contextmanager
-def _annotate_modules(model):
-    """Fallback when DebugMode's built-in module tracker has no usable names."""
-    originals = []
-    root_name = type(model).__name__
-
-    for fqn, mod in model.named_modules():
-        name = fqn or root_name
-        orig = mod.forward
-
-        def wrapped(*args, __orig=orig, __fqn=name, **kwargs):
-            dm = get_active_debug_mode()
-            if dm is None:
-                return __orig(*args, **kwargs)
-            dm._enter_nn_module_call(__fqn, "nn.Mod")
-            try:
-                return __orig(*args, **kwargs)
-            finally:
-                dm._exit_nn_module_call()
-
-        mod.forward = wrapped
-        originals.append((mod, orig))
-
-    try:
-        yield
-    finally:
-        for mod, orig in reversed(originals):
-            mod.forward = orig
-
-def capture(model, run_fn, *, min_numel=0, annotate_modules=False):
-    """run_fn(model) executes the step to compare. Returns ordered list of
-    {key, phase, stats, out_hash, in_hash}."""
-    # backward FQN map: walk the autograd graph from each module's outputs
-    grad_fn_to_fqn = {}
-    id_to_fqn = {id(m): n for n, m in model.named_modules()}
-    pending = {}
-    def _gfns(obj):
-        return {a.grad_fn for a in pytree.tree_leaves(obj)
-                if isinstance(a, torch.Tensor) and a.grad_fn is not None}
-    def pre(mod, args):
-        if id(mod) in id_to_fqn: pending[id(mod)] = _gfns(args)
-    def post(mod, args, output):
-        fqn = id_to_fqn.get(id(mod))
-        if fqn is None: return
-        inputs = pending.pop(id(mod), set())
-        for t in pytree.tree_leaves(output):
-            if not isinstance(t, torch.Tensor) or t.grad_fn is None: continue
-            stack, seen = [t.grad_fn], set()
-            while stack:
-                fn = stack.pop()
-                if fn in seen or fn in inputs: continue
-                seen.add(fn)
-                grad_fn_to_fqn.setdefault(fn, fqn)   # don't overwrite child claims
-                for parent, _ in fn.next_functions:
-                    if parent is not None and parent not in seen: stack.append(parent)
-    h1 = nn.modules.module.register_module_forward_pre_hook(pre)
-    h2 = nn.modules.module.register_module_forward_hook(post)
-
-    # phase + backward-fqn + inline stats must be captured at dispatch time
-    def record_hook(func, types, args, kwargs, result):
-        node = torch._C._current_autograd_node()
-        rec = {"phase": "backward" if node is not None else "forward",
-               "bwd_fqn": grad_fn_to_fqn.get(node) if node is not None else None}
-        leaves = _float_leaves(result, min_numel)
-        if leaves: rec["stats"] = _stats(leaves[0])
-        return rec
-
-    # Prefer DebugMode's built-in module tracking. If the probe shows no usable
-    # markers for the target model, annotate_modules=True installs generic FQN
-    # markers by temporarily wrapping model.named_modules().
+def capture_debug_string(
+    model,
+    run_fn,
+    path,
+    *,
+    show_stack_trace=True,
+    run_compile_with_interpreter=False,
+):
     dm = DebugMode(
         record_realtensor=True,
-        record_nn_module=not annotate_modules,
+        record_nn_module=True,
         record_ids=True,
+        record_stack_trace=show_stack_trace,
+        record_profiler_context=True,
+        run_compile_with_interpreter=run_compile_with_interpreter,
     )
-    module_ctx = _annotate_modules(model) if annotate_modules else contextlib.nullcontext()
-    try:
-        with module_ctx, dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True), \
-                DebugMode.dispatch_hooks(record_hook=record_hook):
-            run_fn(model)
-    finally:
-        h1.remove(); h2.remove()
+    with dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True):
+        run_fn(model)
 
-    # forward FQN: reconstruct from the marker/call_depth stream with a
-    # depth-truncated stack (pop markers at depth >= current before handling)
-    out, mod_stack, counters, root = [], [], {}, None
-    for o in dm.operators:
-        depth = o.call_depth
-        while mod_stack and mod_stack[-1][0] >= depth:
-            mod_stack.pop()
-        if is_module_marker(o):
-            fqn = marker_fqn(o)
-            if root is None: root = fqn
-            mod_stack.append((depth, fqn))
-            continue
-        if not isinstance(o, _OpCall): continue
-        name = _op_name(o.op)
-        if name in EXCLUDED: continue
-        rec, log = o.record or {}, o.log or {}
-        phase = rec.get("phase", "forward")
-        fqn = (rec.get("bwd_fqn") or "<backward>") if phase == "backward" else \
-              (mod_stack[-1][1] if mod_stack else "<none>")
-        if root and fqn.startswith(root + "."): fqn = fqn[len(root) + 1:]
-        elif fqn == root: fqn = "<root>"
-        out_hash, in_hash = _hashstr(log.get("hash")), _hashstr(log.get("input_hash"))
-        if "stats" not in rec and not out_hash and not in_hash: continue
-        seq = counters.get(fqn, 0); counters[fqn] = seq + 1
-        out.append({"key": f"{fqn}/op_{seq}_{name}", "phase": phase,
-                    "stats": rec.get("stats", {}), "out_hash": out_hash, "in_hash": in_hash})
-    return out
-
-def write_log(captures, path):
     with open(path, "w") as f:
-        f.write(f"Total: {len(captures)}\n" + "=" * 60 + "\n\n")
-        for c in captures:
-            f.write(f"[{c['key']}]\n")
-            for k, v in c["stats"].items(): f.write(f"  {k}: {v}\n")
-            if c["out_hash"]: f.write(f"  Output hash: {c['out_hash']}\n")
-            if c["in_hash"]:  f.write(f"  Input hashes: {c['in_hash']}\n")
-            if c["phase"] != "forward": f.write(f"  Phase: {c['phase']}\n")
-            f.write("\n")
+        f.write(dm.debug_string(show_stack_trace=show_stack_trace))
+        f.write("\n")
 ```
 
 Drive it once per run, with identical setup on both sides:
@@ -247,61 +116,138 @@ def step(m, x):
     m(x).sum().backward()
 
 m, x = build()
-write_log(capture(m, lambda mm: step(mm, x)), "run_A.log")
-# ... change the one thing under test (compile, a distributed wrapper, a flag) ...
+capture_debug_string(m, lambda mm: step(mm, x), "run_A_debug.txt")
+
+# Change exactly one thing under test: compile, a distributed wrapper, a flag,
+# a refactor, etc.
 m, x = build()
-write_log(capture(m, lambda mm: step(mm, x)), "run_B.log")
+capture_debug_string(m, lambda mm: step(mm, x), "run_B_debug.txt")
 ```
 
-If the probe shows missing or framework-specific layer markers, use the generic
-module annotation fallback on both sides:
+For strict bitwise checks, switch from the default `norm` hash to:
 
 ```python
-write_log(capture(m, lambda mm: step(mm, x), annotate_modules=True), "run_A.log")
+DebugMode.log_tensor_hashes(hash_fn="hash_tensor", hash_inputs=True)
 ```
 
-Only use `annotate_modules=True` when `record_nn_module=True` is not enough; it
-temporarily monkey-patches `forward` on the model's `named_modules()` entries
-for the captured step and restores them afterwards.
+or log both:
 
-## Backward FQN attribution
+```python
+DebugMode.log_tensor_hashes(hash_fn=["norm", "hash_tensor"], hash_inputs=True)
+```
 
-During backward the C++ autograd engine drives execution, so no
-`nn.Module.forward` runs and the stream has no module markers for backward ops
-(they all sit at `call_depth == 1`). The `grad_fn_to_fqn` map above fixes this:
-global forward hooks walk the autograd graph from each module's outputs and
-claim unclaimed nodes for that module (`setdefault`, so a parent picks up glue
-ops between children while children keep their own). This was verified to
-recover e.g. `features.1.proj` for a backward `mm`. Ops it can't claim fall back
-to `<backward>`.
+For `torch.compile`/AOT eager comparisons, try:
 
-## Compiled / traced runs
+```python
+capture_debug_string(
+    m,
+    lambda mm: step(mm, x),
+    "run_A_debug.txt",
+    run_compile_with_interpreter=True,
+)
+```
 
-Under `torch.compile`/`aot_fx_trace` the graph runs as `gm(*flat_inputs)`,
-bypassing `nn.Module.forward`, so the marker stream is empty and ops land under
-`<none>`/`<backward>`. Two options:
+## Single-step training check
 
-- If the traced `GraphModule` carries node metadata
-  (`node.meta["custom"]["module_fqn"]`, `node.meta["stack_trace"]`,
-  `node.meta.get("autograd_backward")`), replay via a `torch.fx.Interpreter`
-  subclass that sets that context per node so the capture sees the same FQN /
-  phase eager would. (Newer torch exposes `run_compile_with_interpreter` on
-  `DebugMode` for related plumbing -- check the probe's init signature.)
-- Otherwise, compare **by op sequence**: both logs in dispatch order, paired
-  positionally, relying on op-name + shape + hash. FQN columns will be
-  `<none>` but the divergence point is still findable.
+Before collecting a huge dump from a training job, compare scalar outputs from
+one deterministic step. This tells you where to spend attention:
 
-## Customizing
+```python
+def grad_norm(model):
+    total = 0.0
+    for p in model.parameters():
+        if p.grad is not None:
+            total += p.grad.detach().double().pow(2).sum()
+    return total.sqrt()
 
-- **`EXCLUDED`** — add an op that pollutes the diff with structurally
-  identical rows; remove one to gain visibility. Collective comms
-  (`all_gather_into_tensor`, `reduce_scatter_tensor`, `wait_tensor`) are
-  deliberately *not* excluded — they often diverge between eager and traced.
-- **`min_numel`** — raise to drop small tensors (set 0 to capture everything,
-  as in the verified demo). Restrict to specific ops by matching `name`
-  against an allowlist before the `EXCLUDED` check.
-- **`hash_fn`** — `"norm"` (L1, float64; tolerance-friendly), `"hash_tensor"`
-  (`torch.hash_tensor`, XOR-reduce of raw bytes, strict bit-exactness), a
-  callable, or a list of the above for a tuple of hashes.
-- **Scalars** (e.g. the loss `sum`) get an empty output hash — expected; they
-  carry stats but nothing to hash meaningfully.
+def training_step(model, batch):
+    loss = model(batch).sum()
+    loss.backward()
+    return loss.detach(), grad_norm(model).detach()
+```
+
+- Loss diverges: start with forward hashes.
+- Loss matches bitwise but grad norm diverges: forward is probably fine; start
+  at the first backward hash mismatch.
+- Loss and grad norm match: look at optimizer state, data loading, RNG
+  consumption after the checked step, or later iterations.
+
+## Example dump snippets
+
+These excerpts were generated from a tiny two-layer CPU model with
+`conda activate pytorch-3.10` on torch `2.14.0a0+gitc45c69c`.
+
+Eager dumps have source summaries, module scopes, tensor IDs, and hash comments:
+
+```text
+    # File: debugmode_dump_smoke.py:49 in capture, code: loss = model(x)
+    [nn.Mod] Net
+
+      # File: debugmode_dump_smoke.py:27 in forward, code: return self.features(x).sum()
+      [nn.Mod] Net.features
+        [nn.Mod] Net.features.0
+
+          # File: debugmode_dump_smoke.py:18 in forward, code: return torch.relu(self.proj(x))
+          [nn.Mod] Net.features.0.proj
+            aten::t(t$0: f32[4, 4])  ->  t$1: f32[4, 4]  # {'input_hash': ((3.243980646133423,), {}), 'hash': 3.243980646133423}
+            aten::addmm(t$2: f32[4], t$3: f32[2, 4], t$1: f32[4, 4])  ->  t$4: f32[2, 4]  # {'input_hash': ((1.0543809533119202, 7.07875682413578, 3.243980646133423), {}), 'hash': 4.30271789431572}
+          aten::relu(t$4: f32[2, 4])  ->  t$5: f32[2, 4]  # {'input_hash': ((4.30271789431572,), {}), 'hash': 2.3040474951267242}
+
+      aten::sum(t$10: f32[2, 4])  ->  t$11: f32[]  # {'input_hash': ((1.0529326498508453,), {}), 'hash': 1.052932620048523}
+```
+
+With `run_compile_with_interpreter=True`, compiled/AOT dumps may include compile
+region annotations and FX-derived source/module context. Names may be rooted at
+Dynamo locals like `L['self']`:
+
+```text
+  [aot_eager region (compile)] enter
+
+    # File: debugmode_dump_smoke.py:26 in forward, code: def forward(self, x: torch.Tensor) -> torch.Tensor:
+    [nn.Mod (compile)] L['self'].features
+      [nn.Mod (compile)] L['self'].features.0
+        [nn.Mod (compile)] L['self'].features.0.proj
+
+          # File: debugmode_dump_smoke.py:18 in forward, code: return torch.relu(self.proj(x))
+          aten::t(t$0: f32[4, 4])  ->  t$1: f32[4, 4]  # {'input_hash': ((3.243980646133423,), {}), 'hash': 3.243980646133423}
+          aten::addmm(t$2: f32[4], t$3: f32[2, 4], t$1: f32[4, 4])  ->  t$4: f32[2, 4]  # {'input_hash': ((1.0543809533119202, 7.07875682413578, 3.243980646133423), {}), 'hash': 4.30271789431572}
+        aten::relu(t$4: f32[2, 4])  ->  t$5: f32[2, 4]  # {'input_hash': ((4.30271789431572,), {}), 'hash': 2.3040474951267242}
+
+    aten::sum(t$10: f32[2, 4])  ->  t$12: f32[]  # {'input_hash': ((1.0529326498508453,), {}), 'hash': 1.052932620048523}
+  [aot_eager region (compile)] exit
+```
+
+The exact operator names may differ (`linear` in eager can appear as `addmm`
+after tracing/lowering). Match by scope, shape, tensor flow, and hashes rather
+than expecting identical text.
+
+When a run is intentionally perturbed, the first forward mismatch is visible in
+the hash comments. In this example the second layer's weight changed, so the
+first different line has a matching activation input hash but different weight
+and output hashes:
+
+```text
+# Run A
+aten::addmm(..., t$5: f32[2, 4], t$7: f32[4, 4])  ->  t$9: f32[2, 4]  # {'input_hash': ((1.1871147155761719, 2.3040474951267242, 4.564039468765259), {}), 'hash': 1.5524791777133942}
+
+# Run B
+aten::addmm(..., t$5: f32[2, 4], t$7: f32[4, 4])  ->  t$9: f32[2, 4]  # {'input_hash': ((1.1871147155761719, 2.3040474951267242, 4.689039468765259), {}), 'hash': 1.7220753133296967}
+```
+
+## Reading the dump
+
+The dump is indented by call depth. Module markers, profiler scopes, operator
+calls, tensor IDs, and hash comments are all in one text artifact. Compare
+`run_A_debug.txt` and `run_B_debug.txt` directly with a text diff and inspect
+the first op where the output `hash` differs.
+
+When an output hash differs, compare that op's `input_hash` values:
+
+- Inputs match and output differs -> this op is the likely root cause.
+- Inputs already differ -> the divergence is upstream; walk backward through
+  tensor IDs and earlier hash comments.
+- Every op differs from the first real op -> setup mismatch, usually dtype,
+  seed, input, RNG, or determinism.
+- Tiny last-digit differences that do not propagate are usually reduction-order
+  noise. Use judgment; the `norm` hash is a float64 reduction, not a proof of
+  bit-exact equality.

--- a/.claude/skills/numerics-debugging/references/capture-recipe.md
+++ b/.claude/skills/numerics-debugging/references/capture-recipe.md
@@ -1,0 +1,249 @@
+# Capture recipe
+
+Author a throwaway capture script in `agent_space/` that wraps one step in
+`DebugMode` and writes a per-op fingerprint log. Adapt it to the model /
+training loop. Nothing here is committed.
+
+Everything below was verified end-to-end on torch 2.10 (CUDA) and the API
+points re-checked on torch 2.13. `torch.utils._debug_mode` is private and
+version-dependent, so **start with the probe**.
+
+## Step 1: probe the operator stream (do this first, every time)
+
+The capture hinges on how `dm.operators` represents module boundaries, which
+changes across torch versions. Confirm it before writing the capture:
+
+```python
+import torch, torch.nn as nn
+from torch.utils._debug_mode import DebugMode
+
+class Blk(nn.Module):
+    def __init__(s): super().__init__(); s.fc = nn.Linear(64, 64)
+    def forward(s, x): return torch.relu(s.fc(x))
+
+m = nn.Sequential(Blk(), Blk())
+dm = DebugMode(record_realtensor=True, record_nn_module=True, record_ids=True)
+with dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True):
+    m(torch.randn(8, 64)).sum().backward()
+
+for o in dm.operators:
+    t = type(o).__name__
+    if t == "_OpCall":
+        print("op  d=%s %s | log=%s" % (o.call_depth, o.op, o.log))
+    else:
+        attrs = {a: getattr(o, a, None) for a in dir(o)
+                 if not a.startswith("__") and not callable(getattr(o, a, None))}
+        print(t, attrs)
+```
+
+What this tells you:
+
+- The op-call class is `_OpCall` (import: `from torch.utils._debug_mode import
+  _OpCall`). Each has `.op` (the `OpOverload`), `.call_depth`, `.record` (your
+  dispatch-hook dict), and `.log` (the hash dict, e.g.
+  `{'hash': 446.47, 'input_hash': ((7.69, 377.1, 508.4), {})}`).
+- The **module-marker class and its FQN attribute vary by version**. Observed:
+  - torch ~2.10: class `_NNModuleCall`, FQN in `.module_name`
+    (e.g. `Net.blocks.0.fc1`), with `.call_depth`.
+  - torch ~2.13: class `_AnnotateCall` with `header == "nn.Mod"`, FQN in
+    `.tag` (e.g. `Sequential.0.fc`), with `.call_depth`.
+  Set `MODULE_MARKER` / the FQN getter in the capture below to whatever the
+  probe shows.
+- Module ops appear at `call_depth = marker_depth + 1`, right after their
+  marker. Backward ops all sit at `call_depth == 1` with **no** module markers
+  -> they need the grad_fn map (below).
+
+## Step 2: the capture function (verified working)
+
+```python
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch.utils._debug_mode import DebugMode, _OpCall
+
+# --- set these from the probe output ---
+def is_module_marker(o):
+    t = type(o).__name__
+    return t == "_NNModuleCall" or (t == "_AnnotateCall" and getattr(o, "header", None) == "nn.Mod")
+
+def marker_fqn(o):
+    return getattr(o, "module_name", None) or getattr(o, "tag", None)
+# ----------------------------------------
+
+EXCLUDED = frozenset({
+    # no real compute / just rewrap storage -> drop so the diff isn't polluted
+    "t", "transpose", "view", "_unsafe_view", "reshape", "permute", "expand",
+    "squeeze", "unsqueeze", "detach", "clone", "_to_copy", "to", "contiguous",
+    "ones_like", "zeros_like", "empty_like", "slice", "select", "as_strided",
+})
+FLOAT = {torch.float32, torch.float16, torch.bfloat16}
+
+def _op_name(func):
+    return func._schema.name.split("::")[-1] if hasattr(func, "_schema") else str(func).split(".")[-1]
+
+def _float_leaves(result, min_numel):
+    out = []
+    for leaf in pytree.tree_leaves(result):
+        if isinstance(leaf, torch.Tensor) and not isinstance(leaf, torch._subclasses.FakeTensor):
+            if leaf.numel() >= min_numel and leaf.dtype in FLOAT:
+                out.append(leaf)
+    return out
+
+def _stats(t):
+    t = t.detach(); t64 = t.to(torch.float64)
+    return {
+        "Shape": f"{tuple(t.shape)} {t.dtype}",
+        "L2": f"{t64.norm(2).item():.6e}",
+        "Min": f"{t.float().min().item():.6e}",
+        "Max": f"{t.float().max().item():.6e}",
+        "Mean": f"{t64.mean().item():.6e}",
+    }
+
+def _hashstr(h):
+    vals = [v for v in pytree.tree_leaves(h) if v is not None]
+    return ", ".join(f"{v:.6e}" if isinstance(v, float) else str(v) for v in vals)
+
+def capture(model, run_fn, *, min_numel=0):
+    """run_fn(model) executes one forward (+backward). Returns ordered list of
+    {key, phase, stats, out_hash, in_hash}."""
+    # backward FQN map: walk the autograd graph from each module's outputs
+    grad_fn_to_fqn = {}
+    id_to_fqn = {id(m): n for n, m in model.named_modules()}
+    pending = {}
+    def _gfns(obj):
+        return {a.grad_fn for a in pytree.tree_leaves(obj)
+                if isinstance(a, torch.Tensor) and a.grad_fn is not None}
+    def pre(mod, args):
+        if id(mod) in id_to_fqn: pending[id(mod)] = _gfns(args)
+    def post(mod, args, output):
+        fqn = id_to_fqn.get(id(mod))
+        if fqn is None: return
+        inputs = pending.pop(id(mod), set())
+        for t in pytree.tree_leaves(output):
+            if not isinstance(t, torch.Tensor) or t.grad_fn is None: continue
+            stack, seen = [t.grad_fn], set()
+            while stack:
+                fn = stack.pop()
+                if fn in seen or fn in inputs: continue
+                seen.add(fn)
+                grad_fn_to_fqn.setdefault(fn, fqn)   # don't overwrite child claims
+                for parent, _ in fn.next_functions:
+                    if parent is not None and parent not in seen: stack.append(parent)
+    h1 = nn.modules.module.register_module_forward_pre_hook(pre)
+    h2 = nn.modules.module.register_module_forward_hook(post)
+
+    # phase + backward-fqn + inline stats must be captured at dispatch time
+    def record_hook(func, types, args, kwargs, result):
+        node = torch._C._current_autograd_node()
+        rec = {"phase": "backward" if node is not None else "forward",
+               "bwd_fqn": grad_fn_to_fqn.get(node) if node is not None else None}
+        leaves = _float_leaves(result, min_numel)
+        if leaves: rec["stats"] = _stats(leaves[0])
+        return rec
+
+    dm = DebugMode(record_realtensor=True, record_nn_module=True, record_ids=True)
+    try:
+        with dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True), \
+                DebugMode.dispatch_hooks(record_hook=record_hook):
+            run_fn(model)
+    finally:
+        h1.remove(); h2.remove()
+
+    # forward FQN: reconstruct from the marker/call_depth stream with a
+    # depth-truncated stack (pop markers at depth >= current before handling)
+    out, mod_stack, counters, root = [], [], {}, None
+    for o in dm.operators:
+        depth = o.call_depth
+        while mod_stack and mod_stack[-1][0] >= depth:
+            mod_stack.pop()
+        if is_module_marker(o):
+            fqn = marker_fqn(o)
+            if root is None: root = fqn
+            mod_stack.append((depth, fqn))
+            continue
+        if not isinstance(o, _OpCall): continue
+        name = _op_name(o.op)
+        if name in EXCLUDED: continue
+        rec, log = o.record or {}, o.log or {}
+        phase = rec.get("phase", "forward")
+        fqn = (rec.get("bwd_fqn") or "<backward>") if phase == "backward" else \
+              (mod_stack[-1][1] if mod_stack else "<none>")
+        if root and fqn.startswith(root + "."): fqn = fqn[len(root) + 1:]
+        elif fqn == root: fqn = "<root>"
+        out_hash, in_hash = _hashstr(log.get("hash")), _hashstr(log.get("input_hash"))
+        if "stats" not in rec and not out_hash and not in_hash: continue
+        seq = counters.get(fqn, 0); counters[fqn] = seq + 1
+        out.append({"key": f"{fqn}/op_{seq}_{name}", "phase": phase,
+                    "stats": rec.get("stats", {}), "out_hash": out_hash, "in_hash": in_hash})
+    return out
+
+def write_log(captures, path):
+    with open(path, "w") as f:
+        f.write(f"Total: {len(captures)}\n" + "=" * 60 + "\n\n")
+        for c in captures:
+            f.write(f"[{c['key']}]\n")
+            for k, v in c["stats"].items(): f.write(f"  {k}: {v}\n")
+            if c["out_hash"]: f.write(f"  Output hash: {c['out_hash']}\n")
+            if c["in_hash"]:  f.write(f"  Input hashes: {c['in_hash']}\n")
+            if c["phase"] != "forward": f.write(f"  Phase: {c['phase']}\n")
+            f.write("\n")
+```
+
+Drive it once per run, with identical setup on both sides:
+
+```python
+def build():
+    torch.manual_seed(0)
+    return Net().cuda(), torch.randn(16, 256, device="cuda")
+
+def step(m, x):
+    m(x).sum().backward()
+
+m, x = build()
+write_log(capture(m, lambda mm: step(mm, x)), "run_A.log")
+# ... change the one thing under test (compile, FSDP, a flag) ...
+m, x = build()
+write_log(capture(m, lambda mm: step(mm, x)), "run_B.log")
+```
+
+## Backward FQN attribution
+
+During backward the C++ autograd engine drives execution, so no
+`nn.Module.forward` runs and the stream has no module markers for backward ops
+(they all sit at `call_depth == 1`). The `grad_fn_to_fqn` map above fixes this:
+global forward hooks walk the autograd graph from each module's outputs and
+claim unclaimed nodes for that module (`setdefault`, so a parent picks up glue
+ops between children while children keep their own). This was verified to
+recover e.g. `blocks.1.fc2` for a backward `mm`. Ops it can't claim fall back
+to `<backward>`.
+
+## Compiled / traced runs
+
+Under `torch.compile`/`aot_fx_trace` the graph runs as `gm(*flat_inputs)`,
+bypassing `nn.Module.forward`, so the marker stream is empty and ops land under
+`<none>`/`<backward>`. Two options:
+
+- If the traced `GraphModule` carries node metadata
+  (`node.meta["custom"]["module_fqn"]`, `node.meta["stack_trace"]`,
+  `node.meta.get("autograd_backward")`), replay via a `torch.fx.Interpreter`
+  subclass that sets that context per node so the capture sees the same FQN /
+  phase eager would. (Newer torch exposes `run_compile_with_interpreter` on
+  `DebugMode` for related plumbing -- check the probe's init signature.)
+- Otherwise, compare **by op sequence**: both logs in dispatch order, paired
+  positionally, relying on op-name + shape + hash. FQN columns will be
+  `<none>` but the divergence point is still findable.
+
+## Customizing
+
+- **`EXCLUDED`** — add an op that pollutes the diff with structurally
+  identical rows; remove one to gain visibility. Collective comms
+  (`all_gather_into_tensor`, `reduce_scatter_tensor`, `wait_tensor`) are
+  deliberately *not* excluded — they often diverge between eager and traced.
+- **`min_numel`** — raise to drop small tensors (set 0 to capture everything,
+  as in the verified demo). Restrict to specific ops by matching `name`
+  against an allowlist before the `EXCLUDED` check.
+- **`hash_fn`** — `"norm"` (L1, float64; tolerance-friendly), `"hash_tensor"`
+  (`torch.hash_tensor`, XOR-reduce of raw bytes, strict bit-exactness), a
+  callable, or a list of the above for a tuple of hashes.
+- **Scalars** (e.g. the loss `sum`) get an empty output hash — expected; they
+  carry stats but nothing to hash meaningfully.

--- a/.claude/skills/numerics-debugging/references/capture-recipe.md
+++ b/.claude/skills/numerics-debugging/references/capture-recipe.md
@@ -1,8 +1,9 @@
 # Capture recipe
 
 Author a throwaway capture script in `agent_space/` that wraps one step in
-`DebugMode` and writes a per-op fingerprint log. Adapt it to the model /
-training loop. Nothing here is committed.
+`DebugMode` and writes a per-op fingerprint log. Adapt it to the model and
+the exact computation being compared: inference, forward+backward, an optimizer
+step, or a larger training-loop step. Nothing here is committed.
 
 Everything below was verified end-to-end on torch 2.10 (CUDA) and the API
 points re-checked on torch 2.13. `torch.utils._debug_mode` is private and
@@ -11,7 +12,9 @@ version-dependent, so **start with the probe**.
 ## Step 1: probe the operator stream (do this first, every time)
 
 The capture hinges on how `dm.operators` represents module boundaries, which
-changes across torch versions. Confirm it before writing the capture:
+changes across torch versions. Confirm it before writing the capture, and check
+whether the target model gets usable layer names without any framework-specific
+setup:
 
 ```python
 import torch, torch.nn as nn
@@ -44,7 +47,7 @@ What this tells you:
   `{'hash': 446.47, 'input_hash': ((7.69, 377.1, 508.4), {})}`).
 - The **module-marker class and its FQN attribute vary by version**. Observed:
   - torch ~2.10: class `_NNModuleCall`, FQN in `.module_name`
-    (e.g. `Net.blocks.0.fc1`), with `.call_depth`.
+    (e.g. `Net.features.0.proj`), with `.call_depth`.
   - torch ~2.13: class `_AnnotateCall` with `header == "nn.Mod"`, FQN in
     `.tag` (e.g. `Sequential.0.fc`), with `.call_depth`.
   Set `MODULE_MARKER` / the FQN getter in the capture below to whatever the
@@ -52,14 +55,19 @@ What this tells you:
 - Module ops appear at `call_depth = marker_depth + 1`, right after their
   marker. Backward ops all sit at `call_depth == 1` with **no** module markers
   -> they need the grad_fn map (below).
+- If the probe or target model has no useful `nn.Mod` / module markers, do not
+  add one-off model-specific labels. Use `annotate_modules=True` in the capture
+  function below to temporarily annotate every `named_modules()` entry with its
+  FQN for this one debug step.
 
 ## Step 2: the capture function (verified working)
 
 ```python
+import contextlib
 import torch
 import torch.nn as nn
 import torch.utils._pytree as pytree
-from torch.utils._debug_mode import DebugMode, _OpCall
+from torch.utils._debug_mode import DebugMode, _OpCall, get_active_debug_mode
 
 # --- set these from the probe output ---
 def is_module_marker(o):
@@ -103,8 +111,37 @@ def _hashstr(h):
     vals = [v for v in pytree.tree_leaves(h) if v is not None]
     return ", ".join(f"{v:.6e}" if isinstance(v, float) else str(v) for v in vals)
 
-def capture(model, run_fn, *, min_numel=0):
-    """run_fn(model) executes one forward (+backward). Returns ordered list of
+@contextlib.contextmanager
+def _annotate_modules(model):
+    """Fallback when DebugMode's built-in module tracker has no usable names."""
+    originals = []
+    root_name = type(model).__name__
+
+    for fqn, mod in model.named_modules():
+        name = fqn or root_name
+        orig = mod.forward
+
+        def wrapped(*args, __orig=orig, __fqn=name, **kwargs):
+            dm = get_active_debug_mode()
+            if dm is None:
+                return __orig(*args, **kwargs)
+            dm._enter_nn_module_call(__fqn, "nn.Mod")
+            try:
+                return __orig(*args, **kwargs)
+            finally:
+                dm._exit_nn_module_call()
+
+        mod.forward = wrapped
+        originals.append((mod, orig))
+
+    try:
+        yield
+    finally:
+        for mod, orig in reversed(originals):
+            mod.forward = orig
+
+def capture(model, run_fn, *, min_numel=0, annotate_modules=False):
+    """run_fn(model) executes the step to compare. Returns ordered list of
     {key, phase, stats, out_hash, in_hash}."""
     # backward FQN map: walk the autograd graph from each module's outputs
     grad_fn_to_fqn = {}
@@ -141,9 +178,17 @@ def capture(model, run_fn, *, min_numel=0):
         if leaves: rec["stats"] = _stats(leaves[0])
         return rec
 
-    dm = DebugMode(record_realtensor=True, record_nn_module=True, record_ids=True)
+    # Prefer DebugMode's built-in module tracking. If the probe shows no usable
+    # markers for the target model, annotate_modules=True installs generic FQN
+    # markers by temporarily wrapping model.named_modules().
+    dm = DebugMode(
+        record_realtensor=True,
+        record_nn_module=not annotate_modules,
+        record_ids=True,
+    )
+    module_ctx = _annotate_modules(model) if annotate_modules else contextlib.nullcontext()
     try:
-        with dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True), \
+        with module_ctx, dm, DebugMode.log_tensor_hashes(hash_fn="norm", hash_inputs=True), \
                 DebugMode.dispatch_hooks(record_hook=record_hook):
             run_fn(model)
     finally:
@@ -194,17 +239,30 @@ Drive it once per run, with identical setup on both sides:
 ```python
 def build():
     torch.manual_seed(0)
-    return Net().cuda(), torch.randn(16, 256, device="cuda")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    return Net().to(device), torch.randn(16, 256, device=device)
 
 def step(m, x):
+    # For inference-only comparisons, return or consume m(x) without backward.
     m(x).sum().backward()
 
 m, x = build()
 write_log(capture(m, lambda mm: step(mm, x)), "run_A.log")
-# ... change the one thing under test (compile, FSDP, a flag) ...
+# ... change the one thing under test (compile, a distributed wrapper, a flag) ...
 m, x = build()
 write_log(capture(m, lambda mm: step(mm, x)), "run_B.log")
 ```
+
+If the probe shows missing or framework-specific layer markers, use the generic
+module annotation fallback on both sides:
+
+```python
+write_log(capture(m, lambda mm: step(mm, x), annotate_modules=True), "run_A.log")
+```
+
+Only use `annotate_modules=True` when `record_nn_module=True` is not enough; it
+temporarily monkey-patches `forward` on the model's `named_modules()` entries
+for the captured step and restores them afterwards.
 
 ## Backward FQN attribution
 
@@ -214,7 +272,7 @@ During backward the C++ autograd engine drives execution, so no
 global forward hooks walk the autograd graph from each module's outputs and
 claim unclaimed nodes for that module (`setdefault`, so a parent picks up glue
 ops between children while children keep their own). This was verified to
-recover e.g. `blocks.1.fc2` for a backward `mm`. Ops it can't claim fall back
+recover e.g. `features.1.proj` for a backward `mm`. Ops it can't claim fall back
 to `<backward>`.
 
 ## Compiled / traced runs

--- a/.claude/skills/numerics-debugging/references/comparing-runs.md
+++ b/.claude/skills/numerics-debugging/references/comparing-runs.md
@@ -1,131 +1,56 @@
-# Comparing two capture logs
+# Comparing DebugMode Dumps
 
-## Real log format
+Use the plain `dm.debug_string()` output as the source of truth. Do not require
+a custom parser or a custom row format. A text diff is usually enough to find
+the first meaningful mismatch.
 
-This is the exact output `write_log` produces (verified), one block per op:
+## What to compare
 
-```
-[features.0.proj/op_0_addmm]
-  Shape: (16, 512) torch.float32
-  L2: 5.125471e+01
-  Min: -2.010448e+00
-  Max: 2.068169e+00
-  Mean: 3.024476e-03
-  Output hash: 3.691091e+03
-  Input hashes: 1.675600e+01, 3.217083e+03, 4.089176e+03
+Start with the first operator line where the output `hash` differs. Then inspect
+that same line's `input_hash` values:
 
-[features.0/op_0_relu]
-  Shape: (16, 512) torch.float32
-  L2: 3.630413e+01
-  Min: 0.000000e+00
-  Max: 2.068169e+00
-  Mean: 2.267985e-01
-  Output hash: 1.857934e+03
-  Input hashes: 3.691091e+03
+- Matching `input_hash`, different output `hash`: this op is the likely source.
+- Different `input_hash`: this op is only carrying an upstream divergence.
+- Missing output hash on an in-place or `None`-returning op: compare
+  `input_hash`; moved input hashes can be the mutation.
 
-[<none>/op_0_sum]
-  Shape: () torch.float32
-  ...
-  Output hash:
-```
+Use tensor IDs from `record_ids=True` to follow values between nearby lines.
+Use module markers from `record_nn_module=True`, profiler scopes, and stack
+trace summaries to keep the search localized to the same layer/module.
 
-Notes from real captures:
+## Pairing lines
 
-- The header `module_fqn/op_N_opname` is the match key. `op_N` is a per-module
-  counter, so the same op in two runs gets the same key when the module
-  structure matches.
-- `relu` is attributed to the enclosing block (`features.0`), not the linear, by
-  the depth-stack reconstruction — that is correct (it is called in
-  the parent module's `forward`, not inside the linear submodule).
-- The loss `sum` lands under `<none>` (it runs outside any module) and has an
-  **empty** `Output hash` (scalar) — expected, skip it.
-- Backward ops carry a trailing `  Phase: backward` line.
+Prefer direct visual pairing by module scope, operator name, tensor shape, and
+nearby tensor IDs. If the dumps are too different for direct pairing:
 
-## Pairing ops, then diffing
+1. First recapture with `record_stack_trace=True` and
+   `debug_string(show_stack_trace=True)`.
+2. For compiled/AOT regions, try `run_compile_with_interpreter=True`.
+3. Only after that, pair positionally by dispatch order and treat the result as
+   weaker evidence.
 
-`compare` pairs by exact key and reports the first op whose output hash
-differs. The hashes are formatted strings, so **parse them as floats and use a
-relative tolerance** rather than `==` — `norm` hashes are float64 L1 and the
-last printed digit can wobble on legitimate reduction-order noise:
+## Training Runs
 
-```python
-def _floats(s):
-    return [float(x) for x in s.split(",")] if s.strip() else []
+Before diffing long training dumps, run a deterministic single-step check for
+loss and grad norm:
 
-def diverges(ha, hb, rtol=1e-6):
-    fa, fb = _floats(ha), _floats(hb)
-    if len(fa) != len(fb):
-        return True
-    return any(abs(a - b) > rtol * (abs(a) + abs(b) + 1e-30) for a, b in zip(fa, fb))
-```
+- Loss differs: the first mismatch is probably in forward or in setup before
+  forward.
+- Loss matches bitwise but grad norm differs: forward likely matched; inspect
+  the first backward hash mismatch.
+- Both match: inspect optimizer state, RNG/data loading after the checked step,
+  or later iterations.
 
-Pair in passes, most specific first, stopping at the first that matches:
+## Common Mismatches
 
-1. **Exact key** — identical `module_fqn/op_N_opname`. Strip the model-class
-   root prefix on both sides first (FQNs are rooted at the model class, e.g.
-   `Net.features.0...`) so the naming agrees with `named_modules()`.
-2. **Fuzzy key** — same FQN and op name but a shifted `op_N` counter (one side
-   has an extra in-place collective consuming an early slot). Pair by op-name
-   order within the module.
-3. **Positional / stats fallback** — when keys don't resolve (e.g. a traced
-   run with everything under `<none>`), pair by dispatch order and confirm
-   with matching `Shape` + nearest output hash. Treat these pairings as weaker
-   evidence and say so.
+- Recompute can shorten or shift module scopes.
+- Extra bookkeeping, communication, or in-place ops can shift later op order.
+- Compiled/traced runs may lower one eager op into several lower-level ops.
+- Repeated subgraphs can make fuzzy pairing drift by one repeated block.
+- Backward ops may have weaker module attribution than forward ops.
 
-If eager logs contain many `<none>` keys, recapture with
-`annotate_modules=True` before using positional matching. Positional matching
-is for cases where module metadata is genuinely unavailable, such as some
-compiled or traced executions.
+## Before Calling It A Bug
 
-## Reading a divergence
-
-- Compare `Output hash` with the tolerance above. Equal hash + equal `Shape`
-  -> treat the op as matching.
-- If output hashes differ, check `Input hashes`. **If the inputs already
-  differ, the divergence is upstream** — this op only propagates it. Walk back
-  to the op that produced those inputs and continue until you find an op whose
-  inputs match but whose output differs. That op is the root.
-- In-place ops (`_fused_adam_`, names ending in `_`) often have an empty
-  `Output hash` (the dispatch returns `None`); compare their `Input hashes`
-  instead — a moved input hash is the mutation.
-- A single isolated last-digit difference that does not propagate is
-  reduction-order noise, not a bug. A difference that **grows** downstream is
-  the real divergence — report the earliest op in that chain whose inputs
-  still matched.
-
-Verified example (fp32 vs TF32 matmul, same seed/dtype/inputs): all forward
-ops matched; the first divergence was a **backward** `mm` whose two input
-hashes were identical across runs -> the matmul kernel itself is the source.
-Identical-vs-identical runs reported zero divergences across all paired ops
-(no false positives).
-
-## Common key mismatch patterns
-
-When comparing eager vs `torch.compile`/`aot_fx_trace`, keys drift for
-structural reasons. Express known correspondences as a manual override map
-(`{run1_key: run2_key}`) applied before the automatic passes; confirm each by
-matching `Shape` and a near-matching output hash first.
-
-- **Recompute FQN drift** — activation checkpointing or another rematerializer
-  re-runs modules, so one side logs a shorter FQN (`submodule`) while the other
-  keeps the full one (`stage.2.submodule`).
-- **Per-module counter shifts** — one side runs an extra bookkeeping,
-  communication, or in-place op under a module key, shifting every later
-  `op_N` in that module by one.
-- **Distributed op lowering / renaming** — an eager collective or device
-  transfer can correspond to a traced chain of lower-level ops, often
-  re-attributed to the consumer module.
-- **Repeated subgraphs** — models with repeated blocks can execute many
-  similar `mul`/`add`/`mm`/`bmm` patterns, so fuzzy matching can drift by one
-  repeated block.
-- **Backward attribution drift** — a backward op can land under `<backward>`,
-  a parent module, or a generated backward op name when the grad_fn walk can't
-  claim it; pair it explicitly to its eager counterpart.
-
-## Before concluding "real bug"
-
-- Confirm both runs used the **same dtype, seed, inputs**, and determinism
-  settings. If not, every row diverges — fix setup and recapture; not a bug.
-- Distinguish reduction-order noise (isolated, last-digit, non-propagating)
-  from a true divergence (propagates and grows). Report the earliest op whose
-  inputs matched but output diverged.
+Confirm both runs used the same dtype, seed, inputs, RNG behavior, and
+determinism settings. If setup differs, every hash can diverge and the dump will
+not identify a meaningful kernel or operator bug.

--- a/.claude/skills/numerics-debugging/references/comparing-runs.md
+++ b/.claude/skills/numerics-debugging/references/comparing-runs.md
@@ -1,0 +1,127 @@
+# Comparing two capture logs
+
+## Real log format
+
+This is the exact output `write_log` produces (verified), one block per op:
+
+```
+[blocks.0.fc1/op_0_addmm]
+  Shape: (16, 512) torch.float32
+  L2: 5.125471e+01
+  Min: -2.010448e+00
+  Max: 2.068169e+00
+  Mean: 3.024476e-03
+  Output hash: 3.691091e+03
+  Input hashes: 1.675600e+01, 3.217083e+03, 4.089176e+03
+
+[blocks.0/op_0_relu]
+  Shape: (16, 512) torch.float32
+  L2: 3.630413e+01
+  Min: 0.000000e+00
+  Max: 2.068169e+00
+  Mean: 2.267985e-01
+  Output hash: 1.857934e+03
+  Input hashes: 3.691091e+03
+
+[<none>/op_0_sum]
+  Shape: () torch.float32
+  ...
+  Output hash:
+```
+
+Notes from real captures:
+
+- The header `module_fqn/op_N_opname` is the match key. `op_N` is a per-module
+  counter, so the same op in two runs gets the same key when the module
+  structure matches.
+- `relu` is attributed to the enclosing block (`blocks.0`), not the linear, by
+  the depth-stack reconstruction — that is correct (it is called in
+  `Block.forward`, not inside a submodule).
+- The loss `sum` lands under `<none>` (it runs outside any module) and has an
+  **empty** `Output hash` (scalar) — expected, skip it.
+- Backward ops carry a trailing `  Phase: backward` line.
+
+## Pairing ops, then diffing
+
+`compare` pairs by exact key and reports the first op whose output hash
+differs. The hashes are formatted strings, so **parse them as floats and use a
+relative tolerance** rather than `==` — `norm` hashes are float64 L1 and the
+last printed digit can wobble on legitimate reduction-order noise:
+
+```python
+def _floats(s):
+    return [float(x) for x in s.split(",")] if s.strip() else []
+
+def diverges(ha, hb, rtol=1e-6):
+    fa, fb = _floats(ha), _floats(hb)
+    if len(fa) != len(fb):
+        return True
+    return any(abs(a - b) > rtol * (abs(a) + abs(b) + 1e-30) for a, b in zip(fa, fb))
+```
+
+Pair in passes, most specific first, stopping at the first that matches:
+
+1. **Exact key** — identical `module_fqn/op_N_opname`. Strip the model-class
+   root prefix on both sides first (FQNs are rooted at the model class, e.g.
+   `Net.blocks.0...`) so the naming agrees with `named_modules()`.
+2. **Fuzzy key** — same FQN and op name but a shifted `op_N` counter (one side
+   has an extra in-place collective consuming an early slot). Pair by op-name
+   order within the module.
+3. **Positional / stats fallback** — when keys don't resolve (e.g. a traced
+   run with everything under `<none>`), pair by dispatch order and confirm
+   with matching `Shape` + nearest output hash. Treat these pairings as weaker
+   evidence and say so.
+
+## Reading a divergence
+
+- Compare `Output hash` with the tolerance above. Equal hash + equal `Shape`
+  -> treat the op as matching.
+- If output hashes differ, check `Input hashes`. **If the inputs already
+  differ, the divergence is upstream** — this op only propagates it. Walk back
+  to the op that produced those inputs and continue until you find an op whose
+  inputs match but whose output differs. That op is the root.
+- In-place ops (`_fused_adam_`, names ending in `_`) often have an empty
+  `Output hash` (the dispatch returns `None`); compare their `Input hashes`
+  instead — a moved input hash is the mutation.
+- A single isolated last-digit difference that does not propagate is
+  reduction-order noise, not a bug. A difference that **grows** downstream is
+  the real divergence — report the earliest op in that chain whose inputs
+  still matched.
+
+Verified example (fp32 vs TF32 matmul, same seed/dtype/inputs): all 6 forward
+ops matched; the first divergence was a **backward** `mm`
+(`blocks.1.fc2/op_1_mm`) whose two input hashes were identical across runs ->
+the matmul kernel itself is the source. Identical-vs-identical runs reported
+zero divergences across all paired ops (no false positives).
+
+## Common eager-vs-traced mismatch patterns
+
+When comparing eager vs `torch.compile`/`aot_fx_trace`, keys drift for
+structural reasons. Express known correspondences as a manual override map
+(`{run1_key: run2_key}`) applied before the automatic passes; confirm each by
+matching `Shape` and a near-matching output hash first.
+
+- **AC-recompute FQN drift** — selective activation checkpointing re-runs
+  modules on recompute, so one side logs a short FQN (`feed_forward`) while the
+  other keeps the full one (`layers.2.feed_forward`).
+- **Per-layer counter shifts** — an in-place FSDP collective takes an early
+  `op_N` slot under a layer key on one side; the other lacks it, shifting every
+  later op in that layer by one.
+- **Collective lowering / renaming** — eager in-place `_allgather_base_` /
+  `_reduce_scatter_base_` corresponds to a traced
+  `all_gather_into_tensor_out` + `wait_tensor` chain, often re-attributed to
+  the consumer module.
+- **Repeated attention math** — rotary / GQA blocks repeat similar
+  `mul`/`add`/`bmm` patterns, so fuzzy matching can drift by one repeated
+  block.
+- **Backward attribution drift** — a backward op can land under `<backward>`,
+  a parent module, or a generated backward op name when the grad_fn walk can't
+  claim it; pair it explicitly to its eager counterpart.
+
+## Before concluding "real bug"
+
+- Confirm both runs used the **same dtype, seed, inputs**, and determinism
+  settings. If not, every row diverges — fix setup and recapture; not a bug.
+- Distinguish reduction-order noise (isolated, last-digit, non-propagating)
+  from a true divergence (propagates and grows). Report the earliest op whose
+  inputs matched but output diverged.

--- a/.claude/skills/numerics-debugging/references/comparing-runs.md
+++ b/.claude/skills/numerics-debugging/references/comparing-runs.md
@@ -5,7 +5,7 @@
 This is the exact output `write_log` produces (verified), one block per op:
 
 ```
-[blocks.0.fc1/op_0_addmm]
+[features.0.proj/op_0_addmm]
   Shape: (16, 512) torch.float32
   L2: 5.125471e+01
   Min: -2.010448e+00
@@ -14,7 +14,7 @@ This is the exact output `write_log` produces (verified), one block per op:
   Output hash: 3.691091e+03
   Input hashes: 1.675600e+01, 3.217083e+03, 4.089176e+03
 
-[blocks.0/op_0_relu]
+[features.0/op_0_relu]
   Shape: (16, 512) torch.float32
   L2: 3.630413e+01
   Min: 0.000000e+00
@@ -34,9 +34,9 @@ Notes from real captures:
 - The header `module_fqn/op_N_opname` is the match key. `op_N` is a per-module
   counter, so the same op in two runs gets the same key when the module
   structure matches.
-- `relu` is attributed to the enclosing block (`blocks.0`), not the linear, by
+- `relu` is attributed to the enclosing block (`features.0`), not the linear, by
   the depth-stack reconstruction — that is correct (it is called in
-  `Block.forward`, not inside a submodule).
+  the parent module's `forward`, not inside the linear submodule).
 - The loss `sum` lands under `<none>` (it runs outside any module) and has an
   **empty** `Output hash` (scalar) — expected, skip it.
 - Backward ops carry a trailing `  Phase: backward` line.
@@ -63,7 +63,7 @@ Pair in passes, most specific first, stopping at the first that matches:
 
 1. **Exact key** — identical `module_fqn/op_N_opname`. Strip the model-class
    root prefix on both sides first (FQNs are rooted at the model class, e.g.
-   `Net.blocks.0...`) so the naming agrees with `named_modules()`.
+   `Net.features.0...`) so the naming agrees with `named_modules()`.
 2. **Fuzzy key** — same FQN and op name but a shifted `op_N` counter (one side
    has an extra in-place collective consuming an early slot). Pair by op-name
    order within the module.
@@ -71,6 +71,11 @@ Pair in passes, most specific first, stopping at the first that matches:
    run with everything under `<none>`), pair by dispatch order and confirm
    with matching `Shape` + nearest output hash. Treat these pairings as weaker
    evidence and say so.
+
+If eager logs contain many `<none>` keys, recapture with
+`annotate_modules=True` before using positional matching. Positional matching
+is for cases where module metadata is genuinely unavailable, such as some
+compiled or traced executions.
 
 ## Reading a divergence
 
@@ -88,32 +93,31 @@ Pair in passes, most specific first, stopping at the first that matches:
   the real divergence — report the earliest op in that chain whose inputs
   still matched.
 
-Verified example (fp32 vs TF32 matmul, same seed/dtype/inputs): all 6 forward
-ops matched; the first divergence was a **backward** `mm`
-(`blocks.1.fc2/op_1_mm`) whose two input hashes were identical across runs ->
-the matmul kernel itself is the source. Identical-vs-identical runs reported
-zero divergences across all paired ops (no false positives).
+Verified example (fp32 vs TF32 matmul, same seed/dtype/inputs): all forward
+ops matched; the first divergence was a **backward** `mm` whose two input
+hashes were identical across runs -> the matmul kernel itself is the source.
+Identical-vs-identical runs reported zero divergences across all paired ops
+(no false positives).
 
-## Common eager-vs-traced mismatch patterns
+## Common key mismatch patterns
 
 When comparing eager vs `torch.compile`/`aot_fx_trace`, keys drift for
 structural reasons. Express known correspondences as a manual override map
 (`{run1_key: run2_key}`) applied before the automatic passes; confirm each by
 matching `Shape` and a near-matching output hash first.
 
-- **AC-recompute FQN drift** — selective activation checkpointing re-runs
-  modules on recompute, so one side logs a short FQN (`feed_forward`) while the
-  other keeps the full one (`layers.2.feed_forward`).
-- **Per-layer counter shifts** — an in-place FSDP collective takes an early
-  `op_N` slot under a layer key on one side; the other lacks it, shifting every
-  later op in that layer by one.
-- **Collective lowering / renaming** — eager in-place `_allgather_base_` /
-  `_reduce_scatter_base_` corresponds to a traced
-  `all_gather_into_tensor_out` + `wait_tensor` chain, often re-attributed to
-  the consumer module.
-- **Repeated attention math** — rotary / GQA blocks repeat similar
-  `mul`/`add`/`bmm` patterns, so fuzzy matching can drift by one repeated
-  block.
+- **Recompute FQN drift** — activation checkpointing or another rematerializer
+  re-runs modules, so one side logs a shorter FQN (`submodule`) while the other
+  keeps the full one (`stage.2.submodule`).
+- **Per-module counter shifts** — one side runs an extra bookkeeping,
+  communication, or in-place op under a module key, shifting every later
+  `op_N` in that module by one.
+- **Distributed op lowering / renaming** — an eager collective or device
+  transfer can correspond to a traced chain of lower-level ops, often
+  re-attributed to the consumer module.
+- **Repeated subgraphs** — models with repeated blocks can execute many
+  similar `mul`/`add`/`mm`/`bmm` patterns, so fuzzy matching can drift by one
+  repeated block.
 - **Backward attribution drift** — a backward op can land under `<backward>`,
   a parent module, or a generated backward op name when the grad_fn walk can't
   claim it; pair it explicitly to its eager counterpart.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187419

Adds a numerics-debugging skill for localizing numeric divergence between two PyTorch runs by capturing plain torch.utils._debug_mode.DebugMode.debug_string() dumps with tensor hashes enabled. The workflow focuses on comparing the first mismatching hash / input_hash, using record_nn_module, tensor IDs, stack traces, and compiled-region interpreter mode to keep eager and compiled dumps interpretable.

The recipe also includes single-step training triage with loss and grad-norm checks, plus real eager and aot_eager dump examples showing what to inspect.

Authored by Claude, using skill-authoring skill