### PR TITLE
[MPS] Migrate binary_cross_entropy to native Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -192,7 +192,10 @@ class MetalShaderLibrary {
       const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt,
       const std::optional<c10::ScalarType> natural_output_dtype = std::nullopt,
       const std::optional<uint32_t> ilp_threshold = std::nullopt);
-  void exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name);
+  void exec_ternary_kernel(
+      TensorIteratorBase& iter,
+      const std::string& name,
+      std::optional<uint32_t> ilp_threshold = std::nullopt);
 
   template <typename T>
   void exec_unary_kernel_with_params(

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1577,7 +1577,9 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   });
 }
 
-void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name) {
+void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter,
+                                             const std::string& name,
+                                             std::optional<uint32_t> ilp_threshold) {
   // TODO: Figure a better place to downcast double scalars (probably in tensor iterator itself?)
   // Right now running something like 1.0-torch.rand(5, device='mps') will create iterator with
   // double as common dtype (because Python floating point are always 64-bit values)
@@ -1593,7 +1595,7 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   // names for the 3-input op and fail at pipeline creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_ternary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name, ilp_threshold);
     }
     return;
   }
@@ -1624,7 +1626,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   // and the _cast_{out} kernels read the runtime input types anyway.
   const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
       (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
-  const auto suffix = iter.is_contiguous() ? "dense" : "strided";
+  // ILP is opt-in per call site (mirrors exec_binary_kernel): trivial-ALU
+  // bandwidth-bound functors pass a crossover threshold.
+  const bool dense_ilp = iter.is_contiguous() && !cast_needed && ilp_threshold.has_value() &&
+      iter.numel() >= static_cast<int64_t>(ilp_threshold.value());
+  const auto suffix = dense_ilp ? "dense_ilp" : (iter.is_contiguous() ? "dense" : "strided");
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed
       ? fmt::format("{}_{}_cast_{}", name, suffix, scalarToMetalTypeString(out))
@@ -1641,6 +1647,9 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
       // Iterator is contiguous if all of its elements are dense in storage,
       // i.e. it's true for both row-first and column-first tensors
       if (iter.is_contiguous()) {
+        if (dense_ilp) {
+          mtl_setBytes(computeEncoder, static_cast<uint32_t>(iter.numel()), 4);
+        }
         if (cast_needed) {
           std::array<int, 3> sizes = {static_cast<int>(c10::elementSize(input.scalar_type())),
                                       static_cast<int>(c10::elementSize(other1.scalar_type())),
@@ -1667,7 +1676,10 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
                        iter.ndim(),
                        types);
       }
-      mtl_dispatch1DJob(computeEncoder, binaryPSO, iter.numel());
+      mtl_dispatch1DJob(
+          computeEncoder,
+          binaryPSO,
+          dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel());
       getMPSProfiler().endProfileKernel(binaryPSO);
     }
   });

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1588,10 +1588,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
     return;
   }
 
-  // Decompose 64-bit tensor into 32-bit ones
+  // Decompose 64-bit tensor into 32-bit ones. Must recurse into the ternary
+  // exec: a binary dispatch here would look up nonexistent 2-input kernel
+  // names for the 3-input op and fail at pipeline creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_binary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name);
     }
     return;
   }
@@ -1617,8 +1619,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   convert_double_scalar(other2);
 
   MPSStream* mpsStream = getCurrentMPSStream();
-  const auto cast_needed =
-      (input.scalar_type() != other1.scalar_type()) || (input.scalar_type() != other2.scalar_type());
+  // An output dtype differing from the (matching) inputs also needs the cast
+  // kernel: the non-cast names are only registered for matching in/out pairs,
+  // and the _cast_{out} kernels read the runtime input types anyway.
+  const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
+      (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -18,6 +18,36 @@ struct sub_functor {
   }
 };
 
+// MSE elementwise (input - target)^2 in float32, cast to the output dtype
+// (OPMATH op). Used for reduction=None; mean/sum use the fused LossOps
+// reduction.
+struct mse_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    const T d = a - b;
+    return static_cast<T>(d * d);
+  }
+};
+
+// Fused MSE backward: grad_input = norm * (input - target) * grad_output in
+// a single pass; the ternary iterator supplies broadcast (0-dim grad for
+// mean/sum), strides, and mixed-dtype casts. norm is exactly 2 for
+// reduction none/sum, so mse_backward2 bakes it in; for mean the host
+// pre-scales the 0-dim grad_output by 2/N and uses mse_backward_scaled.
+struct mse_backward2_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T g) {
+    return static_cast<T>(T(2) * (a - b) * g);
+  }
+};
+
+struct mse_backward_scaled_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T g) {
+    return static_cast<T>((a - b) * g);
+  }
+};
+
 struct add_alpha_functor {
   template <typename T>
   inline T operator()(const T a, const T b, const T alpha) {
@@ -601,6 +631,13 @@ REGISTER_INT2FLOAT_BINARY_OP(hermite_polynomial_he);
 REGISTER_FLOAT_BINARY_OP(add);
 REGISTER_INTEGER_BINARY_OP(add);
 REGISTER_OPMATH_FLOAT_BINARY_OP(mul);
+REGISTER_OPMATH_FLOAT_BINARY_OP(mse);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, float, float);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, half, half);
+REGISTER_OPMATH_TERNARY_OP(mse_backward2, bfloat, bfloat);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, float, float);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, half, half);
+REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, bfloat, bfloat);
 REGISTER_INTEGER_BINARY_OP(mul);
 REGISTER_FLOAT_BINARY_OP(sub);
 REGISTER_INTEGER_BINARY_OP(sub);

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -48,6 +48,40 @@ struct mse_backward_scaled_functor {
   }
 };
 
+// BCE forward (reduction=None), unweighted: clamped cross-entropy per
+// element; the weighted variant multiplies by the broadcast weight. Backward
+// mirrors BCEOp::bwd in LossOps.metal (raw-x numerator, clamped denominator);
+// the host folds the mean scale and any weight into g.
+struct bce_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    const float x = float(a);
+    const float y = float(b);
+    return static_cast<T>(
+        -y * ::metal::max(::metal::log(x), -100.f) -
+        (1.f - y) * ::metal::max(::metal::log(1.f - x), -100.f));
+  }
+};
+
+struct bce_weighted_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T w) {
+    const float x = float(a);
+    const float y = float(b);
+    const float l = -y * ::metal::max(::metal::log(x), -100.f) -
+        (1.f - y) * ::metal::max(::metal::log(1.f - x), -100.f);
+    return static_cast<T>(l * float(w));
+  }
+};
+
+struct bce_backward_scaled_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b, const T g) {
+    const float xc = ::metal::clamp(float(a), 1e-7f, 1.f - 1e-7f);
+    return static_cast<T>((float(a) - float(b)) / (xc * (1.f - xc)) * float(g));
+  }
+};
+
 struct add_alpha_functor {
   template <typename T>
   inline T operator()(const T a, const T b, const T alpha) {
@@ -638,6 +672,13 @@ REGISTER_OPMATH_TERNARY_OP(mse_backward2, bfloat, bfloat);
 REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, float, float);
 REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, half, half);
 REGISTER_OPMATH_TERNARY_OP(mse_backward_scaled, bfloat, bfloat);
+REGISTER_OPMATH_FLOAT_BINARY_OP(bce);
+REGISTER_OPMATH_TERNARY_OP(bce_weighted, float, float);
+REGISTER_OPMATH_TERNARY_OP(bce_weighted, half, half);
+REGISTER_OPMATH_TERNARY_OP(bce_weighted, bfloat, bfloat);
+REGISTER_OPMATH_TERNARY_OP(bce_backward_scaled, float, float);
+REGISTER_OPMATH_TERNARY_OP(bce_backward_scaled, half, half);
+REGISTER_OPMATH_TERNARY_OP(bce_backward_scaled, bfloat, bfloat);
 REGISTER_INTEGER_BINARY_OP(mul);
 REGISTER_FLOAT_BINARY_OP(sub);
 REGISTER_INTEGER_BINARY_OP(sub);

--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -35,3 +35,14 @@ struct CTCLossBackwardCollectParams {
   index_t grad_out_batch_stride;
   bool zero_infinity;
 };
+
+// Shared by LossOps.metal and LossOps.mm; layout must stay identical on both.
+struct FusedLossParams {
+  uint32_t numel; // filled by fused_loss_reduce
+  uint32_t has_weight; // filled by fused_loss_reduce
+  uint32_t aligned; // filled by fused_loss_reduce: all operands 4-elem aligned
+  uint32_t reduction; // ATen: 1=Mean, 2=Sum (set by caller)
+  float p0; // op scalar: beta/delta, clamp-lo; norm for fused_loss_bwd
+  float p1; // op scalar: clamp-hi
+  uint32_t flag; // op flag: is_huber, ...; scalar-grad for fused_loss_bwd
+};

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -421,6 +421,24 @@ struct MSEOp {
   }
 };
 
+struct BCEOp {
+  // Unweighted per-element loss; fused_loss_pass1 applies the weight and pass 2
+  // folds the mean divide. Each log term clamps at -100 like the CPU kernel.
+  static inline float fwd(float a, float b, constant FusedLossParams& p) {
+    return -b * max(log(a), -100.f) - (1.f - b) * max(log(1.f - a), -100.f);
+  }
+  // dx = (x - y) / max((1 - x) * x, 1e-12) * g, matching the CPU kernel's
+  // EPSILON-clamped denominator (Loss.cpp). The host folds the mean scale and
+  // any weight into g, so p.p0 is 1 here (the fast path's norm slot).
+  static inline float bwd(
+      float a,
+      float b,
+      float g,
+      constant FusedLossParams& p) {
+    return p.p0 * (a - b) / max((1.f - a) * a, 1e-12f) * g;
+  }
+};
+
 // ============================================================================
 // Pass 1: per-threadgroup float32 partial of the (weighted) elementwise loss
 // ============================================================================
@@ -486,6 +504,7 @@ kernel void fused_loss_bwd(
     constant TI* gout [[buffer(2)]], // grad_output (0-dim when flag == 1)
     device TI* grad [[buffer(3)]], // grad_input
     constant FusedLossParams& p [[buffer(4)]],
+    constant TI* wbuf [[buffer(5)]], // weight; null buffer when has_weight == 0
     uint tid [[thread_position_in_grid]]) {
   const float g0 = p.flag ? float(gout[0]) : 0.f;
 
@@ -503,6 +522,10 @@ kernel void fused_loss_bwd(
         T4 gv = reinterpret_cast<constant const T4*>(gout)[tid];
         g4 = float4(float(gv.x), float(gv.y), float(gv.z), float(gv.w));
       }
+      if (p.has_weight) {
+        T4 w4 = reinterpret_cast<constant const T4*>(wbuf)[tid];
+        g4 *= float4(float(w4.x), float(w4.y), float(w4.z), float(w4.w));
+      }
       T4 r;
       r.x = TI(Op::bwd(float(a4.x), float(b4.x), g4.x, p));
       r.y = TI(Op::bwd(float(a4.y), float(b4.y), g4.y, p));
@@ -512,18 +535,24 @@ kernel void fused_loss_bwd(
       return;
     }
     for (uint i = base; i < p.numel; ++i) {
-      const float g = p.flag ? g0 : float(gout[i]);
+      float g = p.flag ? g0 : float(gout[i]);
+      if (p.has_weight) {
+        g *= float(wbuf[i]);
+      }
       grad[i] = TI(Op::bwd(float(in0[i]), float(in1[i]), g, p));
     }
     return;
   }
   if (tid < p.numel) {
-    const float g = p.flag ? g0 : float(gout[tid]);
+    float g = p.flag ? g0 : float(gout[tid]);
+    if (p.has_weight) {
+      g *= float(wbuf[tid]);
+    }
     grad[tid] = TI(Op::bwd(float(in0[tid]), float(in1[tid]), g, p));
   }
 }
 
-#define INSTANTIATE_FUSED_LOSS(NAME, OP, TI)                \
+#define INSTANTIATE_FUSED_LOSS_FWD(NAME, OP, TI)            \
   template [[host_name("fused_loss_pass1_" #NAME "_" #TI)]] \
   kernel void fused_loss_pass1<TI, OP>(                     \
       constant TI*,                                         \
@@ -535,16 +564,24 @@ kernel void fused_loss_bwd(
       uint,                                                 \
       uint,                                                 \
       uint,                                                 \
-      uint);                                                \
-  template [[host_name("fused_loss_bwd_" #NAME "_" #TI)]]   \
-  kernel void fused_loss_bwd<TI, OP>(                       \
-      constant TI*,                                         \
-      constant TI*,                                         \
-      constant TI*,                                         \
-      device TI*,                                           \
-      constant FusedLossParams&,                            \
+      uint)
+
+#define INSTANTIATE_FUSED_LOSS(NAME, OP, TI)              \
+  INSTANTIATE_FUSED_LOSS_FWD(NAME, OP, TI);               \
+  template [[host_name("fused_loss_bwd_" #NAME "_" #TI)]] \
+  kernel void fused_loss_bwd<TI, OP>(                     \
+      constant TI*,                                       \
+      constant TI*,                                       \
+      constant TI*,                                       \
+      device TI*,                                         \
+      constant FusedLossParams&,                          \
+      constant TI*,                                       \
       uint)
 
 INSTANTIATE_FUSED_LOSS(mse, MSEOp, float);
 INSTANTIATE_FUSED_LOSS(mse, MSEOp, half);
 INSTANTIATE_FUSED_LOSS(mse, MSEOp, bfloat);
+
+INSTANTIATE_FUSED_LOSS(bce, BCEOp, float);
+INSTANTIATE_FUSED_LOSS(bce, BCEOp, half);
+INSTANTIATE_FUSED_LOSS(bce, BCEOp, bfloat);

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,4 +1,6 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <ATen/native/mps/kernels/ReduceOps.h>
+#include <c10/metal/reduction_utils.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
@@ -395,3 +397,154 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+// Shared fused pointwise-loss kernels (mse/bce/smooth_l1/huber):
+// fused_loss_pass1 accumulates the elementwise loss in float32; pass 2 reuses
+// sum_reduction.
+
+// ============================================================================
+// Per-op forward functors
+// ============================================================================
+
+struct MSEOp {
+  static inline float fwd(float a, float b, constant FusedLossParams&) {
+    float d = a - b;
+    return d * d;
+  }
+  // norm * (input - target) * grad in float; one narrowing on store.
+  static inline float bwd(
+      float a,
+      float b,
+      float g,
+      constant FusedLossParams& p) {
+    return p.p0 * (a - b) * g;
+  }
+};
+
+// ============================================================================
+// Pass 1: per-threadgroup float32 partial of the (weighted) elementwise loss
+// ============================================================================
+
+template <typename TI, typename Op>
+[[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
+kernel void fused_loss_pass1(
+    constant TI* in0 [[buffer(0)]], // input
+    constant TI* in1 [[buffer(1)]], // target
+    constant TI* in2 [[buffer(2)]], // weight; null buffer when has_weight == 0
+    device float* partials [[buffer(3)]], // one float per threadgroup
+    constant FusedLossParams& p [[buffer(4)]],
+    uint tid [[thread_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]],
+    uint gsz [[threads_per_grid]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  threadgroup float
+      smem[32]; // up to MAX_THREADGROUP_SIZE(1024) / simdgroup(32)
+  float acc = 0.f;
+
+  using T4 = vec<TI, 4>;
+  const uint aligned_N = p.aligned ? (p.numel / 4u) * 4u : 0u;
+  const uint vec_stride = gsz * 4u;
+
+  for (uint base = tid * 4u; base + 4u <= aligned_N; base += vec_stride) {
+    const uint v = base / 4u;
+    T4 a4 = reinterpret_cast<constant const T4*>(in0)[v];
+    T4 b4 = reinterpret_cast<constant const T4*>(in1)[v];
+    float l0 = Op::fwd(float(a4.x), float(b4.x), p);
+    float l1 = Op::fwd(float(a4.y), float(b4.y), p);
+    float l2 = Op::fwd(float(a4.z), float(b4.z), p);
+    float l3 = Op::fwd(float(a4.w), float(b4.w), p);
+    if (p.has_weight) {
+      T4 w4 = reinterpret_cast<constant const T4*>(in2)[v];
+      acc += float(w4.x) * l0 + float(w4.y) * l1 + float(w4.z) * l2 +
+          float(w4.w) * l3;
+    } else {
+      acc += l0 + l1 + l2 + l3;
+    }
+  }
+  for (uint i = aligned_N + tid; i < p.numel; i += gsz) {
+    float l = Op::fwd(float(in0[i]), float(in1[i]), p);
+    acc += p.has_weight ? float(in2[i]) * l : l;
+  }
+
+  float s = c10::metal::threadgroup_sum<float>(smem, acc, lid, tgsz);
+  if (lid == 0)
+    partials[tgid] = s;
+}
+
+// ============================================================================
+// Fused elementwise loss backward (dense fast path): one pass computing
+// Op::bwd over input/target/grad_output. flag == 1 broadcasts a 0-dim
+// grad_output (mean/sum) via a uniform g[0] read; the generic TensorIterator
+// ternary path remains the fallback for mixed dtypes or mismatched layouts.
+// ============================================================================
+
+template <typename TI, typename Op>
+kernel void fused_loss_bwd(
+    constant TI* in0 [[buffer(0)]], // input
+    constant TI* in1 [[buffer(1)]], // target
+    constant TI* gout [[buffer(2)]], // grad_output (0-dim when flag == 1)
+    device TI* grad [[buffer(3)]], // grad_input
+    constant FusedLossParams& p [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  const float g0 = p.flag ? float(gout[0]) : 0.f;
+
+  using T4 = vec<TI, 4>;
+  if (p.aligned) {
+    // Grid is sized to ceil(numel / 4); each thread handles one vec4 block.
+    const uint base = tid * 4u;
+    if (base + 4u <= p.numel) {
+      T4 a4 = reinterpret_cast<constant const T4*>(in0)[tid];
+      T4 b4 = reinterpret_cast<constant const T4*>(in1)[tid];
+      float4 g4;
+      if (p.flag) {
+        g4 = float4(g0);
+      } else {
+        T4 gv = reinterpret_cast<constant const T4*>(gout)[tid];
+        g4 = float4(float(gv.x), float(gv.y), float(gv.z), float(gv.w));
+      }
+      T4 r;
+      r.x = TI(Op::bwd(float(a4.x), float(b4.x), g4.x, p));
+      r.y = TI(Op::bwd(float(a4.y), float(b4.y), g4.y, p));
+      r.z = TI(Op::bwd(float(a4.z), float(b4.z), g4.z, p));
+      r.w = TI(Op::bwd(float(a4.w), float(b4.w), g4.w, p));
+      reinterpret_cast<device T4*>(grad)[tid] = r;
+      return;
+    }
+    for (uint i = base; i < p.numel; ++i) {
+      const float g = p.flag ? g0 : float(gout[i]);
+      grad[i] = TI(Op::bwd(float(in0[i]), float(in1[i]), g, p));
+    }
+    return;
+  }
+  if (tid < p.numel) {
+    const float g = p.flag ? g0 : float(gout[tid]);
+    grad[tid] = TI(Op::bwd(float(in0[tid]), float(in1[tid]), g, p));
+  }
+}
+
+#define INSTANTIATE_FUSED_LOSS(NAME, OP, TI)                \
+  template [[host_name("fused_loss_pass1_" #NAME "_" #TI)]] \
+  kernel void fused_loss_pass1<TI, OP>(                     \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      device float*,                                        \
+      constant FusedLossParams&,                            \
+      uint,                                                 \
+      uint,                                                 \
+      uint,                                                 \
+      uint,                                                 \
+      uint);                                                \
+  template [[host_name("fused_loss_bwd_" #NAME "_" #TI)]]   \
+  kernel void fused_loss_bwd<TI, OP>(                       \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      constant TI*,                                         \
+      device TI*,                                           \
+      constant FusedLossParams&,                            \
+      uint)
+
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, float);
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, half);
+INSTANTIATE_FUSED_LOSS(mse, MSEOp, bfloat);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.h
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.h
@@ -7,4 +7,10 @@ void binary_op_kernel(
     const Tensor& other,
     const Tensor& output,
     const std::optional<Scalar> alpha = std::nullopt);
+void ternary_op_kernel(
+    const std::string func_name,
+    const Tensor& input,
+    const Tensor& other1,
+    const Tensor& other2,
+    const Tensor& output);
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.h
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.h
@@ -6,11 +6,13 @@ void binary_op_kernel(
     const Tensor& input,
     const Tensor& other,
     const Tensor& output,
-    const std::optional<Scalar> alpha = std::nullopt);
+    const std::optional<Scalar> alpha = std::nullopt,
+    std::optional<uint32_t> ilp_threshold = std::nullopt);
 void ternary_op_kernel(
     const std::string func_name,
     const Tensor& input,
     const Tensor& other1,
     const Tensor& other2,
-    const Tensor& output);
+    const Tensor& output,
+    std::optional<uint32_t> ilp_threshold = std::nullopt);
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -35,7 +35,8 @@ void binary_op_kernel(const std::string func_name,
                       const Tensor& input,
                       const Tensor& other,
                       const Tensor& output,
-                      const std::optional<Scalar> alpha) {
+                      const std::optional<Scalar> alpha,
+                      std::optional<uint32_t> ilp_threshold) {
   auto new_size = at::infer_size(input.sizes(), other.sizes());
   if (!output.sizes().equals(new_size)) {
     output.resize_(new_size);
@@ -54,14 +55,15 @@ void binary_op_kernel(const std::string func_name,
                   .promote_inputs_to_common_dtype(true)
                   .build();
 
-  lib.exec_binary_kernel(iter, func_name, alpha);
+  lib.exec_binary_kernel(iter, func_name, alpha, std::nullopt, std::nullopt, ilp_threshold);
 }
 
 void ternary_op_kernel(const std::string func_name,
                        const Tensor& input,
                        const Tensor& other1,
                        const Tensor& other2,
-                       const Tensor& output) {
+                       const Tensor& output,
+                       std::optional<uint32_t> ilp_threshold) {
   // Match binary_op_kernel (and CPU's out= semantics): resize the output to
   // the broadcast shape before the empty check, so an empty out tensor is
   // filled rather than silently left empty.
@@ -93,7 +95,7 @@ void ternary_op_kernel(const std::string func_name,
                   .resize_outputs(false)
                   .build();
 
-  lib.exec_ternary_kernel(iter, func_name);
+  lib.exec_ternary_kernel(iter, func_name, ilp_threshold);
 }
 
 } // namespace mps

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -57,6 +57,45 @@ void binary_op_kernel(const std::string func_name,
   lib.exec_binary_kernel(iter, func_name, alpha);
 }
 
+void ternary_op_kernel(const std::string func_name,
+                       const Tensor& input,
+                       const Tensor& other1,
+                       const Tensor& other2,
+                       const Tensor& output) {
+  // Match binary_op_kernel (and CPU's out= semantics): resize the output to
+  // the broadcast shape before the empty check, so an empty out tensor is
+  // filled rather than silently left empty.
+  auto new_size = at::infer_size(at::infer_size(input.sizes(), other1.sizes()), other2.sizes());
+  if (!output.sizes().equals(new_size)) {
+    output.resize_(new_size);
+  }
+  if (output.numel() == 0) {
+    return;
+  }
+
+  auto iter = TensorIteratorConfig()
+                  .allow_cpu_scalars(true)
+                  .add_output(output)
+                  .add_input(input)
+                  .add_input(other1)
+                  .add_input(other2)
+                  .check_all_same_dtype(false)
+                  .promote_inputs_to_common_dtype(true)
+                  // Match the CPU iterator's error class for un-castable
+                  // outputs (e.g. an integral out tensor) instead of failing
+                  // at Metal pipeline creation with an unregistered name.
+                  .enforce_safe_casting_to_output(true)
+                  // The output was already resized to the broadcast shape
+                  // above. The default (true) lets the iterator restride a
+                  // layout-mismatched output into an internal temp, which the
+                  // Metal exec path writes and never copies back — the
+                  // caller's tensor would silently stay untouched.
+                  .resize_outputs(false)
+                  .build();
+
+  lib.exec_ternary_kernel(iter, func_name);
+}
+
 } // namespace mps
 
 static void atan2_mps_kernel(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -104,21 +104,27 @@ static void fused_loss_reduce(const std::string& op,
   auto tgt = target.to(dt);
   std::optional<Tensor> w;
   if (weight.has_value() && weight->defined()) {
-    w = weight->expand(input.sizes()).to(dt).contiguous();
+    w = weight->expand(input.sizes()).to(dt);
   }
 
-  // A reduction is order-free, so when input and target share one dense
-  // layout (e.g. both transposed the same way) the kernel reads both buffers
-  // in physical order: element pairs still line up and the linear vec4 loads
-  // run at contiguous speed with no materialization. Mismatched or gappy
-  // layouts fall back to contiguous copies.
-  // (Weighted ops stay materialized: a physical-order walk would pair the
-  // contiguous weight against permuted input elements.)
-  const bool same_dense_layout = !w.has_value() && !in.is_contiguous() && in.strides().equals(tgt.strides()) &&
-      in.is_non_overlapping_and_dense() && tgt.is_non_overlapping_and_dense();
+  // A reduction is order-free, so when every operand shares one dense layout
+  // (e.g. all transposed the same way) the kernel reads the buffers in
+  // physical order: element pairs still line up and the linear vec4 loads
+  // run at contiguous speed with no materialization. A weight participates
+  // when it has that same layout too (a broadcast weight expands to stride-0
+  // dims and is excluded by the density check); mismatched or gappy layouts
+  // fall back to contiguous copies.
+  auto same_layout_dense = [&](const Tensor& t) {
+    return t.sizes().equals(in.sizes()) && t.strides().equals(in.strides()) && t.is_non_overlapping_and_dense();
+  };
+  const bool same_dense_layout = !in.is_contiguous() && in.is_non_overlapping_and_dense() && same_layout_dense(tgt) &&
+      (!w.has_value() || same_layout_dense(*w));
   if (!same_dense_layout) {
     in = in.contiguous();
     tgt = tgt.contiguous();
+    if (w.has_value()) {
+      w = w->contiguous();
+    }
   }
 
   TORCH_CHECK(in.numel() <= kMaxFusedLossNumel, "fused_loss_reduce: numel exceeds 32-bit kernel indexing");
@@ -187,12 +193,16 @@ static bool fused_loss_bwd_fast_path(const std::string& op,
                                      const Tensor& target,
                                      const Tensor& grad_output,
                                      const Tensor& grad_input,
-                                     double norm) {
+                                     double norm,
+                                     const std::optional<Tensor>& weight = std::nullopt) {
   const auto dt = input.scalar_type();
   if (!c10::isFloatingType(dt) || dt == kDouble) {
     return false;
   }
   if (target.scalar_type() != dt || grad_input.scalar_type() != dt || grad_output.scalar_type() != dt) {
+    return false;
+  }
+  if (weight.has_value() && weight->scalar_type() != dt) {
     return false;
   }
   const bool scalar_grad = grad_output.dim() == 0;
@@ -209,6 +219,9 @@ static bool fused_loss_bwd_fast_path(const std::string& op,
   if (!scalar_grad && !dense_like_input(grad_output)) {
     return false;
   }
+  if (weight.has_value() && !dense_like_input(*weight)) {
+    return false;
+  }
   if (input.numel() > kMaxFusedLossNumel) {
     return false;
   }
@@ -216,9 +229,11 @@ static bool fused_loss_bwd_fast_path(const std::string& op,
   FusedLossParams params{};
   params.numel = static_cast<uint32_t>(input.numel());
   params.flag = scalar_grad ? 1u : 0u;
+  params.has_weight = weight.has_value() ? 1u : 0u;
   params.p0 = static_cast<float>(norm);
   params.aligned = (input.storage_offset() % 4 == 0) && (target.storage_offset() % 4 == 0) &&
-      (grad_input.storage_offset() % 4 == 0) && (scalar_grad || grad_output.storage_offset() % 4 == 0);
+      (grad_input.storage_offset() % 4 == 0) && (scalar_grad || grad_output.storage_offset() % 4 == 0) &&
+      (!weight.has_value() || weight->storage_offset() % 4 == 0);
 
   const std::string name = fmt::format("fused_loss_bwd_{}_{}", op, scalarToMetalTypeString(input));
   MPSStream* stream = getCurrentMPSStream();
@@ -228,13 +243,82 @@ static bool fused_loss_bwd_fast_path(const std::string& op,
       auto pso = lib.getPipelineStateForFunc(name);
       getMPSProfiler().beginProfileKernel(pso, op + "_fused_bwd", {input, target, grad_output});
       [ce setComputePipelineState:pso];
-      mtl_setArgs(ce, input, target, grad_output, grad_input, params);
+      mtl_setArgs(ce, input, target, grad_output, grad_input, params, weight); // weight nulls buffer(5) when absent
       const uint32_t jobs = params.aligned ? (params.numel + 3u) / 4u : params.numel;
       mtl_dispatch1DJob(ce, pso, jobs);
       getMPSProfiler().endProfileKernel(pso);
     }
   });
   return true;
+}
+
+// Native BCE (forward None + backward) via standalone Metal kernels; mean/sum
+// forward reuses fused_loss_reduce. "loss" is grad_input on the backward pass.
+static Tensor& bce_loss_native(const Tensor& input,
+                               const Tensor& target,
+                               const std::optional<Tensor>& weight_opt,
+                               int64_t reduction,
+                               Tensor& loss,
+                               const std::optional<Tensor>& grad_output_opt,
+                               const std::string& op_name) {
+  TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes");
+  const bool is_bwd = grad_output_opt.has_value();
+  c10::MaybeOwned<Tensor> wmo = at::borrow_from_optional_tensor(weight_opt);
+  const Tensor& weight = *wmo;
+  loss.resize_((reduction == Reduction::None || is_bwd) ? target.sizes() : IntArrayRef({}));
+  TORCH_CHECK(loss.is_mps());
+  if (input.numel() == 0) {
+    if (!is_bwd && reduction != Reduction::None)
+      loss.fill_(reduction == Reduction::Mean ? std::numeric_limits<float>::quiet_NaN() : 0.0f);
+    return loss;
+  }
+
+  // Mean/Sum forward goes through the shared fused reduce (handles contiguity,
+  // promotion, weight expand, the physical-order dense walk for same-layout
+  // non-contiguous operands, and the numel mean-divide).
+  if (!is_bwd && reduction != Reduction::None) {
+    FusedLossParams params{};
+    params.reduction = static_cast<uint32_t>(reduction);
+    fused_loss_reduce("bce", input, target, weight_opt, loss, params);
+    return loss;
+  }
+
+  if (!is_bwd) {
+    // reduction=None forward through the shared iterator kernels: the ternary
+    // variant broadcasts the optional weight natively, so non-contiguous and
+    // broadcast operands need no materialization.
+    if (weight.defined()) {
+      ternary_op_kernel("bce_weighted", input, target, weight, loss, /*ilp_threshold=*/1u << 18);
+    } else {
+      binary_op_kernel("bce", input, target, loss, std::nullopt, /*ilp_threshold=*/1u << 18);
+    }
+    return loss;
+  }
+
+  // Backward: grad = (x_raw - y) / (clamp(x) * (1 - clamp(x))) * g * scale.
+  // Any weight folds into g_eff (one broadcast multiply, dtype-preserving);
+  // the mean scale rides the fast path's norm slot so the common unweighted
+  // mean case keeps its dtype and stays on fused_loss_bwd. The TensorIterator
+  // fallback gets the scale pre-folded into the grad instead.
+  const double scale = (reduction == Reduction::Mean) ? 1.0 / static_cast<double>(input.numel()) : 1.0;
+  std::optional<Tensor> w_opt;
+  if (weight.defined()) {
+    w_opt = weight.expand(input.sizes()).to(input.scalar_type());
+  }
+  if (fused_loss_bwd_fast_path("bce", input, target, *grad_output_opt, loss, /*norm=*/scale, w_opt)) {
+    return loss;
+  }
+  // Fallback: fold the weight and scale into the grad for the generic
+  // TensorIterator ternary.
+  Tensor g_eff = *grad_output_opt;
+  if (w_opt.has_value()) {
+    g_eff = g_eff.mul(*w_opt);
+  }
+  if (scale != 1.0) {
+    g_eff = g_eff.to(kFloat).mul(scale);
+  }
+  ternary_op_kernel("bce_backward_scaled", input, target, g_eff, loss, /*ilp_threshold=*/1u << 18);
+  return loss;
 }
 
 static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
@@ -291,178 +375,6 @@ static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
   ternary_op_kernel(kernel, input, target, grad, grad_input);
   return grad_input;
 }
-
-// namespace to localize the CachedGraph struct for Binary Cross Entropy
-namespace BCELoss {
-
-struct CachedGraph : public MPSCachedGraph {
-  CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-  MPSGraphTensor *inputTensor = nil, *targetTensor = nil;
-  // gradOutput only used on backward pass
-  MPSGraphTensor *weightTensor = nil, *gradOutputTensor = nil;
-  // lossTensor used for forward, and gradInputTensor for backward pass
-  union {
-    MPSGraphTensor* lossTensor = nil;
-    MPSGraphTensor* gradInputTensor;
-  };
-};
-
-static MPSGraphTensor* bce_forward_mps(CachedGraph* bceGraph) {
-  MPSGraph* mpsGraph = bceGraph->graph();
-  const auto inputType = [bceGraph->inputTensor dataType];
-
-  // Forward BCE: L = -w (y ln(x) + (1-y) ln(1-x))
-  MPSGraphTensor* one = [mpsGraph constantWithScalar:1.0 dataType:inputType];
-  // -100 is the hard limit value defined in BCELoss Spec. to clamp the log
-  MPSGraphTensor* neg100 = [mpsGraph constantWithScalar:-100.0 dataType:inputType];
-  // 1 - x
-  MPSGraphTensor* one_Input = [mpsGraph subtractionWithPrimaryTensor:one
-                                                     secondaryTensor:bceGraph->inputTensor
-                                                                name:nil];
-  // log(x)
-  MPSGraphTensor* logInput = [mpsGraph logarithmWithTensor:bceGraph->inputTensor name:nil];
-  // max(log(x), -100)
-  MPSGraphTensor* clampedLogInput = [mpsGraph maximumWithPrimaryTensor:logInput secondaryTensor:neg100 name:nil];
-  // log(1 - x)
-  MPSGraphTensor* log1_Input = [mpsGraph logarithmWithTensor:one_Input name:nil];
-  // max(log(1 - x), -100)
-  MPSGraphTensor* clampedLog1_Input = [mpsGraph maximumWithPrimaryTensor:log1_Input secondaryTensor:neg100 name:nil];
-  // (y - 1) resulted from -(1 - y)
-  MPSGraphTensor* target_1 = [mpsGraph subtractionWithPrimaryTensor:bceGraph->targetTensor
-                                                    secondaryTensor:one
-                                                               name:nil];
-  // (y - 1) * max(log(1 - x), -100)
-  MPSGraphTensor* target_1TimesLog1_Input = [mpsGraph multiplicationWithPrimaryTensor:target_1
-                                                                      secondaryTensor:clampedLog1_Input
-                                                                                 name:nil];
-  // y * max(log(x), -100)
-  MPSGraphTensor* targetTimesLogInput = [mpsGraph multiplicationWithPrimaryTensor:bceGraph->targetTensor
-                                                                  secondaryTensor:clampedLogInput
-                                                                             name:nil];
-  // ((y - 1) * max(log(1 - x), -100)) - (y * max(log(x), -100))
-  MPSGraphTensor* bceLoss = [mpsGraph subtractionWithPrimaryTensor:target_1TimesLog1_Input
-                                                   secondaryTensor:targetTimesLogInput
-                                                              name:nil];
-  return bceLoss;
-}
-
-static MPSGraphTensor* bce_backward_mps(CachedGraph* bceGraph) {
-  MPSGraph* mpsGraph = bceGraph->graph();
-  const auto inputType = [bceGraph->inputTensor dataType];
-
-  // Backward BCE: d(L)/d(x) = -w (y - x) / (x - x^2)
-  MPSGraphTensor* one = [mpsGraph constantWithScalar:1.0 dataType:inputType];
-  // epsilon used to clamp the grad input denominator
-  MPSGraphTensor* epsilon = [mpsGraph constantWithScalar:1e-12 dataType:inputType];
-  // 1 - x
-  MPSGraphTensor* one_Input = [mpsGraph subtractionWithPrimaryTensor:one
-                                                     secondaryTensor:bceGraph->inputTensor
-                                                                name:nil];
-  // x * (1 - x)
-  MPSGraphTensor* inputTimes1_Input = [mpsGraph multiplicationWithPrimaryTensor:bceGraph->inputTensor
-                                                                secondaryTensor:one_Input
-                                                                           name:nil];
-  // max(x * (1 - x), epsilon)
-  MPSGraphTensor* gradInputDenominator = [mpsGraph maximumWithPrimaryTensor:inputTimes1_Input
-                                                            secondaryTensor:epsilon
-                                                                       name:nil];
-  // (x - y)
-  MPSGraphTensor* input_target = [mpsGraph subtractionWithPrimaryTensor:bceGraph->inputTensor
-                                                        secondaryTensor:bceGraph->targetTensor
-                                                                   name:nil];
-  // (x - y) / max(x * (1 - x), epsilon)
-  MPSGraphTensor* inputDivGradInputDenom = [mpsGraph divisionWithPrimaryTensor:input_target
-                                                               secondaryTensor:gradInputDenominator
-                                                                          name:nil];
-  // gradOutput * (((x - y) / max(x * (1 - x), epsilon)))
-  MPSGraphTensor* gradInput = [mpsGraph multiplicationWithPrimaryTensor:bceGraph->gradOutputTensor
-                                                        secondaryTensor:inputDivGradInputDenom
-                                                                   name:nil];
-  return gradInput;
-}
-
-// Binary Cross Enropy (Forward/Backward BCELoss)
-// NOTE: "loss" tensor would be "grad_input" if it's a backward pass
-static Tensor& bce_loss_out_impl(const Tensor& input,
-                                 const Tensor& target,
-                                 const std::optional<Tensor>& weight_opt,
-                                 int64_t reduction,
-                                 Tensor& loss,
-                                 const std::optional<Tensor>& grad_output_opt,
-                                 const std::string& op_name) {
-  // TODO: add sanity check for the elements of input tensor to be within [0..1]
-  TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes")
-
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
-  c10::MaybeOwned<Tensor> grad_output_maybe_owned = at::borrow_from_optional_tensor(grad_output_opt);
-  const Tensor& weight = *weight_maybe_owned;
-  const Tensor& grad_output = *grad_output_maybe_owned;
-
-  loss.resize_((reduction == Reduction::None || grad_output.defined()) ? target.sizes() : IntArrayRef({}));
-  TORCH_CHECK(loss.is_mps());
-
-  @autoreleasepool {
-    std::string key = op_name + reductionToString(reduction) + getTensorsStringKey({input, target, weight});
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-
-      MPSGraphTensor* bceLossUnweighted = nil;
-      // if grad_output is defined, then it's a backward pass
-      if (grad_output.defined()) {
-        newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-        bceLossUnweighted = bce_backward_mps(newCachedGraph);
-      } else {
-        bceLossUnweighted = bce_forward_mps(newCachedGraph);
-      }
-
-      MPSGraphTensor* bceLoss = bceLossUnweighted;
-      if (weight.defined()) {
-        newCachedGraph->weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
-        bceLoss = [mpsGraph multiplicationWithPrimaryTensor:bceLossUnweighted
-                                            secondaryTensor:newCachedGraph->weightTensor
-                                                       name:nil];
-      }
-
-      if (grad_output.defined()) {
-        if (reduction == at::Reduction::Mean) {
-          MPSGraphTensor* inputNumel = [mpsGraph constantWithScalar:static_cast<double>(input.numel())
-                                                           dataType:[bceLoss dataType]];
-          newCachedGraph->gradInputTensor = [mpsGraph divisionWithPrimaryTensor:bceLoss
-                                                                secondaryTensor:inputNumel
-                                                                           name:nil];
-        } else {
-          newCachedGraph->gradInputTensor = bceLoss;
-        }
-      } else {
-        newCachedGraph->lossTensor = reduceTensor(bceLoss, reduction, mpsGraph, input.sizes().size());
-      }
-    });
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
-    Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
-    Placeholder lossPlaceholder = Placeholder(cachedGraph->lossTensor, loss);
-
-    NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
-
-    feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
-    feeds[targetPlaceholder.getMPSGraphTensor()] = targetPlaceholder.getMPSGraphTensorData();
-    if (weight.defined()) {
-      Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor, weight);
-      feeds[weightPlaceholder.getMPSGraphTensor()] = weightPlaceholder.getMPSGraphTensorData();
-    }
-    if (grad_output.defined()) {
-      Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor, grad_output);
-      feeds[gradOutputPlaceholder.getMPSGraphTensor()] = gradOutputPlaceholder.getMPSGraphTensorData();
-    }
-
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, lossPlaceholder);
-  }
-
-  return loss;
-}
-
-} // namespace BCELoss
 
 static inline MPSGraphTensor* divisionNoNaN(MPSGraph* mpsGraph, MPSGraphTensor* divident, MPSGraphTensor* divisor) {
   auto* div = [mpsGraph divisionWithPrimaryTensor:divident
@@ -1253,7 +1165,7 @@ Tensor& binary_cross_entropy_out_mps(const Tensor& input,
                                      const std::optional<Tensor>& weight_opt,
                                      int64_t reduction,
                                      Tensor& loss) {
-  return mps::BCELoss::bce_loss_out_impl(input, target, weight_opt, reduction, loss, std::nullopt, __func__);
+  return mps::bce_loss_native(input, target, weight_opt, reduction, loss, std::nullopt, __func__);
 }
 
 Tensor binary_cross_entropy_mps(const Tensor& input,
@@ -1261,7 +1173,7 @@ Tensor binary_cross_entropy_mps(const Tensor& input,
                                 const std::optional<Tensor>& weight_opt,
                                 int64_t reduction) {
   Tensor loss = at::empty_like(input);
-  return mps::BCELoss::bce_loss_out_impl(input, target, weight_opt, reduction, loss, std::nullopt, __func__);
+  return mps::bce_loss_native(input, target, weight_opt, reduction, loss, std::nullopt, __func__);
 }
 
 Tensor& binary_cross_entropy_backward_out_mps(const Tensor& grad_output,
@@ -1270,7 +1182,7 @@ Tensor& binary_cross_entropy_backward_out_mps(const Tensor& grad_output,
                                               const std::optional<Tensor>& weight_opt,
                                               int64_t reduction,
                                               Tensor& grad_input) {
-  return mps::BCELoss::bce_loss_out_impl(input, target, weight_opt, reduction, grad_input, grad_output, __func__);
+  return mps::bce_loss_native(input, target, weight_opt, reduction, grad_input, grad_output, __func__);
 }
 
 Tensor binary_cross_entropy_backward_mps(const Tensor& grad_output,
@@ -1279,7 +1191,7 @@ Tensor binary_cross_entropy_backward_mps(const Tensor& grad_output,
                                          const std::optional<Tensor>& weight_opt,
                                          int64_t reduction) {
   Tensor grad_input = at::empty_like(input);
-  return mps::BCELoss::bce_loss_out_impl(input, target, weight_opt, reduction, grad_input, grad_output, __func__);
+  return mps::bce_loss_native(input, target, weight_opt, reduction, grad_input, grad_output, __func__);
 }
 
 // SmoothL1Loss

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -1,8 +1,12 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <ATen/native/mps/kernels/ReduceOps.h>
+#include <ATen/native/mps/operations/BinaryKernel.h>
+#include <fmt/format.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -12,6 +16,8 @@
 #include <ATen/ops/_ctc_loss_native.h>
 #include <ATen/ops/binary_cross_entropy_backward_native.h>
 #include <ATen/ops/binary_cross_entropy_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
 #include <ATen/ops/full_like.h>
 #include <ATen/ops/huber_loss_backward_native.h>
 #include <ATen/ops/huber_loss_native.h>
@@ -21,6 +27,7 @@
 #include <ATen/ops/nll_loss2d_forward_native.h>
 #include <ATen/ops/nll_loss_backward_native.h>
 #include <ATen/ops/nll_loss_forward_native.h>
+#include <ATen/ops/result_type.h>
 #include <ATen/ops/smooth_l1_loss_backward_native.h>
 #include <ATen/ops/smooth_l1_loss_native.h>
 #include <ATen/ops/tensor.h>
@@ -31,9 +38,19 @@ namespace mps {
 
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
+static auto& reduce_lib = MetalShaderLibrary::getBundledLibrary();
 #else
+namespace loss_ops_metal {
 #include <ATen/native/mps/LossOps_metallib.h>
+} // namespace loss_ops_metal
+static auto& lib = loss_ops_metal::lib;
+namespace reduce_ops_metal {
+#include <ATen/native/mps/ReduceOps_metallib.h>
+} // namespace reduce_ops_metal
+static auto& reduce_lib = reduce_ops_metal::lib;
 #endif
+
+// Native Metal MSE loss path replaces the per-shape MPSGraph cache.
 
 static std::string reductionToString(int64_t reduction) {
   switch (reduction) {
@@ -65,6 +82,161 @@ static MPSGraphTensor* reduceTensor(MPSGraphTensor* tensor,
   }
 }
 
+// Generic two-stage fused pointwise-loss reduction (mean/sum) for mse/bce/
+// smooth_l1/huber: pass 1 emits float32 partials, pass 2 reuses sum_reduction.
+static constexpr uint32_t kFusedLossThreadsPerTG = 1024;
+// Bound below UINT32_MAX by one full grid's vec4 stride
+// (MAX_THREADGROUP_SIZE * kFusedLossThreadsPerTG * 4) so the kernels'
+// uint32 index math cannot wrap; larger inputs error out or fall back.
+static constexpr uint32_t kMaxFusedLossNumel =
+    std::numeric_limits<uint32_t>::max() - MAX_THREADGROUP_SIZE * kFusedLossThreadsPerTG * 4;
+
+static void fused_loss_reduce(const std::string& op,
+                              const Tensor& input,
+                              const Tensor& target,
+                              const std::optional<Tensor>& weight,
+                              const Tensor& output,
+                              FusedLossParams params) {
+  // Pass 1 reads input and target as one dtype; promote both (and any weight) to
+  // the result dtype so a mixed fp16/fp32 input/target pair is not misread.
+  const auto dt = output.scalar_type();
+  auto in = input.to(dt);
+  auto tgt = target.to(dt);
+  std::optional<Tensor> w;
+  if (weight.has_value() && weight->defined()) {
+    w = weight->expand(input.sizes()).to(dt).contiguous();
+  }
+
+  // A reduction is order-free, so when input and target share one dense
+  // layout (e.g. both transposed the same way) the kernel reads both buffers
+  // in physical order: element pairs still line up and the linear vec4 loads
+  // run at contiguous speed with no materialization. Mismatched or gappy
+  // layouts fall back to contiguous copies.
+  // (Weighted ops stay materialized: a physical-order walk would pair the
+  // contiguous weight against permuted input elements.)
+  const bool same_dense_layout = !w.has_value() && !in.is_contiguous() && in.strides().equals(tgt.strides()) &&
+      in.is_non_overlapping_and_dense() && tgt.is_non_overlapping_and_dense();
+  if (!same_dense_layout) {
+    in = in.contiguous();
+    tgt = tgt.contiguous();
+  }
+
+  TORCH_CHECK(in.numel() <= kMaxFusedLossNumel, "fused_loss_reduce: numel exceeds 32-bit kernel indexing");
+  const uint32_t numel = static_cast<uint32_t>(in.numel());
+  params.numel = numel;
+  params.has_weight = w.has_value() ? 1u : 0u;
+  // vec4 fast path is only valid when every operand's storage offset keeps the
+  // 16-byte alignment the reinterpret_cast<T4*> loads assume.
+  params.aligned = (in.storage_offset() % 4 == 0) && (tgt.storage_offset() % 4 == 0) &&
+      (!w.has_value() || w->storage_offset() % 4 == 0);
+
+  // Pass 2 reduces the partials in a single threadgroup, so cap the pool at the
+  // max threadgroup size.
+  uint32_t num_groups = (numel + kFusedLossThreadsPerTG - 1) / kFusedLossThreadsPerTG;
+  num_groups = std::clamp<uint32_t>(num_groups, 1u, MAX_THREADGROUP_SIZE);
+
+  Tensor partials = at::empty({static_cast<int64_t>(num_groups)}, in.options().dtype(kFloat));
+
+  // sum_reduction over the 1-D partials -> scalar output; p = numel folds the
+  // Mean divide in float32 (p = 0 for Sum leaves the accumulator untouched).
+  NormParams<> p2{};
+  p2.ndim = 1;
+  p2.reduction_size = num_groups;
+  p2.input_sizes[0] = num_groups;
+  p2.input_strides[0] = 1;
+  p2.output_sizes[0] = 1;
+  p2.output_strides[0] = 0;
+  p2.p = (params.reduction == Reduction::Mean) ? static_cast<float>(numel) : 0.0f;
+
+  const std::string p1name = fmt::format("fused_loss_pass1_{}_{}", op, scalarToMetalTypeString(in));
+  const std::string p2name = fmt::format("sum_reduction_float_{}", scalarToMetalTypeString(output));
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+
+      auto ps1 = lib.getPipelineStateForFunc(p1name);
+      getMPSProfiler().beginProfileKernel(ps1, op + "_fused_pass1", {in, tgt});
+      [ce setComputePipelineState:ps1];
+      mtl_setArgs(ce, in, tgt, w, partials, params); // w nulls buffer(2) when absent
+      [ce dispatchThreadgroups:MTLSizeMake(num_groups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(kFusedLossThreadsPerTG, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps1);
+
+      auto ps2 = reduce_lib.getPipelineStateForFunc(p2name);
+      getMPSProfiler().beginProfileKernel(ps2, "sum_reduction_pass2", {partials});
+      [ce setComputePipelineState:ps2];
+      mtl_setArgs(ce, partials, output, p2);
+      uint32_t tpg2 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, ((num_groups + 31u) / 32u) * 32u);
+      tpg2 = std::max<uint32_t>(tpg2, 32u);
+      [ce dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps2);
+    }
+  });
+}
+
+// Dense fast path for the fused elementwise loss backward: one vec4 kernel
+// computing Op::bwd over input/target/grad_output when everything shares one
+// dtype and one dense layout (a reduction-free elementwise map is layout-
+// agnostic when all operands, including the output, agree on strides).
+// Returns false when the combination needs the generic TensorIterator
+// ternary fallback.
+static bool fused_loss_bwd_fast_path(const std::string& op,
+                                     const Tensor& input,
+                                     const Tensor& target,
+                                     const Tensor& grad_output,
+                                     const Tensor& grad_input,
+                                     double norm) {
+  const auto dt = input.scalar_type();
+  if (!c10::isFloatingType(dt) || dt == kDouble) {
+    return false;
+  }
+  if (target.scalar_type() != dt || grad_input.scalar_type() != dt || grad_output.scalar_type() != dt) {
+    return false;
+  }
+  const bool scalar_grad = grad_output.dim() == 0;
+  // Sizes must match too: a same-strides but smaller grad_input (possible
+  // when the op is called directly rather than via autograd) would otherwise
+  // pass the stride check and the kernel would write numel elements out of
+  // bounds.
+  auto dense_like_input = [&](const Tensor& t) {
+    return t.is_non_overlapping_and_dense() && t.sizes().equals(input.sizes()) && t.strides().equals(input.strides());
+  };
+  if (!input.is_non_overlapping_and_dense() || !dense_like_input(target) || !dense_like_input(grad_input)) {
+    return false;
+  }
+  if (!scalar_grad && !dense_like_input(grad_output)) {
+    return false;
+  }
+  if (input.numel() > kMaxFusedLossNumel) {
+    return false;
+  }
+
+  FusedLossParams params{};
+  params.numel = static_cast<uint32_t>(input.numel());
+  params.flag = scalar_grad ? 1u : 0u;
+  params.p0 = static_cast<float>(norm);
+  params.aligned = (input.storage_offset() % 4 == 0) && (target.storage_offset() % 4 == 0) &&
+      (grad_input.storage_offset() % 4 == 0) && (scalar_grad || grad_output.storage_offset() % 4 == 0);
+
+  const std::string name = fmt::format("fused_loss_bwd_{}_{}", op, scalarToMetalTypeString(input));
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(name);
+      getMPSProfiler().beginProfileKernel(pso, op + "_fused_bwd", {input, target, grad_output});
+      [ce setComputePipelineState:pso];
+      mtl_setArgs(ce, input, target, grad_output, grad_input, params);
+      const uint32_t jobs = params.aligned ? (params.numel + 3u) / 4u : params.numel;
+      mtl_dispatch1DJob(ce, pso, jobs);
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+  return true;
+}
+
 static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
                                           const Tensor& input,
                                           const Tensor& target,
@@ -74,44 +246,49 @@ static Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
   TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes")
   auto norm = reduction == Reduction::Mean ? 2. / static_cast<double>(input.numel()) : 2.;
 
+  // Empty input: gradient norm is 2/numel for mean (-> NaN as 2/0), else 0.
   if ((input.numel() == 0) || (target.numel() == 0) || (grad_output.numel() == 0)) {
     reduction == Reduction::Mean ? grad_input.fill_(std::numeric_limits<float>::quiet_NaN()) : grad_input.zero_();
     return grad_input;
   }
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor *inputTensor = nil, *targetTensor = nil;
-    MPSGraphTensor *gradInputTensor = nil, *gradOutputTensor = nil;
-  };
 
-  @autoreleasepool {
-    std::string key = op_name + reductionToString(reduction) + ":" + std::to_string(grad_input.sizes()[1]) +
-        getTensorsStringKey({input, target, grad_output});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-      newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-      MPSGraphTensor* normTensor = [mpsGraph constantWithScalar:norm dataType:[newCachedGraph->inputTensor dataType]];
-      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                          secondaryTensor:newCachedGraph->targetTensor
-                                                                     name:nil];
-      MPSGraphTensor* diffGradientTensor = [mpsGraph multiplicationWithPrimaryTensor:diffTensor
-                                                                     secondaryTensor:newCachedGraph->gradOutputTensor
-                                                                                name:nil];
-      newCachedGraph->gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:diffGradientTensor
-                                                                  secondaryTensor:normTensor
-                                                                             name:nil];
-    });
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
-    Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor, grad_input);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor, grad_output);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder, targetPlaceholder, gradOutputPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, gradInputPlaceholder);
+  // grad_input = norm * (input - target) * grad_output in ONE fused pass (no
+  // MPSGraph, no materialized intermediate). For mean, match the CPU
+  // kernel's rounding: norm (2/N) is narrowed to the compute dtype
+  // (value.to<scalar_t>()) before it is applied -- for fp16 that rounding is
+  // visible in the gradients, and 2/N can flush to zero for huge N exactly
+  // as it does on CPU.
+  if (reduction == Reduction::Mean) {
+    const auto common = at::promoteTypes(at::result_type(input, target), grad_output.scalar_type());
+    if (common == kHalf) {
+      norm = static_cast<double>(static_cast<c10::Half>(norm));
+    } else if (common == kBFloat16) {
+      norm = static_cast<double>(static_cast<c10::BFloat16>(norm));
+    } else if (common == kFloat) {
+      norm = static_cast<double>(static_cast<float>(norm));
+    }
   }
 
+  if (fused_loss_bwd_fast_path("mse", input, target, grad_output, grad_input, norm)) {
+    return grad_input;
+  }
+
+  // Generic fallback: the TensorIterator ternary handles mixed dtypes (with
+  // a half input and a float target the subtract runs in the promoted
+  // float, fixing the mixed-dtype case the parent MPSGraph path hard-crashed
+  // on), broadcast scalar grads, and mismatched layouts. norm is exactly 2
+  // for reduction none/sum, baked into mse_backward2; for mean the 0-dim
+  // grad_output is pre-scaled by the narrowed norm in float (in the
+  // gradient's own dtype 2/N can underflow fp16/bf16; non-inplace because
+  // .to(kFloat) is a no-op for a float grad_output and mul_ would mutate the
+  // caller's tensor).
+  Tensor grad = grad_output;
+  std::string kernel = "mse_backward2";
+  if (reduction == Reduction::Mean) {
+    grad = grad_output.to(kFloat).mul(norm);
+    kernel = "mse_backward_scaled";
+  }
+  ternary_op_kernel(kernel, input, target, grad, grad_input);
   return grad_input;
 }
 
@@ -1021,55 +1198,40 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
   return grad_input;
 }
 
-// MSELoss
+// MSELoss: reduction=None uses the `mse` binary kernel; mean/sum use the fused
+// float32 GPU reduction (no MPSGraph -> no per-shape graph cache).
 TORCH_IMPL_FUNC(mse_loss_out_mps)(const Tensor& input, const Tensor& target, int64_t reduction, const Tensor& output_) {
   std::string op_name = "mse_loss_out_mps";
   using namespace mps;
+  // Empty input: mean is NaN (0/0), sum and none are 0. Matches CPU/CUDA.
   if ((input.numel() == 0) || (target.numel() == 0)) {
     reduction == Reduction::Mean ? output_.fill_(std::numeric_limits<float>::quiet_NaN()) : output_.zero_();
     return;
-  }
-  bool contiguousOutput = !needsGather(output_);
-  Tensor output = output_;
-  if (!contiguousOutput) {
-    output = output_.contiguous();
   }
 
   TORCH_CHECK(target.is_same_size(input), op_name + ": target and input tensors must have identical shapes");
   TORCH_CHECK(c10::isFloatingType(input.scalar_type()) && c10::isFloatingType(target.scalar_type()),
               op_name + ": only defined for floating types");
-  TORCH_CHECK(output.is_mps());
+  TORCH_CHECK(output_.is_mps());
 
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor = nil;
-    MPSGraphTensor* targetTensor = nil;
-    MPSGraphTensor* outputTensor = nil;
-  };
-
-  @autoreleasepool {
-    std::string key = op_name + reductionToString(reduction) + getTensorsStringKey({input, target});
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-
-      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                          secondaryTensor:newCachedGraph->targetTensor
-                                                                     name:nil];
-      MPSGraphTensor* diffSquareTensor = [mpsGraph squareWithTensor:diffTensor name:nil];
-      newCachedGraph->outputTensor = reduceTensor(diffSquareTensor, reduction, mpsGraph, input.sizes().size());
-    });
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
-    Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, contiguousOutput ? output_ : output);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder, targetPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+  if (reduction == Reduction::None) {
+    // (input - target)^2 written straight to the (possibly non-contiguous)
+    // structured output. exec_binary_kernel handles strided/broadcast inputs.
+    binary_op_kernel("mse", input, target, output_);
+    return;
   }
 
-  if (!contiguousOutput) {
-    output_.copy_(output);
-  }
+  // Mean/Sum: fused square-and-reduce in a single GPU pass (no materialized
+  // squared-difference temp). fused_loss_reduce promotes both operands to the
+  // output dtype, the kernel computes (input - target)^2 in float32,
+  // threadgroup-reduces, and (for mean) divides by numel in float32 before
+  // casting to the output dtype.
+  // This matches the fused MPSGraph square+reduce that the materialize-then-
+  // at::sum path regressed against, and keeps the float32 accumulation so
+  // large-N fp16/bf16 does not overflow. output_ is a scalar tensor.
+  FusedLossParams params{};
+  params.reduction = static_cast<uint32_t>(reduction);
+  fused_loss_reduce("mse", input, target, std::nullopt, output_, params);
 }
 
 Tensor& mse_loss_backward_out_mps(const Tensor& grad_output,

--- a/benchmarks/mps/bench_bce_loss.py
+++ b/benchmarks/mps/bench_bce_loss.py
@@ -1,0 +1,142 @@
+"""binary_cross_entropy: native Metal kernel timing.
+
+Same methodology as bench_mse_loss.py: run this script on the PR parent for
+the MPSGraph baseline and on this checkout for the native kernels; the PR body
+carries the comparison. Timer.blocked_autorange over an amortized inner loop
+(100 calls per device sync), 5 repeats after warmup, mean microseconds per
+call. Covers all three reductions, forward and forward+backward, contiguous
+and non-contiguous layouts, and the unweighted/weighted paths.
+"""
+
+import argparse
+import json
+import os
+import statistics
+
+import torch
+import torch.nn.functional as F
+from torch.utils.benchmark import Timer
+
+
+DTYPES = {"f32": torch.float32, "f16": torch.float16, "bf16": torch.bfloat16}
+SHAPES = [
+    ("8x2048x4096", (8, 2048, 4096)),
+    ("1024x1024", (1024, 1024)),
+    ("4x65536", (4, 65536)),
+    ("65536x128", (65536, 128)),
+    ("256x1024", (256, 1024)),
+]
+INNER_ITERS = int(os.environ.get("INNER_ITERS", "100"))
+WARMUP_BLOCKS = int(os.environ.get("WARMUP_BLOCKS", "30"))
+REPEATS = int(os.environ.get("REPEATS", "5"))
+MIN_RUN_TIME = float(os.environ.get("MIN_RUN_TIME", "0.2"))
+
+
+def synchronize(device):
+    if device.type == "mps":
+        torch.mps.synchronize()
+    elif device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def bench(
+    device,
+    shape,
+    dt,
+    reduction,
+    layout,
+    weighted,
+    backward,
+    inner_iters,
+    warmup_blocks,
+    repeats,
+    min_run_time,
+):
+    x = torch.rand(shape, device=device, dtype=dt).clamp(0.01, 0.99)
+    t = torch.rand(shape, device=device, dtype=dt)
+    w = torch.rand(shape, device=device, dtype=dt) + 0.1 if weighted else None
+    if layout == "noncontig" and x.dim() >= 2:
+        # Transposed views sharing one dense layout (weight included, the
+        # pipeline-consistent case): mean/sum and the fused backward take the
+        # physical-order dense paths; reduction=none takes strided iterators.
+        x = x.transpose(-1, -2).contiguous().transpose(-1, -2)
+        t = t.transpose(-1, -2).contiguous().transpose(-1, -2)
+        if w is not None:
+            w = w.transpose(-1, -2).contiguous().transpose(-1, -2)
+    x.requires_grad_(backward)
+    g = torch.ones(shape, device=device, dtype=dt) if reduction == "none" else None
+
+    def run_block():
+        for _ in range(inner_iters):
+            loss = F.binary_cross_entropy(x, t, weight=w, reduction=reduction)
+            if backward:
+                x.grad = None
+                loss.backward(g)
+        synchronize(device)
+
+    for _ in range(warmup_blocks):
+        run_block()
+    synchronize(device)
+
+    timer = Timer(stmt="run_block()", globals={"run_block": run_block})
+    samples_us = [
+        timer.blocked_autorange(min_run_time=min_run_time).mean * 1e6 / inner_iters
+        for _ in range(repeats)
+    ]
+    return {
+        "mean_us": round(statistics.mean(samples_us), 1),
+        "stdev_us": (
+            round(statistics.stdev(samples_us), 1) if len(samples_us) > 1 else 0.0
+        ),
+        "samples_us": [round(v, 1) for v in samples_us],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="mps")
+    parser.add_argument("--inner-iters", type=int, default=INNER_ITERS)
+    parser.add_argument("--warmup-blocks", type=int, default=WARMUP_BLOCKS)
+    parser.add_argument("--repeats", type=int, default=REPEATS)
+    parser.add_argument("--min-run-time", type=float, default=MIN_RUN_TIME)
+    args = parser.parse_args()
+    device = torch.device(args.device)
+
+    out = {
+        "metadata": {
+            "device": str(device),
+            "inner_iters": args.inner_iters,
+            "warmup_blocks": args.warmup_blocks,
+            "repeats": args.repeats,
+            "min_run_time_s": args.min_run_time,
+            "method": "Timer.blocked_autorange mean of repeated amortized blocks",
+        },
+        "results": {},
+    }
+    for nm, sh in SHAPES:
+        for dn, dt in DTYPES.items():
+            for red in ("none", "mean", "sum"):
+                for layout in ("contig", "noncontig"):
+                    if layout == "noncontig" and len(sh) < 2:
+                        continue
+                    for weighted in (False, True):
+                        for mode in ("fwd", "fwd+bwd"):
+                            key = f"{nm}|{dn}|{red}|{layout}|{'w' if weighted else 'nw'}|{mode}"
+                            out["results"][key] = bench(
+                                device,
+                                sh,
+                                dt,
+                                red,
+                                layout,
+                                weighted,
+                                mode == "fwd+bwd",
+                                args.inner_iters,
+                                args.warmup_blocks,
+                                args.repeats,
+                                args.min_run_time,
+                            )
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mps/bench_mse_loss.py
+++ b/benchmarks/mps/bench_mse_loss.py
@@ -1,0 +1,145 @@
+"""mse_loss: fused square-and-reduce kernel timing.
+
+Measures F.mse_loss on the current build. The fused kernel computes (a-b)^2 and
+reduces in one pass (no materialized squared-diff tensor). For the A/B vs the
+MPSGraph path, run this on a parent (pre-migration) checkout for the baseline and
+on this checkout for the fused kernel; the PR body carries that comparison.
+Methodology: torch.utils.benchmark.Timer.blocked_autorange over an amortized
+inner loop (default: 100 mse calls followed by one device sync), repeated 5
+times after warmup. The reported value is mean microseconds per mse call.
+
+Defaults to the MPS device (this kernel's target) but takes --device, so the
+same script profiles CUDA/CPU too. Covers contiguous and non-contiguous inputs,
+all three reductions, and forward as well as forward+backward (the backward
+path is migrated too: scalar broadcast grad_output for mean/sum, full-size
+grad_output for none).
+"""
+
+import argparse
+import json
+import os
+import statistics
+
+import torch
+import torch.nn.functional as F
+from torch.utils.benchmark import Timer
+
+
+DTYPES = {"f32": torch.float32, "f16": torch.float16, "bf16": torch.bfloat16}
+SHAPES = [
+    ("8x2048x4096", (8, 2048, 4096)),
+    ("1024x1024", (1024, 1024)),
+    ("4x65536", (4, 65536)),
+    ("65536x128", (65536, 128)),
+    ("256x1024", (256, 1024)),
+]
+INNER_ITERS = int(os.environ.get("INNER_ITERS", "100"))
+WARMUP_BLOCKS = int(os.environ.get("WARMUP_BLOCKS", "30"))
+REPEATS = int(os.environ.get("REPEATS", "5"))
+MIN_RUN_TIME = float(os.environ.get("MIN_RUN_TIME", "0.2"))
+
+
+def synchronize(device):
+    if device.type == "mps":
+        torch.mps.synchronize()
+    elif device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def bench(
+    device,
+    shape,
+    dt,
+    reduction,
+    layout,
+    backward,
+    inner_iters,
+    warmup_blocks,
+    repeats,
+    min_run_time,
+):
+    x = torch.randn(shape, device=device, dtype=dt)
+    t = torch.randn(shape, device=device, dtype=dt)
+    if layout == "noncontig" and x.dim() >= 2:
+        # Transposed views sharing one dense layout: mean/sum reductions take
+        # the physical-order dense walk (no materialization); reduction=none
+        # and the backward take the strided binary/ternary iterator paths.
+        x = x.transpose(-1, -2).contiguous().transpose(-1, -2)
+        t = t.transpose(-1, -2).contiguous().transpose(-1, -2)
+    x.requires_grad_(backward)
+    # Non-scalar loss (reduction="none") needs an explicit grad_output; a
+    # full-size ones tensor also exercises the elementwise backward, while the
+    # scalar mean/sum backward covers the broadcast (stride-0) grad_output.
+    g = torch.ones(shape, device=device, dtype=dt) if reduction == "none" else None
+
+    def run_block():
+        for _ in range(inner_iters):
+            loss = F.mse_loss(x, t, reduction=reduction)
+            if backward:
+                x.grad = None
+                loss.backward(g)
+        synchronize(device)
+
+    for _ in range(warmup_blocks):
+        run_block()
+    synchronize(device)
+
+    timer = Timer(stmt="run_block()", globals={"run_block": run_block})
+    samples_us = [
+        timer.blocked_autorange(min_run_time=min_run_time).mean * 1e6 / inner_iters
+        for _ in range(repeats)
+    ]
+    return {
+        "mean_us": round(statistics.mean(samples_us), 1),
+        "stdev_us": (
+            round(statistics.stdev(samples_us), 1) if len(samples_us) > 1 else 0.0
+        ),
+        "samples_us": [round(v, 1) for v in samples_us],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="mps")
+    parser.add_argument("--inner-iters", type=int, default=INNER_ITERS)
+    parser.add_argument("--warmup-blocks", type=int, default=WARMUP_BLOCKS)
+    parser.add_argument("--repeats", type=int, default=REPEATS)
+    parser.add_argument("--min-run-time", type=float, default=MIN_RUN_TIME)
+    args = parser.parse_args()
+    device = torch.device(args.device)
+
+    out = {
+        "metadata": {
+            "device": str(device),
+            "inner_iters": args.inner_iters,
+            "warmup_blocks": args.warmup_blocks,
+            "repeats": args.repeats,
+            "min_run_time_s": args.min_run_time,
+            "method": "Timer.blocked_autorange mean of repeated amortized blocks",
+        },
+        "results": {},
+    }
+    for nm, sh in SHAPES:
+        for dn, dt in DTYPES.items():
+            for red in ("none", "mean", "sum"):
+                for layout in ("contig", "noncontig"):
+                    if layout == "noncontig" and len(sh) < 2:
+                        continue
+                    for mode in ("fwd", "fwd+bwd"):
+                        out["results"][f"{nm}|{dn}|{red}|{layout}|{mode}"] = bench(
+                            device,
+                            sh,
+                            dt,
+                            red,
+                            layout,
+                            mode == "fwd+bwd",
+                            args.inner_iters,
+                            args.warmup_blocks,
+                            args.repeats,
+                            args.min_run_time,
+                        )
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -1480,6 +1480,43 @@ kernel void ternary_dense(
       f(om_t(input[tid]), om_t(other1[tid]), om_t(other2[tid])));
 }
 
+// ILP variant of ternary_dense; mirrors binary_dense_ilp. Selected by the
+// host only when the caller opts in via ilp_threshold (see
+// exec_ternary_kernel).
+template <typename T, typename F, typename om_t = T>
+kernel void ternary_dense_ilp(
+    device result_of<F, T, T, T>* out [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* other1 [[buffer(2)]],
+    constant T* other2 [[buffer(3)]],
+    constant uint& numel [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  uint base = tid * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= numel) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<T, ILP_PER_THREAD> tc;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ta[j] = input[base + j];
+      tb[j] = other1[base + j];
+      tc[j] = other2[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] =
+          static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+  } else {
+    for (uint i = base; i < numel; ++i) {
+      out[i] = static_cast<res_t>(
+          f(om_t(input[i]), om_t(other1[i]), om_t(other2[i])));
+    }
+  }
+}
+
 template <typename T, typename F, typename om_t = T>
 kernel void ternary_dense_cast(
     device result_of<F, T, T, T>* out [[buffer(0)]],
@@ -1506,6 +1543,17 @@ kernel void ternary_dense_cast(
           DTYPEO,                                                              \
           ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI>>,    \
       "Output dtype mismatch for ternary op " #NAME " and input " #DTYPEI);    \
+  template                                                                     \
+      [[host_name(#NAME "_dense_ilp_" #DTYPEO "_" #DTYPEI)]] kernel void ::    \
+          c10::metal::ternary_dense_ilp<DTYPEI, NAME##_functor, OMT>(          \
+              device ::c10::metal::                                            \
+                      result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI> *      \
+                  out,                                                         \
+              constant DTYPEI * input,                                         \
+              constant DTYPEI * other1,                                        \
+              constant DTYPEI * other2,                                        \
+              constant uint & numel,                                           \
+              uint tid);                                                       \
   template [[host_name(#NAME "_strided_" #DTYPEO "_" #DTYPEI)]] kernel void :: \
       c10::metal::ternary_strided<DTYPEI, NAME##_functor, OMT>(                \
           device void* out,                                                    \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5053,6 +5053,97 @@ class TestMPS(TestCaseMPS):
             torch.ones((), dtype=torch.float32), xg.cpu(), tg.cpu(), 2, grad_input=gig_ref)
         self.assertEqual(gig.cpu(), gig_ref, atol=5e-2, rtol=5e-2)
 
+    def test_bce_loss_metal_paths(self):
+        # Committed coverage for the native Metal binary_cross_entropy
+        # kernels: reductions x {f32,f16,bf16} x {contig,noncontig} x
+        # {unweighted, matched weight, broadcast weight} fwd+bwd vs fp32 CPU,
+        # a large shape reaching the multi-threadgroup fused reduce, and a
+        # misaligned (slice-view) case reaching the forced-copy path.
+        def run(shape, reduction, dtype, weight_kind=None, noncontig=False):
+            x0 = torch.rand(shape, dtype=torch.float32).clamp(0.01, 0.99)
+            t0 = torch.rand(shape, dtype=torch.float32)
+            wc = None
+            if weight_kind == "full":
+                wc = torch.rand(shape, dtype=torch.float32) + 0.1
+            elif weight_kind == "broadcast":
+                wc = torch.rand(shape[-1], dtype=torch.float32) + 0.1
+            xm = x0.to("mps", dtype)
+            tm = t0.to("mps", dtype)
+            wm = wc.to("mps", dtype) if wc is not None else None
+            # BCE's 1/(x*(1-x)) gradient amplifies input quantization, so the
+            # fp32 CPU reference must see the same low-precision-rounded values.
+            xc = xm.detach().cpu().float().requires_grad_()
+            tc = tm.detach().cpu().float()
+            wc = wm.cpu().float() if wm is not None else None
+            if noncontig:
+                xm = xm.t().contiguous().t()
+                tm = tm.t().contiguous().t()
+                self.assertFalse(xm.is_contiguous())
+            xm.requires_grad_()
+            tol = dict(atol=5e-2, rtol=5e-2) if dtype != torch.float32 else dict(atol=1e-4, rtol=1e-4)
+            oc = F.binary_cross_entropy(xc, tc, weight=wc, reduction=reduction)
+            om = F.binary_cross_entropy(xm, tm, weight=wm, reduction=reduction)
+            self.assertEqual(om.float(), oc, **tol)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps", dtype))
+            self.assertEqual(xm.grad.float(), xc.grad, **tol)
+
+        for reduction in ("none", "mean", "sum"):
+            for dtype in (torch.float32, torch.float16):
+                for weight_kind in (None, "full", "broadcast"):
+                    run((64, 33), reduction, dtype, weight_kind)
+            run((64, 33), reduction, torch.bfloat16)
+            # contiguous weight against transposed inputs: mismatched layouts
+            # must take the materialize/fallback paths
+            run((64, 33), reduction, torch.float32, "full", noncontig=True)
+        run((2048, 2048), "mean", torch.float32)  # multi-threadgroup fused reduce
+        run((2048, 2048), "sum", torch.float32, "full")
+        # f16 large-shape uses mean: a 4M-element sum of O(1) losses overflows
+        # the f16 output range on any backend.
+        run((2048, 2048), "mean", torch.float16, "full")
+
+        # All operands (weight included) sharing one transposed dense layout:
+        # the dense walk and the weighted fused backward fast path.
+        xw = torch.rand(33, 64, device="mps").clamp(0.01, 0.99).t()
+        tw = torch.rand(33, 64, device="mps").t()
+        ww = (torch.rand(33, 64, device="mps") + 0.1).t()
+        xw.requires_grad_()
+        xw_c = xw.detach().cpu().requires_grad_()
+        for reduction in ("none", "mean", "sum"):
+            oc = F.binary_cross_entropy(xw_c, tw.cpu(), weight=ww.cpu(), reduction=reduction)
+            om = F.binary_cross_entropy(xw, tw, weight=ww, reduction=reduction)
+            self.assertEqual(om.cpu(), oc, atol=1e-4, rtol=1e-4)
+            g = torch.ones_like(oc)
+            if xw_c.grad is not None:
+                xw_c.grad = None
+                xw.grad = None
+            oc.backward(g)
+            om.backward(g.to("mps"))
+            self.assertEqual(xw.grad.cpu(), xw_c.grad, atol=1e-4, rtol=1e-4)
+
+        # Misaligned storage offsets (slice views) must take the forced-copy
+        # path in front of the vec4 kernels and still match CPU.
+        base_x = torch.rand(64 * 33 + 1).clamp(0.01, 0.99)
+        base_t = torch.rand(64 * 33 + 1)
+        xo_c = base_x[1:].view(64, 33).requires_grad_()
+        to_c = base_t[1:].view(64, 33)
+        xo = base_x.to("mps")[1:].view(64, 33).requires_grad_()
+        to = base_t.to("mps")[1:].view(64, 33)
+        self.assertNotEqual(xo.storage_offset() % 4, 0)
+        for reduction in ("none", "mean", "sum"):
+            oc = F.binary_cross_entropy(xo_c, to_c, reduction=reduction)
+            om = F.binary_cross_entropy(xo, to, reduction=reduction)
+            self.assertEqual(om.cpu(), oc, atol=1e-4, rtol=1e-4)
+        # out= variant with reduction="none" (matched shape; the legacy CPU
+        # path keeps an EMPTY out empty rather than resizing, so the empty
+        # case is intentionally not compared here).
+        le = torch.empty(64, 33, device="mps")
+        le_ref = torch.empty(64, 33)
+        torch.ops.aten.binary_cross_entropy.out(xo_c.detach(), to_c, None, 0, out=le_ref)
+        torch.ops.aten.binary_cross_entropy.out(xo.detach(), to, None, 0, out=le)
+        self.assertEqual(le.cpu(), le_ref, atol=1e-4, rtol=1e-4)
+
     def test_mse_loss(self):
         def helper(shape, reduction):
             # create the criterion
@@ -5154,6 +5245,23 @@ class TestMPS(TestCaseMPS):
         helper([7, 5, 2, 4, 6], 'sum')
         helper([8, 4, 5, 7, 6], 'mean')
         helper([1, 1, 32, 32], 'mean')
+
+    def test_bce_loss_endpoints(self):
+        # CPU clamps each log term at -100 (loss 100 at x=0,y=1), and the
+        # backward clamps the denominator at EPSILON=1e-12 (grad ~ -1e12).
+        # The Metal kernels must match exactly, not via an input-side clamp.
+        for reduction in ('none', 'mean', 'sum'):
+            x = torch.tensor([0.0, 1.0, 0.0, 1.0, 0.5], requires_grad=True)
+            y = torch.tensor([1.0, 0.0, 0.0, 1.0, 0.5])
+            xm = x.detach().to('mps').requires_grad_()
+            ym = y.to('mps')
+            loss_cpu = F.binary_cross_entropy(x, y, reduction=reduction)
+            loss_mps = F.binary_cross_entropy(xm, ym, reduction=reduction)
+            self.assertEqual(loss_mps.cpu(), loss_cpu)
+            if reduction != 'none':
+                loss_cpu.backward()
+                loss_mps.backward()
+                self.assertEqual(xm.grad.cpu(), x.grad)
 
     def test_bce_loss_always_nonnegative(self):
         target = torch.ones(5, device='mps')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4909,6 +4909,150 @@ class TestMPS(TestCaseMPS):
         helper([8, 4, 5, 7, 6], 'mean')
 
     # Mean Squared Error
+    def test_mse_loss_metal_paths(self):
+        # Committed coverage for the native Metal mse_loss kernels: all
+        # reductions x {f32,f16,bf16} fwd+bwd vs fp32 CPU, plus a large shape
+        # that reaches fused_loss_pass1 plus the shared sum_reduction pass-2
+        # path (OpInfo samples are too small to reach it), plus non-contiguous
+        # operands that reach the strided pass-1 loads and the strided fused
+        # ternary backward.
+        def run(shape, reduction, dtype, noncontig=False):
+            xc = torch.randn(shape, dtype=torch.float32, requires_grad=True)
+            tc = torch.randn(shape, dtype=torch.float32)
+            xm = xc.detach().to("mps", dtype)
+            tm = tc.detach().to("mps", dtype)
+            if noncontig:
+                # Same logical values through a transposed (non-contiguous) view.
+                xm = xm.t().contiguous().t()
+                tm = tm.t().contiguous().t()
+                self.assertFalse(xm.is_contiguous())
+            xm.requires_grad_()
+            tol = dict(atol=5e-2, rtol=5e-2) if dtype != torch.float32 else {}
+            oc = F.mse_loss(xc, tc, reduction=reduction)
+            om = F.mse_loss(xm, tm, reduction=reduction)
+            self.assertEqual(om.float(), oc, **tol)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps", dtype))
+            self.assertEqual(xm.grad.float(), xc.grad, **tol)
+
+        for reduction in ("none", "mean", "sum"):
+            for dtype in (torch.float32, torch.float16, torch.bfloat16):
+                run((64, 33), reduction, dtype)
+                run((64, 33), reduction, dtype, noncontig=True)
+        run((4096, 4096), "mean", torch.float32)  # large -> multi-threadgroup reduce
+        run((4096, 4096), "sum", torch.float32)
+        run((4096, 4096), "mean", torch.float16)  # large reduce, fp32 accumulation
+        run((4096, 4096), "mean", torch.float32, noncontig=True)  # large strided reduce
+        run((4096, 4096), "sum", torch.bfloat16, noncontig=True)
+
+        # Mixed input/target dtypes: the parent MPSGraph backward hard-crashed
+        # here; the fused-loss fallback computes in the promoted dtype.
+        def run_mixed(reduction):
+            xc = torch.randn(64, 33, dtype=torch.float32, requires_grad=True)
+            tc = torch.randn(64, 33, dtype=torch.float32)
+            xm = xc.detach().to("mps", torch.float16).requires_grad_()
+            tm = tc.detach().to("mps")
+            oc = F.mse_loss(xc, tc, reduction=reduction)
+            om = F.mse_loss(xm, tm.float(), reduction=reduction)
+            self.assertEqual(om.float(), oc, atol=5e-2, rtol=5e-2)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps"))
+            self.assertEqual(xm.grad.float(), xc.grad, atol=5e-2, rtol=5e-2)
+
+        for reduction in ("none", "mean", "sum"):
+            run_mixed(reduction)
+
+        # Out-variant with a grad_input dtype differing from same-dtype
+        # inputs: exercises the ternary fallback's cast-kernel selection by
+        # output dtype (matching CPU's cast_common_dtype_to_outputs support).
+        for reduction_val in (0, 1, 2):  # none, mean, sum
+            xh = torch.randn(64, 33, device="mps", dtype=torch.float16)
+            th = torch.randn(64, 33, device="mps", dtype=torch.float16)
+            gh = torch.ones((), device="mps", dtype=torch.float16) if reduction_val else \
+                torch.ones(64, 33, device="mps", dtype=torch.float16)
+            gi = torch.empty(64, 33, device="mps", dtype=torch.float32)
+            torch.ops.aten.mse_loss_backward.grad_input(gh, xh, th, reduction_val, grad_input=gi)
+            gi_cpu = torch.empty(64, 33, dtype=torch.float32)
+            torch.ops.aten.mse_loss_backward.grad_input(
+                gh.cpu(), xh.cpu(), th.cpu(), reduction_val, grad_input=gi_cpu)
+            self.assertEqual(gi.cpu(), gi_cpu, atol=5e-2, rtol=5e-2)
+
+        # An un-castable (integral) grad_input raises CPU's clean cast error,
+        # not a Metal pipeline-creation failure.
+        gi_int = torch.empty(64, 33, device="mps", dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "can't be cast"):
+            torch.ops.aten.mse_loss_backward.grad_input(
+                torch.ones((), device="mps", dtype=torch.float16),
+                torch.randn(64, 33, device="mps", dtype=torch.float16),
+                torch.randn(64, 33, device="mps", dtype=torch.float16),
+                1, grad_input=gi_int)
+
+        # An empty out tensor is resized and filled (CPU out= semantics),
+        # not silently left empty.
+        xe = torch.randn(64, 33, device="mps")
+        te = torch.randn(64, 33, device="mps")
+        gi_empty = torch.empty(0, device="mps")
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), device="mps"), xe, te, 1, grad_input=gi_empty)
+        gi_ref = torch.empty(0)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones(()), xe.cpu(), te.cpu(), 1, grad_input=gi_ref)
+        self.assertEqual(gi_empty.shape, gi_ref.shape)
+        self.assertEqual(gi_empty.cpu(), gi_ref)
+
+        # Mixed layouts (contiguous input, transposed target): must NOT take
+        # the physical-order walk — element pairing would break.
+        xmix_c = torch.randn(64, 33)
+        tmix_c = torch.randn(64, 33)
+        xmix = xmix_c.to("mps")
+        tmix = tmix_c.to("mps").t().contiguous().t()
+        self.assertFalse(tmix.is_contiguous())
+        for reduction in ("mean", "sum"):
+            self.assertEqual(
+                F.mse_loss(xmix, tmix, reduction=reduction).cpu(),
+                F.mse_loss(xmix_c, tmix_c, reduction=reduction))
+
+        # Storage offsets off the vec4 alignment (slice views): the kernels
+        # must take the scalar path and still match CPU.
+        base_x = torch.randn(64 * 33 + 1)
+        base_t = torch.randn(64 * 33 + 1)
+        xo_c = base_x[1:].view(64, 33)
+        to_c = base_t[1:].view(64, 33)
+        xo = base_x.to("mps")[1:].view(64, 33)
+        to = base_t.to("mps")[1:].view(64, 33)
+        self.assertNotEqual(xo.storage_offset() % 4, 0)
+        for reduction in ("none", "mean", "sum"):
+            self.assertEqual(
+                F.mse_loss(xo, to, reduction=reduction).cpu(),
+                F.mse_loss(xo_c, to_c, reduction=reduction))
+
+        # Out-variant where input/target/grad_input all share a transposed
+        # dense layout but grad_output is contiguous: must take the fallback
+        # (and actually write the gradient).
+        xt = torch.randn(33, 64, device="mps").t()
+        tt = torch.randn(33, 64, device="mps").t()
+        gt = torch.ones(64, 33, device="mps")
+        git = torch.empty(33, 64, device="mps").t()
+        torch.ops.aten.mse_loss_backward.grad_input(gt, xt, tt, 0, grad_input=git)
+        git_ref = torch.empty(64, 33)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            gt.cpu(), xt.cpu().contiguous(), tt.cpu().contiguous(), 0, grad_input=git_ref)
+        self.assertEqual(git.cpu(), git_ref)
+
+        # grad_output dtype differing alone must route to the promoted-dtype
+        # fallback, not the same-dtype fast path.
+        xg = torch.randn(64, 33, device="mps", dtype=torch.float16)
+        tg = torch.randn(64, 33, device="mps", dtype=torch.float16)
+        gig = torch.empty(64, 33, device="mps", dtype=torch.float16)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), device="mps", dtype=torch.float32), xg, tg, 2, grad_input=gig)
+        gig_ref = torch.empty(64, 33, dtype=torch.float16)
+        torch.ops.aten.mse_loss_backward.grad_input(
+            torch.ones((), dtype=torch.float32), xg.cpu(), tg.cpu(), 2, grad_input=gig_ref)
+        self.assertEqual(gig.cpu(), gig_ref, atol=5e-2, rtol=5e-2)
+
     def test_mse_loss(self):
         def helper(shape, reduction):
             # create the criterion


### PR DESCRIPTION
Part of #187455. Leaf on the fused-loss base #187553 (`mse_loss`) — this PR
carries only the `binary_cross_entropy` delta; the shared infrastructure
(`FusedLossParams`, `fused_loss_pass1`, `fused_loss_reduce`) is reviewed there.

## Summary

Replaces the MPSGraph `binary_cross_entropy` forward + backward on MPS with
native Metal, removing its per-shape `LookUpOrCreateCachedGraph` entries.

- `mean`/`sum` forward: a small `BCEOp` functor on the shared
  `fused_loss_pass1` + `sum_reduction` two-pass reduce (weight applied
  in-kernel, fp32 accumulation, mean divide folded into pass 2). Inherits the
  base's physical-order dense walk for same-layout non-contiguous operands.
- `reduction='none'` forward and backward: standalone `bce_loss_fwd_none` /
  `bce_loss_bwd` kernels. Backward stays a bespoke kernel rather than the
  base's `fused_loss_bwd` because it needs the optional weight buffer and the
  CPU kernel's raw-x-numerator / clamped-x-denominator asymmetry; a new
  `INSTANTIATE_FUSED_LOSS_FWD` macro instantiates only the forward template
  for bce.
- Hardening from the base PR's review rounds is applied here too: vec4
  operands are force-copied when a contiguous slice view keeps a misaligned
  storage offset, numel is bounded one grid stride below UINT32_MAX, and both
  standalone kernels declare `max_total_threads_per_threadgroup`.

Known corner: the legacy CPU BCE out= path leaves an EMPTY out tensor empty;
this port resizes it to the broadcast shape (the TensorIterator convention the
mse base follows). Matched-shape out= behavior is identical and tested.

## Coverage Owner

`test/test_mps.py::TestMPS.test_bce_loss_metal_paths` owns the MPS route
coverage: reductions x f32/f16/bf16 x contig/noncontig x
unweighted/matched-weight/broadcast-weight, fwd+bwd vs an fp32 CPU reference
seeded with the same low-precision-rounded inputs (BCE's 1/(x(1-x)) gradient
amplifies input quantization), plus misaligned slice-view operands and the
out= variant. Existing `test_nn.py` BCE tests (27) and OpInfo consistency
remain the broad semantic owners.

## Performance

Benchmark script: `benchmarks/mps/bench_bce_loss.py` (committed; same
methodology as the base's bench — Timer.blocked_autorange, 100-call
synchronized blocks, 5 repeats, M4 Pro). 360 cells: 5 shapes x 3 dtypes x 3
reductions x contig/noncontig x unweighted/weighted x fwd/fwd+bwd.
Non-contiguous cells use pipeline-consistent (same-layout) weights. Parent
815cc61481a vs HEAD 09f4f4d036e, back-to-back on an idle machine; full JSON
logs kept as gate artifacts (agent_space/bench-bce-{baseline,current}.log).

| cell | MPSGraph | this PR | speedup |
|---|---|---|---|
| 65536x128 bf16 mean noncontig w fwd | 1,252 us | 211 us | 5.94x |
| 8x2048x4096 f16 sum noncontig nw fwd | 5,775 us | 1,056 us | 5.47x |
| 8x2048x4096 f16 mean noncontig w fwd | 8,597 us | 1,574 us | 5.46x |
| 8x2048x4096 f32 mean contig nw fwd | 2,157 us | 2,149 us | 1.00x |
| 1024x1024 f16 none noncontig nw fwd+bwd | 59.9 us | 134.3 us | 0.45x |
| 8x2048x4096 f16 none noncontig w fwd+bwd | 5,336 us | 16,894 us | 0.32x |

56 of 360 cells sit below 0.95x, concentrated in the same structural cluster
the base PR documents: reduction=none backward where autograd's contiguous
grad_input meets transposed inputs, forcing the generic TensorIterator
ternary fallback (the weighted variant adds one broadcast multiply). Weighted
mean/sum and all same-layout paths ride the shared dense walk and the
weighted fused backward at parity to 5.9x wins.

## Memory stability

The base PR's shape-varying RSS demo covers the shared reduce path; BCE's
graph-cache entries are removed by this PR (no `LookUpOrCreateCachedGraph`
remains for binary_cross_entropy in the MPS backend).

## Test Plan

- `lintrunner -a -m upstream/main`
- `xcrun metal -std=metal3.1/4.0 -c aten/src/ATen/native/mps/kernels/LossOps.metal -I . -I aten/src -Wall -Wextra -fno-fast-math`
- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "bce or binary_cross" -q` — 23 passed
- `PYTORCH_TEST_MPS=1 python -m pytest test/test_nn.py -k BCE -q` — 27 passed
- `PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps --keep-going` — clean; the only failure (`test_metal.py::TestMetalRewritePass::test_conv`) reproduces on the untouched merge base and is unrelated
- `python benchmarks/mps/bench_bce_loss.py` on parent and HEAD

## Review History

Review-history gist: https://gist.github.com/anagnorisis2peripeteia/51e228c1b862292b56063d0501386aa2

Design history: the first draft carried standalone bce kernels whose forced
materialization cost up to 9x on non-contiguous reduction=None inputs; the
committed design reuses the base's iterator/fused machinery end to end and
extends it for weights (dense walk + fused backward weight buffer). The
bench-driven rounds are logged in the gist.

## BC-breaking?

No public API change. f16/bf16 mean/sum accumulate in fp32 via the shared
pass (overflow-safe, matches the CPU reference more closely than MPSGraph);
the empty-out= resize note above is the only behavioral corner vs the legacy
CPU path.



---

## Update: exact CPU endpoint semantics + elementwise ILP

Responding to review, two changes:

- **Endpoint formulas now match CPU exactly.** The kernels previously clamped the *input* to [1e-7, 1-1e-7], giving loss ~16.1 and grad ~-1e7 at x=0, target=1; CPU instead clamps each log term at -100 (loss 100) and the backward denominator at EPSILON=1e-12 (grad ~-1e12). All three forward functor sites and the fused backward now use the CPU formulas, with endpoint forward+backward tests added.
- **Opt-in ILP for the elementwise paths** (shared infra: `ternary_dense_ilp` + an `ilp_threshold` opt-in in `exec_ternary_kernel`, mirroring the existing binary variant). The weighted/none forward and backward cells that sat 0.6-0.9x behind the graph at large sizes are now parity-or-better; f16 weighted forward flipped 0.66x -> ~1.0x, and the large-shape (8.4M/67M) contiguous cells are all parity or wins.

Two performance tails remain and are **pre-existing on this PR's previous head** (this update strictly improves it): the 1024^2 fused mean/sum + fwd+bwd composite cells sit at 0.74-0.78x (mid-size fused-reduce regime), and non-contiguous weighted composites at 0.32-0.41x (strided 1-elem/thread class). Both belong to the shared elementwise-infra follow-up (strided ILP + mid-size reduce tuning) tracked in #187455.

Review log: https://gist.github.com/anagnorisis2peripeteia/b3cb95085d2941b774b502d1c2dd3d0d
