### PR TITLE
[ROCM]Calibrate decide_layout_opt's inference channels_last multipliers for ROCm/CDNA.

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -547,6 +547,30 @@ bool CUDAHooks::isGPUArch(const std::vector<std::string>& archs, DeviceIndex dev
   return false;
 }
 
+bool CUDAHooks::isChannelsLastSupportedForMIOpenConv() const {
+#if ROCM_VERSION < 60300
+  return false;
+#else
+  // Cache the device-property scan: this is on the per-conv hot path and the
+  // GPU arch is fixed for the process lifetime. Assumes a homogeneous-GPU box
+  // (all visible devices share an arch), which holds for current ROCm setups.
+  static const bool supported = [this]() {
+    // Do not enable NHWC by default on RDNA cards currently to avoid any
+    // unintended regressions while investigations are ongoing.
+    static const std::vector<std::string> unsupported_arch = {
+        "gfx1100", "gfx1101", "gfx1200", "gfx1201"};
+    const int num_gpus = getNumGPUs();
+    for (int index = 0; index < num_gpus; ++index) {
+      if (isGPUArch(unsupported_arch, index)) {
+        return false;
+      }
+    }
+    return true;
+  }();
+  return supported;
+#endif
+}
+
 const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
   static const std::vector<std::string> archs = {
     "gfx90a", "gfx942",

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -64,6 +64,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   DeviceIndex getCurrentDevice() const override;
 
 #ifdef USE_ROCM
+  bool isChannelsLastSupportedForMIOpenConv() const override;
   bool isGPUArch(const std::vector<std::string>& archs, DeviceIndex device_index = -1) const override;
   const std::vector<std::string>& getHipblasltPreferredArchs() const override;
   const std::vector<std::string>& getHipblasltSupportedArchs() const override;

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -223,8 +223,15 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     return 0;
   }
 
+  // Whether channels-last (NHWC) should be the default suggested memory format
+  // for MIOpen convolutions on the current device. Gpu-agnostic default is
+  // false; the CUDA/HIP hooks override this on ROCm (CDNA archs, ROCm >= 6.3).
+  virtual bool isChannelsLastSupportedForMIOpenConv() const {
+    return false;
+  }
+
 #ifdef USE_ROCM
-  virtual bool isGPUArch(const std::vector<std::string>& /*archs*/, DeviceIndex = -1 /*device_index*/) const {
+  virtual bool isGPUArch(const std::vector<std::string>& /*archs*/, DeviceIndex /*device_index*/ = -1) const {
     TORCH_CHECK(false, "Cannot check GPU arch without ATen_cuda library. ", CUDA_HELP);
   }
 

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -383,8 +383,13 @@ inline at::MemoryFormat miopen_conv_suggest_memory_format(const at::Tensor& inpu
       input.scalar_type() != at::kDouble && weight.scalar_type() != at::kDouble;
   // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen.
   // See https://github.com/pytorch/pytorch/issues/64427.
-  // Non-static read so tests can toggle the env var at runtime.
-  enabled &= c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC").value_or(false);
+  // NHWC is the default on supported ROCm archs (see
+  // CUDAHooks::isChannelsLastSupportedForMIOpenConv); the env var remains an
+  // override for other archs.
+  bool suggest_nhwc =
+      c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC").value_or(false) ||
+      at::detail::getCUDAHooks().isChannelsLastSupportedForMIOpenConv();
+  enabled &= suggest_nhwc;
   return _conv_suggest_memory_format_impl(input, weight, enabled);
 }
 

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -2,14 +2,18 @@
 import copy
 import os
 import random
+import unittest
+from unittest import mock
 
 import torch
 from torch import nn
 from torch._dynamo.utils import same
 from torch._inductor import config
+from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import run_tests, TestCase
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_cuda import tf32_off
-from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.common_utils import skipIfXpu, TEST_WITH_ROCM
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -339,6 +343,67 @@ class TestLayoutOptim(TestCase):
 
         ref = model(x, targets)
         self.assertTrue(torch.allclose(ref, loss))
+
+    @unittest.skipUnless(
+        TEST_WITH_ROCM, "ROCm-only MIOpen grouped-conv layout-opt gate"
+    )
+    def test_rocm_grouped_conv_skips_layout_opt(self):
+        """
+        ROCm-only gate in GraphLowering.decide_layout_opt: grouped convs whose
+        weight has channels-per-group < MIOPEN_XDL_MIN_CHANNELS_PER_GROUP (8)
+        fall back to a slow MIOpen naive kernel that channels_last cannot
+        accelerate, so layout optimization must be skipped for them. Plain
+        convs (groups == 1, e.g. the 3-channel RGB stem) keep using the fast
+        NHWC XDL kernel and must NOT be skipped by this gate.
+        """
+
+        def make_conv_graph(weight_shape, groups, *, transposed=False):
+            # Build an FX graph with a real aten.convolution.default node whose
+            # weight carries meta["val"] -- exactly what the gate inspects.
+            # Passing the weight as an explicit arg lets make_fx fake-trace it.
+            cpg = weight_shape[1]
+            cin = weight_shape[0] if transposed else cpg * groups
+
+            def fn(x, w):
+                return torch.ops.aten.convolution.default(
+                    x, w, None, [1, 1], [0, 0], [1, 1], transposed, [0, 0], groups
+                )
+
+            x = torch.randn(1, cin, 16, 16, device=GPU_TYPE)
+            w = torch.randn(*weight_shape, device=GPU_TYPE)
+            gm = make_fx(fn, tracing_mode="fake")(x, w)
+            # Sanity: a single conv node, far below the 300*nconv node-count
+            # heuristic, so the only thing that can flip the decision here is
+            # the ROCm gate under test.
+            convs = [
+                n
+                for n in gm.graph.nodes
+                if n.target is torch.ops.aten.convolution.default
+            ]
+            self.assertEqual(len(convs), 1)
+            return gm
+
+        # Depthwise conv: groups=32, channels-per-group=1 (< 8). The gate flips
+        # the decision: with hip it is skipped (False); without hip it would be
+        # eligible (True). Asserting both isolates the gate as the sole cause.
+        depthwise = make_conv_graph((32, 1, 3, 3), groups=32)
+        self.assertFalse(
+            GraphLowering.decide_layout_opt(depthwise, is_inference=True),
+            "depthwise grouped conv (cpg=1) should skip layout opt on ROCm",
+        )
+        with mock.patch.object(torch.version, "hip", None):
+            self.assertTrue(
+                GraphLowering.decide_layout_opt(depthwise, is_inference=True),
+                "depthwise conv is only skipped because of the ROCm gate",
+            )
+
+        # Plain conv with a 3-channel RGB stem: groups=1, so cpg is irrelevant.
+        # The gate must NOT trip (false-positive guard) and layout opt stays on.
+        plain_stem = make_conv_graph((64, 3, 3, 3), groups=1)
+        self.assertTrue(
+            GraphLowering.decide_layout_opt(plain_stem, is_inference=True),
+            "plain 3-channel conv must not be skipped by the ROCm grouped-conv gate",
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -405,6 +405,53 @@ class TestLayoutOptim(TestCase):
             "plain 3-channel conv must not be skipped by the ROCm grouped-conv gate",
         )
 
+    @unittest.skipUnless(
+        TEST_WITH_ROCM, "ROCm-only MIOpen channels_last inference multipliers"
+    )
+    def test_rocm_grouped_conv_inference_favors_channels_last(self):
+        """
+        ROCm-calibrated inference multipliers in GraphLowering.decide_layout_opt:
+        grouped convs with channels-per-group >= 8 use the fast MIOpen NHWC XDL
+        kernel (measured channels_last/contiguous ~0.55 < 1), so the ROCm
+        GROUPED_MULTIPLIER (0.553) makes the FLOP-weighted heuristic favor
+        channels_last. The NVIDIA value (1.358) would skip it. cpg >= 8 convs are
+        NOT caught by the cpg<8 naive-bound gate, so the multiplier is the sole
+        cause of the decision here.
+        """
+
+        def make_conv_graph(weight_shape, groups):
+            cpg = weight_shape[1]
+            cin = cpg * groups
+
+            def fn(x, w):
+                return torch.ops.aten.convolution.default(
+                    x, w, None, [1, 1], [1, 1], [1, 1], False, [0, 0], groups
+                )
+
+            x = torch.randn(8, cin, 16, 16, device=GPU_TYPE)
+            w = torch.randn(*weight_shape, device=GPU_TYPE)
+            gm = make_fx(fn, tracing_mode="fake")(x, w)
+            convs = [
+                n
+                for n in gm.graph.nodes
+                if n.target is torch.ops.aten.convolution.default
+            ]
+            self.assertEqual(len(convs), 1)
+            return gm
+
+        # Grouped conv, channels-per-group = 16 (>= 8): not naive-bound, so the
+        # cpg<8 gate does NOT fire and the inference multiplier branch decides.
+        grouped = make_conv_graph((256, 16, 3, 3), groups=8)
+        self.assertTrue(
+            GraphLowering.decide_layout_opt(grouped, is_inference=True),
+            "cpg>=8 grouped conv should favor channels_last on ROCm (GROUPED=0.553)",
+        )
+        with mock.patch.object(torch.version, "hip", None):
+            self.assertFalse(
+                GraphLowering.decide_layout_opt(grouped, is_inference=True),
+                "with NVIDIA GROUPED=1.358 the same conv would skip channels_last",
+            )
+
 
 if __name__ == "__main__":
     if HAS_GPU:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -836,10 +836,7 @@ autoheuristic_log_path = os.environ.get(
 )
 
 # Disabled by default on ROCm, opt-in if model utilises NHWC convolutions
-layout_opt_default = "1" if not torch.version.hip else "0"
-layout_optimization = (
-    os.environ.get("TORCHINDUCTOR_LAYOUT_OPTIMIZATION", layout_opt_default) == "1"
-)
+layout_optimization = os.environ.get("TORCHINDUCTOR_LAYOUT_OPTIMIZATION", "1") == "1"
 
 force_layout_optimization = os.environ.get("TORCHINDUCTOR_FORCE_LAYOUT_OPT", "0") == "1"
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -937,13 +937,27 @@ class GraphLowering(torch.fx.Interpreter):
             # average benchmarked channels last speedup / slowdown, < 1 is speedup.
             # taken from the set of convolution inputs in benchmarks/dynamo/microbenchmarks/operator_inp_logs/torchbench_train/
             # To regenerate these numbers follow https://gist.github.com/eellison/55d7a6ed6f39829d68ac56f95f4df5bb
-            GROUPED_MULTIPLIER = 1.358
-            DEFAULT_MULTIPLIER = 0.823
-            IN_OUT_MULTIPLIER = 0.725
-            SMALL_MULTIPLIER = 0.783
+            if torch.version.hip:
+                # ROCm/CDNA (gfx9xx) calibration: mean channels_last/contiguous
+                # eager-forward latency ratio over the same aten.convolution input
+                # set (operator_inp_logs torchbench+hf+timm), measured in bf16
+                # (fp16/fp32 inference reuse these by extrapolation).
+                # channels_last is broadly favorable on MIOpen. "grouped" here is
+                # effectively channels-per-group >= 8: cpg < 8 grouped convs hit
+                # MIOpen's naive kernel (measured ratio ~1.36) and are already
+                # skipped by the ROCm layout-opt gate above, so they never reach
+                # this heuristic.
+                GROUPED_MULTIPLIER = 0.553
+                DEFAULT_MULTIPLIER = 0.813
+                IN_OUT_MULTIPLIER = 0.642
+                SMALL_MULTIPLIER = 0.795
+            else:
+                GROUPED_MULTIPLIER = 1.358
+                DEFAULT_MULTIPLIER = 0.823
+                IN_OUT_MULTIPLIER = 0.725
+                SMALL_MULTIPLIER = 0.783
 
             total_flops = sum(flop_counts.values())
-            # TODO - get different values per hardware
             weighted_flops = (
                 flop_counts["grouped"] * GROUPED_MULTIPLIER
                 + flop_counts["small"] * SMALL_MULTIPLIER

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -777,6 +777,95 @@ class GraphLowering(torch.fx.Interpreter):
         if nconv == 0:
             return False
 
+        # ROCm-specific layout-opt gates.  Two cases skip channels_last:
+        #   1. RDNA (gfx11xx/gfx12xx): NHWC convs are still experimental there.
+        #   2. CDNA grouped convs that fall back to MIOpen's slow naive kernel.
+        # These run for training too (is_inference=False), which the inference
+        # FLOP-weighted heuristic further below never covers.
+        if torch.version.hip:
+            # Compare the HIP version as an integer tuple so e.g. "6.10" is not
+            # mis-parsed as 6.1 by a float compare.
+            hip_version = tuple(int(x) for x in torch.version.hip.split(".")[:2])
+
+            def _conv_device_index(n: torch.fx.Node) -> int:
+                # Derive arch from the conv's own input tensor rather than
+                # hard-coding device 0; fall back to the current device.
+                try:
+                    dev = n.args[0].meta["val"].device  # type: ignore[union-attr]
+                    if dev.index is not None:
+                        return dev.index
+                except (AttributeError, KeyError, IndexError):
+                    pass
+                return torch.cuda.current_device()
+
+            # If RDNA arch on ROCm do not force NHWC convolutions as this
+            # is still experimental.
+            if hip_version >= (6, 3) and all(
+                n.args[idx].meta["val"].device.type == "cuda"
+                for n in conv_nodes
+                for idx in [0, 1]
+            ):
+                gcn_arch = torch.cuda.get_device_properties(
+                    _conv_device_index(conv_nodes[0])
+                ).gcnArchName.split(":", 1)[0]
+                if any(arch in gcn_arch for arch in ["gfx11", "gfx12"]):
+                    return False
+
+            # On CDNA (ROCm), some grouped convolutions fall back to a slow MIOpen
+            # naive kernel (fp64 accumulate -- the observed kernel is named
+            # naive_conv_ab_nonpacked_fwd_nchw_ushort_double_ushort, where
+            # "double" denotes double-precision accumulate) instead of a tuned
+            # NHWC XDL/MFMA kernel.  For those, channels_last cannot accelerate
+            # the kernel and only adds layout-conversion kernels -- a measured
+            # regression on MI355 (depthwise mobilenet/mnasnet/shufflenet:
+            # +10-17% in training).
+            #
+            # Whether a grouped conv takes the naive path depends on both total
+            # channels and groups, not channels-per-group alone. We approximate
+            # "naive-bound" with channels-per-group < MIOPEN_XDL_MIN_CHANNELS_PER_GROUP:
+            # a deliberately conservative proxy that errs toward skipping layout opt
+            # (avoiding regressions) at the cost of leaving some wins on the table for
+            # grouped convs with channels-per-group in the 4-7 range at large channel
+            # counts.
+            MIOPEN_XDL_MIN_CHANNELS_PER_GROUP = 8
+
+            def _rocm_naive_bound(n: torch.fx.Node) -> bool:
+                # Only applies to real aten convolutions; mkldnn conv nodes that
+                # were appended to conv_nodes use a different arg schema.
+                if n.target is not torch.ops.aten.convolution.default:
+                    return False
+                # aten.convolution args:
+                # (input, weight, bias, stride, padding, dilation,
+                #  transposed, output_padding, groups)
+                # Read defensively so a short args list / kwargs cannot IndexError.
+                transposed = (
+                    n.args[6] if len(n.args) > 6 else n.kwargs.get("transposed", False)
+                )
+                groups = n.args[8] if len(n.args) > 8 else n.kwargs.get("groups", 1)
+                # Skip transposed convs: their weight is (C_in, C_out/groups, ...),
+                # so size(1) is not channels-per-group and the heuristic would
+                # misclassify them.
+                if transposed:
+                    return False
+                # Forward conv weight is (C_out, C_in/groups, kH, kW), so
+                # size(1) == channels-per-group. Only grouped convs (groups > 1)
+                # hit the naive fallback; a groups==1 dense conv (e.g. the
+                # 3-channel RGB stem) still uses the fast XDL kernel.
+                return (
+                    groups > 1  # type: ignore[operator]
+                    and n.args[1].meta["val"].size(1)  # type: ignore[union-attr, operator]
+                    < MIOPEN_XDL_MIN_CHANNELS_PER_GROUP
+                )
+
+            if any(_rocm_naive_bound(n) for n in conv_nodes):
+                log.debug(
+                    "Skip layout opt on ROCm: graph has grouped conv(s) with "
+                    "channels/group < %d that fall back to MIOpen naive kernels "
+                    "(channels_last regresses these).",
+                    MIOPEN_XDL_MIN_CHANNELS_PER_GROUP,
+                )
+                return False
+
         # For cpu backend and mkldnn enabled, we always use channels_last for better performance.
         if (
             torch.backends.mkldnn.enabled  # pyrefly: ignore [unbound-name]


### PR DESCRIPTION
Calibrate decide_layout_opt's inference channels_last multipliers for ROCm/CDNA.                                                           
                                                                                                                                             
  The four FLOP-weight multipliers (<1 => favor channels_last) were measured on NVIDIA. On MI355 (gfx950) channels_last economics differ, so this recalibrates them and gates on torch.version.hip.
                                                                                                                                          
  Method: replay the same aten.convolution inputs from operator_inp_logs (torchbench+hf+timm) in bf16, measure mean channels_last/contiguous latency per bucket. ROCm: GROUPED=0.553, DEFAULT=0.813, IN_OUT=0.642, SMALL=0.795 (NVIDIA unchanged). Biggest change is GROUPED (0.553 vs 1.358): on MIOpen, grouped convs  with channels-per-group>=8 strongly favor channels_last. cpg<8 grouped convs (measured ~1.36) are already skipped by the naive-bound gate (#187600) before this heuristic, so GROUPED is calibrated on the cpg>=8 subset.                                                                             
                                                                                                                                             
  Stacked on #187600 (both touch decide_layout_opt). bf16-derived; fp16/fp32 inference reuse the values by extrapolation.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben