### PR TITLE
Warn on cdist p-norm overflow for small p

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -5,6 +5,8 @@
 #include <ATen/TensorOperators.h>
 #include <ATen/native/Distance.h>
 #include <c10/util/accumulate.h>
+#include <cmath>
+#include <limits>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -98,6 +100,23 @@ static Tensor cdist_impl(const Tensor& x1, const Tensor& x2, const double p, std
   TORCH_CHECK(!x1.is_cuda() || x1.get_device() == x2.get_device(), "device of X1 (", x1.get_device(), ") must match device of X2 (", x2.get_device(), ")");
   SymInt c1 = x1.sym_size(-1);
   SymInt c2 = x2.sym_size(-1);
+  // For 0 < p < 1 the L-p norm grows like M^(1/p) in the feature dimension M,
+  // which diverges as p -> 0 and overflows the dtype to +inf once (1/p)*log(M)
+  // exceeds log(max_float). This is inherent to small p, not a precision issue:
+  // no rescaling keeps it finite because the true value exceeds the dtype range.
+  // Warn so the resulting +inf is not silent.
+  if (p > 0 && p < 1) {
+    if (auto m_opt = c1.maybe_as_int()) {
+      double m_val = static_cast<double>(*m_opt);
+      if (m_val > 1 && (1.0 / p) * std::log(m_val) > std::log(std::numeric_limits<float>::max())) {
+        TORCH_WARN_ONCE(
+            "cdist: with p=", p, " and feature dimension M=", m_val,
+            ", the p-norm scales as M^(1/p) which exceeds the maximum finite "
+            "float value and overflows to +inf. This is inherent to small p "
+            "(the L-p norm diverges as p approaches 0), not a precision issue.");
+      }
+    }
+  }
   // 0 - default value. If p = 2 and r1 > 25 or r2 > 25 (these values are based on performance metrics),
   // it will try to compute distance using matrix multiplication approach
   // 1 - force to use matrix multiplication for p = 2

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2674,6 +2674,23 @@ class TestTorchDeviceType(TestCase):
             if not torch.isfinite(x.grad).all():
                 raise AssertionError("expected x.grad to be finite")
 
+    # cdist with small p overflows: ||d||_p ~ M^(1/p) diverges as p -> 0,
+    # exceeding fp32 range. Verify we warn rather than silently returning +inf.
+    def test_cdist_small_p_overflow_warns(self, device):
+        x = torch.rand(2, 3, 768, device=device)  # M=768; (1/p)*log(M) >> log(max_float)
+        y = torch.rand(2, 5, 768, device=device)
+        with self.assertWarnsRegex(UserWarning, "overflow"):
+            torch.cdist(x, y, p=0.01)
+
+    # Normal p must not emit the overflow warning.
+    def test_cdist_normal_p_no_overflow_warn(self, device):
+        x = torch.rand(2, 3, 768, device=device)
+        y = torch.rand(2, 5, 768, device=device)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an error
+            for p in [1.0, 2.0, 3.0]:
+                torch.cdist(x, y, p=p)
+
     def test_cumsum(self, device):
         x = torch.rand(100, 100, device=device)
         res1 = torch.cumsum(x, 1)


### PR DESCRIPTION
Fixes #187179

### Summary

`torch.cdist(x1, x2, p)` with `0 < p < 1` silently returns `+inf` on
wide inputs. The p-norm scales as `M^(1/p)` in the feature dimension `M`,
which diverges as `p -> 0` and overflows the dtype once `(1/p)*log(M)`
exceeds `log(max_float)`. For `M=768` (BERT-scale) this hits at
`p ~= 0.043`, well inside the range the docstring admits (`p in [0, inf]`).

### Why a warning rather than a numerical rewrite

The issue suggests a log-space form `exp((1/p)*logsumexp(p*log|diff|))`.
That fixes the *large*-p sibling (#184036) but not this case: for small
`p` it collapses to `M^(1/p)` and overflows at the final `exp`. The same
is true of max-factoring. The result genuinely exceeds the representable
range, so no rescaling keeps it finite — a warning is the correct fix.

I root-caused the overflow to the `pdist_calc` functor in
`cdist_kernel_impl` (CPU + CUDA); the divergence is mathematical, not a
kernel precision issue.

### Implementation

A guard in `cdist_impl` warns when `(1/p)*log(M)` would exceed
`log(max_float)`. It only fires when `M` is statically known and
`p in (0, 1)`; all other paths are untouched and pay no cost.

### Tests

- `test_cdist_small_p_overflow_warns` — warning fires (small p, wide M)
- `test_cdist_normal_p_no_overflow_warn` — silent for normal p

Both pass; `lintrunner` clean.