### PR TITLE
[inductor] Add fuse_region to set fusions,memory reuse boundaries

### DIFF
--- a/test/inductor/test_fuse_regions.py
+++ b/test/inductor/test_fuse_regions.py
@@ -13,6 +13,251 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 
 
 class TestFuseRegions(InductorTestCase):
+    def test_apply_fuse_region_annotations_no_annotations_is_noop(self):
+        from torch._inductor.fx_passes.fuse_regions import apply_fuse_region_annotations
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        sin = graph.call_function(torch.ops.aten.sin.default, (x,))
+        graph.output(sin)
+        gm = GraphModule(torch.nn.Module(), graph)
+        before_nodes = list(gm.graph.nodes)
+
+        apply_fuse_region_annotations(gm.graph)
+
+        self.assertEqual(list(gm.graph.nodes), before_nodes)
+
+    def test_apply_fuse_region_annotations_groups_contiguous_nodes(self):
+        from torch._inductor.fx_passes.fuse_regions import (
+            apply_fuse_region_annotations,
+            FUSE_REGION,
+        )
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        sin = graph.call_function(torch.ops.aten.sin.default, (relu,))
+        cos = graph.call_function(torch.ops.aten.cos.default, (sin,))
+        graph.output(cos)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(4)
+        for node in (x, add, relu, sin, cos):
+            node.meta["val"] = fake
+        for node in (add, relu):
+            node.meta["custom"] = {FUSE_REGION: "region_a"}
+        for node in (sin, cos):
+            node.meta["custom"] = {FUSE_REGION: "region_b"}
+
+        apply_fuse_region_annotations(gm.graph)
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(
+            [node.meta[FUSE_REGION] for node in region_nodes],
+            [
+                "region_a_fwd",
+                "region_b_fwd",
+            ],
+        )
+
+    def test_apply_fuse_region_annotations_is_idempotent(self):
+        from torch._inductor.fx_passes.fuse_regions import (
+            apply_fuse_region_annotations,
+            FUSE_REGION,
+        )
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        graph.output(relu)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(4)
+        for node in (x, add, relu):
+            node.meta["val"] = fake
+        for node in (add, relu):
+            node.meta["custom"] = {FUSE_REGION: "region_a"}
+
+        apply_fuse_region_annotations(gm.graph)
+        apply_fuse_region_annotations(gm.graph)
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(len(region_nodes), 1)
+        self.assertEqual(region_nodes[0].meta[FUSE_REGION], "region_a_fwd")
+
+    def test_apply_fuse_region_annotations_reads_compile_with_inductor_metadata(self):
+        from torch._inductor.fx_passes.fuse_regions import (
+            apply_fuse_region_annotations,
+            FUSE_REGION,
+        )
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        graph.output(relu)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(4)
+        for node in (x, add, relu):
+            node.meta["val"] = fake
+        for node in (add, relu):
+            node.meta["custom"] = {
+                "compile_with_inductor": {FUSE_REGION: "compiled_region"}
+            }
+
+        apply_fuse_region_annotations(gm.graph)
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(len(region_nodes), 1)
+        self.assertEqual(region_nodes[0].meta[FUSE_REGION], "compiled_region_fwd")
+
+    def test_apply_fuse_region_annotations_splits_forward_backward(self):
+        from torch._inductor.fx_passes.fuse_regions import (
+            apply_fuse_region_annotations,
+            FUSE_REGION,
+        )
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        sin = graph.call_function(torch.ops.aten.sin.default, (relu,))
+        cos = graph.call_function(torch.ops.aten.cos.default, (sin,))
+        graph.output(cos)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(4)
+        for node in (x, add, relu, sin, cos):
+            node.meta["val"] = fake
+        for node in (add, relu, sin, cos):
+            node.meta["custom"] = {FUSE_REGION: "shared"}
+        for node in (sin, cos):
+            node.meta["autograd_backward"] = True
+
+        apply_fuse_region_annotations(gm.graph)
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(
+            [node.meta[FUSE_REGION] for node in region_nodes],
+            [
+                "shared_fwd",
+                "shared_bwd",
+            ],
+        )
+
+    def test_apply_fuse_region_annotations_rejects_invalid_annotation(self):
+        from torch._inductor.fx_passes.fuse_regions import (
+            apply_fuse_region_annotations,
+            FUSE_REGION,
+        )
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        graph.output(relu)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(4)
+        for node in (x, add, relu):
+            node.meta["val"] = fake
+        for node in (add, relu):
+            node.meta["custom"] = {FUSE_REGION: 1}
+
+        with self.assertRaisesRegex(AssertionError, "expected custom fuse_region"):
+            apply_fuse_region_annotations(gm.graph)
+
+    def test_post_grad_passes_apply_fuse_region_annotations_by_default(self):
+        from torch._inductor.fx_passes.fuse_regions import FUSE_REGION
+        from torch._inductor.fx_passes.post_grad import post_grad_passes
+        from torch._inductor.virtualized import V
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        sin = graph.call_function(torch.ops.aten.sin.default, (relu,))
+        cos = graph.call_function(torch.ops.aten.cos.default, (sin,))
+        graph.output(cos)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake_mode = FakeTensorMode()
+        fake = fake_mode.from_tensor(torch.empty(4))
+        for node in (x, add, relu, sin, cos):
+            node.meta["val"] = fake
+        for node in (add, relu):
+            node.meta["custom"] = {FUSE_REGION: "region_a"}
+        for node in (sin, cos):
+            node.meta["custom"] = {FUSE_REGION: "region_b"}
+
+        with config.patch(pattern_matcher=False), V.set_fake_mode(fake_mode):
+            post_grad_passes(gm, is_inference=False)
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(
+            [node.meta[FUSE_REGION] for node in region_nodes],
+            [
+                "region_a_fwd",
+                "region_b_fwd",
+            ],
+        )
+
+    def test_fuse_region_annotations_affect_fx_graph_cache_key(self):
+        from torch._inductor.codecache import compiled_fx_graph_hash
+        from torch._inductor.fx_passes.fuse_regions import FUSE_REGION
+
+        def make_gm(annotate: bool):
+            graph = Graph()
+            x = graph.placeholder("x")
+            add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+            relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+            graph.output(relu)
+            gm = GraphModule(torch.nn.Module(), graph)
+            if annotate:
+                for node in (add, relu):
+                    node.meta["custom"] = {FUSE_REGION: "region_a"}
+            return gm
+
+        example_inputs = [torch.empty(4)]
+        unannotated_key, _ = compiled_fx_graph_hash(
+            make_gm(False), example_inputs, {}, []
+        )
+        annotated_key, debug_lines = compiled_fx_graph_hash(
+            make_gm(True), example_inputs, {}, []
+        )
+
+        self.assertNotEqual(unannotated_key, annotated_key)
+        self.assertTrue(any("fuse_region_annotations" in line for line in debug_lines))
+
     def test_mark_fuse_region_preserves_region_id_single_output(self):
         from torch._inductor.fx_passes.fuse_regions import FUSE_REGION, mark_fuse_region
 

--- a/test/inductor/test_fuse_regions.py
+++ b/test/inductor/test_fuse_regions.py
@@ -1,0 +1,294 @@
+# Owner(s): ["module: inductor"]
+
+from operator import getitem
+from types import SimpleNamespace
+
+import torch
+from torch._inductor import config
+from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+from torch.fx import Graph, GraphModule
+from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
+
+
+class TestFuseRegions(InductorTestCase):
+    def test_mark_fuse_region_preserves_region_id_single_output(self):
+        from torch._inductor.fx_passes.fuse_regions import FUSE_REGION, mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        sin = graph.call_function(torch.ops.aten.sin.default, (x,))
+        graph.output(sin)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = torch.empty(4)
+        sin.meta["val"] = torch.empty(4)
+
+        mark_fuse_region(gm.graph, [sin], fuse_region_id="shared")
+
+        region_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        ]
+        self.assertEqual(len(region_nodes), 1)
+        self.assertEqual(region_nodes[0].meta[FUSE_REGION], "shared")
+
+    def test_mark_fuse_region_rejects_invalid_region_id(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        sin = graph.call_function(torch.ops.aten.sin.default, (x,))
+        graph.output(sin)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = torch.empty(4)
+        sin.meta["val"] = torch.empty(4)
+
+        with self.assertRaisesRegex(AssertionError, "None or str"):
+            mark_fuse_region(gm.graph, [sin], fuse_region_id=1)
+
+    def test_mark_fuse_region_rejects_graph_boundaries(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = torch.empty(4)
+
+        with self.assertRaisesRegex(AssertionError, "exclude graph boundaries"):
+            mark_fuse_region(gm.graph, [x])
+
+    @config.patch(reorder_for_locality=False)
+    @requires_gpu()
+    def test_fuse_region_id_allows_separate_islands_to_fuse(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        def fn(x):
+            a = x * 2
+            outside = x + 3
+            b = torch.relu(a)
+            return b, outside
+
+        def add_shared_regions(graph):
+            mul_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mul.Tensor
+            )[0]
+            relu_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.relu.default
+            )[0]
+            mark_fuse_region(graph, [mul_node], fuse_region_id="shared")
+            mark_fuse_region(graph, [relu_node], fuse_region_id="shared")
+            return graph
+
+        def add_unique_regions(graph):
+            mul_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mul.Tensor
+            )[0]
+            relu_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.relu.default
+            )[0]
+            mark_fuse_region(graph, [mul_node], fuse_region_id="mul")
+            mark_fuse_region(graph, [relu_node], fuse_region_id="relu")
+            return graph
+
+        x = torch.rand([256, 256], device=GPU_TYPE)
+
+        torch._dynamo.reset()
+        with config.patch(post_grad_custom_post_pass=add_shared_regions):
+            result, code = run_and_get_code(torch.compile(fn), x)
+        self.assertEqual(result, fn(x))
+        self.assertIn("fused_mul_relu", code[0])
+
+        torch._dynamo.reset()
+        with config.patch(post_grad_custom_post_pass=add_unique_regions):
+            result, code = run_and_get_code(torch.compile(fn), x)
+        self.assertEqual(result, fn(x))
+        self.assertNotIn("fused_mul_relu", code[0])
+        self.assertIn("fused_mul", code[0])
+        self.assertIn("fused_relu", code[0])
+
+    def test_non_adjacent_reuse_respects_fuse_region_config(self):
+        from torch._inductor.codegen.wrapper import AllocateLine
+        from torch._inductor.virtualized import V
+
+        nodes = [
+            SimpleNamespace(region="free"),
+            SimpleNamespace(region="middle"),
+            SimpleNamespace(region="alloc"),
+        ]
+        scheduler = SimpleNamespace(
+            nodes=nodes,
+            get_fuse_region=lambda node: node.region,
+        )
+        graph = SimpleNamespace(scheduler=scheduler)
+        estimate_peak = SimpleNamespace(
+            overall_peak_memory=1024,
+            peak_between=lambda free_line, alloc_line: 0,
+        )
+
+        free_line = SimpleNamespace(scheduler_node_index=0)
+        alloc_line = object.__new__(AllocateLine)
+        alloc_line.comm_buffer = False
+        alloc_line.scheduler_node_index = 2
+        alloc_line.wrapper = SimpleNamespace(estimate_peak=estimate_peak)
+
+        with V.set_graph_handler(graph):
+            self.assertFalse(config.allow_buffer_reuse_across_fuse_regions)
+            self.assertFalse(alloc_line.should_reuse_buffer(free_line, 128))
+
+            with config.patch(allow_buffer_reuse_across_fuse_regions=False):
+                self.assertFalse(alloc_line.should_reuse_buffer(free_line, 128))
+
+            with config.patch(allow_buffer_reuse_across_fuse_regions=True):
+                self.assertTrue(alloc_line.should_reuse_buffer(free_line, 128))
+
+            nodes[2].region = "free"
+            with config.patch(allow_buffer_reuse_across_fuse_regions=False):
+                self.assertTrue(alloc_line.should_reuse_buffer(free_line, 128))
+
+            nodes[1].region = "alloc"
+            adjacent_free_line = SimpleNamespace(scheduler_node_index=1)
+            with config.patch(allow_buffer_reuse_across_fuse_regions=False):
+                self.assertTrue(alloc_line.should_reuse_buffer(adjacent_free_line, 128))
+
+    def test_fuse_region_uses_invoke_subgraph_arg_extraction(self):
+        from torch._inductor.fx_passes.fuse_regions import FUSE_REGION, mark_fuse_region
+        from torch._inductor.fx_utils import _extract_subgraphs_and_args
+
+        def make_region() -> GraphModule:
+            graph = Graph()
+            x = graph.placeholder("x")
+            add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+            mul = graph.call_function(torch.ops.aten.mul.Tensor, (add, 2))
+            graph.output(mul)
+            return GraphModule({}, graph)
+
+        region = make_region()
+        add_node = region.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.add.Tensor
+        )[0]
+        mul_node = region.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.mul.Tensor
+        )[0]
+        placeholder = region.graph.find_nodes(op="placeholder")[0]
+
+        x = torch.empty(1)
+        placeholder.meta["val"] = x
+        add_node.meta["val"] = x
+        mul_node.meta["val"] = x
+
+        mark_fuse_region(region.graph, [add_node, mul_node], fuse_region_id="shared")
+        node = next(
+            node
+            for node in region.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        )
+        subgraph = getattr(region, node.args[0].target)
+        extracted = list(
+            _extract_subgraphs_and_args(
+                node,
+                {subgraph},
+                subgraph,
+                node.args[1],
+                x,
+            )
+        )
+
+        self.assertEqual(len(extracted), 1)
+        self.assertIs(extracted[0][0], subgraph)
+        self.assertIs(extracted[0][1][0], x)
+        self.assertEqual(node.meta[FUSE_REGION], "shared")
+
+    def test_fuse_region_flattens_tuple_boundary_inputs(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        weight = graph.placeholder("weight")
+        bias = graph.placeholder("bias")
+        layer_norm = graph.call_function(
+            torch.ops.aten.native_layer_norm.default,
+            (x, [4], weight, bias, 1e-5),
+        )
+        getitem_0 = graph.call_function(getitem, (layer_norm, 0))
+        graph.output(getitem_0)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(2, 4)
+        x.meta["val"] = fake
+        weight.meta["val"] = torch.empty(4)
+        bias.meta["val"] = torch.empty(4)
+        layer_norm.meta["val"] = (fake, torch.empty(2, 1), torch.empty(2, 1))
+        getitem_0.meta["val"] = fake
+
+        mark_fuse_region(gm.graph, [getitem_0])
+
+        invoke_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.higher_order.invoke_subgraph
+        )
+        self.assertEqual(len(invoke_node.args), 5)
+        self.assertTrue(
+            all(
+                node.op == "call_function" and node.target is getitem
+                for node in invoke_node.args[2:]
+            )
+        )
+
+        subgraph = getattr(gm, invoke_node.args[0].target)
+        self.assertEqual(len(subgraph.graph.find_nodes(op="placeholder")), 3)
+
+    def test_fuse_region_rejects_boundary_cycle(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        mul = graph.call_function(torch.ops.aten.mul.Tensor, (x, 2))
+        add = graph.call_function(torch.ops.aten.add.Tensor, (mul, 3))
+        relu = graph.call_function(torch.ops.aten.relu.default, (add,))
+        graph.output(relu)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        fake = torch.empty(2)
+        x.meta["val"] = fake
+        mul.meta["val"] = fake
+        add.meta["val"] = fake
+        relu.meta["val"] = fake
+
+        with self.assertRaisesRegex(AssertionError, "acyclic"):
+            mark_fuse_region(gm.graph, [mul, relu])
+
+    def test_fuse_region_allows_no_external_outputs(self):
+        from torch._inductor.fx_passes.fuse_regions import mark_fuse_region
+
+        graph = Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        graph.output(x)
+        gm = GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = torch.empty(2, 2)
+        add.meta["val"] = torch.empty(2, 2)
+
+        region_node = mark_fuse_region(gm.graph, [add])
+        gm.recompile()
+
+        self.assertEqual(region_node.meta["val"], ())
+        subgraph = getattr(gm, region_node.args[0].target)
+        output_node = subgraph.graph.find_nodes(op="output")[0]
+        self.assertEqual(output_node.args[0], ())
+        self.assertEqual(gm(torch.ones(2, 2)), torch.ones(2, 2))
+
+
+if __name__ == "__main__":
+    if IS_LINUX:
+        run_tests(needs="filelock")

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1506,6 +1506,14 @@ class FxGraphHashDetails:
                 ):
                     self.cudagraph_annotation = annotation
 
+            from torch._inductor.fx_passes.fuse_regions import (
+                fuse_region_annotations_cache_key,
+            )
+
+            fuse_region_annotations = fuse_region_annotations_cache_key(gm)
+            if fuse_region_annotations:
+                self.fuse_region_annotations = fuse_region_annotations
+
         # Also hash on various system info (including the triton compiler version).
         self.torch_version = torch_key()
         self.system_info = CacheBase.get_system()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -926,6 +926,16 @@ class AllocateLine(MemoryPlanningLine):
             return True
         if free_line.scheduler_node_index + 1 == self.scheduler_node_index:
             return True
+        if not config.allow_buffer_reuse_across_fuse_regions:
+            scheduler = V.graph.scheduler
+            free_region = scheduler.get_fuse_region(
+                scheduler.nodes[free_line.scheduler_node_index]
+            )
+            alloc_region = scheduler.get_fuse_region(
+                scheduler.nodes[self.scheduler_node_index]
+            )
+            if free_region != alloc_region:
+                return False
         overall_peak_memory = self.wrapper.estimate_peak.overall_peak_memory
         peak_memory_in_range = self.wrapper.estimate_peak.peak_between(free_line, self)
         new_peak_memory = size + peak_memory_in_range

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -251,6 +251,9 @@ inplace_buffers = True
 # reuse a buffer for an unrelated purpose
 allow_buffer_reuse = True
 
+# Allow reuse to extend a buffer lifetime across explicit fuse-region boundaries.
+allow_buffer_reuse_across_fuse_regions = False
+
 # Enable pooled allocations for non-output tensors
 memory_planning = os.environ.get("TORCHINDUCTOR_MEMORY_PLANNING", "0") == "1"
 

--- a/torch/_inductor/fx_passes/fuse_regions.py
+++ b/torch/_inductor/fx_passes/fuse_regions.py
@@ -1,0 +1,258 @@
+"""FX helper for carrying Inductor fusion-region boundaries.
+
+``mark_fuse_region`` outlines a set of operation nodes into an
+``invoke_subgraph`` HOP and stores the region id in ``node.meta[FUSE_REGION]``.
+Inductor lowering consumes that metadata, inlines the subgraph, and copies the
+same id onto the generated IR operation annotations. The scheduler then treats
+different ids as fusion and non-adjacent buffer-reuse barriers.
+"""
+
+# mypy: allow-untyped-defs
+from operator import attrgetter, getitem
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.fx._lazy_graph_module import _LazyGraphModule
+from torch.utils._ordered_set import OrderedSet
+
+
+FUSE_REGION = "fuse_region"
+
+
+def _get_subgraph_name(gm: fx.GraphModule, name: str) -> str:
+    i = 0
+    while hasattr(gm, f"{name}_{i}"):
+        i += 1
+    return f"{name}_{i}"
+
+
+def _copy_placeholder_meta(
+    placeholder: fx.Node, input_node: fx.Node, owning_module: fx.GraphModule
+) -> None:
+    if "val" in input_node.meta:
+        placeholder.meta.update(input_node.meta)
+    elif input_node.op == "get_attr" and isinstance(input_node.target, str):
+        placeholder.meta["val"] = attrgetter(input_node.target)(owning_module)
+
+
+def mark_fuse_region(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    fuse_region_id: str | None = None,
+) -> fx.Node | tuple[fx.Node, ...]:
+    """
+    Outline FX nodes into an invoke_subgraph fusion region.
+
+    Inductor lowers the invoke_subgraph inline and annotates the produced IR
+    operations with one fusion-region id. Operations inside the region may fuse
+    with each other, but not with operations outside the region or with another
+    region id.
+    """
+    owning_module = graph.owning_module
+    if owning_module is None:
+        raise AssertionError("expected graph to have an owning_module")
+    if not nodes:
+        raise AssertionError("expected non-empty nodes")
+    if fuse_region_id is not None and not isinstance(fuse_region_id, str):
+        raise AssertionError(
+            f"expected fuse_region_id to be None or str, got {type(fuse_region_id)}"
+        )
+
+    node_set = OrderedSet(nodes)
+    ordered_nodes = [node for node in graph.nodes if node in node_set]
+    if len(ordered_nodes) != len(node_set):
+        raise AssertionError("expected all nodes to belong to graph")
+    if any(node.op in ("placeholder", "output") for node in ordered_nodes):
+        raise AssertionError("expected fuse_region nodes to exclude graph boundaries")
+
+    region_outputs = [
+        node
+        for node in ordered_nodes
+        if any(user not in node_set for user in node.users)
+    ]
+
+    subgraph = fx.Graph(owning_module)
+    env: dict[fx.Node, fx.Node] = {}
+    input_replacements: dict[fx.Node, Any] = {}
+    boundary_args: list[tuple[fx.Node, tuple[int, ...], Any]] = []
+
+    external_inputs: OrderedSet[fx.Node] = OrderedSet()
+    preserved_getattrs: OrderedSet[fx.Node] = OrderedSet()
+
+    def collect_external_input(node: fx.Node) -> fx.Node:
+        if node not in node_set:
+            if (
+                node.op == "get_attr"
+                and isinstance(node.target, str)
+                and isinstance(attrgetter(node.target)(owning_module), fx.GraphModule)
+            ):
+                preserved_getattrs.add(node)
+            else:
+                external_inputs.add(node)
+        return node
+
+    for node in ordered_nodes:
+        fx.map_arg((node.args, node.kwargs), collect_external_input)
+
+    node_order = {node: idx for idx, node in enumerate(graph.nodes)}
+    latest_input = max(
+        external_inputs,
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    first_external_user = min(
+        (
+            user
+            for output_node in region_outputs
+            for user in output_node.users
+            if user not in node_set
+        ),
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    if (
+        first_external_user is not None
+        and latest_input is not None
+        and node_order[latest_input] >= node_order[first_external_user]
+    ):
+        raise AssertionError("expected fuse_region boundary to be acyclic")
+
+    def add_boundary_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        placeholder = subgraph.placeholder(f"arg_{len(boundary_args)}")
+        _copy_placeholder_meta(placeholder, input_node, owning_module)
+        if path:
+            placeholder.meta["val"] = meta_val
+        boundary_args.append((input_node, path, meta_val))
+        return placeholder
+
+    def make_input_replacement(
+        input_node: fx.Node, value: Any, path: tuple[int, ...] = ()
+    ) -> Any:
+        if isinstance(value, (tuple, list)):
+            return type(value)(
+                make_input_replacement(input_node, item, (*path, idx))
+                for idx, item in enumerate(value)
+            )
+        return add_boundary_arg(input_node, path, value)
+
+    for input_node in external_inputs:
+        value = input_node.meta.get("val")
+        if isinstance(value, (tuple, list)):
+            input_replacements[input_node] = make_input_replacement(input_node, value)
+        else:
+            input_replacements[input_node] = add_boundary_arg(input_node, (), value)
+
+    def load_arg(node: fx.Node) -> Any:
+        if node in env:
+            return env[node]
+        if node in node_set:
+            raise AssertionError("expected fuse_region nodes to be topological")
+        if node in preserved_getattrs:
+            if not isinstance(node.target, str):
+                raise AssertionError("expected get_attr target to be a string")
+            get_attr_node = subgraph.get_attr(node.target)
+            get_attr_node.meta.update(node.meta)
+            env[node] = get_attr_node
+            return get_attr_node
+        return input_replacements[node]
+
+    for node in ordered_nodes:
+        env[node] = subgraph.node_copy(node, load_arg)
+
+    subgraph_outputs = tuple(env[node] for node in region_outputs)
+    if len(subgraph_outputs) == 0:
+        out = subgraph.output(())
+        out.meta["val"] = ()
+    elif len(subgraph_outputs) == 1:
+        out = subgraph.output(subgraph_outputs[0])
+        if "val" in region_outputs[0].meta:
+            out.meta["val"] = region_outputs[0].meta["val"]
+    else:
+        out = subgraph.output(subgraph_outputs)
+        out.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+    subgraph.lint()
+
+    subgraph_module = _LazyGraphModule(owning_module, subgraph)
+    region_name = f"fuse_region_{ordered_nodes[0].name}_{ordered_nodes[-1].name}"
+    subgraph_attr_name = _get_subgraph_name(owning_module, region_name)
+    setattr(owning_module, subgraph_attr_name, subgraph_module)
+
+    if latest_input is None or node_order[latest_input] < node_order[ordered_nodes[0]]:
+        with graph.inserting_before(ordered_nodes[0]):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+    else:
+        with graph.inserting_after(latest_input):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+
+    outer_args: list[fx.Node] = []
+    insert_after = get_subgraph
+
+    def make_outer_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        nonlocal insert_after
+        source = input_node
+        for idx in path:
+            with graph.inserting_after(insert_after):
+                source = graph.call_function(
+                    getitem,
+                    args=(source, idx),
+                    name=f"{input_node.name}_fuse_region_arg_{len(outer_args)}",
+                )
+            insert_after = source
+        if path:
+            source.meta["val"] = meta_val
+        return source
+
+    for input_node, path, meta_val in boundary_args:
+        outer_args.append(make_outer_arg(input_node, path, meta_val))
+
+    with graph.inserting_after(insert_after):
+        region_node = graph.call_function(
+            torch.ops.higher_order.invoke_subgraph,
+            args=(get_subgraph, subgraph_attr_name, *outer_args),
+            name=region_name,
+        )
+
+    replacements: list[fx.Node] = []
+    if len(region_outputs) == 0:
+        region_node.meta["val"] = ()
+    elif len(region_outputs) == 1:
+        replacement = region_node
+        replacement.meta = region_outputs[0].meta.copy()
+        replacement.meta.pop("eager_input_vals", None)
+        replacements.append(replacement)
+    else:
+        region_node.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+        insert_after = region_node
+        for idx, output_node in enumerate(region_outputs):
+            with graph.inserting_after(insert_after):
+                replacement = graph.call_function(
+                    getitem,
+                    args=(region_node, idx),
+                    name=f"{output_node.name}_fuse_region",
+                )
+            replacement.meta = output_node.meta.copy()
+            replacement.meta.pop("eager_input_vals", None)
+            replacements.append(replacement)
+            insert_after = replacement
+
+    for output_node, replacement in zip(region_outputs, replacements, strict=True):
+        for user in list(output_node.users):
+            if user not in node_set:
+                user.replace_input_with(output_node, replacement)
+
+    for node in reversed(ordered_nodes):
+        graph.erase_node(node)
+    graph.lint()
+
+    region_node.meta[FUSE_REGION] = (
+        region_name if fuse_region_id is None else fuse_region_id
+    )
+
+    if not replacements:
+        return region_node
+    return replacements[0] if len(replacements) == 1 else tuple(replacements)

--- a/torch/_inductor/fx_passes/fuse_regions.py
+++ b/torch/_inductor/fx_passes/fuse_regions.py
@@ -36,6 +36,145 @@ def _copy_placeholder_meta(
         placeholder.meta["val"] = attrgetter(input_node.target)(owning_module)
 
 
+def _getattr_or_none(module: fx.GraphModule, target: str) -> Any:
+    try:
+        return attrgetter(target)(module)
+    except AttributeError:
+        return None
+
+
+def _has_graph_module_arg(node: fx.Node) -> bool:
+    gm = node.graph.owning_module
+    if gm is None:
+        return False
+    return any(
+        inp.op == "get_attr"
+        and isinstance(inp.target, str)
+        and isinstance(_getattr_or_none(gm, inp.target), fx.GraphModule)
+        for inp in node.all_input_nodes
+    )
+
+
+def fuse_region_key(node: fx.Node) -> str | None:
+    if node.op in ("placeholder", "output", "get_attr"):
+        return None
+    if node.op == "call_function" and isinstance(
+        node.target, torch._ops.HigherOrderOperator
+    ):
+        return None
+    if _has_graph_module_arg(node):
+        return None
+
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return None
+    region = _fuse_region_from_custom(custom)
+    if region is None:
+        return None
+    phase = "bwd" if node.meta.get("autograd_backward") is True else "fwd"
+    return f"{region}_{phase}"
+
+
+def _fuse_region_from_custom(custom: dict[str, Any]) -> str | None:
+    region = custom.get(FUSE_REGION)
+    if region is not None:
+        if not isinstance(region, str):
+            raise AssertionError(
+                f"expected custom {FUSE_REGION} to be a str, got {type(region)}"
+            )
+        return region
+
+    compile_with_inductor = custom.get("compile_with_inductor")
+    if isinstance(compile_with_inductor, dict):
+        region = compile_with_inductor.get(FUSE_REGION)
+        if region is not None:
+            if not isinstance(region, str):
+                raise AssertionError(
+                    f"expected custom compile_with_inductor {FUSE_REGION} "
+                    f"to be a str, got {type(region)}"
+                )
+            return region
+    return None
+
+
+def _strip_fuse_region_from_meta(meta: dict[str, Any]) -> None:
+    custom = meta.get("custom")
+    if not isinstance(custom, dict):
+        return
+
+    custom = custom.copy()
+    custom.pop(FUSE_REGION, None)
+    compile_with_inductor = custom.get("compile_with_inductor")
+    if isinstance(compile_with_inductor, dict):
+        compile_with_inductor = compile_with_inductor.copy()
+        compile_with_inductor.pop(FUSE_REGION, None)
+        custom["compile_with_inductor"] = compile_with_inductor
+
+    if custom:
+        meta["custom"] = custom
+    else:
+        meta.pop("custom", None)
+
+
+def collect_fuse_region_groups(graph: fx.Graph) -> list[tuple[str, list[fx.Node]]]:
+    groups: list[tuple[str, list[fx.Node]]] = []
+    current_key: str | None = None
+    current_nodes: list[fx.Node] = []
+
+    def flush() -> None:
+        nonlocal current_key, current_nodes
+        if current_key is not None and len(current_nodes) > 1:
+            groups.append((current_key, current_nodes))
+        current_key = None
+        current_nodes = []
+
+    for node in list(graph.nodes):
+        key = fuse_region_key(node)
+        if key is None:
+            flush()
+            continue
+        if key != current_key:
+            flush()
+            current_key = key
+        current_nodes.append(node)
+    flush()
+    return groups
+
+
+def fuse_region_annotations_cache_key(
+    gm: fx.GraphModule,
+) -> tuple[tuple[str, tuple[tuple[str, tuple[str, ...]], ...]], ...]:
+    entries = []
+    for module_name, module in gm.named_modules():
+        if not isinstance(module, fx.GraphModule):
+            continue
+        groups = collect_fuse_region_groups(module.graph)
+        if groups:
+            group_entries = tuple(
+                (key, tuple(node.name for node in nodes)) for key, nodes in groups
+            )
+            entries.append((module_name, group_entries))
+    return tuple(entries)
+
+
+def apply_fuse_region_annotations(graph: fx.Graph) -> None:
+    """
+    Outline contiguous FX nodes annotated with ``node.meta["custom"][FUSE_REGION]``.
+
+    ``torch.fx.traceback.annotate`` stores user metadata in ``node.meta["custom"]``.
+    This pass consumes string-valued ``FUSE_REGION`` annotations from that dict,
+    or from the nested ``compile_with_inductor`` annotation used by
+    regional_inductor callers, and turns each contiguous same-id run into one
+    invoke_subgraph fuse region.
+    """
+    groups = collect_fuse_region_groups(graph)
+    if not groups:
+        return
+    for key, nodes in groups:
+        mark_fuse_region(graph, nodes, fuse_region_id=key)
+    graph.lint()
+
+
 def mark_fuse_region(
     graph: fx.Graph,
     nodes: list[fx.Node],
@@ -224,6 +363,7 @@ def mark_fuse_region(
         replacement = region_node
         replacement.meta = region_outputs[0].meta.copy()
         replacement.meta.pop("eager_input_vals", None)
+        _strip_fuse_region_from_meta(replacement.meta)
         replacements.append(replacement)
     else:
         region_node.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
@@ -237,6 +377,7 @@ def mark_fuse_region(
                 )
             replacement.meta = output_node.meta.copy()
             replacement.meta.pop("eager_input_vals", None)
+            _strip_fuse_region_from_meta(replacement.meta)
             replacements.append(replacement)
             insert_after = replacement
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -62,6 +62,7 @@ from ..virtualized import V
 from .b2b_gemm import B2B_GEMM_PASS
 from .control_dependencies import control_deps, preserve_node_ordering
 from .ddp_fusion import fuse_ddp_communication
+from .fuse_regions import apply_fuse_region_annotations
 from .group_batch_fusion import group_batch_fusion_passes, POST_GRAD_FUSIONS
 from .micro_pipeline_tp import micro_pipeline_tp_pass
 from .pre_grad import is_same_dict, save_inductor_dict
@@ -260,6 +261,10 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         GraphTransformObserver(gm, "post_grad_custom_post_pass").apply_graph_pass(
             post_grad_custom_post_pass
         )
+
+    GraphTransformObserver(gm, "apply_fuse_region_annotations").apply_graph_pass(
+        apply_fuse_region_annotations
+    )
 
     if config.fallback_random:
         GraphTransformObserver(gm, "chain_random_ops_ordering").apply_graph_pass(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -71,6 +71,7 @@ from torch.utils._sympy.functions import (
 from .._dynamo.utils import import_submodule
 from . import config, inductor_prims, ir, test_operators  # NOQA: F401
 from .decomposition import decompositions, get_decompositions
+from .fx_passes.fuse_regions import FUSE_REGION
 from .ir import (
     BaseView,
     DtypeView,
@@ -8834,6 +8835,39 @@ register_lowering(
 
 @register_lowering(torch.ops.higher_order.invoke_subgraph, type_promotion_kind=None)
 def invoke_subgraph(subgraph_fn: ir.Subgraph, identifier: str, *operands):
+    region = V.graph.current_node.meta.get(FUSE_REGION)
+    if region is not None:
+        if not isinstance(region, str):
+            raise AssertionError(f"expected fuse_region to be str, got {region}")
+
+        # Boundary inputs must be materialized before operation_len so their
+        # producer ops stay outside the annotated region.
+        for operand in operands:
+            operand_ir_nodes = [
+                operand_leaf
+                for operand_leaf in pytree.tree_leaves(operand)
+                if isinstance(operand_leaf, IRNode)
+            ]
+            for operand_ir_node in operand_ir_nodes:
+                operand_ir_node.realize()
+
+        operation_len = len(V.graph.operations)
+        placeholders = subgraph_fn.graph_module.graph.find_nodes(op="placeholder")
+        if len(placeholders) != len(operands):
+            raise AssertionError("expected placeholder count to match operands")
+
+        output = process_subgraph_nodes(subgraph_fn.graph_module, list(operands))
+        for op in V.graph.operations[operation_len:]:
+            if not hasattr(op, "annotations"):
+                continue
+            existing_region = op.annotations.get(FUSE_REGION)
+            if existing_region is not None and existing_region != region:
+                raise AssertionError(
+                    f"expected one fuse_region per op, got {existing_region} and {region}"
+                )
+            op.annotations[FUSE_REGION] = region
+        return output
+
     result = ir.InvokeSubgraph.create(subgraph_fn, *operands)
     return list(map(TensorBox.create, result))  # type: ignore[call-overload]
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -70,6 +70,7 @@ from .comm_analysis import (
 )
 from .dependencies import Dep, MemoryDep, StarDep, WeakDep
 from .exc import GPUTooOldForTriton, TritonMissing
+from .fx_passes.fuse_regions import FUSE_REGION
 from .fx_utils import count_flops_fx
 from .ir import (
     assign_origin_node,
@@ -3756,6 +3757,9 @@ def pick_loop_order(
 def _replace_operation_buffer(
     orig_node: ir.MultiTemplateBuffer, new_node: ir.OperationBuffer
 ) -> None:
+    if FUSE_REGION in orig_node.annotations:
+        new_node.annotations[FUSE_REGION] = orig_node.annotations[FUSE_REGION]
+
     replaced_buf_name = new_node.get_name()
     orig_buf_name = orig_node.get_name()
     if not (isinstance(orig_buf_name, str) and isinstance(replaced_buf_name, str)):
@@ -4489,6 +4493,36 @@ class Scheduler:
         else:
             raise NotImplementedError(node)
 
+    @staticmethod
+    def get_fuse_region(
+        node: BaseSchedulerNode,
+    ) -> str | None:
+        region: str | None = None
+        seen_region = False
+        for snode in node.get_nodes():
+            op = snode.node
+            if op is None or not hasattr(op, "annotations"):
+                continue
+            op_region = op.annotations.get(FUSE_REGION)
+            if op_region is not None and not isinstance(op_region, str):
+                raise AssertionError(f"expected fuse_region to be str, got {op_region}")
+            if seen_region and region != op_region:
+                raise AssertionError(
+                    f"expected one fuse_region per scheduler node, got {region} and {op_region}"
+                )
+            region = op_region
+            seen_region = True
+        return region
+
+    def _group_by_fuse_region(
+        self,
+        nodes: list[BaseSchedulerNode],
+    ) -> list[list[BaseSchedulerNode]]:
+        groups: dict[str | None, list[BaseSchedulerNode]] = defaultdict(list)
+        for node in nodes:
+            groups[self.get_fuse_region(node)].append(node)
+        return list(groups.values())
+
     def create_foreach_nodes(self) -> None:
         removed_node_names: OrderedSet[str] = OrderedSet()
         fe_nodes = []
@@ -4505,21 +4539,32 @@ class Scheduler:
                 # All nodes eliminated
                 continue
 
-            removed_node_names.update(names)
-            snodes = [self.name_to_node[name] for name in names]
-
-            enable_autotune = config.combo_kernels_autotune > 1
-            fe_node = ForeachKernelSchedulerNode(
-                self,
-                snodes,
-                use_custom_partition_algo=False,
-                enable_autotune=enable_autotune,
-            )
-
-            fe_nodes.append(fe_node)
-
+            name_groups: dict[str | None, list[str]] = defaultdict(list)
             for name in names:
-                self.name_to_fused_node[name] = fe_node
+                name_groups[self.get_fuse_region(self.name_to_node[name])].append(name)
+
+            foreach_name_groups = (
+                [names] if len(name_groups) == 1 else list(name_groups.values())
+            )
+            for name_group in foreach_name_groups:
+                if len(name_group) < 2 and len(name_groups) != 1:
+                    continue
+
+                removed_node_names.update(name_group)
+                snodes = [self.name_to_node[name] for name in name_group]
+
+                enable_autotune = config.combo_kernels_autotune > 1
+                fe_node = ForeachKernelSchedulerNode(
+                    self,
+                    snodes,
+                    use_custom_partition_algo=False,
+                    enable_autotune=enable_autotune,
+                )
+
+                fe_nodes.append(fe_node)
+
+                for name in name_group:
+                    self.name_to_fused_node[name] = fe_node
 
         self.nodes = [
             node for node in self.nodes if node.get_name() not in removed_node_names
@@ -6367,34 +6412,39 @@ class Scheduler:
             if len(members) < 2:
                 continue
 
-            for window in Scheduler._distance_windows(
-                members, node_to_idx, max_distance
-            ):
+            for member_group in self._group_by_fuse_region(members):
                 if num_ck_nodes is not None and count > num_ck_nodes:
                     break
-                if len(window) < 2 or not self.speedup_by_combo_kernel(window):
-                    continue
-                if memory_check:
-                    if mem_ctx is None:
-                        raise AssertionError("expected mem_ctx to be set")
-                    sim_start = time.perf_counter()
-                    self._try_combo_with_halving(
-                        window,
-                        num,
-                        mem_ctx,
-                        enable_autotune=enable_autotune,
-                        on_accept=_register_accept,
-                    )
-                    memory_sim_time += time.perf_counter() - sim_start
-                else:
-                    combo_node = ForeachKernelSchedulerNode(
-                        window[0].scheduler,
-                        window,
-                        use_custom_partition_algo=True,
-                        enable_autotune=enable_autotune,
-                        per_subkernel_blocks=config.combo_kernel_per_subkernel_blocks,
-                    )
-                    _register_accept(combo_node, window, num)
+                for window in Scheduler._distance_windows(
+                    member_group, node_to_idx, max_distance
+                ):
+                    if num_ck_nodes is not None and count > num_ck_nodes:
+                        break
+                    if len(window) < 2 or not self.speedup_by_combo_kernel(window):
+                        continue
+                    if memory_check:
+                        if mem_ctx is None:
+                            raise AssertionError("expected mem_ctx to be set")
+                        sim_start = time.perf_counter()
+                        self._try_combo_with_halving(
+                            window,
+                            num,
+                            mem_ctx,
+                            enable_autotune=enable_autotune,
+                            on_accept=_register_accept,
+                        )
+                        memory_sim_time += time.perf_counter() - sim_start
+                    else:
+                        combo_node = ForeachKernelSchedulerNode(
+                            window[0].scheduler,
+                            window,
+                            use_custom_partition_algo=True,
+                            enable_autotune=enable_autotune,
+                            per_subkernel_blocks=(
+                                config.combo_kernel_per_subkernel_blocks
+                            ),
+                        )
+                        _register_accept(combo_node, window, num)
 
         self.nodes = sorted(fused_nodes, key=lambda x: x.min_order)
         self.nodes = self.topological_sort_schedule(self.nodes)
@@ -7626,6 +7676,13 @@ class Scheduler:
             if stream1 is not None and stream2 is not None and stream1 != stream2:
                 return False
 
+        why = WhyNoFuse(node1, node2)
+        region1 = self.get_fuse_region(node1)
+        region2 = self.get_fuse_region(node2)
+        if region1 != region2:
+            why("fuse_region mismatch (%s vs %s)", region1, region2)
+            return False
+
         if isinstance(node1, FusedNestedReductions):
             return node1.can_fuse_with(node2, can_reorder=can_reorder)
         if isinstance(node2, FusedNestedReductions):
@@ -7637,8 +7694,6 @@ class Scheduler:
             # We don't fuse something before a FusedMixOrderReductions
             # right now
             return False
-
-        why = WhyNoFuse(node1, node2)
 
         if node1.is_template() and self.get_backend(
             node1.get_device()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187846
* #187845
* #187844
* #187843
* #187842
* #187841
* #187840
* #187839
* __->__ #187675

GraphTrainer full-Inductor needs outlined source regions to stay separated through lowering, scheduling, and memory planning. The earlier prototype carried this through control_deps, but that conflated ordering with fusion isolation. This commit keeps control_deps as an ordering-only HOP and adds a dedicated fuse-region helper instead.

mark_fuse_region now outlines selected FX nodes into an invoke_subgraph call. The invoke_subgraph lowering recognizes the fuse-region metadata, realizes boundary operands before entering the region, inline-lowers the subgraph, and annotates the newly produced Inductor IR operations with the region id. The helper flattens tuple/list boundary values into valid invoke_subgraph operands and validates the region id and graph boundary.

The scheduler and memory-planning pieces enforce the barrier after lowering: different fuse regions do not fuse together, foreach/combo-kernel grouping respects region ids, and non-adjacent buffer reuse does not extend lifetimes across fuse-region boundaries by default.

Test Plan:

```bash
lintrunner -a
```

```bash
python -m py_compile test/inductor/test_fuse_regions.py torch/_inductor/fx_passes/fuse_regions.py torch/_higher_order_ops/invoke_subgraph.py
```

```bash
CUDA_VISIBLE_DEVICES= python test/inductor/test_fuse_regions.py
```

Authored with assistance from Codex (AI assistant).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo