### PR TITLE
c10d: route ProcessGroup rank and size through backends

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -12,7 +12,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch._C._distributed_c10d import _create_work_from_future
-from torch.distributed.distributed_c10d import _coalescing_manager, _get_default_group
+from torch.distributed.distributed_c10d import (
+    _coalescing_manager,
+    _get_default_group,
+    ReconfigureOptions,
+)
 from torch.futures import Future
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -314,6 +318,8 @@ class TestPyProcessGroup(TestCase):
         # dispatches back into Python; a raw C++ ProcessGroup would return the
         # base backend name ("undefined") instead.
         self.assertEqual(pg.name(), "store-pg")
+        self.assertEqual(pg.rank(), 0)
+        self.assertEqual(pg.size(), 1)
 
     def test_coalescing_manager(self):
         # The coalescing manager calls _start_coalescing / _end_coalescing, which
@@ -359,6 +365,19 @@ class TestPyProcessGroup(TestCase):
         self.assertEqual(opts.handles, ["a", "b"])
         self.assertEqual(opts.timeout, timeout)
         self.assertEqual(opts.hints, {"k": "v"})
+
+    def test_reconfigure_rejects_multiple_backends(self) -> None:
+        pg = dist.ProcessGroup(0, 1)
+        pg._register_backend(torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO)
+        pg._register_backend(torch.device("cuda"), dist.ProcessGroup.BackendType.NCCL)
+
+        msg = "multiple backends"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.supports_reconfigure
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.get_reconfigure_handle()
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pg.reconfigure(ReconfigureOptions())
 
     def test_window_delegation(self) -> None:
         pg = WindowProcessGroup(0, 1)

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -713,10 +713,8 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   // appropriate logging etc.
   void init();
 
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  const int rank_;
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  const int size_;
+  int rank_;
+  int size_;
   // Debug level setting. It is parsed once when ProcessGroup is constructed and
   // remains the same across use of this process group.
   DebugLevel dist_debug_level_;

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include <algorithm>
 #include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
@@ -166,7 +167,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       !ranks.empty(),
       "Split ranks cannot be empty. Please provide a non-empty list of ranks to split the group.");
   TORCH_CHECK(
-      ranks.size() <= static_cast<size_t>(size_),
+      ranks.size() <= static_cast<size_t>(getSize()),
       "the split group's size should be no larger than the world_size set by init_process_group");
   std::unordered_set<int> ranks_set(ranks.begin(), ranks.end());
   TORCH_CHECK(
@@ -179,21 +180,20 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   if (!deviceTypeFilter.empty()) {
     for (const auto& deviceType : deviceTypeFilter) {
       TORCH_CHECK(
-          deviceTypeToBackendType_.count(deviceType) != 0,
+          deviceTypeToBackendType_.contains(deviceType),
           "Requested device type for splitGroup is not present in the parent process group: ",
           deviceType);
     }
-    auto defaultBackendIt = std::find_if(
-        deviceTypeToBackendType_.begin(),
-        deviceTypeToBackendType_.end(),
+    auto defaultBackendIt = std::ranges::find_if(
+        deviceTypeToBackendType_,
         [&](const auto& p) { return p.second == backendType_; });
     TORCH_CHECK(
         defaultBackendIt != deviceTypeToBackendType_.end() &&
-            deviceTypeFilter.count(defaultBackendIt->first) != 0,
+            deviceTypeFilter.contains(defaultBackendIt->first),
         "splitGroup deviceTypes filter must include the parent process group's default backend device type.");
   }
   std::vector<int> sorted_ranks = ranks;
-  std::sort(sorted_ranks.begin(), sorted_ranks.end());
+  std::ranges::sort(sorted_ranks);
   c10::intrusive_ptr<ProcessGroup> newGroup;
   std::string groupName = name.has_value()
       ? name.value()
@@ -208,7 +208,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
 
-    if (!deviceTypeFilter.empty() && deviceTypeFilter.count(deviceType) == 0) {
+    if (!deviceTypeFilter.empty() && !deviceTypeFilter.contains(deviceType)) {
       continue;
     }
 
@@ -286,6 +286,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::mergeRemoteGroup(
 
 namespace {
 
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class WorkRegistry {
  public:
   void register_work(

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -148,11 +148,21 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   ~ProcessGroup() override;
 
   virtual int getRank() const {
-    return rank_;
+    // Backend state is the canonical source of truth for rank/size (e.g. a
+    // reconfigure-style backend can change them). Fall back to the
+    // constructor-provided values when there is no default backend, which is a
+    // legitimate state for custom multi-backend process groups.
+    if (backendType_ == BackendType::UNDEFINED) {
+      return rank_;
+    }
+    return getDefaultBackend()->getRank();
   }
 
   virtual int getSize() const {
-    return size_;
+    if (backendType_ == BackendType::UNDEFINED) {
+      return size_;
+    }
+    return getDefaultBackend()->getSize();
   }
 
   // Returns a unique opaque ID of this process group object.
@@ -1056,14 +1066,23 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // Fault Tolerance / Reconfigure API. Forwards to the default backend; see
   // Backend.hpp for semantics.
   virtual bool supportsReconfigure() const {
+    TORCH_CHECK(
+        !hasMultipleBackends(),
+        "ProcessGroup reconfigure APIs do not support process groups with multiple backends.");
     return getDefaultBackend()->supportsReconfigure();
   }
 
   virtual ReconfigureHandle get_reconfigure_handle() const {
+    TORCH_CHECK(
+        !hasMultipleBackends(),
+        "ProcessGroup reconfigure APIs do not support process groups with multiple backends.");
     return getDefaultBackend()->get_reconfigure_handle();
   }
 
   virtual c10::intrusive_ptr<Work> reconfigure(const ReconfigureOptions& opts) {
+    TORCH_CHECK(
+        !hasMultipleBackends(),
+        "ProcessGroup reconfigure APIs do not support process groups with multiple backends.");
     return getDefaultBackend()->reconfigure(opts);
   }
 
@@ -1130,7 +1149,25 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // appropriate logging etc.
   void init();
 
+  bool hasMultipleBackends() const {
+    if (backendTypeToBackend_.size() > 1) {
+      return true;
+    }
+    if (deviceTypeToBackendType_.empty()) {
+      return false;
+    }
+    const auto firstBackendType = deviceTypeToBackendType_.begin()->second;
+    for (const auto& pair : deviceTypeToBackendType_) {
+      if (pair.second != firstBackendType) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   c10::intrusive_ptr<c10d::Store> store_;
+  // Fallback rank/size used only when there is no default backend; the default
+  // backend is otherwise the source of truth (see getRank/getSize).
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const int rank_;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -1138,7 +1175,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   BackendType backendType_;
   std::string pg_desc_;
-  int64_t splitCounter_;
+  int64_t splitCounter_{0};
 
   // Debug level setting. It is parsed once when ProcessGroup is constructed and
   // remains the same across use of this process group.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2170,7 +2170,7 @@ def _new_process_group_helper(
             if not backend_class:
                 return GroupMember.NON_GROUP_MEMBER, None
             # create new process group with accurate rank and size
-            if pg.rank() == -1 and pg.size() == -1:
+            if group_rank == -1 and group_size == -1:
                 pg = ProcessGroup(
                     backend_prefix_store,
                     backend_class.rank(),


### PR DESCRIPTION
## Summary

Route base `ProcessGroup` rank and size accessors through the default backend so
backend state is the canonical source of truth. This is needed for
reconfigure-style process groups where the canonical rank and size can belong to
the backend rather than the base `ProcessGroup` object, and `Backend` rank/size
are now mutable so backends can update them.

The base `ProcessGroup` keeps its constructor rank/size and falls back to them
only when there is no default backend. That fallback matters because a default
backend is not always set: custom multi-backend groups (e.g.
`cpu:gloo,cuda:<custom>`) can leave `backendType_` `UNDEFINED`, and paths such as
symmetric memory rendezvous call `ProcessGroup::getRank()/getSize()` on them.
Falling back in the accessors fixes every such call site at once and matches how
the rest of the code already tolerates an `UNDEFINED` default backend (e.g.
symmetric memory looks up the CUDA backend directly), rather than forcing a
default backend onto these groups.

Also reject reconfigure APIs on multi-backend `ProcessGroup`s before delegating,
since the current contract forwards to a single default backend and would
otherwise be ambiguous. The MPI setup path's pre-registration sentinel check uses
the local `group_rank`/`group_size` constructor values instead of `pg.rank()`/
`pg.size()`, since MPI sets its default backend type before its backend is
registered.

This PR intentionally excludes the Gloo implementation changes from the earlier
local branch.

Authored with assistance from an AI assistant.

## Test Plan

```bash
.venv/bin/pip install -e . -v --no-build-isolation
```

```bash
.venv/bin/python test/distributed/test_c10d_pypg.py TestPyProcessGroup
```

```bash
.venv/bin/python test/distributed/test_symmetric_memory.py SymmetricMemoryTest
```

```bash
.venv/bin/python test/distributed/test_c10d_gloo.py GlooProcessGroupWithDispatchedCollectivesTests.test_init_process_group_for_all_backends
```

```bash
uv run --no-sync lintrunner -a
```
