### PR TITLE
Avoid custom op no-grad metadata packing

### DIFF
--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -38,13 +38,8 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
         keyset: _C.DispatchKeySet
         keyword_only_args: dict[str, Any]
 
-    def forward_no_grad(*args):
-        metadata = args[-1]
-        args = args[:-1]
-
+    def redispatch_no_grad(keyset, args, kwargs):
         with _C._AutoDispatchBelowAutograd():
-            keyset = metadata.keyset
-            kwargs = metadata.keyword_only_args
             result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
             return result
 
@@ -144,12 +139,12 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
                     "support automatic differentiation, but one of the arguments "
                     "requires grad."
                 )
-            return forward_no_grad(*args, Metadata(keyset, keyword_only_args))
+            return redispatch_no_grad(keyset, args, keyword_only_args)
 
         if _C.is_grad_enabled() and _C._any_requires_grad(*args):
             result = Generated.apply(*args, Metadata(keyset, keyword_only_args))  # type: ignore[attr-defined]
         else:
-            result = forward_no_grad(*args, Metadata(keyset, keyword_only_args))
+            result = redispatch_no_grad(keyset, args, keyword_only_args)
         return result
 
     return autograd_impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187619
* __->__ #187618
* #187616

The generated custom-op autograd wrapper only needs Metadata for the autograd.Function path. No-grad calls immediately redispatch below Autograd, so packing keyset and kwargs into Metadata and unpacking them again is unnecessary work on the eager hot path.

This keeps the autograd.Function path unchanged and passes the keyset, positional args, and keyword-only args directly to the no-grad redispatch helper.

Test Plan:

```
python test/test_custom_ops.py TestCustomOpAPI.test_no_grad_skips_autograd TestCustomOpAPI.test_library_register_autograd TestCustomOpAPI.test_custom_op_out_tag_autograd TestCustomOpAPI.test_basic -v
```

Authored with assistance from an AI assistant.