### PR TITLE
Fixed heaviside nan propagation issue

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1267,6 +1267,9 @@ void heaviside_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(
       kHalf, kBool, kBFloat16, iter.dtype(), "heaviside_cpu", [&]() {
         cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
+          if (_isnan<scalar_t>(a)) {
+            return a;
+          }
           return a == 0 ? b : static_cast<scalar_t>(a > 0);
         });
       });

--- a/aten/src/ATen/native/cuda/StepKernel.cu
+++ b/aten/src/ATen/native/cuda/StepKernel.cu
@@ -22,7 +22,7 @@ void nextafter_kernel_cuda(TensorIteratorBase& iter) {
 void heaviside_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(), "heaviside_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      if (_isnan(a)) {
+      if (at::_isnan(a)) {
         return a;
       }
       return a == 0 ? b : static_cast<scalar_t>(a > 0);

--- a/aten/src/ATen/native/cuda/StepKernel.cu
+++ b/aten/src/ATen/native/cuda/StepKernel.cu
@@ -22,6 +22,9 @@ void nextafter_kernel_cuda(TensorIteratorBase& iter) {
 void heaviside_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(), "heaviside_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+      if (_isnan(a)) {
+        return a;
+      }
       return a == 0 ? b : static_cast<scalar_t>(a > 0);
     });
   });

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3390,6 +3390,22 @@ class TestBinaryUfuncs(TestCase):
             ):
                 input.heaviside_(values)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float16, torch.float32, torch.float64, torch.bfloat16)
+    def test_heaviside_nan(self, device, dtype):
+        input = torch.tensor(
+            [float("nan"), 0.0, -1.0, 1.0],
+            device=device,
+            dtype=dtype,
+        )
+        values = torch.ones_like(input)
+        result = torch.heaviside(input, values)
+        self.assertTrue(torch.isnan(result[0]))
+        self.assertEqual(
+            result[1:],
+            torch.tensor([1.0, 0.0, 1.0], device=device, dtype=dtype),
+        )
+
     @onlyOn(["cuda", "xpu"])
     def test_heaviside_cross_device(self, device):
         x = torch.tensor([-9, 5, 0, 6, -2, 2], device=device)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1554,9 +1554,10 @@ def gt(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
 )
 def heaviside(input: TensorLikeType, values: TensorLikeType) -> TensorLikeType:
     input_eq_zero = torch.eq(input, 0)
-    input_lt_zero = torch.logical_or(torch.lt(input, 0), torch.isnan(input))
+    input_lt_zero = torch.lt(input, 0)
     zeros_and_ones = torch.where(input_lt_zero, 0, 1)
     output = torch.where(input_eq_zero, values, zeros_and_ones)
+    output = torch.where(torch.isnan(input), input, output)
     return output
 
 


### PR DESCRIPTION
## Summary

Fix `torch.heaviside` to propagate NaN inputs, matching NumPy behavior.

Previously, `torch.heaviside` returned `0` for NaN inputs because NaN comparisons (`a == 0` and `a > 0`) evaluate to `false`, causing the kernel to fall through to the `0` case.

This change updates the CPU and CUDA kernels to preserve NaN values and adds a regression test covering floating-point dtypes.

Fixes #187296

## Test Plan

```bash
python test/test_binary_ufuncs.py -k heaviside
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01