### PR TITLE
 Support fp32 output for row-wise scaled fp8 matmul on the CUTLASS path

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -1047,11 +1047,22 @@ void dispatch_fp8_rowwise_kernel_on_bias_dtype(
         cutlass::half_t>
         (XQ, WQ, x_scale, w_scale, bias, use_fast_accum, out);
   } else {
-    dispatch_fp8_rowwise_kernel_on_input_dtypes<
-        float,
-        cutlass::bfloat16_t>
-        //Types...>
-        (XQ, WQ, x_scale, w_scale, bias, use_fast_accum, out);
+    if (out.dtype() == at::kFloat) {
+      dispatch_fp8_rowwise_kernel_on_input_dtypes<
+          float,
+          float>
+          (XQ, WQ, x_scale, w_scale, bias, use_fast_accum, out);
+    } else if (out.dtype() == at::kHalf) {
+      dispatch_fp8_rowwise_kernel_on_input_dtypes<
+          float,
+          cutlass::half_t>
+          (XQ, WQ, x_scale, w_scale, bias, use_fast_accum, out);
+    } else {
+      dispatch_fp8_rowwise_kernel_on_input_dtypes<
+          float,
+          cutlass::bfloat16_t>
+          (XQ, WQ, x_scale, w_scale, bias, use_fast_accum, out);
+    }
   }
 }
 
@@ -1095,10 +1106,14 @@ void check_inputs(
     TORCH_CHECK(bias->dim() == 1);
     TORCH_CHECK(bias->size(0) == b.size(1));
     TORCH_CHECK(bias->stride(0) == 1);
+    TORCH_CHECK(out.dtype() != at::kFloat, "Bias is not supported when out_dtype is set to Float32");
   }
 
   TORCH_CHECK(out.device() == a.device());
-  TORCH_CHECK(out.dtype() == at::kBFloat16 || out.dtype() == at::kHalf);
+  TORCH_CHECK(
+      out.dtype() == at::kBFloat16 || out.dtype() == at::kHalf ||
+          out.dtype() == at::kFloat,
+      "Output dtype must be bfloat16, float16, or float32, but got ", out.dtype());
   TORCH_CHECK(out.dim() == 2);
   TORCH_CHECK(out.size(0) == a.size(0));
   TORCH_CHECK(out.size(1) == b.size(1));

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -591,7 +591,10 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
     if ((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
         // cuBLAS only supports tiled 1D factor layout for 1D block scaling, no 2D block scales
         ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty()))) {
-      TORCH_CHECK_VALUE(out.dtype() == kBFloat16 || out.dtype() == kHalf, "Only bf16 and fp16 high precision output types are supported for row-wise scaling.");
+      TORCH_CHECK_VALUE(
+          out.dtype() == kBFloat16 || out.dtype() == kHalf ||
+              out.dtype() == kFloat,
+          "Only bf16, fp16, and fp32 high precision output types are supported for row-wise scaling.");
       return _scaled_rowwise_rowwise(
           mat1,
           mat2,
@@ -739,7 +742,10 @@ _scaled_rowwise_rowwise(
   if (((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
       // cuBLAS only supports tiled 1D factor layout for 1D block scaling, no 2D block scales
       ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty())))) {
-    TORCH_CHECK_VALUE(out.dtype() == kBFloat16 || out.dtype() == kHalf, "Only bf16 and fp16 high precision output types are supported for row-wise scaling.");
+    TORCH_CHECK_VALUE(
+        out.dtype() == kBFloat16 || out.dtype() == kHalf ||
+            out.dtype() == kFloat,
+        "Only bf16, fp16, and fp32 high precision output types are supported for row-wise scaling.");
     at::cuda::detail::f8f8bf16_rowwise(
         mat_a,
         mat_b,

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1273,15 +1273,11 @@ class TestFP8Matmul(TestCase):
     @with_tf32_off
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype, shapes, device):
         M, K, N = shapes
-        # Fp32 out_dtype is only supported by cuBLAS, which however only started
-        # shipping row-wise kernels in CUDA 12.9, and only for sm90+.
+        # Fp32 out_dtype works on the cuBLAS row-wise path when available; otherwise
+        # the CUTLASS row-wise fallback now covers the no-bias case.
         if base_dtype is torch.float32:
             if torch.version.hip:
                 raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
-            if torch.cuda.is_available() and _get_torch_cuda_version() < (12, 9):
-                raise unittest.SkipTest("Need CUDA 12.9+ for row-wise fp8 w/ cuBLAS")
-            if torch.cuda.is_available() and torch.cuda.get_device_capability() < (9, 0):
-                raise unittest.SkipTest("Need sm90+ for row-wise fp8 w/ cuBLAS")
 
         if base_dtype is torch.float16:
             if torch.version.hip:
@@ -1323,6 +1319,11 @@ class TestFP8Matmul(TestCase):
 
             if base_dtype in {torch.bfloat16, torch.float16}:
                 atol, rtol = 7e-2, 7e-2
+            elif base_dtype is torch.float32:
+                # Backend routing may choose cuBLAS or the CUTLASS fallback; use a
+                # conservative element-wise tolerance for CUDA fp32 row-wise while
+                # keeping cosine strict.
+                atol, rtol = 5e-3, 5e-3
             else:
                 atol, rtol = 2e-3, 2e-3
 
@@ -1333,16 +1334,85 @@ class TestFP8Matmul(TestCase):
             )
             self.assertGreaterEqual(float(cosine_sim), 0.999)
 
-        # only cuBLAS supports rowwise with fp32 output and cuBLAS only supports
-        # rowwise on SM 9.0
-        if torch.cuda.is_available() and torch.cuda.get_device_capability() != (9, 0) and output_dtype == torch.float:
-            with self.assertRaisesRegex(
-                ValueError,
-                "Only bf16 and fp16 high precision output types are supported for row-wise scaling."
-            ):
-                test()
+        # fp32 output is now supported on both the cuBLAS and CUTLASS row-wise paths.
+        test()
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
+    @skipCUDAIf(not SM89OrLater, "rowwise implementation is currently sm89-sm100 specific")
+    @parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("wrap_v2", [True, False])
+    @with_tf32_off
+    def test_scaled_mm_row_wise_no_bias_output_dtypes(self, output_dtype, wrap_v2, device):
+        # No-bias row-wise binds the output dtype directly; this covers bf16/fp16/fp32
+        # through both public entry points. Backend routing may still choose cuBLAS or
+        # the CUTLASS fallback depending on CUDA version / arch.
+        if torch.version.hip and output_dtype is not torch.bfloat16:
+            raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
+
+        M, K, N = 256, 512, 768
+        torch.manual_seed(42)
+        input_dtype = e4m3_type
+        x = random_matrix_with_scaled_reduction_dim(M, K, dtype=torch.float32, device=device, reduction_dim=-1)
+        y = random_matrix_with_scaled_reduction_dim(N, K, dtype=torch.float32, device=device, reduction_dim=-1).t()
+        x_scales = tensor_to_scale(x, input_dtype, dim=1).float()
+        y_scales = tensor_to_scale(y, input_dtype, dim=0).float()
+        x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
+        y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)
+
+        out = scaled_mm_wrap(
+            x_fp8,
+            y_fp8,
+            scale_a=x_scales.reciprocal(),
+            scale_b=y_scales.reciprocal(),
+            out_dtype=output_dtype,
+            bias=None,
+            wrap_v2=wrap_v2,
+        )
+        out_emulated = mm_float8_emulated(x_fp8, x_scales, y_fp8, y_scales, output_dtype, None)
+
+        self.assertEqual(out.dtype, output_dtype)
+        # fp32 differs from the emulated reference only in accumulation order, so compare
+        # by cosine similarity (robust to kernel differences) rather than element-wise.
+        if output_dtype is torch.float32:
+            cosine_sim = torch.nn.functional.cosine_similarity(
+                out.flatten().float(), out_emulated.flatten().float(), dim=0
+            )
+            self.assertGreaterEqual(float(cosine_sim), 0.999)
         else:
-            test()
+            self.assertEqual(out, out_emulated, atol=7e-2, rtol=7e-2)
+
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
+    @skipCUDAIf(not SM89OrLater, "rowwise implementation is currently sm89-sm100 specific")
+    @parametrize("wrap_v2", [True, False])
+    def test_scaled_mm_row_wise_fp32_out_with_bias_errors(self, wrap_v2, device):
+        # fp32 output combined with a bias is not supported on the row-wise path.
+        if torch.version.hip:
+            raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
+
+        M, K, N = 16, 32, 48
+        input_dtype = e4m3_type
+        x = random_matrix_with_scaled_reduction_dim(M, K, dtype=torch.float32, device=device, reduction_dim=-1)
+        y = random_matrix_with_scaled_reduction_dim(N, K, dtype=torch.float32, device=device, reduction_dim=-1).t()
+        x_scales = tensor_to_scale(x, input_dtype, dim=1).float()
+        y_scales = tensor_to_scale(y, input_dtype, dim=0).float()
+        x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
+        y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)
+        bias = torch.randn((N,), device=device, dtype=torch.bfloat16)
+
+        with self.assertRaisesRegex(
+            (ValueError, RuntimeError),
+            "Bias is not supported when out_dtype is set to Float32",
+        ):
+            scaled_mm_wrap(
+                x_fp8,
+                y_fp8,
+                scale_a=x_scales.reciprocal(),
+                scale_b=y_scales.reciprocal(),
+                out_dtype=torch.float32,
+                bias=bias,
+                wrap_v2=wrap_v2,
+            )
 
     @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)


### PR DESCRIPTION
Follow-up to #166744, which added fp16 output support. This resolves the remaining fp32-output piece of #156771 for the CUTLASS row-wise fallback.



## Summary

`torch._scaled_mm` row-wise scaling already supports fp32 output on the cuBLAS path. However, the CUTLASS `f8f8bf16_rowwise` fallback still rejected fp32 output. This fallback is used in cases such as sm89, CUDA < 12.9, and Blackwell with row-wise scale tensors.

This PR enables fp32 output for the CUTLASS row-wise fallback in the no-bias case.

The no-bias output dtype was previously hardcoded to bf16. The no-bias dispatch now selects `DtypeOutput` from `out.dtype()`:

* `float`
* `cutlass::half_t`
* `cutlass::bfloat16_t`

This enables fp32 output and also makes fp16 no-bias output dtype-correct on the CUTLASS path. The bias branches are unchanged.

## Changes

* Relax the CUTLASS row-wise output-dtype gates to allow fp32 output:

  * the classic `_scaled_mm` entry
  * `_scaled_rowwise_rowwise`
  * `RowwiseScaledMM.cu::check_inputs`
* Bind `DtypeOutput` from `out.dtype()` in the no-bias branch of `dispatch_fp8_rowwise_kernel_on_bias_dtype`.
* Keep fp32 + bias unsupported via the existing high-level check:
  `"Bias is not supported when out_dtype is set to Float32"`.

Notes:

* Accumulation is unchanged: fp32 accumulate, fp32 epilogue.
* fp32 output only skips the final downcast.
* Output alignment is handled by the existing template: `AlignmentOutput = 16 / sizeof(DtypeOutput)`.
* The kernels themselves are unchanged; the only added cost is the extra template instantiations (`<float, float>` and `<float, cutlass::half_t>`) plus a negligible host-side dtype branch.

## Test Plan

Built with:

```bash
pip install -e . -v --no-build-isolation
```

Ran:

```bash
python -m pytest test/test_scaled_matmul_cuda.py \
  -k "(vs_emulated_row_wise or no_bias_output_dtypes or fp32_out_with_bias_errors) and cuda" -q
```

Results, CUDA 13.0:

* RTX PRO 6000 Blackwell, sm_120: 20 passed, 2 skipped, 0 failed
* RTX 4090 D, sm_89: 18 passed, 4 skipped, 0 failed

The fp32 CUDA row-wise cases ran and passed on both machines. On the CUTLASS path, fp32 uses `atol=rtol=5e-3`; the cosine-similarity check remains `>= 0.999`.

## BC

No public API change. `out_dtype=torch.float32` was already accepted on the cuBLAS row-wise path; this extends support to the CUTLASS fallback. No change for bf16 or fp16-with-bias.

cc @slayton58 @drisspg
