### PR TITLE
fix: initialize r to prevent uninitialized memory return in Chebyshev polynomial functions

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -2908,7 +2908,7 @@ inline C10_HOST_DEVICE T chebyshev_polynomial_u_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x + x;
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x) * q - p;
@@ -2964,7 +2964,7 @@ inline C10_HOST_DEVICE T chebyshev_polynomial_v_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x + x - T(1.0);
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x) * q - p;
@@ -3024,7 +3024,7 @@ inline C10_HOST_DEVICE T chebyshev_polynomial_w_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x + x + T(1.0);
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x) * q - p;
@@ -3731,7 +3731,7 @@ inline C10_HOST_DEVICE T shifted_chebyshev_polynomial_t_forward(T x, int64_t n) 
 
     T p = T(1.0);
     T q = x + x - T(1.0);
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x - T(1.0) + (x + x - T(1.0))) * q - p;
@@ -3783,7 +3783,7 @@ inline C10_HOST_DEVICE T shifted_chebyshev_polynomial_u_forward(T x, int64_t n) 
 
     T p = T(1.0);
     T q = x + x - T(1.0) + (x + x - T(1.0));
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x - T(1.0) + (x + x - T(1.0))) * q - p;
@@ -3839,7 +3839,7 @@ inline C10_HOST_DEVICE T shifted_chebyshev_polynomial_v_forward(T x, int64_t n) 
 
     T p = T(1.0);
     T q = x + x - T(1.0) + (x + x - T(1.0)) - T(1.0);
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x - T(1.0) + (x + x - T(1.0))) * q - p;
@@ -3895,7 +3895,7 @@ inline C10_HOST_DEVICE T shifted_chebyshev_polynomial_w_forward(T x, int64_t n) 
 
     T p = T(1.0);
     T q = x + x - T(1.0) + (x + x - T(1.0)) + T(1.0);
-    T r;
+    T r = q;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x - T(1.0) + (x + x - T(1.0))) * q - p;

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -227,6 +227,34 @@ class TestBinaryUfuncs(TestCase):
                 expected = torch.lerp(xref, yref, wref).to(dtype)
                 self.assertEqual(actual, expected, atol=0.0, rtol=0.0)
 
+    def test_chebyshev_polynomial_nan_propagation(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/187761.
+        # When x is NaN and n >= 2, these functions returned uninitialized memory
+        # instead of NaN because `T r` was declared without initialization and the
+        # recurrence loop was never entered (the loop guard is !isnan(q)).
+        nan = float("nan")
+        ops = [
+            torch.special.chebyshev_polynomial_u,
+            torch.special.chebyshev_polynomial_v,
+            torch.special.chebyshev_polynomial_w,
+            torch.special.shifted_chebyshev_polynomial_t,
+            torch.special.shifted_chebyshev_polynomial_u,
+            torch.special.shifted_chebyshev_polynomial_v,
+            torch.special.shifted_chebyshev_polynomial_w,
+        ]
+        for op in ops:
+            with self.subTest(op=op.__name__):
+                x = torch.tensor([nan, nan], dtype=torch.float64)
+                n = torch.tensor([5, 5], dtype=torch.float64)
+                # Contiguous input
+                result = op(x, n)
+                self.assertTrue(result.isnan().all())
+                # Non-contiguous input (non-contiguous inputs were the primary repro)
+                x_nc = x[::1].clone().as_strided((1,), (2,))
+                n_nc = n[::1].clone().as_strided((1,), (2,))
+                result_nc = op(x_nc, n_nc)
+                self.assertTrue(result_nc.isnan().all())
+
 
 class TestBinaryUfuncsDevice(TestCase):
     # Generic tests for elementwise binary (AKA binary universal (u) functions (funcs))


### PR DESCRIPTION
## Summary

Fixes #187761.

When `x` is NaN, `q` is immediately NaN (e.g. `q = x + x`), so the recurrence loop `for (...; !std::isnan(q); ...)` is never entered. The return variable `T r` was declared without initialization, so the functions returned garbage stack memory. Non-contiguous tensors were especially likely to surface this as arbitrary finite values.

The fix initializes `r = q` in each of the seven affected functions in `aten/src/ATen/native/Math.h`:
- `chebyshev_polynomial_u_forward`
- `chebyshev_polynomial_v_forward`
- `chebyshev_polynomial_w_forward`
- `shifted_chebyshev_polynomial_t_forward`
- `shifted_chebyshev_polynomial_u_forward`
- `shifted_chebyshev_polynomial_v_forward`
- `shifted_chebyshev_polynomial_w_forward`

If `q` is NaN (because `x` is NaN), `r` starts as NaN and propagates correctly. If the loop runs, `r` is overwritten in the first iteration — no change for valid inputs.

## Test plan

Added `test_chebyshev_polynomial_nan_propagation` to `test/test_binary_ufuncs.py`, covering contiguous and non-contiguous NaN inputs with `n=5` (takes the recurrence path) for all seven ops.