### PR TITLE
Unpack Python autograd saved tensors in reverse order

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -114,7 +114,8 @@ static PyObject* unpack_saved_variables(
   // because we will never hit this line of code if the buffers are freed--
   // and in any case saved_for will be non-NULL.)
   TORCH_INTERNAL_ASSERT(saved_for);
-  for (const auto i : c10::irange(num_saved)) {
+  for (const auto j : c10::irange(num_saved)) {
+    const auto i = num_saved - 1 - j;
     auto unpacked_var = saved_variables[i].unpack(saved_for);
     THPObjectPtr value;
     if (!unpacked_var.defined()) {


### PR DESCRIPTION
   This PR is proposed for community discussion. The change affects observable hook call order, so I am open to
   feedback on whether this behavior is acceptable, whether it should be guarded by a new API, or whether another
  mechanism would better support offload/prefetch use cases.
 
 ## Problem
  Saved tensor hooks are often used for activation offload and prefetching. In those setups, the order of `unpack_hook`
  calls can matter for performance and scheduling. Today, when Python autograd unpacks `ctx.saved_tensors`, it visits
  saved tensors in their original saved order, which may not match the reverse/backward consumption order expected by
  stack-like offload implementations.
  ## Solution
  This PR changes the internal unpack traversal to visit saved tensors from last to first, while preserving the returned
  tuple layout. User code still sees `ctx.saved_tensors` in the same order; only the order of underlying unpack hook
  calls changes.



