### PR TITLE
[TMA] Fix AOTI eager scratch buffer missing CACHE_TORCH_DEVICE declaration

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -20769,6 +20769,30 @@ if RUN_GPU:
             for a, e in zip(actual, expected):
                 torch.testing.assert_close(a, e)
 
+        @unittest.skipIf(not SM90OrLater, "TMA requires SM90+")
+        @config.patch(
+            {
+                "triton.use_tensor_descriptor": True,
+                "assume_aligned_inputs": True,
+            }
+        )
+        def test_tma_descriptor_aoti_eager_scratch_buffer(self):
+            # Regression test: when TMA generates a kernel with a scratch buffer,
+            # the AOTI cpp wrapper must emit CACHE_TORCH_DEVICE(cuda) so the
+            # cached_torch_device_type_cuda variable is declared before use.
+            # The out= overload triggers the scratch buffer allocation path.
+            a = torch.randn(128, device=GPU_TYPE)
+            out = torch.empty_like(a)
+            ref = torch.clamp(a, min=-0.5, max=0.5)
+
+            with _scoped_library("aten", "IMPL") as lib:
+                register_ops_with_aoti_compile(
+                    "aten", ["clamp"], "CUDA", lib
+                )
+                torch.clamp(a, min=-0.5, max=0.5, out=out)
+
+            self.assertEqual(ref, out)
+
     class RNNTest(TestCase):
         device_type = GPU_TYPE
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -20786,9 +20786,7 @@ if RUN_GPU:
             ref = torch.clamp(a, min=-0.5, max=0.5)
 
             with _scoped_library("aten", "IMPL") as lib:
-                register_ops_with_aoti_compile(
-                    "aten", ["clamp"], "CUDA", lib
-                )
+                register_ops_with_aoti_compile("aten", ["clamp"], "CUDA", lib)
                 torch.clamp(a, min=-0.5, max=0.5, out=out)
 
             self.assertEqual(ref, out)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -265,12 +265,21 @@ class WorkspaceArg(CodegenSymbol):
 
 
 class TritonScratchWorkspace:
-    def __init__(self, size: int, generate_dtype_str: Callable[..., str]):
+    def __init__(
+        self,
+        size: int,
+        generate_dtype_str: Callable[..., str],
+        generate_device_type_str: Callable[..., str],
+    ):
         self.size = size
         self._generate_dtype_str = generate_dtype_str
+        self._generate_device_type_str = generate_device_type_str
 
     def generate_dtype_str(self) -> str:
         return self._generate_dtype_str()
+
+    def generate_device_type_str(self) -> str:
+        return self._generate_device_type_str()
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -41,7 +41,7 @@ from ..utils import (
 from ..virtualized import V
 from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides, TritonScratchWorkspace
-from .cpp_utils import cexpr
+from .cpp_utils import cexpr, DEVICE_TO_ATEN
 from .cpp_wrapper_cpu import CppWrapperCpu
 from .multi_kernel import MultiKernelCall
 from .triton_utils import should_unwrap_unspec_arg
@@ -1099,6 +1099,11 @@ class CppWrapperGpu(CppWrapperCpu):
             f"triton debug sync is not supported with {self.device} cpp_wrapper"
         )
 
+    def _codegen_cached_device_type(self) -> str:
+        device_str = DEVICE_TO_ATEN[self.device][5:].lower()
+        self.used_cached_devices.add(device_str)
+        return f"cached_torch_device_type_{device_str}"
+
     @staticmethod
     def create(
         is_subgraph: bool,
@@ -1482,6 +1487,9 @@ static inline void ensure_triton_kernel_compiles_started() {{
                             size=workspace_size,
                             generate_dtype_str=(
                                 lambda: self.codegen_dtype(torch.uint8)
+                            ),
+                            generate_device_type_str=(
+                                lambda: self._codegen_cached_device_type()
                             ),
                         ),
                         prefix=scratch_name,

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -359,7 +359,7 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
             )
             size_array = f"int64_t {var_name}_size[] = {{{size_expr}}};"
             stride_array = f"int64_t {var_name}_stride[] = {{1}};"
-            device_type = "cached_torch_device_type_cuda"
+            device_type = workspace.generate_device_type_str()
             device_idx = "device_idx_"
 
             return (


### PR DESCRIPTION

When TMA is enabled and a kernel uses tensor descriptors, the AOTI C++ wrapper generates a scratch buffer allocation in a free function that references cached_torch_device_type_cuda. This file-scope static variable is produced by the CACHE_TORCH_DEVICE(cuda) macro in the wrapper prefix.

The bug was that CUDADeviceOpOverrides.cpp_scratch() hardcoded the string "cached_torch_device_type_cuda" without registering the device type in used_cached_devices, so the macro was never emitted. The dtype side worked because generate_dtype_str was already a callback that registered the dtype as a side-effect via codegen_dtype().

The fix adds a generate_device_type_str callback to TritonScratchWorkspace (matching the existing generate_dtype_str pattern) so that cpp_scratch() triggers registration when it generates the device type reference.

Test Plan:
```
python -m pytest test/inductor/test_torchinductor.py::TritonCodeGenTests::test_tma_descriptor_aoti_eager_scratch_buffer -xvs
python -m pytest test/inductor/test_torchinductor.py -k "aoti_eager" -x -v
```

Co-Authored-By: Claude Opus 4.8

cc: @kshitij12345 @jansel 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo