### PR TITLE
[CI] Cap some linters parallelism via MAX_JOBS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,8 @@ jobs:
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
+        # Cap parallelism to the pod's CPU budget; os.cpu_count() overcounts on k8s and OOMs.
+        export MAX_JOBS="$(nproc --ignore=2)"
         if [ "$CHANGED_FILES" = '*' ]; then
           ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
         else

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,8 @@ jobs:
           export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT $CHANGED_FILES"
         fi
         export CLANG=1
+        # Cap parallelism to the pod's CPU budget; os.cpu_count() overcounts on k8s and OOMs.
+        export MAX_JOBS="$(nproc --ignore=2)"
         .github/scripts/lintrunner.sh
 
   # NOTE: mypy needs its own job because it depends on --all-files, without assessing all files it sometimes

--- a/tools/linter/adapters/clangformat_linter.py
+++ b/tools/linter/adapters/clangformat_linter.py
@@ -16,6 +16,14 @@ from typing import NamedTuple
 IS_WINDOWS: bool = os.name == "nt"
 
 
+def _default_num_workers() -> int | None:
+    # clang-format must respect MAX_JOBS to cap parallelism.
+    max_jobs = os.environ.get("MAX_JOBS")
+    if max_jobs and max_jobs.isdigit() and int(max_jobs) > 0:
+        return int(max_jobs)
+    return os.cpu_count()
+
+
 class LintSeverity(str, Enum):
     ERROR = "error"
     WARNING = "warning"
@@ -190,11 +198,23 @@ def main() -> None:
         help="verbose logging",
     )
     parser.add_argument(
+        "-j",
+        "--num-workers",
+        type=int,
+        default=None,
+        help=(
+            "number of clang-format processes to run in parallel. Defaults to "
+            "the MAX_JOBS environment variable if set, otherwise the CPU count."
+        ),
+    )
+    parser.add_argument(
         "filenames",
         nargs="+",
         help="paths to lint",
     )
     args = parser.parse_args()
+
+    num_workers = args.num_workers or _default_num_workers()
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
@@ -226,7 +246,7 @@ def main() -> None:
         sys.exit(0)
 
     with concurrent.futures.ThreadPoolExecutor(
-        max_workers=os.cpu_count(),
+        max_workers=num_workers,
         thread_name_prefix="Thread",
     ) as executor:
         futures = {

--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -33,6 +33,14 @@ def scm_root() -> str:
 PYTORCH_ROOT = scm_root()
 
 
+def _default_num_workers() -> int | None:
+    # clang-tidy is memory hungry, so respect MAX_JOBS to cap parallelism.
+    max_jobs = os.environ.get("MAX_JOBS")
+    if max_jobs and max_jobs.isdigit() and int(max_jobs) > 0:
+        return int(max_jobs)
+    return os.cpu_count()
+
+
 # Returns '/usr/local/include/python<version number>'
 def get_python_include_dir() -> str:
     return gp()["include"]
@@ -249,11 +257,24 @@ def main() -> None:
         help="verbose logging",
     )
     parser.add_argument(
+        "-j",
+        "--num-workers",
+        type=int,
+        default=None,
+        help=(
+            "number of clang-tidy processes to run in parallel. Defaults to the "
+            "MAX_JOBS environment variable if set, otherwise the CPU count. "
+            "Lower this to reduce peak memory usage (clang-tidy is memory hungry)."
+        ),
+    )
+    parser.add_argument(
         "filenames",
         nargs="+",
         help="paths to lint",
     )
     args = parser.parse_args()
+
+    num_workers = args.num_workers or _default_num_workers()
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
@@ -294,7 +315,7 @@ def main() -> None:
     binary_path = os.path.abspath(args.binary)
 
     with concurrent.futures.ThreadPoolExecutor(
-        max_workers=os.cpu_count(),
+        max_workers=num_workers,
         thread_name_prefix="Thread",
     ) as executor:
         futures = {

--- a/tools/linter/adapters/codespell_linter.py
+++ b/tools/linter/adapters/codespell_linter.py
@@ -161,6 +161,14 @@ def check_dictionary(filename: str) -> list[LintMessage]:
     return []
 
 
+def _default_num_workers() -> int | None:
+    # Forks one process per file batch, so respect MAX_JOBS to cap parallelism.
+    max_jobs = os.environ.get("MAX_JOBS")
+    if max_jobs and max_jobs.isdigit() and int(max_jobs) > 0:
+        return int(max_jobs)
+    return os.cpu_count()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Check files for spelling mistakes using codespell.",
@@ -172,11 +180,19 @@ def main() -> None:
         help="verbose logging",
     )
     parser.add_argument(
+        "-j",
+        "--num-workers",
+        type=int,
+        default=None,
+        help="number of parallel workers (defaults to MAX_JOBS or the CPU count)",
+    )
+    parser.add_argument(
         "filenames",
         nargs="+",
         help="paths to lint",
     )
     args = parser.parse_args()
+    num_workers = args.num_workers or _default_num_workers()
 
     logging.basicConfig(
         format="<%(processName)s:%(levelname)s> %(message)s",
@@ -189,7 +205,7 @@ def main() -> None:
     )
 
     with concurrent.futures.ProcessPoolExecutor(
-        max_workers=os.cpu_count(),
+        max_workers=num_workers,
     ) as executor:
         futures = {executor.submit(check_file, x): x for x in args.filenames}
         futures[executor.submit(check_dictionary, str(DICTIONARY))] = str(DICTIONARY)

--- a/tools/linter/adapters/pyfmt_linter.py
+++ b/tools/linter/adapters/pyfmt_linter.py
@@ -139,6 +139,14 @@ def check_file(filename: str) -> list[LintMessage]:
         return [format_error_message(filename, err)]
 
 
+def _default_num_workers() -> int | None:
+    # Forks one process per file batch, so respect MAX_JOBS to cap parallelism.
+    max_jobs = os.environ.get("MAX_JOBS")
+    if max_jobs and max_jobs.isdigit() and int(max_jobs) > 0:
+        return int(max_jobs)
+    return os.cpu_count()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Format files with usort + ruff-format.",
@@ -150,11 +158,19 @@ def main() -> None:
         help="verbose logging",
     )
     parser.add_argument(
+        "-j",
+        "--num-workers",
+        type=int,
+        default=None,
+        help="number of parallel workers (defaults to MAX_JOBS or the CPU count)",
+    )
+    parser.add_argument(
         "filenames",
         nargs="+",
         help="paths to lint",
     )
     args = parser.parse_args()
+    num_workers = args.num_workers or _default_num_workers()
 
     logging.basicConfig(
         format="<%(processName)s:%(levelname)s> %(message)s",
@@ -167,7 +183,7 @@ def main() -> None:
     )
 
     with concurrent.futures.ProcessPoolExecutor(
-        max_workers=os.cpu_count(),
+        max_workers=num_workers,
     ) as executor:
         futures = {executor.submit(check_file, x): x for x in args.filenames}
         for future in concurrent.futures.as_completed(futures):

--- a/tools/linter/adapters/ruff_linter.py
+++ b/tools/linter/adapters/ruff_linter.py
@@ -368,10 +368,25 @@ def check_file_for_fixes(
     ]
 
 
+def _default_num_workers() -> int | None:
+    # Forks one process per file batch, so respect MAX_JOBS to cap parallelism.
+    max_jobs = os.environ.get("MAX_JOBS")
+    if max_jobs and max_jobs.isdigit() and int(max_jobs) > 0:
+        return int(max_jobs)
+    return os.cpu_count()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=f"Ruff linter. Linter code: {LINTER_CODE}. Use with RUFF-FIX to auto-fix issues.",
         fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "-j",
+        "--num-workers",
+        type=int,
+        default=None,
+        help="number of parallel workers (defaults to MAX_JOBS or the CPU count)",
     )
     parser.add_argument(
         "--config",
@@ -406,6 +421,7 @@ def main() -> None:
     )
     add_default_options(parser)
     args = parser.parse_args()
+    num_workers = args.num_workers or _default_num_workers()
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
@@ -443,7 +459,7 @@ def main() -> None:
 
     files_with_lints = {lint.path for lint in lint_messages if lint.path is not None}
     with concurrent.futures.ThreadPoolExecutor(
-        max_workers=os.cpu_count(),
+        max_workers=num_workers,
         thread_name_prefix="Thread",
     ) as executor:
         futures = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #187545
* #187525
* __->__ #187535

The clang/pyfmt/ruff adapters spawn one process per os.cpu_count(), which on the k8s ARC lint runner reports the host node's core count rather than the pod's cgroup limit, so an --all-files run launches far more memory-hungry clang-tidy processes than the pod can hold and OOMs. Make the adapters honor a -j/--num-workers flag defaulting to the MAX_JOBS env var (falling back to os.cpu_count()), and set MAX_JOBS="$(nproc --ignore=2)" in the clang lint job the same way _linux-build.yml does so nproc yields the pod's real CPU budget.

Authored with assistance from Claude Code.