### PR TITLE
Add return type annotation to nn.Module.named_modules

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -428,12 +428,13 @@ class _RemoteModule(nn.Module):
     def modules(self) -> Iterator[Module]:  # type: ignore[return]
         _raise_not_supported(self.modules.__name__)
 
-    def named_modules(
+    def named_modules(  # type: ignore[return]
         self,
         memo: set[Module] | None = None,
         prefix: str = "",
         remove_duplicate: bool = True,
-    ):
+        # pyrefly: ignore [bad-return]
+    ) -> Iterator[tuple[str, Module]]:
         _raise_not_supported(self.named_modules.__name__)
 
     def train(self, mode: bool = True) -> Self:

--- a/torch/fx/passes/param_fetch.py
+++ b/torch/fx/passes/param_fetch.py
@@ -89,6 +89,8 @@ def lift_lowering_attrs_to_nodes(fx_module: GraphModule) -> None:
 
     for node in fx_module.graph.nodes:
         if node.op == "call_module":
+            # When op is "call_module", target is always a string (the module's name).
+            assert isinstance(node.target, str)
             if isinstance(submodules[node.target], GraphModule):
                 lift_lowering_attrs_to_nodes(submodules[node.target])
             else:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2838,7 +2838,7 @@ class Module:
         memo: set["Module"] | None = None,
         prefix: str = "",
         remove_duplicate: bool = True,
-    ):
+    ) -> Iterator[tuple[str, "Module"]]:
         r"""Return an iterator over all modules in the network, yielding both the name of the module as well as the module itself.
 
         Args:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2851,7 +2851,7 @@ class Module:
         memo: set["Module"] | None = None,
         prefix: str = "",
         remove_duplicate: bool = True,
-    ):
+    ) -> Iterator[tuple[str, "Module"]]:
         r"""Return an iterator over all modules in the network, yielding both the name of the module as well as the module itself.
 
         Args:


### PR DESCRIPTION
Fixes #166905

`nn.Module.named_modules()` had no return type annotation, while its siblings `named_children`, `named_parameters`, and `named_buffers` are annotated, so type checkers inferred an untyped result for `named_modules()`.

This adds `-> Iterator[tuple[str, "Module"]]` to match `named_children`. `Iterator` is already imported in the module and there is no runtime behavior change.
