### PR TITLE
Name AOTAutograd backward gradient outputs grad_<primal> (#110700)

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3800,13 +3800,11 @@ def forward(self, tangents_1):
         return bw_graph_cell[0]
 
     def test_backward_grad_output_names(self):
-        # The returned gradient is named grad_<primal> in both the node list and
-        # the rendered graph code. See issue 110700.
+        # The returned gradient is named grad_<primal>. See issue 110700.
         bw_graph = self._bw_graph(
             lambda x: x.sin() @ x.sin(), torch.randn(3, requires_grad=True)
         )
         self.assertEqual(self._bw_output_names(bw_graph), ["grad_primals_1"])
-        self.assertIn("grad_primals_1", bw_graph.code)
 
     def test_backward_grad_output_names_multiple_and_non_differentiable(self):
         # Each gradient is named after the input it differentiates; a slot for a
@@ -3845,9 +3843,11 @@ def forward(self, tangents_1):
         )
         compiled(torch.randn(4, 3, requires_grad=True)).sum().backward()
 
-        names = self._bw_output_names(bw_graph_cell[0])
-        self.assertTrue(any(n and n.startswith("grad_primals_") for n in names))
-        self.assertTrue(all(n is None or n.startswith("grad_primals_") for n in names))
+        # Distinct names (not dedup-collapsed) tie weight/bias/input grads apart.
+        self.assertEqual(
+            self._bw_output_names(bw_graph_cell[0]),
+            ["grad_primals_1", "grad_primals_2", "grad_primals_3"],
+        )
 
     def test_backward_grad_output_names_passthrough_not_renamed(self):
         # A gradient that is a passed-through tangent is a graph input
@@ -3876,7 +3876,7 @@ def forward(self, tangents_1):
         bw_graph = self._bw_graph(lambda x: x.sin(), a)
 
         names = self._bw_output_names(bw_graph)
-        self.assertEqual(len(names), 2)
+        self.assertTrue(names)
         self.assertFalse(any(n is not None and n.startswith("grad_") for n in names))
 
     def test_no_grad_input_output(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3782,6 +3782,103 @@ def forward(self, tangents_1):
     return (tangents_1,)""",
         )
 
+    def _bw_output_names(self, bw_graph):
+        output_node = next(
+            n for n in reversed(bw_graph.graph.nodes) if n.op == "output"
+        )
+        return [n.name if n is not None else None for n in output_node.args[0]]
+
+    def _bw_graph(self, f, *inputs, partition_fn=min_cut_rematerialization_partition):
+        bw_graph_cell = [None]
+        compiled_f = aot_function(
+            f,
+            fw_compiler=nop,
+            bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
+            partition_fn=partition_fn,
+        )
+        compiled_f(*inputs).sum().backward()
+        return bw_graph_cell[0]
+
+    def test_backward_grad_output_names(self):
+        # The returned gradient is named grad_<primal> in both the node list and
+        # the rendered graph code. See issue 110700.
+        bw_graph = self._bw_graph(
+            lambda x: x.sin() @ x.sin(), torch.randn(3, requires_grad=True)
+        )
+        self.assertEqual(self._bw_output_names(bw_graph), ["grad_primals_1"])
+        self.assertIn("grad_primals_1", bw_graph.code)
+
+    def test_backward_grad_output_names_multiple_and_non_differentiable(self):
+        # Each gradient is named after the input it differentiates; a slot for a
+        # non-differentiable input stays None. Uses default_partition to cover
+        # the other partitioner.
+        def f(a, b):
+            return a.sin() * b.cos()
+
+        bw_graph = self._bw_graph(
+            f,
+            torch.randn(4, requires_grad=True),
+            torch.randn(4, requires_grad=True),
+            partition_fn=default_partition,
+        )
+        self.assertEqual(
+            self._bw_output_names(bw_graph), ["grad_primals_1", "grad_primals_2"]
+        )
+
+        bw_graph = self._bw_graph(
+            f,
+            torch.randn(4, requires_grad=True),
+            torch.randn(4, requires_grad=False),
+            partition_fn=default_partition,
+        )
+        self.assertEqual(self._bw_output_names(bw_graph), ["grad_primals_1", None])
+
+    def test_backward_grad_output_names_parameters(self):
+        # Parameter gradients (ParamAOTInput descriptors) are named too.
+        mod = torch.nn.Linear(3, 2)
+        bw_graph_cell = [None]
+        compiled = aot_module(
+            mod,
+            fw_compiler=nop,
+            bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        compiled(torch.randn(4, 3, requires_grad=True)).sum().backward()
+
+        names = self._bw_output_names(bw_graph_cell[0])
+        self.assertTrue(any(n and n.startswith("grad_primals_") for n in names))
+        self.assertTrue(all(n is None or n.startswith("grad_primals_") for n in names))
+
+    def test_backward_grad_output_names_passthrough_not_renamed(self):
+        # A gradient that is a passed-through tangent is a graph input
+        # (placeholder); it must not be renamed.
+        bw_graph = self._bw_graph(
+            lambda x: x.clone(), torch.randn(4, requires_grad=True)
+        )
+        self.assertEqual(self._bw_output_names(bw_graph), ["tangents_1"])
+
+    def test_backward_grad_output_names_shared_grad(self):
+        # When two inputs share one gradient node, it is returned in both slots
+        # and named after the first input it differentiates.
+        bw_graph = self._bw_graph(
+            lambda a, b: (a + b).sum(),
+            torch.randn(4, requires_grad=True),
+            torch.randn(4, requires_grad=True),
+        )
+        self.assertEqual(
+            self._bw_output_names(bw_graph), ["grad_primals_1", "grad_primals_1"]
+        )
+
+    def test_backward_grad_output_names_subclass_unchanged(self):
+        # Subclass-input gradients (SubclassGetAttrAOTOutput, no 1-1 grad/input
+        # correspondence) are left as-is, not renamed grad_<...>.
+        a = TwoTensor(torch.randn(4), torch.randn(4)).detach().requires_grad_(True)
+        bw_graph = self._bw_graph(lambda x: x.sin(), a)
+
+        names = self._bw_output_names(bw_graph)
+        self.assertEqual(len(names), 2)
+        self.assertFalse(any(n is not None and n.startswith("grad_") for n in names))
+
     def test_no_grad_input_output(self):
         def f(a, b):
             return a.cos(), b.cos(), a * b

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -69,6 +69,7 @@ from ._activation_checkpointing.knapsack import (
 from ._activation_checkpointing.knapsack_evaluator import KnapsackEvaluator
 from ._aot_autograd.descriptors import (
     AOTOutput,
+    GradAOTOutput,
     SavedForBackwardsAOTOutput,
     SavedForBackwardsNoVcCheckAOTOutput,
 )
@@ -400,6 +401,31 @@ def _extract_graph_with_inputs_outputs(
             output_values.append(x)
     out = new_graph.output(tuple(output_values))
     out.meta["desc"] = outputs_descs
+
+    if subgraph == "backward":
+        # Name each returned gradient grad_<primal_name>, mapping via the
+        # GradAOTOutput descriptor's grad_of. A gradient shared by several inputs
+        # is named after the first. Subclass grads (SubclassGetAttrAOTOutput) have
+        # no 1-1 grad/input correspondence and are left as-is. Skip placeholder
+        # outputs: a passed-through gradient is a graph input, and renaming inputs
+        # (e.g. tangents that inductor's SDPA matcher keys on) is unsafe.
+        desc_to_name = {
+            node.meta["desc"]: node.name
+            for node in joint_graph.nodes
+            if node.op == "placeholder" and node.meta.get("desc") is not None
+        }
+        renamed: OrderedSet[fx.Node] = OrderedSet()
+        for value, desc in zip(output_values, outputs_descs):
+            if (
+                isinstance(desc, GradAOTOutput)
+                and isinstance(value, fx.Node)
+                and value.op != "placeholder"
+                and value not in renamed
+            ):
+                primal_name = desc_to_name.get(desc.grad_of)
+                if primal_name is not None:
+                    value._rename(f"grad_{primal_name}")
+                    renamed.add(value)
     # Snapshot stack traces on the output node before passes run,
     # as later passes may strip stack_trace from individual nodes.
     out.meta["output_stack_traces"] = [

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -403,19 +403,20 @@ def _extract_graph_with_inputs_outputs(
     out.meta["desc"] = outputs_descs
 
     if subgraph == "backward":
-        # Name each returned gradient grad_<primal_name>, mapping via the
-        # GradAOTOutput descriptor's grad_of. A gradient shared by several inputs
-        # is named after the first. Subclass grads (SubclassGetAttrAOTOutput) have
-        # no 1-1 grad/input correspondence and are left as-is. Skip placeholder
-        # outputs: a passed-through gradient is a graph input, and renaming inputs
-        # (e.g. tangents that inductor's SDPA matcher keys on) is unsafe.
+        # Name each returned gradient grad_<primal_name> via the GradAOTOutput
+        # descriptor's grad_of. None slots (non-differentiable inputs) and
+        # passed-through placeholder gradients are skipped: renaming a backward
+        # input is unsafe (e.g. tangents that inductor's SDPA matcher keys on).
+        # The `renamed` guard keeps a gradient shared by several inputs named
+        # after the first. Subclass grads (SubclassGetAttrAOTOutput) are not
+        # GradAOTOutput (no 1-1 grad/input correspondence) and are left as-is.
         desc_to_name = {
             node.meta["desc"]: node.name
             for node in joint_graph.nodes
             if node.op == "placeholder" and node.meta.get("desc") is not None
         }
         renamed: OrderedSet[fx.Node] = OrderedSet()
-        for value, desc in zip(output_values, outputs_descs):
+        for value, desc in zip(output_values, outputs_descs, strict=True):
             if (
                 isinstance(desc, GradAOTOutput)
                 and isinstance(value, fx.Node)


### PR DESCRIPTION
## Summary

Addresses part 2 of #110700. The joint/backward graph returns its gradients as anonymous compute nodes (e.g. `mul_2`), so `TORCH_LOGS=aot_graphs` output gives no indication of which returned gradient corresponds to which forward input. This names each returned gradient `grad_<primal_name>` using the `GradAOTOutput` descriptor's `grad_of`, which already records the input each gradient differentiates.

For `f(inp): return inp.sin() @ inp.sin()`, the backward graph's return changes from `return (mul_2,)` to `return (grad_primals_1,)`.

The name achievable today is `grad_<aot_input_name>` (i.e. `grad_primals_N`). Fully human-meaningful names such as `grad_inp` additionally require part 1 of the issue (preserving original input names through `make_fx`), which this PR does not attempt. The change is forward-compatible: if part 1 lands later, these names become `grad_inp` automatically with no change here.

## Implementation

In `_extract_graph_with_inputs_outputs` (`torch/_functorch/partitioners.py`), gated on the backward subgraph: build a map from each joint-graph primal/param/buffer placeholder descriptor to its node name, then rename each returned `GradAOTOutput` node to `grad_<primal_name>` via `Node._rename`.

Properties:
- Operates only on the freshly-extracted backward graph, never the joint graph, so name-based joint-graph lookups (RNG functionalization, fp8 quantization, the AOTAutograd cache key) are unaffected.
- Skips placeholder outputs: a passed-through gradient is a graph input, and renaming inputs is unsafe (e.g. inductor's SDPA pattern matcher keys on `tangents_N`).
- Skips subclass gradients (`SubclassGetAttrAOTOutput`), where desugaring breaks the 1-1 grad/input correspondence (cf. the restriction in `get_all_input_and_grad_nodes`); naming them would risk asserting a correspondence that does not hold.
- A gradient shared by multiple inputs is returned in each slot and named after the first.
- Node names are not load-bearing at runtime (FX executes by reference); inductor caches hash graph code, so expect a one-time benign cache miss on rollout.

## Test plan

`test/functorch/test_aotdispatch.py` adds tests covering single-input naming (node list and rendered graph code), multiple inputs plus a non-differentiable `None` slot (exercising `default_partition`), parameter gradients, a pass-through tangent left unrenamed, the shared-gradient case, and subclass gradients left unrenamed.

```
python test/functorch/test_aotdispatch.py -k test_backward_grad_output_names
```