### PR TITLE
[dynamo, nested graph breaks] fix compile_subgraph failure swallowed by _format_value

### DIFF
--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -1557,6 +1557,29 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         # With suppression, the break propagates to the parent, producing more.
         self.assertGreater(cnts.frame_count, 2)
 
+    def test_fstring_graph_break_in_custom_str(self):
+        """f-string formatting of an object whose __str__ causes a graph break.
+
+        Regression test: when generic_str inlines __str__ and compile_subgraph
+        is called (setting should_exit=True) but fails with Unsupported,
+        _format_value must re-raise rather than silently swallowing the error.
+        """
+        import inspect
+
+        def target_fn(x: list[int]) -> int:
+            return sum(x)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnts)
+        def fn(x):
+            sig = inspect.signature(target_fn)
+            f"{sig}"
+            return x + 1
+
+        inp = torch.randn(3)
+        self.assertEqual(fn(inp), inp + 1)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4198,7 +4198,8 @@ class InstructionTranslatorBase(
                     self.push(str_result)
                     return
                 except Unsupported:
-                    pass
+                    if self.output.should_exit:
+                        raise
 
         fmt_var = VariableTracker.build(
             self, "{:" + fmt_spec.as_python_constant() + "}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #171826
* #163503
* #185524
* #186100
* #186657
* #187088
* #187005
* #186243
* __->__ #187701

When `f"{obj}"` is compiled and `obj.__str__()` is inlined via `generic_str`,
a graph break inside the inlined `__str__` chain can cause `compile_subgraph`
to be called and fail with `Unsupported` (e.g. reconstruction failure for a
sourceless variable). Previously, `_format_value`'s `except Unsupported: pass`
silently swallowed this exception, leaving the output in an inconsistent state
(`should_exit=True` with partial prefix instructions but no continuation code),
which later crashed in `stacksize_analysis` with "missing next inst: RESUME".

The fix checks `self.output.should_exit` in the except clause: if
`compile_subgraph` has already committed to exiting (setting `should_exit=True`),
the `Unsupported` exception is re-raised instead of swallowed. When
`should_exit` is False (the normal case where `generic_str` simply can't trace
`__str__`), the fallthrough to `str.format` is preserved.

Test Plan:
Regression test added in `test_fstring_graph_break_in_custom_str` which
compiles an f-string formatting an `inspect.Signature` object (whose
`__str__` triggers a cascading graph break chain). Verified the test crashes
without the fix and passes with it:

```
cd /tmp && python test/dynamo/test_nested_graph_breaks.py \
  NestedGraphBreakTests.test_fstring_graph_break_in_custom_str
```

Also verified no regressions across related test suites:

```
cd /tmp && python test/dynamo/test_nested_graph_breaks.py           # 52 tests OK
cd /tmp && python test/dynamo/test_str_protocol.py                  # 14 tests OK
cd /tmp && PYTORCH_TEST_WITH_DYNAMO=1 python test/test_fx.py \
  TestFXAPIBackwardCompatibility                                    # 5 tests OK
```

Co-authored-by: Claude (Anthropic AI assistant)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98