### PR TITLE
fx/passes: fix non-deterministic ordering in get_source_partitions()

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -13,6 +13,7 @@ from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupport
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions, topo_sort
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
+from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
 
 from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests
 from torch.testing._internal.jit_utils import JitTestCase
@@ -1073,6 +1074,45 @@ class TestFXMatcherUtils(JitTestCase):
         tearDown = getattr(test_model, "tearDown", None)
         if callable(setup):
             tearDown()
+
+
+class TestFXSourceMatcherUtils(JitTestCase):
+    def test_get_source_partitions_input_nodes_deterministic(self):
+        """input_nodes order must follow graph traversal order, not set hash order.
+
+        Regression test for gh#147170: get_source_partitions() used set() for
+        input_nodes/output_nodes, making their order vary across Python
+        invocations (PYTHONHASHSEED). The fix uses insertion-ordered dicts so
+        nodes are returned in the order they were encountered during graph
+        traversal, which is topological.
+        """
+        import torch.fx as fx
+
+        # Build a graph with a two-node partition that has two distinct
+        # external inputs.  x appears before y in the graph, so input_nodes
+        # must always be [x, y], never [y, x].
+        g = fx.Graph()
+        x = g.placeholder("x")
+        y = g.placeholder("y")
+        a = g.call_function(torch.add, (x, y))
+        b = g.call_function(torch.mul, (x, y))
+        a.meta["source_fn_stack"] = [("linear1", torch.nn.Linear)]
+        b.meta["source_fn_stack"] = [("linear1", torch.nn.Linear)]
+        g.output((a, b))
+        gm = fx.GraphModule(torch.nn.Module(), g)
+
+        result = get_source_partitions(gm.graph, [torch.nn.Linear])
+        self.assertIn(torch.nn.Linear, result)
+        parts = result[torch.nn.Linear]
+        self.assertEqual(len(parts), 1)
+
+        # input_nodes must be in graph-traversal order: x appears before y
+        self.assertIs(parts[0].input_nodes[0], x)
+        self.assertIs(parts[0].input_nodes[1], y)
+
+        # output_nodes must be in graph-traversal order: a appears before b
+        self.assertIs(parts[0].output_nodes[0], a)
+        self.assertIs(parts[0].output_nodes[1], b)
 
 
 if __name__ == "__main__":

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -128,22 +128,24 @@ def get_source_partitions(
                 add_to_partition(source_fn[1], source_fn[0], node)
 
     def make_partition(nodes: list[Node], module_type: type) -> SourcePartition:
-        input_nodes = set()
-        output_nodes = set()
-        params = set()
+        # Use dicts instead of sets to deduplicate while preserving graph
+        # traversal order, making input_nodes/output_nodes/params deterministic.
+        input_nodes: dict[Node, None] = {}
+        output_nodes: dict[Node, None] = {}
+        params: dict[Node, None] = {}
         for node in nodes:
             for arg in node.args:
                 if isinstance(arg, Node) and arg not in nodes and arg.op != "get_attr":
-                    input_nodes.add(arg)
+                    input_nodes[arg] = None
 
             if node.op == "get_attr":
-                params.add(node)
+                params[node] = None
                 # get_attr nodes won't be output nodes
                 continue
 
             for user in node.users:
                 if user not in nodes:
-                    output_nodes.add(node)
+                    output_nodes[node] = None
 
         return SourcePartition(
             nodes,


### PR DESCRIPTION
## Summary

Fixes #147170

`make_partition` inside `get_source_partitions()` collected `input_nodes`, `output_nodes`, and `params` using `set()`. Converting a set to a `list` produces an arbitrary iteration order that varies across Python invocations due to hash randomization (`PYTHONHASHSEED`). The issue reporter observed different `input_nodes` orderings for identical inputs in ~25% of runs, causing non-deterministic quantization backend behavior.

**Fix:** Replace the three `set()` collections with `dict[Node, None]`. Python 3.7+ guarantees insertion order for dicts, so nodes are now returned in **graph-traversal (topological) order** — stable, deterministic, and semantically natural.

```python
# Before
input_nodes = set()
input_nodes.add(arg)          # order is random across runs
list(input_nodes)

# After
input_nodes: dict[Node, None] = {}
input_nodes[arg] = None       # insertion order preserved
list(input_nodes)             # always topological order
```

## Changes

- `torch/fx/passes/utils/source_matcher_utils.py` — swap `set()` → `dict[Node, None]` in `make_partition` for `input_nodes`, `output_nodes`, and `params`
- `test/test_fx_passes.py` — add `TestFXSourceMatcherUtils` with a regression test that verifies `input_nodes` and `output_nodes` are in graph-traversal order

## Test plan

- [ ] `python test/test_fx_passes.py TestFXSourceMatcherUtils.test_get_source_partitions_input_nodes_deterministic`
- [ ] `python test/test_fx_passes.py` (full suite)
- [ ] Run with `PYTHONHASHSEED=<various values>` to confirm no ordering variance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @chauhang @penguinwu