### PR TITLE
[dynamo] Fix precompile guard-state load with no active trace

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -446,17 +446,35 @@ def add(x, y):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
+    def test_import_source_unpickle_without_trace(self):
+        # Deserializing an ImportSource happens at torch.compile() time with no
+        # active TracingContext (e.g. precompile warm-load). Reconstructing the
+        # source must not install a guard (which would require a tracing
+        # context), so the round-trip must not raise.
+        import pickle
+
+        from torch._dynamo.source import ImportSource
+
+        source = ImportSource("torch")
+        reloaded = pickle.loads(pickle.dumps(source))
+        self.assertEqual(reloaded, source)
+
     @parametrize("device", ("cpu", "cuda", "xpu"))
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_import_source_guard(self, device):
-        # Warm-loading a guard state with an ImportSource must not raise
+        # Warm-loading a guard state whose serialized sources include an
+        # ImportSource must not raise. `pytree.tree_is_leaf` routes through
+        # `get_pytree_SUPPORTED_NODES_source`, which builds an
+        # `ImportSource("torch")` that ends up in the serialized guard state.
         if device == "cuda" and not HAS_CUDA_AND_TRITON:
             raise unittest.SkipTest("Requires CUDA/Triton")
         if device == "xpu" and not HAS_XPU_AND_TRITON:
             raise unittest.SkipTest("Requires XPU/Triton")
 
         def fn(x):
-            return torch.nn.functional.relu(x) + x.sin()
+            if torch.utils._pytree.tree_is_leaf(x):
+                return torch.nn.functional.relu(x) + x.sin()
+            return x
 
         arg = torch.randn(3, 2, device=device)
         expected = fn(arg)

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -448,6 +448,32 @@ def add(x, y):
 
     @parametrize("device", ("cpu", "cuda", "xpu"))
     @torch._dynamo.config.patch(caching_precompile=True)
+    def test_automatic_dynamo_import_source_guard(self, device):
+        # Warm-loading a guard state with an ImportSource must not raise
+        if device == "cuda" and not HAS_CUDA_AND_TRITON:
+            raise unittest.SkipTest("Requires CUDA/Triton")
+        if device == "xpu" and not HAS_XPU_AND_TRITON:
+            raise unittest.SkipTest("Requires XPU/Triton")
+
+        def fn(x):
+            return torch.nn.functional.relu(x) + x.sin()
+
+        arg = torch.randn(3, 2, device=device)
+        expected = fn(arg)
+        compiled_fn = torch.compile(fn)
+        self.assertEqual(compiled_fn(arg), expected)
+        total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
+
+        self._save_and_reload(expected_backends=1, expected_dynamo=1)
+
+        compiled_fn = torch.compile(fn)
+        with torch.compiler.set_stance("fail_on_recompile"):
+            result = compiled_fn(arg)
+            self.assertEqual(result, expected)
+        self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
+
+    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_recompiles(self, device):
         if device == "cuda" and not HAS_CUDA_AND_TRITON:
             raise unittest.SkipTest("Requires CUDA/Triton")

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -125,24 +125,13 @@ class _GuardedCodeCacheEntry:
 
 
 def load_guards_state(guards_state: bytes) -> Any:
-    from torch._guards import tracing, TracingContext
-
     try:
         import torch.distributed.fsdp._fully_shard._fully_shard as _fully_shard
 
         ctx = _fully_shard.disable_fsdp_module_new_init()
     except ImportError:
         ctx = nullcontext()  # type: ignore[assignment]
-
-    # For runs with no active trace. Use a throwaway context and skip the install
-    if TracingContext.try_get() is not None:
-        tracing_ctx: Any = nullcontext()
-        skip_ctx: Any = nullcontext()
-    else:
-        tc = TracingContext(None)
-        tracing_ctx = tracing(tc)
-        skip_ctx = tc.guards_context.skip_guard_install()
-    with ctx, tracing_ctx, skip_ctx:
+    with ctx:
         return pickle.loads(guards_state)
 
 

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -125,13 +125,24 @@ class _GuardedCodeCacheEntry:
 
 
 def load_guards_state(guards_state: bytes) -> Any:
+    from torch._guards import tracing, TracingContext
+
     try:
         import torch.distributed.fsdp._fully_shard._fully_shard as _fully_shard
 
         ctx = _fully_shard.disable_fsdp_module_new_init()
     except ImportError:
         ctx = nullcontext()  # type: ignore[assignment]
-    with ctx:
+
+    # For runs with no active trace. Use a throwaway context and skip the install
+    if TracingContext.try_get() is not None:
+        tracing_ctx: Any = nullcontext()
+        skip_ctx: Any = nullcontext()
+    else:
+        tc = TracingContext(None)
+        tracing_ctx = tracing(tc)
+        skip_ctx = tc.guards_context.skip_guard_install()
+    with ctx, tracing_ctx, skip_ctx:
         return pickle.loads(guards_state)
 
 

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1100,11 +1100,6 @@ class ImportSource(Source):
 
     module_name: str
 
-    def __post_init__(self) -> None:
-        from .guards import GuardBuilder, install_guard
-
-        install_guard(self.make_guard(GuardBuilder.ID_MATCH))
-
     @functools.cached_property
     def _name_template(self) -> str:
         return f"__import__('{self.module_name}')"

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -141,6 +141,8 @@ class ClosureConversionError(NotImplementedError):
 
 @functools.lru_cache
 def get_pytree_SUPPORTED_NODES_source() -> AttrSource:
+    # Cached, so callers are responsible for installing the ID_MATCH guard on the
+    # embedded ImportSource("torch") themselves.
     return AttrSource(
         AttrSource(AttrSource(ImportSource("torch"), "utils"), "_pytree"),
         "SUPPORTED_NODES",
@@ -3723,7 +3725,9 @@ class PyTreeGetNodeTypeFunctionVariable(UserFunctionVariable):
             type_source = TypeSource(args[0].source)
         python_type = args[0].python_type()
         if is_namedtuple_class(python_type):
-            type_source = AttrSource(ImportSource("collections"), "namedtuple")
+            collections_source = ImportSource("collections")
+            install_guard(collections_source.make_guard(GuardBuilder.ID_MATCH))
+            type_source = AttrSource(collections_source, "namedtuple")
             return VariableTracker.build(
                 tx, vars(collections)["namedtuple"], type_source
             )
@@ -3775,6 +3779,9 @@ class PyTreeTreeIsLeafFunctionVariable(UserFunctionVariable):
 
         # If the SUPPORTED_NODES was seen earlier and mutated, there would be a
         # source and that will give us the mutated SUPPORTED_NODES.
+        # get_pytree_SUPPORTED_NODES_source is cached, so install its
+        # ImportSource("torch") ID_MATCH guard here.
+        install_guard(ImportSource("torch").make_guard(GuardBuilder.ID_MATCH))
         supported_nodes_var = VariableTracker.build(
             tx,
             torch.utils._pytree.SUPPORTED_NODES,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2356,8 +2356,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 source = CallFunctionNoArgsSource(self.source)
                 install_guard(source.make_guard(GuardBuilder.ID_MATCH))
             # assumes `module` is in the form `torch.xyz`
+            torch_source = ImportSource("torch")
+            install_guard(torch_source.make_guard(GuardBuilder.ID_MATCH))
             new_source = AttrSource(
-                ImportSource("torch"),
+                torch_source,
                 module.__name__.rsplit(".", maxsplit=1)[-1],
             )
             return VariableTracker.build(tx, module, new_source)
@@ -2721,8 +2723,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     tx,
                     f"{fn.__name__} takes exactly one argument ({len(args)} given)",
                 )
+            torch_source = ImportSource("torch")
+            install_guard(torch_source.make_guard(GuardBuilder.ID_MATCH))
             current_device_source = CallFunctionNoArgsSource(
-                AttrSource(AttrSource(ImportSource("torch"), "cuda"), "current_device")
+                AttrSource(AttrSource(torch_source, "cuda"), "current_device")
             )
             install_guard(current_device_source.make_guard(GuardBuilder.EQUALS_MATCH))
             arg = args[0].as_python_constant()


### PR DESCRIPTION
Loading a precompile cache deserializes guard state at torch.compile() decoration time, before any trace is active. Unpickling reconstructs Source objects whose __post_init__ calls install_guard(), which requires a TracingContext — raising "TracingContext.get() must be called within an ongoing trace".

Fix by providing a throwaway TracingContext with skip_guard_install() during the unpickle.

Authored with assistance from an AI assistant.

Test Plan:

```
python test/dynamo/test_package.py -k test_automatic_dynamo_import_source_guard
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98