### PR TITLE
Fix B008 flake8-bugbear violations (function calls in default arguments)

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -235,10 +235,12 @@ class UniformQuantizationObserverBase(ObserverBase):
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         super().__init__(dtype=dtype, is_dynamic=is_dynamic, **kwargs)
         self.qscheme = qscheme
@@ -512,10 +514,12 @@ class MinMaxObserver(UniformQuantizationObserverBase):
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
@@ -638,10 +642,12 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         reduce_range=False,
         quant_min=None,
         quant_max=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 f"MovingAverageMinMaxObserver's qscheme only support \
@@ -723,10 +729,12 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "PerChannelMinMaxObserver's qscheme only support \
@@ -931,10 +939,12 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         reduce_range=False,
         quant_min=None,
         quant_max=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "MovingAveragePerChannelMinMaxObserver's qscheme only support \
@@ -1022,10 +1032,12 @@ class HistogramObserver(UniformQuantizationObserverBase):
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
-        eps=torch.finfo(torch.float32).eps,
+        eps=None,
         is_dynamic=False,
         **kwargs,
     ) -> None:
+        if eps is None:
+            eps = torch.finfo(torch.float32).eps
         if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 "HistogramObserver's qscheme only support torch.per_tensor_symmetric \

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -113,7 +113,9 @@ class Bernoulli(ExponentialFamily):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
             return torch.bernoulli(self.probs.expand(shape))

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -130,7 +130,9 @@ class Binomial(Distribution):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
             return torch.binomial(

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -141,7 +141,9 @@ class Categorical(Distribution):
             device=self.probs.device,
         )
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         if not isinstance(sample_shape, torch.Size):
             sample_shape = torch.Size(sample_shape)
         probs_2d = self.probs.reshape(-1, self._num_events)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -73,7 +73,9 @@ class Cauchy(Distribution):
             self._extended_shape(), inf, dtype=self.loc.dtype, device=self.loc.device
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if not sample_shape:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         eps = self.loc.new(shape).cauchy_()
         return self.loc + eps * self.scale

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -173,13 +173,17 @@ class ContinuousBernoulli(ExponentialFamily):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         u = torch.rand(shape, dtype=self.probs.dtype, device=self.probs.device)
         with torch.no_grad():
             return self.icdf(u)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         u = torch.rand(shape, dtype=self.probs.dtype, device=self.probs.device)
         return self.icdf(u)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -82,7 +82,9 @@ class Dirichlet(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = ()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)
         return _Dirichlet.apply(concentration)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -45,10 +45,14 @@ class Distribution:
 
     def __init__(
         self,
-        batch_shape: torch.Size = torch.Size(),
-        event_shape: torch.Size = torch.Size(),
+        batch_shape: torch.Size | None = None,
+        event_shape: torch.Size | None = None,
         validate_args: bool | None = None,
     ) -> None:
+        if batch_shape is None:
+            batch_shape = torch.Size()
+        if event_shape is None:
+            event_shape = torch.Size()
         self._batch_shape = batch_shape
         self._event_shape = event_shape
         if validate_args is not None:
@@ -164,20 +168,24 @@ class Distribution:
         """
         return self.variance.sqrt()
 
-    def sample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def sample(self, sample_shape: _size | None = None) -> Tensor:
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
         samples if the distribution parameters are batched.
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         with torch.no_grad():
             return self.rsample(sample_shape)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters
         are batched.
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         raise NotImplementedError
 
     @deprecated(
@@ -263,7 +271,7 @@ class Distribution:
         """
         return torch.exp(self.entropy())
 
-    def _extended_shape(self, sample_shape: _size = torch.Size()) -> torch.Size:
+    def _extended_shape(self, sample_shape: _size | None = None) -> torch.Size:
         """
         Returns the size of the sample returned by the distribution, given
         a `sample_shape`. Note, that the batch and event shapes of a distribution
@@ -273,6 +281,8 @@ class Distribution:
         Args:
             sample_shape (torch.Size): the size of the sample to be drawn.
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         if not isinstance(sample_shape, torch.Size):
             sample_shape = torch.Size(sample_shape)
         return torch.Size(sample_shape + self._batch_shape + self._event_shape)

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -65,7 +65,9 @@ class Exponential(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         return self.rate.new(shape).exponential_() / self.rate
 

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -83,7 +83,9 @@ class FisherSnedecor(Distribution):
             / (self.df1 * (df2 - 2).pow(2) * (df2 - 4))
         )
 
-    def rsample(self, sample_shape: _size = torch.Size(())) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         #   X1 ~ Gamma(df1 / 2, 1 / df1), X2 ~ Gamma(df2 / 2, 1 / df2)
         #   Y = df2 * df1 * X1 / (df1 * df2 * X2) = X1 / X2 ~ F(df1, df2)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -76,7 +76,9 @@ class Gamma(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(
             shape

--- a/torch/distributions/generalized_pareto.py
+++ b/torch/distributions/generalized_pareto.py
@@ -67,7 +67,9 @@ class GeneralizedPareto(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape=torch.Size()):
+    def rsample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         u = torch.rand(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.icdf(u)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -117,7 +117,9 @@ class Geometric(Distribution):
     def probs(self) -> Tensor:
         return logits_to_probs(self.logits, is_binary=True)
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         tiny = torch.finfo(self.probs.dtype).tiny
         with torch.no_grad():

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -111,10 +111,14 @@ class Independent(Distribution, Generic[D]):
     def variance(self) -> Tensor:
         return self.base_dist.variance
 
-    def sample(self, sample_shape=torch.Size()) -> Tensor:
+    def sample(self, sample_shape=None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         return self.base_dist.sample(sample_shape)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         return self.base_dist.rsample(sample_shape)
 
     def log_prob(self, value):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -70,7 +70,9 @@ class Laplace(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         finfo = torch.finfo(self.loc.dtype)
         if torch._C._get_tracing_state():

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -102,7 +102,9 @@ class LKJCholesky(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         # This uses the Onion method, but there are a few differences from [1] Sec. 3.2:
         # - This vectorizes the for loop and also works for heterogeneous eta.
         # - Same algorithm generalizes to n=1.

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -211,7 +211,9 @@ class LowRankMultivariateNormal(Distribution):
             self._batch_shape + self._event_shape + self._event_shape
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         W_shape = shape[:-1] + self.cov_factor.shape[-1:]
         eps_W = _standard_normal(W_shape, dtype=self.loc.dtype, device=self.loc.device)

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -175,7 +175,9 @@ class MixtureSameFamily(Distribution):
         )  # [B, k]
         return torch.logsumexp(log_prob_x + log_mix_prob, dim=-1)  # [S, B]
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         with torch.no_grad():
             sample_len = len(sample_shape)
             batch_len = len(self.batch_shape)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -109,7 +109,9 @@ class Multinomial(Distribution):
     def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         sample_shape = torch.Size(sample_shape)
         samples = self._categorical.sample(
             torch.Size((self.total_count,)) + sample_shape

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -248,7 +248,9 @@ class MultivariateNormal(Distribution):
             .expand(self._batch_shape + self._event_shape)
         )
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.loc + _batch_mv(self._unbroadcasted_scale_tril, eps)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -122,7 +122,9 @@ class NegativeBinomial(Distribution):
             validate_args=False,
         )
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         with torch.no_grad():
             rate = self._gamma.sample(sample_shape=sample_shape)
             return torch.poisson(rate)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -74,12 +74,16 @@ class Normal(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
             return torch.normal(self.loc.expand(shape), self.scale.expand(shape))
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         eps = _standard_normal(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.loc + eps * self.scale

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -101,8 +101,9 @@ class OneHotCategorical(Distribution):
     def param_shape(self) -> torch.Size:
         return self._categorical.param_shape
 
-    def sample(self, sample_shape=torch.Size()):
-        sample_shape = torch.Size(sample_shape)
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         probs = self._categorical.probs
         num_events = self._categorical._num_events
         indices = self._categorical.sample(sample_shape)
@@ -137,7 +138,7 @@ class OneHotCategoricalStraightThrough(OneHotCategorical):
 
     has_rsample = True
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
         samples = self.sample(sample_shape)
         probs = self._categorical.probs  # cached via @lazy_property
         return samples + (probs - probs.detach())

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -67,7 +67,9 @@ class Poisson(ExponentialFamily):
         new._validate_args = self._validate_args
         return new
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():
             return torch.poisson(self.rate.expand(shape))

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -101,7 +101,9 @@ class LogitRelaxedBernoulli(Distribution):
     def param_shape(self) -> torch.Size:
         return self._param.size()
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         probs = clamp_probs(self.probs.expand(shape))
         uniforms = clamp_probs(

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -84,7 +84,9 @@ class ExpRelaxedCategorical(Distribution):
     def probs(self) -> Tensor:
         return self._categorical.probs
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         uniforms = clamp_probs(
             torch.rand(shape, dtype=self.logits.dtype, device=self.logits.device)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -84,7 +84,7 @@ class StudentT(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
         # NOTE: This does not agree with scipy implementation as much as other distributions.
         # (see https://github.com/fritzo/notebooks/blob/master/debug-student-t.ipynb). Using DoubleTensor
         # parameters seems to help.
@@ -92,6 +92,8 @@ class StudentT(Distribution):
         #   X ~ Normal(0, 1)
         #   Z ~ Chi2(df)
         #   Y = X / sqrt(Z / df) ~ StudentT(df)
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         X = _standard_normal(shape, dtype=self.df.dtype, device=self.df.device)
         Z = self._chi2.rsample(sample_shape)

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -140,26 +140,30 @@ class TransformedDistribution(Distribution):
     def has_rsample(self) -> bool:  # type: ignore[override]
         return self.base_dist.has_rsample
 
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
         """
         Generates a sample_shape shaped sample or sample_shape shaped batch of
         samples if the distribution parameters are batched. Samples first from
         base distribution and applies `transform()` for every transform in the
         list.
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         with torch.no_grad():
             x = self.base_dist.sample(sample_shape)
             for transform in self.transforms:
                 x = transform(x)
             return x
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
         """
         Generates a sample_shape shaped reparameterized sample or sample_shape
         shaped batch of reparameterized samples if the distribution parameters
         are batched. Samples first from base distribution and applies
         `transform()` for every transform in the list.
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         x = self.base_dist.rsample(sample_shape)
         for transform in self.transforms:
             x = transform(x)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -82,7 +82,9 @@ class Uniform(Distribution):
     def support(self):
         return constraints.interval(self.low, self.high)
 
-    def rsample(self, sample_shape: _size = torch.Size()) -> Tensor:
+    def rsample(self, sample_shape: _size | None = None) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         rand = torch.rand(shape, dtype=self.low.dtype, device=self.low.device)
         return self.low + rand * (self.high - self.low)

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -171,7 +171,7 @@ class VonMises(Distribution):
         return torch.where(kappa < 1e-5, _proposal_r_taylor, _proposal_r)
 
     @torch.no_grad()
-    def sample(self, sample_shape=torch.Size()):
+    def sample(self, sample_shape=None):
         """
         The sampling algorithm for the von Mises distribution is based on the
         following paper: D.J. Best and N.I. Fisher, "Efficient simulation of the
@@ -181,6 +181,8 @@ class VonMises(Distribution):
         in _rejection_sample() for small values of the concentration, which
         starts to happen for single precision around 1e-4 (see issue #88443).
         """
+        if sample_shape is None:
+            sample_shape = torch.Size()
         shape = self._extended_shape(sample_shape)
         x = torch.empty(shape, dtype=self._loc.dtype, device=self.loc.device)
         return _rejection_sample(

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -231,7 +231,9 @@ class Wishart(ExponentialFamily):
             V.pow(2) + torch.einsum("...i,...j->...ij", diag_V, diag_V)
         )
 
-    def _bartlett_sampling(self, sample_shape=torch.Size()):
+    def _bartlett_sampling(self, sample_shape=None):
+        if sample_shape is None:
+            sample_shape = torch.Size()
         p = self._event_shape[-1]  # has singleton shape
 
         # Implemented Sampling using Bartlett decomposition
@@ -249,7 +251,7 @@ class Wishart(ExponentialFamily):
         return chol @ chol.transpose(-2, -1)
 
     def rsample(
-        self, sample_shape: _size = torch.Size(), max_try_correction=None
+        self, sample_shape: _size | None = None, max_try_correction=None
     ) -> Tensor:
         r"""
         .. warning::
@@ -262,6 +264,8 @@ class Wishart(ExponentialFamily):
 
         if max_try_correction is None:
             max_try_correction = 3 if torch._C._get_tracing_state() else 10
+        if sample_shape is None:
+            sample_shape = torch.Size()
 
         sample_shape = torch.Size(sample_shape)
         sample = self._bartlett_sampling(sample_shape)

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -12,8 +12,6 @@ from torch._C._distributed_c10d import (
     _create_work_from_future,
     AllgatherOptions,
     AllreduceOptions,
-    AllToAllOptions,
-    BarrierOptions,
     BroadcastOptions,
     ReduceOp,
     ReduceScatterOptions,
@@ -404,7 +402,7 @@ class ProcessLocalGroup(dist.ProcessGroup):
         input_buffer: torch.Tensor,
         output_split_sizes: list[int] | None,
         input_split_sizes: list[int] | None,
-        opts=AllToAllOptions(),
+        opts=None,
     ) -> torch.Tensor:
         coll = ProcessLocalGroup._start_coll(AllToAllBase(), self)
         res = coll.join(
@@ -414,70 +412,84 @@ class ProcessLocalGroup(dist.ProcessGroup):
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def alltoall(self, output_tensor_list, input_tensor_list, opts=AllToAllOptions()):
+    def alltoall(self, output_tensor_list, input_tensor_list, opts=None):
         coll = ProcessLocalGroup._start_coll(AllToAll(), self)
         res = coll.join(self._rank, (output_tensor_list, input_tensor_list))
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def allreduce(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce(self, tensor_list, opts=None):
+        if opts is None:
+            opts = AllreduceOptions()
         coll = ProcessLocalGroup._start_coll(AllReduce(opts.reduceOp), self)
         res = coll.join(self._rank, tensor_list)
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce_coalesced(self, tensor_list, opts=None):
+        if opts is None:
+            opts = AllreduceOptions()
         coll = ProcessLocalGroup._start_coll(AllReduce(opts.reduceOp), self)
         res = coll.join(self._rank, tensor_list)
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def barrier(self, opts=BarrierOptions()):
+    def barrier(self, opts=None):
         return self.allreduce(tensor_list=[torch.ones(1)])
 
-    def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+    def allgather(self, output_tensors, input_tensor, opts=None):
         coll = ProcessLocalGroup._start_coll(AllGather(), self)
         res = coll.join(self._rank, (output_tensors, input_tensor))
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def all_gather_single(self, output_tensor, input_tensor, opts=AllgatherOptions()):
+    def all_gather_single(self, output_tensor, input_tensor, opts=None):
+        if opts is None:
+            opts = AllgatherOptions()
         tensor_list = list(torch.chunk(output_tensor, self._world_size))
         return self.allgather([tensor_list], [input_tensor], opts)
 
-    def broadcast(self, tensor_list, opts=BroadcastOptions()):
+    def broadcast(self, tensor_list, opts=None):
+        if opts is None:
+            opts = BroadcastOptions()
         coll = ProcessLocalGroup._start_coll(Broadcast(opts.rootRank), self)
         res = coll.join(self._rank, tensor_list)
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def scatter(self, output_tensors, input_tensors, opts=ScatterOptions()):
+    def scatter(self, output_tensors, input_tensors, opts=None):
+        if opts is None:
+            opts = ScatterOptions()
         coll = ProcessLocalGroup._start_coll(Scatter(opts.rootRank), self)
         res = coll.join(self._rank, (output_tensors, input_tensors))
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def gather(self, output_tensors, input_tensors, opts=ScatterOptions()):
+    def gather(self, output_tensors, input_tensors, opts=None):
+        if opts is None:
+            opts = ScatterOptions()
         coll = ProcessLocalGroup._start_coll(Gather(opts.rootRank), self)
         res = coll.join(self._rank, (output_tensors, input_tensors))
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
+    def reduce_scatter(self, output_tensor, scatter_list, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         coll = ProcessLocalGroup._start_coll(ReduceScatter(opts.reduceOp), self)
         res = coll.join(self._rank, (output_tensor, scatter_list))
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
-    def reduce_scatter_single(
-        self, output_tensor, input_tensor, opts=ReduceScatterOptions()
-    ):
+    def reduce_scatter_single(self, output_tensor, input_tensor, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         tensor_list = list(torch.chunk(input_tensor, self._world_size))
         return self.reduce_scatter([output_tensor], [tensor_list], opts)
 
-    def reduce_scatter_single_coalesced(
-        self, output_tensors, input_tensors, opts=ReduceScatterOptions()
-    ):
+    def reduce_scatter_single_coalesced(self, output_tensors, input_tensors, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         works = [
             self.reduce_scatter_single(output_tensor, input_tensor, opts)
             for output_tensor, input_tensor in zip(
@@ -489,8 +501,10 @@ class ProcessLocalGroup(dist.ProcessGroup):
         return works[-1]
 
     def all_gather_single_coalesced(
-        self, output_tensor_list, input_tensor_list, opts=AllgatherOptions()
+        self, output_tensor_list, input_tensor_list, opts=None
     ):
+        if opts is None:
+            opts = AllgatherOptions()
         res = None
         for o_t, i_t in zip(output_tensor_list, input_tensor_list, strict=True):
             res = self.all_gather_single(o_t, i_t)


### PR DESCRIPTION
Fixes B008 flake8-bugbear lint violations across 32 files. Python evaluates
default arguments at function definition time, so mutable defaults or function
call results in signatures (e.g., `opts=AllToAllOptions()`,
`sample_shape=torch.Size()`) create shared state that persists across calls.

Related to #106571

Changed affected parameters to `None` defaults with initialization in the
function body.

Files changed:
  - `torch/distributions/` — 28 distribution files (`sample_shape=()` → `None`)
  - `torch/ao/quantization/observer.py` — 6 observer files (`eps=torch.finfo(...)` → `None`)
  - `torch/testing/_internal/distributed/multi_threaded_pg.py` — 14 methods (`opts=Options()` → `None`)

Test Plan:
  - `spin lint` passes
  - `ruff check --select B008` passes