### PR TITLE
Fix flaky gradcheck in _gradcheck_log_prob for simplex distributions.

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1357,7 +1357,7 @@ class TestDistributions(DistributionsTestCase):
             # For simplex-constrained distributions (e.g. RelaxedOneHotCategorical),
             # samples near the boundary cause numerical Jacobian to produce nan
             # because log_prob inverts ExpTransform via log(), and finite
-            # differencing (eps=1e-6) near zero yields log(~0) = -inf/nan.
+            # differencing (eps=1e-6) near zero yields log(<=0) = -inf/nan.
             # Clamp to the simplex interior (1e-4 gives ~100x margin above
             # gradcheck eps) and renormalize.
             if isinstance(distribution.support, constraints._Simplex):

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1353,7 +1353,17 @@ class TestDistributions(DistributionsTestCase):
         distribution = dist_ctor(*ctor_params)
         s = distribution.sample()
         if not distribution.support.is_discrete:
-            s = s.detach().requires_grad_()
+            s = s.detach()
+            # For simplex-constrained distributions (e.g. RelaxedOneHotCategorical),
+            # samples near the boundary cause numerical Jacobian to produce nan
+            # because log_prob inverts ExpTransform via log(), and finite
+            # differencing (eps=1e-6) near zero yields log(~0) = -inf/nan.
+            # Clamp to the simplex interior (1e-4 gives ~100x margin above
+            # gradcheck eps) and renormalize.
+            if isinstance(distribution.support, constraints._Simplex):
+                s = s.clamp(min=1e-4)
+                s = s / s.sum(-1, keepdim=True)
+            s.requires_grad_()
 
         expected_shape = distribution.batch_shape + distribution.event_shape
         self.assertEqual(s.size(), expected_shape)


### PR DESCRIPTION
`_gradcheck_log_prob` samples from the distribution under test and runs `torch.autograd.gradcheck` on its `log_prob`. For simplex-constrained distributions like `RelaxedOneHotCategorical`, low temperatures concentrate samples toward one-hot vectors, frequently producing components near zero. When `gradcheck` finite-differences with `eps=1e-6`, it perturbs these near-zero values to zero or negative, causing `ExpTransform.inv` (i.e. `log()`) to return `-inf`/`nan` and the numerical Jacobian check to fail nondeterministically.

Fix by clamping simplex samples to the interior (`min=1e-4`, providing ~100x margin above gradcheck eps) and renormalizing before running gradcheck. This ensures the test evaluates gradient correctness at a numerically stable point without changing distribution math.

Fixes https://github.com/intel/torch-xpu-ops/issues/4022