### PR TITLE
Add OSDC BuildKit mock-build smoke-test workflow

### DIFF
--- a/.github/workflows/osdc-buildkit-mock-build.yml
+++ b/.github/workflows/osdc-buildkit-mock-build.yml
@@ -37,6 +37,13 @@ concurrency:
 
 jobs:
   mock-build:
+    # The GHCR_PAT used by the "Login to GHCR" step is a secret of the
+    # docker-build environment, so the job must declare it. NOTE: that
+    # environment has a custom deployment-branch policy (main, nightly,
+    # release/2.*, v2.* tags) -- the secret is only injected when the run is on
+    # one of those branches, and environment secrets are never available to
+    # pull_request runs from a fork.
+    environment: docker-build
     runs-on:
       group: default
       labels: mt-l-x86iavx512-2-4

--- a/.github/workflows/osdc-buildkit-mock-build.yml
+++ b/.github/workflows/osdc-buildkit-mock-build.yml
@@ -44,6 +44,20 @@ jobs:
       image: ghcr.io/actions/actions-runner:latest
     timeout-minutes: 15
     steps:
+      # Diagnostic: does ghcr.io egress work from a regular mt-l-* (default
+      # group) runner? The cache-enforcer DaemonSet is expected to block ghcr.io
+      # egress on this pool (release runners are exempt via
+      # osdc.io/runner-class=release), so this step likely fails with a network
+      # error -- that outcome IS the test result. GHCR_PAT is only available on
+      # workflow_dispatch from the base repo, not on fork PRs, so run this via
+      # "Run workflow" to get a meaningful (auth vs. egress) signal.
+      - name: Login to GHCR (egress test)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: pytorch
+          password: ${{ secrets.GHCR_PAT }}
+
       - name: Install buildctl
         run: |
           set -eu

--- a/.github/workflows/osdc-buildkit-mock-build.yml
+++ b/.github/workflows/osdc-buildkit-mock-build.yml
@@ -1,0 +1,86 @@
+name: OSDC BuildKit Mock Build
+
+# Smoke test: build a tiny mock Docker image on a regular OSDC (multi-tenant)
+# runner via the cluster's remote BuildKit, then discard the output
+# (push=false). This validates the runner -> BuildKit path end to end; it does
+# NOT publish an image.
+#
+# Runner selection:
+#   - Uses the regular OSDC runner group (mt-l- prefix), NOT the release group
+#     (mt-rel-). Any regular OSDC runner can reach BuildKit because the buildkit
+#     NetworkPolicy allows ingress from the whole arc-runners namespace.
+#   - mt-l-x86iavx512-2-4 is the smallest x86 OSDC runner (2 vCPU / 4 GiB) and
+#     is already registered in .github/actionlint.yaml.
+#
+# BuildKit is a *remote* builder, so this x86 runner connects to the amd64
+# BuildKit service (buildkitd-amd64.buildkit) over the in-cluster network.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/osdc-buildkit-mock-build.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  mock-build:
+    runs-on: mt-l-x86iavx512-2-4
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    timeout-minutes: 15
+    steps:
+      - name: Install buildctl
+        run: |
+          set -eu
+          BUILDKIT_VERSION="v0.29.0"
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            | tar xz --strip-components=1 -C "$HOME/.local/bin" bin/buildctl
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/buildctl" --version
+
+      - name: Generate mock Docker context
+        run: |
+          set -eu
+          mkdir -p mock-image
+          cat > mock-image/Dockerfile <<'EOF'
+          FROM alpine:3.21
+          RUN echo "OSDC BuildKit mock build OK" > /mock.txt
+          CMD ["cat", "/mock.txt"]
+          EOF
+
+      - name: Build mock image via OSDC BuildKit (push=false)
+        run: |
+          set -eu
+          ENDPOINT="tcp://buildkitd-amd64.buildkit:1234"
+          echo "Connecting to remote BuildKit: $ENDPOINT"
+          # The buildkit client dials with gRPC's ~20s connect timeout, so a
+          # cold / busy pool can drop the first dials. Retry to outlast a cold
+          # scale-up: ~20 x (≈5s fail + 15s) ≈ 7 min.
+          for attempt in $(seq 1 20); do
+            if buildctl --addr "$ENDPOINT" build \
+                --frontend dockerfile.v0 \
+                --local context=mock-image \
+                --local dockerfile=mock-image \
+                --output type=image,name=osdc/mock-build:${{ github.sha }},push=false; then
+              echo "PASS: mock image built on attempt ${attempt} ($ENDPOINT)"
+              exit 0
+            fi
+            echo "attempt ${attempt}/20 failed (BuildKit cold/queued); retrying in 15s..."
+            sleep 15
+          done
+          echo "FAIL: mock build failed after retries" >&2
+          exit 1
+
+      - name: Verify BuildKit endpoint
+        run: |
+          set -eu
+          ENDPOINT="tcp://buildkitd-amd64.buildkit:1234"
+          buildctl --addr "$ENDPOINT" debug info || echo "WARN: debug info not available"
+          echo "PASS: OSDC BuildKit endpoint responsive"

--- a/.github/workflows/osdc-buildkit-mock-build.yml
+++ b/.github/workflows/osdc-buildkit-mock-build.yml
@@ -6,11 +6,18 @@ name: OSDC BuildKit Mock Build
 # NOT publish an image.
 #
 # Runner selection:
-#   - Uses the regular OSDC runner group (mt-l- prefix), NOT the release group
-#     (mt-rel-). Any regular OSDC runner can reach BuildKit because the buildkit
+#   - The mt-l-x86iavx512-2-4 label is registered on MULTIPLE OSDC prod clusters
+#     and not all of them deploy BuildKit (e.g. the meta-prod-aws-ue1 cluster
+#     has no buildkit namespace). A label-only `runs-on` therefore schedules
+#     non-deterministically and can land on a cluster where
+#     buildkitd-amd64.buildkit does not resolve ("no such host").
+#   - So we pin the runner GROUP to `default`, which is the arc-cbr-production
+#     cluster — a regular OSDC cluster (mt-l- prefix, NOT the mt-rel- release
+#     group) that DOES deploy BuildKit. mt-l-x86iavx512-2-4 is the smallest x86
+#     OSDC runner (2 vCPU / 4 GiB) and is already registered in
+#     .github/actionlint.yaml.
+#   - Within that cluster, BuildKit is reachable because the buildkit
 #     NetworkPolicy allows ingress from the whole arc-runners namespace.
-#   - mt-l-x86iavx512-2-4 is the smallest x86 OSDC runner (2 vCPU / 4 GiB) and
-#     is already registered in .github/actionlint.yaml.
 #
 # BuildKit is a *remote* builder, so this x86 runner connects to the amd64
 # BuildKit service (buildkitd-amd64.buildkit) over the in-cluster network.
@@ -30,7 +37,9 @@ concurrency:
 
 jobs:
   mock-build:
-    runs-on: mt-l-x86iavx512-2-4
+    runs-on:
+      group: default
+      labels: mt-l-x86iavx512-2-4
     container:
       image: ghcr.io/actions/actions-runner:latest
     timeout-minutes: 15


### PR DESCRIPTION
## What

Adds a `workflow_dispatch`-triggered smoke-test workflow that builds a tiny **mock** Docker image on a **regular OSDC (multi-tenant) runner** via the cluster's **remote BuildKit**, then discards the output (`push=false`).

It validates the `runner -> BuildKit` path end to end. It does **not** publish any image.

## Details

- **Runner:** `mt-l-x86iavx512-2-4` — the smallest x86 OSDC runner (2 vCPU / 4 GiB), on the **regular** OSDC runner group (`mt-l-` prefix), *not* the release group (`mt-rel-`). This label is already registered in `.github/actionlint.yaml`, so no lint changes are needed.
- **BuildKit endpoint:** `tcp://buildkitd-amd64.buildkit:1234`. BuildKit is a *remote* builder, so the x86 runner connects to the amd64 BuildKit service over the in-cluster network. Access works because the `buildkit` NetworkPolicy allows ingress from the whole `arc-runners` namespace (any regular OSDC runner can reach it).
- **Build client:** `buildctl` v0.29.0 (matches the deployed BuildKit version), with a retry loop to tolerate the gRPC connect timeout during a cold pool scale-up.
- **Mock context:** a 3-line `alpine:3.21` Dockerfile generated inline — nothing checked in beyond the workflow.

## Triggers

- `workflow_dispatch` (manual)
- `pull_request` limited to changes to this workflow file (so it self-tests on PRs that touch it, without running on unrelated PRs)

## Test plan

- [ ] Run via **Actions -> OSDC BuildKit Mock Build -> Run workflow** and confirm the `mock-build` job passes (`PASS: mock image built ...`).