### PR TITLE
[DRAFT] Fix forward AD inconsistency for pow(abs(complex), complex)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12419,6 +12419,37 @@ class TestAutogradForwardMode(TestCase):
             dual_input = fwAD.make_dual(a, b)
             dual_input[1:]
 
+    def test_pow_abs_complex_forward_ad(self):
+        x = torch.tensor(
+            [1.0 + 1.0j],
+            dtype=torch.complex128,
+        )
+
+        def fn(x):
+            exponent = torch.tensor(
+                1.0 + 1.0j,
+                dtype=x.dtype,
+                device=x.device,
+            )
+            return torch.pow(torch.abs(x), exponent)
+
+        def complex_to_real(x):
+            return torch.cat((x.real, x.imag))
+
+        def real_to_complex(x):
+            n = x.numel() // 2
+            return x[:n] + 1j * x[n:]
+
+        def real_fn(x):
+            return complex_to_real(fn(real_to_complex(x)))
+
+        real_x = complex_to_real(x)
+
+        jac_fwd = torch.func.jacfwd(real_fn)(real_x)
+        jac_rev = torch.func.jacrev(real_fn)(real_x)
+
+        self.assertEqual(jac_fwd, jac_rev)
+        
     # The following test functions want to ensure all the following behaviors:
     #   - Ensure that default level system in the python binding works
     #   - Ensure that only level 0 exists and nesting is properly disabled

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1404,7 +1404,7 @@
 - name: pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor
   self: pow_backward_self(grad, self, exponent)
   exponent: pow_backward_exponent(grad, self, exponent, result)
-  result: (pow_backward_self(self_t.conj(), self_p, exponent_p) + pow_backward_exponent(exponent_t.conj(), self_p, exponent_p, result)).conj()
+  result: (pow_backward_self_raw(self_t.conj(), self_p, exponent_p) + pow_backward_exponent(exponent_t.conj(), self_p, exponent_p, result)).conj()
 
 - name: pow.Scalar(Scalar self, Tensor exponent) -> Tensor
   exponent: pow_backward_exponent(grad, self, exponent, result)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -562,10 +562,7 @@ Tensor pow_backward_self(
     const Tensor& grad,
     const Tensor& self,
     const Tensor& exponent) {
-  auto out = pow_backward_self_raw(
-    grad,
-    self,
-    exponent);
+  auto out = pow_backward_self_raw(grad, self, exponent);
   return handle_r_to_c(self, std::move(out));
 }
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -548,14 +548,24 @@ Tensor pow_backward(Tensor grad, const Tensor& self, const Scalar& exponent) {
   }
 }
 
+Tensor pow_backward_self_raw(
+    const Tensor& grad,
+    const Tensor& self,
+    const Tensor& exponent) {
+  return at::where(
+      exponent == 0.0,
+      at::scalar_tensor(0.0, grad.options()),
+      grad * (exponent * self.pow(exponent - 1)).conj());
+}
+
 Tensor pow_backward_self(
     const Tensor& grad,
     const Tensor& self,
     const Tensor& exponent) {
-  auto out = at::where(
-      exponent == 0.0,
-      at::scalar_tensor(0.0, grad.options()),
-      grad * (exponent * self.pow(exponent - 1)).conj());
+  auto out = pow_backward_self_raw(
+    grad,
+    self,
+    exponent);
   return handle_r_to_c(self, std::move(out));
 }
 

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -122,6 +122,10 @@ at::Tensor pow_backward(
     at::Tensor grad,
     const at::Tensor& self,
     const at::Scalar& exponent_);
+at::Tensor pow_backward_self_raw(
+    const at::Tensor& grad,
+    const at::Tensor& self,
+    const at::Tensor& exponent);
 at::Tensor pow_backward_self(
     const at::Tensor& grad,
     const at::Tensor& self,


### PR DESCRIPTION
Related to #185639
## Summary
Fix a forward AD inconsistency for pow(abs(complex), complex).

The generated JVP rule for pow.Tensor_Tensor currently reuses pow_backward_self(...), which applies handle_r_to_c(...). When the base is real (e.g., torch.abs(x)), this projection removes the imaginary component and causes jacfwd and jacrev to disagree.

This PR introduces pow_backward_self_raw(...), which contains the derivative computation without the handle_r_to_c(...) projection, and updates the generated forward AD rule to use the raw helper while leaving reverse-mode behavior unchanged.

---

## Repro

[Code Block Start]
import torch

def fn(x):
    return torch.pow(torch.abs(x), 1.0 + 1.0j)
[Code Block End]

### Before
jacfwd != jacrev

### After
jacfwd == jacrev

---

## Validation
* Reproduced the issue locally.
* Verified that the repro produces matching Jacobians after the change.
* Local build succeeds.

---

## Notes
Opening as a draft PR to get feedback on the proposed approach. In particular, I'd appreciate guidance on whether introducing a raw helper for the forward AD path is preferred, or whether a dedicated forward-mode formula would be more appropriate.