### PR TITLE
[ROCm] periodic-rocm-mi350: run only the 4-GPU distributed tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -204,10 +204,6 @@ if [[ "$TEST_CONFIG" == 'default' ]]; then
   fi
 fi
 
-if [[ "$TEST_CONFIG" == 'distributed' ]] && [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-  export HIP_VISIBLE_DEVICES=0,1,2,3
-fi
-
 if [[ "$TEST_CONFIG" == 'slow' ]]; then
   export PYTORCH_TEST_WITH_SLOW=1
   export PYTORCH_TEST_SKIP_FAST=1
@@ -1641,6 +1637,29 @@ test_distributed_single_gpu() {
   test_distributed not-multigpu
 }
 
+test_distributed_4gpu() {
+  # Run the distributed tests that need more GPUs than the standard 2-GPU
+  # runners provide, on runners with 4-GPU labels (e.g. ROCm gfx950.4). The
+  # threshold is 3 (not 4) so tests requiring exactly 3 GPUs -- which cannot run
+  # on the 2-GPU runners yet are still deselected by a strict >= 4 filter, so
+  # they would otherwise run nowhere -- are included alongside the 4-GPU tests.
+  # PYTORCH_TEST_MIN_GPU activates the collection-time filter in
+  # test/conftest.py (MinGpuFilterPlugin): it resolves each test's accelerator
+  # requirement from existing signals (skip_if_lt_x_gpu, requires_world_size,
+  # and the world_size of the multi-process base classes, gated by
+  # backend/device) and deselects anything below the threshold. This is
+  # independent of main's `multigpu` marker / --multigpu-filter path (which this
+  # job does not use), so there is no double filtering. run_test.py
+  # --distributed-tests discovers every distributed test file dynamically, so a
+  # new multi-GPU test added anywhere under test/distributed is picked up
+  # automatically with no list to maintain.
+  export PYTORCH_TEST_MIN_GPU=3
+  echo "Testing distributed python tests that require more than 2 GPUs"
+  # shellcheck disable=SC2086
+  time python test/run_test.py --distributed-tests --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" $INCLUDE_CLAUSE --verbose
+  assert_git_not_dirty
+}
+
 test_quantization() {
   echo "Testing quantization"
 
@@ -2232,6 +2251,10 @@ elif [[ "$TEST_CONFIG" == distributed ]]; then
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
     test_rpc
   fi
+elif [[ "$TEST_CONFIG" == distributed_4gpu ]]; then
+  install_torchcomms
+  install_spmd_types
+  test_distributed_4gpu
 elif [[ "${TEST_CONFIG}" == *operator_benchmark* ]]; then
   TEST_MODE="short"
 

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -114,11 +114,13 @@ runner_mapping:
   linux.rocm.gpu.gfx942.4: linux.rocm.gpu.gfx942.4
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
+  linux.rocm.gpu.gfx950.4: linux.rocm.gpu.gfx950.4
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
   # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
   amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
   amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
+  amd-do-linux.rocm.gpu.gfx950.4: amd-do-linux.rocm.gpu.gfx950.4
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -32,6 +32,7 @@ ciflow_push_tags:
 - ciflow/periodic
 - ciflow/periodic-rocm-mi200
 - ciflow/periodic-rocm-mi300
+- ciflow/periodic-rocm-mi350
 - ciflow/pull
 - ciflow/riscv64
 - ciflow/rocm-mi200

--- a/.github/workflows/periodic-rocm-mi350.yml
+++ b/.github/workflows/periodic-rocm-mi350.yml
@@ -1,18 +1,15 @@
 # Owner(s): ["module: rocm"]
-# Unneeded for CI: trunk.yml covers the same ROCm testing.
-# Kept in-repo for metrics; auto-triggers below are commented out.
-# workflow_dispatch remains for manual runs.
 name: periodic-rocm-mi350
 
 on:
-  #schedule:
-  #  - cron: 0 0,3,6,9,12,15,18,21 * * *
-  #  - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
-  #push:
-  #  tags:
-  #    - ciflow/periodic-rocm-mi350/*
-  #  branches:
-  #    - release/*
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * *
+    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
+  push:
+    tags:
+      - ciflow/periodic-rocm-mi350/*
+    branches:
+      - release/*
   workflow_dispatch:
 
 concurrency:
@@ -55,11 +52,15 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      # The distributed_4gpu config only runs the distributed tests that require
+      # 4 GPUs, so it must run on the gfx950.4 (4-GPU) runner labels.
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -165,6 +165,9 @@ def pytest_configure(config: Config) -> None:
             HardwareClassificationPytestPlugin(config.getoption("hw_classification")),
             "hw_classification_plugin",
         )
+    min_gpu = int(os.environ.get("PYTORCH_TEST_MIN_GPU", "0"))
+    if min_gpu > 0:
+        config.pluginmanager.register(MinGpuFilterPlugin(min_gpu), "mingpufilterplugin")
 
 
 def pytest_unconfigure(config: Config) -> None:
@@ -453,3 +456,224 @@ class StepcurrentPlugin:
             self.cache.set(self.lastrun_location, self.initial_val)
         if exitstatus != 0:
             self.cache.set(self.made_failing_xml_location, True)
+
+
+def _get_decorator_attr(func: object | None, attr: str, default: int = 0) -> int:
+    """Read ``attr`` from ``func`` or any function in its ``__wrapped__`` chain."""
+    while func is not None:
+        val = getattr(func, attr, None)
+        if val is not None:
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                pass
+        func = getattr(func, "__wrapped__", None)
+    return default
+
+
+class MinGpuFilterPlugin:
+    """Deselect tests whose resolved accelerator requirement is below
+    ``PYTORCH_TEST_MIN_GPU`` so a CI job (e.g. a 4-GPU-only distributed job) can
+    run strictly the tests that need at least that many accelerators, with no
+    per-test list to maintain. Registered only when ``PYTORCH_TEST_MIN_GPU > 0``.
+
+    The requirement is resolved from existing signals (no new annotations):
+      - ``skip_if_lt_x_gpu(n)`` (stamps ``_min_gpus_required``) and
+        ``requires_world_size(n)`` (stamps ``_required_world_size``);
+      - the ``world_size`` of the multi-process base classes, gated by a
+        backend/device check so CPU/gloo ``world_size>=N`` tests are dropped;
+      - for thread-based tests, the accelerator-targeting test id plus
+        ``world_size``, since a thread count is not a physical GPU count.
+    An explicit decorator always overrides the backend/device gate. When the
+    requirement cannot be determined the test is kept (favor coverage).
+    """
+
+    def __init__(self, threshold: int) -> None:
+        import torch
+        from torch.distributed.distributed_c10d import Backend
+        from torch.testing._internal.common_distributed import (
+            ACCELERATOR_DIST_BACKENDS,
+            DEFAULT_WORLD_SIZE,
+            MultiProcContinuousTest,
+            MultiProcessTestCase,
+            MultiThreadedTestCase,
+        )
+        from torch.testing._internal.common_utils import TEST_CUDA, TEST_HPU, TEST_XPU
+
+        self.threshold = threshold
+        self._torch = torch
+        self._process_based = (MultiProcessTestCase, MultiProcContinuousTest)
+        self._thread_based = MultiThreadedTestCase
+        self._default_world_size = int(DEFAULT_WORLD_SIZE)
+        # Backend names whose test modules use a non-accelerator (CPU) backend,
+        # derived from the registered backend list so no hand-maintained list can
+        # drift. gloo/mpi/ucc can drive CUDA too, but their dedicated test
+        # modules (e.g. test_c10d_gloo) exercise the CPU path, so a module whose
+        # basename names one of these is treated as CPU-backed.
+        self._non_accel_backends = tuple(
+            b
+            for b in Backend.backend_list
+            if b not in ACCELERATOR_DIST_BACKENDS
+            and b not in (Backend.UNDEFINED, Backend.FAKE)
+        )
+        tokens = []
+        if TEST_CUDA:
+            tokens.append("cuda")
+        if TEST_XPU:
+            tokens.append("xpu")
+        if TEST_HPU:
+            tokens.append("hpu")
+        self._accel_tokens = tuple(tokens)
+        self._kept_count = 0
+        self._deselected_ids: list[str] = []
+
+    def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
+        """Mutate ``items`` in-place to keep only tests meeting the GPU threshold."""
+        deselected = []
+        kept = []
+        for item in items:
+            if self._required_gpus(item) >= self.threshold:
+                kept.append(item)
+            else:
+                deselected.append(item)
+        self._kept_count = len(kept)
+        self._deselected_ids = [item.nodeid for item in deselected]
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = kept
+
+    def pytest_report_collectionfinish(self, config: Config) -> list[str]:
+        total = self._kept_count + len(self._deselected_ids)
+        lines = [
+            f"MinGpuFilter (PYTORCH_TEST_MIN_GPU={self.threshold}): kept "
+            f"{self._kept_count}/{total}, deselected {len(self._deselected_ids)} "
+            f"test(s) needing <{self.threshold} accelerators"
+        ]
+        # The per-node-id dump is verbose; only emit it at non-negative
+        # verbosity, mirroring StepcurrentPlugin.pytest_report_collectionfinish.
+        if config.getoption("verbose") >= 0:
+            lines += [f"  deselected: {nodeid}" for nodeid in self._deselected_ids]
+        return lines
+
+    def _required_gpus(self, item: Any) -> int:
+        try:
+            return self._resolve(item)
+        except Exception:
+            # Introspection failed; fall back to a deterministic guess rather
+            # than blindly keeping the test.
+            return self._fallback(item)
+
+    def _resolve(self, item: Any) -> int:
+        func = getattr(item, "obj", None)
+        dec = max(
+            _get_decorator_attr(func, "_min_gpus_required"),
+            _get_decorator_attr(func, "_required_world_size"),
+        )
+        cls = getattr(item, "cls", None)
+        if cls is None:
+            # Not a class-based test; rely on an explicit decorator, else keep.
+            return dec if dec else self.threshold
+        if issubclass(cls, self._process_based):
+            required = max(dec, self._world_size(cls))
+            # A CPU-backed multi-process test uses ranks, not GPUs; drop it
+            # unless an explicit decorator asserts the GPU requirement.
+            if (
+                required >= self.threshold
+                and dec < self.threshold
+                and self._is_cpu_backed(item, cls)
+            ):
+                return 0
+            return required
+        if issubclass(cls, self._thread_based):
+            if dec:
+                return dec
+            # Thread count is not a GPU count: keep only accelerator-targeting
+            # variants that also spawn at least `threshold` ranks.
+            if (
+                self._id_targets_accelerator(item)
+                and self._world_size(cls) >= self.threshold
+            ):
+                return self.threshold
+            return 0
+        # Plain TestCase: needs an explicit decorator to qualify as multi-GPU.
+        return dec if dec else 1
+
+    def _fallback(self, item: Any) -> int:
+        cls = getattr(item, "cls", None)
+        if cls is not None and issubclass(cls, self._process_based):
+            return 0 if self._module_is_cpu(item) else self._default_world_size
+        return self.threshold
+
+    def _probe_attr(self, cls: Any, name: str) -> Any:
+        # Read a class attribute / constant-returning ``@property`` without
+        # running ``__init__`` (which spawns/initializes processes at runtime,
+        # not at collection). This is side-effect-free only insofar as the
+        # probed ``world_size`` / ``device`` / ``device_type`` properties are
+        # pure; the distributed base classes define them that way. Returns None
+        # when the value cannot be obtained.
+        try:
+            probe = cls.__new__(cls)
+        except Exception:
+            return None
+        try:
+            return getattr(probe, name)
+        except Exception:
+            return None
+
+    def _world_size(self, cls: Any) -> int:
+        val = self._probe_attr(cls, "world_size")
+        try:
+            resolved = int(val)
+        except (TypeError, ValueError):
+            return self._default_world_size
+        # A non-positive value means the world size is unresolved: e.g.
+        # MultiProcContinuousTest declares ``world_size: int = -2`` as an unset
+        # sentinel populated only at runtime. Treat it like the None case and
+        # fall back to the default so genuine multi-GPU tests are not dropped.
+        if resolved <= 0:
+            return self._default_world_size
+        return resolved
+
+    def _id_targets_accelerator(self, item: Any) -> bool:
+        if not self._accel_tokens:
+            return False
+        parts = item.name.lower().split("_")
+        return any(tok in parts for tok in self._accel_tokens)
+
+    def _is_cpu_backed(self, item: Any, cls: Any) -> bool:
+        verdict = self._device_is_cpu(self._probe_attr(cls, "device"))
+        if verdict is not None:
+            return verdict
+        dtype = self._coerce_str(self._probe_attr(cls, "device_type"))
+        if dtype is not None:
+            return dtype.lower().split(":")[0] == "cpu"
+        return self._module_is_cpu(item)
+
+    def _module_is_cpu(self, item: Any) -> bool:
+        module = getattr(item, "module", None)
+        base = (getattr(module, "__name__", "") or "").rsplit(".", 1)[-1].lower()
+        if any(b in base for b in self._non_accel_backends):
+            return True
+        return base.endswith("_cpu")
+
+    def _coerce_str(self, val: Any) -> "str | None":
+        if isinstance(val, str):
+            return val
+        if callable(val):
+            try:
+                result = val()
+            except Exception:
+                return None
+            return result if isinstance(result, str) else None
+        return None
+
+    def _device_is_cpu(self, dev: Any) -> "bool | None":
+        if dev is None:
+            return None
+        if isinstance(dev, self._torch.device):
+            return dev.type == "cpu"
+        if isinstance(dev, str):
+            return dev.lower().split(":")[0] == "cpu"
+        if isinstance(dev, int):
+            return False  # a device index implies an accelerator
+        return None

--- a/test/distributed/test_min_gpu_filter.py
+++ b/test/distributed/test_min_gpu_filter.py
@@ -1,0 +1,283 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import sys
+import types
+import unittest
+
+import torch
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    MultiProcessTestCase,
+    MultiThreadedTestCase,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# The filter under test lives in test/conftest.py. Make it importable whether the
+# file is run under pytest (test/ already on sys.path) or directly.
+_TEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _TEST_ROOT not in sys.path:
+    sys.path.insert(0, _TEST_ROOT)
+
+from conftest import MinGpuFilterPlugin
+
+
+# The resolver reads ``world_size`` / ``device`` / ``device_type`` off the class
+# via ``cls.__new__(cls)`` (no ``__init__``), so these fakes expose them as the
+# same constant-returning properties / attributes the real distributed test
+# classes use.
+class _MPws4(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 4
+
+
+class _MPws3(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 3
+
+
+class _MPws2(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+
+class _MPws1(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 1
+
+
+class _MPcpuDevWs4(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 4
+
+    @property
+    def device(self):
+        return "cpu"
+
+
+class _MPcpuDevWs2(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+
+class _MPbroken(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        raise RuntimeError("world_size not resolvable at collection time")
+
+
+# MultiProcContinuousTest declares ``world_size: int = -2`` as an unset sentinel
+# populated only at runtime, so an undecorated subclass probes as -2. ``device``
+# is not defined on it and ``device_type`` is a classmethod, matching how the
+# real class exposes them.
+class _MPCunset(MultiProcContinuousTest):
+    @classmethod
+    def device_type(cls):
+        return "cuda"
+
+
+class _MPCunsetCpu(MultiProcContinuousTest):
+    pass
+
+
+class _MTTws4(MultiThreadedTestCase):
+    @property
+    def world_size(self):
+        return 4
+
+
+class _MTTws2(MultiThreadedTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+
+class _FakePlain(unittest.TestCase):
+    pass
+
+
+def _func(min_gpus=None, required_world_size=None):
+    def f():
+        pass
+
+    if min_gpus is not None:
+        f._min_gpus_required = min_gpus
+    if required_world_size is not None:
+        f._required_world_size = required_world_size
+    return f
+
+
+def _item(*, cls=None, obj=None, name="test_x", module_name="test_foo"):
+    return types.SimpleNamespace(
+        obj=obj if obj is not None else _func(),
+        cls=cls,
+        name=name,
+        module=types.SimpleNamespace(__name__=module_name),
+        nodeid=f"{module_name}.py::{name}",
+    )
+
+
+class TestMinGpuFilter(TestCase):
+    # The distributed_4gpu job runs on 4-GPU runners but selects tests needing
+    # MORE GPUs than the 2-GPU runners provide, i.e. a threshold of 3 so that
+    # tests requiring exactly 3 GPUs (which run nowhere under a strict >= 4
+    # filter) are included alongside the 4-GPU tests.
+    THRESHOLD = 3
+
+    def setUp(self):
+        self.plugin = MinGpuFilterPlugin(self.THRESHOLD)
+        # Pin host-dependent state so the resolver is deterministic regardless
+        # of the accelerators / device count of the machine running this test.
+        self.plugin._accel_tokens = ("cuda",)
+        self.plugin._default_world_size = 4
+
+    def _keep(self, item):
+        return self.plugin._required_gpus(item) >= self.THRESHOLD
+
+    # --- process-based: world_size ---
+    def test_process_world_size_4_kept(self):
+        item = _item(cls=_MPws4, module_name="test_c10d_nccl")
+        self.assertTrue(self._keep(item))
+
+    def test_process_world_size_3_at_threshold_kept(self):
+        # 3-GPU tests need more than the 2-GPU runners provide, so the 4-GPU job
+        # (threshold 3) now includes them; a strict >= 4 filter dropped them.
+        item = _item(cls=_MPws3, module_name="test_c10d_nccl")
+        self.assertTrue(self._keep(item))
+
+    def test_process_world_size_2_below_threshold_dropped(self):
+        item = _item(cls=_MPws2, module_name="test_c10d_nccl")
+        self.assertFalse(self._keep(item))
+
+    def test_process_world_size_one_dropped(self):
+        item = _item(cls=_MPws1, module_name="test_c10d_gloo")
+        self.assertFalse(self._keep(item))
+
+    # --- process-based: CPU / gloo gate ---
+    def test_gloo_cpu_module_world_size_4_dropped(self):
+        # Undecorated gloo test (e.g. test_gloo_backend_cpu_module): the file is
+        # gloo-backed so it is treated as CPU and dropped.
+        item = _item(cls=_MPws4, module_name="test_c10d_gloo")
+        self.assertFalse(self._keep(item))
+
+    def test_gloo_1gpu_decorator_2_dropped(self):
+        item = _item(cls=_MPws4, obj=_func(min_gpus=2), module_name="test_c10d_gloo")
+        self.assertFalse(self._keep(item))
+
+    def test_gloo_2gpu_decorator_4_kept(self):
+        # test_gloo_backend_2gpu_module is @skip_if_lt_x_gpu(4): a real 4-GPU test.
+        item = _item(cls=_MPws4, obj=_func(min_gpus=4), module_name="test_c10d_gloo")
+        self.assertTrue(self._keep(item))
+
+    def test_cpu_device_property_world_size_4_dropped(self):
+        item = _item(cls=_MPcpuDevWs4, module_name="test_c10d_nccl")
+        self.assertFalse(self._keep(item))
+
+    def test_cpu_device_property_world_size_2_dropped(self):
+        # CommTest-style: device property returns cpu, world_size == 2.
+        item = _item(cls=_MPcpuDevWs2, module_name="test_c10d_gloo")
+        self.assertFalse(self._keep(item))
+
+    def test_cpu_suffix_module_dropped(self):
+        # e.g. distributed/checkpoint/test_file_system_checkpoint_cpu.
+        item = _item(cls=_MPws4, module_name="test_file_system_checkpoint_cpu")
+        self.assertFalse(self._keep(item))
+
+    def test_cpu_backed_with_decorator_kept(self):
+        # An explicit >= threshold decorator overrides the CPU gate.
+        item = _item(cls=_MPcpuDevWs4, obj=_func(min_gpus=4))
+        self.assertTrue(self._keep(item))
+
+    # --- process-based: robustness when introspection fails ---
+    def test_unresolvable_world_size_gloo_dropped(self):
+        # world_size property raises -> fall back to default world size, then the
+        # gloo module gate drops it.
+        item = _item(cls=_MPbroken, module_name="test_c10d_gloo")
+        self.assertFalse(self._keep(item))
+
+    def test_unresolvable_world_size_accelerator_kept(self):
+        # world_size property raises -> default world size (4) on an
+        # accelerator-backed module keeps the test.
+        item = _item(cls=_MPbroken, module_name="test_c10d_nccl")
+        self.assertTrue(self._keep(item))
+
+    # --- process-based: MultiProcContinuousTest -2 unset sentinel ---
+    def test_continuous_unset_world_size_accelerator_kept(self):
+        # world_size left at the -2 unset sentinel resolves to the default world
+        # size; on an accelerator-reporting class the test is kept.
+        item = _item(cls=_MPCunset, module_name="test_c10d_nccl")
+        self.assertTrue(self._keep(item))
+
+    def test_continuous_unset_world_size_decorator_kept(self):
+        # Even when the class reports as CPU (device_type default), an explicit
+        # >= threshold decorator keeps a MultiProcContinuousTest test.
+        item = _item(
+            cls=_MPCunsetCpu, obj=_func(min_gpus=4), module_name="test_c10d_nccl"
+        )
+        self.assertTrue(self._keep(item))
+
+    # --- thread-based (MultiThreadedTestCase) ---
+    def test_thread_accelerator_variant_world_size_4_kept(self):
+        item = _item(cls=_MTTws4, name="test_broadcast_device_cuda")
+        self.assertTrue(self._keep(item))
+
+    def test_thread_cpu_variant_dropped(self):
+        item = _item(cls=_MTTws4, name="test_broadcast_device_cpu")
+        self.assertFalse(self._keep(item))
+
+    def test_thread_no_device_variant_dropped(self):
+        item = _item(cls=_MTTws4, name="test_expand_1d_rank_list")
+        self.assertFalse(self._keep(item))
+
+    def test_thread_accelerator_variant_world_size_2_dropped(self):
+        item = _item(cls=_MTTws2, name="test_broadcast_device_cuda")
+        self.assertFalse(self._keep(item))
+
+    def test_thread_with_decorator_below_threshold_dropped(self):
+        item = _item(
+            cls=_MTTws4, obj=_func(min_gpus=2), name="test_broadcast_device_cuda"
+        )
+        self.assertFalse(self._keep(item))
+
+    # --- plain TestCase / decorators ---
+    def test_decorated_single_process_kept(self):
+        item = _item(cls=_FakePlain, obj=_func(min_gpus=4))
+        self.assertTrue(self._keep(item))
+
+    def test_requires_world_size_attr_kept(self):
+        item = _item(cls=_FakePlain, obj=_func(required_world_size=4))
+        self.assertTrue(self._keep(item))
+
+    def test_skip_if_lt_3_gpu_decorator_kept(self):
+        # skip_if_lt_x_gpu(3) stamps _min_gpus_required=3: a genuine 3-GPU test.
+        item = _item(cls=_FakePlain, obj=_func(min_gpus=3))
+        self.assertTrue(self._keep(item))
+
+    def test_skip_if_lt_2_gpu_decorator_dropped(self):
+        # 2-GPU tests already run on the 2-GPU runners, so they stay deselected.
+        item = _item(cls=_FakePlain, obj=_func(min_gpus=2))
+        self.assertFalse(self._keep(item))
+
+    def test_plain_testcase_without_signal_dropped(self):
+        item = _item(cls=_FakePlain)
+        self.assertFalse(self._keep(item))
+
+    def test_no_class_without_signal_kept(self):
+        # Non class-based items are kept unless a decorator says otherwise.
+        item = _item(cls=None)
+        self.assertTrue(self._keep(item))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -152,6 +152,15 @@ ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]
 DDP_RANK_DEVICES = ["cuda", "xpu"]
 HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU
 
+# When set (e.g. PYTORCH_TEST_MIN_GPU=4), the collection-time filter in
+# test/conftest.py (MinGpuFilterPlugin) keeps only tests whose resolved
+# accelerator requirement is at least this threshold and deselects the rest.
+# The requirement is resolved from existing signals (skip_if_lt_x_gpu, which
+# stamps `_min_gpus_required`; requires_world_size; and the `world_size` of the
+# multi-process base classes, gated by backend/device), so a CI job can run only
+# the >=N-GPU tests without maintaining an explicit test list.
+TEST_MIN_GPU = int(os.environ.get("PYTORCH_TEST_MIN_GPU", "0"))
+
 
 class TestSkip(NamedTuple):
     exit_code: int
@@ -330,6 +339,9 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
+        # Record the accelerator requirement so the collection-time min-GPU
+        # filter (PYTORCH_TEST_MIN_GPU) can resolve it without running the test.
+        wrapper._min_gpus_required = x
         return wrapper
 
     return decorator


### PR DESCRIPTION

## Superseded by #190680 (recommended) - 2026-07-22

This PR (`MinGpuFilterPlugin` / `PYTORCH_TEST_MIN_GPU=3`) and the alternative
[#190680](https://github.com/pytorch/pytorch/pull/190680) (`--multigpu-filter multigpu_extra`,
built on `main`'s native `multigpu` marker) both make the ROCm `periodic-rocm-mi350` /
`distributed_4gpu` job run the distributed tests that need more than the standard 2-GPU
runners provide. After an empirical, apples-to-apples comparison of the tests actually
selected on the `gfx950.4` (4-GPU) runners in green CI, **#190680 is the recommended
approach and this PR should be closed in its favor.**

### Empirical data sources (both green)

- **#190680** head `91e5167`, run `29849225915` - all 5 `distributed_4gpu` shards passed;
  selected 2112 node-ids (1730 passed / 382 skipped).
- **#187450 (this PR)** head `06067d8`, run `29848200116` - all 5 `distributed_4gpu`
  shards passed; selected 2558 node-ids (2129 passed / 428 skipped / 1 flaky timeout
  unrelated to filtering).
- Ground truth (GT): a test **genuinely needs > 2 physical GPUs** (so it belongs on the
  4-GPU job); 1-2 GPU and CPU/gloo tests do not (they run on the standard 2-GPU
  `distributed` job).

### Confusion matrix (GT = needs > 2 physical GPUs)

| PR | approach | TP | FP | FN | Precision | Recall |
| --- | --- | --- | --- | --- | --- | --- |
| **#190680** | `--multigpu-filter multigpu_extra` | 1493 | 619 | **1** (disabled test -> **0 real**) | **0.707** | **0.999** |
| #187450 (this) | `MinGpuFilterPlugin` (`PYTORCH_TEST_MIN_GPU=3`) | 1319 | 1239 | **175** (173 real; 13 runnable on 4 GPUs now) | 0.516 | 0.883 |

**#190680 wins on both precision and recall, with zero genuine false negatives.**

### Three-bucket set diff (union of all 5 shards, real node-ids)

| Bucket | Count | Composition |
| --- | --- | --- |
| run by both | 1835 | 1318 need > 2 GPUs + 517 over-select shared by both |
| **#190680 only** | 277 | **175 genuine > 2-GPU tests this PR drops** + 98 LocalTensor + 4 other |
| **#187450 only** | 723 | 722 over-selection (`skip_if_lt_x_gpu(1\|2)` on ws>=3, thread/non-spawn, DDP skip(2)) + 1 genuine (but disabled) |

The `#187450-only` bucket is 99.9% over-selection (its single "genuine" member is a
disabled test). The `#190680-only` bucket is ~63% genuine > 2-GPU coverage that this PR
silently drops - including 11x `GlooFaultToleranceTest`,
`checkpoint/test_planner.py::...::test_checkpointable_tensor_shard_save_load`, and
`test_dtensor_testbase.py::DTensorTestBaseUtilCPUTest` (all need 4 GPUs, runnable on the
current runner).

### Root causes of the divergence

- **D1** - this PR keeps `@skip_if_lt_x_gpu(1|2)` / `requires_world_size(1|2)` tests that
  happen to sit in `world_size >= 3` classes (it uses `max(decorator, world_size)`),
  re-running ~539 of them at `world_size=4`. #190680 treats the explicit decorator as
  authoritative and drops them. This is redundant, not lost coverage (they run on the
  2-GPU job).
- **D2** - #190680's `multigpu_extra` marker only applies to
  `MultiProcessTestCase`/`MultiProcContinuousTest` subclasses, so single-process
  `MultiThreadedTestCase` tests are cleanly excluded; this PR over-selects ~36 of them via
  a fragile method-name substring heuristic.
- **D3** - the feared "non-process-spawning test that needs > 2 GPUs would be wrongly
  dropped by #190680" case has **no members**: all 267 `@skip_if_lt_x_gpu(>=3)`
  distributed methods live on process-spawning classes. Confirmed statically and
  empirically (#190680's only FN is a disabled test).
- Conversely, this PR's `MinGpuFilterPlugin` **under-selects** 175 genuine multi-GPU tests
  that #190680 correctly routes to the job.

### Shared caveat (affects both PRs, not a differentiator)

Both PRs still run ~150-220 gloo/CPU tests on the 4-GPU job: the module-name CPU-gate does
not actually fire under `run_test.py` execution (the module does not resolve to a
`gloo`/`_cpu` name at that point; #190680's marker unit test only passes because it mocks
`module.__name__`). Worth a follow-up to make the CPU-gate runtime-robust, but it does not
change the comparison.

### Recommendation

Land **#190680** (native marker-based `multigpu_extra` filter): higher precision *and*
recall, zero genuine false negatives, ~278 vs ~574 insertions, and it plugs into `main`'s
existing marker machinery (so it does not re-introduce the merge conflict that stalled this
PR, and a CUDA 4-GPU job could adopt it with a one-line CI change). Its
`test/distributed/test_multigpu_marker.py` unit test is green (8/8). Keep this PR open only
until reviewers confirm the preference, then close it in favor of #190680.

---

## Update: rebased onto `main` (2026-07-21)

This branch was ~1000+ commits behind and conflicted with `main`, which
introduced a competing `multigpu` pytest marker + `--multigpu-filter`
mechanism in the same two files (`test/conftest.py`, `.ci/pytorch/test.sh`).
Rebased onto current `origin/main` and reconciled to **keep this PR's own
`MinGpuFilterPlugin` / `PYTORCH_TEST_MIN_GPU` approach** while letting main's
new mechanism coexist:

- `test/conftest.py`: keep main's `HardwareClassificationPytestPlugin`,
  `_spawns_multiple_processes`, and the `pytest_itemcollected` `multigpu`
  marker; add back `MinGpuFilterPlugin` + `_get_decorator_attr` and its
  `PYTORCH_TEST_MIN_GPU`-gated registration in `pytest_configure`. The two
  mechanisms are independent hooks and do not collide.
- `.ci/pytorch/test.sh`: keep main's `test_distributed`/`test_distributed_single_gpu`
  (with the `--multigpu-filter` arg) **unchanged**, and add a self-contained
  `test_distributed_4gpu` (sets `PYTORCH_TEST_MIN_GPU=3`, runs the sharded
  distributed suite directly). `distributed` and `distributed_4gpu` are now
  **separate dispatch branches**. The `distributed_4gpu` job never passes
  `--multigpu-filter`, so `MinGpuFilterPlugin` is the sole selector for that
  job and there is no double filtering.

Note: this supersedes the older bullets below that describe a shared
`_test_distributed_python` helper and a folded `distributed`/`distributed_4gpu`
dispatch branch -- both were dropped during the rebase to keep main's
`test_distributed` untouched and avoid interfering with the new marker path.
The threshold is **3** (`PYTORCH_TEST_MIN_GPU=3`), per the "also run the 3-GPU
distributed tests" change; some older bullets/logs below still mention 4.

---

## Summary

- Reenable the `periodic-rocm-mi350` workflow on the `linux.rocm.gpu.gfx950.4` (4-GPU) runner labels, using a dedicated `distributed_4gpu` test config (now **5 shards**) so the scarce 4-GPU runners run only the distributed tests that need >= 4 GPUs.
- Register `ciflow/periodic-rocm-mi350` in `ciflow_push_tags` in `.github/pytorch-probot.yml` so applying the label pushes the trigger tag.
- Add `linux.rocm.gpu.gfx950.4` and `amd-do-linux.rocm.gpu.gfx950.4` passthrough entries to `.github/arc.yaml`'s `runner_mapping` so the OSDC `build-osdc` runner mapper (`map_ec2_to_arc.py`) resolves the 4-GPU labels instead of hard-failing with `no ARC runner found for 'linux.rocm.gpu.gfx950.4'`. Both variants are added because the `distributed_4gpu` shards request `${{ ...amd-do-label-type }}linux.rocm.gpu.gfx950.4`, and the `get-label-type` job runs the runner-determinator with `check_experiments: amd-do`, so the `amd-do-` prefix is reachable.
- Remove the rocm-only `export HIP_VISIBLE_DEVICES=0,1,2,3` override for the `distributed` config; multi-GPU runners already expose their GPUs.
- Strictly select only the >= 4-GPU tests with no per-test list to maintain, by resolving each test's accelerator requirement at pytest collection time, and harden that resolution so CPU / sub-4-GPU process-based tests are reliably dropped:
  - `skip_if_lt_x_gpu(x)` stamps `wrapper._min_gpus_required = x`; `requires_world_size(n)` stamps `_required_world_size`. These are read via a `_get_decorator_attr` helper that walks the `__wrapped__` chain, so the requirement is still found when a real wrapper (e.g. `with_comms`) sits above `skip_if_lt_x_gpu` and only copies standard `functools.wraps` metadata.
  - `test/conftest.py` adds `MinGpuFilterPlugin` (registered only when `PYTORCH_TEST_MIN_GPU > 0`). It resolves `world_size`/`device`/`device_type` off the test class via a side-effect-free `cls.__new__(cls)` probe (reading the constant-returning `@property`s without running `__init__`), instead of the unreliable `item.instance`. On a probe failure, `world_size` falls back to `DEFAULT_WORLD_SIZE` and the requirement uses a deterministic module-name heuristic (non-accelerator backend name or `*_cpu` -> CPU/drop, else `DEFAULT_WORLD_SIZE`) rather than keeping the test. The non-accelerator backend names are derived from `Backend.backend_list` minus `ACCELERATOR_DIST_BACKENDS` (and `UNDEFINED`/`FAKE`) so the heuristic cannot drift from a hand-maintained list. This fixes the prior leak where the whole `test_c10d_gloo` suite, `CommTest` (world_size=2), the dispatched-collectives tests (world_size=1), and `test_file_system_checkpoint_cpu` were kept.
  - The `world_size` resolver treats any **non-positive** probed value (`<= 0`) as unresolved and falls back to `DEFAULT_WORLD_SIZE`. This closes a blind spot for `MultiProcContinuousTest`, which declares `world_size: int = -2` as an unset sentinel populated only at runtime: `-2` used to be returned verbatim and could drop genuine undecorated 4-GPU tests.
  - A `pytest_report_collectionfinish` hook logs a one-line kept/deselected summary unconditionally; the verbose per-node-id deselected dump is gated behind non-negative verbosity, mirroring `StepcurrentPlugin`.
  - `test_distributed_4gpu` in `.ci/pytorch/test.sh` sets `PYTORCH_TEST_MIN_GPU=4` and uses `run_test.py --distributed-tests` dynamic discovery. The shared sharded-python invocation is factored into a `_test_distributed_python` helper used by both `test_distributed` and `test_distributed_4gpu`, and the `distributed` / `distributed_4gpu` dispatch branches are folded together so `install_torchcomms` / `install_spmd_types` are not duplicated (plain `distributed` behavior is unchanged).
  - `test/distributed/test_min_gpu_filter.py` unit-tests the resolver with property-based `MultiProcessTestCase`/`MultiThreadedTestCase`/`MultiProcContinuousTest` fakes (CPU device, world_size 1/2/4, gloo cpu/1gpu/2gpu, nccl world_size=4, `*_cpu` module, broken-`world_size` robustness, decorator override, and the `MultiProcContinuousTest` `-2` unset sentinel undecorated + decorated cases).

### Review feedback (jithunnair-amd)

All of @jithunnair-amd's review comments (inline, 2026-06-25; CHANGES_REQUESTED summary, 2026-06-29) have been addressed, and his inline threads are resolved:

- **Decorator order must not matter.** `_get_decorator_attr` in `test/conftest.py` walks the `__wrapped__` chain (not just the outermost function) and is used by `_resolve()` for both `_min_gpus_required` and `_required_world_size`, so a real wrapper such as `with_comms` stacked over `skip_if_lt_x_gpu` still exposes the requirement regardless of decorator order.
- **Correct backend naming / nature.** The misleadingly-named `_CPU_BACKEND_MODULES = ("gloo", "mpi", "ucc")` tuple is replaced by `_non_accel_backends`, derived at runtime from `Backend.backend_list` minus `ACCELERATOR_DIST_BACKENDS`/`UNDEFINED`/`FAKE` so it cannot drift from a hand-maintained list. The comment clarifies these backends can drive CUDA, but their dedicated `test_c10d_<backend>` modules exercise the CPU path.
- **`test.sh` dispatch structure.** `distributed_4gpu` is folded into the `distributed` elif with a sub-condition (`distributed_4gpu` -> `test_distributed_4gpu`, else `test_distributed` + `test_rpc` on shard 1), so `install_torchcomms`/`install_spmd_types` are not duplicated.
- **`test.sh` duplication.** The shared sharded distributed-python invocation is factored into a `_test_distributed_python` helper used by both `test_distributed` and `test_distributed_4gpu`.
- **Missing docstring.** `MinGpuFilterPlugin.pytest_collection_modifyitems` now has a docstring.

## Test plan

- [x] `periodic-rocm-mi350` runs via the `ciflow/periodic-rocm-mi350` label, with `ci-no-td` and `keep-going`.
- [x] All 5 `linux-noble-rocm-py3.12-mi350 / distributed_4gpu` shards schedule on `gfx950.4` runners and pass.
- [x] The `MinGpuFilter` collection-finish log shows `test_c10d_gloo` CPU/low-world-size tests and `test_file_system_checkpoint_cpu` deselected; genuine 4-GPU tests run.
- [ ] `test/distributed/test_min_gpu_filter.py` passes (includes the new `MultiProcContinuousTest` `-2` sentinel cases); torch is not built locally, so it runs in CI.
- [x] `ruff check` / `ruff format --check` clean on `test/conftest.py` and `test/distributed/test_min_gpu_filter.py`; `bash -n .ci/pytorch/test.sh` passes.

## Validation

Validated on run https://github.com/pytorch/pytorch/actions/runs/28958070896 (head `275b5662bfa`).

- All 5 `distributed_4gpu` shards passed, in ~1h14m-1h42m each (1/5 1h18m, 2/5 1h14m, 3/5 1h24m, 4/5 1h22m, 5/5 1h42m).
- The `MinGpuFilter` deselected 2,641 unique sub-4-GPU test node ids on this run (counted from the shard `logs-*` deselection dumps), identical to the prior validated run since the empty commit did not change the test set; e.g. `test_file_system_checkpoint_cpu` is dropped while genuine 4-GPU tests run. Per-shard unique deselected node ids: 1/5 412; 2/5 864; 3/5 459; 4/5 682; 5/5 402.

## Coverage

The `distributed_4gpu` config executes the 472 distributed tests that require exactly 4 GPUs on ROCm (the ~106 tests needing 6/8 GPUs are collected but self-skip at runtime on a 4-GPU host). See https://github.com/ROCm/frameworks-internal/issues/16970 for the full ROCm UT-parity coverage analysis and known gaps.

Made with Cursor


