### PR TITLE
Add Python c10d Backend trampoline

### DIFF
--- a/test/distributed/test_c10d_pybackend.py
+++ b/test/distributed/test_c10d_pybackend.py
@@ -1,0 +1,523 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import weakref
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+from torch._C._distributed_c10d import (
+    Backend as C10DBackend,
+    ErrorType,
+    ReconfigureOptions,
+)
+from torch.distributed.distributed_c10d import _get_default_group
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class RecordingWork(dist._Work):
+    def __init__(self, result, backend):
+        super().__init__()
+        self.result_ = result
+        self.future_ = torch.futures.Future()
+        self.future_.set_result(result)
+        self.backend_ = weakref.ref(backend)
+
+    def wait(self, timeout):
+        self.backend_().wait_count += 1
+        return True
+
+    def get_future(self):
+        self.backend_().get_future_count += 1
+        return self.future_
+
+
+class RecordingBackend(C10DBackend):
+    def __init__(self, rank, world, name="python-backend"):
+        super().__init__(rank, world)
+        self._name = name
+        self._options = C10DBackend.Options(name, timeout=timedelta(seconds=5))
+        self.wait_count = 0
+        self.get_future_count = 0
+        self.calls = []
+        self._work = []
+        self.reconfigure_opts = None
+        self.start_coalescing_count = 0
+        self.end_coalescing_count = 0
+        self.sequence_number = 0
+        self.registered_hook = None
+        self.wait_for_pending_works_count = 0
+        self.collectives_timing_enabled = False
+        self.eager_device = None
+        self.tensor_alloc_device_idx = None
+        self.allocate_args = None
+        self.aborted = False
+        self.shut_down = False
+        self.suspended = False
+        self.resumed = False
+
+    def _new_work(self, result=None):
+        work = RecordingWork(result, self)
+        self._work.append(work)
+        return work
+
+    @property
+    def supports_splitting(self):
+        return True
+
+    @property
+    def supports_coalescing(self):
+        return True
+
+    @property
+    def supports_time_estimate(self):
+        return True
+
+    @property
+    def supports_shrinking(self):
+        return True
+
+    @property
+    def supports_reconfigure(self):
+        return True
+
+    @property
+    def supports_window(self):
+        return True
+
+    @property
+    def options(self):
+        return self._options
+
+    def getBackendName(self):
+        return self._name
+
+    def set_timeout(self, timeout):
+        self.calls.append(("set_timeout", timeout))
+
+    def shrink(self, ranks_to_exclude, shrink_flags=0, opts_override=None):
+        self.calls.append(("shrink", ranks_to_exclude, shrink_flags, opts_override))
+        return RecordingBackend(self.rank(), self.size(), "shrunk-python-backend")
+
+    def get_reconfigure_handle(self):
+        return "handle-for-python-backend"
+
+    def reconfigure(self, opts):
+        self.reconfigure_opts = opts
+        return self._new_work(None)
+
+    def start_coalescing(self):
+        self.start_coalescing_count += 1
+
+    def end_coalescing(self):
+        self.end_coalescing_count += 1
+        return self._new_work([])
+
+    def broadcast(self, tensor_list, opts):
+        self.calls.append(("broadcast", opts))
+        for tensor in tensor_list:
+            tensor.add_(1)
+        return self._new_work(tensor_list)
+
+    def allreduce(self, tensor_list, opts):
+        self.calls.append(("allreduce", opts))
+        for tensor in tensor_list:
+            tensor.add_(2)
+        return self._new_work(tensor_list)
+
+    def allreduce_sparse(self, tensor_list, opts):
+        self.calls.append(("allreduce_sparse", opts))
+        return self._new_work(tensor_list)
+
+    def allreduce_coalesced(self, tensor_list, opts):
+        self.calls.append(("allreduce_coalesced", opts))
+        for tensor in tensor_list:
+            tensor.add_(3)
+        return self._new_work(tensor_list)
+
+    def reduce(self, tensor_list, opts):
+        self.calls.append(("reduce", opts))
+        for tensor in tensor_list:
+            tensor.add_(4)
+        return self._new_work(tensor_list)
+
+    def allgather(self, output_tensors, input_tensors, opts):
+        self.calls.append(("allgather", opts))
+        for output_tensor_list, input_tensor in zip(output_tensors, input_tensors):
+            for output_tensor in output_tensor_list:
+                output_tensor.copy_(input_tensor)
+        return self._new_work(output_tensors)
+
+    def all_gather_single(self, output_tensor, input_tensor, opts):
+        self.calls.append(("all_gather_single", opts))
+        output_tensor.copy_(input_tensor)
+        return self._new_work(output_tensor)
+
+    def all_gather_single_coalesced(self, outputs, inputs, opts):
+        self.calls.append(("all_gather_single_coalesced", opts))
+        for output, input in zip(outputs, inputs):
+            output.copy_(input)
+        return self._new_work(outputs)
+
+    def allgather_coalesced(self, output_lists, input_list, opts):
+        self.calls.append(("allgather_coalesced", opts))
+        for output_list, input in zip(output_lists, input_list):
+            for output in output_list:
+                output.copy_(input)
+        return self._new_work(output_lists)
+
+    def gather(self, output_tensors, input_tensors, opts):
+        self.calls.append(("gather", opts))
+        if output_tensors:
+            for output, input in zip(output_tensors[0], input_tensors):
+                output.copy_(input)
+        return self._new_work(output_tensors)
+
+    def scatter(self, output_tensors, input_tensors, opts):
+        self.calls.append(("scatter", opts))
+        if input_tensors:
+            for output, input in zip(output_tensors, input_tensors[0]):
+                output.copy_(input)
+        return self._new_work(output_tensors)
+
+    def reduce_scatter(self, output_tensors, input_tensors, opts):
+        self.calls.append(("reduce_scatter", opts))
+        for output, input_list in zip(output_tensors, input_tensors):
+            output.copy_(input_list[self.rank()])
+        return self._new_work(output_tensors)
+
+    def reduce_scatter_single(self, output_tensor, input_tensor, opts):
+        self.calls.append(("reduce_scatter_single", opts))
+        output_tensor.copy_(input_tensor.narrow(0, 0, output_tensor.numel()))
+        return self._new_work(output_tensor)
+
+    def reduce_scatter_single_coalesced(self, outputs, inputs, opts):
+        self.calls.append(("reduce_scatter_single_coalesced", opts))
+        for output, input in zip(outputs, inputs):
+            output.copy_(input.narrow(0, 0, output.numel()))
+        return self._new_work(outputs)
+
+    def all_to_all_single(
+        self, output_tensor, input_tensor, output_split_sizes, input_split_sizes, opts
+    ):
+        self.calls.append(
+            ("all_to_all_single", output_split_sizes, input_split_sizes, opts)
+        )
+        output_tensor.copy_(input_tensor)
+        return self._new_work(output_tensor)
+
+    def alltoall(self, output_tensors, input_tensors, opts):
+        self.calls.append(("alltoall", opts))
+        for output, input in zip(output_tensors, input_tensors):
+            output.copy_(input)
+        return self._new_work(output_tensors)
+
+    def send(self, tensor_list, dst, tag=0):
+        self.calls.append(("send", dst, tag))
+        for tensor in tensor_list:
+            tensor.add_(1)
+        return self._new_work(tensor_list)
+
+    def recv(self, tensor_list, src, tag=0):
+        self.calls.append(("recv", src, tag))
+        for tensor in tensor_list:
+            tensor.add_(2)
+        return self._new_work(tensor_list)
+
+    def recv_anysource(self, tensor_list, tag=0):
+        self.calls.append(("recv_anysource", tag))
+        for tensor in tensor_list:
+            tensor.add_(5)
+        return self._new_work(tensor_list)
+
+    def barrier(self, opts):
+        self.calls.append(("barrier", opts))
+        return self._new_work(None)
+
+    def monitored_barrier(self, opts, wait_all_ranks=False):
+        self.calls.append(("monitored_barrier", opts, wait_all_ranks))
+
+    def _set_sequence_number_for_group(self):
+        self.sequence_number = 123
+
+    def _get_sequence_number_for_group(self):
+        return self.sequence_number
+
+    def _register_on_completion_hook(self, hook):
+        self.registered_hook = hook
+
+    def _wait_for_pending_works(self):
+        self.wait_for_pending_works_count += 1
+
+    def _enable_collectives_timing(self):
+        self.collectives_timing_enabled = True
+
+    def split(self, store, ranks, opts):
+        self.calls.append(("split", store, ranks, opts))
+        return RecordingBackend(ranks.index(self.rank()), len(ranks), "split-backend")
+
+    def merge(self, store, opts, rank, size):
+        self.calls.append(("merge", store, opts, rank, size))
+        return RecordingBackend(rank, size, "merged-backend")
+
+    def eager_connect_single_device(self, device):
+        self.eager_device = device
+
+    def get_error(self):
+        return ErrorType.SUCCESS
+
+    def supports_tensor_alloc(self, device_idx):
+        self.tensor_alloc_device_idx = device_idx
+        return True
+
+    def allocate_tensor(self, size, dtype, device):
+        self.allocate_args = (size, dtype, device)
+        return torch.empty(size, dtype=dtype, device=device)
+
+    def suspend(self):
+        self.suspended = True
+
+    def resume(self):
+        self.resumed = True
+
+    def memory_stats(self):
+        return {"allocated": 7}
+
+    def abort(self):
+        self.aborted = True
+
+    def shutdown(self):
+        self.shut_down = True
+
+
+def create_process_group(backend):
+    group = dist.ProcessGroup(dist.HashStore(), backend.rank(), backend.size())
+    group._register_backend(
+        torch.device("cpu"), dist.ProcessGroup.BackendType.CUSTOM, backend
+    )
+    group._set_default_backend(dist.ProcessGroup.BackendType.CUSTOM)
+    group._set_group_name("pybackend-test")
+    group._set_group_desc("python backend test")
+    return group
+
+
+class TestPyBackend(TestCase):
+    def test_attr_overrides(self) -> None:
+        backend = RecordingBackend(0, 1)
+        group = create_process_group(backend)
+
+        self.assertEqual(group.rank(), 0)
+        self.assertEqual(group.size(), 1)
+
+        for attr in (
+            "supports_splitting",
+            "supports_coalescing",
+            "supports_time_estimate",
+            "supports_shrinking",
+            "supports_reconfigure",
+            "supports_window",
+        ):
+            self.assertTrue(getattr(backend, attr))
+
+        self.assertTrue(group.supports_reconfigure)
+        self.assertTrue(group.supports_window)
+        self.assertEqual(
+            group._get_backend(torch.device("cpu")).options.backend, "python-backend"
+        )
+
+        group._set_group_name("name")
+        group._set_group_desc("desc")
+        self.assertEqual(group.group_name, "name")
+        self.assertEqual(group.group_desc, "desc")
+
+        group.bound_device_id = torch.device("cpu:0")
+        self.assertEqual(group.bound_device_id, torch.device("cpu:0"))
+
+        group.use_pg_for_symm_mem_rendezvous = True
+        self.assertTrue(group.use_pg_for_symm_mem_rendezvous)
+
+    def test_collective_overrides(self) -> None:
+        backend = RecordingBackend(0, 1)
+        group = create_process_group(backend)
+
+        allreduce_tensor = torch.zeros(2)
+        work = group.allreduce([allreduce_tensor])
+        self.assertTrue(work.wait())
+        self.assertEqual(allreduce_tensor, torch.full((2,), 2.0))
+
+        broadcast_tensor = torch.zeros(2)
+        group.broadcast([broadcast_tensor]).wait()
+        self.assertEqual(broadcast_tensor, torch.ones(2))
+
+        output = torch.zeros(2)
+        input = torch.ones(2)
+        group.all_gather_single(output, input).wait()
+        self.assertEqual(output, input)
+        self.assertEqual(backend.calls[-1][0], "all_gather_single")
+
+        outputs = [torch.zeros(2), torch.zeros(2)]
+        inputs = [torch.ones(2), torch.full((2,), 3.0)]
+        group.all_gather_single_coalesced(outputs, inputs).wait()
+        self.assertEqual(outputs, inputs)
+        self.assertEqual(backend.calls[-1][0], "all_gather_single_coalesced")
+
+        rs_output = torch.zeros(2)
+        rs_input = torch.arange(2.0)
+        group.reduce_scatter_single(rs_output, rs_input).wait()
+        self.assertEqual(rs_output, rs_input)
+        self.assertEqual(backend.calls[-1][0], "reduce_scatter_single")
+
+        rs_outputs = [torch.zeros(2), torch.zeros(2)]
+        rs_inputs = [torch.arange(4.0), torch.arange(2.0, 6.0)]
+        group.reduce_scatter_single_coalesced(rs_outputs, rs_inputs).wait()
+        self.assertEqual(rs_outputs, [torch.arange(2.0), torch.arange(2.0, 4.0)])
+        self.assertEqual(backend.calls[-1][0], "reduce_scatter_single_coalesced")
+
+        a2a_output = torch.zeros(2)
+        a2a_input = torch.ones(2)
+        group.all_to_all_single(a2a_output, a2a_input, [], []).wait()
+        self.assertEqual(a2a_output, a2a_input)
+        self.assertEqual(backend.calls[-1][0], "all_to_all_single")
+
+        recv_any = torch.zeros(2)
+        group.recv_anysource([recv_any], 0).wait()
+        self.assertEqual(recv_any, torch.full((2,), 5.0))
+
+        self.assertGreater(backend.wait_count, 0)
+
+    def test_backend_only_overrides(self) -> None:
+        backend = RecordingBackend(0, 1)
+        group = create_process_group(backend)
+
+        timeout = timedelta(seconds=3)
+        group.set_timeout(timeout)
+        self.assertEqual(backend.calls[-1], ("set_timeout", timeout))
+
+        shrunk = group._get_backend(torch.device("cpu")).shrink([1], 7, None)
+        self.assertEqual(shrunk.name(), "shrunk-python-backend")
+        self.assertEqual(backend.calls[-1], ("shrink", [1], 7, None))
+
+        self.assertEqual(group.get_reconfigure_handle(), "handle-for-python-backend")
+        opts = ReconfigureOptions()
+        group.reconfigure(opts).wait()
+        self.assertIs(backend.reconfigure_opts, opts)
+
+        group._start_coalescing(torch.device("cpu"))
+        group._end_coalescing(torch.device("cpu")).wait()
+        self.assertEqual(backend.start_coalescing_count, 1)
+        self.assertEqual(backend.end_coalescing_count, 1)
+
+        backend._set_sequence_number_for_group()
+        self.assertEqual(backend._get_sequence_number_for_group(), 123)
+
+        group.monitored_barrier(timeout, True)
+        self.assertEqual(backend.calls[-1][0], "monitored_barrier")
+
+        group._register_on_completion_hook(lambda work_info: None)
+        self.assertTrue(group._has_hooks())
+        self.assertIsNotNone(backend.registered_hook)
+
+        group._wait_for_pending_works()
+        group._enable_collectives_timing()
+        self.assertEqual(backend.wait_for_pending_works_count, 1)
+        self.assertTrue(backend.collectives_timing_enabled)
+
+        store = dist.HashStore()
+        split_opts = C10DBackend.Options("split")
+        split = group.split_group([0], opts=split_opts)
+        self.assertEqual(
+            split._get_backend(torch.device("cpu")).name(), "split-backend"
+        )
+
+        merge = group.merge_remote_group(store, 1)
+        self.assertEqual(
+            merge._get_backend(torch.device("cpu")).name(), "merged-backend"
+        )
+
+        device = torch.device("cpu:0")
+        backend.eager_connect_single_device(device)
+        self.assertEqual(backend.eager_device, device)
+
+        self.assertEqual(backend.get_error(), ErrorType.SUCCESS)
+        self.assertTrue(backend.supports_tensor_alloc(device))
+        self.assertEqual(backend.tensor_alloc_device_idx, device)
+
+        allocated = backend.allocate_tensor(
+            4,
+            dtype=torch.float64,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(allocated.shape, (4,))
+        self.assertEqual(allocated.dtype, torch.float64)
+        self.assertEqual(backend.allocate_args, (4, torch.float64, torch.device("cpu")))
+
+        backend.suspend()
+        backend.resume()
+        self.assertTrue(backend.suspended)
+        self.assertTrue(backend.resumed)
+        self.assertEqual(backend.memory_stats(), {"allocated": 7})
+
+        group.abort()
+        group.shutdown()
+        self.assertTrue(backend.aborted)
+        self.assertTrue(backend.shut_down)
+
+
+class TestPyBackendProcessGroup(MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @staticmethod
+    def create_backend(store, group_rank, group_size, timeout):
+        return RecordingBackend(group_rank, group_size, "registered-python-backend")
+
+    def test_init_process_group_with_pybackend(self):
+        dist.Backend.register_backend(
+            "pybackend", TestPyBackendProcessGroup.create_backend, devices=["cpu"]
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group("pybackend", rank=self.rank, world_size=self.world_size)
+
+        pg = _get_default_group()
+        backend = pg._get_backend(torch.device("cpu"))
+        self.assertIsInstance(backend, C10DBackend)
+        self.assertNotIsInstance(backend, dist.ProcessGroup)
+        self.assertEqual(backend.name(), "registered-python-backend")
+
+        allreduce_tensor = torch.zeros(2)
+        dist.all_reduce(allreduce_tensor)
+        self.assertEqual(allreduce_tensor, torch.full((2,), 2.0))
+
+        peer = (self.rank + 1) % self.world_size
+        send_tensor = torch.zeros(2)
+        recv_tensor = torch.zeros(2)
+        works = dist.batch_isend_irecv(
+            [
+                dist.P2POp(dist.isend, send_tensor, peer),
+                dist.P2POp(dist.irecv, recv_tensor, peer),
+            ]
+        )
+        for work in works:
+            work.wait()
+
+        self.assertEqual(backend.start_coalescing_count, 1)
+        self.assertEqual(backend.end_coalescing_count, 1)
+        self.assertEqual(send_tensor, torch.ones(2))
+        self.assertEqual(recv_tensor, torch.full((2,), 2.0))
+
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/PyBackend.hpp
+++ b/torch/csrc/distributed/c10d/PyBackend.hpp
@@ -1,0 +1,681 @@
+#pragma once
+
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/PyProcessGroup.hpp>
+#include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/utils/pybind.h>
+
+namespace c10d {
+
+class PyBackend : public Backend {
+ public:
+  using Backend::Backend;
+
+  PyBackend(py::object backend, int rank, int size)
+      : Backend(rank, size), pyBackend_(std::move(backend)) {}
+
+  ~PyBackend() override {
+    pybind11::gil_scoped_acquire gil;
+    if (pyBackend_) {
+      pyBackend_.dec_ref();
+      pyBackend_.ptr() = nullptr;
+    }
+  }
+
+  static c10::intrusive_ptr<Backend> wrap(py::object backend) {
+    if (backend.is_none()) {
+      return nullptr;
+    }
+
+    auto base = backend.cast<c10::intrusive_ptr<Backend>>();
+    if (dynamic_cast<PyBackend*>(base.get()) == nullptr ||
+        !hasPythonBackendClass(backend)) {
+      return base;
+    }
+    return c10::make_intrusive<PyBackend>(
+        std::move(backend), base->getRank(), base->getSize());
+  }
+
+  py::object getPyBackendAttr(const std::string& name) const {
+    if (pyBackend_) {
+      return py::getattr(pyBackend_, name.c_str());
+    }
+    throw py::attribute_error(name);
+  }
+
+ private:
+  static bool isC10dBackendType(py::handle type) {
+    py::object name = py::getattr(type, "__name__", py::none());
+    py::object module = py::getattr(type, "__module__", py::none());
+    return !name.is_none() && !module.is_none() &&
+        name.cast<std::string>() == "Backend" &&
+        module.cast<std::string>() == "torch._C._distributed_c10d";
+  }
+
+  static bool hasPythonBackendClass(py::handle pySelf) {
+    py::tuple mro = py::type::handle_of(pySelf).attr("__mro__");
+    for (py::handle typeHandle : mro) {
+      if (isC10dBackendType(typeHandle)) {
+        return false;
+      }
+      py::object module = py::getattr(typeHandle, "__module__", py::none());
+      if (!module.is_none() &&
+          module.cast<std::string>() != "torch._C._distributed_c10d") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  py::object pySelf() const {
+    if (pyBackend_) {
+      return pyBackend_;
+    }
+    return py::cast(
+        const_cast<PyBackend*>(this), py::return_value_policy::reference);
+  }
+
+  std::optional<py::object> getAttrOverride(const char* name) const {
+    py::object self = pySelf();
+    py::tuple mro = py::type::handle_of(self).attr("__mro__");
+    for (py::handle typeHandle : mro) {
+      if (isC10dBackendType(typeHandle)) {
+        return std::nullopt;
+      }
+      py::object dict = py::getattr(typeHandle, "__dict__", py::none());
+      if (!dict.is_none()) {
+        int hasKey = PyMapping_HasKeyString(dict.ptr(), name);
+        if (hasKey == -1) {
+          throw py::error_already_set();
+        }
+        if (hasKey == 1) {
+          return py::getattr(self, name);
+        }
+      }
+    }
+    return std::nullopt;
+  }
+
+  static c10::intrusive_ptr<Work> wrapWork(py::object work) {
+    return c10::make_intrusive<PyProcessGroup::PyWorkHolder>(std::move(work));
+  }
+
+  py::object getMethodOverride(const char* name) const {
+    if (pyBackend_) {
+      if (auto override = getAttrOverride(name)) {
+        return *override;
+      }
+      return py::object();
+    }
+    return pybind11::get_override(static_cast<const Backend*>(this), name);
+  }
+
+  template <typename Return>
+  std::optional<Return> getAttrOverrideAs(const char* name) const {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = getAttrOverride(name)) {
+      return override->template cast<Return>();
+    }
+    return std::nullopt;
+  }
+
+  template <typename Return, typename... Args>
+  std::optional<Return> callWrappedOverride(const char* name, Args&&... args)
+      const {
+    if (!pyBackend_) {
+      return std::nullopt;
+    }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = getAttrOverride(name)) {
+      return (*override)(std::forward<Args>(args)...).template cast<Return>();
+    }
+    return std::nullopt;
+  }
+
+  template <typename... Args>
+  bool callWrappedVoidOverride(const char* name, Args&&... args) const {
+    if (!pyBackend_) {
+      return false;
+    }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = getAttrOverride(name)) {
+      (*override)(std::forward<Args>(args)...);
+      return true;
+    }
+    return false;
+  }
+
+  template <typename... Args>
+  c10::intrusive_ptr<Work> callWorkOverride(const char* name, Args&&... args)
+      const {
+    pybind11::gil_scoped_acquire gil;
+    py::object override = getMethodOverride(name);
+    if (override) {
+      return wrapWork(override(std::forward<Args>(args)...));
+    }
+    return nullptr;
+  }
+
+  template <typename... Args>
+  c10::intrusive_ptr<Backend> callBackendOverride(
+      const char* name,
+      Args&&... args) const {
+    pybind11::gil_scoped_acquire gil;
+    py::object override = getMethodOverride(name);
+    if (override) {
+      return wrap(override(std::forward<Args>(args)...));
+    }
+    return nullptr;
+  }
+
+  py::object pyBackend_;
+  using AllocatorPtr = std::shared_ptr<c10::Allocator>;
+  using OptionsPtr = c10::intrusive_ptr<Options>;
+  using WindowPtr = c10::intrusive_ptr<Window>;
+  using MemoryStats = std::unordered_map<std::string, uint64_t>;
+
+ public:
+  bool supportsSplitting() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_splitting")) {
+      return *override;
+    }
+    return Backend::supportsSplitting();
+  }
+
+  bool supportsCoalescing() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_coalescing")) {
+      return *override;
+    }
+    return Backend::supportsCoalescing();
+  }
+
+  bool supportsTimeEstimation() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_time_estimate")) {
+      return *override;
+    }
+    return Backend::supportsTimeEstimation();
+  }
+
+  bool supportsShrinking() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_shrinking")) {
+      return *override;
+    }
+    return Backend::supportsShrinking();
+  }
+
+  c10::intrusive_ptr<Backend> shrink(
+      const std::vector<int64_t>& ranks_to_exclude,
+      int shrink_flags = 0,
+      const c10::intrusive_ptr<Options>& opts_override = nullptr) override {
+    if (auto backend = callBackendOverride(
+            "shrink", ranks_to_exclude, shrink_flags, opts_override)) {
+      return backend;
+    }
+    return Backend::shrink(ranks_to_exclude, shrink_flags, opts_override);
+  }
+
+  void setTimeout(std::chrono::milliseconds timeout) override {
+    if (callWrappedVoidOverride("set_timeout", timeout)) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(void, Backend, "set_timeout", setTimeout, timeout);
+  }
+
+  bool supportsReconfigure() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_reconfigure")) {
+      return *override;
+    }
+    return Backend::supportsReconfigure();
+  }
+
+  ReconfigureHandle get_reconfigure_handle() const override {
+    if (auto override =
+            callWrappedOverride<ReconfigureHandle>("get_reconfigure_handle")) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE(ReconfigureHandle, Backend, get_reconfigure_handle);
+  }
+
+  c10::intrusive_ptr<Work> reconfigure(
+      const ReconfigureOptions& opts) override {
+    if (auto work = callWorkOverride("reconfigure", opts)) {
+      return work;
+    }
+    return Backend::reconfigure(opts);
+  }
+
+  bool supportsWindow() const override {
+    if (auto override = getAttrOverrideAs<bool>("supports_window")) {
+      return *override;
+    }
+    return Backend::supportsWindow();
+  }
+
+  c10::intrusive_ptr<Window> new_window(
+      const std::optional<at::Tensor>& tensor = std::nullopt) override {
+    if (auto override = callWrappedOverride<WindowPtr>("new_window", tensor)) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE(c10::intrusive_ptr<Window>, Backend, new_window, tensor);
+  }
+
+  void startCoalescing() override {
+    if (callWrappedVoidOverride("start_coalescing")) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(void, Backend, "start_coalescing", startCoalescing);
+  }
+
+  c10::intrusive_ptr<Work> endCoalescing() override {
+    if (auto work = callWorkOverride("end_coalescing")) {
+      return work;
+    }
+    return Backend::endCoalescing();
+  }
+
+  const std::string getBackendName() const override {
+    if (auto override = callWrappedOverride<std::string>("getBackendName")) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE(std::string, Backend, getBackendName);
+  }
+
+  c10::intrusive_ptr<Options> getBackendOptions() override {
+    if (auto override = getAttrOverrideAs<OptionsPtr>("options")) {
+      return *override;
+    }
+    return Backend::getBackendOptions();
+  }
+
+  c10::intrusive_ptr<Work> broadcast(
+      std::vector<at::Tensor>& tensors,
+      const BroadcastOptions& opts = BroadcastOptions()) override {
+    if (auto work = callWorkOverride("broadcast", tensors, opts)) {
+      return work;
+    }
+    return Backend::broadcast(tensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
+    if (auto work = callWorkOverride("allreduce", tensors, opts)) {
+      return work;
+    }
+    return Backend::allreduce(tensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> allreduce_sparse(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
+    if (auto work = callWorkOverride("allreduce_sparse", tensors, opts)) {
+      return work;
+    }
+    return Backend::allreduce_sparse(tensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> allreduce_coalesced(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
+          AllreduceCoalescedOptions()) override {
+    if (auto work = callWorkOverride("allreduce_coalesced", tensors, opts)) {
+      return work;
+    }
+    return Backend::allreduce_coalesced(tensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
+    if (auto work = callWorkOverride("reduce", tensors, opts)) {
+      return work;
+    }
+    return Backend::reduce(tensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (auto work =
+            callWorkOverride("allgather", outputTensors, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::allgather(outputTensors, inputTensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> all_gather_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (auto work = callWorkOverride(
+            "all_gather_single", outputBuffer, inputBuffer, opts)) {
+      return work;
+    }
+    return Backend::all_gather_single(outputBuffer, inputBuffer, opts);
+  }
+
+  c10::intrusive_ptr<Work> allgather_coalesced(
+      std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (auto work = callWorkOverride(
+            "allgather_coalesced", outputTensorLists, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::allgather_coalesced(outputTensorLists, inputTensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (auto work = callWorkOverride(
+            "all_gather_single_coalesced", outputs, inputs, opts)) {
+      return work;
+    }
+    return Backend::all_gather_single_coalesced(outputs, inputs, opts);
+  }
+
+  c10::intrusive_ptr<Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) override {
+    if (auto work =
+            callWorkOverride("gather", outputTensors, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::gather(outputTensors, inputTensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) override {
+    if (auto work =
+            callWorkOverride("scatter", outputTensors, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::scatter(outputTensors, inputTensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> reduce_scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (auto work = callWorkOverride(
+            "reduce_scatter", outputTensors, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::reduce_scatter(outputTensors, inputTensors, opts);
+  }
+
+  c10::intrusive_ptr<Work> reduce_scatter_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (auto work = callWorkOverride(
+            "reduce_scatter_single", outputBuffer, inputBuffer, opts)) {
+      return work;
+    }
+    return Backend::reduce_scatter_single(outputBuffer, inputBuffer, opts);
+  }
+
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (auto work = callWorkOverride(
+            "reduce_scatter_single_coalesced", outputs, inputs, opts)) {
+      return work;
+    }
+    return Backend::reduce_scatter_single_coalesced(outputs, inputs, opts);
+  }
+
+  c10::intrusive_ptr<Work> all_to_all_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    if (auto work = callWorkOverride(
+            "all_to_all_single",
+            outputBuffer,
+            inputBuffer,
+            outputSplitSizes,
+            inputSplitSizes,
+            opts)) {
+      return work;
+    }
+    return Backend::all_to_all_single(
+        outputBuffer, inputBuffer, outputSplitSizes, inputSplitSizes, opts);
+  }
+
+  c10::intrusive_ptr<Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    if (auto work =
+            callWorkOverride("alltoall", outputTensors, inputTensors, opts)) {
+      return work;
+    }
+    return Backend::alltoall(outputTensors, inputTensors, opts);
+  }
+
+  void monitoredBarrier(const BarrierOptions& opts, bool waitAllRanks = false)
+      override {
+    if (callWrappedVoidOverride("monitored_barrier", opts, waitAllRanks)) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void,
+        Backend,
+        "monitored_barrier",
+        monitoredBarrier,
+        opts,
+        waitAllRanks);
+  }
+
+  void setSequenceNumberForGroup() override {
+    if (callWrappedVoidOverride("_set_sequence_number_for_group")) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void,
+        Backend,
+        "_set_sequence_number_for_group",
+        setSequenceNumberForGroup);
+  }
+
+  uint64_t getSequenceNumberForGroup() override {
+    if (auto override =
+            callWrappedOverride<uint64_t>("_get_sequence_number_for_group")) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        uint64_t,
+        Backend,
+        "_get_sequence_number_for_group",
+        getSequenceNumberForGroup);
+  }
+
+  c10::intrusive_ptr<Work> send(
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag) override {
+    if (auto work = callWorkOverride("send", tensors, dstRank, tag)) {
+      return work;
+    }
+    return Backend::send(tensors, dstRank, tag);
+  }
+
+  c10::intrusive_ptr<Work> recv(
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag) override {
+    if (auto work = callWorkOverride("recv", tensors, srcRank, tag)) {
+      return work;
+    }
+    return Backend::recv(tensors, srcRank, tag);
+  }
+
+  c10::intrusive_ptr<Work> recvAnysource(
+      std::vector<at::Tensor>& tensors,
+      int tag) override {
+    if (auto work = callWorkOverride("recv_anysource", tensors, tag)) {
+      return work;
+    }
+    return Backend::recvAnysource(tensors, tag);
+  }
+
+  c10::intrusive_ptr<Work> barrier(
+      const BarrierOptions& opts = BarrierOptions()) override {
+    if (auto work = callWorkOverride("barrier", opts)) {
+      return work;
+    }
+    return Backend::barrier(opts);
+  }
+
+  void registerOnCompletionHook(
+      std::function<void(std::shared_ptr<WorkInfo>)>&& hook) override {
+    pybind11::gil_scoped_acquire gil;
+    auto hookCopy = hook;
+    onCompletionHook_ = std::move(hook);
+    py::object override = getMethodOverride("_register_on_completion_hook");
+    if (override) {
+      override(std::move(hookCopy));
+    }
+  }
+
+  void waitForPendingWorks() override {
+    if (callWrappedVoidOverride("_wait_for_pending_works")) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void, Backend, "_wait_for_pending_works", waitForPendingWorks);
+  }
+
+  void enableCollectivesTiming() override {
+    if (callWrappedVoidOverride("_enable_collectives_timing")) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void, Backend, "_enable_collectives_timing", enableCollectivesTiming);
+  }
+
+  c10::intrusive_ptr<Backend> split(
+      const c10::intrusive_ptr<Store>& store,
+      const std::vector<int>& ranks,
+      const c10::intrusive_ptr<Options>& opts) override {
+    if (auto backend = callBackendOverride("split", store, ranks, opts)) {
+      return backend;
+    }
+    return Backend::split(store, ranks, opts);
+  }
+
+  c10::intrusive_ptr<Backend> merge(
+      const c10::intrusive_ptr<Store>& store,
+      const c10::intrusive_ptr<Options>& opts,
+      const int& rank,
+      const int& size) override {
+    if (auto backend = callBackendOverride("merge", store, opts, rank, size)) {
+      return backend;
+    }
+    return Backend::merge(store, opts, rank, size);
+  }
+
+  void setGroupUid(const std::string& pg_uid) override {
+    if (callWrappedVoidOverride("_set_group_name", pg_uid)) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void, Backend, "_set_group_name", setGroupUid, pg_uid);
+  }
+
+  void eagerConnectSingleDevice(at::Device device) override {
+    if (callWrappedVoidOverride("eager_connect_single_device", device)) {
+      return;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        void,
+        Backend,
+        "eager_connect_single_device",
+        eagerConnectSingleDevice,
+        device);
+  }
+
+  ErrorType getError() override {
+    if (auto override = callWrappedOverride<ErrorType>("get_error")) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE_NAME(ErrorType, Backend, "get_error", getError);
+  }
+
+  std::shared_ptr<c10::Allocator> getMemAllocator() override {
+    if (auto override = getAttrOverrideAs<AllocatorPtr>("mem_allocator")) {
+      return *override;
+    }
+    return Backend::getMemAllocator();
+  }
+
+  at::Tensor allocateTensor(long size, at::TensorOptions options = {})
+      override {
+    pybind11::gil_scoped_acquire gil;
+    py::object override = getMethodOverride("allocate_tensor");
+    if (override) {
+      c10::ScalarType dtype = c10::optTypeMetaToScalarType(options.dtype_opt())
+                                  .value_or(at::kFloat);
+      c10::Device device =
+          options.device_opt().value_or(c10::Device(c10::DeviceType::CPU));
+      return override(size, dtype, device).cast<at::Tensor>();
+    }
+    return Backend::allocateTensor(size, options);
+  }
+
+  bool supportsTensorAlloc(c10::DeviceIndex deviceIdx) override {
+    if (auto override =
+            callWrappedOverride<bool>("supports_tensor_alloc", deviceIdx)) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        bool, Backend, "supports_tensor_alloc", supportsTensorAlloc, deviceIdx);
+  }
+
+  void abort() override {
+    if (callWrappedVoidOverride("abort")) {
+      return;
+    }
+    PYBIND11_OVERRIDE(void, Backend, abort);
+  }
+
+  void shutdown() override {
+    if (callWrappedVoidOverride("shutdown")) {
+      return;
+    }
+    PYBIND11_OVERRIDE(void, Backend, shutdown);
+  }
+
+  void suspend() override {
+    if (callWrappedVoidOverride("suspend")) {
+      return;
+    }
+    PYBIND11_OVERRIDE(void, Backend, suspend);
+  }
+
+  void resume() override {
+    if (callWrappedVoidOverride("resume")) {
+      return;
+    }
+    PYBIND11_OVERRIDE(void, Backend, resume);
+  }
+
+  std::unordered_map<std::string, uint64_t> getMemoryStats() override {
+    if (auto override = callWrappedOverride<MemoryStats>("memory_stats")) {
+      return *override;
+    }
+    PYBIND11_OVERRIDE_NAME(
+        MemoryStats, Backend, "memory_stats", getMemoryStats);
+  }
+};
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -18,6 +18,7 @@
 #endif
 #include <torch/csrc/distributed/c10d/FakeProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/PyBackend.hpp>
 #include <torch/csrc/distributed/c10d/PyProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/python_callback_work.hpp>
 
@@ -1319,10 +1320,10 @@ Example:
           py::arg("tensor"))
       .def_property_static(
           "signal_pad_size",
-          [](py::object /* self */) {
+          [](const py::object& /* self */) {
             return ::c10d::symmetric_memory::get_signal_pad_size();
           },
-          [](py::object /* self */, size_t size) {
+          [](const py::object& /* self */, size_t size) {
             ::c10d::symmetric_memory::set_signal_pad_size(size);
           })
       .def_static(
@@ -2043,14 +2044,14 @@ Example::
             }
 
             ::c10d::TCPStoreOptions opts{
-                port,
-                isServer,
-                numWorkers,
-                waitWorkers,
-                timeout,
-                multiTenant,
-                masterListenFd,
-                useLibUV};
+                .port = port,
+                .isServer = isServer,
+                .numWorkers = numWorkers,
+                .waitWorkers = waitWorkers,
+                .timeout = timeout,
+                .multiTenant = multiTenant,
+                .masterListenFd = masterListenFd,
+                .useLibUV = useLibUV};
 
             return c10::make_intrusive<::c10d::TCPStore>(host, opts);
           }),
@@ -2936,15 +2937,16 @@ communication mechanism.
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  const c10::Device& device,
                  const ::c10d::ProcessGroup::BackendType& backendType,
-                 const std::optional<c10::intrusive_ptr<::c10d::Backend>>&
-                     backend) {
-                self->setBackend(device.type(), backendType, backend);
+                 py::object backend) {
+                std::optional<c10::intrusive_ptr<::c10d::Backend>> backendPtr;
+                if (!backend.is_none()) {
+                  backendPtr = ::c10d::PyBackend::wrap(std::move(backend));
+                }
+                self->setBackend(device.type(), backendType, backendPtr);
               },
               py::arg("device"),
               py::arg("backend_type"),
-              py::arg("backend") =
-                  std::optional<c10::intrusive_ptr<::c10d::Backend>>(),
-              py::call_guard<py::gil_scoped_release>())
+              py::arg("backend") = py::none())
           .def(
               "_get_backend",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
@@ -3123,7 +3125,6 @@ Arguments:
       &::c10d::set_comm_profiling_name,
       py::arg("name"));
   module.def("_get_comm_profiling_name", &::c10d::get_comm_profiling_name);
-
   py::enum_<::c10d::ProcessGroup::BackendType>(
       processGroup,
       "BackendType",
@@ -3141,11 +3142,33 @@ Arguments:
   // ProcessGroup subclasses (e.g. dist.ProcessGroupGloo). This is not supported
   // and should be removed once all tests are transitioned
   auto backend =
-      py::class_<::c10d::Backend, c10::intrusive_ptr<::c10d::Backend>>(
-          module, "Backend")
+      py::class_<
+          ::c10d::Backend,
+          c10::intrusive_ptr<::c10d::Backend>,
+          ::c10d::PyBackend>(module, "Backend")
+          .def(
+              py::init([](int rank, int size) {
+                // gil_scoped_release is not safe as a call_guard in init.
+                // https://github.com/pybind/pybind11/issues/5473
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::PyBackend>(rank, size);
+              }),
+              py::arg("rank"),
+              py::arg("size"))
           .def("rank", &::c10d::Backend::getRank)
           .def("size", &::c10d::Backend::getSize)
           .def("name", &::c10d::Backend::getBackendName)
+          .def(
+              "__getattr__",
+              [](const ::c10d::Backend& self, const std::string& name) {
+                auto* pyBackend = dynamic_cast<const ::c10d::PyBackend*>(&self);
+                if (pyBackend != nullptr) {
+                  return pyBackend->getPyBackendAttr(name);
+                }
+                throw py::attribute_error(name);
+              },
+              py::arg("name"))
+          .def("_id", &::c10d::Backend::getID)
           .def(
               "abort",
               &::c10d::Backend::abort,
@@ -3160,6 +3183,14 @@ Arguments:
               "setUsePgForSymmMemRendezvous",
               &::c10d::Backend::setUsePgForSymmMemRendezvous,
               py::arg("value"))
+          .def_property(
+              "use_pg_for_symm_mem_rendezvous",
+              &::c10d::Backend::getUsePgForSymmMemRendezvous,
+              &::c10d::Backend::setUsePgForSymmMemRendezvous)
+          .def_property(
+              "bound_device_id",
+              &::c10d::Backend::getBoundDeviceId,
+              &::c10d::Backend::setBoundDeviceId)
           .def_property_readonly(
               "supports_splitting",
               &::c10d::Backend::supportsSplitting,
@@ -3192,6 +3223,21 @@ Arguments:
               py::arg("ranks_to_exclude"),
               py::arg("shrink_flags") = 0,
               py::arg("opts_override") = nullptr,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "split",
+              &::c10d::Backend::split,
+              py::arg("store"),
+              py::arg("ranks"),
+              py::arg("opts"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "merge",
+              &::c10d::Backend::merge,
+              py::arg("store"),
+              py::arg("opts"),
+              py::arg("rank"),
+              py::arg("size"),
               py::call_guard<py::gil_scoped_release>())
           .def(
               "get_reconfigure_handle",
@@ -3249,6 +3295,12 @@ Arguments:
           .def(
               "allreduce",
               &::c10d::Backend::allreduce,
+              py::arg("tensors"),
+              py::arg("opts") = ::c10d::AllreduceOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allreduce_sparse",
+              &::c10d::Backend::allreduce_sparse,
               py::arg("tensors"),
               py::arg("opts") = ::c10d::AllreduceOptions(),
               py::call_guard<py::gil_scoped_release>())
@@ -3362,6 +3414,23 @@ Arguments:
               py::arg("opts") = ::c10d::AllgatherOptions(),
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "all_gather_single_coalesced",
+              &::c10d::Backend::all_gather_single_coalesced,
+              py::arg("output_lists"),
+              py::arg("input_list"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          // Deprecated alias of all_gather_single_coalesced, kept for backward
+          // compatibility. Bound to all_gather_single_coalesced to avoid
+          // referencing the deprecated C++ method.
+          .def(
+              "allgather_into_tensor_coalesced",
+              &::c10d::Backend::all_gather_single_coalesced,
+              py::arg("output_lists"),
+              py::arg("input_list"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
               "gather",
               &::c10d::Backend::gather,
               py::arg("output_tensors"),
@@ -3452,6 +3521,23 @@ Arguments:
               py::arg("inputTensor"),
               py::arg("opts") = ::c10d::ReduceScatterOptions(),
               py::call_guard<py::gil_scoped_release>())
+          .def(
+              "reduce_scatter_single_coalesced",
+              &::c10d::Backend::reduce_scatter_single_coalesced,
+              py::arg("outputTensors"),
+              py::arg("inputTensors"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          // Deprecated alias of reduce_scatter_single_coalesced, kept for
+          // backward compatibility. Bound to reduce_scatter_single_coalesced to
+          // avoid referencing the deprecated C++ method.
+          .def(
+              "reduce_scatter_tensor_coalesced",
+              &::c10d::Backend::reduce_scatter_single_coalesced,
+              py::arg("outputTensors"),
+              py::arg("inputTensors"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
           // Deprecated alias of reduce_scatter_single, kept for backward
           // compatibility. Bound to reduce_scatter_single to avoid referencing
           // the deprecated C++ method.
@@ -3526,6 +3612,8 @@ Arguments:
           .def(
               "recv_anysource",
               &::c10d::Backend::recvAnysource,
+              py::arg("tensors"),
+              py::arg("tag"),
               py::call_guard<py::gil_scoped_release>())
           .def(
               "barrier",
@@ -3564,6 +3652,41 @@ Arguments:
               &::c10d::Backend::getBackendName,
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "_register_on_completion_hook",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 py::object hook) {
+                self->registerOnCompletionHook(
+                    [hookWrapper =
+                         ::c10d::PythonOnCompletionHook(std::move(hook))](
+                        const std::shared_ptr<::c10d::WorkInfo>& workInfo) {
+                      hookWrapper(workInfo);
+                    });
+              },
+              py::arg("hook"),
+              py::call_guard<py::gil_scoped_acquire>())
+          .def(
+              "_wait_for_pending_works",
+              &::c10d::Backend::waitForPendingWorks,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_has_hooks",
+              &::c10d::Backend::hasHooks,
+              py::call_guard<py::gil_scoped_acquire>())
+          .def(
+              "_enable_collectives_timing",
+              &::c10d::Backend::enableCollectivesTiming,
+              py::call_guard<py::gil_scoped_acquire>())
+          .def(
+              "_set_group_name",
+              &::c10d::Backend::setGroupUid,
+              py::call_guard<py::gil_scoped_acquire>())
+          .def_property_readonly("group_name", &::c10d::Backend::getGroupUid)
+          .def(
+              "_set_group_desc",
+              &::c10d::Backend::setGroupDesc,
+              py::call_guard<py::gil_scoped_acquire>())
+          .def_property_readonly("group_desc", &::c10d::Backend::getGroupDesc)
+          .def(
               "_start_coalescing",
               &::c10d::Backend::startCoalescing,
               py::call_guard<py::gil_scoped_release>())
@@ -3594,6 +3717,11 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
           .def_property_readonly(
               "mem_allocator", &::c10d::Backend::getMemAllocator)
+          .def(
+              "get_error",
+              &::c10d::Backend::getError,
+              py::call_guard<py::gil_scoped_release>())
+          .def_property_readonly("options", &::c10d::Backend::getBackendOptions)
           .def("suspend", &::c10d::Backend::suspend)
           .def("resume", &::c10d::Backend::resume)
           .def("memory_stats", &::c10d::Backend::getMemoryStats, R"(


### PR DESCRIPTION
## Summary

Add `PyBackend`, a pybind trampoline for `c10d::Backend`, and bind the Backend APIs needed for Python subclasses to implement Backend-level collectives, p2p operations, fault-tolerance hooks, coalescing, metadata, tensor allocation, and lifecycle methods. Custom backend registration now owns the Python-object lifetime handoff inside `ProcessGroup._register_backend`, so there is no public `_wrap_py_backend` helper and native C++ `Backend` subclasses continue to register directly.

`PyBackend` lives in its own header, separate from the existing `PyProcessGroup` trampoline. Its Python dispatch is intentionally based on the Python-facing `Backend` method names, and the single-tensor collectives dispatch through the current `all_gather_single`, `reduce_scatter_single`, and `all_to_all_single` variants rather than looking for deprecated Python method names. The `Backend` pybind surface still exposes the deprecated collective aliases (`_allgather_base`, `allgather_into_tensor_coalesced`, `_reduce_scatter_base`, `reduce_scatter_tensor_coalesced`, `alltoall_base`), each bound to its canonical C++ method so existing callers that use the old names keep working.

## Test Plan

```bash
USE_CUDA=0 MAX_JOBS=96 CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache pip install -e . -v --no-build-isolation
```

```bash
.venv/bin/python test/distributed/test_c10d_pybackend.py
```

```bash
.venv/bin/python test/distributed/test_c10d_pypg.py
```

```bash
spin quicklint
```

Authored with the assistance of an AI assistant.
