### PR TITLE
Fix incorrect rank in torch.linalg.lstsq(driver='gelsy') due to stale JPVT values

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -16,6 +16,7 @@
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/zeros.h>
 
 #include <algorithm>
 #endif
@@ -596,7 +597,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
   Tensor jpvt;
   int* jpvt_data = nullptr;
   if (driver_t::Gelsy == driver_type) {
-    jpvt = at::empty({std::max<int64_t>(1, n)}, A.options().dtype(at::kInt));
+    jpvt = at::zeros({std::max<int64_t>(1, n)}, A.options().dtype(at::kInt));
     jpvt_data = jpvt.mutable_data_ptr<int>();
   }
 
@@ -654,6 +655,12 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
       rank_working_ptr = rank_working_ptr ? &rank_data[A_linear_batch_idx] : nullptr;
       s_working_ptr = s_working_ptr ? &s_data[A_linear_batch_idx * s_stride] : nullptr;
       int* infos_working_ptr = &infos_data[A_linear_batch_idx];
+
+      // JPVT is an input/output argument for *gelsy. Non-zero values on
+      // input mark fixed columns, so reset it before each call.
+      if (jpvt_data != nullptr) {
+        jpvt.zero_();
+      }
 
       lapack_func(trans, m, n, nrhs,
         A_working_ptr, lda,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -416,6 +416,21 @@ class TestLinalg(TestCase):
             if driver == 'gels' and rcond is None:
                 check_solution_correctness(a, b, sol)
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(torch.double)
+    def test_linalg_lstsq_gelsy_jpvt_is_reset(self, device, dtype):
+        a = torch.zeros(2, 3, 3, device=device, dtype=dtype)
+        a[0] = torch.eye(3, device=device, dtype=dtype)
+        a[1, 0, 1] = 1
+        a[1, 1, 2] = 1
+
+        b = torch.ones(2, 3, 1, device=device, dtype=dtype)
+
+        result = torch.linalg.lstsq(a, b, driver='gelsy')
+        expected_rank = torch.tensor([3, 2], device=device)
+        self.assertEqual(result.rank, expected_rank)
+
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)


### PR DESCRIPTION
## Summary
Fixes #187411

LAPACK `*gelsy` treats the `JPVT` array as an input/output argument. Non-zero entries on input mark fixed columns. Previously, the CPU `lstsq` kernel allocated `JPVT` with `at::empty()` and reused the same buffer across batched calls without zeroing it. Consequently, stale values from the allocator (dirty memory) or a previous batch item could change the pivoting state and produce an incorrect matrix rank.

This PR fixes the issue by:
1. Zero-initializing the `JPVT` array before the LAPACK workspace query.
2. Resetting the `JPVT` array to zeros before each `*gelsy` invocation in the batch loop, ensuring every solve starts with all columns free.
3. Adding a CPU LAPACK regression test to cover the deterministic batched contamination case.

## Test Plan
Successfully ran `lintrunner -a`.
Run the new regression test:
```bash
python test/test_linalg.py -k test_linalg_lstsq_gelsy_jpvt_is_reset 
```
Run all `lstsq` related tests:
```bash
python test/test_linalg.py -k lstsq
```
All tests passed locally.

Authored with the assistance of Codex.
