### PR TITLE
[MPS] Fix vectype specialization for long

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -47,9 +47,9 @@ struct vectypes<int> {
 
 template <>
 struct vectypes<long> {
-  using type4 = short4;
-  using type3 = short3;
-  using type2 = short2;
+  using type4 = long4;
+  using type3 = long3;
+  using type2 = long2;
 };
 
 template <typename T>


### PR DESCRIPTION
Not used anywhere in the code, but should return long4/long3/long2 rather than short4/short3, short2