### PR TITLE
Fix stale_issues year cutoff clamping the day to 28 in every month

### DIFF
--- a/tools/stale_issues.py
+++ b/tools/stale_issues.py
@@ -29,7 +29,13 @@ def parse_older_than(s):
         day = min(today.day, calendar.monthrange(year, month)[1])
         return date(year, month, day)
     elif unit == "year":
-        return date(today.year - n, today.month, min(today.day, 28))
+        year = today.year - n
+        # Clamp to the real length of the target month, same as the month branch:
+        # a hardcoded 28 wrongly shortens 30/31-day months (e.g. going back a
+        # year from 03-31 would yield 03-28 instead of 03-31), while still
+        # handling the leap day landing in a non-leap February.
+        day = min(today.day, calendar.monthrange(year, today.month)[1])
+        return date(year, today.month, day)
 
 
 def gh_issue_list(search, label, limit):

--- a/tools/test/test_stale_issues.py
+++ b/tools/test/test_stale_issues.py
@@ -11,8 +11,10 @@ def _today(value: date) -> type[date]:
     math in ``parse_older_than`` is deterministic regardless of the real clock."""
 
     class PinnedDate(date):
+        # date.today is typed to return Self; this stub pins it to a fixed
+        # date so the relative-date math is deterministic.
         @classmethod
-        def today(cls) -> date:
+        def today(cls) -> date:  # pyrefly: ignore [bad-override]
             return value
 
     return PinnedDate

--- a/tools/test/test_stale_issues.py
+++ b/tools/test/test_stale_issues.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest import main, mock, TestCase
+
+from tools.stale_issues import parse_older_than
+
+
+def _today(value: date) -> type[date]:
+    """A ``date`` subclass whose ``today()`` is pinned, so the relative-date
+    math in ``parse_older_than`` is deterministic regardless of the real clock."""
+
+    class PinnedDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return value
+
+    return PinnedDate
+
+
+class TestParseOlderThan(TestCase):
+    def test_days_and_weeks(self) -> None:
+        with mock.patch("tools.stale_issues.date", _today(date(2025, 3, 15))):
+            self.assertEqual(parse_older_than("10 days"), date(2025, 3, 5))
+            self.assertEqual(parse_older_than("2 weeks"), date(2025, 3, 1))
+
+    def test_months_clamps_to_non_leap_february(self) -> None:
+        # Three months before 2025-05-31 is February 2025 (non-leap), so the day
+        # must clamp to 28 rather than build an invalid 2025-02-31.
+        with mock.patch("tools.stale_issues.date", _today(date(2025, 5, 31))):
+            self.assertEqual(parse_older_than("3 months"), date(2025, 2, 28))
+
+    def test_months_keep_leap_day_in_leap_year(self) -> None:
+        with mock.patch("tools.stale_issues.date", _today(date(2024, 5, 31))):
+            self.assertEqual(parse_older_than("3 months"), date(2024, 2, 29))
+
+    def test_year_keeps_day_in_31_day_month(self) -> None:
+        # A year before 2024-03-31 is 2023-03-31. March has 31 days, so the day
+        # must be preserved, not clamped down to the 28 that only February needs.
+        with mock.patch("tools.stale_issues.date", _today(date(2024, 3, 31))):
+            self.assertEqual(parse_older_than("1 year"), date(2023, 3, 31))
+
+    def test_year_keeps_day_in_30_day_month(self) -> None:
+        # A year before 2024-04-30 is 2023-04-30 (April has 30 days).
+        with mock.patch("tools.stale_issues.date", _today(date(2024, 4, 30))):
+            self.assertEqual(parse_older_than("1 year"), date(2023, 4, 30))
+
+    def test_year_clamps_leap_day_to_non_leap_february(self) -> None:
+        # A year before the leap day 2024-02-29 lands in non-leap February 2023,
+        # which only has 28 days, so the day must clamp to the 28th.
+        with mock.patch("tools.stale_issues.date", _today(date(2024, 2, 29))):
+            self.assertEqual(parse_older_than("1 year"), date(2023, 2, 28))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The `"year"` branch of `parse_older_than` in `tools/stale_issues.py` hardcodes the day to `min(today.day, 28)`:

```python
elif unit == "year":
    return date(today.year - n, today.month, min(today.day, 28))
```

That clamp drops the day to the 28th in every month, even though only February needs it. Going back a year from a 30/31-day day therefore shortens the cutoff:

- from `2024-03-31`, `parse_older_than("1 year")` returns `2023-03-28` instead of `2023-03-31`
- from `2024-04-30`, it returns `2023-04-28` instead of `2023-04-30`

`"1 year"` is one of the documented formats (it's in the error message), and `--older-than` feeds straight into this function, so the cutoff comes out a few days earlier than intended for most days of the month.

This is the same bug #187643 already fixed for the `"month"` branch. This change applies the same approach to the `"year"` branch: clamp to the real length of the target month with `calendar.monthrange`, which keeps 30/31-day months intact and still pins the leap day `02-29` to `02-28` in a non-leap year.

## Test plan

Added three cases for the `"year"` unit (it previously had none): a 31-day month, a 30-day month, and the leap day landing in a non-leap February.

```
python tools/test/test_stale_issues.py
```

The two non-February cases fail before the change and pass after it; the leap-day case passes both ways.
