### PR TITLE
dispatcher: allow PrivateUse1 backends to opt out of CompositeExplicitAutograd decomposition

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -479,6 +479,27 @@ void Dispatcher::deregisterFallback_(DispatchKey dispatchKey) {
   }
 }
 
+RegistrationHandleRAII Dispatcher::setPrivateUse1SkipCEA() {
+  std::lock_guard<std::mutex> lock(guard_->mutex);
+  TORCH_CHECK(
+      !privateuse1_skip_cea_.load(std::memory_order_relaxed),
+      "PrivateUse1 CEA skip is already registered");
+  privateuse1_skip_cea_.store(true, std::memory_order_relaxed);
+  for (auto& op : operators_) {
+    op.op.updateFallback(*this, DispatchKey::PrivateUse1);
+  }
+  return RegistrationHandleRAII([guard = this->guard_, this] {
+    std::lock_guard<std::mutex> lock(guard->mutex);
+    if (!guard->alive.load()) {
+      return;
+    }
+    privateuse1_skip_cea_.store(false, std::memory_order_relaxed);
+    for (auto& op : operators_) {
+      op.op.updateFallback(*this, DispatchKey::PrivateUse1);
+    }
+  });
+}
+
 
 RegistrationHandleRAII Dispatcher::addRegistrationListener(std::unique_ptr<OpRegistrationListener> listener) {
   std::lock_guard<std::mutex> lock(guard_->mutex);

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -10,6 +10,7 @@
 #include <c10/core/SafePyObject.h>
 #include <c10/util/Exception.h>
 #include <c10/util/LeftRight.h>
+#include <atomic>
 #include <condition_variable>
 #include <list>
 #include <mutex>
@@ -297,6 +298,25 @@ class TORCH_API Dispatcher final {
       std::string debug);
 
   /**
+   * Opt the PrivateUse1 backend out of CompositeExplicitAutograd (CEA)
+   * decompositions. When enabled, ops with only a CEA kernel skip alias
+   * lookup and fall through directly to the registered backend fallback.
+   *
+   * This is intended for proxy backends (e.g. remote-GPU backends) that
+   * register a single catch-all fallback kernel and need to receive every
+   * ATen op verbatim, without PyTorch silently decomposing composite ops
+   * into primitives before the backend sees them.
+   *
+   * Returns a RAII handle; destroying the handle restores the previous
+   * behavior and refreshes all affected dispatch table entries.
+   */
+  RegistrationHandleRAII setPrivateUse1SkipCEA();
+
+  bool privateuse1SkipCEA() const {
+    return privateuse1_skip_cea_.load(std::memory_order_relaxed);
+  }
+
+  /**
    * Use to register whenever we had a TORCH_LIBRARY declaration in the frontend
    * API.  These invocations are only permitted once per program, so we raise
    * an error if this is called again for the same namespace.
@@ -411,6 +431,13 @@ class TORCH_API Dispatcher final {
 
   std::array<impl::AnnotatedKernel, num_runtime_entries>
       backendFallbackKernels_;
+
+  // When true, PrivateUse1 dispatch table entries skip CEA/CEANF alias
+  // lookup and fall through to the registered backend fallback instead.
+  // Protected by guard_->mutex for writes; reads are via relaxed atomic
+  // load inside computeDispatchTableEntryWithDebug (always called under
+  // the mutex during table rebuilds).
+  std::atomic<bool> privateuse1_skip_cea_{false};
 
   std::unique_ptr<detail::RegistrationListenerList> listeners_;
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -389,9 +389,16 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
     return {*direct_registration, "kernel"};
   }
 
+  // When a PrivateUse1 backend opts out of CEA decompositions (e.g. a proxy
+  // backend that forwards ops verbatim to a remote device), skip alias lookup
+  // for CEANF and CEA and fall through to the backend fallback instead.
+  // Direct kernel registrations (step 1) still take priority.
+  const bool skip_cea = (dispatch_key == DispatchKey::PrivateUse1 &&
+                         dispatcher.privateuse1SkipCEA());
+
   // 2.1 Use CompositeExplicitAutogradNonFunctional kernel if available.
   //     See Note [Undefined in dispatchTable_] for the special handling for Undefined.
-  if (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutogradNonFunctional)) {
+  if (!skip_cea && (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutogradNonFunctional))) {
     if (auto default_backend_registration = getKernelForDispatchKey(DispatchKey::CompositeExplicitAutogradNonFunctional)) {
       return {*default_backend_registration, "default backend kernel"};
     }
@@ -399,7 +406,7 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
 
   // 2.2 Use CompositeExplicitAutograd kernel if available.
   //     See Note [Undefined in dispatchTable_] for the special handling for Undefined.
-  if (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutograd)) {
+  if (!skip_cea && (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutograd))) {
     if (auto default_backend_registration = getKernelForDispatchKey(DispatchKey::CompositeExplicitAutograd)) {
       return {*default_backend_registration, "default backend kernel"};
     }

--- a/docs/source/accelerator/profiler.md
+++ b/docs/source/accelerator/profiler.md
@@ -10,11 +10,17 @@ There are two primary integration paths for accelerators:
     - Can attach backend-specific hooks via `ProfilerStubs` to record device events and compute elapsed times.
     - Works without Kineto; suitable for PrivateUse1 backends that want a minimal, self-contained path.
 
-2. Kineto-based timeline:
-    - Bridges to Kineto, which aggregates device timelines via vendor libraries (e.g., CUPTI for CUDA).
-    - Provides rich activity traces and advanced export/visualization, but requires a Kineto-capable backend.
+2. Kineto `IActivityProfiler` plugin:
+    - Registers a full activity profiler with Kineto via `REGISTER_PRIVATEUSE1_PROFILER`.
+    - Wires Kineto sessions and correlation-ID plumbing; vendors extend this to emit kernel events, flow links, and Chrome/Perfetto trace compatibility.
+    - Requires Kineto at backend build time (`kineto_LIBRARY` from `find_package(Torch)`, guarded by `USE_KINETO`).
 
-This document focuses on path (1): how a `PrivateUse1` accelerator exposes the minimal hooks to plug into the legacy autograd profiler so ATen ops and `record_function` ranges are correctly attributed to device activity.
+| Path | Python API | Profiler State | What it provides |
+| ---- | ---------- | -------------- | ---------------- |
+| Legacy (1) | `torch.autograd.profiler.profile(use_device="openreg")` (default `use_kineto=False`) | `KINETO_PRIVATEUSE1_FALLBACK` | Operator-level timing via `ProfilerStubs` device events |
+| Kineto plugin (2) | `profile(activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1])` | `KINETO_PRIVATEUSE1` | Kineto session + correlation-ID plumbing; vendors add kernel events and flow links |
+
+Both paths can coexist when the backend extension is built with Kineto available (`kineto_LIBRARY` from `find_package(Torch)`). The legacy stubs path always works; the Kineto plugin path requires `USE_KINETO` at backend build time. PyTorch core already exposes `REGISTER_PRIVATEUSE1_PROFILER`; vendors implement and register their `IActivityProfiler` in the backend extension.
 
 ## Design
 
@@ -39,7 +45,7 @@ This layering keeps PyTorch device-agnostic: Python brokers the session, `Profil
 
 Here we use OpenReg (Open Registration) to illustrate the minimal set of hooks a `PrivateUse1` accelerator needs to expose so the profiler can attribute ATen ops, `record_function` ranges, and user code to device activity. OpenReg keeps upstream code untouched by translating profiler requests into its runtime calls, mirroring what a production accelerator would implement inside an out-of-tree extension.
 
-OpenReg currently relies on the legacy profiler (`torch.autograd.profiler.profile`) interface rather than the modern one (`torch.profiler.profile`) because the latter enforces `use_kineto=True`.
+OpenReg supports both paths: the legacy autograd profiler (`use_kineto=False`, the default) for operator-level timing via stubs, and the modern `torch.profiler.profile` API (`use_kineto=True`) for the Kineto plugin path described below.
 
 ### Profiler stubs (C++)
 
@@ -81,6 +87,55 @@ prof.export_chrome_trace("openreg_trace.json")
 4. The OpenReg stubs allocate `orEvent` objects, attach them to the current stream, and stash CPU timestamps.
 5. When events end, the profiler calls `elapsed()` to compute durations.
 
+## Implementation (Kineto Plugin)
+
+```{note}
+This section covers the Kineto `IActivityProfiler` plugin path for kernel-level tracing. It requires `USE_KINETO` at build time. All Kineto-dependent code must be guarded with `#ifdef USE_KINETO`.
+```
+
+The plugin path has two layers: a **device library** component (the CUPTI analog) and the **PyTorch integration** layer. OpenReg keeps these clearly separated.
+
+### Device library: correlation tracking
+
+The device library provides `openreg::profiler::OpenRegTracer` (`third_party/openreg/csrc/tracer.h/.cpp`) — a singleton with a thread-local correlation-ID stack and an atomic enable/disable flag that the profiler session uses to control the recording window.
+
+Kineto pushes/pops correlation IDs through the session. The session calls C-style activity APIs in `openreg.h` (mirroring CUPTI):
+
+* `orActivityEnableTracing()` / `orActivityDisableTracing()` — control the recording window
+* `orActivityPushExternalCorrelationId()` / `orActivityPopExternalCorrelationId()` — maintain the correlation stack
+
+A real vendor's equivalent would be their device tracing SDK (e.g., CUPTI for CUDA).
+
+### PyTorch integration: IActivityProfiler and IActivityProfilerSession
+
+Implement the two Kineto interfaces from `third_party/kineto/libkineto/include/IActivityProfiler.h`. In OpenReg, these live in `torch_openreg/csrc/profiler/` — the backend extension integration layer.
+
+* **`IActivityProfiler`** — stateless factory. Two `configure()` overloads both create and return a session:
+  - `configure(activity_types, config)` — synchronous overload; required by the interface. The OpenReg stub implements this as the core session-creation path.
+  - `configure(ts_ms, duration_ms, activity_types, config)` — Kineto's child-profiler path calls this overload for all traces (including on-demand), passing `profileStartTime()` epoch ms and `profileDuration()` ms. The OpenReg stub ignores scheduling and delegates to the first overload; vendors use `ts_ms`/`duration_ms` to defer device-SDK activation.
+* **`IActivityProfilerSession`** — per-trace session. `start()`/`stop()` manage the profiling window and toggle activity tracing via `orActivityEnableTracing()`/`orActivityDisableTracing()`; `getTraceBuffer()` returns the buffer to Kineto.
+  - **Reference stub**: `processTrace()` only sets the trace span (`traceBuffer_.span = TraceSpan(startTs_, endTs_, "openreg")`); it emits no kernel records.
+  - **Vendor extension**: replace `processTrace()` to flush records from your device tracing SDK, emit `GenericTraceActivity` entries with timestamps (µs), correlation IDs, and flow links (`flow.id = correlationId`, `flow.type = kLinkAsyncCpuGpu`, `flow.start = 0`).
+
+### Registration and build
+
+Register with one line: `REGISTER_PRIVATEUSE1_PROFILER(OpenRegActivityProfiler)`. The macro (defined in `torch/csrc/profiler/standalone/privateuse1_profiler.h`) creates a static registration object that forwards a factory to Kineto at profiler init time.
+
+Kineto is on by default in PyTorch; no special build flags are needed unless explicitly disabled it with `USE_KINETO=0`. In backend extension, `find_package(Torch)` sets `kineto_LIBRARY`; link against `kineto` and `torch_cpu_library`, and guard Kineto code with `#ifdef USE_KINETO`. Without Kineto, the plugin compiles as a no-op and only the legacy stubs path is available.
+
+### Usage
+
+```python
+import torch
+from torch.profiler import profile, ProfilerActivity
+
+with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1]) as prof:
+    x = torch.randn(512, 512, device="openreg")
+    y = torch.randn(512, 512, device="openreg")
+    z = x @ y
+
+prof.export_chrome_trace("kernel_trace.json")
+```
 
 [PyTorch Profiler README]: https://github.com/pytorch/pytorch/blob/main/torch/csrc/profiler/README.md "PyTorch Profiler README"
 [openreg-stubs]: https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/profiler/stubs/openreg.cpp "OpenReg profiler stubs"

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -35,6 +35,11 @@ torch_openreg/
 │   │   ├── OpenRegExtra.cpp
 │   │   └── OpenRegMinimal.cpp
 │   ├── CMakeLists.txt
+│   ├── profiler
+│   │   ├── OpenRegActivityProfiler.h/.cpp
+│   │   ├── OpenRegActivityProfilerSession.h/.cpp
+│   │   └── stubs
+│   │       └── openreg.cpp
 │   └── runtime
 │       ├── OpenRegDeviceAllocator.cpp
 │       ├── OpenRegDeviceAllocator.h
@@ -54,6 +59,11 @@ torch_openreg/
 ├── setup.py
 ├── third_party
 │   └── openreg
+│       ├── csrc
+│       │   ├── tracer.h/.cpp
+│       │   └── ...
+│       └── include
+│           └── openreg.h
 └── torch_openreg
     ├── csrc
     │   ├── CMakeLists.txt
@@ -105,7 +115,10 @@ There are 4 DSOs in torch_openreg, and the dependencies between them are as foll
       - `csrc/aten/native/OpenRegMinimal.cpp`: The most minimal set of operator implementations (allowing for the creation of Tensors and related operations upon completion).
       - `csrc/aten/native/OpenRegExtra.cpp`: Implementations for other types of operators.
   - `csrc/runtime/`: Implementations for Host memory, device memory, Guard, Hooks, etc.
+  - `csrc/profiler/`: Profiler integration — legacy `ProfilerStubs` and Kineto `IActivityProfiler` plugin (when built with Kineto).
 - `third_party/`: A C++ library that simulates a CUDA-like device using the CPU.
+  - `third_party/openreg/csrc/tracer.h/.cpp`: Correlation-ID stack and activity-tracing enable/disable (CUPTI analog).
+  - `third_party/openreg/include/openreg.h`: C-style activity APIs (`orActivityEnableTracing`, `orActivityPushExternalCorrelationId`, etc.).
 - `torch_openreg/`: Python interface implementation (Python code and C++ Bindings).
   - `torch_openreg/csrc/`: Python C++ binding code.
   - `torch_openreg/openreg/`: Python API.
@@ -181,6 +194,13 @@ print(f"Device of z: {z.device}")
 ## Documentation
 
 Please refer to [this](https://docs.pytorch.org/docs/main/accelerator/index.html) for a series of documents on integrating new accelerators into PyTorch, which will be kept in sync with the `OpenReg` codebase as well.
+
+### Profiler Integration
+
+- **Fallback (operator-level)**: `ProfilerStubs` registration provides operator-level timing via `torch.autograd.profiler.profile(use_device="openreg")` (default `use_kineto=False`). See `csrc/profiler/stubs/openreg.cpp`.
+- **Kineto plugin (correlation + session wiring)**: `IActivityProfiler` registered via `REGISTER_PRIVATEUSE1_PROFILER` provides Kineto session integration and correlation-ID plumbing via `torch.profiler.profile(activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1])`. See `csrc/profiler/OpenRegActivityProfiler.cpp` and `third_party/openreg/csrc/tracer.cpp`. Requires Kineto at build time (`kineto_LIBRARY` from `find_package(Torch)`); vendors extend the stub to emit kernel events and flow links.
+
+For the full integration guide, see the [Profiler Integration](https://docs.pytorch.org/docs/main/accelerator/profiler.html) documentation.
 
 ## Future Plans
 

--- a/test/test_privateuse1_skip_cea.py
+++ b/test/test_privateuse1_skip_cea.py
@@ -1,0 +1,109 @@
+# Owner(s): ["module: PrivateUse1"]
+"""
+Tests for torch.utils.skip_cea_decomposition_for_privateuse1().
+
+Verifies that, once the CEA skip is enabled:
+  - Ops with only a CompositeExplicitAutograd (CEA) kernel route to the
+    PrivateUse1 backend fallback instead of being silently decomposed.
+  - Direct PrivateUse1 kernel registrations are unaffected.
+  - The RAII handle correctly restores the previous behavior on release.
+"""
+
+import torch
+import torch.library
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
+
+
+# _setup_privateuseone_for_python_backend can only be called once per process.
+_setup_privateuseone_for_python_backend("fakedev")
+
+
+class TestPrivateUse1SkipCEA(TestCase):
+    def test_skip_cea_flag_initially_false(self):
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_raii_sets_and_restores_flag(self):
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        self.assertTrue(torch._C._dispatch_privateuse1_skip_cea_enabled())
+        del handle
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_context_manager_restores_on_exception(self):
+        class _Ctx:
+            def __enter__(self):
+                self._handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+                return self
+
+            def __exit__(self, *_):
+                del self._handle
+
+        with _Ctx():
+            self.assertTrue(torch._C._dispatch_privateuse1_skip_cea_enabled())
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_double_registration_raises(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "already registered"):
+                torch.utils.skip_cea_decomposition_for_privateuse1()
+        finally:
+            del handle
+
+    def test_cea_op_routes_to_fallback(self):
+        """
+        torch.ops.aten.abs.default has a CEA kernel and no direct PrivateUse1
+        kernel.  With skip enabled it must reach the backend fallback rather
+        than being handled by the CEA decomposition.
+        """
+        fallback_calls: list[str] = []
+
+        def recording_fallback(op, args, kwargs):
+            fallback_calls.append(op.name())
+            # Raise so the test can verify dispatch reached us without needing
+            # a full fakedev tensor implementation.
+            raise RuntimeError(f"fakedev fallback: {op.name()}")
+
+        lib = torch.library.Library("_", "IMPL", "fakedev")
+        lib.fallback(recording_fallback)
+
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            t = torch.empty(2, device="fakedev")
+            with self.assertRaises(RuntimeError):
+                torch.abs(t)
+            self.assertTrue(
+                any("abs" in c for c in fallback_calls),
+                f"Expected aten::abs to reach the fallback; got calls: {fallback_calls}",
+            )
+        finally:
+            del handle
+            del lib
+
+    def test_direct_kernel_unaffected_by_skip(self):
+        """
+        Direct PrivateUse1 kernel registrations take priority over CEA and must
+        remain unaffected when the CEA skip is enabled.
+        """
+        direct_calls: list[str] = []
+
+        lib = torch.library.Library("aten", "IMPL", "fakedev")
+
+        @lib.impl("aten::neg.default")
+        def fakedev_neg(self):
+            direct_calls.append("neg")
+            return self  # identity for test purposes
+
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            t = torch.empty(2, device="fakedev")
+            torch.neg(t)
+            self.assertIn("neg", direct_calls)
+        finally:
+            del handle
+            del lib
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -847,6 +847,36 @@ static PyObject* THModule_get_privateuse1_backend_name(
   END_HANDLE_TH_ERRORS
 }
 
+// Opt the PrivateUse1 backend out of CompositeExplicitAutograd decompositions.
+// Returns an opaque handle object; CEA skip is active while the handle is alive.
+static PyObject* THModule_set_privateuse1_skip_cea(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  auto handle = c10::Dispatcher::singleton().setPrivateUse1SkipCEA();
+  // Wrap the RAII handle in a PyCapsule so Python keeps it alive.
+  auto* raw = new c10::RegistrationHandleRAII(std::move(handle));
+  return PyCapsule_New(
+      raw,
+      "PrivateUse1SkipCEAHandle",
+      [](PyObject* cap) {
+        delete static_cast<c10::RegistrationHandleRAII*>(
+            PyCapsule_GetPointer(cap, "PrivateUse1SkipCEAHandle"));
+      });
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THModule_privateuse1_skip_cea_enabled(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  if (c10::Dispatcher::singleton().privateuse1SkipCEA()) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
@@ -2185,6 +2215,14 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      nullptr},
     {"_get_privateuse1_backend_name",
      THModule_get_privateuse1_backend_name,
+     METH_NOARGS,
+     nullptr},
+    {"_dispatch_set_privateuse1_skip_cea",
+     THModule_set_privateuse1_skip_cea,
+     METH_NOARGS,
+     nullptr},
+    {"_dispatch_privateuse1_skip_cea_enabled",
+     THModule_privateuse1_skip_cea_enabled,
      METH_NOARGS,
      nullptr},
     {"set_flush_denormal", THPModule_setFlushDenormal, METH_O, nullptr},

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -15,6 +15,7 @@ from torch.utils import (
 from torch.utils.backend_registration import (
     generate_methods_for_privateuse1_backend,
     rename_privateuse1_backend,
+    skip_cea_decomposition_for_privateuse1,
 )
 from torch.utils.cpp_backtrace import get_cpp_backtrace
 from torch.utils.throughput_benchmark import ThroughputBenchmark

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -8,6 +8,7 @@ from torch.overrides import handle_torch_function, has_torch_function_unary
 __all__ = [
     "rename_privateuse1_backend",
     "generate_methods_for_privateuse1_backend",
+    "skip_cea_decomposition_for_privateuse1",
 ]
 
 # TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
@@ -501,6 +502,39 @@ def _get_custom_mod_func(func_name: str):
         message += f"BackendModule needs to have the following API's:\n `{func_name}(*args, **kwargs)`. \n"
         raise RuntimeError(message)
     return function
+
+
+def skip_cea_decomposition_for_privateuse1():
+    r"""Opt the PrivateUse1 backend out of CompositeExplicitAutograd (CEA) decompositions.
+
+    By default, PyTorch resolves CompositeExplicitAutograd kernels before the
+    backend fallback.  Backends that register a single catch-all fallback (e.g.
+    proxy backends that forward ATen ops to a remote GPU server) therefore never
+    see composite ops—they only receive the decomposed primitives (e.g.
+    ``softmax`` → ``_softmax``, ``convolution`` → ``convolution_overrideable``).
+
+    After calling this function, ops that have *only* a CEA registration and no
+    direct PrivateUse1 kernel will skip the alias lookup and route to the
+    backend fallback instead.  Ops that do have a direct PrivateUse1 kernel
+    registered are unaffected (direct registrations always win).
+
+    Returns an opaque handle.  The opt-out is active for as long as the handle
+    is alive; releasing it (or deleting it) restores the previous behavior and
+    refreshes the affected dispatch table entries automatically.
+
+    Note: This function can only be called once per process. Attempting to call
+    it again before releasing the previous handle will raise an error.
+
+    Example::
+
+        >>> # xdoctest: +SKIP("requires PrivateUse1 backend")
+        >>> handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        >>> # All CEA-only ops now route to the PrivateUse1 fallback.
+        >>> # Release when done (e.g. at process exit or in a test teardown):
+        >>> del handle
+
+    """
+    return torch._C._dispatch_set_privateuse1_skip_cea()
 
 
 class _DummyBackendModule:


### PR DESCRIPTION
## Summary

Fixes #187576

The PyTorch dispatch table resolves `CompositeExplicitAutograd` (CEA) kernels **before** the backend fallback, so PrivateUse1 backends using a catch-all fallback never see composite ops — they only receive decomposed primitives (`softmax` → `_softmax`, `convolution` → `convolution_overrideable`, etc.).

For proxy backends like [SkyTorch](https://github.com/astefanutti/skytorch) (PyTorch with remote GPUs) that need to forward ATen ops verbatim to a remote server, this silent decomposition is the core problem: **538 ops** have CEA registrations and SkyTorch currently registers **280+** ops manually to work around it. Every PyTorch release can silently introduce new CEA decompositions that break the backend.

This PR adds a one-line opt-out:

```python
handle = torch.utils.skip_cea_decomposition_for_privateuse1()
# All CEA-only ops now route to the PrivateUse1 fallback verbatim.
# Release handle to restore previous behavior (RAII).
del handle
```

### How it works

**Before** (current resolution order for PrivateUse1):
```
1. Direct PrivateUse1 kernel     -- wins
2a. CEANF alias kernel           -- silently decomposes the op
2b. CEA alias kernel             -- silently decomposes the op
3. Backend fallback              -- never reached for CEA-covered ops
```

**After** (with skip enabled):
```
1. Direct PrivateUse1 kernel     -- wins (unchanged)
2a. CEANF alias                  -- SKIPPED for PrivateUse1
2b. CEA alias                    -- SKIPPED for PrivateUse1
3. Backend fallback              -- now reached for CEA-only ops
```

Direct `PrivateUse1` kernel registrations are completely unaffected.

### Implementation

| File | Change |
|---|---|
| `aten/src/ATen/core/dispatch/Dispatcher.h` | New `setPrivateUse1SkipCEA()` + `privateuse1SkipCEA()` + `std::atomic<bool>` field |
| `aten/src/ATen/core/dispatch/Dispatcher.cpp` | Implement `setPrivateUse1SkipCEA()`: set atomic, refresh all PrivateUse1 dispatch entries, return RAII handle |
| `aten/src/ATen/core/dispatch/OperatorEntry.cpp` | In `computeDispatchTableEntryWithDebug`: skip CEANF/CEA alias lookup when `dispatcher.privateuse1SkipCEA()` is set |
| `torch/csrc/Module.cpp` | `_dispatch_set_privateuse1_skip_cea` and `_dispatch_privateuse1_skip_cea_enabled` Python bindings |
| `torch/utils/backend_registration.py` | `skip_cea_decomposition_for_privateuse1()` public Python API |
| `torch/utils/__init__.py` | Re-export the new function |
| `test/test_privateuse1_skip_cea.py` | New test: RAII semantics, double-registration error, CEA op routing, direct-kernel unaffected |

## Test plan

```bash
python test/test_privateuse1_skip_cea.py -v
```

Tests cover:
- Flag is `False` initially
- RAII handle sets flag on enter and restores on `del`
- Double registration raises `RuntimeError("already registered")`
- A known CEA op (`aten::abs`) reaches the fallback (not CEA decomposition) when skip is enabled
- A direct `PrivateUse1` kernel registration is unaffected by the skip flag

Authored with AI assistant (Sonnet 4.6).

Made with [Cursor](https://cursor.com)