### PR TITLE
[docs] Clarify Softplus overflow behavior for reduced-precision dtypes

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -967,6 +967,12 @@ class Softplus(Module):
     For numerical stability the implementation reverts to the linear function
     when :math:`input \times \beta > threshold`.
 
+    For reduced-precision floating-point dtypes (e.g. ``torch.float16``),
+    intermediate computations may be performed in higher precision and the
+    result is then converted back to the output dtype. If the result exceeds
+    the representable range of the output dtype, the conversion may overflow
+    and produce ``inf``.
+
     Args:
         beta: the :math:`\beta` value for the Softplus formulation. Default: 1
         threshold: values above this revert to a linear function. Default: 20


### PR DESCRIPTION
## Summary

Adds a note to the `nn.Softplus` documentation describing overflow behavior for reduced-precision floating-point dtypes.

When the result exceeds the representable range of the output dtype (for example, `torch.float16`), conversion to the output dtype may overflow and produce `inf` according to IEEE floating-point semantics.

This documentation update was motivated by discussion in the associated issue.

Addresses documentation discussion in #187180 