### PR TITLE
[executorch][dynamo] Import torch._utils before Dynamo variable registration

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -27,6 +27,7 @@ traceable graph nodes while preserving correct semantics and handling edge cases
 
 import enum
 import functools
+import importlib
 import inspect
 import logging
 import math
@@ -38,6 +39,8 @@ from typing_extensions import TypeIs
 
 import torch._C
 import torch._refs
+
+torch._utils = importlib.import_module("torch._utils")
 import torch.fx
 import torch.nn
 import torch.utils._pytree as _pytree


### PR DESCRIPTION
Summary: `torch/_dynamo/variables/torch.py` reads `torch._utils` at module scope (`constant_fold_functions` includes `torch._utils._get_device_index`, and the tracing-state dict maps `torch._utils.is_compiling`). Under lazy imports, `torch/__init__`'s `from torch._utils import ...` is deferred and `torch.__getattr__` does not resolve `_utils`, so importing this module raises `AttributeError: module 'torch' has no attribute '_utils'` -- which breaks Dynamo import and makes dependent tests error at collection (and then get skipped). A plain `import torch._utils` is also deferred under lazy imports and does not fix the ordering; `importlib.import_module` forces eager binding before the module-scope reads run.

Test Plan: Confirmed the failure mode statically and at runtime: lazy imports are active in the affected environment (`importlib.is_lazy_imports_enabled()` returns `True`), and `torch.__getattr__` resolves only `_dynamo`/`_inductor`/`_export`/`onnx` -- not `_utils` -- so a module-scope `torch._utils` access at import time raises `AttributeError` when the submodule has not yet been bound.

Differential Revision: D108760554




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98