### PR TITLE
Return empty result for FFT with empty batch on MKL backend

### DIFF
--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -487,15 +487,22 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
 #endif
 #endif
 
-  auto descriptor = _plan_mkl_fft(
-      input.strides(), out.strides(), signal_size, input.is_complex(),
-      out.is_complex(), normalization, forward, value_type);
+  // MKL DFTI rejects a zero-length (empty) transform with an opaque
+  // "Inconsistent configuration parameters" error. An empty batch produces a
+  // correctly-sized empty `out` above, so skip the compute. A zero-length
+  // signal dimension is already rejected at the dispatcher level
+  // (SpectralOps.cpp), so it never reaches here.
+  if (input.numel() > 0) {
+    auto descriptor = _plan_mkl_fft(
+        input.strides(), out.strides(), signal_size, input.is_complex(),
+        out.is_complex(), normalization, forward, value_type);
 
-  // run the FFT
-  if (forward) {
-    MKL_DFTI_CHECK(DftiComputeForward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
-  } else {
-    MKL_DFTI_CHECK(DftiComputeBackward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    // run the FFT
+    if (forward) {
+      MKL_DFTI_CHECK(DftiComputeForward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    } else {
+      MKL_DFTI_CHECK(DftiComputeBackward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    }
   }
 
   // Inplace reshaping to original batch shape and inverting the dimension permutation

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -496,15 +496,22 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
 #endif
 #endif
 
-  auto descriptor = _plan_mkl_fft(
-      input.strides(), out.strides(), signal_size, input.is_complex(),
-      out.is_complex(), normalization, forward, value_type);
+  // MKL DFTI rejects a zero-length (empty) transform with an opaque
+  // "Inconsistent configuration parameters" error. An empty batch produces a
+  // correctly-sized empty `out` above, so skip the compute. A zero-length
+  // signal dimension is already rejected at the dispatcher level
+  // (SpectralOps.cpp), so it never reaches here.
+  if (input.numel() > 0) {
+    auto descriptor = _plan_mkl_fft(
+        input.strides(), out.strides(), signal_size, input.is_complex(),
+        out.is_complex(), normalization, forward, value_type);
 
-  // run the FFT
-  if (forward) {
-    MKL_DFTI_CHECK(DftiComputeForward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
-  } else {
-    MKL_DFTI_CHECK(DftiComputeBackward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    // run the FFT
+    if (forward) {
+      MKL_DFTI_CHECK(DftiComputeForward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    } else {
+      MKL_DFTI_CHECK(DftiComputeBackward(descriptor.get(), const_cast<void*>(input.const_data_ptr()), out.data_ptr()));
+    }
   }
 
   // Inplace reshaping to original batch shape and inverting the dimension permutation

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -252,6 +252,21 @@ class TestFFT(TestCase):
             with self.assertRaisesRegex(RuntimeError, match):
                 f(t)
 
+    # gh-174984: an empty batch dimension with a valid signal length must
+    # return a correctly-shaped empty result, not raise an opaque backend error.
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.cfloat)
+    def test_fft_empty_batch(self, device, dtype):
+        t = torch.zeros(0, 2, 16, device=device, dtype=dtype)
+        self.assertEqual(torch.fft.fft(t, dim=-1).shape, torch.Size([0, 2, 16]))
+        self.assertEqual(torch.fft.ifft(t, dim=-1).shape, torch.Size([0, 2, 16]))
+        self.assertEqual(torch.fft.fftn(t, dim=(-2, -1)).shape, torch.Size([0, 2, 16]))
+        if dtype.is_complex:
+            # c2r path (irfft) goes through a separate entry point.
+            self.assertEqual(torch.fft.irfft(t, dim=-1).shape, torch.Size([0, 2, 30]))
+        else:
+            self.assertEqual(torch.fft.rfft(t, dim=-1).shape, torch.Size([0, 2, 9]))
+
     @onlyNativeDeviceTypes
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -253,6 +253,21 @@ class TestFFT(TestCase):
             with self.assertRaisesRegex(RuntimeError, match):
                 f(t)
 
+    # gh-174984: an empty batch dimension with a valid signal length must
+    # return a correctly-shaped empty result, not raise an opaque backend error.
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.cfloat)
+    def test_fft_empty_batch(self, device, dtype):
+        t = torch.zeros(0, 2, 16, device=device, dtype=dtype)
+        self.assertEqual(torch.fft.fft(t, dim=-1).shape, torch.Size([0, 2, 16]))
+        self.assertEqual(torch.fft.ifft(t, dim=-1).shape, torch.Size([0, 2, 16]))
+        self.assertEqual(torch.fft.fftn(t, dim=(-2, -1)).shape, torch.Size([0, 2, 16]))
+        if dtype.is_complex:
+            # c2r path (irfft) goes through a separate entry point.
+            self.assertEqual(torch.fft.irfft(t, dim=-1).shape, torch.Size([0, 2, 30]))
+        else:
+            self.assertEqual(torch.fft.rfft(t, dim=-1).shape, torch.Size([0, 2, 9]))
+
     @onlyNativeDeviceTypes
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)


### PR DESCRIPTION
Fixes #174984

### Summary
On x86 (MKL), `torch.fft.rfft` (and the other FFTs) raised an opaque `MKL FFT error: Intel oneMKL DFTI ERROR: Inconsistent configuration parameters` when given a tensor with an empty batch dimension but a valid signal length, e.g. `torch.zeros([0, 2, 16])`. On ARM (pocketfft) the same input already returns an empty tensor.

### Root cause
In `_exec_fft`, an empty batch collapses to `batch_size == 0`, and MKL's `DftiComputeForward/Backward` reject a zero-length transform. The output tensor is already correctly sized and strided before the compute, so for an empty input there is nothing to compute.

### Fix
Guard the MKL descriptor creation and `DftiCompute` calls with `input.numel() > 0`. A zero-length signal dimension (a genuinely invalid FFT) is unaffected: it is rejected earlier at the dispatcher level in `native/SpectralOps.cpp` with "Invalid number of data points" before `_exec_fft` is reached, so this guard only skips the empty-batch case.

### Test Plan
Added `test_fft_empty_batch` in `test/test_spectral_ops.py` covering c2c (fft/ifft), n-dimensional (fftn), r2c (rfft) and c2r (irfft) on an empty-batch input.
```
python test/test_spectral_ops.py -v -k test_fft_empty_batch
lintrunner -a aten/src/ATen/native/mkl/SpectralOps.cpp test/test_spectral_ops.py
```

Note: the modified `_exec_fft` is inside `#elif AT_MKL_ENABLED()` and only compiles on x86/MKL builds; the fix is therefore exercised by x86 CI. Locally (arm64/pocketfft) the new test confirms the expected empty-output shapes.