### PR TITLE
Replace CUDA APIs with generic torch.accelerator equivalents

### DIFF
--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -239,7 +239,9 @@ def benchmark_utilization(
     acc = torch.accelerator.current_accelerator(check_available=True)
     if acc is not None:
         device_type = acc.type
-        device_activity = _DEVICE_TO_ACTIVITY.get(device_type, ProfilerActivity.PrivateUse1)
+        device_activity = _DEVICE_TO_ACTIVITY.get(
+            device_type, ProfilerActivity.PrivateUse1
+        )
         activities = (
             [device_activity]
             if device_activity in supported_activities()

--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -10,7 +10,7 @@ from typing import Any, TYPE_CHECKING
 from typing_extensions import TypeVar
 
 import torch
-from torch.profiler import profile, ProfilerActivity
+from torch.profiler import profile, ProfilerActivity, supported_activities
 
 
 if TYPE_CHECKING:
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
 
 
 _R = TypeVar("_R")
+
+_DEVICE_TO_ACTIVITY: dict[str, ProfilerActivity] = {
+    "cuda": ProfilerActivity.CUDA,
+    "xpu": ProfilerActivity.XPU,
+    "mtia": ProfilerActivity.MTIA,
+    "hpu": ProfilerActivity.HPU,
+}
 
 
 def synchronize() -> None:
@@ -46,7 +53,8 @@ def dump_chrome_trace(
     """
 
     if devices is None:
-        devices = ["cuda"]
+        acc = torch.accelerator.current_accelerator(check_available=True)
+        devices = [acc.type] if acc is not None else ["cpu"]
 
     global synchronize
     if devices != ["cpu"] and torch.accelerator.is_available():
@@ -197,7 +205,7 @@ def benchmark_utilization(
         return a.sum()
 
 
-    a = torch.rand(2**20, device="cuda")
+    a = torch.rand(2**20, device=torch.accelerator.current_accelerator())
     utilization, mm_conv_utilization = benchmark_utilization(
         f, a, "tmp", trace_file_name="tmp_chrome_trace"
     )
@@ -228,15 +236,28 @@ def benchmark_utilization(
     if optimize_ctx is None:
         optimize_ctx = contextlib.nullcontext()
 
+    acc = torch.accelerator.current_accelerator(check_available=True)
+    if acc is not None:
+        device_type = acc.type
+        device_activity = _DEVICE_TO_ACTIVITY.get(device_type, ProfilerActivity.PrivateUse1)
+        activities = (
+            [device_activity]
+            if device_activity in supported_activities()
+            else [ProfilerActivity.CPU]
+        )
+    else:
+        device_type = "cpu"
+        activities = [ProfilerActivity.CPU]
+
     chrome_trace_file_name = os.path.join(trace_folder, trace_file_name + ".json")
     total_length = dump_chrome_trace(
         f,
         input_,
         chrome_trace_file_name,
         optimize_ctx,
-        [ProfilerActivity.CUDA],
+        activities,
         num_runs=num_runs,
-        devices=["cuda"],
+        devices=[device_type],
     )
     utilization, mm_conv_utilization = compute_utilization(
         chrome_trace_file_name, total_length

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -770,8 +770,13 @@ class DebugFormatter:
 
         general_properties = {
             "op_name": name,
+            # cuda_device_* keys are kept for backward compatibility with existing
+            # downstream JSON parsers; remove once downstream consumers have
+            # migrated to the generic device_* equivalents.
             "cuda_device_name": torch.cuda.get_device_name(),
             "cuda_device_count": torch.cuda.device_count(),
+            "device_name": torch.accelerator.get_device_name(),
+            "device_count": torch.accelerator.device_count(),
             "input_nodes": [build_node_info(node) for node in input_nodes],
             "autotuning_time": elapse,
             "precompile_time": precompile_elapse,

--- a/torch/_inductor/fx_passes/numeric_utils.py
+++ b/torch/_inductor/fx_passes/numeric_utils.py
@@ -37,7 +37,7 @@ def set_deterministic() -> None:
 def clean_memory() -> None:
     """Clean memory to avoid OOM."""
     gc.collect()
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
 
 
 # We compare the numerical results before and after pre/post grad fx passes

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -403,14 +403,14 @@ def ncu_analyzer(
 def collect_memory_snapshot(
     benchmark_compiled_module_fn: BenchmarkCallableType,
 ) -> None:
-    if not torch.cuda.is_available():
-        raise AssertionError("CUDA is not available")
+    if not torch.accelerator.is_available():
+        raise AssertionError("No accelerator is available")
 
-    torch.cuda.memory._record_memory_history(max_entries=100000)
+    torch.accelerator.memory._record_memory_history(max_entries=100000)
     benchmark_compiled_module_fn(times=10, repeat=1)  # run 10 times
     snapshot_path = f"{tempfile.gettempdir()}/memory_snapshot.pickle"
-    torch.cuda.memory._dump_snapshot(snapshot_path)
-    torch.cuda.memory._record_memory_history(enabled=None)
+    torch.accelerator.memory._dump_snapshot(snapshot_path)
+    torch.accelerator.memory._record_memory_history(enabled=None)
     print(f"The collect memory snapshot has been written to {snapshot_path}")
 
 
@@ -445,13 +445,13 @@ def compiled_module_main(
         help="Whether to profile the compiled module",
     )
     parser.add_argument(
-        "--cuda-memory-snapshot",
+        "--memory-snapshot",
         action="store_true",
-        help="""
-            Whether to collect CUDA memory snapshot. Refer to
-            "https://pytorch.org/blog/understanding-gpu-memory-1/
-            for details about how to visualize the collected snapshot
-        """,
+        help=(
+            "Whether to collect an accelerator memory snapshot. Refer to "
+            "https://pytorch.org/blog/understanding-gpu-memory-1/ "
+            "for details about how to visualize the collected snapshot."
+        ),
     )
     parser.add_argument(
         "--ncu",
@@ -498,15 +498,15 @@ def compiled_module_main(
         times = args.times
         repeat = args.repeat
 
-        if torch.cuda.is_available():
-            torch.cuda.reset_peak_memory_stats()
+        if torch.accelerator.is_available():
+            torch.accelerator.reset_peak_memory_stats()
         wall_time_ms = benchmark_compiled_module_fn(times=times, repeat=repeat) * 1000
 
-        if torch.cuda.is_available():
-            peak_mem = torch.cuda.max_memory_allocated()
+        if torch.accelerator.is_available():
+            peak_mem = torch.accelerator.max_memory_allocated()
             print(f"Peak GPU memory usage {peak_mem / 1e6:.3f} MB")
 
-        if torch.cuda.is_available() and args.cuda_memory_snapshot:
+        if torch.accelerator.is_available() and args.memory_snapshot:
             collect_memory_snapshot(benchmark_compiled_module_fn)
 
         if args.profile:


### PR DESCRIPTION
## Summary

Replace CUDA-specific API calls with generic `torch.accelerator` equivalents
in `torch._inductor` and `torch._functorch` so that diagnostic and
instrumentation code works across all backends (CUDA, XPU, MPS,
third-party) without device-specific branching.

Changes:
- `numeric_utils.clean_memory()`: `torch.cuda.empty_cache()` → `torch.accelerator.empty_cache()`
- `debug.log_autotuning_results()`: add generic `device_name`/`device_count` fields alongside `cuda_*` fields (retained for backward compatibility)
- `wrapper_benchmark.collect_memory_snapshot()`: replace `torch.cuda.memory.*` calls with `torch.accelerator.memory.*` equivalents
- `wrapper_benchmark.compiled_module_main()`: replace `torch.cuda` memory stat calls with `torch.accelerator` equivalents; rename `--cuda-memory-snapshot` flag to `--memory-snapshot`
- `benchmark_utils.benchmark_utilization()`: replace hardcoded `ProfilerActivity.CUDA`/`devices=["cuda"]` with runtime dispatch via `torch.accelerator.current_accelerator()` guarded by `torch.profiler.supported_activities()`
- 
**Depends on #187205** (adds `torch.accelerator.get_device_name()` and
`torch.accelerator.memory._record_memory_history/dump_snapshot`).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo