### PR TITLE
[Test] Improve test reuse in test/test_maskedtensor.py for out-of-tree backends

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -243,7 +243,14 @@ class TestBasics(TestCase):
             mask = sample.kwargs["mask"]
             mt = masked_tensor(data, mask, requires_grad=True)
 
-            new_device = torch.device("cuda") if device != "cuda" and torch.cuda.is_available() else torch.device("cpu")
+            if device == "cpu":
+                new_device = torch.device(
+                    torch.accelerator.current_accelerator().type
+                    if torch.accelerator.is_available()
+                    else "cpu"
+                )
+            else:
+                new_device = torch.device("cpu")
             mt_device = mt.to(new_device)
 
             self.assertEqual(mt_device.device.type, new_device.type)


### PR DESCRIPTION
## Summary

Improve test reuse in `test/test_maskedtensor.py` for out-of-tree backends by removing hardcoded CUDA assumptions.

Before:

```python
new_device = torch.device("cuda") if device != "cuda" and torch.cuda.is_available() else torch.device("cpu")
```

After:

```python
if device == "cpu":
    new_device = torch.device(
        torch.accelerator.current_accelerator().type
        if torch.accelerator.is_available()
        else "cpu"
    )
else:
    new_device = torch.device("cpu")
```



## Test Plan

Verified on CUDA and CPU: `pytest test/test_maskedtensor.py -vv`

before:

- 1690 passed, 12 skipped

after:

- 1690 passed, 12 skipped

