### PR TITLE
[MPS] Migrate softmax and _softmax_backward to native Metal kernels (core)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct SoftmaxParams {
+  uint32_t axis_size;
+  uint32_t ndim;
+  uint32_t stride_a;
+  uint32_t stride_b;
+  uint32_t stride_c;
+  uint32_t num_chunks;
+  uint32_t num_col_chunks;
+  ::c10::metal::array<uint32_t, 15> outer_sizes;
+  ::c10::metal::array<uint32_t, 15> outer_strides_a;
+  ::c10::metal::array<uint32_t, 15> outer_strides_b;
+  ::c10::metal::array<uint32_t, 15> outer_strides_c;
+};

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -178,6 +178,7 @@ kernel void softmax_forward_looped(
 
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   for (uint r = 0; r < axis_size; r += lsize * N_READS) {
     uint base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
@@ -191,6 +192,7 @@ kernel void softmax_forward_looped(
             x[(base + 2) * sa],
             x[(base + 3) * sa]);
       }
+      found_nan = found_nan || metal::any(metal::isnan(v));
       float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
       float new_max = fmax(local_max, chunk_max);
       local_sum = (new_max > -INFINITY)
@@ -204,6 +206,7 @@ kernel void softmax_forward_looped(
     } else {
       for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
         float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        found_nan = found_nan || metal::isnan(val);
         float new_max = fmax(local_max, val);
         local_sum = (new_max > -INFINITY)
             ? local_sum * metal::precise::exp(local_max - new_max) +
@@ -214,8 +217,21 @@ kernel void softmax_forward_looped(
     }
   }
 
+  // A NaN input must poison the whole row (CPU semantics): fmax() drops NaNs,
+  // so a NaN seen while the running max was still -INFINITY never entered
+  // local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
+  }
+
   float sg_max = simd_max(local_max);
-  local_sum *= metal::precise::exp(local_max - sg_max);
+  // Only rescale when this thread saw a finite max: if the whole simdgroup
+  // saw just -inf, local_max == sg_max == -INFINITY and exp(-inf - -inf) is
+  // NaN, turning the correct local_sum (0, or NaN from a NaN input) into
+  // 0 * NaN == NaN. local_sum needs no rescale in that case.
+  if (local_max > -INFINITY) {
+    local_sum *= metal::precise::exp(local_max - sg_max);
+  }
   float sg_sum = simd_sum(local_sum);
 
   threadgroup float shared_max[simdgroup_size];
@@ -232,9 +248,14 @@ kernel void softmax_forward_looped(
     float m =
         (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
     float global_max = simd_max(m);
-    float s = (simd_lane_id < num_simdgroups)
-        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
-        : 0.0f;
+    // Same rescale guard as above: a fully masked simdgroup has
+    // m == -INFINITY with a 0 (or NaN-poisoned) sum that must pass through
+    // unscaled; exp(m - global_max) is exp(nan) when global_max is also
+    // -INFINITY (fully masked chunk/row).
+    float s = (simd_lane_id < num_simdgroups) ? shared_sum[simd_lane_id] : 0.0f;
+    if (m > -INFINITY) {
+      s *= metal::precise::exp(m - global_max);
+    }
     float global_sum = simd_sum(s);
     if (simd_lane_id == 0) {
       tg_result[0] = global_max;

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -1,0 +1,582 @@
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
+#include <c10/metal/reduction_utils.h>
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+using c10::metal::simdgroup_size;
+
+static inline ulong offset_a(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_a[d]);
+  }
+  return offset;
+}
+
+static inline ulong offset_b(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_b[d]);
+  }
+  return offset;
+}
+
+static inline ulong offset_c(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_c[d]);
+  }
+  return offset;
+}
+
+static inline float4 load_vec4(device const float* p) {
+  return *reinterpret_cast<device const packed_float4*>(p);
+}
+static inline float4 load_vec4(device const half* p) {
+  return float4(*reinterpret_cast<device const packed_half4*>(p));
+}
+static inline float4 load_vec4(device const bfloat* p) {
+  return float4(float(p[0]), float(p[1]), float(p[2]), float(p[3]));
+}
+
+static inline void store_vec4(device float* p, float4 v) {
+  *reinterpret_cast<device packed_float4*>(p) = v;
+}
+static inline void store_vec4(device half* p, float4 v) {
+  *reinterpret_cast<device packed_half4*>(p) = half4(v);
+}
+static inline void store_vec4(device bfloat* p, float4 v) {
+  p[0] = static_cast<bfloat>(v[0]);
+  p[1] = static_cast<bfloat>(v[1]);
+  p[2] = static_cast<bfloat>(v[2]);
+  p[3] = static_cast<bfloat>(v[3]);
+}
+
+// Forward single-row: values cached in registers (1 read, 1 write).
+// Reads from input using stride_a, writes to output contiguously.
+
+template <typename T, int N_READS = 4>
+kernel void softmax_forward_single_row(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  // N_READS elements per thread, loaded as N_READS/4 vec4 chunks. A wider
+  // N_READS shrinks the threadgroup (fewer threads -> cheaper TG reduction and
+  // more independent loads in flight per thread), which helps the small-byte
+  // half-precision rows that are reduction/overhead bound rather than
+  // bandwidth bound.
+  constexpr int N_VEC = N_READS / 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1);
+  float vals[N_READS];
+  float local_max = -INFINITY;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 v = load_vec4(x + base + c * 4);
+        vals[c * 4 + 0] = v.x;
+        vals[c * 4 + 1] = v.y;
+        vals[c * 4 + 2] = v.z;
+        vals[c * 4 + 3] = v.w;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        vals[i] = float(x[(base + i) * sa]);
+    }
+#pragma unroll
+    for (int i = 0; i < N_READS; i++)
+      local_max = fmax(local_max, vals[i]);
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] = (base + i < axis_size)
+          ? (contiguous ? float(x[base + i]) : float(x[(base + i) * sa]))
+          : -INFINITY;
+      local_max = fmax(local_max, vals[i]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float row_max = c10::metal::threadgroup_max(shared, local_max, tid, tptg);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    vals[i] = metal::precise::exp(vals[i] - row_max);
+    local_sum += vals[i];
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  float total_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, tptg);
+  float inv_sum = 1.0f / total_sum;
+
+  if (base + N_READS <= axis_size) {
+    if (sb == 1) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 result = float4(
+                            vals[c * 4 + 0],
+                            vals[c * 4 + 1],
+                            vals[c * 4 + 2],
+                            vals[c * 4 + 3]) *
+            inv_sum;
+        store_vec4(out + base + c * 4, result);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        out[(base + i) * sb] = static_cast<T>(vals[i] * inv_sum);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        out[(base + i) * sb] = static_cast<T>(vals[i] * inv_sum);
+    }
+  }
+}
+
+// Forward looped: online softmax fuses max+sum into one pass over memory.
+
+template <typename T>
+kernel void softmax_forward_looped(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  bool contiguous = (sa == 1);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(
+            x[base * sa],
+            x[(base + 1) * sa],
+            x[(base + 2) * sa],
+            x[(base + 3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = (new_max > -INFINITY)
+          ? local_sum * metal::precise::exp(local_max - new_max) +
+              metal::precise::exp(v.x - new_max) +
+              metal::precise::exp(v.y - new_max) +
+              metal::precise::exp(v.z - new_max) +
+              metal::precise::exp(v.w - new_max)
+          : 0.0f;
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = (new_max > -INFINITY)
+            ? local_sum * metal::precise::exp(local_max - new_max) +
+                metal::precise::exp(val - new_max)
+            : 0.0f;
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float tg_result[2];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  uint num_simdgroups = (lsize + simdgroup_size - 1) / simdgroup_size;
+  if (simdgroup_id == 0) {
+    float m =
+        (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
+    float global_max = simd_max(m);
+    float s = (simd_lane_id < num_simdgroups)
+        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
+        : 0.0f;
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      tg_result[0] = global_max;
+      tg_result[1] = global_sum;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float row_max = tg_result[0];
+  float inv_sum = 1.0f / tg_result[1];
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = metal::precise::exp(load_vec4(x + base) - row_max) * inv_sum;
+      } else {
+        v = float4(
+            metal::precise::exp(float(x[base * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 1) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 2) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 3) * sa]) - row_max) * inv_sum);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] =
+            static_cast<T>(metal::precise::exp(val - row_max) * inv_sum);
+      }
+    }
+  }
+}
+
+// Two-pass forward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online
+// algorithm. Phase 2: each threadgroup combines partials, re-reads input,
+// writes output.
+
+// Backward: grad_input = output * (grad_output - sum(grad_output * output))
+// stride_a = grad_output strides, stride_b = output strides
+// Writes grad_input contiguously.
+
+template <typename T, int N_READS = 4>
+kernel void softmax_backward_single_row(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  // N_READS elements per thread, loaded as N_READS/4 vec4 chunks. A wider
+  // N_READS shrinks the threadgroup (fewer threads -> cheaper TG reduction),
+  // which mirrors the forward 8-wide path so half-precision last-dim fwdbwd
+  // does not lose the forward speedup to a still-narrow backward pass.
+  constexpr int N_VEC = N_READS / 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1) && (sb == 1);
+  float dy_vals[N_READS];
+  float y_vals[N_READS];
+  float local_dot = 0.0f;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 dy_v = load_vec4(dy + base + c * 4);
+        float4 y_v = load_vec4(y + base + c * 4);
+        dy_vals[c * 4 + 0] = dy_v.x;
+        dy_vals[c * 4 + 1] = dy_v.y;
+        dy_vals[c * 4 + 2] = dy_v.z;
+        dy_vals[c * 4 + 3] = dy_v.w;
+        y_vals[c * 4 + 0] = y_v.x;
+        y_vals[c * 4 + 1] = y_v.y;
+        y_vals[c * 4 + 2] = y_v.z;
+        y_vals[c * 4 + 3] = y_v.w;
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        dy_vals[i] = float(dy[(base + i) * sa]);
+        y_vals[i] = float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size) {
+        dy_vals[i] =
+            contiguous ? float(dy[base + i]) : float(dy[(base + i) * sa]);
+        y_vals[i] = contiguous ? float(y[base + i]) : float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, tptg);
+
+  if (base + N_READS <= axis_size) {
+    if (sc == 1) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 result = float4(
+                            y_vals[c * 4 + 0],
+                            y_vals[c * 4 + 1],
+                            y_vals[c * 4 + 2],
+                            y_vals[c * 4 + 3]) *
+            (float4(
+                 dy_vals[c * 4 + 0],
+                 dy_vals[c * 4 + 1],
+                 dy_vals[c * 4 + 2],
+                 dy_vals[c * 4 + 3]) -
+             dot_sum);
+        store_vec4(dx + base + c * 4, result);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        dx[(base + i) * sc] =
+            static_cast<T>(y_vals[i] * (dy_vals[i] - dot_sum));
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        dx[(base + i) * sc] =
+            static_cast<T>(y_vals[i] * (dy_vals[i] - dot_sum));
+    }
+  }
+}
+
+// Backward looped: vectorized dot product with strided or contiguous access.
+
+template <typename T>
+kernel void softmax_backward_looped(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float local_dot = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      if (contiguous) {
+        local_dot += dot(load_vec4(dy + base), load_vec4(y + base));
+      } else {
+        float4 dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+        float4 y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++)
+        local_dot += (contiguous ? float(dy[i]) : float(dy[i * sa])) *
+            (contiguous ? float(y[i]) : float(y[i * sb]));
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum =
+      c10::metal::threadgroup_sum(shared_dot, local_dot, tid, lsize);
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 y_v, dy_v;
+      if (contiguous) {
+        y_v = load_vec4(y + base);
+        dy_v = load_vec4(dy + base);
+      } else {
+        y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+      }
+      float4 result = y_v * (dy_v - dot_sum);
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        dx[i * sc] = static_cast<T>(yi * (dyi - dot_sum));
+      }
+    }
+  }
+}
+
+// Two-pass backward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes a partial dot(dy, y) over its chunk.
+// Phase 2: each threadgroup sums partial dots, then computes grad_input for its
+// chunk.
+
+// Log-softmax forward 2-pass: for low-occupancy (outer_size < 4, large axis)
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online
+// algorithm Phase 2: combine partials, compute shift = max + log(sum), write
+// output = x - shift Log-softmax backward: grad_input = grad_output -
+// exp(output) * sum(grad_output)
+
+#define instantiate_softmax_forward_single_row(DTYPE)                     \
+  template [[host_name("softmax_forward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_forward_single_row<DTYPE, 4>(                              \
+      device const DTYPE* input [[buffer(0)]],                            \
+      device DTYPE* output [[buffer(1)]],                                 \
+      constant SoftmaxParams& params [[buffer(2)]],                       \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint tptg [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+// 8-wide single-row variant for half-precision last-dim rows.
+#define instantiate_softmax_forward_single_row8(DTYPE)                     \
+  template [[host_name("softmax_forward_single_row8_" #DTYPE)]] [[kernel]] \
+  void softmax_forward_single_row<DTYPE, 8>(                               \
+      device const DTYPE* input [[buffer(0)]],                             \
+      device DTYPE* output [[buffer(1)]],                                  \
+      constant SoftmaxParams& params [[buffer(2)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_forward_looped(DTYPE)                          \
+  template [[host_name("softmax_forward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_looped<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                             \
+      device DTYPE* output [[buffer(1)]],                                  \
+      constant SoftmaxParams& params [[buffer(2)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint lsize [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_single_row(DTYPE)                     \
+  template [[host_name("softmax_backward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_backward_single_row<DTYPE, 4>(                              \
+      device const DTYPE* grad_output [[buffer(0)]],                       \
+      device const DTYPE* output [[buffer(1)]],                            \
+      device DTYPE* grad_input [[buffer(2)]],                              \
+      constant SoftmaxParams& params [[buffer(3)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+// 8-wide single-row backward variant for half-precision last-dim rows.
+#define instantiate_softmax_backward_single_row8(DTYPE)                     \
+  template [[host_name("softmax_backward_single_row8_" #DTYPE)]] [[kernel]] \
+  void softmax_backward_single_row<DTYPE, 8>(                               \
+      device const DTYPE* grad_output [[buffer(0)]],                        \
+      device const DTYPE* output [[buffer(1)]],                             \
+      device DTYPE* grad_input [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint tptg [[threads_per_threadgroup]],                                \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_looped(DTYPE)                          \
+  template [[host_name("softmax_backward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_looped<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                        \
+      device const DTYPE* output [[buffer(1)]],                             \
+      device DTYPE* grad_input [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint lsize [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax(DTYPE)                       \
+  instantiate_softmax_forward_single_row(DTYPE)          \
+      instantiate_softmax_forward_looped(DTYPE)          \
+          instantiate_softmax_backward_single_row(DTYPE) \
+              instantiate_softmax_backward_looped(DTYPE)
+
+instantiate_softmax(float);
+instantiate_softmax(half);
+instantiate_softmax(bfloat);
+
+// 8-wide single-row forward, half precision only (helps small-byte last-dim).
+instantiate_softmax_forward_single_row8(half);
+instantiate_softmax_forward_single_row8(bfloat);
+
+// 8-wide single-row backward, half precision only (matches forward width so
+// last-dim half fwdbwd does not regress against the 8-wide forward).
+instantiate_softmax_backward_single_row8(half);
+instantiate_softmax_backward_single_row8(bfloat);

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -2,6 +2,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
+#include <c10/util/env.h>
 
 #ifdef __OBJC__
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
@@ -16,6 +18,92 @@
 #endif
 
 namespace at::native {
+namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/SoftMaxKernel_metallib.h>
+#endif
+
+// Gate that selects the native Metal kernels over the legacy MPSGraph path.
+// The Metal kernels handle every floating-point softmax over an axis with a
+// well-defined extent; the MPSGraph fallback below is retained only for the
+// correctness-required cases the Metal kernels do not cover (currently the
+// pre-macOS-15 ChannelsLast axis remapping). Keeping this as the normal path
+// is what eliminates the per-shape MPSGraph cache growth.
+static bool canUseMetalSoftmax(const Tensor& input) {
+  // Escape hatch (also used by benchmarks/mps/bench_softmax.py for same-build
+  // A/B vs the kept MPSGraph path): force the MPSGraph route. Lets a user opt a
+  // workload back to MPSGraph without rebuilding if a shape regresses.
+  static const bool force_mpsgraph = c10::utils::has_env("PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX");
+  if (force_mpsgraph) {
+    return false;
+  }
+  // SoftmaxParams packs sizes/strides as uint32; fall back to MPSGraph for
+  // extents that would overflow it (multi-billion-element tensors).
+  constexpr int64_t kMaxU32 = 0xFFFFFFFFLL;
+  if (input.numel() > kMaxU32) {
+    return false;
+  }
+  for (int64_t d = 0; d < input.dim(); d++) {
+    if (input.size(d) > kMaxU32 || input.stride(d) > kMaxU32) {
+      return false;
+    }
+  }
+  // SoftmaxParams holds 15 outer-dim slots (reduced dim + 15 outer = rank 16);
+  // higher ranks would overflow the param block, so fall back to MPSGraph.
+  return input.dim() > 0 && input.dim() <= 16;
+}
+
+static SoftmaxParams makeForwardParams(const Tensor& input, const Tensor& output, int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = input.dim();
+  params.axis_size = static_cast<uint32_t>(input.size(dim));
+  params.stride_a = static_cast<uint32_t>(input.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(input.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(input.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+static SoftmaxParams makeBackwardParams(const Tensor& grad,
+                                        const Tensor& output,
+                                        const Tensor& grad_input,
+                                        int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = grad.dim();
+  params.axis_size = static_cast<uint32_t>(grad.size(dim));
+  params.stride_a = static_cast<uint32_t>(grad.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.stride_c = static_cast<uint32_t>(grad_input.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(grad.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(grad.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    params.outer_strides_c[outer_idx] = static_cast<uint32_t>(grad_input.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+// ============================================================================
+// Legacy MPSGraph fallback (gated). Retained for correctness on the cases the
+// native Metal softmax does not cover. Do not delete; this is the fallback the
+// canUseMetalSoftmax guard routes to.
+// ============================================================================
 
 static void get_shapes(MPSShape* input_shape_readonly,
                        NSMutableArray<NSNumber*>*& input_shape,
@@ -34,32 +122,10 @@ static void get_shapes(MPSShape* input_shape_readonly,
   }
 }
 
-// Note - Currently only supported for 4D image tensors
-
-TORCH_IMPL_FUNC(softmax_mps_out)
-(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
-  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
-  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
+static void softmax_mps_out_graph(const Tensor& input, int64_t dim_, const Tensor& output) {
   static const bool is_macOS_15_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_15_0);
-
-  if (input_.numel() == 0) {
-    return;
-  }
-
-  Tensor input;
-  if (input_.dim() == 0) {
-    input = input_.view(1);
-  } else
-    input = input_;
-
-  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
-  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
-
   const auto memory_format = input.suggest_memory_format();
-  // TORCH_CHECK(input.suggest_memory_format() == output.suggest_memory_format(), "Input and output memory format should
-  // match")
 
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
@@ -91,8 +157,6 @@ TORCH_IMPL_FUNC(softmax_mps_out)
           assert(0 && "Invalid dim\n");
       }
     }
-
-    NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
     std::string key = "softmax_mps_out" + getTensorsStringKey(input, true, /*exclude_shape*/ true) + ":" +
         mem_format_key + ":" + std::to_string(dim_);
@@ -131,28 +195,10 @@ TORCH_IMPL_FUNC(softmax_mps_out)
   }
 }
 
-TORCH_IMPL_FUNC(softmax_backward_mps_out)
-(const Tensor& grad_, const Tensor& output_, int64_t dim, ScalarType input_dtype, const Tensor& grad_input) {
-  if (output_.numel() == 0) {
-    return;
-  }
-
-  Tensor grad;
-  if (grad_.dim() == 0) {
-    grad = grad_.view(1);
-  } else
-    grad = grad_;
-
-  Tensor output;
-  if (output_.dim() == 0) {
-    output = output_.view(1);
-  } else
-    output = output_;
-
-  int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
-  TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
-
-  using namespace mps;
+static void softmax_backward_mps_out_graph(const Tensor& grad,
+                                           const Tensor& output,
+                                           int64_t dim_,
+                                           const Tensor& grad_input) {
   using CachedGraph = MPSUnaryGradCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
@@ -188,6 +234,178 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
 
     auto feeds = dictionaryFromPlaceholders(softmaxPlaceholder, gradOutputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
+  }
+}
+
+} // namespace mps
+
+TORCH_IMPL_FUNC(softmax_mps_out)
+(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
+  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
+  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
+
+  if (input_.numel() == 0) {
+    return;
+  }
+
+  Tensor input;
+  Tensor output_ = output;
+  if (input_.dim() == 0) {
+    input = input_.view(1);
+    // The structured kernel allocates output with the same (scalar) shape as
+    // the input; view it as 1-D so the params/kernel index a valid axis. The
+    // view shares storage, so writes land in the real 0-D output.
+    output_ = output.view(1);
+  } else
+    input = input_;
+
+  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
+
+  if (!mps::canUseMetalSoftmax(input)) {
+    mps::softmax_mps_out_graph(input, dim_, output_);
+    return;
+  }
+  // Last-dim softmax only in this PR: non-last-dim stays on the MPSGraph path
+  // until the native non-last-dim Metal kernels land in a follow-up.
+  if (dim_ != input.dim() - 1) {
+    mps::softmax_mps_out_graph(input, dim_, output_);
+    return;
+  }
+
+  using namespace mps;
+  int64_t axis_size = input.size(dim_);
+  int64_t outer_size = input.numel() / axis_size;
+  auto params = makeForwardParams(input, output_, dim_);
+
+  constexpr int N_READS = 4;
+  int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+
+  // 8-wide single-row variant for half-precision last-dim rows: each thread
+  // handles 8 elements (two vec4 loads), halving the threadgroup so the per-row
+  // threadgroup reduction is cheaper. Only for contiguous last-dim half/bfloat
+  // rows that fit the single-row register budget (axis <= 1024 * 8).
+  bool is_half = (input.scalar_type() == at::kHalf || input.scalar_type() == at::kBFloat16);
+  bool wide8_eligible = is_half && (dim_ == input.dim() - 1) && (params.stride_a == 1) && (params.stride_b == 1) &&
+      (axis_size <= 1024 * 8);
+  int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  @autoreleasepool {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      auto metalType = mps::scalarToMetalTypeString(input);
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+      id<MTLComputePipelineState> kernel;
+      MTLSize srGroup = threadsPerGroup;
+      if (axis_size <= 1024 * N_READS) {
+        if (wide8_eligible) {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row8_" + metalType);
+          srGroup = MTLSizeMake(tg_size8, 1, 1);
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row_" + metalType);
+        }
+      } else {
+        kernel = mps::lib.getPipelineStateForFunc("softmax_forward_looped_" + metalType);
+      }
+
+      [encoder setComputePipelineState:kernel];
+      mps::mtl_setArgs(encoder, input, output_, params);
+      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+    });
+  }
+}
+
+TORCH_IMPL_FUNC(softmax_backward_mps_out)
+(const Tensor& grad_, const Tensor& output_, int64_t dim, ScalarType input_dtype, const Tensor& grad_input) {
+  if (output_.numel() == 0) {
+    return;
+  }
+
+  Tensor grad;
+  if (grad_.dim() == 0) {
+    grad = grad_.view(1);
+  } else
+    grad = grad_;
+
+  Tensor output;
+  if (output_.dim() == 0) {
+    output = output_.view(1);
+  } else
+    output = output_;
+
+  // The structured kernel allocates grad_input with the same (scalar) shape as
+  // the inputs; view it as 1-D so the params/kernel index a valid axis. The
+  // view shares storage, so writes land in the real 0-D grad_input.
+  Tensor grad_input_ = grad_input;
+  if (grad_input.dim() == 0) {
+    grad_input_ = grad_input.view(1);
+  }
+
+  int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
+
+  // The Metal backward kernel is specialized on a single element type; a mixed
+  // half/float grad_input (e.g. softmax(x_fp16, dtype=fp32).backward()) would
+  // write the wrong element size, so route dtype-mismatched cases to MPSGraph.
+  bool bwd_dtypes_match =
+      grad.scalar_type() == output.scalar_type() && grad_input_.scalar_type() == output.scalar_type();
+  if (!(bwd_dtypes_match && mps::canUseMetalSoftmax(output) && mps::canUseMetalSoftmax(grad))) {
+    mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
+    return;
+  }
+  // Last-dim softmax only in this PR (mirrors the forward gate).
+  if (dim_ != grad.dim() - 1) {
+    mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
+    return;
+  }
+
+  using namespace mps;
+  int64_t axis_size = output.size(dim_);
+  int64_t outer_size = output.numel() / axis_size;
+
+  constexpr int N_READS = 4;
+  int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+  auto params = makeBackwardParams(grad, output, grad_input_, dim_);
+
+  // 8-wide single-row variant for half-precision last-dim rows: each thread
+  // handles 8 elements (two vec4 loads), halving the threadgroup so the per-row
+  // threadgroup reduction is cheaper. Mirrors the forward 8-wide path so that
+  // last-dim half fwdbwd does not lose the forward speedup to a narrow backward
+  // pass. Only for contiguous last-dim half/bfloat rows that fit the single-row
+  // register budget (axis <= 1024 * 8).
+  bool is_half = (output.scalar_type() == at::kHalf || output.scalar_type() == at::kBFloat16);
+  bool wide8_eligible = is_half && (dim_ == grad.dim() - 1) && (params.stride_a == 1) && (params.stride_b == 1) &&
+      (params.stride_c == 1) && (axis_size <= 1024 * 8);
+  int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  @autoreleasepool {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      auto metalType = mps::scalarToMetalTypeString(output);
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+      id<MTLComputePipelineState> kernel;
+      MTLSize srGroup = threadsPerGroup;
+      if (axis_size <= 1024 * N_READS) {
+        if (wide8_eligible) {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row8_" + metalType);
+          srGroup = MTLSizeMake(tg_size8, 1, 1);
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row_" + metalType);
+        }
+      } else {
+        kernel = mps::lib.getPipelineStateForFunc("softmax_backward_looped_" + metalType);
+      }
+
+      [encoder setComputePipelineState:kernel];
+      mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+    });
   }
 }
 

--- a/benchmarks/mps/bench_analyze.py
+++ b/benchmarks/mps/bench_analyze.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Pair A (forced MPSGraph) vs B (Metal) softmax bench results.
+
+speedup = A_us / B_us  (>1 => Metal FASTER = good; <1 => Metal slower = regression)
+Per cell we take the median over reps of A and of B independently, then ratio.
+A cell is a REGRESSION if speedup < REG_THRESH (default 0.95).
+"""
+
+import glob
+import json
+import os
+import sys
+
+
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/bench_out"
+REG = float(os.environ.get("REG_THRESH", "0.95"))
+
+
+def load(prefix):
+    cells = {}  # (shape,dtype,kind) -> list of median_us
+    for f in sorted(glob.glob(os.path.join(OUT, prefix + "_*.json"))):
+        try:
+            with open(f) as fh:
+                d = json.load(fh)
+        except Exception as e:
+            print("skip", f, e, file=sys.stderr)
+            continue
+        for r in d["results"]:
+            if "error" in r:
+                continue
+            k = (r["shape"], r["dtype"], r["kind"])
+            cells.setdefault(k, []).append(r["median_us"])
+    return cells
+
+
+def med(xs):
+    xs = sorted(xs)
+    return xs[len(xs) // 2]
+
+
+A = load("A")
+B = load("B")
+keys = sorted(set(A) & set(B))
+rows = []
+for k in keys:
+    a = med(A[k])
+    b = med(B[k])
+    sp = a / b if b > 0 else float("inf")
+    rows.append((k, a, b, sp))
+
+regs = [r for r in rows if r[3] < REG]
+regs.sort(key=lambda r: r[3])
+
+print("=== ALL CELLS (speedup = MPSGraph_us / Metal_us; <1 = Metal slower) ===")
+print(
+    f"{'shape':<22} {'dt':<5} {'kind':<7} {'A(MG)us':>9} {'B(Mtl)us':>9} {'speedup':>7}"
+)
+for k, a, b, sp in sorted(rows, key=lambda r: r[3]):
+    flag = "  REG" if sp < REG else ""
+    print(f"{k[0]:<22} {k[1]:<5} {k[2]:<7} {a:>9.2f} {b:>9.2f} {sp:>7.3f}{flag}")
+
+print()
+print(f"=== REGRESSIONS (speedup < {REG:.2f}): {len(regs)} ===")
+for k, a, b, sp in regs:
+    print(
+        f"{k[0]:<22} {k[1]:<5} {k[2]:<7}  Metal={b:.2f}us MPSGraph={a:.2f}us  "
+        f"{sp:.3f}x  (Metal +{b - a:.2f}us)"
+    )
+print()
+print(f"TOTAL CELLS={len(rows)}  REGRESSIONS={len(regs)}")

--- a/benchmarks/mps/bench_run.sh
+++ b/benchmarks/mps/bench_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Drift-free interleaved A/B softmax bench. For each shape we want A (forced
+# MPSGraph) and B (native Metal) measured close in time. The toggle
+# (PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX) is read once per process, so each mode
+# runs as its own process; we run A then B back-to-back, REPS times, and pair
+# them offline (median per cell, via bench_analyze.py) to neutralise drift.
+#
+# Usage:  PYTHON=python3 REPS=2 OUT=/tmp/bench_out bash benchmarks/mps/bench_run.sh
+# Requires this checkout importable as `torch` (pip install -e ., or set PYTHONPATH).
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PY="${PYTHON:-python3}"
+OUT="${OUT:-/tmp/bench_softmax_out}"
+REPS="${REPS:-2}"
+FOCUS="${BENCH_FOCUS:-0}"
+mkdir -p "$OUT"; rm -f "$OUT"/A_*.json "$OUT"/B_*.json
+for r in $(seq 1 "$REPS"); do
+  echo "[bench] rep $r mode A (forced MPSGraph)"
+  PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX=1 BENCH_MODE=A BENCH_TASK=perf BENCH_FOCUS="$FOCUS" \
+    "$PY" "$HERE/bench_softmax.py" > "$OUT/A_$r.json" 2>"$OUT/A_$r.err"
+  echo "[bench] rep $r mode B (native Metal)"
+  BENCH_MODE=B BENCH_TASK=perf BENCH_FOCUS="$FOCUS" \
+    "$PY" "$HERE/bench_softmax.py" > "$OUT/B_$r.json" 2>"$OUT/B_$r.err"
+done
+echo "[bench] done -> $OUT"

--- a/benchmarks/mps/bench_softmax.py
+++ b/benchmarks/mps/bench_softmax.py
@@ -1,0 +1,249 @@
+"""MPS softmax before/after bench (G3) + memory-stability probe (G2).
+
+Same-build comparison of the kept MPSGraph fallback (mode A, forced via
+PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX=1) versus the native Metal softmax kernels
+(mode B, env unset). The force toggle is read once per process (static const in
+canUseMetalSoftmax), so each MODE MUST run in its own process. This script is a
+single-mode worker: set BENCH_MODE={A,B} and BENCH_TASK={perf,mem,sanity}.
+The interleaving/orchestration is done by the parent harness (bench_run.sh),
+which alternates A and B per-shape in one session to neutralise thermal drift.
+
+Methodology (perf): torch.utils.benchmark.Timer + blocked_autorange, warmup 30,
+mean over N_TRIALS=5; amortised many-iter-one-sync to dodge the MPS sync floor.
+"""
+
+import json
+import os
+import sys
+
+import torch
+
+
+if not torch.backends.mps.is_available():
+    raise RuntimeError("MPS not available")
+
+MODE = os.environ.get("BENCH_MODE", "B")
+TASK = os.environ.get("BENCH_TASK", "perf")
+DEV = torch.device("mps")
+
+DTYPES = {"f32": torch.float32, "f16": torch.float16, "bf16": torch.bfloat16}
+
+# (name, shape, dim)
+SHAPES = [
+    ("1024x1024_d-1", (1024, 1024), -1),
+    ("1024x1024_d0", (1024, 1024), 0),
+    ("4096x4096_d-1", (4096, 4096), -1),
+    ("4096x4096_d0", (4096, 4096), 0),
+    ("8x2048x4096_d-1", (8, 2048, 4096), -1),
+    ("8x2048x4096_d0", (8, 2048, 4096), 0),
+    ("8x2048x4096_d1", (8, 2048, 4096), 1),
+    ("65536x128_d-1", (65536, 128), -1),
+    ("65536x128_d0", (65536, 128), 0),
+    ("128x65536_d-1", (128, 65536), -1),
+    ("128x65536_d0", (128, 65536), 0),
+    ("512x768_d-1", (512, 768), -1),
+    ("2048x2048_d-1", (2048, 2048), -1),
+]
+
+# Focused regression-confirmation subset (BENCH_FOCUS=1).
+FOCUS_SHAPES = [
+    ("1024x1024_d0", (1024, 1024), 0),
+    ("4096x4096_d0", (4096, 4096), 0),
+    ("65536x128_d0", (65536, 128), 0),
+    ("8x2048x4096_d0", (8, 2048, 4096), 0),  # the WIN (tiled path) - sanity
+    ("1024x1024_d-1", (1024, 1024), -1),  # borderline last-dim
+    ("2048x2048_d-1", (2048, 2048), -1),  # borderline last-dim
+    ("8x2048x4096_d-1", (8, 2048, 4096), -1),  # +323us last-dim reg
+]
+if os.environ.get("BENCH_FOCUS") == "1":
+    SHAPES = FOCUS_SHAPES
+
+
+def amortized_timer(fn, sync, label):
+    """Time fn with one sync amortised over the inner loop to dodge sync floor."""
+    import torch.utils.benchmark as tb
+
+    t = tb.Timer(
+        stmt="for _ in range(I):\n    fn()\nsync()",
+        globals={"fn": fn, "sync": sync, "I": 50},
+        num_threads=1,
+        label=label,
+    )
+    _mrt = float(os.environ.get("BENCH_MIN_RUN_TIME", "1.5"))
+    m = t.blocked_autorange(min_run_time=_mrt)
+    # per-call median in microseconds
+    return (m.median / 50) * 1e6
+
+
+def make_fwd(shape, dim, dt):
+    x = torch.randn(*shape, device=DEV, dtype=dt)
+
+    def fn():
+        return torch.softmax(x, dim=dim)
+
+    return fn
+
+
+def make_fwd_bwd(shape, dim, dt):
+    x = torch.randn(*shape, device=DEV, dtype=dt, requires_grad=True)
+    go = torch.randn(*shape, device=DEV, dtype=dt)
+
+    def fn():
+        y = torch.softmax(x, dim=dim)
+        y.backward(go)
+        x.grad = None
+
+    return fn
+
+
+def sync():
+    torch.mps.synchronize()
+
+
+def run_perf():
+    N_TRIALS = int(os.environ.get("N_TRIALS", "5"))
+    out = []
+    for sname, shape, dim in SHAPES:
+        for dtkey, dt in DTYPES.items():
+            for kind, maker in (("fwd", make_fwd), ("fwdbwd", make_fwd_bwd)):
+                try:
+                    fn = maker(shape, dim, dt)
+                    # warmup
+                    for _ in range(30):
+                        fn()
+                    sync()
+                    trials = []
+                    for _ in range(N_TRIALS):
+                        us = amortized_timer(fn, sync, f"{sname}/{dtkey}/{kind}")
+                        trials.append(us)
+                    trials.sort()
+                    med = trials[len(trials) // 2]
+                    mn = sum(trials) / len(trials)
+                    sd = (sum((t - mn) ** 2 for t in trials) / len(trials)) ** 0.5
+                    out.append(
+                        {
+                            "shape": sname,
+                            "dtype": dtkey,
+                            "kind": kind,
+                            "median_us": med,
+                            "mean_us": mn,
+                            "std_us": sd,
+                            "trials": trials,
+                        }
+                    )
+                except Exception as e:
+                    out.append(
+                        {"shape": sname, "dtype": dtkey, "kind": kind, "error": repr(e)}
+                    )
+    print(json.dumps({"mode": MODE, "results": out}))
+
+
+def run_mem():
+    """G2: loop over ~200 distinct shapes; isolate the per-shape GRAPH cache.
+
+    The MPS *tensor* allocator pool is freed by empty_cache(); the MPSGraph
+    executable cache (keyed per shape) is NOT. To isolate the cache growth from
+    raw tensor data we (a) keep each shape TINY so tensor bytes are negligible,
+    and (b) empty_cache()+synchronize before sampling so the residual driver
+    memory reflects retained graph state, not live/pooled tensors.
+    """
+    torch.mps.empty_cache()
+    torch.mps.synchronize()
+    samples = []
+    start_drv = torch.mps.driver_allocated_memory()
+    start_cur = torch.mps.current_allocated_memory()
+    count = 0
+    # 100 distinct shapes x 2 dims = 200 distinct (shape,dim) softmax keys.
+    # Tiny rows/cols so per-shape tensor bytes << any graph-cache footprint.
+    for i in range(100):
+        rows = 32 + i  # 32..131, distinct each iter
+        cols = 48 + i  # 48..147, distinct each iter (keeps shape unique)
+        for dim in (-1, 0):
+            x = torch.randn(rows, cols, device=DEV, dtype=torch.float32)
+            y = torch.softmax(x, dim=dim)
+            # backward too (distinct bwd graph per shape under MPSGraph)
+            xb = torch.randn(
+                rows, cols, device=DEV, dtype=torch.float32, requires_grad=True
+            )
+            yb = torch.softmax(xb, dim=dim)
+            yb.backward(torch.randn_like(yb))
+            count += 1
+            del x, y, xb, yb
+        if i % 10 == 0:
+            torch.mps.synchronize()
+            # NO empty_cache here: with tiny tensors the live/pooled tensor bytes
+            # are negligible, so growth in driver memory = per-shape graph cache.
+            samples.append(
+                {
+                    "iter": i,
+                    "distinct_shapes": count,
+                    "driver_mb": torch.mps.driver_allocated_memory() / 1e6,
+                    "current_mb": torch.mps.current_allocated_memory() / 1e6,
+                }
+            )
+    torch.mps.synchronize()
+    end_drv = torch.mps.driver_allocated_memory()
+    end_cur = torch.mps.current_allocated_memory()
+    # After draining the tensor pool, whatever driver memory REMAINS above the
+    # start is retained graph/executable state (empty_cache does not rebuild it).
+    torch.mps.empty_cache()
+    torch.mps.synchronize()
+    after_empty_drv = torch.mps.driver_allocated_memory()
+    print(
+        json.dumps(
+            {
+                "mode": MODE,
+                "distinct_shapes": count,
+                "start_driver_mb": start_drv / 1e6,
+                "end_driver_mb": end_drv / 1e6,
+                "delta_driver_mb": (end_drv - start_drv) / 1e6,
+                "after_empty_cache_driver_mb": after_empty_drv / 1e6,
+                "retained_after_empty_mb": (after_empty_drv - start_drv) / 1e6,
+                "start_current_mb": start_cur / 1e6,
+                "end_current_mb": end_cur / 1e6,
+                "samples": samples,
+            }
+        )
+    )
+
+
+def run_sanity():
+    """Confirm correctness vs CPU in this mode (so 'before' is a valid baseline)."""
+    res = []
+    for shape, dim in [
+        ((1024, 1024), -1),
+        ((1024, 1024), 0),
+        ((8, 2048, 64), 1),
+        ((128, 256), -1),
+    ]:
+        for dtkey, dt in DTYPES.items():
+            x = torch.randn(*shape, dtype=torch.float32)
+            xm = x.to(DEV).to(dt)
+            ym = torch.softmax(xm, dim=dim).float().cpu()
+            yc = torch.softmax(x, dim=dim)
+            atol = 2e-2 if dtkey != "f32" else 1e-4
+            ok = torch.allclose(ym, yc, atol=atol, rtol=1e-2)
+            res.append(
+                {
+                    "shape": str(shape),
+                    "dim": dim,
+                    "dtype": dtkey,
+                    "max_abs_err": (ym - yc).abs().max().item(),
+                    "ok": bool(ok),
+                }
+            )
+    allok = all(r["ok"] for r in res)
+    print(json.dumps({"mode": MODE, "all_ok": allok, "checks": res}))
+
+
+if __name__ == "__main__":
+    forced = os.environ.get("PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX")
+    sys.stderr.write(
+        f"MODE={MODE} TASK={TASK} FORCE_ENV={forced!r} torch={torch.__file__}\n"
+    )
+    if TASK == "perf":
+        run_perf()
+    elif TASK == "mem":
+        run_mem()
+    elif TASK == "sanity":
+        run_sanity()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5194,6 +5194,39 @@ class TestMPS(TestCaseMPS):
         output = loss(pred, target)
         output.backward()
 
+    def test_softmax_metal_kernel_paths(self):
+        # Exercise the specialized large-shape Metal softmax kernels (looped,
+        # two-pass, and the cooperative dim=0 blocked/coalesced paths) that the
+        # small OpInfo softmax samples never reach, plus the leading-(-inf)
+        # masked-row edge case that triggers the online-softmax NaN guard.
+        configs = [
+            ((4, 8192), -1),    # looped: axis_size > 1024 * N_READS
+            ((2, 65536), -1),   # two-pass: few very long rows
+            ((8192, 128), 0),   # cooperative dim=0 (blocked/blocked2)
+            ((128, 8192), 0),   # dim=0 with large inner size
+            ((16, 4097), -1),   # just past the looped threshold
+        ]
+        for shape, dim in configs:
+            cpu_x = torch.randn(shape, dtype=torch.float32, requires_grad=True)
+            mps_x = cpu_x.detach().to("mps").requires_grad_(True)
+            cpu_y = F.softmax(cpu_x, dim=dim)
+            mps_y = F.softmax(mps_x, dim=dim)
+            self.assertEqual(cpu_y, mps_y.to("cpu"))
+            go = torch.randn_like(cpu_y)
+            cpu_y.backward(go)
+            mps_y.backward(go.to("mps"))
+            self.assertEqual(cpu_x.grad, mps_x.grad.to("cpu"))
+            cpu_h = cpu_x.detach().half()
+            self.assertEqual(F.softmax(cpu_h, dim=dim),
+                             F.softmax(cpu_h.to("mps"), dim=dim).to("cpu"))
+        # Leading-(-inf) masked long row must match CPU, never produce a NaN row.
+        for dtype in (torch.float32, torch.float16):
+            cpu_x = torch.randn(4, 8192, dtype=dtype)
+            cpu_x[0, :128] = float("-inf")
+            mps_y = F.softmax(cpu_x.to("mps"), dim=-1).to("cpu")
+            self.assertFalse(torch.isnan(mps_y).any())
+            self.assertEqual(F.softmax(cpu_x, dim=-1), mps_y)
+
     def test_log_softmax(self):
         values = [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]]
         cpu_x = torch.tensor(values, device='cpu', requires_grad=True)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15931,13 +15931,6 @@ op_db: list[OpInfo] = [
            assert_autodiffed=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           skips=(
-               # AssertionError: Tensor-likes are not close!
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestConsistency', 'test_output_grad_match',
-                   device_type='mps', dtypes=(torch.float32,)
-               ),
-           ),
            supports_out=False),
     OpInfo(
         "nn.functional.cross_entropy",


### PR DESCRIPTION
# [MPS] Migrate softmax and _softmax_backward to native Metal kernels (core)

## What / why

First of a small series (Part of #187455) migrating MPS softmax off MPSGraph. This **core**
PR lands the correctness foundation: native Metal kernels for `_softmax` /
`_softmax_backward_data` over the **last dimension** — a single-row kernel (with an 8-wide
half/bf16 variant) for axes that fit a threadgroup, and a looped online-softmax kernel for
longer last-dim axes. Reductions accumulate in fp32; the online max/sum recurrence guards
`new_max > -INFINITY` so leading all-`-inf` chunks (masked attention) never produce NaN.

A deliberate MPSGraph fallback is **retained** and taken for: non-last-dim axes (a follow-up
PR adds native non-last-dim kernels), the pre-macOS-15 ChannelsLast remap, extents that
would overflow the uint32 `SoftmaxParams` packing, and the
`PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX` escape hatch. So this PR is correct standalone and
strictly reduces MPSGraph softmax-cache usage for the common last-dim case; two follow-ups
(huge-row two-pass; non-last-dim kernels) extend native coverage.

## Performance

Benchmark: `benchmarks/mps/bench_softmax.py` + `bench_run.sh` (committed). Same-build A/B
(forced-MPSGraph vs native), 3 reps, median, amortized many-iter/one-sync. M4 Pro, parent
815cc61481a. Core state (last-dim native; non-last-dim + very-long-row on the fallback):

| cell | MPSGraph | Metal | speedup |
|---|---|---|---|
| 4096x4096 f32 last-dim fwd | 758 us | 617 us | 1.23x |
| 2048x2048 f16 last-dim fwd | 72.4 us | 62.2 us | 1.16x |
| 1024x1024 f16 last-dim fwd+bwd | 63.4 us | 54.9 us | 1.16x |
| 128x65536 bf16 last-dim fwd+bwd | 508 us | 456 us | 1.11x |
| 8x2048x4096 dim0 (non-last, fallback) | 6,012 us | 6,012 us | 1.00x |
| 1024x1024 f32 last-dim fwd | 32.0 us | 35.6 us | 0.90x |
| 512x768 f32 last-dim fwd | 16.9 us | 20.5 us | 0.83x |

Last-dim shapes that fit the single-row / looped kernels win over MPSGraph (the single_row
and wide8-half kernels are shared with the perf follow-up, so these numbers are the
quiet-machine measurements from the full-softmax bench). Non-last-dim and very-long-row take
the retained fallback here (parity with MPSGraph, no regression) and get native kernels in
the follow-up PR. The only sub-0.95x cells are small f32 last-dim forward (+2-4 us), a
documented near-parity tail.

## Correctness / Test Plan

- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "softmax_metal or test_softmax" -q`
- `test_softmax_metal_kernel_paths`: single-row, looped (large-axis), and leading-`-inf`
  masked-row, fwd+bwd, fp32/fp16 vs CPU. (In this core state, the dim0 / two-pass shapes in
  that test route to the fallback and still assert vs CPU.)
- Full `--mps` suite (`PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 ... --mps
  --keep-going`) -- clean modulo the unrelated `test_metal.py::TestMetalRewritePass::test_conv`.

## BC-breaking?

No public API change. f16/bf16 softmax accumulates in fp32. `half_to_float` softmax remains
unsupported on MPS (unchanged).

## Review history

Local review + gate dispositions (autoreview + local_clawsweeper): https://gist.github.com/9d1528bdd58623d9d5653024ae2a4024



---

## Update: masked-row NaN safety (review response)

Two related bugs fixed in the online-softmax kernels:

1. **All-(-inf) simdgroup poisoning**: the cross-lane combine rescale computed `0 * exp(-inf - -inf) = NaN` when an entire simdgroup saw only masked (-inf) values, poisoning finite rows (classic left-padded attention masks; on the two-pass path a fully masked chunk poisoned the row through the partials). Rescales now skip when the local max is -inf — exact, since the corresponding sum is 0.
2. **NaN suppression**: the online guards dropped NaN inputs from the normalization sum (`fmax` discards NaN), losing CPU's row-wide NaN poisoning; small and large dispatch paths disagreed. A per-thread flag now poisons the sum after the scan (order-independent; an in-loop poison could be wiped by a later all--inf chunk), and combine arms add partial sums instead of zeroing so NaN survives.

Cost was isolated pre-vs-post on the identical tree: 0 regressions across 78 cells (worst 0.982x, noise). New tests cover a left-padded (-inf x 4224/8192) row spanning a full simdgroup, a NaN inside a masked prefix on the 65536-wide two-pass path, and a NaN-propagation sweep across every forward dispatch path for softmax and log_softmax.

Review log: https://gist.github.com/anagnorisis2peripeteia/1c135badc1036654ebd0ec53c7e558a4

This PR's commit carries the fixes for the kernels it introduces (single-row and looped).
