### PR TITLE
Fix segfault in torch.lu_unpack with mismatched LU_pivots shape

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -781,6 +781,18 @@ TORCH_META_FUNC(lu_unpack)(const Tensor& LU, const Tensor& pivots, bool unpack_d
   const auto n = sizes.cend()[-1];
   const auto k = std::min(m, n);
 
+  if (unpack_pivots) {
+    // pivots is produced by lu_factor and must have shape (*LU.shape[:-2], min(m, n)).
+    // Without this check, a mismatched pivots tensor leads to out-of-bounds reads in
+    // the unpack_pivots kernel.
+    auto expected_pivots_sizes = LU.sizes().vec();
+    expected_pivots_sizes.pop_back();
+    expected_pivots_sizes.back() = k;
+    TORCH_CHECK_VALUE(pivots.sizes() == IntArrayRef(expected_pivots_sizes),
+        "Expected LU_pivots to have shape ", IntArrayRef(expected_pivots_sizes),
+        " but got ", pivots.sizes(), " instead.");
+  }
+
   // P.shape[-2:] == (m, m) (or size zero if pivot == False)
   sizes.end()[-1] = m;
   if (unpack_pivots) {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5724,6 +5724,12 @@ class TestLinalg(TestCase):
         with self.assertRaisesRegex(RuntimeError, "torch.int32 dtype"):
             torch.lu_unpack(lu_data, lu_pivots.long())
 
+        # mismatched LU_pivots shape must be rejected, not crash (see gh-177829)
+        with self.assertRaisesRegex(ValueError, "Expected LU_pivots to have shape"):
+            torch.lu_unpack(lu_data, torch.empty(0, dtype=torch.int32, device=device))
+        with self.assertRaisesRegex(ValueError, "Expected LU_pivots to have shape"):
+            torch.lu_unpack(lu_data, lu_pivots[..., :-1])
+
         # check that once flags are unset, Nones are returned
         p, l, u = torch.lu_unpack(lu_data, lu_pivots, unpack_data=False)
         self.assertTrue(l.numel() == 0 and u.numel() == 0)


### PR DESCRIPTION
Fixes #177829

### Summary
`torch.lu_unpack` segfaulted when `LU_pivots` had a shape inconsistent with `LU_data` (e.g. an empty pivots tensor against a 3x3 LU).

### Root cause
`TORCH_META_FUNC(lu_unpack)` validated only that `LU` has >= 2 dimensions and that `pivots` has int32 dtype; it never checked the pivots shape. The `unpack_pivots` kernel derives its loop bound `dim_size = min(m, n)` from `LU`'s shape and reads `pivots_data[0 .. dim_size-1]`. When `pivots` is empty or undersized, this reads out of bounds, producing a garbage 1-based index that is then used as a write offset in `std::swap`, corrupting memory and crashing.

### Fix
Validate, in the meta function, that `pivots` has the expected shape `(*LU.shape[:-2], min(m, n))` whenever `unpack_pivots` is set, raising a clear error otherwise. The meta function runs before the kernel for this structured op, so the bad input is rejected before any unchecked indexing occurs.

### Test Plan
```
python test/test_linalg.py -v -k test_lu_unpack_check_input
python test/test_linalg.py -v -k test_linalg_lu_family
lintrunner -a aten/src/ATen/native/BatchLinearAlgebra.cpp test/test_linalg.py
```
All pass; the previously-crashing reproducer now raises a clear `RuntimeError` instead of segfaulting.