### PR TITLE
Suppress clang-tidy failures on trunk

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -224,6 +224,7 @@ exclude_patterns = [
     # See https://github.com/pytorch/pytorch/issue/178341
     # Pre-existing violations surfaced when --all-files linting got re-enabled for
     # clang-tidy
+    'aten/src/ATen/CPUApplyUtils.h',
     'aten/src/ATen/core/IListRef.h',
     'aten/src/ATen/dlpack.h',
     'aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp',
@@ -241,13 +242,17 @@ exclude_patterns = [
     'c10/core/Stream.h',
     'c10/core/SymInt.h',
     'c10/core/SymIntArrayRef.h',
+    'c10/core/TensorOptions.h',
+    'c10/cuda/CUDACachingAllocator.cpp',
     'c10/cuda/CUDACachingAllocator.h',
     'c10/cuda/CUDAEvent.h',
+    'c10/cuda/PeerToPeerAccess.cpp',
     'c10/mobile/CPUProfilingAllocator.cpp',
     'c10/util/accumulate.h',
     'c10/util/ApproximateClock.cpp',
     'c10/util/BFloat16-math.h',
     'c10/util/generic_math.h',
+    'c10/util/int128.cpp',
     'c10/util/IntrusiveList.h',
     'c10/util/irange.h',
     'c10/util/llvmMathExtras.h',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187689

The lintrunner-clang-all CI job on main is failing because clang-tidy
flags violations in files not yet on the suppression list. Add them to
the temporary exclude block (tracking issue #178341) to unblock trunk:

- aten/src/ATen/CPUApplyUtils.h
- c10/core/TensorOptions.h
- c10/cuda/CUDACachingAllocator.cpp
- c10/cuda/PeerToPeerAccess.cpp
- c10/util/int128.cpp

CUDACachingAllocator.cpp regressed when commit eb54d224f32 reverted the
warning fixes from #186308 (only the .h was previously suppressed); the
other four are pre-existing violations surfaced by --all-files linting.

Test Plan:

```
lintrunner -a .lintrunner.toml
```

Confirmed the flagged files come from the failing Lint run on main
(GitHub Actions run 27778060562, job lintrunner-clang-all).

Authored with assistance from Claude Code.