### PR TITLE
[CI] Point OSDC lint workflow at the .ci/docker linter images

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -248,10 +248,12 @@ case "$tag" in
     ;;
   pytorch-linux-jammy-linter)
     PYTHON_VERSION=3.10
+    CLANG_VERSION=18
     ;;
   pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-linter)
     PYTHON_VERSION=3.10
     CUDA_VERSION=13.0.2
+    CLANG_VERSION=18
     ;;
   pytorch-linux-jammy-aarch64-py3.10-gcc13)
     ANACONDA_PYTHON_VERSION=3.10

--- a/.ci/docker/common/install_linter.sh
+++ b/.ci/docker/common/install_linter.sh
@@ -4,7 +4,7 @@ set -ex
 
 if [ -n "${UBUNTU_VERSION}" ]; then
   apt update
-  apt-get install -y clang doxygen git graphviz nodejs npm libtinfo5
+  apt-get install -y doxygen git graphviz nodejs npm libtinfo5
 fi
 
 # Do shallow clone of PyTorch so that we can init lintrunner in Docker build context

--- a/.ci/docker/linter-cuda/Dockerfile
+++ b/.ci/docker/linter-cuda/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends libomp-dev && a
 COPY ./common/install_user.sh install_user.sh
 RUN bash ./install_user.sh && rm install_user.sh
 
+# Install clang
+ARG CLANG_VERSION
+COPY ./common/install_clang.sh install_clang.sh
+RUN bash ./install_clang.sh && rm install_clang.sh
+
 # Install conda and other packages (e.g., numpy, pytest)
 ARG PYTHON_VERSION
 ARG PIP_CMAKE

--- a/.ci/docker/linter/Dockerfile
+++ b/.ci/docker/linter/Dockerfile
@@ -14,6 +14,11 @@ RUN bash ./install_base.sh && rm install_base.sh
 COPY ./common/install_user.sh install_user.sh
 RUN bash ./install_user.sh && rm install_user.sh
 
+# Install clang
+ARG CLANG_VERSION
+COPY ./common/install_clang.sh install_clang.sh
+RUN bash ./install_clang.sh && rm install_clang.sh
+
 # Install conda and other packages (e.g., numpy, pytest)
 ARG PYTHON_VERSION
 ENV PATH /var/lib/jenkins/ci_env/bin:$PATH

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -23,43 +23,10 @@ jobs:
       image: ${{ inputs.docker-image }}
     timeout-minutes: 120
     steps:
-      - name: Fix Git ownership
-        shell: bash
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
-          fetch-depth: 0
-          submodules: true
-          no-sudo: true
-          checkout-mode: treeless
-
-      - name: Setup uv
-        uses: pytorch/test-infra/.github/actions/setup-uv@main
-        with:
-          python-version: "3.12"
-          activate-environment: true
-
-      - name: Install pip requirements
-        shell: bash
-        run: |
-          set -eux
-          uv pip install -r .ci/docker/requirements-ci.txt
-
-      - name: Install system requirements
-        shell: bash
-        run: |
-          set -eux
-          # Update repository
-          dnf install -y doxygen graphviz nodejs npm
-
-      - name: Install Node.js packages
-        shell: bash
-        run: |
-          set -eux
-          npm install -g markdown-toc
+          use-arc: true
 
       - name: Prepare lintrunner
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,7 +57,7 @@ jobs:
       )
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cuda-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         if [ "$CHANGED_FILES" = "*" ]; then
@@ -84,7 +84,7 @@ jobs:
       )
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running pyrefly"
@@ -96,7 +96,7 @@ jobs:
     needs: [get-label-type, get-changed-files]
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
@@ -112,7 +112,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Ensure no non-breaking spaces
         # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
@@ -162,7 +162,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Regenerate workflows
         .github/scripts/generate_ci_workflows.py
@@ -193,7 +193,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Regenerate ToCs and check that they didn't change
         set -eu
@@ -226,7 +226,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       runner: mt-l-x86iamx-8-16
-      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-810d48d
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
         # Test tools
         PYTHONPATH=$(pwd) pytest tools/stats


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187524

Have _lint.yml pull the .ci/docker linter images (cuda13.0 linter for
lintrunner-clang, plain linter elsewhere, including the link-check job)
instead of the prebuilt ghcr.io/pytorch/test-infra images, passed fully
qualified with the ci-docker-hash suffix. Drop the setup steps now baked
into the image (uv, pip requirements, system packages, markdown-toc) and
use the shared setup-linux action so the checkout works as the jenkins
user on ARC runners.

Fixes https://github.com/pytorch/ci-infra/issues/776

Authored-with: Claude (Anthropic AI assistant)