### PR TITLE
Support large float32 tensors in quantile by computing ranks in float64

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -285,17 +285,35 @@ Tensor quantile_compute(
   in_shape[in_shape.size() - 1] = sorted.sym_size(-1);
   sorted = sorted.view_symint(in_shape);
 
-  // Ensure converting from int64_t to double won't overflow
+  // quantile maps q to ranks via q * (size - 1), rounded to gather indices, so
+  // size must be exactly representable in the rank dtype. float32 reaches only
+  // 2^24, so ranks use double (exact to 2^53) where it exists; MPS has no
+  // double, so float32 there keeps float32 ranks and the 2^24 cap.
+  TORCH_INTERNAL_ASSERT(
+      self.scalar_type() == kFloat || self.scalar_type() == kDouble,
+      "quantile() rank computation assumes a float or double input");
+  const bool double_ranks =
+      self.scalar_type() == kDouble || self.device().type() != kMPS;
+  const auto rank_dtype = double_ranks ? kDouble : self.scalar_type();
+  const int64_t max_size = double_ranks
+      ? (1LL << std::numeric_limits<double>::digits)
+      : (1LL << std::numeric_limits<float>::digits);
   TORCH_SYM_CHECK(
-      sorted.sym_size(-1).sym_le(1 << 24),
-      "quantile() input tensor is too large");
+      sorted.sym_size(-1).sym_le(max_size),
+      "quantile() input tensor is too large for ",
+      self.scalar_type(),
+      " dtype: the dimension being reduced has ",
+      sorted.sym_size(-1),
+      " elements but at most ",
+      max_size,
+      " are supported");
 
   // Convert q in [0, 1] to ranks in [0, reduction_size)
   Tensor ranks;
   if (ignore_nan) {
     // For nanquantile, compute ranks based on number of non-nan values.
     // If all values are nan, set rank to 0 so the quantile computed is nan.
-    ranks = q * (sorted.isnan().logical_not_().sum(-1, true) - 1);
+    ranks = q.to(rank_dtype) * (sorted.isnan().logical_not_().sum(-1, true) - 1);
     // For Composite Compliance,
     // if `ranks` is `CCT` but it's tangent is a regular Tensor,
     // then while computing jvp, we end calling `masked_fill_`
@@ -310,8 +328,8 @@ Tensor quantile_compute(
     // For quantile, compute ranks based on reduction size. If there is nan
     // set rank to last index so the quantile computed will be nan.
     auto last_index = sorted.sym_size(-1) - 1;
-    std::vector<Tensor> tl =
-        at::broadcast_tensors({q * last_index, sorted.isnan().any(-1, true)});
+    std::vector<Tensor> tl = at::broadcast_tensors(
+        {q.to(rank_dtype) * last_index, sorted.isnan().any(-1, true)});
     ranks = at::masked_fill(tl[0], tl[1], last_index);
   }
 
@@ -331,9 +349,11 @@ Tensor quantile_compute(
   if (interpolation == QUANTILE_INTERPOLATION_MODE::LINEAR ||
       interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT) {
     // calculate weights for linear and midpoint
+    // ranks may be double while values stay float32; the lerp weight must match
+    // the value dtype or the interpolation upcasts the output.
     Tensor weights = interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT
-        ? at::full_like(ranks, 0.5)
-        : ranks - ranks_below;
+        ? at::full_like(ranks, 0.5, self.options())
+        : (ranks - ranks_below).to(self.scalar_type());
 
     // Interpolate to compute quantiles and store in values_below
     Tensor ranks_above = ranks.ceil_().toType(kLong);

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2823,6 +2823,44 @@ class TestReductions(TestCase):
                     RuntimeError, r'quantile\(\) out tensor must be on the same device as the input tensor'):
                 torch.quantile(torch.randn(1, device=device), 0.5, out=torch.scalar_tensor(1))
 
+    @skipIfMPS  # MPS caps float32 at 2^24 and has no float64, so >2^24 can't run there
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float32, torch.float64)
+    def test_quantile_large_input(self, device, dtype):
+        # gh-64947: quantile must stay correct past the old 2^24 cap. float32
+        # works because ranks are computed in float64; float64 reaches 2^53.
+        # Oracle is numpy in float64 (the true value) for both, all modes + nan.
+        n = 17_000_000
+        torch.manual_seed(0)
+        a = torch.randn(n, dtype=dtype, device=device)
+        a_nan = a.clone()
+        a_nan[torch.randint(n, (32,), device=device)] = float('nan')
+        q = torch.tensor([0.0, 0.1, 0.5, 0.9, 1.0], dtype=dtype, device=device)
+        a_np = a.double().cpu().numpy()
+        a_nan_np = a_nan.double().cpu().numpy()
+        q_np = q.double().cpu().numpy()
+        for interpolation in ('linear', 'lower', 'higher', 'midpoint', 'nearest'):
+            res = torch.quantile(a, q, interpolation=interpolation)
+            expected = np.quantile(a_np, q_np, method=interpolation)
+            self.assertEqual(res.cpu(), torch.from_numpy(np.asarray(expected)).to(res))
+
+            res_nan = torch.nanquantile(a_nan, q, interpolation=interpolation)
+            expected_nan = np.nanquantile(a_nan_np, q_np, method=interpolation)
+            self.assertEqual(res_nan.cpu(), torch.from_numpy(np.asarray(expected_nan)).to(res_nan))
+
+    @onlyNativeDeviceTypes
+    def test_quantile_size_limit(self, device):
+        # float32 ranks are exact only to 2^24; computing them in float64 lifts
+        # the limit to 2^53. MPS has no float64, so it keeps the 2^24 cap and
+        # raises past it, while CPU/CUDA support larger float32 inputs.
+        over_cap = (1 << 24) + 1
+        if self.device_type == "mps":
+            torch.quantile(torch.empty(1 << 24, dtype=torch.float32, device=device), 0.5)
+            with self.assertRaisesRegex(RuntimeError, r'quantile\(\) input tensor is too large'):
+                torch.quantile(torch.empty(over_cap, dtype=torch.float32, device=device), 0.5)
+        else:
+            torch.quantile(torch.empty(over_cap, dtype=torch.float32, device=device), 0.5)
+
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)
         for dim in range(x.dim()):


### PR DESCRIPTION
## Summary

_**(1/2)** DONE_
Performance fix pending.

Addresses the size limitation in #64947.  

EDIT: **(2/2)** landed at https://github.com/pytorch/pytorch/pull/188394.


Lifts the ~16M element limit in `torch.quantile` / `torch.nanquantile` for `float32` (and `float64`): large inputs now compute correctly instead of raising `quantile() input tensor is too large`. 

## Root cause

quantile maps `q` to a rank `q * (size - 1)`, rounds it to an int64 gather index, and interpolates the sorted values. The rank was computed in the input dtype, so for `float32` a rank above `2^24` is not exactly representable: distinct ranks alias to one index and interpolation weights quantize. The size cap rejected such inputs to avoid silently wrong results.

## Fix

Compute the ranks in `float64` wherever it exists. The sorted values stay `float32`; only the rank arithmetic and the int64 gather indices change, and those are exact in `float64` out to `2^53`. The interpolation weight is cast back to the value dtype so the `float32` output is not upcast.

`MPS` has no `float64`, so `float32` there keeps `float32` ranks and the original `2^24` cap; the cap is now dtype- and device-aware.

The branch is on dtype and device, not on the (symbolic) size, so it stays compile- and export-safe. It shifts existing `float32` results by at most one ulp, toward the `float64` value numpy returns; `float64` and `MPS` are unchanged. The change is cost-neutral: ranks and weights are output-sized, so quantile stays sort-bound (on 16M `float32` the added arithmetic is microseconds against a ~1s sort).

## Verification

Base [`083e2617b8ee`](https://github.com/pytorch/pytorch/commit/083e2617b8ee20b66def9e05dfcee5be84af623a). Built CPU+MPS on an Apple M5 and validated CUDA on an NVIDIA A40. quantile is a device-agnostic composite, so the same sort/gather/lerp kernels run the fix's exact numerics on every device.

| Case | Before | After |
|---|---|---|
| `float32` 17M, q=[0.1, 0.5] | RuntimeError "too large" | matches numpy float64 oracle; output `float32` |
| `float32`/`float64` sweep (2^24-1 .. 2^25, 5 modes, quantile + nanquantile, scalar/1D q, dim None/last/middle, keepdim) | n/a (capped) | 470/470 match numpy (CPU) |
| MPS small `float32` vs CPU; >2^24 | unchanged | matches CPU; cap still raises |
| CUDA `float32`+`float64` 17M, all modes + nan path | RuntimeError | 20/20 match numpy |

```
python test/test_reductions.py -k quantile -v   # 9 passed, 5 MPS-skipped
```

New `test_quantile_large_input` (`float32` and `float64` at 17M vs numpy, all interpolation modes + nanquantile) and `test_quantile_size_limit` (device-aware boundary) are device-generic, so CI also runs them on CUDA.

## Not in this PR

#64947 also asks for a faster, lower-memory implementation. This keeps the full `O(n log n)` sort; a partial-selection (`kthvalue`) rewrite is a separate follow-up (it is device-specific: faster on CPU, but the radix sort already wins on CUDA).
