### PR TITLE
[BE] Use `std::numbers` in `c10/util/MathConstants.h`

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -251,7 +251,6 @@ exclude_patterns = [
     'c10/util/IntrusiveList.h',
     'c10/util/irange.h',
     'c10/util/llvmMathExtras.h',
-    'c10/util/MathConstants.h',
     'c10/util/NetworkFlow.cpp',
     'c10/util/order_preserving_flat_hash_map.h',
     'c10/util/overflows.h',

--- a/c10/util/MathConstants.h
+++ b/c10/util/MathConstants.h
@@ -4,82 +4,84 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
 
+#include <numbers>
+
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
 #endif
 
 namespace c10 {
-// TODO: Replace me with inline constexpr variable when C++17 becomes available
 namespace detail {
 template <typename T>
 C10_HOST_DEVICE inline constexpr T e() {
-  return static_cast<T>(2.718281828459045235360287471352662);
+  return static_cast<T>(std::numbers::e);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T euler() {
-  return static_cast<T>(0.577215664901532860606512090082402);
+  return static_cast<T>(std::numbers::egamma);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T frac_1_pi() {
-  return static_cast<T>(0.318309886183790671537767526745028);
+  return static_cast<T>(std::numbers::inv_pi);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T frac_1_sqrt_pi() {
-  return static_cast<T>(0.564189583547756286948079451560772);
+  return static_cast<T>(std::numbers::inv_sqrtpi);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T frac_sqrt_2() {
+  // No std::numbers equivalent for 1/sqrt(2).
   return static_cast<T>(0.707106781186547524400844362104849);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T frac_sqrt_3() {
-  return static_cast<T>(0.577350269189625764509148780501957);
+  return static_cast<T>(std::numbers::inv_sqrt3);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T golden_ratio() {
-  return static_cast<T>(1.618033988749894848204586834365638);
+  return static_cast<T>(std::numbers::phi);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T ln_10() {
-  return static_cast<T>(2.302585092994045684017991454684364);
+  return static_cast<T>(std::numbers::ln10);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T ln_2() {
-  return static_cast<T>(0.693147180559945309417232121458176);
+  return static_cast<T>(std::numbers::ln2);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T log_10_e() {
-  return static_cast<T>(0.434294481903251827651128918916605);
+  return static_cast<T>(std::numbers::log10e);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T log_2_e() {
-  return static_cast<T>(1.442695040888963407359924681001892);
+  return static_cast<T>(std::numbers::log2e);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T pi() {
-  return static_cast<T>(3.141592653589793238462643383279502);
+  return static_cast<T>(std::numbers::pi);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T sqrt_2() {
-  return static_cast<T>(1.414213562373095048801688724209698);
+  return static_cast<T>(std::numbers::sqrt2);
 }
 
 template <typename T>
 C10_HOST_DEVICE inline constexpr T sqrt_3() {
-  return static_cast<T>(1.732050807568877293527446341505872);
+  return static_cast<T>(std::numbers::sqrt3);
 }
 
 template <>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187545
* #187525

Replace the hardcoded math literals with the bit-identical std::numbers constants (1/sqrt(2) has no equivalent and is kept) and drop the file from the CLANGTIDY burn-down list.

Authored with assistance from Claude Code.