### PR TITLE
Support in-tree XNNPACK build on Windows ARM64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
 [submodule "third_party/XNNPACK"]
     ignore = dirty
     path = third_party/XNNPACK
-    url = https://github.com/google/XNNPACK.git
+	url = https://github.com/chrisdMSFT/XNNPACK.git
 [submodule "third_party/fmt"]
     ignore = dirty
     path = third_party/fmt

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -380,7 +380,7 @@ if(USE_NNPACK OR USE_PYTORCH_QNNPACK OR USE_XNNPACK)
         "Turn this warning off by USE_{Q/X}NNPACK=OFF.")
       set(DISABLE_NNPACK_AND_FAMILY ON)
     endif()
-    if(NOT IOS AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i686|AMD64|x86_64|armv[0-9].*|arm64|aarch64)$"))
+    if(NOT IOS AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i686|AMD64|x86_64|armv[0-9].*|arm64|aarch64|ARM64)$"))
       message(WARNING
         "Target architecture \"${CMAKE_SYSTEM_PROCESSOR}\" is not supported in {Q/X}NNPACK. "
         "Supported architectures are x86, x86-64, ARM, and ARM64. "
@@ -572,6 +572,15 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
 
     # Disable I8MM For CI since clang 9 does not support neon i8mm.
     set(XNNPACK_ENABLE_ARM_I8MM OFF CACHE BOOL "")
+
+    # On MSVC ARM64, match scripts/build-windows-arm64-native.cmd: enable i8mm
+    # (MSVC arm64 builds it) and disable the clang-only assembly / ARM
+    # fp16-scalar micro-kernels.
+    if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+      set(XNNPACK_ENABLE_ARM_I8MM ON CACHE BOOL "" FORCE)
+      set(XNNPACK_ENABLE_ASSEMBLY OFF CACHE BOOL "" FORCE)
+      set(XNNPACK_ENABLE_ARM_FP16_SCALAR OFF CACHE BOOL "" FORCE)
+    endif()
 
     # Disable avxvnni int8
     set(XNNPACK_ENABLE_AVXVNNIINT8 OFF CACHE BOOL "")


### PR DESCRIPTION
The PR aims at enabling XNNPACK for Windows ARM64 builds. Three changes are required.

Windows ARM64 reports CMAKE_SYSTEM_PROCESSOR=ARM64 (uppercase), which the lowercase-only {Q/X}NNPACK architecture guard in cmake/Dependencies.cmake did not match, so USE_XNNPACK was silently force-disabled there. Add ARM64 to the guard.

XNNPACK's assembly and ARM fp16-scalar/bf16 micro-kernels require clang-cl on Windows and do not build with MSVC cl.exe, whereas i8mm does. Scope the in-tree feature flags to MSVC ARM64 to mirror scripts/build-windows-arm64-native.cmd (i8mm on; assembly and ARM fp16-scalar off). Other platforms keep their existing defaults.

Point the third_party/XNNPACK submodule temporarily at the chrisdMSFT windows-arm64-native branch, which carries the fixes that let these micro-kernels compile under MSVC.

Test Plan:
Built a CPU Windows ARM64 wheel from this branch, from an MSVC arm64 developer prompt, with XNNPACK enabled:

    set USE_XNNPACK=1
    python -m build --wheel --no-isolation

MSVC compiled the in-tree XNNPACK micro-kernels, archived XNNPACK.lib and microkernels-prod.lib, and linked them into torch_cpu.dll; the wheel built with no compile or link errors.

TODOs:
- [ ] Once the XNNPACK fix is available in official XNNAPCK, update dependency URL and commit ID
- [ ] enable and test `USE_XNNPACK` for wim_arm64 CI builds