### PR TITLE
[Inductor][HOP] Handle unbacked FlexAttention predicates

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4724,6 +4724,102 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.assertEqual(decode_out.shape, (1, 2, 64, 64))
         torch.testing.assert_close(default_out, decode_out, atol=3e-3, rtol=3e-3)
 
+    def test_unbacked_flex_decoding_eligibility_falls_back(self, device):
+        from torch._inductor.kernel.flex.flex_decoding import _use_flex_decoding
+        from torch._inductor.sizevars import SizeVarAllocator
+        from torch._inductor.virtualized import V
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        class FakeBuffer:
+            def __init__(self, size):
+                self.size = size
+
+            def get_size(self):
+                return self.size
+
+        shape_env = ShapeEnv()
+        seq_len = shape_env.create_unbacked_symint().node.expr
+        shape_env.var_to_hint_override[seq_len] = 64
+        graph = mock.Mock(sizevars=SizeVarAllocator(shape_env))
+
+        with V.set_graph_handler(graph):
+            self.assertFalse(
+                _use_flex_decoding(
+                    FakeBuffer([1, 2, seq_len, 64]),
+                    FakeBuffer([1, 1, 1, 1]),
+                    FakeBuffer([1, 2, seq_len, 64]),
+                    {},
+                    False,
+                )
+            )
+
+    def test_backward_fake_symbolic_query_key_batch_metadata(self, device):
+        from torch._dynamo.source import LocalSource
+        from torch._higher_order_ops.flex_attention import (
+            flex_attention_backward_fake_tensor_mode,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+
+        def fakeify(t, name, shape_id=None):
+            dynamic_sizes = [DimDynamic.STATIC] * t.dim()
+            shape_ids = {}
+            if shape_id is not None:
+                dynamic_sizes[0] = DimDynamic.UNBACKED
+                shape_ids[0] = shape_id
+            return fake_mode.from_tensor(
+                t,
+                source=LocalSource(name, is_input=True),
+                symbolic_context=StatelessSymbolicContext(
+                    dynamic_sizes=dynamic_sizes,
+                    shape_ids=shape_ids,
+                ),
+            )
+
+        B, H, S, D = 4, 2, 8, 16
+
+        def run(query, key, value, out, logsumexp, grad_out, grad_logsumexp):
+            with fake_mode:
+                _, grad_key, grad_value, _ = flex_attention_backward_fake_tensor_mode(
+                    query,
+                    key,
+                    value,
+                    out,
+                    logsumexp,
+                    grad_out,
+                    grad_logsumexp,
+                    None,
+                    None,
+                    (),
+                    1.0,
+                    {},
+                )
+            return grad_key, grad_value
+
+        query = fakeify(torch.empty(B, H, S, D, device=device), "query", "batch")
+        key = fakeify(torch.empty(B, H, S, D, device=device), "key", "batch")
+        value = fakeify(torch.empty(B, H, S, D, device=device), "value", "batch")
+        out = fakeify(torch.empty(B, H, S, D, device=device), "out", "batch")
+        grad_out = fakeify(torch.empty(B, H, S, D, device=device), "grad_out", "batch")
+        logsumexp = fakeify(torch.empty(B, H, S, device=device), "logsumexp", "batch")
+        grad_logsumexp = fakeify(
+            torch.empty(B, H, S, device=device), "grad_logsumexp", "batch"
+        )
+
+        grad_key, grad_value = run(
+            query, key, value, out, logsumexp, grad_out, grad_logsumexp
+        )
+
+        self.assertEqual(grad_key.shape, key.shape)
+        self.assertEqual(grad_value.shape, value.shape)
+
     @supported_platform
     @skip_on_cpu
     @skip_on_mps  # asserts Triton-specific BACKEND='TRITON_DECODE' error
@@ -5731,6 +5827,76 @@ class GraphModule(torch.nn.Module):
         torch.testing.assert_close(compiled_dk, ref_dk)
         torch.testing.assert_close(compiled_dv, ref_dv)
         self.assertEqual(compiled_buffer_grads, ref_buffer_grads)
+
+    @supported_platform
+    @skip_on_cpu
+    @expected_not_implemented_on_mps  # backward Triton lowering
+    def test_direct_backward_inductor_supports_scalar_score_mod_buffers(self, device):
+        def score_mod(score, b, h, m, n, head_dim):
+            # Explicit HOP captures are recorded in subgraph_inps even when the
+            # score graph does not use them.
+            return score
+
+        def mask_mod(b, h, m, n):
+            return m >= n
+
+        block_mask = create_block_mask(
+            mask_mod,
+            B=2,
+            H=2,
+            Q_LEN=128,
+            KV_LEN=128,
+            device=device,
+        )
+        scale = 1.0 / 16**0.5
+        dtype = torch.float32
+        q = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        k = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        v = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        backward_grad = torch.randn((2, 2, 128, 16), dtype=dtype, device=device)
+        static_head_dim = q.shape[-1]
+
+        out, logsumexp = flex_attention_fwd(
+            q,
+            k,
+            v,
+            _identity,
+            block_mask,
+            scale,
+        )
+
+        @torch.compile(fullgraph=True)
+        def compiled_bw(query, key, value, fwd_out, lse, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                fwd_out,
+                lse,
+                grad_out,
+                None,
+                score_mod,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {"BACKEND": "TRITON"},
+                (static_head_dim,),
+                (),
+            )
+
+        with torch.no_grad():
+            dq, dk, dv, _ = compiled_bw(
+                q,
+                k,
+                v,
+                out.detach(),
+                logsumexp.detach(),
+                backward_grad,
+            )
+
+        self.assertEqual(dq.shape, q.shape)
+        self.assertEqual(dk.shape, k.shape)
+        self.assertEqual(dv.shape, v.shape)
 
     @supported_platform
     def test_tensor_subclass_dispatch_order(self, device):
@@ -7355,11 +7521,11 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
 
         block_mask = create_block_mask(mask_mod, None, None, 1024, 1024, device=device)
         flex_attention_call(*create_inputs(1024), block_mask=block_mask)
-        with self.assertRaisesRegex(ValueError, "block_mask was created for"):
+        with self.assertRaisesRegex(RuntimeError, "block_mask was created for"):
             flex_attention_call(*create_inputs(2048), block_mask=block_mask)
 
         block_mask = create_block_mask(mask_mod, None, None, 1023, 1023, device=device)
-        with self.assertRaisesRegex(ValueError, "block_mask was created for"):
+        with self.assertRaisesRegex(RuntimeError, "block_mask was created for"):
             flex_attention_call(*create_inputs(1024), block_mask=block_mask)
 
     @supported_platform

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -21,7 +21,7 @@ from torch._inductor.autotune_process import (
 )
 from torch._inductor.choices import InductorChoices
 from torch._inductor.codegen.common import KernelTemplate
-from torch._inductor.ir import FixedLayout
+from torch._inductor.ir import FixedLayout, ShapeAsConstantBuffer
 from torch._inductor.kernel_inputs import KernelInputs
 from torch._inductor.runtime.triton_compat import Config as TritonConfig
 from torch._inductor.select_algorithm import (
@@ -116,6 +116,14 @@ class TestAlgorithmSelectorChoiceTypes(TestCase):
                     ),
                     expected,
                 )
+
+    def test_realize_inputs_preserves_shape_constant(self):
+        import sympy
+
+        out = select_algorithm.realize_inputs(sympy.Integer(2048))
+
+        self.assertIsInstance(out, ShapeAsConstantBuffer)
+        self.assertEqual(out.expr, sympy.Integer(2048))
 
 
 class TestSelectAlgorithm(TestCase):

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1473,10 +1473,19 @@ def flex_attention_backward_fake_tensor_mode(
     broadcasted_grad_value = value.new_empty((Bq, Hkv, seq_len_kv, v_head_dim))
     broadcasted_grad_value = _permute_strides(broadcasted_grad_value, value.stride())
 
-    if Bq > 1 and Bkv == 1:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_and
+
+    # This branch chooses fake tensor metadata, including strides. Guarding is
+    # valid for backed symbolic sizes, while unbacked/data-dependent predicates
+    # conservatively fall through to the non-broadcast contract below.
+    if guard_or_false(sym_and(Bkv == 1, Bq > 1)):
         grad_key = torch.sum(broadcasted_grad_key, dim=0, keepdim=True)
         grad_value = torch.sum(broadcasted_grad_value, dim=0, keepdim=True)
     else:
+        torch._check(
+            Bq == Bkv,
+            lambda: "grad_key/grad_value batch must match key/value batch.",
+        )
         grad_key = broadcasted_grad_key
         grad_value = broadcasted_grad_value
 

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -49,6 +49,10 @@ from ...utils import load_template
 SubgraphResults = list[ComputedBuffer | None] | ComputedBuffer | None
 
 
+def is_tensor_ir_node(node: object) -> bool:
+    return isinstance(node, IRNode) and node.has_tensor_output()
+
+
 def _flex_kernel_options_example(kind: str) -> str:
     match kind:
         case "backward":

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -34,6 +34,7 @@ from .common import (
     freeze_irnodes,
     get_fwd_subgraph_outputs,
     infer_dense_strides,
+    is_tensor_ir_node,
     load_flex_template,
     maybe_realize,
     realize_captures_for_cutedsl,
@@ -554,9 +555,9 @@ def flex_attention(
     out, _ = autotune_select_algorithm(
         "flex_attention",
         choices,
-        # Need to filter out symbols since there is an invariant
-        # that all input_nodes are of type IRNode
-        [x for x in inputs_for_autotuning if isinstance(x, torch._inductor.ir.IRNode)],
+        # Autotuning materializes benchmark tensors. Scalar shape captures stay
+        # in subgraph_inps below for dependency tracking and codegen.
+        [x for x in inputs_for_autotuning if is_tensor_ir_node(x)],
         layout,
         input_gen_fns=input_gen_fns,
     )
@@ -1092,6 +1093,9 @@ def flex_attention_backward(*args, **kwargs):
             SPARSE_KV_BLOCK_SIZE,
         )
 
+    score_mod_other_buffers = maybe_realize(score_mod_other_buffers)
+    mask_mod_other_buffers = maybe_realize(mask_mod_other_buffers)
+
     inputs_for_autotuning = (
         [
             query,
@@ -1129,7 +1133,9 @@ def flex_attention_backward(*args, **kwargs):
     broadcasted_grad_key, _ = autotune_select_algorithm(
         "flex_attention_backward",
         choices,
-        [x for x in inputs_for_autotuning if isinstance(x, torch._inductor.ir.IRNode)],
+        # Autotuning materializes benchmark tensors. Scalar shape captures stay
+        # in subgraph_inps below for dependency tracking and codegen.
+        [x for x in inputs_for_autotuning if is_tensor_ir_node(x)],
         layout_broadcasted_k,
         input_gen_fns=input_gen_fns,
     )  # [Bq, Hkv, seq_len_kv, k_head_dim]

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -27,6 +27,7 @@ from .common import (
     create_num_blocks_fake_generator,
     freeze_irnodes,
     get_fwd_subgraph_outputs,
+    is_tensor_ir_node,
     load_flex_template,
     maybe_realize,
     set_head_dim_values,
@@ -70,10 +71,19 @@ def _use_flex_decoding(query, kv_indices, value, kernel_options, enable_gqa) -> 
     """
     force_flex = kernel_options.get("FORCE_USE_FLEX_ATTENTION", False)
 
-    short_query_length = V.graph.sizevars.evaluate_expr(
+    # Decode eligibility is an optimization choice, not a user-visible contract,
+    # so every predicate below uses guard_or_false (case 2 of Note [guard_or_]:
+    # the program behaves equivalently whether we pick decode or the general
+    # kernel). guard_or_false returns the real result when ShapeEnv can prove or
+    # guard it, and conservatively returns False for an unprovable unbacked size.
+    # We deliberately do NOT use torch._check here: failing to prove eligibility
+    # must fall back to the general FlexAttention kernel, never impose a runtime
+    # constraint on the user's shapes. We also do NOT use guard_or_true: an
+    # unknown predicate should disable decode, not silently enable it.
+    short_query_length = V.graph.sizevars.guard_or_false(
         sympy.Lt(query.get_size()[-2], 128)
     )
-    non_zero_length = V.graph.sizevars.evaluate_expr(sympy.Gt(query.get_size()[-2], 0))
+    non_zero_length = V.graph.sizevars.guard_or_false(sympy.Gt(query.get_size()[-2], 0))
     static_batch = isinstance(query.get_size()[0], (int, sympy.Integer))
     static_num_heads = isinstance(query.get_size()[1], (int, sympy.Integer))
     if enable_gqa:
@@ -81,11 +91,11 @@ def _use_flex_decoding(query, kv_indices, value, kernel_options, enable_gqa) -> 
         # same kv head are handled by the same block. So it's hard to support different
         # kv num blocks for grouped query heads. We just fall back to main flex_attention
         # kernel where each query head is handled by a separate block.
-        valid_block_mask_num_heads = V.graph.sizevars.evaluate_expr(
+        valid_block_mask_num_heads = V.graph.sizevars.guard_or_false(
             sympy.Eq(kv_indices.get_size()[1], 1)
         )
     else:
-        valid_block_mask_num_heads = V.graph.sizevars.evaluate_expr(
+        valid_block_mask_num_heads = V.graph.sizevars.guard_or_false(
             sympy.Or(
                 sympy.Eq(kv_indices.get_size()[1], 1),
                 sympy.Eq(kv_indices.get_size()[1], query.get_size()[1]),
@@ -431,13 +441,6 @@ def create_flex_decoding_kernel(*args, **kwargs):
             SPARSE_KV_BLOCK_SIZE,
         )
 
-    filtered_score_mod_buffers = [
-        buf for buf in score_mod_other_buffers if not isinstance(buf, sympy.Expr)
-    ]
-    filtered_mask_mod_buffers = [
-        buf for buf in mask_mod_other_buffers if not isinstance(buf, sympy.Expr)
-    ]
-
     inputs_for_flex_decoding = (
         [
             query,
@@ -450,8 +453,8 @@ def create_flex_decoding_kernel(*args, **kwargs):
             full_kv_num_blocks,
             full_kv_indices,
         ]
-        + filtered_score_mod_buffers
-        + filtered_mask_mod_buffers
+        + list(score_mod_other_buffers)
+        + list(mask_mod_other_buffers)
     )
 
     input_gen_fns = {
@@ -464,7 +467,9 @@ def create_flex_decoding_kernel(*args, **kwargs):
     buf_ACC, _ = autotune_select_algorithm(
         "flex_decoding",
         choices,
-        inputs_for_flex_decoding,
+        # Autotuning materializes benchmark tensors. Scalar shape captures stay
+        # in subgraph_inps below for dependency tracking and codegen.
+        [x for x in inputs_for_flex_decoding if is_tensor_ir_node(x)],
         layout_acc,
         input_gen_fns=input_gen_fns,
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -6005,7 +6005,12 @@ def clear_preprocessing_fns(clear_defaults: bool = False):
 
 def realize_inputs(*args):
     if len(args) == 1:
-        return ir.ExternKernel.require_stride1(ir.ExternKernel.realize_input(args[0]))
+        realized = ir.ExternKernel.realize_input(args[0])
+        # Shape scalars are represented as scalar IR, e.g. ShapeAsConstantBuffer.
+        # Tensor layout constraints such as stride-1 only apply to tensor IR.
+        if not realized.has_tensor_output():
+            return realized
+        return ir.ExternKernel.require_stride1(realized)
     return [realize_inputs(x) for x in args]
 
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -2366,28 +2366,45 @@ def flex_attention(
         # This corresponds to the case where we essentially have a "no-op" block mask.
         pass
     else:
+        q_len = query.size(-2)
+        kv_len = key.size(-2)
         block_mask_q_len = block_mask.shape[-2]
         block_mask_kv_len = block_mask.shape[-1]
-        if query.size(-2) > block_mask_q_len or key.size(-2) > block_mask_kv_len:
-            raise ValueError(
-                f"block_mask was created for block_mask.shape={block_mask.shape} but got q_len={query.size(-2)} and kv_len={key.size(-2)}. "
-                "As the block mask was created for a smaller length than you're using it for, you likely need to create a new block mask."
+
+        def block_mask_too_small_error():
+            return (
+                "block_mask was created for a smaller length than you're "
+                "using it for, you likely need to create a new block mask."
             )
-        elif (
-            query.size(-2) < block_mask_q_len and key.size(-2) <= block_mask_kv_len
-        ) or (query.size(-2) <= block_mask_q_len and key.size(-2) < block_mask_kv_len):
-            raise ValueError(
-                f"block_mask was created for block_mask.shape={block_mask.shape} but got q_len={query.size(-2)} and kv_len={key.size(-2)}. "
-                "As the block mask was created for a larger length than you're using it for, you can either 1. create a new block mask with the correct length, or 2. 'adjust' the existing block mask to the correct length by calling block_mask._adjust(q_len, kv_len). This essentially 'crops' the block mask to the upper left corner, which does not work for all mask_mods!"
+
+        def block_mask_too_large_error():
+            return (
+                "block_mask was created for a larger length than you're "
+                "using it for, you can either 1. create a new block mask with "
+                "the correct length, or 2. 'adjust' the existing block mask to "
+                "the correct length by calling block_mask._adjust(q_len, kv_len). "
+                "This essentially 'crops' the block mask to the upper left corner, "
+                "which does not work for all mask_mods!"
             )
-        if query.size(-2) != block_mask_q_len:
-            raise AssertionError(
-                f"query.size(-2) ({query.size(-2)}) != block_mask_q_len ({block_mask_q_len})"
-            )
-        if key.size(-2) != block_mask_kv_len:
-            raise AssertionError(
-                f"key.size(-2) ({key.size(-2)}) != block_mask_kv_len ({block_mask_kv_len})"
-            )
+
+        # Keep these as separate checks: explicit sym_and/sym_or calls become
+        # trace-visible non-Tensor ops under Dynamo.
+        torch._check(
+            q_len <= block_mask_q_len,
+            block_mask_too_small_error,
+        )
+        torch._check(
+            kv_len <= block_mask_kv_len,
+            block_mask_too_small_error,
+        )
+        torch._check(
+            q_len >= block_mask_q_len,
+            block_mask_too_large_error,
+        )
+        torch._check(
+            kv_len >= block_mask_kv_len,
+            block_mask_too_large_error,
+        )
 
     if scale is None:
         scale = 1.0 / math.sqrt(query.size(-1))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187491
* #187490
* __->__ #187489

EP-overlap graph chunking traces FlexAttention with unbacked symbolic batch and sequence dimensions. These are valid runtime sizes, but several FlexAttention predicate and lowering sites forced trace-time decisions that should either fall back to the general kernel or remain represented as symbolic assertions.

Flex decoding remains an optional optimized implementation. Its predicates use guard_or_false because they are kernel eligibility checks, not user-visible invariants: when ShapeEnv can prove eligibility, decode can be selected; when an unbacked predicate is not provable, the general FlexAttention kernel is used. Failing to prove an optimization must not impose a runtime shape contract on user inputs.

Backward fake propagation preserves the accepted KV-batch-broadcast metadata contract. It reduces grad_key and grad_value back to key/value batch when key/value batch is one and query batch is known or runtime-checked to satisfy the eager broadcast precondition; otherwise it records the non-broadcast invariant with torch._check(Bq == Bkv).

Public BlockMask length validation is expressed as symbolic torch._check predicates. Concrete mismatches still fail with the existing guidance, while unbacked symbolic lengths become deferred runtime assertions instead of forcing Python to branch on an unbacked expression.

The FlexAttention lowering keeps scalar shape captures as subgraph inputs for dependency tracking and codegen, but autotuning only receives tensor-valued IR inputs because benchmarking materializes real tensors. Captured Python ints and SymInts are realized as scalar IR, including in backward lowering, so realize_inputs also avoids applying tensor stride constraints to non-tensor scalar IR. This preserves the existing algorithm-selector contract instead of teaching global autotune to key or benchmark scalar captures.

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python -m pytest test/inductor/test_flex_attention.py -q -s -k "unbacked_flex_decoding_eligibility_falls_back or backward_fake_symbolic_query_key_batch_metadata or block_mask_vs_sequence_lengths or direct_backward_inductor_supports_scalar_score_mod_buffers"
```

```bash
python test/inductor/test_select_algorithm.py TestAlgorithmSelectorChoiceTypes
```

```bash
python test/inductor/test_flex_attention.py -k direct_backward_supports_symint_score_mod_buffers -v
```

```bash
python test/inductor/test_dependencies.py TestDependencies.test_extern_kernel_nested_ir_args_are_dependencies
```

```bash
python test/inductor/test_mkldnn_pattern_matcher.py TestPatternMatcher.test_linear_add_bias TestPatternMatcher.test_linear_add_bias_float_constant
```

```bash
lintrunner -a
```

Downstream EP-overlap integration was also run for full-Inductor FlexAttention graph chunking across moe_batch, moe_seq, and transformer_batch in both concretize and no_concretize modes.

stack-info: PR: https://github.com/pytorch/pytorch/pull/183838, branch: sanketpurandare/stack/12