### PR TITLE
Fix typos in comments, docstrings, and warning messages across torch/utils and related modules

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -297,7 +297,7 @@ def _validate_loaded_sparse_tensors():
     try:
         # We disable pinning check (see check_pinning=False below) to
         # avoid gh-153143. In fact, pinning check is unnecessary
-        # anywhy when loading sparse data from external sources.
+        # anyway when loading sparse data from external sources.
         for t in _sparse_tensors_to_validate:
             if t.layout is torch.sparse_coo:
                 torch._validate_sparse_coo_tensor_args(

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -655,7 +655,7 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         # Warnings for unsupported cases:
         if m == 1 or n == 1 or k == 1:
             warnings.warn(
-                "Offline tuning is not support for this GEMM. Use online tuning instead. "
+                "Offline tuning is not supported for this GEMM. Use online tuning instead. "
                 + f"Skipped tuning for: {untuned_gemm[1]}",
                 stacklevel=2,
             )

--- a/torch/utils/_debug_mode/_mode.py
+++ b/torch/utils/_debug_mode/_mode.py
@@ -447,7 +447,7 @@ class DebugMode(TorchDispatchMode):
                 self._record_call(call)
 
         # Run pre-hooks before executing the operation to hash inputs
-        # We have to run becore the func() call in case there's any
+        # We have to run before the func() call in case there's any
         # in-place mutation
         if call:
             _run_dispatch_pre_log_hooks(call, func, types, args, kwargs)

--- a/torch/utils/_get_clean_triton.py
+++ b/torch/utils/_get_clean_triton.py
@@ -156,7 +156,7 @@ def get_clean_triton(
     """Run experiments and output results to file
 
     Args:
-        input_path (Path): Path to inductor generated output codede
+        input_path (Path): Path to inductor generated output code
         output_path (Path): Path to write out the new python file
         auto_generate_params (bool): Whether to automatically generate launch_params if missing
     """

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -864,7 +864,7 @@ def _namedtuple_serialize(context: Context) -> DumpableContext:
     if context not in SUPPORTED_SERIALIZED_TYPES:
         raise NotImplementedError(
             f"Can't serialize TreeSpec of namedtuple class {context} because we "
-            "didn't register a serializated_type_name. Please register using "
+            "didn't register a serialized_type_name. Please register using "
             "`_register_namedtuple`."
         )
 
@@ -874,7 +874,7 @@ def _namedtuple_serialize(context: Context) -> DumpableContext:
     if serialized_type_name == NO_SERIALIZED_TYPE_NAME_FOUND:
         raise NotImplementedError(
             f"Can't serialize TreeSpec of namedtuple class {context} because we "
-            "couldn't find a serializated_type_name. Please register using "
+            "couldn't find a serialized_type_name. Please register using "
             "`_register_namedtuple`."
         )
     return serialized_type_name
@@ -884,7 +884,7 @@ def _namedtuple_deserialize(dumpable_context: DumpableContext) -> Context:
     if dumpable_context not in SERIALIZED_TYPE_TO_PYTHON_TYPE:
         raise NotImplementedError(
             f"Can't deserialize TreeSpec of namedtuple class {dumpable_context} "
-            "because we couldn't find a serializated name."
+            "because we couldn't find a serialized name."
         )
 
     typ = SERIALIZED_TYPE_TO_PYTHON_TYPE[dumpable_context]

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -845,7 +845,7 @@ class SymPyValueRangeAnalysis:
         # If you want to implement it, compute the partial derivatives of a ** b
         # and check the ranges where the function is increasing / decreasing
         # Another non-tight way of doing this is defaulting to doing noting that for a > 0,  a ** b == exp(b * log(a))
-        # If this second option is implemented, by carefult about the types and possible infinities here and there.
+        # If this second option is implemented, be careful about the types and possible infinities here and there.
         if not b.is_singleton():
             return ValueRanges.unknown()
 

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -129,7 +129,7 @@ if HAS_TABULATE:
         This is a simple utility that can be used to benchmark torch.compile
         In particular it ensures that your GPU is setup to use tensor cores if it supports its
         It also tries out all the main backends and prints a table of results so you can easily compare them all
-        Many of the backendds have their own optional dependencies so please pip install them separately
+        Many of the backends have their own optional dependencies so please pip install them separately
 
         You will get one table for inference and another for training
         If you'd like to leverage this utility for training make sure to pass in a torch.optim.Optimizer

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -389,7 +389,7 @@ class Timer:
             max_run_time: float = 10.0,
             callback: Callable[[int, float], NoReturn] | None = None,
     ) -> common.Measurement:
-        """Similar to `blocked_autorange` but also checks for variablility in measurements
+        """Similar to `blocked_autorange` but also checks for variability in measurements
         and repeats until iqr/median is smaller than `threshold` or `max_run_time` is reached.
 
 

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -232,7 +232,7 @@ class CallgrindStats:
         """Diff two sets of counts.
 
         One common reason to collect instruction counts is to determine the
-        the effect that a particular change will have on the number of instructions
+        effect that a particular change will have on the number of instructions
         needed to perform some unit of work. If a change increases that number, the
         next logical question is "why". This generally involves looking at what part
         if the code increased in instruction count. This function automates that

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -250,7 +250,7 @@ def _join_sycl_home(*paths) -> str:
     only once we need to get any SYCL-specific path.
     """
     if SYCL_HOME is None:
-        raise OSError('SYCL runtime is not dected. Please setup the pytorch '
+        raise OSError('SYCL runtime is not detected. Please setup the pytorch '
                       'prerequisites for Intel GPU following the instruction in '
                       'https://github.com/pytorch/pytorch?tab=readme-ov-file#intel-gpu-support '
                       'or install intel-sycl-rt via pip.')
@@ -714,7 +714,7 @@ def _wrap_sycl_host_flags(cflags):
 
         # Some versions of DPC++ compiler pass paths to SYCL headers as user include paths (`-I`) rather
         # than system paths (`-isystem`). This makes host compiler to report warnings encountered in the
-        # SYCL headers, such as deprecated warnings, even if warmed API is not actually used in the program.
+        # SYCL headers, such as deprecated warnings, even if warned API is not actually used in the program.
         # We expect that this issue will be addressed in the later version of DPC++ compiler. To workaround the
         # issue now we wrap paths to SYCL headers in `/external:I`. Warning free compilation is especially important
         # for Windows build as `/sdl` compilation flag assumes that and we will fail compilation otherwise.
@@ -1543,7 +1543,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
     An exception to this rule is "dynamic parallelism" (nested kernel launches)  which is not used a lot anymore.
     `Relocatable device code` is less optimized so it needs to be used only on object files that need it.
     Using `-dlto` (Device Link Time Optimization) at the device code compilation step and `dlink` step
-    helps reduce the protentional perf degradation of `-rdc`.
+    helps reduce the potential perf degradation of `-rdc`.
     Note that it needs to be used at both steps to be useful.
 
     If you have `rdc` objects you need to have an extra `-dlink` (device linking) step before the CPU symbol linking step.

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -104,7 +104,7 @@ def generate_mobile_module_lints(script_module: torch.jit.ScriptModule):
         if "dropout" in op_name:
             lint_list.append({"name": LintCode.DROPOUT.name,
                               "message": f"Operator {op_name} exists, remember to call eval() before "
-                              "saving the module.and call torch.utils.mobile_optimizer.optimize_for_mobile to drop dropout "
+                              "saving the module and call torch.utils.mobile_optimizer.optimize_for_mobile to drop dropout "
                               "operator."})
         if "batch_norm" in op_name:
             lint_list.append({"name": LintCode.BATCHNORM.name,

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -21,7 +21,7 @@ methods_OP = [
     "outputsSize",
     "scopeName",
 ]
-# Some additional methods to explure for methods_IO are
+# Some additional methods to explore for methods_IO are
 #
 #   'unique' (type int)
 #   'type' (type <Tensor<class 'torch._C.Type'>>)

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -42,7 +42,7 @@ def _prepare_video(V):
     """
     Convert a 5D tensor into 4D tensor.
 
-    Convesrion is done from [batchsize, time(frame), channel(color), height, width]  (5D tensor)
+    Conversion is done from [batchsize, time(frame), channel(color), height, width]  (5D tensor)
     to [time(frame), new_width, new_height, channel] (4D tensor).
 
     A batch of images are spread to a grid, which forms a frame.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187511

No functional changes; corrects spelling in user-facing strings and code comments.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01