### PR TITLE
Release the GIL in the _disable_profiler pybind binding

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -439,7 +439,10 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       py::arg("config"),
       py::arg("activities"),
       py::arg("scopes") = std::unordered_set<at::RecordScope>());
-  m.def("_disable_profiler", disableProfiler);
+  m.def(
+      "_disable_profiler",
+      disableProfiler,
+      py::call_guard<py::gil_scoped_release>());
   m.def(
       "_prepare_profiler",
       prepareProfiler,


### PR DESCRIPTION
**Problem**

`_disable_profiler()` holds the GIL for the entire `disableProfiler()` call, unlike its sibling profiler control bindings `_prepare_profiler()` and `_toggle_collection_dynamic()`, which release it. Holding the GIL across profiler teardown is both unnecessary and risky. `disableProfiler()` can block for a non-trivial time (trace finalization, when global callbacks are installed, waiting for in-flight RecordFunction callbacks to finish, and the newly introduced drain in https://github.com/pytorch/pytorch/pull/187483).

Global callbacks (KINETO_ONDEMAND, or KINETO with profile_all_threads) fire on every thread; if one is in flight on another thread and needs the GIL to run to completion, it cannot proceed while the disabling thread blocks holding the GIL -- a deadlock.

**Fix**

Release the GIL for the duration of the call via
`py::call_guard<py::gil_scoped_release>()`, matching `_prepare_profiler()` and `_toggle_collection_dynamic()`.

The only Python-touching work reachable from `disableProfiler()` is the python tracer, which acquires the GIL itself. The rest is pure C++. Releasing the GIL also lets other Python threads make progress during a potentially slow teardown rather than blocking on it.

This change was authored with assistance from Claude, an AI assistant.