### PR TITLE
Fix binary pointwise ops on jagged NJTs with equal offsets

### DIFF
--- a/docs/source/nested.md
+++ b/docs/source/nested.md
@@ -193,14 +193,17 @@ each other.
 >>> nt1.offsets() is nt2.offsets()
 False
 >>> nt3 = nt1 + nt2
-RuntimeError: cannot call binary pointwise function add.Tensor with inputs of shapes (2, j2, 128) and (2, j3, 128)
+>>> nt3.shape
+torch.Size([2, j1, 128])
 ```
 
-In the above example, even though the conceptual shapes of the two NJTs are the same, they don't
-share a reference to the same ``offsets`` tensor, so their shapes differ, and they are not
-compatible. We recognize that this behavior is unintuitive and are working hard to relax this
-restriction for the beta release of nested tensors. For a workaround, see the
-{ref}`Troubleshooting <ragged_structure_incompatibility>` section of this document.
+In the above example the two NJTs print different ragged symbols because each independently
+constructed ``offsets`` tensor is assigned its own symbol. In eager mode a binary op between them
+still succeeds, because when the symbols differ the op falls back to comparing the underlying
+``offsets`` for value equality and proceeds when they match. Sharing the same ``offsets`` object,
+as described in the {ref}`Troubleshooting <ragged_structure_incompatibility>` section, remains the
+way to guarantee a shared symbol, and is required under ``torch.compile`` where the offsets are not
+available for value comparison.
 
 In addition to the ``offsets`` metadata, NJTs can also compute and cache the minimum and maximum
 sequence lengths for its components, which can be useful for invoking particular kernels (e.g. SDPA).
@@ -414,9 +417,12 @@ in a future PyTorch release.
     RuntimeError: cannot call binary pointwise function add.Tensor with inputs of shapes (2, j2, 128) and (2, j3, 128)
 ```
 
-This error occurs when calling an op that operates over multiple NJTs with incompatible ragged
-structures. Currently, it is required that input NJTs have the exact same ``offsets`` constituent
-in order to have the same symbolic ragged structure symbol (e.g. ``j1``).
+This error occurs when calling an op that operates over multiple NJTs with genuinely incompatible
+ragged structures. In eager mode, two NJTs with distinct ``offsets`` objects whose values are
+identical are accepted, since the op compares the ``offsets`` by value when the ragged symbols
+differ. The error is therefore raised only when the ``offsets`` actually differ in value, or under
+``torch.compile``, where the ``offsets`` cannot be value-compared and a shared symbol is still
+required.
 
 As a workaround for this situation, it is possible to construct NJTs from the ``values`` and
 ``offsets`` components directly. With both NJTs referencing the same ``offsets`` components, they

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4263,26 +4263,72 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         b = torch.randn(3, 3, requires_grad=True, dtype=torch.float64, device=device)
         c = torch.randn(4, 3, requires_grad=True, dtype=torch.float64, device=device)
 
-        # Incorrect usage: shape check will fail if the offsets tensor are not
-        #                  the same exact tensor object
+        # Value-identical offsets from independent construction are accepted even
+        # though the offsets objects differ. See issue #187582.
         nt1 = torch.nested.as_nested_tensor([a, b, c], layout=torch.jagged)
         nt2 = torch.nested.as_nested_tensor([a, b, c], layout=torch.jagged)
+        self.assertIsNot(nt1.offsets(), nt2.offsets())
 
-        self.assertRaisesRegex(
-            RuntimeError,
-            "cannot call binary pointwise function .* with inputs of shapes",
-            lambda: nt1 * nt2,
-        )
+        out = nt1 * nt2
+        self.assertEqual(out.offsets(), nt1.offsets())
+        self.assertEqual(out.values(), nt1.values() * nt2.values())
 
-        # Correct usage: chain the calls using the same offsets tensor object
         def grad_test_func(a, b, c):
             nt1 = torch.nested.as_nested_tensor([a, b, c], layout=torch.jagged)
-            # TODO: Switch to public API that takes in (values, offsets) once it exists
             nt2, offsets = jagged_from_list([a, b, c], nt1.offsets())
             out = nt1 * nt2
             return out.values()
 
         gradcheck(grad_test_func, inputs=(a, b, c), check_batched_grad=False)
+
+    def test_binary_pointwise_same_offsets_different_objects(self, device):
+        a = torch.randn(12, 5, 32, device=device)
+        b = torch.randn(12, 5, 32, device=device)
+
+        A = torch.nested.as_nested_tensor(a, layout=torch.jagged)
+        B = torch.nested.as_nested_tensor(b, layout=torch.jagged)
+        self.assertIsNot(A.offsets(), B.offsets())
+        self.assertTrue(torch.equal(A.offsets(), B.offsets()))
+
+        for f, ref in ((torch.add, a + b), (torch.sub, a - b), (torch.mul, a * b)):
+            C = f(A, B)
+            self.assertEqual(C.offsets(), A.offsets())
+            self.assertEqual(C.values(), ref.flatten(end_dim=1))
+
+    def test_binary_pointwise_mismatched_offsets_still_raises(self, device):
+        a = torch.randn(2, 5, 32, device=device)
+        b0 = torch.randn(3, 32, device=device)
+        b1 = torch.randn(7, 32, device=device)
+        A = torch.nested.as_nested_tensor(a, layout=torch.jagged)
+        B = torch.nested.nested_tensor([b0, b1], layout=torch.jagged)
+        with self.assertRaisesRegex(
+            RuntimeError, "cannot call binary pointwise function"
+        ):
+            A - B
+
+    def test_binary_pointwise_same_offsets_different_objects_broadcasting(self, device):
+        a = torch.randn(12, 5, 32, device=device)
+        b = torch.randn(12, 5, 1, device=device)
+
+        A = torch.nested.as_nested_tensor(a, layout=torch.jagged)
+        B = torch.nested.as_nested_tensor(b, layout=torch.jagged)
+        self.assertIsNot(A.offsets(), B.offsets())
+        self.assertTrue(torch.equal(A.offsets(), B.offsets()))
+
+        C = A + B
+        self.assertEqual(C.offsets(), A.offsets())
+        self.assertEqual(C.values(), (a + b).flatten(end_dim=1))
+
+    def test_binary_pointwise_incompatible_non_ragged_still_raises(self, device):
+        a = torch.randn(12, 5, 32, device=device)
+        b = torch.randn(12, 5, 7, device=device)
+
+        A = torch.nested.as_nested_tensor(a, layout=torch.jagged)
+        B = torch.nested.as_nested_tensor(b, layout=torch.jagged)
+        with self.assertRaisesRegex(
+            RuntimeError, "cannot call binary pointwise function"
+        ):
+            A + B
 
     def test_binary_pointwise_transposed(self, device):
         a, b, c = (

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -194,6 +194,45 @@ def raggedness_matches(nt, size):
     )
 
 
+def raggedness_matches_by_value(a, b):
+    if a._ragged_idx != b._ragged_idx or len(a._size) != len(b._size):
+        return False
+
+    from torch._subclasses.fake_tensor import FakeTensor
+    from torch._subclasses.functional_tensor import FunctionalTensor
+
+    def _untraceable(t):
+        return isinstance(t, (FakeTensor, FunctionalTensor))
+
+    a_off, a_len = a._offsets, a._lengths
+    b_off, b_len = b._offsets, b._lengths
+    if _untraceable(a_off) or _untraceable(b_off):
+        return False
+    if (a_len is None) != (b_len is None):
+        return False
+    if a_len is not None and (_untraceable(a_len) or _untraceable(b_len)):
+        return False
+
+    for i in range(len(a._size)):
+        if i < a._ragged_idx:
+            if a._size[i] != b._size[i]:
+                return False
+        elif i > a._ragged_idx:
+            if a._size[i] != b._size[i] and a._size[i] != 1 and b._size[i] != 1:
+                return False
+
+    if a_off.device != b_off.device or a_off.shape != b_off.shape:
+        return False
+
+    # slow path only when the symbolic dims already differ
+    # one D2H sync on a tiny 1-D tensor
+    if not torch.equal(a_off, b_off):
+        return False
+    if a_len is not None and not torch.equal(a_len, b_len):
+        return False
+    return True
+
+
 def squeeze_leading_ones(t):
     # Note: [ Squeezing leading ones ]
     #
@@ -316,7 +355,7 @@ def jagged_binary_pointwise(func, *args, **kwargs):
     if isinstance(a, NestedTensor) and isinstance(b, NestedTensor):
         # ex: (B, j0, D) + (B, j0, D)
         # ex: (B, j0, D) + (B, j0, 1)
-        if raggedness_matches(a, b._size):
+        if raggedness_matches(a, b._size) or raggedness_matches_by_value(a, b):
             return NestedTensor(
                 func(a._values, b._values, *args[2:], **kwargs), **extract_kwargs(a)
             )


### PR DESCRIPTION
## Summary

Fixes binary pointwise ops on jagged NJTs when two independently constructed inputs have value-identical ragged structure but different symbolic ragged dimension labels. 

The issue is that each jagged NJT gets its symbolic ragged dimension from its offsets tensor. Since that symbol is keyed on offsets object identity, two NJTs built independently from identical offsets can receive different symbols, for example `(12, j1, 32)` and `(12, j2, 32)`. The old binary pointwise path rejected those inputs before reaching the actual values operation.

This PR keeps the existing symbolic fast path,then falls back to an eager-only value-based compatibility check when the symbols differ. The helper confirms equal `ragged_idx`, broadcast-compatible non-ragged dims, and value-identical offsets and lengths, then lets the underlying op broadcast the dense tail exactly as the shared-offsets fast path does.

## Test plan

```text
python -m pytest test/test_nestedtensor.py -k binary_pointwise -v 
python -m pytest test/test_nestedtensor.py -k "TestNestedTensorOpInfo and binary" -v
```

Fixes #187582