### PR TITLE
Fix FX graph cache with legacy ShapeEnv guards

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -830,6 +830,93 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(stats.hit, 1)
         cache_stats._stats.clear()
 
+    def test_save_graph_with_legacy_shape_env(self):
+        from torch._inductor.compile_fx import CompiledFxGraph
+
+        class LegacyShapeEnv:
+            def __init__(self):
+                self.produce_guards_expression_called = False
+
+            def get_pruned_guards(self, symints):
+                self.symints = symints
+                return []
+
+            def produce_guards_expression(
+                self, placeholders, *, guards=None, ignore_static=True
+            ):
+                self.produce_guards_expression_called = True
+                self.placeholders = placeholders
+                self.guards = guards
+                return "legacy_guard"
+
+        compiled_graph = object.__new__(CompiledFxGraph)
+        compiled_graph.current_callable = None
+        compiled_graph.recursively_apply_fns = None
+        compiled_graph.compiled_fn_runner = None
+        compiled_graph._compile_context = None
+        compiled_graph._original_gm = None
+
+        shape_env = LegacyShapeEnv()
+        with mock.patch.object(FxGraphCache, "_get_shape_env", return_value=shape_env):
+            FxGraphCache._save_graph(
+                "legacy_shape_env_test",
+                compiled_graph,
+                [],
+                local=False,
+                remote_cache=None,
+            )
+
+        self.assertTrue(shape_env.produce_guards_expression_called)
+        self.assertEqual(shape_env.symints, [])
+        self.assertEqual(shape_env.placeholders, [])
+        self.assertEqual(shape_env.guards, [])
+        self.assertEqual(compiled_graph.guards_expr, "legacy_guard")
+        self.assertIsNone(compiled_graph.guards_expr_with_source)
+        self.assertIsNone(compiled_graph.guards_expr_with_source_arg_count)
+
+    def test_cache_load_falls_back_to_plain_guards_with_legacy_shape_env(self):
+        class LegacyShapeEnv:
+            def __init__(self):
+                self.evaluated_guards = None
+                self.guards = []
+
+            def evaluate_guards_expression(self, code, args):
+                self.evaluated_guards = (code, args)
+                return True
+
+        shape_env = LegacyShapeEnv()
+        graph = types.SimpleNamespace(
+            guards_expr="legacy_guard",
+            guards_expr_with_source=[object()],
+            guards_expr_with_source_arg_count=0,
+            extern_libs_key=None,
+        )
+
+        with (
+            mock.patch.object(FxGraphCache, "_get_shape_env", return_value=shape_env),
+            mock.patch.object(
+                FxGraphCache,
+                "find_guarded_entry",
+                return_value=(graph, None, {}),
+            ),
+            mock.patch.object(
+                FxGraphCache,
+                "cache_hit_post_compile",
+                return_value=("compiled_graph", {}),
+            ),
+        ):
+            compiled_graph, cache_info = FxGraphCache._lookup_graph(
+                "legacy_shape_env_test",
+                [],
+                local=False,
+                remote_cache=None,
+                constants=mock.sentinel.constants,
+            )
+
+        self.assertEqual(compiled_graph, "compiled_graph")
+        self.assertEqual(cache_info, {})
+        self.assertEqual(shape_env.evaluated_guards, ("legacy_guard", []))
+
     @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
     @functorch_config.patch({"enable_autograd_cache": False})
     def test_default_dtype_affects_factory_cache_key(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2178,6 +2178,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                 guards_expr_with_source is not None
                 and guards_expr_with_source_arg_count == len(symints)
                 and not config.unsafe_skip_cache_dynamic_shape_guards
+                and hasattr(shape_env, "evaluate_guards_expression_with_source_info")
             )
             if can_replay_guards_with_source:
                 check = shape_env.evaluate_guards_expression_with_source_info(
@@ -2240,12 +2241,18 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             raise AssertionError("ShapeEnv is not set for cache serialization")
         symints = FxGraphCache._filter_backed_symints(example_inputs)
         guards = shape_env.get_pruned_guards(symints)
-        (
-            compiled_graph.guards_expr,
-            compiled_graph.guards_expr_with_source,
-        ) = shape_env.produce_guards_expression_with_source_info(
-            placeholders=symints, guards=guards
-        )
+        if hasattr(shape_env, "produce_guards_expression_with_source_info"):
+            (
+                compiled_graph.guards_expr,
+                compiled_graph.guards_expr_with_source,
+            ) = shape_env.produce_guards_expression_with_source_info(
+                symints, guards=guards
+            )
+        else:
+            compiled_graph.guards_expr = shape_env.produce_guards_expression(
+                symints, guards=guards
+            )
+            compiled_graph.guards_expr_with_source = None
         compiled_graph.guards_expr_with_source_arg_count = (
             len(symints) if compiled_graph.guards_expr_with_source is not None else None
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187734

FxGraphCache started saving per-guard source information by calling
ShapeEnv.produce_guards_expression_with_source_info unconditionally. That made
FX graph cache serialization depend on a newer ShapeEnv method even though the
cache still only needs a plain guards expression to decide whether a cached graph
is valid. Custom ShapeEnv-like implementations such as vLLM's always-hit env can
satisfy the older guard-expression contract without implementing the newer
source-info helpers, so standalone compile crashed while saving a graph.

Make source-info guard serialization and replay optional. Shape envs that expose
the newer source-info APIs keep the richer cache metadata. Shape envs that only
expose the older produce/evaluate_guards_expression methods fall back to the
plain guard expression path, matching older cache entries and avoiding a hard API
requirement on out-of-tree custom envs.

I considered adding default source-info methods to the ShapeEnv class, but that
would not help duck-typed custom env objects that do not subclass the current
ShapeEnv. The cache boundary already supports source-less guard entries, so the
compatibility check belongs at the cache save/load call sites.

Fixes #187728
Generated by my agent

Test Plan:
- python test/inductor/test_codecache.py TestFxGraphCache.test_save_graph_with_legacy_shape_env TestFxGraphCache.test_cache_load_falls_back_to_plain_guards_with_legacy_shape_env
- python test/inductor/test_codecache.py TestFxGraphCache.test_save_graph_with_legacy_shape_env TestFxGraphCache.test_cache_load_falls_back_to_plain_guards_with_legacy_shape_env TestFxGraphCache.test_local_cache_stats
- lintrunner torch/_inductor/codecache.py test/inductor/test_codecache.py
- lintrunner -a (fails on unrelated repo-wide clang-tidy findings outside this change)

Benchmark Results:
Changed guard blocks, 7 rounds of 1,000,000 iterations:
- save before/source-info env: 146.6 ns/op; after/source-info env: 180.0 ns/op
- save legacy env: before raised AttributeError; after: 151.1 ns/op
- load before/source-info env: 92.9 ns/op; after/source-info env: 133.6 ns/op
- load legacy env: before raised AttributeError; after: 125.9 ns/op

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo