### PR TITLE
Fix calculate_out_dimension using stride[0] for the width dimension

### DIFF
--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -9,6 +9,7 @@ from torch.fx import GraphModule, symbolic_trace
 from torch.fx.annotate import annotate
 from torch.fx.experimental.graph_gradual_typechecker import (
     broadcast_types,
+    calculate_out_dimension,
     GraphTypeChecker,
     Refine,
 )
@@ -142,6 +143,16 @@ class AnnotationsTest(TestCase):
 
 
 class TypeCheckerTest(TestCase):
+    def test_calculate_out_dimension_asymmetric_stride(self):
+        # The width dimension (index=1) must use stride[1], not stride[0]. With
+        # an asymmetric stride the two dimensions otherwise disagree.
+        conv = torch.nn.Conv2d(3, 6, kernel_size=3, stride=(2, 3))
+        # n = 32 + 2*0 - 1*(3-1) - 1 = 29
+        # height (index=0): 29 // stride[0]=2 + 1 = 15
+        # width  (index=1): 29 // stride[1]=3 + 1 = 10
+        self.assertEqual(calculate_out_dimension(32, conv, 0), 15)
+        self.assertEqual(calculate_out_dimension(32, conv, 1), 10)
+
     def test_type_check_add_with_broadcast(self):
         class M(torch.nn.Module):
             def forward(self, x: TensorType((1, 2, 3, Dyn)), y: TensorType((2, 3, 4))):

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -397,7 +397,7 @@ def calculate_out_dimension(d_in: Any, module_instance: Any, index: int) -> Any:
     elif isinstance(d_in, DIMENSION_TYPES):
         n = d_in + 2 * padding[index] - dilation[index] * (kernel_size[index] - 1) - 1
 
-        return (n // stride[0]) + 1
+        return (n // stride[index]) + 1
 
     else:
         raise TypeError(


### PR DESCRIPTION
In `graph_gradual_typechecker.calculate_out_dimension`, `padding`, `dilation` and `kernel_size` are all indexed by the `index` argument (0 for height, 1 for width), but the stride is hardcoded to `stride[0]`:

```python
n = d_in + 2 * padding[index] - dilation[index] * (kernel_size[index] - 1) - 1
return (n // stride[0]) + 1
```

The function is called once per spatial dimension — `calculate_out_dimension(h_in, m, 0)` and `calculate_out_dimension(w_in, m, 1)` (see lines 446-447 / 486-487 / 887-888). So for a module with an asymmetric stride (e.g. `Conv2d(..., stride=(2, 3))`) the width dimension is computed with the height stride, giving the wrong inferred output width.

This changes `stride[0]` to `stride[index]`, matching how the other parameters are indexed.

## Test

Added `test_calculate_out_dimension_asymmetric_stride` in `test/fx/test_gradual_type.py`: a `Conv2d(3, 6, kernel_size=3, stride=(2, 3))` with `d_in=32` should infer height `15` (`29 // 2 + 1`) and width `10` (`29 // 3 + 1`). It fails on `main` (width comes back as `15`, using `stride[0]=2`) and passes with this change.

I verified the arithmetic in isolation (`stride[1]=3` gives width 10, `stride[0]=2` gives 15) and ran `ruff check` / `ruff format --check` clean; I couldn't import the built `torch` locally, so the unit test runs in CI.
