### PR TITLE
[ShapesSpec] @dynamic_spec decorator for attaching ShapesSpec to functions/modules. (DS property of compiled function)

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -1960,10 +1960,10 @@ class TestDynamicSpecDecoratorCompile(TestCase):
         _reset_uid_counter()
         torch._dynamo.reset()
 
-    def test_dynamic_spec_decorator_per_param_form(self):
+    def test_dynamic_spec_decorator_dict_form(self):
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
-        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+        @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
         def fn(x):
             return x.sum(0)
 
@@ -1976,23 +1976,43 @@ class TestDynamicSpecDecoratorCompile(TestCase):
         self.assertEqual(len(backend.graphs), 1)
         # Find the tensor placeholder (could be other SymInt placeholders too).
         tensor_phs = [
-            n
-            for n in backend.graphs[0].graph.nodes
+            n for n in backend.graphs[0].graph.nodes
             if n.op == "placeholder"
-            and isinstance(n.meta.get("example_value", n.meta.get("val")), torch.Tensor)
+            and isinstance(
+                n.meta.get("example_value", n.meta.get("val")), torch.Tensor
+            )
         ]
         self.assertEqual(len(tensor_phs), 1)
         val = tensor_phs[0].meta.get("example_value", tensor_phs[0].meta.get("val"))
         self.assertEqual(len(free_unbacked_symbols(val.shape[0])), 1)
 
-    def test_dynamic_spec_decorator_full_form_with_assumptions(self):
+    def test_dynamic_spec_decorator_on_nn_module_forward(self):
+        """``@dynamic_spec`` on ``forward`` is picked up when
+        ``torch.compile(module)`` is invoked (module path -- the resolver
+        reads from ``module.forward``, not the bound method)."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        class M(torch.nn.Module):
+            @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
+            def forward(self, x):
+                return x.sum(0)
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(M(), backend=backend, fullgraph=True)
+        compiled(torch.randn(8, 3))
+        compiled(torch.randn(20, 3))
+        self.assertEqual(len(backend.graphs), 1)
+
+    def test_dynamic_spec_decorator_with_assumptions(self):
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
         B = ShapeVar("batch")
 
         @dynamic_spec(
-            params_spec=ParamsSpec({"x": TensorSpec([B, STATIC])}),
-            assumptions=[B % 2 == 0],
+            ShapesSpec(
+                ParamsSpec({"x": TensorSpec([B, STATIC])}),
+                assumptions=[B % 2 == 0],
+            )
         )
         def fn(x):
             # Branching on the assumed relation: without the assumption being
@@ -2011,7 +2031,7 @@ class TestDynamicSpecDecoratorCompile(TestCase):
     def test_dynamic_spec_decorator_and_explicit_kwarg_raises(self):
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
-        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+        @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
         def fn(x):
             return x.sum(0)
 

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -1976,11 +1976,10 @@ class TestDynamicSpecDecoratorCompile(TestCase):
         self.assertEqual(len(backend.graphs), 1)
         # Find the tensor placeholder (could be other SymInt placeholders too).
         tensor_phs = [
-            n for n in backend.graphs[0].graph.nodes
+            n
+            for n in backend.graphs[0].graph.nodes
             if n.op == "placeholder"
-            and isinstance(
-                n.meta.get("example_value", n.meta.get("val")), torch.Tensor
-            )
+            and isinstance(n.meta.get("example_value", n.meta.get("val")), torch.Tensor)
         ]
         self.assertEqual(len(tensor_phs), 1)
         val = tensor_phs[0].meta.get("example_value", tensor_phs[0].meta.get("val"))
@@ -2043,6 +2042,21 @@ class TestDynamicSpecDecoratorCompile(TestCase):
                 fn,
                 shapes_spec=ParamsSpec({"x": TensorSpec([ShapeVar("Z"), STATIC])}),
             )(torch.randn(8, 3))
+
+    def test_dynamic_spec_stacked_decorators_raise(self):
+        """Stacking ``@dynamic_spec`` on the same function should raise --
+        silently overwriting the previously attached spec would mask user
+        error."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        with self.assertRaisesRegex(
+            ValueError, r"@dynamic_spec\(\.\.\.\) is already attached"
+        ):
+
+            @dynamic_spec({"x": TensorSpec([ShapeVar("A"), STATIC])})
+            @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
+            def fn(x):
+                return x.sum(0)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -524,7 +524,7 @@ class TestShapeVarCompile(TestCase):
         self.assertEqual(len(backend.graphs), 1)
         shape = _tensor_placeholder_shape(backend.graphs[0])
         self.assertIsInstance(shape[0], torch.SymInt)
-        self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
+        self.assertEqual(len(free_unbacked_symbols(shape[0])), 1)
 
     @_fx_experimental_config.patch(no_data_dependent_graph_break=True)
     def test_unbacked_raises_dde_on_branching(self):
@@ -1950,6 +1950,79 @@ class TestWalkSpecRaises(TestCase):
             "\"cfg['x']\", at 'cfg' the spec is TensorSpec, but "
             "the source has further access past it",
         )
+
+
+class TestDynamicSpecDecoratorCompile(TestCase):
+    """``@dynamic_spec`` auto-applied by ``torch.compile``."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_uid_counter()
+        torch._dynamo.reset()
+
+    def test_dynamic_spec_decorator_per_param_form(self):
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+        def fn(x):
+            return x.sum(0)
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        compiled(torch.randn(8, 3))
+        # Re-invoking at a different batch size must hit the same compiled
+        # graph (dim 0 is unbacked) -- proving the decorator was picked up.
+        compiled(torch.randn(20, 3))
+        self.assertEqual(len(backend.graphs), 1)
+        # Find the tensor placeholder (could be other SymInt placeholders too).
+        tensor_phs = [
+            n
+            for n in backend.graphs[0].graph.nodes
+            if n.op == "placeholder"
+            and isinstance(n.meta.get("example_value", n.meta.get("val")), torch.Tensor)
+        ]
+        self.assertEqual(len(tensor_phs), 1)
+        val = tensor_phs[0].meta.get("example_value", tensor_phs[0].meta.get("val"))
+        self.assertEqual(len(free_unbacked_symbols(val.shape[0])), 1)
+
+    def test_dynamic_spec_decorator_full_form_with_assumptions(self):
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        B = ShapeVar("batch")
+
+        @dynamic_spec(
+            params_spec=ParamsSpec({"x": TensorSpec([B, STATIC])}),
+            assumptions=[B % 2 == 0],
+        )
+        def fn(x):
+            # Branching on the assumed relation: without the assumption being
+            # wired into the shape env, this would raise a DDE on the unbacked
+            # symbol. With it, the branch resolves statically at trace time.
+            if x.shape[0] % 2 == 0:
+                return x.sum(0)
+            return x.sum(0) * -1
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        compiled(torch.randn(8, 3))
+        compiled(torch.randn(20, 3))
+        self.assertEqual(len(backend.graphs), 1)
+
+    def test_dynamic_spec_decorator_and_explicit_kwarg_raises(self):
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+        def fn(x):
+            return x.sum(0)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`@dynamic_spec\(\.\.\.\)` is attached.*AND a `dynamic_shapes=`",
+        ):
+            torch.compile(
+                fn,
+                shapes_spec=ParamsSpec({"x": TensorSpec([ShapeVar("Z"), STATIC])}),
+            )(torch.randn(8, 3))
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -1974,7 +1974,7 @@ class TestDynamicSpecDecoratorCompile(TestCase):
         # graph (dim 0 is unbacked) -- proving the decorator was picked up.
         compiled(torch.randn(20, 3))
         self.assertEqual(len(backend.graphs), 1)
-        # Find the tensor placeholder (could be other SymInt placeholders too).
+        # Find the tensor placeholder.
         tensor_phs = [
             n
             for n in backend.graphs[0].graph.nodes

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -815,6 +815,62 @@ Range constraints: {u0: VR[0, int_oo]}""",
         self.assertEqual(int(vr.lower), 10)
         self.assertEqual(int(vr.upper), 100)
 
+    # ---- @dynamic_spec(...) decorator (auto-attach) ----
+
+    def test_spec_decorator_per_param_form(self):
+        """``@dynamic_spec(x=...)`` attached to ``forward`` is auto-applied when
+        ``export()`` is called without ``dynamic_shapes=``."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        class M(torch.nn.Module):
+            @dynamic_spec(x=T([VAR("B"), STATIC]))
+            def forward(self, x):
+                return x.sum(0)
+
+        ep = export(M(), (torch.randn(8, 3),), strict=self.strict)
+        shape = _first_tensor_placeholder_shape(ep.graph_module)
+        self.assertIsInstance(shape[0], torch.SymInt)
+        self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
+
+    def test_spec_decorator_full_form_with_assumptions(self):
+        """``@dynamic_spec(params_spec=..., assumptions=...)`` form is auto-applied."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        B = VAR("batch")
+
+        class M(torch.nn.Module):
+            @dynamic_spec(
+                params_spec=PARAMS({"x": T([B, STATIC])}),
+                assumptions=[B % 2 == 0],
+            )
+            def forward(self, x):
+                return x.sum(0)
+
+        ep = export(M(), (torch.randn(8, 3),), strict=self.strict)
+        # The assumption fires as a runtime assert in the graph.
+        self.assertTrue(_has_assert_scalar(ep.graph_module))
+
+    def test_spec_decorator_and_explicit_dynamic_shapes_raises(self):
+        """Mixing ``@dynamic_spec(...)`` with an explicit ``dynamic_shapes=`` kwarg
+        is ambiguous and must raise."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        class M(torch.nn.Module):
+            @dynamic_spec(x=T([VAR("B"), STATIC]))
+            def forward(self, x):
+                return x.sum(0)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`@dynamic_spec\(\.\.\.\)` is attached.*AND a `dynamic_shapes=`",
+        ):
+            export(
+                M(),
+                (torch.randn(8, 3),),
+                dynamic_shapes=PARAMS({"x": T([VAR("B"), STATIC])}),
+                strict=self.strict,
+            )
+
     def test_export_to_torch_ir_shapes_spec_direct(self):
         # Strict-only internal-API test; skip in non-strict mode.
         if not self.strict:

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -818,11 +818,11 @@ Range constraints: {u0: VR[0, int_oo]}""",
     # ---- @dynamic_spec(...) decorator (auto-attach) ----
 
     def test_spec_decorator_per_param_form(self):
-        """``@dynamic_spec(x=...)`` attached to ``forward`` is auto-applied."""
+        """``@dynamic_spec({"x": ...})`` attached to ``forward`` is auto-applied."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
         class M(torch.nn.Module):
-            @dynamic_spec(x=T([VAR("B"), STATIC]))
+            @dynamic_spec({"x": T([VAR("B"), STATIC])})
             def forward(self, x):
                 return x.sum(0)
 
@@ -832,7 +832,7 @@ Range constraints: {u0: VR[0, int_oo]}""",
         self.assertEqual(len(free_unbacked_symbols(shape[0])), 1)
 
     def test_spec_decorator_full_form_with_assumptions(self):
-        """``@dynamic_spec(params_spec=..., assumptions=...)`` form is auto-applied,
+        """``@dynamic_spec(ShapesSpec(params=..., assumptions=...))`` form is auto-applied,
         and the assumption is enforced as a runtime assertion."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
@@ -840,8 +840,10 @@ Range constraints: {u0: VR[0, int_oo]}""",
 
         class M(torch.nn.Module):
             @dynamic_spec(
-                params_spec=PARAMS({"x": T([B, STATIC])}),
-                assumptions=[B % 2 == 0],
+                ShapesSpec(
+                    PARAMS({"x": T([B, STATIC])}),
+                    assumptions=[B % 2 == 0],
+                )
             )
             def forward(self, x):
                 return x.sum(0)
@@ -861,7 +863,7 @@ Range constraints: {u0: VR[0, int_oo]}""",
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
         class M(torch.nn.Module):
-            @dynamic_spec(x=T([VAR("B"), STATIC]))
+            @dynamic_spec({"x": T([VAR("B"), STATIC])})
             def forward(self, x):
                 return x.sum(0)
 

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -818,8 +818,7 @@ Range constraints: {u0: VR[0, int_oo]}""",
     # ---- @dynamic_spec(...) decorator (auto-attach) ----
 
     def test_spec_decorator_per_param_form(self):
-        """``@dynamic_spec(x=...)`` attached to ``forward`` is auto-applied when
-        ``export()`` is called without ``dynamic_shapes=``."""
+        """``@dynamic_spec(x=...)`` attached to ``forward`` is auto-applied."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
         class M(torch.nn.Module):
@@ -833,7 +832,8 @@ Range constraints: {u0: VR[0, int_oo]}""",
         self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
 
     def test_spec_decorator_full_form_with_assumptions(self):
-        """``@dynamic_spec(params_spec=..., assumptions=...)`` form is auto-applied."""
+        """``@dynamic_spec(params_spec=..., assumptions=...)`` form is auto-applied,
+        and the assumption is enforced as a runtime assertion."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
         B = VAR("batch")
@@ -847,8 +847,13 @@ Range constraints: {u0: VR[0, int_oo]}""",
                 return x.sum(0)
 
         ep = export(M(), (torch.randn(8, 3),), strict=self.strict)
-        # The assumption fires as a runtime assert in the graph.
-        self.assertTrue(_has_assert_scalar(ep.graph_module))
+        # Valid input (dim 0 is even) -- runs cleanly.
+        ep.module()(torch.randn(8, 3))
+        ep.module()(torch.randn(20, 3))
+        # Violation (dim 0 is odd) -- runtime assertion fires, proving the
+        # assumption from the decorator was actually wired into the graph.
+        with self.assertRaisesRegex(RuntimeError, "Runtime assertion failed"):
+            ep.module()(torch.randn(7, 3))
 
     def test_spec_decorator_and_explicit_dynamic_shapes_raises(self):
         """Mixing ``@dynamic_spec(...)`` with an explicit ``dynamic_shapes=`` kwarg

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -120,7 +120,7 @@ class _TestExportDynamicSpecBase(TestCase):
         )
         shape = _first_tensor_placeholder_shape(ep.graph_module)
         self.assertIsInstance(shape[0], torch.SymInt)
-        self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
+        self.assertEqual(len(free_unbacked_symbols(shape[0])), 1)
         self.assertExpectedInline(
             str(ep).strip(),
             """\
@@ -829,7 +829,7 @@ Range constraints: {u0: VR[0, int_oo]}""",
         ep = export(M(), (torch.randn(8, 3),), strict=self.strict)
         shape = _first_tensor_placeholder_shape(ep.graph_module)
         self.assertIsInstance(shape[0], torch.SymInt)
-        self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
+        self.assertEqual(len(free_unbacked_symbols(shape[0])), 1)
 
     def test_spec_decorator_full_form_with_assumptions(self):
         """``@dynamic_spec(params_spec=..., assumptions=...)`` form is auto-applied,

--- a/test/test_dynamic_spec_make_fx.py
+++ b/test/test_dynamic_spec_make_fx.py
@@ -557,11 +557,11 @@ class <lambda>(torch.nn.Module):
 
     # ---- @dynamic_spec(...) decorator (auto-attach) ----
 
-    def test_dynamic_spec_decorator_per_param_form(self):
-        """``@dynamic_spec(x=...)`` on a function is auto-applied by make_fx."""
+    def test_dynamic_spec_decorator_dict_form(self):
+        """``@dynamic_spec({"x": ...})`` on a function is auto-applied by make_fx."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
-        @dynamic_spec(x=T([VAR("B"), STATIC]))
+        @dynamic_spec({"x": T([VAR("B"), STATIC])})
         def fn(x):
             return x.sum(0)
 
@@ -570,8 +570,8 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(val, torch.Tensor)
         self.assertEqual(len(free_unbacked_symbols(val.shape[0])), 1)
 
-    def test_dynamic_spec_decorator_full_form_with_assumptions(self):
-        """``@dynamic_spec(params_spec=..., assumptions=...)`` is auto-applied
+    def test_dynamic_spec_decorator_with_assumptions(self):
+        """``@dynamic_spec(ShapesSpec(params=..., assumptions=...))`` is auto-applied
         and the assumption is wired into the shape env: branching on the
         assumed relation resolves statically (no DDE) and the assertion
         appears in the traced graph."""
@@ -580,8 +580,10 @@ class <lambda>(torch.nn.Module):
         B = VAR("batch")
 
         @dynamic_spec(
-            params_spec=PARAMS({"x": T([B, STATIC])}),
-            assumptions=[B % 2 == 0],
+            ShapesSpec(
+                PARAMS({"x": T([B, STATIC])}),
+                assumptions=[B % 2 == 0],
+            )
         )
         def fn(x):
             # Branching on the assumption: without it, this would raise a DDE.
@@ -601,7 +603,7 @@ class <lambda>(torch.nn.Module):
         is ambiguous and must raise."""
         from torch.fx.experimental.dynamic_spec import dynamic_spec
 
-        @dynamic_spec(x=T([VAR("B"), STATIC]))
+        @dynamic_spec({"x": T([VAR("B"), STATIC])})
         def fn(x):
             return x.sum(0)
 

--- a/test/test_dynamic_spec_make_fx.py
+++ b/test/test_dynamic_spec_make_fx.py
@@ -83,7 +83,7 @@ class TestMakeFxDynamicSpec(TestCase):
 
         shape = _first_tensor_placeholder_shape(gm)
         self.assertIsInstance(shape[0], torch.SymInt)
-        self.assertGreater(len(free_unbacked_symbols(shape[0])), 0)
+        self.assertEqual(len(free_unbacked_symbols(shape[0])), 1)
         # Static dim stays an int.
         self.assertEqual(int(shape[1]), 3)
 
@@ -554,6 +554,66 @@ class <lambda>(torch.nn.Module):
             ignore_comments=True,
             ignore_empty_lines=True,
         )
+
+    # ---- @dynamic_spec(...) decorator (auto-attach) ----
+
+    def test_dynamic_spec_decorator_per_param_form(self):
+        """``@dynamic_spec(x=...)`` on a function is auto-applied by make_fx."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        @dynamic_spec(x=T([VAR("B"), STATIC]))
+        def fn(x):
+            return x.sum(0)
+
+        gm = make_fx(fn, tracing_mode="fake")(torch.randn(8, 3))
+        (val,) = _user_input_placeholder_vals(gm)
+        self.assertIsInstance(val, torch.Tensor)
+        self.assertEqual(len(free_unbacked_symbols(val.shape[0])), 1)
+
+    def test_dynamic_spec_decorator_full_form_with_assumptions(self):
+        """``@dynamic_spec(params_spec=..., assumptions=...)`` is auto-applied
+        and the assumption is wired into the shape env: branching on the
+        assumed relation resolves statically (no DDE) and the assertion
+        appears in the traced graph."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        B = VAR("batch")
+
+        @dynamic_spec(
+            params_spec=PARAMS({"x": T([B, STATIC])}),
+            assumptions=[B % 2 == 0],
+        )
+        def fn(x):
+            # Branching on the assumption: without it, this would raise a DDE.
+            if x.shape[0] % 2 == 0:
+                return x.sum(0)
+            return x.sum(0) * -1
+
+        gm = make_fx(fn, tracing_mode="fake")(torch.randn(8, 3))
+        # The assumption (``Eq(Mod(u0, 2), 0)``) is also materialized as a
+        # runtime assertion in the traced graph.
+        graph_repr = gm.print_readable(print_output=False)
+        self.assertIn("Mod(u0, 2)", graph_repr)
+        self.assertIn("_assert_scalar", graph_repr)
+
+    def test_dynamic_spec_decorator_and_explicit_kwarg_raises(self):
+        """Mixing the decorator with ``make_fx(..., dynamic_shapes=...)``
+        is ambiguous and must raise."""
+        from torch.fx.experimental.dynamic_spec import dynamic_spec
+
+        @dynamic_spec(x=T([VAR("B"), STATIC]))
+        def fn(x):
+            return x.sum(0)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`@dynamic_spec\(\.\.\.\)` is attached.*AND a `dynamic_shapes=`",
+        ):
+            make_fx(
+                fn,
+                tracing_mode="fake",
+                dynamic_shapes=PARAMS({"x": T([VAR("Z"), STATIC])}),
+            )(torch.randn(8, 3))
 
 
 if __name__ == "__main__":

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3148,6 +3148,13 @@ def compile(
         if isinstance(shapes_spec, ParamsSpec):
             shapes_spec = ShapesSpec(shapes_spec)
 
+    # If ``model`` carries an ``@dynamic_spec(...)`` decorator, the attached
+    # ``ShapesSpec`` is used as ``shapes_spec``. Passing both raises.
+    if model is not None:
+        from torch.fx.experimental.dynamic_spec import _resolve_dynamic_shapes
+
+        shapes_spec = _resolve_dynamic_shapes(model, shapes_spec)
+
     # Decorator mode
     if model is None:
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -214,6 +214,12 @@ def export(
             "using `TS2EPConverter(mod, args, kwargs).convert()` instead."
         )
 
+    # If ``mod.forward`` carries an ``@dynamic_spec(...)`` decorator, the
+    # attached ``ShapesSpec`` is used as ``dynamic_shapes``. Passing both raises.
+    from torch.fx.experimental.dynamic_spec import _resolve_dynamic_shapes
+
+    dynamic_shapes = _resolve_dynamic_shapes(mod, dynamic_shapes)
+
     try:
         return _export(
             mod,

--- a/torch/fx/experimental/dynamic_spec.py
+++ b/torch/fx/experimental/dynamic_spec.py
@@ -7,15 +7,22 @@ from __future__ import annotations
 
 import itertools
 import threading
-from typing import Any, cast, TYPE_CHECKING, TypeAlias
+from typing import Any, cast, TYPE_CHECKING, TypeAlias, TypeVar
 
 from torch import SymBool, SymInt
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Callable, Iterator, Sequence
+
+    import torch.nn
 
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    # Generic kwarg type so ``_resolve_dynamic_shapes`` returns the same
+    # narrower type the caller passes in (e.g. ``make_fx`` doesn't accept
+    # the legacy tuple form).
+    _DynamicShapesKwargT = TypeVar("_DynamicShapesKwargT")
 
 
 __all__ = [
@@ -31,6 +38,7 @@ __all__ = [
     "LeafSpec",
     "LeafIntSpec",
     "IntermediateSpec",
+    "dynamic_spec",
 ]
 
 
@@ -741,3 +749,106 @@ def _coerce_to_shapes_spec(
         f"dynamic spec expects a dict, ShapesSpec, or ParamsSpec, "
         f"got {type(x).__name__}"
     )
+
+
+# Attribute used to store the resolved ``ShapesSpec`` on a decorated function
+# (or ``nn.Module.forward``). Read by ``_resolve_dynamic_shapes`` below.
+_SPEC_ATTR = "_dynamo_spec"
+
+
+def dynamic_spec(
+    params_spec: Any = None,
+    *,
+    assumptions: Any = None,
+    **per_param: Any,
+) -> Any:
+    """Attach a ``ShapesSpec`` to a function (or ``nn.Module.forward``).
+
+    When :func:`torch.compile`, :func:`torch.export.export`, or
+    :func:`torch.fx.experimental.proxy_tensor.make_fx` is invoked on a
+    function (or module) that carries this metadata, the attached
+    ``ShapesSpec`` is used as the dynamic-shape spec **unless** the caller
+    also passes an explicit ``dynamic_shapes=`` kwarg, in which case the
+    two-source ambiguity is rejected with ``ValueError``.
+
+    Two equivalent surface forms::
+
+        # 1) Full form -- pass a ShapesSpec or ParamsSpec (or a dict).
+        @dynamic_spec(
+            params_spec=ParamsSpec(
+                {"x": TensorSpec([ShapeVar("B"), STATIC])}
+            ),
+            assumptions=[B > 0],
+        )
+        def fn(x): ...
+
+        # 2) Per-parameter sugar -- kwargs are auto-wrapped into a
+        # ``ParamsSpec`` keyed by parameter name.
+        @dynamic_spec(
+            x=TensorSpec([ShapeVar("B"), STATIC]), assumptions=[B > 0]
+        )
+        def fn(x): ...
+
+    The two forms are mutually exclusive: mixing ``params_spec=`` with
+    per-parameter kwargs raises ``ValueError``.
+
+    Equivalent for an ``nn.Module``::
+
+        class M(nn.Module):
+            @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+            def forward(self, x): ...
+    """
+    if params_spec is not None and per_param:
+        raise ValueError(
+            "dynamic_spec(): pass either `params_spec=...` OR per-parameter "
+            "kwargs (e.g. `dynamic_spec(x=..., y=...)`), not both."
+        )
+
+    if params_spec is not None:
+        resolved = _coerce_to_shapes_spec(params_spec)
+        if resolved is None:
+            raise ValueError("dynamic_spec(): `params_spec` must not be None")
+        if assumptions:
+            resolved = ShapesSpec(
+                params=resolved._params,
+                assumptions=list(resolved._assumptions or []) + list(assumptions),
+            )
+    else:
+        resolved = ShapesSpec(
+            ParamsSpec(per_param), assumptions=assumptions or None
+        )
+
+    def _decorator(fn: Any) -> Any:
+        setattr(fn, _SPEC_ATTR, resolved)
+        return fn
+
+    return _decorator
+
+
+def _resolve_dynamic_shapes(
+    fn_or_module: Callable[..., Any] | torch.nn.Module,
+    dynamic_shapes_kwarg: _DynamicShapesKwargT,
+) -> _DynamicShapesKwargT | ShapesSpec:
+    """Resolve the effective dynamic-shapes spec for a call site.
+
+    Reads ``@dynamic_spec(...)`` metadata from ``fn_or_module`` (for an
+    ``nn.Module``, the metadata is read from its bound ``forward`` method).
+    Raises ``ValueError`` if both the decorator and an explicit
+    ``dynamic_shapes_kwarg`` are present, since the precedence is ambiguous.
+    Returns ``dynamic_shapes_kwarg`` if the decorator is absent, else the
+    attached ``ShapesSpec``.
+    """
+    fn = fn_or_module
+    import torch.nn
+
+    if isinstance(fn_or_module, torch.nn.Module):
+        fn = fn_or_module.forward
+    attached = getattr(fn, _SPEC_ATTR, None)
+    if attached is None:
+        return dynamic_shapes_kwarg
+    if dynamic_shapes_kwarg is not None:
+        raise ValueError(
+            "Both `@dynamic_spec(...)` is attached to the function/forward "
+            "AND a `dynamic_shapes=` argument was passed. Provide only one."
+        )
+    return attached

--- a/torch/fx/experimental/dynamic_spec.py
+++ b/torch/fx/experimental/dynamic_spec.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
     import torch.nn
-
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
     # Generic kwarg type so ``_resolve_dynamic_shapes`` returns the same
@@ -779,18 +778,15 @@ def dynamic_spec(
 
         # 1) Full form -- pass a ShapesSpec or ParamsSpec (or a dict).
         @dynamic_spec(
-            params_spec=ParamsSpec(
-                {"x": TensorSpec([ShapeVar("B"), STATIC])}
-            ),
+            params_spec=ParamsSpec({"x": TensorSpec([ShapeVar("B"), STATIC])}),
             assumptions=[B > 0],
         )
         def fn(x): ...
 
+
         # 2) Per-parameter sugar -- kwargs are auto-wrapped into a
         # ``ParamsSpec`` keyed by parameter name.
-        @dynamic_spec(
-            x=TensorSpec([ShapeVar("B"), STATIC]), assumptions=[B > 0]
-        )
+        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]), assumptions=[B > 0])
         def fn(x): ...
 
     The two forms are mutually exclusive: mixing ``params_spec=`` with
@@ -818,9 +814,7 @@ def dynamic_spec(
                 assumptions=list(resolved._assumptions or []) + list(assumptions),
             )
     else:
-        resolved = ShapesSpec(
-            ParamsSpec(per_param), assumptions=assumptions or None
-        )
+        resolved = ShapesSpec(ParamsSpec(per_param), assumptions=assumptions or None)
 
     def _decorator(fn: Any) -> Any:
         setattr(fn, _DYNAMIC_SPEC_ATTR, resolved)

--- a/torch/fx/experimental/dynamic_spec.py
+++ b/torch/fx/experimental/dynamic_spec.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import itertools
 import logging
 import threading
-from typing import Any, cast, TYPE_CHECKING, TypeAlias, TypeVar
+from typing import Any, cast, TYPE_CHECKING, TypeAlias
 
 from torch import SymBool, SymInt
 
@@ -20,12 +20,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
     import torch.nn
-    from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
-    # Generic kwarg type so ``_resolve_dynamic_shapes`` returns the same
-    # narrower type the caller passes in (e.g. ``make_fx`` doesn't accept
-    # the legacy tuple form).
-    _DynamicShapesKwargT = TypeVar("_DynamicShapesKwargT")
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 
 __all__ = [
@@ -759,12 +755,7 @@ def _coerce_to_shapes_spec(
 _DYNAMIC_SPEC_ATTR = "_dynamo_spec"
 
 
-def dynamic_spec(
-    params_spec: Any = None,
-    *,
-    assumptions: Any = None,
-    **per_param: Any,
-) -> Any:
+def dynamic_spec(spec: Any) -> Any:
     """Attach a ``ShapesSpec`` to a function (or ``nn.Module.forward``).
 
     When :func:`torch.compile`, :func:`torch.export.export`, or
@@ -774,47 +765,39 @@ def dynamic_spec(
     also passes an explicit ``dynamic_shapes=`` kwarg, in which case the
     two-source ambiguity is rejected with ``ValueError``.
 
-    Two equivalent surface forms::
+    ``spec`` accepts the same types as the call-site
+    ``dynamic_shapes=`` a ``dict``, a ``ParamsSpec``, or a ``ShapesSpec``.
+    To attach assumptions, build a ``ShapesSpec(params=..., assumptions=[...])``
+    and pass it.
 
-        # 1) Full form -- pass a ShapesSpec or ParamsSpec (or a dict).
+    Usage::
+
+        # Simple per-param mapping (no assumptions):
+        @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
+        def fn(x): ...
+
+        # With assumptions: build a ShapesSpec.
+        B = ShapeVar("B")
         @dynamic_spec(
-            params_spec=ParamsSpec({"x": TensorSpec([ShapeVar("B"), STATIC])}),
-            assumptions=[B > 0],
+            ShapesSpec(
+                ParamsSpec({"x": TensorSpec([B, STATIC])}),
+                assumptions=[B % 2 == 0],
+            )
         )
         def fn(x): ...
-
-
-        # 2) Per-parameter sugar -- kwargs are auto-wrapped into a
-        # ``ParamsSpec`` keyed by parameter name.
-        @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]), assumptions=[B > 0])
-        def fn(x): ...
-
-    The two forms are mutually exclusive: mixing ``params_spec=`` with
-    per-parameter kwargs raises ``ValueError``.
 
     Equivalent for an ``nn.Module``::
 
         class M(nn.Module):
-            @dynamic_spec(x=TensorSpec([ShapeVar("B"), STATIC]))
+            @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
             def forward(self, x): ...
     """
-    if params_spec is not None and per_param:
-        raise ValueError(
-            "dynamic_spec(): pass either `params_spec=...` OR per-parameter "
-            "kwargs (e.g. `dynamic_spec(x=..., y=...)`), not both."
+    resolved = _coerce_to_shapes_spec(spec)
+    if resolved is None:
+        raise TypeError(
+            f"dynamic_spec(): `spec` must be a dict, ParamsSpec, or "
+            f"ShapesSpec, got {type(spec).__name__}."
         )
-
-    if params_spec is not None:
-        resolved = _coerce_to_shapes_spec(params_spec)
-        if resolved is None:
-            raise ValueError("dynamic_spec(): `params_spec` must not be None")
-        if assumptions:
-            resolved = ShapesSpec(
-                params=resolved._params,
-                assumptions=list(resolved._assumptions or []) + list(assumptions),
-            )
-    else:
-        resolved = ShapesSpec(ParamsSpec(per_param), assumptions=assumptions or None)
 
     def _decorator(fn: Any) -> Any:
         setattr(fn, _DYNAMIC_SPEC_ATTR, resolved)
@@ -825,8 +808,8 @@ def dynamic_spec(
 
 def _resolve_dynamic_shapes(
     fn_or_module: Callable[..., Any] | torch.nn.Module,
-    dynamic_shapes_kwarg: _DynamicShapesKwargT,
-) -> _DynamicShapesKwargT | ShapesSpec:
+    dynamic_shapes_kwarg: Any,
+) -> Any:
     """Resolve the effective dynamic-shapes spec for a call site.
 
     Reads ``@dynamic_spec(...)`` metadata from ``fn_or_module`` (for an

--- a/torch/fx/experimental/dynamic_spec.py
+++ b/torch/fx/experimental/dynamic_spec.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
     import torch.nn
-
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 
@@ -752,7 +751,7 @@ def _coerce_to_shapes_spec(
 
 # Attribute used to store the resolved ``ShapesSpec`` on a decorated function
 # (or ``nn.Module.forward``). Read by ``_resolve_dynamic_shapes`` below.
-_DYNAMIC_SPEC_ATTR = "_dynamo_spec"
+_DYNAMIC_SPEC_ATTR = "_dynamic_spec"
 
 
 def dynamic_spec(spec: Any) -> Any:
@@ -776,8 +775,11 @@ def dynamic_spec(spec: Any) -> Any:
         @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
         def fn(x): ...
 
+
         # With assumptions: build a ShapesSpec.
         B = ShapeVar("B")
+
+
         @dynamic_spec(
             ShapesSpec(
                 ParamsSpec({"x": TensorSpec([B, STATIC])}),
@@ -800,6 +802,13 @@ def dynamic_spec(spec: Any) -> Any:
         )
 
     def _decorator(fn: Any) -> Any:
+        if hasattr(fn, _DYNAMIC_SPEC_ATTR):
+            raise ValueError(
+                "@dynamic_spec(...) is already attached to "
+                f"{getattr(fn, '__qualname__', repr(fn))}. Stacking multiple "
+                "@dynamic_spec decorators on the same function is not "
+                "allowed; merge them into a single spec."
+            )
         setattr(fn, _DYNAMIC_SPEC_ATTR, resolved)
         return fn
 

--- a/torch/fx/experimental/dynamic_spec.py
+++ b/torch/fx/experimental/dynamic_spec.py
@@ -6,10 +6,14 @@ Currently only supports unbacked dynamic shapes.
 from __future__ import annotations
 
 import itertools
+import logging
 import threading
 from typing import Any, cast, TYPE_CHECKING, TypeAlias, TypeVar
 
 from torch import SymBool, SymInt
+
+
+log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -753,7 +757,7 @@ def _coerce_to_shapes_spec(
 
 # Attribute used to store the resolved ``ShapesSpec`` on a decorated function
 # (or ``nn.Module.forward``). Read by ``_resolve_dynamic_shapes`` below.
-_SPEC_ATTR = "_dynamo_spec"
+_DYNAMIC_SPEC_ATTR = "_dynamo_spec"
 
 
 def dynamic_spec(
@@ -819,7 +823,7 @@ def dynamic_spec(
         )
 
     def _decorator(fn: Any) -> Any:
-        setattr(fn, _SPEC_ATTR, resolved)
+        setattr(fn, _DYNAMIC_SPEC_ATTR, resolved)
         return fn
 
     return _decorator
@@ -843,7 +847,7 @@ def _resolve_dynamic_shapes(
 
     if isinstance(fn_or_module, torch.nn.Module):
         fn = fn_or_module.forward
-    attached = getattr(fn, _SPEC_ATTR, None)
+    attached = getattr(fn, _DYNAMIC_SPEC_ATTR, None)
     if attached is None:
         return dynamic_shapes_kwarg
     if dynamic_shapes_kwarg is not None:
@@ -851,4 +855,9 @@ def _resolve_dynamic_shapes(
             "Both `@dynamic_spec(...)` is attached to the function/forward "
             "AND a `dynamic_shapes=` argument was passed. Provide only one."
         )
+    log.info(
+        "Using @dynamic_spec attached to %s: %s",
+        getattr(fn, "__qualname__", repr(fn)),
+        attached,
+    )
     return attached

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -3194,6 +3194,12 @@ def make_fx(
             f"tracing_mode must be real/fake/symbolic, got {tracing_mode}"
         )
 
+    # If ``f`` carries an ``@dynamic_spec(...)`` decorator, the attached
+    # ``ShapesSpec`` is used as ``dynamic_shapes``. Passing both raises.
+    from torch.fx.experimental.dynamic_spec import _resolve_dynamic_shapes
+
+    dynamic_shapes = _resolve_dynamic_shapes(f, dynamic_shapes)
+
     from torch._inductor import config
 
     make_fx_tracer = _MakefxTracer(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187010
* __->__ #187639
* #187602

ShapesSpec] @dynamic_spec decorator for attaching ShapesSpec to functions/modules

Adds ``torch.fx.experimental.dynamic_spec.dynamic_spec`` decorator that
lets users attach a ``ShapesSpec`` directly to a function (or
``nn.Module.forward``). When ``torch.compile``,
``torch.export.export``, or ``torch.fx.experimental.proxy_tensor.make_fx``
is invoked on a decorated callable, the attached spec is auto-applied.

Surface API (single positional arg, mirrors the call-site  dynamic_shapes= kwarg)::
```python 
 
    @dynamic_spec(<dict | ParamsSpec | ShapesSpec>)
    def fn(x): ...

Example::

    @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
    def fn(x):
        return x.sum(0)

    compiled = torch.compile(fn)             # attached spec is applied
    gm       = make_fx(fn, tracing_mode="fake")(torch.randn(8, 3))

    class M(nn.Module):
        @dynamic_spec({"x": TensorSpec([ShapeVar("B"), STATIC])})
        def forward(self, x):
            return x.sum(0)

    ep = export(M(), (torch.randn(8, 3),))   # attached spec is applied
```

To attach assumptions, build a ``ShapesSpec`` and pass it::
```python
    @dynamic_spec(
        ShapesSpec(
            ParamsSpec({"x": TensorSpec([B, STATIC])}),
            assumptions=[B % 2 == 0],
        )
    )
    def fn(x): ...

```
Guardrails:
- Passing both ``@dynamic_spec(...)`` and an explicit
  ``dynamic_shapes=`` / ``shapes_spec=`` kwarg at the call site raises
  ``ValueError`` (ambiguous precedence).
- Stacking multiple ``@dynamic_spec(...)`` decorators on the same
  function raises ``ValueError`` (would silently overwrite).
- Invalid ``spec`` types raise ``TypeError`` listing the accepted set
  (``dict | ParamsSpec | ShapesSpec``).

Wired into all three entry points; tested under
``torch.compile`` (free function + ``nn.Module.forward``), ``make_fx``,
and both strict and non-strict ``torch.export.export``.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98