### PR TITLE
Revert PR 179286

### DIFF
--- a/aten/src/ATen/DeviceAccelerator.h
+++ b/aten/src/ATen/DeviceAccelerator.h
@@ -37,8 +37,12 @@ inline bool isAcceleratorExcluded(
     c10::DeviceType device_type,
     c10::DeviceType first_excluded,
     T... rest_excluded) {
-  return isAccelerator(device_type) && (device_type != first_excluded) &&
-      ((device_type != rest_excluded) && ...);
+  if constexpr (sizeof...(rest_excluded) > 0) {
+    return device_type != first_excluded &&
+        isAcceleratorExcluded(device_type, rest_excluded...);
+  } else {
+    return device_type != first_excluded && isAccelerator(device_type);
+  }
 }
 
 // Return the number of the device available. Note that this is *REQUIRED* to

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -22,12 +22,12 @@ namespace at {
 // (uselessly) convert to floating point and then do the test.
 // This function is.
 
-template <std::integral T>
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T /*val*/) {
   return false;
 }
 
-template <std::floating_point T>
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return ::isnan(val);

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -9,7 +9,6 @@
 #include <c10/util/MathConstants.h>
 #include <cfloat>
 #include <cmath>
-#include <concepts>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
@@ -148,8 +147,9 @@ jiterator_also_stringify_as(jiterator_code(
 
 #define CENTRAL_RANGE 0.7
 
-template <std::floating_point T>
-inline T calc_erfinv(T y) {
+template <typename T>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+calc_erfinv(T y) {
 /* Function to calculate inverse error function.  Rational approximation
 is used to generate an initial approximation, which is then improved to
 full accuracy by two steps of Newton's method.  Code is a direct
@@ -1242,8 +1242,9 @@ template <>
   return v;
 }
 
-template <std::integral T>
-inline T calc_gcd(T a, T b) {
+template <typename T>
+inline typename std::enable_if_t<std::is_integral_v<T>, T>
+calc_gcd(T a, T b) {
   a = abs_impl(a);
   b = abs_impl(b);
   while (a != 0) {
@@ -1290,8 +1291,9 @@ C10_HOST_DEVICE c10::complex<T> exp2_impl(c10::complex<T> x) {
  * If the coefficients are for the inverted interval, in which (a, b) is mapped to (1/b, 1/a), the transformation
  * required is x -> 2(2ab/x - b - a)/(b-a).  If b is infinity, this becomes x -> 4a/x - 1.
  */
-template <std::floating_point T>
-inline T chbevl(const T x, const T array[], size_t len) {
+template <typename T>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+chbevl(const T x, const T array[], size_t len) {
   T b0, b1, b2 = static_cast<T>(0.0);
 
   b0 = array[0];
@@ -1468,8 +1470,9 @@ chebyshev_coefficients_i1e_B() {
   return std::make_tuple(coeff, 7);
 }
 
-template <std::floating_point T>
-inline T calc_i0(T _x) {
+template <typename T>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+calc_i0(T _x) {
   T x = std::abs(_x);
 
   if (x <= T{8.0}) {
@@ -1494,8 +1497,9 @@ inline c10::Half calc_i0(c10::Half a) { return calc_i0(static_cast<float>(a)); }
  * One approximates the function over [0, 8], and the other over (8, infinity). This function takes the absolute value
  * of all inputs to convert them into the domain of the approximation.
  */
-template <std::floating_point T>
-inline T calc_i1(T _x) {
+template <typename T>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+calc_i1(T _x) {
   T x = std::abs(_x);
 
   if (x <= T{8.0}) {
@@ -1523,8 +1527,9 @@ inline c10::Half calc_i1(c10::Half a) { return calc_i1(static_cast<float>(a)); }
  * One approximates the function over [0, 8], and the other over (8, infinity). This function takes the absolute value
  * of all inputs to convert them into the domain of the approximation.
  */
-template <std::floating_point T>
-inline T calc_i1e(T _x) {
+template <typename T>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+calc_i1e(T _x) {
   T x = std::abs(_x);
 
   if (x <= T{8.0}) {
@@ -1738,8 +1743,9 @@ inline C10_HOST_DEVICE T calc_ndtri(T y0) {
    compared to fitting the whole [0,1] interval with a single polynomial. */
 
 
-template <std::floating_point T>
-C10_HOST_DEVICE inline T erfcx_y100(T y100)
+template <typename T>
+C10_HOST_DEVICE  inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+erfcx_y100(T y100)
 {
   switch (static_cast<int>(y100)) {
 case 0: {
@@ -2148,8 +2154,9 @@ return 0.97771701335885035464e0 + (0.22000938572830479551e-1 + (0.27951610702682
   return 1.0;
 }
 
-template <std::floating_point T>
-C10_HOST_DEVICE inline T calc_erfcx(T x)
+template <typename T>
+C10_HOST_DEVICE inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
+calc_erfcx(T x)
 {
   if (at::_isnan(x)) {
     return x;

--- a/aten/src/ATen/test/rng_test.h
+++ b/aten/src/ATen/test/rng_test.h
@@ -6,48 +6,55 @@
 #include <optional>
 #include <torch/all.h>
 #include <stdexcept>
-#include <concepts>
 
 namespace {
 
 constexpr auto int64_min_val = std::numeric_limits<int64_t>::lowest();
 constexpr auto int64_max_val = std::numeric_limits<int64_t>::max();
-template <std::floating_point T>
+template <typename T,
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _min_val() {
   return int64_min_val;
 }
 
-template <std::integral T>
+template <typename T,
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _min_val() {
   return static_cast<int64_t>(std::numeric_limits<T>::lowest());
 }
 
-template <std::floating_point T>
+template <typename T,
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _min_from() {
   return -(static_cast<int64_t>(1) << std::numeric_limits<T>::digits);
 }
 
-template <std::integral T>
+template <typename T,
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _min_from() {
   return _min_val<T>();
 }
 
-template <std::floating_point T>
+template <typename T,
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _max_val() {
   return int64_max_val;
 }
 
-template <std::integral T>
+template <typename T,
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _max_val() {
   return static_cast<int64_t>(std::numeric_limits<T>::max());
 }
 
-template <std::floating_point T>
+template <typename T,
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _max_to() {
   return static_cast<int64_t>(1) << std::numeric_limits<T>::digits;
 }
 
-template <std::integral T>
+template <typename T,
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _max_to() {
   return _max_val<T>();
 }

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -76,7 +76,6 @@ C10_DIAGNOSTIC_POP()
 
 #include <torch/csrc/jit/jit_log.h>
 
-#include <concepts>
 #include <memory>
 
 using namespace torch::jit::tensorexpr;
@@ -1084,13 +1083,17 @@ void LLVMCodeGenImpl::visit(const CompareSelectPtr& v) {
   value_ = v->bias() == kUnbiased ? genUnbiased() : genBiased();
 }
 
-template <std::integral T>
-llvm::Value* getFromType(llvm::Type* type, T value) {
+template <typename T>
+std::enable_if_t<std::is_integral_v<T>, llvm::Value*> getFromType(
+    llvm::Type* type,
+    T value) {
   return llvm::ConstantInt::get(type, value, std::is_signed_v<T>);
 }
 
-template <std::floating_point T>
-llvm::Value* getFromType(llvm::Type* type, T value) {
+template <typename T>
+std::enable_if_t<std::is_floating_point_v<T>, llvm::Value*> getFromType(
+    llvm::Type* type,
+    T value) {
   return llvm::ConstantFP::get(type, value);
 }
 
@@ -1970,7 +1973,7 @@ static bool wantSleef(const std::string& name) {
       "fabsf",
       "floorf",
   };
-  return !noSleef.contains(name);
+  return noSleef.find(name) == noSleef.end();
 }
 
 LLVMCodeGenImpl::SimdCallee LLVMCodeGenImpl::getSimdFunction(


### PR DESCRIPTION
Summary:
This diff reverts [PR 179286](https://github.com/pytorch/pytorch/pull/179286?) which breaks overall 2000 ExecuTorch cis. The reason is ExecuTorch relys on c++17 standard and relys on pytorch/pytorch as well.

example failure:

 ```
BUILD FAILED: cortex_m/ops:op_quantized_conv2d (cfg: embedded-arm32-embedded-no-san)
```

Depends on D108538984

Test Plan: NA

Differential Revision: D109036014




cc @EikanWang @jgong5