### PR TITLE
[CUDA] solve_triangular: fix silently wrong batched results and slowness in large-RHS workaround

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -218,16 +218,23 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
 }
 
 void triangular_solve_batched_cublas(const Tensor& A, const Tensor& B, bool left, bool upper, TransposeType transpose, bool unitriangular) {
-  // Workaround the following a bug on CUDA < 12.1
-  // RuntimeError: CUDA error: CUBLAS_STATUS_EXECUTION_FAILED when calling `cublasStrsmBatched
+  // Workaround the following bug on CUDA < 12.1
+  // RuntimeError: CUDA error: CUBLAS_STATUS_EXECUTION_FAILED when calling `cublasStrsmBatched`
   // See https://github.com/pytorch/pytorch/issues/79191#issuecomment-1154222580
-#if defined(CUSOLVER_VERSION) && CUSOLVER_VERSION < 12100
+#if defined(CUDA_VERSION) && CUDA_VERSION < 12010
   constexpr auto max_batch_size = 524280;
   if (B.size(-1) > max_batch_size) {
     auto n_chunks = (B.size(-1) + max_batch_size - 1) / max_batch_size; // ceildiv
-    auto splits = B.split(n_chunks, /*dim=*/-1);
+    auto splits = B.chunk(n_chunks, /*dim=*/-1);
     for (const Tensor& b : splits) {
-      triangular_solve_batched_cublas(A, b, left, upper, transpose, unitriangular);
+      // Each chunk is a non-contiguous view of B, but get_device_pointers()
+      // assumes the matrices are tightly packed (batch stride == rows*cols).
+      // Clone into a contiguous column-major tensor so the device pointers are
+      // computed correctly and b_cm has the layout cuBLAS expects.
+      Tensor b_cm = cloneBatchedColumnMajor(b);
+      triangular_solve_batched_cublas(A, b_cm, left, upper, transpose, unitriangular);
+      // Copy solution back into the output view
+      b.copy_(b_cm);
     }
     return;
   }

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4878,8 +4878,10 @@ class TestLinalg(TestCase):
     @dtypes(torch.float)
     def test_triangular_solve_large(self, device, dtype):
         # Repro for https://github.com/pytorch/pytorch/issues/79191
-        A = torch.randn(1, 2, 2, device=device, dtype=dtype).tril_()
-        B = torch.randn(1, 2, 524281, device=device, dtype=dtype)
+        # B.size(-1) > 524280 triggers the cuBLAS large-input workaround on CUDA < 12.1.
+        # batch sizes >= 2 guard a regression where the batched path returned silently wrong results.
+        A = torch.randn(2, 2, 2, device=device, dtype=dtype).tril_()
+        B = torch.randn(2, 2, 524281, device=device, dtype=dtype)
         X = torch.linalg.solve_triangular(A, B, upper=False)
         self.assertEqual(A @ X, B)
 


### PR DESCRIPTION
## Summary

PR #117636 added a workaround for a cuBLAS crash on CUDA < 12.1 in `torch.linalg.solve_triangular` when `B.size(-1) >= 524281` (#79191). This PR refines that implementation to address three unexpected side effects: the workaround triggers until CUDA 13.1, returns silently wrong results on batched inputs, and is slow.

## Workaround triggers until CUDA 13.1, not just CUDA 12.1

The guard `CUSOLVER_VERSION < 12100` was meant to target CUDA < 12.1, but cuSOLVER and CUDA version numbers don't line up: CUDA 13.1 ships cuSOLVER 12.0.7.41 and CUDA 13.2 ships 12.1.0.51. So `CUSOLVER_VERSION` stays below 12100 through CUDA 13.1. Switching the guard to `CUDA_VERSION < 12010` restricts it to the intended versions.

## Silent wrong results for `bs >= 2`

Minimal repro on CUDA 13.0:

```python
import torch
import scipy
torch.manual_seed(0)

bs, m, k = 2, 2, 524281
A = torch.randn(bs, m, m).tril_()
B = torch.randn(bs, m, k)

results = {}
for device in ["cpu", "cuda"]:
    results[device] = torch.linalg.solve_triangular(A.to(device), B.to(device), upper=False)
results["scipy"] = scipy.linalg.solve_triangular(A, B, lower=True)

diff_cuda_cpu = results["cuda"].cpu() - results["cpu"]
print("CUDA-CPU error:", diff_cuda_cpu.abs().max().item())
diff_scipy_cpu = torch.tensor(results["scipy"]) - results["cpu"]
print("scipy-CPU error:", diff_scipy_cpu.abs().max().item())
```

```
CUDA-CPU error: 18.254364013671875
scipy-CPU error: 9.5367431640625e-07
```

`apply_triangular_solve_batched` calls `get_device_pointers`, which derives the inter-matrix stride from `matrixStride(input)`, assuming a contiguous layout. However, `chunk(..., dim=-1)` produces non-contiguous views. Cloning each chunk with `cloneBatchedColumnMajor` restores contiguity, after which CUDA matches CPU:

```
CUDA-CPU error: 1.9073486328125e-06
scipy-CPU error: 9.5367431640625e-07
```

## Slowness

`B.split(n_chunks, dim=-1)` splits `B` into chunks of size `n_chunks`, not into `n_chunks` chunks. With `B.size(-1) == 524281` and `n_chunks == 2`, this issues 262141 calls to `triangular_solve_batched_cublas` instead of the intended 2. `B.chunk(n_chunks, dim=-1)` has the meaning the code wants. On an RTX 5070 Ti this drops `solve_triangular` on the input above from 2.26s to 0.47ms.

## Testing

Updated the batch size in `test_triangular_solve_large` from 1 to 2. On CUDA 13.0, the test fails before this PR and passes after.
```
pytest test/test_linalg.py -k test_triangular_solve_large -v
```
