### PR TITLE
Fix docs coverage failure for torch.SymFloat.has_hint

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1898,6 +1898,8 @@ coverage_ignore_classes = [
     # torch.torch_version
     "TorchVersion",
     # torch.types
+    "SymBool",
+    "SymFloat",
     "SymInt",
     # torch.utils.benchmark.examples.compare
     "FauxTorch",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187485

PR #186323 added typed has_hint()/hint/constant accessors to SymInt,
SymFloat, and SymBool. has_hint is a public method with no docstring. The
Sphinx coverage builder (run via `make coverage` with -W) counts an
undocumented public method whenever it belongs to a documented class that
is not listed in coverage_ignore_classes. SymInt was already in that list,
but SymFloat and SymBool were not, so torch.SymFloat.has_hint was reported
undocumented, dropping the torch module coverage to 96.97% (1 undocumented)
and failing the docs build.

SymFloat previously passed only because all of its public non-dunder
methods happened to carry docstrings; the new accessor broke that. Rather
than document an internal accessor on SymFloat while the identical
SymInt.has_hint stays undocumented (ignored), this adds SymFloat and
SymBool next to SymInt in coverage_ignore_classes so the three sibling Sym
classes are treated consistently and a future SymBool.has_hint-style
addition won't regress.

Test Plan:
```
cd docs && make coverage
```
The torch module now reports 100.00% (0 undocumented); previously it was
96.97% with 1 undocumented (torch.SymFloat.has_hint). A fully clean local
exit also requires z3-solver installed, otherwise unrelated z3 autosummary
import warnings are promoted to errors by -W.

Authored with Claude.