### PR TITLE
Disable C++20-only clang-tidy checks instead of suppressing whole files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,10 @@
 ---
 # NOTE there must be no spaces before the '-', so put the comma last.
+# NOTE the modernize-use-{ranges,constraints,designated-initializers} and
+# readability-container-contains checks are disabled because they advise
+# C++20-only constructs (std::ranges, requires-clauses, designated
+# initializers, associative-container .contains()) that some internal builds
+# still on C++17 cannot compile.
 # The check bugprone-unchecked-optional-access is also turned on.
 # Note that it can cause clang-tidy to hang randomly. The tracking issue
 # can be found at https://github.com/llvm/llvm-project/issues/69369.
@@ -55,9 +60,11 @@ modernize-*,
 -modernize-use-using,
 -modernize-use-trailing-return-type,
 -modernize-use-nodiscard,
+-modernize-use-ranges,
+-modernize-use-constraints,
+-modernize-use-designated-initializers,
 performance-*,
 -performance-enum-size,
-readability-container-contains,
 readability-container-size-empty,
 readability-delete-null-pointer,
 readability-duplicate-include,

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -224,7 +224,6 @@ exclude_patterns = [
     # See https://github.com/pytorch/pytorch/issue/178341
     # Pre-existing violations surfaced when --all-files linting got re-enabled for
     # clang-tidy
-    'aten/src/ATen/CPUApplyUtils.h',
     'aten/src/ATen/core/IListRef.h',
     'aten/src/ATen/dlpack.h',
     'aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp',
@@ -242,7 +241,6 @@ exclude_patterns = [
     'c10/core/Stream.h',
     'c10/core/SymInt.h',
     'c10/core/SymIntArrayRef.h',
-    'c10/core/TensorOptions.h',
     'c10/cuda/CUDACachingAllocator.cpp',
     'c10/cuda/CUDACachingAllocator.h',
     'c10/cuda/CUDAEvent.h',
@@ -252,7 +250,6 @@ exclude_patterns = [
     'c10/util/ApproximateClock.cpp',
     'c10/util/BFloat16-math.h',
     'c10/util/generic_math.h',
-    'c10/util/int128.cpp',
     'c10/util/IntrusiveList.h',
     'c10/util/irange.h',
     'c10/util/llvmMathExtras.h',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #187697

The clang-tidy trunk failures are dominated by checks that advise C++20-only
constructs, which some internal builds still on C++17 cannot compile (the same
reason #186308 and #187208 were reverted). Rather than excluding entire files,
turn the offending checks off in .clang-tidy:

- modernize-use-ranges (std::ranges algorithms)
- modernize-use-constraints (requires-clauses / concepts)
- modernize-use-designated-initializers (designated initializers)
- readability-container-contains (associative-container .contains())


Authored with assistance from Claude Code.