### PR TITLE
Fix torch.gcd returning negative results for INT_MIN inputs

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1245,14 +1245,19 @@ template <>
 template <typename T>
 inline typename std::enable_if_t<std::is_integral_v<T>, T>
 calc_gcd(T a, T b) {
-  a = abs_impl(a);
-  b = abs_impl(b);
-  while (a != 0) {
-    T c = a;
-    a = b % a;
-    b = c;
+  // Use unsigned arithmetic to avoid undefined behavior when a or b
+  // is INT_MIN, where std::abs() overflows because |INT_MIN| > INT_MAX.
+  // Note: gcd(INT_MIN, 0) returns INT_MIN (negative) because the true
+  // result |INT_MIN| is not representable in T. Same as NumPy.
+  using U = std::make_unsigned_t<T>;
+  U ua = (a < 0) ? -static_cast<U>(a) : static_cast<U>(a);
+  U ub = (b < 0) ? -static_cast<U>(b) : static_cast<U>(b);
+  while (ua != 0) {
+    U c = ua;
+    ua = ub % ua;
+    ub = c;
   }
-  return b;
+  return static_cast<T>(ub);
 }
 
 template <typename T>

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -187,18 +187,27 @@ const auto log_ndtr_string = jiterator_stringify(
 ); // log_ndtr_string
 
 const auto gcd_string = jiterator_stringify(
+  template <typename T> struct make_unsigned_impl;
+  template <> struct make_unsigned_impl<unsigned char> { using type = unsigned char; };
+  template <> struct make_unsigned_impl<signed char> { using type = unsigned char; };
+  template <> struct make_unsigned_impl<short> { using type = unsigned short; };
+  template <> struct make_unsigned_impl<int> { using type = unsigned int; };
+  template <> struct make_unsigned_impl<long> { using type = unsigned long; };
+  template <> struct make_unsigned_impl<long long> { using type = unsigned long long; };
+
   template <typename T>
   T gcd(const T a_in, const T b_in) {
-    T a = abs(a_in);
-    T b = abs(b_in);
+    using U = typename make_unsigned_impl<T>::type;
+    U a = (a_in < T{0}) ? -static_cast<U>(a_in) : static_cast<U>(a_in);
+    U b = (b_in < T{0}) ? -static_cast<U>(b_in) : static_cast<U>(b_in);
 
-    while (a != T{0}) {
-      T c = a;
+    while (a != U{0}) {
+      U c = a;
       a = b % a;
       b = c;
     }
 
-    return b;
+    return static_cast<T>(b);
   }
 ); // gcd_string
 
@@ -3055,14 +3064,15 @@ const auto spherical_bessel_j0_string = jiterator_stringify(
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_gcd(scalar_t a_in, scalar_t b_in) {
-  scalar_t a = ::abs(a_in);
-  scalar_t b = ::abs(b_in);
+  using U = ::cuda::std::make_unsigned_t<scalar_t>;
+  U a = (a_in < 0) ? -static_cast<U>(a_in) : static_cast<U>(a_in);
+  U b = (b_in < 0) ? -static_cast<U>(b_in) : static_cast<U>(b_in);
   while (a != 0) {
-    scalar_t c = a;
+    U c = a;
     a = b % a;
     b = c;
   }
-  return b;
+  return static_cast<scalar_t>(b);
 }
 
 /*

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3068,6 +3068,23 @@ class TestBinaryUfuncsDevice(TestCase):
             self.assertEqual(actual, expected)
 
     @onlyNativeDeviceTypes
+    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_gcd_int_min(self, device, dtype):
+        int_min = torch.iinfo(dtype).min
+        a = torch.tensor([int_min], dtype=dtype, device=device)
+        b = torch.tensor([6], dtype=dtype, device=device)
+        self.assertEqual(torch.gcd(a, b).item(), 2)
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_gcd_int_min_larger_divisor(self, device, dtype):
+        int_min = torch.iinfo(dtype).min
+        quarter = int_min // 4
+        a = torch.tensor([int_min], dtype=dtype, device=device)
+        b = torch.tensor([quarter], dtype=dtype, device=device)
+        self.assertEqual(torch.gcd(a, b).item(), -quarter)
+
+    @onlyNativeDeviceTypes
     @dtypes(torch.int16, torch.int32, torch.int64)
     def test_lcm(self, device, dtype):
         # Tests lcm(0, 0), lcm(0, a) cases


### PR DESCRIPTION
`torch.gcd` returns incorrect negative results when one input is the minimum value of a signed integer type. For example, `gcd(-128, 124)` returns `-4` instead of `4` for int8.

`calc_gcd` calls `std::abs()` on inputs, which is undefined behavior for INT_MIN because the positive result overflows. The fix uses unsigned arithmetic instead: cast to `std::make_unsigned_t<T>` before negation, which is well-defined.

Fixed on CPU and CUDA (precompiled and Jiterator). The Jiterator path requires an inline `make_unsigned_impl` trait since the JIT compilation environment does not include `<type_traits>`.

Edge case: `gcd(INT_MIN, 0)` returns INT_MIN (negative) because the true result is not representable in the signed type. This matches NumPy.

Fixes #187338


cc @albanD