### PR TITLE
Add Sequential.__getitem__ overloads for precise int/slice typing

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -130,6 +130,12 @@ class Sequential(Module):
         idx %= size
         return next(islice(iterator, idx, None))
 
+    @overload
+    def __getitem__(self, idx: slice) -> Sequential: ...
+
+    @overload
+    def __getitem__(self, idx: int) -> Module: ...
+
     @_copy_to_script_wrapper
     def __getitem__(self, idx: slice | int) -> Sequential | Module:
         if isinstance(idx, slice):


### PR DESCRIPTION
### Summary

`Sequential.__getitem__` is annotated `slice | int -> Sequential | Module`, so every index widens to the full union regardless of the key type:

```python
seq = nn.Sequential(nn.Linear(2, 2))
layer = seq[0]      # typed Sequential | Module  (should be Module)
sub   = seq[0:1]    # typed Sequential | Module  (should be Sequential)
```

`ModuleList.__getitem__` already distinguishes these with `@overload` (int -> `Module`, slice -> `ModuleList`). This mirrors that pattern on `Sequential` so int indexing narrows to `Module` and slice indexing narrows to `Sequential`. Runtime behavior is unchanged (the overloads are typing-only stubs; the implementation and its `@_copy_to_script_wrapper` are untouched), consistent with how `ModuleList` already combines `@overload` with the script wrapper.

This reduces the over-general indexing typing reported in #181861. Note it does not fully resolve that issue: the nested-container case there (`model[0][0]`) requires knowing the element type, which is a broader generics discussion for `nn.Sequential`; this PR is scoped to the single-index/slice precision that matches `ModuleList`.

### Test plan

Type-checking only; runtime behavior is unchanged. `seq[0]` now type-checks as `Module` and `seq[0:2]` as `Sequential`.


cc @lolpack @maggiemoss @ndmitchell @kinto0 @samwgoldman