### PR TITLE
[MTIA][PyTorch Tests] Add MTIA branch to _has_sufficient_memory (@largeTensorTest) (#187676)

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1512,7 +1512,7 @@ class skipPRIVATEUSE1If(skipIf):
 def _has_sufficient_memory(device, size):
     device_ = torch.device(device)
     device_type = device_.type
-    if device_type in ["cuda", "xpu"]:
+    if device_type in ["cuda", "xpu", "mtia"]:
         acc = torch.accelerator.current_accelerator()
         # Case 1: no accelerator found
         if not acc:
@@ -1538,6 +1538,11 @@ def _has_sufficient_memory(device, size):
 
         if device_type == "xpu":
             return torch.xpu.memory.mem_get_info(device_)[0] >= size
+
+        if device_type == "mtia":
+            # MTIA has no mem_get_info; the dram stats dict exposes free_bytes
+            # (see torch/csrc bindings / mtia_hooks.cpp).
+            return torch.mtia.memory_stats(device_)["dram"]["free_bytes"] >= size
 
     if device_type == "xla":
         raise unittest.SkipTest("TODO: Memory availability checks for XLA?")


### PR DESCRIPTION
Summary:

`largeTensorTest`-decorated tests skip at runtime on MTIA with `unittest.SkipTest("Unknown device type")` because `_has_sufficient_memory()` in `common_device_type.py` has no MTIA branch.

Reviewed By: egienvalue, danielhou0515

Differential Revision: D108792483


