### PR TITLE
[functorch] Fix jvp through vmap with stack_module_state

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3901,6 +3901,34 @@ class TestComposability(TestCase):
             local_exclude_set = torch._C._dispatch_tls_local_exclude_set()
             self.assertTrue(local_exclude_set.has(DispatchKey.Autograd))
 
+    def test_jvp_through_vmap_with_stack_module_state(self, device):
+        in_features, out_features = 3, 4
+        models = [
+            nn.Linear(in_features, out_features, bias=False, device=device),
+            nn.Linear(in_features, out_features, bias=False, device=device),
+        ]
+        with torch.device("meta"):
+            meta_head = nn.Linear(in_features, out_features, bias=False)
+
+        def fmodel(params, buffers, x):
+            return functional_call(meta_head, (params, buffers), args=(x,))
+
+        vmodel = vmap(fmodel, in_dims=(0, 0, None))
+
+        def ensemble_forward(x):
+            params, buffers = stack_module_state(models)
+            return vmodel(params, buffers, x)
+
+        x = torch.randn(in_features, device=device)
+        x_t = torch.randn(in_features, device=device)
+
+        primals, tangents = jvp(ensemble_forward, (x,), (x_t,))
+
+        expected_primals = torch.stack([m(x) for m in models])
+        expected_tangents = torch.stack([x_t @ m.weight.T for m in models])
+        self.assertEqual(primals, expected_primals)
+        self.assertEqual(tangents, expected_tangents)
+
 
 @markDynamoStrictTest
 class TestMakeFunctional(TestCase):

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -4,8 +4,10 @@ from collections.abc import Sequence
 from typing import Any
 
 import torch
+import torch.autograd.forward_ad as fwAD
 import torch.nn as nn
 from torch import Tensor
+from torch._functorch.eager_transforms import enable_inplace_requires_grad
 from torch._functorch.utils import exposed_in
 
 
@@ -260,5 +262,9 @@ def construct_stacked_leaf(
         )
     result = torch.stack(tensors)
     if all_requires_grad:
-        result = result.detach().requires_grad_()
+        tangent = fwAD.unpack_dual(result).tangent
+        with enable_inplace_requires_grad(True):
+            result = result.detach().requires_grad_()
+        if tangent is not None:
+            result = fwAD.make_dual(result, tangent)
     return result


### PR DESCRIPTION
Fixes #182842

## Summary

`construct_stacked_leaf` in `stack_module_state` calls `detach().requires_grad_()` to create a fresh leaf tensor from stacked parameters. This failed inside `jvp` (and other functorch transforms) because:

1. `requires_grad_()` is blocked inside transforms by the `checkSupportsInplaceRequiresGrad` guard
2. `detach()` strips forward-AD tangents

The fix:
- Wraps the `requires_grad_()` call with `enable_inplace_requires_grad(True)`, matching the pattern used in `_create_differentiable`
- Preserves forward-AD tangents across `detach()` by unpacking them before and re-attaching with `make_dual` after

## Known limitation

Differentiating w.r.t. **parameters** (passing weights as primals to `jvp` and wrapping them in `nn.Parameter` before `stack_module_state`) still produces zero tangents because `nn.Parameter.__new__` also calls `detach()`, stripping tangents before `construct_stacked_leaf` is reached. This is a separate issue in `nn.Parameter`. Users can work around it by pre-stacking weights and passing them directly to `functional_call` with `vmap`, bypassing `nn.Parameter` and `stack_module_state` entirely.