### PR TITLE
[DDP] Fix static_graph=True + no_sync() gradient accumulation regression

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -583,8 +583,8 @@ void Reducer::set_mixed_precision_param_dtype(c10::ScalarType dtype) {
   }
 }
 
-// Right now delay_all_reduce is only called when static_graph_=true and
-// num_iterations_==1.
+// Right now delay_all_reduce is only called when static_graph_=true on the
+// first gradient-syncing backward (enqueued once from _DDPSink.backward).
 void Reducer::delay_all_reduce() {
   std::lock_guard<std::mutex> lock(this->mutex_);
 
@@ -692,7 +692,14 @@ void Reducer::autograd_hook(size_t index) {
     });
   }
 
-  if (static_graph_first_iteration()) {
+  // expect_autograd_hooks_ (set by prepare_for_backward, which _post_forward
+  // skips under no_sync()) restricts this to syncing backwards. Otherwise
+  // every no_sync accumulation micro-batch backward also increments the map,
+  // since num_bwd_calls_ stays 1 across the whole first-iteration window so
+  // static_graph_first_iteration() stays true. Those inflated counts stop the
+  // per-iteration counter from reaching zero on later iterations, so the
+  // gradients are never all-reduced.
+  if (static_graph_first_iteration() && expect_autograd_hooks_) {
     numGradHooksTriggeredMap_[index] += 1;
     return;
   }

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -393,14 +393,23 @@ class _DDPSink(Function):
     @staticmethod
     def backward(ctx, *grad_outputs):
         # Enqueue delay allreduce for static graph training on the first
-        # iteration.
+        # gradient-syncing iteration.
         ddp_weakref = ctx.ddp_weakref()
         reducer = ddp_weakref.reducer
         static_graph = ddp_weakref.static_graph
         delay_ar_enqueued = (
             static_graph and ddp_weakref._static_graph_delay_allreduce_enqueued
         )
-        if static_graph and not delay_ar_enqueued:
+        # Only enqueue on a syncing backward. Under no_sync() _post_forward skips
+        # prepare_for_backward, so expect_autograd_hooks_ is never set and
+        # enqueueing here would trip its assert in finalize_backward(). Deferring
+        # to the first syncing backward also keeps accumulation correct: the
+        # no_sync backwards accumulate .grad locally and it is all-reduced then.
+        if (
+            static_graph
+            and not delay_ar_enqueued
+            and ddp_weakref.require_backward_grad_sync
+        ):
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce
             )

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -10256,6 +10256,89 @@ class DistributedTest:
 
             dist.barrier()
 
+        @skip_but_pass_in_sandcastle_if(
+            BACKEND != "nccl" and BACKEND != "gloo",
+            "Only Nccl & Gloo backend support DistributedDataParallel",
+        )
+        @nccl_skip_if_lt_x_gpu(BACKEND, 2)
+        def test_static_graph_no_sync_gradient_accumulation(self):
+            # Regression test for static_graph=True + no_sync() gradient
+            # accumulation (regressed by #103487, reported in
+            # huggingface/accelerate#3679). Without the fix the first no_sync
+            # backward trips an expect_autograd_hooks_ assert, and once that is
+            # unblocked gradients are silently not all-reduced from iter 2 on.
+            # Distinct per-rank data makes a missing all-reduce observable
+            # (identical data would hide it: un-reduced local grad == averaged).
+            class Net(nn.Module):
+                def __init__(self) -> None:
+                    super().__init__()
+                    self.lin1 = nn.Linear(10, 10)
+                    self.relu = nn.ReLU()
+                    self.lin2 = nn.Linear(10, 10)
+
+                def forward(self, x):
+                    return self.lin2(self.relu(self.lin1(x)))
+
+            if BACKEND == "nccl":
+                torch.cuda.set_device(self.rank)
+                device = torch.device("cuda", self.rank)
+            else:
+                device = torch.device("cpu")
+
+            torch.manual_seed(31415)
+            model = Net().to(device)
+            ddp_model = torch.nn.parallel.DistributedDataParallel(
+                model,
+                device_ids=[self.rank] if BACKEND == "nccl" else None,
+                static_graph=True,
+            )
+            # Reference model with the (broadcast) DDP weights on every rank, so
+            # gradients can be checked on all ranks rather than just rank 0.
+            ref_model = copy.deepcopy(ddp_model.module).to(device)
+
+            world_size = dist.get_world_size()
+            num_microbatches = 3  # 2 accumulated under no_sync + 1 syncing
+
+            def make_batch(it, mb):
+                # Distinct data per (rank, iteration, micro-batch).
+                g = torch.Generator().manual_seed(1000 * self.rank + 10 * it + mb + 1)
+                return torch.randn(4, 10, generator=g).to(device)
+
+            for it in range(3):
+                # --- DDP gradient accumulation: no_sync for all but the last. ---
+                ddp_model.zero_grad()
+                for mb in range(num_microbatches):
+                    batch = make_batch(it, mb)
+                    if mb < num_microbatches - 1:
+                        with ddp_model.no_sync():
+                            ddp_model(batch).sum().backward()
+                    else:
+                        ddp_model(batch).sum().backward()
+
+                # --- Reference: accumulate the same micro-batches locally, then
+                # all-reduce-mean across ranks (this is exactly what correct DDP
+                # gradient accumulation must produce). ---
+                ref_model.zero_grad()
+                for mb in range(num_microbatches):
+                    ref_model(make_batch(it, mb)).sum().backward()
+                ref_grads = []
+                for p in ref_model.parameters():
+                    g = p.grad.detach().clone()
+                    dist.all_reduce(g, op=dist.ReduceOp.SUM)
+                    g /= world_size
+                    ref_grads.append(g)
+
+                for (name, p_ddp), g_ref in zip(
+                    ddp_model.module.named_parameters(), ref_grads, strict=True
+                ):
+                    self.assertTrue(
+                        torch.allclose(p_ddp.grad, g_ref, atol=1e-5, rtol=1e-5),
+                        f"iter {it} param {name}: ddp grad does not match "
+                        f"all-reduced reference (missing/double all-reduce). "
+                        f"max abs diff "
+                        f"{(p_ddp.grad - g_ref).abs().max().item()}",
+                    )
+
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             BACKEND != "nccl" and BACKEND != "gloo",


### PR DESCRIPTION
DDP(static_graph=True) with gradient accumulation via no_sync() crashes on the first backward with an expect_autograd_hooks_ INTERNAL ASSERT, and once that is unblocked it silently stops all-reducing gradients from the second iteration on. Both are regressions from #103487, which re-keyed the static-graph "first iteration" check from num_iterations_ (advances only on syncing forwards) to num_bwd_calls_ (advances on every backward). Reported in huggingface/accelerate#3679.

Under no_sync() require_backward_grad_sync is False, so _post_forward skips prepare_for_backward() and expect_autograd_hooks_ stays false for the whole accumulation window. The crash: _DDPSink.backward still enqueued the one-shot static-graph delay_all_reduce, whose finalize_backward() asserts expect_autograd_hooks_; it now only enqueues on a syncing backward. The wrong gradients: with num_bwd_calls_ stuck at 1, static_graph_first_iteration() stays true, so every micro-batch backward incremented numGradHooksTriggeredMap_, inflating the per-parameter counts until the per-iteration counter could no longer reach zero and parameters were never marked ready; the increment is now gated on expect_autograd_hooks_ so only the syncing backward records it. This preserves https://github.com/pytorch/pytorch/pull/103487's multiple-forward support, whose single backward syncs.

Test Plan:
New test_static_graph_no_sync_gradient_accumulation runs static_graph + no_sync accumulation for several iterations, checking grads against an all-reduced local reference, with distinct per-rank data so a missing all-reduce is visible. Without the Python fix it asserts on iteration 1; without the C++ fix it fails the grad check from iteration 2.

```bash
touch /tmp/barrier
TEMP_DIR=/tmp BACKEND=gloo WORLD_SIZE=2 python \
    test/distributed/test_distributed_spawn.py -v \
    -k test_static_graph_no_sync_gradient_accumulation
```

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh