### PR TITLE
Pin H100/B200 runners to Meta ARC fleet

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -107,10 +107,11 @@ runner_mapping:
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
 
-
-# H100/B200 hardware exists only on the Meta ARC fleet; pin these labels
-# to the 'mt-' prefix regardless of the build job's fleet assignment.
-always_arc_runners:
+# Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
+# equivalent). The mapper forces the 'mt-' prefix on these regardless of which
+# experiment drives the build runner. When adding a new H100/B200 (or similar
+# Meta-only) variant to runner_mapping above, also add it here.
+meta_only_runners:
   - linux.aws.h100
   - linux.aws.h100.4
   - linux.aws.h100.8

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -106,3 +106,12 @@ runner_mapping:
   linux.rocm.gpu.mi210.2: linux.rocm.gpu.mi210.2
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
+
+
+# H100/B200 hardware exists only on the Meta ARC fleet; pin these labels
+# to the 'mt-' prefix regardless of the build job's fleet assignment.
+always_arc_runners:
+  - linux.aws.h100
+  - linux.aws.h100.4
+  - linux.aws.h100.8
+  - linux.dgx.b200

--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -47,10 +47,10 @@ def load_mapping(arc_yaml: Path) -> dict[str, str]:
     return data["runner_mapping"]
 
 
-def load_always_arc(arc_yaml: Path) -> set[str]:
+def load_meta_only(arc_yaml: Path) -> set[str]:
     with open(arc_yaml) as f:
         data = yaml.safe_load(f)
-    return set(data.get("always_arc_runners") or [])
+    return set(data.get("meta_only_runners") or [])
 
 
 def set_output(name: str, val: str) -> None:
@@ -65,7 +65,7 @@ def main() -> None:
     args = parse_args()
     arc_yaml = Path(__file__).resolve().parent.parent / "arc.yaml"
     mapping = load_mapping(arc_yaml)
-    always_arc = load_always_arc(arc_yaml)
+    meta_only = load_meta_only(arc_yaml)
 
     matrix = yaml.safe_load(args.matrix)
     if not matrix:
@@ -99,9 +99,9 @@ def main() -> None:
             print(f"error: no ARC runner found for '{clean}'", file=sys.stderr)
             sys.exit(1)
         mapped = mapping[clean]
-        # H100/B200 hardware exists only on the Meta ARC fleet, so force the
+        # Some hardware (H100, B200) exists only on the Meta fleet, so force the
         # 'mt-' prefix regardless of the build job's fleet assignment.
-        if clean in always_arc:
+        if clean in meta_only:
             entry["runner"] = "mt-" + mapped
             continue
         # Passthrough runners (e.g. linux.rocm.gpu.2, linux.idc.xpu) are not

--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -47,6 +47,12 @@ def load_mapping(arc_yaml: Path) -> dict[str, str]:
     return data["runner_mapping"]
 
 
+def load_always_arc(arc_yaml: Path) -> set[str]:
+    with open(arc_yaml) as f:
+        data = yaml.safe_load(f)
+    return set(data.get("always_arc_runners") or [])
+
+
 def set_output(name: str, val: str) -> None:
     print(f"Setting {name}={val}")
     github_output = os.getenv("GITHUB_OUTPUT")
@@ -59,6 +65,7 @@ def main() -> None:
     args = parse_args()
     arc_yaml = Path(__file__).resolve().parent.parent / "arc.yaml"
     mapping = load_mapping(arc_yaml)
+    always_arc = load_always_arc(arc_yaml)
 
     matrix = yaml.safe_load(args.matrix)
     if not matrix:
@@ -92,6 +99,11 @@ def main() -> None:
             print(f"error: no ARC runner found for '{clean}'", file=sys.stderr)
             sys.exit(1)
         mapped = mapping[clean]
+        # H100/B200 hardware exists only on the Meta ARC fleet, so force the
+        # 'mt-' prefix regardless of the build job's fleet assignment.
+        if clean in always_arc:
+            entry["runner"] = "mt-" + mapped
+            continue
         # Passthrough runners (e.g. linux.rocm.gpu.2, linux.idc.xpu) are not
         # OSDC-managed so they keep their original label without the prefix.
         entry["runner"] = mapped if mapped == clean else args.prefix + mapped

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -188,6 +188,79 @@ def test_github_output_file():
         os.unlink(tmp_path)
 
 
+def test_h100_forces_mt_prefix_when_no_prefix():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
+    ]}"""
+    result = run(matrix)
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(output["include"][0]["runner"] == "mt-l-x86iamx-22-225-h100")
+
+
+def test_h100_forces_mt_prefix_overriding_lf():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.aws.h100" },
+    ]}"""
+    result = run(matrix, prefix="lf-")
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(
+        output["include"][0]["runner"] == "mt-l-x86iamx-22-225-h100",
+        f"expected mt- override, got {output['include'][0]['runner']}",
+    )
+
+
+def test_h100_with_mt_prefix_idempotent():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "mt-linux.aws.h100" },
+    ]}"""
+    result = run(matrix, prefix="mt-")
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(output["include"][0]["runner"] == "mt-l-x86iamx-22-225-h100")
+
+
+def test_b200_forces_mt_prefix_overriding_lf():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.dgx.b200" },
+    ]}"""
+    result = run(matrix, prefix="lf-")
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(output["include"][0]["runner"] == "mt-l-x86iamx-22-225-b200")
+
+
+def test_non_h100_keeps_lf_prefix():
+    """Regression guard: non-H100/B200 runners must not be forced to mt-."""
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.4xlarge" },
+    ]}"""
+    result = run(matrix, prefix="lf-")
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    check(output["include"][0]["runner"] == "lf-l-x86iavx512-16-128")
+
+
+def test_h100_multi_gpu_variants_force_mt():
+    matrix = """{ include: [
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.aws.h100.4" },
+      { config: "default", shard: 1, num_shards: 1, runner: "lf-linux.aws.h100.8" },
+    ]}"""
+    result = run(matrix, prefix="lf-")
+    check(result.returncode == 0, result.stderr)
+    output = parse_output(result.stdout)
+    runners = [e["runner"] for e in output["include"]]
+    check(
+        runners
+        == [
+            "mt-l-x86iamx-88-900-h100-4",
+            "mt-l-bx86iamx-176-1800-h100-8",
+        ],
+        f"unexpected runners: {runners}",
+    )
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
- Add `always_arc_runners` list to arc.yaml for labels that must always use the Meta (`mt-`) fleet prefix regardless of the build job's fleet assignment
- Update map_ec2_to_arc.py to load the new list and force the `mt-` prefix for matching runners, overriding whatever prefix the caller passed
- Add seven tests covering H100 single/multi-GPU and B200 forced-prefix behavior, including idempotency and a regression guard for non-pinned runners

H100 and B200 hardware only exists on the Meta ARC fleet. When a build job runs on the Linux Foundation (`lf-`) fleet, its test jobs currently inherit the `lf-` prefix, which routes GPU tests to a fleet that has no H100/B200 nodes. This change ensures those runner labels are always pinned to `mt-` so GPU tests land on hardware that actually exists.

Test Plan:
```
python .github/scripts/test_map_ec2_to_arc.py
```