### PR TITLE
[ROCM] Fix test_cross_entropy_loss_2d_out_of_bounds_class

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13326,7 +13326,9 @@ if __name__ == '__main__':
         # CUDA says "device-side assert triggered"
         # ROCm says "unspecified launch failure", or HSA_STATUS_ERROR_EXCEPTION
         has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
-        has_hip_assert = 'launch failure' in stderr or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
+        has_hip_assert = ('launch failure' in stderr
+                          or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
+                          or 'illegal memory access' in stderr)
         self.assertTrue(has_cuda_assert or has_hip_assert,
                         f"Expected device assert error in stderr, got: {stderr}")
 


### PR DESCRIPTION
On ROCM GPU memory access error is reported as
```
CUDA error: an illegal memory access was encountered (hipErrorIllegalAddress)
```
instead of GPU segfault since ROCM 7.0


The test needs to capture this signature change.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil