### PR TITLE
Truncate long fused kernel names on Windows

### DIFF
--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+from unittest import mock
 
 import torch
 from torch._inductor import utils
@@ -9,6 +10,7 @@ from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
 from torch.autograd import DeviceType
+from torch.utils._ordered_set import OrderedSet
 
 
 log = logging.getLogger(__name__)
@@ -144,6 +146,38 @@ class TestBench(TestCase):
             ),
             0.003,
         )
+
+    def test_get_fused_kernel_name_windows_truncation(self):
+        class FakeOrigin:
+            def __init__(self, name):
+                self.name = name
+                self.op = "call_function"
+
+        class FakeIRNode:
+            def __init__(self, origins):
+                self.origins = origins
+
+        class FakeSchedulerNode:
+            def __init__(self, origins):
+                self.node = FakeIRNode(origins)
+
+        origins = OrderedSet(
+            FakeOrigin(f"some_very_long_op_name_that_exceeds_the_limit_{i}")
+            for i in range(10)
+        )
+        node_schedule = [FakeSchedulerNode(origins)]
+
+        # On non-Windows the full descriptive name is kept.
+        with mock.patch("torch._inductor.utils.is_windows", return_value=False):
+            name = utils.get_fused_kernel_name(node_schedule, "inductor_node")
+            self.assertGreater(len(name), 50)
+
+        # On Windows the name is truncated and a hash suffix is appended.
+        with mock.patch("torch._inductor.utils.is_windows", return_value=True):
+            name_win = utils.get_fused_kernel_name(node_schedule, "inductor_node")
+            self.assertLessEqual(len(name_win), 50)
+            self.assertTrue(name_win.startswith("fused_"))
+            self.assertEqual(len(name_win.rsplit("_", 1)[-1]), 8)
 
     def test_do_bench_profile_result_requires_record_function_event(self):
         with self.assertRaisesRegex(RuntimeError, "Failed to capture"):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -5,6 +5,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
+import hashlib
 import importlib
 import inspect
 import io
@@ -959,7 +960,15 @@ def get_fused_kernel_name(
         ]
     else:
         raise NotImplementedError
-    return "_".join(["fused"] + sources)
+    name = "_".join(["fused"] + sources)
+    # On Windows the default MAX_PATH (260) limit means a long descriptive
+    # kernel name can push the Triton cache path past the limit, making the
+    # generated .ttir unopenable. Cap the name and append a hash to keep it
+    # both short and unique.
+    if is_windows() and len(name) > 50:
+        h = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+        name = f"{name[:41].rstrip('_')}_{h}"
+    return name
 
 
 def get_kernel_metadata(


### PR DESCRIPTION
On Windows, long descriptive fused kernel names produced by Inductor can push the Triton cache path past the legacy 260-character `MAX_PATH` limit, preventing the generated kernel files from being reopened. This change caps the descriptive portion of the fused kernel name on Windows and appends a short SHA-256 hash so the resulting cache path stays well under the limit while remaining unique.

Resolves #187283

Changes:
- In `torch/_inductor/utils.py`, `get_fused_kernel_name` now truncates the concatenated name to 41 characters (stripping any trailing underscores) and appends an 8-character SHA-256 hash when running on Windows and the name exceeds 50 characters.
- Added `test_get_fused_kernel_name_windows_truncation` in `test/inductor/test_inductor_utils.py` covering both the non-Windows path (full descriptive name preserved) and the Windows path (truncated, hash-suffixed name within the 50-character cap).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo