### PR TITLE
Support autograd for Tensor?[] (optional tensor list) outputs 

### DIFF
--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -118,6 +118,19 @@ class TestInferSchemaWithAnnotation(TestCase):
         result = torch.library.infer_schema(foo_op_7, mutates_args=mutates_args)
         self.assertEqual(result, "(Scalar x) -> Scalar")
 
+    def test_optional_tensor_list_return(self):
+        def foo_op(x: Tensor) -> typing.List[typing.Optional[Tensor]]:  # noqa: UP006,UP045
+            return [x.clone(), None]
+
+        result = torch.library.infer_schema(foo_op, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> Tensor?[]")
+
+        def foo_op_2(x: Tensor) -> list[typing.Optional[Tensor]]:  # noqa: UP045
+            return [x.clone(), None]
+
+        result = torch.library.infer_schema(foo_op_2, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> Tensor?[]")
+
     @unittest.expectedFailure
     def test_no_library_prefix(self):
         def foo_op(x: Tensor) -> Tensor:

--- a/test/test_autograd_fallback.py
+++ b/test/test_autograd_fallback.py
@@ -458,6 +458,34 @@ class TestAutogradFallback(TestCase):
                     retain_graph=True,
                 )
 
+    @parametrize("mode", ("nothing", "warn"))
+    def test_supports_optional_tensor_lists(self, mode):
+        with autograd_fallback_mode(mode):
+            lib = self.get_lib()
+            lib.define("foo(Tensor[] a) -> Tensor?[]")
+            op = self.get_op("foo")
+
+            def foo_impl(a):
+                x, y, z = a
+                with torch.no_grad():
+                    return [x + y + z, None, x * y * z]
+
+            lib.impl("foo", foo_impl, "CPU")
+            x = torch.randn(3, requires_grad=True)
+            y = torch.randn(1, requires_grad=True)
+            z = torch.randn(2, 1, requires_grad=True)
+            a, none, b = op([x, y, z])
+            self.assertIsNone(none)
+            for out in (a, b):
+                with self._check_ctx(mode, mode_nothing_raises=True):
+                    torch.autograd.grad(
+                        out,
+                        (x, y, z),
+                        torch.ones_like(out),
+                        allow_unused=True,
+                        retain_graph=True,
+                    )
+
 
 instantiate_parametrized_tests(TestAutogradFallback)
 

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4079,11 +4079,14 @@ class TestCustomOpAPI(TestCase):
         (grad_x,) = torch.autograd.grad(out[0].sum(), x)
         self.assertEqual(grad_x, x.cos())
 
-    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_library_register_autograd_optional_tensorlist_all_none_output(self):
         # All-None output: no tensor to differentiate through, op must still run.
         @torch.library.custom_op("mylib::all_none", mutates_args=())
         def all_none(x: Tensor) -> List[Optional[Tensor]]:
+            return [None, None]
+
+        @all_none.register_fake
+        def _(x: Tensor) -> List[Optional[Tensor]]:
             return [None, None]
 
         def setup_context(ctx, inputs, output):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4024,8 +4024,6 @@ class TestCustomOpAPI(TestCase):
     def test_supports_tensorlist_optional_output(self):
         # Tensor?[] output with a None hole: the present tensors must still be
         # tracked by autograd and receive gradients.
-        test = self
-
         @torch._library.autograd.supports_tensorlist
         class Foo(torch.autograd.Function):
             @staticmethod
@@ -4036,7 +4034,7 @@ class TestCustomOpAPI(TestCase):
             @staticmethod
             def backward(ctx, grads):
                 g0, gnone, g2 = grads
-                test.assertIsNone(gnone)
+                self.assertIsNone(gnone)
                 x0, x1 = ctx.saved_tensors
                 return [g0 * x0.cos(), -g2 * x1.sin()]
 
@@ -4052,11 +4050,14 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(g0, x0.cos())
         self.assertEqual(g1, -x1.sin())
 
-    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_library_register_autograd_optional_tensorlist_output(self):
         @torch.library.custom_op("mylib::sin_with_hole", mutates_args=())
         def sin_with_hole(x: Tensor) -> List[Optional[Tensor]]:
             return [x.sin(), None]
+
+        @sin_with_hole.register_fake
+        def _(x: Tensor) -> List[Optional[Tensor]]:
+            return [torch.empty_like(x), None]
 
         def setup_context(ctx, inputs, output):
             (x,) = inputs

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4021,6 +4021,86 @@ class TestCustomOpAPI(TestCase):
         result = [xi.grad for xi in xs]
         self.assertEqual(result, torch.tensor([1.0, 2, 1, 2, 3]).unbind(0))
 
+    def test_supports_tensorlist_optional_output(self):
+        # Tensor?[] output with a None hole: the present tensors must still be
+        # tracked by autograd and receive gradients.
+        test = self
+
+        @torch._library.autograd.supports_tensorlist
+        class Foo(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, xs):
+                ctx.save_for_backward(*xs)
+                return [xs[0].sin(), None, xs[1].cos()]
+
+            @staticmethod
+            def backward(ctx, grads):
+                g0, gnone, g2 = grads
+                test.assertIsNone(gnone)
+                x0, x1 = ctx.saved_tensors
+                return [g0 * x0.cos(), -g2 * x1.sin()]
+
+        x0 = torch.randn([], requires_grad=True)
+        x1 = torch.randn([], requires_grad=True)
+        ys = Foo.apply([x0, x1])
+        self.assertEqual(len(ys), 3)
+        self.assertIsNone(ys[1])
+        self.assertTrue(ys[0].requires_grad)
+        self.assertTrue(ys[2].requires_grad)
+
+        g0, g1 = torch.autograd.grad(ys[0].sum() + ys[2].sum(), [x0, x1])
+        self.assertEqual(g0, x0.cos())
+        self.assertEqual(g1, -x1.sin())
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_library_register_autograd_optional_tensorlist_output(self):
+        @torch.library.custom_op("mylib::sin_with_hole", mutates_args=())
+        def sin_with_hole(x: Tensor) -> List[Optional[Tensor]]:
+            return [x.sin(), None]
+
+        def setup_context(ctx, inputs, output):
+            (x,) = inputs
+            ctx.save_for_backward(x)
+
+        def backward(ctx, grads):
+            g0, g1 = grads
+            (x,) = ctx.saved_tensors
+            return g0 * x.cos()
+
+        torch.library.register_autograd(
+            "mylib::sin_with_hole", backward, setup_context=setup_context
+        )
+
+        x = torch.randn(3, requires_grad=True)
+        out = sin_with_hole(x)
+        self.assertIsNone(out[1])
+        self.assertTrue(out[0].requires_grad)
+        (grad_x,) = torch.autograd.grad(out[0].sum(), x)
+        self.assertEqual(grad_x, x.cos())
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_library_register_autograd_optional_tensorlist_all_none_output(self):
+        # All-None output: no tensor to differentiate through, op must still run.
+        @torch.library.custom_op("mylib::all_none", mutates_args=())
+        def all_none(x: Tensor) -> List[Optional[Tensor]]:
+            return [None, None]
+
+        def setup_context(ctx, inputs, output):
+            pass
+
+        def backward(ctx, grads):
+            return torch.zeros(1)
+
+        torch.library.register_autograd(
+            "mylib::all_none", backward, setup_context=setup_context
+        )
+
+        x = torch.randn(3, requires_grad=True)
+        out = all_none(x)
+        self.assertEqual(len(out), 2)
+        self.assertIsNone(out[0])
+        self.assertIsNone(out[1])
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_default_values(self):
         defaults = []

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -181,7 +181,9 @@ def supports_tensorlist(cls: Any) -> Any:
         metadata.result_is_tuple = isinstance(result, tuple)
         if not metadata.result_is_tuple:
             result = (result,)
-        flat_result, output_spec = _pytree.tree_flatten(result, not_list_of_tensor)
+        flat_result, output_spec = _pytree.tree_flatten(
+            result, not_list_of_optional_tensor
+        )
         metadata.output_spec = output_spec
 
         if hasattr(ctx, "_pt_metadata"):
@@ -237,7 +239,11 @@ def supports_tensorlist(cls: Any) -> Any:
         return tuple(flat_grad_inputs + [None])
 
     def new_apply(*args):
-        flat_args, input_spec = _pytree.tree_flatten(args, is_leaf=not_list_of_tensor)
+        # input_spec must use the same leaf predicate as the grad spec in
+        # new_backward, otherwise Tensor?[] inputs with None holes mismatch.
+        flat_args, input_spec = _pytree.tree_flatten(
+            args, is_leaf=not_list_of_optional_tensor
+        )
         metadata = TensorListMetadata(input_spec)
         result = orig_apply(*flat_args, metadata)  # type: ignore[misc]
         if metadata.output_spec is None:
@@ -257,14 +263,6 @@ def supports_tensorlist(cls: Any) -> Any:
     cls.backward = new_backward
     cls.apply = new_apply
     return cls
-
-
-def not_list_of_tensor(tree):
-    if isinstance(tree, tuple):
-        return False
-    if isinstance(tree, list):
-        return any(not isinstance(l, Tensor) for l in tree)
-    return True
 
 
 def not_list_of_optional_tensor(tree):

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -366,6 +366,8 @@ SUPPORTED_RETURN_TYPES = {
     Tensor: "Tensor",
     typing.List[Tensor]: "Tensor[]",  # noqa: UP006
     list[Tensor]: "Tensor[]",
+    typing.List[typing.Optional[Tensor]]: "Tensor?[]",  # noqa: UP006,UP045
+    list[typing.Optional[Tensor]]: "Tensor?[]",  # noqa: UP045
     int: "SymInt",
     float: "float",
     bool: "bool",

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3735,15 +3735,18 @@ def inferred_fake_kernel_from_real_out(
     if mode.shape_env is None:
         raise AssertionError("mode.shape_env must not be None")
 
-    # Only support operators that have all Tensor outputs
+    # Only support operators that have Tensor or None outputs (None for Tensor?[]).
     # This is a general limitation on custom ops that we impose for PT2
     # to avoid baking non-symbolic float/int outputs into the graph.
     real_flat_out, spec = pytree.tree_flatten(real_out)
-    if not all(isinstance(t, torch.Tensor) for t in real_flat_out):
+    if not all(isinstance(t, torch.Tensor) or t is None for t in real_flat_out):
         raise RuntimeError(
             f"propagate_real_tensors: we don't support operators that return "
             f"non-Tensors. Got {op._schema}"
         )
 
-    fake_flat_out = [_infer_fake_from_real_tensor(mode, op, t) for t in real_flat_out]
+    fake_flat_out = [
+        None if t is None else _infer_fake_from_real_tensor(mode, op, t)
+        for t in real_flat_out
+    ]
     return pytree.tree_unflatten(fake_flat_out, spec)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2575,7 +2575,12 @@ class FakeTensorMode(TorchDispatchMode):
                 # in this case we can default to inferring non-aliasing fake kernels from the real outputs.
                 _clear_pending_unbacked()
                 return tree_map(
-                    lambda x: _infer_fake_from_real_tensor(self, func, x), real_out
+                    lambda x: (
+                        None
+                        if x is None
+                        else _infer_fake_from_real_tensor(self, func, x)
+                    ),
+                    real_out,
                 )
             else:
                 raise MetadataMismatchError(

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -27,7 +27,7 @@ void _foreach_tensor(
     torch::jit::Stack* stack,
     size_t stack_start,
     size_t size) {
-  // Enumerate over tensors in a stack, including ones in TensorLists
+  // Enumerate over tensors in a stack, including ones in (Optional)TensorLists
   int idx_tensor = 0;
   for (const auto idx_arg : c10::irange(size)) {
     auto& ivalue = (*stack)[stack_start + idx_arg];
@@ -37,6 +37,15 @@ void _foreach_tensor(
       idx_tensor++;
     } else if (ivalue.isTensorList()) {
       for (const auto& iv : ivalue.toListRef()) {
+        const auto& tensor = iv.toTensor();
+        fn(idx_tensor, idx_arg, tensor);
+        idx_tensor++;
+      }
+    } else if (ivalue.isOptionalTensorList()) {
+      for (const auto& iv : ivalue.toListRef()) {
+        if (iv.isNone()) {
+          continue;
+        }
         const auto& tensor = iv.toTensor();
         fn(idx_tensor, idx_arg, tensor);
         idx_tensor++;


### PR DESCRIPTION
## Support autograd for `Tensor?[]` (optional tensor list) outputs of custom ops

**Part of the effort of enabling the torch.compile support for the Transformer Engine library.**

Custom ops returning `Tensor?[]` couldn't propagate gradients — the present tensors were silently detached from the autograd graph. Three fixes:

- **`torch/_library/autograd.py`**: `supports_tensorlist` flattened forward outputs with `not_list_of_tensor`, which treats a list with any `None` as one opaque leaf, so a `Tensor?[]` output's tensors were never registered as differentiable. Switched output (and, for spec symmetry, input) flattening to `not_list_of_optional_tensor`, which keeps `None` holes in the pytree spec. `not_list_of_tensor` is now unused and removed.
- **`torch/_library/infer_schema.py`**: added `List[Optional[Tensor]]` to `SUPPORTED_RETURN_TYPES`; the high-level `custom_op` decorator rejected the return annotation before.
- **`torch/csrc/autograd/autograd_not_implemented_fallback.cpp`**: `_foreach_tensor` had no `isOptionalTensorList()` branch, so `set_history` was skipped for `Tensor?[]` outputs of ops without a registered autograd kernel. Added one that skips `None` holes, mirroring the `isTensorList()` branch.

Repro:

```python
import torch
from torch import Tensor
from typing import List, Optional

@torch.library.custom_op('mylib::split_with_hole', mutates_args=(), schema='(Tensor x) -> Tensor?[]')
def split_with_hole(x: Tensor) -> List[Optional[Tensor]]:
    return [x.sin(), None, x.cos()]

def setup_context(ctx, inputs, output):
    (x,) = inputs
    ctx.save_for_backward(x)

def backward(ctx, grad_sin, grad_none, grad_cos):
    (x,) = ctx.saved_tensors
    return grad_sin * x.cos() - grad_cos * x.sin()

torch.library.register_autograd('mylib::split_with_hole', backward, setup_context=setup_context)

x = torch.randn(3, requires_grad=True)
out = split_with_hole(x)

print(f'out[0].requires_grad = {out[0].requires_grad}')  # False -- silent bug
```

Prepared with Claude Code with Opus 4.8