### PR TITLE
Preserve boxed lifetimes for regional compiled calls

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1912,8 +1912,8 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
     """Tests for _RegionScooper partitioning behavior.
 
     Uses CapabilityBasedPartitioner per region ID. Nodes with the same region ID
-    are merged as aggressively as possible (only cycles prevent merging). Nodes
-    with different region IDs are never merged.
+    only merge through supported data dependencies. Nodes with different region
+    IDs are never merged.
     """
 
     def _make_tag_node(self, g, inp, scalar, tagged):
@@ -1960,7 +1960,7 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
                 self.assertEqual(self._scoop_and_count(gm), expected)
 
     def test_parallel_branches_not_fused(self):
-        """Two adjacent independent tagged branches form 1 partition."""
+        """Two adjacent independent tagged branches form separate partitions."""
         g = torch.fx.Graph()
         x = g.placeholder("x")
         mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
@@ -1969,11 +1969,11 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         out.meta["val"] = torch.empty(10)
         g.output(out)
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
-        self.assertEqual(self._scoop_and_count(gm), 1)
+        self.assertEqual(self._scoop_and_count(gm), 2)
 
     def test_parallel_branches_with_gap_same_region(self):
         """Two independent tagged nodes separated by an untagged node but
-        sharing the same region ID are fused into 1 partition (no cycle).
+        sharing the same region ID form separate partitions.
         """
         g = torch.fx.Graph()
         x = g.placeholder("x")
@@ -1985,7 +1985,7 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         out.meta["val"] = torch.empty(10)
         g.output(out)
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
-        self.assertEqual(self._scoop_and_count(gm), 1)
+        self.assertEqual(self._scoop_and_count(gm), 2)
 
     def test_parallel_branches_with_gap_different_regions(self):
         """Two independent tagged nodes with different region IDs produce
@@ -2019,6 +2019,18 @@ class RegionalInductorPartitionTests(torch._inductor.test_case.TestCase):
         g.output(mul_b)
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertEqual(self._scoop_and_count(gm), 1)
+
+    def test_dependent_through_unsupported_gap_not_merged(self):
+        """Supported nodes are not fused across an unsupported dependency."""
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        mul_a = self._make_tag_node(g, x, 2.0, tagged=True)
+        sin = g.call_function(torch.ops.aten.sin.default, (mul_a,))
+        sin.meta["val"] = torch.empty(10)
+        mul_b = self._make_tag_node(g, sin, 3.0, tagged=True)
+        g.output(mul_b)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+        self.assertEqual(self._scoop_and_count(gm), 2)
 
     def test_different_annotations_not_merged(self):
         """Two tagged nodes with different region IDs are NOT merged,

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -6,6 +6,7 @@ import re
 import unittest
 import unittest.mock as mock
 import warnings
+import weakref
 
 from parameterized import parameterized_class
 
@@ -50,6 +51,41 @@ if HAS_GPU:
 
 @skipIfTorchDynamo("Not a torch._dynamo test")
 class TestInvokeSubgraph(TestCase):
+    def test_infer_releases_boxed_operands_before_dispatch(self):
+        from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer
+
+        class Holder:
+            pass
+
+        alive_during_call = []
+
+        class BoxedSubgraph:
+            _boxed_call = True
+
+            def __call__(self, args):
+                holder_ref = weakref.ref(args[0])
+                args.clear()
+                alive_during_call.append(holder_ref() is not None)
+                return "ok"
+
+        self.assertEqual(invoke_subgraph_infer(BoxedSubgraph(), Holder()), "ok")
+        self.assertEqual(alive_during_call, [False])
+
+        class CallBoxedSubgraph:
+            _boxed_call = True
+
+            def __call__(self, args):
+                raise AssertionError("expected call_boxed")
+
+            def call_boxed(self, args):
+                holder_ref = weakref.ref(args[0])
+                args.clear()
+                alive_during_call.append(holder_ref() is not None)
+                return "ok"
+
+        self.assertEqual(invoke_subgraph_infer(CallBoxedSubgraph(), Holder()), "ok")
+        self.assertEqual(alive_during_call, [False, False])
+
     def test_simple(self):
         def gn(x, y):
             return torch.mul(x, y)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -387,6 +387,52 @@ class TestFX(JitTestCase):
         self.assertIn("multi_boxed_call_boxed_arg_2 = [b];  b = None", gm.code)
         self.assertNotIn("a = b = None", gm.code)
 
+    def test_boxed_dummy_wrapper_codegen_releases_inputs_before_dispatch(self):
+        from torch.fx.passes.regional_inductor import _boxed_dummy_wrapper
+
+        class Holder:
+            pass
+
+        alive_during_call = []
+
+        class CompiledCallable:
+            def __call__(self, *args):
+                raise AssertionError("expected boxed call")
+
+            def call_boxed(self, args):
+                holder_ref = weakref.ref(args[0])
+                args.clear()
+                alive_during_call.append(holder_ref() is not None)
+                return "ok"
+
+        wrapped = _boxed_dummy_wrapper(CompiledCallable())
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        out = graph.call_function(wrapped, ([x],))
+        graph.output(out)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        self.assertEqual(getattr(wrapped, "_boxed_arg_indices", None), (0,))
+        self.assertRegex(gm.code, r"_boxed_arg_0 = \[x\];  x = None")
+        self.assertEqual(gm.forward(Holder()), "ok")
+        self.assertEqual(alive_during_call, [False])
+
+    def test_boxed_dummy_wrapper_copies_immutable_list_args(self):
+        from torch.fx.passes.regional_inductor import _boxed_dummy_wrapper
+
+        test_case = self
+
+        class CompiledCallable:
+            def call_boxed(self, args):
+                test_case.assertIs(type(args), list)
+                args.clear()
+                return "ok"
+
+        wrapped = _boxed_dummy_wrapper(CompiledCallable())
+        args = immutable_list([object()])
+        self.assertEqual(wrapped(args), "ok")
+        self.assertEqual(len(args), 1)
+
     def test_args_kwargs(self):
         class T(torch.nn.Module):
             def forward(self, *args, **kwargs):

--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -219,3 +219,11 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.compiled_fn(*args, **kwargs)
+
+    def call_boxed(self, args: list[Any]) -> Any:
+        call_boxed = getattr(self.compiled_fn, "call_boxed", None)
+        if call_boxed is not None:
+            return call_boxed(args)
+        if getattr(self.compiled_fn, "_boxed_call", False):
+            return self.compiled_fn(args)
+        return self.compiled_fn(*args)

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -741,6 +741,11 @@ def deserialize_bundled_cache_entry(
     def forward(*runtime_args: Any) -> Any:
         return compiled_fn(list(runtime_args))
 
+    def call_boxed(runtime_args: list[Any]) -> Any:
+        return compiled_fn.call_boxed(runtime_args)
+
+    forward.call_boxed = call_boxed  # type: ignore[attr-defined]
+
     if not hasattr(compiled_fn, "serialize"):
         raise AssertionError("compiled_fn must have serialize attribute")
     forward.serialize = compiled_fn.serialize  # type: ignore[attr-defined]

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2547,6 +2547,14 @@ class SerializableCompiledFunction:
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.compiled_fn(*args, **kwargs)
 
+    def call_boxed(self, args: list[Any]) -> Any:
+        call_boxed = getattr(self.compiled_fn, "call_boxed", None)
+        if call_boxed is not None:
+            return call_boxed(args)
+        if getattr(self.compiled_fn, "_boxed_call", False):
+            return self.compiled_fn(args)
+        return self.compiled_fn(*args)
+
 
 @dataclass
 class AOTDispatchAutogradCompileSpec:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1262,6 +1262,8 @@ def aot_module_simplified(
                 raise AssertionError("compiled_fn must not be None")
             return compiled_fn(flat_args)
 
+        forward.call_boxed = forward  # type: ignore[attr-defined]
+
     else:
         # TODO: There is something deeply wrong here; compiled_fn running with
         # the boxed calling convention, but aot_module_simplified somehow
@@ -1277,6 +1279,17 @@ def aot_module_simplified(
             if compiled_fn is None:
                 raise AssertionError("compiled_fn must not be None")
             return compiled_fn(full_args)
+
+        def call_boxed(runtime_args: list[Any]) -> Any:
+            full_args = []
+            full_args.extend(params_buffers_flat)
+            full_args.extend(runtime_args)
+            runtime_args.clear()
+            if compiled_fn is None:
+                raise AssertionError("compiled_fn must not be None")
+            return compiled_fn(full_args)
+
+        forward.call_boxed = call_boxed  # type: ignore[attr-defined]
 
     # Just for convenience
     forward.zero_grad = mod.zero_grad  # type: ignore[attr-defined]

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -335,10 +335,11 @@ def invoke_subgraph_infer(
     proxy_mode = get_proxy_mode()
     if proxy_mode is None:
         # No tracing active, just call the subgraph directly
-        if getattr(subgraph, "_boxed_call", False):
-            return subgraph(list(operands))
-        else:
-            return subgraph(*operands)
+        if _should_call_boxed_subgraph(subgraph):
+            boxed_operands = list(operands)
+            del operands
+            return _call_boxed_subgraph(subgraph, boxed_operands)
+        return subgraph(*operands)
 
     from torch._dynamo.utils import get_unique_name_wrt
 
@@ -956,8 +957,10 @@ def _(subgraph, identifier, *operands):
     # Eager backends run the captured HOP with real tensors and no AOTAutograd
     # fake mode. Let regular autograd record through the subgraph in that case.
     if detect_fake_mode(operands) is None:
-        if getattr(subgraph, "_boxed_call", False):
-            return subgraph(list(operands))
+        if _should_call_boxed_subgraph(subgraph):
+            boxed_operands = list(operands)
+            del operands
+            return _call_boxed_subgraph(subgraph, boxed_operands)
         return subgraph(*operands)
 
     # Check if we have already traced the subgraph.
@@ -1000,8 +1003,10 @@ def _(debug_mode, subgraph, identifier, *operands):
     # If the HOP is dispatched from DebugMode, we should enable debug_mode
     # for the subgraph call.
     with debug_mode:
-        if getattr(subgraph, "_boxed_call", False):
-            result = subgraph(list(operands))
+        if _should_call_boxed_subgraph(subgraph):
+            boxed_operands = list(operands)
+            del operands
+            result = _call_boxed_subgraph(subgraph, boxed_operands)
         else:
             result = subgraph(*operands)
     debug_mode._handle_annotate(f"[exit InvokeSubgraph HOP] {identifier}")
@@ -1020,10 +1025,11 @@ def _(subgraph, identifier, *operands):
     if mode is not None:
         raise AssertionError("Mode should never be enabled for CPU/CUDA key")
 
-    if getattr(subgraph, "_boxed_call", False):
-        return subgraph(list(operands))
-    else:
-        return subgraph(*operands)
+    if _should_call_boxed_subgraph(subgraph):
+        boxed_operands = list(operands)
+        del operands
+        return _call_boxed_subgraph(subgraph, boxed_operands)
+    return subgraph(*operands)
 
 
 @invoke_subgraph.py_functionalize_impl
@@ -1145,8 +1151,10 @@ def _(subgraph, identifier, *operands):
     from torch._dynamo.utils import dynamo_timed
 
     with dynamo_timed("invoke_subgraph_fake_tensor", log_pt2_compile_event=True):
-        if getattr(subgraph, "_boxed_call", False):
-            return subgraph(list(operands))
+        if _should_call_boxed_subgraph(subgraph):
+            boxed_operands = list(operands)
+            del operands
+            return _call_boxed_subgraph(subgraph, boxed_operands)
         return subgraph(*operands)
 
 
@@ -1275,6 +1283,19 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
     )
 
 
+def _should_call_boxed_subgraph(subgraph) -> bool:
+    return getattr(subgraph, "call_boxed", None) is not None or getattr(
+        subgraph, "_boxed_call", False
+    )
+
+
+def _call_boxed_subgraph(subgraph, boxed_operands):
+    call_boxed = getattr(subgraph, "call_boxed", None)
+    if call_boxed is not None:
+        return call_boxed(boxed_operands)
+    return subgraph(boxed_operands)
+
+
 def invoke_subgraph_inductor_compile(
     gm, example_inputs, inductor_config_patches=None, **kwargs
 ):
@@ -1326,6 +1347,14 @@ def invoke_subgraph_inductor_compile(
         full_args = []
         full_args.extend(runtime_args)
         return compiled_fn_inner(full_args)
+
+    def call_boxed(runtime_args: list[Any]):
+        full_args = []
+        full_args.extend(runtime_args)
+        runtime_args.clear()
+        return compiled_fn_inner(full_args)
+
+    forward.call_boxed = call_boxed  # type: ignore[attr-defined]
 
     # Just for convenience
     forward.zero_grad = gm.zero_grad  # type: ignore[attr-defined]

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -344,6 +344,9 @@ class AOTCompiledArtifact(CompiledArtifact):
     def __call__(self, *args: Any) -> Any:
         return self.inner_fn(*args)
 
+    def call_boxed(self, args: list[Any]) -> Any:
+        return self.inner_fn.call_boxed(args)
+
     def save(
         self, *, path: str, format: Literal["binary", "unpacked"] = "binary"
     ) -> None:

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -28,6 +28,25 @@ def _dummy_wrapper(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     return inner
 
 
+def _call_boxed(fn: Callable[..., _R], args: list[Any], kwargs: dict[str, Any]) -> _R:
+    boxed_args = args if type(args) is list else list(args)
+    call_boxed = getattr(fn, "call_boxed", None)
+    if call_boxed is not None and not kwargs:
+        return call_boxed(boxed_args)
+    if getattr(fn, "_boxed_call", False) and not kwargs:
+        return fn(boxed_args)
+    return fn(*args, **kwargs)
+
+
+def _boxed_dummy_wrapper(fn: Callable[..., _R]) -> Callable[..., _R]:
+    @functools.wraps(fn)
+    def inner(args: list[Any], **kwargs: Any) -> _R:
+        return _call_boxed(fn, args, kwargs)
+
+    inner._boxed_arg_indices = (0,)  # type: ignore[attr-defined]
+    return inner
+
+
 @contextlib.contextmanager
 def _disable_remat_for_regional_subcompile() -> Iterator[None]:
     # In torch.compile, regional_inductor subcompiles run after the enclosing
@@ -54,7 +73,6 @@ def _compile_submod(gm: torch.fx.GraphModule, prefix: str) -> torch.fx.GraphModu
                     )
 
             submod = getattr(gm, node.target)
-
             # Get inductor configs from annotation
             # TODO we should change partition when there are multiple differently
             # annotated regions.
@@ -105,11 +123,12 @@ def _compile_submod(gm: torch.fx.GraphModule, prefix: str) -> torch.fx.GraphModu
                 raise AssertionError(
                     f"Expected AOTCompiledArtifact, got {type(compiled_fn)}"
                 )
-            # _dummy_wrapper is to make call_function happy
-            compiled_submod = _dummy_wrapper(compiled_fn)
+            # _boxed_dummy_wrapper is to make call_function happy while keeping
+            # regional inputs under FX boxed-argument lifetime handling.
+            compiled_submod = _boxed_dummy_wrapper(compiled_fn)
             with gm.graph.inserting_after(node):
                 new_node = gm.graph.call_function(
-                    compiled_submod, args=node.args, kwargs=node.kwargs
+                    compiled_submod, args=(list(node.args),), kwargs=node.kwargs
                 )
                 new_node.meta = node.meta
                 node.replace_all_uses_with(new_node)
@@ -177,7 +196,10 @@ class _RegionScooper:
         for region_nodes in regions.values():
             support = create_op_support(_is_in_region(region_nodes))
             partitioner = CapabilityBasedPartitioner(
-                gm, support, allows_single_node_partition=True
+                gm,
+                support,
+                allows_single_node_partition=True,
+                skip_horizontal_fusion=True,
             )
             for partition in partitioner.propose_partitions():
                 all_partitions.append(partition.nodes)

--- a/torch/fx/passes/regional_inductor_invoke_subgraph.py
+++ b/torch/fx/passes/regional_inductor_invoke_subgraph.py
@@ -7,8 +7,8 @@ from torch._inductor.standalone_compile import AOTCompiledArtifact
 from torch.compiler._cache import CacheArtifactManager
 from torch.fx._compatibility import compatibility
 from torch.fx.passes.regional_inductor import (
+    _boxed_dummy_wrapper,
     _disable_remat_for_regional_subcompile,
-    _dummy_wrapper,
 )
 
 
@@ -81,14 +81,13 @@ def _compile_submod(
     if not isinstance(compiled_fn, AOTCompiledArtifact):
         raise AssertionError(f"Expected AOTCompiledArtifact, got {type(compiled_fn)}")
 
-    # _dummy_wrapper is to make call_function happy
-    compiled_submod = _dummy_wrapper(compiled_fn)
+    compiled_submod = _boxed_dummy_wrapper(compiled_fn)
     for node in subgraph_users:
         with gm.graph.inserting_after(node):
             new_node = gm.graph.call_function(
                 # exclude graph nodes input args
                 compiled_submod,
-                args=node.args[2:],
+                args=(list(node.args[2:]),),
                 kwargs=node.kwargs,
             )
             new_node.meta = node.meta


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187675
* __->__ #187674

Graph Trainer exposed a lifetime regression in the regional compiled-call path. The compiled subgraphs themselves use boxed calling conventions, but regional_inductor and invoke_subgraph were rebuilding Python argument tuples around those calls. That kept the original operand containers alive in the caller frame until after the compiled region returned, which was enough to extend large activation lifetimes at HOP and regional boundaries.

Propagate call_boxed through the AOT compiled-function wrappers and teach regional_inductor to emit FX boxed-argument calls for compiled submodules. The invoke_subgraph eager/runtime dispatches now build a boxed operand list, delete the varargs tuple in the dispatch frame, and prefer call_boxed when available. Regional partitioning also disables horizontal fusion so independent HOP regions with the same annotation do not get merged into a wider compiled region with a larger live set.

On the target Rigi configuration, the full stack moved graph_trainer regional/no-final from above compile to below compile active memory:

```text
d8/w1024/v256 torch.compile active peak: 2.9098 GiB
d8/w1024/v256 graph_trainer old full baseline: 3.3285 GiB
d8/w1024/v256 graph_trainer full boxed/no-horizontal/no-final: 3.2209 GiB
d8/w1024/v256 graph_trainer regional boxed/no-horizontal/no-final: 2.5147 GiB
```

Test Plan:

```bash
lintrunner -a
```

```bash
python -m py_compile torch/fx/passes/regional_inductor.py torch/fx/passes/regional_inductor_invoke_subgraph.py torch/_higher_order_ops/invoke_subgraph.py torch/_functorch/aot_autograd.py torch/_functorch/_aot_autograd/aot_autograd_result.py torch/_functorch/_aot_autograd/runtime_wrappers.py torch/_dynamo/aot_compile_types.py torch/_inductor/standalone_compile.py test/dynamo/test_regional_inductor.py test/test_fx.py test/higher_order_ops/test_invoke_subgraph.py
```

```bash
CUDA_VISIBLE_DEVICES= python test/dynamo/test_regional_inductor.py RegionalInductorPartitionTests.test_parallel_branches_not_fused RegionalInductorPartitionTests.test_parallel_branches_with_gap_same_region RegionalInductorPartitionTests.test_dependent_through_unsupported_gap_not_merged
```

```bash
CUDA_VISIBLE_DEVICES= python - <<'PY'
import weakref
import torch
from torch.fx import GraphModule
from torch.fx.passes.regional_inductor import _boxed_dummy_wrapper

class Holder:
    pass

alive_during_call = []

class CompiledCallable:
    def __call__(self, *args):
        raise AssertionError('expected boxed call')
    def call_boxed(self, args):
        holder_ref = weakref.ref(args[0])
        args.clear()
        alive_during_call.append(holder_ref() is not None)
        return 'ok'

wrapped = _boxed_dummy_wrapper(CompiledCallable())
graph = torch.fx.Graph()
x = graph.placeholder('x')
out = graph.call_function(wrapped, ([x],))
graph.output(out)
gm = GraphModule(torch.nn.Module(), graph)
assert getattr(wrapped, '_boxed_arg_indices', None) == (0,)
assert '_boxed_arg_0 = [x];  x = None' in gm.code
assert gm.forward(Holder()) == 'ok'
assert alive_during_call == [False], alive_during_call
print('boxed_dummy_wrapper smoke: OK')
PY
```

```bash
CUDA_VISIBLE_DEVICES= python - <<'PY'
import weakref
from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer

class Holder:
    pass

alive = []

class BoxedSubgraph:
    _boxed_call = True
    def __call__(self, args):
        holder_ref = weakref.ref(args[0])
        args.clear()
        alive.append(holder_ref() is not None)
        return 'ok'

class CallBoxedSubgraph:
    _boxed_call = True
    def __call__(self, args):
        raise AssertionError('expected call_boxed')
    def call_boxed(self, args):
        holder_ref = weakref.ref(args[0])
        args.clear()
        alive.append(holder_ref() is not None)
        return 'ok'

assert invoke_subgraph_infer(BoxedSubgraph(), Holder()) == 'ok'
assert invoke_subgraph_infer(CallBoxedSubgraph(), Holder()) == 'ok'
assert alive == [False, False], alive
print('invoke_subgraph boxed/call_boxed smoke: OK')
PY
```

Attempted but blocked locally:

```bash
CUDA_VISIBLE_DEVICES= python test/test_fx.py TestFX.test_boxed_dummy_wrapper_codegen_releases_inputs_before_dispatch
```

blocked by missing `/data/users/ivankobzarev/e/pytorch/torch/build/lib/libtorchbind_test.so`.

```bash
CUDA_VISIBLE_DEVICES= python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraph.test_infer_releases_boxed_operands_before_dispatch
```

blocked by missing `parameterized` Python package; no `.venv` was present under the repo or parent.

Authored with assistance from Codex (AI assistant).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98