### PR TITLE
Fix ldexp backward zero gradient for negative integer exponents

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16857,6 +16857,15 @@ class TestAutogradMultipleDispatch(TestCase):
         z.backward()
         self.assertEqual(x.grad, torch.zeros_like(x))
         self.assertEqual(y.grad, torch.zeros_like(y))
+    def test_ldexp_negative_int_exponent_gradient_187460(self):
+        # ldexp(input, other) = input * 2**other, so d/d_input = 2**other.
+        # For an integer-typed `other`, the backward must compute 2**other in
+        # floating point; otherwise negative exponents floor to 0 (see #187460).
+        for e_val, expected in [(-1, 0.5), (-2, 0.25), (0, 1.0), (2, 4.0)]:
+            m = torch.tensor([0.5], requires_grad=True)
+            e = torch.tensor([e_val], dtype=torch.int32)
+            torch.ldexp(m, e).backward()
+            self.assertEqual(m.grad, torch.full_like(m, expected))
 
     # Test that torch.autograd.backward respects __torch_function__ on tensor subclasses.
     def test_backward_respects_torch_function(self):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -929,7 +929,7 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2, other.to(result.scalar_type())).conj()
+  self: grad * at::pow(2.0, other).conj()
   other: grad * result.conj() * M_LN2
   result: self_t * at::pow(2, other_p) + other_t * result * M_LN2
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -929,7 +929,7 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2, other).conj()
+  self: grad * at::pow(2, other.to(result.scalar_type())).conj()
   other: grad * result.conj() * M_LN2
   result: self_t * at::pow(2, other_p) + other_t * result * M_LN2
 


### PR DESCRIPTION
Fixes #187460
torch.ldexp(input, other) computes input * 2**other, so the gradient w.r.t. input is 2**other. As @OE-GOD diagnosed in the issue, the backward formula in derivatives.yaml computed at::pow(2, other) with an integer-typed other, so 2**e was evaluated in integer arithmetic and floored to 0 for any negative e — silently zeroing the gradient while the forward pass stayed correct.
Fix: cast other to the result's floating dtype before the pow, matching the forward path:

`self: grad * at::pow(2, other.to(result.scalar_type())).conj()`

Test: added a regression test in test_autograd.py covering negative, zero, and positive integer exponents (-1, -2, 0, 2), asserting the mantissa gradient equals 2**e. The existing BinaryUfuncInfo gradcheck coverage never exercised a negative integer exponent with grad on the mantissa, which is why this went unnoticed.
I couldn't build locally (hardware constraints) so I'm relying on CI to verify. Happy to also add an OpInfo sample input for ldexp covering this case if reviewers prefer that over the standalone test.
cc @soulitzer @albanD