### PR TITLE
[MPS] Fix opaque RuntimeError for complex64 input to avg_pool3d / avg_pool2d(ceil_mode=True)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -785,6 +785,7 @@ static void avg_pool_out_mps_template(const Tensor& output,
                                       std::optional<int64_t> divisor_override,
                                       const int32_t pooling_dims,
                                       const std::string& op_name) {
+  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(input.scalar_type()), "Not implemented for complex");
   auto [dims, output_size, kernel_size, stride, padding, _] =
       process_pool_sizes(input, _kernel_size, _stride, _padding, std::nullopt, ceil_mode, pooling_dims, op_name);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -845,6 +845,18 @@ class TestAvgPool(TestCaseMPS):
         bn_cpu = torch.nn.BatchNorm2d(64).eval()(x.cpu())
         self.assertEqual(bn_mps.cpu(), bn_cpu)
 
+    def test_avg_pool_complex_dtype_rejected(self):
+        # Regression test for gh-187611: complex64 input must raise
+        # NotImplementedError instead of "Failed to create function state
+        # object for avg_pool_float2" when routed through avg_pool3d or
+        # avg_pool2d with ceil_mode=True on MPS.
+        x3d = torch.randn(2, 3, 4, 4, 4, dtype=torch.cfloat, device="mps")
+        with self.assertRaisesRegex(NotImplementedError, "Not implemented for complex"):
+            F.avg_pool3d(x3d, kernel_size=2)
+        x2d = torch.randn(1, 3, 4, 4, dtype=torch.cfloat, device="mps")
+        with self.assertRaisesRegex(NotImplementedError, "Not implemented for complex"):
+            F.avg_pool2d(x2d, kernel_size=2, ceil_mode=True)
+
 
 class TestMPS(TestCaseMPS):
     def ulpAssertAllClose(self, output, reference, n_ulps):


### PR DESCRIPTION
Fixes #187611

## Summary

`avg_pool_out_mps_template` — the shared Metal dispatch path for `avg_pool3d_out_mps` and for `avg_pool2d_out_mps` with `ceil_mode=True` — had no complex-dtype guard. A `complex64` input would reach the line that constructs the Metal kernel name (`"avg_pool_" + scalarToMetalTypeString(input)`), producing the name `avg_pool_float2`. The MPS runtime then fails to create a pipeline state for that name, surfacing the opaque error:

```
RuntimeError: Failed to create function state object for: avg_pool_float2
```

instead of the clean `NotImplementedError` that the CPU backend raises (`"avg_pool2d" not implemented for 'ComplexFloat'`).

The sibling `avg_pool2d_template` (used by the non-`ceil_mode` 2-D path) already had the correct guard:

```cpp
TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(input.scalar_type()), "Not implemented for complex");
```

This PR adds the same one-line guard at the top of `avg_pool_out_mps_template`, so complex input is rejected before Metal dispatch for both `avg_pool3d` and the `ceil_mode=True` `avg_pool2d` path.

## Test plan

Added `test_avg_pool_complex_dtype_rejected` to `TestAvgPool` in `test/test_mps.py`. The test asserts `NotImplementedError` is raised for:
- `F.avg_pool3d` with `cfloat` input on MPS
- `F.avg_pool2d(..., ceil_mode=True)` with `cfloat` input on MPS

```
python test/test_mps.py TestAvgPool.test_avg_pool_complex_dtype_rejected
```