### PR TITLE
[ROCm] Enable miopen convolution to handle zero-sized spatial outputs

### DIFF
--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -1061,31 +1061,43 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> miopen_convolution_transpose_back
   Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
 
   Tensor grad_input, grad_weight, grad_bias;
-  if (output_mask[0]) {
-    grad_input = miopen_convolution_transpose_backward_input(
-        grad_output,
-        weight,
-        padding,
-        stride,
-        dilation,
-        groups,
-        benchmark,
-        deterministic);
-  }
-  if (output_mask[1]) {
-    grad_weight = miopen_convolution_transpose_backward_weight(
-        weight.sizes(),
-        grad_output,
-        input,
-        padding,
-        stride,
-        dilation,
-        groups,
-        benchmark,
-        deterministic);
-  }
-  if (output_mask[2]) {
-    grad_bias = miopen_convolution_backward_bias(grad_output);
+  if (grad_output.numel() == 0) {
+    if (output_mask[0]) {
+      grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+    if (output_mask[1]) {
+      grad_weight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+    if (output_mask[2]) {
+      grad_bias = at::zeros({weight.size(1) * groups}, grad_output.options());
+    }
+  } else {
+    if (output_mask[0]) {
+      grad_input = miopen_convolution_transpose_backward_input(
+          grad_output,
+          weight,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic);
+    }
+    if (output_mask[1]) {
+      grad_weight = miopen_convolution_transpose_backward_weight(
+          weight.sizes(),
+          grad_output,
+          input,
+          padding,
+          stride,
+          dilation,
+          groups,
+          benchmark,
+          deterministic);
+    }
+    if (output_mask[2]) {
+      grad_bias = miopen_convolution_backward_bias(grad_output);
+    }
   }
 
   return std::tuple<Tensor,Tensor,Tensor>{std::move(grad_input), std::move(grad_weight), std::move(grad_bias)};
@@ -1226,6 +1238,9 @@ Tensor miopen_convolution_backward_input(
   TensorArg grad_input{grad_input_t, "result", 0};
   convolution_shape_check(
       c, grad_input, weight, grad_output, padding, stride, dilation, groups);
+  if (grad_input_t.numel() == 0) {
+    return grad_input_t;
+  }
 
   Tensor weight_contig = weight->contiguous(memory_format);
   Tensor grad_output_contig = grad_output->contiguous(memory_format);
@@ -1658,6 +1673,9 @@ Tensor miopen_convolution_transpose(
       groups,
       benchmark,
       deterministic);
+  if (output_t.numel() == 0) {
+    return output_t;
+  }
   if (bias->defined()) {
     miopen_convolution_add_bias_(c, { output_t, "result", 0 }, bias);
   }

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16609,12 +16609,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             with self.assertRaisesRegex(RuntimeError, "Output size is too small"):
                 _ = torch.compile(model)(inputs)
 
-    @skipIfRocm
     @requires_cuda
     def test_conv_transpose_zero_size_output(self):
-        # Only CUDA (cuDNN) supports zero-sized spatial outputs for conv_transpose.
-        # ROCm/miopen fails with miopenStatusBadParm, MPS fails with empty placeholder assert.
-        # This test ensures compiled mode matches eager behavior on CUDA.
+        # CUDA/HIP support zero-sized spatial outputs for conv_transpose by
+        # short-circuiting before backend libraries see empty tensor descriptors.
+        # This test ensures compiled mode matches eager behavior.
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2683,7 +2683,7 @@ def calc_conv_nd_return_shape(
     # CUDA (cuDNN) and HIP handle zero-sized conv_transpose outputs by short-circuiting,
     # but other backends fail: CPU rejects it and MPS asserts "Placeholder tensor is empty".
     from torch._subclasses.fake_tensor import FakeTensor
-    from torch.fx.experimental.symbolic_shapes import sym_and
+    from torch.fx.experimental.symbolic_shapes import sym_and, sym_or
 
     device = (
         input_tensor.fake_device
@@ -2693,8 +2693,8 @@ def calc_conv_nd_return_shape(
 
     # ROCm reports device.type as "cuda"; keep the existing NVIDIA CUDA behavior
     # unchanged and only apply the new check to HIP.
-    is_cuda = device.type == "cuda"
-    is_hip = is_cuda and torch.version.hip is not None
+    is_cudnn = device.type == "cuda" and torch.version.hip is None
+    is_hip = device.type == "cuda" and torch.version.hip is not None
     if is_hip:
         torch._check(
             sym_and(*[x >= 0 for x in ret_shape[2:]]),
@@ -2702,9 +2702,9 @@ def calc_conv_nd_return_shape(
             f"Calculated output size per channel: {ret_shape[2:]}. "
             f"Output size is too small",
         )
-    elif not is_cuda:
+    elif not is_cudnn:
         torch._check(
-            sym_and(*[x > 0 for x in ret_shape[2:]]),
+            sym_or(*[x > 0 for x in ret_shape[2:]]),
             lambda: f"Given input size per channel: {list(dims)}. "
             f"Calculated output size per channel: {ret_shape[2:]}. "
             f"Output size is too small",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2680,7 +2680,7 @@ def calc_conv_nd_return_shape(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
     # NOTE: Backend behavior for zero-sized spatial dimensions is inconsistent.
-    # CUDA and HIP handle zero-sized conv_transpose outputs by short-circuiting,
+    # CUDA (cuDNN) and HIP handle zero-sized conv_transpose outputs by short-circuiting,
     # but other backends fail: CPU rejects it and MPS asserts "Placeholder tensor is empty".
     from torch._subclasses.fake_tensor import FakeTensor
     from torch.fx.experimental.symbolic_shapes import sym_and
@@ -2691,18 +2691,24 @@ def calc_conv_nd_return_shape(
         else input_tensor.device
     )
 
-    allow_zero_size_output = device.type == "cuda"
-    output_size_check = (
-        sym_and(*[x >= 0 for x in ret_shape[2:]])
-        if allow_zero_size_output
-        else sym_and(*[x > 0 for x in ret_shape[2:]])
-    )
-    torch._check(
-        output_size_check,
-        lambda: f"Given input size per channel: {list(dims)}. "
-        f"Calculated output size per channel: {ret_shape[2:]}. "
-        f"Output size is too small",
-    )
+    # ROCm reports device.type as "cuda"; keep the existing NVIDIA CUDA behavior
+    # unchanged and only apply the new check to HIP.
+    is_cuda = device.type == "cuda"
+    is_hip = is_cuda and torch.version.hip is not None
+    if is_hip:
+        torch._check(
+            sym_and(*[x >= 0 for x in ret_shape[2:]]),
+            lambda: f"Given input size per channel: {list(dims)}. "
+            f"Calculated output size per channel: {ret_shape[2:]}. "
+            f"Output size is too small",
+        )
+    elif not is_cuda:
+        torch._check(
+            sym_and(*[x > 0 for x in ret_shape[2:]]),
+            lambda: f"Given input size per channel: {list(dims)}. "
+            f"Calculated output size per channel: {ret_shape[2:]}. "
+            f"Output size is too small",
+        )
 
     return ret_shape
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2680,12 +2680,10 @@ def calc_conv_nd_return_shape(
                 _formula(dims[i], padding[i], dilation[i], kernel_size[i], stride[i])
             )
     # NOTE: Backend behavior for zero-sized spatial dimensions is inconsistent.
-    # CUDA (cuDNN) handles zero-sized outputs gracefully by short-circuiting,
-    # but other backends fail: CPU rejects it, ROCm/miopen returns
-    # miopenStatusBadParm, and MPS asserts "Placeholder tensor is empty".
-    # We only allow zero-sized outputs on CUDA with cuDNN (not ROCm/HIP).
+    # CUDA and HIP handle zero-sized conv_transpose outputs by short-circuiting,
+    # but other backends fail: CPU rejects it and MPS asserts "Placeholder tensor is empty".
     from torch._subclasses.fake_tensor import FakeTensor
-    from torch.fx.experimental.symbolic_shapes import sym_or
+    from torch.fx.experimental.symbolic_shapes import sym_and
 
     device = (
         input_tensor.fake_device
@@ -2693,15 +2691,18 @@ def calc_conv_nd_return_shape(
         else input_tensor.device
     )
 
-    # ROCm also reports device.type as "cuda", but miopen doesn't support zero-sized outputs
-    is_cudnn = device.type == "cuda" and torch.version.hip is None
-    if not is_cudnn:
-        torch._check(
-            sym_or(*[x > 0 for x in ret_shape[2:]]),
-            lambda: f"Given input size per channel: {list(dims)}. "
-            f"Calculated output size per channel: {ret_shape[2:]}. "
-            f"Output size is too small",
-        )
+    allow_zero_size_output = device.type == "cuda"
+    output_size_check = (
+        sym_and(*[x >= 0 for x in ret_shape[2:]])
+        if allow_zero_size_output
+        else sym_and(*[x > 0 for x in ret_shape[2:]])
+    )
+    torch._check(
+        output_size_check,
+        lambda: f"Given input size per channel: {list(dims)}. "
+        f"Calculated output size per channel: {ret_shape[2:]}. "
+        f"Output size is too small",
+    )
 
     return ret_shape
 


### PR DESCRIPTION
Enable MIOpen convolution to handle zero-sized spatial outputs consistently with CUDA/cuDNN.

ROCm previously computed valid zero-sized outputs such as (1, 1, 0, 0), but still called into MIOpen. MIOpen rejects zero-length tensor descriptors, causing eager mode to fail with miopenStatusBadParm. This change short-circuits empty transposed-convolution outputs before invoking MIOpen, updates HIP fake/meta shape handling, and unskips the Inductor coverage.

Details:

- Return the allocated empty output for MIOpen transposed convolution when numel() == 0, avoiding zero-length MIOpen descriptors.
- Return zero gradients for empty grad_output in MIOpen transposed-convolution backward.
- Allow HIP fake tensor shape propagation to represent zero-sized conv_transpose spatial outputs while preserving existing NVIDIA CUDA and CPU/MPS behavior.
- Unskip test_conv_transpose_zero_size_output on ROCm.

Coauthored by Claude

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben