### PR TITLE
Stash coalesced tensors on the endCoalescing Work, not the per-call Work

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -46,26 +46,6 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
-# Opaque custom op so torch.compile traces the coalescing manager into the graph
-# (Dynamo otherwise graph-breaks on it) and reduce-overhead captures the
-# coalesced collective into a cudagraph. Used by test_coalescing_manager_reduce_overhead.
-@torch.library.custom_op("test_c10d_ops_nccl::coalesced_all_gather", mutates_args=())
-def _coalesced_all_gather(
-    inp: torch.Tensor, world_size: int, group_name: str
-) -> torch.Tensor:
-    group = c10d.distributed_c10d._resolve_process_group(group_name)
-    out = inp.new_empty(inp.numel() * world_size)
-    with dist._coalescing_manager(group=group, device=inp.device, async_ops=True) as cm:
-        dist.all_gather_single(out, inp)
-    cm.wait()
-    return out
-
-
-@_coalesced_all_gather.register_fake
-def _(inp, world_size, group_name):
-    return inp.new_empty(inp.numel() * world_size)
-
-
 class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @classmethod
     def backend_str(cls) -> str:
@@ -398,41 +378,6 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
         self.assertEqual(static_output.sum().item(), expected_sum)
         torch.cuda.memory._set_allocator_settings("expandable_segments:False")
-
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
-    def test_coalescing_manager_reduce_overhead(self):
-        # An async coalescing manager around a fast-path collective used to
-        # stash the gathered tensors on the discarded per-call Work, so
-        # cm.wait() never freed them and reduce-overhead cudagraph capture
-        # failed its "not tracked as outputs" pool check. The gathered buffer is
-        # an intermediate here (consumed by + 1), so the leak is not masked by
-        # being a graph output.
-        idx = self.rank_to_GPU[self.rank][0]
-        torch.cuda.set_device(idx)
-        device = torch.device(f"cuda:{idx}")
-        group_name = self.pg.group_name
-
-        def f(inp):
-            gathered = torch.ops.test_c10d_ops_nccl.coalesced_all_gather(
-                inp, self.world_size, group_name
-            )
-            return gathered + 1
-
-        compiled = torch.compile(f, mode="reduce-overhead")
-        inp = torch.full((16,), self.rank + 1.0, device=device)
-        expected = (
-            torch.cat(
-                [
-                    torch.full((16,), r + 1.0, device=device)
-                    for r in range(self.world_size)
-                ]
-            )
-            + 1
-        )
-        for _ in range(3):  # warmup iters before cudagraph capture kicks in
-            self.assertEqual(compiled(inp), expected)
-        torch.cuda.synchronize(device=device)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -46,6 +46,26 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
+# Opaque custom op so torch.compile traces the coalescing manager into the graph
+# (Dynamo otherwise graph-breaks on it) and reduce-overhead captures the
+# coalesced collective into a cudagraph. Used by test_coalescing_manager_reduce_overhead.
+@torch.library.custom_op("test_c10d_ops_nccl::coalesced_all_gather", mutates_args=())
+def _coalesced_all_gather(
+    inp: torch.Tensor, world_size: int, group_name: str
+) -> torch.Tensor:
+    group = c10d.distributed_c10d._resolve_process_group(group_name)
+    out = inp.new_empty(inp.numel() * world_size)
+    with dist._coalescing_manager(group=group, device=inp.device, async_ops=True) as cm:
+        dist.all_gather_single(out, inp)
+    cm.wait()
+    return out
+
+
+@_coalesced_all_gather.register_fake
+def _(inp, world_size, group_name):
+    return inp.new_empty(inp.numel() * world_size)
+
+
 class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
     @classmethod
     def backend_str(cls) -> str:
@@ -378,6 +398,41 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
         self.assertEqual(static_output.sum().item(), expected_sum)
         torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_coalescing_manager_reduce_overhead(self):
+        # An async coalescing manager around a fast-path collective used to
+        # stash the gathered tensors on the discarded per-call Work, so
+        # cm.wait() never freed them and reduce-overhead cudagraph capture
+        # failed its "not tracked as outputs" pool check. The gathered buffer is
+        # an intermediate here (consumed by + 1), so the leak is not masked by
+        # being a graph output.
+        idx = self.rank_to_GPU[self.rank][0]
+        torch.cuda.set_device(idx)
+        device = torch.device(f"cuda:{idx}")
+        group_name = self.pg.group_name
+
+        def f(inp):
+            gathered = torch.ops.test_c10d_ops_nccl.coalesced_all_gather(
+                inp, self.world_size, group_name
+            )
+            return gathered + 1
+
+        compiled = torch.compile(f, mode="reduce-overhead")
+        inp = torch.full((16,), self.rank + 1.0, device=device)
+        expected = (
+            torch.cat(
+                [
+                    torch.full((16,), r + 1.0, device=device)
+                    for r in range(self.world_size)
+                ]
+            )
+            + 1
+        )
+        for _ in range(3):  # warmup iters before cudagraph capture kicks in
+            self.assertEqual(compiled(inp), expected)
+        torch.cuda.synchronize(device=device)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -65,6 +65,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._python_dispatch import TorchDispatchMode
 
+
 # Opaque custom op so torch.compile traces the coalescing manager into the graph
 # (Dynamo otherwise graph-breaks on it) and reduce-overhead captures the
 # coalesced collective into a cudagraph. Used by

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -65,6 +65,28 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._python_dispatch import TorchDispatchMode
 
+# Opaque custom op so torch.compile traces the coalescing manager into the graph
+# (Dynamo otherwise graph-breaks on it) and reduce-overhead captures the
+# coalesced collective into a cudagraph. Used by
+# TestCollectivesMultiProc.test_coalescing_manager_reduce_overhead.
+@torch.library.custom_op(
+    "test_inductor_collectives::coalesced_all_gather", mutates_args=()
+)
+def _coalesced_all_gather(
+    inp: torch.Tensor, world_size: int, group_name: str
+) -> torch.Tensor:
+    group = c10d.distributed_c10d._resolve_process_group(group_name)
+    out = inp.new_empty(inp.numel() * world_size)
+    with c10d._coalescing_manager(group=group, device=inp.device, async_ops=True) as cm:
+        c10d.all_gather_single(out, inp)
+    cm.wait()
+    return out
+
+
+@_coalesced_all_gather.register_fake
+def _(inp, world_size, group_name):
+    return inp.new_empty(inp.numel() * world_size)
+
 
 class TestBucketingTrace(torch._dynamo.test_case.TestCase):
     def _make_hinted_unbacked_chunked_fake_inputs(self, *, hint=None):
@@ -328,6 +350,41 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 for _ in range(3):
                     compiled_out = compiled_func(x)
                     self.assertEqual(golden_out, compiled_out)
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    def test_coalescing_manager_reduce_overhead(self):
+        # An async coalescing manager around a fast-path collective used to
+        # stash the gathered tensors on the discarded per-call Work, so
+        # cm.wait() never freed them and reduce-overhead cudagraph capture
+        # failed its "not tracked as outputs" pool check. The gathered buffer is
+        # an intermediate here (consumed by + 1), so the leak is not masked by
+        # being a graph output.
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            group_name = (
+                torch.distributed.distributed_c10d._get_default_group().group_name
+            )
+
+            def f(inp):
+                gathered = torch.ops.test_inductor_collectives.coalesced_all_gather(
+                    inp, self.world_size, group_name
+                )
+                return gathered + 1
+
+            compiled = torch.compile(f, mode="reduce-overhead")
+            inp = torch.full((16,), self.rank + 1.0, device=self.device)
+            expected = (
+                torch.cat(
+                    [
+                        torch.full((16,), r + 1.0, device=self.device)
+                        for r in range(self.world_size)
+                    ]
+                )
+                + 1
+            )
+            for _ in range(3):  # warmup iters before cudagraph capture kicks in
+                self.assertEqual(compiled(inp), expected)
+            torch.cuda.synchronize(device=self.device)
 
     def test_c10d_functional_tagged_pt2_compliant(self):
         op = torch.ops._c10d_functional.all_reduce.default

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3990,6 +3990,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
     syncStream(device, ncclEvents_[key], ncclStream);
   }
 
+  // When nested in a coalescing manager, this per-call Work is discarded:
+  // endCoalescing returns the single Work the user tracks/waits and that owns
+  // the stash, so neither record nor enqueue this one. Mirrors collective().
+  bool enqueue =
+      !coalescing_state_ && capture_status == c10::cuda::CaptureStatus::None;
   auto work = initWork(
       device,
       rank_,
@@ -3998,7 +4003,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
       profilingTitle,
       inputs,
       outputs,
-      /*record=*/true);
+      /*record=*/enqueue);
 
   // Store references to outputs to be used by WorkNCCL::result and operator<<.
   work->outputs_ = std::make_shared<std::vector<at::Tensor>>(outputs);
@@ -4007,8 +4012,15 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   // stream, we don't need to do anything for tensor lifetime management.
   // Otherwise, we need to stage the tensors will `work.wait()`.
   if (asyncOp) {
-    work->stashed_for_allocator_safety_->stash(inputs);
-    work->stashed_for_allocator_safety_->stash(outputs);
+    // Stash onto coalescedTensors_ when nested in a coalescing manager, so the
+    // endCoalescing Work owns it and frees it on wait(); otherwise onto `work`.
+    if (coalescing_state_) {
+      coalescedTensors_.stash(inputs);
+      coalescedTensors_.stash(outputs);
+    } else {
+      work->stashed_for_allocator_safety_->stash(inputs);
+      work->stashed_for_allocator_safety_->stash(outputs);
+    }
   }
 
   // Start event should only be recorded before the ncclGroupStart() (which
@@ -4091,7 +4103,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   any FR events during cudagraph capture? if so, they won't be safe to poll for
   completion status.
   */
-  if (capture_status == c10::cuda::CaptureStatus::None) {
+  if (enqueue) {
     workEnqueue(work);
   }
   // TODO(whc) if the work isn't enqueued, I don't feel great about returning


### PR DESCRIPTION
# Stash coalesced tensors on the endCoalescing Work, not the per-call Work

**Part of the effort of enabling the torch.compile support for the Transformer Engine library.**

## Summary

An async coalesced collective issued through
`_coalescing_manager(group, device=..., async_ops=True)` (i.e. `all_reduce` /
`all_gather_single` / `reduce_scatter_single` taking the fast path) failed CUDA
graph capture under `torch.compile(mode="reduce-overhead")`:

```
RuntimeError: ... is not tracked as output of cudagraph ...
```
(or, with `torch._inductor.config.triton.slow_path_cudagraph_asserts = True`, the
`check_memory_pool` assertion in `cudagraph_trees.py`).

## Root cause

When the fast path runs inside a coalescing manager, two `WorkNCCL`s are created:

1. the per-call Work returned by `collectiveCoalesced`, and
2. the Work returned by `endCoalescing`, which is the one `_coalescing_manager`
   tracks and the user waits on via `cm.wait()`.

`endCoalescing` transfers `coalescedTensors_` (the inflight stash) onto its
Work, so that is where the gathered input/output tensors must be stashed for
allocator safety. But `collectiveCoalesced` stashed them onto its own per-call
Work and enqueued that Work to the watchdog instead. As a result `cm.wait()`
unstashed an empty shelf, and the gathered buffers were released only when the
NCCL watchdog later retired the orphaned per-call Work (~100ms later, and never
during a capture, since `cudaEventQuery` is illegal while capturing). That
asynchronous reclaim is too late for the synchronous memory-pool check that
CUDA graph capture performs.

The single-collective `collective()` path already handles this correctly: when
`coalescing_state_` is set it stashes onto `coalescedTensors_` and does not
record/enqueue the per-call Work. `collectiveCoalesced` simply never mirrored
that, and this PR makes it consistent.

## Fix

In `collectiveCoalesced`, when `coalescing_state_` is set, stash inputs/outputs
onto `coalescedTensors_` (so the single `endCoalescing` Work owns and frees them
on `wait()`) and gate record/enqueue of the per-call Work on
`!coalescing_state_`, exactly as `collective()` does. The single `endCoalescing`
Work then both bounds completion (its end event is recorded after the group
launch) and releases the stash synchronously on `cm.wait()`.

Non-coalescing and non-`device` paths are unchanged. As a consequence of
aligning with `collective()`, a standalone coalesced collective is no longer
flight-recorded during graph capture, which matches `collective()` and the
existing concern in `Note [cuda graph capture and workEnqueue]`.

---
Authored with assistance from Claude Opus 4.8 (1M context).