### PR TITLE
Fix windows mem_bandwith 0 division

### DIFF
--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -151,6 +151,8 @@ def get_transfer_time(flat_args_kwargs, flat_outs) -> float:  # type: ignore[no-
         float: The estimated memory transfer time in nanoseconds.
     """
     gpu_memory_bandwidth = get_gpu_dram_gbps()
+    if gpu_memory_bandwidth == 0:
+        return 0.0
     read_bytes = sum(
         get_num_bytes(t) for t in flat_args_kwargs if isinstance(t, torch.Tensor)
     )


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/4073.

Issue surfaced after relevant fixes to linux path for the estimation and test enablement. The root cause is windows driver not supporting the needed device info query which leads to getting 0 from `get_gpu_dram_gbps`  specifically from `c10/xpu/XPUDeviceProp.h:136`. To mitigate this problem an early return was added to prevent 0 division.