### PR TITLE
[inductor][test] Keep backend options out of FXIR call args

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -178,6 +178,41 @@ class FxirTestCase(InductorTestCase):
         args = [torch.randn(length, device=self.device) for length in [517, 1029]]
         self._compile_and_check(foo, args, expected_num_triton_kernels=2)
 
+    def test_backend_options_not_in_kernel_call_args(self):
+        """
+        Backend compiler options attached to a kernel Config via extra_options
+        (as out-of-tree backends can do) must not be routed into the Triton
+        kernel call args and through _generate_sym_node -- non-numeric options
+        (str/dict) used to crash FXIR conversion there. They are carried to the
+        backend via node meta instead.
+        """
+        extra_options = {
+            "mock_str_option": "mock_value",
+            "mock_dict_option": {"mock_key": ["mock_value"]},
+        }
+
+        orig_generate_triton_call = FxConverter._generate_triton_call
+
+        def generate_triton_call(conv_self, line):
+            tuner = conv_self.kernels[line.kernel_name].tuner
+            tuner.compile_results[0].config.extra_options = extra_options
+            return orig_generate_triton_call(conv_self, line)
+
+        args = [torch.randn(8, device=self.device) for _ in range(2)]
+        with unittest.mock.patch.object(
+            FxConverter, "_generate_triton_call", generate_triton_call
+        ):
+            (gm,) = self._run_and_capture_graphs(torch.compile(torch.add), args)
+
+        (triton_node,) = gm.graph.find_nodes(
+            op="call_function", target=triton_kernel_wrapper_mutation
+        )
+        # Pure backend options must not leak into the kernel call kwargs.
+        for name in extra_options:
+            self.assertNotIn(name, triton_node.kwargs["kwargs"])
+        # They are carried to the backend via node meta instead.
+        self.assertEqual(triton_node.meta["extra_options"], extra_options)
+
     def test_free(self):
         """
         Test a program that frees a buffer which is no longer in use.


### PR DESCRIPTION
Summary:
Adds an FXIR regression test that backend compiler options attached to a kernel `Config` via `extra_options` (a third-party-backend channel for custom `triton.compile` options) are not routed into the Triton kernel call args. In `_generate_triton_call` the call kwargs are passed through `_generate_sym_node`, which only accepts symbolic/numeric values; a non-numeric option (a `str` or a `dict`) would raise `ValueError: ... is not a valid input`, surfacing as `InductorKernelError: torch.inductor compilation failed`. That was the failure mode introduced by D108642893 (pytorch/pytorch#187028), since reverted; this test guards against it being reintroduced (e.g. on a re-import of that PR). The options remain available to the backend via `triton_node.meta["extra_options"]`.

Test-only; no production code change.

Test Plan:
```
buck test fbcode//caffe2/test/inductor:fxir_backend -- test_backend_options_not_in_kernel_call_args
```

`FxirTestCase` is `requires_gpu`, so it runs in GPU CI. The test injects a `str` and a `dict` into `Config.extra_options`, runs FXIR conversion, and asserts that conversion does not crash, the options are absent from the Triton kernel call kwargs, and they are present in `triton_node.meta["extra_options"]`.

Differential Revision: D108781944




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo