### PR TITLE
Add NanDetectMode for forward-pass NaN/Inf detection

### DIFF
--- a/test/test_nan_detect.py
+++ b/test/test_nan_detect.py
@@ -1,0 +1,65 @@
+# Owner(s): ["module: autograd"]
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils.nan_detect import NanDetectMode
+
+
+class TestNanDetectMode(TestCase):
+    def test_nan_detected(self):
+        with self.assertRaisesRegex(RuntimeError, "returned NaN"):
+            with NanDetectMode():
+                x = torch.tensor([1.0, float("nan")])
+                x + 1
+
+    def test_clean_tensors_pass(self):
+        with NanDetectMode():
+            x = torch.randn(4, 4)
+            y = x @ x.t()
+            z = y.relu()
+        self.assertFalse(torch.isnan(z).any())
+
+    def test_inf_not_detected_by_default(self):
+        with NanDetectMode():
+            x = torch.tensor([1.0, float("inf")])
+            y = x + 1
+        self.assertTrue(torch.isinf(y).any())
+
+    def test_inf_detected_when_enabled(self):
+        with self.assertRaisesRegex(RuntimeError, "non-finite"):
+            with NanDetectMode(check_inf=True):
+                x = torch.tensor([1.0, float("inf")])
+                x + 1
+
+    def test_integer_tensors_skipped(self):
+        with NanDetectMode():
+            x = torch.tensor([1, 2, 3])
+            y = x + 1
+        self.assertEqual(y.tolist(), [2, 3, 4])
+
+    def test_empty_tensors_skipped(self):
+        with NanDetectMode():
+            x = torch.empty(0)
+            y = x + 1
+        self.assertEqual(y.numel(), 0)
+
+    def test_nn_module(self):
+        with self.assertRaisesRegex(RuntimeError, "returned NaN"):
+            with NanDetectMode():
+                m = torch.nn.Linear(4, 4)
+                x = torch.tensor([[1.0, float("nan"), 3.0, 4.0]])
+                m(x)
+
+    def test_context_manager_restores(self):
+        x = torch.tensor([float("nan")])
+        try:
+            with NanDetectMode():
+                x + 1
+        except RuntimeError:
+            pass
+        y = x + 1
+        self.assertTrue(torch.isnan(y).any())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/utils/nan_detect.py
+++ b/torch/utils/nan_detect.py
@@ -1,0 +1,62 @@
+"""Forward-pass NaN/Inf detection via TorchDispatchMode.
+
+Usage::
+
+    with torch.utils.nan_detect.NanDetectMode():
+        out = model(x)
+    # RuntimeError raised immediately when any op produces NaN
+
+Based on the prototype at https://github.com/albanD/subclass_zoo/blob/main/nan_detect.py
+"""
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten
+
+
+class NanDetectMode(TorchDispatchMode):
+    """Detect NaN (and optionally Inf) in the output of every operation.
+
+    When enabled, every ATen operation is followed by a check of its outputs.
+    If any floating-point output tensor contains NaN (or non-finite values when
+    ``check_inf=True``), a ``RuntimeError`` is raised immediately with the name
+    of the offending operation.
+
+    This complements :func:`torch.autograd.detect_anomaly`, which only checks
+    for NaN during the backward pass.
+
+    Args:
+        check_inf (bool): If ``True``, also raise on ``±Inf`` values.
+            Default: ``False`` (only check for NaN).
+
+    Example::
+
+        >>> with NanDetectMode():
+        ...     x = torch.tensor([1.0, float('nan')])
+        ...     y = x + 1  # raises RuntimeError
+    """
+
+    def __init__(self, *, check_inf: bool = False) -> None:
+        super().__init__()
+        self.check_inf = check_inf
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        res = func(*args, **kwargs)
+        flat_res, _ = tree_flatten(res)
+        for t in flat_res:
+            if not isinstance(t, torch.Tensor):
+                continue
+            if not t.is_floating_point() or t.numel() == 0:
+                continue
+            try:
+                if self.check_inf:
+                    if not torch.isfinite(t).all():
+                        raise RuntimeError(
+                            f"Function {func} returned non-finite values"
+                        )
+                elif torch.isnan(t).any():
+                    raise RuntimeError(f"Function {func} returned NaN values")
+            except NotImplementedError:
+                pass
+        return res

--- a/torch/utils/nan_detect.py
+++ b/torch/utils/nan_detect.py
@@ -31,6 +31,7 @@ class NanDetectMode(TorchDispatchMode):
 
     Example::
 
+        >>> # xdoctest: +SKIP(NanDetectMode raises on NaN)
         >>> with NanDetectMode():
         ...     x = torch.tensor([1.0, float('nan')])
         ...     y = x + 1  # raises RuntimeError


### PR DESCRIPTION
Fixes #160016

Adds a `TorchDispatchMode` that detects NaN (and optionally Inf) in the output of every operation during the forward pass:

```python
from torch.utils.nan_detect import NanDetectMode

with NanDetectMode():
    out = model(x)
# RuntimeError: Function aten.add.Tensor returned NaN values
```

This complements `torch.autograd.detect_anomaly()`, which only checks for NaN during the backward pass. As @soulitzer noted on the issue: "As a first step, we can bring a basic version of nan_detect to core as a mode, off by default."

**Implementation** (based on [albanD/subclass_zoo `nan_detect.py`](https://github.com/albanD/subclass_zoo/blob/main/nan_detect.py)):
- `torch/utils/nan_detect.py`: `NanDetectMode(TorchDispatchMode)` that calls `func`, flattens outputs via pytree, checks each floating-point tensor for NaN/non-finite values
- `check_inf=True` option for also detecting `±Inf` (off by default, per profPlum's request on the issue)
- Skips non-floating-point tensors, empty tensors, and gracefully handles meta/fake tensors

**Tests** (`test/test_nan_detect.py`):
- NaN detection, clean pass-through, Inf opt-in/opt-out, integer/empty tensor skipping, nn.Module integration, context restore on exception

cc @soulitzer @albanD