### PR TITLE
Cache custom op out-tag lookup

### DIFF
--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -25,6 +25,7 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     name: str = f"GeneratedBackwardFor_{op._namespace}_{op._opname}_{op._overloadname}"
 
     schema = op._schema
+    is_out_op = utils.is_out(op)
     has_kwarg_only_args = utils.has_kwarg_only_args(op._schema)
     num_positional_args = sum(not a.kwarg_only for a in schema.arguments)
     has_tensorlist_like_args = any(
@@ -134,7 +135,7 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     # The dispatcher passes any keyword-only-args as kwargs and the
     # rest of the args (even if specified as kwargs) as args.
     def autograd_impl(keyset, *args, **keyword_only_args):
-        if utils.is_out(op):
+        if is_out_op:
             if _C.is_grad_enabled() and _C._any_requires_grad(
                 *args, **keyword_only_args
             ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187619
* #187618
* __->__ #187616

The generated custom-op autograd wrapper checked whether the operator had torch.Tag.out on every invocation. That value is fixed for the operator, so compute it once when creating the wrapper.

Test Plan:

```
python test/test_custom_ops.py TestCustomOpAPI.test_custom_op_out_tag_autograd -v
```

Authored with assistance from an AI assistant.