### PR TITLE
[SR] Node executor registry in SR

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -70,6 +70,42 @@ bool allArgsAreTensors(const Node* node) {
 
 } // namespace
 
+#ifdef FBCODE_CAFFE2
+
+C10_DEFINE_REGISTRY(SRNodeExecutorRegistry, NodeExecutorFunctor)
+
+namespace {
+
+static void sequentialExecute(
+    BlockRunner& block_runner,
+    ProcessedNode* nodes,
+    size_t num_nodes,
+    void* /*ctx*/) {
+  for (size_t i = 0; i < num_nodes; ++i) {
+    nodes[i].run();
+    // Check for incorrect schema alias info.
+    block_runner.verify_and_correct_memory_overlap(nodes[i]);
+  }
+}
+
+struct SequentialNodeExecutorFunctor : public NodeExecutorFunctor {
+  NodeExecutorFn Create(
+      const BlockInfo& /*block_info*/,
+      const StaticModuleOptions& /*opts*/,
+      void** /*context*/) override {
+    return &sequentialExecute;
+  }
+};
+
+} // namespace
+
+C10_REGISTER_CLASS(
+    SRNodeExecutorRegistry,
+    node_executor,
+    SequentialNodeExecutorFunctor)
+
+#endif // FBCODE_CAFFE2
+
 // A manually curated set of ops that are disallowed in static runtime.
 // These are rarely-used ops. Disallowing them typically eliminates
 // corner cases in graph optimizations, allowing for more aggressive
@@ -948,6 +984,20 @@ BlockRunner::BlockRunner(
     }
     pnode.set_metadata(std::move(block_runners));
   }
+
+#ifdef FBCODE_CAFFE2
+  // Initialize the pluggable node executor from the registry. If no executor is
+  // registered, or the registered one opts out (returns nullptr), fall back to
+  // the default sequential execution to preserve baseline semantics.
+  node_executor_owner_ = SRNodeExecutorRegistry()->Create("node_executor");
+  if (node_executor_owner_ != nullptr) {
+    node_executor_fn_ = node_executor_owner_->Create(
+        block_info_, sm.opts(), &node_executor_ctx_);
+  }
+  if (node_executor_fn_ == nullptr) {
+    node_executor_fn_ = &sequentialExecute;
+  }
+#endif
 }
 
 BlockRunner::BlockRunner(BlockRunner&&) noexcept = default;
@@ -1320,12 +1370,18 @@ c10::IValue BlockRunner::run_impl(
 
     set_inputs(std::forward<IValueList>(args), kwargs);
 
+#ifdef FBCODE_CAFFE2
+    DCHECK(node_executor_fn_ != nullptr);
+    node_executor_fn_(*this, nodes_.data(), nodes_.size(), node_executor_ctx_);
+#else
     for (auto& n : nodes_) {
       // LOG(INFO) << "Running node: " << PrintNode(n.node());
       n.run();
       // Check for incorrect schema alias info.
       verify_and_correct_memory_overlap(n);
     }
+#endif
+
     on_exit.setFinished();
   }
 

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #ifdef FBCODE_CAFFE2
+#include <c10/util/Registry.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #endif
@@ -248,6 +249,19 @@ class StaticRuntime;
 using SROperator = std::function<void(ProcessedNode*)>;
 
 #ifdef FBCODE_CAFFE2
+
+class BlockRunner;
+
+// Node execution function pointer type. Called once per inference in place of
+// the sequential node loop. `block_runner` owns the nodes and exposes per-run
+// state such as the live MemoryPlanner. The context pointer holds
+// executor-specific state created at model load time.
+using NodeExecutorFn = void (*)(
+    BlockRunner& block_runner,
+    ProcessedNode* nodes,
+    size_t num_nodes,
+    void* context);
+
 struct TORCH_API SROperatorObserver {
   using OperatorCallback = void (*)(const Node*);
   OperatorCallback startCb = nullptr;
@@ -433,6 +447,22 @@ class BlockInfo {
   std::vector<uint16_t> output_indices_;
   Block& block_;
 };
+
+#ifdef FBCODE_CAFFE2
+// Factory base class for pluggable node execution strategies.
+// Used only at model load time (not on the hot path).
+struct TORCH_API NodeExecutorFunctor {
+  // Called once at model load. Returns a function pointer for inference.
+  // The context is owned by the functor and must outlive the BlockRunner.
+  virtual NodeExecutorFn Create(
+      const BlockInfo& block_info,
+      const StaticModuleOptions& opts,
+      void** context) = 0;
+  virtual ~NodeExecutorFunctor() = default;
+};
+
+TORCH_DECLARE_REGISTRY(SRNodeExecutorRegistry, NodeExecutorFunctor);
+#endif // FBCODE_CAFFE2
 
 class TORCH_API StaticModule {
  public:
@@ -705,6 +735,10 @@ class TORCH_API BlockRunner {
     return planner_.get();
   }
 
+  // Detect and correct incorrect schema alias info for a node's outputs at
+  // runtime. Public so pluggable node executors can invoke it.
+  void verify_and_correct_memory_overlap(ProcessedNode& n);
+
   bool check_for_memory_leak(
       bool output_returned = true,
       bool recurse_on_sub_blocks = false);
@@ -791,7 +825,6 @@ class TORCH_API BlockRunner {
   bool fast_check_and_correct_overlap_with(
       ProcessedNode& n,
       c10::IValue& tensor_ival);
-  void verify_and_correct_memory_overlap(ProcessedNode& n);
 
   // clean up owning refs of input IValues
   void clean_up_input_ivalues() noexcept {
@@ -843,6 +876,14 @@ class TORCH_API BlockRunner {
 
   std::vector<IValue*> outputs_;
   std::vector<ProcessedNode> nodes_;
+
+#ifdef FBCODE_CAFFE2
+  // Pluggable node execution strategy. Initialized from
+  // SRNodeExecutorRegistry at model load time.
+  NodeExecutorFn node_executor_fn_ = nullptr;
+  void* node_executor_ctx_ = nullptr;
+  std::unique_ptr<NodeExecutorFunctor> node_executor_owner_;
+#endif
 };
 
 inline size_t BlockInfo::num_nodes() const {


### PR DESCRIPTION
Summary:
Add a pluggable node execution strategy to Static Runtime's BlockRunner, gated entirely behind FBCODE_CAFFE2. The OSS code path is unchanged.

In fbcode, this introduces:
- NodeExecutorFn: a function pointer type that replaces the sequential for-loop in BlockRunner::operator(). Using a raw function pointer keeps zero overhead on the inference hot path.
- NodeExecutorFunctor: a factory base class whose Create() method receives BlockInfo and StaticModuleOptions at model load time, returns a NodeExecutorFn and optionally populates an opaque context pointer.
- SRNodeExecutorRegistry: a C10 registry that allows alternative execution strategies (e.g. DAG-based parallel execution) to be registered with REGISTRY_PREFERRED to override the default, without modifying impl.cpp.
- A default SequentialNodeExecutorFunctor that reproduces the existing sequential loop behavior exactly.

In OSS (non-FBCODE_CAFFE2), the original sequential for-loop remains untouched — no new types, members, includes, or registry machinery.

Test Plan:
Existing static runtime tests (467 tests, all pass):
buck test mode/dev caffe2/benchmarks/static_runtime:static_runtime_cpptest

AdFinder servicelab:
https://www.internalfb.com/servicelab/experiment/833678662913851/

AdRanker servicelab
https://www.internalfb.com/servicelab/experiment/1707258653640939/

Reviewed By: georgiaphillips

Differential Revision: D108688819


