### PR TITLE
Specialize symbolic range bounds in Dynamo RangeVariable

### DIFF
--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -1027,6 +1027,41 @@ class TestRangeUserIndex(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(), "type_error")
 
 
+class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
+    # With assume_static_by_default=False a captured range object's
+    # start/stop/step are wrapped as symbolic ints; range math must specialize
+    # them instead of assuming a plain python constant.
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_range_index_symbolic_bounds(self):
+        keys = range(10)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return keys[0]
+
+        self.assertEqual(fn(), 0)
+
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_range_slice_symbolic_bounds(self):
+        keys = range(1, 10, 2)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return keys[1:3]
+
+        self.assertEqual(fn(), range(1, 10, 2)[1:3])
+
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_range_iter_symbolic_bounds(self):
+        keys = range(5)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return list(keys)
+
+        self.assertEqual(fn(), [0, 1, 2, 3, 4])
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -589,13 +589,13 @@ class RangeVariable(BaseListVariable):
     # range math needs concrete bounds; with assume_static_by_default=False a
     # range object's start/stop/step are wrapped as symbolic ints, so specialize
     # them (installing a guard) rather than assuming a plain constant.
-    def start(self) -> Any:
+    def start(self) -> int:
         return guard_if_dyn(self.items[0])
 
-    def stop(self) -> Any:
+    def stop(self) -> int:
         return guard_if_dyn(self.items[1])
 
-    def step(self) -> Any:
+    def step(self) -> int:
         return guard_if_dyn(self.items[2])
 
     def range_length(self) -> int:

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -586,14 +586,17 @@ class RangeVariable(BaseListVariable):
     def python_type(self) -> type:
         return range
 
+    # range math needs concrete bounds; with assume_static_by_default=False a
+    # range object's start/stop/step are wrapped as symbolic ints, so specialize
+    # them (installing a guard) rather than assuming a plain constant.
     def start(self) -> Any:
-        return self.items[0].as_python_constant()
+        return guard_if_dyn(self.items[0])
 
     def stop(self) -> Any:
-        return self.items[1].as_python_constant()
+        return guard_if_dyn(self.items[1])
 
     def step(self) -> Any:
-        return self.items[2].as_python_constant()
+        return guard_if_dyn(self.items[2])
 
     def range_length(self) -> int:
         lo = self.start()
@@ -721,7 +724,8 @@ class RangeVariable(BaseListVariable):
     def unpack_var_sequence(
         self, tx: Optional["InstructionTranslatorBase"] = None
     ) -> list[VariableTracker]:
-        return [variables.ConstantVariable.create(x) for x in self.as_python_constant()]
+        rng = range(self.start(), self.stop(), self.step())
+        return [variables.ConstantVariable.create(x) for x in rng]
 
     def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for range objects."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187605
* #187129
* #187128
* #187377

Authored with assistance from an AI assistant (Claude).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98