### PR TITLE
[caffe2][ovrsource] Build AOTInductor CUDA C-shim into libtorch_cuda_ovrsource

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -430,6 +430,14 @@ def get_aten_generated_files(enabled_backends):
         # build CUDA is not enabled and thus the ufunc codegen for CUDA gets
         # skipped
         src_files.extend(aten_ufunc_generated_cuda_sources())
+        # AOTInductor CUDA C-shim (aoti_torch_cuda_*), the CUDA counterpart of
+        # c_shim_cpu.cpp above. torchgen always emits this when --aoti_install_dir
+        # is set (aoti_backends hardcodes DispatchKey.CUDA in torchgen/gen.py), but
+        # it must be declared as a genrule output to be consumable. Required so
+        # AOTInductor .pt2 models can resolve the CUDA fallback-op shim at runtime.
+        src_files.append(
+            "torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp",
+        )
 
     res = {}
     for file_name in src_files:


### PR DESCRIPTION
Summary:
**Context:**

In order to utilise AOTI CUDA models on Gravity nodes (to be aligned with execution path on fbcode) we need a proper support for libtorch AOTI. `libtorch_cuda_ovrsource` is missing the generated `c_shim_cuda.cpp` that fbcode's `libtorch_cuda` includes via `target_definitions.bzl:327`. This causes undefined symbol: `aoti_torch_cuda_*` errors when loading AOTI-compiled CUDA models in arvr builds (e.g., Gravity nodes in Codec Avatar).


**This diff:**

This diff adds the CUDA shim to `gen_aten_ovrsource` outputs and includes it in `libtorch_cuda_ovrsource` sources, mirroring what fbcode already does.
This resolves "undefined symbol" runtime errors for dlopen'd AOTInductor .pt2 CUDA models by ensuring the required AOTInductor CUDA C-shim is exposed by codegen and compiled into `libtorch_cuda_ovrsource`.

Test Plan:
Build-system change enabling a generated source; the build is the verification.
- `buck2 build arvr/mode/fb-linux-nh/cuda12_8/opt arvr/mode/cuda/a100 'fbsource//xplat/caffe2:gen_aten_ovrsource[torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp]'` — codegen now exposes the CUDA shim.
- `buck2 build arvr/mode/fb-linux-nh/cuda12_8/opt arvr/mode/cuda/a100 fbsource//xplat/caffe2:libtorch_cuda_ovrsource` — builds clean with the shim compiled in.

Differential Revision: D108946058


