### PR TITLE
test: Command to reproduce error is incorrect

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -630,6 +630,27 @@ class TestEnvironmentDefFlag(TestCase):
                 "FOO_DF_5", env_var="FOO_DF_5",
                 default=True, implied_by_fn=lambda: True))
 
+    def test_repro_prefix_uses_env_var_name_not_flag_name(self):
+        # Regression test for #106377: the repro command shown on test failure
+        # must use the actual environment variable name (e.g. PYTORCH_TEST_WITH_INDUCTOR),
+        # not the Python flag name (e.g. TEST_WITH_TORCHINDUCTOR).
+        from torch.testing._internal.common_utils import TestEnvironment
+        saved = TestEnvironment.repro_env_vars.copy()
+        try:
+            TestEnvironment.repro_env_vars.clear()
+            with unittest.mock.patch.dict(os.environ, {"MY_ACTUAL_ENV_VAR_6": "1"}):
+                self._def_flag(
+                    "MY_PYTHON_FLAG_6",
+                    env_var="MY_ACTUAL_ENV_VAR_6",
+                    include_in_repro=True,
+                )
+                prefix = TestEnvironment.repro_env_var_prefix()
+                self.assertIn("MY_ACTUAL_ENV_VAR_6=1", prefix)
+                self.assertNotIn("MY_PYTHON_FLAG_6", prefix)
+        finally:
+            TestEnvironment.repro_env_vars.clear()
+            TestEnvironment.repro_env_vars.update(saved)
+
 
 def make_assert_close_inputs(actual: Any, expected: Any) -> list[tuple[Any, Any]]:
     """Makes inputs for :func:`torch.testing.assert_close` functions based on two examples.


### PR DESCRIPTION
## Summary

When `TestEnvironment.def_flag` stores a flag in `repro_env_vars`, the original buggy code used the Python flag name (`name` parameter, e.g. `TEST_WITH_TORCHINDUCTOR`) as the dict key instead of the actual environment variable name (`env_var` parameter, e.g.


## Root cause

When `TestEnvironment.def_flag` stores a flag in `repro_env_vars`, the original
buggy code used the Python flag name (`name` parameter, e.g. `TEST_WITH_TORCHINDUCTOR`)
as the dict key instead of the actual environment variable name (`env_var` parameter,
e.g. `PYTORCH_TEST_WITH_INDUCTOR`).

This caused the repro command printed on test failure to show:

```
TEST_WITH_TORCHINDUCTOR=1 python test/test_torch.py -k test_nondeterministic_alert_NLLLoss_cuda
```

instead of the correct:

```
PYTORCH_TEST_WITH_INDUCTOR=1 python test/test_torch.py -k test_nondeterministic_alert_NLLLoss_cuda
```

The fix (already present in the current codebase at
`torch/testing/_internal/common_utils.py` line 200) is:

```python
TestEnvironment.repro_env_vars[env_var] = env_var_val # env_var, not name
```


## What changed

Added a regression test to `TestEnvironmentDefFlag` in `test/test_testing.py`:
`TestEnvironmentDefFlag.test_repro_prefix_uses_env_var_name_not_flag_name`.

The test:
1. Registers a flag with a distinct Python name (`MY_PYTHON_FLAG_6`) and env var name
 (`MY_ACTUAL_ENV_VAR_6`).
2. Calls `TestEnvironment.repro_env_var_prefix()`.
3. Asserts the prefix contains the env var name (`MY_ACTUAL_ENV_VAR_6=1`) and does
 NOT contain the Python flag name (`MY_PYTHON_FLAG_6`).

The test is placed in the existing `TestEnvironmentDefFlag` class alongside similar
`def_flag` regression tests. It saves and restores `TestEnvironment.repro_env_vars`
to avoid polluting global state for other tests.


## Issue

Fixes #106377

Issue: https://github.com/pytorch/pytorch/issues/106377


## Diffstat

```
test/test_testing.py | 21 +++++++++++++++++++++
 1 file changed, 21 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.