### PR TITLE
Fix baddbmm nan propagation and test

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -815,9 +815,7 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
       MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
       MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
 
-      // Intermediates for beta and alpha
-      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
-                                                       dataType:getMPSScalarType(input.scalar_type())];
+      // Intermediate for alpha
       MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
                                                         dataType:getMPSScalarType(batch1.scalar_type())];
 
@@ -830,18 +828,25 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
         reductionSumTensor = [mpsGraph reductionSumWithTensor:productTensor axis:0 name:@"reductionSum(batch1@batch2)"];
       }
 
-      // Intermediates for multiplying by beta and alpha
+      // Intermediate for multiplying by alpha
       MPSGraphTensor* reductionSumTimesAlphaTensor =
           [mpsGraph multiplicationWithPrimaryTensor:reductionSumTensor
                                     secondaryTensor:alphaTensor
                                                name:@"alpha*(batch1@batch2)"];
-      MPSGraphTensor* biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                      secondaryTensor:betaTensor
-                                                                                 name:@"beta*input"];
 
-      MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:reductionSumTimesAlphaTensor
-                                                         secondaryTensor:biasTimesBetaTensor
-                                                                    name:@"beta*input + alpha*(batch1@batch2)"];
+      // When beta == 0, input is ignored so nan/inf in it are not propagated (matches CPU/CUDA and addmm).
+      const double betaVal = beta.toDouble();
+      MPSGraphTensor* outputTensor = reductionSumTimesAlphaTensor;
+      if (betaVal != 0.0) {
+        MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:betaVal
+                                                         dataType:getMPSScalarType(input.scalar_type())];
+        MPSGraphTensor* biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                        secondaryTensor:betaTensor
+                                                                                   name:@"beta*input"];
+        outputTensor = [mpsGraph additionWithPrimaryTensor:reductionSumTimesAlphaTensor
+                                           secondaryTensor:biasTimesBetaTensor
+                                                      name:@"beta*input + alpha*(batch1@batch2)"];
+      }
 
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->batch1Tensor_ = batch1Tensor;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1465,6 +1465,25 @@ class TestMPS(TestCaseMPS):
         helper(input_shape=(10, 3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(1, 77, 77), batch1_shape=(8, 77, 64), batch2_shape=(8, 64, 77))
 
+    def test_baddbmm_beta_zero_ignores_input(self):
+        # When beta == 0 the input/bias must be ignored entirely. nan/inf in it
+        # must not be propagated. Regression test for: #187521.
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            batch1 = torch.randn(8, 77, 64, dtype=dtype, device="mps")
+            batch2 = torch.randn(8, 64, 77, dtype=dtype, device="mps")
+            for bad in [float("nan"), float("inf"), float("-inf")]:
+                inp = torch.full((8, 77, 77), bad, dtype=dtype, device="mps")
+                out = torch.baddbmm(inp, batch1, batch2, beta=0, alpha=0.125)
+                self.assertFalse(out.isnan().any() or out.isinf().any(),
+                                 f"baddbmm beta=0 propagated {bad} for dtype={dtype}")
+                ref = torch.bmm(batch1, batch2) * 0.125
+                self.assertEqual(out, ref)
+
+                inp_a = torch.full((77, 77), bad, dtype=dtype, device="mps")
+                out_a = torch.addbmm(inp_a, batch1, batch2, beta=0, alpha=0.125)
+                self.assertFalse(out_a.isnan().any() or out_a.isinf().any(),
+                                 f"addbmm beta=0 propagated {bad} for dtype={dtype}")
+
     def test_local_scalar_dense_mps(self):
         x_cpu = torch.randn(1)
         y_mps = x_cpu.to("mps")


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/187521.

The op implementation was not following the contract by the baddbmm doc page that we should not propagate nan/inf if beta is zero. This fixes the issue and adds a regression test.