### PR TITLE
linalg.svdvals: propagate NaN from input to singular values

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3163,6 +3163,14 @@ TORCH_IMPL_FUNC(_linalg_svd_out)(const Tensor& A,
   // from svd_cusolver to this function. We should then make sure that this function
   // never errors out.
   at::_linalg_check_errors(info, "linalg.svd", /*is_matrix*/A.dim() == 2);
+
+  // LAPACK's dgesdd with jobz='N' (the compute_uv=false path used by svdvals) does
+  // not propagate NaN from the input to the singular values, while jobz='S'/'A'
+  // (compute_uv=true) does so accidentally via the U/Vh computation.  Ensure any
+  // NaN in A surfaces in S so that svdvals() does not silently swallow bad input.
+  if (!compute_uv) {
+    S.masked_fill_(A.isnan().flatten(-2, -1).any(-1, /*keepdim=*/true), NAN);
+  }
 }
 
 std::tuple<Tensor&, Tensor&, Tensor&>

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3021,6 +3021,29 @@ class TestLinalg(TestCase):
                 self.assertEqual(S_s, S)
 
     @skipCPUIfNoLapack
+    @dtypes(torch.float64, torch.complex128)
+    def test_svdvals_nan_propagation(self, device, dtype):
+        # gh-187759: svdvals must propagate NaN from input to singular values.
+        # LAPACK dgesdd with jobz='N' silently discards NaN; we fix it in the
+        # ATen wrapper so svdvals() is consistent with svd().S.
+        A = torch.zeros(2, 2, dtype=dtype, device=device)
+        A[0, 0] = float('nan')
+
+        S = torch.linalg.svdvals(A)
+        self.assertTrue(S.isnan().any(), f"Expected NaN in svdvals output, got {S}")
+        # svdvals() must agree with svd().S on whether NaN is present.
+        self.assertEqual(S.isnan().any(), torch.linalg.svd(A).S.isnan().any())
+
+        # Batched: only matrices with NaN input should yield NaN singular values.
+        B = torch.zeros(3, 2, 2, dtype=dtype, device=device)
+        B[0, 0, 0] = float('nan')
+        B[2, 1, 1] = float('nan')
+        S_b = torch.linalg.svdvals(B)
+        self.assertTrue(S_b[0].isnan().any(), f"Batch[0] expected NaN, got {S_b[0]}")
+        self.assertFalse(S_b[1].isnan().any(), f"Batch[1] expected no NaN, got {S_b[1]}")
+        self.assertTrue(S_b[2].isnan().any(), f"Batch[2] expected NaN, got {S_b[2]}")
+
+    @skipCPUIfNoLapack
     @skipCUDAIf(
         not TEST_WITH_ROCM and _get_torch_cuda_version() < (12, 8) and not torch.cuda.has_magma,
         "torch.linalg.eig requires MAGMA for CUDA versions < 12.8",


### PR DESCRIPTION
## Summary

`torch.linalg.svdvals` was silently swallowing NaN from its input and returning finite singular values, while `torch.linalg.svd` (which uses `compute_uv=True`) propagated the NaN. This caused `matrix_rank` to report full rank for matrices with undefined entries.

**Root cause:** `_linalg_svd_out` dispatches to LAPACK `dgesdd` with `jobz='N'` when `compute_uv=False` (the `svdvals` path). LAPACK does not propagate NaN in this mode. The `compute_uv=True` path (`jobz='S'`/`'A'`) happens to propagate NaN via the U/Vh computation, making the two paths inconsistent.

**Fix:** After the LAPACK call in `_linalg_svd_out`, when `compute_uv=False`, broadcast an `isnan` mask over A's matrix dimensions and `masked_fill_` any corresponding S rows with `NAN`. This is a no-op in the common (no-NaN) case.

Before:
```python
M = torch.tensor([[float('nan'), 0.], [0., 1.]], dtype=torch.float64)
torch.linalg.svdvals(M)      # tensor([1., 1.])   <- NaN silently dropped
torch.linalg.svd(M).S        # tensor([1., nan])  <- NaN preserved
torch.linalg.matrix_rank(M)  # tensor(2)          <- wrong
```

After:
```python
torch.linalg.svdvals(M)      # tensor([nan, nan]) <- NaN propagated
torch.linalg.matrix_rank(M)  # tensor(0)          <- correct
```

## Test plan

New test `test_svdvals_nan_propagation` in `test/test_linalg.py`:
- Single matrix: verifies `svdvals` output contains NaN when input does
- Cross-check: `svdvals(A).isnan().any() == svd(A).S.isnan().any()`
- Batched: verifies only NaN-containing matrices in a batch produce NaN singular values; clean matrices are unaffected

Covers `float64` and `complex128` on CPU.

Fixes https://github.com/pytorch/pytorch/issues/187759