### PR TITLE
Fix wrong width dimension in calculate_out_dimension for asymmetric strides

### DIFF
--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -9,6 +9,7 @@ from torch.fx import GraphModule, symbolic_trace
 from torch.fx.annotate import annotate
 from torch.fx.experimental.graph_gradual_typechecker import (
     broadcast_types,
+    calculate_out_dimension,
     GraphTypeChecker,
     Refine,
 )
@@ -449,6 +450,17 @@ class TypeCheckerTest(TestCase):
         tc = GraphTypeChecker({}, traced)
         with self.assertRaises(TypeError):
             tc.type_check()
+
+    def test_calculate_out_dimension_asymmetric_stride(self):
+        # Regression: calculate_out_dimension indexed stride with a hardcoded 0,
+        # so an asymmetric stride computed the wrong width even though padding,
+        # kernel_size and dilation were already indexed per dimension.
+        conv = torch.nn.Conv2d(3, 6, kernel_size=3, stride=(2, 3))
+        # n = d_in + 2*padding - dilation*(kernel - 1) - 1 = 32 + 0 - 2 - 1 = 29
+        # height (index 0, stride 2): 29 // 2 + 1 = 15
+        # width  (index 1, stride 3): 29 // 3 + 1 = 10  (was 15 using stride[0])
+        self.assertEqual(calculate_out_dimension(32, conv, 0), 15)
+        self.assertEqual(calculate_out_dimension(32, conv, 1), 10)
 
     def test_type_check_conv2D(self):
         class BasicBlock(torch.nn.Module):

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -397,7 +397,7 @@ def calculate_out_dimension(d_in: Any, module_instance: Any, index: int) -> Any:
     elif isinstance(d_in, DIMENSION_TYPES):
         n = d_in + 2 * padding[index] - dilation[index] * (kernel_size[index] - 1) - 1
 
-        return (n // stride[0]) + 1
+        return (n // stride[index]) + 1
 
     else:
         raise TypeError(


### PR DESCRIPTION
### Summary

`calculate_out_dimension` in the FX gradual typechecker indexes `stride` with a hardcoded `0`, while `padding`, `kernel_size` and `dilation` are all indexed by the per-dimension `index`:

```python
n = d_in + 2 * padding[index] - dilation[index] * (kernel_size[index] - 1) - 1
return (n // stride[0]) + 1   # should be stride[index]
```

For an asymmetric stride such as `stride=(2, 3)`, the width (computed with `index=1`) ends up using the height's stride, so the inferred width dimension is wrong. `conv2d_inference_rule` and `maxpool2d_check` both call it with `index=1` for the width, so the path is reachable.

Example: `Conv2d(3, 6, kernel_size=3, stride=(2, 3))` on an input dim of 32 should give height `29 // 2 + 1 = 15` and width `29 // 3 + 1 = 10`, but the width came out as `15` (using `stride[0]`).

### Fix

Use `stride[index]`, to match the other indexed parameters.

### Test

The existing conv2d tests only use symmetric (scalar) strides, where `stride[0] == stride[index]`, so the bug was never exercised. Added `test_calculate_out_dimension_asymmetric_stride` with `stride=(2, 3)`, which fails before this change and passes after.

I'm not set up to build PyTorch locally, so I verified the arithmetic and the reachability (the `index=1` call sites) by hand and rely on CI to run the test.
