### PR TITLE
Fix Inductor memory planning for reused output aliases

### DIFF
--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import unittest
+from types import SimpleNamespace
 
 from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
@@ -37,6 +38,70 @@ except ImportError:
     from test_aot_inductor import (  # @manual=fbcode//caffe2/test/inductor:test_aot_inductor-library
         AOTIRunnerUtil,
     )
+
+
+class TestMemoryPlanningOutputGroups(TestCase):
+    class FakeBuffer:
+        def __init__(self, name):
+            self._name = name
+
+        def get_name(self):
+            return self._name
+
+    class FakeOutputNode:
+        def get_name(self):
+            return "OUTPUT"
+
+    @staticmethod
+    def make_line(cls, *args):
+        line = object.__new__(cls)
+        line.wrapper = None
+        if cls.__name__ == "AllocateLine":
+            (line.node,) = args
+            line.comm_buffer = False
+        else:
+            line.node, line.reused_as = args
+            line.delete_old = True
+            line.comm_buffer = False
+        return line
+
+    def compute_single_group(self, *, graph_outputs=(), scheduler_buffers=None):
+        from torch._inductor.codegen.memory_planning import MemoryPlanner
+        from torch._inductor.codegen.wrapper import AllocateLine, ReuseLine
+        from torch._inductor.virtualized import V
+
+        old = self.FakeBuffer("buf16")
+        alias = self.FakeBuffer("buf48")
+        fake_graph = SimpleNamespace(
+            get_output_names=lambda: list(graph_outputs),
+            scheduler=SimpleNamespace(name_to_buf=scheduler_buffers or {}),
+        )
+
+        planner = MemoryPlanner(wrapper=None)
+        lines = [
+            self.make_line(AllocateLine, old),
+            self.make_line(ReuseLine, old, alias),
+        ]
+        with V.set_graph_handler(fake_graph):
+            planner.compute_buffer_groups(lines)
+
+        self.assertEqual(len(planner.buffer_groups), 1)
+        return planner.buffer_groups[0]
+
+    def test_reused_graph_output_group_is_output(self):
+        group = self.compute_single_group(graph_outputs=("buf48",))
+        self.assertEqual(group.names, ["buf16", "buf48"])
+        self.assertTrue(group.is_output)
+
+    def test_reused_scheduler_output_user_group_is_output(self):
+        scheduler_buffers = {
+            "buf48": SimpleNamespace(
+                users=[SimpleNamespace(node=self.FakeOutputNode())],
+            )
+        }
+        group = self.compute_single_group(scheduler_buffers=scheduler_buffers)
+        self.assertEqual(group.names, ["buf16", "buf48"])
+        self.assertTrue(group.is_output)
 
 
 @requires_gpu()

--- a/torch/_inductor/codegen/memory_planning.py
+++ b/torch/_inductor/codegen/memory_planning.py
@@ -718,7 +718,11 @@ class MemoryPlanner:
         outputs = OrderedSet(V.graph.get_output_names())
         unique_groups = [*{id(g): g for g in name_to_group.values()}.values()]
         for group in unique_groups:
-            group.is_output = any(x in outputs for x in group.names)
+            group.is_output = any(x in outputs for x in group.names) or any(
+                any(user.node.get_name() == "OUTPUT" for user in buf.users)
+                for name in group.names
+                if (buf := V.graph.scheduler.name_to_buf.get(name)) is not None
+            )
 
         if self.buffer_groups is not None:
             raise AssertionError("buffer_groups already computed")


### PR DESCRIPTION
Inductor memory planning can group multiple buffer names that share the same underlying storage through reuse, for example buf48 = buf16. In this case buf48 may not appear directly in V.graph.get_output_names(), but the scheduler can still know it is live because it has an OUTPUT user, such as when returned views alias that storage.

The memory planner only marked a buffer group as output-like when one of the group names was a direct graph output. As a result, it could treat the group as an intermediate, destroy the allocation pool too early, and emit wrapper code that deleted a local before later generated code read it. This showed up as errors like:

UnboundLocalError: cannot access local variable 'buf48'

Fix:

Update MemoryPlanner.compute_buffer_groups() to also mark a buffer group as output-like if any grouped buffer has a scheduler OUTPUT user. This extends the pool live range to the end of the wrapper for alias-backed outputs and prevents early pool destruction.

Added CPU-only regression tests covering:

- reused buffer groups where the reused name is a direct graph output
- reused buffer groups where the reused name is live through a scheduler OUTPUT user

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo