### PR TITLE
[c10d] Silence clang-tidy false positives in TraceUtils.h

### DIFF
--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -62,6 +62,7 @@ inline std::string ranksToString(const std::vector<int>& ranks) {
 }
 
 inline std::string ranksFromTrace(
+    // NOLINTNEXTLINE(readability-named-parameter)
     const std::vector<std::pair<int, std::string>>& items) {
   fmt::memory_buffer buf;
   bool first = true;
@@ -249,6 +250,7 @@ inline std::string retrieveDesyncReport(
   report += c10::str(
       "\n\t - [", myRank, "] Timeout at collective: ", thisCol, ", #", thisSeq);
 
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if (!missingRanks.empty()) {
     report += analyzeMissingRanks(missingRanks);
   } else {


### PR DESCRIPTION
## Summary

Two clang-tidy checks misfire on correct code in `TraceUtils.h` under `-warnings-as-errors`:

- `readability-named-parameter` flags the parameter of `ranksFromTrace`, but that parameter is named (`items`).
- `bugprone-branch-clone` flags the `if/else` in `retrieveDesyncReport`, but the two branches are not identical (one calls `analyzeMissingRanks`, the other `analyzeLaggingRanks` + `dumpSnapshot`).

Both are false positives, so this adds two targeted `NOLINTNEXTLINE` suppressions rather than changing behavior.

## Why this matters (it autoreverts unrelated PRs)

These violations are pre-existing and latent. `TraceUtils.h` only gets analyzed by the whole-repo `lintrunner-clang-all` job, which began enforcing clang-tidy across the entire tree after #187525 ("spin lint to honor `--all-files` for slow linters"). Because that run is sensitive to the build graph, **any unrelated PR that perturbs it can surface these dormant diagnostics and be autoreverted for code it never touched.**

That is exactly what happened to #178230 (a SymmMem feature that does not modify `TraceUtils.h`): `lintrunner-clang-all` was green on its parent, red on its merge (the only failures being these two `TraceUtils.h` lines), and green again after the autorevert. This change makes the file clean so it stops tripping innocent PRs and lets #178230 re-land unchanged.

## Test Plan

```
# Before (on main): fails on both checks
lintrunner --take CLANGTIDY torch/csrc/distributed/c10d/TraceUtils.h

# After: clean
lintrunner --take CLANGTIDY,CLANGFORMAT torch/csrc/distributed/c10d/TraceUtils.h
# -> ok No lint issues.
```

Authored with assistance from Claude Code.
