### PR TITLE
Register ProcessGroup opaque type globally

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -902,6 +902,28 @@ class ProcessGroupArgTest(TestCase):
         torch.ops._c10d_functional.wait_tensor(out)
 
 
+class ProcessGroupOpaqueTypeRegistrationTest(TestCase):
+    def test_process_group_is_registered_on_distributed_import(self) -> None:
+        from torch._library.opaque_object import (
+            get_member_type,
+            is_opaque_type,
+            MemberType,
+        )
+
+        self.assertTrue(is_opaque_type(dist.ProcessGroup))
+        self.assertEqual(
+            get_member_type(dist.ProcessGroup, "size"), MemberType.USE_REAL
+        )
+
+        def f(x: torch.Tensor, pg: dist.ProcessGroup) -> torch.Tensor:
+            return x
+
+        self.assertEqual(
+            torch.library.infer_schema(f, mutates_args=()),
+            "(Tensor x, torch.distributed.distributed_c10d.ProcessGroup pg) -> Tensor",
+        )
+
+
 def find_buffer_assignments(code):
     pattern = r"buf(\d+) = empty_strided_"
     matches = re.finditer(pattern, code)

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -2036,7 +2036,7 @@ class ProcessGroupOpaqueTypeTest(TestCase):
     def test_registered_members_exist_on_process_group(self):
         from torch._library.opaque_object import get_member_type
 
-        # Every member registered in _register_distributed_opaque_types()
+        # Every member registered in _register_process_group_opaque_type()
         # must actually exist on ProcessGroup. This catches renames or
         # removals of C++ attributes that would cause torch.compile
         # (fullgraph=True) to silently register a stale name while the
@@ -2053,8 +2053,8 @@ class ProcessGroupOpaqueTypeTest(TestCase):
             self.assertIsNotNone(
                 get_member_type(ProcessGroup, member_name),
                 f"'{member_name}' is not registered as a ProcessGroup opaque "
-                f"type member. Add it to _register_distributed_opaque_types() "
-                f"in torch/distributed/device_mesh.py",
+                f"type member. Add it to _register_process_group_opaque_type() "
+                f"in torch/distributed/distributed_c10d.py",
             )
             self.assertTrue(
                 hasattr(ProcessGroup, member_name),

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2365,6 +2365,12 @@ from torch._classes import classes as classes  # usort: skip
 sys.modules.setdefault(f"{__name__}.ops", ops)
 sys.modules.setdefault(f"{__name__}.classes", classes)
 
+if hasattr(torch._C, "_c10d_init"):
+    from torch.distributed.distributed_c10d import _register_process_group_opaque_type
+
+    _register_process_group_opaque_type()
+    del _register_process_group_opaque_type
+
 # quantization depends on torch.fx and torch.ops
 # Import quantization
 from torch import quantization as quantization  # usort: skip

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -45,6 +45,7 @@ else:
     from torch.distributed import config as dist_config
     from torch.distributed.distributed_c10d import (
         _get_default_group,
+        _register_process_group_opaque_type,
         _resolve_process_group,
         get_backend,
         get_process_group_ranks,
@@ -1676,19 +1677,7 @@ def _register_distributed_opaque_types():
 
     from torch._library.opaque_object import MemberType, register_opaque_type
 
-    register_opaque_type(
-        ProcessGroup,
-        typ="reference",
-        members={
-            "size": MemberType.USE_REAL,
-            "rank": MemberType.USE_REAL,
-            "_get_backend_name": MemberType.USE_REAL,
-            "group_name": MemberType.USE_REAL,
-            "group_desc": MemberType.USE_REAL,
-            "__eq__": MemberType.USE_REAL,
-            "__ne__": MemberType.USE_REAL,
-        },
-    )
+    _register_process_group_opaque_type()
 
     register_opaque_type(
         DeviceMesh,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -59,6 +59,31 @@ from .constants import default_pg_nccl_timeout, default_pg_timeout
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
 
 
+def _register_process_group_opaque_type() -> None:
+    from torch._library.opaque_object import (
+        is_opaque_type,
+        MemberType,
+        register_opaque_type,
+    )
+
+    if is_opaque_type(ProcessGroup):
+        return
+
+    register_opaque_type(
+        ProcessGroup,
+        typ="reference",
+        members={
+            "size": MemberType.USE_REAL,
+            "rank": MemberType.USE_REAL,
+            "_get_backend_name": MemberType.USE_REAL,
+            "group_name": MemberType.USE_REAL,
+            "group_desc": MemberType.USE_REAL,
+            "__eq__": MemberType.USE_REAL,
+            "__ne__": MemberType.USE_REAL,
+        },
+    )
+
+
 __all__ = [
     "Backend",
     "BackendConfig",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187459

This makes ProcessGroup usable as a custom operator input type.
Previously ProcessGroup was only usable as a custom operator input type
if you imported DeviceMesh, but not everyone imports DeviceMesh, so this
didn't make sense.

The registration call is deliberately placed after core torch initialization to avoid the circular import hit by importing torch._library.opaque_object from distributed_c10d too early.

Test Plan:

```bash
python - <<'PY'
import torch
import torch.distributed as dist
from torch._library.opaque_object import get_member_type, is_opaque_type

print(is_opaque_type(dist.ProcessGroup))
print(get_member_type(dist.ProcessGroup, "size"))

def f(x: torch.Tensor, pg: dist.ProcessGroup) -> torch.Tensor:
    return x
print(torch.library.infer_schema(f, mutates_args=()))
PY
```

```bash
python test/distributed/test_c10d_functional_native.py -k ProcessGroupOpaqueTypeRegistrationTest
```

```bash
python test/distributed/test_device_mesh.py -k ProcessGroupOpaqueTypeTest
```

```bash
python -m py_compile torch/distributed/distributed_c10d.py torch/distributed/device_mesh.py test/distributed/test_c10d_functional_native.py test/distributed/test_device_mesh.py
```

```bash
lintrunner -a
```

Authored with AI assistant.