### PR TITLE
[CI] Parameterize _link_check.yml docker image

### DIFF
--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -5,6 +5,9 @@ on:
       runner:
         type: string
         required: true
+      docker-image:
+        type: string
+        required: true
       ref:
         type: string
         required: true
@@ -15,7 +18,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: ${{ inputs.docker-image }}
       script: |
         ./scripts/lint_urls.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -36,7 +39,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: ${{ inputs.docker-image }}
       script: |
         ./scripts/lint_xrefs.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -327,6 +327,7 @@ jobs:
     uses: ./.github/workflows/_link_check.yml
     with:
       runner: ${{ needs.get-label-type.outputs.label-type }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   doc-redirects-check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -327,7 +327,7 @@ jobs:
     uses: ./.github/workflows/_link_check.yml
     with:
       runner: ${{ needs.get-label-type.outputs.label-type }}
-      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
+      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   doc-redirects-check:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187524
* __->__ #187523

Add a required docker-image input to _link_check.yml and thread it through
the lint-urls and lint-xrefs jobs. lint.yml's link-check job keeps passing
the existing ghcr.io/pytorch/test-infra image, so this is a no-op refactor
that lets a follow-up swap the image without touching _link_check.yml.

Authored-with: Claude (Anthropic AI assistant)