### PR TITLE
[dynamo] extract call_getattr_fallback from UDOV's generic_getattr

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -239,6 +239,24 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager")(MyObj())
         self.assertEqual(result, 123)
 
+    def test_udov_non_function_getattr_graph_breaks(self):
+        """Non-function __getattr__ (callable instance) triggers a graph break."""
+
+        class CallableGetattr:
+            def __call__(self, name):
+                return 42
+
+        class MyObj:
+            __getattr__ = CallableGetattr()
+
+        def fn(obj):
+            return obj.dynamic
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        result = torch.compile(fn, backend=cnt)(MyObj())
+        self.assertEqual(result, 42)
+        self.assertEqual(cnt.frame_count, 0)
+
     def test_udov_getattribute_override(self):
         class MyObj:
             def __getattribute__(self, name):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3277,47 +3277,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 pass
 
         # Step 6: __getattr__ fallback.
-        getattr_fn = self._check_for_getattr()
-        if isinstance(getattr_fn, types.FunctionType):
-            if (
-                getattr_fn is unpatched_nn_module_getattr
-                and isinstance(self, variables.UnspecializedNNModuleVariable)
-                and istype(self.value._parameters, dict)  # type: ignore[attr-defined]
-                and istype(self.value._buffers, dict)  # type: ignore[attr-defined]
-                and istype(self.value._modules, dict)  # type: ignore[attr-defined]
-            ):
-                out = self.manually_trace_nn_module_getattr(tx, name)
-            else:
-                new_source = None
-                if self.source:
-                    new_source = AttrSource(self.source, "__getattr__")
-                out = variables.UserMethodVariable(
-                    getattr_fn, self, source=new_source
-                ).call_function(tx, [variables.ConstantVariable.create(name)], {})
-
-            if self.source and getattr_fn is torch.nn.Module.__getattr__:
-                if isinstance(
-                    out,
-                    (
-                        variables.UnspecializedNNModuleVariable,
-                        variables.NNModuleVariable,
-                    ),
-                ):
-                    out.set_nn_module_stack_source(  # type: ignore[attr-defined]
-                        AttrSource(self.get_nn_module_stack_source(), name)  # type: ignore[attr-defined]
-                    )
-            return out
-
-        elif getattr_fn is not None:
-            unimplemented(
-                gb_type="User-defined object with non-function __getattr__",
-                context=f"object={self.value}, name={name}, getattr_fn={getattr_fn}",
-                explanation=f"Found a non-function __getattr__ {getattr_fn} from a user-defined object {self.value} "
-                f" when attempting to getattr `{name}`",
-                hints=[
-                    "Ensure the object's __getattr__ is a function type.",
-                ],
-            )
+        result = self.call_getattr_fallback(tx, name)
+        if result is not None:
+            return result
 
         # Step 7: AttributeError.
         raise_observed_exception(
@@ -3596,6 +3558,53 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             subobj = self.value.__dict__[name]
             source = self.maybe_wrap_nn_module_source_for_instance(tx, name, source)
             return VariableTracker.build(tx, subobj, source)
+
+        return None
+
+    def call_getattr_fallback(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker | None:
+        getattr_fn = self._check_for_getattr()
+        if isinstance(getattr_fn, types.FunctionType):
+            if (
+                getattr_fn is unpatched_nn_module_getattr
+                and isinstance(self, variables.UnspecializedNNModuleVariable)
+                and istype(self.value._parameters, dict)  # type: ignore[attr-defined]
+                and istype(self.value._buffers, dict)  # type: ignore[attr-defined]
+                and istype(self.value._modules, dict)  # type: ignore[attr-defined]
+            ):
+                out = self.manually_trace_nn_module_getattr(tx, name)
+            else:
+                new_source = None
+                if self.source:
+                    new_source = AttrSource(self.source, "__getattr__")
+                out = variables.UserMethodVariable(
+                    getattr_fn, self, source=new_source
+                ).call_function(tx, [variables.ConstantVariable.create(name)], {})
+
+            if self.source and getattr_fn is torch.nn.Module.__getattr__:
+                if isinstance(
+                    out,
+                    (
+                        variables.UnspecializedNNModuleVariable,
+                        variables.NNModuleVariable,
+                    ),
+                ):
+                    out.set_nn_module_stack_source(  # type: ignore[attr-defined]
+                        AttrSource(self.get_nn_module_stack_source(), name)  # type: ignore[attr-defined]
+                    )
+            return out
+
+        elif getattr_fn is not None:
+            unimplemented(
+                gb_type="User-defined object with non-function __getattr__",
+                context=f"object={self.value}, name={name}, getattr_fn={getattr_fn}",
+                explanation=f"Found a non-function __getattr__ {getattr_fn} from a user-defined object {self.value} "
+                f" when attempting to getattr `{name}`",
+                hints=[
+                    "Ensure the object's __getattr__ is a function type.",
+                ],
+            )
 
         return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187708
* #187707
* #187532
* #187531
* __->__ #187474
* #187469
* #187468
* #187398
* #187226
* #187200
* #187196
* #187113
* #186013

Move UDOV's __getattr__ fallback logic (step 6 of the CPython attribute
lookup algorithm) from inline in generic_getattr into a
call_getattr_fallback override, matching the hook on base VariableTracker.

The code is moved verbatim -- no logic changes. generic_getattr step 6
now calls self.call_getattr_fallback(tx, name) and checks for None,
matching the pattern used by object_generic_getattr.

Authored with the help of an AI assistant.

Test Plan:
```
python test/dynamo/test_tp_getattro.py -v          # 67 tests pass
python test/dynamo/test_misc.py -v                 # 805 tests pass
python test/dynamo/test_functions.py -v            # 516 tests pass
python test/dynamo/test_modules.py -v              # 140 tests pass
python test/dynamo/test_higher_order_ops.py -v     # 241 tests pass
```