### PR TITLE
[CI] Point OSDC lint workflow at the .ci/docker linter images

### DIFF
--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -5,6 +5,9 @@ on:
       runner:
         type: string
         required: true
+      docker-image:
+        type: string
+        required: true
       ref:
         type: string
         required: true
@@ -15,7 +18,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: ${{ inputs.docker-image }}
       script: |
         ./scripts/lint_urls.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -36,7 +39,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: ${{ inputs.docker-image }}
       script: |
         ./scripts/lint_xrefs.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -23,43 +23,10 @@ jobs:
       image: ${{ inputs.docker-image }}
     timeout-minutes: 120
     steps:
-      - name: Fix Git ownership
-        shell: bash
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
-          fetch-depth: 0
-          submodules: true
-          no-sudo: true
-          checkout-mode: treeless
-
-      - name: Setup uv
-        uses: pytorch/test-infra/.github/actions/setup-uv@main
-        with:
-          python-version: "3.12"
-          activate-environment: true
-
-      - name: Install pip requirements
-        shell: bash
-        run: |
-          set -eux
-          uv pip install -r .ci/docker/requirements-ci.txt
-
-      - name: Install system requirements
-        shell: bash
-        run: |
-          set -eux
-          # Update repository
-          dnf install -y doxygen graphviz nodejs npm
-
-      - name: Install Node.js packages
-        shell: bash
-        run: |
-          set -eux
-          npm install -g markdown-toc
+          use-arc: true
 
       - name: Prepare lintrunner
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,7 +57,7 @@ jobs:
       )
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cuda-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         if [ "$CHANGED_FILES" = "*" ]; then
@@ -84,7 +84,7 @@ jobs:
       )
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running pyrefly"
@@ -96,7 +96,7 @@ jobs:
     needs: [get-label-type, get-changed-files]
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
@@ -112,7 +112,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Ensure no non-breaking spaces
         # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
@@ -162,7 +162,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Regenerate workflows
         .github/scripts/generate_ci_workflows.py
@@ -193,7 +193,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Regenerate ToCs and check that they didn't change
         set -eu
@@ -226,7 +226,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Test tools
         PYTHONPATH=$(pwd) pytest tools/stats

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -327,6 +327,7 @@ jobs:
     uses: ./.github/workflows/_link_check.yml
     with:
       runner: ${{ needs.get-label-type.outputs.label-type }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   doc-redirects-check:


### PR DESCRIPTION
Keep the lint jobs on the OSDC ARC runners via `_lint.yml`, but pull the `.ci/docker` linter images instead of the `ghcr.io/pytorch/test-infra:*` ones: `pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-linter` for clang, `pytorch-linux-jammy-linter` for the rest. They are passed as the fully-qualified ECR `ci-image` with the `.ci/docker` tree-hash suffix (`ci-docker-hash` from `get-label-type`), since `_lint.yml` uses `docker-image` verbatim as `container: image:`.

The setup steps now baked into those images are dropped from `_lint.yml`: Setup uv, Install pip requirements, Install system requirements, and Install Node.js packages.

This PR was authored with an AI assistant.