### PR TITLE
Fix torch.where silently casting out-of-range scalar to +/-Inf for reduced-precision floats

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -1,6 +1,7 @@
 #include <limits>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/ScalarOps.h>
 #include <ATen/TensorIndexing.h>
 #include <ATen/TensorMeta.h>
@@ -588,6 +589,56 @@ static Device out_device(Args&... inps) {
   return at::kCPU;
 }
 
+// [Note: where scalar overflow]
+// The scalar overloads of torch.where materialize the scalar operand with
+// at::scalar_tensor, whose CPU fast path (at::detail::scalar_fill) intentionally
+// performs a *relaxed*, IEEE-conformant cast for reduced-precision floating
+// types (half / bfloat16 / float8). That matches the torch.tensor constructor,
+// which turns out-of-range values into +/-Inf rather than raising.
+//
+// `where`, however, semantically *fills* the result with the scalar wherever
+// `condition` is true, so it should mirror the strict filling family
+// (full_like / full / fill_), which reject scalars that do not fit in the
+// result dtype via c10::checked_convert. Without this guard,
+// `torch.where(cond, 1e7, fp16_tensor)` silently writes +/-Inf while
+// `torch.full_like(fp16_tensor, 1e7)` raises, an inconsistency reported in
+// https://github.com/pytorch/pytorch/issues/187429 (a regression from <=2.5.1,
+// which raised in both cases).
+static void check_where_scalar_fits_in_result_type(
+    const Scalar& value,
+    ScalarType result_type) {
+  // The relaxed scalar_fill cast above is selected by the *target* dtype, so it
+  // applies to both floating point and integral scalars whose result dtype is a
+  // reduced-precision float. A complex scalar can never promote to one of those
+  // result dtypes, so it never reaches the strict conversion below; skip it
+  // explicitly to keep the dispatch (which has no complex member) well-formed.
+  if (value.isComplex()) {
+    return;
+  }
+  switch (result_type) {
+    case kHalf:
+    case kBFloat16:
+    case kFloat8_e5m2:
+    case kFloat8_e5m2fnuz:
+    case kFloat8_e4m3fn:
+    case kFloat8_e4m3fnuz:
+    case kFloat8_e8m0fnu:
+      break;
+    default:
+      return;
+  }
+  // Scalar::to<scalar_t>() routes through c10::checked_convert, which throws
+  // "value cannot be converted to type <T> without overflow" - exactly the
+  // error full_like / full / fill_ produce for the same scalar and dtype.
+  AT_DISPATCH_V2(
+      result_type,
+      "check_where_scalar_fits_in_result_type",
+      AT_WRAP([&] { value.to<scalar_t>(); }),
+      kHalf,
+      kBFloat16,
+      AT_EXPAND(AT_FLOAT8_TYPES));
+}
+
 Tensor& where_self_out(
     const Tensor& condition,
     const Tensor& self,
@@ -648,6 +699,7 @@ Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
 
 Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
   auto result_type = at::native::result_type(other, self);
+  check_where_scalar_fits_in_result_type(self, result_type);
   auto self_converted =
       at::scalar_tensor(self, other.options().dtype(result_type));
   auto other_converted = other.to(result_type);
@@ -656,6 +708,7 @@ Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
 
 Tensor where(const Tensor& condition, const Tensor& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
+  check_where_scalar_fits_in_result_type(other, result_type);
   auto other_converted =
       at::scalar_tensor(other, self.options().dtype(result_type));
   auto self_converted = self.to(result_type);
@@ -664,6 +717,8 @@ Tensor where(const Tensor& condition, const Tensor& self, const Scalar& other) {
 
 Tensor where(const Tensor& condition, const Scalar& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
+  check_where_scalar_fits_in_result_type(self, result_type);
+  check_where_scalar_fits_in_result_type(other, result_type);
   const Tensor& other_t =
       at::scalar_tensor(other, condition.options().dtype(result_type));
   const Tensor& self_t =

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6202,6 +6202,52 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(out, expected)
 
     @onlyNativeDeviceTypes
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_where_scalar_overflow_matches_fill(self, device, dtype):
+        # torch.where with a Python scalar operand semantically fills the
+        # output with the scalar wherever condition is True, so it must reject
+        # scalars that do not fit in the (reduced-precision) result dtype, the
+        # same way full_like / full / fill_ do. Previously where silently cast
+        # the out-of-range scalar to +/-Inf. See gh-187429.
+        finfo = torch.finfo(dtype)
+        # Finite Python double that is out of range for `dtype` (e.g. 1.3e5 for
+        # float16, ~6.8e38 for bfloat16) -- casting it would silently overflow.
+        big = finfo.max * 2.0
+        cond = torch.tensor([True, False, True], device=device)
+        other = torch.zeros(3, dtype=dtype, device=device)
+
+        # full_like is the reference behavior we want to match.
+        with self.assertRaisesRegex(RuntimeError, "without overflow"):
+            torch.full_like(other, big)
+
+        # ScalarSelf and ScalarOther overloads: the tensor operand fixes the
+        # (reduced) result dtype, so the out-of-range scalar must be rejected.
+        for x, y in ((big, other), (other, big)):
+            with self.assertRaisesRegex(RuntimeError, "without overflow"):
+                torch.where(cond, x, y)
+
+        if dtype == torch.float16:
+            # Integral scalars overflow the reduced dtype too, and full_like
+            # rejects them as well. (100000000 fits in int64 but not float16.)
+            with self.assertRaisesRegex(RuntimeError, "without overflow"):
+                torch.full_like(other, 100000000)
+            with self.assertRaisesRegex(RuntimeError, "without overflow"):
+                torch.where(cond, 100000000, other)
+
+        # In-range scalars, and the IEEE-special inf / nan values (which are
+        # representable in the reduced dtype) must still go through.
+        self.assertEqual(
+            torch.where(cond, 2.0, other),
+            torch.tensor([2.0, 0.0, 2.0], dtype=dtype, device=device),
+        )
+        for special in (float("inf"), float("-inf"), float("nan")):
+            # Mirrors torch.full_like(other, special), which does not raise.
+            torch.full_like(other, special)
+            out = torch.where(cond, special, other)
+            self.assertEqual(out.dtype, dtype)
+        self.assertTrue(torch.where(cond, finfo.max, other).isfinite().all())
+
+    @onlyNativeDeviceTypes
     @dtypes(torch.uint16, torch.uint32, torch.uint64)
     def test_eq_ne_barebones_unsigned(self, device, dtype):
         # The eq/ne kernels dispatch over uint16/uint32/uint64 via


### PR DESCRIPTION
Fixes #187429

## Problem

`torch.where(cond, python_scalar, fp16_tensor)` silently casts an out-of-range Python scalar to `+/-Inf` for reduced-precision floating dtypes, while the strict *filling* family (`full_like` / `full` / `fill_`) raises `RuntimeError: value cannot be converted to type ... without overflow` for the same scalar and dtype:

```python
>>> torch.where(torch.tensor([True]), 1e7, torch.zeros(1, dtype=torch.float16))
tensor([inf], dtype=torch.float16)        # silent overflow
>>> torch.full_like(torch.zeros(1, dtype=torch.float16), 1e7)
RuntimeError: value cannot be converted to type at::Half without overflow
```

This is a regression from <= 2.5.1 (which raised in both cases) and breaks the common fp16 mask-sentinel pattern `logits = torch.where(pad_mask, -1e9, logits)`, where an all-masked row becomes all `-Inf` and `softmax` returns `NaN`.

## Root cause

The scalar overloads of `where` materialize the scalar via `at::scalar_tensor`, whose CPU fast path `at::detail::scalar_fill` (`aten/src/ATen/ScalarOps.cpp`) intentionally performs a *relaxed*, unchecked cast for reduced-precision floating types (half / bfloat16 / float8) so that `scalar_tensor` / `torch.tensor` produce `+/-Inf` on overflow (matching the IEEE-conformant `torch.tensor` constructor). The strict `fill_stub` path used by `full_like` / `full` / `fill_` keeps the `c10::checked_convert` guard, so `where` and the filling family diverged.

## Fix

`where` semantically *fills* the output with the scalar wherever `condition` is true, so it should mirror the strict filling family. This PR re-instates the overflow guard in the three scalar overloads of `where` (`TensorCompare.cpp`) by validating the scalar against the (reduced-float) result dtype with the same checked conversion (`Scalar::to<scalar_t>()` -> `c10::checked_convert`) the filling APIs use. The check is scoped to exactly the reduced-precision floating result types that take the relaxed `scalar_fill` cast; all other dtypes already go through the strict path and are unaffected. IEEE specials (`inf` / `nan`) and in-range values still pass through, matching `full_like`. Integral scalars that overflow the reduced dtype are rejected too, again matching `full_like`.

`scalar_tensor` / `torch.tensor` behavior is deliberately left unchanged.

## Test

Added `test_where_scalar_overflow_matches_fill` (parametrized over `float16` / `bfloat16`) asserting that out-of-range scalars raise the same error as `full_like`, while in-range values and `inf` / `nan` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)