### PR TITLE
Add a debug log when we skip sync_decision_cross_ranks (#187699)

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -2621,6 +2621,41 @@ class TestSyncDecisionCrossRanks(MultiProcessTestCase):
         self.assertEqual(saved_values, [wt1])
 
     @skip_if_lt_x_gpu(2)
+    def test_sync_decision_cross_ranks_different_inputs_skips_sync(self):
+        # When ranks have structurally different graphs, has_same_nodes returns
+        # False and the cross-rank sync is skipped, so each rank keeps its own
+        # saved_values instead of converging to a single rank's decision.
+        from torch._functorch.partitioners import _sync_decision_cross_ranks
+
+        test_graph = torch.fx.Graph()
+        node1 = test_graph.placeholder("x")
+        ag = test_graph.create_node(
+            "call_function",
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            (node1,),
+        )
+        wt = test_graph.create_node(
+            "call_function", torch.ops._c10d_functional.wait_tensor.default, (ag,)
+        )
+        wt.meta["val"] = torch.randn(10, 10)
+
+        # Diverge the graph structure across ranks so the canonical hashes differ.
+        if self.rank == 0:
+            extra = test_graph.create_node(
+                "call_function", torch.ops.aten.relu.default, (wt,)
+            )
+        else:
+            extra = test_graph.create_node(
+                "call_function", torch.ops.aten.neg.default, (wt,)
+            )
+        extra.meta["val"] = torch.randn(10, 10)
+        test_graph.output((extra,))
+
+        self._init_process_group()
+        saved_values = _sync_decision_cross_ranks(test_graph, [extra])
+        self.assertEqual(saved_values, [extra])
+
+    @skip_if_lt_x_gpu(2)
     def test_sync_decision_cross_ranks_different_node_order(self):
         # Reproduces the cross-rank sync bug: when ranks have topologically
         # identical graphs but different node creation orders (from different

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3851,7 +3851,14 @@ def _sync_decision_cross_ranks(
         with no_dispatch(), unset_fake_temporarily():
             # TODO: maybe use a different process group?
             torch.distributed.all_gather_object(all_inputs, inputs)
-        return all(all_inputs[0] == x for x in all_inputs)
+            for rank, x in enumerate(all_inputs):
+                if all_inputs[0] != x:
+                    log.debug(
+                        "Skipping sync decision cross rank due to different inputs between rank 0 and rank %s",
+                        rank,
+                    )
+                    return False
+        return True
 
     if has_same_nodes(joint_graph):
         with no_dispatch(), unset_fake_temporarily():


### PR DESCRIPTION
Summary:

When there is collectives in the graph but there is no sync decision cross ranks, it could potentially have issue of inconsistent decisions on different ranks on what to save. So adding this debug log to facilitate debug when the inconsistent issue happens.

Test Plan: Existing tests already cover it

Reviewed By: IvanKobzarev

Differential Revision: D109077916


