### PR TITLE
Narrow ModuleDict.__getattr__ return type to Module for type checkers

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -5,7 +5,7 @@ import operator
 from collections import abc as container_abcs, OrderedDict
 from itertools import chain, islice
 from typing import Any, overload, TYPE_CHECKING, TypeVar
-from typing_extensions import deprecated, Self
+from typing_extensions import deprecated, override, Self
 
 import torch
 from torch._jit_internal import _copy_to_script_wrapper
@@ -548,8 +548,10 @@ class ModuleDict(Module):
     if TYPE_CHECKING:
         # ModuleDict stores only submodules, so attribute access always resolves
         # to a Module. Narrow the inherited ``Module.__getattr__`` return type
-        # (``Union[Tensor, Module]``) to ``Module`` for type checkers. This is a
-        # typing-only override with no runtime effect.
+        # (``Union[Tensor, Module]``) to ``Module`` for type checkers. Kept under
+        # ``TYPE_CHECKING`` so it stays a typing-only override with no runtime
+        # effect (``__getattr__`` is hot and we do not want to add a real call).
+        @override
         def __getattr__(self, name: str) -> Module:
             return self._modules[name]
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -545,6 +545,14 @@ class ModuleDict(Module):
 
     _modules: dict[str, Module]  # type: ignore[assignment]
 
+    if TYPE_CHECKING:
+        # ModuleDict stores only submodules, so attribute access always resolves
+        # to a Module. Narrow the inherited ``Module.__getattr__`` return type
+        # (``Union[Tensor, Module]``) to ``Module`` for type checkers. This is a
+        # typing-only override with no runtime effect.
+        def __getattr__(self, name: str) -> Module:
+            return self._modules[name]
+
     def __init__(self, modules: Mapping[str, Module] | None = None) -> None:
         super().__init__()
         if modules is not None:


### PR DESCRIPTION
Fixes #146938

### Summary

`nn.ModuleDict` does not override `__getattr__`, so attribute access such as `module_dict.foo` inherits `Module.__getattr__`'s annotated return type `Union[Tensor, Module]`. A type checker then reports false positives on otherwise-valid code, for example:

```python
mods = nn.ModuleDict({"foo": nn.Linear(4, 8)})
y = mods.foo(x)  # error: Object of type "Tensor" is not callable
```

even though a `ModuleDict` only ever stores submodules.

This adds a `TYPE_CHECKING`-only `__getattr__` override on `ModuleDict` that narrows the return type to `Module`, which is the approach @mikaylagawarecki suggested in the issue. It is guarded by `TYPE_CHECKING`, so there is **no runtime change** (and no effect on TorchScript): at runtime attribute access still goes through `Module.__getattr__`. The narrowed return type is sound because `ModuleDict._modules` is `dict[str, Module]`.

### Test plan

Type-checking only. With the override, the snippet above type-checks cleanly (`mods.foo` is `Module`, which is callable) while the runtime behavior is unchanged.
