### PR TITLE
Add deterministic mode test for embedding backward and use DeterministicGuard

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
     _assertGradAndGradgradChecks,
+    DeterministicGuard,
     dtype2prec_DONTUSE,
     instantiate_parametrized_tests,
     IS_JETSON,
@@ -708,71 +709,76 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         4. In non-deterministic mode
 
         """
-        torch.use_deterministic_algorithms(False)
+        with DeterministicGuard(False):
+            num_embeddings = 100
+            embedding_dim = 256
+            num_unique_indices = 5
+            repetitions_per_index = 1000
 
-        num_embeddings = 100
-        embedding_dim = 256
-        num_unique_indices = 5
-        repetitions_per_index = 1000
+            unique_indices = torch.randint(
+                0,
+                num_embeddings,
+                (num_unique_indices,),
+                device=device,
+                dtype=torch.long,
+            )
+            indices = unique_indices.repeat(repetitions_per_index)
+            total_indices = indices.numel()
 
-        unique_indices = torch.randint(
-            0, num_embeddings, (num_unique_indices,), device=device, dtype=torch.long
-        )
-        indices = unique_indices.repeat(repetitions_per_index)
-        total_indices = indices.numel()
+            embedding = nn.Embedding(num_embeddings, embedding_dim).to(device, dtype)
+            embedding.zero_grad()
 
-        embedding = nn.Embedding(num_embeddings, embedding_dim).to(device, dtype)
-        embedding.zero_grad()
+            output = embedding(indices)
+            grad_output = torch.randn_like(output)
+            output.backward(grad_output)
 
-        output = embedding(indices)
-        grad_output = torch.randn_like(output)
-        output.backward(grad_output)
+            # Verify gradient shape and basic correctness
+            self.assertEqual(
+                embedding.weight.grad.shape, (num_embeddings, embedding_dim)
+            )
 
-        # Verify gradient shape and basic correctness
-        self.assertEqual(embedding.weight.grad.shape, (num_embeddings, embedding_dim))
+            # Verify that only the used indices have non-zero gradients
+            used_indices_set = set(unique_indices.tolist())
+            for i in range(num_embeddings):
+                if i in used_indices_set:
+                    # Used indices should have non-zero gradients (accumulated from repetitions)
+                    self.assertGreater(
+                        embedding.weight.grad[i].abs().sum(),
+                        0,
+                        f"Expected non-zero gradient for used index {i}",
+                    )
+                else:
+                    # Unused indices should have zero gradients
+                    self.assertEqual(
+                        embedding.weight.grad[i].abs().sum(),
+                        0,
+                        f"Expected zero gradient for unused index {i}",
+                    )
 
-        # Verify that only the used indices have non-zero gradients
-        used_indices_set = set(unique_indices.tolist())
-        for i in range(num_embeddings):
-            if i in used_indices_set:
-                # Used indices should have non-zero gradients (accumulated from repetitions)
-                self.assertGreater(
-                    embedding.weight.grad[i].abs().sum(),
-                    0,
-                    f"Expected non-zero gradient for used index {i}",
-                )
+            # Test correctness by comparing with a reference computation
+            # Manually compute expected gradients using the same accumulation type as the kernel:
+            # - For half/bfloat16: accumulate in float (acc_type)
+            # - For float/double: accumulate in the same dtype
+            acc_dtype = torch.float if dtype in [torch.half, torch.bfloat16] else dtype
+            expected_grad = torch.zeros(
+                num_embeddings, embedding_dim, device=device, dtype=acc_dtype
+            )
+            grad_output_acc = grad_output.to(acc_dtype)
+            for i in range(total_indices):
+                idx = indices[i].item()
+                expected_grad[idx] += grad_output_acc[i]
+            expected_grad = expected_grad.to(dtype)
+
+            # Compare with computed gradients (use appropriate tolerance for dtype)
+            if dtype in [torch.half, torch.bfloat16]:
+                atol = 1e-3
+                rtol = 1e-3
             else:
-                # Unused indices should have zero gradients
-                self.assertEqual(
-                    embedding.weight.grad[i].abs().sum(),
-                    0,
-                    f"Expected zero gradient for unused index {i}",
-                )
-
-        # Test correctness by comparing with a reference computation
-        # Manually compute expected gradients using the same accumulation type as the kernel:
-        # - For half/bfloat16: accumulate in float (acc_type)
-        # - For float/double: accumulate in the same dtype
-        acc_dtype = torch.float if dtype in [torch.half, torch.bfloat16] else dtype
-        expected_grad = torch.zeros(
-            num_embeddings, embedding_dim, device=device, dtype=acc_dtype
-        )
-        grad_output_acc = grad_output.to(acc_dtype)
-        for i in range(total_indices):
-            idx = indices[i].item()
-            expected_grad[idx] += grad_output_acc[i]
-        expected_grad = expected_grad.to(dtype)
-
-        # Compare with computed gradients (use appropriate tolerance for dtype)
-        if dtype in [torch.half, torch.bfloat16]:
-            atol = 1e-3
-            rtol = 1e-3
-        else:
-            atol = 5e-5
-            rtol = 5e-5
-        torch.testing.assert_close(
-            embedding.weight.grad, expected_grad, atol=atol, rtol=rtol
-        )
+                atol = 5e-5
+                rtol = 5e-5
+            torch.testing.assert_close(
+                embedding.weight.grad, expected_grad, atol=atol, rtol=rtol
+            )
 
     @onlyOn(["cuda", "xpu"])
     @dtypes(
@@ -789,41 +795,91 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         Test that embedding_dense_backward with padding_idx works correctly
         when using the atomic accmulate kernel path.
         """
-        torch.use_deterministic_algorithms(False)
+        with DeterministicGuard(False):
+            num_embeddings = 50
+            embedding_dim = 128
+            padding_idx = 5
+            repetitions_per_index = 1000
 
-        num_embeddings = 50
-        embedding_dim = 128
-        padding_idx = 5
-        repetitions_per_index = 1000
-
-        unique_indices = torch.tensor(
-            [padding_idx, 10, 20, 30], device=device, dtype=torch.long
-        )
-        indices = unique_indices.repeat(repetitions_per_index)
-
-        embedding = nn.Embedding(
-            num_embeddings, embedding_dim, padding_idx=padding_idx
-        ).to(device, dtype)
-        embedding.zero_grad()
-
-        output = embedding(indices)
-        grad_output = torch.randn_like(output)
-        output.backward(grad_output)
-
-        # Verify padding_idx has zero gradient
-        self.assertEqual(
-            embedding.weight.grad[padding_idx].abs().sum(),
-            0,
-            f"Expected zero gradient for padding_idx {padding_idx}",
-        )
-
-        # Verify other used indices have non-zero gradients
-        for idx in [10, 20, 30]:
-            self.assertGreater(
-                embedding.weight.grad[idx].abs().sum(),
-                0,
-                f"Expected non-zero gradient for index {idx}",
+            unique_indices = torch.tensor(
+                [padding_idx, 10, 20, 30], device=device, dtype=torch.long
             )
+            indices = unique_indices.repeat(repetitions_per_index)
+
+            embedding = nn.Embedding(
+                num_embeddings, embedding_dim, padding_idx=padding_idx
+            ).to(device, dtype)
+            embedding.zero_grad()
+
+            output = embedding(indices)
+            grad_output = torch.randn_like(output)
+            output.backward(grad_output)
+
+            # Verify padding_idx has zero gradient
+            self.assertEqual(
+                embedding.weight.grad[padding_idx].abs().sum(),
+                0,
+                f"Expected zero gradient for padding_idx {padding_idx}",
+            )
+
+            # Verify other used indices have non-zero gradients
+            for idx in [10, 20, 30]:
+                self.assertGreater(
+                    embedding.weight.grad[idx].abs().sum(),
+                    0,
+                    f"Expected non-zero gradient for index {idx}",
+                )
+
+    @onlyOn(["cuda", "xpu"])
+    @dtypes(
+        *(
+            (torch.float, torch.double, torch.bfloat16, torch.half)
+            if TEST_WITH_ROCM
+            else (torch.float, torch.double, torch.half)
+        )
+    )
+    def test_embedding_backward_deterministic(self, device, dtype):
+        """
+        Test that embedding_dense_backward produces bitwise-identical results
+        across multiple runs when deterministic algorithms are enabled, even in
+        scenarios that would otherwise trigger the non-deterministic atomic
+        accumulate kernel.
+        """
+        with DeterministicGuard(True):
+            num_embeddings = 100
+            embedding_dim = 256
+            num_unique_indices = 5
+            repetitions_per_index = 1000
+
+            unique_indices = torch.randint(
+                0,
+                num_embeddings,
+                (num_unique_indices,),
+                device=device,
+                dtype=torch.long,
+            )
+            indices = unique_indices.repeat(repetitions_per_index)
+
+            weight = torch.randn(
+                num_embeddings,
+                embedding_dim,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            grad_output = torch.randn(
+                indices.numel(), embedding_dim, device=device, dtype=dtype
+            )
+
+            reference_grad = None
+            for _ in range(5):
+                out = torch.nn.functional.embedding(input=indices, weight=weight)
+                out.backward(grad_output)
+                if reference_grad is None:
+                    reference_grad = weight.grad.clone()
+                else:
+                    self.assertEqual(weight.grad, reference_grad, atol=0, rtol=0)
+                weight.grad = None
 
     @onlyOn(["cuda", "xpu"])
     @dtypes(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1758,6 +1758,7 @@ def use_deterministic_algorithms(
         * :func:`torch.Tensor.scatter` when `src` type is Tensor and called on CUDA tensor
         * :func:`torch.Tensor.scatter_reduce` when ``reduce='sum'`` or ``reduce='mean'`` and called on CUDA tensor
         * :class:`torch.nn.MaxPool3d` when attempting to differentiate a CUDA tensor
+        * :class:`torch.nn.Embedding` when attempting to differentiate a CUDA tensor
 
     The following normally-nondeterministic operations will throw a
     :class:`RuntimeError` when ``mode=True``:


### PR DESCRIPTION
## Author Notes

Simple follow up from https://github.com/pytorch/pytorch/pull/172454 to make it clearer and keep test coverage.

## Agent Notes

The fused atomic accumulate kernel added in #172454 for `embedding_dense_backward` uses `gpuAtomicAddNoReturn`, which is non-deterministic. The kernel is correctly gated on `at::globalContext().deterministicAlgorithms()`, but the PR lacked a test verifying the deterministic fallback path and the existing tests did not properly restore the deterministic flag.

This change:
- Adds `test_embedding_backward_deterministic` that enables deterministic mode and asserts bitwise-identical gradients across 5 backward passes, using the same scenario (few unique indices, many repetitions) that would trigger the atomic kernel.
- Converts the two existing atomic-kernel tests to use `DeterministicGuard` instead of bare `torch.use_deterministic_algorithms(False)`, so the flag is properly restored on exit.
- Documents `torch.nn.Embedding` in the `use_deterministic_algorithms` docstring under operations that become deterministic when `mode=True`.

Test Plan:
```
python test/nn/test_embedding.py -k test_embedding_backward_deterministic
python test/nn/test_embedding.py -k test_embedding_backward_atomic_accumulate_kernel
```

This PR was authored with the help of an AI assistant (Claude Code).