### PR TITLE
Remove Dynamo guard from custom op kernels

### DIFF
--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -500,7 +500,6 @@ class CustomOpDef:
 
                 # Wrap function to choose between the default implementation or the device-specific
                 # implementation depending on if the kernel is disabled.
-                @torch._disable_dynamo
                 def wrapped_fn(*args, **kwargs):
                     if device_type in self._disabled_kernel:
                         return self._init_fn(*args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187619
* #187618
* #187616

The custom-op backend wrapper decorates every registered kernel with torch._disable_dynamo. That guard was added in afb73d253cfe with test_dynamo_disabled_in_custom_op_kernels because Dynamo could previously turn itself back on inside custom-op implementations.

That guard appears to be unnecessary now: removing it still passes the original regression test, and compiled fullgraph functions still record torch.ops.<ns>.op.default in the FX graph instead of inlining the Python kernel. I do not know which later Dynamo change made the guard redundant, so this change is intentionally backed by the original regression test rather than a deeper root-cause claim.

Removing the decorator leaves the set_kernel_enabled wrapper in place but avoids Dynamo eval-frame bookkeeping on the eager custom-op hot path.

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_dynamo_disabled_in_custom_op_kernels -v
python test/test_custom_ops.py TestCustomOpAPI.test_basic TestCustomOpAPI.test_set_kernel_enabled TestCustomOpAPI.test_no_grad_skips_autograd TestCustomOpAPI.test_library_register_autograd TestCustomOpAPI.test_custom_op_out_tag_autograd TestCustomOpAPI.test_custom_op_inplace_tag_compile_eager TestCustomOpAPI.test_custom_op_inplace_tag_compile_eager_fullgraph TestCustomOpAPI.test_custom_op_out_tag_compile_eager TestCustomOpAPI.test_custom_op_out_tag_compile_eager_fullgraph -v
```

Also manually verified a compiled fullgraph function records torch.ops.<ns>.f.default in the FX graph instead of inlining the Python kernel.

Authored with assistance from an AI assistant.