### PR TITLE
Update inductor_torchbench training graph-break baselines for mnasnet and mobilenet

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -90,11 +90,11 @@ microbench_unbacked_tolist_sum,pass,9
 
 
 
-mnasnet1_0,pass,7
+mnasnet1_0,pass,0
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,0
 
 
 


### PR DESCRIPTION
inductor_torchbench CI (shard 2/2) reported IMPROVED graph breaks for mnasnet1_0 and mobilenet_v2 training: actual 0 vs expected 7 and 6. Update benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv so check_graph_breaks.py accepts the new zero-break baseline.

Authored with an AI assistant (Cursor automode).

Ref: https://github.com/pytorch/pytorch/actions/runs/27731614990/job/82046656096
Rel: #186997

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98