### PR TITLE
Reject complex scale/zero_point tensors in quantize_per_tensor with an explicit dtype error instead of value cannot be converted to type double without overflow.

### DIFF
--- a/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
+++ b/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/quantized/FakeQuantAffine.h>
+#include <ATen/quantized/Quantizer.h>
 
 // FakeQuantize Op for PerTensorAffine quantization scheme.
 
@@ -45,6 +46,8 @@ Tensor fake_quantize_per_tensor_affine(
     const Tensor& zero_point,
     int64_t quant_min,
     int64_t quant_max) {
+  checkPerTensorQParamTensors(
+      scale, zero_point, "fake_quantize_per_tensor_affine");
   auto res = at::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
       self, scale, zero_point, at::ones(1, self.options().dtype(at::kLong)), quant_min, quant_max);
   return std::get<0>(std::move(res));
@@ -96,6 +99,8 @@ std::tuple<Tensor, Tensor> _fake_quantize_per_tensor_affine_cachemask_tensor_qpa
     const Tensor& fake_quant_enabled,
     int64_t quant_min,
     int64_t quant_max) {
+  checkPerTensorQParamTensors(
+      scale, zero_point, "fake_quantize_per_tensor_affine");
   TORCH_CHECK(
       quant_min <= quant_max,
       "`quant_min` should be less than or \

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -69,6 +69,7 @@ Tensor quantize_per_tensor_tensor_qparams(
     const Tensor& scale,
     const Tensor& zero_point,
     ScalarType dtype) {
+  checkPerTensorQParamTensors(scale, zero_point);
   auto quantizer = make_per_tensor_affine_quantizer(scale.item().toDouble(), zero_point.item().toLong(), dtype);
   return quantizer->quantize(self);
 }
@@ -78,6 +79,7 @@ std::vector<Tensor> quantize_per_tensor_list_cpu(
     const Tensor& scales,
     const Tensor& zero_points,
     ScalarType dtype) {
+  checkPerTensorQParamTensors(scales, zero_points);
   std::vector<Tensor> quantized_tensors;
   quantized_tensors.reserve(tensors.size());
   for (const auto i : c10::irange(tensors.size())) {

--- a/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
@@ -2,6 +2,7 @@
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
 #include <ATen/native/vulkan/ops/Utils.h>
+#include <ATen/quantized/Quantizer.h>
 #include <torch/library.h>
 
 namespace at {
@@ -98,6 +99,7 @@ Tensor quantize_per_tensor_tensor_qparams(
   TORCH_CHECK(
       (scale.numel() == 1 && zero_point.numel() == 1),
       "Only 1 element expected in scale and zero_point");
+  checkPerTensorQParamTensors(scale, zero_point);
   return quantize_per_tensor(
       input_arg, scale.item().toDouble(), zero_point.item().toLong(), dtype);
 }

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -230,6 +230,22 @@ TORCH_API QTensorImpl* get_qtensorimpl(const TensorBase& self);
 
 // double and int64_t are because of the native function API, we only have these
 // argument types right now in native functions
+inline void checkPerTensorQParamTensors(
+    const Tensor& scale,
+    const Tensor& zero_point,
+    const char* op_name = "quantize_per_tensor") {
+  TORCH_CHECK_VALUE(
+      !c10::isComplexType(scale.scalar_type()),
+      op_name,
+      ": scale tensor must be a real floating point or integral type, but got ",
+      scale.scalar_type());
+  TORCH_CHECK_VALUE(
+      !c10::isComplexType(zero_point.scalar_type()),
+      op_name,
+      ": zero_point tensor must be a real floating point or integral type, but got ",
+      zero_point.scalar_type());
+}
+
 TORCH_API QuantizerPtr
 make_per_tensor_affine_quantizer(
     double scale, int64_t zero_point, ScalarType scalar_type);

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -506,6 +506,26 @@ class TestQuantizedTensor(TestCase):
             rqr = qr.dequantize()
             self.assertTrue(np.allclose(r.numpy(), rqr.numpy(), atol=2 / scale))
 
+    def test_quantize_per_tensor_complex_scale_raises(self):
+        x = torch.randn(2, 2)
+        scale = torch.tensor([1 + 2j])
+        zero_point = torch.tensor(0)
+        error_msg = "scale tensor must be a real floating point or integral type"
+        with self.assertRaisesRegex(ValueError, error_msg):
+            torch.quantize_per_tensor(x, scale, zero_point, torch.qint8)
+        with self.assertRaisesRegex(ValueError, error_msg):
+            torch.quantize_per_tensor(
+                [torch.randn(2), torch.randn(2)],
+                torch.tensor([1 + 2j, 0.2]),
+                torch.tensor([0, 10]),
+                torch.quint8,
+            )
+        with self.assertRaisesRegex(ValueError, error_msg):
+            torch.fake_quantize_per_tensor_affine(
+                x, scale, zero_point, 0, 255)
+        torch.quantize_per_tensor(
+            x, torch.tensor(0.1), torch.tensor(10), torch.quint8)
+
     @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
     def test_per_tensor_to_device(self):
         dtypes = [


### PR DESCRIPTION
Reject complex scale/zero_point tensors in quantize_per_tensor with an explicit dtype error instead of value cannot be converted to type double without overflow. (Fixes #137468)

- Added shared checkPerTensorQParamTensors() in Quantizer.h and wired it into tensor-qparams, list, fake-quant, and Vulkan entry points.
- Added regression test test_quantize_per_tensor_complex_scale_raises