### PR TITLE
[inductor][mtia] Strip AMD-only autotune kwargs from MTIA Triton compile configs (#187471)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -991,6 +991,91 @@ class TestRecheckAutotuneCache(TestCase):
 
 
 @triton.jit
+def mtia_sqr_kernel(in_ptr, out_ptr, numel, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    data = tl.load(in_ptr + offsets, mask=offsets < numel)
+    sqr = data * data
+    tl.store(out_ptr + offsets, sqr, mask=offsets < numel)
+
+
+class TestMTIASpecialConfigArgs(TestCase):
+    """Unit tests for the MTIA branch of CachingAutotuner._create_compile_meta /
+    _create_compile_options.
+
+    The MTIA Triton backend is built on the AMD backend, so AMD-only autotune
+    kwargs (waves_per_eu/matrix_instr_nonkdim/kpack) leak into a config's kwargs
+    even though they are not MTIA kernel signature args. They must be stripped
+    out of the compile-meta constants (constexprs) and forwarded as Triton
+    backend options instead, exactly like the HIP path. These tests construct a
+    CachingAutotuner directly with a mocked mtia device so they need no GPU/MTIA
+    hardware and no real Triton compilation.
+    """
+
+    @staticmethod
+    def _make_mtia_autotuner():
+        device = DeviceProperties(
+            type="mtia",
+            index=0,
+            multi_processor_count=64,
+            cc=0,
+            max_threads_per_block=1024,
+            warp_size=64,
+        )
+        triton_meta = {
+            "signature": {
+                "in_ptr": "*fp32",
+                "out_ptr": "*fp32",
+                "numel": "i32",
+                "BLOCK_SIZE": "constexpr",
+            },
+            "device": device,
+            "constants": {},
+            "configs": [
+                AttrsDescriptorWrapper(divisible_by_16=(0, 1, 2), equal_to_1=())
+            ],
+        }
+        # waves_per_eu is an AMD-only backend option. It is present in the config
+        # kwargs but intentionally absent from the kernel signature above.
+        cfg = triton.Config(
+            {"BLOCK_SIZE": 64, "waves_per_eu": 3}, num_warps=4, num_stages=1
+        )
+        autotuner = CachingAutotuner(
+            fn=mtia_sqr_kernel,
+            triton_meta=triton_meta,
+            configs=[cfg],
+            save_cache_hook=False,
+            mutated_arg_names=[],
+            reset_to_zero_arg_names=[],
+            optimize_mem=False,
+            heuristic_type=HeuristicType.POINTWISE,
+            inductor_meta={},
+        )
+        return autotuner, cfg
+
+    def test_create_compile_meta_strips_special_arg_from_constants(self):
+        autotuner, cfg = self._make_mtia_autotuner()
+        compile_meta = autotuner._create_compile_meta(cfg)
+
+        # waves_per_eu is not a signature arg, so it must not leak into the
+        # constexpr constants (this is what previously made ASTSource raise
+        # "'waves_per_eu' is not in list" on MTIA).
+        self.assertNotIn("waves_per_eu", compile_meta["constants"])
+        # A real signature kwarg (BLOCK_SIZE) is still materialized as a constant.
+        self.assertEqual(compile_meta["constants"]["BLOCK_SIZE"], 64)
+        # And the backend-only option is stashed separately for forwarding.
+        self.assertEqual(compile_meta["backend_options"], {"waves_per_eu": 3})
+
+    def test_create_compile_options_forwards_special_arg(self):
+        autotuner, cfg = self._make_mtia_autotuner()
+        compile_meta = autotuner._create_compile_meta(cfg)
+        options = autotuner._create_compile_options(cfg, compile_meta)
+
+        # The AMD-only option must be forwarded as a Triton backend option.
+        self.assertEqual(options["waves_per_eu"], 3)
+
+
+@triton.jit
 def hip_autotune_kernel(
     in_ptr,
     out_ptr,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1106,12 +1106,18 @@ class CachingAutotuner(KernelInterface):
         compile_meta["num_stages"] = cfg.num_stages
 
         cfg_kwargs = {**cfg.kwargs}
-        if self.device_props.type == "hip":
+        if self.device_props.type in ("hip", "mtia"):
             # `compile_meta["signature"]` contains the actual Triton kernel argument
             # names, including constexprs such as XBLOCK_0/XBLOCK_1 for combo kernels.
-            # Any HIP config kwarg that is *not* in that signature is not a kernel
+            # Any HIP/MTIA config kwarg that is *not* in that signature is not a kernel
             # argument at all; it is a backend compile option that should be forwarded
-            # to triton.compile via `options`, not materialized as a constexpr.
+            # to triton.compile via `options`, not materialized as a constexpr. The MTIA
+            # Triton backend is built on the AMD backend, so AMD-only autotune kwargs
+            # (waves_per_eu/matrix_instr_nonkdim/kpack) leak into cfg.kwargs for MTIA as
+            # well; they are not MTIA kernel args, so leaving them in constants makes
+            # ASTSource raise "'waves_per_eu' is not in list". Stripping them here (and
+            # forwarding as backend options below, where MTIA drops the AMD-only ones)
+            # mirrors the HIP path and fixes MTIA inductor kernel compilation.
             signature_arg_names = OrderedSet(compile_meta["signature"])
             backend_options = {
                 key: value
@@ -1193,9 +1199,12 @@ class CachingAutotuner(KernelInterface):
             for k in tlx_only_cuda_options():
                 if v := getattr(cfg, k, None):
                     options[k] = v
-        if self.device_props.type == "hip":
-            # HIP backend options are consumed by Triton out-of-band from the kernel
-            # signature. They are intentionally *not* present in `constants`.
+        if self.device_props.type in ("hip", "mtia"):
+            # HIP/MTIA backend options are consumed by Triton out-of-band from the kernel
+            # signature. They are intentionally *not* present in `constants`. The MTIA
+            # backend filters out any option that is not a real MTIAOptions field (e.g.
+            # the AMD-only waves_per_eu/matrix_instr_nonkdim/kpack), so forwarding them
+            # here is safe.
             options.update(compile_meta.get("backend_options", {}))
 
         if self.device_props.type == "xpu" and XPU_KERNEL_FORMAT == "zebin":


### PR DESCRIPTION
Summary:

The MTIA Triton backend is built on top of the AMD/HIP backend, so AMD-only autotune kwargs (waves_per_eu, matrix_instr_nonkdim, kpack) end up in cfg.kwargs for MTIA autotune configs. In the Inductor AOT compile path these are not MTIA kernel arguments, so leaving them in the compile-meta constants makes ASTSource raise: 'waves_per_eu' is not in list, and MTIA Inductor kernel compilation fails. Extend the existing HIP-only handling in _create_compile_meta and _create_compile_options (torch/_inductor/runtime/triton_heuristics.py) to also apply when the device type is mtia: any config kwarg not present in the kernel signature is stripped from the constexpr constants and forwarded as a Triton backend option instead (the MTIA backend then drops any option that is not a real MTIAOptions field). Mirrors the signature-based strip already done in the triton_mtia AOT path.

Test Plan:
asserts that for the mtia device an AMD-only autotune kwarg (waves_per_eu) not in the kernel signature is removed from the compile-meta constants and forwarded into backend options

`buck2 test //caffe2/test/inductor:triton_heuristics -- TestMTIASpecialConfigArgs`
https://www.internalfb.com/intern/testinfra/testrun/22799473140324559

Differential Revision: D108701969




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo