### PR TITLE
[MPS] Fix `baddbmm` operation to handle zero-sized dimensions correctly

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -794,7 +794,11 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     if (result.numel() == 0) {
       return result;
     } else if (batch1.size(2) == 0) {
-      beta.toComplexDouble() == 0.0 ? result.zero_() : result.mul_(beta);
+      if (beta.toComplexDouble() == 0.0) {
+        result.zero_();
+      } else {
+        result.mul_(beta);
+      }
       return result;
     }
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -790,6 +790,15 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     }
   }
 
+  if (opType == BADDBMM_OP_TYPE) {
+    if (result.numel() == 0) {
+      return result;
+    } else if (batch1.size(2) == 0) {
+      beta.toComplexDouble() == 0.0 ? result.zero_() : result.mul_(beta);
+      return result;
+    }
+  }
+
   // Use Metal kernels for integer and complex types
   if (c10::isIntegralType(batch1.scalar_type(), true) || c10::isComplexType(batch1.scalar_type())) {
     return do_metal_addbmm_or_baddbmm(input, batch1, batch2, alpha, beta, result, opType == BADDBMM_OP_TYPE);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1202,7 +1202,11 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     if (result.numel() == 0) {
       return result;
     } else if (batch1.size(2) == 0) {
-      beta.toComplexDouble() == 0.0 ? result.zero_() : result.mul_(beta);
+      if (beta.toComplexDouble() == 0.0) {
+        result.zero_();
+      } else {
+        result.mul_(beta);
+      }
       return result;
     }
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1198,6 +1198,15 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     return result;
   }
 
+  if (opType == BADDBMM_OP_TYPE) {
+    if (result.numel() == 0) {
+      return result;
+    } else if (batch1.size(2) == 0) {
+      beta.toComplexDouble() == 0.0 ? result.zero_() : result.mul_(beta);
+      return result;
+    }
+  }
+
   // Use Metal kernels for integer and complex types
   if (c10::isIntegralType(batch1.scalar_type(), true) || c10::isComplexType(batch1.scalar_type())) {
     return do_metal_addbmm_or_baddbmm(input, batch1, batch2, alpha, beta, result, opType == BADDBMM_OP_TYPE);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1444,12 +1444,10 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output_cpu.size(), output_mps.size())
 
     def test_baddbmm(self):
-        def helper(input_shape, batch1_shape, batch2_shape):
+        def helper(input_shape, batch1_shape, batch2_shape, beta=0.8, alpha=1.2):
             M_cpu = torch.randn(input_shape)
             batch1_cpu = torch.randn(batch1_shape)
             batch2_cpu = torch.randn(batch2_shape)
-            alpha = 1.2
-            beta = 0.8
 
             M_mps = M_cpu.detach().clone().to("mps")
             batch1_mps = batch1_cpu.detach().clone().to("mps")
@@ -1464,6 +1462,11 @@ class TestMPS(TestCaseMPS):
         helper(input_shape=(3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(10, 3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(1, 77, 77), batch1_shape=(8, 77, 64), batch2_shape=(8, 64, 77))
+        # Size-0 dims must match CPU instead of asserting, see
+        # https://github.com/pytorch/pytorch/issues/187399
+        helper(input_shape=(2, 0, 1), batch1_shape=(2, 0, 3), batch2_shape=(2, 3, 1), beta=0.5, alpha=100)
+        helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0.8)
+        helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0)
 
     def test_baddbmm_beta_zero_ignores_input(self):
         # When beta == 0 the input/bias must be ignored entirely. nan/inf in it

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1462,8 +1462,6 @@ class TestMPS(TestCaseMPS):
         helper(input_shape=(3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(10, 3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(1, 77, 77), batch1_shape=(8, 77, 64), batch2_shape=(8, 64, 77))
-        # Size-0 dims must match CPU instead of asserting, see
-        # https://github.com/pytorch/pytorch/issues/187399
         helper(input_shape=(2, 0, 1), batch1_shape=(2, 0, 3), batch2_shape=(2, 3, 1), beta=0.5, alpha=100)
         helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0.8)
         helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1755,8 +1755,6 @@ class TestMPS(TestCaseMPS):
         helper(input_shape=(3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(10, 3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(1, 77, 77), batch1_shape=(8, 77, 64), batch2_shape=(8, 64, 77))
-        # Size-0 dims must match CPU instead of asserting, see
-        # https://github.com/pytorch/pytorch/issues/187399
         helper(input_shape=(2, 0, 1), batch1_shape=(2, 0, 3), batch2_shape=(2, 3, 1), beta=0.5, alpha=100)
         helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0.8)
         helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1737,12 +1737,10 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output_cpu.size(), output_mps.size())
 
     def test_baddbmm(self):
-        def helper(input_shape, batch1_shape, batch2_shape):
+        def helper(input_shape, batch1_shape, batch2_shape, beta=0.8, alpha=1.2):
             M_cpu = torch.randn(input_shape)
             batch1_cpu = torch.randn(batch1_shape)
             batch2_cpu = torch.randn(batch2_shape)
-            alpha = 1.2
-            beta = 0.8
 
             M_mps = M_cpu.detach().clone().to("mps")
             batch1_mps = batch1_cpu.detach().clone().to("mps")
@@ -1757,6 +1755,11 @@ class TestMPS(TestCaseMPS):
         helper(input_shape=(3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(10, 3, 5), batch1_shape=(10, 3, 4), batch2_shape=(10, 4, 5))
         helper(input_shape=(1, 77, 77), batch1_shape=(8, 77, 64), batch2_shape=(8, 64, 77))
+        # Size-0 dims must match CPU instead of asserting, see
+        # https://github.com/pytorch/pytorch/issues/187399
+        helper(input_shape=(2, 0, 1), batch1_shape=(2, 0, 3), batch2_shape=(2, 3, 1), beta=0.5, alpha=100)
+        helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0.8)
+        helper(input_shape=(2, 3, 5), batch1_shape=(2, 3, 0), batch2_shape=(2, 0, 5), beta=0)
 
     def test_baddbmm_beta_zero_ignores_input(self):
         # When beta == 0 the input/bias must be ignored entirely. nan/inf in it


### PR DESCRIPTION
Fixes #187399 

### Problem

`torch.baddbmm` raised an opaque internal assertion on MPS whenever an operand had a size 0 dimension

```
  RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED at
  ".../aten/src/ATen/native/mps/OperationUtils.mm":525, please report a bug
  to PyTorch. Placeholder tensor is empty!
```

### Fix

added same return guard that CPU/CUDA already use in `bmm_out_or_baddbmm_`
- zero sized output (numel == 0) returns empty
- zero contraction dim returns beta * input (zeroed when beta == 0)

cc @malfet @Isalia20