### PR TITLE
Gate viable/strict promotion on docs-build

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: pytorch/pytorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"trunk\", \"lint\"]'
+          requires: '[\"pull\", \"trunk\", \"lint\", \"docs-build\"]'
           secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}


### PR DESCRIPTION
## Summary

Adds `docs-build` to the `requires` list in the Update viable/strict workflow, so a commit must have a green `docs-build` before it can be promoted to `viable/strict`.

## Why

`docs-build` is being added as a viable/strict blocking workflow across the stack — the auto-revert bot (pytorch-gha-infra) and HUD (test-infra). This workflow is the actual promotion gate that those mirror, so it must include `docs-build` too; otherwise viable/strict would advance on commits with a failing `docs-build`, leaving the systems inconsistent.