### PR TITLE
perf(dynamo): add guard lookup token plan

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -769,6 +769,28 @@ num_guards_executed=0)
         self.assertEqual(stats["slow_guard_fallback"], 0)
         self.assertGreater(stats["actual_partial_enabled"], 0)
 
+    def test_token_plan_fast_hit_allows_token_covered_leaf_guard(self):
+        modules = {"block": {}}
+        guard_manager = RootGuardManager()
+        modules_manager = guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            modules,
+            default_mgr_enum,
+        )
+        modules_manager.add_dict_version_guard(
+            modules, ["dict version matches modules"]
+        )
+
+        stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": modules}, 4
+        )
+
+        self.assertTrue(stats["result"])
+        self.assertGreater(stats["actual_partial_hit"], 0)
+        self.assertEqual(stats["actual_partial_miss"], 0)
+        self.assertEqual(stats["slow_guard_fallback"], 0)
+
     def test_token_plan_miss_falls_back_to_slow_guard(self):
         guard_manager = RootGuardManager()
         guard_manager.dict_getitem_manager(

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -8,7 +8,7 @@ import torch._dynamo
 import torch._dynamo.test_case
 from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
-from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+from torch._dynamo.eval_frame import _debug_get_cache_entry_list, reset_code
 from torch.testing._internal.common_utils import set_default_dtype
 
 
@@ -572,6 +572,34 @@ num_guards_executed=0)
         stats = guard_manager.get_guard_lookup_stats()
         self.assertIn("actual_partial_receipt_created", stats)
         self.assertEqual(stats["actual_partial_enabled"], 0)
+
+    def test_guard_lookup_stats_reject_stale_extra_state(self):
+        def fn(x):
+            return x + 1
+
+        opt_fn = torch.compile(fn, backend="eager")
+        opt_fn(torch.ones(3))
+
+        cache_entries = _debug_get_cache_entry_list(fn.__code__)
+        self.assertEqual(len(cache_entries), 1)
+        guard_manager = cache_entries[0].guard_manager
+
+        stats = guard_manager.get_guard_lookup_stats()
+        self.assertIn("actual_partial_receipt_created", stats)
+
+        reset_code(fn.__code__)
+        self.assertIsNone(guard_manager.extra_state)
+
+        with self.assertRaisesRegex(
+            (RuntimeError, AttributeError),
+            "guard lookup stats are unavailable|extra_state",
+        ):
+            guard_manager.get_guard_lookup_stats()
+        with self.assertRaisesRegex(
+            (RuntimeError, AttributeError),
+            "guard lookup stats are unavailable|extra_state",
+        ):
+            guard_manager.reset_guard_lookup_stats()
 
     def test_dict_getitem_accessor(self):
         foo = {

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -578,6 +578,8 @@ num_guards_executed=0)
         self.assertEqual(stats["actual_partial_hit"], 0)
         self.assertEqual(stats["actual_partial_miss"], 0)
         self.assertEqual(stats["slow_guard_fallback"], 0)
+        self.assertIn("actual_partial_disabled_reasons", stats)
+        self.assertEqual(stats["actual_partial_disabled_reasons"], {})
 
     def test_guard_lookup_stats_reject_stale_extra_state(self):
         def fn(x):
@@ -813,6 +815,9 @@ num_guards_executed=0)
         self.assertFalse(stats["result"])
         self.assertGreater(stats["actual_partial_miss"], 0)
         self.assertGreater(stats["slow_guard_fallback"], 0)
+        self.assertGreater(
+            stats["actual_partial_disabled_reasons"]["token_mismatch"], 0
+        )
 
     def test_token_plan_fast_hit_preserves_other_guards(self):
         guard_manager = RootGuardManager()
@@ -880,6 +885,47 @@ num_guards_executed=0)
         self.assertGreater(stats["actual_partial_miss"], 0)
         self.assertGreater(stats["slow_guard_fallback"], 0)
         self.assertEqual(stats["actual_partial_hit"], 0)
+        self.assertGreater(
+            stats["actual_partial_disabled_reasons"]["unsupported_leaf"], 0
+        )
+
+    def test_token_plan_unsupported_accessor_falls_back(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": [True]},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            [True],
+            default_mgr_enum,
+        ).list_getitem_manager(
+            0,
+            "L['self']._modules['block'][0]",
+            True,
+            default_mgr_enum,
+        ).add_equals_match_guard(
+            True, ["block[0] == True"]
+        )
+
+        stats = guards._debug_check_guard_lookup_receipt_sequence(
+            guard_manager,
+            [
+                {"mods": {"block": [True]}},
+                {"mods": {"block": [True]}},
+                {"mods": {"block": [True]}},
+                {"mods": {"block": [False]}},
+            ],
+        )
+
+        self.assertFalse(stats["result"])
+        self.assertGreater(stats["actual_partial_miss"], 0)
+        self.assertGreater(stats["slow_guard_fallback"], 0)
+        self.assertGreater(
+            stats["actual_partial_disabled_reasons"]["unsupported_accessor"], 0
+        )
 
     def test_dict_getitem_accessor(self):
         foo = {

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -685,6 +685,35 @@ num_guards_executed=0)
         self.assertEqual(stats["actual_partial_candidate"], 0)
         self.assertEqual(stats["actual_partial_token_count"], 0)
 
+    def test_self_modules_token_plan_replaces_receipt_tokens(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+
+        first_stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": {}}
+        )
+        second_stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": {}}, 2
+        )
+
+        self.assertTrue(first_stats["result"])
+        self.assertTrue(second_stats["result"])
+        self.assertGreater(first_stats["actual_partial_candidate"], 0)
+        self.assertGreater(first_stats["actual_partial_token_count"], 0)
+        self.assertEqual(
+            second_stats["actual_partial_candidate"],
+            first_stats["actual_partial_candidate"],
+        )
+        self.assertEqual(
+            second_stats["actual_partial_token_count"],
+            first_stats["actual_partial_token_count"],
+        )
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -820,6 +820,45 @@ num_guards_executed=0)
         self.assertFalse(stats["result"])
         self.assertGreater(stats["actual_partial_hit"], 0)
 
+    def test_token_plan_unsupported_inner_leaf_falls_back(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": {"training": True}},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            {"training": True},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "training",
+            "L['self']._modules['block']['training']",
+            True,
+            default_mgr_enum,
+        ).add_equals_match_guard(
+            True, ["training == True"]
+        )
+
+        frame = {"mods": {"block": {"training": True}}}
+
+        def values():
+            yield frame
+            yield frame
+            yield frame
+            frame["mods"]["block"]["training"] = False
+            yield frame
+
+        stats = guards._debug_check_guard_lookup_receipt_sequence(
+            guard_manager, values()
+        )
+
+        self.assertFalse(stats["result"])
+        self.assertGreater(stats["actual_partial_miss"], 0)
+        self.assertGreater(stats["slow_guard_fallback"], 0)
+        self.assertEqual(stats["actual_partial_hit"], 0)
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -601,6 +601,33 @@ num_guards_executed=0)
         ):
             guard_manager.reset_guard_lookup_stats()
 
+    def test_self_modules_token_plan_records_tokens(self):
+        class StableModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = torch.nn.Sequential(torch.nn.ReLU())
+
+            def forward(self, x):
+                return self.block(x)
+
+        model = StableModule()
+        opt_model = torch.compile(model, backend="eager")
+        x = torch.randn(2, 3)
+        ref = opt_model(x)
+
+        cache_entries = _debug_get_cache_entry_list(model.forward.__code__)
+        self.assertEqual(len(cache_entries), 1)
+        guard_manager = cache_entries[0].guard_manager
+        guard_manager.reset_guard_lookup_stats()
+
+        with torch._dynamo.set_stance("fail_on_recompile"):
+            res = opt_model(x)
+        self.assertEqual(ref, res)
+
+        stats = guard_manager.get_guard_lookup_stats()
+        self.assertGreater(stats["actual_partial_candidate"], 0)
+        self.assertGreater(stats["actual_partial_token_count"], 0)
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -27,6 +27,7 @@ x = torch.tensor(4)
 weakref_x = weakref.ref(x)
 
 default_mgr_enum = torch._dynamo.guards.GuardManagerType.GUARD_MANAGER
+dict_mgr_enum = torch._dynamo.guards.GuardManagerType.DICT_GUARD_MANAGER
 
 
 class Pair:
@@ -662,7 +663,7 @@ num_guards_executed=0)
             "L['self']._modules_extra._modules",
             {},
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(bad) == 0"])
+        ).add_dict_length_check_guard(0, ["len(bad) == 0"])
 
         stats = guards._debug_check_guard_lookup_receipt(
             guard_manager, {"bad": {}}
@@ -678,7 +679,7 @@ num_guards_executed=0)
             "L['self']._modules",
             {},
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        ).add_dict_length_check_guard(0, ["len(mods) == 0"])
         guard_manager.dict_getitem_manager(
             "x",
             "L['x']",
@@ -700,7 +701,7 @@ num_guards_executed=0)
             "L['self']._modules",
             {},
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        ).add_dict_length_check_guard(0, ["len(mods) == 0"])
 
         first_stats = guards._debug_check_guard_lookup_receipt(
             guard_manager, {"mods": {}}
@@ -729,7 +730,7 @@ num_guards_executed=0)
             "L['self']._modules",
             {},
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        ).add_dict_length_check_guard(0, ["len(mods) == 0"])
 
         stats = guards._debug_check_guard_lookup_receipt(
             guard_manager, {"mods": {}}, 3
@@ -756,7 +757,7 @@ num_guards_executed=0)
             "block",
             "L['self']._modules['block']",
             {},
-            default_mgr_enum,
+            dict_mgr_enum,
         ).add_dict_length_check_guard(
             {}, ["len(block) == 0"]
         )
@@ -770,6 +771,76 @@ num_guards_executed=0)
         self.assertEqual(stats["actual_partial_miss"], 0)
         self.assertEqual(stats["slow_guard_fallback"], 0)
         self.assertGreater(stats["actual_partial_enabled"], 0)
+
+    def test_token_plan_fast_hit_requires_same_entry_and_root(self):
+        first_root = RootGuardManager()
+        first_root.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": {}},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            {},
+            dict_mgr_enum,
+        ).add_dict_length_check_guard(
+            {}, ["len(block) == 0"]
+        )
+
+        second_root = RootGuardManager()
+        second_root.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": {}},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            {},
+            dict_mgr_enum,
+        ).add_dict_length_check_guard(
+            {}, ["len(block) == 0"]
+        )
+
+        stats = guards._debug_check_guard_lookup_receipt_cross_root(
+            first_root,
+            second_root,
+            {"mods": {"block": {}}},
+            3,
+        )
+
+        self.assertTrue(stats["result"])
+        self.assertEqual(stats["actual_partial_hit"], 0)
+        self.assertGreater(stats["actual_partial_enabled_before_cross"], 0)
+
+    def test_token_plan_fast_hit_requires_same_self(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": {}},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            {},
+            dict_mgr_enum,
+        ).add_dict_length_check_guard(
+            {}, ["len(block) == 0"]
+        )
+
+        stats = guards._debug_check_guard_lookup_receipt_cross_self(
+            guard_manager,
+            {"mods": {"block": {}}},
+            object(),
+            object(),
+            3,
+        )
+
+        self.assertTrue(stats["result"])
+        self.assertEqual(stats["actual_partial_hit"], 0)
+        self.assertGreater(stats["actual_partial_enabled_before_cross"], 0)
 
     def test_token_plan_fast_hit_allows_token_covered_leaf_guard(self):
         modules = {"block": {}}
@@ -794,20 +865,21 @@ num_guards_executed=0)
         self.assertEqual(stats["slow_guard_fallback"], 0)
 
     def test_token_plan_miss_falls_back_to_slow_guard(self):
+        modules = {}
         guard_manager = RootGuardManager()
         guard_manager.dict_getitem_manager(
             "mods",
             "L['self']._modules",
-            {},
+            modules,
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        ).add_dict_length_check_guard(0, ["len(mods) == 0"])
 
         stats = guards._debug_check_guard_lookup_receipt_sequence(
             guard_manager,
             [
-                {"mods": {}},
-                {"mods": {}},
-                {"mods": {}},
+                {"mods": modules},
+                {"mods": modules},
+                {"mods": modules},
                 {"mods": {"extra": object()}},
             ],
         )
@@ -820,13 +892,14 @@ num_guards_executed=0)
         )
 
     def test_token_plan_fast_hit_preserves_other_guards(self):
+        modules = {}
         guard_manager = RootGuardManager()
         guard_manager.dict_getitem_manager(
             "mods",
             "L['self']._modules",
-            {},
+            modules,
             default_mgr_enum,
-        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        ).add_dict_length_check_guard(0, ["len(mods) == 0"])
         guard_manager.dict_getitem_manager(
             "x",
             "L['x']",
@@ -837,10 +910,10 @@ num_guards_executed=0)
         stats = guards._debug_check_guard_lookup_receipt_sequence(
             guard_manager,
             [
-                {"mods": {}, "x": 1},
-                {"mods": {}, "x": 1},
-                {"mods": {}, "x": 1},
-                {"mods": {}, "x": 2},
+                {"mods": modules, "x": 1},
+                {"mods": modules, "x": 1},
+                {"mods": modules, "x": 1},
+                {"mods": modules, "x": 2},
             ],
         )
 
@@ -890,16 +963,18 @@ num_guards_executed=0)
         )
 
     def test_token_plan_unsupported_accessor_falls_back(self):
+        block = [True]
+        modules = {"block": block}
         guard_manager = RootGuardManager()
         guard_manager.dict_getitem_manager(
             "mods",
             "L['self']._modules",
-            {"block": [True]},
+            modules,
             default_mgr_enum,
         ).dict_getitem_manager(
             "block",
             "L['self']._modules['block']",
-            [True],
+            block,
             default_mgr_enum,
         ).list_getitem_manager(
             0,
@@ -913,9 +988,9 @@ num_guards_executed=0)
         stats = guards._debug_check_guard_lookup_receipt_sequence(
             guard_manager,
             [
-                {"mods": {"block": [True]}},
-                {"mods": {"block": [True]}},
-                {"mods": {"block": [True]}},
+                {"mods": modules},
+                {"mods": modules},
+                {"mods": modules},
                 {"mods": {"block": [False]}},
             ],
         )

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -638,18 +638,14 @@ num_guards_executed=0)
         self.assertGreater(stats["actual_partial_token_count"], 0)
 
     def test_self_modules_token_plan_candidate_is_segment_aware(self):
-        self.assertTrue(
-            guards._debug_is_self_modules_candidate("L['self']._modules")
-        )
+        self.assertTrue(guards._debug_is_self_modules_candidate("L['self']._modules"))
         self.assertTrue(
             guards._debug_is_self_modules_candidate(
                 "L['self']._modules['block']._modules"
             )
         )
         self.assertFalse(
-            guards._debug_is_self_modules_candidate(
-                "L['self']._modules_extra._modules"
-            )
+            guards._debug_is_self_modules_candidate("L['self']._modules_extra._modules")
         )
         self.assertFalse(
             guards._debug_is_self_modules_candidate(
@@ -665,9 +661,7 @@ num_guards_executed=0)
             default_mgr_enum,
         ).add_dict_length_check_guard(0, ["len(bad) == 0"])
 
-        stats = guards._debug_check_guard_lookup_receipt(
-            guard_manager, {"bad": {}}
-        )
+        stats = guards._debug_check_guard_lookup_receipt(guard_manager, {"bad": {}})
         self.assertTrue(stats["result"])
         self.assertEqual(stats["actual_partial_candidate"], 0)
         self.assertEqual(stats["actual_partial_token_count"], 0)
@@ -732,9 +726,7 @@ num_guards_executed=0)
             default_mgr_enum,
         ).add_dict_length_check_guard(0, ["len(mods) == 0"])
 
-        stats = guards._debug_check_guard_lookup_receipt(
-            guard_manager, {"mods": {}}, 3
-        )
+        stats = guards._debug_check_guard_lookup_receipt(guard_manager, {"mods": {}}, 3)
 
         self.assertTrue(stats["result"])
         self.assertGreaterEqual(stats["actual_partial_shadow_passes"], 2)

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -572,6 +572,9 @@ num_guards_executed=0)
         stats = guard_manager.get_guard_lookup_stats()
         self.assertIn("actual_partial_receipt_created", stats)
         self.assertEqual(stats["actual_partial_enabled"], 0)
+        self.assertEqual(stats["actual_partial_shadow_passes"], 0)
+        self.assertEqual(stats["actual_partial_candidate"], 0)
+        self.assertEqual(stats["actual_partial_token_count"], 0)
 
     def test_guard_lookup_stats_reject_stale_extra_state(self):
         def fn(x):
@@ -713,6 +716,25 @@ num_guards_executed=0)
             second_stats["actual_partial_token_count"],
             first_stats["actual_partial_token_count"],
         )
+
+    def test_token_plan_enables_after_shadow(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+
+        stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": {}}, 3
+        )
+
+        self.assertTrue(stats["result"])
+        self.assertGreaterEqual(stats["actual_partial_shadow_passes"], 2)
+        self.assertGreater(stats["actual_partial_enabled"], 0)
+        self.assertGreater(stats["actual_partial_candidate"], 0)
+        self.assertGreater(stats["actual_partial_token_count"], 0)
 
     def test_dict_getitem_accessor(self):
         foo = {

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -557,6 +557,22 @@ num_guards_executed=0)
             guard_str,
         )
 
+    def test_guard_last_success_receipt_initializes(self):
+        def fn(x):
+            return x + 1
+
+        opt_fn = torch.compile(fn, backend="eager")
+        opt_fn(torch.ones(3))
+
+        cache_entries = _debug_get_cache_entry_list(fn.__code__)
+        self.assertEqual(len(cache_entries), 1)
+
+        guard_manager = cache_entries[0].guard_manager
+        guard_manager.reset_guard_lookup_stats()
+        stats = guard_manager.get_guard_lookup_stats()
+        self.assertIn("actual_partial_receipt_created", stats)
+        self.assertEqual(stats["actual_partial_enabled"], 0)
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -575,6 +575,9 @@ num_guards_executed=0)
         self.assertEqual(stats["actual_partial_shadow_passes"], 0)
         self.assertEqual(stats["actual_partial_candidate"], 0)
         self.assertEqual(stats["actual_partial_token_count"], 0)
+        self.assertEqual(stats["actual_partial_hit"], 0)
+        self.assertEqual(stats["actual_partial_miss"], 0)
+        self.assertEqual(stats["slow_guard_fallback"], 0)
 
     def test_guard_lookup_stats_reject_stale_extra_state(self):
         def fn(x):
@@ -739,6 +742,83 @@ num_guards_executed=0)
             stats["actual_partial_token_count"],
             stats["actual_partial_candidate"],
         )
+
+    def test_token_plan_fast_hit_skips_self_modules_subtree(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {"block": {}},
+            default_mgr_enum,
+        ).dict_getitem_manager(
+            "block",
+            "L['self']._modules['block']",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard(
+            {}, ["len(block) == 0"]
+        )
+
+        stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": {"block": {}}}, 4
+        )
+
+        self.assertTrue(stats["result"])
+        self.assertGreater(stats["actual_partial_hit"], 0)
+        self.assertEqual(stats["actual_partial_miss"], 0)
+        self.assertEqual(stats["slow_guard_fallback"], 0)
+        self.assertGreater(stats["actual_partial_enabled"], 0)
+
+    def test_token_plan_miss_falls_back_to_slow_guard(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+
+        stats = guards._debug_check_guard_lookup_receipt_sequence(
+            guard_manager,
+            [
+                {"mods": {}},
+                {"mods": {}},
+                {"mods": {}},
+                {"mods": {"extra": object()}},
+            ],
+        )
+
+        self.assertFalse(stats["result"])
+        self.assertGreater(stats["actual_partial_miss"], 0)
+        self.assertGreater(stats["slow_guard_fallback"], 0)
+
+    def test_token_plan_fast_hit_preserves_other_guards(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        guard_manager.dict_getitem_manager(
+            "x",
+            "L['x']",
+            1,
+            default_mgr_enum,
+        ).add_equals_match_guard(1, ["x == 1"])
+
+        stats = guards._debug_check_guard_lookup_receipt_sequence(
+            guard_manager,
+            [
+                {"mods": {}, "x": 1},
+                {"mods": {}, "x": 1},
+                {"mods": {}, "x": 1},
+                {"mods": {}, "x": 2},
+            ],
+        )
+
+        self.assertFalse(stats["result"])
+        self.assertGreater(stats["actual_partial_hit"], 0)
 
     def test_dict_getitem_accessor(self):
         foo = {

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -735,6 +735,10 @@ num_guards_executed=0)
         self.assertGreater(stats["actual_partial_enabled"], 0)
         self.assertGreater(stats["actual_partial_candidate"], 0)
         self.assertGreater(stats["actual_partial_token_count"], 0)
+        self.assertGreater(
+            stats["actual_partial_token_count"],
+            stats["actual_partial_candidate"],
+        )
 
     def test_dict_getitem_accessor(self):
         foo = {

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -628,6 +628,63 @@ num_guards_executed=0)
         self.assertGreater(stats["actual_partial_candidate"], 0)
         self.assertGreater(stats["actual_partial_token_count"], 0)
 
+    def test_self_modules_token_plan_candidate_is_segment_aware(self):
+        self.assertTrue(
+            guards._debug_is_self_modules_candidate("L['self']._modules")
+        )
+        self.assertTrue(
+            guards._debug_is_self_modules_candidate(
+                "L['self']._modules['block']._modules"
+            )
+        )
+        self.assertFalse(
+            guards._debug_is_self_modules_candidate(
+                "L['self']._modules_extra._modules"
+            )
+        )
+        self.assertFalse(
+            guards._debug_is_self_modules_candidate(
+                "L['self']._modules['block']._modules_extra._modules"
+            )
+        )
+
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "bad",
+            "L['self']._modules_extra._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(bad) == 0"])
+
+        stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"bad": {}}
+        )
+        self.assertTrue(stats["result"])
+        self.assertEqual(stats["actual_partial_candidate"], 0)
+        self.assertEqual(stats["actual_partial_token_count"], 0)
+
+    def test_self_modules_token_plan_discards_failed_root_tokens(self):
+        guard_manager = RootGuardManager()
+        guard_manager.dict_getitem_manager(
+            "mods",
+            "L['self']._modules",
+            {},
+            default_mgr_enum,
+        ).add_dict_length_check_guard({}, ["len(mods) == 0"])
+        guard_manager.dict_getitem_manager(
+            "x",
+            "L['x']",
+            1,
+            default_mgr_enum,
+        ).add_equals_match_guard(2, ["x == 2"])
+
+        stats = guards._debug_check_guard_lookup_receipt(
+            guard_manager, {"mods": {}, "x": 1}
+        )
+        self.assertFalse(stats["result"])
+        self.assertEqual(stats["actual_partial_candidate"], 0)
+        self.assertEqual(stats["actual_partial_token_count"], 0)
+
     def test_dict_getitem_accessor(self):
         foo = {
             "a": 1,

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -22,7 +22,33 @@ CacheEntry* ExtraState::get_first_entry() {
 }
 
 ExtraState::ExtraState(PyCodeObject* orig_code_arg)
-    : orig_code(orig_code_arg) {}
+    : orig_code(orig_code_arg),
+      last_success_receipt(
+          torch::dynamo::create_guard_last_success_receipt()) {}
+
+py::dict ExtraState::get_guard_lookup_stats() const {
+  py::dict stats;
+  stats["actual_partial_receipt_created"] =
+      this->last_success_receipt != nullptr;
+  stats["actual_partial_enabled"] =
+      this->last_success_receipt != nullptr &&
+          this->last_success_receipt->actual_partial_state ==
+              torch::dynamo::GuardPartialMemoState::Enabled
+      ? 1
+      : 0;
+  return stats;
+}
+
+void ExtraState::reset_guard_lookup_stats() {
+  if (this->last_success_receipt == nullptr) {
+    this->last_success_receipt =
+        torch::dynamo::create_guard_last_success_receipt();
+    return;
+  }
+  this->last_success_receipt->actual_partial_shadow_passes = 0;
+  this->last_success_receipt->actual_partial_state =
+      torch::dynamo::GuardPartialMemoState::Training;
+}
 
 void ExtraState::move_to_front(CacheEntry* cache_entry) {
   CHECK(cache_entry->_owner == this);
@@ -203,6 +229,14 @@ CacheEntry* create_cache_entry(
       py::cast(*new_iter, py::return_value_policy::reference);
   guard_manager.attr("extra_state") =
       py::cast(extra_state, py::return_value_policy::reference);
+  guard_manager.attr("reset_guard_lookup_stats") =
+      py::cpp_function([extra_state]() {
+        extra_state->reset_guard_lookup_stats();
+      });
+  guard_manager.attr("get_guard_lookup_stats") =
+      py::cpp_function([extra_state]() {
+        return extra_state->get_guard_lookup_stats();
+      });
   return &*new_iter;
 }
 

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -14,6 +14,27 @@
 
 Py_ssize_t extra_index = -1;
 
+namespace {
+
+ExtraState* get_live_extra_state_from_guard_manager(
+    const py::object& guard_manager_ref) {
+  py::object guard_manager = guard_manager_ref();
+  if (guard_manager.is_none() ||
+      !py::hasattr(guard_manager, "extra_state")) {
+    throw std::runtime_error(
+        "guard lookup stats are unavailable: guard manager is gone");
+  }
+
+  py::object extra_state = guard_manager.attr("extra_state");
+  if (extra_state.is_none()) {
+    throw std::runtime_error(
+        "guard lookup stats are unavailable: extra_state was cleared");
+  }
+  return extra_state.cast<ExtraState*>();
+}
+
+} // namespace
+
 CacheEntry* ExtraState::get_first_entry() {
   if (this->cache_entry_list.empty()) {
     return nullptr;
@@ -229,13 +250,19 @@ CacheEntry* create_cache_entry(
       py::cast(*new_iter, py::return_value_policy::reference);
   guard_manager.attr("extra_state") =
       py::cast(extra_state, py::return_value_policy::reference);
+  py::object guard_manager_ref =
+      py::module::import("weakref").attr("ref")(guard_manager);
   guard_manager.attr("reset_guard_lookup_stats") =
-      py::cpp_function([extra_state]() {
-        extra_state->reset_guard_lookup_stats();
+      py::cpp_function([guard_manager_ref]() {
+        ExtraState* live_extra_state =
+            get_live_extra_state_from_guard_manager(guard_manager_ref);
+        live_extra_state->reset_guard_lookup_stats();
       });
   guard_manager.attr("get_guard_lookup_stats") =
-      py::cpp_function([extra_state]() {
-        return extra_state->get_guard_lookup_stats();
+      py::cpp_function([guard_manager_ref]() {
+        ExtraState* live_extra_state =
+            get_live_extra_state_from_guard_manager(guard_manager_ref);
+        return live_extra_state->get_guard_lookup_stats();
       });
   return &*new_iter;
 }

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -69,6 +69,18 @@ py::dict ExtraState::get_guard_lookup_stats() const {
       this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_shadow_passes;
+  stats["actual_partial_hit"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->actual_partial_hit;
+  stats["actual_partial_miss"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->actual_partial_miss;
+  stats["slow_guard_fallback"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->slow_guard_fallback;
   return stats;
 }
 
@@ -79,6 +91,9 @@ void ExtraState::reset_guard_lookup_stats() {
     return;
   }
   this->last_success_receipt->actual_partial_shadow_passes = 0;
+  this->last_success_receipt->actual_partial_hit = 0;
+  this->last_success_receipt->actual_partial_miss = 0;
+  this->last_success_receipt->slow_guard_fallback = 0;
   this->last_success_receipt->actual_partial_state =
       torch::dynamo::GuardPartialMemoState::Training;
   this->last_success_receipt->actual_partial_stability_tokens.clear();

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -65,6 +65,10 @@ py::dict ExtraState::get_guard_lookup_stats() const {
       this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_tokens.size();
+  stats["actual_partial_shadow_passes"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->actual_partial_shadow_passes;
   return stats;
 }
 

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -19,8 +19,7 @@ namespace {
 ExtraState* get_live_extra_state_from_guard_manager(
     const py::object& guard_manager_ref) {
   py::object guard_manager = guard_manager_ref();
-  if (guard_manager.is_none() ||
-      !py::hasattr(guard_manager, "extra_state")) {
+  if (guard_manager.is_none() || !py::hasattr(guard_manager, "extra_state")) {
     throw std::runtime_error(
         "guard lookup stats are unavailable: guard manager is gone");
   }
@@ -44,41 +43,34 @@ CacheEntry* ExtraState::get_first_entry() {
 
 ExtraState::ExtraState(PyCodeObject* orig_code_arg)
     : orig_code(orig_code_arg),
-      last_success_receipt(
-          torch::dynamo::create_guard_last_success_receipt()) {}
+      last_success_receipt(torch::dynamo::create_guard_last_success_receipt()) {
+}
 
 py::dict ExtraState::get_guard_lookup_stats() const {
   py::dict stats;
   stats["actual_partial_receipt_created"] =
       this->last_success_receipt != nullptr;
-  stats["actual_partial_enabled"] =
-      this->last_success_receipt != nullptr &&
+  stats["actual_partial_enabled"] = this->last_success_receipt != nullptr &&
           this->last_success_receipt->actual_partial_state ==
               torch::dynamo::GuardPartialMemoState::Enabled
       ? 1
       : 0;
-  stats["actual_partial_candidate"] =
-      this->last_success_receipt == nullptr
+  stats["actual_partial_candidate"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_stability_tokens.size();
-  stats["actual_partial_token_count"] =
-      this->last_success_receipt == nullptr
+  stats["actual_partial_token_count"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_tokens.size();
-  stats["actual_partial_shadow_passes"] =
-      this->last_success_receipt == nullptr
+  stats["actual_partial_shadow_passes"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_shadow_passes;
-  stats["actual_partial_hit"] =
-      this->last_success_receipt == nullptr
+  stats["actual_partial_hit"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_hit;
-  stats["actual_partial_miss"] =
-      this->last_success_receipt == nullptr
+  stats["actual_partial_miss"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->actual_partial_miss;
-  stats["slow_guard_fallback"] =
-      this->last_success_receipt == nullptr
+  stats["slow_guard_fallback"] = this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->slow_guard_fallback;
   py::dict actual_partial_disabled_reasons;
@@ -88,8 +80,7 @@ py::dict ExtraState::get_guard_lookup_stats() const {
       actual_partial_disabled_reasons[py::str(item.first)] = item.second;
     }
   }
-  stats["actual_partial_disabled_reasons"] =
-      actual_partial_disabled_reasons;
+  stats["actual_partial_disabled_reasons"] = actual_partial_disabled_reasons;
   return stats;
 }
 
@@ -239,14 +230,13 @@ void lookup(
 
     if (valid) {
       try {
-        valid =
-            torch::dynamo::run_root_guard_manager_with_last_success_receipt(
-                extra_state->last_success_receipt.get(),
-                &cache_entry,
-                is_skip_guard_eval_unsafe ? cache_entry.diff_guard_root_mgr
-                                          : cache_entry.root_mgr,
-                f_locals,
-                is_skip_guard_eval_unsafe);
+        valid = torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+            extra_state->last_success_receipt.get(),
+            &cache_entry,
+            is_skip_guard_eval_unsafe ? cache_entry.diff_guard_root_mgr
+                                      : cache_entry.root_mgr,
+            f_locals,
+            is_skip_guard_eval_unsafe);
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {
           py::handle guard_error_hook_handle(guard_error_hook);

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -57,6 +57,14 @@ py::dict ExtraState::get_guard_lookup_stats() const {
               torch::dynamo::GuardPartialMemoState::Enabled
       ? 1
       : 0;
+  stats["actual_partial_candidate"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->actual_partial_stability_tokens.size();
+  stats["actual_partial_token_count"] =
+      this->last_success_receipt == nullptr
+      ? 0
+      : this->last_success_receipt->actual_partial_tokens.size();
   return stats;
 }
 
@@ -69,6 +77,8 @@ void ExtraState::reset_guard_lookup_stats() {
   this->last_success_receipt->actual_partial_shadow_passes = 0;
   this->last_success_receipt->actual_partial_state =
       torch::dynamo::GuardPartialMemoState::Training;
+  this->last_success_receipt->actual_partial_stability_tokens.clear();
+  this->last_success_receipt->actual_partial_tokens.clear();
 }
 
 void ExtraState::move_to_front(CacheEntry* cache_entry) {
@@ -200,7 +210,9 @@ void lookup(
               cache_entry.diff_guard_root_mgr, f_locals);
         } else {
           valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.root_mgr, f_locals);
+              cache_entry.root_mgr,
+              f_locals,
+              extra_state->last_success_receipt.get());
         }
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -239,15 +239,14 @@ void lookup(
 
     if (valid) {
       try {
-        if (is_skip_guard_eval_unsafe) {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.diff_guard_root_mgr, f_locals);
-        } else {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.root_mgr,
-              f_locals,
-              extra_state->last_success_receipt.get());
-        }
+        valid =
+            torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+                extra_state->last_success_receipt.get(),
+                &cache_entry,
+                is_skip_guard_eval_unsafe ? cache_entry.diff_guard_root_mgr
+                                          : cache_entry.root_mgr,
+                f_locals,
+                is_skip_guard_eval_unsafe);
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {
           py::handle guard_error_hook_handle(guard_error_hook);

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -81,6 +81,15 @@ py::dict ExtraState::get_guard_lookup_stats() const {
       this->last_success_receipt == nullptr
       ? 0
       : this->last_success_receipt->slow_guard_fallback;
+  py::dict actual_partial_disabled_reasons;
+  if (this->last_success_receipt != nullptr) {
+    for (const auto& item :
+         this->last_success_receipt->actual_partial_disabled_reasons) {
+      actual_partial_disabled_reasons[py::str(item.first)] = item.second;
+    }
+  }
+  stats["actual_partial_disabled_reasons"] =
+      actual_partial_disabled_reasons;
   return stats;
 }
 
@@ -94,6 +103,11 @@ void ExtraState::reset_guard_lookup_stats() {
   this->last_success_receipt->actual_partial_hit = 0;
   this->last_success_receipt->actual_partial_miss = 0;
   this->last_success_receipt->slow_guard_fallback = 0;
+  this->last_success_receipt->actual_partial_disabled_reasons.clear();
+  this->last_success_receipt->actual_partial_entry_key = nullptr;
+  this->last_success_receipt->actual_partial_root_key = nullptr;
+  this->last_success_receipt->actual_partial_self_object = nullptr;
+  this->last_success_receipt->actual_partial_self_type = nullptr;
   this->last_success_receipt->actual_partial_state =
       torch::dynamo::GuardPartialMemoState::Training;
   this->last_success_receipt->actual_partial_stability_tokens.clear();
@@ -134,6 +148,7 @@ void ExtraState::invalidate(
   CHECK(cache_entry->_owner == this);
   CHECK(!this->cache_entry_list.empty());
   CHECK(cache_entry == &*cache_entry->_owner_loc);
+  reset_guard_lookup_stats();
   cache_entry->invalidate(std::move(deleted_guard_manager));
   // Move the cache entry to the end of the list because these will always
   // return False.

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -56,8 +56,7 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   std::list<CacheEntry> cache_entry_list;
   // Frame state to detect dynamic shape dims
   py::dict frame_state;
-  std::unique_ptr<torch::dynamo::GuardLastSuccessReceipt>
-      last_success_receipt;
+  std::unique_ptr<torch::dynamo::GuardLastSuccessReceipt> last_success_receipt;
   // Actions to apply to all frames with this code object
   FrameExecStrategy strategy{DEFAULT, DEFAULT};
 

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -6,6 +6,7 @@
 
 #ifdef __cplusplus
 
+#include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/dynamo/utils.h>
 #include <torch/csrc/utils/pybind.h>
 #include <list>
@@ -55,10 +56,14 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   std::list<CacheEntry> cache_entry_list;
   // Frame state to detect dynamic shape dims
   py::dict frame_state;
+  std::unique_ptr<torch::dynamo::GuardLastSuccessReceipt>
+      last_success_receipt;
   // Actions to apply to all frames with this code object
   FrameExecStrategy strategy{DEFAULT, DEFAULT};
 
   ExtraState(PyCodeObject* orig_code_arg);
+  py::dict get_guard_lookup_stats() const;
+  void reset_guard_lookup_stats();
   CacheEntry* get_first_entry();
   void move_to_front(CacheEntry* cache_entry);
   void move_to_back(CacheEntry* cache_entry);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -762,6 +762,87 @@ static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   return THPUtils_packUInt64(get_dict_version_unchecked(obj));
 }
 
+static thread_local GuardLastSuccessReceipt* active_actual_partial_receipt =
+    nullptr;
+
+static bool is_self_modules_candidate(const std::string& source) {
+  if (source == "L['self']._modules") {
+    return true;
+  }
+  const std::string prefix = "L['self']._modules";
+  return source.rfind(prefix, 0) == 0 &&
+      source.find("._modules", prefix.size()) != std::string::npos;
+}
+
+static void record_actual_partial_token(
+    std::vector<GuardSubtreeEntryToken>& tokens,
+    const GuardSubtreeEntryToken& token) {
+  tokens.emplace_back(token);
+}
+
+static void record_actual_partial_tokens(
+    const std::string& source,
+    PyObject* value) {
+  if (active_actual_partial_receipt == nullptr || value == nullptr ||
+      !is_self_modules_candidate(source)) {
+    return;
+  }
+
+  GuardSubtreeEntryToken identity_token;
+  identity_token.kind = GuardSubtreeTokenKind::ObjectIdentity;
+  identity_token.object_id = reinterpret_cast<uintptr_t>(value);
+  record_actual_partial_token(
+      active_actual_partial_receipt->actual_partial_stability_tokens,
+      identity_token);
+  record_actual_partial_token(
+      active_actual_partial_receipt->actual_partial_tokens, identity_token);
+
+  GuardSubtreeEntryToken type_token;
+  type_token.kind = GuardSubtreeTokenKind::ObjectType;
+  type_token.type_id = reinterpret_cast<uintptr_t>(Py_TYPE(value));
+  record_actual_partial_token(
+      active_actual_partial_receipt->actual_partial_tokens, type_token);
+
+  if (PyDict_Check(value)) {
+    GuardSubtreeEntryToken version_token;
+    version_token.kind = GuardSubtreeTokenKind::DictVersion;
+    version_token.version = get_dict_version_unchecked(value);
+    record_actual_partial_token(
+        active_actual_partial_receipt->actual_partial_tokens, version_token);
+
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyDict_Size(value);
+    record_actual_partial_token(
+        active_actual_partial_receipt->actual_partial_tokens, size_token);
+  } else if (PyList_CheckExact(value)) {
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyList_GET_SIZE(value);
+    record_actual_partial_token(
+        active_actual_partial_receipt->actual_partial_tokens, size_token);
+  } else if (PyTuple_CheckExact(value)) {
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyTuple_GET_SIZE(value);
+    record_actual_partial_token(
+        active_actual_partial_receipt->actual_partial_tokens, size_token);
+  }
+}
+
+struct ActiveGuardReceiptScope {
+  explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
+      : previous(active_actual_partial_receipt) {
+    active_actual_partial_receipt = receipt;
+  }
+
+  ~ActiveGuardReceiptScope() {
+    active_actual_partial_receipt = previous;
+  }
+
+  GuardLastSuccessReceipt* previous;
+};
+
 static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
   /*
    Assert that a given tensor has a given size/stride, but ignore strides
@@ -2378,13 +2459,24 @@ class GuardManager {
   // guards and does not change the fail count. For simplicity, we duplicate
   // the code here.
   template <typename T>
-  bool check_nopybind_template(T* value) { // borrowed ref
+  bool check_nopybind_template(
+      T* value,
+      bool record_tokens = true) { // borrowed ref
 
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
     }
 
-    return this->check_accessors_nopybind(value);
+    if (!this->check_accessors_nopybind(value)) {
+      return false;
+    }
+
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (record_tokens) {
+        record_actual_partial_tokens(this->get_source(), value);
+      }
+    }
+    return true;
   }
 
   virtual bool check_nopybind(PyObject* value) {
@@ -2952,6 +3044,7 @@ class DictGuardManager : public GuardManager {
 
     // Early return
     if (_size == 0) {
+      record_actual_partial_tokens(this->get_source(), obj);
       return true;
     }
 
@@ -2963,7 +3056,7 @@ class DictGuardManager : public GuardManager {
     // directly into DictGuardManager.  Similarly, incorporating guards such as
     // DICT_CONTAINS and DICT_VERSION as leaf guards offers a simpler solution
     // than embedding these functionalities within the DictGuardManager itself.
-    if (!GuardManager::check_nopybind(obj)) {
+    if (!GuardManager::check_nopybind_template(obj, false)) {
       _fail_count += 1;
       // No need to shuffle the child guards, just return.
       return false;
@@ -2994,6 +3087,7 @@ class DictGuardManager : public GuardManager {
       }
       dict_pointer += 1;
     }
+    record_actual_partial_tokens(this->get_source(), obj);
     return true;
   }
 
@@ -5216,10 +5310,18 @@ void* convert_to_root_guard_manager(py::object root) {
 }
 
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals) {
+  return run_root_guard_manager(root, f_locals, nullptr);
+}
+
+bool run_root_guard_manager(
+    void* root,
+    FrameLocalsMapping* f_locals,
+    GuardLastSuccessReceipt* receipt) {
   // for invalidated guards, return false
   if (root == nullptr) {
     return false;
   }
+  ActiveGuardReceiptScope receipt_scope(receipt);
   py::object config_module = py::module_::import("torch._dynamo.config");
   bool enable_cpp_framelocals_guard_eval =
       config_module.attr("enable_cpp_framelocals_guard_eval").cast<bool>();

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -765,6 +765,7 @@ static PyObject* dict_version(PyObject* dummy, PyObject* args) {
 struct ActiveGuardReceiptScope;
 static thread_local ActiveGuardReceiptScope* active_actual_partial_scope =
     nullptr;
+constexpr uint64_t kActualPartialShadowPassThreshold = 2;
 
 static bool is_self_modules_candidate(const std::string& source) {
   if (source == "L['self']._modules") {
@@ -809,8 +810,30 @@ struct ActiveGuardReceiptScope {
     if (receipt == nullptr || committed) {
       return;
     }
-    receipt->actual_partial_stability_tokens = pending_stability_tokens;
-    receipt->actual_partial_tokens = pending_tokens;
+    if (pending_stability_tokens.empty()) {
+      receipt->actual_partial_shadow_passes = 0;
+      receipt->actual_partial_state = GuardPartialMemoState::Training;
+      receipt->actual_partial_stability_tokens.clear();
+      receipt->actual_partial_tokens.clear();
+      committed = true;
+      return;
+    }
+
+    if (receipt->actual_partial_stability_tokens == pending_stability_tokens) {
+      ++receipt->actual_partial_shadow_passes;
+    } else {
+      receipt->actual_partial_shadow_passes = 0;
+      receipt->actual_partial_state = GuardPartialMemoState::Training;
+      receipt->actual_partial_stability_tokens = pending_stability_tokens;
+    }
+
+    if (receipt->actual_partial_shadow_passes >=
+        kActualPartialShadowPassThreshold) {
+      receipt->actual_partial_state = GuardPartialMemoState::Enabled;
+      receipt->actual_partial_tokens = receipt->actual_partial_stability_tokens;
+    } else {
+      receipt->actual_partial_tokens = pending_tokens;
+    }
     committed = true;
   }
 
@@ -5335,6 +5358,10 @@ py::dict debug_check_guard_lookup_receipt(
   stats["actual_partial_candidate"] =
       receipt->actual_partial_stability_tokens.size();
   stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
+  stats["actual_partial_shadow_passes"] =
+      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_enabled"] =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
   return stats;
 }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -830,7 +830,7 @@ struct ActiveGuardReceiptScope {
     if (receipt->actual_partial_shadow_passes >=
         kActualPartialShadowPassThreshold) {
       receipt->actual_partial_state = GuardPartialMemoState::Enabled;
-      receipt->actual_partial_tokens = receipt->actual_partial_stability_tokens;
+      receipt->actual_partial_tokens = pending_tokens;
     } else {
       receipt->actual_partial_tokens = pending_tokens;
     }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -861,6 +861,41 @@ static void reset_actual_partial_plan(GuardLastSuccessReceipt* receipt) {
   receipt->actual_partial_tokens.clear();
 }
 
+static const char* actual_partial_disabled_reason_name(
+    ActualPartialReplayFailureReason reason) {
+  switch (reason) {
+    case ActualPartialReplayFailureReason::UnsupportedAccessor:
+      return "unsupported_accessor";
+    case ActualPartialReplayFailureReason::UnsupportedLeaf:
+      return "unsupported_leaf";
+    case ActualPartialReplayFailureReason::None:
+      return "token_mismatch";
+  }
+  return "token_mismatch";
+}
+
+static void record_actual_partial_disabled_reason(
+    GuardLastSuccessReceipt* receipt,
+    ActualPartialReplayFailureReason reason) {
+  if (receipt == nullptr) {
+    return;
+  }
+  auto reason_name = actual_partial_disabled_reason_name(reason);
+  ++receipt->actual_partial_disabled_reasons[reason_name];
+}
+
+static py::dict actual_partial_disabled_reasons_to_dict(
+    const GuardLastSuccessReceipt* receipt) {
+  py::dict reasons;
+  if (receipt == nullptr) {
+    return reasons;
+  }
+  for (const auto& item : receipt->actual_partial_disabled_reasons) {
+    reasons[py::str(item.first)] = item.second;
+  }
+  return reasons;
+}
+
 struct ActiveGuardReceiptScope {
   explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
       : receipt(receipt), previous(active_actual_partial_scope) {
@@ -2362,7 +2397,11 @@ class GuardAccessor {
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
   virtual bool replay_actual_partial_tokens(
       PyObject* obj,
-      std::vector<GuardSubtreeEntryToken>& tokens) {
+      std::vector<GuardSubtreeEntryToken>& tokens,
+      ActualPartialReplayFailureReason* reason = nullptr) {
+    if (reason != nullptr) {
+      *reason = ActualPartialReplayFailureReason::UnsupportedAccessor;
+    }
     return false;
   }
   virtual std::string repr() const = 0;
@@ -2600,12 +2639,16 @@ class GuardManager {
 
   virtual bool replay_actual_partial_tokens(
       PyObject* value,
-      std::vector<GuardSubtreeEntryToken>& tokens) {
+      std::vector<GuardSubtreeEntryToken>& tokens,
+      ActualPartialReplayFailureReason* reason = nullptr) {
     if (has_unsupported_actual_partial_leaf_guards()) {
+      if (reason != nullptr) {
+        *reason = ActualPartialReplayFailureReason::UnsupportedLeaf;
+      }
       return false;
     }
     for (const auto& accessor : _accessors) {
-      if (!accessor->replay_actual_partial_tokens(value, tokens)) {
+      if (!accessor->replay_actual_partial_tokens(value, tokens, reason)) {
         return false;
       }
     }
@@ -3306,8 +3349,12 @@ class DictGuardManager : public GuardManager {
 
   bool replay_actual_partial_tokens(
       PyObject* obj,
-      std::vector<GuardSubtreeEntryToken>& tokens) override {
+      std::vector<GuardSubtreeEntryToken>& tokens,
+      ActualPartialReplayFailureReason* reason = nullptr) override {
     if (has_unsupported_actual_partial_leaf_guards()) {
+      if (reason != nullptr) {
+        *reason = ActualPartialReplayFailureReason::UnsupportedLeaf;
+      }
       return false;
     }
     if (Py_TYPE(obj) != _expected_type) {
@@ -3319,7 +3366,7 @@ class DictGuardManager : public GuardManager {
     }
 
     for (const auto& accessor : _accessors) {
-      if (!accessor->replay_actual_partial_tokens(obj, tokens)) {
+      if (!accessor->replay_actual_partial_tokens(obj, tokens, reason)) {
         return false;
       }
     }
@@ -3336,12 +3383,13 @@ class DictGuardManager : public GuardManager {
         KeyValueManager& key_value_manager = _key_value_managers[dict_pointer];
         std::unique_ptr<GuardManager>& key_manager = key_value_manager.first;
         if (key_manager &&
-            !key_manager->replay_actual_partial_tokens(key, tokens)) {
+            !key_manager->replay_actual_partial_tokens(key, tokens, reason)) {
           return false;
         }
         std::unique_ptr<GuardManager>& value_manager = key_value_manager.second;
         if (value_manager &&
-            !value_manager->replay_actual_partial_tokens(value, tokens)) {
+            !value_manager->replay_actual_partial_tokens(
+                value, tokens, reason)) {
           return false;
         }
       }
@@ -3513,7 +3561,9 @@ static bool try_actual_partial_fast_path(
   }
 
   std::vector<GuardSubtreeEntryToken> tokens;
-  if (guard_manager->replay_actual_partial_tokens(value, tokens) &&
+  ActualPartialReplayFailureReason reason =
+      ActualPartialReplayFailureReason::None;
+  if (guard_manager->replay_actual_partial_tokens(value, tokens, &reason) &&
       tokens == receipt->actual_partial_tokens) {
     ++receipt->actual_partial_hit;
     active_actual_partial_scope->saw_fast_hit = true;
@@ -3522,6 +3572,7 @@ static bool try_actual_partial_fast_path(
 
   ++receipt->actual_partial_miss;
   reset_actual_partial_plan(receipt);
+  record_actual_partial_disabled_reason(receipt, reason);
   ++receipt->slow_guard_fallback;
   return false;
 }
@@ -3776,13 +3827,15 @@ class GetAttrGuardAccessor : public GuardAccessor {
 
   bool replay_actual_partial_tokens(
       PyObject* obj,
-      std::vector<GuardSubtreeEntryToken>& tokens) override {
+      std::vector<GuardSubtreeEntryToken>& tokens,
+      ActualPartialReplayFailureReason* reason = nullptr) override {
     PyObject* x = PyObject_GetAttr(obj, _attr_name); // new ref
     if (x == nullptr) {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->replay_actual_partial_tokens(x, tokens);
+    bool result =
+        _guard_manager->replay_actual_partial_tokens(x, tokens, reason);
     Py_DECREF(x);
     return result;
   }
@@ -4226,13 +4279,14 @@ class DictGetItemGuardAccessor : public GuardAccessor {
 
   bool replay_actual_partial_tokens(
       PyObject* obj,
-      std::vector<GuardSubtreeEntryToken>& tokens) override {
+      std::vector<GuardSubtreeEntryToken>& tokens,
+      ActualPartialReplayFailureReason* reason = nullptr) override {
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
     if (x == nullptr) {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->replay_actual_partial_tokens(x, tokens);
+    return _guard_manager->replay_actual_partial_tokens(x, tokens, reason);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5572,6 +5626,8 @@ py::dict debug_check_guard_lookup_receipt(
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
   stats["actual_partial_miss"] = receipt->actual_partial_miss;
   stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
+  stats["actual_partial_disabled_reasons"] =
+      actual_partial_disabled_reasons_to_dict(receipt.get());
   return stats;
 }
 
@@ -5600,6 +5656,8 @@ py::dict debug_check_guard_lookup_receipt_sequence(
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
   stats["actual_partial_miss"] = receipt->actual_partial_miss;
   stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
+  stats["actual_partial_disabled_reasons"] =
+      actual_partial_disabled_reasons_to_dict(receipt.get());
   return stats;
 }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -768,6 +768,24 @@ static thread_local ActiveGuardReceiptScope* active_actual_partial_scope =
     nullptr;
 constexpr uint64_t kActualPartialShadowPassThreshold = 2;
 
+static PyObject* guard_last_success_self_key() {
+  static PyObject* key = PyUnicode_InternFromString("self");
+  return key;
+}
+
+static PyObject* guard_last_success_current_self(
+    FrameLocalsMapping* f_locals) {
+  if (f_locals == nullptr) {
+    return nullptr;
+  }
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return nullptr;
+  }
+  return PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+}
+
 static bool is_self_modules_candidate(const std::string& source) {
   if (source == "L['self']._modules") {
     return true;
@@ -855,6 +873,10 @@ static void append_actual_partial_tokens(
 }
 
 static void reset_actual_partial_plan(GuardLastSuccessReceipt* receipt) {
+  receipt->actual_partial_entry_key = nullptr;
+  receipt->actual_partial_root_key = nullptr;
+  receipt->actual_partial_self_object = nullptr;
+  receipt->actual_partial_self_type = nullptr;
   receipt->actual_partial_shadow_passes = 0;
   receipt->actual_partial_state = GuardPartialMemoState::Training;
   receipt->actual_partial_stability_tokens.clear();
@@ -897,8 +919,17 @@ static py::dict actual_partial_disabled_reasons_to_dict(
 }
 
 struct ActiveGuardReceiptScope {
-  explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
-      : receipt(receipt), previous(active_actual_partial_scope) {
+  explicit ActiveGuardReceiptScope(
+      GuardLastSuccessReceipt* receipt,
+      void* entry_key = nullptr,
+      void* root_key = nullptr,
+      PyObject* self_object = nullptr)
+      : receipt(receipt),
+        previous(active_actual_partial_scope),
+        entry_key(entry_key),
+        root_key(root_key),
+        self_object(self_object),
+        self_type(self_object == nullptr ? nullptr : Py_TYPE(self_object)) {
     active_actual_partial_scope = this;
   }
 
@@ -918,9 +949,17 @@ struct ActiveGuardReceiptScope {
       return;
     }
 
-    if (receipt->actual_partial_stability_tokens == pending_stability_tokens) {
+    if (receipt->actual_partial_entry_key == entry_key &&
+        receipt->actual_partial_root_key == root_key &&
+        receipt->actual_partial_self_object == self_object &&
+        receipt->actual_partial_self_type == self_type &&
+        receipt->actual_partial_stability_tokens == pending_stability_tokens) {
       ++receipt->actual_partial_shadow_passes;
     } else {
+      receipt->actual_partial_entry_key = entry_key;
+      receipt->actual_partial_root_key = root_key;
+      receipt->actual_partial_self_object = self_object;
+      receipt->actual_partial_self_type = self_type;
       receipt->actual_partial_shadow_passes = 0;
       receipt->actual_partial_state = GuardPartialMemoState::Training;
       receipt->actual_partial_stability_tokens = pending_stability_tokens;
@@ -938,6 +977,10 @@ struct ActiveGuardReceiptScope {
 
   GuardLastSuccessReceipt* receipt;
   ActiveGuardReceiptScope* previous;
+  void* entry_key;
+  void* root_key;
+  PyObject* self_object;
+  PyTypeObject* self_type;
   std::vector<GuardSubtreeEntryToken> pending_stability_tokens;
   std::vector<GuardSubtreeEntryToken> pending_tokens;
   bool committed = false;
@@ -2861,6 +2904,10 @@ class GuardManager {
   // False. This is used for sorting optimization.
   int64_t _fail_count{0};
 
+  const std::vector<std::unique_ptr<GuardAccessor>>& accessors() const {
+    return _accessors;
+  }
+
  private:
   // Root of the guard manager, this is the used to install the relational
   // guard resetters.
@@ -3365,7 +3412,7 @@ class DictGuardManager : public GuardManager {
       return false;
     }
 
-    for (const auto& accessor : _accessors) {
+    for (const auto& accessor : accessors()) {
       if (!accessor->replay_actual_partial_tokens(obj, tokens, reason)) {
         return false;
       }
@@ -3404,7 +3451,7 @@ class DictGuardManager : public GuardManager {
     return true;
   }
 
-  void skip_adding_guard(const py::object& a, const py::object& b) {
+  void skip_adding_guard(py::object a, py::object b) {
     // The `add_leaf_guard` method in `DictGuardManager` is overridden to block
     // the addition of leaf guards. However, this is too strict. Python side of
     // guard management frequently adds TYPE_MATCH and DICT_LENGTH on
@@ -3557,6 +3604,15 @@ static bool try_actual_partial_fast_path(
 
   GuardLastSuccessReceipt* receipt = active_actual_partial_scope->receipt;
   if (receipt->actual_partial_state != GuardPartialMemoState::Enabled) {
+    return false;
+  }
+  if (receipt->actual_partial_entry_key !=
+          active_actual_partial_scope->entry_key ||
+      receipt->actual_partial_root_key != active_actual_partial_scope->root_key ||
+      receipt->actual_partial_self_object !=
+          active_actual_partial_scope->self_object ||
+      receipt->actual_partial_self_type !=
+          active_actual_partial_scope->self_type) {
     return false;
   }
 
@@ -5607,7 +5663,7 @@ py::dict debug_check_guard_lookup_receipt(
   auto receipt = create_guard_last_success_receipt();
   bool result = false;
   for (int i = 0; i < iterations; ++i) {
-    ActiveGuardReceiptScope receipt_scope(receipt.get());
+    ActiveGuardReceiptScope receipt_scope(receipt.get(), &root, &root);
     result = root.check_nopybind(value.ptr());
     if (result) {
       receipt_scope.commit();
@@ -5637,7 +5693,7 @@ py::dict debug_check_guard_lookup_receipt_sequence(
   auto receipt = create_guard_last_success_receipt();
   bool result = false;
   for (py::handle value : values) {
-    ActiveGuardReceiptScope receipt_scope(receipt.get());
+    ActiveGuardReceiptScope receipt_scope(receipt.get(), &root, &root);
     result = root.check_nopybind(value.ptr());
     if (result) {
       receipt_scope.commit();
@@ -5653,6 +5709,97 @@ py::dict debug_check_guard_lookup_receipt_sequence(
       receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
+  stats["actual_partial_hit"] = receipt->actual_partial_hit;
+  stats["actual_partial_miss"] = receipt->actual_partial_miss;
+  stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
+  stats["actual_partial_disabled_reasons"] =
+      actual_partial_disabled_reasons_to_dict(receipt.get());
+  return stats;
+}
+
+py::dict debug_check_guard_lookup_receipt_cross_root(
+    RootGuardManager& first_root,
+    RootGuardManager& second_root,
+    py::handle value,
+    int first_iterations = 3) {
+  auto receipt = create_guard_last_success_receipt();
+  bool result = false;
+  for (int i = 0; i < first_iterations; ++i) {
+    ActiveGuardReceiptScope receipt_scope(
+        receipt.get(), &first_root, &first_root);
+    result = first_root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
+  }
+  const bool enabled_before_cross =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled;
+  {
+    ActiveGuardReceiptScope receipt_scope(
+        receipt.get(), &second_root, &second_root);
+    result = second_root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
+  }
+
+  py::dict stats;
+  stats["result"] = result;
+  stats["actual_partial_candidate"] =
+      receipt->actual_partial_stability_tokens.size();
+  stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
+  stats["actual_partial_shadow_passes"] =
+      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_enabled"] =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
+  stats["actual_partial_enabled_before_cross"] =
+      enabled_before_cross ? 1 : 0;
+  stats["actual_partial_hit"] = receipt->actual_partial_hit;
+  stats["actual_partial_miss"] = receipt->actual_partial_miss;
+  stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
+  stats["actual_partial_disabled_reasons"] =
+      actual_partial_disabled_reasons_to_dict(receipt.get());
+  return stats;
+}
+
+py::dict debug_check_guard_lookup_receipt_cross_self(
+    RootGuardManager& root,
+    py::handle value,
+    py::handle first_self,
+    py::handle second_self,
+    int first_iterations = 3) {
+  auto receipt = create_guard_last_success_receipt();
+  bool result = false;
+  for (int i = 0; i < first_iterations; ++i) {
+    ActiveGuardReceiptScope receipt_scope(
+        receipt.get(), &root, &root, first_self.ptr());
+    result = root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
+  }
+  const bool enabled_before_cross =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled;
+  {
+    ActiveGuardReceiptScope receipt_scope(
+        receipt.get(), &root, &root, second_self.ptr());
+    result = root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
+  }
+
+  py::dict stats;
+  stats["result"] = result;
+  stats["actual_partial_candidate"] =
+      receipt->actual_partial_stability_tokens.size();
+  stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
+  stats["actual_partial_shadow_passes"] =
+      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_enabled"] =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
+  stats["actual_partial_enabled_before_cross"] =
+      enabled_before_cross ? 1 : 0;
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
   stats["actual_partial_miss"] = receipt->actual_partial_miss;
   stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
@@ -5686,15 +5833,20 @@ bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals) {
   return run_root_guard_manager(root, f_locals, nullptr);
 }
 
-bool run_root_guard_manager(
+static bool run_root_guard_manager(
     void* root,
     FrameLocalsMapping* f_locals,
-    GuardLastSuccessReceipt* receipt) {
+    GuardLastSuccessReceipt* receipt,
+    void* entry_key) {
   // for invalidated guards, return false
   if (root == nullptr) {
     return false;
   }
-  ActiveGuardReceiptScope receipt_scope(receipt);
+  ActiveGuardReceiptScope receipt_scope(
+      receipt,
+      entry_key,
+      root,
+      guard_last_success_current_self(f_locals));
   py::object config_module = py::module_::import("torch._dynamo.config");
   bool enable_cpp_framelocals_guard_eval =
       config_module.attr("enable_cpp_framelocals_guard_eval").cast<bool>();
@@ -5709,6 +5861,25 @@ bool run_root_guard_manager(
     receipt_scope.commit();
   }
   return result;
+}
+
+bool run_root_guard_manager(
+    void* root,
+    FrameLocalsMapping* f_locals,
+    GuardLastSuccessReceipt* receipt) {
+  return run_root_guard_manager(root, f_locals, receipt, nullptr);
+}
+
+bool run_root_guard_manager_with_last_success_receipt(
+    GuardLastSuccessReceipt* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe) {
+  if (is_skip_guard_eval_unsafe || receipt == nullptr) {
+    return run_root_guard_manager(root, f_locals);
+  }
+  return run_root_guard_manager(root, f_locals, receipt, entry_key);
 }
 
 PyObject* torch_c_dynamo_guards_init() {
@@ -6581,8 +6752,22 @@ PyObject* torch_c_dynamo_guards_init() {
           &DictGuardManager::get_key_value_managers,
           py::return_value_policy::reference)
       // Skipped leaf guards
-      .def("add_type_match_guard", &DictGuardManager::skip_adding_guard)
-      .def("add_dict_length_check_guard", &DictGuardManager::skip_adding_guard)
+      .def(
+          "add_type_match_guard",
+          [](DictGuardManager& self,
+             py::object value,
+             py::object verbose_code_parts) -> void {
+            self.skip_adding_guard(
+                std::move(value), std::move(verbose_code_parts));
+          })
+      .def(
+          "add_dict_length_check_guard",
+          [](DictGuardManager& self,
+             py::object value,
+             py::object verbose_code_parts) -> void {
+            self.skip_adding_guard(
+                std::move(value), std::move(verbose_code_parts));
+          })
       // Permitted leaf guards
       .def(
           "add_dict_contains_guard",
@@ -6681,6 +6866,21 @@ PyObject* torch_c_dynamo_guards_init() {
       debug_check_guard_lookup_receipt_sequence,
       py::arg("root"),
       py::arg("values"));
+  py_m.def(
+      "_debug_check_guard_lookup_receipt_cross_root",
+      debug_check_guard_lookup_receipt_cross_root,
+      py::arg("first_root"),
+      py::arg("second_root"),
+      py::arg("value"),
+      py::arg("first_iterations") = 3);
+  py_m.def(
+      "_debug_check_guard_lookup_receipt_cross_self",
+      debug_check_guard_lookup_receipt_cross_self,
+      py::arg("root"),
+      py::arg("value"),
+      py::arg("first_self"),
+      py::arg("second_self"),
+      py::arg("first_iterations") = 3);
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -75,6 +75,11 @@ typedef struct {
 
 namespace torch::dynamo {
 
+std::unique_ptr<GuardLastSuccessReceipt>
+create_guard_last_success_receipt() {
+  return std::make_unique<GuardLastSuccessReceipt>();
+}
+
 // Macro to skip addition of duplicate guards like EQUALS_MATCH
 #define SKIP_IF_GUARD_ALREADY_PRESENT(name) \
   if (self.is_leaf_guard_present(name)) {   \

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1556,6 +1556,10 @@ class LeafGuard {
     return check_nopybind((PyObject*)map->to_dict());
   }
 
+  virtual bool is_actual_partial_token_covered() const {
+    return false;
+  }
+
   virtual ~LeafGuard() = default;
 
  protected:
@@ -1636,6 +1640,10 @@ class TYPE_MATCH : public LeafGuard {
     return Py_TYPE(value) == (void*)_expected;
   }
 
+  bool is_actual_partial_token_covered() const override {
+    return true;
+  }
+
  private:
   // id of the type of the original object.
   intptr_t _expected;
@@ -1651,6 +1659,10 @@ class ID_MATCH : public LeafGuard {
   bool check_nopybind(PyObject* value) override { // borrowed ref
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     return value == (void*)_expected;
+  }
+
+  bool is_actual_partial_token_covered() const override {
+    return true;
   }
 
  private:
@@ -1795,6 +1807,10 @@ class DICT_LENGTH : public LeafGuard {
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
     return PyDict_Check(value) && PyDict_Size(value) == _length;
+  }
+
+  bool is_actual_partial_token_covered() const override {
+    return true;
   }
 
  private:
@@ -2270,6 +2286,10 @@ class DICT_VERSION : public LeafGuard {
     return PyDict_Check(value) && get_dict_version_unchecked(value) == _tag;
   }
 
+  bool is_actual_partial_token_covered() const override {
+    return true;
+  }
+
   // Saved dict version.
   uint64_t _tag;
 };
@@ -2581,7 +2601,7 @@ class GuardManager {
   virtual bool replay_actual_partial_tokens(
       PyObject* value,
       std::vector<GuardSubtreeEntryToken>& tokens) {
-    if (has_leaf_guards()) {
+    if (has_unsupported_actual_partial_leaf_guards()) {
       return false;
     }
     for (const auto& accessor : _accessors) {
@@ -2724,6 +2744,21 @@ class GuardManager {
 
   bool has_leaf_guards() const {
     return !_leaf_guards.empty();
+  }
+
+  bool has_unsupported_actual_partial_leaf_guards() const {
+    if (_leaf_guards.empty()) {
+      return false;
+    }
+    if (!is_self_modules_candidate(_source)) {
+      return true;
+    }
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->is_actual_partial_token_covered()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   int64_t fail_count() const {
@@ -3272,10 +3307,14 @@ class DictGuardManager : public GuardManager {
   bool replay_actual_partial_tokens(
       PyObject* obj,
       std::vector<GuardSubtreeEntryToken>& tokens) override {
-    if (has_leaf_guards()) {
+    if (has_unsupported_actual_partial_leaf_guards()) {
       return false;
     }
-    if (!PyDict_Check(obj)) {
+    if (Py_TYPE(obj) != _expected_type) {
+      return false;
+    }
+
+    if (PyDict_Size(obj) != _size) {
       return false;
     }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -762,6 +762,7 @@ static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   return THPUtils_packUInt64(get_dict_version_unchecked(obj));
 }
 
+class GuardManager;
 struct ActiveGuardReceiptScope;
 static thread_local ActiveGuardReceiptScope* active_actual_partial_scope =
     nullptr;
@@ -796,6 +797,70 @@ static void record_actual_partial_token(
   tokens.emplace_back(token);
 }
 
+static void append_actual_partial_tokens(
+    const std::string& source,
+    PyObject* value,
+    std::vector<GuardSubtreeEntryToken>* stability_tokens,
+    std::vector<GuardSubtreeEntryToken>* tokens) {
+  if (value == nullptr || !is_self_modules_candidate(source)) {
+    return;
+  }
+
+  GuardSubtreeEntryToken identity_token;
+  identity_token.kind = GuardSubtreeTokenKind::ObjectIdentity;
+  identity_token.object_id = reinterpret_cast<uintptr_t>(value);
+  if (stability_tokens != nullptr) {
+    record_actual_partial_token(*stability_tokens, identity_token);
+  }
+  if (tokens != nullptr) {
+    record_actual_partial_token(*tokens, identity_token);
+  }
+
+  GuardSubtreeEntryToken type_token;
+  type_token.kind = GuardSubtreeTokenKind::ObjectType;
+  type_token.type_id = reinterpret_cast<uintptr_t>(Py_TYPE(value));
+  if (tokens != nullptr) {
+    record_actual_partial_token(*tokens, type_token);
+  }
+
+  if (PyDict_Check(value)) {
+    GuardSubtreeEntryToken version_token;
+    version_token.kind = GuardSubtreeTokenKind::DictVersion;
+    version_token.version = get_dict_version_unchecked(value);
+    if (tokens != nullptr) {
+      record_actual_partial_token(*tokens, version_token);
+    }
+
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyDict_Size(value);
+    if (tokens != nullptr) {
+      record_actual_partial_token(*tokens, size_token);
+    }
+  } else if (PyList_CheckExact(value)) {
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyList_GET_SIZE(value);
+    if (tokens != nullptr) {
+      record_actual_partial_token(*tokens, size_token);
+    }
+  } else if (PyTuple_CheckExact(value)) {
+    GuardSubtreeEntryToken size_token;
+    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
+    size_token.size = PyTuple_GET_SIZE(value);
+    if (tokens != nullptr) {
+      record_actual_partial_token(*tokens, size_token);
+    }
+  }
+}
+
+static void reset_actual_partial_plan(GuardLastSuccessReceipt* receipt) {
+  receipt->actual_partial_shadow_passes = 0;
+  receipt->actual_partial_state = GuardPartialMemoState::Training;
+  receipt->actual_partial_stability_tokens.clear();
+  receipt->actual_partial_tokens.clear();
+}
+
 struct ActiveGuardReceiptScope {
   explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
       : receipt(receipt), previous(active_actual_partial_scope) {
@@ -811,10 +876,9 @@ struct ActiveGuardReceiptScope {
       return;
     }
     if (pending_stability_tokens.empty()) {
-      receipt->actual_partial_shadow_passes = 0;
-      receipt->actual_partial_state = GuardPartialMemoState::Training;
-      receipt->actual_partial_stability_tokens.clear();
-      receipt->actual_partial_tokens.clear();
+      if (!saw_fast_hit) {
+        reset_actual_partial_plan(receipt);
+      }
       committed = true;
       return;
     }
@@ -842,6 +906,7 @@ struct ActiveGuardReceiptScope {
   std::vector<GuardSubtreeEntryToken> pending_stability_tokens;
   std::vector<GuardSubtreeEntryToken> pending_tokens;
   bool committed = false;
+  bool saw_fast_hit = false;
 };
 
 static void record_actual_partial_tokens(
@@ -853,46 +918,16 @@ static void record_actual_partial_tokens(
     return;
   }
 
-  GuardSubtreeEntryToken identity_token;
-  identity_token.kind = GuardSubtreeTokenKind::ObjectIdentity;
-  identity_token.object_id = reinterpret_cast<uintptr_t>(value);
-  record_actual_partial_token(
-      active_actual_partial_scope->pending_stability_tokens, identity_token);
-  record_actual_partial_token(
-      active_actual_partial_scope->pending_tokens, identity_token);
-
-  GuardSubtreeEntryToken type_token;
-  type_token.kind = GuardSubtreeTokenKind::ObjectType;
-  type_token.type_id = reinterpret_cast<uintptr_t>(Py_TYPE(value));
-  record_actual_partial_token(
-      active_actual_partial_scope->pending_tokens, type_token);
-
-  if (PyDict_Check(value)) {
-    GuardSubtreeEntryToken version_token;
-    version_token.kind = GuardSubtreeTokenKind::DictVersion;
-    version_token.version = get_dict_version_unchecked(value);
-    record_actual_partial_token(
-        active_actual_partial_scope->pending_tokens, version_token);
-
-    GuardSubtreeEntryToken size_token;
-    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
-    size_token.size = PyDict_Size(value);
-    record_actual_partial_token(
-        active_actual_partial_scope->pending_tokens, size_token);
-  } else if (PyList_CheckExact(value)) {
-    GuardSubtreeEntryToken size_token;
-    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
-    size_token.size = PyList_GET_SIZE(value);
-    record_actual_partial_token(
-        active_actual_partial_scope->pending_tokens, size_token);
-  } else if (PyTuple_CheckExact(value)) {
-    GuardSubtreeEntryToken size_token;
-    size_token.kind = GuardSubtreeTokenKind::SequenceSize;
-    size_token.size = PyTuple_GET_SIZE(value);
-    record_actual_partial_token(
-        active_actual_partial_scope->pending_tokens, size_token);
-  }
+  append_actual_partial_tokens(
+      source,
+      value,
+      &active_actual_partial_scope->pending_stability_tokens,
+      &active_actual_partial_scope->pending_tokens);
 }
+
+static bool try_actual_partial_fast_path(
+    GuardManager* guard_manager,
+    PyObject* value);
 
 static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
   /*
@@ -2305,6 +2340,11 @@ class GuardAccessor {
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
   }
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
+  virtual bool replay_actual_partial_tokens(
+      PyObject* obj,
+      std::vector<GuardSubtreeEntryToken>& tokens) {
+    return false;
+  }
   virtual std::string repr() const = 0;
 
   virtual ~GuardAccessor() = default;
@@ -2536,6 +2576,18 @@ class GuardManager {
 
   virtual bool check_nopybind(FrameLocalsMapping* value) {
     return check_nopybind_template(value);
+  }
+
+  virtual bool replay_actual_partial_tokens(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>& tokens) {
+    for (const auto& accessor : _accessors) {
+      if (!accessor->replay_actual_partial_tokens(value, tokens)) {
+        return false;
+      }
+    }
+    append_actual_partial_tokens(this->get_source(), value, nullptr, &tokens);
+    return true;
   }
 
   template <typename T>
@@ -3210,6 +3262,51 @@ class DictGuardManager : public GuardManager {
     return GuardDebugInfo(true, num_guards_executed);
   }
 
+  bool replay_actual_partial_tokens(
+      PyObject* obj,
+      std::vector<GuardSubtreeEntryToken>& tokens) override {
+    if (!PyDict_Check(obj)) {
+      return false;
+    }
+
+    for (const auto& accessor : _accessors) {
+      if (!accessor->replay_actual_partial_tokens(obj, tokens)) {
+        return false;
+      }
+    }
+
+    PyObject *key = nullptr, *value = nullptr;
+    Py_ssize_t pos = 0;
+    size_t index_pointer = 0;
+    Py_ssize_t dict_pointer = 0;
+
+    while (index_pointer < _indices.size() &&
+           PyDict_Next(obj, &pos, &key, &value)) {
+      if (dict_pointer == _indices[index_pointer]) {
+        ++index_pointer;
+        KeyValueManager& key_value_manager = _key_value_managers[dict_pointer];
+        std::unique_ptr<GuardManager>& key_manager = key_value_manager.first;
+        if (key_manager &&
+            !key_manager->replay_actual_partial_tokens(key, tokens)) {
+          return false;
+        }
+        std::unique_ptr<GuardManager>& value_manager = key_value_manager.second;
+        if (value_manager &&
+            !value_manager->replay_actual_partial_tokens(value, tokens)) {
+          return false;
+        }
+      }
+      ++dict_pointer;
+    }
+
+    if (index_pointer != _indices.size()) {
+      return false;
+    }
+
+    append_actual_partial_tokens(this->get_source(), obj, nullptr, &tokens);
+    return true;
+  }
+
   void skip_adding_guard(const py::object& a, const py::object& b) {
     // The `add_leaf_guard` method in `DictGuardManager` is overridden to block
     // the addition of leaf guards. However, this is too strict. Python side of
@@ -3350,6 +3447,34 @@ GuardManager* clone_guard_manager(
     RootGuardManager* cloned_root,
     const py::function& clone_filter_fn) {
   return from->clone(cloned_root, clone_filter_fn);
+}
+
+static bool try_actual_partial_fast_path(
+    GuardManager* guard_manager,
+    PyObject* value) {
+  if (active_actual_partial_scope == nullptr ||
+      active_actual_partial_scope->receipt == nullptr ||
+      guard_manager == nullptr || value == nullptr) {
+    return false;
+  }
+
+  GuardLastSuccessReceipt* receipt = active_actual_partial_scope->receipt;
+  if (receipt->actual_partial_state != GuardPartialMemoState::Enabled) {
+    return false;
+  }
+
+  std::vector<GuardSubtreeEntryToken> tokens;
+  if (guard_manager->replay_actual_partial_tokens(value, tokens) &&
+      tokens == receipt->actual_partial_tokens) {
+    ++receipt->actual_partial_hit;
+    active_actual_partial_scope->saw_fast_hit = true;
+    return true;
+  }
+
+  ++receipt->actual_partial_miss;
+  reset_actual_partial_plan(receipt);
+  ++receipt->slow_guard_fallback;
+  return false;
 }
 
 void add_relational_guard_resetter_to_cloned_root(
@@ -3590,7 +3715,25 @@ class GetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
+    if (get_source() == "L['self']._modules" &&
+        try_actual_partial_fast_path(_guard_manager.get(), x)) {
+      Py_DECREF(x);
+      return true;
+    }
     bool result = _guard_manager->check_nopybind(x);
+    Py_DECREF(x);
+    return result;
+  }
+
+  bool replay_actual_partial_tokens(
+      PyObject* obj,
+      std::vector<GuardSubtreeEntryToken>& tokens) override {
+    PyObject* x = PyObject_GetAttr(obj, _attr_name); // new ref
+    if (x == nullptr) {
+      PyErr_Clear();
+      return false;
+    }
+    bool result = _guard_manager->replay_actual_partial_tokens(x, tokens);
     Py_DECREF(x);
     return result;
   }
@@ -4024,8 +4167,23 @@ class DictGetItemGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
+    if (get_source() == "L['self']._modules" &&
+        try_actual_partial_fast_path(_guard_manager.get(), x)) {
+      return true;
+    }
     bool result = _guard_manager->check_nopybind(x);
     return result;
+  }
+
+  bool replay_actual_partial_tokens(
+      PyObject* obj,
+      std::vector<GuardSubtreeEntryToken>& tokens) override {
+    PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+    if (x == nullptr) {
+      PyErr_Clear();
+      return false;
+    }
+    return _guard_manager->replay_actual_partial_tokens(x, tokens);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5362,6 +5520,37 @@ py::dict debug_check_guard_lookup_receipt(
       receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
+  stats["actual_partial_hit"] = receipt->actual_partial_hit;
+  stats["actual_partial_miss"] = receipt->actual_partial_miss;
+  stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
+  return stats;
+}
+
+py::dict debug_check_guard_lookup_receipt_sequence(
+    RootGuardManager& root,
+    py::iterable values) {
+  auto receipt = create_guard_last_success_receipt();
+  bool result = false;
+  for (py::handle value : values) {
+    ActiveGuardReceiptScope receipt_scope(receipt.get());
+    result = root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
+  }
+
+  py::dict stats;
+  stats["result"] = result;
+  stats["actual_partial_candidate"] =
+      receipt->actual_partial_stability_tokens.size();
+  stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
+  stats["actual_partial_shadow_passes"] =
+      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_enabled"] =
+      receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
+  stats["actual_partial_hit"] = receipt->actual_partial_hit;
+  stats["actual_partial_miss"] = receipt->actual_partial_miss;
+  stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
   return stats;
 }
 
@@ -6380,6 +6569,11 @@ PyObject* torch_c_dynamo_guards_init() {
       py::arg("root"),
       py::arg("value"),
       py::arg("iterations") = 1);
+  py_m.def(
+      "_debug_check_guard_lookup_receipt_sequence",
+      debug_check_guard_lookup_receipt_sequence,
+      py::arg("root"),
+      py::arg("values"));
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -762,7 +762,8 @@ static PyObject* dict_version(PyObject* dummy, PyObject* args) {
   return THPUtils_packUInt64(get_dict_version_unchecked(obj));
 }
 
-static thread_local GuardLastSuccessReceipt* active_actual_partial_receipt =
+struct ActiveGuardReceiptScope;
+static thread_local ActiveGuardReceiptScope* active_actual_partial_scope =
     nullptr;
 
 static bool is_self_modules_candidate(const std::string& source) {
@@ -770,8 +771,22 @@ static bool is_self_modules_candidate(const std::string& source) {
     return true;
   }
   const std::string prefix = "L['self']._modules";
-  return source.rfind(prefix, 0) == 0 &&
-      source.find("._modules", prefix.size()) != std::string::npos;
+  if (source.rfind(prefix, 0) != 0 || source.size() == prefix.size() ||
+      source[prefix.size()] != '[') {
+    return false;
+  }
+
+  bool saw_nested_modules = false;
+  size_t next_modules = source.find("._modules", prefix.size() + 1);
+  while (next_modules != std::string::npos) {
+    const size_t segment_end = next_modules + std::string("._modules").size();
+    if (segment_end != source.size() && source[segment_end] != '[') {
+      return false;
+    }
+    saw_nested_modules = true;
+    next_modules = source.find("._modules", segment_end);
+  }
+  return saw_nested_modules;
 }
 
 static void record_actual_partial_token(
@@ -780,10 +795,43 @@ static void record_actual_partial_token(
   tokens.emplace_back(token);
 }
 
+struct ActiveGuardReceiptScope {
+  explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
+      : receipt(receipt), previous(active_actual_partial_scope) {
+    active_actual_partial_scope = this;
+  }
+
+  ~ActiveGuardReceiptScope() {
+    active_actual_partial_scope = previous;
+  }
+
+  void commit() {
+    if (receipt == nullptr || committed) {
+      return;
+    }
+    receipt->actual_partial_stability_tokens.insert(
+        receipt->actual_partial_stability_tokens.end(),
+        pending_stability_tokens.begin(),
+        pending_stability_tokens.end());
+    receipt->actual_partial_tokens.insert(
+        receipt->actual_partial_tokens.end(),
+        pending_tokens.begin(),
+        pending_tokens.end());
+    committed = true;
+  }
+
+  GuardLastSuccessReceipt* receipt;
+  ActiveGuardReceiptScope* previous;
+  std::vector<GuardSubtreeEntryToken> pending_stability_tokens;
+  std::vector<GuardSubtreeEntryToken> pending_tokens;
+  bool committed = false;
+};
+
 static void record_actual_partial_tokens(
     const std::string& source,
     PyObject* value) {
-  if (active_actual_partial_receipt == nullptr || value == nullptr ||
+  if (active_actual_partial_scope == nullptr ||
+      active_actual_partial_scope->receipt == nullptr || value == nullptr ||
       !is_self_modules_candidate(source)) {
     return;
   }
@@ -792,56 +840,42 @@ static void record_actual_partial_tokens(
   identity_token.kind = GuardSubtreeTokenKind::ObjectIdentity;
   identity_token.object_id = reinterpret_cast<uintptr_t>(value);
   record_actual_partial_token(
-      active_actual_partial_receipt->actual_partial_stability_tokens,
-      identity_token);
+      active_actual_partial_scope->pending_stability_tokens, identity_token);
   record_actual_partial_token(
-      active_actual_partial_receipt->actual_partial_tokens, identity_token);
+      active_actual_partial_scope->pending_tokens, identity_token);
 
   GuardSubtreeEntryToken type_token;
   type_token.kind = GuardSubtreeTokenKind::ObjectType;
   type_token.type_id = reinterpret_cast<uintptr_t>(Py_TYPE(value));
   record_actual_partial_token(
-      active_actual_partial_receipt->actual_partial_tokens, type_token);
+      active_actual_partial_scope->pending_tokens, type_token);
 
   if (PyDict_Check(value)) {
     GuardSubtreeEntryToken version_token;
     version_token.kind = GuardSubtreeTokenKind::DictVersion;
     version_token.version = get_dict_version_unchecked(value);
     record_actual_partial_token(
-        active_actual_partial_receipt->actual_partial_tokens, version_token);
+        active_actual_partial_scope->pending_tokens, version_token);
 
     GuardSubtreeEntryToken size_token;
     size_token.kind = GuardSubtreeTokenKind::SequenceSize;
     size_token.size = PyDict_Size(value);
     record_actual_partial_token(
-        active_actual_partial_receipt->actual_partial_tokens, size_token);
+        active_actual_partial_scope->pending_tokens, size_token);
   } else if (PyList_CheckExact(value)) {
     GuardSubtreeEntryToken size_token;
     size_token.kind = GuardSubtreeTokenKind::SequenceSize;
     size_token.size = PyList_GET_SIZE(value);
     record_actual_partial_token(
-        active_actual_partial_receipt->actual_partial_tokens, size_token);
+        active_actual_partial_scope->pending_tokens, size_token);
   } else if (PyTuple_CheckExact(value)) {
     GuardSubtreeEntryToken size_token;
     size_token.kind = GuardSubtreeTokenKind::SequenceSize;
     size_token.size = PyTuple_GET_SIZE(value);
     record_actual_partial_token(
-        active_actual_partial_receipt->actual_partial_tokens, size_token);
+        active_actual_partial_scope->pending_tokens, size_token);
   }
 }
-
-struct ActiveGuardReceiptScope {
-  explicit ActiveGuardReceiptScope(GuardLastSuccessReceipt* receipt)
-      : previous(active_actual_partial_receipt) {
-    active_actual_partial_receipt = receipt;
-  }
-
-  ~ActiveGuardReceiptScope() {
-    active_actual_partial_receipt = previous;
-  }
-
-  GuardLastSuccessReceipt* previous;
-};
 
 static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
   /*
@@ -5288,6 +5322,24 @@ double profile_guard_manager(
   return (total_elapsed.count() * 1e6) / n_iters;
 }
 
+py::dict debug_check_guard_lookup_receipt(
+    RootGuardManager& root,
+    py::handle value) {
+  auto receipt = create_guard_last_success_receipt();
+  ActiveGuardReceiptScope receipt_scope(receipt.get());
+  const bool result = root.check_nopybind(value.ptr());
+  if (result) {
+    receipt_scope.commit();
+  }
+
+  py::dict stats;
+  stats["result"] = result;
+  stats["actual_partial_candidate"] =
+      receipt->actual_partial_stability_tokens.size();
+  stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
+  return stats;
+}
+
 } // namespace
 
 static void* _torchinductor_pyobject_tensor_data_ptr(PyObject* obj) {
@@ -5325,12 +5377,17 @@ bool run_root_guard_manager(
   py::object config_module = py::module_::import("torch._dynamo.config");
   bool enable_cpp_framelocals_guard_eval =
       config_module.attr("enable_cpp_framelocals_guard_eval").cast<bool>();
+  bool result;
   if (enable_cpp_framelocals_guard_eval) {
-    return ((RootGuardManager*)root)->check_nopybind(f_locals);
+    result = ((RootGuardManager*)root)->check_nopybind(f_locals);
   } else {
-    return ((RootGuardManager*)root)
-        ->check_nopybind((PyObject*)f_locals->to_dict());
+    result = ((RootGuardManager*)root)
+                 ->check_nopybind((PyObject*)f_locals->to_dict());
   }
+  if (result) {
+    receipt_scope.commit();
+  }
+  return result;
 }
 
 PyObject* torch_c_dynamo_guards_init() {
@@ -6290,6 +6347,11 @@ PyObject* torch_c_dynamo_guards_init() {
       py::arg("symbolic") = true);
   py_m.def("install_symbolic_shape_guard", install_symbolic_shape_guard);
   py_m.def("profile_guard_manager", profile_guard_manager);
+  py_m.def(
+      "_debug_is_self_modules_candidate", is_self_modules_candidate);
+  py_m.def(
+      "_debug_check_guard_lookup_receipt",
+      debug_check_guard_lookup_receipt);
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2581,7 +2581,7 @@ class GuardManager {
   virtual bool replay_actual_partial_tokens(
       PyObject* value,
       std::vector<GuardSubtreeEntryToken>& tokens) {
-    if (!_leaf_guards.empty()) {
+    if (has_leaf_guards()) {
       return false;
     }
     for (const auto& accessor : _accessors) {
@@ -2720,6 +2720,10 @@ class GuardManager {
 
   bool has_no_accessors() {
     return _accessors.empty();
+  }
+
+  bool has_leaf_guards() const {
+    return !_leaf_guards.empty();
   }
 
   int64_t fail_count() const {
@@ -3268,7 +3272,7 @@ class DictGuardManager : public GuardManager {
   bool replay_actual_partial_tokens(
       PyObject* obj,
       std::vector<GuardSubtreeEntryToken>& tokens) override {
-    if (!_leaf_guards.empty()) {
+    if (has_leaf_guards()) {
       return false;
     }
     if (!PyDict_Check(obj)) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -809,14 +809,8 @@ struct ActiveGuardReceiptScope {
     if (receipt == nullptr || committed) {
       return;
     }
-    receipt->actual_partial_stability_tokens.insert(
-        receipt->actual_partial_stability_tokens.end(),
-        pending_stability_tokens.begin(),
-        pending_stability_tokens.end());
-    receipt->actual_partial_tokens.insert(
-        receipt->actual_partial_tokens.end(),
-        pending_tokens.begin(),
-        pending_tokens.end());
+    receipt->actual_partial_stability_tokens = pending_stability_tokens;
+    receipt->actual_partial_tokens = pending_tokens;
     committed = true;
   }
 
@@ -5324,12 +5318,16 @@ double profile_guard_manager(
 
 py::dict debug_check_guard_lookup_receipt(
     RootGuardManager& root,
-    py::handle value) {
+    py::handle value,
+    int iterations = 1) {
   auto receipt = create_guard_last_success_receipt();
-  ActiveGuardReceiptScope receipt_scope(receipt.get());
-  const bool result = root.check_nopybind(value.ptr());
-  if (result) {
-    receipt_scope.commit();
+  bool result = false;
+  for (int i = 0; i < iterations; ++i) {
+    ActiveGuardReceiptScope receipt_scope(receipt.get());
+    result = root.check_nopybind(value.ptr());
+    if (result) {
+      receipt_scope.commit();
+    }
   }
 
   py::dict stats;
@@ -6351,7 +6349,10 @@ PyObject* torch_c_dynamo_guards_init() {
       "_debug_is_self_modules_candidate", is_self_modules_candidate);
   py_m.def(
       "_debug_check_guard_lookup_receipt",
-      debug_check_guard_lookup_receipt);
+      debug_check_guard_lookup_receipt,
+      py::arg("root"),
+      py::arg("value"),
+      py::arg("iterations") = 1);
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -75,8 +75,7 @@ typedef struct {
 
 namespace torch::dynamo {
 
-std::unique_ptr<GuardLastSuccessReceipt>
-create_guard_last_success_receipt() {
+std::unique_ptr<GuardLastSuccessReceipt> create_guard_last_success_receipt() {
   return std::make_unique<GuardLastSuccessReceipt>();
 }
 
@@ -773,8 +772,7 @@ static PyObject* guard_last_success_self_key() {
   return key;
 }
 
-static PyObject* guard_last_success_current_self(
-    FrameLocalsMapping* f_locals) {
+static PyObject* guard_last_success_current_self(FrameLocalsMapping* f_locals) {
   if (f_locals == nullptr) {
     return nullptr;
   }
@@ -3608,7 +3606,8 @@ static bool try_actual_partial_fast_path(
   }
   if (receipt->actual_partial_entry_key !=
           active_actual_partial_scope->entry_key ||
-      receipt->actual_partial_root_key != active_actual_partial_scope->root_key ||
+      receipt->actual_partial_root_key !=
+          active_actual_partial_scope->root_key ||
       receipt->actual_partial_self_object !=
           active_actual_partial_scope->self_object ||
       receipt->actual_partial_self_type !=
@@ -5675,8 +5674,7 @@ py::dict debug_check_guard_lookup_receipt(
   stats["actual_partial_candidate"] =
       receipt->actual_partial_stability_tokens.size();
   stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
-  stats["actual_partial_shadow_passes"] =
-      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_shadow_passes"] = receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
@@ -5705,8 +5703,7 @@ py::dict debug_check_guard_lookup_receipt_sequence(
   stats["actual_partial_candidate"] =
       receipt->actual_partial_stability_tokens.size();
   stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
-  stats["actual_partial_shadow_passes"] =
-      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_shadow_passes"] = receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
@@ -5748,12 +5745,10 @@ py::dict debug_check_guard_lookup_receipt_cross_root(
   stats["actual_partial_candidate"] =
       receipt->actual_partial_stability_tokens.size();
   stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
-  stats["actual_partial_shadow_passes"] =
-      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_shadow_passes"] = receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
-  stats["actual_partial_enabled_before_cross"] =
-      enabled_before_cross ? 1 : 0;
+  stats["actual_partial_enabled_before_cross"] = enabled_before_cross ? 1 : 0;
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
   stats["actual_partial_miss"] = receipt->actual_partial_miss;
   stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
@@ -5794,12 +5789,10 @@ py::dict debug_check_guard_lookup_receipt_cross_self(
   stats["actual_partial_candidate"] =
       receipt->actual_partial_stability_tokens.size();
   stats["actual_partial_token_count"] = receipt->actual_partial_tokens.size();
-  stats["actual_partial_shadow_passes"] =
-      receipt->actual_partial_shadow_passes;
+  stats["actual_partial_shadow_passes"] = receipt->actual_partial_shadow_passes;
   stats["actual_partial_enabled"] =
       receipt->actual_partial_state == GuardPartialMemoState::Enabled ? 1 : 0;
-  stats["actual_partial_enabled_before_cross"] =
-      enabled_before_cross ? 1 : 0;
+  stats["actual_partial_enabled_before_cross"] = enabled_before_cross ? 1 : 0;
   stats["actual_partial_hit"] = receipt->actual_partial_hit;
   stats["actual_partial_miss"] = receipt->actual_partial_miss;
   stats["slow_guard_fallback"] = receipt->slow_guard_fallback;
@@ -5843,10 +5836,7 @@ static bool run_root_guard_manager(
     return false;
   }
   ActiveGuardReceiptScope receipt_scope(
-      receipt,
-      entry_key,
-      root,
-      guard_last_success_current_self(f_locals));
+      receipt, entry_key, root, guard_last_success_current_self(f_locals));
   py::object config_module = py::module_::import("torch._dynamo.config");
   bool enable_cpp_framelocals_guard_eval =
       config_module.attr("enable_cpp_framelocals_guard_eval").cast<bool>();
@@ -6853,8 +6843,7 @@ PyObject* torch_c_dynamo_guards_init() {
       py::arg("symbolic") = true);
   py_m.def("install_symbolic_shape_guard", install_symbolic_shape_guard);
   py_m.def("profile_guard_manager", profile_guard_manager);
-  py_m.def(
-      "_debug_is_self_modules_candidate", is_self_modules_candidate);
+  py_m.def("_debug_is_self_modules_candidate", is_self_modules_candidate);
   py_m.def(
       "_debug_check_guard_lookup_receipt",
       debug_check_guard_lookup_receipt,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2581,6 +2581,9 @@ class GuardManager {
   virtual bool replay_actual_partial_tokens(
       PyObject* value,
       std::vector<GuardSubtreeEntryToken>& tokens) {
+    if (!_leaf_guards.empty()) {
+      return false;
+    }
     for (const auto& accessor : _accessors) {
       if (!accessor->replay_actual_partial_tokens(value, tokens)) {
         return false;
@@ -3265,6 +3268,9 @@ class DictGuardManager : public GuardManager {
   bool replay_actual_partial_tokens(
       PyObject* obj,
       std::vector<GuardSubtreeEntryToken>& tokens) override {
+    if (!_leaf_guards.empty()) {
+      return false;
+    }
     if (!PyDict_Check(obj)) {
       return false;
     }

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -3,6 +3,8 @@
 #include <torch/csrc/dynamo/framelocals_mapping.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
+#include <cstdint>
+#include <memory>
 
 namespace torch::dynamo {
 
@@ -12,6 +14,25 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+
+enum class GuardPartialMemoState : uint8_t {
+  Training = 0,
+  Enabled = 1,
+  Disabled = 2,
+};
+
+struct GuardLastSuccessReceipt {
+  void* actual_partial_entry_key = nullptr;
+  void* actual_partial_root_key = nullptr;
+  PyObject* actual_partial_self_object = nullptr;
+  PyTypeObject* actual_partial_self_type = nullptr;
+  uint64_t actual_partial_shadow_passes = 0;
+  GuardPartialMemoState actual_partial_state =
+      GuardPartialMemoState::Training;
+};
+
+std::unique_ptr<GuardLastSuccessReceipt>
+create_guard_last_success_receipt();
 
 struct LocalState {
   // TLS state that changes operators

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -23,6 +23,12 @@ bool run_root_guard_manager(
     void* root,
     FrameLocalsMapping* f_locals,
     GuardLastSuccessReceipt* receipt);
+bool run_root_guard_manager_with_last_success_receipt(
+    GuardLastSuccessReceipt* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe);
 
 enum class GuardPartialMemoState : uint8_t {
   Training = 0,

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -5,6 +5,8 @@
 #include <torch/csrc/utils/pybind.h>
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace torch::dynamo {
@@ -36,6 +38,12 @@ enum class GuardSubtreeTokenKind : uint8_t {
   TensorMetadata,
 };
 
+enum class ActualPartialReplayFailureReason : uint8_t {
+  None = 0,
+  UnsupportedAccessor = 1,
+  UnsupportedLeaf = 2,
+};
+
 struct GuardSubtreeEntryToken {
   GuardSubtreeTokenKind kind;
   uintptr_t object_id = 0;
@@ -61,6 +69,7 @@ struct GuardLastSuccessReceipt {
   uint64_t actual_partial_hit = 0;
   uint64_t actual_partial_miss = 0;
   uint64_t slow_guard_fallback = 0;
+  std::unordered_map<std::string, uint64_t> actual_partial_disabled_reasons;
   GuardPartialMemoState actual_partial_state =
       GuardPartialMemoState::Training;
   std::vector<GuardSubtreeEntryToken> actual_partial_stability_tokens;

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -5,6 +5,7 @@
 #include <torch/csrc/utils/pybind.h>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace torch::dynamo {
 
@@ -15,10 +16,32 @@ PyObject* torch_c_dynamo_guards_init();
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
 
+struct GuardLastSuccessReceipt;
+bool run_root_guard_manager(
+    void* root,
+    FrameLocalsMapping* f_locals,
+    GuardLastSuccessReceipt* receipt);
+
 enum class GuardPartialMemoState : uint8_t {
   Training = 0,
   Enabled = 1,
   Disabled = 2,
+};
+
+enum class GuardSubtreeTokenKind : uint8_t {
+  ObjectIdentity,
+  ObjectType,
+  DictVersion,
+  SequenceSize,
+  TensorMetadata,
+};
+
+struct GuardSubtreeEntryToken {
+  GuardSubtreeTokenKind kind;
+  uintptr_t object_id = 0;
+  uintptr_t type_id = 0;
+  uint64_t version = 0;
+  int64_t size = -1;
 };
 
 struct GuardLastSuccessReceipt {
@@ -29,6 +52,8 @@ struct GuardLastSuccessReceipt {
   uint64_t actual_partial_shadow_passes = 0;
   GuardPartialMemoState actual_partial_state =
       GuardPartialMemoState::Training;
+  std::vector<GuardSubtreeEntryToken> actual_partial_stability_tokens;
+  std::vector<GuardSubtreeEntryToken> actual_partial_tokens;
 };
 
 std::unique_ptr<GuardLastSuccessReceipt>

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -76,14 +76,12 @@ struct GuardLastSuccessReceipt {
   uint64_t actual_partial_miss = 0;
   uint64_t slow_guard_fallback = 0;
   std::unordered_map<std::string, uint64_t> actual_partial_disabled_reasons;
-  GuardPartialMemoState actual_partial_state =
-      GuardPartialMemoState::Training;
+  GuardPartialMemoState actual_partial_state = GuardPartialMemoState::Training;
   std::vector<GuardSubtreeEntryToken> actual_partial_stability_tokens;
   std::vector<GuardSubtreeEntryToken> actual_partial_tokens;
 };
 
-std::unique_ptr<GuardLastSuccessReceipt>
-create_guard_last_success_receipt();
+std::unique_ptr<GuardLastSuccessReceipt> create_guard_last_success_receipt();
 
 struct LocalState {
   // TLS state that changes operators

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -44,6 +44,14 @@ struct GuardSubtreeEntryToken {
   int64_t size = -1;
 };
 
+inline bool operator==(
+    const GuardSubtreeEntryToken& lhs,
+    const GuardSubtreeEntryToken& rhs) {
+  return lhs.kind == rhs.kind && lhs.object_id == rhs.object_id &&
+      lhs.type_id == rhs.type_id && lhs.version == rhs.version &&
+      lhs.size == rhs.size;
+}
+
 struct GuardLastSuccessReceipt {
   void* actual_partial_entry_key = nullptr;
   void* actual_partial_root_key = nullptr;

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -58,6 +58,9 @@ struct GuardLastSuccessReceipt {
   PyObject* actual_partial_self_object = nullptr;
   PyTypeObject* actual_partial_self_type = nullptr;
   uint64_t actual_partial_shadow_passes = 0;
+  uint64_t actual_partial_hit = 0;
+  uint64_t actual_partial_miss = 0;
+  uint64_t slow_guard_fallback = 0;
   GuardPartialMemoState actual_partial_state =
       GuardPartialMemoState::Training;
   std::vector<GuardSubtreeEntryToken> actual_partial_stability_tokens;


### PR DESCRIPTION
## Summary

This PR proposes a conservative guard lookup fast path for stable
`L['self']._modules` guard subtrees in TorchDynamo.

The implementation records a Last Successful Guard Memo for each cache entry,
trains a token plan from repeated successful guard evaluations, and reuses that
plan only when the current lookup still matches the previous cache entry, root
guard manager, `self` object, `self` type, and stability tokens.

Any mismatch, unsupported coverage, invalidated state, or changed object identity
falls back to the original slow guard path. The goal of this draft is to collect
early feedback on the design and safety boundary before expanding token coverage
or making workload-level performance claims.

## Motivation

In stable `torch.compile` module workloads, Dynamo cache lookup may repeatedly
traverse the same large `self._modules` guard subtree even when the module
structure is unchanged. This PR explores whether a mechanically checkable token
plan can reduce repeated guard traversal while preserving the original guard
semantics through conservative fallback.

## Changes

- Store Last Successful Guard Memo state on Dynamo `ExtraState`.
- Route cache lookup through a receipt-aware root guard-manager entry point.
- Detect conservative `L['self']._modules` token-plan candidates.
- Train token plans after repeated successful shadow passes.
- Validate the fast path against the cache entry, root guard manager, `self`
  object, `self` type, and stability tokens.
- Replay the token plan only when all stability checks match.
- Fall back to the original slow guard path on token mismatch, unsupported
  leaf/accessor coverage, invalidated state, or changed entry/root/self identity.
- Add lookup stats for receipt creation, enabled state, candidate/token counts,
  fast hits, misses, slow fallbacks, and disabled reasons.
- Add targeted guard-manager tests for fast hit, cross-entry/root/self rejection,
  fallback behavior, unsupported coverage, stale extra state, and stats reset.

## Safety

The fast path is intentionally conservative:

- It does not bypass guard evaluation unless the token plan has been trained
  from successful slow-path evaluations.
- It requires the same cache entry, root guard manager, `self` object, and
  `self` type before replaying a plan.
- Unsupported guards are not approximated; they disable the fast path and fall
  back to the original slow guard path.
- Token mismatch resets the memo and falls back to slow guard evaluation.
- Existing guard failure semantics are preserved.

## Test Plan

Validated on a remote `release/2.7` PyTorch checkout at base `e2d141d`:

- `git diff --check -- test/dynamo/test_guard_manager.py torch/csrc/dynamo/extra_state.cpp torch/csrc/dynamo/extra_state.h torch/csrc/dynamo/guards.cpp torch/csrc/dynamo/guards.h`
- `PYTHONPATH=. /usr/bin/python3 -m py_compile test/dynamo/test_guard_manager.py`
- `PYTHONPATH=. /usr/bin/python3 test/dynamo/test_guard_manager.py -k fast_hit -v`
  - 5 tests OK
- `PYTHONPATH=. /usr/bin/python3 test/dynamo/test_guard_manager.py -k token_plan -v`
  - 13 tests OK
- `PYTHONPATH=. /usr/bin/python3 test/dynamo/test_guard_manager.py -v`
  - 48 tests OK, 1 CUDA skip

Additional evidence:

- The full PyTorch `test/run_test.py --keep-going` runner executed
  `dynamo/test_guard_manager` successfully.
- A direct `_debug_check_guard_lookup_receipt(...)` counter probe produced
  `actual_partial_enabled=1`, `actual_partial_hit=1`,
  `actual_partial_miss=0`, and `slow_guard_fallback=0`, proving that the
  synthetic guard-manager fast path is reached.
- A separate `torch.compile(nn.Module, backend="eager")` smoke probe enabled
  the receipt but fell back with
  `actual_partial_disabled_reasons={'unsupported_leaf': 1}`. This is the
  intended conservative boundary for unsupported coverage.

A broader CPU-only full-test run still has unrelated failures in other test
files on the remote environment; no `dynamo/test_guard_manager` failure was
observed.

## Notes For Reviewers

This draft is intentionally narrow. The main questions are:

- Is the Last Successful Guard Memo shape acceptable for Dynamo cache lookup?
- Is the `entry/root/self/type/token` validation boundary sufficient?
- Is this conservative fallback behavior the right starting point before
  expanding token coverage?
- What additional workload-level hit-rate counters or benchmarks would be most
  useful before moving this beyond draft?

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @ipiszy @muchulee8 @aakhundov @coconutruben