### PR TITLE
Fix bmm outer product Triton launch on non-current CUDA device

### DIFF
--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -93,6 +93,29 @@ class TestBmmOuterProduct(TestCase):
         with self.assertRaises(RuntimeError):
             torch.bmm(a, b)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_non_current_device_outer_product(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("requires at least 2 visible CUDA devices")
+
+        old_device = torch.cuda.current_device()
+        try:
+            torch.cuda.set_device(0)
+            a = torch.randn(4, 8, 1, device="cuda:1")
+            b = torch.randn(4, 1, 16, device="cuda:1")
+
+            out = torch.bmm(a, b)
+
+            self.assertEqual(torch.cuda.current_device(), 0)
+            self.assertEqual(out.device, torch.device("cuda:1"))
+            self.assertEqual(out, a * b)
+
+            mismatched_a = torch.randn(4, 8, 1, device="cuda:0")
+            with self.assertRaisesRegex(RuntimeError, "same device|different"):
+                torch.bmm(mismatched_a, b)
+        finally:
+            torch.cuda.set_device(old_device)
+
 
 class TestOuterProductDetection(TestCase):
     def test_is_outer_product(self):

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -23,7 +23,12 @@ def _bmm_outer_product_impl(
 ) -> torch.Tensor:
     from .triton_kernels import bmm_outer_product
 
-    return bmm_outer_product(a, b)
+    device = a.get_device()
+    if device == torch.cuda.current_device():
+        return bmm_outer_product(a, b)
+
+    with torch.cuda.device(device):
+        return bmm_outer_product(a, b)
 
 
 def _bmm_outer_product_cond(
@@ -37,6 +42,7 @@ def _bmm_outer_product_cond(
     if (
         a.is_cuda
         and b.is_cuda
+        and a.device == b.device
         and _is_outer_product(a, b)
         and not (a_is_cow or b_is_cow)
     ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187733

The Python native bmm outer-product override launches a Triton kernel for
CUDA inputs shaped like `(B, M, 1) x (B, 1, N)`. Unlike the generated C++
ATen CUDA path, this Python dispatch path does not get an automatic CUDA
device guard before launching the kernel. In vLLM multimodal tests, the
model hooks can run the relevant rotary embedding buffers and inputs on
`cuda:1` while the process current device is still `cuda:0`; Triton then
launches on the wrong device/stream and rejects the `cuda:1` pointers with
`ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)`.

Guard the Triton call when the input device is not already current, while
leaving the common already-current path direct to avoid unnecessary Python
context manager overhead. Also require both bmm inputs to be on the same CUDA
device before selecting the override, so mismatched CUDA inputs fall back to
native bmm and report the normal same-device error instead of reaching the
Triton kernel.

I considered guarding unconditionally, but a small same-device benchmark showed
that the Python context manager adds measurable overhead for small outer-product
bmm calls. The conditional guard keeps the fix scoped to the non-current-device
case that needs it.

Fixes #187729
Generated by my agent

Benchmark Results:
- Command: `CUDA_VISIBLE_DEVICES=0 python - <<'PY' ...` benchmarking 7 trials of 1000 `torch.bmm` calls on `(32, 128, 1) x (32, 1, 512)` CUDA tensors with current device matching the inputs.
- Before: median 24.210 us/call; raw `[24.34, 24.365, 24.195, 24.206, 24.21, 24.272, 24.142]`.
- After: median 24.946 us/call; raw `[25.045, 24.909, 25.008, 25.042, 24.906, 24.946, 24.926]`.

Test Plan:
- `CUDA_VISIBLE_DEVICES=0,1 python - <<'PY' ...` minimal repro: before the fix failed with the Triton pointer `ValueError`; after the fix produced a `cuda:1` result and preserved current device `0`.
- `CUDA_VISIBLE_DEVICES=0,1 python -m pytest test/test_bmm_outer_product.py -q -rs` passed: `11 passed, 10 subtests passed`.
- `lintrunner torch/_native/ops/bmm_outer_product/triton_impl.py test/test_bmm_outer_product.py` passed.
- `git diff --cached --check` passed.
- `lintrunner -a` was run and failed on unrelated pre-existing clang-tidy findings in untouched C++ files.