### PR TITLE
[Dynamo] Only count torch-owned handlers in `emit_post_hook`

### DIFF
--- a/torch/testing/_internal/logging_utils.py
+++ b/torch/testing/_internal/logging_utils.py
@@ -163,22 +163,28 @@ class LoggingTestCase(torch._dynamo.test_case.TestCase):
             nonlocal record_list
             record_list.append(record)
 
-        # registered logs are the only ones with handlers, so patch those
+        # Pytest attaches capture handlers directly to non-propagating loggers.
+        # Only Torch-owned handlers participate in these logging assertions.
         for log_qname in torch._logging._internal.log_registry.get_log_qnames():
             logger = logging.getLogger(log_qname)
-            num_handlers = len(logger.handlers)
+            logger_handlers = [
+                handler
+                for handler in logger.handlers
+                if torch._logging._internal._is_torch_handler(handler)
+            ]
+            num_handlers = len(logger_handlers)
             self.assertLessEqual(
                 num_handlers,
                 2,
-                "All pt2 loggers should only have at most two handlers (debug artifacts and messages above debug level).",
+                "All pt2 loggers should only have at most two Torch handlers (debug artifacts and messages above debug level).",
             )
 
-            self.assertGreater(num_handlers, 0, "All pt2 loggers should have more than zero handlers")
+            self.assertGreater(num_handlers, 0, "All pt2 loggers should have more than zero Torch handlers")
 
-            for handler in logger.handlers:
+            for handler in logger_handlers:
                 old_emit = handler.emit
 
-                def new_emit(record):
+                def new_emit(record, old_emit=old_emit):
                     old_emit(record)
                     emit_post_hook(record)
 


### PR DESCRIPTION
authored with codex

otherwise we seem to observe failures like 
```
File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
yield
File "/usr/lib/python3.12/unittest/case.py", line 634, in run
self._callTestMethod(testMethod)
File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
if method() is not None:
^^^^^^^^
File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3532, in wrapper
method(*args, **kwargs)
File "/usr/lib/python3.12/contextlib.py", line 81, in inner
return func(*args, **kwds)
^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/logging_utils.py", line 90, in test_fn
with log_settings(kwargs_to_settings(**kwargs)), self._handler_watcher(records):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/logging_utils.py", line 170, in _handler_watcher
self.assertLessEqual(
File "/usr/lib/python3.12/unittest/case.py", line 1263, in assertLessEqual
self.fail(self._formatMessage(msg, standardMsg))
File "/usr/lib/python3.12/unittest/case.py", line 715, in fail
raise self.failureException(msg)
AssertionError: 5 not less than or equal to 2 : All pt2 loggers should only have at most two handlers (debug artifacts and messages above debug level).
```