### PR TITLE
[dynamo] Remove hardcoded CUDA references in test_logging.py

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -431,7 +431,7 @@ Found from :
         exitstack.close()
 
     @requires_distributed()
-    @requires_cuda_and_triton
+    @requires_gpu
     @make_logging_test(ddp_graphs=True)
     def test_ddp_graphs(self, records):
         class ToyModel(torch.nn.Module):
@@ -449,10 +449,14 @@ Found from :
         os.environ["MASTER_PORT"] = str(find_free_port())
         dist.init_process_group("gloo", rank=0, world_size=1)
 
-        model = DDP(ToyModel().to("cuda:0"), device_ids=[0], bucket_cap_mb=4)
+        device = f"{device_type}:0"
+        ddp_kwargs = {"bucket_cap_mb": 4}
+        if device_type == "cuda":
+            ddp_kwargs["device_ids"] = [0]
+        model = DDP(ToyModel().to(device), **ddp_kwargs)
         ddp_model = torch.compile(model, backend="inductor")
 
-        ddp_model(torch.randn(1024, 1024, device="cuda:0"))
+        ddp_model(torch.randn(1024, 1024, device=device))
 
         dist.destroy_process_group()
         self.assertEqual(len([r for r in records if "__ddp_graphs" in r.name]), 4)
@@ -1327,17 +1331,18 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
             """+- GLOBAL_STATE: ___check_global_state() against {"allow_bf16_reduce": "#","allow_fp16_reduce": "#","allow_tf32": "#","autocast_state":{"cached_enabled": "#","dtype": "#","enabled": "#"},"default_dtype": "#","deterministic_algorithms": "#","deterministic_algorithms_warn_only": "#","grad_mode": "#","num_threads": "#","torch_function": "#","torch_function_all_disabled": "#"}""",
         )
 
+    @requires_cuda_and_triton
     @make_logging_test(cudagraph_static_inputs=True)
     def test_cudagraph_static_inputs(self, records):
         @torch.compile(mode="reduce-overhead")
         def fn(x):
             return x + 1
 
-        x = torch.ones(2, 2)
+        x = torch.ones(2, 2, device=device_type)
         torch._dynamo.mark_static_address(x)
         fn(x)
         self.assertGreater(len(records), 0)
-        self.assertLess(len(records), 4)
+        self.assertLess(len(records), 8)
 
     @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/157778
     @make_logging_test(perf_hints=True)


### PR DESCRIPTION
## Summary

Makes `test/dynamo/test_logging.py` device-agnostic by fixing two tests that had hardcoded CUDA dependencies:

- **`test_ddp_graphs`**: Replaced `@requires_cuda_and_triton` with `@requires_gpu` and substituted hardcoded `"cuda:0"` with the module-level `device_type` variable. Made `device_ids` conditional since it is a CUDA-specific DDP parameter.
- **`test_cudagraph_static_inputs`**: Added missing `@requires_cuda_and_triton` guard since the test relies on `mode="reduce-overhead"` (CUDA graphs). Placed tensor on the appropriate device and widened the log record upper bound to accommodate additional CUDA-path logging.

## Motivation

This is part of the effort to decouple the test suite from specific hardware, enabling new accelerator backends to reuse existing tests without modification.

## Test plan

- `TEST_CONFIG=cpu python3 test/run_test.py -i dynamo/test_logging` — all tests pass
- `test_ddp_graphs` passes on CUDA
- `test_cudagraph_static_inputs` passes on CUDA with updated bound

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98