### PR TITLE
Fix DTensor out variant detection

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -377,6 +377,48 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         out.to_local().sum().backward()
         self.assertIsNotNone(local.grad)
 
+    @unittest.skipIf(not HAS_GPU, "standalone_compile requires GPU and triton")
+    @skipIfXpu(msg="standalone_compile coverage is CUDA-only")
+    @skip_if_lt_x_gpu(1)
+    @patch.object(torch._inductor.config, "compile_threads", 1)
+    def test_aot_standalone_compile_dtensor_to_dtype_layout(self):
+        from torch._inductor import standalone_compile
+
+        device = torch.device(self.device_type, 0)
+        mesh = DeviceMesh(self.device_type, torch.arange(1))
+        index = DTensor.from_local(
+            torch.arange(2, device=device, dtype=torch.int64),
+            mesh,
+            [Replicate()],
+            run_check=False,
+        )
+        rope_cache = DTensor.from_local(
+            torch.randn(4, 4, device=device),
+            mesh,
+            [Replicate()],
+            run_check=False,
+        )
+
+        def backend(gm, example_inputs):
+            return standalone_compile(
+                gm,
+                example_inputs,
+                dynamic_shapes="from_graph",
+                options={"config_patches": {}},
+                aot=True,
+                donate_graph_module=True,
+            )
+
+        def index_to(index, rope_cache):
+            return rope_cache[index].to(device=device).to_local()
+
+        with torch._dynamo.config.patch(enable_aot_compile=True):
+            compiled = torch.compile(index_to, backend=backend, fullgraph=True)
+        with torch.inference_mode():
+            artifact = compiled.aot_compile(((index, rope_cache), {}))
+
+        self.assertIsNotNone(artifact)
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW or TEST_XPU,
         "https://github.com/pytorch/pytorch/issues/178745",

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -44,6 +44,7 @@
 #include <ATen/ATen.h>
 
 #include <structmember.h>
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <sstream>
@@ -1631,11 +1632,12 @@ py::object dispatchDTensorOp(
   // enough for now.
   const bool is_inplace_op =
       !operator_name.name.empty() && operator_name.name.back() == '_';
-  // Simple analysis of function schema to determine if this is an
-  // ou variant. It might not be entirely correct, but it's good
-  // enough for now.
+  const auto& schema_arguments = op.schema().arguments();
   const bool is_out_variant_op = !is_inplace_op &&
-      operator_name.overload_name.find("out") != std::string::npos;
+      std::any_of(
+          schema_arguments.begin(),
+          schema_arguments.end(),
+          [](const c10::Argument& argument) { return argument.is_out(); });
 
   // Fast path for default or view ops.
   const auto output_spec =


### PR DESCRIPTION
DTensor's C++ fast path used the operator overload name to decide whether an op was an out variant. That misclassified overloads such as aten.to.dtype_layout because layout contains out, causing AOT standalone compilation to enter the out-variant tail path even though the schema has no output arguments.

Use the ATen schema's explicit output-argument metadata instead. This keeps real out variants on the existing path while letting dtype_layout wrap its local result normally.

Added test: test_aot_standalone_compile_dtensor_to_dtype_layout.

This commit was authored with assistance from an AI assistant.

Fixes: https://github.com/pytorch/pytorch/issues/187443