### PR TITLE
Fix extract_scripts step-index zero-padding off-by-one

### DIFF
--- a/tools/extract_scripts.py
+++ b/tools/extract_scripts.py
@@ -69,7 +69,7 @@ def main() -> None:
             if "steps" not in job:
                 continue
             steps = job["steps"]
-            index_chars = len(str(len(steps) - 1))
+            index_chars = len(str(len(steps)))
             for i, step in enumerate(steps, start=1):
                 extracted = extract(step)
                 if extracted:

--- a/tools/test/test_extract_scripts.py
+++ b/tools/test/test_extract_scripts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.extract_scripts import main
+
+
+class TestExtractScripts(unittest.TestCase):
+    def test_index_prefix_padded_to_widest_step(self) -> None:
+        # A job with exactly ten script steps sits on the power-of-ten
+        # boundary: the indices run 1..10, so every filename prefix must be two
+        # digits for the extracted files to sort in step order.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            steps = "\n".join(f"      - run: echo {n}" for n in range(10))
+            (workflows / "ci.yml").write_text(f"jobs:\n  build:\n    steps:\n{steps}\n")
+            out = root / "out"
+
+            cwd = os.getcwd()
+            os.chdir(root)
+            try:
+                with mock.patch.object(
+                    sys, "argv", ["extract_scripts.py", "--out", str(out)]
+                ):
+                    main()
+            finally:
+                os.chdir(cwd)
+
+            job_dir = out / ".github" / "workflows" / "ci.yml" / "build"
+            names = sorted(p.name for p in job_dir.iterdir())
+            self.assertEqual(len(names), 10)
+            # The first and tenth steps must share the same prefix width, else
+            # "10.sh" would sort between "1.sh" and "2.sh".
+            self.assertIn("01.sh", names)
+            self.assertIn("10.sh", names)
+            self.assertTrue(all(re.fullmatch(r"\d{2}\.sh", n) for n in names), names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`extract_scripts.py` numbers each extracted step with a 1-based index (`enumerate(steps, start=1)`), so the indices run `1..len(steps)`. The zero-pad width, however, is computed from `len(steps) - 1`:

```python
index_chars = len(str(len(steps) - 1))
for i, step in enumerate(steps, start=1):
    ...
    filename = f"{i:0{index_chars}}{sanitized}{extension}"
```

When a job has exactly a power-of-ten number of steps (10, 100, ...), the largest index needs one more digit than `len(steps) - 1`, so the prefix is padded one digit too narrow and the filenames stop sorting in step order. For a 10-step job the extracted files come out as:

```
1.sh  10.sh  2.sh  3.sh  ...  9.sh
```

which defeats the "avoid ambiguity in file sorting" reason the prefix is zero-padded in the first place. Computing the width from `len(steps)` (the actual maximum index) fixes it:

```
01.sh  02.sh  ...  09.sh  10.sh
```

Added `tools/test/test_extract_scripts.py`, which runs the extractor on a 10-step job and checks every prefix is two digits. It fails on `main` (`'01.sh' not found in ['1.sh', '10.sh', '2.sh', ...]`) and passes with this change.
