### PR TITLE
Fix control_deps handling in partitioner for forward/backward extraction

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9685,6 +9685,345 @@ def forward(self, primals_1, tangents_1):
         with functorch_config.patch(unsafe_treat_script_objects_as_zero_size=True):
             self.assertEqual(_size_of(node), 0)
 
+    def _build_control_deps_graph(
+        self,
+        deps,
+        additional_deps=(),
+        subgraph_op=None,
+        fwd_uses=None,
+    ):
+        """Build a minimal control_deps test graph.
+
+        Args:
+            deps: list of ("fwd" | "bw") indicating validity of each dep
+            additional_deps: list of ("fwd" | "bw") for ordering deps
+            subgraph_op: if provided, the subgraph's first output is
+                         op(dep_0) instead of None
+            fwd_uses: which dep indices (0-based) to consume in the forward
+                      output. Defaults to all fwd deps.
+        Returns: (graph, inputs, outputs, outputs_descs, mod)
+        """
+        import torch.fx as fx
+        from torch._functorch._aot_autograd.descriptors import DummyAOTOutput
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        g = fx.Graph()
+        mod = torch.nn.Module()
+        t = torch.randn(4)
+
+        fwd_in = g.placeholder("primals_0")
+        fwd_in.meta = {"val": t}
+        bw_in = g.placeholder("tangents_0")
+        bw_in.meta = {"val": t}
+
+        def _make_val(label):
+            if label == "fwd":
+                n = g.call_function(torch.ops.aten.sin.default, (fwd_in,))
+            else:
+                n = g.call_function(torch.ops.aten.cos.default, (bw_in,))
+            n.meta = {"val": t}
+            return n
+
+        dep_nodes = [_make_val(d) for d in deps]
+        addl_nodes = [_make_val(d) for d in additional_deps]
+
+        sg = fx.Graph()
+        sg_phs = [sg.placeholder(f"d{i}") for i in range(len(deps))]
+        if subgraph_op is not None:
+            op_out = sg.call_function(subgraph_op, (sg_phs[0],))
+            sg.output(tuple([op_out] + sg_phs))
+        else:
+            sg.output(tuple([None] + sg_phs))
+        sg_name = "_test_cd_sg"
+        setattr(mod, sg_name, fx.GraphModule(torch.nn.Module(), sg))
+        g.owning_module = mod  # type: ignore[assignment]
+
+        sg_node = g.get_attr(sg_name)
+        sg_node.meta = {}
+
+        n_outputs = 1 + len(deps)
+        cd = g.call_function(
+            cd_hop,
+            args=(tuple(addl_nodes), sg_node, *dep_nodes),
+        )
+        cd.meta = {"val": tuple(t for _ in range(n_outputs))}
+
+        for i in range(n_outputs):
+            gi = g.call_function(operator.getitem, (cd, i))
+            gi.meta = {"val": t}
+
+        if fwd_uses is None:
+            fwd_uses = [i for i, d in enumerate(deps) if d == "fwd"]
+        fwd_getitems = []
+        for gi_node in list(g.nodes):
+            if (
+                gi_node.op == "call_function"
+                and gi_node.target is operator.getitem
+                and gi_node.args[0] is cd
+            ):
+                idx = gi_node.args[1]
+                if idx == 0 and subgraph_op is not None:
+                    fwd_getitems.append(gi_node)
+                elif idx - 1 in fwd_uses:
+                    fwd_getitems.append(gi_node)
+
+        if len(fwd_getitems) == 0:
+            fwd_out = g.call_function(torch.ops.aten.sin.default, (fwd_in,))
+        elif len(fwd_getitems) == 1:
+            fwd_out = g.call_function(torch.ops.aten.relu.default, (fwd_getitems[0],))
+        else:
+            fwd_out = fwd_getitems[0]
+            for gi in fwd_getitems[1:]:
+                fwd_out = g.call_function(torch.ops.aten.add.Tensor, (fwd_out, gi))
+        fwd_out.meta = {"val": t}
+        g.output((fwd_out,))
+
+        return (
+            g,
+            [fwd_in],
+            [fwd_out],
+            [DummyAOTOutput(0)],
+            mod,
+        )
+
+    def _extract_and_check(self, graph, inputs, outputs, descs):
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        new_graph = _extract_graph_with_inputs_outputs(
+            graph, inputs, outputs, descs, ignore_must_be_in_fw_bw=True
+        )
+        new_graph.lint()
+        cd_nodes = [
+            n for n in new_graph.nodes if n.op == "call_function" and n.target is cd_hop
+        ]
+        gi_nodes = [
+            n
+            for n in new_graph.nodes
+            if n.op == "call_function" and n.target is operator.getitem
+        ]
+        return new_graph, cd_nodes, gi_nodes
+
+    def test_extract_graph_control_deps_mixed_validity(self):
+        g, ins, outs, descs, _ = self._build_control_deps_graph(deps=["fwd", "bw"])
+        _, cd_nodes, gi_nodes = self._extract_and_check(g, ins, outs, descs)
+        self.assertEqual(len(cd_nodes), 1)
+        self.assertEqual(len(cd_nodes[0].args) - 2, 1)
+        self.assertEqual(len(gi_nodes), 1)
+        self.assertEqual(gi_nodes[0].args[1], 1)
+
+    def test_extract_graph_control_deps_all_invalid(self):
+        g, ins, outs, descs, _ = self._build_control_deps_graph(deps=["bw"])
+        _, cd_nodes, _ = self._extract_and_check(g, ins, outs, descs)
+        self.assertEqual(len(cd_nodes), 0)
+
+    def test_extract_graph_control_deps_getitem_index_remap(self):
+        g, ins, outs, descs, _ = self._build_control_deps_graph(deps=["bw", "fwd"])
+        _, cd_nodes, gi_nodes = self._extract_and_check(g, ins, outs, descs)
+        self.assertEqual(len(cd_nodes), 1)
+        self.assertEqual(len(gi_nodes), 1)
+        self.assertEqual(gi_nodes[0].args[1], 1)
+
+    def test_extract_graph_control_deps_additional_deps_filtered(self):
+        g, ins, outs, descs, _ = self._build_control_deps_graph(
+            deps=["fwd", "bw"], additional_deps=["fwd"]
+        )
+        _, cd_nodes, _ = self._extract_and_check(g, ins, outs, descs)
+        self.assertEqual(len(cd_nodes), 1)
+        self.assertEqual(len(cd_nodes[0].args[0]), 1)
+        self.assertEqual(len(cd_nodes[0].args) - 2, 1)
+
+    def test_extract_graph_control_deps_preserves_subgraph_operation(self):
+        g, ins, outs, descs, mod = self._build_control_deps_graph(
+            deps=["fwd", "bw"], subgraph_op=torch.ops.aten.abs.default
+        )
+        _, cd_nodes, gi_nodes = self._extract_and_check(g, ins, outs, descs)
+        self.assertEqual(len(cd_nodes), 1)
+        sg_mod = getattr(mod, cd_nodes[0].args[1].target)
+        sg_ops = [n for n in sg_mod.graph.nodes if n.op == "call_function"]
+        self.assertEqual(len(sg_ops), 1)
+        self.assertEqual(sg_ops[0].target, torch.ops.aten.abs.default)
+        gi_indices = sorted(n.args[1] for n in gi_nodes)
+        self.assertIn(0, gi_indices)
+        self.assertIn(1, gi_indices)
+        self.assertNotIn(2, gi_indices)
+
+    def _build_backward_extract_graph(self, dep_labels, cd_tag, subgraph_op):
+        """Build a graph for testing backward extraction of control_deps.
+
+        Args:
+            dep_labels: list of ("bw_input" | "not_input") per dep.
+                "bw_input" deps become backward extraction inputs.
+                "not_input" deps are placeholders NOT in the input list.
+            cd_tag: partitioner_tag for the control_deps node.
+            subgraph_op: op for the sync subgraph (makes _control_deps_has_sync_op True).
+        Returns: (graph, bw_inputs, bw_output_node, descs, mod)
+        """
+        import torch.fx as fx
+        from torch._functorch._aot_autograd.descriptors import DummyAOTOutput
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        g = fx.Graph()
+        mod = torch.nn.Module()
+        t = torch.randn(4)
+
+        dep_nodes = []
+        bw_inputs = []
+        for i, label in enumerate(dep_labels):
+            ph = g.placeholder(f"dep_{i}")
+            ph.meta = {"val": t}
+            dep_nodes.append(ph)
+            if label == "bw_input":
+                bw_inputs.append(ph)
+
+        sg = fx.Graph()
+        sg_phs = [sg.placeholder(f"d{i}") for i in range(len(dep_labels))]
+        op_out = sg.call_function(subgraph_op, (sg_phs[0],))
+        sg.output(tuple([op_out] + sg_phs))
+        sg_name = "_test_cd_sg"
+        setattr(mod, sg_name, fx.GraphModule(torch.nn.Module(), sg))
+        g.owning_module = mod  # type: ignore[assignment]
+
+        sg_node = g.get_attr(sg_name)
+        sg_node.meta = {}
+
+        n_outputs = 1 + len(dep_labels)
+        cd = g.call_function(cd_hop, args=((), sg_node, *dep_nodes))
+        cd.meta = {
+            "val": tuple(t for _ in range(n_outputs)),
+            "partitioner_tag": cd_tag,
+        }
+
+        getitems = []
+        for i in range(n_outputs):
+            gi = g.call_function(operator.getitem, (cd, i))
+            gi.meta = {"val": t}
+            getitems.append(gi)
+
+        # Build an output that uses only bw_input getitems (indices 1-based).
+        bw_input_set = {id(n) for n in bw_inputs}
+        used = [
+            getitems[i + 1]
+            for i, dep in enumerate(dep_nodes)
+            if id(dep) in bw_input_set
+        ]
+        if not used:
+            out = g.call_function(torch.ops.aten.sin.default, (bw_inputs[0],))
+        elif len(used) == 1:
+            out = g.call_function(torch.ops.aten.relu.default, (used[0],))
+        else:
+            out = used[0]
+            for u in used[1:]:
+                out = g.call_function(torch.ops.aten.add.Tensor, (out, u))
+        out.meta = {"val": t}
+        g.output((out,))
+
+        return g, bw_inputs, [out], [DummyAOTOutput(0)], mod
+
+    def test_backward_extract_eliminates_fwd_sync_fully_valid(self):
+        """All deps are backward inputs -- forward sync control_deps
+        should be eliminated entirely, getitems resolve to deps."""
+        from torch._functorch._aot_autograd.streams import _SYNC_OPS
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        g, ins, outs, descs, _ = self._build_backward_extract_graph(
+            dep_labels=["bw_input", "bw_input"],
+            cd_tag="is_forward",
+            subgraph_op=_SYNC_OPS[0],
+        )
+        new_graph = _extract_graph_with_inputs_outputs(
+            g, ins, outs, descs, subgraph="backward"
+        )
+        new_graph.lint()
+        cd_nodes = [
+            n for n in new_graph.nodes if n.op == "call_function" and n.target is cd_hop
+        ]
+        self.assertEqual(len(cd_nodes), 0)
+        phs = [n for n in new_graph.nodes if n.op == "placeholder"]
+        self.assertEqual(len(phs), 2)
+        out_node = next(n for n in new_graph.nodes if n.op == "output")
+        self.assertIsNotNone(out_node)
+
+    def test_backward_extract_eliminates_fwd_sync_mixed_validity(self):
+        """Some deps are backward inputs, some are not -- forward sync
+        control_deps eliminated, valid getitems resolve to deps."""
+        from torch._functorch._aot_autograd.streams import _SYNC_OPS
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        g, ins, outs, descs, _ = self._build_backward_extract_graph(
+            dep_labels=["bw_input", "not_input"],
+            cd_tag="is_forward",
+            subgraph_op=_SYNC_OPS[0],
+        )
+        new_graph = _extract_graph_with_inputs_outputs(
+            g, ins, outs, descs, subgraph="backward"
+        )
+        new_graph.lint()
+        cd_nodes = [
+            n for n in new_graph.nodes if n.op == "call_function" and n.target is cd_hop
+        ]
+        self.assertEqual(len(cd_nodes), 0)
+        phs = [n for n in new_graph.nodes if n.op == "placeholder"]
+        self.assertEqual(len(phs), 1)
+
+    def test_backward_extract_preserves_bwd_sync_control_deps(self):
+        """Backward-tagged sync control_deps must stay in the backward graph."""
+        from torch._functorch._aot_autograd.streams import _SYNC_OPS
+        from torch._inductor.fx_passes.control_dependencies import (
+            control_deps as cd_hop,
+        )
+
+        g, ins, outs, descs, _ = self._build_backward_extract_graph(
+            dep_labels=["bw_input"],
+            cd_tag="must_be_in_backward",
+            subgraph_op=_SYNC_OPS[0],
+        )
+        new_graph = _extract_graph_with_inputs_outputs(
+            g, ins, outs, descs, subgraph="backward"
+        )
+        new_graph.lint()
+        cd_nodes = [
+            n for n in new_graph.nodes if n.op == "call_function" and n.target is cd_hop
+        ]
+        self.assertEqual(len(cd_nodes), 1)
+        sg_node = cd_nodes[0].args[1]
+        sg_mod = getattr(
+            g.owning_module,
+            sg_node.target,  # type: ignore[union-attr]
+        )
+        sg_ops = [n for n in sg_mod.graph.nodes if n.op == "call_function"]
+        self.assertEqual(len(sg_ops), 1)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_control_deps_mixed_fwd_bw_deps_e2e(self):
+        """Forward compilation and backward must not crash when
+        wait_stream's control_deps collects forward deps."""
+
+        def fn(x, w):
+            s1 = torch.cuda.Stream()
+            s1.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s1):
+                h = x @ w
+            ev = torch.cuda.Event()
+            ev.record(s1)
+            ev.wait()
+            return h
+
+        w = torch.randn(64, 64, device="cuda", requires_grad=True)
+        x = torch.randn(4, 64, device="cuda", requires_grad=True)
+        compiled = torch.compile(fn, backend="aot_eager")
+        out = compiled(x, w)
+        out.sum().backward()
+
 
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -413,6 +413,11 @@ def _wrap_sync_node(
             kwargs={},
         )
 
+    # Propagate partitioner_tag so the partitioner can distinguish
+    # forward vs backward sync control_deps during graph extraction.
+    if "partitioner_tag" in sync_node.meta:
+        control_deps_node.meta["partitioner_tag"] = sync_node.meta["partitioner_tag"]
+
     # Mark newly created nodes as visited so subsequent syncs don't
     # misclassify them as "after the sync" during replacement.
     visited.add(get_subgraph)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -28,11 +28,16 @@ from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
+from torch._functorch._aot_autograd.streams import _SYNC_OPS
 from torch._functorch._aot_autograd.utils import is_with_effects
 from torch._inductor import config as inductor_config
 from torch._inductor.custom_graph_pass import (
     CustomKnapsackSolver,
     CustomRuntimeEstimator,
+)
+from torch._inductor.fx_passes.control_dependencies import (
+    control_deps as control_deps_hop,
+    get_subgraph_name,
 )
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_opaque_value
@@ -295,6 +300,173 @@ def _find_input_for_invalid_output(
     return None
 
 
+def _control_deps_has_sync_op(node: fx.Node) -> bool:
+    """Check if a control_deps node's subgraph has a sync operation."""
+    sg_node = node.args[1]
+    if not (
+        isinstance(sg_node, fx.Node)
+        and sg_node.op == "get_attr"
+        and isinstance(sg_node.target, str)
+    ):
+        raise AssertionError(f"expected get_attr subgraph node, got {sg_node}")
+    owning_mod = node.graph.owning_module
+    if owning_mod is None:
+        raise AssertionError("expected graph to have an owning_module")
+    sg_mod = getattr(owning_mod, sg_node.target)
+    if not isinstance(sg_mod, fx.GraphModule):
+        raise AssertionError(f"expected GraphModule, got {type(sg_mod)}")
+    return any(
+        n.op == "call_function" and n.target in _SYNC_OPS for n in sg_mod.graph.nodes
+    )
+
+
+def _build_see_through_map(cd_node: fx.Node) -> dict[int, fx.Node]:
+    """Build a mapping from getitem indices to underlying dep nodes.
+
+    For a control_deps(additional_deps, subgraph, *deps), getitem index k
+    (k >= 1) corresponds to deps[k-1] which is args[k+1].
+    """
+    deps = cd_node.args[2:]
+    return {i + 1: dep for i, dep in enumerate(deps) if isinstance(dep, fx.Node)}
+
+
+def _try_clone_subgraph_filtering_deps(
+    original_sg_mod: fx.GraphModule,
+    valid_dep_indices: list[int],
+) -> tuple[fx.Graph, dict[int, int]] | None:
+    """Clone a control_deps subgraph, keeping only valid-dep placeholders.
+
+    Preserves any call_function nodes (the side-effecting operation) as long
+    as all placeholders they reference are in the valid set.  Returns
+    (new_graph, idx_remap) where idx_remap maps old getitem indices to new
+    ones, or None if the operation uses an invalid dep.
+    """
+    orig_phs = original_sg_mod.graph.find_nodes(op="placeholder")
+    valid_dep_set = OrderedSet(valid_dep_indices)
+    dropped_phs = OrderedSet(
+        [ph for i, ph in enumerate(orig_phs) if i not in valid_dep_set]
+    )
+
+    for n in original_sg_mod.graph.nodes:
+        if n.op == "call_function":
+            if any(inp in dropped_phs for inp in n.all_input_nodes):
+                return None
+
+    sg = fx.Graph()
+    sg_env: dict[fx.Node, fx.Node] = {}
+    for n in original_sg_mod.graph.nodes:
+        if n.op == "output" or n in dropped_phs:
+            continue
+        sg_env[n] = sg.node_copy(n, lambda x, _env=sg_env: _env[x])
+
+    orig_out_arg = original_sg_mod.graph.output_node().args[0]
+    if isinstance(orig_out_arg, tuple):
+        sg.output(
+            tuple(
+                sg_env[item] if isinstance(item, fx.Node) else item
+                for item in orig_out_arg
+                if not isinstance(item, fx.Node) or item in sg_env
+            )
+        )
+    elif isinstance(orig_out_arg, fx.Node) and orig_out_arg in sg_env:
+        sg.output(sg_env[orig_out_arg])
+    else:
+        sg.output(orig_out_arg)
+
+    preserved_op = any(n.op == "call_function" for n in sg.nodes)
+    idx_remap: dict[int, int] = {
+        old_i + 1: new_j + 1 for new_j, old_i in enumerate(valid_dep_indices)
+    }
+    if preserved_op:
+        idx_remap[0] = 0
+    return sg, idx_remap
+
+
+def _rebuild_control_deps_for_extract(
+    node: fx.Node,
+    env: dict[fx.Node, Any],
+    new_graph: fx.Graph,
+) -> tuple[fx.Node, dict[int, int]] | None:
+    """Rebuild a control_deps node with only valid deps for graph extraction.
+
+    When a control_deps node mixes valid (forward) and invalid (backward) args,
+    this creates a new control_deps in new_graph with only the valid deps and a
+    matching subgraph.  Returns (new_node, idx_remap) where idx_remap maps old
+    getitem indices to new getitem indices, or None if no valid deps remain.
+
+    additional_deps (args[0]) and deps (args[2:]) are filtered independently --
+    additional_deps are ordering-only constraints and may reference nodes that
+    are not in the deps set.
+    """
+    deps = node.args[2:]
+    valid_dep_indices = [
+        i
+        for i, dep in enumerate(deps)
+        if isinstance(dep, fx.Node) and not isinstance(env.get(dep), InvalidNodeBase)
+    ]
+    if not valid_dep_indices:
+        return None
+
+    # pyrefly: ignore [bad-index]
+    new_deps = tuple(env[deps[i]] for i in valid_dep_indices)
+
+    additional_deps = node.args[0]
+    if not isinstance(additional_deps, (tuple, list)):
+        raise AssertionError(
+            f"expected tuple/list additional_deps, got {type(additional_deps)}"
+        )
+    valid_additional_deps = tuple(
+        env[d]
+        for d in additional_deps
+        if isinstance(d, fx.Node) and not isinstance(env.get(d), InvalidNodeBase)
+    )
+
+    owning_mod = node.graph.owning_module
+    if owning_mod is None:
+        raise AssertionError("expected graph to have an owning_module")
+
+    sg_node = node.args[1]
+    if not (
+        isinstance(sg_node, fx.Node)
+        and sg_node.op == "get_attr"
+        and isinstance(sg_node.target, str)
+    ):
+        raise AssertionError(f"expected get_attr subgraph node, got {sg_node}")
+    original_sg_mod = getattr(owning_mod, sg_node.target)
+    if not isinstance(original_sg_mod, fx.GraphModule):
+        raise AssertionError(f"expected GraphModule, got {type(original_sg_mod)}")
+
+    result = _try_clone_subgraph_filtering_deps(original_sg_mod, valid_dep_indices)
+    if result is not None:
+        sg, idx_remap = result
+    else:
+        sg = fx.Graph()
+        sg_placeholders = [sg.placeholder(f"dep_{i}") for i in range(len(new_deps))]
+        sg.output((None, *sg_placeholders))
+        idx_remap = {
+            old_i + 1: new_j + 1 for new_j, old_i in enumerate(valid_dep_indices)
+        }
+
+    sg_name = get_subgraph_name(owning_mod, "cd_extract")
+    setattr(owning_mod, sg_name, fx.GraphModule(torch.nn.Module(), sg))
+    new_sg_node = new_graph.get_attr(sg_name)
+
+    new_cd = new_graph.create_node(
+        "call_function",
+        control_deps_hop,
+        args=(valid_additional_deps, new_sg_node, *new_deps),
+        name=node.name,
+    )
+    new_cd.meta = node.meta.copy()
+    if "val" in node.meta and isinstance(node.meta["val"], tuple):
+        orig_val = node.meta["val"]
+        new_cd.meta["val"] = (orig_val[0],) + tuple(
+            orig_val[i + 1] for i in valid_dep_indices if i + 1 < len(orig_val)
+        )
+
+    return new_cd, idx_remap
+
+
 def _extract_graph_with_inputs_outputs(
     joint_graph: fx.Graph,
     inputs: list[fx.Node],
@@ -315,6 +487,15 @@ def _extract_graph_with_inputs_outputs(
     """
     new_graph = fx.Graph()
     env: dict[fx.Node, fx.Node] = {}
+    # For control_deps nodes with mixed valid/invalid args, we create a new
+    # control_deps with only the valid deps.  This dict maps the original
+    # control_deps node to a {old_getitem_idx: new_getitem_idx} remapping so
+    # downstream getitem nodes can be rewritten to the correct indices.
+    _control_deps_idx_remap: dict[fx.Node, dict[int, int]] = {}
+    # For forward sync control_deps eliminated during backward extraction,
+    # maps the control_deps node to {getitem_idx: joint_graph_dep_node}.
+    # Getitems resolve directly to env[dep_node], bypassing the control_deps.
+    _control_deps_see_through: dict[fx.Node, dict[int, fx.Node]] = {}
 
     # Add new placeholder nodes in the order specified by the inputs
     for node in inputs:
@@ -350,6 +531,37 @@ def _extract_graph_with_inputs_outputs(
         elif node.op == "placeholder":
             env[node] = InvalidNode  # type: ignore[assignment]
         elif node.op == "call_function":
+            if (
+                node.target is operator.getitem
+                and node.args[0] in _control_deps_see_through
+            ):
+                dep_map = _control_deps_see_through[node.args[0]]
+                idx = node.args[1]
+                if idx in dep_map:
+                    env[node] = env[dep_map[idx]]
+                else:
+                    env[node] = InvalidNode  # type: ignore[assignment]
+                continue
+            if (
+                node.target is operator.getitem
+                and node.args[0] in _control_deps_idx_remap
+            ):
+                idx_map = _control_deps_idx_remap[node.args[0]]
+                idx = node.args[1]
+                if idx in idx_map:
+                    new_idx = idx_map[idx]
+                    new_getitem = new_graph.create_node(
+                        "call_function",
+                        operator.getitem,
+                        args=(env[node.args[0]], new_idx),
+                        name=node.name,
+                    )
+                    new_getitem.meta = node.meta
+                    env[node] = new_getitem
+                else:
+                    env[node] = InvalidNode  # type: ignore[assignment]
+                continue
+
             all_args = pytree.arg_tree_leaves(*node.args, **node.kwargs)
             all_args = [
                 isinstance(env[x], InvalidNodeBase)
@@ -357,6 +569,43 @@ def _extract_graph_with_inputs_outputs(
                 if isinstance(x, fx.Node)
             ]
             if any(all_args):
+                if node.target is control_deps_hop:
+                    # During backward extraction, eliminate forward sync
+                    # control_deps entirely -- their subgraphs reference
+                    # forward-only runtime state (streams/events) that is
+                    # dead at backward time.  Getitems are resolved directly
+                    # to the underlying deps via _control_deps_see_through.
+                    if (
+                        subgraph == "backward"
+                        and not (
+                            _has_tag_is_backward(node)
+                            or _has_tag_must_be_in_backward(node)
+                        )
+                        and _control_deps_has_sync_op(node)
+                    ):
+                        _control_deps_see_through[node] = _build_see_through_map(node)
+                        env[node] = InvalidNode  # type: ignore[assignment]
+                        continue
+                    new_cd_node = _rebuild_control_deps_for_extract(
+                        node, env, new_graph
+                    )
+                    if new_cd_node is not None:
+                        env[node] = new_cd_node[0]
+                        _control_deps_idx_remap[node] = new_cd_node[1]
+                        continue
+                env[node] = InvalidNode  # type: ignore[assignment]
+                continue
+            # During backward extraction, eliminate forward sync control_deps
+            # entirely.  See above for rationale.
+            if (
+                node.target is control_deps_hop
+                and subgraph == "backward"
+                and not (
+                    _has_tag_is_backward(node) or _has_tag_must_be_in_backward(node)
+                )
+                and _control_deps_has_sync_op(node)
+            ):
+                _control_deps_see_through[node] = _build_see_through_map(node)
                 env[node] = InvalidNode  # type: ignore[assignment]
                 continue
             # pyrefly: ignore [unsupported-operation, bad-argument-type]
@@ -3717,7 +3966,28 @@ def classify_nodes(
             required_bw_nodes.add(node)
 
         if node in required_bw_nodes:
-            required_bw_nodes.update(node.users)
+            if node.op == "call_function" and node.target is control_deps_hop:
+                # control_deps mixes forward and backward deps.  Only
+                # propagate required_bw to getitem users that extract a
+                # backward-only dep.  getitem(cd, k) with k>=1 maps to
+                # deps[k-1] (args[k+1]).
+                deps = node.args[2:]
+                for user in node.users:
+                    if (
+                        user.target is operator.getitem
+                        and isinstance(user.args[1], int)
+                        and 1 <= user.args[1] <= len(deps)
+                    ):
+                        dep = deps[user.args[1] - 1]
+                        if isinstance(dep, fx.Node) and dep in required_bw_nodes:
+                            required_bw_nodes.add(user)
+                    else:
+                        # Chained control_deps (e.g. wait/sync cd depends on
+                        # the record's cd via additional_deps) -- taint
+                        # conservatively.
+                        required_bw_nodes.add(user)
+            else:
+                required_bw_nodes.update(node.users)
 
     primal_inputs = list(filter(_is_primal, joint_module.graph.nodes))
     fwd_seed_offset_inputs = list(filter(_is_fwd_seed_offset, joint_module.graph.nodes))
@@ -3741,7 +4011,7 @@ def classify_nodes(
     required_fw_nodes: OrderedSet[fx.Node] = OrderedSet(
         name_to_node[node.name]
         for node in forward_only_graph.nodes
-        if node.op != "output"
+        if node.op != "output" and node.name in name_to_node
     )
     unclaimed_nodes: OrderedSet[fx.Node] = OrderedSet(
         node


### PR DESCRIPTION
## TL;DR

`torch.compile` crashes on models that use explicit CUDA streams when the
compiled function requires gradients. The forward partition crashes because the
partitioner incorrectly invalidates forward outputs that flow through stream
sync `control_deps`, and the backward partition crashes because forward-only
stream/event objects (dead at backward time) get copied into the backward graph.
This PR fixes both by teaching the partitioner to handle mixed forward/backward
deps in `control_deps` and to eliminate forward sync wrappers from the backward
graph while preserving the underlying data flow. Eliminating forward syncs from
backward is safe because the backward partition independently handles
synchronization for any nodes that are on different streams (via
`insert_backward_syncs`).

## Repro

```python
import torch

def fn(x, w):
    s1 = torch.cuda.Stream()
    s1.wait_stream(torch.cuda.current_stream())
    with torch.cuda.stream(s1):
        h = x @ w
    ev = torch.cuda.Event()
    ev.record(s1)
    ev.wait()
    return h

w = torch.randn(64, 64, device="cuda", requires_grad=True)
x = torch.randn(4, 64, device="cuda", requires_grad=True)
compiled = torch.compile(fn, backend="aot_eager")
out = compiled(x, w)      # Bug 1: AssertionError: Node _unsafe_view was invalid, but is output
out.sum().backward()      # Bug 2: AssertionError: User object is no longer alive
```

### Step-by-step walkthrough

**1. Joint graph after `wrap_all_sync_nodes_with_control_deps`:**

The streams pass runs on the joint fwd+bwd graph before partitioning. Each sync
op (`wait_stream`, `record_event`, `wait_event`) gets wrapped in a `control_deps`
HOP that threads through any tensors with uses after the sync point, creating
explicit data dependencies for ordering:

```
# --- Inputs ---
primals_1: f32[64, 64]   # w
primals_2: f32[4, 64]    # x
tangents_1: f32[4, 64]   # grad of output (backward input)

# --- Forward sync: wait_stream(s1, default) ---
# Threads primals AND tangents because all three have uses after the sync
# in the joint graph (backward ops consume them).
control_deps = control_deps(
    (primals_1, primals_2, tangents_1),   # additional_deps for ordering
    subgraph_wait_stream,                  # contains: wait_stream(1, 0)
    primals_1, primals_2, tangents_1       # pass-through deps
)
getitem   = control_deps[1]   # primals_1 (w)
getitem_1 = control_deps[2]   # primals_2 (x)
getitem_2 = control_deps[3]   # tangents_1

# --- Forward compute on s1 ---
mm = aten.mm(getitem_1, getitem)           # h = x @ w

# --- Forward sync: record_event(ev, s1) ---
control_deps_1 = control_deps((mm,), subgraph_record_event, mm)

# --- Forward sync: wait_event(ev, default) ---
control_deps_2 = control_deps((control_deps_1,), subgraph_wait_event)

# --- Backward compute ---
t     = aten.t(getitem_1)                  # x.T
mm_1  = aten.mm(t, getitem_2)             # grad_w = x.T @ tangents
t_1   = aten.t(getitem)                    # w.T
mm_2  = aten.mm(getitem_2, t_1)           # grad_x = tangents @ w.T

output: [mm, mm_2, mm_1]
#        fwd   grad_x  grad_w
```

The problem: `tangents_1` is threaded through the forward `control_deps`
because `_collect_wait_stream_forward_deps` scans all subsequent ops on the
waiting stream -- including backward ops. Since `tangents_1` has uses after
the sync point in the joint graph, it gets included in `deps_with_uses_after_sync`.

**2. Bug 1 — Forward extraction crash:**

`classify_nodes` sees that `tangents_1` (a backward dep) flows through
`control_deps`, so it taints the entire `control_deps` as backward. This
propagates to ALL getitem users — including `getitem` and `getitem_1` which
extract `primals_1` and `primals_2` (forward-only deps). Forward extraction
then marks these primals as `InvalidNode`, but they're needed as forward
outputs, causing:

```
AssertionError: Node _unsafe_view was invalid, but is output
```

**3. Bug 2 — Backward extraction crash:**

After fixing bug 1, forward compilation succeeds. But during backward
extraction, all three forward sync `control_deps` get copied into the backward
graph because their deps (`primals_1`, `primals_2`, `tangents_1`) are all valid
backward inputs. The min-cut partitioner rematerializes the forward `mm` from
saved primals, so the backward graph contains:

```
control_deps   = control_deps((primals_1, tangents_1, primals_2), subgraph_wait_stream, ...)
control_deps_1 = control_deps((mm,), subgraph_record_event, ...)
control_deps_2 = control_deps((control_deps_1,), subgraph_wait_event)
```

At backward runtime, `subgraph_wait_stream` calls `wait_stream(1, 0)` which
looks up stream index 1 — a forward-created Python `torch.cuda.Stream` object
that is no longer alive at backward time:

```
AssertionError: User object is no longer alive
```

## Fix

**Bug 1:** `classify_nodes` now inspects each getitem user individually — only
marks it backward if the specific dep it extracts (via the getitem index) is
itself backward. For mixed-validity `control_deps` during forward extraction,
`_rebuild_control_deps_for_extract` creates a new `control_deps` with only the
valid deps, cloning the subgraph and remapping downstream getitem indices.

**Bug 2:** During backward extraction, forward sync `control_deps` are
eliminated via a "see-through" approach. The `control_deps` node becomes
`InvalidNode`, and downstream getitems resolve directly to `env[dep]` — the
underlying dep in the backward graph. No nodes are erased; every value that
flowed through the `control_deps` still flows in backward, just without the
sync wrapper. The sync itself is only needed in the forward (where it remains
untouched), and the backward independently handles synchronization for nodes
on different streams via `insert_backward_syncs`.

Forward vs backward sync `control_deps` are distinguished by propagating
`partitioner_tag` from the original sync node to the `control_deps` node in
`_wrap_sync_node` (streams.py).

## Test plan
- Unit tests for backward extraction (fully-valid and mixed-validity elimination, backward sync preservation)
- Unit tests for forward extraction (mixed validity rebuild, index remapping, subgraph cloning)
- E2E CUDA test that runs both forward and backward on a multi-stream model
- All tests verified to fail without the fix

```
python -m pytest test/functorch/test_aotdispatch.py -xvs \
  -k "test_extract_graph_control_deps or test_control_deps_mixed_fwd_bw or test_backward_extract"
```

Co-authored-by: AI Assistant