### PR TITLE
Skip test_progressive perf assertion on XPU to avoid flakiness

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -196,9 +196,11 @@ class TestSubprocess(TestCase):
         # Warmup
         baseline(x, y)
 
-        self.assertGreater(
-            do_bench(lambda: baseline(x, y)), do_bench(lambda: optimized(x, y))
-        )
+        # Skip the perf assertion to avoid flakiness on XPU.
+        if GPU_TYPE != "xpu":
+            self.assertGreater(
+                do_bench(lambda: baseline(x, y)), do_bench(lambda: optimized(x, y))
+            )
         self.assertTrue("'max_autotune': True" in source_codes[-1])
 
     @patch("torch._inductor.compile_fx.fx_compile_async", True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187638
# Motivation
Same reason due to https://github.com/pytorch/pytorch/issues/157724, skip the perf assertion on XPU to avoid the flakiness.
For example:
- https://github.com/pytorch/pytorch/actions/runs/27731427622/job/82041924155?pr=174670#step:13:8024
- https://github.com/pytorch/pytorch/actions/runs/27731427622/job/82041924148?pr=174670#step:13:2724

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo