### PR TITLE
[Native DSL] Decline FakeTensors in the eager override router

### DIFF
--- a/test/python_native/test_registry.py
+++ b/test/python_native/test_registry.py
@@ -559,6 +559,46 @@ class TestRegistryRuntime(TestCase):
         self.assertEqual(out.shape, torch.Size([3, 4]))
         self.assertEqual(out.dtype, torch.float32)
 
+    def test_eager_router_declines_fake_tensors(self):
+        """The eager router must decline FakeTensors and fall through to the
+        native aten kernel rather than running the real DSL impl on fakes.
+
+        Fakes are meant to reach the impl only via the compile/export router
+        and its `_native::<id>` fake kernel, never the eager backend router.
+        """
+        impl_called = [False]
+
+        def cond(*a, **k):
+            return True
+
+        def impl(a, b):
+            impl_called[0] = True
+            return torch.full_like(a, 123.0)
+
+        self.registry.register_op_override(
+            "test_dsl", "aten", "mul.Tensor", "CPU", cond, impl
+        )
+        self._install("mul.Tensor", "CPU")
+
+        # Real tensors: the override fires.
+        a = torch.tensor([2.0, 3.0])
+        b = torch.tensor([4.0, 5.0])
+        self.assertTrue(
+            torch.equal(torch.ops.aten.mul.Tensor(a, b), torch.tensor([123.0, 123.0]))
+        )
+        self.assertTrue(impl_called[0])
+
+        # Fake tensors: the impl must not run; shape inference flows through
+        # the native aten kernel's meta instead.
+        impl_called[0] = False
+        with FakeTensorMode():
+            fa = torch.empty(3, 4, dtype=torch.float32)
+            fb = torch.empty(3, 4, dtype=torch.float32)
+            out = torch.ops.aten.mul.Tensor(fa, fb)
+        self.assertFalse(impl_called[0])
+        self.assertEqual(out.shape, torch.Size([3, 4]))
+        self.assertEqual(out.dtype, torch.float32)
+
     def test_unconditional_override_cond_none(self):
         """`cond=None` + `unconditional_override=True` must substitute a
         trivially-true predicate so the impl fires on every call.

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -569,6 +569,24 @@ def _always_true(*args: object, **kwargs: object) -> bool:
     return True
 
 
+def _args_have_fake_tensor(args: tuple, kwargs: dict) -> bool:
+    """Return True if any (possibly nested) argument is a FakeTensor.
+
+    The eager router runs real DSL `impl` kernels at the backend key; a
+    FakeTensor reaching it would invoke a real kernel on fake data. Fakes
+    are instead meant to flow through the compile/export router via the
+    `_native::<id>` fake kernel. `is_fake` returns False for non-tensors,
+    so this is safe over arbitrary leaves.
+    """
+    # Local imports: both modules are already loaded by the time
+    # `import torch._native` runs (it imports last), so this is cheap and
+    # keeps module-level imports minimal.
+    from torch._subclasses.fake_tensor import is_fake
+    from torch.utils._pytree import tree_leaves
+
+    return any(is_fake(leaf) for leaf in tree_leaves((args, kwargs)))
+
+
 def register_op_override(
     backend: str,
     lib_symbol: str,
@@ -920,6 +938,13 @@ def _register_overrides_from_graph(
         return _NO_MATCH
 
     def eager_router(keyset, *args, _fallback=fallback_kernel, **kwargs):
+        # Decline FakeTensors universally: the eager router runs real DSL
+        # kernels, so a fake input must fall through to the native aten
+        # kernel (whose meta handles fakes). Fakes route to the DSL impl
+        # only via the compile/export router and its `_native::<id>` fake
+        # kernel.
+        if _args_have_fake_tensor(args, kwargs):
+            return _fallback.call_boxed(keyset, *args, **kwargs)
         result = _dispatch(args, kwargs, swallow_cond_exceptions=False)
         if result is _NO_MATCH:
             return _fallback.call_boxed(keyset, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187488

The registry runs real DSL `impl` kernels in its eager router at the
backend key; FakeTensors are only meant for the compile/export router,
which routes them through the `_native::<id>` op for shape inference.
Nothing stopped a fake from reaching the eager router and running a real
kernel on fake data -- previously avoided only by each `cond` happening
to reject fakes. Universally refuse FakeTensors in the eager router,
falling through to the native aten kernel instead, so the guarantee is
enforced once rather than relying on every override author to remember
it.

Test Plan:

```
pytest test/python_native/test_registry.py test/python_native/test_decomp.py -q
```

This change was authored with the assistance of an AI coding agent.