### PR TITLE
Fix nightly.yml startup failure: pass required docker-image to _link_check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/_link_check.yml
     with:
       runner: ${{ needs.get-label-type.outputs.label-type }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       ref:    ${{ github.sha }}
     secrets: inherit
 


### PR DESCRIPTION
## Summary

The scheduled nightly workflow on `main` has been failing with `startup_failure` (0 jobs scheduled) on every run since #187523 merged.

**Root cause:** #187523 added a `required: true` `docker-image` input to `.github/workflows/_link_check.yml` and updated the `lint.yml` caller, but not the `link-check` job in `nightly.yml`, which still passed only `runner` + `ref`. Reusable-workflow inputs are validated at load time, so the missing required input causes GitHub to reject the **entire** nightly workflow at startup. This takes out all nightly jobs (docs build/push, link/xref checks, update-commit-hash, and the metamates bot jobs), not just link-check.

**Fix:** Add the `docker-image` input to the `link-check` job's `with:` block, mirroring the value already used by `lint.yml`'s link-check caller. The `ci-docker-hash` output is already provided by the `get-label-type` job (`_runner-determinator.yml`) and used elsewhere in `nightly.yml`, so the expression resolves correctly.

This PR was authored with the assistance of an AI coding assistant.