### PR TITLE
[MPS] Support KV batch broadcasting in flex_attention

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -992,7 +992,19 @@ class TestFlexAttention(InductorTestCase):
         compiled_out, compiled_lse = self.run_paged_attention(
             score_mod, q, k, v, dtype, device, block_mask
         )
-        golden_out, golden_lse = sdpa_partial(q_gold, k_gold, v_gold, return_lse=True)
+        if _is_mps_device(device):
+            # MPS has no float64; the golden runs on CPU, so its score_mod
+            # captures and block_mask must be relocated off-device too.
+            sdpa_partial_gold = create_attention(
+                _relocate_captures(score_mod, "cpu"),
+                block_mask.to("cpu"),
+                enable_gqa=(Q_H != KV_H),
+            )
+        else:
+            sdpa_partial_gold = sdpa_partial
+        golden_out, golden_lse = sdpa_partial_gold(
+            q_gold, k_gold, v_gold, return_lse=True
+        )
         ref_out, ref_lse = sdpa_partial(q_ref, k_ref, v_ref, return_lse=True)
         self._check_out(
             golden_out,
@@ -1460,7 +1472,6 @@ class TestFlexAttention(InductorTestCase):
         self.assertEqual(backend.frame_count, 2)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # run_test_with_paged_attention captures the page table
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
@@ -1548,7 +1559,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     def test_builtin_score_mods_different_seqlen(
         self, device, dtype: torch.dtype, score_mod: Callable
     ):
@@ -1574,7 +1584,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("BLOCK_SIZE", test_block_size)
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     def test_builtin_score_mods_different_block_size(
         self,
         device,
@@ -1597,7 +1606,6 @@ class TestFlexAttention(InductorTestCase):
     @common_utils.parametrize("batch_dims", test_Bq_Bkv)
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
     @common_utils.parametrize("score_mod", test_score_mods)
-    @expected_not_implemented_on_mps
     def test_kv_batch_broadcast(
         self,
         device,
@@ -1810,7 +1818,6 @@ class TestFlexAttention(InductorTestCase):
     @common_utils.parametrize("batch_dims", test_Bq_Bkv)
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
     @common_utils.parametrize("score_mod", test_score_mods)
-    @expected_not_implemented_on_mps
     def test_kv_batch_broadcast_causal_mask(
         self,
         device,
@@ -1842,7 +1849,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_call(attention, dtype, device, Bq, Hq, S, D, Bkv, Hkv, S, D)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
@@ -1865,7 +1871,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_paged_attention(*inputs)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # alibi score_mod captures slope buffer
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
@@ -1972,7 +1977,6 @@ class TestFlexAttention(InductorTestCase):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_doc_mask_sparse(self, device):
         document_id = torch.zeros(S, dtype=torch.int, device=device)
         for i in range(0, S, 256):
@@ -1989,7 +1993,6 @@ class TestFlexAttention(InductorTestCase):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_index_multiple(self, device):
         bias = torch.randn(B, S, device=device)
 
@@ -2000,7 +2003,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_paged_attention(index_multiple, torch.float16, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_index_weird1(self, device):
         bias = torch.randn(4, B, H, S, device=device)
 
@@ -2011,7 +2013,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_paged_attention(index_weird1, torch.float16, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_index_weird2(self, device):
         bias = torch.randn(B, H, 4, S, device=device)
         which_bias = torch.tensor(0, device=device)
@@ -2023,7 +2024,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_paged_attention(index_weird2, torch.float16, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
@@ -2035,7 +2035,6 @@ class TestFlexAttention(InductorTestCase):
         self.run_test_with_paged_attention(score_mod, dtype, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
@@ -2056,7 +2055,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
-    @expected_not_implemented_on_mps
     def test_captured_buffers_all_dims(self, device, dtype: torch.dtype):
         head_scale = torch.randn(H, device=device)
         batch_scale = torch.randn(B, device=device)
@@ -2142,7 +2140,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_seq_masking(self, device, dtype):
         seq_idx = torch.zeros(S, device=device, dtype=torch.bool)
         seq_idx[S // 2 :] = 1
@@ -2157,7 +2154,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_load_from_bias_seq_only(self, device, dtype):
         bias = torch.randn(S, S, device=device, dtype=dtype)
 
@@ -2171,7 +2167,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_load_from_bias_seq_batch(self, device, dtype):
         bias = torch.randn(B, S, S, device=device, dtype=dtype)
 
@@ -2233,7 +2228,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_load_from_bias_head_seq_batch(self, device, dtype):
         bias = torch.randn(B, H, S, S, device=device, dtype=dtype)
 
@@ -2247,7 +2241,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_load_rel_bias(self, device, dtype):
         rel_bias = torch.randn(2 * S, device=device, dtype=dtype)
 
@@ -2261,7 +2254,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_dependent_causal_bidirectional(self, device, dtype):
         num_bidirectional = torch.randint(0, S, (B,), device=device, dtype=torch.int32)
 
@@ -2284,7 +2276,6 @@ class TestFlexAttention(InductorTestCase):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     def test_natten_2d(self, device, dtype):
         H = 32
         W = S // H
@@ -2355,7 +2346,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
@@ -2389,7 +2379,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_captured_scale(self, device, dtype):
         scale = torch.ones((), device=device, dtype=torch.int32)
 
@@ -2404,7 +2393,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cuda"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_captured_scalar_grad(self, device, dtype):
         """Test learnable scalar parameter with shape (1,) using literal index."""
         self._run_test_captured_scalar_grad(device, dtype)
@@ -2435,7 +2423,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
-    @expected_not_implemented_on_mps
     def test_recompile_changed_score_mod(self, device, dtype):
         scale = torch.ones((), device=device, dtype=torch.int32)
         ADD = True
@@ -3106,7 +3093,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.assertTrue((out - out2).abs().mean() < 1e-2)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_multiple_score_mod_calls_paged_attention(self, device):
         query = torch.randn((1, 8, 1024, 64), dtype=torch.float32, device=device)
         keys = [
@@ -3186,7 +3172,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_multiple_score_mod_calls2_paged_attention(self, device):
         query = torch.randn((1, 8, 1024, 64), dtype=torch.float32, device=device)
         keys = [
@@ -3409,7 +3394,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
-    @expected_not_implemented_on_mps
     def test_njt_causal(self, device, dtype):
         offsets = torch.tensor(
             [0, 1024, 1024 + 512, S], device=device, dtype=torch.int32
@@ -3640,7 +3624,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(bias_mod, dtype=torch.float32, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps  # paged-attention leg captures the page table
     @common_utils.parametrize("score_mod", test_score_mods)
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
@@ -3701,7 +3684,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test_with_call(attention, dtype=torch.float16, device=device)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_causal_block_paged_attention(self, device):
         def mask_mod(b, h, q, kv):
             return q >= kv
@@ -3745,7 +3727,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(_rel_bias, dtype, device, B, H, S, head_dim, B, H, S, head_dim)
 
     @supported_platform
-    @expected_not_implemented_on_mps
     def test_GQA_causal_mask(self, device):
         def mask_mod(b, h, q, kv):
             return q >= kv
@@ -8295,6 +8276,14 @@ class TestPagedAttention(InductorTestCase):
         fudge_factor: float,
         tensor_name: str | None = None,
     ):
+        if (
+            golden_out.device != ref_out.device
+            or golden_out.device != compiled_out.device
+        ):
+            # MPS golden runs on CPU (no float64); compare everything on CPU.
+            golden_out = golden_out.cpu()
+            ref_out = ref_out.cpu()
+            compiled_out = compiled_out.cpu()
         compiled_error = (golden_out - compiled_out).abs().mean()
         ref_error = (golden_out - ref_out).abs().mean()
         if torch.isnan(compiled_error).any() or torch.isnan(ref_error).any():
@@ -8645,7 +8634,18 @@ class TestPagedAttention(InductorTestCase):
 
         sdpa_partial = create_attention(score_mod, block_mask, enable_gqa=False)
 
-        golden_out = sdpa_partial(q_gold, k_gold, v_gold)
+        if _is_mps_device(device):
+            # MPS has no float64; the golden runs on CPU, so its score_mod
+            # captures and block_mask must be relocated off-device too.
+            sdpa_partial_gold = create_attention(
+                _relocate_captures(score_mod, "cpu"),
+                block_mask.to("cpu"),
+                enable_gqa=False,
+            )
+        else:
+            sdpa_partial_gold = sdpa_partial
+
+        golden_out = sdpa_partial_gold(q_gold, k_gold, v_gold)
         ref_out = sdpa_partial(q_ref, k_ref, v_ref)
 
         MAX_CACHED_SEQ_LEN = n_pages * page_size
@@ -9882,7 +9882,11 @@ instantiate_device_type_tests(
     allow_mps=True,
 )
 instantiate_device_type_tests(
-    TestPagedAttention, globals(), only_for=test_device, allow_xpu=True
+    TestPagedAttention,
+    globals(),
+    only_for=test_device,
+    allow_xpu=True,
+    allow_mps=True,
 )
 instantiate_device_type_tests(
     TestBlockMask,

--- a/torch/_inductor/codegen/metal_flex_attention_template.py
+++ b/torch/_inductor/codegen/metal_flex_attention_template.py
@@ -242,6 +242,19 @@ def _fx_graph_to_metal(
             else:
                 code_lines.append(f"float {t} = {v};")
         elif target in (
+            torch.ops.aten.div.Tensor_mode,
+            torch.ops.aten.div.Scalar_mode,
+        ):
+            # Floor/trunc division (e.g. paged attention's kv_idx // page_size).
+            mode = args[2] if len(args) > 2 else node.kwargs.get("rounding_mode")
+            quot = f"static_cast<float>({_val(args[0])}) / static_cast<float>({_val(args[1])})"
+            if mode == "floor":
+                code_lines.append(f"float {t} = metal::floor({quot});")
+            elif mode == "trunc":
+                code_lines.append(f"float {t} = metal::trunc({quot});")
+            else:
+                code_lines.append(f"float {t} = {quot};")
+        elif target in (
             torch.ops.aten.full_like.default,
             torch.ops.aten.full.default,
         ):
@@ -326,7 +339,7 @@ def _generate_mma_shader(
                 int d = i % D_QK;
                 if (n_local < tile_size) {{
                     int n_global = tile_start + n_local;
-                    long k_off = b_idx * stride_kz + hkv_idx * stride_kh + (long)n_global * stride_kn + (long)d * stride_kk;
+                    long k_off = b_kv * stride_kz + hkv_idx * stride_kh + (long)n_global * stride_kn + (long)d * stride_kk;
                     KV_tg[n_local * D_QK + d] = K[k_off];
                 }} else {{
                     KV_tg[n_local * D_QK + d] = ({metal_dtype})0;
@@ -362,7 +375,7 @@ def _generate_mma_shader(
                 int n_local = i / D_V;
                 int d = i % D_V;
                 int n_global = tile_start + n_local;
-                long v_off = b_idx * stride_vz + hkv_idx * stride_vh + (long)n_global * stride_vn + (long)d * stride_vk;
+                long v_off = b_kv * stride_vz + hkv_idx * stride_vh + (long)n_global * stride_vn + (long)d * stride_vk;
                 KV_tg[n_local * D_V + d] = V[v_off];
             }}
             threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -423,6 +436,7 @@ kernel void flex_attn_fwd(
     int q_block = tgpos.x;
     int h_idx = tgpos.y;
     int b_idx = tgpos.z;
+    int b_kv = b_idx % (int)Bkv;
     int m_base = q_block * BLOCK_M;
     int m_idx = m_base + (int)tid;
     bool active = (m_idx < N_Q);
@@ -572,6 +586,7 @@ def _generate_metal_shader(
     # Pack scalars into one buffer to stay under Metal's 31-buffer limit.
     scalar_names = [
         "B",
+        "Bkv",
         "Hq",
         "Hkv",
         "N_Q",
@@ -674,7 +689,7 @@ def _generate_metal_shader(
                 int n_local = i / D_QK;
                 int d = i % D_QK;
                 int n_global = tile_start + n_local;
-                long k_off = b_idx * stride_kz + hkv_idx * stride_kh + (long)n_global * stride_kn + (long)d * stride_kk;
+                long k_off = b_kv * stride_kz + hkv_idx * stride_kh + (long)n_global * stride_kn + (long)d * stride_kk;
                 K_tile[n_local * D_QK + d] = K[k_off];
             }}
 
@@ -682,7 +697,7 @@ def _generate_metal_shader(
                 int n_local = i / D_V;
                 int d = i % D_V;
                 int n_global = tile_start + n_local;
-                long v_off = b_idx * stride_vz + hkv_idx * stride_vh + (long)n_global * stride_vn + (long)d * stride_vk;
+                long v_off = b_kv * stride_vz + hkv_idx * stride_vh + (long)n_global * stride_vn + (long)d * stride_vk;
                 V_tile[n_local * D_V + d] = V[v_off];
             }}
 
@@ -750,6 +765,7 @@ kernel void flex_attn_fwd(
     int q_block = tgpos.x;
     int h_idx = tgpos.y;
     int b_idx = tgpos.z;
+    int b_kv = b_idx % (int)Bkv;
     int m_idx = q_block * BLOCK_M + (int)tid;
     bool active = (m_idx < N_Q);
 

--- a/torch/_inductor/kernel/flex/flex_mps.py
+++ b/torch/_inductor/kernel/flex/flex_mps.py
@@ -110,16 +110,8 @@ def lower_mps(
         )
 
     sizevars = V.graph.sizevars
-    # Kernel indexes K/V with the same b_idx as Q; no broadcast logic for Bkv=1 yet.
-    # check_equals adds a runtime guard B == Bkv; it raises AssertionError if it
-    # can prove they differ — convert to NIE so callers see the right error.
-    try:
-        sizevars.check_equals(B, Bkv)
-    except AssertionError:
-        raise NotImplementedError(
-            f"flex_attention on MPS does not yet support batch broadcasting "
-            f"between query and key/value (Bq != Bkv); got Bq={B} Bkv={Bkv}"
-        ) from None
+    if not sizevars.evaluate_expr(sympy.Eq(B, Bkv) | sympy.Eq(Bkv, 1)):
+        raise AssertionError(f"Bq and Bkv must broadcastable. Got Bq={B} and Bkv={Bkv}")
 
     SPARSE_KV_BLOCK_SIZE_val = sizevars.guard_int(SPARSE_KV_BLOCK_SIZE)
     SPARSE_Q_BLOCK_SIZE_val = sizevars.guard_int(SPARSE_Q_BLOCK_SIZE)
@@ -212,6 +204,7 @@ def lower_mps(
     # Order must match the unpack in metal_flex_attention_template's `scalar_names`.
     scalar_args = [
         B,
+        Bkv,
         Hq,
         Hkv,
         seq_len_q,


### PR DESCRIPTION
Make the MPS flex kernel handle Bkv == 1 (KV shared across the query batch). Prerequisite for paged attention.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo