### PR TITLE
Fix torch.sign to propagate NaN instead of returning 0

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -306,14 +306,19 @@ static void sign_kernel(TensorIteratorBase& iter){
 
         cpu_kernel_vec(
           iter,
-          [=](scalar_t a) -> scalar_t { return (0 < a) - c10::is_negative(a); },
+          [=](scalar_t a) -> scalar_t {
+            if (a != a) return a; // propagate NaN
+            return (0 < a) - c10::is_negative(a);
+          },
           [=](Vectorized<scalar_t> self_vec){
 
               // Comparison operators returns bitmask.
               auto left = Vectorized<scalar_t>::blendv(zero_vec, one_vec, zero_vec < self_vec);
               auto right = Vectorized<scalar_t>::blendv(zero_vec, one_vec, self_vec < zero_vec);
 
-              return left - right;
+              auto result = left - right;
+              // Propagate NaN: blend result with input where input is NaN
+              return Vectorized<scalar_t>::blendv(result, self_vec, self_vec.isnan());
           });
     });
   }

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -67,6 +67,7 @@ void sign_kernel_cuda(TensorIteratorBase& iter){
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "sign_cuda", [&]() {
         gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+            if (a != a) return a; // propagate NaN
             return c10::signum(a);
         });
     });

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -253,6 +253,16 @@ def silu(x: torch.Tensor) -> torch.Tensor:
     return x / (1 + x.neg().exp())
 
 
+@register_decomposition([aten.sign])
+def sign(x: torch.Tensor) -> torch.Tensor:
+    if x.dtype == torch.bool:
+        return x.clone()
+    result = (x > 0).to(x.dtype) - (x < 0).to(x.dtype)
+    if x.is_floating_point():
+        return torch.where(torch.isnan(x), x, result)
+    return result
+
+
 @register_decomposition([aten.full])
 def full(
     size: list[int | torch.SymInt],

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19261,12 +19261,7 @@ op_db: list[OpInfo] = [
                    supports_sparse_csr=True,
                    supports_sparse_csc=True,
                    supports_sparse_bsr=True,
-                   supports_sparse_bsc=True,
-                   skips=(
-                       # Reference: https://github.com/pytorch/pytorch/issues/41245
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                    dtypes=[torch.bfloat16, torch.float16, torch.float32, torch.float64]),
-                   )),
+                   supports_sparse_bsc=True),
     UnaryUfuncInfo('sgn',
                    ref=reference_sgn,
                    dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.half, torch.chalf),
@@ -19282,9 +19277,6 @@ op_db: list[OpInfo] = [
                    supports_sparse_bsr=True,
                    supports_sparse_bsc=True,
                    skips=(
-                       # Reference: https://github.com/pytorch/pytorch/issues/41245
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                    dtypes=[torch.bfloat16, torch.float16, torch.float32, torch.float64]),
                        DecorateInfo(unittest.skip("Skipped! sparse backward not supported"),
                                     'TestSparseUnaryUfuncs', 'test_sparse_fn_grad'),
                    )),


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/187295
Fixes https://github.com/pytorch/pytorch/issues/41245

## Summary

`torch.sign` incorrectly returns `0` for NaN inputs due to the comparison-based implementation `(0 < x) - (x < 0)`, where IEEE 754 comparisons with NaN are always `false`. This diverges from NumPy's `np.sign`, which propagates NaN.

**Changes:**
- Fix the eager **CPU kernel** (scalar + SIMD vectorized paths) to propagate NaN
- Fix the eager **CUDA kernel** to check for NaN before calling `c10::signum`
- Add an **Inductor decomposition** for `aten.sign` that handles NaN propagation for all compiled backends in one place
- **Un-skip OpInfo** `test_reference_numerics_extremal` tests for `sign` and `sgn`

## Test plan

- [ ] `pytest test/test_unary_ufuncs.py -k "sign and test_reference_numerics_extremal"` passes for all float dtypes
- [ ] `pytest test/test_unary_ufuncs.py -k "sgn and test_reference_numerics_extremal"` passes for all float dtypes
- [ ] Inductor correctness validated via OpInfo tests (decomposition covers all backends)
- [ ] Integer dtypes unaffected (NaN check `a != a` is always false for integers, optimized away)

cc @ezyang @gchanan @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo