### PR TITLE
[ROCm] [Operator Benchmark] Add gfx950 ROCm nightly CI lane and docker image

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -192,6 +192,14 @@ case "$tag" in
     KATEX=yes
     PYTORCH_ROCM_ARCH="gfx942"
     ;;
+    pytorch-linux-noble-rocm-nightly-py3-gfx950)
+    ANACONDA_PYTHON_VERSION=3.12
+    GCC_VERSION=13
+    ROCM_VERSION=nightly
+    TRITON=yes
+    KATEX=yes
+    PYTORCH_ROCM_ARCH="gfx950"
+    ;;
   pytorch-linux-jammy-xpu-n-1-py3)
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=11

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2111,14 +2111,25 @@ test_operator_microbenchmark() {
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)
   local op_list="${OP_BENCHMARK_TESTS:-matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm}"
   for op in $op_list; do
-    $TASKSET python -m "pt.${op}_test" --tag-filter long \
-      --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-      --benchmark-name "PyTorch operator microbenchmark" --use-compile \
-      2>"${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.stderr.log"
-    $TASKSET python -m "pt.${op}_test" --tag-filter long \
-      --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
-      --benchmark-name "PyTorch operator microbenchmark" \
-      2>"${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.stderr.log"
+    if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+      # ROCm hipBLASLt can flood stderr; discard for usable CI logs (errors still fail via exit code).
+      # Temporary until https://github.com/ROCm/rocm-libraries/pull/8184 is reflected in the CI image.
+      $TASKSET python -m "pt.${op}_test" --tag-filter long \
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
+        --benchmark-name "PyTorch operator microbenchmark" --use-compile \
+        2>/dev/null
+      $TASKSET python -m "pt.${op}_test" --tag-filter long \
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
+        --benchmark-name "PyTorch operator microbenchmark" \
+        2>/dev/null
+    else
+      $TASKSET python -m "pt.${op}_test" --tag-filter long \
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
+        --benchmark-name "PyTorch operator microbenchmark" --use-compile
+      $TASKSET python -m "pt.${op}_test" --tag-filter long \
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
+        --benchmark-name "PyTorch operator microbenchmark"
+    fi
   done
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2110,18 +2110,19 @@ test_operator_microbenchmark() {
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)
   local op_list="${OP_BENCHMARK_TESTS:-matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm}"
+  local op_list="${OP_BENCHMARK_TESTS:-scaled_grouped_mm}"
   for op in $op_list; do
     if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
       # ROCm hipBLASLt can flood stderr; discard for usable CI logs (errors still fail via exit code).
       # Temporary until https://github.com/ROCm/rocm-libraries/pull/8184 is reflected in the CI image.
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" --use-compile \
-        2>/dev/null
+        --benchmark-name "PyTorch operator microbenchmark" --use-compile #\
+        #2>/dev/null
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" #\
         --benchmark-name "PyTorch operator microbenchmark" \
-        2>/dev/null
+        #2>/dev/null
     else
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2110,19 +2110,18 @@ test_operator_microbenchmark() {
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)
   local op_list="${OP_BENCHMARK_TESTS:-matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm}"
-  local op_list="${OP_BENCHMARK_TESTS:-scaled_grouped_mm}"
   for op in $op_list; do
     if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-      # ROCm hipBLASLt can flood stderr; discard for usable CI logs (errors still fail via exit code).
-      # Temporary until https://github.com/ROCm/rocm-libraries/pull/8184 is reflected in the CI image.
+      # ROCm hipBLASLt spams this line to stderr (see ROCm/rocm-libraries#8184); drop only that line from logs.
+      local _hipblaslt_stderr_filter='Warning: Stream-K Data Parallel does not support GSU > 1'
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" --use-compile #\
-        #2>/dev/null
+        --benchmark-name "PyTorch operator microbenchmark" --use-compile \
+        2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2)
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" #\
+        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
         --benchmark-name "PyTorch operator microbenchmark" \
-        #2>/dev/null
+        2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2)
     else
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2113,10 +2113,12 @@ test_operator_microbenchmark() {
   for op in $op_list; do
     $TASKSET python -m "pt.${op}_test" --tag-filter long \
       --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-      --benchmark-name "PyTorch operator microbenchmark" --use-compile
+      --benchmark-name "PyTorch operator microbenchmark" --use-compile \
+      2>"${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.stderr.log"
     $TASKSET python -m "pt.${op}_test" --tag-filter long \
       --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
-      --benchmark-name "PyTorch operator microbenchmark"
+      --benchmark-name "PyTorch operator microbenchmark" \
+      2>"${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.stderr.log"
   done
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2110,27 +2110,13 @@ test_operator_microbenchmark() {
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)
   local op_list="${OP_BENCHMARK_TESTS:-matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm}"
-  local op_list="${OP_BENCHMARK_TESTS:-scaled_grouped_mm}" # DEBUG, TO BE REMOVED
   for op in $op_list; do
-    if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-      # ROCm hipBLASLt spams this line to stderr (see ROCm/rocm-libraries#8184); drop only that line from logs.
-      local _hipblaslt_stderr_filter='Warning: Stream-K Data Parallel does not support GSU > 1'
-      $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" --use-compile #\ # DEBUG, TO BE REMOVED
-        #2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2) # DEBUG, TO BE REMOVED
-      $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" #\ # DEBUG, TO BE REMOVED
-        #2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2) # DEBUG, TO BE REMOVED
-    else
-      $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" --use-compile
-      $TASKSET python -m "pt.${op}_test" --tag-filter long \
-        --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark"
-    fi
+    $TASKSET python -m "pt.${op}_test" --tag-filter long \
+      --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
+      --benchmark-name "PyTorch operator microbenchmark" --use-compile
+    $TASKSET python -m "pt.${op}_test" --tag-filter long \
+      --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
+      --benchmark-name "PyTorch operator microbenchmark"
   done
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2110,18 +2110,19 @@ test_operator_microbenchmark() {
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   # OP_BENCHMARK_TESTS env var can override the default operator list (set via _linux-test.yml matrix)
   local op_list="${OP_BENCHMARK_TESTS:-matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm}"
+  local op_list="${OP_BENCHMARK_TESTS:-scaled_grouped_mm}" # DEBUG, TO BE REMOVED
   for op in $op_list; do
     if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
       # ROCm hipBLASLt spams this line to stderr (see ROCm/rocm-libraries#8184); drop only that line from logs.
       local _hipblaslt_stderr_filter='Warning: Stream-K Data Parallel does not support GSU > 1'
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" --use-compile \
-        2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2)
+        --benchmark-name "PyTorch operator microbenchmark" --use-compile #\ # DEBUG, TO BE REMOVED
+        #2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2) # DEBUG, TO BE REMOVED
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}${suffix}.json" \
-        --benchmark-name "PyTorch operator microbenchmark" \
-        2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2)
+        --benchmark-name "PyTorch operator microbenchmark" #\ # DEBUG, TO BE REMOVED
+        #2> >(grep --line-buffered -vF "${_hipblaslt_stderr_filter}" >&2) # DEBUG, TO BE REMOVED
     else
       $TASKSET python -m "pt.${op}_test" --tag-filter long \
         --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${op}_compile${suffix}.json" \

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -57,6 +57,7 @@ jobs:
           pytorch-linux-jammy-rocm-n-py3,
           pytorch-linux-noble-rocm-n-py3,
           pytorch-linux-noble-rocm-nightly-py3,
+          pytorch-linux-noble-rocm-nightly-py3-gfx950,
           pytorch-linux-jammy-rocm-n-py3-benchmarks,
           pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-clang18,
           pytorch-linux-jammy-py3-gcc11-inductor-benchmarks,

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -119,7 +119,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-noble-rocm-nightly-py3.12-gfx950
+      # Pinned .ci/docker tree (git rev-parse <ref>:.ci/docker). Resolves to the same ECR tag as
+      # pytorch-linux-noble-rocm-nightly-py3-gfx950-<hash>. Bump when gfx950 Dockerfiles change.
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
+      ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -122,7 +122,7 @@ jobs:
       # Pinned .ci/docker tree (git rev-parse <ref>:.ci/docker). Resolves to the same ECR tag as
       # pytorch-linux-noble-rocm-nightly-py3-gfx950-<hash>. Bump when gfx950 Dockerfiles change.
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
-      ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
+      # ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -118,8 +118,8 @@ jobs:
     name: opmicrobenchmark-build-rocm
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
-      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
+      build-environment: linux-noble-rocm-nightly-py3.12-gfx950
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -86,7 +86,9 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-noble-rocm-nightly-py3.12-gfx950
+      # Pinned .ci/docker tree (not HEAD). Same tag as pytorch-linux-noble-rocm-nightly-py3-gfx950-<hash> in ECR.
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
+      ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -76,3 +76,41 @@ jobs:
       docker-image: ${{ needs.linux-noble-rocm-nightly-py3_12-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-noble-rocm-nightly-py3_12-build.outputs.test-matrix }}
     secrets: inherit
+
+
+  linux-noble-rocm-nightly-py3_12-gfx950-build:
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    name: linux-noble-rocm-nightly-py3.12-gfx950
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-noble-rocm-nightly-py3.12-gfx950
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.gfx950.1" },
+        ]}
+    secrets: inherit
+
+  linux-noble-rocm-nightly-py3_12-gfx950-test:
+    permissions:
+      id-token: write
+      contents: read
+    name: linux-noble-rocm-nightly-py3.12-gfx950
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-noble-rocm-nightly-py3_12-gfx950-build
+      - target-determination
+    with:
+      build-environment: ${{ needs.linux-noble-rocm-nightly-py3_12-gfx950-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-noble-rocm-nightly-py3_12-gfx950-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-rocm-nightly-py3_12-gfx950-build.outputs.test-matrix }}
+    secrets: inherit

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -88,7 +88,7 @@ jobs:
       build-environment: linux-noble-rocm-nightly-py3.12-gfx950
       # Pinned .ci/docker tree (not HEAD). Same tag as pytorch-linux-noble-rocm-nightly-py3-gfx950-<hash> in ECR.
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3-gfx950
-      ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
+      # ci-docker-hash: 86f7face98a79f30f65e8ceccf5edebefc56a56b
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },


### PR DESCRIPTION
## Summary

Add a gfx950-specific ROCm nightly docker image and CI lane for MI350X, instead of running gfx950 hardware with the gfx942 `pytorch-linux-noble-rocm-nightly-py3` stack, ran into issues with that approach [here](https://github.com/pytorch/pytorch/pull/183592). gfx950 runners were getting gfx942 hipBLASLt libs (e.g. `scaled_mm` / missing gfx950 Tensile assets). A separate image avoids stale docker layers and mismatched ROCm vs GPU.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang