### PR TITLE
Warn when convert_sync_batchnorm silently drops module behavior

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7671,6 +7671,38 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 self.assertEqual(layer.state_dict()[key].device, converted_layer.state_dict()[key].device)
                 self.assertEqual(layer.state_dict()[key], converted_layer.state_dict()[key])
 
+    def test_convert_sync_batchnorm_warns_on_lossy_conversion(self):
+        # convert_sync_batchnorm rebuilds anything that is not a stock eager BN
+        # as a bare SyncBatchNorm, silently dropping an overridden forward, child
+        # modules, or uninitialized lazy parameters (gh-187298).
+        class BatchNormAct2d(nn.BatchNorm2d):
+            def __init__(self, num_features):
+                super().__init__(num_features)
+                self.act = nn.ReLU()
+
+            def forward(self, x):
+                return self.act(super().forward(x))
+
+        with self.assertWarnsRegex(UserWarning, "BatchNormAct2d"):
+            torch.nn.SyncBatchNorm.convert_sync_batchnorm(BatchNormAct2d(4))
+
+        # An uninitialized lazy BN keeps _BatchNorm.forward and has no children,
+        # yet converting it yields a SyncBatchNorm with num_features=0 and
+        # uninitialized parameters, so it must warn too.
+        for lazy in (nn.LazyBatchNorm1d(), nn.LazyBatchNorm2d(), nn.LazyBatchNorm3d()):
+            with self.assertWarnsRegex(UserWarning, type(lazy).__name__):
+                torch.nn.SyncBatchNorm.convert_sync_batchnorm(lazy)
+
+        # Once a lazy BN has initialized it is exactly a stock BatchNorm*d and
+        # converts faithfully, like the stock classes themselves.
+        initialized_lazy = nn.LazyBatchNorm2d()
+        initialized_lazy(torch.randn(2, 4, 3, 3))
+        for stock in (nn.BatchNorm1d(4), nn.BatchNorm2d(4), nn.BatchNorm3d(4),
+                      nn.SyncBatchNorm(4), initialized_lazy):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                torch.nn.SyncBatchNorm.convert_sync_batchnorm(stock)
+
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_sync_batchnorm_backward_elemt(self):
         device = 'cuda'

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7673,8 +7673,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_convert_sync_batchnorm_warns_on_lossy_conversion(self):
         # convert_sync_batchnorm rebuilds anything that is not a stock eager BN
-        # as a bare SyncBatchNorm, silently dropping an overridden forward, child
-        # modules, or uninitialized lazy parameters (gh-187298).
+        # as a bare SyncBatchNorm. Attributes, parameters, buffers and children
+        # survive the rebuild but the type does not, so an overridden forward or
+        # the lazy initialization hooks are lost silently (gh-187298).
         class BatchNormAct2d(nn.BatchNorm2d):
             def __init__(self, num_features):
                 super().__init__(num_features)
@@ -7702,6 +7703,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
                 torch.nn.SyncBatchNorm.convert_sync_batchnorm(stock)
+
+        # Nested lossy layers warn once from the top-level call, naming every
+        # offending type, and the warning is attributed to the caller rather
+        # than to the recursive conversion inside batchnorm.py.
+        model = nn.Sequential(BatchNormAct2d(4), nn.BatchNorm2d(4), nn.LazyBatchNorm2d())
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+        self.assertEqual(len(warns), 1)
+        self.assertIn("BatchNormAct2d, LazyBatchNorm2d", str(warns[0].message))
+        self.assertEqual(warns[0].filename, __file__)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_sync_batchnorm_backward_elemt(self):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -923,27 +923,35 @@ class SyncBatchNorm(_BatchNorm):
             >>> sync_bn_module = torch.nn.SyncBatchNorm.convert_sync_batchnorm(module, process_group)
 
         """
+        lossy_types: dict[str, None] = {}
+        module_output = cls._convert_sync_batchnorm(module, process_group, lossy_types)
+        if lossy_types:
+            warnings.warn(
+                f"convert_sync_batchnorm rebuilt {', '.join(lossy_types)} as a plain "
+                "SyncBatchNorm, keeping only the BatchNorm attributes, parameters "
+                "and buffers. Behavior that the type itself provides (an overridden "
+                "forward, lazy initialization hooks, any other subclass state) does "
+                "not survive the rebuild, so the converted model may compute a "
+                "different function. Provide a custom conversion if that behavior "
+                "must be preserved.",
+                stacklevel=2,
+            )
+        return module_output
+
+    @classmethod
+    def _convert_sync_batchnorm(cls, module, process_group, lossy_types):
         module_output = module
         if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
-            # Only the types below round-trip faithfully; everything else is
-            # rebuilt as a bare SyncBatchNorm carrying just the BatchNorm
-            # attributes. A lazy BN that has already initialized has swapped its
-            # __class__ to BatchNorm{1,2,3}d, so it is matched here.
+            # Only the types below round-trip faithfully. A lazy BN that has
+            # already initialized has swapped its __class__ to BatchNorm{1,2,3}d,
+            # so it is matched here.
             if type(module) not in (
                 torch.nn.BatchNorm1d,
                 torch.nn.BatchNorm2d,
                 torch.nn.BatchNorm3d,
                 torch.nn.SyncBatchNorm,
             ):
-                warnings.warn(
-                    f"convert_sync_batchnorm rebuilds {type(module).__name__} as a "
-                    "plain SyncBatchNorm and only copies the BatchNorm attributes. "
-                    "Anything else the type carries (an overridden forward, child "
-                    "modules, uninitialized lazy parameters) is dropped, which may "
-                    "silently change the model's output. Provide a custom "
-                    "conversion if that behavior must be preserved.",
-                    stacklevel=2,
-                )
+                lossy_types[type(module).__name__] = None
             module_output = torch.nn.SyncBatchNorm(
                 module.num_features,
                 module.eps,
@@ -965,7 +973,8 @@ class SyncBatchNorm(_BatchNorm):
                 module_output.qconfig = module.qconfig
         for name, child in module.named_children():
             module_output.add_module(
-                name, cls.convert_sync_batchnorm(child, process_group)
+                name,
+                cls._convert_sync_batchnorm(child, process_group, lossy_types),
             )
         del module
         return module_output

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import warnings
 from typing import Any
 
 import torch
@@ -924,6 +925,25 @@ class SyncBatchNorm(_BatchNorm):
         """
         module_output = module
         if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+            # Only the types below round-trip faithfully; everything else is
+            # rebuilt as a bare SyncBatchNorm carrying just the BatchNorm
+            # attributes. A lazy BN that has already initialized has swapped its
+            # __class__ to BatchNorm{1,2,3}d, so it is matched here.
+            if type(module) not in (
+                torch.nn.BatchNorm1d,
+                torch.nn.BatchNorm2d,
+                torch.nn.BatchNorm3d,
+                torch.nn.SyncBatchNorm,
+            ):
+                warnings.warn(
+                    f"convert_sync_batchnorm rebuilds {type(module).__name__} as a "
+                    "plain SyncBatchNorm and only copies the BatchNorm attributes. "
+                    "Anything else the type carries (an overridden forward, child "
+                    "modules, uninitialized lazy parameters) is dropped, which may "
+                    "silently change the model's output. Provide a custom "
+                    "conversion if that behavior must be preserved.",
+                    stacklevel=2,
+                )
             module_output = torch.nn.SyncBatchNorm(
                 module.num_features,
                 module.eps,


### PR DESCRIPTION
Fixes #187298

### Summary
`torch.nn.SyncBatchNorm.convert_sync_batchnorm` rebuilds every `_BatchNorm` instance as a bare `SyncBatchNorm`, copying only the BatchNorm attributes. Anything else the original type carried is **silently dropped**: the converted model computes a different function with no error or warning.

Two ways this bites:

* A `_BatchNorm` **subclass** with an overridden `forward` that fuses an activation (e.g. timm's `BatchNormAct2d`) loses the activation. Its child modules are even copied onto the new `SyncBatchNorm` but are never invoked.
* An uninitialized `LazyBatchNorm{1,2,3}d` loses its lazy hooks and class-swap behavior, yielding a `SyncBatchNorm` with `num_features=0` and `UninitializedParameter` weights.

This silent, deferred failure mode has bitten multiple users (the issue documents a model that trained to 0.82 val F1 but exported to 0.00), and timm, mmengine, and detectron2 each ship their own `convert_sync_batchnorm` to route around it.

### Fix
Emit a `UserWarning` naming the offending type whenever the module is not exactly one of `BatchNorm1d`, `BatchNorm2d`, `BatchNorm3d` or `SyncBatchNorm`, which are the only types that round-trip faithfully.

The narrower heuristic (warn only when the type overrides `forward` or has children) was tried first and rejected: it misses the lazy case, since `LazyBatchNorm` inherits `_BatchNorm.forward` and has no children. The exact-type check needs no special case for lazy modules, because a lazy BN that has already initialized has swapped its `__class__` to `BatchNorm{1,2,3}d` and so matches the allowlist directly. The cost is a conservative warning for subclasses that override nothing meaningful, which is acceptable given conversion does discard the type there.

The warning does not change conversion behavior. It only surfaces the silent data loss so users can supply a custom conversion.

### Test Plan
```
python test/test_nn.py -k test_convert_sync_batchnorm -v
python test/test_quantization.py -k syncbn -v
lintrunner -a torch/nn/modules/batchnorm.py test/test_nn.py
```
The new CPU test asserts a `UserWarning` naming the type is raised for a `BatchNormAct2d`-style subclass and for each uninitialized `LazyBatchNorm{1,2,3}d`, and that no warning is raised for stock `BatchNorm1d/2d/3d`, `SyncBatchNorm`, or an already-initialized lazy BN. The quantization run covers the in-tree callers that convert a BatchNorm reached through a fused QAT `ConvBn2d`, confirming they do not start warning.
