### PR TITLE
[inductor] Use NVML fallback for max_clock_rate without nvidia-smi

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,9 +10,10 @@ import sys
 import tempfile
 import textwrap
 import traceback
+import types
 import unittest
 import warnings
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.cuda
@@ -1036,6 +1037,57 @@ class TestTryImport(TestCase):
     def test_import_missing(self):
         missing_module = try_import("missing_module")
         self.assertIsNone(missing_module)
+
+
+class TestUtilsInternal(TestCase):
+    def test_max_clock_rate_falls_back_to_pynvml_when_nvidia_smi_missing(self):
+        def nvsmi(_query):
+            raise FileNotFoundError("nvidia-smi")
+
+        triton = types.ModuleType("triton")
+        triton_testing = types.ModuleType("triton.testing")
+        cast(Any, triton_testing).nvsmi = nvsmi
+        cast(Any, triton).testing = triton_testing
+
+        pynvml = types.ModuleType("pynvml")
+        cast(Any, pynvml).NVML_CLOCK_SM = 1
+        calls = []
+
+        def nvmlDeviceGetMaxClockInfo(handle, clock_type):
+            calls.append(("max_clock", handle, clock_type))
+            return 1980
+
+        def nvmlShutdown():
+            calls.append("shutdown")
+
+        cast(Any, pynvml).nvmlDeviceGetMaxClockInfo = nvmlDeviceGetMaxClockInfo
+        cast(Any, pynvml).nvmlShutdown = nvmlShutdown
+
+        torch._utils_internal.max_clock_rate.cache_clear()
+        try:
+            with (
+                unittest.mock.patch.dict(
+                    sys.modules,
+                    {
+                        "triton": triton,
+                        "triton.testing": triton_testing,
+                        "pynvml": pynvml,
+                    },
+                ),
+                unittest.mock.patch.object(torch.version, "hip", None),
+                unittest.mock.patch.object(
+                    torch.cuda, "_get_pynvml_handler", return_value="handle"
+                ) as get_pynvml_handler,
+            ):
+                self.assertEqual(torch._utils_internal.max_clock_rate(), 1980)
+                get_pynvml_handler.assert_called_once_with()
+        finally:
+            torch._utils_internal.max_clock_rate.cache_clear()
+
+        self.assertEqual(
+            calls,
+            [("max_clock", "handle", 1), "shutdown"],
+        )
 
 
 @deprecated()

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -228,7 +228,16 @@ def max_clock_rate():
     if not torch.version.hip:
         from triton.testing import nvsmi
 
-        return nvsmi(["clocks.max.sm"])[0]
+        try:
+            return nvsmi(["clocks.max.sm"])[0]
+        except FileNotFoundError:
+            import pynvml  # type: ignore[import]
+
+            handle = torch.cuda._get_pynvml_handler()
+            try:
+                return pynvml.nvmlDeviceGetMaxClockInfo(handle, pynvml.NVML_CLOCK_SM)
+            finally:
+                pynvml.nvmlShutdown()
     else:
         # Manually set max-clock speeds on ROCm until equivalent nvmsi
         # functionality in triton.testing or via pyamdsmi enablement. Required


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187427

Inductor runtime estimation can reach Triton's clock-based device estimator when the current GPU is not covered by the datasheet table. That estimator asks torch._utils_internal.max_clock_rate() for the max SM clock, and the existing CUDA path delegates to triton.testing.nvsmi(), which shells out to the nvidia-smi executable.

That dependency is reasonable on a normal host driver install, but it is not a Python or conda package dependency. nvidia-smi is shipped with the NVIDIA driver utilities on the host/cluster image, while conda/fbpkg environments usually contain Python packages and CUDA libraries rather than the driver CLI. In containers and fbpkg jobs it is therefore possible to have working CUDA driver access and NVML access, but no nvidia-smi binary in PATH. In that situation runtime estimation fails with FileNotFoundError even though the driver can still answer the clock query.

Keep the existing nvidia-smi path unchanged when it is available. Only when the executable is missing, fall back to pynvml and query NVML for the same max SM clock value. The fallback uses torch.cuda._get_pynvml_handler() so PyTorch's CUDA_VISIBLE_DEVICES mapping and NVML driver error handling remain consistent with the rest of torch.cuda.

This is intentionally narrow: if neither nvidia-smi nor pynvml/NVML is available, max_clock_rate() still fails because there is no working mechanism to query the clock. The change only covers the packaging gap where the driver/NVML path exists but the driver CLI was not included in the Python runtime environment.

Test Plan:

```bash
python -m py_compile torch/_utils_internal.py test/test_utils.py
```

```bash
git diff --check -- torch/_utils_internal.py test/test_utils.py
```

```bash
python test/test_utils.py -k TestUtilsInternal
```

```bash
lintrunner -a
```

This change was authored with assistance from an AI assistant.