### PR TITLE
[BE] Detect MKL via pip instead of conda in build.sh

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -48,39 +48,26 @@ if [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
 fi
 
 
-if ! which conda; then
-  # In ROCm CIs, we are doing cross compilation on build machines with
-  # intel cpu and later run tests on machines with amd cpu.
-  # Also leave out two builds to make sure non-mkldnn builds still work.
+# mkl-static/mkl-include are pip-installed into the active Python environment
+# (a conda env or a venv), not provided by conda. Detect MKL directly rather
+# than guessing from the presence of conda.
+if ! python -m pip show mkl-static >/dev/null 2>&1; then
+  # No MKL (e.g. aarch64/s390x, or ROCm cross compilation on intel build
+  # machines that later run on amd). Enable MKLDNN, except for ROCm where we
+  # deliberately keep some non-mkldnn builds working.
   if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
     export USE_MKLDNN=1
   else
     export USE_MKLDNN=0
   fi
 else
-  # CMAKE_PREFIX_PATH precedences
-  # 1. $CONDA_PREFIX, if defined. This follows the pytorch official build instructions.
-  # 2. /opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}, if ANACONDA_PYTHON_VERSION defined.
-  #    This is for CI, which defines ANACONDA_PYTHON_VERSION but not CONDA_PREFIX.
-  # 3. $(conda info --base). The fallback value of pytorch official build
-  #    instructions actually refers to this.
-  #    Commonly this is /opt/conda/
-  if [[ -v CONDA_PREFIX ]]; then
-    export CMAKE_PREFIX_PATH=${CONDA_PREFIX}
-  elif [[ -v ANACONDA_PYTHON_VERSION ]]; then
-    export CMAKE_PREFIX_PATH="/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}"
-  else
-    # already checked by `! which conda`
-    CMAKE_PREFIX_PATH="$(conda info --base)"
-    export CMAKE_PREFIX_PATH
-  fi
-
-  # Workaround required for MKL library linkage
-  # https://github.com/pytorch/pytorch/issues/119557
-  if [[ "$ANACONDA_PYTHON_VERSION" = "3.12" || "$ANACONDA_PYTHON_VERSION" = "3.13" ]]; then
-    export CMAKE_LIBRARY_PATH="/opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/lib/"
-    export CMAKE_INCLUDE_PATH="/opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/include/"
-  fi
+  # Point CMAKE_PREFIX_PATH at the environment prefix (sys.prefix) so cmake can
+  # find the pip-installed mkl-static/mkl-include. FindMKL uses plain
+  # find_library/find_path, which already search <prefix>/lib and <prefix>/include
+  # for each CMAKE_PREFIX_PATH entry, so no extra CMAKE_LIBRARY_PATH/INCLUDE_PATH
+  # hints are needed.
+  CMAKE_PREFIX_PATH="$(python -c 'import sys; print(sys.prefix)')"
+  export CMAKE_PREFIX_PATH
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *aarch64* ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #187610
* __->__ #187623

The build's CMAKE_PREFIX_PATH logic keyed off `which conda`, but mkl-static and mkl-include are pip-installed into the active Python environment (a conda env or a venv) and have not actually come from conda for a long time. The conda branch only worked because the conda env prefix happened to be where pip placed MKL, so the check breaks as soon as Python is provisioned from a plain venv.

Instead, detect MKL directly with `pip show mkl-static` and, when present, point CMAKE_PREFIX_PATH at the interpreter's `sys.prefix` (the venv or conda env root) so cmake finds it regardless of how Python was provisioned. When MKL is absent (e.g. aarch64/s390x) the existing MKLDNN fallback is kept.

This also drops the old 3.12/3.13 CMAKE_LIBRARY_PATH/CMAKE_INCLUDE_PATH workaround (https://pytorch/pytorch/issues/119557): FindMKL.cmake locates libraries and headers with plain find_library/find_path (no NO_DEFAULT_PATH), which already search <prefix>/lib and <prefix>/include for every CMAKE_PREFIX_PATH entry, so the explicit hints are redundant once CMAKE_PREFIX_PATH points at sys.prefix.

Test plan: Take [Linux build](https://github.com/pytorch/pytorch/actions/runs/27726582947/job/82024203058?pr=187623) and observe that MKL is still there for example
```
-- Looking for cblas_gemm_f16f16f32 - found
-- MKL libraries: /opt/conda/envs/py_3.14/lib/libmkl_intel_lp64.a;/opt/conda/envs/py_3.14/lib/libmkl_intel_thread.a;/opt/conda/envs/py_3.14/lib/libmkl_core.a;/opt/conda/envs/py_3.14/lib/libiomp5.so;/usr/lib/x86_64-linux-gnu/libpthread.a;/usr/lib/x86_64-linux-gnu/libm.so;/usr/lib/x86_64-linux-gnu/libdl.a
-- MKL include directory: /opt/conda/envs/py_3.14/include
-- MKL OpenMP type: Intel
-- MKL OpenMP library: /opt/conda/envs/py_3.14/lib/libiomp5.so
```

Authored-with: Claude (Claude Code)