### PR TITLE
[MPS] Migrate mse_loss to a native fused Metal kernel

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1588,10 +1588,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
     return;
   }
 
-  // Decompose 64-bit tensor into 32-bit ones
+  // Decompose 64-bit tensor into 32-bit ones. Must recurse into the ternary
+  // exec: a binary dispatch here would look up nonexistent 2-input kernel
+  // names for the 3-input op and fail at pipeline creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_binary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name);
     }
     return;
   }
@@ -1617,8 +1619,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   convert_double_scalar(other2);
 
   MPSStream* mpsStream = getCurrentMPSStream();
-  const auto cast_needed =
-      (input.scalar_type() != other1.scalar_type()) || (input.scalar_type() != other2.scalar_type());
+  // An output dtype differing from the (matching) inputs also needs the cast
+  // kernel: the non-cast names are only registered for matching in/out pairs,
+  // and the _cast_{out} kernels read the runtime input types anyway.
+  const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
+      (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -18,6 +18,36 @@ struct sub_functor {
   }
 };
 
+// MSE elementwise (input - target)^2 in float32, cast to the output dtype
+// (OPMATH op). Used for reduction=None; mean/sum use the fused LossOps
+// reduction.
+struct mse_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    const T d = a - b;
+    return static_cast<T>(d * d);
+  }
+};
+
+// Fused MSE backward: grad_input = norm * (input - target) * grad_output in
+// a single pass; the ternary iterator supplies broadcast (0-dim grad for
+// mean/sum), strides, and mixed-dtype casts. norm is exactly 2 for
+// reduction none/sum, so mse_backward2 bakes it in; for mean the host
+// pre-scales the 0-dim grad_output by 2/N and uses mse_backward_scaled.
+struct mse_backward2_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T g) {
+    return static_cast<T>(T(2) * (a - b) * g);
+  }
+};
+
+struct mse_backward_scaled_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T g) {
+    return static_cast<T>((a - b) * g);
+  }
+};
+
 struct add_alpha_functor {
   template <typename T>
   inline T operator()(const T a, const T b, const T alpha) {
@@ -601,6 +631,13 @@ REGISTER_INT2FLOAT_BINARY_OP(hermite_polynomial_he);
 REGISTER_FLOAT_BINARY_OP(add);
 REGISTER_INTEGER_BINARY_OP(add);
 REGISTER_OPMATH_FLOAT_BINARY_OP(mul);
+REGISTER_OPMATH_FLOAT_BINARY_OP(mse);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, float, float);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, half, half);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, bfloat, bfloat);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, float, float);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, half, half);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, bfloat, bfloat);
 REGISTER_INTEGER_BINARY_OP(mul);
 REGISTER_FLOAT_BINARY_OP(sub);
 REGISTER_INTEGER_BINARY_OP(sub);

--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -35,3 +35,14 @@ struct CTCLossBackwardCollectParams {
   index_t grad_out_batch_stride;
   bool zero_infinity;
 };
+
+// Shared by LossOps.metal and LossOps.mm; layout must stay identical on both.
+struct FusedLossParams {
+  uint32_t numel; // filled by fused_loss_reduce
+  uint32_t has_weight; // filled by fused_loss_reduce
+  uint32_t aligned; // filled by fused_loss_reduce: all operands 4-elem aligned
+  uint32_t reduction; // ATen: 1=Mean, 2=Sum (set by caller)
+  float p0; // op scalar: beta/delta, clamp-lo; norm for fused_loss_bwd
+  float p1; // op scalar: clamp-hi
+  uint32_t flag; // op flag: is_huber, ...; scalar-grad for fused_loss_bwd
+};

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,4 +1,6 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <ATen/native/mps/kernels/ReduceOps.h>
+#include <c10/metal/reduction_utils.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
@@ -395,3 +397,154 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+// Shared fused pointwise-loss kernels (mse/bce/smooth_l1/huber):
+// fused_loss_pass1 accumulates the elementwise loss in float32; pass 2 reuses
+// sum_reduction.
+
+// ============================================================================
+// Per-op forward functors
+// ============================================================================
+
+struct MSEOp {
+  static inline float fwd(float a, float b, constant FusedLossParams&) {
+    float d = a - b;
+    return d * d;
+  }
+  // norm * (input - target) * grad in float; one narrowing on store.
+  static inline float bwd(
+      float a,
+      float b,
+      float g,
+      constant FusedLossParams& p) {
+    return p.p0 * (a - b) * g;
+  }
+};
+
+// ============================================================================
+// Pass 1: per-threadgroup float32 partial of the (weighted) elementwise loss
+// ============================================================================
+
+template <typename TI, typename Op>
+[[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
+kernel void fused_loss_pass1(
+    constant TI* in0 [[buffer(0)]], // input
+    constant TI* in1 [[buffer(1)]], // target
+    constant TI* in2 [[buffer(2)]], // weight; null buffer when has_weight == 0
+    device float* partials [[buffer(3)]], // one float per threadgroup
+    constant FusedLossParams& p [[buffer(4)]],
+    uint tid [[thread_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]],
+    uint gsz [[threads_per_grid]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  threadgroup float
+      smem[32]; // up to MAX_THREADGROUP_SIZE(1024) / simdgroup(32)
+  float acc = 0.f;
+
+  using T4 = vec<TI, 4>;
+  const uint aligned_N = p.aligned ? (p.numel / 4u) * 4u : 0u;
+  const uint vec_stride = gsz * 4u;
+
+  for (uint base = tid * 4u; base + 4u <= aligned_N; base += vec_stride) {
+    const uint v = base / 4u;
+    T4 a4 = reinterpret_cast<constant const T4*>(in0)[v];
+    T4 b4 = reinterpret_cast<constant const T4*>(in1)[v];
+    float l0 = Op::fwd(float(a4.x), float(b4.x), p);
+    float l1 = Op::fwd(float(a4.y), float(b4.y), p);
+    float l2 = Op::fwd(float(a4.z), float(b4.z), p);
+    float l3 = Op::fwd(float(a4.w), float(b4.w), p);
+    if (p.has_weight) {
+      T4 w4 = reinterpret_cast<constant const T4*>(in2)[v];
+      acc += float(w4.x) * l0 + float(w4.y) * l1 + float(w4.z) * l2 +
+          float(w4.w) * l3;
+    } else {
+      acc += l0 + l1 + l2 + l3;
+    }
+  }
+  for (uint i = aligned_N + tid; i < p.numel; i += gsz) {
+    float l = Op::fwd(float(in0[i]), float(in1[i]), p);
+    acc += p.has_weight ? float(in2[i]) * l : l;
+  }
+
+  float s = c10::metal::threadgroup_sum<float>(smem, acc, lid, tgsz);
+  if (lid == 0)
+    partials[tgid] = s;
+}
+
+// ============================================================================
+// Fused elementwise loss backward (dense fast path): one pass computing
+// Op::bwd over input/target/grad_output. flag == 1 broadcasts a 0-dim
+// grad_output (mean/sum) via a uniform g[0] read; the generic TensorIterator
+// ternary path remains the fallback for mixed dtypes or mismatched layouts.
+// ============================================================================
+
+template <typename TI, typename Op>
+kernel void fused_loss_bwd(
+    constant TI* in0 [[buffer(0)]], // input
+    constant TI* in1 [[buffer(1)]], // target
+    constant TI* gout [[buffer(2)]], // grad_output (0-dim when flag == 1)
+    device TI* grad [[buffer(3)]], // grad_input
+    constant FusedLossParams& p [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  const float g0 = p.flag ? float(gout[0]) : 0.f;
+
+  using T4 = vec<TI, 4>;
+  if (p.aligned) {
+    // Grid is sized to ceil(numel / 4); each thread handles one vec4 block.
+    const uint base = tid * 4u;
+    if (base + 4u <= p.numel) {
+      T4 a4 = reinterpret_cast<constant const T4*>(in0)[tid];
+      T4 b4 = reinterpret_cast<constant const T4*>(in1)[tid];
+      float4 g4;
+      if (p.flag) {
+        g4 = float4(g0);
+      } else {
+        T4 gv = reinterpret_cast<constant const T4*>(gout)[tid];
+        g4 = float4(float(gv.x), float(gv.y), float(gv.z), float(gv.w));
+      }
+      T4 r;
+      r.x = TI(Op::bwd(float(a4.x), float(b4.x), g4.x, p));
+      r.y = TI(Op::bwd(float(a4.y), float(b4.y), g4.y, p));
+      r.z = TI(Op::bwd(float(a4.z), float(b4.z), g4.z, p));
+      r.w = TI(Op::bwd(float(a4.w), float(b4.w), g4.w, p));
+      reinterpret_cast<device T4*>(grad)[tid] = r;
+      return;
+    }
+    for (uint i = base; i < p.numel; ++i) {
+      const float g = p.flag ? g0 : float(gout[i]);
+      grad[i] = TI(Op::bwd(float(in0[i]), float(in1[i]), g, p));
+    }
+    return;
+  }
+  if (tid < p.numel) {
+    const float g = p.flag ? g0 : float(gout[tid]);
+    grad[tid] = TI(Op::bwd(float(in0[tid]), float(in1[tid]), g, p));
+  }
+}
+
+#define INSTANTIATE_FUSED_LOSS(NAME, OP, TI)                \
+  template [[host_name("fused_loss_pass1_" #NAME "_" #TI)]] \
+  kernel void fused_loss_pass1<TI, OP>(                     \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      device float*,                                        \
+      constant FusedLossParams&,                            \
+      uint,                                                 \
+      uint,                                                 \
+      uint,                                                 \
+      uint,                                                 \
+      uint);                                                \
+  template [[host_name("fused_loss_bwd_" #NAME "_" #TI)]]   \
+  kernel void fused_loss_bwd<TI, OP>(                       \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      device TI*,                                           \
+      constant FusedLossParams&,                            \
+      uint)
+
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, float);
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, half);
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, bfloat);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.h
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.h
@@ -7,4 +7,10 @@ void binary_op_kernel(
     const Tensor& other,
     const Tensor& output,
     const std::optional<Scalar> alpha = std::nullopt);
+void ternary_op_kernel(
+    const std::string func_name,
+    const Tensor& input,
+    const Tensor& other1,
+    const Tensor& other2,
+    const Tensor& output);
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -57,6 +57,45 @@ void binary_op_kernel(const std::string func_name,
   lib.exec_binary_kernel(iter, func_name, alpha);
 }
 
+void ternary_op_kernel(const std::string func_name,
+                       const Tensor& input,
+                       const Tensor& other1,
+                       const Tensor& other2,
+                       const Tensor& output) {
+  // Match binary_op_kernel (and CPU's out= semantics): resize the output to
+  // the broadcast shape before the empty check, so an empty out tensor is
+  // filled rather than silently left empty.
+  auto new_size = at::infer_size(at::infer_size(input.sizes(), other1.sizes()), other2.sizes());
+  if (!output.sizes().equals(new_size)) {
+    output.resize_(new_size);
+  }
+  if (output.numel() == 0) {
+    return;
+  }
+
+  auto iter = TensorIteratorConfig()
+                  .allow_cpu_scalars(true)
+                  .add_output(output)
+                  .add_input(input)
+                  .add_input(other1)
+                  .add_input(other2)
+                  .check_all_same_dtype(false)
+                  .promote_inputs_to_common_dtype(true)
+                  // Match the CPU iterator's error class for un-castable
+                  // outputs (e.g. an integral out tensor) instead of failing
+                  // at Metal pipeline creation with an unregistered name.
+                  .enforce_safe_casting_to_output(true)
+                  // The output was already resized to the broadcast shape
+                  // above. The default (true) lets the iterator restride a
+                  // layout-mismatched output into an internal temp, which the
+                  // Metal exec path writes and never copies back — the
+                  // caller's tensor would silently stay untouched.
+                  .resize_outputs(false)
+                  .build();
+
+  lib.exec_ternary_kernel(iter, func_name);
+}
+
 } // namespace mps
 
 static void atan2_mps_kernel(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -1,5 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/ExpandUtils.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -243,11 +244,21 @@ static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
                                           int64_t reduction,
                                           Tensor& grad_input,
                                           const std::string& op_name) {
-  TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes")
+  // CPU broadcasts input/target/grad_output through a TensorIterator; match
+  // that instead of requiring identical shapes. Only broadcastability is
+  // validated here (infer_size raises the standard size-mismatch error):
+  // the dense fast path below self-rejects mismatched sizes and the ternary
+  // iterator fallback broadcasts natively.
+  if (!target.is_same_size(input)) {
+    (void)at::infer_size_dimvector(input.sizes(), target.sizes());
+  }
   auto norm = reduction == Reduction::Mean ? 2. / static_cast<double>(input.numel()) : 2.;
 
   // Empty input: gradient norm is 2/numel for mean (-> NaN as 2/0), else 0.
-  if ((input.numel() == 0) || (target.numel() == 0) || (grad_output.numel() == 0)) {
+  // Same-size only: an empty-via-broadcast pair falls through to the
+  // ternary iterator, which resizes grad_input to the (empty) common shape
+  // exactly like the CPU TensorIterator.
+  if (target.is_same_size(input) && ((input.numel() == 0) || (grad_output.numel() == 0))) {
     reduction == Reduction::Mean ? grad_input.fill_(std::numeric_limits<float>::quiet_NaN()) : grad_input.zero_();
     return grad_input;
   }
@@ -1209,7 +1220,6 @@ TORCH_IMPL_FUNC(mse_loss_out_mps)(const Tensor& input, const Tensor& target, int
     return;
   }
 
-  TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes");
   TORCH_CHECK(c10::isFloatingType(input.scalar_type()) && c10::isFloatingType(target.scalar_type()),
               op_name + ": only defined for floating types");
   TORCH_CHECK(output_.is_mps());
@@ -1229,9 +1239,15 @@ TORCH_IMPL_FUNC(mse_loss_out_mps)(const Tensor& input, const Tensor& target, int
   // This matches the fused MPSGraph square+reduce that the materialize-then-
   // at::sum path regressed against, and keeps the float32 accumulation so
   // large-N fp16/bf16 does not overflow. output_ is a scalar tensor.
+  // The structured meta has already validated and broadcast the shapes (CPU
+  // parity). The fused kernel walks one flat dense pair, so materialize
+  // numpy-style broadcast views first: expand_outplace borrows when the
+  // shapes already match (no copy on the equal-shape hot path), and
+  // fused_loss_reduce's contiguous() copies any stride-0 expanded view.
+  auto [b_input, b_target] = at::expand_outplace(input, target);
   FusedLossParams params{};
   params.reduction = static_cast<uint32_t>(reduction);
-  fused_loss_reduce("mse", input, target, std::nullopt, output_, params);
+  fused_loss_reduce("mse", *b_input, *b_target, std::nullopt, output_, params);
 }
 
 Tensor& mse_loss_backward_out_mps(const Tensor& grad_output,

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -1,8 +1,12 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <ATen/native/mps/kernels/ReduceOps.h>
+#include <ATen/native/mps/operations/BinaryKernel.h>
+#include <fmt/format.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -12,6 +16,8 @@
 #include <ATen/ops/_ctc_loss_native.h>
 #include <ATen/ops/binary_cross_entropy_backward_native.h>
 #include <ATen/ops/binary_cross_entropy_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
 #include <ATen/ops/full_like.h>
 #include <ATen/ops/huber_loss_backward_native.h>
 #include <ATen/ops/huber_loss_native.h>
@@ -21,6 +27,7 @@
 #include <ATen/ops/nll_loss2d_forward_native.h>
 #include <ATen/ops/nll_loss_backward_native.h>
 #include <ATen/ops/nll_loss_forward_native.h>
+#include <ATen/ops/result_type.h>
 #include <ATen/ops/smooth_l1_loss_backward_native.h>
 #include <ATen/ops/smooth_l1_loss_native.h>
 #include <ATen/ops/tensor.h>
@@ -31,9 +38,19 @@ namespace mps {
 
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
+static auto& reduce_lib = MetalShaderLibrary::getBundledLibrary();
 #else
+namespace loss_ops_metal {
 #include <ATen/native/mps/LossOps_metallib.h>
+} // namespace loss_ops_metal
+static auto& lib = loss_ops_metal::lib;
+namespace reduce_ops_metal {
+#include <ATen/native/mps/ReduceOps_metallib.h>
+} // namespace reduce_ops_metal
+static auto& reduce_lib = reduce_ops_metal::lib;
 #endif
+
+// Native Metal MSE loss path replaces the per-shape MPSGraph cache.
 
 static std::string reductionToString(int64_t reduction) {
   switch (reduction) {
@@ -65,6 +82,161 @@ static MPSGraphTensor* reduceTensor(MPSGraphTensor* tensor,
   }
 }
 
+// Generic two-stage fused pointwise-loss reduction (mean/sum) for mse/bce/
+// smooth_l1/huber: pass 1 emits float32 partials, pass 2 reuses sum_reduction.
+static constexpr uint32_t kFusedLossThreadsPerTG = 1024;
+// Bound below UINT32_MAX by one full grid's vec4 stride
+// (MAX_THREADGROUP_SIZE * kFusedLossThreadsPerTG * 4) so the kernels'
+// uint32 index math cannot wrap; larger inputs error out or fall back.
+static constexpr uint32_t kMaxFusedLossNumel =
+    std::numeric_limits<uint32_t>::max() - MAX_THREADGROUP_SIZE * kFusedLossThreadsPerTG * 4;
+
+static void fused_loss_reduce(const std::string& op,
+                              const Tensor& input,
+                              const Tensor& target,
+                              const std::optional<Tensor>& weight,
+                              const Tensor& output,
+                              FusedLossParams params) {
+  // Pass 1 reads input and target as one dtype; promote both (and any weight) to
+  // the result dtype so a mixed fp16/fp32 input/target pair is not misread.
+  const auto dt = output.scalar_type();
+  auto in = input.to(dt);
+  auto tgt = target.to(dt);
+  std::optional<Tensor> w;
+  if (weight.has_value() && weight->defined()) {
+    w = weight->expand(input.sizes()).to(dt).contiguous();
+  }
+
+  // A reduction is order-free, so when input and target share one dense
+  // layout (e.g. both transposed the same way) the kernel reads both buffers
+  // in physical order: element pairs still line up and the linear vec4 loads
+  // run at contiguous speed with no materialization. Mismatched or gappy
+  // layouts fall back to contiguous copies.
+  // (Weighted ops stay materialized: a physical-order walk would pair the
+  // contiguous weight against permuted input elements.)
+  const bool same_dense_layout = !w.has_value() && !in.is_contiguous() && in.strides().equals(tgt.strides()) &&
+      in.is_non_overlapping_and_dense() && tgt.is_non_overlapping_and_dense();
+  if (!same_dense_layout) {
+    in = in.contiguous();
+    tgt = tgt.contiguous();
+  }
+
+  TORCH_CHECK(in.numel() <= kMaxFusedLossNumel, "fused_loss_reduce: numel exceeds 32-bit kernel indexing");
+  const uint32_t numel = static_cast<uint32_t>(in.numel());
+  params.numel = numel;
+  params.has_weight = w.has_value() ? 1u : 0u;
+  // vec4 fast path is only valid when every operand's storage offset keeps the
+  // 16-byte alignment the reinterpret_cast<T4*> loads assume.
+  params.aligned = (in.storage_offset() % 4 == 0) && (tgt.storage_offset() % 4 == 0) &&
+      (!w.has_value() || w->storage_offset() % 4 == 0);
+
+  // Pass 2 reduces the partials in a single threadgroup, so cap the pool at the
+  // max threadgroup size.
+  uint32_t num_groups = (numel + kFusedLossThreadsPerTG - 1) / kFusedLossThreadsPerTG;
+  num_groups = std::clamp<uint32_t>(num_groups, 1u, MAX_THREADGROUP_SIZE);
+
+  Tensor partials = at::empty({static_cast<int64_t>(num_groups)}, in.options().dtype(kFloat));
+
+  // sum_reduction over the 1-D partials -> scalar output; p = numel folds the
+  // Mean divide in float32 (p = 0 for Sum leaves the accumulator untouched).
+  NormParams<> p2{};
+  p2.ndim = 1;
+  p2.reduction_size = num_groups;
+  p2.input_sizes[0] = num_groups;
+  p2.input_strides[0] = 1;
+  p2.output_sizes[0] = 1;
+  p2.output_strides[0] = 0;
+  p2.p = (params.reduction == Reduction::Mean) ? static_cast<float>(numel) : 0.0f;
+
+  const std::string p1name = fmt::format("fused_loss_pass1_{}_{}", op, scalarToMetalTypeString(in));
+  const std::string p2name = fmt::format("sum_reduction_float_{}", scalarToMetalTypeString(output));
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+
+      auto ps1 = lib.getPipelineStateForFunc(p1name);
+      getMPSProfiler().beginProfileKernel(ps1, op + "_fused_pass1", {in, tgt});
+      [ce setComputePipelineState:ps1];
+      mtl_setArgs(ce, in, tgt, w, partials, params); // w nulls buffer(2) when absent
+      [ce dispatchThreadgroups:MTLSizeMake(num_groups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(kFusedLossThreadsPerTG, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps1);
+
+      auto ps2 = reduce_lib.getPipelineStateForFunc(p2name);
+      getMPSProfiler().beginProfileKernel(ps2, "sum_reduction_pass2", {partials});
+      [ce setComputePipelineState:ps2];
+      mtl_setArgs(ce, partials, output, p2);
+      uint32_t tpg2 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, ((num_groups + 31u) / 32u) * 32u);
+      tpg2 = std::max<uint32_t>(tpg2, 32u);
+      [ce dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps2);
+    }
+  });
+}
+
+// Dense fast path for the fused elementwise loss backward: one vec4 kernel
+// computing Op::bwd over input/target/grad_output when everything shares one
+// dtype and one dense layout (a reduction-free elementwise map is layout-
+// agnostic when all operands, including the output, agree on strides).
+// Returns false when the combination needs the generic TensorIterator
+// ternary fallback.
+static bool fused_loss_bwd_fast_path(const std::string& op,
+                                     const Tensor& input,
+                                     const Tensor& target,
+                                     const Tensor& grad_output,
+                                     const Tensor& grad_input,
+                                     double norm) {
+  const auto dt = input.scalar_type();
+  if (!c10::isFloatingType(dt) || dt == kDouble) {
+    return false;
+  }
+  if (target.scalar_type() != dt || grad_input.scalar_type() != dt || grad_output.scalar_type() != dt) {
+    return false;
+  }
+  const bool scalar_grad = grad_output.dim() == 0;
+  // Sizes must match too: a same-strides but smaller grad_input (possible
+  // when the op is called directly rather than via autograd) would otherwise
+  // pass the stride check and the kernel would write numel elements out of
+  // bounds.
+  auto dense_like_input = [&](const Tensor& t) {
+    return t.is_non_overlapping_and_dense() && t.sizes().equals(input.sizes()) && t.strides().equals(input.strides());
+  };
+  if (!input.is_non_overlapping_and_dense() || !dense_like_input(target) || !dense_like_input(grad_input)) {
+    return false;
+  }
+  if (!scalar_grad && !dense_like_input(grad_output)) {
+    return false;
+  }
+  if (input.numel() > kMaxFusedLossNumel) {
+    return false;
+  }
+
+  FusedLossParams params{};
+  params.numel = static_cast<uint32_t>(input.numel());
+  params.flag = scalar_grad ? 1u : 0u;
+  params.p0 = static_cast<float>(norm);
+  params.aligned = (input.storage_offset() % 4 == 0) && (target.storage_offset() % 4 == 0) &&
+      (grad_input.storage_offset() % 4 == 0) && (scalar_grad || grad_output.storage_offset() % 4 == 0);
+
+  const std::string name = fmt::format("fused_loss_bwd_{}_{}", op, scalarToMetalTypeString(input));
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(name);
+      getMPSProfiler().beginProfileKernel(pso, op + "_fused_bwd", {input, target, grad_output});
+      [ce setComputePipelineState:pso];
+      mtl_setArgs(ce, input, target, grad_output, grad_input, params);
+      const uint32_t jobs = params.aligned ? (params.numel + 3u) / 4u : params.numel;
+      mtl_dispatch1DJob(ce, pso, jobs);
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+  return true;
+}
+
 static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
                                           const Tensor& input,
                                           const Tensor& target,
@@ -74,44 +246,49 @@ static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
   TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes")
   auto norm = reduction == Reduction::Mean ? 2. / static_cast<double>(input.numel()) : 2.;
 
+  // Empty input: gradient norm is 2/numel for mean (-> NaN as 2/0), else 0.
   if ((input.numel() == 0) || (target.numel() == 0) || (grad_output.numel() == 0)) {
     reduction == Reduction::Mean ? grad_input.fill_(std::numeric_limits<float>::quiet_NaN()) : grad_input.zero_();
     return grad_input;
   }
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor *inputTensor = nil, *targetTensor = nil;
-    MPSGraphTensor *gradInputTensor = nil, *gradOutputTensor = nil;
-  };
 
-  @autoreleasepool {
-    std::string key = op_name + reductionToString(reduction) + ":" + std::to_string(grad_input.sizes()[1]) +
-        getTensorsStringKey({input, target, grad_output});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-      newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-      MPSGraphTensor* normTensor = [mpsGraph constantWithScalar:norm dataType:[newCachedGraph->inputTensor dataType]];
-      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                          secondaryTensor:newCachedGraph->targetTensor
-                                                                     name:nil];
-      MPSGraphTensor* diffGradientTensor = [mpsGraph multiplicationWithPrimaryTensor:diffTensor
-                                                                     secondaryTensor:newCachedGraph->gradOutputTensor
-                                                                                name:nil];
-      newCachedGraph->gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:diffGradientTensor
-                                                                  secondaryTensor:normTensor
-                                                                             name:nil];
-    });
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
-    Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor, grad_input);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor, grad_output);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder, targetPlaceholder, gradOutputPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, gradInputPlaceholder);
+  // grad_input = norm * (input - target) * grad_output in ONE fused pass (no
+  // MPSGraph, no materialized intermediate). For mean, match the CPU
+  // kernel's rounding: norm (2/N) is narrowed to the compute dtype
+  // (value.to<scalar_t>()) before it is applied -- for fp16 that rounding is
+  // visible in the gradients, and 2/N can flush to zero for huge N exactly
+  // as it does on CPU.
+  if (reduction == Reduction::Mean) {
+    const auto common = at::promoteTypes(at::result_type(input, target), grad_output.scalar_type());
+    if (common == kHalf) {
+      norm = static_cast<double>(static_cast<c10::Half>(norm));
+    } else if (common == kBFloat16) {
+      norm = static_cast<double>(static_cast<c10::BFloat16>(norm));
+    } else if (common == kFloat) {
+      norm = static_cast<double>(static_cast<float>(norm));
+    }
   }
 
+  if (fused_loss_bwd_fast_path("mse", input, target, grad_output, grad_input, norm)) {
+    return grad_input;
+  }
+
+  // Generic fallback: the TensorIterator ternary handles mixed dtypes (with
+  // a half input and a float target the subtract runs in the promoted
+  // float, fixing the mixed-dtype case the parent MPSGraph path hard-crashed
+  // on), broadcast scalar grads, and mismatched layouts. norm is exactly 2
+  // for reduction none/sum, baked into mse_backward2; for mean the 0-dim
+  // grad_output is pre-scaled by the narrowed norm in float (in the
+  // gradient's own dtype 2/N can underflow fp16/bf16; non-inplace because
+  // .to(kFloat) is a no-op for a float grad_output and mul_ would mutate the
+  // caller's tensor).
+  Tensor grad = grad_output;
+  std::string kernel = "mse_backward2";
+  if (reduction == Reduction::Mean) {
+    grad = grad_output.to(kFloat).mul(norm);
+    kernel = "mse_backward_scaled";
+  }
+  ternary_op_kernel(kernel, input, target, grad, grad_input);
   return grad_input;
 }
 
@@ -1021,55 +1198,40 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
   return grad_input;
 }
 
-// MSELoss
+// MSELoss: reduction=None uses the `mse` binary kernel; mean/sum use the fused
+// float32 GPU reduction (no MPSGraph -> no per-shape graph cache).
 TORCH_IMPL_FUNC(mse_loss_out_mps)(const Tensor& input, const Tensor& target, int64_t reduction, const Tensor& output_) {
   std::string op_name = "mse_loss_out_mps";
   using namespace mps;
+  // Empty input: mean is NaN (0/0), sum and none are 0. Matches CPU/CUDA.
   if ((input.numel() == 0) || (target.numel() == 0)) {
     reduction == Reduction::Mean ? output_.fill_(std::numeric_limits<float>::quiet_NaN()) : output_.zero_();
     return;
-  }
-  bool contiguousOutput = !needsGather(output_);
-  Tensor output = output_;
-  if (!contiguousOutput) {
-    output = output_.contiguous();
   }
 
   TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes");
   TORCH_CHECK(c10::isFloatingType(input.scalar_type()) && c10::isFloatingType(target.scalar_type()),
               op_name + ": only defined for floating types");
-  TORCH_CHECK(output.is_mps());
+  TORCH_CHECK(output_.is_mps());
 
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor = nil;
-    MPSGraphTensor* targetTensor = nil;
-    MPSGraphTensor* outputTensor = nil;
-  };
-
-  @autoreleasepool {
-    std::string key = op_name + reductionToString(reduction) + getTensorsStringKey({input, target});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-
-      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                          secondaryTensor:newCachedGraph->targetTensor
-                                                                     name:nil];
-      MPSGraphTensor* diffSquareTensor = [mpsGraph squareWithTensor:diffTensor name:nil];
-      newCachedGraph->outputTensor = reduceTensor(diffSquareTensor, reduction, mpsGraph, input.sizes().size());
-    });
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
-    Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, contiguousOutput ? output_ : output);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder, targetPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+  if (reduction == Reduction::None) {
+    // (input - target)^2 written straight to the (possibly non-contiguous)
+    // structured output. exec_binary_kernel handles strided/broadcast inputs.
+    binary_op_kernel("mse", input, target, output_);
+    return;
   }
 
-  if (!contiguousOutput) {
-    output_.copy_(output);
-  }
+  // Mean/Sum: fused square-and-reduce in a single GPU pass (no materialized
+  // squared-difference temp). fused_loss_reduce promotes both operands to the
+  // output dtype, the kernel computes (input - target)^2 in float32,
+  // threadgroup-reduces, and (for mean) divides by numel in float32 before
+  // casting to the output dtype.
+  // This matches the fused MPSGraph square+reduce that the materialize-then-
+  // at::sum path regressed against, and keeps the float32 accumulation so
+  // large-N fp16/bf16 does not overflow. output_ is a scalar tensor.
+  FusedLossParams params{};
+  params.reduction = static_cast<uint32_t>(reduction);
+  fused_loss_reduce("mse", input, target, std::nullopt, output_, params);
 }
 
 Tensor& mse_loss_backward_out_mps(const Tensor& grad_output,

--- a/benchmarks/mps/bench_mse_loss.py
+++ b/benchmarks/mps/bench_mse_loss.py
@@ -1,0 +1,145 @@
+"""mse_loss: fused square-and-reduce kernel timing.
+
+Measures F.mse_loss on the current build. The fused kernel computes (a-b)^2 and
+reduces in one pass (no materialized squared-diff tensor). For the A/B vs the
+MPSGraph path, run this on a parent (pre-migration) checkout for the baseline and
+on this checkout for the fused kernel; the PR body carries that comparison.
+Methodology: torch.utils.benchmark.Timer.blocked_autorange over an amortized
+inner loop (default: 100 mse calls followed by one device sync), repeated 5
+times after warmup. The reported value is mean microseconds per mse call.
+
+Defaults to the MPS device (this kernel's target) but takes --device, so the
+same script profiles CUDA/CPU too. Covers contiguous and non-contiguous inputs,
+all three reductions, and forward as well as forward+backward (the backward
+path is migrated too: scalar broadcast grad_output for mean/sum, full-size
+grad_output for none).
+"""
+
+import argparse
+import json
+import os
+import statistics
+
+import torch
+import torch.nn.functional as F
+from torch.utils.benchmark import Timer
+
+
+DTYPES = {"f32": torch.float32, "f16": torch.float16, "bf16": torch.bfloat16}
+SHAPES = [
+    ("8x2048x4096", (8, 2048, 4096)),
+    ("1024x1024", (1024, 1024)),
+    ("4x65536", (4, 65536)),
+    ("65536x128", (65536, 128)),
+    ("256x1024", (256, 1024)),
+]
+INNER_ITERS = int(os.environ.get("INNER_ITERS", "100"))
+WARMUP_BLOCKS = int(os.environ.get("WARMUP_BLOCKS", "30"))
+REPEATS = int(os.environ.get("REPEATS", "5"))
+MIN_RUN_TIME = float(os.environ.get("MIN_RUN_TIME", "0.2"))
+
+
+def synchronize(device):
+    if device.type == "mps":
+        torch.mps.synchronize()
+    elif device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def bench(
+    device,
+    shape,
+    dt,
+    reduction,
+    layout,
+    backward,
+    inner_iters,
+    warmup_blocks,
+    repeats,
+    min_run_time,
+):
+    x = torch.randn(shape, device=device, dtype=dt)
+    t = torch.randn(shape, device=device, dtype=dt)
+    if layout == "noncontig" and x.dim() >= 2:
+        # Transposed views sharing one dense layout: mean/sum reductions take
+        # the physical-order dense walk (no materialization); reduction=none
+        # and the backward take the strided binary/ternary iterator paths.
+        x = x.transpose(-1, -2).contiguous().transpose(-1, -2)
+        t = t.transpose(-1, -2).contiguous().transpose(-1, -2)
+    x.requires_grad_(backward)
+    # Non-scalar loss (reduction="none") needs an explicit grad_output; a
+    # full-size ones tensor also exercises the elementwise backward, while the
+    # scalar mean/sum backward covers the broadcast (stride-0) grad_output.
+    g = torch.ones(shape, device=device, dtype=dt) if reduction == "none" else None
+
+    def run_block():
+        for _ in range(inner_iters):
+            loss = F.mse_loss(x, t, reduction=reduction)
+            if backward:
+                x.grad = None
+                loss.backward(g)
+        synchronize(device)
+
+    for _ in range(warmup_blocks):
+        run_block()
+    synchronize(device)
+
+    timer = Timer(stmt="run_block()", globals={"run_block": run_block})
+    samples_us = [
+        timer.blocked_autorange(min_run_time=min_run_time).mean * 1e6 / inner_iters
+        for _ in range(repeats)
+    ]
+    return {
+        "mean_us": round(statistics.mean(samples_us), 1),
+        "stdev_us": (
+            round(statistics.stdev(samples_us), 1) if len(samples_us) > 1 else 0.0
+        ),
+        "samples_us": [round(v, 1) for v in samples_us],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="mps")
+    parser.add_argument("--inner-iters", type=int, default=INNER_ITERS)
+    parser.add_argument("--warmup-blocks", type=int, default=WARMUP_BLOCKS)
+    parser.add_argument("--repeats", type=int, default=REPEATS)
+    parser.add_argument("--min-run-time", type=float, default=MIN_RUN_TIME)
+    args = parser.parse_args()
+    device = torch.device(args.device)
+
+    out = {
+        "metadata": {
+            "device": str(device),
+            "inner_iters": args.inner_iters,
+            "warmup_blocks": args.warmup_blocks,
+            "repeats": args.repeats,
+            "min_run_time_s": args.min_run_time,
+            "method": "Timer.blocked_autorange mean of repeated amortized blocks",
+        },
+        "results": {},
+    }
+    for nm, sh in SHAPES:
+        for dn, dt in DTYPES.items():
+            for red in ("none", "mean", "sum"):
+                for layout in ("contig", "noncontig"):
+                    if layout == "noncontig" and len(sh) < 2:
+                        continue
+                    for mode in ("fwd", "fwd+bwd"):
+                        out["results"][f"{nm}|{dn}|{red}|{layout}|{mode}"] = bench(
+                            device,
+                            sh,
+                            dt,
+                            red,
+                            layout,
+                            mode == "fwd+bwd",
+                            args.inner_iters,
+                            args.warmup_blocks,
+                            args.repeats,
+                            args.min_run_time,
+                        )
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5084,6 +5084,36 @@ class TestMPS(TestCaseMPS):
         helper((3, 3, 0), 'mean')
         helper((3, 3, 0), 'none')
 
+    def test_mse_loss_broadcast(self):
+        # CPU broadcasts input/target through a TensorIterator; the Metal path
+        # must match (expand_outplace before the fused reduce, iterator
+        # fallbacks for backward). Includes the swapped-arg autograd path
+        # (target.requires_grad) which relies on the engine's sum_to.
+        cases = [((64, 10), (10,)), ((64, 10), (64, 1)), ((64, 10), ()),
+                 ((64, 10), (64, 10))]
+        for reduction in ('none', 'mean', 'sum'):
+            for in_shape, tgt_shape in cases:
+                x = torch.randn(in_shape, requires_grad=True)
+                t = (torch.randn(tgt_shape) if tgt_shape else torch.tensor(0.5)).requires_grad_()
+                xm = x.detach().to('mps').requires_grad_()
+                tm = t.detach().to('mps').requires_grad_()
+                lc = F.mse_loss(x, t, reduction=reduction)
+                lm = F.mse_loss(xm, tm, reduction=reduction)
+                self.assertEqual(lm.cpu(), lc)
+                g = torch.randn(lc.shape)
+                lc.backward(g)
+                lm.backward(g.to('mps'))
+                self.assertEqual(xm.grad.cpu(), x.grad)
+                self.assertEqual(tm.grad.cpu(), t.grad)
+        # expanded stride-0 same-size target (regression guard)
+        base = torch.randn(10)
+        t = base.expand(64, 10)
+        x = torch.randn(64, 10)
+        self.assertEqual(F.mse_loss(x.to('mps'), t.to('mps')).cpu(), F.mse_loss(x, t))
+        # non-broadcastable rejection matches CPU error class
+        with self.assertRaises(RuntimeError):
+            F.mse_loss(torch.randn(64, 10, device='mps'), torch.randn(3, device='mps'))
+
     def test_mse_loss_strided_output(self):
         # https://github.com/pytorch/pytorch/issues/124621
         lf = nn.MSELoss(reduction='none')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4909,6 +4909,150 @@ class TestMPS(TestCaseMPS):
         helper([8, 4, 5, 7, 6], 'mean')
 
     # Mean Squared Error
+    def test_mse_loss_metal_paths(self):
+        # Committed coverage for the native Metal mse_loss kernels: all
+        # reductions x {f32,f16,bf16} fwd+bwd vs fp32 CPU, plus a large shape
+        # that reaches fused_loss_pass1 plus the shared sum_reduction pass-2
+        # path (OpInfo samples are too small to reach it), plus non-contiguous
+        # operands that reach the strided pass-1 loads and the strided fused
+        # ternary backward.
+        def run(shape, reduction, dtype, noncontig=False):
+            xc = torch.randn(shape, dtype=torch.float32, requires_grad=True)
+            tc = torch.randn(shape, dtype=torch.float32)
+            xm = xc.detach().to("mps", dtype)
+            tm = tc.detach().to("mps", dtype)
+            if noncontig:
+                # Same logical values through a transposed (non-contiguous) view.
+                xm = xm.t().contiguous().t()
+                tm = tm.t().contiguous().t()
+                self.assertFalse(xm.is_contiguous())
+            xm.requires_grad_()
+            tol = dict(atol=5e-2, rtol=5e-2) if dtype != torch.float32 else {}
+            oc = F.mse_loss(xc, tc, reduction=reduction)
+            om = F.mse_loss(xm, tm, reduction=reduction)
+            self.assertEqual(om.float(), oc, **tol)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps", dtype))
+            self.assertEqual(xm.grad.float(), xc.grad, **tol)
+
+        for reduction in ("none", "mean", "sum"):
+            for dtype in (torch.float32, torch.float16, torch.bfloat16):
+                run((64, 33), reduction, dtype)
+                run((64, 33), reduction, dtype, noncontig=True)
+        run((4096, 4096), "mean", torch.float32)  # large -> multi-threadgroup reduce
+        run((4096, 4096), "sum", torch.float32)
+        run((4096, 4096), "mean", torch.float16)  # large reduce, fp32 accumulation
+        run((4096, 4096), "mean", torch.float32, noncontig=True)  # large strided reduce
+        run((4096, 4096), "sum", torch.bfloat16, noncontig=True)
+
+        # Mixed input/target dtypes: the parent MPSGraph backward hard-crashed
+        # here; the fused-loss fallback computes in the promoted dtype.
+        def run_mixed(reduction):
+            xc = torch.randn(64, 33, dtype=torch.float32, requires_grad=True)
+            tc = torch.randn(64, 33, dtype=torch.float32)
+            xm = xc.detach().to("mps", torch.float16).requires_grad_()
+            tm = tc.detach().to("mps")
+            oc = F.mse_loss(xc, tc, reduction=reduction)
+            om = F.mse_loss(xm, tm.float(), reduction=reduction)
+            self.assertEqual(om.float(), oc, atol=5e-2, rtol=5e-2)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps"))
+            self.assertEqual(xm.grad.float(), xc.grad, atol=5e-2, rtol=5e-2)
+
+        for reduction in ("none", "mean", "sum"):
+            run_mixed(reduction)
+
+        # Out-variant with a grad_input dtype differing from same-dtype
+        # inputs: exercises the ternary fallback's cast-kernel selection by
+        # output dtype (matching CPU's cast_common_dtype_to_outputs support).
+        for reduction_val in (0, 1, 2):  # none, mean, sum
+            xh = torch.randn(64, 33, device="mps", dtype=torch.float16)
+            th = torch.randn(64, 33, device="mps", dtype=torch.float16)
+            gh = torch.ones((), device="mps", dtype=torch.float16) if reduction_val else \
+                torch.ones(64, 33, device="mps", dtype=torch.float16)
+            gi = torch.empty(64, 33, device="mps", dtype=torch.float32)
+            torch.ops.aten.mse_loss_backward.grad_input(gh, xh, th, reduction_val, grad_input=gi)
+            gi_cpu = torch.empty(64, 33, dtype=torch.float32)
+            torch.ops.aten.mse_loss_backward.grad_input(
+                gh.cpu(), xh.cpu(), th.cpu(), reduction_val, grad_input=gi_cpu)
+            self.assertEqual(gi.cpu(), gi_cpu, atol=5e-2, rtol=5e-2)
+
+        # An un-castable (integral) grad_input raises CPU's clean cast error,
+        # not a Metal pipeline-creation failure.
+        gi_int = torch.empty(64, 33, device="mps", dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "can't be cast"):
+            torch.ops.aten.mse_loss_backward.grad_input(
+                torch.ones((), device="mps", dtype=torch.float16),
+                torch.randn(64, 33, device="mps", dtype=torch.float16),
+                torch.randn(64, 33, device="mps", dtype=torch.float16),
+                1, grad_input=gi_int)
+
+        # An empty out tensor is resized and filled (CPU out= semantics),
+        # not silently left empty.
+        xe = torch.randn(64, 33, device="mps")
+        te = torch.randn(64, 33, device="mps")
+        gi_empty = torch.empty(0, device="mps")
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), device="mps"), xe, te, 1, grad_input=gi_empty)
+        gi_ref = torch.empty(0)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones(()), xe.cpu(), te.cpu(), 1, grad_input=gi_ref)
+        self.assertEqual(gi_empty.shape, gi_ref.shape)
+        self.assertEqual(gi_empty.cpu(), gi_ref)
+
+        # Mixed layouts (contiguous input, transposed target): must NOT take
+        # the physical-order walk — element pairing would break.
+        xmix_c = torch.randn(64, 33)
+        tmix_c = torch.randn(64, 33)
+        xmix = xmix_c.to("mps")
+        tmix = tmix_c.to("mps").t().contiguous().t()
+        self.assertFalse(tmix.is_contiguous())
+        for reduction in ("mean", "sum"):
+            self.assertEqual(
+                F.mse_loss(xmix, tmix, reduction=reduction).cpu(),
+                F.mse_loss(xmix_c, tmix_c, reduction=reduction))
+
+        # Storage offsets off the vec4 alignment (slice views): the kernels
+        # must take the scalar path and still match CPU.
+        base_x = torch.randn(64 * 33 + 1)
+        base_t = torch.randn(64 * 33 + 1)
+        xo_c = base_x[1:].view(64, 33)
+        to_c = base_t[1:].view(64, 33)
+        xo = base_x.to("mps")[1:].view(64, 33)
+        to = base_t.to("mps")[1:].view(64, 33)
+        self.assertNotEqual(xo.storage_offset() % 4, 0)
+        for reduction in ("none", "mean", "sum"):
+            self.assertEqual(
+                F.mse_loss(xo, to, reduction=reduction).cpu(),
+                F.mse_loss(xo_c, to_c, reduction=reduction))
+
+        # Out-variant where input/target/grad_input all share a transposed
+        # dense layout but grad_output is contiguous: must take the fallback
+        # (and actually write the gradient).
+        xt = torch.randn(33, 64, device="mps").t()
+        tt = torch.randn(33, 64, device="mps").t()
+        gt = torch.ones(64, 33, device="mps")
+        git = torch.empty(33, 64, device="mps").t()
+        torch.ops.aten.mse_loss_backward.grad_input(gt, xt, tt, 0, grad_input=git)
+        git_ref = torch.empty(64, 33)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            gt.cpu(), xt.cpu().contiguous(), tt.cpu().contiguous(), 0, grad_input=git_ref)
+        self.assertEqual(git.cpu(), git_ref)
+
+        # grad_output dtype differing alone must route to the promoted-dtype
+        # fallback, not the same-dtype fast path.
+        xg = torch.randn(64, 33, device="mps", dtype=torch.float16)
+        tg = torch.randn(64, 33, device="mps", dtype=torch.float16)
+        gig = torch.empty(64, 33, device="mps", dtype=torch.float16)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), device="mps", dtype=torch.float32), xg, tg, 2, grad_input=gig)
+        gig_ref = torch.empty(64, 33, dtype=torch.float16)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), dtype=torch.float32), xg.cpu(), tg.cpu(), 2, grad_input=gig_ref)
+        self.assertEqual(gig.cpu(), gig_ref, atol=5e-2, rtol=5e-2)
+
     def test_mse_loss(self):
         def helper(shape, reduction):
             # create the criterion


### PR DESCRIPTION
Part of #187455.

## Summary

This is the base PR for the pointwise fused-loss stack. It migrates `mse_loss`
forward and backward on MPS from the shape-keyed MPSGraph path to native Metal.

- `reduction='none'` uses the existing binary-op iterator with the new `mse`
  functor.
- `mean`/`sum` use `fused_loss_pass1` to accumulate `(input - target)^2` into
  fp32 threadgroup partials, then reuse the existing `sum_reduction` pass for
  the scalar result — no materialized squared-difference tensor, no per-shape
  MPSGraph cache entry. When input and target share one dense layout (e.g.
  both transposed the same way), the reduction walks physical order, so the
  vec4 loads stay linear and non-contiguous operands cost the same as
  contiguous ones.
- Backward is one fused pass: the dense vec4 `fused_loss_bwd` kernel computes
  `norm * (input - target) * grad_output` directly (uniform `g[0]` read for
  the 0-dim mean/sum grad). Mixed dtypes or mismatched layouts fall back to a
  generic TensorIterator ternary (`mse_backward2` / `mse_backward_scaled`),
  which computes in the promoted dtype — fixing the mixed-dtype gradients the
  parent MPSGraph path hard-crashed on. The mean norm (2/N) is narrowed to
  the compute dtype first, matching the CPU kernel's rounding.

The shared pieces (`FusedLossParams`, `fused_loss_pass1`, `fused_loss_bwd`,
`fused_loss_reduce`, the ternary fallback helper) are what follow-up PRs
#187557 (`binary_cross_entropy`) and #187556 (`smooth_l1_loss` /
`huber_loss`) stack on with small per-op functors.

Also fixes an upstream bug in `exec_ternary_kernel`: its 64-bit split path
dispatched sub-iterators to `exec_binary_kernel`, which would look up
nonexistent 2-input kernel names for any ternary op above 2^31 elements.

Because pass 2 reuses `sum_reduction` from the ReduceOps shader library,
`LossOps.mm` binds two library handles: with bundled shaders both alias the
single bundled metallib, but under `PYTORCH_JIT_COMPILE_SHADERS` the
`LossOps_metallib.h` and `ReduceOps_metallib.h` headers are distinct objects,
so each is included in its own namespace.

## Memory stability (the mission gate)

1,000 iterations over distinct shapes, all three reductions, forward +
backward (`agent_space` demo script; RSS via ru_maxrss, driver via
`torch.mps.driver_allocated_memory()`):

| | RSS start | RSS end | driver after `empty_cache()` |
|---|---|---|---|
| parent 815cc61 (MPSGraph) | 396 MB | **5,391 MB** (unreclaimed) | 32 MB |
| this PR | 382 MB | **384 MB** | 16.5 MB |

The parent leaks ~5 MB of cached graph per distinct shape and
`empty_cache()` does not reclaim it; this branch is flat.

## Coverage Owner

`test/test_mps.py::TestMPS.test_mse_loss_metal_paths` owns the MPS route
coverage: all reductions x f32/f16/bf16, forward and backward vs an fp32 CPU
reference, contiguous and non-contiguous (transposed) operands — reaching the
physical-order dense walk, the strided binary/ternary fallbacks, and the
multi-threadgroup pass-2 path (OpInfo samples are too small to reach it).
Existing `mse_loss` OpInfo (including the f16 grad consistency test, which
pinned the CPU norm-rounding parity), `test_nn.py`, and `test_modules.py`
remain the broad semantic owners.

## Performance

Benchmark script: `benchmarks/mps/bench_mse_loss.py` (committed). 180 cells:
5 shapes x f32/f16/bf16 x none/mean/sum x contig/noncontig x fwd/fwd+bwd.
`Timer.blocked_autorange` over 100-call synchronized blocks, 5 repeats after
30 warmup blocks, mean us per call, M4 Pro, macOS 26.4. Baseline = parent
815cc61481a (MPSGraph), head = this PR, run back-to-back on an idle machine.

Headline cells from the final gate run (baseline 815cc61481a vs HEAD
7cb9f340368, back-to-back; full 180-cell JSON logs kept as gate artifacts —
agent_space/bench-{baseline,current}-v8.log):

| cell | MPSGraph | this PR | speedup |
|---|---|---|---|
| 8x2048x4096 f16 sum noncontig fwd | 5,643 us | 1,043 us | 5.41x |
| 8x2048x4096 bf16 mean noncontig fwd | 5,522 us | 1,050 us | 5.26x |
| 65536x128 bf16 mean noncontig fwd | 627 us | 138 us | 4.54x |
| 256x1024 f16 sum noncontig fwd | 68.2 us | 14.4 us | 4.74x |
| 8x2048x4096 f32 mean contig fwd | parity | parity | ~0.97-1.0x |
| 1024x1024 f16 mean contig fwd+bwd | 59.3 us | 93.5 us | 0.63x |
| 1024x1024 f16 none noncontig fwd+bwd | 116 us | 208 us | 0.56x |

59 of 180 cells sit below 0.95x, in two understood clusters: ~1M-element
shapes where the two-dispatch reduce pays a fixed ~9 us against MPSGraph's
single fused kernel, and mixed-layout backward combinations on the generic
TensorIterator fallback. Functional-level backward is at parity (0.97-0.98x);
the fwd+bwd cell gaps are per-iteration overhead, not kernel cost.

The wins come from removing MPSGraph's per-shape graph launch overhead
(small shapes) and from the physical-order dense walk (non-contiguous
reductions run at contiguous speed instead of gathering).

## Test Plan

- `lintrunner -a -m upstream/main`
- `xcrun metal -std=metal3.1 -c aten/src/ATen/native/mps/kernels/{LossOps,BinaryKernel}.metal -I . -I aten/src -Wall -Wextra -fno-fast-math` (and `-std=metal4.0`)
- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k mse_loss -q` — 10/10
- `PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps --keep-going` — 29,830 passed; the only failure (`test_metal.py::TestMetalRewritePass::test_conv`) reproduces identically on the untouched merge base and is unrelated to this diff.
- `python benchmarks/mps/bench_mse_loss.py` on parent and HEAD (above)

## Review History

Review-history gist: https://gist.github.com/f8e81a7d506a95f2aea6d2cbfbc621b6

- The review loop ran eight iterations; every finding and its disposition is
  in the gist, including: two P3 kernel hardenings (uint32 wrap bound,
  max_total_threads attribute), a P1 size-unchecked fast path (OOB write on
  direct op calls), mixed-dtype compute semantics (`REGISTER_OPMATH_TERNARY_OP`)
  with fwd+bwd coverage, empty-out resize semantics, integral-out error-class
  parity, and a silent write-drop for layout-mismatched out tensors
  (TensorIterator restride temp; found by mutation-driven testing).
- The final HEAD's local ClawSweeper pass is clean (A/A/A, zero findings);
  `autoreview` + local ClawSweeper entries for it are the latest gist entries.

## BC-breaking?

No public API change. Three numeric notes: (1) f16/bf16 `mean`/`sum` now
accumulate in fp32 (overflow-safe; can differ slightly from MPSGraph while
matching the CPU reference more closely); (2) mixed-dtype backward computes
in the promoted dtype and returns the CPU/CUDA gradient where MPSGraph
crashed; (3) the mean backward narrows `2/N` to the compute dtype before
applying it, bit-matching CPU (including fp16 flush-to-zero for huge N).



---

## Update: numpy-style broadcast support

Responding to review: input/target broadcasting now matches CPU. The fused mean/sum forward materializes broadcast views via `expand_outplace` (borrowed refs when shapes already match, so the equal-shape hot path is unchanged; stride-0 expanded views ride the existing `contiguous()` fallback — removing the check naively would have let the flat pass-1 kernel read out of bounds). The backward relaxes the same-size check to a broadcastability validation and rides the already-broadcast-native ternary iterator. Note the same-size restriction predates this PR (the MPSGraph code carried the identical `TORCH_CHECK`), so this is a parity enhancement rather than a regression fix. New tests cover trailing-dim/keepdim/0-dim targets, expanded stride-0 targets, the swapped-arg autograd path, and rejection parity.

Review log: https://gist.github.com/anagnorisis2peripeteia/a94ef0efd3a3ee06c9b72e18674e75b7
