### PR TITLE
[MPS] Add error handling for complex dtypes in max unpooling operations

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -572,6 +572,8 @@ static void max_unpool_out_mps_template(const Tensor& input,
                                         Tensor& output,
                                         const int32_t pooling_dims,
                                         const std::string& op_name) {
+  TORCH_CHECK_NOT_IMPLEMENTED(!input.is_complex(), op_name, ": not implemented for complex dtypes");
+
   TORCH_CHECK(output_size_.size() == static_cast<size_t>(pooling_dims),
               op_name,
               "There should be exactly ",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1250,20 +1250,16 @@ class TestMPS(TestCaseMPS):
             self.assertEqual(res2, res2_cpu)
         [helper(dtype) for dtype in [torch.int32, torch.int64, torch.float32]]
 
-    def test_max_unpool_complex_error(self):
-        pool = torch.nn.MaxPool3d(2, return_indices=True)
-        x = torch.randn(1, 1, 4, 4, 4, device="mps")
+    @parametrize("dim", [2, 3])
+    def test_max_unpool_complex_error(self, dim):
+        pool_cls = torch.nn.MaxPool2d if dim == 2 else torch.nn.MaxPool3d
+        max_unpool = F.max_unpool2d if dim == 2 else F.max_unpool3d
+        pool = pool_cls(2, return_indices=True)
+        x = torch.randn((1, 1) + (4,) * dim, device="mps")
         _, indices = pool(x)
-        z = torch.zeros(1, 1, 2, 2, 2, dtype=torch.complex64, device="mps")
+        z = torch.zeros((1, 1) + (2,) * dim, dtype=torch.complex64, device="mps")
         with self.assertRaisesRegex(NotImplementedError, "not implemented for complex dtypes"):
-            torch.nn.functional.max_unpool3d(z, indices, kernel_size=2)
-
-        pool2 = torch.nn.MaxPool2d(2, return_indices=True)
-        x2 = torch.randn(1, 1, 4, 4, device="mps")
-        _, indices2 = pool2(x2)
-        z2 = torch.zeros(1, 1, 2, 2, dtype=torch.complex64, device="mps")
-        with self.assertRaisesRegex(NotImplementedError, "not implemented for complex dtypes"):
-            torch.nn.functional.max_unpool2d(z2, indices2, kernel_size=2)
+            max_unpool(z, indices, kernel_size=2)
 
     def test_cross(self):
         a = torch.randn(4, 3, device="mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1250,6 +1250,21 @@ class TestMPS(TestCaseMPS):
             self.assertEqual(res2, res2_cpu)
         [helper(dtype) for dtype in [torch.int32, torch.int64, torch.float32]]
 
+    def test_max_unpool_complex_error(self):
+        pool = torch.nn.MaxPool3d(2, return_indices=True)
+        x = torch.randn(1, 1, 4, 4, 4, device="mps")
+        _, indices = pool(x)
+        z = torch.zeros(1, 1, 2, 2, 2, dtype=torch.complex64, device="mps")
+        with self.assertRaisesRegex(NotImplementedError, "not implemented for complex dtypes"):
+            torch.nn.functional.max_unpool3d(z, indices, kernel_size=2)
+
+        pool2 = torch.nn.MaxPool2d(2, return_indices=True)
+        x2 = torch.randn(1, 1, 4, 4, device="mps")
+        _, indices2 = pool2(x2)
+        z2 = torch.zeros(1, 1, 2, 2, dtype=torch.complex64, device="mps")
+        with self.assertRaisesRegex(NotImplementedError, "not implemented for complex dtypes"):
+            torch.nn.functional.max_unpool2d(z2, indices2, kernel_size=2)
+
     def test_cross(self):
         a = torch.randn(4, 3, device="mps")
         b = torch.randn(4, 3, device="mps")


### PR DESCRIPTION
Fixes #187233

Adds an early MPS dtype check for `max_unpool2d` and `max_unpool3d` so complex inputs fail with a clear `NotImplementedError` instead of falling through to Metal kernel creation and raising an internal runtime error like `max_unpool_float2`.

Also adds MPS regression coverage for complex `max_unpool2d` and `max_unpool3d` inputs.

Test Plan:

```bash
python test/test_mps.py -k test_max_unpool_complex_error
```

cc @malfet @Isalia20