### PR TITLE
[inductor][XPU] Return None instead of raising on missing ValueRange in _maybe_evaluate_static_worker

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1097,6 +1097,13 @@ def forward(self, x_1):
         self.assertTrue(shape_env.evaluate_expr(test1))
         self.assertTrue(shape_env.evaluate_expr(test2))
 
+    def test_simplify_max_missing_var_to_range(self):
+        shape_env = ShapeEnv()
+        s = sympy.Symbol("test_sym", integer=True)
+        expr = sympy.Max(0, s)
+        result = shape_env.simplify(expr)
+        self.assertIsNotNone(result)
+
     def test_sympy_optimized_add(self):
         shape_env = ShapeEnv()
         s0 = create_symint(shape_env, 2)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2558,7 +2558,10 @@ def _maybe_evaluate_static_worker(
             # for jagged layout NestedTensors today
             continue
         if vr is None:
-            raise AssertionError(f"vr must not be None for symbol {k}")
+            log.warning(
+                "Symbol %s missing from var_to_range, skipping static evaluation", k
+            )
+            return None
         if size_oblivious and is_size_like:
             lower = max(2, vr.lower)
             # Clamping size-oblivious to some quantity below sys.maxsize


### PR DESCRIPTION
Issue: https://github.com/pytorch/pytorch/issues/187337:
File "/root/miniforge3/envs/jianyi/lib/python3.10/site-packages/torch/fx/experimental/symbolic_shapes.py", line 7230, in simplify
if a == 0 and self._maybe_evaluate_static(sympy.Ge(b, 0)):
File "/root/miniforge3/envs/jianyi/lib/python3.10/site-packages/torch/fx/experimental/symbolic_shapes.py", line 2767, in wrapper
return fn_cache(self, *args, **kwargs)
File "/root/miniforge3/envs/jianyi/lib/python3.10/site-packages/torch/fx/experimental/symbolic_shapes.py", line 7168, in _maybe_evaluate_static
r = _maybe_evaluate_static_worker(
File "/root/miniforge3/envs/jianyi/lib/python3.10/site-packages/torch/fx/experimental/symbolic_shapes.py", line 2542, in _maybe_evaluate_static_worker
raise AssertionError(f"vr must not be None for symbol {k}")
torch._inductor.exc.InductorError: AssertionError: vr must not be None for symbol q3

Fix: `max_pool2d_with_indices_backward` lowering can produce expressions with loop variables (e.g. q1, q2) that are not in `ShapeEnv.var_to_range`. When `_maybe_evaluate_static` recurses into `simplify()` → `_maybe_evaluate_static(Ge(b, 0))` without passing `var_to_range`, these variables get `vr=None` and crash

Fix: Return None instead of raising AssertionError when vr is None, gracefully falling back to non-static evaluation.