### PR TITLE
Validate non-zero norm_type in lp_pool

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7959,6 +7959,19 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                     expected_neg_inf,
                 )
 
+    def test_lp_pool_zero_norm_type(self):
+        cases = [
+            (F.lp_pool1d, torch.randn(1, 1, 4), 2, 1),
+            (F.lp_pool2d, torch.randn(1, 1, 4, 4), 2, 1),
+            (F.lp_pool3d, torch.randn(1, 1, 4, 4, 4), 2, 1),
+        ]
+        for lp_pool, inp, kernel_size, stride in cases:
+            with self.subTest(lp_pool=lp_pool.__name__):
+                with self.assertRaisesRegex(
+                    ValueError, "norm_type must be non-zero"
+                ):
+                    lp_pool(inp, 0, kernel_size, stride)
+
     def test_pickle_module_no_weights_only_warning(self):
         with warnings.catch_warnings(record=True) as w:
             pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1138,6 +1138,8 @@ def lp_pool3d(
         )
     kd, kw, kh = _triple(kernel_size)
     if isinstance(norm_type, (int, float)):
+        if norm_type == 0:
+            raise ValueError("norm_type must be non-zero")
         if norm_type == float("inf"):
             return max_pool3d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
         if norm_type == -float("inf"):
@@ -1185,6 +1187,8 @@ def lp_pool2d(
         )
     kw, kh = _pair(kernel_size)
     if isinstance(norm_type, (int, float)):
+        if norm_type == 0:
+            raise ValueError("norm_type must be non-zero")
         if norm_type == float("inf"):
             return max_pool2d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
         if norm_type == -float("inf"):
@@ -1228,6 +1232,8 @@ def lp_pool1d(
             ceil_mode=ceil_mode,
         )
     if isinstance(norm_type, (int, float)):
+        if norm_type == 0:
+            raise ValueError("norm_type must be non-zero")
         if norm_type == float("inf"):
             return max_pool1d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
         if norm_type == -float("inf"):


### PR DESCRIPTION
Fixes #187743

Raise `ValueError` when lp_pool ops are called with `norm_type=0`.

`lp_pool1d`, `lp_pool2d`, and `lp_pool3d` currently raise

`ZeroDivisionError: float division by zero`

because they evaluate

`1.0 / norm_type`

without validating the input first.

Although the issue was reported for `lp_pool2d`, the same code path exists in `lp_pool1d` and `lp_pool3d`.

This change adds explicit `norm_type == 0` validation to `lp_pool1d`, `lp_pool2d`, and `lp_pool3d`, raising a descriptive `ValueError` instead, and adds a `test_lp_pool_zero_norm_type` regression test covering all three variants.
