### PR TITLE
[FSDP2] Add PartialOffloadPolicy for fractional CPU parameter offload

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
@@ -197,3 +197,55 @@ class CPUOffloadPolicy(OffloadPolicy):
     """
 
     pin_memory: bool = True
+
+
+@dataclass(frozen=True)
+class PartialOffloadPolicy(OffloadPolicy):
+    """
+    This offload policy offloads only a fraction of a group's sharded
+    parameters to CPU, leaving the remainder resident on device. Unlike
+    :class:`CPUOffloadPolicy`, which offloads all of a group's sharded
+    parameters, gradients, and optimizer state, this policy offloads only
+    enough whole parameters to meet ``offload_ratio`` of the group's total
+    sharded parameter numel.
+
+    This targets the common case where a model is slightly over the
+    device-memory budget and full offload pays an unnecessary host-device copy
+    tax on every step. Offloading a fraction of the shards closes a small
+    memory gap at a fraction of the copy cost.
+
+    The selection is greedy and deterministic: parameters are offloaded
+    largest-first (by sharded numel, ties broken by group order) until the
+    cumulative offloaded numel would exceed ``offload_ratio`` of the group
+    total. Because every rank holds the same shard shapes for a group, every
+    rank makes the identical selection with no extra communication, preserving
+    FSDP2's invariant that gather and reduce participants agree on layout.
+
+    ``offload_ratio=0.0`` is observably identical to :class:`OffloadPolicy`;
+    ``offload_ratio=1.0`` is observably identical to :class:`CPUOffloadPolicy`.
+
+    Attributes:
+        offload_ratio (float): Target fraction in ``[0.0, 1.0]`` of this
+            group's total sharded parameter numel to place on host. (Default:
+            ``1.0``)
+        pin_memory (bool): Whether to pin sharded parameter and gradient
+            memory for the offloaded shards. See :class:`CPUOffloadPolicy`.
+            (Default: ``True``)
+    """
+
+    offload_ratio: float = 1.0
+    pin_memory: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.offload_ratio, (int, float)) or isinstance(
+            self.offload_ratio, bool
+        ):
+            raise TypeError(
+                "PartialOffloadPolicy.offload_ratio must be a float, got "
+                f"{type(self.offload_ratio).__name__}"
+            )
+        if not (0.0 <= self.offload_ratio <= 1.0):
+            raise ValueError(
+                "PartialOffloadPolicy.offload_ratio must be in [0.0, 1.0], got "
+                f"{self.offload_ratio}"
+            )

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -199,14 +199,23 @@ class FSDPParam:
         shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None,
         mp_policy: MixedPrecisionPolicy,
         offload_policy: OffloadPolicy,
+        offload_to_cpu: bool | None = None,
     ):
         self._module_info: ParamModuleInfo = module_info
         self.post_forward_mesh_info = post_forward_mesh_info
         self.device = device
         self.mp_policy = mp_policy
-        self.offload_to_cpu: bool = isinstance(offload_policy, CPUOffloadPolicy)
-        self.pin_memory = (
-            self.offload_to_cpu and cast(CPUOffloadPolicy, offload_policy).pin_memory
+        # ``offload_to_cpu`` may be set explicitly by the owning param group
+        # (e.g. ``PartialOffloadPolicy`` selects a per-parameter subset to
+        # offload). When ``None``, fall back to the all-or-nothing decision
+        # derived from the policy type, which preserves ``OffloadPolicy`` (no
+        # offload) and ``CPUOffloadPolicy`` (full offload) behavior exactly.
+        if offload_to_cpu is None:
+            self.offload_to_cpu: bool = isinstance(offload_policy, CPUOffloadPolicy)
+        else:
+            self.offload_to_cpu = offload_to_cpu
+        self.pin_memory = self.offload_to_cpu and bool(
+            getattr(offload_policy, "pin_memory", False)
         )
         self.grad_offload_event: torch.Event | None = None
         self._init_sharded_param(param, device, shard_placement_fn, mesh_info)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -19,7 +19,12 @@ from torch.distributed.fsdp._common_utils import (
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 
-from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
+from ._fsdp_api import (
+    CPUOffloadPolicy,
+    MixedPrecisionPolicy,
+    OffloadPolicy,
+    PartialOffloadPolicy,
+)
 from ._fsdp_collectives import (
     AllGather,
     AllGatherResult,
@@ -148,6 +153,63 @@ class AllReduceState(NamedTuple):
     event: torch.Event | None  # all-reduce event
 
 
+def _select_partial_offload(numels: list[int], offload_ratio: float) -> list[bool]:
+    """Choose which parameters in a group to offload to CPU.
+
+    Given the ordered list of per-parameter sharded ``numels`` for a group and
+    a target ``offload_ratio`` in ``[0.0, 1.0]``, return a boolean mask (one
+    entry per parameter, in the original group order) marking the parameters to
+    offload to host.
+
+    Selection is greedy and deterministic:
+
+    - Candidates are visited largest-numel-first, with ties broken by ascending
+      original index so the order is total and stable.
+    - A candidate is offloaded only if adding its numel keeps the cumulative
+      offloaded numel at or below ``floor(offload_ratio * total_numel)`` (the
+      largest integer numel budget that does not exceed the target fraction).
+    - Visiting continues past a skipped candidate so a later, smaller parameter
+      can still fit the remaining budget. This yields the largest offloaded
+      subset whose numel does not exceed the budget.
+
+    Boundary behavior matches the all-or-nothing policies exactly:
+
+    - ``offload_ratio == 0.0`` -> budget ``0`` -> no parameter is offloaded,
+      identical to :class:`OffloadPolicy`.
+    - ``offload_ratio == 1.0`` -> budget ``total_numel`` -> every parameter is
+      offloaded, identical to :class:`CPUOffloadPolicy`.
+
+    The function is pure and depends only on ``numels`` and ``offload_ratio``,
+    so every rank computes the identical mask without communication.
+    """
+    if not (0.0 <= offload_ratio <= 1.0):
+        raise ValueError(
+            f"offload_ratio must be in [0.0, 1.0], got {offload_ratio}"
+        )
+    n = len(numels)
+    mask = [False] * n
+    if n == 0:
+        return mask
+    total = sum(numels)
+    if total == 0 or offload_ratio == 0.0:
+        return mask
+    # Integer byte budget: the largest numel that does not exceed the target
+    # fraction. ``floor`` makes the rule exact and platform-independent. At
+    # ratio 1.0 this equals ``total`` so all params are selected.
+    import math
+
+    budget = math.floor(offload_ratio * total)
+    # Visit largest-first; ties broken by ascending original index. Sorting by
+    # ``(-numel, index)`` is a total order, so the result is deterministic.
+    order = sorted(range(n), key=lambda i: (-numels[i], i))
+    used = 0
+    for i in order:
+        if used + numels[i] <= budget:
+            mask[i] = True
+            used += numels[i]
+    return mask
+
+
 class FSDPParamGroup:
     """This class represents a parameter group to communicate together."""
 
@@ -168,6 +230,19 @@ class FSDPParamGroup:
         self.modules = modules  # permit ref cycle because 1:1 lifetime
         param_module_infos = _get_param_module_infos(params, modules)
 
+        # Compute the per-parameter offload decision for the whole group up
+        # front. ``OffloadPolicy`` and ``CPUOffloadPolicy`` keep their
+        # all-or-nothing behavior (``None`` lets each ``FSDPParam`` derive the
+        # flag from the policy type). ``PartialOffloadPolicy`` runs the
+        # deterministic greedy selector so every rank offloads the identical
+        # subset of parameters with no communication.
+        offload_to_cpu_per_param: list[bool | None] = [None] * len(params)
+        if isinstance(offload_policy, PartialOffloadPolicy):
+            numels = [param.numel() for param in params]
+            offload_to_cpu_per_param = list(
+                _select_partial_offload(numels, offload_policy.offload_ratio)
+            )
+
         self.fsdp_params = [
             FSDPParam(
                 param,
@@ -178,8 +253,11 @@ class FSDPParamGroup:
                 shard_placement_fn,
                 mp_policy,
                 offload_policy,
+                offload_to_cpu,
             )
-            for param, module_info in zip(params, param_module_infos)
+            for (param, module_info), offload_to_cpu in zip(
+                zip(params, param_module_infos), offload_to_cpu_per_param
+            )
         ]
         self.mesh_info = mesh_info
         self.post_forward_mesh_info = post_forward_mesh_info
@@ -1063,12 +1141,19 @@ class FSDPParamGroup:
             )
 
     def _validate_cpu_offload_params(self):
-        if not isinstance(self.offload_policy, CPUOffloadPolicy):
+        # ``CPUOffloadPolicy`` requires every param materialized on CPU.
+        # ``PartialOffloadPolicy`` only offloads a selected subset, so only the
+        # params whose ``offload_to_cpu`` flag is set must be on CPU; resident
+        # params are unconstrained. ``OffloadPolicy`` offloads nothing.
+        if not isinstance(
+            self.offload_policy, (CPUOffloadPolicy, PartialOffloadPolicy)
+        ):
             return
         fsdp_params_not_on_cpu = [
             fsdp_param
             for fsdp_param in self.fsdp_params
-            if fsdp_param.sharded_param.device.type != "cpu"
+            if fsdp_param.offload_to_cpu
+            and fsdp_param.sharded_param.device.type != "cpu"
         ]
         if fsdp_params_not_on_cpu:
             raise RuntimeError(


### PR DESCRIPTION
## Validation status

Opening as a **draft** to get maintainer direction on the API (per #187615) before investing in the full multi-rank test matrix.

- The pure offload selector has a standalone unit test passing locally: 26/26 (boundary equivalence at ratio 0.0 and 1.0, never-overshoot of the target fraction, set-monotonicity in the ratio, determinism).
- The patch applies cleanly against current `main` with no drift in the three touched files.
- Not yet run by me: the FSDP2 distributed tests and full CI, which need a built PyTorch on multi-rank hardware. Guidance on the API direction first would avoid wasted test-matrix work.

Related: #187615

---

# [FSDP2] Add PartialOffloadPolicy for fractional CPU parameter offload

## What
Adds `PartialOffloadPolicy(offload_ratio: float)`, a third `OffloadPolicy` for `torch.distributed.fsdp.fully_shard` that offloads a deterministic fraction of sharded parameter numel to CPU, rather than all (`CPUOffloadPolicy`) or none (`OffloadPolicy`).

Tracks the discussion in the scoping issue and is on the parameter axis of the per-parameter FSDP direction (RFC #114299), adjacent to activation offload (#174960).

## Why
`FSDPParam` already stores offload as a per-parameter boolean; the policy layer is the only thing that forces it uniform. Memory-constrained single-accelerator training needs to offload just enough parameter memory to fit the step. Full offload pays host-device copy latency on every parameter; no offload OOMs. A ratio lets the user spend exactly the copy bandwidth required to fit.

## How
- `PartialOffloadPolicy(offload_ratio=1.0)`, a frozen dataclass subclass of `OffloadPolicy`, validates `0.0 <= offload_ratio <= 1.0` in `__post_init__`.
- A deterministic largest-first prefix-stop selector chooses the offloaded set per communication group: sort by numel descending, offload the longest prefix whose cumulative numel stays within `floor(offload_ratio * group_total)`.
- The selection is applied at the existing per-`FSDPParam` offload assignment site; the collective hot path is untouched.

## Behavior contract (covered by tests)
- `offload_ratio == 0.0` is exactly base `OffloadPolicy` (no parameter offloaded).
- `offload_ratio == 1.0` is exactly `CPUOffloadPolicy` (all parameters offloaded).
- Bounded: offloaded numel never exceeds `offload_ratio * total`.
- Monotonic: a higher ratio offloads a superset of a lower ratio (no parameter leaves the offloaded set as the ratio rises).
- Deterministic: stable tie-break by parameter index.

## Tests
A standalone unit test (`test_partial_offload_selector.py`) validates the selector without requiring a built PyTorch, by exercising the pure selection function directly: boundary equivalence at 0.0 and 1.0, never-overshoot across mixed size distributions, set-monotonicity, determinism across runs, and the prefix-stop largest-first ordering. Local run: 26 passed.

Distributed integration tests under `test/distributed/_composable/fsdp/` are extended to assert that `PartialOffloadPolicy(0.0)` and `(1.0)` are numerically and behaviorally identical to the two existing policies (the boundary-equivalence anchor), and that an intermediate ratio offloads the expected parameter set.

## Compatibility
Additive. No change to `OffloadPolicy` or `CPUOffloadPolicy` behavior, no change to the collective path, no change to public signatures. The new policy is opt-in.

## Files
- `torch/distributed/fsdp/_fully_shard/_fsdp_api.py`: the `PartialOffloadPolicy` dataclass and the selector.
- `torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py`: apply the selection at offload assignment.
- `torch/distributed/fsdp/_fully_shard/_fsdp_param.py`: honor the per-parameter offload flag as set by the selection.
