### PR TITLE
Add float16/bfloat16 support to sparse CSR sampled_addmm

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1354,7 +1354,7 @@ void sampled_addmm_out_sparse_csr(
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       kHalf, kBFloat16,
-      C.scalar_type(),
+      st,
       "sampled_addmm_out_sparse_csr",
       [&] {
         // cuSPARSE SDDMM supports float16 and bfloat16 with float32 accumulation

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1341,10 +1341,14 @@ void sampled_addmm_out_sparse_csr(
   c10::MaybeOwned<Tensor> A_ = prepare_dense_matrix_for_cusparse(A);
   c10::MaybeOwned<Tensor> B_ = prepare_dense_matrix_for_cusparse(B);
 
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      kHalf, kBFloat16,
       C.scalar_type(),
       "sampled_addmm_out_sparse_csr",
       [&] {
+        // cuSPARSE SDDMM accumulates in float32 for half/bfloat16 inputs.
+        // opmath_type<half/bfloat16> == float, so alpha/beta and compute_type use float.
+        using opmath_t = at::opmath_type<scalar_t>;
         // CUDA 11.6 doesn't support batched inputs, it raises an error:
         // ** On entry to cusparseSDDMM_bufferSize(): batched SDDMM is not supported
         // So we need to resort to the for loop
@@ -1353,9 +1357,9 @@ void sampled_addmm_out_sparse_csr(
           auto descB = at::cuda::sparse::CuSparseConstDnMatDescriptor(*B_, /*batch_offset=*/i);
           auto descC = at::cuda::sparse::CuSparseSpMatCsrDescriptor(C, /*batch_offset=*/i);
 
-          auto beta_ = beta.to<scalar_t>();
-          auto alpha_ = alpha.to<scalar_t>();
-          auto compute_type = at::cuda::getCudaDataType<scalar_t>();
+          auto beta_ = beta.to<opmath_t>();
+          auto alpha_ = alpha.to<opmath_t>();
+          cudaDataType compute_type = at::cuda::getCudaDataType<opmath_t>();
           auto handle = at::cuda::getCurrentCUDASparseHandle();
           size_t buffer_size = 0;
           TORCH_CUDASPARSE_CHECK(cusparseSDDMM_bufferSize(

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1341,13 +1341,13 @@ void sampled_addmm_out_sparse_csr(
   c10::MaybeOwned<Tensor> A_ = prepare_dense_matrix_for_cusparse(A);
   c10::MaybeOwned<Tensor> B_ = prepare_dense_matrix_for_cusparse(B);
 
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-      kHalf, kBFloat16,
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
+      kHalf,
       C.scalar_type(),
       "sampled_addmm_out_sparse_csr",
       [&] {
-        // cuSPARSE SDDMM accumulates in float32 for half/bfloat16 inputs.
-        // opmath_type<half/bfloat16> == float, so alpha/beta and compute_type use float.
+        // cuSPARSE SDDMM supports float16 with float32 accumulation, but not bfloat16.
+        // opmath_type<half> == float, so alpha/beta and compute_type use float.
         using opmath_t = at::opmath_type<scalar_t>;
         // CUDA 11.6 doesn't support batched inputs, it raises an error:
         // ** On entry to cusparseSDDMM_bufferSize(): batched SDDMM is not supported

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1336,30 +1336,34 @@ void sampled_addmm_out_sparse_csr(
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(batchCount(A) == batchCount(B));
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(batchCount(A) == batchCount(C));
 
+  // cuSPARSE SDDMM has a native float16 kernel (with float32 accumulation) but
+  // no bfloat16 kernel: cusparseSDDMM_bufferSize returns
+  // CUSPARSE_STATUS_NOT_SUPPORTED for bfloat16 even on Ampere/Ada (e.g. sm_89),
+  // so this is not a compute-capability gate. Run bfloat16 in float32 -- which
+  // is already its opmath/accumulation type, so the only rounding is the
+  // bfloat16 input/output itself -- and copy the result back into the bfloat16
+  // output. float16 keeps its native cuSPARSE path below.
+  if (C.scalar_type() == kBFloat16) {
+    Tensor C_f32 = C.to(kFloat);
+    sampled_addmm_out_sparse_csr(A.to(kFloat), B.to(kFloat), beta, alpha, C_f32);
+    C.values().copy_(C_f32.values());
+    return;
+  }
+
   cusparseOperation_t opA = CUSPARSE_OPERATION_NON_TRANSPOSE;
   cusparseOperation_t opB = CUSPARSE_OPERATION_NON_TRANSPOSE;
 
   c10::MaybeOwned<Tensor> A_ = prepare_dense_matrix_for_cusparse(A);
   c10::MaybeOwned<Tensor> B_ = prepare_dense_matrix_for_cusparse(B);
 
-  const auto st = C.scalar_type();
-  if (st == kHalf || st == kBFloat16) {
-    TORCH_CHECK(
-        at::cuda::getCurrentDeviceProperties()->major >= 8,
-        "sampled_addmm: float16/bfloat16 inputs are only supported on GPUs with "
-        "compute capability >= 8.0 (Ampere or newer); got sm_",
-        at::cuda::getCurrentDeviceProperties()->major,
-        at::cuda::getCurrentDeviceProperties()->minor);
-  }
-
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-      kHalf, kBFloat16,
-      st,
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
+      kHalf,
+      C.scalar_type(),
       "sampled_addmm_out_sparse_csr",
       [&] {
-        // cuSPARSE SDDMM supports float16 and bfloat16 with float32 accumulation
-        // on Ampere and newer (CC >= 8.0). opmath_type<half/bfloat16> == float,
-        // so alpha/beta and compute_type correctly select fp32 accumulation.
+        // cuSPARSE SDDMM has a native float16 kernel that accumulates in
+        // float32. opmath_type<Half> == float, so alpha/beta and compute_type
+        // select the float32 accumulation path automatically.
         using opmath_t = at::opmath_type<scalar_t>;
         // CUDA 11.6 doesn't support batched inputs, it raises an error:
         // ** On entry to cusparseSDDMM_bufferSize(): batched SDDMM is not supported

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/cuda/MiscUtils.h>
 #include <ATen/native/sparse/SparseBlasImpl.h>
 #include <ATen/native/sparse/cuda/SparseBlasImpl.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -1341,13 +1342,24 @@ void sampled_addmm_out_sparse_csr(
   c10::MaybeOwned<Tensor> A_ = prepare_dense_matrix_for_cusparse(A);
   c10::MaybeOwned<Tensor> B_ = prepare_dense_matrix_for_cusparse(B);
 
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
-      kHalf,
+  const auto st = C.scalar_type();
+  if (st == kHalf || st == kBFloat16) {
+    TORCH_CHECK(
+        at::cuda::getCurrentDeviceProperties()->major >= 8,
+        "sampled_addmm: float16/bfloat16 inputs are only supported on GPUs with "
+        "compute capability >= 8.0 (Ampere or newer); got sm_",
+        at::cuda::getCurrentDeviceProperties()->major,
+        at::cuda::getCurrentDeviceProperties()->minor);
+  }
+
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      kHalf, kBFloat16,
       C.scalar_type(),
       "sampled_addmm_out_sparse_csr",
       [&] {
-        // cuSPARSE SDDMM supports float16 with float32 accumulation, but not bfloat16.
-        // opmath_type<half> == float, so alpha/beta and compute_type use float.
+        // cuSPARSE SDDMM supports float16 and bfloat16 with float32 accumulation
+        // on Ampere and newer (CC >= 8.0). opmath_type<half/bfloat16> == float,
+        // so alpha/beta and compute_type correctly select fp32 accumulation.
         using opmath_t = at::opmath_type<scalar_t>;
         // CUDA 11.6 doesn't support batched inputs, it raises an error:
         // ** On entry to cusparseSDDMM_bufferSize(): batched SDDMM is not supported

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -272,7 +272,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     ("normal", "in_place"): {f16, f32, f64},
     ("normal", "number_mean"): {f16, f32, f64},
     "normal": {f16, f32, f64},
-    "sparse.sampled_addmm": {f32, f64},
+    "sparse.sampled_addmm": {f32, f64, f16},
     "torch.ops.aten._flash_attention_forward": {f16},
     "torch.ops.aten._efficient_attention_forward": {f16, f32},
     "to_sparse": {
@@ -290,7 +290,7 @@ inductor_expected_failures_single_sample["xpu"] = {
     ("normal", "in_place"): {f16, f32, f64},
     ("normal", "number_mean"): {f16, f32, f64},
     "normal": {f16, f32, f64},
-    "sparse.sampled_addmm": {f32, f64},
+    "sparse.sampled_addmm": {f32, f64, f16},
     "tan": {f16},
     "torch.ops.aten._flash_attention_forward": {f16},
     "torch.ops.aten._efficient_attention_forward": {f16, f32},

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2430,12 +2430,10 @@ class TestSparseCSR(TestCase):
             run_test(n, k, upper, unitriangular, transpose, zero)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(
-        torch.half,
-        *([torch.bfloat16] if PLATFORM_SUPPORTS_BF16 else [])))
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8,
-                        torch.half: 1e-2, torch.bfloat16: 3.5e-2})
+                        torch.half: 1e-2})
     def test_sampled_addmm(self, device, dtype):
         def run_test(c, a, b, op_a, op_b, *, alpha=None, beta=None):
             if dtype.is_complex:
@@ -2484,12 +2482,10 @@ class TestSparseCSR(TestCase):
                     run_test(c, a, b, op_a, op_b)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(
-        torch.half,
-        *([torch.bfloat16] if PLATFORM_SUPPORTS_BF16 else [])))
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8,
-                        torch.half: 1e-2, torch.bfloat16: 3.5e-2})
+                        torch.half: 1e-2})
     def test_sampled_addmm_autograd(self, device, dtype):
         from torch.testing._internal.common_methods_invocations import sample_inputs_sparse_sampled_addmm
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2430,8 +2430,10 @@ class TestSparseCSR(TestCase):
             run_test(n, k, upper, unitriangular, transpose, zero)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
-                        torch.float64: 1e-8, torch.complex128: 1e-8})
+                        torch.float64: 1e-8, torch.complex128: 1e-8,
+                        torch.half: 1e-2, torch.bfloat16: 3.5e-2})
     def test_sampled_addmm(self, device, dtype):
         def run_test(c, a, b, op_a, op_b, *, alpha=None, beta=None):
             if dtype.is_complex:
@@ -2480,6 +2482,10 @@ class TestSparseCSR(TestCase):
                     run_test(c, a, b, op_a, op_b)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
+    @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
+                        torch.float64: 1e-8, torch.complex128: 1e-8,
+                        torch.half: 1e-2, torch.bfloat16: 3.5e-2})
     def test_sampled_addmm_autograd(self, device, dtype):
         from torch.testing._internal.common_methods_invocations import sample_inputs_sparse_sampled_addmm
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2432,8 +2432,7 @@ class TestSparseCSR(TestCase):
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
-                        torch.float64: 1e-8, torch.complex128: 1e-8,
-                        torch.half: 1e-2})
+                        torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_sampled_addmm(self, device, dtype):
         def run_test(c, a, b, op_a, op_b, *, alpha=None, beta=None):
             if dtype.is_complex:
@@ -2484,8 +2483,7 @@ class TestSparseCSR(TestCase):
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
-                        torch.float64: 1e-8, torch.complex128: 1e-8,
-                        torch.half: 1e-2})
+                        torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_sampled_addmm_autograd(self, device, dtype):
         from torch.testing._internal.common_methods_invocations import sample_inputs_sparse_sampled_addmm
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import \
      IS_FBCODE, IS_REMOTE_GPU, suppress_warnings)
 from torch.testing._internal.common_device_type import \
     (ops, instantiate_device_type_tests, dtypes, OpDTypes, dtypesIfCUDA, onlyCPU, onlyCUDA, skipCUDAIfNoSparseGeneric,
-     precisionOverride, skipMeta, skipCUDAIfRocm, skipCPUIfNoMklSparse, largeTensorTest)
+     precisionOverride, toleranceOverride, tol, skipMeta, skipCUDAIfRocm, skipCPUIfNoMklSparse, largeTensorTest)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, sparse_csr_unary_ufuncs, ReductionOpInfo)
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -2433,6 +2433,8 @@ class TestSparseCSR(TestCase):
     @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
+    @toleranceOverride({torch.float16: tol(atol=1e-3, rtol=1.6e-2),
+                        torch.bfloat16: tol(atol=1e-2, rtol=1.6e-2)})
     def test_sampled_addmm(self, device, dtype):
         if dtype in (torch.half, torch.bfloat16) and torch.cuda.is_available() and \
                 torch.cuda.get_device_capability()[0] < 8:
@@ -2488,6 +2490,8 @@ class TestSparseCSR(TestCase):
     @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
+    @toleranceOverride({torch.float16: tol(atol=1e-3, rtol=1.6e-2),
+                        torch.bfloat16: tol(atol=1e-2, rtol=1.6e-2)})
     def test_sampled_addmm_autograd(self, device, dtype):
         if dtype in (torch.half, torch.bfloat16) and torch.cuda.is_available() and \
                 torch.cuda.get_device_capability()[0] < 8:

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2430,10 +2430,14 @@ class TestSparseCSR(TestCase):
             run_test(n, k, upper, unitriangular, transpose, zero)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_sampled_addmm(self, device, dtype):
+        if dtype in (torch.half, torch.bfloat16) and torch.cuda.is_available() and \
+                torch.cuda.get_device_capability()[0] < 8:
+            self.skipTest("cuSPARSE SDDMM fp16/bf16 requires compute capability >= 8.0")
+
         def run_test(c, a, b, op_a, op_b, *, alpha=None, beta=None):
             if dtype.is_complex:
                 alpha = random.random() + 0.3j if alpha is None else alpha
@@ -2481,10 +2485,14 @@ class TestSparseCSR(TestCase):
                     run_test(c, a, b, op_a, op_b)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half))
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_sampled_addmm_autograd(self, device, dtype):
+        if dtype in (torch.half, torch.bfloat16) and torch.cuda.is_available() and \
+                torch.cuda.get_device_capability()[0] < 8:
+            self.skipTest("cuSPARSE SDDMM fp16/bf16 requires compute capability >= 8.0")
+
         from torch.testing._internal.common_methods_invocations import sample_inputs_sparse_sampled_addmm
 
         samples = list(sample_inputs_sparse_sampled_addmm(None, device, dtype, requires_grad=True))

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2430,7 +2430,9 @@ class TestSparseCSR(TestCase):
             run_test(n, k, upper, unitriangular, transpose, zero)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
+    @dtypesIfCUDA(*floating_and_complex_types_and(
+        torch.half,
+        *([torch.bfloat16] if PLATFORM_SUPPORTS_BF16 else [])))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8,
                         torch.half: 1e-2, torch.bfloat16: 3.5e-2})
@@ -2482,7 +2484,9 @@ class TestSparseCSR(TestCase):
                     run_test(c, a, b, op_a, op_b)
 
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
+    @dtypesIfCUDA(*floating_and_complex_types_and(
+        torch.half,
+        *([torch.bfloat16] if PLATFORM_SUPPORTS_BF16 else [])))
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8,
                         torch.half: 1e-2, torch.bfloat16: 3.5e-2})

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14654,6 +14654,12 @@ op_db: list[OpInfo] = [
            supports_out=False),
     OpInfo('sparse.sampled_addmm',
            dtypes=floating_and_complex_types(),
+           # CUDA forward also supports float16 (native cuSPARSE SDDMM) and
+           # bfloat16 (computed in float32; cuSPARSE SDDMM has no bf16 kernel).
+           dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
+           # Backward for float16/bfloat16 is not fully supported across all
+           # samples yet, so keep backward at floating_and_complex_types only.
+           backward_dtypesIfCUDA=floating_and_complex_types(),
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14654,12 +14654,11 @@ op_db: list[OpInfo] = [
            supports_out=False),
     OpInfo('sparse.sampled_addmm',
            dtypes=floating_and_complex_types(),
-           # CUDA forward also supports float16 (native cuSPARSE SDDMM) and
-           # bfloat16 (computed in float32; cuSPARSE SDDMM has no bf16 kernel).
+           # CUDA forward and backward also support float16 (native cuSPARSE
+           # SDDMM) and bfloat16 (computed in float32; cuSPARSE SDDMM has no
+           # bf16 kernel). backward_dtypesIfCUDA is omitted so it inherits
+           # dtypesIfCUDA, matching what test_dtypes observes at runtime.
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
-           # Backward for float16/bfloat16 is not fully supported across all
-           # samples yet, so keep backward at floating_and_complex_types only.
-           backward_dtypesIfCUDA=floating_and_complex_types(),
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14654,17 +14654,23 @@ op_db: list[OpInfo] = [
            supports_out=False),
     OpInfo('sparse.sampled_addmm',
            dtypes=floating_and_complex_types(),
-           # CUDA forward and backward also support float16 (native cuSPARSE
-           # SDDMM) and bfloat16 (computed in float32; cuSPARSE SDDMM has no
-           # bf16 kernel). backward_dtypesIfCUDA is omitted so it inherits
-           # dtypesIfCUDA, matching what test_dtypes observes at runtime.
+           # CUDA forward supports float16 (native cuSPARSE SDDMM) and bfloat16
+           # (computed in float32; cuSPARSE has no bf16 SDDMM kernel). Backward
+           # routes through cuSPARSE SpMM: float16 needs CC >= 5.3, bfloat16 needs
+           # CC >= 8.0, and ROCm's hipSPARSE SpMM implements neither dtype.
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
+           backward_dtypesIfCUDA=floating_and_complex_types_and(
+               *([torch.half] if not TEST_WITH_ROCM else []),
+               *([torch.bfloat16] if SM80OrLater and not TEST_WITH_ROCM else [])),
            supports_autograd=True,
            sample_inputs_func=sample_inputs_sparse_sampled_addmm,
            decorators=[
                skipCPUIfNoMklSparse,
                skipXPU],
            skips=(
+               # Reduced-precision sampled_addmm needs CC >= 5.3 (cuSPARSE SDDMM);
+               # skip the dtype check on older CUDA arches that have no CI runner.
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
                # NotImplementedError: Tensors of type SparseCsrTensorImpl do not have is_contiguous
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_noncontiguous_samples'),
                # RuntimeError: Sparse CSR tensors do not have strides.


### PR DESCRIPTION
## Summary

`torch.sparse.sampled_addmm` (the cuSPARSE SDDMM path) previously supported only
float and complex on CUDA. The backward of `torch.sparse.mm(CSR, dense)` routes
through `sampled_addmm`, so bfloat16/float16 inputs failed there (#164666).

This adds float16 and bfloat16 support on CUDA:

- **float16** uses the native cuSPARSE SDDMM kernel, which accumulates in
  float32 (`opmath_type<Half> == float`, selected via `opmath_t` for alpha, beta
  and the compute type).
- **bfloat16** has *no* native cuSPARSE SDDMM kernel — `cusparseSDDMM_bufferSize`
  returns `CUSPARSE_STATUS_NOT_SUPPORTED` for bf16 even on Ada (sm_89), so it is
  **not** a compute-capability issue (this was the earlier `operation not
  supported` CI failure on the L4 runner). bfloat16 is therefore computed in
  float32 — already its accumulation type, so the only rounding is the bf16
  input/output itself — and the result is written back into the bf16 output.

### Test changes
- `test_sampled_addmm` / `test_sampled_addmm_autograd`: add `toleranceOverride`
  for float16/bfloat16. `precisionOverride` only sets `atol`, but the observed
  failures were relative (float16's default `rtol` is a tight `1e-3`).
- `sparse.sampled_addmm` OpInfo: declare `dtypesIfCUDA` with half/bfloat16 for
  forward, and set an explicit `backward_dtypesIfCUDA` that matches the
  cuSPARSE/hipSPARSE SpMM support actually available in backward. float16 and
  bfloat16 are dropped on ROCm (hipSPARSE SpMM implements neither), and bfloat16
  is gated on `SM80OrLater` for CUDA (float16 SpMM works from CC >= 5.3, bfloat16
  needs CC >= 8.0). A `not SM53OrLater` skip guards the forward dtype check on
  pre-5.3 CUDA arches that have no CI runner.
- `test_torchinductor_opinfo`: add float16 to the existing
  `sparse.sampled_addmm` inductor expected-failures (cuda and xpu). The inductor
  OpInfo harness cannot clone sparse CSR inputs regardless of dtype, so fp32/fp64
  are already expected failures; float16 is now exercised and needs the same
  entry. bfloat16 is not in the inductor `allowed_dtypes`, so it is not listed.

### Backward / issue status
Backward is now claimed for fp16/bf16 on the configurations where cuSPARSE SpMM
actually supports them (CUDA: fp16 from CC >= 5.3, bf16 from CC >= 8.0; not on
ROCm), which is the path #164666 is about. The reference is kept non-closing
(`Addresses #164666`) so maintainers can confirm backward completeness across
the full sample set before the issue is closed.

### Note
I don't currently have access to a CUDA GPU, so I couldn't run the sparse CSR
tests locally and am relying on CI (the L4/sm_89 and ROCm runners that caught
the earlier failures) to validate. Happy to iterate on the tolerances or the
backward dtype claim based on the results.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo