### PR TITLE
[testintro][DO NOT LAND] xpu descriptor validation on real Intel-GPU hardware

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -33,6 +33,7 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
 
   linux-jammy-xpu-n-1-py3_10-build:
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: linux-jammy-xpu-n-1-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -81,6 +82,7 @@ jobs:
     secrets: inherit
 
   linux-noble-xpu-n-py3_10-test:
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: linux-noble-xpu-n-py3.10
     uses: ./.github/workflows/_xpu-test.yml
     needs: linux-noble-xpu-n-py3_10-build
@@ -90,7 +92,69 @@ jobs:
       test-matrix: ${{ needs.linux-noble-xpu-n-py3_10-build.outputs.test-matrix }}
     secrets: inherit
 
+  # TEMPORARY (DO NOT LAND): validate the testintro xpu descriptor against real Intel
+  # GPU hardware. Reuses the noble xpu build, runs the real-vs-simulated enumeration
+  # comparison on linux.idc.xpu, and prints VALIDATION_RESULT to this job's log. Once
+  # confirmed, drop this commit (and tools/testing/introspection/_validate_device.py).
+  xpu-validate-testintro:
+    name: xpu-validate-testintro
+    needs: linux-noble-xpu-n-py3_10-build
+    runs-on: linux.idc.xpu
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+
+      - name: Setup XPU
+        uses: ./.github/actions/setup-xpu
+
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        with:
+          docker-image-name: ${{ needs.linux-noble-xpu-n-py3_10-build.outputs.docker-image }}
+
+      - name: Pull docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+
+      - name: Download build artifacts
+        uses: ./.github/actions/download-build-artifacts
+        with:
+          name: ${{ needs.linux-noble-xpu-n-py3_10-build.outputs.build-environment }}
+
+      - name: Validate xpu descriptor vs real device
+        env:
+          DOCKER_IMAGE: ${{ needs.linux-noble-xpu-n-py3_10-build.outputs.docker-image }}
+        run: |
+          set -x
+          # shellcheck disable=SC2086
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            --security-opt seccomp=unconfined \
+            --cap-add=SYS_PTRACE \
+            --shm-size=8g \
+            --tty \
+            --detach \
+            --user jenkins \
+            --privileged \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}"
+          )
+          docker exec -t "${container_name}" sh -c "
+            cd .. && cp -R workspace pytorch && cd pytorch
+            pip install dist/*.whl
+            python tools/testing/introspection/_validate_device.py \
+              linux-xpu/default test/test_xpu.py test/test_view_ops.py
+          "
+
   linux-noble-xpu-n-py3_10-client-build:
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: linux-noble-xpu-n-py3.10-client
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
@@ -107,6 +171,7 @@ jobs:
     secrets: inherit
 
   linux-noble-xpu-n-py3_10-client-test:
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: linux-noble-xpu-n-py3.10-client
     uses: ./.github/workflows/_xpu-test.yml
     needs: linux-noble-xpu-n-py3_10-client-build
@@ -117,7 +182,7 @@ jobs:
     secrets: inherit
 
   windows-xpu-n-1-build:
-    if: github.repository_owner == 'pytorch'
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: win-vs2022-xpu-n-1-py3
     uses: ./.github/workflows/_win-build.yml
     with:
@@ -129,7 +194,7 @@ jobs:
     secrets: inherit
 
   windows-xpu-n-build:
-    if: github.repository_owner == 'pytorch'
+    if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)
     name: win-vs2022-xpu-n-py3
     uses: ./.github/workflows/_win-build.yml
     with:

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -146,12 +146,18 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t "${container_name}" sh -c "
+          docker exec -t "${container_name}" bash -c '
             cd .. && cp -R workspace pytorch && cd pytorch
             pip install dist/*.whl
+            # Source the Intel oneAPI runtime (libsycl etc.) like .ci/pytorch/test.sh does.
+            source /opt/intel/oneapi/compiler/latest/env/vars.sh
+            for c in umf tcm ccl mpi pti; do
+              f=/opt/intel/oneapi/$c/latest/env/vars.sh
+              [ -f "$f" ] && source "$f"
+            done
             python tools/testing/introspection/_validate_device.py \
               linux-xpu/default test/test_xpu.py test/test_view_ops.py
-          "
+          '
 
   linux-noble-xpu-n-py3_10-client-build:
     if: false  # TEMPORARY: disabled for testintro xpu validation (DO NOT LAND)

--- a/tools/testing/introspection/_validate_device.py
+++ b/tools/testing/introspection/_validate_device.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: ci"]
+"""TEMPORARY (DO NOT LAND): compare testintro's simulated enumeration against the real
+device, for a platform/config + files. Used by the throwaway CI validation jobs that
+run on real hardware (e.g. linux.idc.xpu). Exits non-zero on any mismatch. Delete this
+file with the validation commit.
+
+    python tools/testing/introspection/_validate_device.py linux-xpu/default test/test_xpu.py
+"""
+
+import sys
+
+
+sys.path.insert(0, "test")  # let test files resolve sibling imports
+
+from tools.testing.introspection import collector, platforms
+
+
+def main() -> int:
+    job = platforms.get_job(sys.argv[1])
+    ok = True
+    for f in sys.argv[2:]:
+        mod = collector._import_target(
+            f, gut=False, mod_name="real_" + f.replace("/", "_").replace(".", "_")
+        )
+        real = {f"{c}::{m}" for c, ms in collector._enumerate(mod).items() for m in ms}
+        sim = {
+            f"{c}::{m}"
+            for c, ms in collector.enumerate_tests(f, job, use_cache=False).items()
+            for m in ms
+        }
+        miss, extra = sorted(real - sim), sorted(sim - real)
+        status = "MATCH" if real == sim else f"MISMATCH -{len(miss)} +{len(extra)}"
+        print(f"=== {f}: real={len(real)} sim={len(sim)} {status}")
+        for t in miss[:25]:
+            print("  MISSING (real has, sim lacks):", t)
+        for t in extra[:25]:
+            print("  EXTRA   (sim has, real lacks):", t)
+        ok = ok and real == sim
+    print("VALIDATION_RESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/testing/introspection/_validate_device.py
+++ b/tools/testing/introspection/_validate_device.py
@@ -8,7 +8,14 @@ file with the validation commit.
 """
 
 import sys
+from pathlib import Path
 
+
+# Run by path (python tools/.../_validate_device.py), so the package root isn't on
+# sys.path. Append it (not prepend) so `tools` imports while the wheel torch in
+# site-packages stays ahead of any repo torch/ source -- same bootstrap as collector.py.
+if not __package__:
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 sys.path.insert(0, "test")  # let test files resolve sibling imports
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187637
* #187497
* #187496
* #187495
* #187546

Temporary: adds an xpu.yml job (linux.idc.xpu) that runs the real-vs-simulated
enumeration comparison and prints VALIDATION_RESULT, plus the _validate_device.py
helper it calls. Trigger via ciflow/xpu; read the result from the job log, then
drop this commit. Authored by Claude.