### PR TITLE
[MPS] Refactor inlined Metal reduction logic into shared header

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -779,75 +779,10 @@ REGISTER_COUNT_NONZERO_INNER(half2);
 // input element to {0, 1} (nonzero, NaN -> 1) before the reduction.
 // =============================================================================
 
-// Reduction op functors. Each Op defines identity<T>(), combine(), and
-// threadgroup_reduce(). Identity is the "neutral" element for the op (-INF
-// for max on floats, numeric_limits<T>::lowest() for integers, etc.).
-// combine() and threadgroup_reduce() delegate to c10::metal helpers, which
-// propagate NaN for floats.
-struct MaxOp {
-  template <
-      typename T,
-      ::metal::enable_if_t<!is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return ::metal::numeric_limits<T>::lowest();
-  }
-  // Float identity is -INFINITY (not -FLT_MAX): max(-INF, x) = x for any
-  // finite x including -FLT_MAX, but max(-FLT_MAX, -INFINITY) would
-  // incorrectly return -FLT_MAX.
-  template <
-      typename T,
-      ::metal::enable_if_t<is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return T(-INFINITY);
-  }
-  template <typename T>
-  static inline T combine(T a, T b) {
-    return c10::metal::max(a, b);
-  }
-  template <typename T>
-  static inline T simd_reduce(T val) {
-    return c10::metal::simd_max(val);
-  }
-  template <typename T>
-  static inline T threadgroup_reduce(
-      threadgroup T* shared,
-      T val,
-      uint tid,
-      uint tptg) {
-    return c10::metal::threadgroup_max(shared, val, tid, tptg);
-  }
-};
-
-struct MinOp {
-  template <
-      typename T,
-      ::metal::enable_if_t<!is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return ::metal::numeric_limits<T>::max();
-  }
-  template <
-      typename T,
-      ::metal::enable_if_t<is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return T(INFINITY);
-  }
-  template <typename T>
-  static inline T combine(T a, T b) {
-    return c10::metal::min(a, b);
-  }
-  template <typename T>
-  static inline T simd_reduce(T val) {
-    return c10::metal::simd_min(val);
-  }
-  template <typename T>
-  static inline T threadgroup_reduce(
-      threadgroup T* shared,
-      T val,
-      uint tid,
-      uint tptg) {
-    return c10::metal::threadgroup_min(shared, val, tid, tptg);
-  }
-};
+// Reduction op functors MaxOp / MinOp (identity, replace, combine,
+// simd_reduce, threadgroup_reduce) live in c10/metal/reduction_utils.h so the
+// inductor MPS codegen can reuse the same identity/replace pair; both are
+// pulled in via the file-scope `using namespace c10::metal`.
 
 // Load functors decide how an input element is converted into the
 // accumulator type. IdentityLoad casts (min/max keep the value unchanged);
@@ -874,7 +809,7 @@ struct PredicateLoad {
 // runtime tptg value, which in turn lets c10::metal::threadgroup_min/max
 // constant-fold its size-vs-simdgroup_size branch.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -905,7 +840,8 @@ kernel void value_reduction(
   }
 
   using TA = TO;
-  const TA identity_val = Op::template identity<TA>();
+  using Op = OpFn<TA>;
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;
@@ -973,7 +909,7 @@ kernel void value_reduction(
 // threads split the M rows. Mirrors sum_reduction_outer; uses the same
 // (Op, Load) abstraction as value_reduction.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -988,6 +924,7 @@ kernel void value_reduction_outer(
     uint2 tid_tg [[thread_position_in_threadgroup]],
     uint2 tg_pos [[threadgroup_position_in_grid]]) {
   using TA = TO;
+  using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
   const uint out_stride = sizes.z;
@@ -1001,7 +938,7 @@ kernel void value_reduction_outer(
   uint row_start = tid_tg.y * rows_per_y;
   uint row_end = min(row_start + rows_per_y, M);
 
-  const TA identity_val = Op::template identity<TA>();
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;
@@ -1047,7 +984,7 @@ kernel void value_reduction_outer(
 // SIMD groups per TG for occupancy. No shared memory needed since
 // simd_reduce suffices for intra-row collapse. Mirrors sum_reduction_inner.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -1061,6 +998,7 @@ kernel void value_reduction_inner(
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
   using TA = TO;
+  using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
   const uint num_simd_groups = tptg / simdgroup_size;
@@ -1072,7 +1010,7 @@ kernel void value_reduction_inner(
 
   constant TI* row_ptr = input + row * N;
 
-  const TA identity_val = Op::template identity<TA>();
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -414,5 +414,92 @@ IDX_T threadgroup_argmin(
   return idx_data[0];
 }
 
+// Reduction op functors bundling identity, replace predicate, and the value
+// reduction helpers (combine / simd_reduce / threadgroup_reduce) used by both
+// value and arg reductions. NaN handling: for floats, isnan-propagating
+// max/min and a strict "replace" predicate that lets NaN beat any finite
+// value and lets any finite value beat -INF/+INF identity.
+//
+// Float identity is +/-INFINITY (not numeric_limits::lowest/max, i.e.
+// -/+FLT_MAX): max(-INF, x) = x for any finite x including -FLT_MAX, but
+// max(-FLT_MAX, -INFINITY) would incorrectly return -FLT_MAX.
+//
+// The isnan() calls below route through static_cast<float>() so the float
+// branch type-checks even when T is integral (Metal 3 lowers `if IF_CONSTEXPR`
+// to a runtime `if` and parses both arms). Both branches' bodies still get
+// dropped on Metal 4 where IF_CONSTEXPR is real `if constexpr`.
+template <typename T>
+struct MaxOp {
+  static inline constexpr T identity() {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      return T(-INFINITY);
+    } else {
+      return ::metal::numeric_limits<T>::lowest();
+    }
+  }
+
+  // Strict "should-replace" predicate: returns true iff cand strictly beats
+  // cur. NaN-propagating: NaN cand beats finite cur; finite cand never beats
+  // NaN cur.
+  static inline bool replace(T cand, T cur) {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      if (::metal::isnan(static_cast<float>(cur))) {
+        return false;
+      }
+      return ::metal::isnan(static_cast<float>(cand)) || cand > cur;
+    }
+    return cand > cur;
+  }
+
+  static inline T combine(T a, T b) {
+    return c10::metal::max(a, b);
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_max(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_max(shared, val, tid, tptg);
+  }
+};
+
+template <typename T>
+struct MinOp {
+  static inline constexpr T identity() {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      return T(INFINITY);
+    } else {
+      return ::metal::numeric_limits<T>::max();
+    }
+  }
+
+  static inline bool replace(T cand, T cur) {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      if (::metal::isnan(static_cast<float>(cur))) {
+        return false;
+      }
+      return ::metal::isnan(static_cast<float>(cand)) || cand < cur;
+    }
+    return cand < cur;
+  }
+
+  static inline T combine(T a, T b) {
+    return c10::metal::min(a, b);
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_min(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_min(shared, val, tid, tptg);
+  }
+};
+
 } // namespace metal
 } // namespace c10

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -74,9 +74,6 @@ test_failures = {
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction2_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction3_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction5_dynamic_shapes": TestFailure(("mps",)),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
     "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(
         ("mps",), is_skip=True

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -755,8 +755,8 @@ class MetalKernel(SIMDKernel):
             if not self.multistage_reduction_entry:
                 val = cast_value  # type: ignore[assignment]
             else:
-                lim_fn = "lowest" if reduction_type.endswith("max") else "max"
-                limit_val = f"::metal::numeric_limits<{src_metal_type}>::{lim_fn}()"
+                op_struct = "MaxOp" if reduction_type == "max" else "MinOp"
+                limit_val = f"::c10::metal::{op_struct}<{src_metal_type}>::identity()"
                 val = self._new_idxvar(
                     src_dtype, default_value=limit_val, is_threadgroup=False
                 )
@@ -777,8 +777,8 @@ class MetalKernel(SIMDKernel):
                 val = cast_value  # type: ignore[assignment]
                 idx_val = f"static_cast<{DTYPE_TO_METAL[dtype]}>({reduction_idx})"
             else:
-                lim_fn = "lowest" if reduction_type.endswith("max") else "max"
-                limit_val = f"::metal::numeric_limits<{src_metal_type}>::{lim_fn}()"
+                op_struct = "MaxOp" if reduction_type == "argmax" else "MinOp"
+                limit_val = f"::c10::metal::{op_struct}<{src_metal_type}>::identity()"
                 val = self._new_idxvar(
                     src_dtype, default_value=limit_val, is_threadgroup=False
                 )
@@ -786,15 +786,9 @@ class MetalKernel(SIMDKernel):
                 idx_var = next(
                     t for t in self.range_tree_nodes.values() if t.is_reduction
                 )
-                cmp_op = ">" if reduction_type == "argmax" else "<"
-                nan_suffix = (
-                    f" || ::metal::isnan({value}) "
-                    if src_dtype.is_floating_point
-                    else ""
-                )
                 self.compute.splice(f"""
-                if ({value} {cmp_op} {val}{nan_suffix}) {{
-                    {val} = {value};
+                if (::c10::metal::{op_struct}<{src_metal_type}>::replace({cast_value}, {val})) {{
+                    {val} = {cast_value};
                     {idx_val} = {idx_var.name};
                 }}
                 """)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187304
* __->__ #187541

Pulls the open-coded identity / replace / combine / simd_reduce / threadgroup_reduce helpers used by the Metal min/max value-reduction kernels (and by the inductor MPS codegen's max/min and argmin/argmax paths) into shared `c10::metal::MaxOp<T>` / `MinOp<T>` structs in `c10/metal/reduction_utils.h`. The follow-up change migrating argmin/argmax will reuse those primitives as well.

Fix latent bug in MPSInducotr when min/max would not identify -INFINITY, as identity used to be `-FLT_MIN` in inductor inlined reduction code, that allows one to remove xfails from bunch of dynamic shapes reduction tests

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo