### PR TITLE
Reject aliased Q/R out tensors in torch.linalg.qr

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/Dispatch.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
 #include <ATen/TensorSubclassLikeUtils.h>
@@ -707,6 +708,18 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
   at::native::checkIsMatrix(A, "linalg.qr");
   at::native::checkFloatingOrComplex(A, "linalg.qr");
   auto [compute_q, reduced_mode] = at::native::_parse_qr_mode(mode);
+
+  // When computing Q, the Q and R outputs are distinct and must not share
+  // storage (e.g. out=(B, B)), otherwise one silently overwrites the other.
+  // Checked here, before set_output may substitute internal proxy tensors, so
+  // the user-provided out tensors are still visible via maybe_get_output.
+  if (compute_q) {
+    const auto& Q_out = maybe_get_output(0);
+    const auto& R_out = maybe_get_output(1);
+    if (Q_out.defined() && R_out.defined()) {
+      at::assert_no_overlap(Q_out, R_out);
+    }
+  }
 
   auto A_shape = A.sizes().vec();
   const auto m = A_shape.cend()[-2];

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/Dispatch.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
@@ -707,6 +708,18 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
   at::native::checkIsMatrix(A, "linalg.qr");
   at::native::checkFloatingOrComplex(A, "linalg.qr");
   auto [compute_q, reduced_mode] = at::native::_parse_qr_mode(mode);
+
+  // When computing Q, the Q and R outputs are distinct and must not share
+  // storage (e.g. out=(B, B)), otherwise one silently overwrites the other.
+  // Checked here, before set_output may substitute internal proxy tensors, so
+  // the user-provided out tensors are still visible via maybe_get_output.
+  if (compute_q) {
+    const auto& Q_out = maybe_get_output(0);
+    const auto& R_out = maybe_get_output(1);
+    if (Q_out.defined() && R_out.defined()) {
+      at::assert_no_overlap(Q_out, R_out);
+    }
+  }
 
   auto A_shape = A.sizes().vec();
   const auto m = A_shape.cend()[-2];

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4178,6 +4178,22 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
     @dtypes(torch.float)
+    def test_qr_out_aliased(self, device, dtype):
+        # gh-180377: Q and R out tensors must not share storage, otherwise one
+        # silently overwrites the other (previously accepted for square inputs).
+        A = torch.randn(3, 3, device=device, dtype=dtype)
+        B = torch.empty_like(A)
+        with self.assertRaisesRegex(RuntimeError, "single memory location"):
+            torch.linalg.qr(A, out=(B, B))
+
+        # mode='r' does not compute Q, so the overlap check is skipped and
+        # aliasing the out tensors must not raise.
+        Q = torch.empty(0, device=device, dtype=dtype)
+        torch.linalg.qr(A, mode='r', out=(Q, Q))
+
+    @skipCPUIfNoLapack
+    @skipCUDAIfNoCusolver
+    @dtypes(torch.float)
     def test_linalg_qr_autograd(self, device, dtype):
         # Check differentiability for modes as specified in the docs.
         # Differentiability in all cases is only guaranteed if first k = min(m, n) columns are linearly independent.

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4172,6 +4172,22 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
     @dtypes(torch.float)
+    def test_qr_out_aliased(self, device, dtype):
+        # gh-180377: Q and R out tensors must not share storage, otherwise one
+        # silently overwrites the other (previously accepted for square inputs).
+        A = torch.randn(3, 3, device=device, dtype=dtype)
+        B = torch.empty_like(A)
+        with self.assertRaisesRegex(RuntimeError, "single memory location"):
+            torch.linalg.qr(A, out=(B, B))
+
+        # mode='r' does not compute Q, so the overlap check is skipped and
+        # aliasing the out tensors must not raise.
+        Q = torch.empty(0, device=device, dtype=dtype)
+        torch.linalg.qr(A, mode='r', out=(Q, Q))
+
+    @skipCPUIfNoLapack
+    @skipCUDAIfNoCusolver
+    @dtypes(torch.float)
     def test_linalg_qr_autograd(self, device, dtype):
         # Check differentiability for modes as specified in the docs.
         # Differentiability in all cases is only guaranteed if first k = min(m, n) columns are linearly independent.


### PR DESCRIPTION
Fixes #180377

### Summary
`torch.linalg.qr(X, out=(B, B))` silently accepted the same tensor for both Q and R when X is square, so R overwrote Q and the Q result was lost. For non-square inputs it errored only incidentally, via a shape mismatch.

### Root cause
Nothing checked that the two distinct outputs Q and R refer to non-overlapping storage. The check cannot live in the structured kernel (`TORCH_IMPL_FUNC`): when the user's out tensor is not in the F-contiguous layout the kernel requires (e.g. a plain contiguous tensor), the structured framework substitutes separate internal proxy tensors for each output and copies them back afterwards, so the impl only ever sees distinct proxies and never observes the aliasing.

### Fix
Perform the check in `TORCH_META_FUNC(linalg_qr)`, which runs before the proxies are substituted, so `maybe_get_output()` still returns the user-provided out tensors. When Q is computed and both outputs are defined (the out= variant), `at::assert_no_overlap` rejects aliased Q/R. The functional variant (outputs undefined at meta time) and `mode='r'` (Q is discarded) are correctly skipped.

### Test Plan
```
python test/test_linalg.py -k test_qr_out_aliased
python test/test_linalg.py -k test_qr
python test/test_linalg.py -k test_linalg_qr_autograd
lintrunner -a aten/src/ATen/native/BatchLinearAlgebra.cpp test/test_linalg.py
```
All pass; the reported square `out=(B, B)` case now raises a clear error, while distinct out tensors, the functional form, and `mode='r'` are unaffected.