### PR TITLE
Fix cpu flash sdpa incorrect results when inputs' innermost dim is not contiguous

### DIFF
--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -359,9 +359,9 @@ void cpu_flash_attention(
   //    -> (Batch x KV_seq_len   x KV_num_heads x Dim_per_head)
   // Value (Batch x KV_num_heads x KV_seq_len   x Dim_per_head)
   //    -> (Batch x KV_seq_len   x KV_num_heads x Dim_per_head)
-  at::Tensor query = q.transpose(1, 2);
-  at::Tensor key = k.transpose(1, 2);
-  at::Tensor value = v.transpose(1, 2);
+  at::Tensor query = q.stride(-1) == 1 ? q.transpose(1, 2) : q.transpose(1, 2).contiguous();
+  at::Tensor key = k.stride(-1) == 1 ? k.transpose(1, 2) : k.transpose(1, 2).contiguous();
+  at::Tensor value = v.stride(-1) == 1 ? v.transpose(1, 2) : v.transpose(1, 2).contiguous();
 
   constexpr bool is_reduced_type = is_reduced_floating_point_v<scalar_t>;
   using accum_t = at::opmath_type<scalar_t>;
@@ -798,9 +798,9 @@ void cpu_flash_attention_backward(
     const at::Tensor& grad_k,
     const at::Tensor& grad_v,
     const at::Tensor& grad_out,
-    const at::Tensor& query,
-    const at::Tensor& key,
-    const at::Tensor& value,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
     const at::Tensor& out,
     const at::Tensor& logsumexp,
     double dropout_p,
@@ -810,15 +810,18 @@ void cpu_flash_attention_backward(
   constexpr bool is_reduced_type = is_reduced_floating_point_v<scalar_t>;
   using accum_t = at::opmath_type<scalar_t>;
   using Vec = vec::Vectorized<accum_t>;
+  // Query (Batch x Q_seq_len  x Num_heads    x Dim_per_head)
+  // Key   (Batch x KV_seq_len x KV_num_heads x Dim_per_head)
+  // Value (Batch x KV_seq_len x KV_num_heads x Dim_per_head)
+  at::Tensor query = q.stride(-1) == 1 ? q.transpose(1, 2) : q.transpose(1, 2).contiguous();
+  at::Tensor key = k.stride(-1) == 1 ? k.transpose(1, 2) : k.transpose(1, 2).contiguous();
+  at::Tensor value = v.stride(-1) == 1 ? v.transpose(1, 2) : v.transpose(1, 2).contiguous();
   accum_t scaling_factor =
       sdp::calculate_scale(query, scale).expect_float();
 
   // Sizes
   TORCH_CHECK((query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
         "scaled_dot_product_attention_flash_attention_backward: Q/K/V should have the same head size");
-  // Query (Batch x Q_seq_len  x Num_heads    x Dim_per_head)
-  // Key   (Batch x KV_seq_len x KV_num_heads x Dim_per_head)
-  // Value (Batch x KV_seq_len x KV_num_heads x Dim_per_head)
   int64_t batchSize = query.size(0);
   int64_t qSize = query.size(1);
   int64_t kvSize = value.size(1);

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -404,7 +404,6 @@ skip_noncontig = {
     "_batch_norm_with_update",
     "as_strided_copy",
     "native_group_norm",
-    "torch.ops.aten._scaled_dot_product_flash_attention_for_cpu",
 }
 
 bool_unsupported_ordered_ops = {
@@ -1115,7 +1114,6 @@ class TestOperators(TestCase):
             skip("nn.functional.alpha_dropout"),  # randomness
             skip("nn.functional.scaled_dot_product_attention"),  # randomness
             xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
-            xfail("torch.ops.aten._scaled_dot_product_flash_attention_for_cpu"),
             skip("nn.functional.multi_head_attention_forward"),  # randomness
             xfail(
                 "index_put", ""
@@ -1516,6 +1514,9 @@ class TestOperators(TestCase):
                     "index_fill"
                 ),  # aten::_unique hit the vmap fallback which is currently disabled
                 xfail("native_group_norm"),
+                xfail(
+                    "torch.ops.aten._scaled_dot_product_flash_attention_for_cpu"
+                ),  # aten::_scaled_dot_product_flash_attention_for_cpu hit the vmap fallback which is currently disabled
             }
         ),
     )

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4524,6 +4524,7 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("nn.functional.scaled_dot_product_attention"),  # randomness
                 xfail("nn.functional.multi_head_attention_forward"),  # randomness
                 xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+                xfail("torch.ops.aten._scaled_dot_product_flash_attention_for_cpu"),
                 xfail("resize_"),
                 xfail("view_as_complex"),
                 xfail("fft.ihfft2"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01