### PR TITLE
[dynamo] don't reconstruct live torch.Stream values as StreamContext across graph breaks

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2403,6 +2403,38 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(actual_s2, expected_s2)
         self.assertEqual(actual_default, default_s.cuda_stream)
 
+    @requires_cuda
+    def test_stream_value_live_across_graph_break_in_stream_context(self):
+        # Regression test: a plain torch.Stream value that is live across a
+        # graph break occurring inside `with torch.cuda.stream(side):` must be
+        # reconstructed as a Stream, not rebuilt as a StreamContext.
+        #
+        # StreamVariable subclasses StreamContextVariable for code reuse, so
+        # OutputGraph._get_stack_values_to_restore used to misclassify the live
+        # stream `s` as an inactive context manager and rebuild it in the resume
+        # function via torch.cuda.stream(s) -> a StreamContext.  The eager
+        # record_stream() call below then died with "unknown parameter type".
+
+        @torch._dynamo.disable
+        def eager_record_stream(t, stream):
+            assert isinstance(stream, torch.Stream), type(stream)
+            t.record_stream(stream)
+
+        def fn(x):
+            s = torch.cuda.current_stream()
+            side = torch.cuda.Stream()
+            with torch.cuda.stream(side):
+                y = x + 1
+                torch._dynamo.graph_break()
+                out = y + 1
+            del y
+            eager_record_stream(out, s)
+            return out
+
+        x = torch.ones(3, device="cuda")
+        out = torch.compile(fn, backend="eager")(x)
+        self.assertEqual(out, torch.full((3,), 3.0, device="cuda"))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1860,7 +1860,10 @@ class OutputGraph(OutputGraphCommon):
                 meta.stack_null_idxes.append(i)
             else:
                 stack_values.append(value)
-            if isinstance(value, ContextWrappingVariable):
+            if (
+                isinstance(value, ContextWrappingVariable)
+                and not value.reconstructs_as_value_in_resume()
+            ):
                 target_values = (
                     () if value.target_values is None else tuple(value.target_values)
                 )
@@ -1913,7 +1916,10 @@ class OutputGraph(OutputGraphCommon):
                         "variable should never be NULL in Python < 3.12"
                     )
             meta.locals_names[k] = len(meta.locals_names)
-            if isinstance(v, ContextWrappingVariable):
+            if (
+                isinstance(v, ContextWrappingVariable)
+                and not v.reconstructs_as_value_in_resume()
+            ):
                 target_values = (
                     () if v.target_values is None else tuple(v.target_values)
                 )

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -161,6 +161,26 @@ class ContextWrappingVariable(VariableTracker):
     def exit_on_graph_break(self) -> bool:
         return True
 
+    def reconstructs_as_value_in_resume(self) -> bool:
+        # A context manager that is live across a graph break but not entered is
+        # normally rebuilt in the resume function by *re-running its
+        # constructor*: reconstruct_type() pushes the class and the resume
+        # prologue calls it with target_values (see
+        # OutputGraph._get_stack_values_to_restore and resume_execution). This
+        # indirection exists because Dynamo recognizes context managers at their
+        # construction call, not as opaque pre-built objects, so
+        # reconstructing-by-construction is what keeps the resume body's `with`
+        # re-traceable.
+        #
+        # A few VTs (e.g. StreamVariable) instead represent a concrete object
+        # that round-trips exactly -- it is re-recognized from its live instance
+        # by VariableBuilder and reconstructed via the user-object registry.
+        # Such VTs return True so they are reconstructed as the object itself
+        # rather than rebuilt from their class, which would otherwise change the
+        # type (e.g. Stream -> StreamContext) and lose the concrete
+        # subtype/identity.
+        return False
+
     def cleanup(self) -> None:
         if self.cleanup_fn is not None:
             self.cleanup_fn()

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -1,4 +1,6 @@
 import collections
+import contextlib
+import functools
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -319,7 +321,60 @@ class SymbolicStreamState:
         return id(stream.value)
 
 
-class StreamContextVariable(FxTracebackAnnotateVariable):
+class StreamContextWrappingVariable(FxTracebackAnnotateVariable):
+    """Shared implementation for VTs that select a stream when used as a `with`
+    context.
+
+    Both torch.Stream (via its own __enter__/__exit__) and torch.cuda.StreamContext
+    are context managers that make a stream current, and neither subclasses the
+    other in torch -- so StreamVariable and StreamContextVariable are siblings
+    that share only this behavior, expressed here in terms of get_stream().
+    """
+
+    def enter(
+        self, tx: "InstructionTranslatorBase", *args: VariableTracker
+    ) -> VariableTracker:
+        strm: StreamVariable = self.get_stream()
+        # Entering makes `strm` the current stream; exiting restores the prior one.
+        tx.symbolic_stream_state.enter_stream(strm)
+        # annotate + preserve_node_meta: this ensures the captured nodes have
+        # appropriate node.meta["custom"]["stream"] annotations.
+        if strm.user_object_index is None:
+            raise AssertionError("stream not registered")
+        annotation: dict[str, Any] = {"stream": strm.user_object_index}
+        stack = contextlib.ExitStack()
+        stack.enter_context(torch.fx.traceback.annotate(annotation))
+        stack.enter_context(torch.fx.traceback.preserve_node_meta())
+        self.set_cleanup_hook(tx, lambda: stack.close())
+        return ConstantVariable.create(None)
+
+    def exit(
+        self, tx: "InstructionTranslatorBase", *args: VariableTracker
+    ) -> VariableTracker:
+        tx.symbolic_stream_state.exit_stream()
+        return super().exit(tx, *args)
+
+    def reconstruct_type(self, codegen: "PyCodegen") -> None:
+        # The base ContextWrappingVariable.reconstruct_type reconstructs
+        # `torch._C.<fn_name>` and calls it, but there is no direct constructor to
+        # reference for a stream context. Instead push a 0-arg callable that
+        # builds a fresh StreamContext re-selecting this stream when entered:
+        # functools.partial over torch.cuda.stream, installed as a global so the
+        # resume prologue can LOAD_GLOBAL it (partial is a builtin Dynamo
+        # retraces natively; a closure defined in torch/_dynamo would be
+        # skiplisted during the prologue retrace).
+        thunk = functools.partial(torch.cuda.stream, self.get_stream().value)
+        name = codegen.tx.output.install_global_by_id("_stream_ctx_thunk", thunk)
+        codegen.append_output(codegen.create_load_global(name, add=True))
+
+    def supports_graph_breaks(self) -> bool:
+        return True
+
+    def get_stream(self) -> "StreamVariable":
+        raise NotImplementedError
+
+
+class StreamContextVariable(StreamContextWrappingVariable):
     """This represents torch.cuda.StreamContext"""
 
     @staticmethod
@@ -336,32 +391,13 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
         super().__init__(
-            target_values={"stream": self.get_stream().user_object_index},
+            target_values=(),
             initial_values=None,
             **kwargs,
         )
 
-    def enter(
-        self, tx: "InstructionTranslatorBase", *args: VariableTracker
-    ) -> VariableTracker:
-        # to stream, from stream is the order of the arguments
-        # we are entering the target, and leaving the initial stream
-        tx.symbolic_stream_state.enter_stream(self.get_stream())
-        return super().enter(tx)
-
-    def exit(
-        self, tx: "InstructionTranslatorBase", *args: VariableTracker
-    ) -> VariableTracker:
-        # to stream, from stream is the order of the arguments
-        # we are leaving the target, and entering the initial stream
-        tx.symbolic_stream_state.exit_stream()
-        return super().exit(tx, *args)
-
     def python_type(self) -> type:
         return torch.cuda.StreamContext
-
-    def supports_graph_breaks(self) -> bool:
-        return True
 
     def get_stream(self) -> "StreamVariable":
         if not self.stream:
@@ -369,10 +405,17 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         return self.stream
 
 
-class StreamVariable(StreamContextVariable):
-    """Represents the device-agnostic torch.Stream class"""
+class StreamVariable(StreamContextWrappingVariable):
+    """Represents the device-agnostic torch.Stream class.
 
-    _cpython_type: type = torch.Stream  # pyrefly: ignore [bad-override]
+    A Stream is a concrete value that can *also* be used directly as a context
+    manager (`with stream:`). It shares StreamContextWrappingVariable with
+    StreamContextVariable but is not a subclass of it -- a Stream is not a
+    *kind of* StreamContext (in torch, torch.Stream and torch.cuda.StreamContext
+    are unrelated classes).
+    """
+
+    _cpython_type: type = torch.Stream  # pyre-ignore[bad-override]
     # Subclasses set this to the device-specific handle attribute name
     # (e.g. "cuda_stream", "sycl_queue").  None means no special handling.
     _device_handle_attr: str | None = None
@@ -397,7 +440,7 @@ class StreamVariable(StreamContextVariable):
         self.device = value.device
 
         self.user_object_index = user_object_index
-        super().__init__(None, **kwargs)
+        super().__init__(target_values=(), initial_values=None, **kwargs)
 
     def python_type(self) -> type:
         return self._cpython_type
@@ -558,6 +601,20 @@ class StreamVariable(StreamContextVariable):
 
     def get_stream(self) -> "StreamVariable":
         return self
+
+    # reconstruct_type (the torch.cuda.stream rebuild, used when a bare stream is
+    # the *active* `with stream:` context being re-entered in a resume function)
+    # is inherited from StreamContextWrappingVariable. A live stream *value* does
+    # not go through it -- see reconstructs_as_value_in_resume below.
+
+    def reconstructs_as_value_in_resume(self) -> bool:
+        # A live torch.Stream value round-trips exactly: it is registered in the
+        # user-object table and reconstructed via get_external_object_by_index
+        # (see reconstruct), and re-recognized from its instance by
+        # VariableBuilder. So across a graph break it is reconstructed as the
+        # object itself rather than rebuilt from its class -- the latter would
+        # yield a StreamContext and drop the concrete torch.cuda.Stream subtype.
+        return True
 
     @staticmethod
     def make_construct_in_graph_stream_fn(


### PR DESCRIPTION
Summary:
A plain `torch.Stream` value that is live across a graph break occurring inside a `with torch.cuda.stream(side):` block was being silently corrupted into a `torch.cuda.StreamContext`. A subsequent eager `Tensor.record_stream(s)` then crashed with `RuntimeError: unknown parameter type` (the C++ arg parser has no `STREAM` overload to match a `StreamContext`).

Root cause: `OutputGraph._get_stack_values_to_restore` records every live value where `isinstance(value, ContextWrappingVariable)` as an "inactive context variable". The resume function rebuilds those from their context-manager class -- `reconstruct_type()` pushes the class and the resume prologue calls it with `target_values` (see the `handle_inactive_ctx` path in `symbolic_convert._create_resume`). `StreamVariable` was a `ContextWrappingVariable` (it subclassed `StreamContextVariable`) for code reuse, so a plain stream value `s` matched this check and was rebuilt as `torch.cuda.stream(s)` -> a `StreamContext`.

Why the class-rebuild exists at all: Dynamo recognizes context managers at their construction call, not as opaque pre-built objects, so a context manager that is live-but-not-entered is made re-traceable in the resume function by re-running its constructor. This is the right mechanism for managers like `torch.no_grad()`, but it is both unnecessary and lossy for a `torch.Stream`: a stream is registered in the user-object table, reconstructs to the exact original object via `get_external_object_by_index`, and is re-recognized from its live instance by `VariableBuilder` (`builder.py`), so it round-trips perfectly as a value. Rebuilding it from its class instead changes the type (`Stream` -> `StreamContext`) and drops the concrete `torch.cuda.Stream` subtype (e.g. `.cuda_stream` disappears).

This stayed latent until #184487 (D108074476): before that, `StreamContextVariable.reconstruct_type` was inherited from `FxTracebackAnnotateVariable` and raised `Unsupported` unconditionally, so the misclassification could not silently produce a wrong object. #184487 added a real `reconstruct_type` (installing a `functools.partial(torch.cuda.stream, ...)` thunk) to round-trip the genuine `with torch.cuda.stream(...)` context manager across a graph break, which turned the latent misclassification into silent data corruption for plain stream values.

Fix: introduce `ContextWrappingVariable.reconstructs_as_value_in_resume()` (default `False`). A VT returns `True` when it reconstructs as a concrete, re-traceable object rather than needing the constructor-rebuild; `StreamVariable` returns `True`. `_get_stack_values_to_restore` skips such VTs when populating `stack_ctx_args`/`locals_ctx_args`, so a live stream reconstructs as the exact object (full subtype/identity fidelity) instead of being rebuilt as a `StreamContext`.

Also restructure the class hierarchy to mirror torch's: `torch.cuda.Stream` subclasses `torch.Stream`, while `torch.cuda.StreamContext` is an unrelated class. Previously `StreamVariable` subclassed `StreamContextVariable`, which encoded the fiction that a `Stream` is a kind of `StreamContext` and is what let a stream value flow into the context-manager rebuild path. Now `StreamVariable` (`torch.Stream`) and `StreamContextVariable` (`torch.cuda.StreamContext`) are not in a subclass relationship; they share a new `StreamContextWrappingVariable` base holding the common stream-selecting `enter`/`exit`/`reconstruct_type` (written in terms of `get_stream()`), and `CudaStreamVariable`/`XpuStreamVariable` continue to subclass `StreamVariable` just as `torch.cuda.Stream`/`torch.xpu.Stream` subclass `torch.Stream`. The genuine active-context cases are unchanged -- `with torch.cuda.stream(s):` and bare `with stream:` are restored via the block stack and still rebuild a fresh `StreamContext` to re-enter.

Authored with Claude Code.

Test Plan:
New regression test `test_stream_value_live_across_graph_break_in_stream_context` in `test/dynamo/test_streams.py` fails before the fix (`RuntimeError: unknown parameter type`) and passes after.

```
buck2 test fbcode//mode/opt -c fbcode.enable_gpu_sections=true fbcode//caffe2/test/dynamo:test_streams
```

Full suite on an H100/A100 host: `Pass 65. Fail 0. Skip 6` (the legitimate round-trip tests `test_target_values_dict_round_trips_through_graph_break` and `test_stream_context_graph_break` still pass).

Differential Revision: D108682817




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98