### PR TITLE
fix: aten embed bwd thread sync before proceeding to next batch

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -123,7 +123,8 @@ __global__ void embedding_backward_feature_kernel
         }
       }
     }
-    // Make sure updates are done before indices_batch is updated in the next iter.
+    // Wait for every warp to finish consuming the current indices_batch before
+    // any thread reloads it for the next batch.
     __syncthreads();
   }
 }

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -123,6 +123,8 @@ __global__ void embedding_backward_feature_kernel
         }
       }
     }
+    // Make sure updates are done before indices_batch is updated in the next iter.
+    __syncthreads();
   }
 }
 


### PR DESCRIPTION
  ## Problem
  `embedding_backward_feature_kernel` reuses the shared-memory `indices_batch` buffer across outer-loop batches. The
  existing barriers only synchronize work inside each chunk, so one warp may start loading the next batch into
  `indices_batch` while another warp is still reading entries from the previous batch. This can cause rare
  nondeterministic incorrect gradients in the CUDA dense embedding backward fast path.
  ## Solution
  Add a `__syncthreads()` after finishing all chunks for the current batch, before the next batch reloads
  `indices_batch`.
  ## Test
  No deterministic unit test is added because the failure depends on warp scheduling within a CTA; a normal correctness
  test may pass both before and after the fix. The change is a local synchronization fix for a shared-memory reuse race.
