### PR TITLE
Add vmap batching rule for repeat_interleave.Tensor (#135424)

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1311,7 +1311,7 @@ std::tuple<Tensor, std::optional<int64_t>> repeat_interleave_Tensor_batch_rule(
       "repeat_interleave: the `repeats` tensor must be 1-dimensional for each "
       "batch element, but got a ", repeat_.dim() - 1, "-dimensional tensor.");
 
-  const auto out_size = output_size.value();
+  auto out_size = output_size.value();
   // Construct the gather indices without any data-dependent shapes so the rule
   // is a regular batched computation. For each batch element b:
   //   marks[b, cumsum(repeat[b])] += 1
@@ -1322,7 +1322,7 @@ std::tuple<Tensor, std::optional<int64_t>> repeat_interleave_Tensor_batch_rule(
   const auto cumsum = repeat_.cumsum(-1);
   auto marks = at::zeros_symint({batch_size, out_size + 1}, repeat_.options());
   marks = marks.scatter_add(-1, cumsum.to(at::kLong), at::ones_like(cumsum));
-  auto result = marks.narrow_symint(-1, 0, out_size).cumsum(-1);
+  auto result = marks.narrow_symint(-1, 0, std::move(out_size)).cumsum(-1);
   return std::make_tuple(std::move(result), 0);
 }
 

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1319,9 +1319,13 @@ std::tuple<Tensor, std::optional<int64_t>> repeat_interleave_Tensor_batch_rule(
   // which yields index i repeated repeat[b, i] times, e.g.
   //   repeat = [4, 0, 8] -> [0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2].
   const auto batch_size = repeat_.sym_size(0);
-  const auto cumsum = repeat_.cumsum(-1);
-  auto marks = at::zeros_symint({batch_size, out_size + 1}, repeat_.options());
-  marks = marks.scatter_add(-1, cumsum.to(at::kLong), at::ones_like(cumsum));
+  // Accumulate in int64 to avoid overflowing `repeat_`'s dtype for large
+  // outputs, and to keep the gather indices in the dtype repeat_interleave
+  // is expected to return.
+  const auto cumsum = repeat_.cumsum(-1, at::kLong);
+  auto marks = at::zeros_symint(
+      {batch_size, out_size + 1}, repeat_.options().dtype(at::kLong));
+  marks = marks.scatter_add(-1, cumsum, at::ones_like(cumsum));
   auto result = marks.narrow_symint(-1, 0, std::move(out_size)).cumsum(-1);
   return std::make_tuple(std::move(result), 0);
 }

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1284,6 +1284,48 @@ std::tuple<Tensor, std::optional<int64_t>> index_fill_int_tensor_batch_rule(
   return index_fill_int_tensor_batch_rule_impl(self_, self_bdim, dim, index, index_bdim, value, value_bdim, false);
 }
 
+std::tuple<Tensor, std::optional<int64_t>> repeat_interleave_Tensor_batch_rule(
+    const Tensor& repeat, std::optional<int64_t> repeat_bdim,
+    std::optional<c10::SymInt> output_size) {
+  if (!repeat_bdim.has_value()) {
+    // `repeat` is not batched, so the output length (the sum of `repeat`) is
+    // the same for every element of the batch. Re-dispatch to the regular
+    // implementation, which also handles any outer vmap levels correctly.
+    auto result = at::repeat_interleave_symint(repeat, std::move(output_size));
+    return std::make_tuple(std::move(result), std::nullopt);
+  }
+  // When `repeat` is batched the output length is data-dependent (it equals the
+  // sum of `repeat`, which may differ between batch elements), so vmap cannot
+  // infer a single static output shape. Require the user to pass `output_size`.
+  TORCH_CHECK(
+      output_size.has_value(),
+      "repeat_interleave: vmapping over the `repeats` tensor requires the "
+      "`output_size` argument to be specified, because the size of the output "
+      "equals the sum of `repeats`, which is data-dependent and may differ "
+      "between batch elements. Please pass output_size, e.g. "
+      "output_size=int(repeats.sum(-1).max()).");
+
+  const auto repeat_ = moveBatchDimToFront(repeat, repeat_bdim);
+  TORCH_CHECK(
+      repeat_.dim() == 2,
+      "repeat_interleave: the `repeats` tensor must be 1-dimensional for each "
+      "batch element, but got a ", repeat_.dim() - 1, "-dimensional tensor.");
+
+  const auto out_size = output_size.value();
+  // Construct the gather indices without any data-dependent shapes so the rule
+  // is a regular batched computation. For each batch element b:
+  //   marks[b, cumsum(repeat[b])] += 1
+  //   out[b] = marks[b, :output_size].cumsum()
+  // which yields index i repeated repeat[b, i] times, e.g.
+  //   repeat = [4, 0, 8] -> [0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2].
+  const auto batch_size = repeat_.sym_size(0);
+  const auto cumsum = repeat_.cumsum(-1);
+  auto marks = at::zeros_symint({batch_size, out_size + 1}, repeat_.options());
+  marks = marks.scatter_add(-1, cumsum.to(at::kLong), at::ones_like(cumsum));
+  auto result = marks.narrow_symint(-1, 0, out_size).cumsum(-1);
+  return std::make_tuple(std::move(result), 0);
+}
+
 }
 
 TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
@@ -1304,6 +1346,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   VMAP_SUPPORT(index_add, index_add_batch_rule);
   VMAP_SUPPORT(diagonal_scatter, diagonal_scatter_batch_rule);
   VMAP_SUPPORT(gather, gather_batch_rule);
+  VMAP_SUPPORT2(repeat_interleave, Tensor, repeat_interleave_Tensor_batch_rule);
   VMAP_SUPPORT2(scatter, value, scatter_value_batch_rule);
   VMAP_SUPPORT2(scatter, src, scatter_src_batch_rule);
   VMAP_SUPPORT(scatter_add, scatter_add_batch_rule);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -2922,9 +2922,7 @@ class TestVmapOperators(Namespace.TestVmapBase):
         # https://github.com/pytorch/pytorch/issues/135424
         # Vmapping over the `repeats` tensor requires `output_size` because the
         # output length (the sum of `repeats`) is data-dependent.
-        repeats = torch.tensor(
-            [[4, 0, 8], [2, 2, 8], [4, 2, 6], [2, 4, 6], [0, 4, 8]]
-        )
+        repeats = torch.tensor([[4, 0, 8], [2, 2, 8], [4, 2, 6], [2, 4, 6], [0, 4, 8]])
         output_size = 12  # every row sums to 12
 
         # repeat_interleave.Tensor: the base overload returning gather indices.

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -2918,6 +2918,50 @@ class TestVmapOperators(Namespace.TestVmapBase):
         test(lambda x: op(x, (2, 3)), (torch.rand(B0, 1, 1),))
         test(lambda x: op(x, (2, 3)), (torch.rand(1, B0, 1),), in_dims=1)
 
+    def test_repeat_interleave(self):
+        # https://github.com/pytorch/pytorch/issues/135424
+        # Vmapping over the `repeats` tensor requires `output_size` because the
+        # output length (the sum of `repeats`) is data-dependent.
+        repeats = torch.tensor(
+            [[4, 0, 8], [2, 2, 8], [4, 2, 6], [2, 4, 6], [0, 4, 8]]
+        )
+        output_size = 12  # every row sums to 12
+
+        # repeat_interleave.Tensor: the base overload returning gather indices.
+        def index_op(rep):
+            return torch.repeat_interleave(rep, output_size=output_size)
+
+        expected = torch.stack([index_op(r) for r in repeats])
+        self.assertEqual(vmap(index_op)(repeats), expected)
+
+        # repeat_interleave.self_Tensor: torch.repeat_interleave(input, repeats).
+        def op(rep):
+            values = torch.arange(1, rep.shape[0] + 1)
+            return torch.repeat_interleave(values, rep, output_size=output_size)
+
+        expected = torch.stack([op(r) for r in repeats])
+        self.assertEqual(vmap(op)(repeats), expected)
+
+        # Batching `values` while leaving `repeats` an unbatched constant keeps
+        # the output length the same per sample, so `output_size` is optional.
+        values = torch.randn(5, 3)
+        const_repeats = torch.tensor([2, 1, 3])
+
+        def op2(v):
+            return torch.repeat_interleave(v, const_repeats)
+
+        expected = torch.stack([op2(v) for v in values])
+        self.assertEqual(vmap(op2)(values), expected)
+
+        # Omitting `output_size` while vmapping over `repeats` is data-dependent
+        # and must raise a clear error.
+        def bad(rep):
+            values = torch.arange(1, rep.shape[0] + 1)
+            return torch.repeat_interleave(values, rep)
+
+        with self.assertRaisesRegex(RuntimeError, "output_size"):
+            vmap(bad)(repeats)
+
     @skipIfTorchDynamo()
     def test_slogdet(self):
         test = functools.partial(self._vmap_test, check_propagates_grad=False)


### PR DESCRIPTION
Fixes #135424

### Summary

`vmap`-ing a function that calls `torch.repeat_interleave` over a **batched `repeats` tensor** previously failed with:

```
RuntimeError: ... no batching rule implemented for aten::repeat_interleave.Tensor ...
```

The `repeat_interleave.self_Tensor` / `.self_int` overloads are already decomposed for functorch (`BatchRulesDecompositions.cpp`), but both bottom out in the `repeat_interleave.Tensor(Tensor repeats, *, SymInt? output_size=None)` primitive, which had no batching rule. This PR adds it.

### Why `output_size` is required when `repeats` is batched

The output length of `repeat_interleave.Tensor` is `sum(repeats)`, i.e. **data-dependent**. When `repeats` is batched, that sum can differ between batch elements, so `vmap` cannot infer a single static output shape. The new batch rule:

* **Unbatched `repeats`** (the pre-existing, already-working case where only the *values* are vmapped and `repeats` is a constant): re-dispatches to the regular implementation, so there is no behavior change and any outer vmap levels are handled correctly.
* **Batched `repeats`**: requires `output_size` and builds the gather indices in a shape-static, fully batched way:

  ```
  marks[b, cumsum(repeats[b])] += 1
  out[b] = marks[b, :output_size].cumsum(-1)
  ```

  which yields index `i` repeated `repeats[b, i]` times, e.g. `repeats = [4, 0, 8]`, `output_size = 12` → `[0,0,0,0, 2,2,2,2,2,2,2,2]`.

A clear error is raised when `output_size` is omitted for a batched `repeats`.

### Repro from the issue (now works with `output_size`)

```python
import torch
from torch.func import vmap

indices = torch.tensor([[4, 0, 8], [2, 2, 8], [4, 2, 6], [2, 4, 6], [0, 4, 8]])

def func(rep):
    values = torch.arange(1, rep.shape[0] + 1)
    return torch.repeat_interleave(values, rep, output_size=12)  # all rows sum to 12

print(vmap(func)(indices))
```

### Test

Adds `TestVmapOperators.test_repeat_interleave` covering: the indices overload, the `self_Tensor` overload, the unbatched-`repeats` fallback path, and the missing-`output_size` error.

> Note: I was unable to build PyTorch locally, so this relies on CI for build/test validation. The index-construction algorithm was verified against a reference implementation for the issue's inputs and edge cases (empty / single-element / leading & trailing zeros).

cc @zou3519 @Chillee @kshitij12345
