### PR TITLE
xfail Inductor tests that require Triton on accelerators

### DIFF
--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -9,7 +9,6 @@ from torch.testing._internal.torchbind_impls import init_torchbind_implementatio
 HAS_CUDA = torch.cuda.is_available()
 
 
-@xfailIfNoAcceleratorTriton
 class TestTorchbindAOTI(TestCase):
     """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
     via AOTIModelPackageLoader.get_custom_objs() after load.
@@ -38,6 +37,7 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
+    @xfailIfNoAcceleratorTriton
     def test_custom_objs_exposed_through_loader(self):
         device = "cuda" if HAS_CUDA else "cpu"
         m = self._make_model().to(device)
@@ -62,6 +62,7 @@ class TestTorchbindAOTI(TestCase):
             msg=f"Expected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
+    @xfailIfNoAcceleratorTriton
     def test_mutating_custom_obj_after_load_affects_run(self):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -98,6 +99,7 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
+    @xfailIfNoAcceleratorTriton
     def test_custom_objs_empty_when_no_torchbind(self):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -2,13 +2,14 @@
 
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, xfailIfNoAcceleratorTriton
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
 HAS_CUDA = torch.cuda.is_available()
 
 
+@xfailIfNoAcceleratorTriton
 class TestTorchbindAOTI(TestCase):
     """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
     via AOTIModelPackageLoader.get_custom_objs() after load.

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,8 +1,11 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import run_tests, xfailIfNoAcceleratorTriton
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
@@ -37,7 +40,7 @@ class TestTorchbindAOTI(TestCase):
 
         return M()
 
-    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
     def test_custom_objs_exposed_through_loader(self):
         device = "cuda" if HAS_CUDA else "cpu"
         m = self._make_model().to(device)
@@ -62,7 +65,7 @@ class TestTorchbindAOTI(TestCase):
             msg=f"Expected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
-    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
     def test_mutating_custom_obj_after_load_affects_run(self):
         # The central contract: IValues returned by get_custom_objs() share
         # intrusive_ptr ownership with the live entries inside
@@ -99,7 +102,7 @@ class TestTorchbindAOTI(TestCase):
         after = loader.run([x])[0]
         torch.testing.assert_close(after, 40 * x + x)
 
-    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(HAS_CUDA and not HAS_TRITON, "requires triton on CUDA builds")
     def test_custom_objs_empty_when_no_torchbind(self):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):

--- a/test/inductor/test_fusion_regions.py
+++ b/test/inductor/test_fusion_regions.py
@@ -9,6 +9,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.ops import aten
+from torch.testing._internal.common_utils import xfailIfNoAcceleratorTriton
 
 
 HAS_GPU = torch.cuda.is_available()
@@ -103,6 +104,7 @@ class TestFusionRegionDetection(InductorTestCase):
             "Ops before and after mm should not be in the same fusion region",
         )
 
+    @xfailIfNoAcceleratorTriton
     def test_estimate_fused_node_costs(self):
         """Test that fused costs correctly exclude internal I/O."""
         from torch._inductor.fx_passes.fusion_regions import (
@@ -179,6 +181,7 @@ class TestFusionRegionDetection(InductorTestCase):
         self.assertIsNotNone(qr_node)
         self.assertFalse(is_fusible_node(qr_node))
 
+    @xfailIfNoAcceleratorTriton
     def test_fused_costs_does_not_mutate_graph(self):
         """estimate_fused_node_costs must not mutate the graph."""
         from torch._inductor.fx_passes.fusion_regions import (
@@ -213,6 +216,7 @@ class TestFusionRegionDetection(InductorTestCase):
             "Graph must not be mutated by estimate_fused_node_costs",
         )
 
+    @xfailIfNoAcceleratorTriton
     def test_fused_costs_handles_forced_bad_region(self):
         """estimate_fused_node_costs works for any region_of mapping."""
         from torch._inductor.fx_passes.fusion_regions import estimate_fused_node_costs

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfNoAcceleratorTriton,
 )
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
@@ -1370,6 +1371,7 @@ class TestFlexAttentionEstimation(TestCase):
         expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
         self.assertEqual(fwd_flops, expected_flops)
 
+    @xfailIfNoAcceleratorTriton
     @unittest.skipIf(not HAS_CUDA, "requires CUDA")
     def test_flex_attention_roofline_estimate(self):
         """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""


### PR DESCRIPTION
### Summary

Use skipIf for torchbind AOTI tests on CUDA builds without Triton, so they skip on cuda backend when Triton is missing, instead of failing with `ModuleNotFoundError` or `InductorError: TritonMissing`.

These tests fall back to CPU when CUDA is unavailable. On CPU-only hosts without Triton it would run via the AOTI C++/OpenMP backend.

Skip only when `HAS_CUDA and not HAS_TRITON`; CPU-only configs still run.

### Test plan
```powershell
python -m pytest .\pytorch\test\inductor\test_aoti_torchbind_constants.py
python -m pytest .\pytorch\test\inductor\test_fusion_regions.py
python -m pytest .\pytorch\test\test_flop_counter.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo