### PR TITLE
[ROCm] Register .hip with MSVCCompiler for HIP extensions on Windows

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -857,7 +857,7 @@ class BuildExtension(_LazyBuildExt):
             self.compiler.src_extensions += ['.mm']
         # Save the original _compile method for later.
         if self.compiler.compiler_type == 'msvc':
-            self.compiler._cpp_extensions += ['.cu', '.cuh']
+            self.compiler._cpp_extensions += ['.cu', '.cuh', '.hip']
             original_compile = self.compiler.compile
             original_spawn = self.compiler.spawn
         else:


### PR DESCRIPTION
BuildExtension registers .hip as a source extension but never adds it to MSVCCompiler._cpp_extensions, so a hipified .hip source (hipify renames .cu -> .hip) fails with "Don't know how to compile <file>.hip" before hipcc is invoked. .cu/.cuh were added in #5548 and .hip reached src_extensions in #32669 but not the MSVC list; this adds it to match.

Prepared with the assistance of Claude (AI).

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang