### PR TITLE
[HOP] Adding input mutation support for map (2/2)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10218,11 +10218,12 @@ class <lambda>(torch.nn.Module):
         """Stripped-down version of self.check that runs eager + aot_eager
         but NOT inductor.
 
-        scan currently only has Steps 1-3 (gen_schema, py_functionalize_impl,
+        Used by HOP input-mutation tests (scan, map, ...). These HOPs
+        currently only have Steps 1-3 (gen_schema, py_functionalize_impl,
         Dynamo) wired for input mutation. Step 4 (Inductor MutationOutput
         emission) is a follow-up; until then the Inductor arm of the full
-        check() helper trips on the un-tracked mutation. This helper exercises
-        everything that IS in place for scan.
+        check() helper trips on the un-tracked mutation. This helper
+        exercises everything that IS in place.
         """
         args = pytree.tree_map(lambda t: t.to(device=device), args)
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10409,20 +10409,14 @@ class <lambda>(torch.nn.Module):
 
     @skipIfTorchDynamo()
     @parametrize("dynamic", [True, False])
-    def test_map_auto_functionalize_buffer_mutation(self, dynamic):
+    def test_map_auto_functionalize_xs_mutation(self, dynamic):
         device = "cpu"
 
         class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer(
-                    "buf", torch.ones(4, requires_grad=False, device=device)
-                )
-
             def forward(self, xs):
                 def body_fn(x):
-                    self.buf.add_(x)
-                    return x * 2 + self.buf.sum()
+                    x.add_(1)
+                    return x * 2 + x.sum()
 
                 return control_flow.map(body_fn, xs)
 
@@ -10434,52 +10428,50 @@ class <lambda>(torch.nn.Module):
 
     @skipIfTorchDynamo()
     @parametrize("dynamic", [True, False])
-    def test_map_auto_functionalize_multiple_buffer_mutation(self, dynamic):
+    def test_map_auto_functionalize_multiple_xs_mutation(self, dynamic):
         device = "cpu"
 
         class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer("buf1", torch.ones(4, device=device))
-                self.register_buffer("buf2", torch.zeros(4, device=device))
+            def forward(self, xs1, xs2):
+                def body_fn(xs):
+                    x1, x2 = xs
+                    x1.add_(1)
+                    x2.sub_(1)
+                    return x1 + x2, x1 * x2
 
-            def forward(self, xs):
-                def body_fn(x):
-                    self.buf1.add_(x)
-                    self.buf2.add_(self.buf1)
-                    return x * 2
+                return control_flow.map(body_fn, (xs1, xs2))
 
-                return control_flow.map(body_fn, xs)
-
-        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
-        fw_gm = self._check_eager_and_aot_eager_only(M, (xs,), device, dynamic)
+        xs1 = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        xs2 = torch.arange(20, dtype=torch.float32).reshape(5, 4) + 100
+        fw_gm = self._check_eager_and_aot_eager_only(M, (xs1, xs2), device, dynamic)
         graph_str = fw_gm.print_readable(print_output=False)
         self.assertIn("auto_functionalized_v2", graph_str)
 
-    @skipIfTorchDynamo()
-    @parametrize("dynamic", [True, False])
-    def test_map_auto_functionalize_captured_tensor_mutation(self, dynamic):
-        device = "cpu"
-
-        class M(torch.nn.Module):
-            def forward(self, xs, y):
-                def body_fn(x):
-                    y.add_(-1)
-                    return x * 2 + y.sum()
-
-                out = control_flow.map(body_fn, xs)
-                return out + y.sum()
-
-        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
-        y = torch.ones(4, requires_grad=False)
-        fw_gm = self._check_eager_and_aot_eager_only(M, (xs, y), device, dynamic)
-        graph_str = fw_gm.print_readable(print_output=False)
-        self.assertIn("auto_functionalized_v2", graph_str)
-
-    def test_map_xs_mutation_graph_breaks(self):
-        def body_fn(x):
-            x.add_(1)  # mutating xs[t] is disallowed
+    def test_map_pos_args_mutation_graph_breaks(self):
+        def body_fn(x, buf):
+            buf.add_(x)  # mutating pos_args is disallowed
             return x * 2
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        buf = torch.zeros(4)
+
+        def fn(xs, buf):
+            return control_flow.map(body_fn, xs, buf)
+
+        torch._dynamo.reset()
+        with torch.no_grad():
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.UncapturedHigherOrderOpError,
+                r"Higher Order Operator: torch\.ops\.higher_order\.map_impl",
+            ):
+                torch.compile(fn, backend="eager", fullgraph=True)(xs, buf)
+
+    def test_map_captured_tensor_mutation_graph_breaks(self):
+        y = torch.ones(4)
+
+        def body_fn(x):
+            y.add_(-1)  # mutating a captured (loop-invariant) tensor is disallowed
+            return x * 2 + y.sum()
 
         xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
 
@@ -10496,42 +10488,42 @@ class <lambda>(torch.nn.Module):
 
     @skipIfTorchDynamo()
     @parametrize("dynamic", [True, False])
-    def test_map_auto_functionalize_partial_buffer_mutation(self, dynamic):
+    def test_map_auto_functionalize_partial_xs_mutation(self, dynamic):
         device = "cpu"
 
         class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer("buf0", torch.zeros(4, device=device))
-                self.register_buffer("buf1", torch.zeros(4, device=device))
-                self.register_buffer("buf2", torch.zeros(4, device=device))
+            def forward(self, xs0, xs1, xs2):
+                def body_fn(xs):
+                    x0, x1, x2 = xs
+                    # Skip x1 to make a non-contiguous mutation set.
+                    x0.add_(1)
+                    x2.add_(1)
+                    return x0 * 2 + x1.sum() + x2.sum()
 
-            def forward(self, xs):
-                def body_fn(x):
-                    # Skip buf1 to make non-contiguous mutation set.
-                    self.buf0.add_(x)
-                    self.buf2.add_(x)
-                    return x * 2 + self.buf1.sum()
+                return control_flow.map(body_fn, (xs0, xs1, xs2))
 
-                return control_flow.map(body_fn, xs)
-
-        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
-        fw_gm = self._check_eager_and_aot_eager_only(M, (xs,), device, dynamic)
+        xs0 = torch.zeros(5, 4)
+        xs1 = torch.zeros(5, 4)
+        xs2 = torch.zeros(5, 4)
+        fw_gm = self._check_eager_and_aot_eager_only(
+            M, (xs0, xs1, xs2), device, dynamic
+        )
         graph_str = fw_gm.print_readable(print_output=False)
         self.assertIn("auto_functionalized_v2", graph_str)
 
-    def test_map_eager_xs_mutation_raises(self):
-        def body_fn(x):
-            x.add_(1)
+    def test_map_eager_pos_args_mutation_raises(self):
+        def body_fn(x, buf):
+            buf.add_(x)
             return x * 2
 
         xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        buf = torch.zeros(4)
 
         with self.assertRaisesRegex(
             torch._dynamo.exc.UncapturedHigherOrderOpError,
             r"Higher Order Operator: torch\.ops\.higher_order\.map_impl",
         ):
-            control_flow.map(body_fn, xs)
+            control_flow.map(body_fn, xs, buf)
 
 
 _hop_schema_test_schema_types = [
@@ -10942,35 +10934,35 @@ class TestHopSchema(TestCase):
         )
 
     def test_map_gen_schema_with_mutated_arg_indices_kwarg(self):
-        def body_fn(x, buf0, buf1):
+        def body_fn(x):
             return x * 2
 
         schema = torch.ops.higher_order.map_impl.gen_schema(
             body_fn,
             (torch.randn(5, 3, 4),),
-            (torch.randn(3, 4), torch.randn(3, 4)),
-            "2",
+            (),
+            "0",
         )
         self.assertExpectedInline(
             str(schema),
-            """map_impl(Any f, Tensor xs0, Tensor additional_input0, Tensor(a3!) additional_input1) -> ((Tensor))""",
+            """map_impl(Any f, Tensor(a1!) xs0) -> ((Tensor))""",
         )
 
-    def test_map_gen_schema_multiple_pos_args_mutation_via_kwarg(self):
-        def body_fn(x, b0, b1, b2):
-            b1.add_(x)
-            b2.add_(x)
-            return x * 2
+    def test_map_gen_schema_multiple_xs_mutation_via_kwarg(self):
+        def body_fn(x0, x1, x2):
+            x0.add_(1)
+            x2.add_(1)
+            return x0 + x1 + x2
 
         schema = torch.ops.higher_order.map_impl.gen_schema(
             body_fn,
-            (torch.randn(5, 3, 4),),
-            (torch.randn(3, 4), torch.randn(3, 4), torch.randn(3, 4)),
-            "2,3",
+            (torch.randn(5, 3, 4), torch.randn(5, 3, 4), torch.randn(5, 3, 4)),
+            (),
+            "0,2",
         )
         self.assertExpectedInline(
             str(schema),
-            """map_impl(Any f, Tensor xs0, Tensor additional_input0, Tensor(a3!) additional_input1, Tensor(a4!) additional_input2) -> ((Tensor))""",
+            """map_impl(Any f, Tensor(a1!) xs0, Tensor xs1, Tensor(a3!) xs2) -> ((Tensor))""",
         )
 
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10407,6 +10407,132 @@ class <lambda>(torch.nn.Module):
         ):
             scan(combine_fn, init, xs, dim=0)
 
+    @skipIfTorchDynamo()
+    @parametrize("dynamic", [True, False])
+    def test_map_auto_functionalize_buffer_mutation(self, dynamic):
+        device = "cpu"
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "buf", torch.ones(4, requires_grad=False, device=device)
+                )
+
+            def forward(self, xs):
+                def body_fn(x):
+                    self.buf.add_(x)
+                    return x * 2 + self.buf.sum()
+
+                return control_flow.map(body_fn, xs)
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        fw_gm = self._check_eager_and_aot_eager_only(M, (xs,), device, dynamic)
+        graph_str = fw_gm.print_readable(print_output=False)
+        self.assertIn("auto_functionalized_v2", graph_str)
+        self.assertIn("torch.ops.higher_order.map_impl", graph_str)
+
+    @skipIfTorchDynamo()
+    @parametrize("dynamic", [True, False])
+    def test_map_auto_functionalize_multiple_buffer_mutation(self, dynamic):
+        device = "cpu"
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buf1", torch.ones(4, device=device))
+                self.register_buffer("buf2", torch.zeros(4, device=device))
+
+            def forward(self, xs):
+                def body_fn(x):
+                    self.buf1.add_(x)
+                    self.buf2.add_(self.buf1)
+                    return x * 2
+
+                return control_flow.map(body_fn, xs)
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        fw_gm = self._check_eager_and_aot_eager_only(M, (xs,), device, dynamic)
+        graph_str = fw_gm.print_readable(print_output=False)
+        self.assertIn("auto_functionalized_v2", graph_str)
+
+    @skipIfTorchDynamo()
+    @parametrize("dynamic", [True, False])
+    def test_map_auto_functionalize_captured_tensor_mutation(self, dynamic):
+        device = "cpu"
+
+        class M(torch.nn.Module):
+            def forward(self, xs, y):
+                def body_fn(x):
+                    y.add_(-1)
+                    return x * 2 + y.sum()
+
+                out = control_flow.map(body_fn, xs)
+                return out + y.sum()
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        y = torch.ones(4, requires_grad=False)
+        fw_gm = self._check_eager_and_aot_eager_only(M, (xs, y), device, dynamic)
+        graph_str = fw_gm.print_readable(print_output=False)
+        self.assertIn("auto_functionalized_v2", graph_str)
+
+    def test_map_xs_mutation_graph_breaks(self):
+        def body_fn(x):
+            x.add_(1)  # mutating xs[t] is disallowed
+            return x * 2
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+
+        def fn(xs):
+            return control_flow.map(body_fn, xs)
+
+        torch._dynamo.reset()
+        with torch.no_grad():
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.UncapturedHigherOrderOpError,
+                r"Higher Order Operator: torch\.ops\.higher_order\.map_impl",
+            ):
+                torch.compile(fn, backend="eager", fullgraph=True)(xs)
+
+    @skipIfTorchDynamo()
+    @parametrize("dynamic", [True, False])
+    def test_map_auto_functionalize_partial_buffer_mutation(self, dynamic):
+        device = "cpu"
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buf0", torch.zeros(4, device=device))
+                self.register_buffer("buf1", torch.zeros(4, device=device))
+                self.register_buffer("buf2", torch.zeros(4, device=device))
+
+            def forward(self, xs):
+                def body_fn(x):
+                    # Skip buf1 to make non-contiguous mutation set.
+                    self.buf0.add_(x)
+                    self.buf2.add_(x)
+                    return x * 2 + self.buf1.sum()
+
+                return control_flow.map(body_fn, xs)
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+        fw_gm = self._check_eager_and_aot_eager_only(M, (xs,), device, dynamic)
+        graph_str = fw_gm.print_readable(print_output=False)
+        self.assertIn("auto_functionalized_v2", graph_str)
+
+    def test_map_eager_xs_mutation_raises(self):
+        def body_fn(x):
+            x.add_(1)
+            return x * 2
+
+        xs = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UncapturedHigherOrderOpError,
+            r"Higher Order Operator: torch\.ops\.higher_order\.map_impl",
+        ):
+            control_flow.map(body_fn, xs)
+
 
 _hop_schema_test_schema_types = [
     "bool",
@@ -10815,67 +10941,37 @@ class TestHopSchema(TestCase):
             """map_impl(Any f, Tensor xs0, Tensor xs1) -> (Tensor, Tensor)""",
         )
 
-    def test_map_gen_schema_with_xs_mutation(self):
-        def body_fn(x):
-            x.add_(1)
+    def test_map_gen_schema_with_mutated_arg_indices_kwarg(self):
+        def body_fn(x, buf0, buf1):
             return x * 2
 
         schema = torch.ops.higher_order.map_impl.gen_schema(
             body_fn,
             (torch.randn(5, 3, 4),),
-            (),
+            (torch.randn(3, 4), torch.randn(3, 4)),
+            "2",
         )
         self.assertExpectedInline(
             str(schema),
-            """map_impl(Any f, Tensor(a1!) xs0) -> ((Tensor))""",
+            """map_impl(Any f, Tensor xs0, Tensor additional_input0, Tensor(a3!) additional_input1) -> ((Tensor))""",
         )
 
-    def test_map_gen_schema_with_multiple_xs_mutation(self):
-        def body_fn(x1, x2):
-            x1.add_(1)
-            x2.sub_(1)
-            return x1 + x2, x1 * x2
+    def test_map_gen_schema_multiple_pos_args_mutation_via_kwarg(self):
+        def body_fn(x, b0, b1, b2):
+            b1.add_(x)
+            b2.add_(x)
+            return x * 2
 
         schema = torch.ops.higher_order.map_impl.gen_schema(
             body_fn,
-            (torch.randn(5, 3, 4), torch.randn(5, 3, 4)),
-            (),
+            (torch.randn(5, 3, 4),),
+            (torch.randn(3, 4), torch.randn(3, 4), torch.randn(3, 4)),
+            "2,3",
         )
         self.assertExpectedInline(
             str(schema),
-            """map_impl(Any f, Tensor(a1!) xs0, Tensor(a2!) xs1) -> (Tensor, Tensor)""",
+            """map_impl(Any f, Tensor xs0, Tensor additional_input0, Tensor(a3!) additional_input1, Tensor(a4!) additional_input2) -> ((Tensor))""",
         )
-
-    def test_map_gen_schema_pos_args_mutation_raises(self):
-        def body_fn(x, buf):
-            buf.add_(x)
-            return x * 2
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "For map, f cannot mutate pos_args inputs",
-        ):
-            torch.ops.higher_order.map_impl.gen_schema(
-                body_fn,
-                (torch.randn(5, 3, 4),),
-                (torch.randn(3, 4),),
-            )
-
-    def test_map_gen_schema_xs_and_pos_args_mutation_raises(self):
-        def body_fn(x1, x2, buf):
-            x1.add_(1)
-            buf.sub_(x2)
-            return x1 + x2, x1 * x2
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "For map, f cannot mutate pos_args inputs",
-        ):
-            torch.ops.higher_order.map_impl.gen_schema(
-                body_fn,
-                (torch.randn(5, 3, 4), torch.randn(5, 3, 4)),
-                (torch.randn(3, 4),),
-            )
 
 
 class DynamicCondModel(torch.nn.Module):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -62,6 +62,16 @@
       ]
     }
   ],
+  "GB4774": [
+    {
+      "Gb_type": "torch.map: f mutates pos_args",
+      "Context": "pos_args={pos_args_mutated}",
+      "Explanation": "map only supports in-place mutation of xs (each iteration sees a storage-disjoint slice). pos_args are loop-invariant: every iteration sees the same tensor, so a mutation makes iterations depend on each other, breaking map's independence contract and introducing a data race under any parallel lowering. Use scan or while_loop if sequential buffer updates are required.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
   "GB2861": [
     {
       "Gb_type": "Untraceable C tp_hash",
@@ -699,6 +709,16 @@
         "with `DataPtrVariable` due to a graph break between the `.data_ptr()` call and ",
         "`create_{self.rank}d_tma_descriptor`. Please ensure there were no graph breaks ",
         "between these two calls."
+      ]
+    }
+  ],
+  "GB3946": [
+    {
+      "Gb_type": "torch.map: f mutates xs",
+      "Context": "xs={xs_mutated}",
+      "Explanation": "map only supports in-place mutation of pos_args (loop-invariant tensors). xs[t] is a fresh, storage-disjoint slice each step, so a mutation cannot be observed by any other iteration. The only externally-observable effect of mutating xs[t] is a write-back to xs's t-th slice, which is already expressible via the f return value. For in-place lifted buffers, pass them via pos_args.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
       ]
     }
   ],

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -712,16 +712,6 @@
       ]
     }
   ],
-  "GB3946": [
-    {
-      "Gb_type": "torch.map: f mutates xs",
-      "Context": "xs={xs_mutated}",
-      "Explanation": "map only supports in-place mutation of pos_args (loop-invariant tensors). xs[t] is a fresh, storage-disjoint slice each step, so a mutation cannot be observed by any other iteration. The only externally-observable effect of mutating xs[t] is a write-back to xs's t-th slice, which is already expressible via the f return value. For in-place lifted buffers, pass them via pos_args.",
-      "Hints": [
-        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
-      ]
-    }
-  ],
   "GB4297": [
     {
       "Gb_type": "Call to `torch._dynamo.skip_frame()`",

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2982,6 +2982,16 @@
       ]
     }
   ],
+  "GB6183": [
+    {
+      "Gb_type": "torch.map: f mutates a captured tensor",
+      "Context": "freevars={freevars_mutated}",
+      "Explanation": "map only supports in-place mutation of xs. A tensor captured from the enclosing scope (lifted parameter) is loop-invariant: every iteration sees the same tensor, so a mutation makes iterations depend on each other, breaking map's independence contract and introducing a data race under any parallel lowering. Pass the buffer through xs, or use scan / while_loop if sequential buffer updates are required.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
   "GB9198": [
     {
       "Gb_type": "Attempted to call repr() method implemented in C/C++",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3392,49 +3392,46 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             [br for bm, br in zip(none_mask, body_r_vars) if not bm]
         )
 
-        # Mutation handling: map allows in-place writes only to pos_args
-        # (lifted, loop-invariant tensors). Mutations of xs are unsafe
-        # (see MapImpl.gen_schema for the contract) so we graph-break here
-        # with a precise message. The remaining indices are mapped through
-        # the parent-side input list to produce a comma-joined
-        # ``mutated_arg_indices`` kwarg for the HOP call, mirroring
-        # scan / while_loop.
+        # Mutation handling: map allows in-place writes only to xs
+        # (each iteration sees a storage-disjoint slice). Mutations of
+        # pos_args are unsafe (see MapImpl.gen_schema for the contract)
+        # so we graph-break here with a precise message. The remaining
+        # indices are mapped through the parent-side input list to produce
+        # a comma-joined ``mutated_arg_indices`` kwarg for the HOP call,
+        # mirroring scan / while_loop.
         n_xs = len(unpacked_xs)
 
-        xs_mutated = sorted(i for i in body_mutated_inputs if i < n_xs)
-        if xs_mutated:
+        pos_args_mutated = sorted(i - n_xs for i in body_mutated_inputs if i >= n_xs)
+        if pos_args_mutated:
             unimplemented(
-                gb_type="torch.map: f mutates xs",
-                context=f"xs={xs_mutated}",
+                gb_type="torch.map: f mutates pos_args",
+                context=f"pos_args={pos_args_mutated}",
                 explanation=(
-                    "map only supports in-place mutation of pos_args "
-                    "(loop-invariant tensors). xs[t] is a fresh, storage-"
-                    "disjoint slice each step, so a mutation cannot be "
-                    "observed by any other iteration. The only externally-"
-                    "observable effect of mutating xs[t] is a write-back to "
-                    "xs's t-th slice, which is already expressible via the "
-                    "f return value. For in-place lifted buffers, pass them "
-                    "via pos_args."
+                    "map only supports in-place mutation of xs (each "
+                    "iteration sees a storage-disjoint slice). pos_args "
+                    "are loop-invariant: every iteration sees the same "
+                    "tensor, so a mutation makes iterations depend on each "
+                    "other, breaking map's independence contract and "
+                    "introducing a data race under any parallel lowering. "
+                    "Use scan or while_loop if sequential buffer updates "
+                    "are required."
                 ),
                 hints=[
                     *graph_break_hints.USER_ERROR,
                 ],
             )
 
-        # pos_args (subgraph indices [n_xs, ...)) plus any lifted freevars
-        # (indices >= n_xs + n_pos_args). Both are carried as pos_args at
-        # the HOP-call layer.
+        # Build a parent-storage set from the xs subgraph placeholders that
+        # were detected as mutated, then re-map through ``all_map_inputs``
+        # to recover the parent-side indices. Lifted freevars are appended
+        # so storage matching also covers any captured-tensor that aliases
+        # an xs slice's storage.
         all_map_inputs: list[VariableTracker | Proxy] = (
-            list(unpacked_xs)
-            + list(unpacked_args)
-            + list(body_lifted_freevars)
+            list(unpacked_xs) + list(unpacked_args) + list(body_lifted_freevars)
         )
-        # Build a parent-storage set from the subgraph placeholders that were
-        # detected as mutated, then re-map through ``all_map_inputs`` so we
-        # cover both regular pos_args and lifted freevars.
         mutated_input_storages = subgraph_mutated_input_storages(
             body_graph,
-            {i for i in body_mutated_inputs if i >= n_xs},
+            {i for i in body_mutated_inputs if i < n_xs},
         )
         mutated_inputs = parent_mutated_input_indices(
             all_map_inputs, mutated_input_storages

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3456,11 +3456,14 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             [arg.as_proxy() for arg in unpacked_args]
             + list(body_lifted_freevars.keys()),
         )
+        hop_kwargs = (
+            {"mutated_arg_indices": mutated_arg_indices} if mutated_arg_indices else {}
+        )
         return _call_function_and_unflatten_output(
             tx,
             torch.ops.higher_order.map_impl,
             p_args,
-            {"mutated_arg_indices": mutated_arg_indices},
+            hop_kwargs,
             None,
             body_spec,
             body_r,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3290,7 +3290,6 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.ops.higher_order.map_impl"
     _ALLOW_FALLBACK_TO_EAGER = False
-    supports_input_mutation = False
     supports_aliasing = False
 
     def _call_function(
@@ -3299,6 +3298,11 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        # Input mutation is only safe in inference: under autograd the
+        # functional rewrite of a mutating subgraph would lose the storage
+        # identity required for the backward pass.
+        self.supports_input_mutation = not torch.is_grad_enabled()
+
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
 
         if len(kwargs) > 0:
@@ -3376,6 +3380,10 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             supports_aliasing=self.supports_aliasing,
         )
 
+        body_mutated_inputs = set(
+            getattr(body_graph, "_dynamo_mutated_input_indices", ())
+        )
+
         # Check all outputs of map are tensors.
         # For map, outputting None is OK, thus ignore None values in the check
         body_r_vars = unpack_iterable(tx, body_r)
@@ -3383,6 +3391,55 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         _check_all_tensorvariable(
             [br for bm, br in zip(none_mask, body_r_vars) if not bm]
         )
+
+        # Mutation handling: map allows in-place writes only to pos_args
+        # (lifted, loop-invariant tensors). Mutations of xs are unsafe
+        # (see MapImpl.gen_schema for the contract) so we graph-break here
+        # with a precise message. The remaining indices are mapped through
+        # the parent-side input list to produce a comma-joined
+        # ``mutated_arg_indices`` kwarg for the HOP call, mirroring
+        # scan / while_loop.
+        n_xs = len(unpacked_xs)
+
+        xs_mutated = sorted(i for i in body_mutated_inputs if i < n_xs)
+        if xs_mutated:
+            unimplemented(
+                gb_type="torch.map: f mutates xs",
+                context=f"xs={xs_mutated}",
+                explanation=(
+                    "map only supports in-place mutation of pos_args "
+                    "(loop-invariant tensors). xs[t] is a fresh, storage-"
+                    "disjoint slice each step, so a mutation cannot be "
+                    "observed by any other iteration. The only externally-"
+                    "observable effect of mutating xs[t] is a write-back to "
+                    "xs's t-th slice, which is already expressible via the "
+                    "f return value. For in-place lifted buffers, pass them "
+                    "via pos_args."
+                ),
+                hints=[
+                    *graph_break_hints.USER_ERROR,
+                ],
+            )
+
+        # pos_args (subgraph indices [n_xs, ...)) plus any lifted freevars
+        # (indices >= n_xs + n_pos_args). Both are carried as pos_args at
+        # the HOP-call layer.
+        all_map_inputs: list[VariableTracker | Proxy] = (
+            list(unpacked_xs)
+            + list(unpacked_args)
+            + list(body_lifted_freevars)
+        )
+        # Build a parent-storage set from the subgraph placeholders that were
+        # detected as mutated, then re-map through ``all_map_inputs`` so we
+        # cover both regular pos_args and lifted freevars.
+        mutated_input_storages = subgraph_mutated_input_storages(
+            body_graph,
+            {i for i in body_mutated_inputs if i >= n_xs},
+        )
+        mutated_inputs = parent_mutated_input_indices(
+            all_map_inputs, mutated_input_storages
+        )
+        mutated_arg_indices = ",".join(str(i) for i in mutated_inputs)
 
         body_nn_modules = dict(tx.output.nn_modules)
 
@@ -3399,9 +3456,14 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             [arg.as_proxy() for arg in unpacked_args]
             + list(body_lifted_freevars.keys()),
         )
-
         return _call_function_and_unflatten_output(
-            tx, torch.ops.higher_order.map_impl, p_args, {}, None, body_spec, body_r
+            tx,
+            torch.ops.higher_order.map_impl,
+            p_args,
+            {"mutated_arg_indices": mutated_arg_indices},
+            None,
+            body_spec,
+            body_r,
         )
 
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3416,20 +3416,26 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
 
         # Build a parent-storage set from the xs subgraph placeholders that
-        # were detected as mutated, then re-map through ``all_map_inputs``
-        # to recover the parent-side indices. Lifted freevars are appended
-        # so storage matching also covers any captured-tensor that aliases
-        # an xs slice's storage.
-        all_map_inputs: list[VariableTracker | Proxy] = (
-            list(unpacked_xs) + list(unpacked_args) + list(body_lifted_freevars)
-        )
+        # were detected as mutated, then re-map through ``unpacked_xs`` to
+        # recover the parent-side xs indices. We deliberately only match
+        # against xs (not pos_args / freevars): map's contract permits
+        # mutation of xs only, and ``gen_schema`` only marks xs entries as
+        # mutated. If a pos_arg or freevar happened to share storage with
+        # an xs slice, matching it here would emit an index >= n_xs that
+        # ``auto_functionalize`` would then treat as a mutated pos_arg,
+        # creating a mismatch with the schema.
         mutated_input_storages = subgraph_mutated_input_storages(
             body_graph,
             {i for i in body_mutated_inputs if i < n_xs},
         )
         mutated_inputs = parent_mutated_input_indices(
-            all_map_inputs, mutated_input_storages
+            list(unpacked_xs), mutated_input_storages
         )
+        if any(i >= n_xs for i in mutated_inputs):
+            raise AssertionError(
+                f"map mutated_inputs must reference xs only "
+                f"(n_xs={n_xs}): {mutated_inputs}"
+            )
         mutated_arg_indices = ",".join(str(i) for i in mutated_inputs)
 
         body_nn_modules = dict(tx.output.nn_modules)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3290,6 +3290,7 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
     _HOP_NAME = "torch.ops.higher_order.map_impl"
     _ALLOW_FALLBACK_TO_EAGER = False
+    supports_input_mutation = False
     supports_aliasing = False
 
     def _call_function(
@@ -3298,9 +3299,6 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        # Input mutation is only safe in inference: under autograd the
-        # functional rewrite of a mutating subgraph would lose the storage
-        # identity required for the backward pass.
         self.supports_input_mutation = not torch.is_grad_enabled()
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
@@ -3395,10 +3393,6 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # Mutation handling: map allows in-place writes only to xs
         # (each iteration sees a storage-disjoint slice). Mutations of
         # pos_args are unsafe (see MapImpl.gen_schema for the contract)
-        # so we graph-break here with a precise message. The remaining
-        # indices are mapped through the parent-side input list to produce
-        # a comma-joined ``mutated_arg_indices`` kwarg for the HOP call,
-        # mirroring scan / while_loop.
         n_xs = len(unpacked_xs)
 
         pos_args_mutated = sorted(i - n_xs for i in body_mutated_inputs if i >= n_xs)
@@ -3453,14 +3447,11 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             [arg.as_proxy() for arg in unpacked_args]
             + list(body_lifted_freevars.keys()),
         )
-        hop_kwargs = (
-            {"mutated_arg_indices": mutated_arg_indices} if mutated_arg_indices else {}
-        )
         return _call_function_and_unflatten_output(
             tx,
             torch.ops.higher_order.map_impl,
             p_args,
-            hop_kwargs,
+            {"mutated_arg_indices": mutated_arg_indices} if mutated_arg_indices else {},
             None,
             body_spec,
             body_r,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3392,10 +3392,14 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         # Mutation handling: map allows in-place writes only to xs
         # (each iteration sees a storage-disjoint slice). Mutations of
-        # pos_args are unsafe (see MapImpl.gen_schema for the contract)
+        # pos_args or captured freevars are unsafe (see MapImpl.gen_schema
+        # for the contract). Placeholder order is [xs, pos_args, freevars].
         n_xs = len(unpacked_xs)
+        n_pos = len(unpacked_args)
 
-        pos_args_mutated = sorted(i - n_xs for i in body_mutated_inputs if i >= n_xs)
+        pos_args_mutated = sorted(
+            i - n_xs for i in body_mutated_inputs if n_xs <= i < n_xs + n_pos
+        )
         if pos_args_mutated:
             unimplemented(
                 gb_type="torch.map: f mutates pos_args",
@@ -3409,6 +3413,28 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     "introducing a data race under any parallel lowering. "
                     "Use scan or while_loop if sequential buffer updates "
                     "are required."
+                ),
+                hints=[
+                    *graph_break_hints.USER_ERROR,
+                ],
+            )
+
+        freevars_mutated = sorted(
+            i - n_xs - n_pos for i in body_mutated_inputs if i >= n_xs + n_pos
+        )
+        if freevars_mutated:
+            unimplemented(
+                gb_type="torch.map: f mutates a captured tensor",
+                context=f"freevars={freevars_mutated}",
+                explanation=(
+                    "map only supports in-place mutation of xs. A tensor "
+                    "captured from the enclosing scope (lifted parameter) is loop-invariant: "
+                    "every iteration sees the same tensor, so a mutation "
+                    "makes iterations depend on each other, breaking map's "
+                    "independence contract and introducing a data race "
+                    "under any parallel lowering. Pass the buffer through "
+                    "xs, or use scan / while_loop if sequential buffer "
+                    "updates are required."
                 ),
                 hints=[
                     *graph_break_hints.USER_ERROR,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3415,28 +3415,9 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 ],
             )
 
-        # Build a parent-storage set from the xs subgraph placeholders that
-        # were detected as mutated, then re-map through ``unpacked_xs`` to
-        # recover the parent-side xs indices. We deliberately only match
-        # against xs (not pos_args / freevars): map's contract permits
-        # mutation of xs only, and ``gen_schema`` only marks xs entries as
-        # mutated. If a pos_arg or freevar happened to share storage with
-        # an xs slice, matching it here would emit an index >= n_xs that
-        # ``auto_functionalize`` would then treat as a mutated pos_arg,
-        # creating a mismatch with the schema.
-        mutated_input_storages = subgraph_mutated_input_storages(
-            body_graph,
-            {i for i in body_mutated_inputs if i < n_xs},
-        )
-        mutated_inputs = parent_mutated_input_indices(
-            list(unpacked_xs), mutated_input_storages
-        )
-        if any(i >= n_xs for i in mutated_inputs):
-            raise AssertionError(
-                f"map mutated_inputs must reference xs only "
-                f"(n_xs={n_xs}): {mutated_inputs}"
-            )
-        mutated_arg_indices = ",".join(str(i) for i in mutated_inputs)
+        # No storage round-trip needed: aliasing graph-breaks upstream, so the
+        # mutated subgraph placeholder indices are already the parent xs indices.
+        mutated_arg_indices = ",".join(str(i) for i in sorted(body_mutated_inputs))
 
         body_nn_modules = dict(tx.output.nn_modules)
 

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -69,17 +69,17 @@ class MapImpl(HigherOrderOperator):
         body_gm = materialize_as_graph(f, all_inputs)
 
         # Mutation semantics for map:
-        # - pos_args is mutable: lifted, loop-invariant tensors (e.g. module
-        #   buffers, KV caches), same semantics as scan's additional_inputs
-        #   and while_loop's additional_inputs. Mutations are surfaced via
-        #   auto_functionalize_v2 so the parent graph sees them.
-        # - xs is NOT mutable: each iteration sees a fresh, storage-disjoint
-        #   slice (xs[t] and xs[t+1] share no storage), so a mutation on
-        #   xs[t] cannot be observed by any other iteration. The only
-        #   externally-observable effect is "write-back to xs's t-th slice",
-        #   which is already expressible via the output path at no extra
-        #   cost. If xs-like in-place updates are required, pass the buffer
-        #   via pos_args and index into it inside f.
+        # - xs is mutable: each iteration sees a storage-disjoint slice
+        #   (xs[t] and xs[t+1] share no storage), so in-place writes are
+        #   race-free regardless of evaluation order, preserving map's
+        #   "iterations are independent" contract. Mutations are surfaced
+        #   via auto_functionalize_v2 so the parent graph sees them.
+        # - pos_args is NOT mutable: every iteration sees the same tensor,
+        #   so mutating it makes iterations depend on each other, breaking
+        #   the independence contract and introducing a data race under any
+        #   parallel lowering. Users who need a shared mutable buffer
+        #   should use scan / while_loop, where sequential iteration is
+        #   part of the contract.
         outputs = get_graph_output_example_values(body_gm)
         mutated_set = (
             {int(i) for i in mutated_arg_indices.split(",") if i}
@@ -91,15 +91,10 @@ class MapImpl(HigherOrderOperator):
         schema_gen.add_arg("f", body_gm)
 
         for idx, x in enumerate(xs):
-            schema_gen.add_arg(f"xs{idx}", x)
+            schema_gen.add_arg(f"xs{idx}", x, is_mutated=idx in mutated_set)
 
-        offset = len(xs)
         for idx, arg in enumerate(pos_args):
-            schema_gen.add_arg(
-                f"additional_input{idx}",
-                arg,
-                is_mutated=(offset + idx) in mutated_set,
-            )
+            schema_gen.add_arg(f"additional_input{idx}", arg)
 
         for out in outputs:
             schema_gen.add_output(out)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -43,11 +43,17 @@ class MapImpl(HigherOrderOperator):
         super().__init__("map_impl")
 
     def __call__(self, f, xs, pos_args, *, mutated_arg_indices: str = ""):
-        kwargs = {}
-        if mutated_arg_indices:
-            kwargs["mutated_arg_indices"] = mutated_arg_indices
         # pyrefly: ignore [missing-attribute]
-        return super().__call__(f, xs, pos_args, **kwargs)
+        return super().__call__(
+            f,
+            xs,
+            pos_args,
+            **(
+                {"mutated_arg_indices": mutated_arg_indices}
+                if mutated_arg_indices
+                else {}
+            ),
+        )
 
     # pyrefly: ignore [bad-override]
     def gen_schema(self, f, xs, pos_args, mutated_arg_indices=""):
@@ -320,11 +326,12 @@ def trace_map(proxy_mode, func_overload, f, xs, pos_args, mutated_arg_indices=""
 
     node_args = (body_graph, list(xs), list(pos_args))
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
-    kwargs = {}
-    if mutated_arg_indices:
-        kwargs["mutated_arg_indices"] = mutated_arg_indices
     out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, kwargs, name="map_impl"
+        "call_function",
+        func_overload,
+        proxy_args,
+        {"mutated_arg_indices": mutated_arg_indices} if mutated_arg_indices else {},
+        name="map_impl",
     )
     return track_tensor_tree(
         fake_outs, out_proxy, constant=None, tracer=proxy_mode.tracer

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -7,12 +7,29 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._dispatch.python import suspend_functionalization
+from torch._higher_order_ops.auto_functionalize import (
+    can_auto_functionalize,
+    do_auto_functionalize_v2,
+)
 from torch._higher_order_ops.utils import (
+    _from_fun,
     _maybe_run_with_interpreter,
+    _stack_pytree,
+    _unstack_pytree,
+    create_bw_fn,
+    fill_none_with_masks,
+    filter_with_masks,
+    first_slice_copy,
+    get_graph_output_example_values,
+    HopInstance,
+    materialize_as_graph,
     reenter_make_fx,
-    register_fake,
+    save_values_for_backward,
+    saved_values,
+    split_into_chunks,
 )
 from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -20,78 +37,69 @@ from torch.fx.experimental.proxy_tensor import (
     track_tensor_tree,
 )
 
-from .utils import (
-    _from_fun,
-    _stack_pytree,
-    _unstack_pytree,
-    check_input_alias_and_mutation_return_outputs,
-    create_bw_fn,
-    fill_none_with_masks,
-    filter_with_masks,
-    first_slice_copy,
-    materialize_as_graph,
-    save_values_for_backward,
-    saved_values,
-    split_into_chunks,
-)
-
 
 class MapImpl(HigherOrderOperator):
     def __init__(self):
         super().__init__("map_impl")
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, f, xs, pos_args, *, mutated_arg_indices: str = ""):
+        kwargs = {}
+        if mutated_arg_indices:
+            kwargs["mutated_arg_indices"] = mutated_arg_indices
         # pyrefly: ignore [missing-attribute]
-        return super().__call__(*args, **kwargs)
+        return super().__call__(f, xs, pos_args, **kwargs)
 
     # pyrefly: ignore [bad-override]
-    def gen_schema(self, f, xs, pos_args):
+    def gen_schema(self, f, xs, pos_args, mutated_arg_indices=""):
         from torch._higher_order_ops.schema import HopSchemaGenerator
 
+        all_inputs = tuple(
+            [
+                torch.empty_strided(
+                    x.shape[1:],
+                    x.stride()[1:],
+                    dtype=x.dtype,
+                    device=x.device,
+                    requires_grad=x.requires_grad,
+                )
+                for x in xs
+            ]
+            + list(pos_args)
+        )
+        body_gm = materialize_as_graph(f, all_inputs)
+
         # Mutation semantics for map:
-        # - xs is mutable: each iteration sees a storage-disjoint slice
-        #   (xs[t] and xs[t+1] share no storage), so in-place writes are
-        #   race-free regardless of evaluation order, preserving map's
-        #   "iterations are independent" contract.
-        # - pos_args is NOT mutable: every iteration sees the same
-        #   tensor, so mutating it makes iterations depend on each
-        #   other, breaking the independence contract and introducing a
-        #   data race under any parallel lowering. Users who need a
-        #   shared mutable buffer should use scan / while_loop, where
-        #   sequential iteration is part of the contract.
-        xs_slices = [first_slice_copy(x) for x in xs]
-        all_inputs = tuple(xs_slices + list(pos_args))
-
-        body_gm: torch.fx.GraphModule = materialize_as_graph(f, all_inputs)
-        (
-            _,
-            _,
-            _,
-            mutated_inputs,
-            outputs,
-        ) = check_input_alias_and_mutation_return_outputs(body_gm)
-
-        n_xs = len(xs)
-        pos_args_mutated = [i for i in mutated_inputs if i >= n_xs]
-        if pos_args_mutated:
-            raise RuntimeError(
-                "For map, f cannot mutate pos_args inputs but found "
-                f"{[i - n_xs for i in pos_args_mutated]}-th pos_args inputs "
-                "are mutated. Map iterations are independent, so mutating "
-                "a shared pos_args buffer is undefined under parallel "
-                "lowering. Use scan or while_loop if sequential buffer "
-                "updates are required."
-            )
-        mutated_set = set(mutated_inputs)
+        # - pos_args is mutable: lifted, loop-invariant tensors (e.g. module
+        #   buffers, KV caches), same semantics as scan's additional_inputs
+        #   and while_loop's additional_inputs. Mutations are surfaced via
+        #   auto_functionalize_v2 so the parent graph sees them.
+        # - xs is NOT mutable: each iteration sees a fresh, storage-disjoint
+        #   slice (xs[t] and xs[t+1] share no storage), so a mutation on
+        #   xs[t] cannot be observed by any other iteration. The only
+        #   externally-observable effect is "write-back to xs's t-th slice",
+        #   which is already expressible via the output path at no extra
+        #   cost. If xs-like in-place updates are required, pass the buffer
+        #   via pos_args and index into it inside f.
+        outputs = get_graph_output_example_values(body_gm)
+        mutated_set = (
+            {int(i) for i in mutated_arg_indices.split(",") if i}
+            if mutated_arg_indices
+            else set()
+        )
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("f", body_gm)
 
         for idx, x in enumerate(xs):
-            schema_gen.add_arg(f"xs{idx}", x, is_mutated=idx in mutated_set)
+            schema_gen.add_arg(f"xs{idx}", x)
 
+        offset = len(xs)
         for idx, arg in enumerate(pos_args):
-            schema_gen.add_arg(f"additional_input{idx}", arg)
+            schema_gen.add_arg(
+                f"additional_input{idx}",
+                arg,
+                is_mutated=(offset + idx) in mutated_set,
+            )
 
         for out in outputs:
             schema_gen.add_output(out)
@@ -300,28 +308,28 @@ def _broadcast_to_batch(output, batch_size):
     return pytree.tree_map(expand_with_batch, output)
 
 
-def trace_map(proxy_mode, func_overload, f, xs, pos_args):
-    from torch._higher_order_ops.utils import first_slice_copy
-
+def trace_map(proxy_mode, func_overload, f, xs, pos_args, mutated_arg_indices=""):
     with disable_proxy_modes_tracing():
         # Use first_slice_copy instead of _unstack_pytree to avoid
         # iterating over batch dim, which would guard on symbolic sizes.
         example_input = pytree.tree_map(first_slice_copy, xs)
 
-        body_graph = f
-
-        body_graph = reenter_make_fx(body_graph)(*example_input, *pos_args)
+        body_graph = reenter_make_fx(f)(*example_input, *pos_args)
 
     next_name = proxy_mode.tracer.get_fresh_qualname("body_graph_")
-
     proxy_mode.tracer.root.register_module(next_name, body_graph)
 
-    fake_outs = map_impl(body_graph, xs, pos_args)
+    fake_outs = map_impl(
+        body_graph, xs, pos_args, mutated_arg_indices=mutated_arg_indices
+    )
 
     node_args = (body_graph, list(xs), list(pos_args))
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
+    kwargs = {}
+    if mutated_arg_indices:
+        kwargs["mutated_arg_indices"] = mutated_arg_indices
     out_proxy = proxy_mode.tracer.create_proxy(
-        "call_function", func_overload, proxy_args, {}, name="map_impl"
+        "call_function", func_overload, proxy_args, kwargs, name="map_impl"
     )
     return track_tensor_tree(
         fake_outs, out_proxy, constant=None, tracer=proxy_mode.tracer
@@ -329,44 +337,58 @@ def trace_map(proxy_mode, func_overload, f, xs, pos_args):
 
 
 @map_impl.py_impl(DispatchKey.CompositeExplicitAutograd)
-def map_dense(f, xs, pos_args):
+def map_dense(f, xs, pos_args, mutated_arg_indices=""):
     pytrees = [f(*inp, *pos_args) for inp in _unstack_pytree(xs)]
     return _stack_pytree(pytrees)
 
 
 @map_impl.py_autograd_impl
-def map_autograd(f, xs, pos_args):
+def map_autograd(f, xs, pos_args, mutated_arg_indices=""):
     num_mapped_args = len(xs)
     flat_out = MapAutogradOp.apply(f, num_mapped_args, *xs, *pos_args)
     return flat_out
 
 
 @map_impl.py_impl(ProxyTorchDispatchMode)
-def map_proxy_torch_dispatch_mode(mode, f, xs, args):
-    return trace_map(mode, map_impl, f, xs, args)
+def map_proxy_torch_dispatch_mode(mode, f, xs, pos_args, mutated_arg_indices=""):
+    return trace_map(
+        mode, map_impl, f, xs, pos_args, mutated_arg_indices=mutated_arg_indices
+    )
 
 
-@register_fake(map_impl, skip_cache=True)
-def map_fake_tensor_mode(f, xs, args):
-    from torch._higher_order_ops.utils import first_slice_copy
+@map_impl.py_impl(FakeTensorMode)
+def map_fake_tensor_mode(mode, f, xs, pos_args, mutated_arg_indices=""):
+    with mode:
+        # Use first_slice_copy instead of _unstack_pytree to avoid
+        # iterating over batch dim, which would guard on symbolic sizes.
+        first_row = pytree.tree_map(first_slice_copy, xs)
+        example_output = f(*first_row, *pos_args)
 
-    # Use first_slice_copy instead of _unstack_pytree to avoid
-    # iterating over batch dim, which would guard on symbolic sizes.
-    first_row = pytree.tree_map(first_slice_copy, xs)
-    example_output = f(*first_row, *args)
+        flat_xs, _ = pytree.tree_flatten(xs)
+        batch_size = flat_xs[0].shape[0]
 
-    flat_xs, _ = pytree.tree_flatten(xs)
-    batch_size = flat_xs[0].shape[0]
-
-    return _broadcast_to_batch(example_output, batch_size)
+        return _broadcast_to_batch(example_output, batch_size)
 
 
 @map_impl.py_functionalize_impl
-def map_functionalize(ctx, f, xs, pos_args):
-    from torch._higher_order_ops.utils import (
-        _check_alias_and_mutation,
-        first_slice_copy,
-    )
+def map_functionalize(ctx, f, xs, pos_args, mutated_arg_indices=""):
+    from torch._higher_order_ops.utils import _check_alias_and_mutation
+
+    if hasattr(ctx, "mode"):
+        hop_instance = HopInstance.create(
+            map_impl,
+            f,
+            xs,
+            pos_args,
+            mutated_arg_indices=mutated_arg_indices,
+        )
+        if can_auto_functionalize(hop_instance):
+            return do_auto_functionalize_v2(
+                ctx.mode,
+                hop_instance,
+                tuple(pytree.tree_flatten((f, xs, pos_args))[0]),
+                {},
+            )
 
     unwrapped_xs = ctx.unwrap_tensors(xs)
     unwrapped_args = ctx.unwrap_tensors(pos_args)
@@ -381,7 +403,12 @@ def map_functionalize(ctx, f, xs, pos_args):
         )
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         _check_alias_and_mutation(f, example_inputs, "map", pre_dispatch)
-        map_return = map_impl(wrapped_fn, unwrapped_xs, unwrapped_args)
+        map_return = map_impl(
+            wrapped_fn,
+            unwrapped_xs,
+            unwrapped_args,
+            mutated_arg_indices=mutated_arg_indices,
+        )
         return ctx.wrap_tensors(map_return)
 
 

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import Any
 from typing_extensions import TypeVarTuple
 
 import torch
@@ -24,12 +25,12 @@ from torch._higher_order_ops.utils import (
     HopInstance,
     materialize_as_graph,
     reenter_make_fx,
+    register_fake,
     save_values_for_backward,
     saved_values,
     split_into_chunks,
 )
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._subclasses.functional_tensor import disable_functional_mode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -42,14 +43,21 @@ class MapImpl(HigherOrderOperator):
     def __init__(self):
         super().__init__("map_impl")
 
-    def __call__(self, f, xs, pos_args, *, mutated_arg_indices: str = ""):
+    def __call__(
+        self,
+        f: Callable[..., Any],
+        xs: Sequence[torch.Tensor],
+        pos_args: Sequence[torch.fx.node.BaseArgumentTypes],
+        *,
+        mutated_arg_indices: str = "",
+    ) -> Any:
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
             f, xs, pos_args, mutated_arg_indices=mutated_arg_indices
         )
 
     # pyrefly: ignore [bad-override]
-    def gen_schema(self, f, xs, pos_args, mutated_arg_indices:str = ""):
+    def gen_schema(self, f, xs, pos_args, mutated_arg_indices: str = ""):
         from torch._higher_order_ops.schema import HopSchemaGenerator
 
         all_inputs = tuple(
@@ -297,7 +305,14 @@ def _broadcast_to_batch(output, batch_size):
     return pytree.tree_map(expand_with_batch, output)
 
 
-def trace_map(proxy_mode, func_overload, f, xs, pos_args, mutated_arg_indices=""):
+def trace_map(
+    proxy_mode: ProxyTorchDispatchMode,
+    func_overload: HigherOrderOperator,
+    f: Callable[..., Any],
+    xs: Sequence[torch.Tensor],
+    pos_args: Sequence[torch.fx.node.BaseArgumentTypes],
+    mutated_arg_indices: str = "",
+) -> Any:
     with disable_proxy_modes_tracing():
         # Use first_slice_copy instead of _unstack_pytree to avoid
         # iterating over batch dim, which would guard on symbolic sizes.
@@ -346,18 +361,17 @@ def map_proxy_torch_dispatch_mode(mode, f, xs, pos_args, mutated_arg_indices="")
     )
 
 
-@map_impl.py_impl(FakeTensorMode)
-def map_fake_tensor_mode(mode, f, xs, pos_args, mutated_arg_indices=""):
-    with mode:
-        # Use first_slice_copy instead of _unstack_pytree to avoid
-        # iterating over batch dim, which would guard on symbolic sizes.
-        first_row = pytree.tree_map(first_slice_copy, xs)
-        example_output = f(*first_row, *pos_args)
+@register_fake(map_impl, skip_cache=True)
+def map_fake_tensor_mode(f, xs, pos_args, mutated_arg_indices=""):
+    # Use first_slice_copy instead of _unstack_pytree to avoid
+    # iterating over batch dim, which would guard on symbolic sizes.
+    first_row = pytree.tree_map(first_slice_copy, xs)
+    example_output = f(*first_row, *pos_args)
 
-        flat_xs, _ = pytree.tree_flatten(xs)
-        batch_size = flat_xs[0].shape[0]
+    flat_xs, _ = pytree.tree_flatten(xs)
+    batch_size = flat_xs[0].shape[0]
 
-        return _broadcast_to_batch(example_output, batch_size)
+    return _broadcast_to_batch(example_output, batch_size)
 
 
 @map_impl.py_functionalize_impl

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -78,14 +78,13 @@ class MapImpl(HigherOrderOperator):
         # - xs is mutable: each iteration sees a storage-disjoint slice
         #   (xs[t] and xs[t+1] share no storage), so in-place writes are
         #   race-free regardless of evaluation order, preserving map's
-        #   "iterations are independent" contract. Mutations are surfaced
-        #   via auto_functionalize_v2 so the parent graph sees them.
-        # - pos_args is NOT mutable: every iteration sees the same tensor,
-        #   so mutating it makes iterations depend on each other, breaking
-        #   the independence contract and introducing a data race under any
-        #   parallel lowering. Users who need a shared mutable buffer
-        #   should use scan / while_loop, where sequential iteration is
-        #   part of the contract.
+        #   "iterations are independent" contract.
+        # - pos_args is NOT mutable: every iteration sees the same
+        #   tensor, so mutating it makes iterations depend on each
+        #   other, breaking the independence contract and introducing a
+        #   data race under any parallel lowering. Users who need a
+        #   shared mutable buffer should use scan / while_loop, where
+        #   sequential iteration is part of the contract.
         outputs = get_graph_output_example_values(body_gm)
         mutated_set = (
             {int(i) for i in mutated_arg_indices.split(",") if i}

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -306,7 +306,7 @@ def _broadcast_to_batch(output, batch_size):
 
 
 def trace_map(
-    proxy_mode: ProxyTorchDispatchMode,
+    proxy_mode,
     func_overload: HigherOrderOperator,
     f: Callable[..., Any],
     xs: Sequence[torch.Tensor],

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -45,14 +45,7 @@ class MapImpl(HigherOrderOperator):
     def __call__(self, f, xs, pos_args, *, mutated_arg_indices: str = ""):
         # pyrefly: ignore [missing-attribute]
         return super().__call__(
-            f,
-            xs,
-            pos_args,
-            **(
-                {"mutated_arg_indices": mutated_arg_indices}
-                if mutated_arg_indices
-                else {}
-            ),
+            f, xs, pos_args, mutated_arg_indices=mutated_arg_indices
         )
 
     # pyrefly: ignore [bad-override]

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -79,11 +79,7 @@ class MapImpl(HigherOrderOperator):
         #   shared mutable buffer should use scan / while_loop, where
         #   sequential iteration is part of the contract.
         outputs = get_graph_output_example_values(body_gm)
-        mutated_set = (
-            {int(i) for i in mutated_arg_indices.split(",") if i}
-            if mutated_arg_indices
-            else set()
-        )
+        mutated_set = {int(i) for i in mutated_arg_indices.split(",") if i}
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("f", body_gm)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -56,7 +56,7 @@ class MapImpl(HigherOrderOperator):
         )
 
     # pyrefly: ignore [bad-override]
-    def gen_schema(self, f, xs, pos_args, mutated_arg_indices=""):
+    def gen_schema(self, f, xs, pos_args, mutated_arg_indices:str = ""):
         from torch._higher_order_ops.schema import HopSchemaGenerator
 
         all_inputs = tuple(


### PR DESCRIPTION
This PR introduces the second part of the input mutation for `map`. The input mutation contract for the input mutation remains unchanged and only the inputs `xs` are allowed to be in-place mutated. It follows the same notation as done for `scan` in https://github.com/pytorch/pytorch/pull/186474

This change was authored with the assistance of an AI coding assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98