### PR TITLE
Cuda allocator fixes on windows

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5835,9 +5835,28 @@ class TestCudaAllocator(TestCase):
             )
 
     def test_allocator_backend(self):
+        def subprocess_env():
+            if IS_WINDOWS:
+                # An empty env breaks Windows stdlib/CUDA extension loading (no PATH).
+                return {
+                    k: os.environ[k]
+                    for k in (
+                        "SYSTEMROOT",
+                        "SYSTEMDRIVE",
+                        "WINDIR",
+                        "COMSPEC",
+                        "PATH",
+                    )
+                    if k in os.environ
+                }
+            return {}
+
         def check_output(script: str) -> str:
+            kwargs = {"env": subprocess_env(), "text": True}
+            if IS_WINDOWS:
+                kwargs["cwd"] = tempfile.gettempdir()
             return subprocess.check_output(
-                [sys.executable, "-c", script], env={}, text=True
+                [sys.executable, "-c", script], **kwargs
             ).strip()
 
         test_script = """\

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1436,12 +1436,33 @@ def _use_uvm(device: "Device" = None):
                 _advise_uses_struct = False
         return _runtime.cudaMemAdvise(ptr, size, advice, device_id)
 
+    _uvm_advise_supported_cache: dict[tuple[int, int], bool] = {}
+
+    def _device_supports_uvm_advise(device_id, _runtime=_rt):
+        cache_key = (device_id, id(_runtime))
+        if cache_key in _uvm_advise_supported_cache:
+            return _uvm_advise_supported_cache[cache_key]
+        attr = getattr(
+            _runtime.cudaDeviceAttr, "cudaDevAttrConcurrentManagedAccess", None
+        )
+        if attr is None:
+            supported = False
+        else:
+            result = _runtime.cudaDeviceGetAttribute(attr, device_id)
+            err = result if not isinstance(result, tuple) else result[0]
+            if err != _runtime.cudaError_t.cudaSuccess:
+                supported = False
+            else:
+                supported = bool(result[1])
+        _uvm_advise_supported_cache[cache_key] = supported
+        return supported
+
     def _uvm_alloc(size, device, stream, _runtime=_rt):
         try:
             err, ptr = _runtime.cudaMallocManaged(size, _runtime.cudaMemAttachGlobal)
             _check(err, f"cudaMallocManaged({size})")
             ptr = int(ptr)
-            if device >= 0:
+            if device >= 0 and _device_supports_uvm_advise(device, _runtime):
                 _check(
                     _mem_advise(
                         ptr,


### PR DESCRIPTION
This fixes two allocator-related failures on windows.

### Summary
`TestCudaAllocator.test_allocator_backend` spawned subprocesses with an empty environment. On Windows, that removes required process variables like `PATH`/`SYSTEMROOT`, which can break Python stdlib or CUDA extension loading. The test now preserves a minimal Windows environment and runs subprocesses from a temp directory so imports do not resolve against the source tree accidentally.

`torch.cuda._use_uvm()` used `cudaMallocManaged` and then unconditionally issued `cudaMemAdvise` placement/access hints. Some systems support managed memory but report `cudaDevAttrConcurrentManagedAccess == 0`; on those systems the advice calls can fail with `cudaErrorInvalidDevice`, causing the custom allocator to return null and PyTorch to surface a misleading OOM. The UVM allocator now skips advice when concurrent managed access is unavailable, while still using the valid managed-memory allocation.

### Test Plan
```powershell
python .\pytorch\test\run_test.py -i test_cuda
```

Authored with the assistance of an AI coding assistant.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex