### PR TITLE
[MPS] Migrate nll_loss to native Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -35,3 +35,13 @@ struct CTCLossBackwardCollectParams {
   index_t grad_out_batch_stride;
   bool zero_infinity;
 };
+
+// Shared by LossOps.metal (Metal kernels) and LossOps.mm (dispatch).
+// The binary layout must stay identical on both sides.
+struct NLLParams {
+  int64_t ignore_index; // int64 so any Python-level value compares exactly
+  uint32_t N;
+  uint32_t C;
+  uint32_t reduction;
+  uint32_t has_weight;
+};

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,4 +1,7 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
+#include <c10/metal/reduction_utils.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
@@ -395,3 +398,213 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+// ============================================================================
+// Phase-2: merge per-threadgroup float partials into loss[0]
+// Always dispatched with a single 256-thread threadgroup.
+// ============================================================================
+
+template <typename T>
+kernel void loss_reduce_partials_typed(
+    device const float* partial [[buffer(0)]],
+    device T* loss [[buffer(1)]],
+    constant uint32_t& nparts [[buffer(2)]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]]) {
+  threadgroup float smem[256];
+  float acc = 0.f;
+  for (uint i = lid; i < nparts; i += tgsz)
+    acc += partial[i];
+  acc = c10::metal::threadgroup_sum<float>(smem, acc, lid, tgsz);
+  if (lid == 0)
+    loss[0] = T(acc);
+}
+
+#define INST_REDUCE_PARTIALS(T)                      \
+  template [[host_name("loss_reduce_partials_" #T)]] \
+  kernel void loss_reduce_partials_typed<T>(         \
+      device const float*, device T*, constant uint32_t&, uint, uint)
+INST_REDUCE_PARTIALS(float);
+INST_REDUCE_PARTIALS(half);
+INST_REDUCE_PARTIALS(bfloat);
+
+// ============================================================================
+// NLL Loss 1-D  (input (N,C) log-probs, target (N,) int class indices)
+// C++ handles final scale (Mean denominator) after phase-2 reduction.
+// Caller must pre-zero grad_in before dispatching nll_loss_bwd.
+// ============================================================================
+
+template <typename T>
+kernel void nll_loss_fwd_none(
+    device const T* log_prob [[buffer(0)]], // (N, C)
+    device const long* target [[buffer(1)]], // (N,)
+    device const T* weight [[buffer(2)]],
+    device T* out [[buffer(3)]], // (N,)
+    constant NLLParams& p [[buffer(4)]],
+    device c10::metal::ErrorMessages* error_buf [[buffer(5)]],
+    uint gid [[thread_position_in_grid]],
+    uint tpg [[threads_per_grid]]) {
+  for (uint n = gid; n < p.N; n += tpg) {
+    long t = target[n];
+    if (t == p.ignore_index) {
+      out[n] = T(0);
+      continue;
+    }
+    if (t < 0 || t >= long(p.C)) {
+      TORCH_REPORT_ERROR(
+          error_buf,
+          "nll_loss: Target ",
+          t,
+          " is out of bounds [0, ",
+          uint(p.C),
+          ")");
+      out[n] = T(0);
+      continue;
+    }
+    float l = -float(log_prob[n * p.C + uint32_t(t)]);
+    out[n] = T(p.has_weight ? l * float(weight[t]) : l);
+  }
+}
+
+template <typename T>
+kernel void nll_loss_fwd_reduce(
+    device const T* log_prob [[buffer(0)]],
+    device const long* target [[buffer(1)]],
+    device const T* weight [[buffer(2)]],
+    device float* partial [[buffer(3)]], // (n_tg,) loss sums
+    device float* wpartial [[buffer(4)]], // (n_tg,) weight sums
+    constant NLLParams& p [[buffer(5)]],
+    device c10::metal::ErrorMessages* error_buf [[buffer(6)]],
+    uint gid [[thread_position_in_grid]],
+    uint tpg [[threads_per_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  threadgroup float smem[256], wsmem[256];
+  float acc = 0.f, wacc = 0.f;
+  for (uint n = gid; n < p.N; n += tpg) {
+    long t = target[n];
+    if (t == p.ignore_index)
+      continue;
+    if (t < 0 || t >= long(p.C)) {
+      TORCH_REPORT_ERROR(
+          error_buf,
+          "nll_loss: Target ",
+          t,
+          " is out of bounds [0, ",
+          uint(p.C),
+          ")");
+      continue;
+    }
+    float w = p.has_weight ? float(weight[t]) : 1.f;
+    acc += -float(log_prob[n * p.C + uint32_t(t)]) * w;
+    wacc += w;
+  }
+  acc = c10::metal::threadgroup_sum<float>(smem, acc, lid, tgsz);
+  wacc = c10::metal::threadgroup_sum<float>(wsmem, wacc, lid, tgsz);
+  if (lid == 0) {
+    partial[tgid] = acc;
+    wpartial[tgid] = wacc;
+  }
+}
+
+// Backward: writes -grad_out_scaled to grad_in[n, target[n]].
+// Caller zeros grad_in before dispatch; each thread handles one n.
+template <typename T>
+kernel void nll_loss_bwd(
+    device const T* grad_out [[buffer(0)]], // scalar (reduce) or (N,)
+    device const long* target [[buffer(1)]],
+    device const T* weight [[buffer(2)]],
+    device T* grad_in [[buffer(3)]], // (N, C) pre-zeroed
+    device const T* total_w [[buffer(4)]], // scalar weight sum (Mean)
+    constant NLLParams& p [[buffer(5)]],
+    device c10::metal::ErrorMessages* error_buf [[buffer(6)]],
+    uint gid [[thread_position_in_grid]],
+    uint tpg [[threads_per_grid]]) {
+  for (uint n = gid; n < p.N; n += tpg) {
+    long t = target[n];
+    if (t == p.ignore_index)
+      continue;
+    if (t < 0 || t >= long(p.C)) {
+      TORCH_REPORT_ERROR(
+          error_buf,
+          "nll_loss: Target ",
+          t,
+          " is out of bounds [0, ",
+          uint(p.C),
+          ")");
+      continue;
+    }
+    float w = p.has_weight ? float(weight[t]) : 1.f;
+    float scale;
+    if (p.reduction == 0) {
+      scale = -float(grad_out[n]) * w;
+    } else if (p.reduction == 1) {
+      // Mean: divide by the summed weight. total_w == 0 is reachable only in
+      // the degenerate all-zero-weight case, where 0/0 -> NaN matches CPU.
+      scale = -float(grad_out[0]) * w / float(total_w[0]);
+    } else {
+      scale = -float(grad_out[0]) * w;
+    }
+    grad_in[n * p.C + uint32_t(t)] = T(scale);
+  }
+}
+
+#define INSTANTIATE_NLL(T)                          \
+  template [[host_name("nll_loss_fwd_none_" #T)]]   \
+  kernel void nll_loss_fwd_none<T>(                 \
+      device const T*,                              \
+      device const long*,                           \
+      device const T*,                              \
+      device T*,                                    \
+      constant NLLParams&,                          \
+      device c10::metal::ErrorMessages*,            \
+      uint,                                         \
+      uint);                                        \
+  template [[host_name("nll_loss_fwd_reduce_" #T)]] \
+  kernel void nll_loss_fwd_reduce<T>(               \
+      device const T*,                              \
+      device const long*,                           \
+      device const T*,                              \
+      device float*,                                \
+      device float*,                                \
+      constant NLLParams&,                          \
+      device c10::metal::ErrorMessages*,            \
+      uint,                                         \
+      uint,                                         \
+      uint,                                         \
+      uint,                                         \
+      uint);                                        \
+  template [[host_name("nll_loss_bwd_" #T)]]        \
+  kernel void nll_loss_bwd<T>(                      \
+      device const T*,                              \
+      device const long*,                           \
+      device const T*,                              \
+      device T*,                                    \
+      device const T*,                              \
+      constant NLLParams&,                          \
+      device c10::metal::ErrorMessages*,            \
+      uint,                                         \
+      uint);
+
+INSTANTIATE_NLL(float)
+INSTANTIATE_NLL(half)
+INSTANTIATE_NLL(bfloat)
+
+// Phase-3 for NLL Mean reduction: divide typed output[0] by typed
+// total_weight[0]. Dispatched with a single thread after the two
+// encode_reduce_partials calls.
+template <typename T>
+kernel void nll_finalize_mean(
+    device T* loss [[buffer(0)]],
+    device const T* total_weight [[buffer(1)]]) {
+  float tw = float(total_weight[0]);
+  loss[0] = (tw == 0.f) ? T(NAN) : T(float(loss[0]) / tw);
+}
+
+#define INST_NLL_FINALIZE(T)                      \
+  template [[host_name("nll_finalize_mean_" #T)]] \
+  kernel void nll_finalize_mean<T>(device T*, device const T*)
+INST_NLL_FINALIZE(float);
+INST_NLL_FINALIZE(half);
+INST_NLL_FINALIZE(bfloat);

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -29,11 +29,27 @@
 namespace at::native {
 namespace mps {
 
+// Metal kernel library (LossOps.metal). NLLParams comes from kernels/LossOps.h.
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/LossOps_metallib.h>
 #endif
+
+static constexpr uint32_t kLossKernelTgsz = 256;
+// Cap reduce threadgroup count: avoids O(N/256) barrier calls at large N
+static constexpr uint32_t kMaxReduceTGs = 256u;
+
+static void encode_reduce_partials(id<MTLComputeCommandEncoder> enc,
+                                   const Tensor& partial,
+                                   const Tensor& loss_out,
+                                   uint32_t n_tg) {
+  const std::string dt_out = scalarToMetalTypeString(loss_out);
+  auto pso = lib.getPipelineStateForFunc("loss_reduce_partials_" + dt_out);
+  [enc setComputePipelineState:pso];
+  mtl_setArgs(enc, partial, loss_out, n_tg);
+  [enc dispatchThreads:MTLSizeMake(kLossKernelTgsz, 1, 1) threadsPerThreadgroup:MTLSizeMake(kLossKernelTgsz, 1, 1)];
+}
 
 static std::string reductionToString(int64_t reduction) {
   switch (reduction) {
@@ -296,6 +312,183 @@ static inline MPSGraphTensor* divisionNoNaN(MPSGraph* mpsGraph, MPSGraphTensor* 
                          truePredicateTensor:div
                         falsePredicateTensor:[mpsGraph constantWithScalar:0.0 dataType:div.dataType]
                                         name:nil];
+}
+
+// NLLLoss
+static void nll_loss_fwd_metal(Tensor& output,
+                               Tensor& total_weight,
+                               const Tensor& input_arg,
+                               const Tensor& target_arg,
+                               const Tensor& weight,
+                               int64_t reduction,
+                               int64_t ignore_index) {
+  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(output.scalar_type()),
+                              "nll_loss for complex is not supported for MPS");
+  if (weight.defined()) {
+    TORCH_CHECK(input_arg.scalar_type() == weight.scalar_type(),
+                "expected scalar type ",
+                input_arg.scalar_type(),
+                " but found ",
+                weight.scalar_type());
+  }
+  if (c10::isIntegralType(input_arg.scalar_type(), /*includeBool=*/true)) {
+    Tensor input_f = input_arg.to(at::kFloat);
+    Tensor weight_f = weight.defined() ? weight.to(at::kFloat) : weight;
+    Tensor output_f = at::empty_like(output, output.options().dtype(at::kFloat));
+    Tensor tw_f = at::empty_like(total_weight, total_weight.options().dtype(at::kFloat));
+    nll_loss_fwd_metal(output_f, tw_f, input_f, target_arg, weight_f, reduction, ignore_index);
+    output.copy_(output_f);
+    total_weight.copy_(tw_f);
+    return;
+  }
+  auto input = input_arg.dim() == 1 ? input_arg.view({1, input_arg.size(0)}) : input_arg;
+  auto target = target_arg.dim() == 0 ? target_arg.view({1}) : target_arg;
+
+  const uint32_t N = static_cast<uint32_t>(target.numel());
+  const uint32_t C = static_cast<uint32_t>(input.size(1));
+
+  if (reduction == Reduction::None)
+    output.resize_(target_arg.sizes());
+  else
+    output.resize_({});
+  total_weight.resize_({});
+
+  // Kernels are stride-blind: force contiguous copies before dispatch.
+  input = input.contiguous();
+  const Tensor weight_c = weight.defined() ? (weight.is_contiguous() ? weight : weight.contiguous()) : weight;
+  const bool need_out_copy = !output.is_contiguous();
+  Tensor out_buf = need_out_copy ? at::empty_like(output, at::MemoryFormat::Contiguous) : output;
+
+  if (N == 0 || input.numel() == 0) {
+    reduction == Reduction::Mean ? output.fill_(std::numeric_limits<float>::quiet_NaN()) : output.zero_();
+    total_weight.zero_();
+    return;
+  }
+
+  TORCH_CHECK(input.numel() <= std::numeric_limits<uint32_t>::max(),
+              "MPS nll_loss does not support inputs with more than 2^32 elements");
+  NLLParams p{ignore_index, N, C, static_cast<uint32_t>(reduction), weight.defined() ? 1u : 0u};
+  const std::string dt = scalarToMetalTypeString(input);
+  // Kernels read target as int64 (no narrowing); convert only legacy non-Long targets
+  // to() is a no-op for Long input and contiguous() for dense targets, so the
+  // hot path stays zero-copy; strided or non-Long targets get one dense copy.
+  const Tensor tgt_i64 = target.to(at::kLong).contiguous();
+  // Use input as a valid dummy buffer when no class weights provided
+  const Tensor& wt = weight_c.defined() ? weight_c : input;
+  MPSStream* stream = getCurrentMPSStream();
+
+  if (reduction == Reduction::None) {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto pso = lib.getPipelineStateForFunc("nll_loss_fwd_none_" + dt);
+        [enc setComputePipelineState:pso];
+        mtl_setArgs(enc, input, tgt_i64, wt, out_buf, p, stream->getErrorBuffer());
+        [enc dispatchThreads:MTLSizeMake(N, 1, 1) threadsPerThreadgroup:MTLSizeMake(kLossKernelTgsz, 1, 1)];
+      }
+    });
+    stream->synchronize(SyncType::COMMIT);
+    // Reference leaves total_weight at 0 for the None reduction (it is unused
+    // by the None backward, which reads per-element grad_output directly).
+    total_weight.zero_();
+  } else {
+    const uint32_t n_tg = std::min((N + kLossKernelTgsz - 1) / kLossKernelTgsz, kMaxReduceTGs);
+    Tensor partial = at::empty({static_cast<int64_t>(n_tg)}, input.options().dtype(at::kFloat));
+    Tensor wpartial = at::empty({static_cast<int64_t>(n_tg)}, input.options().dtype(at::kFloat));
+    // Weight sum always accumulated as float; copy back to total_weight (any dtype) after commit
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        // Phase 1: per-threadgroup loss and weight sums
+        auto pso = lib.getPipelineStateForFunc("nll_loss_fwd_reduce_" + dt);
+        [enc setComputePipelineState:pso];
+        mtl_setArgs(enc, input, tgt_i64, wt, partial, wpartial, p, stream->getErrorBuffer());
+        [enc dispatchThreadgroups:MTLSizeMake(n_tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(kLossKernelTgsz, 1, 1)];
+        // Phase 2a: reduce loss partials -> typed output[0]
+        encode_reduce_partials(enc, partial, out_buf, n_tg);
+        // Phase 2b: reduce weight partials -> typed total_weight[0]
+        encode_reduce_partials(enc, wpartial, total_weight, n_tg);
+        // Phase 3 (Mean only): out_buf[0] /= total_weight[0]
+        if (reduction == Reduction::Mean) {
+          auto pso3 = lib.getPipelineStateForFunc("nll_finalize_mean_" + dt);
+          [enc setComputePipelineState:pso3];
+          mtl_setArgs(enc, out_buf, total_weight);
+          [enc dispatchThreads:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+        }
+      }
+    });
+    stream->synchronize(SyncType::COMMIT);
+  }
+  if (need_out_copy)
+    output.copy_(out_buf);
+}
+
+static void nll_loss_bwd_metal(Tensor& grad_input,
+                               const Tensor& grad_output,
+                               const Tensor& input_arg,
+                               const Tensor& target_arg,
+                               const Tensor& weight,
+                               int64_t reduction,
+                               int64_t ignore_index,
+                               const Tensor& total_weight) {
+  if (c10::isIntegralType(input_arg.scalar_type(), /*includeBool=*/true)) {
+    Tensor input_f = input_arg.to(at::kFloat);
+    Tensor weight_f = weight.defined() ? weight.to(at::kFloat) : weight;
+    Tensor gi_f = at::empty_like(grad_input, grad_input.options().dtype(at::kFloat));
+    nll_loss_bwd_metal(gi_f,
+                       grad_output.to(at::kFloat),
+                       input_f,
+                       target_arg,
+                       weight_f,
+                       reduction,
+                       ignore_index,
+                       total_weight.to(at::kFloat));
+    grad_input.copy_(gi_f);
+    return;
+  }
+  auto input = input_arg.dim() == 1 ? input_arg.view({1, input_arg.size(0)}) : input_arg;
+  auto target = target_arg.dim() == 0 ? target_arg.view({1}) : target_arg;
+
+  const uint32_t N = static_cast<uint32_t>(target.numel());
+  const uint32_t C = static_cast<uint32_t>(input.size(1));
+
+  grad_input.resize_as_(input_arg);
+  grad_input.zero_();
+
+  if (N == 0 || input.numel() == 0)
+    return;
+
+  // Kernel is stride-blind: force contiguous copies for input/weight,
+  // and route writes through a contiguous grad_input buffer if needed.
+  input = input.contiguous();
+  const Tensor weight_c = weight.defined() ? (weight.is_contiguous() ? weight : weight.contiguous()) : weight;
+  const bool need_gi_copy = !grad_input.is_contiguous();
+  Tensor gi = need_gi_copy ? at::empty_like(grad_input, at::MemoryFormat::Contiguous) : grad_input;
+
+  TORCH_CHECK(input.numel() <= std::numeric_limits<uint32_t>::max(),
+              "MPS nll_loss does not support inputs with more than 2^32 elements");
+  NLLParams p{ignore_index, N, C, static_cast<uint32_t>(reduction), weight_c.defined() ? 1u : 0u};
+  const std::string dt = scalarToMetalTypeString(input);
+  // to() is a no-op for Long input and contiguous() for dense targets, so the
+  // hot path stays zero-copy; strided or non-Long targets get one dense copy.
+  const Tensor tgt_i64 = target.to(at::kLong).contiguous();
+  const Tensor& wt = weight_c.defined() ? weight_c : input;
+  // grad_output may have stride-0 (expanded) layout when coming from sum().backward()
+  const Tensor grad_out_c = grad_output.is_contiguous() ? grad_output : grad_output.contiguous();
+  MPSStream* stream = getCurrentMPSStream();
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("nll_loss_bwd_" + dt);
+      [enc setComputePipelineState:pso];
+      mtl_setArgs(enc, grad_out_c, tgt_i64, wt, gi, total_weight, p, stream->getErrorBuffer());
+      [enc dispatchThreads:MTLSizeMake(N, 1, 1) threadsPerThreadgroup:MTLSizeMake(kLossKernelTgsz, 1, 1)];
+    }
+  });
+  stream->synchronize(SyncType::COMMIT);
+  if (need_gi_copy)
+    grad_input.copy_(gi);
 }
 
 // NLLLoss
@@ -1149,8 +1342,8 @@ TORCH_IMPL_FUNC(nll_loss_backward_out_mps)
  const Tensor& grad_input) {
   const Tensor& weight = weight_opt.getTensorRef();
 
-  mps::nllnd_loss_backward_impl(
-      (Tensor&)grad_input, grad_output, self, target, weight, reduction, ignore_index, total_weight, false);
+  mps::nll_loss_bwd_metal(
+      (Tensor&)grad_input, grad_output, self, target, weight, reduction, ignore_index, total_weight);
   return;
 }
 
@@ -1164,8 +1357,7 @@ TORCH_IMPL_FUNC(nll_loss_forward_out_mps)
  const Tensor& total_weight) {
   const Tensor& weight = weight_opt.getTensorRef();
 
-  mps::nllnd_loss_forward_impl(
-      (Tensor&)output, (Tensor&)total_weight, self, target, weight, reduction, ignore_index, false);
+  mps::nll_loss_fwd_metal((Tensor&)output, (Tensor&)total_weight, self, target, weight, reduction, ignore_index);
 
   return;
 }

--- a/benchmarks/mps/bench_nll_loss.py
+++ b/benchmarks/mps/bench_nll_loss.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""A/B benchmark for MPS nll_loss migrated from MPSGraph to Metal.
+
+Run once with a stock nightly wheel (MPSGraph baseline) and once with this
+build (Metal); each cell amortizes K iterations behind a single
+torch.mps.synchronize() so the ~110us sync floor does not mask kernel cost.
+"""
+
+import argparse
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+K = 20
+# (N, C) class problems spanning small-batch/large-vocab and the reverse,
+# tied to real model output shapes (classification heads and LM heads).
+CASES = [(4096, 10), (128, 32000), (4096, 1000), (65536, 10)]
+DTYPES = [torch.float32, torch.float16]
+
+
+def bench_cell(stmt, glb):
+    t = Timer(stmt=stmt, globals=glb)
+    return t.blocked_autorange(min_run_time=0.4).median / K * 1e3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", default="run")
+    args = parser.parse_args()
+    print(f"label={args.label} torch={torch.__version__}")
+
+    for dt in DTYPES:
+        for N, C in CASES:
+            x = torch.randn(N, C, device="mps", dtype=dt).log_softmax(-1)
+            t = torch.randint(0, C, (N,), device="mps")
+            w = torch.rand(C, device="mps", dtype=dt) + 0.5
+            g = torch.tensor(1.0, device="mps", dtype=dt)
+            tw = torch.tensor(float(N), device="mps", dtype=dt)
+            glb = {
+                "torch": torch,
+                "F": torch.nn.functional,
+                "x": x,
+                "t": t,
+                "w": w,
+                "g": g,
+                "tw": tw,
+                "K": K,
+            }
+            cells = {
+                "fwd_mean": "\nfor _ in range(K): F.nll_loss(x, t)\ntorch.mps.synchronize()",
+                "fwd_none": "\nfor _ in range(K): F.nll_loss(x, t, reduction='none')\ntorch.mps.synchronize()",
+                "fwd_mean_w": "\nfor _ in range(K): F.nll_loss(x, t, weight=w)\ntorch.mps.synchronize()",
+                "bwd_mean": (
+                    "\nfor _ in range(K): torch.ops.aten.nll_loss_backward(g, x, t, None, 1, -100, tw)"
+                    "\ntorch.mps.synchronize()"
+                ),
+            }
+            for name, stmt in cells.items():
+                ms = bench_cell(stmt, glb)
+                print(
+                    f"{name} {str(dt).replace('torch.', ''):<9} N{N}xC{C:<7} {ms:10.5f}"
+                )
+        # spatial (nll_loss2d) case
+        xi = torch.randn(16, 5, 64, 64, device="mps", dtype=dt).log_softmax(1)
+        ti = torch.randint(0, 5, (16, 64, 64), device="mps")
+        glb = {"torch": torch, "F": torch.nn.functional, "xi": xi, "ti": ti, "K": K}
+        ms = bench_cell(
+            "\nfor _ in range(K): F.nll_loss(xi, ti)\ntorch.mps.synchronize()", glb
+        )
+        print(f"fwd_2d_mean {str(dt).replace('torch.', ''):<9} 16x5x64x64 {ms:10.5f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10545,6 +10545,35 @@ class TestSmoothL1Loss(TestCaseMPS):
         helper((3, 3, 0))
 
 class TestNLLLoss(TestCaseMPS):
+    def test_nll_loss_metal_paths(self):
+        # Committed coverage for the native Metal nll_loss kernels the OpInfo
+        # samples are too small to reach: the backward kernel across all
+        # reductions, the weighted path, fp16/bf16, ignore_index, and the
+        # multi-threadgroup reduce (large N -> phase-2 partial merge).
+        def run(N, C, reduction, dtype, weighted, ignore=-100):
+            xc = torch.randn(N, C, dtype=torch.float32, requires_grad=True)
+            tc = torch.randint(0, C, (N,))
+            wc = torch.rand(C, dtype=torch.float32) if weighted else None
+            xm = xc.detach().to("mps", dtype).requires_grad_()
+            tm = tc.to("mps")
+            wm = None if wc is None else wc.to("mps", dtype)
+            oc = F.nll_loss(xc, tc, weight=wc, reduction=reduction, ignore_index=ignore)
+            om = F.nll_loss(xm, tm, weight=wm, reduction=reduction, ignore_index=ignore)
+            tol = dict(atol=5e-2, rtol=5e-2) if dtype != torch.float32 else {}
+            self.assertEqual(om.float(), oc, **tol)
+            g = torch.ones_like(oc)
+            oc.backward(g)
+            om.backward(g.to("mps", dtype))
+            self.assertEqual(xm.grad.float(), xc.grad, **tol)
+
+        for reduction in ("none", "mean", "sum"):
+            for dtype in (torch.float32, torch.float16, torch.bfloat16):
+                for weighted in (False, True):
+                    run(128, 10, reduction, dtype, weighted)
+        run(65536, 10, "mean", torch.float32, True)   # large N -> phase-2 merge
+        run(65536, 10, "sum", torch.float32, False)
+        run(256, 1000, "mean", torch.float32, True, ignore=7)  # ignore_index + large C
+
     def test_nll_loss_mismatched_batch(self, device='mps'):
         x = torch.randn((10, 3), requires_grad=True, device=device)
         # t should have size (10,)


### PR DESCRIPTION
# [MPS] Migrate nll_loss to native Metal kernels

Part of the MPSGraph shape-keyed graph-cache elimination effort (#187455). Replaces the MPSGraph implementation of 1-D `nll_loss` forward and backward with Metal kernels (two-phase float-accumulated reduction for mean/sum), removing the 1-D nll graph-cache sites. `nll_loss2d` stays on MPSGraph as a follow-up. Rebased over trunk's new ctc_loss kernels in the same files.

## Safety and correctness

- **Targets and `ignore_index` ride at int64 end-to-end** — no narrowing. Previously-drafted int32 handling silently wrapped `ignore_index=2^32` to 0 (changing which classes are ignored) and indexed wrong classes for out-of-int32 targets. Also removes the target conversion copy on the hot path (`to(kLong).contiguous()` are both no-ops for dense Long targets).
- Three kernels validate `target ∈ [0, C)` via the async error buffer and raise on out-of-bounds like CPU; `ignore_index` outside `[0, C)` never raises and ignores correctly.
- **All-zero-weight mean backward matches CPU's NaN gradients** (0/0 propagates; no denominator fallback).
- Inputs above 2^32 elements are rejected explicitly (kernels index 32-bit).
- Partial sums accumulate in float for half/bfloat; f16 large-N accuracy exceeds the CPU-f16 kernel. Reduction is bitwise deterministic (fixed two-phase pass, no atomics).
- **Fixes a pre-existing MPSGraph failure**: f16 inputs with N > 65504 threw "value cannot be converted to type c10::Half without overflow" on the graph path; the Metal path matches CPU-f16 semantics instead.

Known divergence (nit): C == 0 with non-empty non-ignored targets returns zeros/NaN instead of CPU's IndexError (validating would need a host-side target read).

## Perf

`benchmarks/mps/bench_nll_loss.py` (Timer.blocked_autorange, K=20 amortized behind one synchronize, median of 3 interleaved A/B reps vs stock nightly), M4 Pro — 29/29 comparable cells, 0 regressions:

| cell | dtype | shape | speedup |
|---|---|---|---|
| fwd_mean | f32 | N4096×C10 | 3.70x |
| fwd_mean | f32 | N128×C32000 | 3.13x |
| fwd_mean | f32 | N4096×C1000 | 2.39x |
| fwd_mean | f32 | N65536×C10 | 2.34x |
| fwd_none | f32 | N4096×C1000 | 3.64x |
| fwd_mean_w | f32 | N4096×C10 | 4.25x |
| bwd_mean | f32 | N4096×C1000 | 3.20x |
| bwd_mean | f32 | N65536×C10 | 1.19x |
| fwd_mean | f16 | N128×C32000 | 3.20x |
| bwd_mean | f16 | N4096×C1000 | 2.47x |
| (remaining 19 cells) | | | 1.19–4.14x |

The four f16 N=65536 cells have no baseline column: the MPSGraph path hard-errors on them (the overflow bug above); the Metal path runs them at f32-comparable speed.

## Not tested

- `nll_loss2d` (still MPSGraph; deliberate follow-up — the spatial bench cell documents the boundary).
- complex (not supported by nll_loss on any backend).

## Test plan

```
python -m pytest test/test_mps.py -k nll
python -m pytest test/test_ops.py -k "mps and nll"
python -m pytest test/test_modules.py -k "mps and NLL"
python benchmarks/mps/bench_nll_loss.py
```

Full `--mps` CI matrix run locally (13 files; only failure is the known `test_metal` desktop-build artifact). Plus a 49-check standalone review-repro suite committed in the PR worktree covering OOB/ignore_index edges, weights (zero/negative/noncontiguous/dtype-mismatch), backward for all reductions with ignored positions, noncontiguous self/target/grad_output/grad_input, stride-0 grad_output, reduction determinism, and f16/bf16 accumulation accuracy.



Review log: https://gist.github.com/anagnorisis2peripeteia/f8cf5beaab478a440eb86a6a08aca74f
