### PR TITLE
[precompile] Add torch._inductor.compile_to_python

### DIFF
--- a/test/inductor/test_compile_to_python.py
+++ b/test/inductor/test_compile_to_python.py
@@ -1,0 +1,71 @@
+# Owner(s): ["module: inductor"]
+import torch
+import torch.utils._pytree as pytree
+from torch._inductor import compile_to_python as inductor_compile_to_python
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.nn.utils import stateless
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _capture(m, x):
+    """Capture m(x) as a flat-input ATen graph (params+buffers then x lifted to
+    inputs), mirroring how torch.precompile feeds standalone graphs to a backend.
+
+    NOTE: tracing runs m(x) once, which mutates m's buffers for stateful modules;
+    callers should capture from a throwaway model and run on a fresh one.
+    """
+    pnames = [n for n, _ in m.named_parameters()]
+    bnames = [n for n, _ in m.named_buffers()]
+    pb = [p for _, p in m.named_parameters()] + [b for _, b in m.named_buffers()]
+    k = len(pnames)
+
+    def flat_fn(flat):
+        params = dict(zip(pnames, flat[:k]))
+        buffers = dict(zip(bnames, flat[k : k + len(bnames)]))
+        with stateless._reparametrize_module(
+            m, {**params, **buffers}, tie_weights=True
+        ):
+            out = m(flat[-1])
+        leaves, _ = pytree.tree_flatten(out)
+        return leaves
+
+    with torch.enable_grad():
+        gm = make_fx(flat_fn)(pb + [x])
+    return gm
+
+
+def _flat_inputs(m, x):
+    return (
+        [p for _, p in m.named_parameters()] + [b for _, b in m.named_buffers()] + [x]
+    )
+
+
+def _exec(src):
+    ns = {"__name__": "_compiled"}
+    exec(compile(src, "<compiled>", "exec"), ns)
+    return ns["call"]
+
+
+class TestInductorCompileToPython(TestCase):
+    # torch._inductor.compile_to_python returns the INNER call only (no epilogue);
+    # for a dense graph that is the whole computation, run under no_grad.
+    def test_inner_call_dense_matches_eager(self):
+        torch.manual_seed(0)
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 3)
+        ).eval()
+        x = torch.randn(5, 4)
+        gm = _capture(m, x)
+
+        inner_src, cache = inductor_compile_to_python(gm, _flat_inputs(m, x))
+        self.assertIsInstance(inner_src, str)
+        self.assertIsNotNone(cache)  # non-mutating graph is serializable
+
+        call = _exec(inner_src)
+        with torch.no_grad():
+            out = call(_flat_inputs(m, x))
+        self.assertEqual(out[0], m(x))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, IO, Literal, Optional, TYPE_CHECKING, Union
 
 import torch.fx
 
-from .standalone_compile import CompiledArtifact, DynamicShapesType  # noqa: TC001
+from .standalone_compile import compile_to_python, CompiledArtifact, DynamicShapesType
 
 
 if TYPE_CHECKING:
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "compile",
+    "compile_to_python",
     "list_mode_options",
     "list_options",
     "cudagraph_mark_step_begin",

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pickle
 import shutil
+import tempfile
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Literal, TYPE_CHECKING
@@ -563,6 +564,128 @@ def standalone_compile(
             )
 
     return CacheCompiledArtifact(compiled_fn, artifacts)
+
+
+def _strip_compile_time_autotune_block(text: str) -> str:
+    """Drop the leading compile-time auto-tuning block from an Inductor module.
+
+    When ``autotune_at_compile_time`` is on (it is, for standalone compiles) Inductor
+    prepends the autotuning source to the output as a no-op ``r\"\"\"...\"\"\"`` string
+    (see graph.py); the autotuning itself already ran at compile time, so this string
+    is debug-only and often ~40% of the module. Inner ``\"\"\"`` are escaped, so the
+    first ``\\n\"\"\"\\n`` terminates it. Returns ``text`` unchanged if absent.
+    """
+    prefix = 'r"""\nCompile-time auto-tuning block:'
+    if not text.startswith(prefix):
+        return text
+    end = text.find('\n"""\n')
+    if end == -1:
+        return text
+    return text[end + len('\n"""\n') :]
+
+
+def _extract_inductor_output_module(artifact: CompiledArtifact) -> str:
+    """Return the single Inductor output-code module that defines the runnable
+    module-level ``call`` entry point (``call = runner.call``).
+
+    The artifact is unpacked to a temp dir; of the emitted ``.py`` files we want the
+    one exposing ``call``, with the debug-only blocks dropped: the leading compile-
+    time auto-tuning string (always present, since standalone compiles autotune at
+    compile time) and any trailing ``__main__`` (a defensive fallback --
+    ``compile_to_python`` disables ``benchmark_harness`` so it normally is absent).
+    """
+    chunks: list[str] = []
+    with tempfile.TemporaryDirectory() as unpack_dir:
+        try:
+            artifact.save(path=unpack_dir, format="unpacked")
+        except RuntimeError as e:
+            # The artifact is not saveable, so there is no source to read back. A
+            # common cause is a non-cacheable HOP in the graph (e.g. with_effects);
+            # the underlying error ({e}) names the specific reason.
+            raise NotImplementedError(
+                "compile_to_python cannot lower this graph to standalone source: its "
+                f"Inductor artifact is not saveable ({e})."
+            ) from e
+        for root, _dirs, files in os.walk(unpack_dir):
+            for name in sorted(files):
+                if not name.endswith(".py"):
+                    continue
+                with open(os.path.join(root, name)) as f:
+                    text = f.read()
+                if "def call(" in text and "call = runner.call" in text:
+                    text = _strip_compile_time_autotune_block(text)
+                    marker = '\nif __name__ == "__main__":'
+                    idx = text.find(marker)
+                    if idx != -1:
+                        text = text[:idx].rstrip() + "\n"
+                    chunks.append(text)
+    if len(chunks) != 1:
+        raise RuntimeError(
+            f"expected exactly one runnable Inductor output module, found "
+            f"{len(chunks)}; compile_standalone_python cannot inline this artifact."
+        )
+    return chunks[0]
+
+
+def _binary_cache_bytes(artifact: CompiledArtifact) -> bytes | None:
+    """Serialize the artifact to opaque cache bytes, or None if it is not
+    serializable (e.g. graphs with input mutations currently do not produce a
+    saveable aot_autograd artifact). The source still runs standalone without it."""
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
+        tmp = tf.name
+    try:
+        artifact.save(path=tmp, format="binary")
+        with open(tmp, "rb") as f:
+            return f.read()
+    except Exception:
+        # Some graphs legitimately have no saveable artifact (e.g. certain
+        # input-mutating graphs); the source still runs standalone without it. Log
+        # at debug so a genuine serialization regression is not silently masked as
+        # an "uncacheable" fallback (which only shows up as a missing FxGraphCache
+        # hit on reload).
+        log.debug("standalone artifact is not serializable; no cache", exc_info=True)
+        return None
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def compile_to_python(
+    gm: GraphModule,
+    example_inputs: Sequence[InputType],
+    *,
+    dynamic_shapes: DynamicShapesType = "from_example_inputs",
+    options: Any = None,
+) -> tuple[str, bytes | None]:
+    """Compile ``gm`` and return ``(inner_python, cache)`` -- the INNER half of the
+    backend contract behind ``torch.precompile``.
+
+    ``inner_python`` is the Inductor output module exposing ``call(args) -> outs``
+    for the post-AOTAutograd inner graph (dense, functionalized). It is the inductor
+    piece only: it carries NO prelude/epilogue (subclass flatten/unflatten, input-
+    mutation copy-back, output-alias regen, grad disabling). Those belong to the AOT
+    layer -- see ``torch._functorch.aot_autograd.compile_to_python``, which calls
+    this and composes AOTAutograd's codegen'd runtime wrappers around the result.
+    Callers must run ``call`` under ``torch.no_grad()`` (the kernels use out= ops).
+
+    The kernels JIT-compile from the inlined source on first call, so ``inner_python``
+    needs no cache. ``cache`` is an opaque acceleration (or ``None`` when the graph
+    is not serializable, e.g. some input-mutating graphs).
+    """
+    # benchmark_harness emits get_args()/benchmark_compiled_module()/__main__ for the
+    # tlparse debug dump. The export artifact is meant to run, not to be profiled, so
+    # those are dead code here -- disable the harness at codegen time rather than
+    # stripping it out afterward.
+    with torch.no_grad(), config.patch("benchmark_harness", False):
+        artifact = standalone_compile(
+            gm,
+            example_inputs,
+            dynamic_shapes=dynamic_shapes,
+            options=options if options else {},
+        )
+    inner_python = _extract_inductor_output_module(artifact)
+    cache = _binary_cache_bytes(artifact)
+    return inner_python, cache
 
 
 def autograd_cache_key(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187670
* #187669
* #187668
* __->__ #187667

Adds the inner layer of the AOT->Python backend contract that torch.precompile
will lower through. compile_to_python(gm, example_inputs) -> (python, cache)
standalone-compiles a post-AOTAutograd dense graph and returns the Inductor
output module exposing call(args) -> outs (kernels JIT-compile from the inlined
source on first call) plus an opaque cache that is purely an acceleration
(None when the graph is not serializable). It carries no prelude/epilogue --
subclass flatten/unflatten, input-mutation copy-back, and output-alias regen
belong to the AOT layer added later in the stack; callers run call under
torch.no_grad().

The benchmark/debug harness and the compile-time auto-tuning block are stripped
so the emitted module is meant to run, not be profiled.

Test Plan:

```
python test/inductor/test_compile_to_python.py -k TestInductorCompileToPython
```

Authored with an AI assistant.