### PR TITLE
[TEST] Bump tolerances for `TestOperatorsCUDA.test_jvp_nn_functional_linear_cross_entropy_cuda_float32`

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -641,6 +641,11 @@ class TestOperators(TestCase):
             tol1("svd_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
             tol1("pca_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
             tol1(
+                "nn.functional.linear_cross_entropy",
+                {torch.float32: tol(atol=2e-05, rtol=3e-06)},
+                device_type="cuda",
+            ),
+            tol1(
                 "nn.functional.multi_head_attention_forward",
                 {torch.float32: tol(atol=6e-05, rtol=2e-05)},
             ),


### PR DESCRIPTION
otherwise seems to fail on Ampere with e.g., 
```
Expected -2.788013458251953 but got -2.787994384765625.
Absolute difference: 1.9073486328125e-05 (up to 1e-05 allowed)
Relative difference: 6.8412461466681075e-06 (up to 1.3e-06 allowed)

Caused by sample input at index 25: SampleInput(input=Tensor[size=(8, 8), device="cuda:0", dtype=torch.float32], args=TensorList[Tensor[size=(8, 8), device="cuda:0", dtype=torch.float32], Tensor[size=(8, 8), device="cuda:0", dtype=torch.float32]], kwargs={'reduction': "'sum'"}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=25 python test/functorch/test_ops.py TestOperatorsCUDA.test_jvp_nn_functional_linear_cross_entropy_cuda_float32
    ```
This is a compound op with multiple reductions so generic fp32 tolerances seem to be too strict

authored manually

cc @ptrblck @msaroufim @tinglvv @nWEIdia @mruberry