### PR TITLE
Add overflow check to FBGEMM version of quantize_val_arm

### DIFF
--- a/aten/src/ATen/native/quantized/AffineQuantizerBase.cpp
+++ b/aten/src/ATen/native/quantized/AffineQuantizerBase.cpp
@@ -79,7 +79,17 @@ T quantize_val_arm(
   constexpr int32_t qmin = std::numeric_limits<T>::min();
   constexpr int32_t qmax = std::numeric_limits<T>::max();
   float inv_scale = 1.0f / scale;
+#ifndef _MSC_VER
+  auto r = static_cast<int32_t>(std::nearbyint(value * inv_scale));
+  // builtin_add_overflow() returns true in case of overflow
+  if (__builtin_add_overflow(zero_point, r, &r)) {
+    // zero_point must be a non-negative value between qmin and qmax,
+    // i.e. only overflow can happen.
+    r = qmax;
+  }
+#else
   auto r = zero_point + static_cast<int32_t>(std::nearbyint(value * inv_scale));
+#endif
   r = std::max(r, qmin);
   r = std::min(r, qmax);
   return static_cast<T>(r);


### PR DESCRIPTION
`AffineQuantizerBase.cpp` has two copies of `quantize_val_arm`, one inside `#ifdef USE_FBGEMM` and one on the `#else` branch. The latter copy calls `__builtin_add_overflow`, but the FBGEMM version does not. This PR adds the overflow check to the FBGEMM copy, fixing some quantization test failures on GB200.

Fixes #187480

Authored with Claude

cc @eqy