### PR TITLE
check_binary_symbols: exclude windows-specific header from headers check

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -322,6 +322,7 @@ def check_headeronly_symbols(install_root: Path) -> None:
     # Filter out platform-specific headers that may not compile everywhere
     platform_specific_keywords = [
         "cpu/vec",
+        "win32-headers.h",
     ]
 
     filtered_headers = []


### PR DESCRIPTION
Windows-specific header causes test errors when running this test on Linux.