### PR TITLE
Skip custom op alias checks for scalar returns

### DIFF
--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -436,6 +436,12 @@ class CustomOpDef:
                 dtypes = list(device_types)
             for device_type in dtypes:
                 if device_type not in self._backend_fns:
+                    schema = self._opoverload._schema
+                    check_aliasing = not schema._is_view_op() and any(
+                        utils.is_tensor_like_type(ret.type)
+                        or utils.is_tensorlist_like_type(ret.type)
+                        for ret in schema.returns
+                    )
 
                     def backend_impl(*args, **kwargs):
                         result = self._backend_fns[device_type](*args, **kwargs)
@@ -444,7 +450,6 @@ class CustomOpDef:
                             fn = self._backend_fns[device_type]
                             return inspect.getmodule(fn)
 
-                        schema = self._opoverload._schema
                         if self._is_inplace:
                             if result is not args[0]:
                                 raise RuntimeError(
@@ -455,7 +460,8 @@ class CustomOpDef:
                         elif self._is_out:
                             out_kwarg_names = self._out_kwarg_names
                             if len(out_kwarg_names) == 1:
-                                returns_out_args = result is kwargs[out_kwarg_names[0]]
+                                out_arg_name = out_kwarg_names[0]
+                                returns_out_args = result is kwargs[out_arg_name]
                             else:
                                 returns_out_args = (
                                     isinstance(result, tuple)
@@ -471,7 +477,7 @@ class CustomOpDef:
                                     "An operator tagged with torch.Tag.out must "
                                     "return its mutable keyword-only arguments."
                                 )
-                        elif not schema._is_view_op():
+                        elif check_aliasing:
                             utils._c_check_aliasing_constraint(
                                 self._name,
                                 args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187619
* #187618
* __->__ #187617
* #187616

Custom-op backend wrappers always ran the output alias checker for non-view operators after invoking the Python kernel. That check is only meaningful for tensor-like returns, so scalar-returning custom ops paid for an unnecessary C++ alias-check call on every invocation.

This precomputes whether the schema can return tensors when registering the backend wrapper, then only runs the alias checker for tensor-like returns. The existing inplace and out-tag checks are unchanged.

Test Plan:

```

python test/test_custom_ops.py TestCustomOpAPI.test_disallows_output_aliasing TestCustomOpAPI.test_basic TestCustomOpAPI.test_multi_types -v

python agent_space/custom_op_hotpath_bench.py

lintrunner -a

```

lintrunner -a currently fails on unrelated Pyrefly errors in torch.bcomplex32 references and torch/cuda/_graph_annotations.py; neither failure is in files touched by this change.

Authored with assistance from an AI assistant.