### PR TITLE
[ROCm][CI] Skip S3 upload on ROCm CI and drop invalid ecr-login aws-region input

### DIFF
--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -98,8 +98,11 @@ runs:
       id: ecr-login
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
+        # amazon-ecr-login has no aws-region input; it reads the region from the
+        # AWS_REGION env set by configure-aws-credentials (OIDC) or the step above
+        # (instance profile). Passing aws-region triggers an "Unexpected input(s)"
+        # annotation on every job that logs in to ECR.
         registries: 308535385114  # META_AWS_ACCOUNT_ID
-        aws-region: ${{ inputs.aws-region }}
 
     - name: Verify ECR login
       shell: bash

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -19,6 +19,15 @@ inputs:
     description: S3 bucket to upload artifacts to
     required: false
     default: "gha-artifacts"
+  skip-s3:
+    description: |
+      If 'true', skip the S3 upload entirely and upload directly to GitHub
+      Actions artifacts. Set this on runners that have no credentials capable
+      of writing to the S3 bucket (e.g. ROCm runners, which only assume the
+      read-only ECR login role) to avoid noisy s3:PutObject "not authorized"
+      errors.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -103,6 +112,7 @@ runs:
     # ===========================================
     - name: Store Test Downloaded JSONs on S3
       id: s3-upload-jsons
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -115,6 +125,7 @@ runs:
 
     - name: Store Test Reports on S3
       id: s3-upload-reports
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -127,6 +138,7 @@ runs:
 
     - name: Store Usage Logs on S3
       id: s3-upload-logs
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -139,6 +151,7 @@ runs:
 
     - name: Store Debug Artifacts on S3
       id: s3-upload-debug
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -151,6 +164,7 @@ runs:
 
     - name: Store Profiler Traces on S3
       id: s3-upload-profiler-traces
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -163,6 +177,7 @@ runs:
 
     - name: Store TLParse Output on S3
       id: s3-upload-tlparse
+      if: ${{ inputs.skip-s3 != 'true' }}
       uses: seemethere/upload-artifact-s3@v5
       continue-on-error: true
       with:
@@ -177,8 +192,14 @@ runs:
     - name: Check S3 upload status
       id: check-s3
       shell: bash
+      env:
+        SKIP_S3: ${{ inputs.skip-s3 }}
+        S3_REPORTS_OUTCOME: ${{ steps.s3-upload-reports.outcome }}
       run: |
-        if [[ "${{ steps.s3-upload-reports.outcome }}" == "failure" ]]; then
+        if [[ "${SKIP_S3}" == "true" ]]; then
+          echo "S3 upload skipped, uploading to GHA"
+          echo "s3-failed=true" >> "$GITHUB_OUTPUT"
+        elif [[ "${S3_REPORTS_OUTCOME}" == "failure" ]]; then
           echo "S3 upload failed, will fallback to GHA"
           echo "s3-failed=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -301,7 +301,11 @@ jobs:
         uses: ./.github/actions/upload-test-artifacts
         if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
-          use-gha: true
+          # ROCm runners are not on EC2 and have no IAM instance profile, so the
+          # only AWS identity available is the read-only ECR login role, which
+          # cannot write to the gha-artifacts bucket. Skip S3 and upload directly
+          # to GHA to avoid s3:PutObject "not authorized" errors.
+          skip-s3: true
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
 
       - name: Collect backtraces from coredumps (if any)


### PR DESCRIPTION
## Summary

ROCm test jobs emit `is not authorized to perform: s3:PutObject` errors when uploading test artifacts (e.g. the assumed role `gha_workflow_s3_and_ecr_read_only/gha-ecr-login` cannot write to the `gha-artifacts` bucket). ROCm runners are not EC2 instances and have no IAM instance profile, so the only AWS identity available is the read-only role assumed by the `ecr-login` action. CUDA jobs on EC2 succeed because the instance profile grants S3 write; ROCm has no such profile. PR #170439 made `upload-test-artifacts` always try S3 first and deprecated the `use-gha` input ROCm relied on, so ROCm now always attempts an unauthorized `s3:PutObject` before falling back to GHA, producing a noisy permission error on every shard.

- Add a `skip-s3` input to the `upload-test-artifacts` action that bypasses the S3 steps and uploads directly to GitHub Actions artifacts via the existing fallback path.
- Set `skip-s3: true` in `_rocm-test.yml` (replacing the now-ignored `use-gha` input). Artifacts still land via GHA; only the doomed S3 attempt is removed.
- Drop the invalid `aws-region` input passed to the "Log in to ECR" step in `.github/actions/ecr-login/action.yml`. On run 27110938665 (linux-jammy-rocm-py3.10-mi300 build + test shards) the ECR login step annotated `Unexpected input(s) 'aws-region', valid inputs are ['http-proxy', 'mask-password', 'registries', 'registry-type', 'skip-logout']`. `aws-actions/amazon-ecr-login@...v2.0.1` has no `aws-region` input and reads its region from the `AWS_REGION` env var, so the passthrough was a no-op that only produced the annotation. The fix removes only that passthrough; the `aws-region` input and its other uses (instance-profile `AWS_REGION` setup and `configure-aws-credentials`) are retained.

Tracked in ROCm/frameworks-internal #16873; observed in https://github.com/pytorch/pytorch/actions/runs/27110938665.

## Test plan

- [x] All three changed YAML files parse cleanly (`yaml.safe_load`).
- [x] Run the inductor ROCm MI300 workflow and confirm "Upload test artifacts" no longer logs `s3:PutObject` permission errors.
- [ ] Confirm the ECR login step no longer warns about an unexpected `aws-region` input (validated post-merge only: ROCm CI reaches ECR login via setup-rocm -> ecr-login@main, so this PR's copy isn't exercised; the warning clears once merged to main).
- [x] Confirm test artifacts are still uploaded (via GHA) for ROCm jobs.
- [x] Verify CUDA jobs still upload artifacts to S3 successfully (skip-s3 is ROCm-only; the default S3 path is unchanged for CUDA/EC2 runners).

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang