### PR TITLE
perf(dynamo): add opt-in guard lookup token plan

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2235,6 +2235,18 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             "        )\n"
             "        pending.extend(manager.get_child_managers())\n"
             "    return leaves, accessors\n"
+            "from torch._dynamo.testing import CompileCounter\n"
+            "def _warm_model(model, enabled=True):\n"
+            "    counter = CompileCounter()\n"
+            "    compiled = torch.compile(model, backend=counter, fullgraph=True)\n"
+            "    x = torch.zeros(2)\n"
+            "    expected = model(x)\n"
+            "    for _ in range(8):\n"
+            "        torch.testing.assert_close(compiled(x), expected)\n"
+            "    assert counter.frame_count == 1, counter.frame_count\n"
+            "    entry = _only_cache_entry(type(model).forward.__code__)\n"
+            "    assert entry._debug_fast_guard_enabled is enabled\n"
+            "    return compiled, counter, entry, x\n"
         )
         subprocess.run(
             [sys.executable, "-c", prefix + textwrap.dedent(script)],
@@ -3420,6 +3432,241 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             torch.testing.assert_close(compiled(x), model(x))
             assert counter.frame_count == 4, counter.frame_count
             assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_static_module_attr_binding(self):
+        script = """
+            import types
+
+            namespace = types.ModuleType("fastguard_static_module")
+            original = torch.ones(2)
+            namespace.scale = original
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.namespace = namespace
+
+                def forward(self, x):
+                    return self.namespace.scale + x
+
+            model = Model()
+            compiled, counter, original_entry, x = _warm_model(model)
+
+            namespace.scale = torch.full((2,), 3.0)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            namespace.scale = original
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            dynamic_values = [torch.ones(2)]
+            dynamic_namespace = types.ModuleType("fastguard_dynamic_module")
+
+            def module_getattr(name):
+                if name == "scale":
+                    return dynamic_values[0]
+                raise AttributeError(name)
+
+            dynamic_namespace.__getattr__ = module_getattr
+
+            class DynamicModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.namespace = dynamic_namespace
+
+                def forward(self, x):
+                    return self.namespace.scale + x
+
+            dynamic_model = DynamicModel()
+            _warm_model(dynamic_model, enabled=False)
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_static_type_attr_binding(self):
+        script = """
+            original = torch.ones(2)
+
+            class Namespace:
+                scale = original
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.namespace = Namespace
+
+                def forward(self, x):
+                    return self.namespace.scale + x
+
+            model = Model()
+            compiled, counter, original_entry, x = _warm_model(model)
+
+            Namespace.scale = torch.full((2,), 3.0)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            Namespace.scale = original
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            class Descriptor:
+                def __init__(self):
+                    self.value = torch.ones(2)
+
+                def __get__(self, obj, owner):
+                    return self.value
+
+            class DynamicNamespace:
+                scale = Descriptor()
+
+            class DynamicModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.namespace = DynamicNamespace
+
+                def forward(self, x):
+                    return self.namespace.scale + x
+
+            dynamic_model = DynamicModel()
+            _warm_model(dynamic_model, enabled=False)
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_type_method_binding(self):
+        script = """
+            import types
+
+            class Model(torch.nn.Module):
+                def helper(self, x):
+                    return x + 1
+
+                def forward(self, x):
+                    return self.helper(x)
+
+            model = Model()
+            compiled, counter, original_entry, x = _warm_model(model)
+
+            def replacement(self, value):
+                return value + 4
+
+            model.helper = types.MethodType(replacement, model)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            del model.helper
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            original_helper = Model.helper
+            Model.helper = replacement
+            try:
+                torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 3, counter.frame_count
+            finally:
+                Model.helper = original_helper
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 3, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            class ClassMethodModel(torch.nn.Module):
+                @classmethod
+                def helper(cls, value):
+                    return value + 1
+
+                def forward(self, value):
+                    return self.helper(value)
+
+            class_method_model = ClassMethodModel()
+            _warm_model(class_method_model, enabled=False)
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_function_code_binding(self):
+        script = """
+            def helper(value):
+                return value + 1
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.helper = helper
+
+                def forward(self, x):
+                    return self.helper(x)
+
+            model = Model()
+            compiled, counter, original_entry, x = _warm_model(model)
+            _, accessors = _guard_tree_shapes(original_entry)
+            assert any(
+                kind == "CodeGuardAccessor" and source.startswith("L['self']")
+                for source, kind in accessors
+            ), accessors
+            original_code = helper.__code__
+
+            def replacement(value):
+                return value + 4
+
+            helper.__code__ = replacement.__code__
+            try:
+                torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 2, counter.frame_count
+            finally:
+                helper.__code__ = original_code
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_exact_set_equals_token(self):
+        script = """
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.mode = {1, 2}
+
+                def forward(self, x):
+                    if self.mode == {1, 2}:
+                        return x + 1
+                    return x - 1
+
+            model = Model()
+            compiled, counter, original_entry, x = _warm_model(model)
+            leaves, _ = _guard_tree_shapes(original_entry)
+            assert any(
+                kind == "EQUALS_MATCH" and source.startswith("L['self']")
+                for source, kind in leaves
+            ), leaves
+            model.mode.add(3)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            model.mode.remove(3)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            class FancySet(set):
+                pass
+
+            class FancySetModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.mode = FancySet({1, 2})
+
+                def forward(self, value):
+                    if self.mode == {1, 2}:
+                        return value + 1
+                    return value - 1
+
+            fancy_model = FancySetModel()
+            _warm_model(fancy_model, enabled=False)
         """
         self._run_guard_lookup_memo_script(script)
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -3670,6 +3670,86 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
         """
         self._run_guard_lookup_memo_script(script)
 
+    def test_precompile_entry_owns_actual_partial_receipt(self):
+        script = """
+            import threading
+
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_precompile_entries,
+                _load_precompile_entry,
+                _reset_precompile_entries,
+            )
+            from torch._dynamo.testing import CompileCounter
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.scale = 2.0
+
+                def forward(self, x):
+                    return x * self.scale
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=True
+            )
+            x = torch.ones(4)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            code = Model.forward.__code__
+            source_entry = _only_cache_entry(code)
+            should_block = threading.Event()
+            guard_entered = threading.Event()
+            guard_release = threading.Event()
+
+            def blocking_guard(_):
+                if should_block.is_set():
+                    guard_entered.set()
+                    assert guard_release.wait(10), "timed out waiting for reset"
+                return True
+
+            source_entry.guard_manager.root.add_lambda_guard(
+                blocking_guard, ["blocking precompile guard"], None
+            )
+            _reset_precompile_entries(code)
+            _load_precompile_entry(
+                code, source_entry.guard_manager, source_entry.code
+            )
+
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+
+            precompile_entries = _debug_get_precompile_entries(code)
+            assert len(precompile_entries) == 1, len(precompile_entries)
+            assert precompile_entries[0]._debug_fast_guard_enabled
+
+            # Do not let the debug wrapper mask the container/lookup ownership
+            # race that this reset is intended to exercise.
+            del precompile_entries
+
+            errors = []
+
+            def run_lookup():
+                try:
+                    torch.testing.assert_close(compiled(x), model(x))
+                except BaseException as exc:
+                    errors.append(exc)
+
+            should_block.set()
+            worker = threading.Thread(target=run_lookup)
+            worker.start()
+            assert guard_entered.wait(10), "guard lookup did not block"
+            _reset_precompile_entries(code)
+            guard_release.set()
+            worker.join(10)
+            assert not worker.is_alive(), "guard lookup did not finish"
+            assert not errors, errors
+            assert _debug_get_precompile_entries(code) == []
+        """
+        self._run_guard_lookup_memo_script(script)
+
     def test_guard_lookup_memo_defaults_off(self):
         script = """
             import torch

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -385,6 +385,32 @@ user_stack=None)
 
         self.assertFalse(guard_manager.check(f_locals_unaliased))
 
+    @torch._dynamo.config.patch(skip_tensor_guards_with_matching_dict_tags=True)
+    def test_dict_tag_does_not_skip_immutable_object_aliasing_guard(self):
+        value = tuple([1, 2])
+        different = tuple([1, 3])
+        container = {"value": value}
+
+        root = RootGuardManager()
+        dict_manager = root.list_getitem_manager(
+            0, "", container, default_mgr_enum
+        )
+        dict_value_manager = dict_manager.dict_getitem_manager(
+            "value", "", value, default_mgr_enum
+        )
+        peer_manager = root.list_getitem_manager(
+            1, "", value, default_mgr_enum
+        )
+        install_object_aliasing_guard(
+            dict_value_manager,
+            peer_manager,
+            ["container['value'] is peer"],
+            None,
+        )
+
+        self.assertTrue(root.check([container, value]))
+        self.assertFalse(root.check([container, different]))
+
     def test_dict_version_guard(self):
         root = RootGuardManager()
         foo = {"a": 1, "b": 2}
@@ -2249,6 +2275,300 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             b = torch.full((4,), 2.0)
             torch.testing.assert_close(compiled_alias(a, a), alias_sensitive(a, a))
             torch.testing.assert_close(compiled_alias(a, b), alias_sensitive(a, b))
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_plan_is_per_cache_entry(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.mode = 1
+
+                def forward(self, x):
+                    return x + self.mode + GLOBAL_DICT["used"]
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=False
+            )
+            inputs = (torch.zeros(2), torch.zeros(3))
+            for i in range(8):
+                GLOBAL_DICT["noise"] = [i]
+                for x in inputs:
+                    torch.testing.assert_close(
+                        compiled(x), torch.full_like(x, 2.0)
+                    )
+            assert counter.frame_count == 2, counter.frame_count
+            original_entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(original_entries) == 2, len(original_entries)
+            assert all(
+                entry._debug_fast_guard_enabled for entry in original_entries
+            ), [entry._debug_fast_guard_enabled for entry in original_entries]
+
+            model.mode = 5
+            for i, x in enumerate(inputs):
+                GLOBAL_DICT["noise"] = [100 + i]
+                torch.testing.assert_close(
+                    compiled(x), torch.full_like(x, 6.0)
+                )
+            assert counter.frame_count == 4, counter.frame_count
+            assert all(
+                entry._debug_fast_guard_enabled for entry in original_entries
+            ), [entry._debug_fast_guard_enabled for entry in original_entries]
+
+            model.mode = 1
+            for i, x in enumerate(inputs):
+                GLOBAL_DICT["noise"] = [200 + i]
+                torch.testing.assert_close(
+                    compiled(x), torch.full_like(x, 2.0)
+                )
+            assert counter.frame_count == 4, counter.frame_count
+            assert all(
+                entry._debug_fast_guard_enabled for entry in original_entries
+            ), [entry._debug_fast_guard_enabled for entry in original_entries]
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_preserves_cross_slice_alias_relations(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("value", torch.ones(2))
+
+                def forward(self, x):
+                    return self.value + x + GLOBAL_DICT["used"]
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            same = model.value
+            for i in range(8):
+                GLOBAL_DICT["noise"] = [i]
+                torch.testing.assert_close(compiled(same), torch.full((2,), 3.0))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(original_entry) == 1, len(original_entry)
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            GLOBAL_DICT["noise"] = [100]
+            different = torch.zeros_like(same)
+            torch.testing.assert_close(compiled(different), torch.full((2,), 2.0))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            GLOBAL_DICT["noise"] = [200]
+            torch.testing.assert_close(compiled(same), torch.full((2,), 3.0))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            class DistinctModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("value", torch.ones(2))
+
+                def forward(self, x):
+                    return self.value + x + GLOBAL_DICT["used"]
+
+            distinct_model = DistinctModel()
+            distinct_counter = CompileCounter()
+            distinct = torch.compile(
+                distinct_model, backend=distinct_counter, fullgraph=True
+            )
+            for i in range(8):
+                GLOBAL_DICT["noise"] = [i + 300]
+                current = torch.full((2,), float(i + 2))
+                torch.testing.assert_close(
+                    distinct(current), distinct_model.value + current + 1
+                )
+            assert distinct_counter.frame_count == 1, distinct_counter.frame_count
+            distinct_entry = _debug_get_cache_entry_list(
+                DistinctModel.forward.__code__
+            )
+            assert len(distinct_entry) == 1, len(distinct_entry)
+            assert distinct_entry[0]._debug_fast_guard_enabled
+
+            GLOBAL_DICT["noise"] = [400]
+            torch.testing.assert_close(
+                distinct(distinct_model.value), torch.full((2,), 3.0)
+            )
+            assert distinct_counter.frame_count == 2, distinct_counter.frame_count
+            assert distinct_entry[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_preserves_dict_tagged_alias_relations(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            def run_case(recursive_tags):
+                torch._dynamo.reset()
+                torch._dynamo.config.skip_tensor_guards_with_matching_dict_tags = True
+                torch._dynamo.config.use_recursive_dict_tags_for_guards = recursive_tags
+                torch._dynamo.config.use_lamba_guard_for_object_aliasing = False
+                torch._dynamo.config.skip_no_tensor_aliasing_guards_on_parameters = False
+
+                alias_dict = {}
+
+                class Model(torch.nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.register_buffer("value", torch.ones(2))
+                        alias_dict["peer"] = self.value
+
+                    def forward(self):
+                        if self.value is alias_dict["peer"]:
+                            return self.value + 2
+                        return self.value - 2
+
+                model = Model()
+                counter = CompileCounter()
+                compiled = torch.compile(model, backend=counter, fullgraph=True)
+                for _ in range(8):
+                    torch.testing.assert_close(compiled(), torch.full((2,), 3.0))
+                assert counter.frame_count == 1, counter.frame_count
+                original_entry = _debug_get_cache_entry_list(Model.forward.__code__)
+                assert len(original_entry) == 1, len(original_entry)
+                assert original_entry[0]._debug_fast_guard_enabled
+
+                old_value = model.value
+                model.value = torch.zeros(2)
+                torch.testing.assert_close(compiled(), torch.full((2,), -2.0))
+                assert counter.frame_count == 2, counter.frame_count
+                assert original_entry[0]._debug_fast_guard_enabled
+
+                model.value = old_value
+                torch.testing.assert_close(compiled(), torch.full((2,), 3.0))
+                assert counter.frame_count == 2, counter.frame_count
+                assert original_entry[0]._debug_fast_guard_enabled
+
+            run_case(False)
+            run_case(True)
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_preserves_dimension_marking_guard(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self._cached_tensor = torch.ones(2)
+                    self.weight = torch.nn.Parameter(torch.ones(2))
+
+                def forward(self, x):
+                    return (
+                        self._cached_tensor
+                        + self.weight
+                        + x
+                        + GLOBAL_DICT["used"]
+                    )
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=True
+            )
+            x = torch.zeros(2)
+            for i in range(8):
+                GLOBAL_DICT["noise"] = [i]
+                torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(original_entry) == 1, len(original_entry)
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            model._cached_tensor._dynamo_dynamic_indices = {0}
+            model._cached_tensor._has_dynamo_dim_marking = True
+            GLOBAL_DICT["noise"] = [100]
+            torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            del model._cached_tensor._dynamo_dynamic_indices
+            del model._cached_tensor._has_dynamo_dim_marking
+            GLOBAL_DICT["noise"] = [200]
+            torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            model.weight._has_dynamo_dim_marking = None
+            GLOBAL_DICT["noise"] = [300]
+            torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 3, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            del model.weight._has_dynamo_dim_marking
+            GLOBAL_DICT["noise"] = [400]
+            torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 3, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+
+            torch.Tensor._has_dynamo_dim_marking = False
+            try:
+                GLOBAL_DICT["noise"] = [500]
+                torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+                assert counter.frame_count == 4, counter.frame_count
+                assert original_entry[0]._debug_fast_guard_enabled
+            finally:
+                del torch.Tensor._has_dynamo_dim_marking
+
+            GLOBAL_DICT["noise"] = [600]
+            torch.testing.assert_close(compiled(x), torch.full((2,), 3.0))
+            assert counter.frame_count == 4, counter.frame_count
+            assert original_entry[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_rejects_existing_dimension_marking(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self._cached_tensor = torch.ones(2)
+                    self._cached_tensor._dynamo_dynamic_indices = {0}
+                    self._cached_tensor._has_dynamo_dim_marking = True
+
+                def forward(self, x):
+                    return self._cached_tensor + x
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=True
+            )
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), torch.ones(2))
+            assert counter.frame_count == 1, counter.frame_count
+            entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(entries) == 1, len(entries)
+            assert not entries[0]._debug_fast_guard_enabled
         """
         self._run_guard_lookup_memo_script(script)
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -3212,6 +3212,44 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             assert len(cache_entries) == 1, len(cache_entries)
             assert not cache_entries[0]._debug_fast_guard_enabled
 
+            class Holder:
+                def __init__(self, value):
+                    self.scale = torch.full((3,), value)
+                    self.bias = torch.full((3,), value + 1)
+
+            class OrdinaryAccessorModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holders = [Holder(float(i)) for i in range(32)]
+
+                def forward(self, x):
+                    result = x
+                    for holder in self.holders:
+                        result = (
+                            result
+                            + holder.scale
+                            + holder.__dict__["bias"]
+                        )
+                    return result
+
+            accessor_model = OrdinaryAccessorModel()
+            accessor_counter = CompileCounter()
+            accessor_compiled = torch.compile(
+                accessor_model, backend=accessor_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(
+                    accessor_compiled(x), accessor_model(x)
+                )
+            assert (
+                accessor_counter.frame_count == 1
+            ), accessor_counter.frame_count
+            accessor_entries = _debug_get_cache_entry_list(
+                OrdinaryAccessorModel.forward.__code__
+            )
+            assert len(accessor_entries) == 1, len(accessor_entries)
+            assert not accessor_entries[0]._debug_fast_guard_enabled
+
             class ObjectAliasModel(torch.nn.Module):
                 def forward(self, x, y):
                     if x is y:

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2211,8 +2211,30 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
     @staticmethod
     def _run_guard_lookup_memo_script(script):
         prefix = (
-            "import torch; "
+            "import torch\n"
             "torch._dynamo.config.enable_guard_lookup_memo = True\n"
+            "from torch._dynamo.eval_frame import _debug_get_cache_entry_list\n"
+            "def _only_cache_entry(code):\n"
+            "    entries = _debug_get_cache_entry_list(code)\n"
+            "    assert len(entries) == 1, len(entries)\n"
+            "    return entries[0]\n"
+            "def _guard_tree_shapes(entry):\n"
+            "    leaves = []\n"
+            "    accessors = []\n"
+            "    pending = [entry.guard_manager.root]\n"
+            "    while pending:\n"
+            "        manager = pending.pop()\n"
+            "        source = manager.get_source()\n"
+            "        leaves.extend(\n"
+            "            (source, type(guard).__name__)\n"
+            "            for guard in manager.get_leaf_guards()\n"
+            "        )\n"
+            "        accessors.extend(\n"
+            "            (source, type(accessor).__name__)\n"
+            "            for accessor in manager.get_accessors()\n"
+            "        )\n"
+            "        pending.extend(manager.get_child_managers())\n"
+            "    return leaves, accessors\n"
         )
         subprocess.run(
             [sys.executable, "-c", prefix + textwrap.dedent(script)],
@@ -2250,20 +2272,25 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
 
             cache_entries = _debug_get_cache_entry_list(Model.forward.__code__)
             assert len(cache_entries) == 1, len(cache_entries)
-            assert cache_entries[0]._debug_fast_guard_enabled
+            original_entry = cache_entries[0]
+            assert original_entry._debug_fast_guard_enabled
 
             model.scale = 4.0
             torch.testing.assert_close(compiled(x), model(x))
+            assert original_entry._debug_fast_guard_enabled
 
             model.offsets[0] = 5.0
             torch.testing.assert_close(compiled(x), model(x))
+            assert original_entry._debug_fast_guard_enabled
 
             global_bias = torch.tensor(7.0)
             torch.testing.assert_close(compiled(x), model(x))
+            assert original_entry._debug_fast_guard_enabled
 
             model.scale = 6.0
             x = torch.ones(9)
             torch.testing.assert_close(compiled(x), model(x))
+            assert original_entry._debug_fast_guard_enabled
 
             def alias_sensitive(a, b):
                 return a + b if a is b else a - b
@@ -2275,6 +2302,375 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             b = torch.full((4,), 2.0)
             torch.testing.assert_close(compiled_alias(a, a), alias_sensitive(a, a))
             torch.testing.assert_close(compiled_alias(a, b), alias_sensitive(a, b))
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_fail_closed_leaf_and_container_shapes(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class ExactContainerModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = [torch.ones(2)]
+                    self.options = (torch.full((2,), 2.0),)
+
+                def forward(self, x):
+                    return (
+                        x
+                        + self.values[0]
+                        + len(self.values)
+                        + self.options[0]
+                        + len(self.options)
+                    )
+
+            exact_model = ExactContainerModel()
+            exact_counter = CompileCounter()
+            exact_compiled = torch.compile(
+                exact_model, backend=exact_counter, fullgraph=True
+            )
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(exact_compiled(x), exact_model(x))
+            assert exact_counter.frame_count == 1, exact_counter.frame_count
+            exact_entry = _only_cache_entry(ExactContainerModel.forward.__code__)
+            _, exact_accessors = _guard_tree_shapes(exact_entry)
+            assert any(
+                kind == "ListGetItemGuardAccessor"
+                and source.startswith("L['self']")
+                for source, kind in exact_accessors
+            ), exact_accessors
+            assert any(
+                kind == "TupleGetItemGuardAccessor"
+                and source.startswith("L['self']")
+                for source, kind in exact_accessors
+            ), exact_accessors
+            assert exact_entry._debug_fast_guard_enabled
+
+            class Holder:
+                pass
+
+            class NoHasattrModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = Holder()
+
+                def forward(self, x):
+                    if hasattr(self.holder, "scale"):
+                        return x + self.holder.scale
+                    return x + 1
+
+            no_hasattr_model = NoHasattrModel()
+            no_hasattr_counter = CompileCounter()
+            no_hasattr_compiled = torch.compile(
+                no_hasattr_model, backend=no_hasattr_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(
+                    no_hasattr_compiled(x), no_hasattr_model(x)
+                )
+            assert no_hasattr_counter.frame_count == 1, no_hasattr_counter.frame_count
+            no_hasattr_entry = _only_cache_entry(NoHasattrModel.forward.__code__)
+            leaves, _ = _guard_tree_shapes(no_hasattr_entry)
+            assert any(
+                kind == "NO_HASATTR" and source.startswith("L['self']")
+                for source, kind in leaves
+            ), leaves
+            assert not no_hasattr_entry._debug_fast_guard_enabled
+
+            no_hasattr_model.holder.scale = torch.full((2,), 4.0)
+            torch.testing.assert_close(
+                no_hasattr_compiled(x), no_hasattr_model(x)
+            )
+            assert no_hasattr_counter.frame_count == 2, no_hasattr_counter.frame_count
+
+            class MutableEqualsModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.mode = [1, 2]
+
+                def forward(self, x):
+                    if self.mode == [1, 2]:
+                        return x + 1
+                    return x - 1
+
+            mutable_model = MutableEqualsModel()
+            mutable_counter = CompileCounter()
+            mutable_compiled = torch.compile(
+                mutable_model, backend=mutable_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(mutable_compiled(x), mutable_model(x))
+            assert mutable_counter.frame_count == 1, mutable_counter.frame_count
+            mutable_entry = _only_cache_entry(MutableEqualsModel.forward.__code__)
+            leaves, _ = _guard_tree_shapes(mutable_entry)
+            assert any(
+                kind == "EQUALS_MATCH" and source.startswith("L['self']")
+                for source, kind in leaves
+            ), leaves
+            assert not mutable_entry._debug_fast_guard_enabled
+
+            mutable_model.mode.append(3)
+            torch.testing.assert_close(mutable_compiled(x), mutable_model(x))
+            assert mutable_counter.frame_count == 2, mutable_counter.frame_count
+
+            class FancyList(list):
+                pass
+
+            class NonExactListModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = FancyList([1.0])
+
+                def forward(self, x):
+                    return x + self.values[0] + len(self.values)
+
+            nonexact_model = NonExactListModel()
+            nonexact_counter = CompileCounter()
+            nonexact_compiled = torch.compile(
+                nonexact_model, backend=nonexact_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(nonexact_compiled(x), nonexact_model(x))
+            assert nonexact_counter.frame_count == 1, nonexact_counter.frame_count
+            nonexact_entry = _only_cache_entry(NonExactListModel.forward.__code__)
+            leaves, accessors = _guard_tree_shapes(nonexact_entry)
+            assert any(
+                kind == "LENGTH_CHECK" and source.startswith("L['self']")
+                for source, kind in leaves
+            ), leaves
+            assert any(
+                kind == "ListGetItemGuardAccessor"
+                and source.startswith("L['self']")
+                for source, kind in accessors
+            ), accessors
+            assert not nonexact_entry._debug_fast_guard_enabled
+
+            nonexact_model.values.append(2.0)
+            torch.testing.assert_close(nonexact_compiled(x), nonexact_model(x))
+            assert nonexact_counter.frame_count == 2, nonexact_counter.frame_count
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_instance_attr_binding_and_type_refresh(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class Holder:
+                def __init__(self):
+                    self.scale = torch.ones(2)
+
+            class OtherHolder:
+                pass
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = Holder()
+
+                def forward(self, x):
+                    return self.holder.scale + x
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _only_cache_entry(Model.forward.__code__)
+            assert original_entry._debug_fast_guard_enabled
+
+            Holder._fastguard_unrelated_type_change = None
+            try:
+                torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 1, counter.frame_count
+                assert original_entry._debug_fast_guard_enabled
+            finally:
+                del Holder._fastguard_unrelated_type_change
+
+            original_scale = model.holder.scale
+            model.holder.scale = torch.full((2,), 3.0)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            model.holder.scale = original_scale
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            Holder.scale = property(lambda self: torch.full((2,), 5.0))
+            try:
+                torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 3, counter.frame_count
+                assert original_entry._debug_fast_guard_enabled
+            finally:
+                del Holder.scale
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 3, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            model.holder.__class__ = OtherHolder
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 4, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            model.holder.__class__ = Holder
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 4, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_default_getattribute_change(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class InitiallyCustomHolder:
+                def __init__(self):
+                    self.scale = torch.ones(2)
+
+                def __getattribute__(self, name):
+                    return object.__getattribute__(self, name)
+
+            class InitiallyCustomModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = InitiallyCustomHolder()
+
+                def forward(self, x):
+                    return self.holder.scale + x
+
+            initial_model = InitiallyCustomModel()
+            initial_counter = CompileCounter()
+            initial_compiled = torch.compile(
+                initial_model, backend=initial_counter, fullgraph=True
+            )
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(initial_compiled(x), initial_model(x))
+            assert initial_counter.frame_count == 1, initial_counter.frame_count
+            initial_entry = _only_cache_entry(
+                InitiallyCustomModel.forward.__code__
+            )
+            assert not initial_entry._debug_fast_guard_enabled
+
+            class InitiallyGetattrHolder:
+                def __init__(self):
+                    self.scale = torch.ones(2)
+
+                def __getattr__(self, name):
+                    raise AttributeError(name)
+
+            class InitiallyGetattrModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = InitiallyGetattrHolder()
+
+                def forward(self, x):
+                    return self.holder.scale + x
+
+            getattr_model = InitiallyGetattrModel()
+            getattr_counter = CompileCounter()
+            getattr_compiled = torch.compile(
+                getattr_model, backend=getattr_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(
+                    getattr_compiled(x), getattr_model(x)
+                )
+            assert getattr_counter.frame_count == 1, getattr_counter.frame_count
+            getattr_entry = _only_cache_entry(
+                InitiallyGetattrModel.forward.__code__
+            )
+            assert not getattr_entry._debug_fast_guard_enabled
+
+            class Holder:
+                def __init__(self):
+                    self.scale = torch.ones(2)
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = Holder()
+
+                def forward(self, x):
+                    return self.holder.scale + x
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _only_cache_entry(Model.forward.__code__)
+            assert original_entry._debug_fast_guard_enabled
+
+            replacement_scale = torch.full((2,), 5.0)
+
+            def replacement_getattribute(self, name):
+                if name == "scale":
+                    return replacement_scale
+                return object.__getattribute__(self, name)
+
+            Holder.__getattribute__ = replacement_getattribute
+            try:
+                torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 2, counter.frame_count
+                assert original_entry._debug_fast_guard_enabled
+            finally:
+                del Holder.__getattribute__
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_generic_dict_binding_proof(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class Holder:
+                def __init__(self):
+                    self.scale = torch.ones(2)
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = Holder()
+
+                def forward(self, x):
+                    return self.holder.__dict__["scale"] + x
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _only_cache_entry(Model.forward.__code__)
+            _, accessors = _guard_tree_shapes(original_entry)
+            assert any(
+                kind == "GetGenericDictGuardAccessor"
+                and source.startswith("L['self']")
+                for source, kind in accessors
+            ), accessors
+            assert original_entry._debug_fast_guard_enabled
+
+            original_dict = model.holder.__dict__
+            model.holder.__dict__ = {"scale": torch.full((2,), 4.0)}
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            model.holder.__dict__ = original_dict
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
         """
         self._run_guard_lookup_memo_script(script)
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -4,7 +4,9 @@ import functools
 import gc
 import inspect
 import os
+import subprocess
 import sys
+import textwrap
 import unittest
 import weakref
 from unittest import mock
@@ -2177,6 +2179,103 @@ class GuardCheckSpecTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(handler.eval_fn({"a": 10, "b": 20, "c": 30}, expected))
         self.assertFalse(handler.eval_fn({"a": 1, "b": 2}, expected))
         self.assertFalse(handler.eval_fn({"x": 1, "y": 2, "z": 3}, expected))
+
+
+class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
+    @staticmethod
+    def _run_guard_lookup_memo_script(script):
+        prefix = (
+            "import torch; "
+            "torch._dynamo.config.enable_guard_lookup_memo = True\n"
+        )
+        subprocess.run(
+            [sys.executable, "-c", prefix + textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            check=True,
+        )
+
+    def test_actual_partial_preserves_module_and_residual_guards(self):
+        script = """
+            import torch
+            from torch._dynamo.testing import CompileCounter
+
+            global_bias = torch.tensor(3.0)
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("scale", torch.tensor(2.0))
+                    self.offsets = [1.0]
+
+                def forward(self, x):
+                    return x * self.scale + self.offsets[0] + global_bias
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=True
+            )
+
+            x = torch.ones(4)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            model.scale = torch.tensor(4.0)
+            torch.testing.assert_close(compiled(x), model(x))
+
+            model.scale.resize_(4).fill_(6.0)
+            torch.testing.assert_close(compiled(x), model(x))
+
+            model.offsets[0] = 5.0
+            torch.testing.assert_close(compiled(x), model(x))
+
+            global_bias = torch.tensor(7.0)
+            torch.testing.assert_close(compiled(x), model(x))
+
+            model.scale = torch.tensor(6.0)
+            x = torch.ones(9)
+            torch.testing.assert_close(compiled(x), model(x))
+
+            def alias_sensitive(a, b):
+                return a + b if a is b else a - b
+
+            compiled_alias = torch.compile(
+                alias_sensitive, backend="eager", fullgraph=True
+            )
+            a = torch.ones(4)
+            b = torch.full((4,), 2.0)
+            torch.testing.assert_close(compiled_alias(a, a), alias_sensitive(a, a))
+            torch.testing.assert_close(compiled_alias(a, b), alias_sensitive(a, b))
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_guard_lookup_memo_defaults_off(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+            assert torch._dynamo.config.enable_guard_lookup_memo is False
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return x + 1
+
+            model = Model()
+            compiled = torch.compile(model, backend="eager", fullgraph=True)
+            x = torch.ones(3)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+
+            cache_entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(cache_entries) == 1, len(cache_entries)
+            assert not cache_entries[0]._debug_fast_guard_enabled
+        """
+        subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            check=True,
+        )
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -3513,6 +3513,48 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             assert counter.frame_count == 2, counter.frame_count
             assert original_entry._debug_fast_guard_enabled
 
+            class DescriptorValue:
+                def __init__(self, value):
+                    self.value = value
+
+            original_value = DescriptorValue(torch.ones(2))
+            replacement_value = DescriptorValue(torch.full((2,), 5.0))
+
+            class MutableDescriptorNamespace:
+                scale = original_value
+
+            class MutableDescriptorModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.namespace = MutableDescriptorNamespace
+
+                def forward(self, x):
+                    return self.namespace.scale.value + x
+
+            mutable_descriptor_model = MutableDescriptorModel()
+            mutable_compiled, mutable_counter, mutable_entry, mutable_x = (
+                _warm_model(mutable_descriptor_model)
+            )
+
+            def descriptor_get(self, obj, owner):
+                return replacement_value
+
+            DescriptorValue.__get__ = descriptor_get
+            try:
+                torch.testing.assert_close(
+                    mutable_compiled(mutable_x),
+                    mutable_descriptor_model(mutable_x),
+                )
+                assert mutable_counter.frame_count == 2, mutable_counter.frame_count
+            finally:
+                del DescriptorValue.__get__
+
+            torch.testing.assert_close(
+                mutable_compiled(mutable_x), mutable_descriptor_model(mutable_x)
+            )
+            assert mutable_counter.frame_count == 2, mutable_counter.frame_count
+            assert mutable_entry._debug_fast_guard_enabled
+
             class Descriptor:
                 def __init__(self):
                     self.value = torch.ones(2)
@@ -3667,6 +3709,32 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
 
             fancy_model = FancySetModel()
             _warm_model(fancy_model, enabled=False)
+
+            class Comparable(int):
+                __hash__ = int.__hash__
+
+                def __eq__(self, other):
+                    return int.__eq__(self, other)
+
+            expected_mode = {Comparable(1), Comparable(2)}
+
+            class CallbackSetModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.mode = {Comparable(1), Comparable(2)}
+
+                def forward(self, value):
+                    if self.mode == expected_mode:
+                        return value + 1
+                    return value - 1
+
+            callback_model = CallbackSetModel()
+            _, _, callback_entry, _ = _warm_model(callback_model, enabled=False)
+            callback_leaves, _ = _guard_tree_shapes(callback_entry)
+            assert any(
+                kind == "EQUALS_MATCH" and source.startswith("L['self']")
+                for source, kind in callback_leaves
+            ), callback_leaves
         """
         self._run_guard_lookup_memo_script(script)
 
@@ -3747,6 +3815,7 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             assert not worker.is_alive(), "guard lookup did not finish"
             assert not errors, errors
             assert _debug_get_precompile_entries(code) == []
+            torch.testing.assert_close(compiled(x), model(x))
         """
         self._run_guard_lookup_memo_script(script)
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2250,6 +2250,247 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             check=True,
         )
 
+    def test_extra_state_reads_loaded_config_without_import(self):
+        script = """
+            import builtins
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_precompile_entries,
+                _load_precompile_entry,
+            )
+
+            class SourceModel(torch.nn.Module):
+                def forward(self, x):
+                    return x + 1
+
+            model = SourceModel()
+            compiled, counter, source_entry, x = _warm_model(model)
+            fresh_code = SourceModel.forward.__code__.replace()
+
+            config_imports = []
+            original_import = builtins.__import__
+
+            def recording_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name == "torch._dynamo.config":
+                    config_imports.append(name)
+                return original_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = recording_import
+            try:
+                _load_precompile_entry(
+                    fresh_code,
+                    source_entry.guard_manager,
+                    source_entry.code,
+                )
+            finally:
+                builtins.__import__ = original_import
+
+            SourceModel.forward.__code__ = fresh_code
+            expected = model(x)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), expected)
+            assert counter.frame_count == 1, counter.frame_count
+
+            entries = _debug_get_precompile_entries(fresh_code)
+            assert len(entries) == 1, len(entries)
+            assert entries[0]._debug_fast_guard_enabled
+            assert config_imports == [], config_imports
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_selects_cloned_self_by_framelocals_key(self):
+        script = """
+            from torch._C._dynamo import guards as cpp_guards
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_precompile_entries,
+                _load_precompile_entry,
+            )
+            from torch._dynamo.guards import GuardManagerType, GuardManagerWrapper
+            from torch._dynamo.testing import CompileCounter
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return x + 1
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.ones(2)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            source_entry = _only_cache_entry(Model.forward.__code__)
+            fresh_code = Model.forward.__code__.replace()
+            root = cpp_guards.RootGuardManager()
+            self_manager = root.framelocals_manager(
+                ("self", 0),
+                "<structural-self>",
+                model,
+                GuardManagerType.GUARD_MANAGER,
+            )
+            self_manager.add_id_match_guard(
+                id(model), ["self identity changed"], None
+            )
+            root = root.clone_manager(lambda _: True)
+            _load_precompile_entry(
+                fresh_code,
+                GuardManagerWrapper(root),
+                source_entry.code,
+            )
+
+            Model.forward.__code__ = fresh_code
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            entries = _debug_get_precompile_entries(fresh_code)
+            assert len(entries) == 1, len(entries)
+            assert entries[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_ignores_self_source_decoy(self):
+        script = """
+            from torch._C._dynamo import guards as cpp_guards
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_precompile_entries,
+                _load_precompile_entry,
+            )
+            from torch._dynamo.guards import GuardManagerType, GuardManagerWrapper
+            from torch._dynamo.testing import CompileCounter
+
+            class Decoy:
+                def __init__(self):
+                    self.value = 1
+
+            class Model(torch.nn.Module):
+                def forward(self, x, decoy):
+                    return x + decoy.value
+
+            model = Model()
+            decoy = Decoy()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.ones(2)
+            torch.testing.assert_close(compiled(x, decoy), model(x, decoy))
+            assert counter.frame_count == 1, counter.frame_count
+
+            source_entry = _only_cache_entry(Model.forward.__code__)
+            fresh_code = Model.forward.__code__.replace()
+            root = cpp_guards.RootGuardManager()
+            self_manager = root.framelocals_manager(
+                ("self", 0),
+                "<structural-self>",
+                model,
+                GuardManagerType.GUARD_MANAGER,
+            )
+            self_manager.add_id_match_guard(
+                id(model), ["self identity changed"], None
+            )
+            decoy_manager = root.framelocals_manager(
+                ("decoy", 2),
+                "L['self']",
+                decoy,
+                GuardManagerType.GUARD_MANAGER,
+            )
+            decoy_manager.add_lambda_guard(
+                lambda value: value.value == 1,
+                ["decoy value changed"],
+                None,
+            )
+            _load_precompile_entry(
+                fresh_code,
+                GuardManagerWrapper(root),
+                source_entry.code,
+            )
+
+            Model.forward.__code__ = fresh_code
+            for _ in range(8):
+                torch.testing.assert_close(
+                    compiled(x, decoy), model(x, decoy)
+                )
+            assert counter.frame_count == 1, counter.frame_count
+
+            entries = _debug_get_precompile_entries(fresh_code)
+            assert len(entries) == 1, len(entries)
+            original_entry = entries[0]
+            assert original_entry._debug_fast_guard_enabled
+
+            decoy.value = 2
+            torch.testing.assert_close(compiled(x, decoy), model(x, decoy))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_rejects_unsupported_leaf_by_self_membership(self):
+        script = """
+            from torch._C._dynamo import guards as cpp_guards
+            from torch._C._dynamo.eval_frame import (
+                _debug_get_precompile_entries,
+                _load_precompile_entry,
+            )
+            from torch._dynamo.guards import GuardManagerType, GuardManagerWrapper
+            from torch._dynamo.testing import CompileCounter
+
+            class Holder:
+                def __init__(self):
+                    self.value = 1
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.holder = Holder()
+
+                def forward(self, x):
+                    return x + self.holder.value
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.ones(2)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            source_entry = _only_cache_entry(Model.forward.__code__)
+            fresh_code = Model.forward.__code__.replace()
+            root = cpp_guards.RootGuardManager()
+            self_manager = root.framelocals_manager(
+                ("self", 0),
+                "L['self']",
+                model,
+                GuardManagerType.GUARD_MANAGER,
+            )
+            self_manager.add_id_match_guard(
+                id(model), ["self identity changed"], None
+            )
+            holder_manager = self_manager.getattr_manager(
+                "holder",
+                "<opaque-holder-source>",
+                model.holder,
+                GuardManagerType.GUARD_MANAGER,
+            )
+            holder_manager.add_lambda_guard(
+                lambda value: value.value == 1,
+                ["holder value changed"],
+                None,
+            )
+            _load_precompile_entry(
+                fresh_code,
+                GuardManagerWrapper(root),
+                source_entry.code,
+            )
+
+            Model.forward.__code__ = fresh_code
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+
+            entries = _debug_get_precompile_entries(fresh_code)
+            assert len(entries) == 1, len(entries)
+            assert not entries[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
     def test_actual_partial_preserves_module_and_residual_guards(self):
         script = """
             import torch

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -3177,6 +3177,252 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
         """
         self._run_guard_lookup_memo_script(script)
 
+    def test_actual_partial_retains_exact_list_items(self):
+        script = """
+            import gc
+            import weakref
+            from torch._dynamo.testing import CompileCounter
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = [torch.ones(2)]
+
+                def forward(self, x):
+                    return x + self.values[0] + len(self.values)
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _only_cache_entry(Model.forward.__code__)
+            assert original_entry._debug_fast_guard_enabled
+
+            original_value = model.values[0]
+            original_ref = weakref.ref(original_value)
+            model.values[0] = torch.full((2,), 4, dtype=torch.int64)
+            del original_value
+            gc.collect()
+            assert original_ref() is not None
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            model.values[0] = original_ref()
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_bounds_unstable_and_large_list_training(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class UnstableListModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = [object()]
+
+                def forward(self, x):
+                    return x + len(self.values)
+
+            unstable_model = UnstableListModel()
+            unstable_counter = CompileCounter()
+            unstable_compiled = torch.compile(
+                unstable_model, backend=unstable_counter, fullgraph=True
+            )
+            x = torch.zeros(2)
+            torch.testing.assert_close(
+                unstable_compiled(x), unstable_model(x)
+            )
+            unstable_model.values[0] = object()
+            torch.testing.assert_close(
+                unstable_compiled(x), unstable_model(x)
+            )
+            for _ in range(8):
+                unstable_model.values[0] = object()
+                torch.testing.assert_close(
+                    unstable_compiled(x), unstable_model(x)
+                )
+            assert unstable_counter.frame_count == 1, unstable_counter.frame_count
+            unstable_entry = _only_cache_entry(
+                UnstableListModel.forward.__code__
+            )
+
+            # Once the changing signature exhausts its training budget, later
+            # stable calls stay on the original guard path instead of resuming
+            # unbounded recording and eventually enabling a plan.
+            for _ in range(8):
+                torch.testing.assert_close(
+                    unstable_compiled(x), unstable_model(x)
+                )
+            assert unstable_counter.frame_count == 1, unstable_counter.frame_count
+            assert not unstable_entry._debug_fast_guard_enabled
+
+            class BoundaryListModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = [object()]
+
+                def forward(self, x):
+                    return x + len(self.values)
+
+            boundary_model = BoundaryListModel()
+            boundary_counter = CompileCounter()
+            boundary_compiled = torch.compile(
+                boundary_model, backend=boundary_counter, fullgraph=True
+            )
+            torch.testing.assert_close(boundary_compiled(x), boundary_model(x))
+            boundary_model.values[0] = object()
+            torch.testing.assert_close(boundary_compiled(x), boundary_model(x))
+            for _ in range(7):
+                boundary_model.values[0] = object()
+                torch.testing.assert_close(
+                    boundary_compiled(x), boundary_model(x)
+                )
+            for _ in range(3):
+                torch.testing.assert_close(
+                    boundary_compiled(x), boundary_model(x)
+                )
+            assert boundary_counter.frame_count == 1, boundary_counter.frame_count
+            boundary_entry = _only_cache_entry(
+                BoundaryListModel.forward.__code__
+            )
+            assert boundary_entry._debug_fast_guard_enabled
+
+            class OversizedListModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.values = [object() for _ in range(4097)]
+
+                def forward(self, x):
+                    return x + len(self.values)
+
+            oversized_model = OversizedListModel()
+            oversized_counter = CompileCounter()
+            oversized_compiled = torch.compile(
+                oversized_model, backend=oversized_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(
+                    oversized_compiled(x), oversized_model(x)
+                )
+            assert oversized_counter.frame_count == 1, oversized_counter.frame_count
+            oversized_entry = _only_cache_entry(
+                OversizedListModel.forward.__code__
+            )
+            assert not oversized_entry._debug_fast_guard_enabled
+
+            class AggregateWithinBudgetModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    marker = object()
+                    self.groups = tuple(
+                        [marker] * 4096 for _ in range(16)
+                    )
+
+                def forward(self, x):
+                    return x + sum(len(group) for group in self.groups)
+
+            within_model = AggregateWithinBudgetModel()
+            within_counter = CompileCounter()
+            within_compiled = torch.compile(
+                within_model, backend=within_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(
+                    within_compiled(x), within_model(x)
+                )
+            assert within_counter.frame_count == 1, within_counter.frame_count
+            within_entry = _only_cache_entry(
+                AggregateWithinBudgetModel.forward.__code__
+            )
+            assert within_entry._debug_fast_guard_enabled
+
+            class AggregateOverBudgetModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    marker = object()
+                    self.groups = tuple(
+                        [marker] * 4096 for _ in range(17)
+                    )
+
+                def forward(self, x):
+                    return x + sum(len(group) for group in self.groups)
+
+            over_model = AggregateOverBudgetModel()
+            over_counter = CompileCounter()
+            over_compiled = torch.compile(
+                over_model, backend=over_counter, fullgraph=True
+            )
+            for _ in range(8):
+                torch.testing.assert_close(over_compiled(x), over_model(x))
+            assert over_counter.frame_count == 1, over_counter.frame_count
+            over_entry = _only_cache_entry(
+                AggregateOverBudgetModel.forward.__code__
+            )
+            assert not over_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_preserves_local_state_transitions(self):
+        script = """
+            from torch._dynamo.testing import CompileCounter
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("scale", torch.ones(2))
+
+                def forward(self, x):
+                    state = 0
+                    if torch.is_grad_enabled():
+                        state += 1
+                    if torch.is_inference_mode_enabled():
+                        state += 2
+                    if torch.is_autocast_enabled("cpu"):
+                        state += 4
+                    return x + self.scale + state
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entry = _only_cache_entry(Model.forward.__code__)
+            assert original_entry._debug_fast_guard_enabled
+
+            with torch.no_grad():
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+
+            with torch.inference_mode():
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 3, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            with torch.autocast("cpu"):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 4, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 4, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
     def test_guard_lookup_memo_defaults_off(self):
         script = """
             import torch

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2197,6 +2197,7 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
     def test_actual_partial_preserves_module_and_residual_guards(self):
         script = """
             import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
             from torch._dynamo.testing import CompileCounter
 
             global_bias = torch.tensor(3.0)
@@ -2204,7 +2205,7 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             class Model(torch.nn.Module):
                 def __init__(self):
                     super().__init__()
-                    self.register_buffer("scale", torch.tensor(2.0))
+                    self.scale = 2.0
                     self.offsets = [1.0]
 
                 def forward(self, x):
@@ -2221,10 +2222,11 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
                 torch.testing.assert_close(compiled(x), model(x))
             assert counter.frame_count == 1, counter.frame_count
 
-            model.scale = torch.tensor(4.0)
-            torch.testing.assert_close(compiled(x), model(x))
+            cache_entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(cache_entries) == 1, len(cache_entries)
+            assert cache_entries[0]._debug_fast_guard_enabled
 
-            model.scale.resize_(4).fill_(6.0)
+            model.scale = 4.0
             torch.testing.assert_close(compiled(x), model(x))
 
             model.offsets[0] = 5.0
@@ -2233,7 +2235,7 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             global_bias = torch.tensor(7.0)
             torch.testing.assert_close(compiled(x), model(x))
 
-            model.scale = torch.tensor(6.0)
+            model.scale = 6.0
             x = torch.ones(9)
             torch.testing.assert_close(compiled(x), model(x))
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2411,6 +2411,146 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
         """
         self._run_guard_lookup_memo_script(script)
 
+    def test_actual_partial_preserves_all_residual_alias_relations(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            torch._dynamo.config.use_lamba_guard_for_object_aliasing = False
+
+            def relation_source_groups(entry):
+                groups = {}
+                pending = [entry.guard_manager.root]
+                while pending:
+                    manager = pending.pop()
+                    source = manager.get_source()
+                    for guard in manager.get_leaf_guards():
+                        if type(guard).__name__ in {
+                            "OBJECT_ALIASING",
+                            "NO_TENSOR_ALIASING",
+                        }:
+                            # Keep the pybind guard wrapper alive as the key.  The
+                            # same C++ relation guard is exposed as the same wrapper,
+                            # while retaining it prevents Python id reuse.
+                            groups.setdefault(guard, []).append(source)
+                    pending.extend(manager.get_child_managers())
+                return list(groups.values())
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.bias = 1.0
+
+                def forward(self, x, y):
+                    if x is y:
+                        return x + y + self.bias
+                    return x - y + self.bias
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            same = torch.ones(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(same, same), model(same, same))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(original_entries) == 1, len(original_entries)
+            original_entry = original_entries[0]
+            assert original_entry._debug_fast_guard_enabled
+
+            groups = relation_source_groups(original_entry)
+            assert any(
+                len(group) >= 2
+                and all(not source.startswith("L['self']") for source in group)
+                for group in groups
+            ), groups
+
+            different = torch.zeros_like(same)
+            torch.testing.assert_close(
+                compiled(same, different), model(same, different)
+            )
+            assert counter.frame_count == 2, counter.frame_count
+            assert len(_debug_get_cache_entry_list(Model.forward.__code__)) == 2
+            assert original_entry._debug_fast_guard_enabled
+
+            torch.testing.assert_close(compiled(same, same), model(same, same))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_preserves_all_self_alias_relations(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            torch._dynamo.config.use_lamba_guard_for_object_aliasing = False
+
+            def relation_source_groups(entry):
+                groups = {}
+                pending = [entry.guard_manager.root]
+                while pending:
+                    manager = pending.pop()
+                    source = manager.get_source()
+                    for guard in manager.get_leaf_guards():
+                        if type(guard).__name__ in {
+                            "OBJECT_ALIASING",
+                            "NO_TENSOR_ALIASING",
+                        }:
+                            # Keep the pybind guard wrapper alive as the key.  The
+                            # same C++ relation guard is exposed as the same wrapper,
+                            # while retaining it prevents Python id reuse.
+                            groups.setdefault(guard, []).append(source)
+                    pending.extend(manager.get_child_managers())
+                return list(groups.values())
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    shared = torch.ones(2)
+                    self.register_buffer("left", shared)
+                    self.register_buffer("right", shared)
+
+                def forward(self, x):
+                    if self.left is self.right:
+                        return x + self.left + self.right
+                    return x + self.left - self.right
+
+            model = Model()
+            original_right = model.right
+            counter = CompileCounter()
+            compiled = torch.compile(model, backend=counter, fullgraph=True)
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            original_entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(original_entries) == 1, len(original_entries)
+            original_entry = original_entries[0]
+            assert original_entry._debug_fast_guard_enabled
+
+            groups = relation_source_groups(original_entry)
+            assert any(
+                len(group) >= 2
+                and all(source.startswith("L['self']") for source in group)
+                for group in groups
+            ), groups
+
+            model.right = torch.zeros(2)
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert len(_debug_get_cache_entry_list(Model.forward.__code__)) == 2
+            assert original_entry._debug_fast_guard_enabled
+
+            model.right = original_right
+            torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 2, counter.frame_count
+            assert original_entry._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
     def test_actual_partial_preserves_dict_tagged_alias_relations(self):
         script = """
             import torch
@@ -2569,6 +2709,75 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             entries = _debug_get_cache_entry_list(Model.forward.__code__)
             assert len(entries) == 1, len(entries)
             assert not entries[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_rejects_tensor_subclass(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            class TensorSubclass(torch.Tensor):
+                pass
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self._cached_tensor = torch.ones(2).as_subclass(TensorSubclass)
+
+                def forward(self, x):
+                    return self._cached_tensor + x
+
+            model = Model()
+            counter = CompileCounter()
+            compiled = torch.compile(
+                model, backend=counter, fullgraph=True, dynamic=True
+            )
+            x = torch.zeros(2)
+            for _ in range(8):
+                torch.testing.assert_close(compiled(x), model(x))
+            assert counter.frame_count == 1, counter.frame_count
+            entries = _debug_get_cache_entry_list(Model.forward.__code__)
+            assert len(entries) == 1, len(entries)
+            assert not entries[0]._debug_fast_guard_enabled
+        """
+        self._run_guard_lookup_memo_script(script)
+
+    def test_actual_partial_rejects_dimension_marking_descriptor(self):
+        script = """
+            import torch
+            from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
+
+            class MissingSentinel:
+                def __get__(self, instance, owner):
+                    raise AttributeError("sentinel remains absent")
+
+            torch.Tensor._has_dynamo_dim_marking = MissingSentinel()
+            try:
+                class Model(torch.nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self._cached_tensor = torch.ones(2)
+
+                    def forward(self, x):
+                        return self._cached_tensor + x
+
+                model = Model()
+                counter = CompileCounter()
+                compiled = torch.compile(
+                    model, backend=counter, fullgraph=True, dynamic=True
+                )
+                x = torch.zeros(2)
+                for _ in range(8):
+                    torch.testing.assert_close(compiled(x), model(x))
+                assert counter.frame_count == 1, counter.frame_count
+                entries = _debug_get_cache_entry_list(Model.forward.__code__)
+                assert len(entries) == 1, len(entries)
+                assert not entries[0]._debug_fast_guard_enabled
+            finally:
+                del torch.Tensor._has_dynamo_dim_marking
         """
         self._run_guard_lookup_memo_script(script)
 

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2785,8 +2785,22 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
         script = """
             import torch
             from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+            from torch._dynamo.testing import CompileCounter
 
             assert torch._dynamo.config.enable_guard_lookup_memo is False
+            torch._dynamo.config.use_lamba_guard_for_object_aliasing = False
+
+            def relation_guard_names(entry):
+                names = set()
+                pending = [entry.guard_manager.root]
+                while pending:
+                    manager = pending.pop()
+                    names.update(
+                        type(guard).__name__
+                        for guard in manager.get_leaf_guards()
+                    )
+                    pending.extend(manager.get_child_managers())
+                return names
 
             class Model(torch.nn.Module):
                 def forward(self, x):
@@ -2801,6 +2815,92 @@ class GuardActualPartialFastPathTests(torch._dynamo.test_case.TestCase):
             cache_entries = _debug_get_cache_entry_list(Model.forward.__code__)
             assert len(cache_entries) == 1, len(cache_entries)
             assert not cache_entries[0]._debug_fast_guard_enabled
+
+            class ObjectAliasModel(torch.nn.Module):
+                def forward(self, x, y):
+                    if x is y:
+                        return x + y
+                    return x - y
+
+            object_model = ObjectAliasModel()
+            object_counter = CompileCounter()
+            object_compiled = torch.compile(
+                object_model, backend=object_counter, fullgraph=True
+            )
+            same = torch.ones(3)
+            for _ in range(8):
+                torch.testing.assert_close(
+                    object_compiled(same, same), object_model(same, same)
+                )
+            assert object_counter.frame_count == 1, object_counter.frame_count
+            object_entries = _debug_get_cache_entry_list(
+                ObjectAliasModel.forward.__code__
+            )
+            assert len(object_entries) == 1, len(object_entries)
+            assert "OBJECT_ALIASING" in relation_guard_names(object_entries[0])
+            assert not object_entries[0]._debug_fast_guard_enabled
+
+            different = torch.zeros_like(same)
+            torch.testing.assert_close(
+                object_compiled(same, different), object_model(same, different)
+            )
+            assert object_counter.frame_count == 2, object_counter.frame_count
+            torch.testing.assert_close(
+                object_compiled(same, same), object_model(same, same)
+            )
+            assert object_counter.frame_count == 2, object_counter.frame_count
+            assert all(
+                not entry._debug_fast_guard_enabled
+                for entry in _debug_get_cache_entry_list(
+                    ObjectAliasModel.forward.__code__
+                )
+            )
+
+            class NoTensorAliasModel(torch.nn.Module):
+                def forward(self, x, y):
+                    return x + 2 * y
+
+            no_tensor_model = NoTensorAliasModel()
+            no_tensor_counter = CompileCounter()
+            no_tensor_compiled = torch.compile(
+                no_tensor_model, backend=no_tensor_counter, fullgraph=True
+            )
+            left = torch.ones(3)
+            right = torch.zeros(3)
+            for _ in range(8):
+                torch.testing.assert_close(
+                    no_tensor_compiled(left, right), no_tensor_model(left, right)
+                )
+            assert (
+                no_tensor_counter.frame_count == 1
+            ), no_tensor_counter.frame_count
+            no_tensor_entries = _debug_get_cache_entry_list(
+                NoTensorAliasModel.forward.__code__
+            )
+            assert len(no_tensor_entries) == 1, len(no_tensor_entries)
+            assert "NO_TENSOR_ALIASING" in relation_guard_names(
+                no_tensor_entries[0]
+            )
+            assert not no_tensor_entries[0]._debug_fast_guard_enabled
+
+            torch.testing.assert_close(
+                no_tensor_compiled(left, left), no_tensor_model(left, left)
+            )
+            assert (
+                no_tensor_counter.frame_count == 2
+            ), no_tensor_counter.frame_count
+            torch.testing.assert_close(
+                no_tensor_compiled(left, right), no_tensor_model(left, right)
+            )
+            assert (
+                no_tensor_counter.frame_count == 2
+            ), no_tensor_counter.frame_count
+            assert all(
+                not entry._debug_fast_guard_enabled
+                for entry in _debug_get_cache_entry_list(
+                    NoTensorAliasModel.forward.__code__
+                )
+            )
         """
         subprocess.run(
             [sys.executable, "-c", textwrap.dedent(script)],

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -387,20 +387,16 @@ user_stack=None)
 
     @torch._dynamo.config.patch(skip_tensor_guards_with_matching_dict_tags=True)
     def test_dict_tag_does_not_skip_immutable_object_aliasing_guard(self):
-        value = tuple([1, 2])
-        different = tuple([1, 3])
+        value = (1, 2)
+        different = (1, 3)
         container = {"value": value}
 
         root = RootGuardManager()
-        dict_manager = root.list_getitem_manager(
-            0, "", container, default_mgr_enum
-        )
+        dict_manager = root.list_getitem_manager(0, "", container, default_mgr_enum)
         dict_value_manager = dict_manager.dict_getitem_manager(
             "value", "", value, default_mgr_enum
         )
-        peer_manager = root.list_getitem_manager(
-            1, "", value, default_mgr_enum
-        )
+        peer_manager = root.list_getitem_manager(1, "", value, default_mgr_enum)
         install_object_aliasing_guard(
             dict_value_manager,
             peer_manager,

--- a/torch/_C/_dynamo/eval_frame.pyi
+++ b/torch/_C/_dynamo/eval_frame.pyi
@@ -37,6 +37,7 @@ class _CacheEntry:
 
 class _PrecompileEntry:
     guard_manager: GuardManagerWrapper
+    _debug_fast_guard_enabled: bool
 
 class _ExtraState:
     def invalidate(

--- a/torch/_C/_dynamo/eval_frame.pyi
+++ b/torch/_C/_dynamo/eval_frame.pyi
@@ -33,6 +33,7 @@ class _CacheEntry:
     guard_manager: GuardManagerWrapper
     backend: Callable
     isolate_recompiles_id: int
+    _debug_fast_guard_enabled: bool
 
 class _PrecompileEntry:
     guard_manager: GuardManagerWrapper

--- a/torch/_C/_dynamo/guards.pyi
+++ b/torch/_C/_dynamo/guards.pyi
@@ -242,6 +242,7 @@ class GuardManager:
         equals_val: Any,
         verbose_code_parts: list[str],
         user_stack: traceback.StackSummary | None,
+        actual_partial_safe_constant: bool = False,
     ) -> None: ...
     def add_global_state_guard(
         self,

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -604,6 +604,10 @@ install_free_tensors_for_export = True
 # Use C++ FrameLocalsMapping (raw array view of Python frame fastlocals) (deprecated: always True)
 enable_cpp_framelocals_guard_eval = True
 
+# Enable the experimental last-success guard lookup plan. This value is sampled
+# once when an ExtraState is created.
+enable_guard_lookup_memo: bool = False
+
 # Whether to automatically find and replace identical graph
 # regions with a call to invoke_subgraph
 use_graph_deduplication = False

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -185,6 +185,7 @@ from .utils import (
     get_torch_function_mode_stack,
     get_torch_function_mode_stack_at,
     guard_failures,
+    is_safe_constant,
     istype,
     key_is_id,
     key_to_id,
@@ -1054,7 +1055,10 @@ def getitem_on_dict_manager(
             example_value=source.index,
             guard_manager_enum=GuardManagerType.GUARD_MANAGER,
         ).add_equals_match_guard(
-            source.index, [f"{key_source} == {key_example_value!r}"], None
+            source.index,
+            [f"{key_source} == {key_example_value!r}"],
+            None,
+            is_safe_constant(source.index),
         )
 
     return base_guard_manager.get_value_manager(
@@ -1448,6 +1452,7 @@ class GuardBuilder(GuardBuilderBase):
                     key,
                     get_verbose_code_parts(f"{key_source} == {key!r}", guard),
                     guard.user_stack,
+                    is_safe_constant(key),
                 )
 
     @staticmethod
@@ -1515,7 +1520,12 @@ class GuardBuilder(GuardBuilderBase):
                     source=key_source,
                     example_value=key,
                     guard_manager_enum=GuardManagerType.GUARD_MANAGER,
-                ).add_equals_match_guard(key, [f"{key_source} == {key!r}"], None)
+                ).add_equals_match_guard(
+                    key,
+                    [f"{key_source} == {key!r}"],
+                    None,
+                    is_safe_constant(key),
+                )
 
                 # Install the value manager
                 return mgr.get_value_manager(
@@ -2925,7 +2935,10 @@ class GuardBuilder(GuardBuilderBase):
             ]
 
         self.get_guard_manager(guard).add_equals_match_guard(
-            val, verbose_code_parts, guard.user_stack
+            val,
+            verbose_code_parts,
+            guard.user_stack,
+            is_safe_constant(val),
         )
         self._set_guard_export_info(guard, code)
         return

--- a/torch/csrc/dynamo/cache_entry.cpp
+++ b/torch/csrc/dynamo/cache_entry.cpp
@@ -34,8 +34,7 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED(
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-copy-dtor")
 // NOLINTNEXTLINE(bugprone-exception-escape)
 CacheEntry::~CacheEntry() {
-  torch::dynamo::destroy_guard_last_success_receipt(
-      this->last_success_receipt);
+  torch::dynamo::destroy_guard_last_success_receipt(this->last_success_receipt);
   // prevent guard_manager from use-after-free when invalidating
   this->guard_manager.attr("cache_entry") = py::none();
   this->guard_manager.attr("extra_state") = py::none();
@@ -44,8 +43,7 @@ C10_DIAGNOSTIC_POP()
 C10_DIAGNOSTIC_POP()
 
 void CacheEntry::invalidate(py::object deleted_guard_manager) {
-  torch::dynamo::reset_guard_last_success_receipt(
-      this->last_success_receipt);
+  torch::dynamo::reset_guard_last_success_receipt(this->last_success_receipt);
   // Keep the current pointer alive but make the fields as if no-op
   this->guard_manager.attr("cache_entry") = py::none();
   this->guard_manager.attr("extra_state") = py::none();

--- a/torch/csrc/dynamo/cache_entry.cpp
+++ b/torch/csrc/dynamo/cache_entry.cpp
@@ -4,7 +4,10 @@
 #include <torch/csrc/dynamo/debug_macros.h>
 #include <torch/csrc/dynamo/extra_state.h>
 
-CacheEntry::CacheEntry(const py::handle& guarded_code, PyObject* backend)
+CacheEntry::CacheEntry(
+    const py::handle& guarded_code,
+    PyObject* backend,
+    bool enable_guard_lookup_memo)
     : backend{py::cast<py::object>(get_backend(backend))} {
   this->guard_manager = guarded_code.attr("guard_manager");
   this->code = guarded_code.attr("code");
@@ -20,6 +23,10 @@ CacheEntry::CacheEntry(const py::handle& guarded_code, PyObject* backend)
       this->guard_manager.attr("root"));
   this->diff_guard_root_mgr = torch::dynamo::convert_to_root_guard_manager(
       this->guard_manager.attr("diff_guard_root"));
+  if (enable_guard_lookup_memo) {
+    this->last_success_receipt =
+        torch::dynamo::create_guard_last_success_receipt();
+  }
 }
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED(
@@ -27,6 +34,8 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED(
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-copy-dtor")
 // NOLINTNEXTLINE(bugprone-exception-escape)
 CacheEntry::~CacheEntry() {
+  torch::dynamo::destroy_guard_last_success_receipt(
+      this->last_success_receipt);
   // prevent guard_manager from use-after-free when invalidating
   this->guard_manager.attr("cache_entry") = py::none();
   this->guard_manager.attr("extra_state") = py::none();
@@ -35,6 +44,8 @@ C10_DIAGNOSTIC_POP()
 C10_DIAGNOSTIC_POP()
 
 void CacheEntry::invalidate(py::object deleted_guard_manager) {
+  torch::dynamo::reset_guard_last_success_receipt(
+      this->last_success_receipt);
   // Keep the current pointer alive but make the fields as if no-op
   this->guard_manager.attr("cache_entry") = py::none();
   this->guard_manager.attr("extra_state") = py::none();

--- a/torch/csrc/dynamo/cache_entry.h
+++ b/torch/csrc/dynamo/cache_entry.h
@@ -52,6 +52,8 @@ typedef struct VISIBILITY_HIDDEN CacheEntry {
   void* root_mgr{nullptr};
   // diff guard root guard manager if exists
   void* diff_guard_root_mgr{nullptr};
+  // Per-entry storage for the last-success actual-partial guard plan.
+  void* last_success_receipt{nullptr};
   // backend used to create this cache entry
   py::object backend;
   // Reference to owning ExtraState
@@ -63,11 +65,14 @@ typedef struct VISIBILITY_HIDDEN CacheEntry {
   // Reference to string representation of the CompileContext
   std::string trace_annotation;
 
-  CacheEntry(const py::handle& guarded_code, PyObject* backend);
-  CacheEntry(const CacheEntry&) = default;
-  CacheEntry(CacheEntry&&) = default;
-  CacheEntry& operator=(const CacheEntry&) = default;
-  CacheEntry& operator=(CacheEntry&&) = default;
+  CacheEntry(
+      const py::handle& guarded_code,
+      PyObject* backend,
+      bool enable_guard_lookup_memo);
+  CacheEntry(const CacheEntry&) = delete;
+  CacheEntry(CacheEntry&&) = delete;
+  CacheEntry& operator=(const CacheEntry&) = delete;
+  CacheEntry& operator=(CacheEntry&&) = delete;
   ~CacheEntry();
 
   void invalidate(py::object deleted_guard_manager);

--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -534,12 +534,14 @@ PyObject* dynamo__custom_eval_frame(
   DEBUG_CHECK(PyDict_CheckExact(frame->f_builtins));
 
   PyObject* maybe_cached_code = nullptr;
+  PyObject* matched_precompile_code_owner_raw = nullptr;
   std::unique_ptr<FrameLocalsMapping> locals;
   if (!try_lookup_without_guard_eval(
           extra,
           backend,
           isolate_recompiles_id,
           &maybe_cached_code,
+          &matched_precompile_code_owner_raw,
           &trace_annotation,
           is_skip_guard_eval_unsafe)) {
     locals = std::make_unique<FrameLocalsMapping>(frame);
@@ -551,10 +553,15 @@ PyObject* dynamo__custom_eval_frame(
         backend,
         isolate_recompiles_id,
         &maybe_cached_code,
+        &matched_precompile_code_owner_raw,
         &trace_annotation,
         is_skip_guard_eval_unsafe);
     _pytorch_record_function_exit(rf);
   }
+  py::object matched_precompile_code_owner =
+      matched_precompile_code_owner_raw == nullptr
+      ? py::object()
+      : py::reinterpret_steal<py::object>(matched_precompile_code_owner_raw);
 
   // A callback of Py_False indicates "run only" mode, the cache is checked,
   // but we never compile.

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -24,6 +24,14 @@ bool enable_guard_lookup_memo() {
   py::object config_module = py::module_::import("torch._dynamo.config");
   return config_module.attr("enable_guard_lookup_memo").cast<bool>();
 }
+
+std::vector<std::shared_ptr<PrecompileEntry>> snapshot_precompile_entries(
+    ExtraState* extra_state) {
+  std::lock_guard<std::mutex> lock(extra_state->precompile_entries_mutex);
+  return {
+      extra_state->precompile_entries.begin(),
+      extra_state->precompile_entries.end()};
+}
 } // namespace
 
 Py_ssize_t extra_index = -1;
@@ -290,14 +298,27 @@ void lookup(
     PyObject* backend,
     int64_t isolate_recompiles_id,
     PyObject** maybe_cached_code,
+    PyObject** matched_precompile_code_owner,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
+  *matched_precompile_code_owner = nullptr;
   CacheEntry* found = nullptr;
   bool guard_error = false;
 
-  for (const auto& entry : extra_state->precompile_entries) {
-    if (torch::dynamo::run_root_guard_manager(entry.root_mgr, f_locals)) {
-      *maybe_cached_code = entry.code.ptr();
+  for (const auto& entry : snapshot_precompile_entries(extra_state)) {
+    const bool valid = entry->last_success_receipt == nullptr
+        ? torch::dynamo::run_root_guard_manager(entry->root_mgr, f_locals)
+        : torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+              entry->last_success_receipt,
+              entry.get(),
+              entry->root_mgr,
+              f_locals,
+              is_skip_guard_eval_unsafe);
+    if (valid) {
+      PyObject* code = entry->code.ptr();
+      Py_INCREF(code);
+      *matched_precompile_code_owner = code;
+      *maybe_cached_code = code;
       return;
     }
   }
@@ -345,15 +366,21 @@ bool try_lookup_without_guard_eval(
     PyObject* backend,
     int64_t isolate_recompiles_id,
     PyObject** maybe_cached_code,
+    PyObject** matched_precompile_code_owner,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
-  if (!extra_state->precompile_entries.empty()) {
+  *matched_precompile_code_owner = nullptr;
+  auto precompile_entries = snapshot_precompile_entries(extra_state);
+  if (!precompile_entries.empty()) {
     // Only the first precompile entry can be safely fast-pathed: a later
     // guardless entry must not preempt an earlier guarded entry whose guards
     // may pass.
-    const auto& entry = extra_state->precompile_entries.front();
-    if (torch::dynamo::root_guard_manager_has_no_guards(entry.root_mgr)) {
-      *maybe_cached_code = entry.code.ptr();
+    const auto& entry = precompile_entries.front();
+    if (torch::dynamo::root_guard_manager_has_no_guards(entry->root_mgr)) {
+      PyObject* code = entry->code.ptr();
+      Py_INCREF(code);
+      *matched_precompile_code_owner = code;
+      *maybe_cached_code = code;
       return true;
     }
     return false;
@@ -476,12 +503,22 @@ size_t _get_total_cache_entry_count(const py::handle& code_obj) {
   return extra->total_cache_entry_count;
 }
 
-PrecompileEntry::PrecompileEntry(py::object gm, py::object c)
+PrecompileEntry::PrecompileEntry(
+    py::object gm,
+    py::object c,
+    bool enable_guard_lookup_memo)
     : guard_manager(std::move(gm)), code(std::move(c)) {
   TORCH_CHECK(
       PyCode_Check(code.ptr()), "Expecting CodeType from PrecompileEntry.");
   root_mgr =
       torch::dynamo::convert_to_root_guard_manager(guard_manager.attr("root"));
+  if (enable_guard_lookup_memo) {
+    last_success_receipt = torch::dynamo::create_guard_last_success_receipt();
+  }
+}
+
+PrecompileEntry::~PrecompileEntry() {
+  torch::dynamo::destroy_guard_last_success_receipt(last_success_receipt);
 }
 
 void _reset_precompile_entries(const py::handle& code_obj) {
@@ -490,9 +527,12 @@ void _reset_precompile_entries(const py::handle& code_obj) {
       "expected a code object!");
   PyCodeObject* code = (PyCodeObject*)code_obj.ptr();
   ExtraState* extra = get_extra_state(code);
-  py::list result;
   if (extra != nullptr) {
-    extra->precompile_entries.clear();
+    std::list<std::shared_ptr<PrecompileEntry>> retired_entries;
+    {
+      std::lock_guard<std::mutex> lock(extra->precompile_entries_mutex);
+      retired_entries.swap(extra->precompile_entries);
+    }
   }
 }
 
@@ -509,9 +549,14 @@ void _load_precompile_entry(
   if (extra == nullptr) {
     extra = init_and_set_extra_state(code);
   }
-  auto entry =
-      PrecompileEntry(std::move(guard_manager), std::move(dynamo_code));
-  extra->precompile_entries.push_back(std::move(entry));
+  auto entry = std::make_shared<PrecompileEntry>(
+      std::move(guard_manager),
+      std::move(dynamo_code),
+      extra->guard_lookup_memo_enabled);
+  {
+    std::lock_guard<std::mutex> lock(extra->precompile_entries_mutex);
+    extra->precompile_entries.emplace_back(std::move(entry));
+  }
 }
 
 void _set_lru_cache(py::object boolean) {
@@ -530,8 +575,8 @@ py::list _debug_get_precompile_entries(const py::handle& code_obj) {
   ExtraState* extra = get_extra_state(code);
   py::list result;
   if (extra != nullptr) {
-    for (PrecompileEntry& e : extra->precompile_entries) {
-      result.append(py::cast(e, py::return_value_policy::reference));
+    for (const auto& entry : snapshot_precompile_entries(extra)) {
+      result.append(py::cast(entry));
     }
   }
   return result;

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include <c10/util/Exception.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/dynamo/extra_state.h>
 
 #include <torch/csrc/dynamo/cache_entry.h>
@@ -21,8 +22,36 @@ namespace {
 bool use_lru = true;
 
 bool enable_guard_lookup_memo() {
-  py::object config_module = py::module_::import("torch._dynamo.config");
-  return config_module.attr("enable_guard_lookup_memo").cast<bool>();
+  PyObject* modules = PyImport_GetModuleDict();
+  if (modules == nullptr) {
+    if (PyErr_Occurred()) {
+      throw python_error();
+    }
+    return false;
+  }
+  PyObject* config_module = nullptr;
+  if (PyDict_GetItemStringRef(modules, "torch._dynamo.config", &config_module) <
+      0) {
+    throw python_error();
+  }
+  if (config_module == nullptr) {
+    return false;
+  }
+  py::object config_module_ref =
+      py::reinterpret_steal<py::object>(config_module);
+
+  PyObject* enabled = PyObject_GetAttrString(
+      config_module_ref.ptr(), "enable_guard_lookup_memo");
+  if (enabled == nullptr) {
+    throw python_error();
+  }
+  py::object enabled_ref = py::reinterpret_steal<py::object>(enabled);
+
+  int result = PyObject_IsTrue(enabled_ref.ptr());
+  if (result < 0) {
+    throw python_error();
+  }
+  return result != 0;
 }
 
 std::vector<std::shared_ptr<PrecompileEntry>> snapshot_precompile_entries(

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -305,21 +305,23 @@ void lookup(
   CacheEntry* found = nullptr;
   bool guard_error = false;
 
-  for (const auto& entry : snapshot_precompile_entries(extra_state)) {
-    const bool valid = entry->last_success_receipt == nullptr
-        ? torch::dynamo::run_root_guard_manager(entry->root_mgr, f_locals)
-        : torch::dynamo::run_root_guard_manager_with_last_success_receipt(
-              entry->last_success_receipt,
-              entry.get(),
-              entry->root_mgr,
-              f_locals,
-              is_skip_guard_eval_unsafe);
-    if (valid) {
-      PyObject* code = entry->code.ptr();
-      Py_INCREF(code);
-      *matched_precompile_code_owner = code;
-      *maybe_cached_code = code;
-      return;
+  if (extra_state->has_precompile_entries.load(std::memory_order_relaxed)) {
+    for (const auto& entry : snapshot_precompile_entries(extra_state)) {
+      const bool valid = entry->last_success_receipt == nullptr
+          ? torch::dynamo::run_root_guard_manager(entry->root_mgr, f_locals)
+          : torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+                entry->last_success_receipt,
+                entry.get(),
+                entry->root_mgr,
+                f_locals,
+                is_skip_guard_eval_unsafe);
+      if (valid) {
+        PyObject* code = entry->code.ptr();
+        Py_INCREF(code);
+        *matched_precompile_code_owner = code;
+        *maybe_cached_code = code;
+        return;
+      }
     }
   }
 
@@ -370,20 +372,22 @@ bool try_lookup_without_guard_eval(
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
   *matched_precompile_code_owner = nullptr;
-  auto precompile_entries = snapshot_precompile_entries(extra_state);
-  if (!precompile_entries.empty()) {
-    // Only the first precompile entry can be safely fast-pathed: a later
-    // guardless entry must not preempt an earlier guarded entry whose guards
-    // may pass.
-    const auto& entry = precompile_entries.front();
-    if (torch::dynamo::root_guard_manager_has_no_guards(entry->root_mgr)) {
-      PyObject* code = entry->code.ptr();
-      Py_INCREF(code);
-      *matched_precompile_code_owner = code;
-      *maybe_cached_code = code;
-      return true;
+  if (extra_state->has_precompile_entries.load(std::memory_order_relaxed)) {
+    auto precompile_entries = snapshot_precompile_entries(extra_state);
+    if (!precompile_entries.empty()) {
+      // Only the first precompile entry can be safely fast-pathed: a later
+      // guardless entry must not preempt an earlier guarded entry whose guards
+      // may pass.
+      const auto& entry = precompile_entries.front();
+      if (torch::dynamo::root_guard_manager_has_no_guards(entry->root_mgr)) {
+        PyObject* code = entry->code.ptr();
+        Py_INCREF(code);
+        *matched_precompile_code_owner = code;
+        *maybe_cached_code = code;
+        return true;
+      }
+      return false;
     }
-    return false;
   }
 
   int64_t ids_to_search[] = {isolate_recompiles_id, -1};
@@ -532,6 +536,7 @@ void _reset_precompile_entries(const py::handle& code_obj) {
     {
       std::lock_guard<std::mutex> lock(extra->precompile_entries_mutex);
       retired_entries.swap(extra->precompile_entries);
+      extra->has_precompile_entries.store(false, std::memory_order_relaxed);
     }
   }
 }
@@ -556,6 +561,7 @@ void _load_precompile_entry(
   {
     std::lock_guard<std::mutex> lock(extra->precompile_entries_mutex);
     extra->precompile_entries.emplace_back(std::move(entry));
+    extra->has_precompile_entries.store(true, std::memory_order_relaxed);
   }
 }
 

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -19,12 +19,18 @@
 namespace {
 // Short-term fix for: https://github.com/pytorch/pytorch/issues/166926
 bool use_lru = true;
+
+bool enable_guard_lookup_memo() {
+  py::object config_module = py::module_::import("torch._dynamo.config");
+  return config_module.attr("enable_guard_lookup_memo").cast<bool>();
+}
 } // namespace
 
 Py_ssize_t extra_index = -1;
 
 ExtraState::ExtraState(PyCodeObject* orig_code_arg)
-    : orig_code(orig_code_arg) {}
+    : orig_code(orig_code_arg),
+      guard_lookup_memo_enabled(enable_guard_lookup_memo()) {}
 
 std::list<CacheEntry>& ExtraState::cache_entry_list(
     int64_t isolate_recompiles_id) {
@@ -220,8 +226,15 @@ static CacheEntry* lookup_in_list(
               torch::dynamo::run_root_guard_manager(
                       cache_entry.diff_guard_root_mgr, f_locals);
         } else {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.root_mgr, f_locals);
+          valid = cache_entry.last_success_receipt == nullptr
+              ? torch::dynamo::run_root_guard_manager(
+                    cache_entry.root_mgr, f_locals)
+              : torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+                    cache_entry.last_success_receipt,
+                    &cache_entry,
+                    cache_entry.root_mgr,
+                    f_locals,
+                    /*is_skip_guard_eval_unsafe=*/false);
         }
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {
@@ -385,10 +398,12 @@ CacheEntry* create_cache_entry(
   auto& entries = extra_state->cache_entry_list(id);
   std::list<CacheEntry>::iterator new_iter;
   if (use_lru) {
-    entries.emplace_front(guarded_code, backend);
+    entries.emplace_front(
+        guarded_code, backend, extra_state->guard_lookup_memo_enabled);
     new_iter = entries.begin();
   } else {
-    entries.emplace_back(guarded_code, backend);
+    entries.emplace_back(
+        guarded_code, backend, extra_state->guard_lookup_memo_enabled);
     new_iter = std::prev(entries.end());
   }
   new_iter->_owner = extra_state;

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -68,6 +68,8 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   // Total cache entries across all compile scopes (for O(1)
   // has_any_cache_entries)
   size_t total_cache_entry_count{0};
+  // Sampled once when this ExtraState is created.
+  bool guard_lookup_memo_enabled{false};
   // Frame state to detect dynamic shape dims
   py::dict frame_state;
   // Actions to apply to all frames with this code object (non-isolated)
@@ -77,6 +79,10 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   std::unordered_map<int64_t, FrameExecStrategy> region_strategy_map;
 
   ExtraState(PyCodeObject* orig_code_arg);
+  ExtraState(const ExtraState&) = delete;
+  ExtraState(ExtraState&&) = delete;
+  ExtraState& operator=(const ExtraState&) = delete;
+  ExtraState& operator=(ExtraState&&) = delete;
   std::list<CacheEntry>& cache_entry_list(int64_t isolate_recompiles_id);
   bool has_any_cache_entries() const;
   void move_to_front(CacheEntry* cache_entry, std::list<CacheEntry>& entries);

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -9,6 +9,8 @@
 #include <torch/csrc/dynamo/utils.h>
 #include <torch/csrc/utils/pybind.h>
 #include <list>
+#include <memory>
+#include <mutex>
 #include <unordered_map>
 
 namespace py = pybind11;
@@ -51,16 +53,23 @@ typedef struct CacheEntry CacheEntry;
 typedef struct VISIBILITY_HIDDEN PrecompileEntry {
   py::object guard_manager;
   py::object code;
-  void* root_mgr;
+  void* root_mgr{nullptr};
+  void* last_success_receipt{nullptr};
 
-  PrecompileEntry(py::object gm, py::object c);
+  PrecompileEntry(py::object gm, py::object c, bool enable_guard_lookup_memo);
+  PrecompileEntry(const PrecompileEntry&) = delete;
+  PrecompileEntry(PrecompileEntry&&) = delete;
+  PrecompileEntry& operator=(const PrecompileEntry&) = delete;
+  PrecompileEntry& operator=(PrecompileEntry&&) = delete;
+  ~PrecompileEntry();
 } PrecompileEntry;
 
 typedef struct VISIBILITY_HIDDEN ExtraState {
   // A pointer to the orig_code object to prevent race conditions in invalidate
   // function.
   PyCodeObject* orig_code;
-  std::list<PrecompileEntry> precompile_entries;
+  std::list<std::shared_ptr<PrecompileEntry>> precompile_entries;
+  std::mutex precompile_entries_mutex;
   // Per-compile cache map: isolate_recompiles_id -> list of CacheEntry.
   // id -1 is the default (non-isolated) bucket. id >= 0 are isolated compiles.
   // All cache entries live in this map — there is no separate default list.
@@ -197,6 +206,8 @@ ExtraState* init_and_set_extra_state(PyCodeObject* code);
 //  - extra_state: Borrowed
 // return:
 //   - Py_None or PyCodeObject: Borrowed reference.
+//   - matched_precompile_code_owner: New reference when a precompile entry
+//     matches, otherwise nullptr. The caller owns this reference.
 //   - Py_None or PyObject: Trace id of the compiled code.
 void lookup(
     ExtraState* extra_state,
@@ -204,6 +215,7 @@ void lookup(
     PyObject* backend,
     int64_t isolate_recompiles_id,
     PyObject** maybe_cached_code,
+    PyObject** matched_precompile_code_owner,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe);
 
@@ -215,6 +227,7 @@ bool try_lookup_without_guard_eval(
     PyObject* backend,
     int64_t isolate_recompiles_id,
     PyObject** maybe_cached_code,
+    PyObject** matched_precompile_code_owner,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe);
 

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -8,6 +8,7 @@
 
 #include <torch/csrc/dynamo/utils.h>
 #include <torch/csrc/utils/pybind.h>
+#include <atomic>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -70,6 +71,9 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   PyCodeObject* orig_code;
   std::list<std::shared_ptr<PrecompileEntry>> precompile_entries;
   std::mutex precompile_entries_mutex;
+  // Lock-free empty-list hint for the ordinary cache hot path. A false reader
+  // never touches the list; a true reader still takes the mutex and snapshots.
+  std::atomic<bool> has_precompile_entries{false};
   // Per-compile cache map: isolate_recompiles_id -> list of CacheEntry.
   // id -1 is the default (non-isolated) bucket. id >= 0 are isolated compiles.
   // All cache entries live in this map — there is no separate default list.

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1129,8 +1129,7 @@ enum class GuardCrossSliceRelationKind : uint8_t {
 };
 
 struct GuardCrossSliceRelationPlan {
-  GuardCrossSliceRelationKind kind{
-      GuardCrossSliceRelationKind::ObjectAliasing};
+  GuardCrossSliceRelationKind kind{GuardCrossSliceRelationKind::ObjectAliasing};
   const void* guard{nullptr};
   size_t expected_operand_count{0};
   std::vector<py::object> stable_operands;
@@ -1538,8 +1537,7 @@ static bool guard_subtree_dimension_marking_absent_token_matches_current(
     PyErr_Clear();
     return false;
   }
-  const int contains =
-      PyDict_Contains(*dictptr, token.dimension_marking_key);
+  const int contains = PyDict_Contains(*dictptr, token.dimension_marking_key);
   if (contains < 0) {
     PyErr_Clear();
     return false;
@@ -1702,14 +1700,13 @@ static bool guard_last_success_add_type_proof(
     }
   }
   unsigned int version = 0;
-  if (!guard_subtree_ensure_absent_type_version(
-          type, lookup_key, version)) {
+  if (!guard_subtree_ensure_absent_type_version(type, lookup_key, version)) {
     PyErr_Clear();
     return false;
   }
   GuardSubtreeTypeProof proof;
-  proof.type = py::reinterpret_borrow<py::object>(
-      reinterpret_cast<PyObject*>(type));
+  proof.type =
+      py::reinterpret_borrow<py::object>(reinterpret_cast<PyObject*>(type));
   proof.lookup_key = py::reinterpret_borrow<py::object>(lookup_key);
   proof.version = version;
   proofs.push_back(std::move(proof));
@@ -1754,8 +1751,7 @@ static bool guard_last_success_build_partial_plan_tokens(
     std::vector<py::object>& retained_token_objects) {
   stability_tokens = partial_tokens;
   if (!guard_subtree_aliasing_tokens_have_reachability_proof(partial_tokens) ||
-      !guard_last_success_make_partial_hot_tokens(
-          partial_tokens, hot_tokens) ||
+      !guard_last_success_make_partial_hot_tokens(partial_tokens, hot_tokens) ||
       !guard_last_success_build_relation_plans(
           full_tokens, partial_tokens, relation_plans)) {
     return false;
@@ -1775,9 +1771,7 @@ static bool guard_last_success_build_partial_plan_tokens(
     if (token.kind ==
             GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent &&
         !guard_last_success_add_type_proof(
-            token.type,
-            token.dimension_marking_key,
-            type_proofs)) {
+            token.type, token.dimension_marking_key, type_proofs)) {
       return false;
     }
   }
@@ -2232,8 +2226,7 @@ struct GuardSubtreeMemoRecorderScope {
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
     active_guard_subtree_memo_debug_paths = previous_debug_paths;
-    active_guard_actual_partial_supported =
-        previous_actual_partial_supported;
+    active_guard_actual_partial_supported = previous_actual_partial_supported;
     active_guard_subtree_memo_relax_global_dicts =
         previous_relax_global_dicts;
   }
@@ -3174,8 +3167,7 @@ class LeafGuard {
   virtual bool supports_subtree_memo() const {
     return true;
   }
-  virtual bool supports_actual_partial_subtree_memo(
-      PyObject* /*value*/) const {
+  virtual bool supports_actual_partial_subtree_memo(PyObject* /*value*/) const {
     return supports_subtree_memo();
   }
   virtual bool emits_subtree_memo_token() const {
@@ -4646,8 +4638,7 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
     return false;
   }
 
-  bool supports_actual_partial_subtree_memo(
-      PyObject* value) const override {
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
     if (!_all_absent || !THPVariable_CheckExact(value) ||
         Py_TYPE(value)->tp_getattro != PyObject_GenericGetAttr) {
       return false;
@@ -4655,8 +4646,7 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
     // A type/MRO descriptor or custom attribute protocol can synthesize the
     // sentinel without touching the instance dict, so either forces the plan
     // to fail closed.
-    PyObject* descriptor =
-        _PyType_Lookup(Py_TYPE(value), has_marking_str());
+    PyObject* descriptor = _PyType_Lookup(Py_TYPE(value), has_marking_str());
     if (descriptor != nullptr) {
       return false;
     }
@@ -5677,8 +5667,7 @@ class GuardManager {
           const bool actual_partial_supported =
               guard->supports_actual_partial_subtree_memo(value);
           if (active_guard_actual_partial_supported != nullptr &&
-              is_self_local_source_path(_source) &&
-              !actual_partial_supported) {
+              is_self_local_source_path(_source) && !actual_partial_supported) {
             *active_guard_actual_partial_supported = false;
           }
           emit_subtree_memo_token = actual_partial_supported &&
@@ -6122,10 +6111,9 @@ class RootGuardManager : public GuardManager {
         *actual_partial_token_miss = true;
         return false;
       }
-      for (const auto& relation :
-           actual_partial_plan->cross_slice_relations) {
-        auto* guard = static_cast<RelationalGuard*>(
-            const_cast<void*>(relation.guard));
+      for (const auto& relation : actual_partial_plan->cross_slice_relations) {
+        auto* guard =
+            static_cast<RelationalGuard*>(const_cast<void*>(relation.guard));
         if (guard == nullptr ||
             !guard->preload_actual_partial_relation(relation)) {
           *actual_partial_token_miss = true;
@@ -6167,10 +6155,9 @@ class RootGuardManager : public GuardManager {
     }
 
     if constexpr (HasActualPartial) {
-      for (const auto& relation :
-           actual_partial_plan->cross_slice_relations) {
-        auto* guard = static_cast<RelationalGuard*>(
-            const_cast<void*>(relation.guard));
+      for (const auto& relation : actual_partial_plan->cross_slice_relations) {
+        auto* guard =
+            static_cast<RelationalGuard*>(const_cast<void*>(relation.guard));
         if (guard == nullptr ||
             !guard->actual_partial_relation_is_complete(relation)) {
           *actual_partial_token_miss = true;
@@ -9592,7 +9579,6 @@ bool run_root_guard_manager_with_last_success_receipt(
     state->actual_partial.disable();
     return true;
   }
-
 
   state->actual_partial.observe_successful_training_pass(
       entry_key,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -5603,8 +5603,6 @@ class RootGuardManager : public GuardManager {
       LocalState state;
       _local_state = state;
     }
-    GuardLocalStateScope local_state_scope(&_local_state);
-
 
     if (!GuardManager::check_leaf_guards_nopybind(value)) {
       _reset_relational_guard_state();
@@ -6536,9 +6534,7 @@ class TENSOR_MATCH : public LeafGuard {
             root_guard_manager,
             std::move(verbose_code_parts),
             std::move(user_stack)),
-        _tensor_name(py::cast<std::string>(std::move(tensor_name))),
-        _supports_subtree_memo_token(
-            tensor_match_source_supports_subtree_memo(_tensor_name)) {
+        _tensor_name(py::cast<std::string>(std::move(tensor_name))) {
     root_guard_manager->set_init_local_state_flag();
     PyObject* item = value.ptr();
 
@@ -6609,10 +6605,10 @@ class TENSOR_MATCH : public LeafGuard {
   }
 
   bool supports_subtree_memo() const override {
-    return _supports_subtree_memo_token;
+    return tensor_match_source_supports_subtree_memo(_tensor_name);
   }
   bool emits_subtree_memo_token() const override {
-    return _supports_subtree_memo_token;
+    return tensor_match_source_supports_subtree_memo(_tensor_name);
   }
 
   bool append_subtree_memo_token(
@@ -6630,7 +6626,6 @@ class TENSOR_MATCH : public LeafGuard {
 
  private:
   std::string _tensor_name;
-  bool _supports_subtree_memo_token;
   std::unique_ptr<TensorCheck> _tensor_check;
 };
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1086,12 +1086,16 @@ static bool guard_subtree_type_version_is_valid(PyTypeObject* type) {
 #endif
 }
 
-static bool guard_subtree_ensure_absent_type_version(
+static bool guard_actual_partial_uses_default_getattribute(PyTypeObject* type) {
+  return type != nullptr && type->tp_getattr == nullptr &&
+      type->tp_getattro == PyObject_GenericGetAttr;
+}
+
+static bool guard_subtree_refresh_absent_lookup_type_version(
     PyTypeObject* type,
     PyObject* lookup_key,
     unsigned int& version) {
   if (type == nullptr || lookup_key == nullptr ||
-      type->tp_getattro != PyObject_GenericGetAttr ||
       _PyType_Lookup(type, lookup_key) != nullptr) {
     return false;
   }
@@ -1114,12 +1118,82 @@ static bool guard_subtree_ensure_absent_type_version(
 struct GuardSubtreeTypeProof {
   py::object type;
   py::object lookup_key;
+  getattrfunc getattr{nullptr};
+  getattrofunc getattro{nullptr};
+  bool requires_default_getattribute{false};
   unsigned int version{0};
 
-  bool matches_current() const {
+  bool matches_or_refreshes_current() {
     auto* current_type = reinterpret_cast<PyTypeObject*>(type.ptr());
-    return guard_subtree_type_version_is_valid(current_type) &&
-        current_type->tp_version_tag == version;
+    if (guard_subtree_type_version_is_valid(current_type) &&
+        current_type->tp_version_tag == version) {
+      return !requires_default_getattribute ||
+          guard_actual_partial_uses_default_getattribute(current_type);
+    }
+    if (current_type == nullptr || current_type->tp_getattr != getattr ||
+        current_type->tp_getattro != getattro ||
+        (requires_default_getattribute &&
+         !guard_actual_partial_uses_default_getattribute(current_type))) {
+      return false;
+    }
+    return guard_subtree_refresh_absent_lookup_type_version(
+        current_type, lookup_key.ptr(), version);
+  }
+};
+
+enum class GuardActualPartialAccessorRecordKind : uint8_t {
+  GenericDictBinding,
+  InstanceAttrBinding,
+};
+
+struct GuardActualPartialAccessorRecord {
+  GuardActualPartialAccessorRecordKind kind{
+      GuardActualPartialAccessorRecordKind::GenericDictBinding};
+  py::object owner;
+  PyObject* owner_ptr{nullptr};
+  py::object key;
+  py::object resolved;
+  py::object owner_dict;
+  PyTypeObject* owner_type{nullptr};
+  bool requires_default_getattribute{false};
+};
+
+struct GuardSubtreeGenericDictOwnerProof {
+  py::object owner;
+  PyObject* owner_ptr{nullptr};
+  py::object dict;
+  PyTypeObject* owner_type{nullptr};
+  bool owner_is_self{false};
+
+  bool matches_current(PyObject* current_self) const {
+    PyObject* current_owner = owner_is_self ? current_self : owner.ptr();
+    if (current_owner == nullptr || Py_TYPE(current_owner) != owner_type) {
+      return false;
+    }
+    PyObject** dictptr = _PyObject_GetDictPtr(current_owner);
+    return dictptr != nullptr && *dictptr == dict.ptr() &&
+        PyDict_CheckExact(*dictptr);
+  }
+};
+
+struct GuardSubtreeInstanceAttrOwnerProof {
+  py::object owner;
+  PyObject* owner_ptr{nullptr};
+  py::object key;
+  py::object expected;
+  py::object dict;
+  PyTypeObject* owner_type{nullptr};
+  bool owner_is_self{false};
+
+  bool matches_current(PyObject* current_self) const {
+    PyObject* current_owner = owner_is_self ? current_self : owner.ptr();
+    if (current_owner == nullptr || Py_TYPE(current_owner) != owner_type) {
+      return false;
+    }
+    PyObject** dictptr = _PyObject_GetDictPtr(current_owner);
+    return dictptr != nullptr && *dictptr == dict.ptr() &&
+        PyDict_CheckExact(*dictptr) &&
+        PyDict_GetItem(*dictptr, key.ptr()) == expected.ptr();
   }
 };
 
@@ -1453,7 +1527,6 @@ static bool guard_subtree_token_vectors_match(
 
 enum class GuardLastSuccessPartialTokenDecision : uint8_t {
   Keep,
-  DropReachabilityOnly,
   UnsupportedBail,
 
 };
@@ -1467,11 +1540,10 @@ guard_last_success_partial_token_decision(
   }
   switch (token.kind) {
     case GuardSubtreeProbeTokenKind::ObjectOnly:
-      // Parent container tokens prove whether this object is still reachable.
-      // Dropping this token is safe only for reachability-only objects: any
-      // semantic guard attached to the object must emit its own token or force
-      // the partial plan to bail.
-      return GuardLastSuccessPartialTokenDecision::DropReachabilityOnly;
+      // Preserve the cheap identity/type proof. TYPE_MATCH can be attached to
+      // an otherwise reachability-only node, and __class__ may change in place
+      // without changing its parent binding.
+      return GuardLastSuccessPartialTokenDecision::Keep;
     case GuardSubtreeProbeTokenKind::BoundMethod:
       // Keep bound methods as hot tokens. A stored bound method is protected by
       // its parent structural token; the runtime matcher validates the bound
@@ -1508,8 +1580,6 @@ static bool guard_last_success_make_partial_hot_tokens(
     switch (guard_last_success_partial_token_decision(tokens[i], i)) {
       case GuardLastSuccessPartialTokenDecision::Keep:
         hot_tokens.push_back(tokens[i]);
-        break;
-      case GuardLastSuccessPartialTokenDecision::DropReachabilityOnly:
         break;
       case GuardLastSuccessPartialTokenDecision::UnsupportedBail:
         return false;
@@ -1692,15 +1762,26 @@ static bool guard_last_success_build_relation_plans(
 static bool guard_last_success_add_type_proof(
     PyTypeObject* type,
     PyObject* lookup_key,
+    bool requires_default_getattribute,
     std::vector<GuardSubtreeTypeProof>& proofs) {
-  for (const auto& proof : proofs) {
+  for (auto& proof : proofs) {
     if (proof.type.ptr() == reinterpret_cast<PyObject*>(type) &&
         proof.lookup_key.ptr() == lookup_key) {
+      if (requires_default_getattribute &&
+          !proof.requires_default_getattribute) {
+        if (!guard_actual_partial_uses_default_getattribute(type)) {
+          return false;
+        }
+        proof.requires_default_getattribute = true;
+      }
       return true;
     }
   }
   unsigned int version = 0;
-  if (!guard_subtree_ensure_absent_type_version(type, lookup_key, version)) {
+  if ((requires_default_getattribute &&
+       !guard_actual_partial_uses_default_getattribute(type)) ||
+      !guard_subtree_refresh_absent_lookup_type_version(
+          type, lookup_key, version)) {
     PyErr_Clear();
     return false;
   }
@@ -1708,6 +1789,9 @@ static bool guard_last_success_add_type_proof(
   proof.type =
       py::reinterpret_borrow<py::object>(reinterpret_cast<PyObject*>(type));
   proof.lookup_key = py::reinterpret_borrow<py::object>(lookup_key);
+  proof.getattr = type->tp_getattr;
+  proof.getattro = type->tp_getattro;
+  proof.requires_default_getattribute = requires_default_getattribute;
   proof.version = version;
   proofs.push_back(std::move(proof));
   return true;
@@ -1771,12 +1855,77 @@ static bool guard_last_success_build_partial_plan_tokens(
     if (token.kind ==
             GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent &&
         !guard_last_success_add_type_proof(
-            token.type, token.dimension_marking_key, type_proofs)) {
+            token.type, token.dimension_marking_key, true, type_proofs)) {
       return false;
     }
   }
   guard_last_success_retain_token_objects(
       partial_tokens, retained_token_objects);
+  return true;
+}
+
+static bool guard_last_success_build_accessor_proofs(
+    const std::vector<GuardActualPartialAccessorRecord>& records,
+    PyObject* current_self,
+    std::vector<GuardSubtreeTypeProof>& type_proofs,
+    std::vector<GuardSubtreeGenericDictOwnerProof>& generic_dict_proofs,
+    std::vector<GuardSubtreeInstanceAttrOwnerProof>& instance_attr_proofs) {
+  generic_dict_proofs.clear();
+  instance_attr_proofs.clear();
+  for (const auto& record : records) {
+    if (record.owner_ptr == nullptr || record.owner_type == nullptr ||
+        Py_TYPE(record.owner_ptr) != record.owner_type) {
+      return false;
+    }
+    if (record.kind ==
+        GuardActualPartialAccessorRecordKind::GenericDictBinding) {
+      if (record.resolved.ptr() == nullptr ||
+          !PyDict_CheckExact(record.resolved.ptr())) {
+        return false;
+      }
+      PyObject** dictptr = _PyObject_GetDictPtr(record.owner_ptr);
+      if (dictptr == nullptr || *dictptr != record.resolved.ptr()) {
+        return false;
+      }
+      GuardSubtreeGenericDictOwnerProof proof;
+      proof.owner_is_self = record.owner_ptr == current_self;
+      if (!proof.owner_is_self) {
+        proof.owner = record.owner;
+        proof.owner_ptr = record.owner_ptr;
+      }
+      proof.dict = record.resolved;
+      proof.owner_type = record.owner_type;
+      generic_dict_proofs.push_back(std::move(proof));
+      continue;
+    }
+
+    if (record.key.ptr() == nullptr || record.resolved.ptr() == nullptr ||
+        record.owner_dict.ptr() == nullptr ||
+        !PyUnicode_Check(record.key.ptr()) ||
+        !PyDict_CheckExact(record.owner_dict.ptr()) ||
+        PyDict_GetItem(record.owner_dict.ptr(), record.key.ptr()) !=
+            record.resolved.ptr() ||
+        _PyType_Lookup(record.owner_type, record.key.ptr()) != nullptr ||
+        !guard_last_success_add_type_proof(
+            record.owner_type,
+            record.key.ptr(),
+            record.requires_default_getattribute,
+            type_proofs)) {
+      PyErr_Clear();
+      return false;
+    }
+    GuardSubtreeInstanceAttrOwnerProof proof;
+    proof.owner_is_self = record.owner_ptr == current_self;
+    if (!proof.owner_is_self) {
+      proof.owner = record.owner;
+      proof.owner_ptr = record.owner_ptr;
+    }
+    proof.key = record.key;
+    proof.expected = record.resolved;
+    proof.dict = record.owner_dict;
+    proof.owner_type = record.owner_type;
+    instance_attr_proofs.push_back(std::move(proof));
+  }
   return true;
 }
 
@@ -1803,12 +1952,6 @@ static bool guard_subtree_bound_method_token_matches_current(
   return token.bound_c_method_func != nullptr;
 }
 
-static bool guard_subtree_token_is_reachability_only(
-    const GuardSubtreeEntryToken& token,
-    size_t index) {
-  return index != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly;
-}
-
 enum class GuardLastSuccessPartialPlanState : uint8_t {
   Empty,
   Training,
@@ -1829,6 +1972,8 @@ struct GuardLastSuccessPartialPlan {
     stability_tokens.clear();
     tokens.clear();
     type_proofs.clear();
+    generic_dict_owner_proofs.clear();
+    instance_attr_owner_proofs.clear();
     cross_slice_relations.clear();
     retained_token_objects.clear();
   }
@@ -1853,6 +1998,10 @@ struct GuardLastSuccessPartialPlan {
       std::vector<GuardSubtreeEntryToken>&& new_stability_tokens,
       std::vector<GuardSubtreeEntryToken>&& new_tokens,
       std::vector<GuardSubtreeTypeProof>&& new_type_proofs,
+      std::vector<GuardSubtreeGenericDictOwnerProof>&&
+          new_generic_dict_owner_proofs,
+      std::vector<GuardSubtreeInstanceAttrOwnerProof>&&
+          new_instance_attr_owner_proofs,
       std::vector<GuardCrossSliceRelationPlan>&& new_cross_slice_relations,
       std::vector<py::object>&& new_retained_token_objects) {
     const bool stable = entry_key == new_entry_key &&
@@ -1870,6 +2019,8 @@ struct GuardLastSuccessPartialPlan {
     }
     tokens = std::move(new_tokens);
     type_proofs = std::move(new_type_proofs);
+    generic_dict_owner_proofs = std::move(new_generic_dict_owner_proofs);
+    instance_attr_owner_proofs = std::move(new_instance_attr_owner_proofs);
     cross_slice_relations = std::move(new_cross_slice_relations);
     retained_token_objects = std::move(new_retained_token_objects);
     if (state != GuardLastSuccessPartialPlanState::Enabled &&
@@ -1891,6 +2042,8 @@ struct GuardLastSuccessPartialPlan {
   std::vector<GuardSubtreeEntryToken> stability_tokens;
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<GuardSubtreeTypeProof> type_proofs;
+  std::vector<GuardSubtreeGenericDictOwnerProof> generic_dict_owner_proofs;
+  std::vector<GuardSubtreeInstanceAttrOwnerProof> instance_attr_owner_proofs;
   std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
   std::vector<py::object> retained_token_objects;
 };
@@ -1966,10 +2119,6 @@ static bool guard_subtree_memo_tokens_match(
       if (!guard_subtree_bound_method_token_matches_current(token)) {
         return false;
       }
-      continue;
-    }
-    if (guard_subtree_token_is_reachability_only(token, i)) {
-      // Parent tokens prove whether this non-root object is still reachable.
       continue;
     }
     if (token.kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
@@ -2112,6 +2261,8 @@ struct GuardLastSuccessPartialPlanBuild {
   std::vector<GuardSubtreeEntryToken> stability_tokens;
   std::vector<GuardSubtreeEntryToken> hot_tokens;
   std::vector<GuardSubtreeTypeProof> type_proofs;
+  std::vector<GuardSubtreeGenericDictOwnerProof> generic_dict_owner_proofs;
+  std::vector<GuardSubtreeInstanceAttrOwnerProof> instance_attr_owner_proofs;
   std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
   std::vector<py::object> retained_token_objects;
 };
@@ -2122,6 +2273,7 @@ static bool guard_last_success_prepare_actual_partial(
     int self_framelocals_index,
     const std::vector<GuardSubtreeEntryToken>& tokens,
     const std::vector<std::string>& debug_paths,
+    const std::vector<GuardActualPartialAccessorRecord>& accessor_records,
     GuardLastSuccessPartialPlanBuild& build) {
   std::vector<GuardSubtreeEntryToken> partial_tokens;
   if (!guard_last_success_extract_self_partial_tokens(
@@ -2153,18 +2305,26 @@ static bool guard_last_success_prepare_actual_partial(
   plan->self_type = Py_TYPE(current_self);
   plan->self_framelocals_index = self_framelocals_index;
 
-  return guard_last_success_build_partial_plan_tokens(
-      tokens,
-      partial_tokens,
-      build.stability_tokens,
-      build.hot_tokens,
+  if (!guard_last_success_build_partial_plan_tokens(
+          tokens,
+          partial_tokens,
+          build.stability_tokens,
+          build.hot_tokens,
+          build.type_proofs,
+          build.cross_slice_relations,
+          build.retained_token_objects)) {
+    return false;
+  }
+  return guard_last_success_build_accessor_proofs(
+      accessor_records,
+      current_self,
       build.type_proofs,
-      build.cross_slice_relations,
-      build.retained_token_objects);
+      build.generic_dict_owner_proofs,
+      build.instance_attr_owner_proofs);
 }
 
 static bool guard_last_success_actual_partial_tokens_match(
-    const GuardLastSuccessPartialPlan& plan,
+    GuardLastSuccessPartialPlan& plan,
     FrameLocalsMapping* f_locals,
     const LocalState* local_state) {
   if (plan.tokens.empty()) {
@@ -2189,8 +2349,18 @@ static bool guard_last_success_actual_partial_tokens_match(
   if (!self_matches) {
     return false;
   }
-  for (const auto& proof : plan.type_proofs) {
-    if (!proof.matches_current()) {
+  for (const auto& proof : plan.generic_dict_owner_proofs) {
+    if (!proof.matches_current(current_self)) {
+      return false;
+    }
+  }
+  for (const auto& proof : plan.instance_attr_owner_proofs) {
+    if (!proof.matches_current(current_self)) {
+      return false;
+    }
+  }
+  for (auto& proof : plan.type_proofs) {
+    if (!proof.matches_or_refreshes_current()) {
       return false;
     }
   }
@@ -2204,21 +2374,92 @@ thread_local std::vector<std::string>*
     active_guard_subtree_memo_debug_paths = nullptr;
 thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
 thread_local bool* active_guard_actual_partial_supported = nullptr;
+thread_local std::vector<GuardActualPartialAccessorRecord>*
+    active_guard_actual_partial_accessor_records = nullptr;
+
+static void guard_actual_partial_mark_unsupported() {
+  if (active_guard_actual_partial_supported != nullptr) {
+    *active_guard_actual_partial_supported = false;
+  }
+}
+
+static void guard_actual_partial_record_generic_dict_binding(
+    PyObject* owner,
+    PyObject* dict,
+    const std::string& source) {
+  if (active_guard_actual_partial_accessor_records == nullptr ||
+      !is_self_local_source_path(source)) {
+    return;
+  }
+  PyObject** dictptr = owner == nullptr ? nullptr : _PyObject_GetDictPtr(owner);
+  if (dict == nullptr || dictptr == nullptr || *dictptr != dict ||
+      !PyDict_CheckExact(dict)) {
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  GuardActualPartialAccessorRecord record;
+  record.owner = py::reinterpret_borrow<py::object>(owner);
+  record.owner_ptr = owner;
+  record.resolved = py::reinterpret_borrow<py::object>(dict);
+  record.owner_type = Py_TYPE(owner);
+  active_guard_actual_partial_accessor_records->push_back(std::move(record));
+}
+
+static void guard_actual_partial_record_instance_attr_binding(
+    PyObject* owner,
+    PyObject* key,
+    PyObject* expected,
+    const std::string& source,
+    bool require_default_getattribute) {
+  if (active_guard_actual_partial_accessor_records == nullptr ||
+      !is_self_local_source_path(source)) {
+    return;
+  }
+  if (owner == nullptr || key == nullptr || expected == nullptr ||
+      !PyUnicode_Check(key) ||
+      (require_default_getattribute &&
+       !guard_actual_partial_uses_default_getattribute(Py_TYPE(owner)))) {
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  PyObject** dictptr = _PyObject_GetDictPtr(owner);
+  if (dictptr == nullptr || *dictptr == nullptr ||
+      !PyDict_CheckExact(*dictptr) ||
+      PyDict_GetItem(*dictptr, key) != expected ||
+      _PyType_Lookup(Py_TYPE(owner), key) != nullptr) {
+    PyErr_Clear();
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  GuardActualPartialAccessorRecord record;
+  record.kind = GuardActualPartialAccessorRecordKind::InstanceAttrBinding;
+  record.owner = py::reinterpret_borrow<py::object>(owner);
+  record.owner_ptr = owner;
+  record.key = py::reinterpret_borrow<py::object>(key);
+  record.resolved = py::reinterpret_borrow<py::object>(expected);
+  record.owner_dict = py::reinterpret_borrow<py::object>(*dictptr);
+  record.owner_type = Py_TYPE(owner);
+  record.requires_default_getattribute = require_default_getattribute;
+  active_guard_actual_partial_accessor_records->push_back(std::move(record));
+}
 
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
       std::vector<GuardSubtreeEntryToken>* tokens,
       std::vector<std::string>* debug_paths = nullptr,
+      std::vector<GuardActualPartialAccessorRecord>* accessor_records = nullptr,
       bool* actual_partial_supported = nullptr,
       bool relax_global_dicts = false)
       : previous(active_guard_subtree_memo_recorder),
         previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_accessor_records(active_guard_actual_partial_accessor_records),
         previous_actual_partial_supported(
             active_guard_actual_partial_supported),
         previous_relax_global_dicts(
             active_guard_subtree_memo_relax_global_dicts) {
     active_guard_subtree_memo_recorder = tokens;
     active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_actual_partial_accessor_records = accessor_records;
     active_guard_actual_partial_supported = actual_partial_supported;
     active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
   }
@@ -2226,6 +2467,7 @@ struct GuardSubtreeMemoRecorderScope {
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
     active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_actual_partial_accessor_records = previous_accessor_records;
     active_guard_actual_partial_supported = previous_actual_partial_supported;
     active_guard_subtree_memo_relax_global_dicts =
         previous_relax_global_dicts;
@@ -2233,6 +2475,8 @@ struct GuardSubtreeMemoRecorderScope {
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
   std::vector<std::string>* previous_debug_paths{nullptr};
+  std::vector<GuardActualPartialAccessorRecord>* previous_accessor_records{
+      nullptr};
   bool* previous_actual_partial_supported{nullptr};
   bool previous_relax_global_dicts{false};
 };
@@ -3167,8 +3411,9 @@ class LeafGuard {
   virtual bool supports_subtree_memo() const {
     return true;
   }
-  virtual bool supports_actual_partial_subtree_memo(PyObject* /*value*/) const {
-    return supports_subtree_memo();
+  virtual bool supports_actual_partial_subtree_memo(
+      PyObject* /*parent*/) const {
+    return false;
   }
   virtual bool emits_subtree_memo_token() const {
     return false;
@@ -3297,6 +3542,10 @@ class TYPE_MATCH : public LeafGuard {
     return Py_TYPE(value) == (void*)_expected;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+
  private:
   // id of the type of the original object.
   intptr_t _expected;
@@ -3369,6 +3618,10 @@ class ID_MATCH : public LeafGuard {
     return value == (void*)_expected;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+
  private:
   // id of the original object.
   intptr_t _expected;
@@ -3388,6 +3641,10 @@ class NONE_MATCH : public LeafGuard {
   bool check_nopybind(PyObject* value) override { // borrowed ref
     return Py_IsNone(value);
   }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
 };
 
 class TRUE_MATCH : public LeafGuard {
@@ -3403,6 +3660,10 @@ class TRUE_MATCH : public LeafGuard {
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
     return Py_IsTrue(value);
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 };
 
@@ -3420,22 +3681,47 @@ class FALSE_MATCH : public LeafGuard {
   bool check_nopybind(PyObject* value) override { // borrowed ref
     return Py_IsFalse(value);
   }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
 };
+
+static bool guard_actual_partial_is_deeply_immutable(
+    PyObject* value,
+    size_t depth = 0) {
+  if (value == Py_None || PyBool_Check(value) || PyLong_CheckExact(value) ||
+      PyFloat_CheckExact(value) || PyComplex_CheckExact(value) ||
+      PyUnicode_CheckExact(value) || PyBytes_CheckExact(value)) {
+    return true;
+  }
+  if (!PyTuple_CheckExact(value) || depth >= 32) {
+    return false;
+  }
+  for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(value); ++i) {
+    if (!guard_actual_partial_is_deeply_immutable(
+            PyTuple_GET_ITEM(value, i), depth + 1)) {
+      return false;
+    }
+  }
+  return true;
+}
 
 class EQUALS_MATCH : public LeafGuard {
  public:
-
   EQUALS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
       py::object verbose_code_parts,
-      py::object user_stack)
+      py::object user_stack,
+      bool actual_partial_safe_constant = false)
       : LeafGuard(
             root_guard_manager,
             std::move(verbose_code_parts),
             std::move(user_stack)),
         _value(value),
-        _value_type(Py_TYPE(value.ptr())) {}
+        _value_type(Py_TYPE(value.ptr())),
+        _actual_partial_safe_constant(actual_partial_safe_constant) {}
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
     // Fast path - pointer equality check. Pointer equality checks are ok
@@ -3450,6 +3736,11 @@ class EQUALS_MATCH : public LeafGuard {
     return true;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return _actual_partial_safe_constant ||
+        guard_actual_partial_is_deeply_immutable(value);
+  }
+
  private:
   // value to compare against. This is py::object so that we hold on to the
   // original value and prevent garbage collection. We run EQUALS_MATCH only on
@@ -3459,6 +3750,7 @@ class EQUALS_MATCH : public LeafGuard {
 
   // Type of the value
   PyTypeObject* _value_type;
+  bool _actual_partial_safe_constant{false};
 };
 
 class RANGE_ITERATOR_MATCH : public LeafGuard {
@@ -3574,6 +3866,10 @@ class LENGTH_CHECK : public LeafGuard {
     return length == _length;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return PyList_CheckExact(value) || PyTuple_CheckExact(value);
+  }
+
  private:
   // Length of the guarded list
   Py_ssize_t _length;
@@ -3597,6 +3893,10 @@ class DICT_LENGTH : public LeafGuard {
     return PyDict_Check(value) && PyDict_Size(value) == _length;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return PyDict_CheckExact(value);
+  }
+
  private:
   // Length of the guarded dict
   Py_ssize_t _length;
@@ -3615,6 +3915,10 @@ class NOT_NONE : public LeafGuard {
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
     return !Py_IsNone(value);
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 };
 
@@ -3643,6 +3947,10 @@ class MAPPING_KEYS_MATCH : public LeafGuard {
     return match;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return PyDict_CheckExact(value);
+  }
+
  private:
   py::object _keys;
 };
@@ -3662,6 +3970,10 @@ class DEFAULT_DEVICE : public LeafGuard {
     // Save the dict using py::object
     _utils_device_dict = device_module.attr("__dict__");
     _device = _utils_device_dict["CURRENT_DEVICE"];
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 
   template <typename T>
@@ -3778,6 +4090,10 @@ class GLOBAL_STATE : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+
   bool supports_subtree_memo() const override {
     return true;
   }
@@ -3872,6 +4188,10 @@ class DICT_CONTAINS : public LeafGuard {
     return result == _contains;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return PyDict_CheckExact(value);
+  }
+
  private:
   int _contains;
   py::object _key;
@@ -3926,6 +4246,10 @@ class FLOAT_IS_NAN : public LeafGuard {
     }
     return std::isnan(PyFloat_AsDouble(value));
   }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
 };
 
 // Check if the float is nan
@@ -3946,6 +4270,10 @@ class COMPLEX_IS_NAN : public LeafGuard {
     }
     Py_complex c_value = PyComplex_AsCComplex(value);
     return std::isnan(c_value.real) || std::isnan(c_value.imag);
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 };
 
@@ -4101,6 +4429,10 @@ class OBJECT_ALIASING : public RelationalGuard {
         _operand_count == plan.expected_operand_count;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+
   bool supports_subtree_memo() const override {
     return true;
   }
@@ -4184,6 +4516,10 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
         return false;
       }
     }
+    return true;
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
     return true;
   }
 
@@ -4738,6 +5074,10 @@ class DICT_VERSION : public LeafGuard {
     return PyDict_Check(value) && get_dict_version_unchecked(value) == _tag;
   }
 
+  bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    return PyDict_CheckExact(value);
+  }
+
   // Saved dict version.
   uint64_t _tag;
 };
@@ -4881,6 +5221,10 @@ class GuardAccessor {
   bool check_child_manager_nopybind(PyObject* obj);
   virtual bool supports_subtree_memo() const {
     return true;
+  }
+  virtual bool supports_actual_partial_subtree_memo(
+      PyObject* /*parent*/) const {
+    return false;
   }
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
   virtual std::string repr() const = 0;
@@ -5719,6 +6063,14 @@ class GuardManager {
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
+      if constexpr (std::is_same_v<T, PyObject>) {
+        if (C10_UNLIKELY(
+                active_guard_actual_partial_supported != nullptr &&
+                is_self_local_source_path(accessor->get_source()) &&
+                !accessor->supports_actual_partial_subtree_memo(value))) {
+          *active_guard_actual_partial_supported = false;
+        }
+      }
       const bool accessor_result =
           accessor->check_nopybind(value, matches_dict_tag);
       if (!accessor_result) { // early exit
@@ -6080,7 +6432,7 @@ class RootGuardManager : public GuardManager {
   bool check_nopybind_template(
       T* value,
       const std::string* skip_accessor_source = nullptr,
-      const GuardLastSuccessPartialPlan* actual_partial_plan = nullptr,
+      GuardLastSuccessPartialPlan* actual_partial_plan = nullptr,
       bool* actual_partial_token_miss = nullptr) { // borrowed ref
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions with GIL.
@@ -6185,7 +6537,7 @@ class RootGuardManager : public GuardManager {
   bool check_nopybind_actual_partial(
       FrameLocalsMapping* value,
       const std::string& skip_accessor_source,
-      const GuardLastSuccessPartialPlan& plan,
+      GuardLastSuccessPartialPlan& plan,
       bool& token_miss) {
     return check_nopybind_template<true>(
         value, &skip_accessor_source, &plan, &token_miss);
@@ -6977,6 +7329,9 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   bool supports_subtree_memo() const override {
     return true;
   }
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
   bool emits_subtree_memo_token() const override {
     return true;
   }
@@ -7141,6 +7496,12 @@ class TENSOR_MATCH : public LeafGuard {
   bool supports_subtree_memo() const override {
     return tensor_match_source_supports_subtree_memo(_tensor_name);
   }
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+  bool emits_actual_partial_subtree_memo_token() const override {
+    return true;
+  }
   bool emits_subtree_memo_token() const override {
     return tensor_match_source_supports_subtree_memo(_tensor_name);
   }
@@ -7193,9 +7554,15 @@ class GetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
+    guard_actual_partial_record_instance_attr_binding(
+        obj, _attr_name, x, get_source(), true);
     bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -7274,9 +7641,15 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
+    guard_actual_partial_record_instance_attr_binding(
+        obj, _attr_name, x, get_source(), false);
     bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -7359,10 +7732,15 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
+    guard_actual_partial_record_generic_dict_binding(obj, x, get_source());
     bool result = _guard_manager->check_nopybind(x);
     Py_DECREF(x);
     return result;
 
+  }
+
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -7481,6 +7859,10 @@ class GetItemGuardAccessor : public GuardAccessor {
  */
 class FrameLocalsGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject*) const override {
+    return true;
+  }
+
   int framelocals_index() const override {
     return _framelocals_idx;
   }
@@ -7610,6 +7992,10 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
  */
 class DictGetItemGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject* parent) const override {
+    return PyDict_CheckExact(parent);
+  }
+
   DictGetItemGuardAccessor(
       RootGuardManager* root,
       py::object key,
@@ -7702,6 +8088,10 @@ class DictGetItemGuardAccessor : public GuardAccessor {
  */
 class ListGetItemGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject* parent) const override {
+    return PyList_CheckExact(parent);
+  }
+
   ListGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -7878,6 +8268,10 @@ class SetGetItemGuardAccessor : public GuardAccessor {
  */
 class TupleGetItemGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject* parent) const override {
+    return PyTuple_CheckExact(parent);
+  }
+
   TupleGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -9546,10 +9940,11 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<std::string> debug_paths;
+  std::vector<GuardActualPartialAccessorRecord> accessor_records;
   bool actual_partial_supported = true;
   {
     GuardSubtreeMemoRecorderScope recorder(
-        &tokens, &debug_paths, &actual_partial_supported);
+        &tokens, &debug_paths, &accessor_records, &actual_partial_supported);
     if (!run_root_guard_manager(root, f_locals)) {
       // Cache lookup probes entries that commonly do not own the current
       // input. Keep this entry's plan and training state on a probe miss.
@@ -9575,6 +9970,7 @@ bool run_root_guard_manager_with_last_success_receipt(
           self_framelocals_index,
           tokens,
           debug_paths,
+          accessor_records,
           build)) {
     state->actual_partial.disable();
     return true;
@@ -9586,6 +9982,8 @@ bool run_root_guard_manager_with_last_success_receipt(
       std::move(build.stability_tokens),
       std::move(build.hot_tokens),
       std::move(build.type_proofs),
+      std::move(build.generic_dict_owner_proofs),
+      std::move(build.instance_attr_owner_proofs),
       std::move(build.cross_slice_relations),
       std::move(build.retained_token_objects));
   return true;
@@ -9749,7 +10147,13 @@ PyObject* torch_c_dynamo_guards_init() {
       .def("__call__", &FALSE_MATCH::check);
   py::class_<EQUALS_MATCH, LeafGuard, std::shared_ptr<EQUALS_MATCH>>(
       py_m, "EQUALS_MATCH")
-      .def(py::init<RootGuardManager*, py::object, py::list, py::object>())
+      .def(
+          py::init<RootGuardManager*, py::object, py::list, py::object, bool>(),
+          py::arg("root_guard_manager"),
+          py::arg("value"),
+          py::arg("verbose_code_parts"),
+          py::arg("user_stack"),
+          py::arg("actual_partial_safe_constant") = false)
       .def("__call__", &EQUALS_MATCH::check);
   py::class_<LENGTH_CHECK, LeafGuard, std::shared_ptr<LENGTH_CHECK>>(
       py_m, "LENGTH_CHECK")
@@ -10142,14 +10546,20 @@ PyObject* torch_c_dynamo_guards_init() {
           [](GuardManager& self,
              py::object value,
              py::object verbose_code_parts,
-             py::object user_stack) -> void {
+             py::object user_stack,
+             bool actual_partial_safe_constant) -> void {
             SKIP_IF_GUARD_ALREADY_PRESENT("EQUALS_MATCH");
             self.add_leaf_guard(std::make_shared<EQUALS_MATCH>(
                 self.get_root(),
                 std::move(value),
                 std::move(verbose_code_parts),
-                std::move(user_stack)));
-          })
+                std::move(user_stack),
+                actual_partial_safe_constant));
+          },
+          py::arg("value"),
+          py::arg("verbose_code_parts"),
+          py::arg("user_stack"),
+          py::arg("actual_partial_safe_constant") = false)
       .def(
           "add_length_check_guard",
           [](GuardManager& self,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -4061,7 +4061,13 @@ class OBJECT_ALIASING : public RelationalGuard {
             std::move(user_stack)) {}
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
-    ++_operand_count;
+    // Object aliasing collapses every operand to the same pointer, so there is
+    // no container size from which the actual-partial operand count can be
+    // derived. A nonzero count is the preload-installed tracking sentinel;
+    // ordinary guard checks only pay this predicted-false read and never write.
+    if (C10_UNLIKELY(_operand_count != 0)) {
+      ++_operand_count;
+    }
     if (_is_first_call) {
       _first_tensor = value;
       _is_first_call = false;
@@ -4141,12 +4147,6 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
   }
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
-    ++_operand_count;
-    if (_actual_partial_static_tensors != nullptr &&
-        _actual_partial_static_tensors->find(value) !=
-            _actual_partial_static_tensors->end()) {
-      return false;
-    }
     auto insertion = _unique_tensors.insert({value, nullptr});
     if (!insertion.second) {
       // No need to clear _unique_tensors, reset_state will do
@@ -4168,8 +4168,6 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
 
   void reset_state() final {
     _unique_tensors.clear();
-    _actual_partial_static_tensors = nullptr;
-    _operand_count = 0;
   }
 
   bool preload_actual_partial_relation(
@@ -4177,11 +4175,15 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     if (plan.kind != GuardCrossSliceRelationKind::NoTensorAliasing ||
         plan.guard != static_cast<const void*>(this) ||
         plan.stable_operands.empty() ||
-        plan.stable_operand_set.size() != plan.stable_operands.size()) {
+        plan.stable_operand_set.size() != plan.stable_operands.size() ||
+        !_unique_tensors.empty()) {
       return false;
     }
-    _actual_partial_static_tensors = &plan.stable_operand_set;
-    _operand_count = plan.stable_operands.size();
+    for (const auto& operand : plan.stable_operands) {
+      if (!_unique_tensors.insert({operand.ptr(), nullptr}).second) {
+        return false;
+      }
+    }
     return true;
   }
 
@@ -4189,7 +4191,7 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
       const GuardCrossSliceRelationPlan& plan) const final {
     return plan.kind == GuardCrossSliceRelationKind::NoTensorAliasing &&
         plan.guard == static_cast<const void*>(this) &&
-        _operand_count == plan.expected_operand_count;
+        _unique_tensors.size() == plan.expected_operand_count;
   }
 
   bool supports_subtree_memo() const override {
@@ -4215,8 +4217,6 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
  private:
   py::list _tensor_names;
   ska::flat_hash_map<PyObject*, std::nullptr_t> _unique_tensors;
-  const ska::flat_hash_set<PyObject*>* _actual_partial_static_tensors{nullptr};
-  size_t _operand_count{0};
 };
 
 /**

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -109,6 +109,9 @@ uint64_t count_instructions(const std::function<void()>& fn) {
 
 #define Py_BUILD_CORE
 #include <internal/pycore_range.h> // _PyRangeIterObject
+#if PY_VERSION_HEX >= 0x030D0000
+#include <internal/pycore_setobject.h> // _PySet_NextEntry
+#endif
 #include <internal/pycore_tuple.h> // _PyTupleIterObject
 #undef Py_BUILD_CORE
 
@@ -1216,6 +1219,7 @@ struct GuardSubtreeInstanceAttrOwnerProof {
   py::object dict;
   PyTypeObject* owner_type{nullptr};
   bool owner_is_self{false};
+  bool requires_non_descriptor_value{false};
 
   bool matches_current(PyObject* current_self) const {
     PyObject* current_owner = owner_is_self ? current_self : owner.ptr();
@@ -1225,7 +1229,9 @@ struct GuardSubtreeInstanceAttrOwnerProof {
     PyObject** dictptr = _PyObject_GetDictPtr(current_owner);
     return dictptr != nullptr && *dictptr == dict.ptr() &&
         PyDict_CheckExact(*dictptr) &&
-        PyDict_GetItem(*dictptr, key.ptr()) == expected.ptr();
+        PyDict_GetItem(*dictptr, key.ptr()) == expected.ptr() &&
+        (!requires_non_descriptor_value ||
+         Py_TYPE(expected.ptr())->tp_descr_get == nullptr);
   }
 };
 
@@ -2088,6 +2094,7 @@ static bool guard_last_success_build_accessor_proofs(
     proof.expected = record.resolved;
     proof.dict = record.owner_dict;
     proof.owner_type = record.owner_type;
+    proof.requires_non_descriptor_value = type_binding;
     instance_attr_proofs.push_back(std::move(proof));
   }
   return true;
@@ -2244,6 +2251,13 @@ struct GuardLastSuccessReceipt {
 
 static bool py_equals(PyObject* a, PyObject* b, bool false_on_error);
 
+static bool guard_actual_partial_is_deeply_immutable(
+    PyObject* value,
+    size_t depth = 0);
+
+static bool guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+    PyObject* value);
+
 static bool guard_subtree_exact_list_token_matches_current(
     const GuardSubtreeEntryToken& token,
     PyObject* current_object) {
@@ -2371,7 +2385,12 @@ static bool guard_subtree_exact_set_equals_token_matches_current(
   if (token.object == nullptr || Py_TYPE(token.object) != token.type ||
       !PySet_CheckExact(token.object) || token.expected_value == nullptr ||
       !PySet_CheckExact(token.expected_value) ||
-      PySet_GET_SIZE(token.expected_value) != token.size) {
+      PySet_GET_SIZE(token.expected_value) != token.size ||
+      !guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+          token.object) ||
+      (token.object != token.expected_value &&
+       !guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+           token.expected_value))) {
     return false;
   }
   return py_equals(token.object, token.expected_value, /*false_on_error=*/true);
@@ -4127,7 +4146,7 @@ class FALSE_MATCH : public LeafGuard {
 
 static bool guard_actual_partial_is_deeply_immutable(
     PyObject* value,
-    size_t depth = 0) {
+    size_t depth) {
   if (value == Py_None || PyBool_Check(value) || PyLong_CheckExact(value) ||
       PyFloat_CheckExact(value) || PyComplex_CheckExact(value) ||
       PyUnicode_CheckExact(value) || PyBytes_CheckExact(value)) {
@@ -4139,6 +4158,22 @@ static bool guard_actual_partial_is_deeply_immutable(
   for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(value); ++i) {
     if (!guard_actual_partial_is_deeply_immutable(
             PyTuple_GET_ITEM(value, i), depth + 1)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+    PyObject* value) {
+  if (!PySet_CheckExact(value)) {
+    return false;
+  }
+  Py_ssize_t position = 0;
+  PyObject* item = nullptr;
+  Py_hash_t hash = 0;
+  while (_PySet_NextEntry(value, &position, &item, &hash)) {
+    if (!guard_actual_partial_is_deeply_immutable(item)) {
       return false;
     }
   }
@@ -4175,18 +4210,31 @@ class EQUALS_MATCH : public LeafGuard {
   }
 
   bool supports_actual_partial_subtree_memo(PyObject* value) const override {
+    if (PySet_CheckExact(_value.ptr()) || PySet_CheckExact(value)) {
+      return guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+                 _value.ptr()) &&
+          (value == _value.ptr() ||
+           guard_actual_partial_is_exact_set_of_deeply_immutable_values(value));
+    }
     return _actual_partial_safe_constant ||
-        guard_actual_partial_is_deeply_immutable(value) ||
-        (PySet_CheckExact(_value.ptr()) && PySet_CheckExact(value));
+        guard_actual_partial_is_deeply_immutable(value);
   }
 
   bool emits_actual_partial_subtree_memo_token() const override {
-    return PySet_CheckExact(_value.ptr());
+    return guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+        _value.ptr());
   }
 
   bool append_actual_partial_subtree_memo_token(
       PyObject* value,
       std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+            _value.ptr()) ||
+        (value != _value.ptr() &&
+         !guard_actual_partial_is_exact_set_of_deeply_immutable_values(
+             value))) {
+      return false;
+    }
     if (!check_nopybind(value)) {
       return false;
     }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -172,9 +172,7 @@ constexpr uint64_t kGuardLastSuccessActualMaxUnstablePasses = 8;
 thread_local bool* active_guard_actual_partial_supported = nullptr;
 thread_local size_t active_guard_actual_partial_list_items = 0;
 
-static bool source_ends_with(
-    const std::string& source,
-    const char* suffix) {
+static bool source_ends_with(const std::string& source, const char* suffix) {
   const size_t suffix_len = std::strlen(suffix);
   return source.size() >= suffix_len &&
       source.compare(source.size() - suffix_len, suffix_len, suffix) == 0;
@@ -575,7 +573,6 @@ PyObject* TensorGuards_check(
   }
 
   Py_RETURN_TRUE;
-
 }
 
 PyObject* TensorGuards_check_verbose(
@@ -889,7 +886,6 @@ PyObject* GlobalStateGuard_reason(
     PyObject* args,
     PyObject* kwargs) {
   return PyUnicode_FromString(self->reason().c_str());
-
 }
 
 PyObject* GlobalStateGuard_dump(
@@ -1013,8 +1009,7 @@ static uint64_t get_dict_version_unchecked(PyObject* dict) {
 static bool tensor_layout_does_not_support_stride(const at::Tensor& tensor) {
   return tensor.layout() == c10::kSparseCsr ||
       tensor.layout() == c10::kSparseCsc ||
-      tensor.layout() == c10::kSparseBsc ||
-      tensor.layout() == c10::kSparseBsr;
+      tensor.layout() == c10::kSparseBsc || tensor.layout() == c10::kSparseBsr;
 }
 
 static bool tensor_strides_match_guard_check(
@@ -1750,7 +1745,6 @@ static bool guard_subtree_special_token_matches_current(
 
 static bool guard_subtree_token_is_aliasing_guard(
     GuardSubtreeProbeTokenKind kind) {
-
   return kind == GuardSubtreeProbeTokenKind::NoTensorAliasing ||
       kind == GuardSubtreeProbeTokenKind::ObjectAliasing;
 }
@@ -2107,7 +2101,7 @@ static bool guard_subtree_aliasing_token_matches_current(
   // receipt tokens would be tautological; the live runtime check here is that
   // the recorded alias operand is still the same object/type. Actual-partial
   // plan construction applies an additional conservative reachability gate
-    // before these tokens are admitted.
+  // before these tokens are admitted.
   return token.object != nullptr && token.type != nullptr &&
       Py_TYPE(token.object) == token.type;
 }
@@ -2495,9 +2489,7 @@ static bool guard_subtree_memo_tokens_match(
   return true;
 }
 
-static bool source_starts_with(
-    const std::string& source,
-    const char* prefix) {
+static bool source_starts_with(const std::string& source, const char* prefix) {
   const size_t prefix_len = std::strlen(prefix);
   return source.size() >= prefix_len &&
       source.compare(0, prefix_len, prefix) == 0;
@@ -2509,12 +2501,10 @@ static bool is_self_local_source_path(const std::string& source) {
     return false;
   }
   return source.size() == std::strlen(kSelf) ||
-      source[std::strlen(kSelf)] == '.' ||
-      source[std::strlen(kSelf)] == '[';
+      source[std::strlen(kSelf)] == '.' || source[std::strlen(kSelf)] == '[';
 }
 
 static bool is_local_source_path(const std::string& source) {
-
   return source_starts_with(source, "L[");
 }
 
@@ -2713,8 +2703,8 @@ static bool guard_last_success_actual_partial_tokens_match(
 
 thread_local std::vector<GuardSubtreeEntryToken>*
     active_guard_subtree_memo_recorder = nullptr;
-thread_local std::vector<std::string>*
-    active_guard_subtree_memo_debug_paths = nullptr;
+thread_local std::vector<std::string>* active_guard_subtree_memo_debug_paths =
+    nullptr;
 thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
 thread_local std::vector<GuardActualPartialAccessorRecord>*
     active_guard_actual_partial_accessor_records = nullptr;
@@ -2903,8 +2893,7 @@ struct GuardSubtreeMemoRecorderScope {
     active_guard_actual_partial_accessor_records = previous_accessor_records;
     active_guard_actual_partial_supported = previous_actual_partial_supported;
     active_guard_actual_partial_list_items = previous_actual_partial_list_items;
-    active_guard_subtree_memo_relax_global_dicts =
-        previous_relax_global_dicts;
+    active_guard_subtree_memo_relax_global_dicts = previous_relax_global_dicts;
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
@@ -2988,7 +2977,6 @@ static bool check_size_stride(
     std::stringstream msg;
     msg << "wrong number of dimensions" << ndim;
     if (op_name) {
-
       msg << " for op: " << op_name;
     }
     PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
@@ -3116,7 +3104,6 @@ static PyObject* assert_size_stride_grouped(PyObject* dummy, PyObject* args) {
   }
 
   Py_RETURN_TRUE;
-
 }
 
 static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
@@ -3421,7 +3408,6 @@ struct StaticMeta {
 
   static int64_t size(const Tensor& t, int64_t i) {
     return t.size(i);
-
   }
 
   static int64_t stride(const Tensor& t, int64_t i) {
@@ -3725,7 +3711,6 @@ class GuardDebugInfo {
         num_guards_executed(num_guards_executed),
         user_stack(std::move(user_stack)) {}
 
-
   // This constructor is used when guard succeeds.
   GuardDebugInfo(bool result, int num_guards_executed)
       : result(result),
@@ -3770,7 +3755,6 @@ class GuardDebugInfo {
 class GuardManager;
 class RootGuardManager;
 class DictGuardManager;
-
 
 // Global registry used by the *recursive-dict-tag* optimisation.
 //
@@ -3923,7 +3907,6 @@ class LeafGuard {
  */
 class LAMBDA_GUARD : public LeafGuard {
  public:
-
   LAMBDA_GUARD(
       RootGuardManager* root_guard_manager,
       py::object guard_check_fn,
@@ -3981,7 +3964,6 @@ class LAMBDA_GUARD : public LeafGuard {
 
 class TYPE_MATCH : public LeafGuard {
  public:
-
   // type_id = id(type(obj))
   TYPE_MATCH(
       RootGuardManager* root_guard_manager,
@@ -4057,7 +4039,6 @@ class FAKE_SCRIPT_TYPE_MATCH : public LeafGuard {
 
 class ID_MATCH : public LeafGuard {
  public:
-
   // obj_id = id(obj)
   ID_MATCH(
       RootGuardManager* root_guard_manager,
@@ -4262,7 +4243,6 @@ class EQUALS_MATCH : public LeafGuard {
 
 class RANGE_ITERATOR_MATCH : public LeafGuard {
  public:
-
   RANGE_ITERATOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object start,
@@ -4314,7 +4294,6 @@ class RANGE_ITERATOR_MATCH : public LeafGuard {
 
 class TUPLE_ITERATOR_LEN : public LeafGuard {
  public:
-
   TUPLE_ITERATOR_LEN(
       RootGuardManager* root_guard_manager,
       py::object length,
@@ -4349,7 +4328,6 @@ class TUPLE_ITERATOR_LEN : public LeafGuard {
 
 class LENGTH_CHECK : public LeafGuard {
  public:
-
   LENGTH_CHECK(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -4384,7 +4362,6 @@ class LENGTH_CHECK : public LeafGuard {
 
 class DICT_LENGTH : public LeafGuard {
  public:
-
   DICT_LENGTH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -4431,7 +4408,6 @@ class NOT_NONE : public LeafGuard {
 
 class MAPPING_KEYS_MATCH : public LeafGuard {
  public:
-
   MAPPING_KEYS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -4464,7 +4440,6 @@ class MAPPING_KEYS_MATCH : public LeafGuard {
 
 class DEFAULT_DEVICE : public LeafGuard {
  public:
-
   DEFAULT_DEVICE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -4525,7 +4500,6 @@ class DEFAULT_DEVICE : public LeafGuard {
       FrameLocalsMapping* value,
       std::vector<GuardSubtreeEntryToken>* tokens) override {
     return append_subtree_memo_token_template(value, tokens);
-
   }
 
  private:
@@ -4551,7 +4525,6 @@ class DEFAULT_DEVICE : public LeafGuard {
 
 class GLOBAL_STATE : public LeafGuard {
  public:
-
   GLOBAL_STATE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -4645,7 +4618,6 @@ class GLOBAL_STATE : public LeafGuard {
 // HASATTR guard.
 class NO_HASATTR : public LeafGuard {
  public:
-
   NO_HASATTR(
       RootGuardManager* root_guard_manager,
       py::object attr_name,
@@ -4672,7 +4644,6 @@ class NO_HASATTR : public LeafGuard {
 // being faster.
 class DICT_CONTAINS : public LeafGuard {
  public:
-
   DICT_CONTAINS(
       RootGuardManager* root_guard_manager,
       bool contains,
@@ -4850,7 +4821,6 @@ class DUAL_LEVEL_MATCH : public LeafGuard {
  */
 class RelationalGuard : public LeafGuard {
  public:
-
   RelationalGuard(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -4885,7 +4855,6 @@ class RelationalGuard : public LeafGuard {
  */
 class OBJECT_ALIASING : public RelationalGuard {
  public:
-
   OBJECT_ALIASING(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -4971,7 +4940,6 @@ class OBJECT_ALIASING : public RelationalGuard {
  */
 class NO_TENSOR_ALIASING : public RelationalGuard {
  public:
-
   NO_TENSOR_ALIASING(
       RootGuardManager* root_guard_manager,
       const py::list& tensor_names,
@@ -5075,7 +5043,6 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
  */
 class STORAGE_OVERLAPPING : public RelationalGuard {
  public:
-
   STORAGE_OVERLAPPING(
       RootGuardManager* root_guard_manager,
       bool overlapping,
@@ -5112,7 +5079,6 @@ class STORAGE_OVERLAPPING : public RelationalGuard {
  */
 class SYMBOLIC_SHAPE_GUARD : public RelationalGuard {
  public:
-
   SYMBOLIC_SHAPE_GUARD(
       RootGuardManager* root_guard_manager,
       py::int_ nargs_int,
@@ -5562,7 +5528,6 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
 
 class DICT_VERSION : public LeafGuard {
  public:
-
   DICT_VERSION(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -5781,7 +5746,6 @@ class GuardAccessor {
   // A string that can be eval'd on f_locals or f_globals to access the variable
   // value. Only used for debugging.
   std::string _source;
-
 };
 
 /**
@@ -5893,7 +5857,6 @@ class GuardManager {
  public:
   // relational guard helpers
   void set_has_object_aliasing_guard() {
-
     _has_object_aliasing_guard = true;
   }
 
@@ -5969,7 +5932,6 @@ class GuardManager {
       std::vector<RecordedTensorMetadata>&& tensor_metadata) {
     _tensor_metadata_pointers[value] = std::move(tensor_metadata);
   }
-
 
   void disable_recursive_dict_tag_optimization() {
     dict_to_guard_managers.withLock([&](DictToGuardManagersMap& map) {
@@ -6644,7 +6606,6 @@ class GuardManager {
       if (_is_dict) {
         new_tag = get_dict_version_unchecked(value);
         matches_dict_tag = (new_tag == _dict_tag);
-
       }
     }
 
@@ -7084,7 +7045,6 @@ class RootGuardManager : public GuardManager {
     std::lock_guard<std::mutex> lock_guard(_lock);
     Py_BLOCK_THREADS; // ; is added to avoid clang-formatting
 
-
     // Get the local state. This will be used for TENSOR_MATCH guards.
     if (_init_local_state) {
       LocalState state;
@@ -7326,7 +7286,6 @@ class DictGuardManager : public GuardManager {
         _expected_type(Py_TYPE(example_value.ptr())),
         _is_exact_dict_type(PyDict_CheckExact(example_value.ptr())) {}
 
-
   GuardManager* get_key_manager(
       py::object key_index,
       std::string source,
@@ -7409,7 +7368,6 @@ class DictGuardManager : public GuardManager {
         KeyValueManager& key_value_manager = _key_value_managers[dict_pointer];
         std::unique_ptr<GuardManager>& key_manager = key_value_manager.first;
         if (key_manager && !key_manager->check_nopybind(key)) {
-
           return false;
         }
         std::unique_ptr<GuardManager>& value_manager = key_value_manager.second;
@@ -7626,7 +7584,6 @@ class DictGuardManager : public GuardManager {
           cloned_mgr->_key_value_managers[index].second =
               std::unique_ptr<GuardManager>(cloned_value_manager);
         }
-
       }
     }
     return cloned_mgr;
@@ -7796,7 +7753,6 @@ const LocalState& get_local_state(RootGuardManager* root) {
 
 class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
  public:
-
   TORCH_FUNCTION_MODE_STACK(
       RootGuardManager* root_guard_manager,
       const py::list& initial_stack,
@@ -7895,7 +7851,6 @@ static bool torch_function_mode_stack_guard_matches(const void* guard) {
 
 class DISPATCH_KEY_SET_MATCH : public LeafGuard {
  public:
-
   DISPATCH_KEY_SET_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -7927,7 +7882,6 @@ class DISPATCH_KEY_SET_MATCH : public LeafGuard {
 
 class TENSOR_MATCH : public LeafGuard {
  public:
-
   TENSOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -8033,8 +7987,7 @@ class TENSOR_MATCH : public LeafGuard {
             value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
       return false;
     }
-    append_guard_subtree_memo_token(
-        tokens, std::move(token), _tensor_name);
+    append_guard_subtree_memo_token(tokens, std::move(token), _tensor_name);
     return true;
   }
 
@@ -8048,7 +8001,6 @@ class TENSOR_MATCH : public LeafGuard {
  */
 class GetAttrGuardAccessor : public GuardAccessor {
  public:
-
   GetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -8147,7 +8099,6 @@ class GetAttrGuardAccessor : public GuardAccessor {
  */
 class GenericGetAttrGuardAccessor : public GuardAccessor {
  public:
-
   GenericGetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -8610,7 +8561,6 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   }
 
  public: // cloning functions
-
   DictGetItemGuardAccessor(
       GuardManager* guard_manager,
       DictGetItemGuardAccessor* from)
@@ -8920,7 +8870,6 @@ std::string to_string(TensorProperty prop) {
 template <TensorProperty _prop>
 class TensorPropertyGuardAccessor : public GuardAccessor {
  public:
-
   TensorPropertyGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -9049,7 +8998,6 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
  */
 class IndexedGuardAccessor : public GuardAccessor {
  public:
-
   IndexedGuardAccessor(
       RootGuardManager* root,
       py::int_ index,
@@ -9112,7 +9060,6 @@ class IndexedGuardAccessor : public GuardAccessor {
  */
 class GradGuardAccessor : public GuardAccessor {
  public:
-
   GradGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -9183,7 +9130,6 @@ class GradGuardAccessor : public GuardAccessor {
  */
 class FuncDefaultsGuardAccessor : public GuardAccessor {
  public:
-
   FuncDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -9251,7 +9197,6 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
       const py::function& clone_filter_fn) override {
     return clone_common<FuncDefaultsGuardAccessor>(
         cloned_root, clone_filter_fn);
-
   }
 };
 
@@ -9260,7 +9205,6 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
  */
 class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  public:
-
   FuncKwDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -9338,7 +9282,6 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  */
 class GlobalsGuardAccessor : public GuardAccessor {
  public:
-
   GlobalsGuardAccessor(
       RootGuardManager* root,
       py::dict globals_dict,
@@ -9580,7 +9523,6 @@ class TypeMROGuardAccessor : public GuardAccessor {
   }
 
  public: // cloning functions
-
   TypeMROGuardAccessor(GuardManager* guard_manager, TypeMROGuardAccessor* from)
       : GuardAccessor(guard_manager, from) {
     from->clone_visitor(this);
@@ -9600,7 +9542,6 @@ class TypeMROGuardAccessor : public GuardAccessor {
  */
 class TupleIteratorGetItemAccessor : public GuardAccessor {
  public:
-
   TupleIteratorGetItemAccessor(
       RootGuardManager* root,
       py::object index,
@@ -9680,7 +9621,6 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
  */
 class GlobalWeakRefGuardAccessor : public GuardAccessor {
  public:
-
   GlobalWeakRefGuardAccessor(
       RootGuardManager* root,
       py::object global_name,
@@ -9792,7 +9732,6 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
  */
 class WeakRefCallGuardAccessor : public GuardAccessor {
  public:
-
   WeakRefCallGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -10052,7 +9991,6 @@ class ClosureGuardAccessor : public GuardAccessor {
  */
 class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  public:
-
   CallFunctionNoArgsGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -10114,7 +10052,6 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
     return false;
   }
 
-
  public: // cloning functions
   CallFunctionNoArgsGuardAccessor(
       GuardManager* guard_manager,
@@ -10139,7 +10076,6 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  */
 class PythonLambdaGuardAccessor : public GuardAccessor {
  public:
-
   PythonLambdaGuardAccessor(
       RootGuardManager* root,
       py::function accessor_fn,
@@ -10196,7 +10132,6 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
       GuardManager* guard_manager,
       PythonLambdaGuardAccessor* from)
       : GuardAccessor(guard_manager, from) {
-
     from->clone_visitor(this);
   }
 
@@ -10452,8 +10387,6 @@ bool root_guard_manager_has_no_guards(void* root) {
   }
   return ((RootGuardManager*)root)->has_no_guards();
 }
-
-
 
 void* create_guard_last_success_receipt() {
 #ifdef Py_GIL_DISABLED

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3,6 +3,7 @@
 #include <c10/core/SafePyObject.h>
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/util/Exception.h>
+#include <c10/util/ScopeExit.h>
 #define PY_SSIZE_T_CLEAN
 #include <ATen/EmptyTensor.h>
 #include <ATen/SparseCsrTensorUtils.h>
@@ -53,6 +54,7 @@
 #include <sstream>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -151,6 +153,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   ObjectAliasing,
   BoundMethod,
   FrameGlobals,
+  TensorDimensionMarkingAbsent,
 };
 
 constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
@@ -1073,6 +1076,67 @@ static bool is_global_source_path(const std::string& source) {
        (source[1] == '[' || source[1] == '.'));
 }
 
+static bool guard_subtree_type_version_is_valid(PyTypeObject* type) {
+#if PY_VERSION_HEX >= 0x030D0000
+  return type != nullptr && type->tp_version_tag != 0;
+#else
+  return type != nullptr &&
+      PyType_HasFeature(type, Py_TPFLAGS_VALID_VERSION_TAG) &&
+      type->tp_version_tag != 0;
+#endif
+}
+
+static bool guard_subtree_ensure_absent_type_version(
+    PyTypeObject* type,
+    PyObject* lookup_key,
+    unsigned int& version) {
+  if (type == nullptr || lookup_key == nullptr ||
+      type->tp_getattro != PyObject_GenericGetAttr ||
+      _PyType_Lookup(type, lookup_key) != nullptr) {
+    return false;
+  }
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    return false;
+  }
+#if PY_VERSION_HEX >= 0x030C0000
+  if (PyUnstable_Type_AssignVersionTag(type) == 0) {
+    return false;
+  }
+#endif
+  if (!guard_subtree_type_version_is_valid(type)) {
+    return false;
+  }
+  version = type->tp_version_tag;
+  return true;
+}
+
+struct GuardSubtreeTypeProof {
+  py::object type;
+  py::object lookup_key;
+  unsigned int version{0};
+
+  bool matches_current() const {
+    auto* current_type = reinterpret_cast<PyTypeObject*>(type.ptr());
+    return guard_subtree_type_version_is_valid(current_type) &&
+        current_type->tp_version_tag == version;
+  }
+};
+
+enum class GuardCrossSliceRelationKind : uint8_t {
+  ObjectAliasing,
+  NoTensorAliasing,
+};
+
+struct GuardCrossSliceRelationPlan {
+  GuardCrossSliceRelationKind kind{
+      GuardCrossSliceRelationKind::ObjectAliasing};
+  const void* guard{nullptr};
+  size_t expected_operand_count{0};
+  std::vector<py::object> stable_operands;
+  ska::flat_hash_set<PyObject*> stable_operand_set;
+};
+
 struct GuardSubtreeEntryToken {
   PyObject* object{nullptr};
   PyTypeObject* type{nullptr};
@@ -1100,6 +1164,7 @@ struct GuardSubtreeEntryToken {
   PyCFunction bound_c_method_func{nullptr};
   PyTypeObject* bound_c_method_class{nullptr};
   int bound_c_method_flags{0};
+  PyObject* dimension_marking_key{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -1254,6 +1319,17 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_dimension_marking_absent(
+      PyObject* obj,
+      PyObject* key) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent;
+    token.dimension_marking_key = key;
+    return token;
+  }
+
   bool matches_tensor_current(const LocalState* state) const {
     if (state == nullptr) {
       return false;
@@ -1354,6 +1430,9 @@ struct GuardSubtreeEntryToken {
     if (kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
       return object_aliasing_guard == other.object_aliasing_guard;
     }
+    if (kind == GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent) {
+      return dimension_marking_key == other.dimension_marking_key;
+    }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
   }
@@ -1440,11 +1519,32 @@ static bool guard_last_success_make_partial_hot_tokens(
   return true;
 }
 
-extern thread_local const LocalState* active_guard_local_state;
-
 static bool guard_subtree_tensor_token_matches_current(
+    const GuardSubtreeEntryToken& token,
+    const LocalState* local_state) {
+  return token.matches_tensor_current(local_state);
+}
+
+static bool guard_subtree_dimension_marking_absent_token_matches_current(
     const GuardSubtreeEntryToken& token) {
-  return token.matches_tensor_current(active_guard_local_state);
+  if (token.object == nullptr || token.dimension_marking_key == nullptr ||
+      Py_TYPE(token.object) != token.type ||
+      !THPVariable_CheckExact(token.object)) {
+    return false;
+  }
+  PyObject** dictptr = _PyObject_GetDictPtr(token.object);
+  if (dictptr == nullptr || *dictptr == nullptr ||
+      !PyDict_CheckExact(*dictptr)) {
+    PyErr_Clear();
+    return false;
+  }
+  const int contains =
+      PyDict_Contains(*dictptr, token.dimension_marking_key);
+  if (contains < 0) {
+    PyErr_Clear();
+    return false;
+  }
+  return contains == 0;
 }
 
 static bool guard_subtree_special_token_matches_current(
@@ -1484,32 +1584,206 @@ static bool guard_subtree_token_proves_child_reachability(
 
 static bool guard_subtree_aliasing_tokens_have_reachability_proof(
     const std::vector<GuardSubtreeEntryToken>& tokens) {
-  bool saw_reachability_proof = false;
-  for (size_t i = 0; i < tokens.size(); ++i) {
-    const auto& token = tokens[i];
+  std::unordered_set<PyObject*> reachable_objects;
+  for (const auto& token : tokens) {
     if (guard_subtree_token_proves_child_reachability(token)) {
-      saw_reachability_proof = true;
+      reachable_objects.insert(token.object);
     }
+  }
+  for (const auto& token : tokens) {
     if (!guard_subtree_token_is_aliasing_guard(token.kind)) {
       continue;
     }
-    if (!saw_reachability_proof || token.object == nullptr ||
-        token.type == nullptr) {
+    if (token.object == nullptr || token.type == nullptr ||
+        reachable_objects.find(token.object) == reachable_objects.end()) {
       return false;
     }
   }
   return true;
 }
 
-static bool guard_last_success_build_partial_plan_tokens(
+static const void* guard_subtree_aliasing_guard_identity(
+    const GuardSubtreeEntryToken& token) {
+  if (token.kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+    return token.object_aliasing_guard;
+  }
+  if (token.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+    return token.no_tensor_aliasing_guard;
+  }
+  return nullptr;
+}
+
+static bool guard_last_success_build_relation_plans(
+    const std::vector<GuardSubtreeEntryToken>& full_tokens,
     const std::vector<GuardSubtreeEntryToken>& partial_tokens,
-    std::vector<GuardSubtreeEntryToken>& stability_tokens,
-    std::vector<GuardSubtreeEntryToken>& hot_tokens) {
-  stability_tokens = partial_tokens;
-  if (!guard_subtree_aliasing_tokens_have_reachability_proof(partial_tokens)) {
+    std::vector<GuardCrossSliceRelationPlan>& plans) {
+  struct RelationGroup {
+    GuardCrossSliceRelationKind kind{
+        GuardCrossSliceRelationKind::ObjectAliasing};
+    std::vector<const GuardSubtreeEntryToken*> full;
+    std::vector<const GuardSubtreeEntryToken*> partial;
+  };
+
+  std::unordered_map<const void*, RelationGroup> groups;
+  std::vector<const void*> order;
+  for (const auto& token : full_tokens) {
+    const void* guard = guard_subtree_aliasing_guard_identity(token);
+    if (guard == nullptr) {
+      continue;
+    }
+    const auto kind = token.kind == GuardSubtreeProbeTokenKind::ObjectAliasing
+        ? GuardCrossSliceRelationKind::ObjectAliasing
+        : GuardCrossSliceRelationKind::NoTensorAliasing;
+    auto insertion = groups.emplace(guard, RelationGroup{});
+    if (insertion.second) {
+      insertion.first->second.kind = kind;
+      order.push_back(guard);
+    } else if (insertion.first->second.kind != kind) {
+      return false;
+    }
+    insertion.first->second.full.push_back(&token);
+  }
+  for (const auto& token : partial_tokens) {
+    const void* guard = guard_subtree_aliasing_guard_identity(token);
+    if (guard == nullptr) {
+      continue;
+    }
+    auto found = groups.find(guard);
+    if (found == groups.end()) {
+      return false;
+    }
+    found->second.partial.push_back(&token);
+  }
+
+  plans.clear();
+  for (const void* guard : order) {
+    const auto& group = groups.at(guard);
+    if (group.partial.empty() || group.partial.size() == group.full.size()) {
+      continue;
+    }
+    if (group.partial.size() > group.full.size()) {
+      return false;
+    }
+    GuardCrossSliceRelationPlan plan;
+    plan.kind = group.kind;
+    plan.guard = guard;
+    plan.expected_operand_count = group.full.size();
+    PyObject* alias_baseline = nullptr;
+    for (const auto* token : group.partial) {
+      if (token->object == nullptr || token->type == nullptr ||
+          Py_TYPE(token->object) != token->type) {
+        return false;
+      }
+      if (group.kind == GuardCrossSliceRelationKind::ObjectAliasing) {
+        if (alias_baseline == nullptr) {
+          alias_baseline = token->object;
+        } else if (alias_baseline != token->object) {
+          return false;
+        }
+      } else if (!plan.stable_operand_set.insert(token->object).second) {
+        return false;
+      }
+      plan.stable_operands.push_back(
+          py::reinterpret_borrow<py::object>(token->object));
+    }
+    plans.push_back(std::move(plan));
+  }
+  return true;
+}
+
+static bool guard_last_success_add_type_proof(
+    PyTypeObject* type,
+    PyObject* lookup_key,
+    std::vector<GuardSubtreeTypeProof>& proofs) {
+  for (const auto& proof : proofs) {
+    if (proof.type.ptr() == reinterpret_cast<PyObject*>(type) &&
+        proof.lookup_key.ptr() == lookup_key) {
+      return true;
+    }
+  }
+  unsigned int version = 0;
+  if (!guard_subtree_ensure_absent_type_version(
+          type, lookup_key, version)) {
+    PyErr_Clear();
     return false;
   }
-  return guard_last_success_make_partial_hot_tokens(partial_tokens, hot_tokens);
+  GuardSubtreeTypeProof proof;
+  proof.type = py::reinterpret_borrow<py::object>(
+      reinterpret_cast<PyObject*>(type));
+  proof.lookup_key = py::reinterpret_borrow<py::object>(lookup_key);
+  proof.version = version;
+  proofs.push_back(std::move(proof));
+  return true;
+}
+
+static void guard_last_success_retain_token_objects(
+    const std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::vector<py::object>& retained_token_objects) {
+  retained_token_objects.clear();
+  if (partial_tokens.empty()) {
+    return;
+  }
+  PyObject* current_self = partial_tokens.front().object;
+  std::unordered_set<PyObject*> retained;
+  auto retain = [&](PyObject* object) {
+    if (object != nullptr && object != current_self &&
+        retained.insert(object).second) {
+      retained_token_objects.push_back(
+          py::reinterpret_borrow<py::object>(object));
+    }
+  };
+  for (size_t i = 1; i < partial_tokens.size(); ++i) {
+    const auto& token = partial_tokens[i];
+    if (token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      retain(token.bound_method_self);
+      retain(token.bound_method_func);
+      retain(reinterpret_cast<PyObject*>(token.bound_c_method_class));
+    } else {
+      retain(token.object);
+    }
+  }
+}
+
+static bool guard_last_success_build_partial_plan_tokens(
+    const std::vector<GuardSubtreeEntryToken>& full_tokens,
+    const std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::vector<GuardSubtreeEntryToken>& stability_tokens,
+    std::vector<GuardSubtreeEntryToken>& hot_tokens,
+    std::vector<GuardSubtreeTypeProof>& type_proofs,
+    std::vector<GuardCrossSliceRelationPlan>& relation_plans,
+    std::vector<py::object>& retained_token_objects) {
+  stability_tokens = partial_tokens;
+  if (!guard_subtree_aliasing_tokens_have_reachability_proof(partial_tokens) ||
+      !guard_last_success_make_partial_hot_tokens(
+          partial_tokens, hot_tokens) ||
+      !guard_last_success_build_relation_plans(
+          full_tokens, partial_tokens, relation_plans)) {
+    return false;
+  }
+
+  hot_tokens.erase(
+      std::remove_if(
+          hot_tokens.begin(),
+          hot_tokens.end(),
+          [](const GuardSubtreeEntryToken& token) {
+            return guard_subtree_token_is_aliasing_guard(token.kind);
+          }),
+      hot_tokens.end());
+
+  type_proofs.clear();
+  for (const auto& token : partial_tokens) {
+    if (token.kind ==
+            GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent &&
+        !guard_last_success_add_type_proof(
+            token.type,
+            token.dimension_marking_key,
+            type_proofs)) {
+      return false;
+    }
+  }
+  guard_last_success_retain_token_objects(
+      partial_tokens, retained_token_objects);
+  return true;
 }
 
 static bool guard_subtree_aliasing_token_matches_current(
@@ -1555,11 +1829,14 @@ struct GuardLastSuccessPartialPlan {
     root_key = nullptr;
 
     stable_passes = 0;
-    self_object = nullptr;
+    self_weakref = py::object();
     self_type = nullptr;
     self_framelocals_index = -1;
     stability_tokens.clear();
     tokens.clear();
+    type_proofs.clear();
+    cross_slice_relations.clear();
+    retained_token_objects.clear();
   }
 
   void disable() {
@@ -1580,7 +1857,10 @@ struct GuardLastSuccessPartialPlan {
       void* new_entry_key,
       void* new_root_key,
       std::vector<GuardSubtreeEntryToken>&& new_stability_tokens,
-      std::vector<GuardSubtreeEntryToken>&& new_tokens) {
+      std::vector<GuardSubtreeEntryToken>&& new_tokens,
+      std::vector<GuardSubtreeTypeProof>&& new_type_proofs,
+      std::vector<GuardCrossSliceRelationPlan>&& new_cross_slice_relations,
+      std::vector<py::object>&& new_retained_token_objects) {
     const bool stable = entry_key == new_entry_key &&
         root_key == new_root_key && !stability_tokens.empty() &&
         guard_subtree_token_vectors_match(
@@ -1591,10 +1871,13 @@ struct GuardLastSuccessPartialPlan {
       entry_key = new_entry_key;
       root_key = new_root_key;
       stability_tokens = std::move(new_stability_tokens);
-      tokens = std::move(new_tokens);
       stable_passes = 1;
       state = GuardLastSuccessPartialPlanState::Training;
     }
+    tokens = std::move(new_tokens);
+    type_proofs = std::move(new_type_proofs);
+    cross_slice_relations = std::move(new_cross_slice_relations);
+    retained_token_objects = std::move(new_retained_token_objects);
     if (state != GuardLastSuccessPartialPlanState::Enabled &&
         stable_passes >= kGuardLastSuccessActualStablePasses) {
       state = GuardLastSuccessPartialPlanState::Enabled;
@@ -1608,11 +1891,14 @@ struct GuardLastSuccessPartialPlan {
   void* entry_key{nullptr};
   void* root_key{nullptr};
   uint64_t stable_passes{0};
-  PyObject* self_object{nullptr};
+  py::object self_weakref;
   PyTypeObject* self_type{nullptr};
   int self_framelocals_index{-1};
   std::vector<GuardSubtreeEntryToken> stability_tokens;
   std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<GuardSubtreeTypeProof> type_proofs;
+  std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
+  std::vector<py::object> retained_token_objects;
 };
 
 struct GuardLastSuccessReceipt {
@@ -1621,19 +1907,6 @@ struct GuardLastSuccessReceipt {
   }
 
   GuardLastSuccessPartialPlan actual_partial;
-};
-
-struct GuardLocalStateScope {
-  explicit GuardLocalStateScope(const LocalState* state)
-      : previous(active_guard_local_state) {
-    active_guard_local_state = state;
-  }
-
-  ~GuardLocalStateScope() {
-    active_guard_local_state = previous;
-  }
-
-  const LocalState* previous{nullptr};
 };
 
 static bool guard_subtree_exact_list_token_matches_current(
@@ -1660,11 +1933,20 @@ static bool guard_subtree_exact_list_token_matches_current(
 
 static bool guard_subtree_memo_tokens_match(
     const std::vector<GuardSubtreeEntryToken>& tokens,
-    PyObject* root_value) {
+    PyObject* root_value,
+    const LocalState* local_state) {
   for (size_t i = 0; i < tokens.size(); ++i) {
     const auto& token = tokens[i];
     if (token.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
-      if (!guard_subtree_tensor_token_matches_current(token)) {
+      if (!guard_subtree_tensor_token_matches_current(token, local_state)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind ==
+        GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent) {
+      if (!guard_subtree_dimension_marking_absent_token_matches_current(
+              token)) {
         return false;
       }
       continue;
@@ -1835,6 +2117,9 @@ static bool guard_last_success_extract_self_partial_tokens(
 struct GuardLastSuccessPartialPlanBuild {
   std::vector<GuardSubtreeEntryToken> stability_tokens;
   std::vector<GuardSubtreeEntryToken> hot_tokens;
+  std::vector<GuardSubtreeTypeProof> type_proofs;
+  std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
+  std::vector<py::object> retained_token_objects;
 };
 
 static bool guard_last_success_prepare_actual_partial(
@@ -1865,33 +2150,58 @@ static bool guard_last_success_prepare_actual_partial(
   if (partial_tokens[0].object != current_self) {
     return false;
   }
-  plan->self_object = current_self;
+  PyObject* weakref = PyWeakref_NewRef(current_self, nullptr);
+  if (weakref == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  plan->self_weakref = py::reinterpret_steal<py::object>(weakref);
   plan->self_type = Py_TYPE(current_self);
   plan->self_framelocals_index = self_framelocals_index;
 
   return guard_last_success_build_partial_plan_tokens(
+      tokens,
       partial_tokens,
       build.stability_tokens,
-      build.hot_tokens);
+      build.hot_tokens,
+      build.type_proofs,
+      build.cross_slice_relations,
+      build.retained_token_objects);
 }
 
 static bool guard_last_success_actual_partial_tokens_match(
     const GuardLastSuccessPartialPlan& plan,
-    FrameLocalsMapping* f_locals) {
+    FrameLocalsMapping* f_locals,
+    const LocalState* local_state) {
   if (plan.tokens.empty()) {
     return false;
   }
   PyObject* current_self =
       guard_last_success_get_self(f_locals, plan.self_framelocals_index);
-  if (current_self == nullptr ||
-      current_self != plan.self_object ||
+  if (current_self == nullptr || plan.self_weakref.ptr() == nullptr ||
       Py_TYPE(current_self) != plan.self_type) {
     return false;
   }
-  LocalState state;
-  GuardLocalStateScope local_state_scope(&state);
+  PyObject* expected_self = nullptr;
+  const int weakref_status =
+      PyWeakref_GetRef(plan.self_weakref.ptr(), &expected_self);
+  if (weakref_status != 1 || expected_self == nullptr) {
+    Py_XDECREF(expected_self);
+    PyErr_Clear();
+    return false;
+  }
+  const bool self_matches = current_self == expected_self;
+  Py_DECREF(expected_self);
+  if (!self_matches) {
+    return false;
+  }
+  for (const auto& proof : plan.type_proofs) {
+    if (!proof.matches_current()) {
+      return false;
+    }
+  }
   return guard_subtree_memo_tokens_match(
-      plan.tokens, plan.tokens[0].object);
+      plan.tokens, current_self, local_state);
 }
 
 thread_local std::vector<GuardSubtreeEntryToken>*
@@ -1899,31 +2209,38 @@ thread_local std::vector<GuardSubtreeEntryToken>*
 thread_local std::vector<std::string>*
     active_guard_subtree_memo_debug_paths = nullptr;
 thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
-thread_local const LocalState* active_guard_local_state = nullptr;
+thread_local bool* active_guard_actual_partial_supported = nullptr;
 
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
       std::vector<GuardSubtreeEntryToken>* tokens,
       std::vector<std::string>* debug_paths = nullptr,
+      bool* actual_partial_supported = nullptr,
       bool relax_global_dicts = false)
       : previous(active_guard_subtree_memo_recorder),
         previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_actual_partial_supported(
+            active_guard_actual_partial_supported),
         previous_relax_global_dicts(
             active_guard_subtree_memo_relax_global_dicts) {
     active_guard_subtree_memo_recorder = tokens;
     active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_actual_partial_supported = actual_partial_supported;
     active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
   }
 
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
     active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_actual_partial_supported =
+        previous_actual_partial_supported;
     active_guard_subtree_memo_relax_global_dicts =
         previous_relax_global_dicts;
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
   std::vector<std::string>* previous_debug_paths{nullptr};
+  bool* previous_actual_partial_supported{nullptr};
   bool previous_relax_global_dicts{false};
 };
 
@@ -2857,8 +3174,15 @@ class LeafGuard {
   virtual bool supports_subtree_memo() const {
     return true;
   }
+  virtual bool supports_actual_partial_subtree_memo(
+      PyObject* /*value*/) const {
+    return supports_subtree_memo();
+  }
   virtual bool emits_subtree_memo_token() const {
     return false;
+  }
+  virtual bool emits_actual_partial_subtree_memo_token() const {
+    return emits_subtree_memo_token();
   }
   virtual bool emits_subtree_memo_token_for_frame_locals() const {
     return false;
@@ -2867,6 +3191,11 @@ class LeafGuard {
       PyObject* value,
       std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
     return check_nopybind(value);
+  }
+  virtual bool append_actual_partial_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    return append_subtree_memo_token(value, tokens);
   }
   virtual bool append_subtree_memo_token(
       FrameLocalsMapping* value,
@@ -3712,6 +4041,16 @@ class RelationalGuard : public LeafGuard {
   // guard manager.
 
   virtual void reset_state() = 0;
+
+  virtual bool preload_actual_partial_relation(
+      const GuardCrossSliceRelationPlan& /*plan*/) {
+    return false;
+  }
+
+  virtual bool actual_partial_relation_is_complete(
+      const GuardCrossSliceRelationPlan& /*plan*/) const {
+    return false;
+  }
 };
 
 /**
@@ -3730,6 +4069,7 @@ class OBJECT_ALIASING : public RelationalGuard {
             std::move(user_stack)) {}
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
+    ++_operand_count;
     if (_is_first_call) {
       _first_tensor = value;
       _is_first_call = false;
@@ -3740,6 +4080,27 @@ class OBJECT_ALIASING : public RelationalGuard {
 
   void reset_state() final {
     _is_first_call = true;
+    _operand_count = 0;
+  }
+
+  bool preload_actual_partial_relation(
+      const GuardCrossSliceRelationPlan& plan) final {
+    if (plan.kind != GuardCrossSliceRelationKind::ObjectAliasing ||
+        plan.guard != static_cast<const void*>(this) ||
+        plan.stable_operands.empty()) {
+      return false;
+    }
+    _first_tensor = plan.stable_operands.front().ptr();
+    _is_first_call = false;
+    _operand_count = plan.stable_operands.size();
+    return true;
+  }
+
+  bool actual_partial_relation_is_complete(
+      const GuardCrossSliceRelationPlan& plan) const final {
+    return plan.kind == GuardCrossSliceRelationKind::ObjectAliasing &&
+        plan.guard == static_cast<const void*>(this) &&
+        _operand_count == plan.expected_operand_count;
   }
 
   bool supports_subtree_memo() const override {
@@ -3765,6 +4126,7 @@ class OBJECT_ALIASING : public RelationalGuard {
  private:
   bool _is_first_call{true};
   PyObject* _first_tensor{nullptr};
+  size_t _operand_count{0};
 };
 
 /**
@@ -3787,6 +4149,12 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
   }
 
   bool check_nopybind(PyObject* value) override { // borrowed ref
+    ++_operand_count;
+    if (_actual_partial_static_tensors != nullptr &&
+        _actual_partial_static_tensors->find(value) !=
+            _actual_partial_static_tensors->end()) {
+      return false;
+    }
     auto insertion = _unique_tensors.insert({value, nullptr});
     if (!insertion.second) {
       // No need to clear _unique_tensors, reset_state will do
@@ -3808,6 +4176,28 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
 
   void reset_state() final {
     _unique_tensors.clear();
+    _actual_partial_static_tensors = nullptr;
+    _operand_count = 0;
+  }
+
+  bool preload_actual_partial_relation(
+      const GuardCrossSliceRelationPlan& plan) final {
+    if (plan.kind != GuardCrossSliceRelationKind::NoTensorAliasing ||
+        plan.guard != static_cast<const void*>(this) ||
+        plan.stable_operands.empty() ||
+        plan.stable_operand_set.size() != plan.stable_operands.size()) {
+      return false;
+    }
+    _actual_partial_static_tensors = &plan.stable_operand_set;
+    _operand_count = plan.stable_operands.size();
+    return true;
+  }
+
+  bool actual_partial_relation_is_complete(
+      const GuardCrossSliceRelationPlan& plan) const final {
+    return plan.kind == GuardCrossSliceRelationKind::NoTensorAliasing &&
+        plan.guard == static_cast<const void*>(this) &&
+        _operand_count == plan.expected_operand_count;
   }
 
   bool supports_subtree_memo() const override {
@@ -3833,6 +4223,8 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
  private:
   py::list _tensor_names;
   ska::flat_hash_map<PyObject*, std::nullptr_t> _unique_tensors;
+  const ska::flat_hash_set<PyObject*>* _actual_partial_static_tensors{nullptr};
+  size_t _operand_count{0};
 };
 
 /**
@@ -4252,6 +4644,67 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
 
   bool supports_subtree_memo() const override {
     return false;
+  }
+
+  bool supports_actual_partial_subtree_memo(
+      PyObject* value) const override {
+    if (!_all_absent || !THPVariable_CheckExact(value) ||
+        Py_TYPE(value)->tp_getattro != PyObject_GenericGetAttr) {
+      return false;
+    }
+    // A type/MRO descriptor or custom attribute protocol can synthesize the
+    // sentinel without touching the instance dict, so either forces the plan
+    // to fail closed.
+    PyObject* descriptor =
+        _PyType_Lookup(Py_TYPE(value), has_marking_str());
+    if (descriptor != nullptr) {
+      return false;
+    }
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      return false;
+    }
+    return true;
+  }
+
+  bool emits_actual_partial_subtree_memo_token() const override {
+    return true;
+  }
+
+  bool append_actual_partial_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    // Materialize and validate a managed instance dict while recording. The
+    // Enabled matcher can then read the already-materialized slot without
+    // allocating on its hot path.
+    PyObject** dictptr = _PyObject_GetDictPtr(value);
+    if (dictptr == nullptr || *dictptr == nullptr ||
+        !PyDict_CheckExact(*dictptr)) {
+      PyErr_Clear();
+      if (active_guard_actual_partial_supported != nullptr) {
+        *active_guard_actual_partial_supported = false;
+      }
+      return true;
+    }
+    const int contains = PyDict_Contains(*dictptr, has_marking_str());
+    if (contains != 0) {
+      if (contains < 0) {
+        PyErr_Clear();
+      }
+      if (active_guard_actual_partial_supported != nullptr) {
+        *active_guard_actual_partial_supported = false;
+      }
+      return true;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_dimension_marking_absent(
+            value, has_marking_str()),
+        "<TENSOR_DIMENSION_MARKING_ABSENT>");
+    return true;
   }
 
  private:
@@ -5149,6 +5602,20 @@ class GuardManager {
     return true;
   }
 
+  virtual bool supports_actual_partial_subtree_memo_recursive() const {
+    // Leaf capability can depend on the live value (notably the mainline
+    // dimension-marking guard), so the recorder validates leaves as it walks
+    // the self subtree. This preflight only rejects unsupported topology.
+    for (const auto& accessor : _accessors) {
+      if (!accessor->supports_subtree_memo() ||
+          !accessor->get_guard_manager()
+               ->supports_actual_partial_subtree_memo_recursive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   bool supports_accessor_subtree_memo_recursive(
       const std::string& source,
       int* framelocals_index = nullptr) const {
@@ -5173,6 +5640,29 @@ class GuardManager {
     return false;
   }
 
+  bool supports_actual_partial_accessor_subtree_memo_recursive(
+      const std::string& source,
+      int* framelocals_index = nullptr) const {
+    if (framelocals_index != nullptr) {
+      *framelocals_index = -1;
+    }
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() != source) {
+        continue;
+      }
+      if (!accessor->supports_subtree_memo() ||
+          !accessor->get_guard_manager()
+               ->supports_actual_partial_subtree_memo_recursive()) {
+        return false;
+      }
+      if (framelocals_index != nullptr) {
+        *framelocals_index = accessor->framelocals_index();
+      }
+      return true;
+    }
+    return false;
+  }
+
   virtual bool check_nopybind(FrameLocalsMapping* value) {
     return check_nopybind_template(value);
   }
@@ -5184,14 +5674,27 @@ class GuardManager {
       if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
         bool emit_subtree_memo_token = false;
         if constexpr (std::is_same_v<T, PyObject>) {
-          emit_subtree_memo_token = guard->emits_subtree_memo_token();
+          const bool actual_partial_supported =
+              guard->supports_actual_partial_subtree_memo(value);
+          if (active_guard_actual_partial_supported != nullptr &&
+              is_self_local_source_path(_source) &&
+              !actual_partial_supported) {
+            *active_guard_actual_partial_supported = false;
+          }
+          emit_subtree_memo_token = actual_partial_supported &&
+              guard->emits_actual_partial_subtree_memo_token();
         } else {
           emit_subtree_memo_token =
               guard->emits_subtree_memo_token_for_frame_locals();
         }
         if (emit_subtree_memo_token) {
-          result = guard->append_subtree_memo_token(
-              value, active_guard_subtree_memo_recorder);
+          if constexpr (std::is_same_v<T, PyObject>) {
+            result = guard->append_actual_partial_subtree_memo_token(
+                value, active_guard_subtree_memo_recorder);
+          } else {
+            result = guard->append_subtree_memo_token(
+                value, active_guard_subtree_memo_recorder);
+          }
         } else {
           result = guard->check_nopybind(value);
         }
@@ -5584,16 +6087,20 @@ class RootGuardManager : public GuardManager {
   }
 
   // Fast check function.
-  template <typename T>
+  template <bool HasActualPartial = false, typename T>
   bool check_nopybind_template(
       T* value,
-      const std::string* skip_accessor_source = nullptr) { // borrowed ref
+      const std::string* skip_accessor_source = nullptr,
+      const GuardLastSuccessPartialPlan* actual_partial_plan = nullptr,
+      bool* actual_partial_token_miss = nullptr) { // borrowed ref
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions with GIL.
     PyThreadState* _save = nullptr;
     Py_UNBLOCK_THREADS; // ; is added to avoid clang-formatting
     std::lock_guard<std::mutex> lock_guard(_lock);
     Py_BLOCK_THREADS; // ; is added to avoid clang-formatting
+    auto relational_guard_state_reset =
+        c10::make_scope_exit([this]() { _reset_relational_guard_state(); });
 
     // Clean up dict pointer recording for tag safe roots
     reset_dict_tag_recording_variables();
@@ -5604,8 +6111,30 @@ class RootGuardManager : public GuardManager {
       _local_state = state;
     }
 
+    if constexpr (HasActualPartial) {
+      if (actual_partial_plan == nullptr ||
+          actual_partial_token_miss == nullptr) {
+        return false;
+      }
+      *actual_partial_token_miss = false;
+      if (!guard_last_success_actual_partial_tokens_match(
+              *actual_partial_plan, value, &_local_state)) {
+        *actual_partial_token_miss = true;
+        return false;
+      }
+      for (const auto& relation :
+           actual_partial_plan->cross_slice_relations) {
+        auto* guard = static_cast<RelationalGuard*>(
+            const_cast<void*>(relation.guard));
+        if (guard == nullptr ||
+            !guard->preload_actual_partial_relation(relation)) {
+          *actual_partial_token_miss = true;
+          return false;
+        }
+      }
+    }
+
     if (!GuardManager::check_leaf_guards_nopybind(value)) {
-      _reset_relational_guard_state();
       return false;
     }
 
@@ -5618,28 +6147,37 @@ class RootGuardManager : public GuardManager {
         at::impl::PythonTorchFunctionTLS::get_disabled_state();
     at::impl::PythonTorchFunctionTLS::set_disabled_state(
         at::impl::TorchFunctionDisabledState::ALL_DISABLED);
+    auto torch_function_state_reset = c10::make_scope_exit([old_state]() {
+      at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+    });
 
     const bool accessor_result = skip_accessor_source == nullptr
         ? GuardManager::check_accessors_nopybind(value)
         : GuardManager::check_accessors_nopybind_skipping_source(
               value, *skip_accessor_source);
     if (!accessor_result) {
-      at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
-      _reset_relational_guard_state();
       return false;
     }
 
     // Iterate over epilogue leaf guards.
     for (const auto& guard : _epilogue_lambda_guards) {
       if (!guard->check_nopybind(value)) { // early exit
-        at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
-        _reset_relational_guard_state();
         return false;
       }
     }
 
-    at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
-    _reset_relational_guard_state();
+    if constexpr (HasActualPartial) {
+      for (const auto& relation :
+           actual_partial_plan->cross_slice_relations) {
+        auto* guard = static_cast<RelationalGuard*>(
+            const_cast<void*>(relation.guard));
+        if (guard == nullptr ||
+            !guard->actual_partial_relation_is_complete(relation)) {
+          *actual_partial_token_miss = true;
+          return false;
+        }
+      }
+    }
     return true;
   }
 
@@ -5655,6 +6193,15 @@ class RootGuardManager : public GuardManager {
       FrameLocalsMapping* value,
       const std::string& skip_accessor_source) {
     return check_nopybind_template(value, &skip_accessor_source);
+  }
+
+  bool check_nopybind_actual_partial(
+      FrameLocalsMapping* value,
+      const std::string& skip_accessor_source,
+      const GuardLastSuccessPartialPlan& plan,
+      bool& token_miss) {
+    return check_nopybind_template<true>(
+        value, &skip_accessor_source, &plan, &token_miss);
   }
 
   bool supports_subtree_memo_recursive() const override {
@@ -7096,8 +7643,13 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
     if (matches_dict_tag && _is_immutable_object && !_is_tensor &&
+        active_guard_subtree_memo_recorder == nullptr &&
+        !_guard_manager->has_object_aliasing_guard() &&
+        !_guard_manager->has_no_tensor_aliasing_guard() &&
         !is_recording_dict_pointers(get_guard_manager()->get_root()) &&
         _guard_manager->has_no_accessors()) {
+      // Relational guards must observe every operand even when a matching
+      // dict tag proves the immutable value itself did not change.
       return true;
     }
 
@@ -8983,11 +9535,15 @@ bool run_root_guard_manager_with_last_success_receipt(
   static const std::string self_source = "L['self']";
 
   if (state->actual_partial.is_enabled_for(entry_key, root)) {
-    if (guard_last_success_actual_partial_tokens_match(
-            state->actual_partial, f_locals)) {
-      return root_mgr->check_nopybind_skipping_source(f_locals, self_source);
+    bool token_miss = false;
+    const bool result = root_mgr->check_nopybind_actual_partial(
+        f_locals, self_source, state->actual_partial, token_miss);
+    if (!token_miss) {
+      return result;
     }
-    state->actual_partial.reset();
+    // This input does not invalidate the plan owned by this cache entry. A
+    // later lookup may still match it, so fall back without destroying it.
+    return run_root_guard_manager(root, f_locals);
   }
 
   if (!state->actual_partial.should_train()) {
@@ -8995,7 +9551,7 @@ bool run_root_guard_manager_with_last_success_receipt(
   }
 
   int self_framelocals_index = -1;
-  if (!root_mgr->supports_accessor_subtree_memo_recursive(
+  if (!root_mgr->supports_actual_partial_accessor_subtree_memo_recursive(
           self_source, &self_framelocals_index)) {
     state->actual_partial.disable();
     return run_root_guard_manager(root, f_locals);
@@ -9003,12 +9559,20 @@ bool run_root_guard_manager_with_last_success_receipt(
 
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<std::string> debug_paths;
+  bool actual_partial_supported = true;
   {
-    GuardSubtreeMemoRecorderScope recorder(&tokens, &debug_paths);
+    GuardSubtreeMemoRecorderScope recorder(
+        &tokens, &debug_paths, &actual_partial_supported);
     if (!run_root_guard_manager(root, f_locals)) {
-      state->reset();
+      // Cache lookup probes entries that commonly do not own the current
+      // input. Keep this entry's plan and training state on a probe miss.
       return false;
     }
+  }
+
+  if (!actual_partial_supported) {
+    state->actual_partial.disable();
+    return true;
   }
 
   if (tokens.empty() || debug_paths.size() != tokens.size() ||
@@ -9034,7 +9598,10 @@ bool run_root_guard_manager_with_last_success_receipt(
       entry_key,
       root,
       std::move(build.stability_tokens),
-      std::move(build.hot_tokens));
+      std::move(build.hot_tokens),
+      std::move(build.type_proofs),
+      std::move(build.cross_slice_relations),
+      std::move(build.retained_token_objects));
   return true;
 }
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -157,9 +157,16 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
 };
 
 constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
+constexpr size_t kGuardLastSuccessActualMaxAccessorRecords = 65536;
+constexpr size_t kGuardLastSuccessActualMaxListItemsPerToken = 4096;
+constexpr size_t kGuardLastSuccessActualMaxRetainedListItems = 65536;
 constexpr uint64_t kGuardLastSuccessActualStablePasses = 3;
+constexpr uint64_t kGuardLastSuccessActualMaxUnstablePasses = 8;
 
 } // namespace
+
+thread_local bool* active_guard_actual_partial_supported = nullptr;
+thread_local size_t active_guard_actual_partial_list_items = 0;
 
 static bool source_ends_with(
     const std::string& source,
@@ -1262,9 +1269,14 @@ struct GuardSubtreeEntryToken {
     } else if (PyList_CheckExact(obj)) {
       token.kind = GuardSubtreeProbeTokenKind::ExactList;
       token.size = PyList_GET_SIZE(obj);
-      token.list_items.reserve(static_cast<size_t>(token.size));
-      for (Py_ssize_t i = 0; i < token.size; ++i) {
-        token.list_items.push_back(PyList_GET_ITEM(obj, i));
+      const size_t list_size = static_cast<size_t>(token.size);
+      bool capture_items = active_guard_actual_partial_supported == nullptr &&
+          list_size <= kGuardLastSuccessActualMaxListItemsPerToken;
+      if (capture_items) {
+        token.list_items.reserve(static_cast<size_t>(token.size));
+        for (Py_ssize_t i = 0; i < token.size; ++i) {
+          token.list_items.push_back(PyList_GET_ITEM(obj, i));
+        }
       }
     } else if (PyTuple_CheckExact(obj)) {
       token.kind = GuardSubtreeProbeTokenKind::ExactTuple;
@@ -1797,12 +1809,12 @@ static bool guard_last_success_add_type_proof(
   return true;
 }
 
-static void guard_last_success_retain_token_objects(
+static bool guard_last_success_retain_token_objects(
     const std::vector<GuardSubtreeEntryToken>& partial_tokens,
     std::vector<py::object>& retained_token_objects) {
   retained_token_objects.clear();
   if (partial_tokens.empty()) {
-    return;
+    return true;
   }
   PyObject* current_self = partial_tokens.front().object;
   std::unordered_set<PyObject*> retained;
@@ -1813,6 +1825,7 @@ static void guard_last_success_retain_token_objects(
           py::reinterpret_borrow<py::object>(object));
     }
   };
+  size_t retained_list_items = 0;
   for (size_t i = 1; i < partial_tokens.size(); ++i) {
     const auto& token = partial_tokens[i];
     if (token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
@@ -1821,8 +1834,24 @@ static void guard_last_success_retain_token_objects(
       retain(reinterpret_cast<PyObject*>(token.bound_c_method_class));
     } else {
       retain(token.object);
+      if (token.kind == GuardSubtreeProbeTokenKind::ExactList) {
+        if (token.size < 0 ||
+            static_cast<size_t>(token.size) != token.list_items.size() ||
+            token.list_items.size() >
+                kGuardLastSuccessActualMaxListItemsPerToken ||
+            retained_list_items > kGuardLastSuccessActualMaxRetainedListItems -
+                    token.list_items.size()) {
+          retained_token_objects.clear();
+          return false;
+        }
+        retained_list_items += token.list_items.size();
+        for (PyObject* item : token.list_items) {
+          retain(item);
+        }
+      }
     }
   }
+  return true;
 }
 
 static bool guard_last_success_build_partial_plan_tokens(
@@ -1859,9 +1888,8 @@ static bool guard_last_success_build_partial_plan_tokens(
       return false;
     }
   }
-  guard_last_success_retain_token_objects(
+  return guard_last_success_retain_token_objects(
       partial_tokens, retained_token_objects);
-  return true;
 }
 
 static bool guard_last_success_build_accessor_proofs(
@@ -1966,6 +1994,7 @@ struct GuardLastSuccessPartialPlan {
     root_key = nullptr;
 
     stable_passes = 0;
+    unstable_passes = 0;
     self_weakref = py::object();
     self_type = nullptr;
     self_framelocals_index = -1;
@@ -2004,13 +2033,24 @@ struct GuardLastSuccessPartialPlan {
           new_instance_attr_owner_proofs,
       std::vector<GuardCrossSliceRelationPlan>&& new_cross_slice_relations,
       std::vector<py::object>&& new_retained_token_objects) {
-    const bool stable = entry_key == new_entry_key &&
-        root_key == new_root_key && !stability_tokens.empty() &&
+    const bool same_entry =
+        entry_key == new_entry_key && root_key == new_root_key;
+    const bool has_training_signature = same_entry && !stability_tokens.empty();
+    const bool stable = has_training_signature &&
         guard_subtree_token_vectors_match(
-            new_stability_tokens, stability_tokens);
+                            new_stability_tokens, stability_tokens);
     if (stable) {
       stable_passes += 1;
     } else {
+      if (has_training_signature) {
+        unstable_passes += 1;
+        if (unstable_passes >= kGuardLastSuccessActualMaxUnstablePasses) {
+          disable();
+          return false;
+        }
+      } else {
+        unstable_passes = 0;
+      }
       entry_key = new_entry_key;
       root_key = new_root_key;
       stability_tokens = std::move(new_stability_tokens);
@@ -2026,6 +2066,7 @@ struct GuardLastSuccessPartialPlan {
     if (state != GuardLastSuccessPartialPlanState::Enabled &&
         stable_passes >= kGuardLastSuccessActualStablePasses) {
       state = GuardLastSuccessPartialPlanState::Enabled;
+      unstable_passes = 0;
       return true;
     }
     return false;
@@ -2036,6 +2077,7 @@ struct GuardLastSuccessPartialPlan {
   void* entry_key{nullptr};
   void* root_key{nullptr};
   uint64_t stable_passes{0};
+  uint64_t unstable_passes{0};
   py::object self_weakref;
   PyTypeObject* self_type{nullptr};
   int self_framelocals_index{-1};
@@ -2275,6 +2317,9 @@ static bool guard_last_success_prepare_actual_partial(
     const std::vector<std::string>& debug_paths,
     const std::vector<GuardActualPartialAccessorRecord>& accessor_records,
     GuardLastSuccessPartialPlanBuild& build) {
+  if (accessor_records.size() > kGuardLastSuccessActualMaxAccessorRecords) {
+    return false;
+  }
   std::vector<GuardSubtreeEntryToken> partial_tokens;
   if (!guard_last_success_extract_self_partial_tokens(
           tokens, debug_paths, partial_tokens)) {
@@ -2373,7 +2418,6 @@ thread_local std::vector<GuardSubtreeEntryToken>*
 thread_local std::vector<std::string>*
     active_guard_subtree_memo_debug_paths = nullptr;
 thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
-thread_local bool* active_guard_actual_partial_supported = nullptr;
 thread_local std::vector<GuardActualPartialAccessorRecord>*
     active_guard_actual_partial_accessor_records = nullptr;
 
@@ -2383,12 +2427,26 @@ static void guard_actual_partial_mark_unsupported() {
   }
 }
 
+static bool guard_actual_partial_can_record_accessor() {
+  if (active_guard_actual_partial_accessor_records == nullptr) {
+    return false;
+  }
+  if ((active_guard_actual_partial_supported != nullptr &&
+       !*active_guard_actual_partial_supported) ||
+      active_guard_actual_partial_accessor_records->size() >=
+          kGuardLastSuccessActualMaxAccessorRecords) {
+    guard_actual_partial_mark_unsupported();
+    return false;
+  }
+  return true;
+}
+
 static void guard_actual_partial_record_generic_dict_binding(
     PyObject* owner,
     PyObject* dict,
     const std::string& source) {
-  if (active_guard_actual_partial_accessor_records == nullptr ||
-      !is_self_local_source_path(source)) {
+  if (!is_self_local_source_path(source) ||
+      !guard_actual_partial_can_record_accessor()) {
     return;
   }
   PyObject** dictptr = owner == nullptr ? nullptr : _PyObject_GetDictPtr(owner);
@@ -2411,8 +2469,8 @@ static void guard_actual_partial_record_instance_attr_binding(
     PyObject* expected,
     const std::string& source,
     bool require_default_getattribute) {
-  if (active_guard_actual_partial_accessor_records == nullptr ||
-      !is_self_local_source_path(source)) {
+  if (!is_self_local_source_path(source) ||
+      !guard_actual_partial_can_record_accessor()) {
     return;
   }
   if (owner == nullptr || key == nullptr || expected == nullptr ||
@@ -2455,12 +2513,15 @@ struct GuardSubtreeMemoRecorderScope {
         previous_accessor_records(active_guard_actual_partial_accessor_records),
         previous_actual_partial_supported(
             active_guard_actual_partial_supported),
+        previous_actual_partial_list_items(
+            active_guard_actual_partial_list_items),
         previous_relax_global_dicts(
             active_guard_subtree_memo_relax_global_dicts) {
     active_guard_subtree_memo_recorder = tokens;
     active_guard_subtree_memo_debug_paths = debug_paths;
     active_guard_actual_partial_accessor_records = accessor_records;
     active_guard_actual_partial_supported = actual_partial_supported;
+    active_guard_actual_partial_list_items = 0;
     active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
   }
 
@@ -2469,6 +2530,7 @@ struct GuardSubtreeMemoRecorderScope {
     active_guard_subtree_memo_debug_paths = previous_debug_paths;
     active_guard_actual_partial_accessor_records = previous_accessor_records;
     active_guard_actual_partial_supported = previous_actual_partial_supported;
+    active_guard_actual_partial_list_items = previous_actual_partial_list_items;
     active_guard_subtree_memo_relax_global_dicts =
         previous_relax_global_dicts;
   }
@@ -2478,6 +2540,7 @@ struct GuardSubtreeMemoRecorderScope {
   std::vector<GuardActualPartialAccessorRecord>* previous_accessor_records{
       nullptr};
   bool* previous_actual_partial_supported{nullptr};
+  size_t previous_actual_partial_list_items{0};
   bool previous_relax_global_dicts{false};
 };
 
@@ -2485,6 +2548,28 @@ static void append_guard_subtree_memo_token(
     std::vector<GuardSubtreeEntryToken>* tokens,
     GuardSubtreeEntryToken&& token,
     const std::string& debug_path) {
+  if (active_guard_actual_partial_supported != nullptr &&
+      (!*active_guard_actual_partial_supported ||
+       tokens->size() >= kGuardLastSuccessActualMaxTokens)) {
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  if (active_guard_actual_partial_supported != nullptr &&
+      token.kind == GuardSubtreeProbeTokenKind::ExactList &&
+      is_self_local_source_path(debug_path)) {
+    const size_t list_size = static_cast<size_t>(token.size);
+    if (list_size > kGuardLastSuccessActualMaxListItemsPerToken ||
+        active_guard_actual_partial_list_items >
+            kGuardLastSuccessActualMaxRetainedListItems - list_size) {
+      guard_actual_partial_mark_unsupported();
+      return;
+    }
+    token.list_items.reserve(list_size);
+    for (Py_ssize_t i = 0; i < token.size; ++i) {
+      token.list_items.push_back(PyList_GET_ITEM(token.object, i));
+    }
+    active_guard_actual_partial_list_items += list_size;
+  }
   tokens->emplace_back(std::move(token));
   if (active_guard_subtree_memo_debug_paths != nullptr) {
     active_guard_subtree_memo_debug_paths->push_back(debug_path);
@@ -9926,7 +10011,14 @@ bool root_guard_manager_has_no_guards(void* root) {
 
 
 void* create_guard_last_success_receipt() {
+#ifdef Py_GIL_DISABLED
+  // The plan stores Python-owned state and relies on serialized guard
+  // evaluation. Keep free-threaded builds on the original guard path until
+  // that ownership and synchronization contract is made explicit.
+  return nullptr;
+#else
   return new GuardLastSuccessReceipt();
+#endif
 }
 
 void destroy_guard_last_success_receipt(void* receipt) {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/inductor/inductor_ops.h>
@@ -42,12 +43,18 @@
 #include <ATen/native/mtia/EmptyTensor.h>
 #endif
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <cstring>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 // Uncomment next line to count instructions for guard eval.
 // #define GUARD_INSTRUCTION_COUNT
@@ -129,6 +136,45 @@ typedef struct {
 
 namespace torch::dynamo {
 
+namespace {
+
+enum class GuardSubtreeProbeTokenKind : uint8_t {
+  ObjectOnly,
+  ExactDict,
+  ExactList,
+  ExactTuple,
+  TensorMatch,
+  DefaultDevice,
+  GlobalState,
+  TorchFunctionModeStack,
+  NoTensorAliasing,
+  ObjectAliasing,
+  BoundMethod,
+  FrameGlobals,
+};
+
+constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
+constexpr uint64_t kGuardLastSuccessActualStablePasses = 3;
+
+} // namespace
+
+static bool source_ends_with(
+    const std::string& source,
+    const char* suffix) {
+  const size_t suffix_len = std::strlen(suffix);
+  return source.size() >= suffix_len &&
+      source.compare(source.size() - suffix_len, suffix_len, suffix) == 0;
+}
+
+static bool tensor_match_source_supports_subtree_memo(
+    const std::string& source) {
+  return source.find("._parameters[") != std::string::npos ||
+      source.find("._buffers[") != std::string::npos ||
+      source_ends_with(source, "._cached_tensor") ||
+      (source.find("L['self']._modules[") != std::string::npos &&
+       source_ends_with(source, ".scale"));
+}
+
 thread_local bool tls_is_in_mode_without_ignore_compile_internals = false;
 
 void set_is_in_mode_without_ignore_compile_internals(bool value) {
@@ -198,6 +244,7 @@ TensorCheck::TensorCheck(
 TensorCheck::TensorCheck(
     const LocalState& state,
     PyTypeObject* pt,
+
     c10::DispatchKeySet dispatch_key_set,
     at::ScalarType dtype,
     at::DeviceIndex device_index,
@@ -219,6 +266,7 @@ bool TensorCheck::check(const LocalState& state, const at::Tensor& v) {
   // In terms of a sparse_csr tensor, it does not support strides information
   c10::SymIntArrayRef sym_strides(std::vector<SymInt>(v.ndimension(), -1));
   bool does_not_support_stride = v.layout() == c10::kSparseCsr ||
+
       v.layout() == c10::kSparseCsc || v.layout() == c10::kSparseBsc ||
       v.layout() == c10::kSparseBsr;
   if (!does_not_support_stride) {
@@ -492,6 +540,7 @@ PyObject* TensorGuards_check(
   // Note - all the tensors that make it to guards must be unique. Dynamo
   // builder handles guarding for positive aliases (X is Y). However, we do not
   // create guards for negative alias (X is not Y) as that is an N^2
+
   // relationship. Instead, we rely on the uniqueness upstream to verify, at
   // check_fn time (this function).
   ska::flat_hash_map<PyObject*, std::nullptr_t> unique_tensors;
@@ -512,6 +561,7 @@ PyObject* TensorGuards_check(
   }
 
   Py_RETURN_TRUE;
+
 }
 
 PyObject* TensorGuards_check_verbose(
@@ -805,6 +855,7 @@ int GlobalStateGuard_init(
     PyObject* args,
     PyObject* kwargs) {
   self->init();
+
   return 0;
 }
 
@@ -824,6 +875,7 @@ PyObject* GlobalStateGuard_reason(
     PyObject* args,
     PyObject* kwargs) {
   return PyUnicode_FromString(self->reason().c_str());
+
 }
 
 PyObject* GlobalStateGuard_dump(
@@ -944,6 +996,947 @@ static uint64_t get_dict_version_unchecked(PyObject* dict) {
 #endif
 }
 
+static bool tensor_layout_does_not_support_stride(const at::Tensor& tensor) {
+  return tensor.layout() == c10::kSparseCsr ||
+      tensor.layout() == c10::kSparseCsc ||
+      tensor.layout() == c10::kSparseBsc ||
+      tensor.layout() == c10::kSparseBsr;
+}
+
+static bool tensor_strides_match_guard_check(
+    const at::Tensor& tensor,
+    const std::vector<int64_t>& stride_indices,
+    const std::vector<c10::SymInt>& stride_values) {
+  if (stride_indices.size() != stride_values.size()) {
+    return false;
+  }
+  if (tensor_layout_does_not_support_stride(tensor)) {
+    const int64_t ndim = tensor.ndimension();
+    const c10::SymInt unsupported_stride(static_cast<int64_t>(-1));
+    for (auto i : c10::irange(stride_indices.size())) {
+      const int64_t index = stride_indices[i];
+      if (index < 0 || index >= ndim ||
+          stride_values[i] != unsupported_stride) {
+        return false;
+      }
+    }
+    return true;
+  }
+  const auto current_strides = tensor.sym_strides();
+  for (auto i : c10::irange(stride_indices.size())) {
+    const int64_t index = stride_indices[i];
+    if (index < 0 || index >= static_cast<int64_t>(current_strides.size()) ||
+        stride_values[i] != current_strides[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static PyObject* current_device_key() {
+  static PyObject* key = PyUnicode_InternFromString("CURRENT_DEVICE");
+  return key;
+}
+
+static bool default_device_matches(
+    PyObject* utils_device_dict,
+    PyObject* expected) {
+  if (utils_device_dict == nullptr || expected == nullptr) {
+    return false;
+  }
+  PyObject* key = current_device_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  PyObject* device = PyDict_GetItem(utils_device_dict, key);
+  if (device == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  if (device == expected) {
+    return true;
+  }
+  const int result = PyObject_RichCompareBool(device, expected, Py_EQ);
+  if (result == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  return result == 1;
+}
+
+static bool torch_function_mode_stack_guard_matches(const void* guard);
+
+static bool is_global_source_path(const std::string& source) {
+  return source == "G" ||
+      (source.size() > 1 && source[0] == 'G' &&
+       (source[1] == '[' || source[1] == '.'));
+}
+
+struct GuardSubtreeEntryToken {
+  PyObject* object{nullptr};
+  PyTypeObject* type{nullptr};
+  GuardSubtreeProbeTokenKind kind{GuardSubtreeProbeTokenKind::ObjectOnly};
+  uint64_t version{0};
+  Py_ssize_t size{0};
+  std::vector<PyObject*> list_items;
+  uint64_t tensor_dispatch_key{0};
+  at::ScalarType tensor_dtype{at::ScalarType::Undefined};
+  c10::DeviceIndex tensor_device_index{-1};
+  bool tensor_requires_grad{false};
+  int64_t tensor_dim{0};
+  std::vector<int64_t> tensor_size_indices;
+  std::vector<c10::SymInt> tensor_size_values;
+  std::vector<int64_t> tensor_stride_indices;
+  std::vector<c10::SymInt> tensor_stride_values;
+  PyObject* default_device_dict{nullptr};
+  PyObject* default_device{nullptr};
+  GlobalStateGuard* global_state_guard{nullptr};
+  const void* torch_function_mode_stack_guard{nullptr};
+  const void* no_tensor_aliasing_guard{nullptr};
+  const void* object_aliasing_guard{nullptr};
+  PyObject* bound_method_self{nullptr};
+  PyObject* bound_method_func{nullptr};
+  PyCFunction bound_c_method_func{nullptr};
+  PyTypeObject* bound_c_method_class{nullptr};
+  int bound_c_method_flags{0};
+
+  static GuardSubtreeEntryToken make(PyObject* obj) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    if (PyMethod_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyMethod_GET_SELF(obj);
+      token.bound_method_func = PyMethod_GET_FUNCTION(obj);
+    } else if (PyCFunction_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyCFunction_GET_SELF(obj);
+      token.bound_c_method_func = PyCFunction_GET_FUNCTION(obj);
+      token.bound_c_method_flags = PyCFunction_GET_FLAGS(obj);
+#ifdef PyCFunction_GET_CLASS
+      token.bound_c_method_class = PyCFunction_GET_CLASS(obj);
+#endif
+    } else if (PyDict_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactDict;
+      token.version = get_dict_version_unchecked(obj);
+      token.size = PyDict_GET_SIZE(obj);
+    } else if (PyList_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactList;
+      token.size = PyList_GET_SIZE(obj);
+      token.list_items.reserve(static_cast<size_t>(token.size));
+      for (Py_ssize_t i = 0; i < token.size; ++i) {
+        token.list_items.push_back(PyList_GET_ITEM(obj, i));
+      }
+    } else if (PyTuple_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactTuple;
+      token.size = PyTuple_GET_SIZE(obj);
+    }
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_for_source(
+      PyObject* obj,
+      const std::string& source) {
+    if (is_global_source_path(source) && PyDict_CheckExact(obj)) {
+      GuardSubtreeEntryToken token;
+      token.object = obj;
+      token.type = Py_TYPE(obj);
+      token.kind = GuardSubtreeProbeTokenKind::FrameGlobals;
+      return token;
+    }
+    return make(obj);
+  }
+
+  static bool make_tensor_match(
+      PyObject* obj,
+      TensorCheck& tensor_check,
+      const LocalState& state,
+      GuardSubtreeEntryToken* token) {
+    if (Py_TYPE(obj) != tensor_check.pytype) {
+      return false;
+    }
+    if (!THPVariable_CheckExact(obj) && !THPVariable_Check(obj)) {
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(obj);
+    if (!tensor_check.check(state, tensor)) {
+      return false;
+    }
+
+    token->object = obj;
+
+    token->type = Py_TYPE(obj);
+    token->kind = GuardSubtreeProbeTokenKind::TensorMatch;
+    token->tensor_dispatch_key = state.apply(tensor.key_set()).raw_repr();
+    token->tensor_dtype = tensor.dtype().toScalarType();
+    token->tensor_device_index = tensor.device().index();
+    token->tensor_requires_grad = tensor.requires_grad();
+    token->tensor_dim = tensor.ndimension();
+
+    const auto& expected_sizes = tensor_check.sizes();
+    token->tensor_size_indices.reserve(expected_sizes.size());
+    token->tensor_size_values.reserve(expected_sizes.size());
+    for (auto i : c10::irange(expected_sizes.size())) {
+      const auto& expected_size = expected_sizes[i];
+      if (expected_size.has_value()) {
+        // Dynamic dimensions are represented as nullopt by TensorCheck and are
+        // deliberately not tokenized. Fast-path tensor tokens must not make a
+        // dynamic dimension more static than the original guard.
+        token->tensor_size_indices.push_back(static_cast<int64_t>(i));
+
+        token->tensor_size_values.push_back(expected_size.value());
+      }
+    }
+
+    const auto& expected_strides = tensor_check.strides();
+    token->tensor_stride_indices.reserve(expected_strides.size());
+    token->tensor_stride_values.reserve(expected_strides.size());
+    for (auto i : c10::irange(expected_strides.size())) {
+      const auto& expected_stride = expected_strides[i];
+      if (expected_stride.has_value()) {
+        // Same rule as sizes: only original static stride guards become token
+        // checks; dynamic stride entries stay unchecked here.
+        token->tensor_stride_indices.push_back(static_cast<int64_t>(i));
+        token->tensor_stride_values.push_back(expected_stride.value());
+      }
+    }
+    return true;
+  }
+
+  static GuardSubtreeEntryToken make_default_device(
+      PyObject* utils_device_dict,
+      PyObject* device) {
+    GuardSubtreeEntryToken token;
+    token.object = utils_device_dict;
+    token.type = Py_TYPE(utils_device_dict);
+    token.kind = GuardSubtreeProbeTokenKind::DefaultDevice;
+    token.default_device_dict = utils_device_dict;
+    token.default_device = device;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_global_state(GlobalStateGuard* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::GlobalState;
+    token.global_state_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_torch_function_mode_stack(
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::TorchFunctionModeStack;
+    token.torch_function_mode_stack_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_no_tensor_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::NoTensorAliasing;
+    token.no_tensor_aliasing_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_object_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::ObjectAliasing;
+    token.object_aliasing_guard = guard;
+    return token;
+  }
+
+  bool matches_tensor_current(const LocalState* state) const {
+    if (state == nullptr) {
+      return false;
+    }
+    if (object == nullptr) {
+      return false;
+    }
+    if (Py_TYPE(object) != type) {
+      return false;
+    }
+    if (!THPVariable_CheckExact(object) && !THPVariable_Check(object)) {
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(object);
+    if (state->apply(tensor.key_set()).raw_repr() != tensor_dispatch_key) {
+      return false;
+    }
+    if (tensor.dtype().toScalarType() != tensor_dtype) {
+      return false;
+    }
+    if (tensor.device().index() != tensor_device_index) {
+      return false;
+    }
+    if (tensor.requires_grad() != tensor_requires_grad) {
+      return false;
+    }
+    if (tensor.ndimension() != tensor_dim) {
+      return false;
+    }
+
+    const auto current_sizes = tensor.sym_sizes();
+    for (auto i : c10::irange(tensor_size_indices.size())) {
+      const int64_t index = tensor_size_indices[i];
+      if (index < 0 || index >= static_cast<int64_t>(current_sizes.size()) ||
+          tensor_size_values[i] != current_sizes[index]) {
+        return false;
+      }
+    }
+
+    if (!tensor_strides_match_guard_check(
+            tensor, tensor_stride_indices, tensor_stride_values)) {
+      return false;
+    }
+    return true;
+  }
+
+  bool matches_default_device_current() const {
+    return default_device_matches(default_device_dict, default_device);
+  }
+
+  bool matches_global_state_current() const {
+    return global_state_guard != nullptr && global_state_guard->check();
+  }
+
+  bool matches(const GuardSubtreeEntryToken& other) const {
+    if (kind != other.kind || type != other.type) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      return bound_method_self == other.bound_method_self &&
+          bound_method_func == other.bound_method_func &&
+          bound_c_method_func == other.bound_c_method_func &&
+          bound_c_method_class == other.bound_c_method_class &&
+          bound_c_method_flags == other.bound_c_method_flags;
+    }
+    if (object != other.object) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      return true;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      return tensor_dispatch_key == other.tensor_dispatch_key &&
+          tensor_dtype == other.tensor_dtype &&
+          tensor_device_index == other.tensor_device_index &&
+          tensor_requires_grad == other.tensor_requires_grad &&
+          tensor_dim == other.tensor_dim &&
+          tensor_size_indices == other.tensor_size_indices &&
+          tensor_size_values == other.tensor_size_values &&
+          tensor_stride_indices == other.tensor_stride_indices &&
+          tensor_stride_values == other.tensor_stride_values;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+      return default_device_dict == other.default_device_dict &&
+          default_device == other.default_device;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::GlobalState) {
+      return global_state_guard == other.global_state_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      return torch_function_mode_stack_guard ==
+          other.torch_function_mode_stack_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+      return no_tensor_aliasing_guard == other.no_tensor_aliasing_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+      return object_aliasing_guard == other.object_aliasing_guard;
+    }
+    return version == other.version && size == other.size &&
+        list_items == other.list_items;
+  }
+};
+
+static bool guard_subtree_token_vectors_match(
+    const std::vector<GuardSubtreeEntryToken>& lhs,
+    const std::vector<GuardSubtreeEntryToken>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!lhs[i].matches(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+enum class GuardLastSuccessPartialTokenDecision : uint8_t {
+  Keep,
+  DropReachabilityOnly,
+  UnsupportedBail,
+
+};
+
+static GuardLastSuccessPartialTokenDecision
+guard_last_success_partial_token_decision(
+    const GuardSubtreeEntryToken& token,
+    size_t index) {
+  if (index == 0) {
+    return GuardLastSuccessPartialTokenDecision::Keep;
+  }
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      // Parent container tokens prove whether this object is still reachable.
+      // Dropping this token is safe only for reachability-only objects: any
+      // semantic guard attached to the object must emit its own token or force
+      // the partial plan to bail.
+      return GuardLastSuccessPartialTokenDecision::DropReachabilityOnly;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      // Keep bound methods as hot tokens. A stored bound method is protected by
+      // its parent structural token; the runtime matcher validates the bound
+      // target payload without dereferencing the possibly short-lived method
+      // wrapper.
+      return GuardLastSuccessPartialTokenDecision::Keep;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+    case GuardSubtreeProbeTokenKind::GlobalState:
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      // These tokens are valid in the full slow receipt, but the partial fast
+      // path has no local proof that dropping them preserves guard semantics.
+      // Conservatively disable the partial plan instead of silently filtering
+      // them out and later reporting a fast hit.
+      return GuardLastSuccessPartialTokenDecision::UnsupportedBail;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      // Relational guard tokens are part of the measured hot path. They are
+      // safe only if kept as hot tokens: dropping them would silently skip the
+      // relation, while keeping them lets container tokens prove rebinding did
+      // not happen and the token matcher verify the guarded objects/types.
+      return GuardLastSuccessPartialTokenDecision::Keep;
+    default:
+      return GuardLastSuccessPartialTokenDecision::Keep;
+  }
+}
+
+static bool guard_last_success_make_partial_hot_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    std::vector<GuardSubtreeEntryToken>& hot_tokens) {
+  hot_tokens.clear();
+  hot_tokens.reserve(tokens.size());
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    switch (guard_last_success_partial_token_decision(tokens[i], i)) {
+      case GuardLastSuccessPartialTokenDecision::Keep:
+        hot_tokens.push_back(tokens[i]);
+        break;
+      case GuardLastSuccessPartialTokenDecision::DropReachabilityOnly:
+        break;
+      case GuardLastSuccessPartialTokenDecision::UnsupportedBail:
+        return false;
+    }
+  }
+  return true;
+}
+
+extern thread_local const LocalState* active_guard_local_state;
+
+static bool guard_subtree_tensor_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  return token.matches_tensor_current(active_guard_local_state);
+}
+
+static bool guard_subtree_special_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      return token.matches_default_device_current();
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      return token.matches_global_state_current();
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      return torch_function_mode_stack_guard_matches(
+          token.torch_function_mode_stack_guard);
+    default:
+      return false;
+  }
+}
+
+static bool guard_subtree_token_is_aliasing_guard(
+    GuardSubtreeProbeTokenKind kind) {
+
+  return kind == GuardSubtreeProbeTokenKind::NoTensorAliasing ||
+      kind == GuardSubtreeProbeTokenKind::ObjectAliasing;
+}
+
+static bool guard_subtree_token_proves_child_reachability(
+    const GuardSubtreeEntryToken& token) {
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+    case GuardSubtreeProbeTokenKind::ExactDict:
+    case GuardSubtreeProbeTokenKind::ExactList:
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      return token.object != nullptr;
+    default:
+      return false;
+  }
+}
+
+static bool guard_subtree_aliasing_tokens_have_reachability_proof(
+    const std::vector<GuardSubtreeEntryToken>& tokens) {
+  bool saw_reachability_proof = false;
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    if (guard_subtree_token_proves_child_reachability(token)) {
+      saw_reachability_proof = true;
+    }
+    if (!guard_subtree_token_is_aliasing_guard(token.kind)) {
+      continue;
+    }
+    if (!saw_reachability_proof || token.object == nullptr ||
+        token.type == nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_last_success_build_partial_plan_tokens(
+    const std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::vector<GuardSubtreeEntryToken>& stability_tokens,
+    std::vector<GuardSubtreeEntryToken>& hot_tokens) {
+  stability_tokens = partial_tokens;
+  if (!guard_subtree_aliasing_tokens_have_reachability_proof(partial_tokens)) {
+    return false;
+  }
+  return guard_last_success_make_partial_hot_tokens(partial_tokens, hot_tokens);
+}
+
+static bool guard_subtree_aliasing_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  // Relational guards are fully evaluated during the slow receipt pass before
+  // a partial plan is trained. Rechecking the recorded relation among immutable
+  // receipt tokens would be tautological; the live runtime check here is that
+  // the recorded alias operand is still the same object/type. Actual-partial
+  // plan construction applies an additional conservative reachability gate
+    // before these tokens are admitted.
+  return token.object != nullptr && token.type != nullptr &&
+      Py_TYPE(token.object) == token.type;
+}
+
+static bool guard_subtree_bound_method_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  if (token.type == nullptr) {
+    return false;
+  }
+  if (token.bound_method_func != nullptr) {
+    return token.bound_method_self != nullptr;
+  }
+  return token.bound_c_method_func != nullptr;
+}
+
+static bool guard_subtree_token_is_reachability_only(
+    const GuardSubtreeEntryToken& token,
+    size_t index) {
+  return index != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly;
+}
+
+enum class GuardLastSuccessPartialPlanState : uint8_t {
+  Empty,
+  Training,
+  Enabled,
+  Disabled,
+};
+
+struct GuardLastSuccessPartialPlan {
+  void reset() {
+    state = GuardLastSuccessPartialPlanState::Empty;
+    entry_key = nullptr;
+    root_key = nullptr;
+
+    stable_passes = 0;
+    self_object = nullptr;
+    self_type = nullptr;
+    self_framelocals_index = -1;
+    stability_tokens.clear();
+    tokens.clear();
+  }
+
+  void disable() {
+    reset();
+    state = GuardLastSuccessPartialPlanState::Disabled;
+  }
+
+  bool is_enabled_for(void* current_entry_key, void* current_root_key) const {
+    return state == GuardLastSuccessPartialPlanState::Enabled &&
+        entry_key == current_entry_key && root_key == current_root_key;
+  }
+
+  bool should_train() const {
+    return state != GuardLastSuccessPartialPlanState::Disabled;
+  }
+
+  bool observe_successful_training_pass(
+      void* new_entry_key,
+      void* new_root_key,
+      std::vector<GuardSubtreeEntryToken>&& new_stability_tokens,
+      std::vector<GuardSubtreeEntryToken>&& new_tokens) {
+    const bool stable = entry_key == new_entry_key &&
+        root_key == new_root_key && !stability_tokens.empty() &&
+        guard_subtree_token_vectors_match(
+            new_stability_tokens, stability_tokens);
+    if (stable) {
+      stable_passes += 1;
+    } else {
+      entry_key = new_entry_key;
+      root_key = new_root_key;
+      stability_tokens = std::move(new_stability_tokens);
+      tokens = std::move(new_tokens);
+      stable_passes = 1;
+      state = GuardLastSuccessPartialPlanState::Training;
+    }
+    if (state != GuardLastSuccessPartialPlanState::Enabled &&
+        stable_passes >= kGuardLastSuccessActualStablePasses) {
+      state = GuardLastSuccessPartialPlanState::Enabled;
+      return true;
+    }
+    return false;
+  }
+
+  GuardLastSuccessPartialPlanState state{
+      GuardLastSuccessPartialPlanState::Empty};
+  void* entry_key{nullptr};
+  void* root_key{nullptr};
+  uint64_t stable_passes{0};
+  PyObject* self_object{nullptr};
+  PyTypeObject* self_type{nullptr};
+  int self_framelocals_index{-1};
+  std::vector<GuardSubtreeEntryToken> stability_tokens;
+  std::vector<GuardSubtreeEntryToken> tokens;
+};
+
+struct GuardLastSuccessReceipt {
+  void reset() {
+    actual_partial.reset();
+  }
+
+  GuardLastSuccessPartialPlan actual_partial;
+};
+
+struct GuardLocalStateScope {
+  explicit GuardLocalStateScope(const LocalState* state)
+      : previous(active_guard_local_state) {
+    active_guard_local_state = state;
+  }
+
+  ~GuardLocalStateScope() {
+    active_guard_local_state = previous;
+  }
+
+  const LocalState* previous{nullptr};
+};
+
+static bool guard_subtree_exact_list_token_matches_current(
+    const GuardSubtreeEntryToken& token,
+    PyObject* current_object) {
+  if (current_object == nullptr || current_object != token.object ||
+      Py_TYPE(current_object) != token.type ||
+      !PyList_CheckExact(current_object) || token.version != 0) {
+    return false;
+  }
+  const Py_ssize_t size = PyList_GET_SIZE(current_object);
+  if (size != token.size ||
+      static_cast<size_t>(size) != token.list_items.size()) {
+    return false;
+  }
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    if (PyList_GET_ITEM(current_object, i) !=
+        token.list_items[static_cast<size_t>(i)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_subtree_memo_tokens_match(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    PyObject* root_value) {
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    if (token.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      if (!guard_subtree_tensor_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::DefaultDevice ||
+        token.kind == GuardSubtreeProbeTokenKind::GlobalState ||
+        token.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      if (!guard_subtree_special_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (guard_subtree_token_is_aliasing_guard(token.kind)) {
+      // Keep the hot path O(1). The original relation was checked by the slow
+      // receipt pass; here we only prove the recorded alias operand is still
+      // live with the same type.
+      if (!guard_subtree_aliasing_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      if (!guard_subtree_bound_method_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (guard_subtree_token_is_reachability_only(token, i)) {
+      // Parent tokens prove whether this non-root object is still reachable.
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      // FrameGlobals is only safe for full slow-guard receipt comparison,
+      // where every run records a fresh child token vector. Existing hot
+      // memo checks rely on exact parent container tokens to prove non-root
+      // ObjectOnly tokens are still reachable.
+      return false;
+    }
+    PyObject* current_object = i == 0 ? root_value : token.object;
+    if (token.kind == GuardSubtreeProbeTokenKind::ObjectOnly) {
+      if (current_object != token.object ||
+          Py_TYPE(current_object) != token.type) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::ExactDict) {
+      if (current_object != token.object ||
+          !PyDict_CheckExact(current_object) ||
+          Py_TYPE(current_object) != token.type ||
+          get_dict_version_unchecked(current_object) != token.version ||
+          PyDict_GET_SIZE(current_object) != token.size) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::ExactList) {
+      if (!guard_subtree_exact_list_token_matches_current(
+              token, current_object)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::ExactTuple) {
+      if (current_object != token.object ||
+          !PyTuple_CheckExact(current_object) ||
+          Py_TYPE(current_object) != token.type ||
+          PyTuple_GET_SIZE(current_object) != token.size) {
+        return false;
+      }
+      continue;
+    }
+    GuardSubtreeEntryToken current =
+        GuardSubtreeEntryToken::make(current_object);
+    if (!current.matches(token)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool source_starts_with(
+    const std::string& source,
+    const char* prefix) {
+  const size_t prefix_len = std::strlen(prefix);
+  return source.size() >= prefix_len &&
+      source.compare(0, prefix_len, prefix) == 0;
+}
+
+static bool is_self_local_source_path(const std::string& source) {
+  static constexpr const char* kSelf = "L['self']";
+  if (!source_starts_with(source, kSelf)) {
+    return false;
+  }
+  return source.size() == std::strlen(kSelf) ||
+      source[std::strlen(kSelf)] == '.' ||
+      source[std::strlen(kSelf)] == '[';
+}
+
+static bool is_local_source_path(const std::string& source) {
+
+  return source_starts_with(source, "L[");
+}
+
+static PyObject* guard_last_success_self_key() {
+  static PyObject* key = PyUnicode_InternFromString("self");
+
+  return key;
+}
+
+static PyObject* guard_last_success_get_self(
+    FrameLocalsMapping* f_locals,
+    int framelocals_index) {
+  if (framelocals_index >= 0) {
+    PyObject* current_self = f_locals->get(framelocals_index);
+    if (current_self != nullptr) {
+      return current_self;
+    }
+  }
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return nullptr;
+  }
+  return PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+}
+
+static bool guard_last_success_extract_self_partial_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::vector<GuardSubtreeEntryToken>& partial_tokens) {
+  partial_tokens.clear();
+  if (tokens.empty()) {
+    return false;
+  }
+  if (tokens.size() != debug_paths.size()) {
+    return false;
+  }
+
+  size_t start = tokens.size();
+  for (size_t i = 0; i < debug_paths.size(); ++i) {
+    if (debug_paths[i] == "L['self']") {
+      start = i;
+      break;
+    }
+  }
+  if (start == tokens.size()) {
+    return false;
+  }
+
+  size_t end = tokens.size();
+  for (size_t i = start + 1; i < debug_paths.size(); ++i) {
+    const auto& path = debug_paths[i];
+    if (is_global_source_path(path) ||
+        (is_local_source_path(path) && !is_self_local_source_path(path))) {
+      end = i;
+      break;
+    }
+  }
+  if (end <= start) {
+    return false;
+  }
+
+  partial_tokens.assign(tokens.begin() + start, tokens.begin() + end);
+  return true;
+}
+
+struct GuardLastSuccessPartialPlanBuild {
+  std::vector<GuardSubtreeEntryToken> stability_tokens;
+  std::vector<GuardSubtreeEntryToken> hot_tokens;
+};
+
+static bool guard_last_success_prepare_actual_partial(
+    GuardLastSuccessPartialPlan* plan,
+    FrameLocalsMapping* f_locals,
+    int self_framelocals_index,
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    GuardLastSuccessPartialPlanBuild& build) {
+  std::vector<GuardSubtreeEntryToken> partial_tokens;
+  if (!guard_last_success_extract_self_partial_tokens(
+          tokens, debug_paths, partial_tokens)) {
+    return false;
+  }
+  if (partial_tokens.size() > kGuardLastSuccessActualMaxTokens) {
+    return false;
+  }
+  if (partial_tokens.empty() ||
+      partial_tokens[0].kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+    return false;
+  }
+
+  PyObject* current_self =
+      guard_last_success_get_self(f_locals, self_framelocals_index);
+  if (current_self == nullptr) {
+    return false;
+  }
+  if (partial_tokens[0].object != current_self) {
+    return false;
+  }
+  plan->self_object = current_self;
+  plan->self_type = Py_TYPE(current_self);
+  plan->self_framelocals_index = self_framelocals_index;
+
+  return guard_last_success_build_partial_plan_tokens(
+      partial_tokens,
+      build.stability_tokens,
+      build.hot_tokens);
+}
+
+static bool guard_last_success_actual_partial_tokens_match(
+    const GuardLastSuccessPartialPlan& plan,
+    FrameLocalsMapping* f_locals) {
+  if (plan.tokens.empty()) {
+    return false;
+  }
+  PyObject* current_self =
+      guard_last_success_get_self(f_locals, plan.self_framelocals_index);
+  if (current_self == nullptr ||
+      current_self != plan.self_object ||
+      Py_TYPE(current_self) != plan.self_type) {
+    return false;
+  }
+  LocalState state;
+  GuardLocalStateScope local_state_scope(&state);
+  return guard_subtree_memo_tokens_match(
+      plan.tokens, plan.tokens[0].object);
+}
+
+thread_local std::vector<GuardSubtreeEntryToken>*
+    active_guard_subtree_memo_recorder = nullptr;
+thread_local std::vector<std::string>*
+    active_guard_subtree_memo_debug_paths = nullptr;
+thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
+thread_local const LocalState* active_guard_local_state = nullptr;
+
+struct GuardSubtreeMemoRecorderScope {
+  explicit GuardSubtreeMemoRecorderScope(
+      std::vector<GuardSubtreeEntryToken>* tokens,
+      std::vector<std::string>* debug_paths = nullptr,
+      bool relax_global_dicts = false)
+      : previous(active_guard_subtree_memo_recorder),
+        previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_relax_global_dicts(
+            active_guard_subtree_memo_relax_global_dicts) {
+    active_guard_subtree_memo_recorder = tokens;
+    active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
+  }
+
+  ~GuardSubtreeMemoRecorderScope() {
+    active_guard_subtree_memo_recorder = previous;
+    active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_subtree_memo_relax_global_dicts =
+        previous_relax_global_dicts;
+  }
+
+  std::vector<GuardSubtreeEntryToken>* previous{nullptr};
+  std::vector<std::string>* previous_debug_paths{nullptr};
+  bool previous_relax_global_dicts{false};
+};
+
+static void append_guard_subtree_memo_token(
+    std::vector<GuardSubtreeEntryToken>* tokens,
+    GuardSubtreeEntryToken&& token,
+    const std::string& debug_path) {
+  tokens->emplace_back(std::move(token));
+  if (active_guard_subtree_memo_debug_paths != nullptr) {
+    active_guard_subtree_memo_debug_paths->push_back(debug_path);
+  }
+}
+
 static PyObject* dict_version(PyObject* dummy, PyObject* obj) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(PyDict_Check(obj), "dict_version expects a dict");
@@ -984,6 +1977,7 @@ static bool check_size_stride(
     std::stringstream msg;
     msg << "wrong number of dimensions" << ndim;
     if (op_name) {
+
       msg << " for op: " << op_name;
     }
     PyErr_SetString(PyExc_AssertionError, std::move(msg).str().c_str());
@@ -1111,6 +2105,7 @@ static PyObject* assert_size_stride_grouped(PyObject* dummy, PyObject* args) {
   }
 
   Py_RETURN_TRUE;
+
 }
 
 static PyObject* assert_alignment(PyObject* dummy, PyObject* args) {
@@ -1415,6 +2410,7 @@ struct StaticMeta {
 
   static int64_t size(const Tensor& t, int64_t i) {
     return t.size(i);
+
   }
 
   static int64_t stride(const Tensor& t, int64_t i) {
@@ -1456,6 +2452,7 @@ struct DynamicMeta {
  * becoming relevant if it's run enough times.
  */
 template <class Meta>
+
 bool tensors_definitely_do_not_overlap(const Tensor& x, const Tensor& y) {
   if (x.is_same(y)) {
     return false;
@@ -1717,6 +2714,7 @@ class GuardDebugInfo {
         num_guards_executed(num_guards_executed),
         user_stack(std::move(user_stack)) {}
 
+
   // This constructor is used when guard succeeds.
   GuardDebugInfo(bool result, int num_guards_executed)
       : result(result),
@@ -1762,6 +2760,7 @@ class GuardManager;
 class RootGuardManager;
 class DictGuardManager;
 
+
 // Global registry used by the *recursive-dict-tag* optimisation.
 //
 // Key   : `PyObject*` pointing to a watched `dict`
@@ -1769,7 +2768,7 @@ class DictGuardManager;
 //
 // Why is this global?
 // -------------------
-// * CPython allows only a small, fixed number of dict-watcher IDs (≈64).
+// * CPython allows only a small, fixed number of dict-watcher IDs (about 64).
 //   All `GuardManager`s therefore share a single watcher callback.
 // * Different guard managers (possibly across different frames) can end up
 //   watching the same dictionary pointer. Therefore, we have a list of guard
@@ -1788,7 +2787,7 @@ class DictGuardManager;
 // Expected size
 // -------------
 // Every compilation frame contributes its tag-safe dicts to this registry, so
-// the container can grow large over the lifetime of the process.  That’s
+// the container can grow large over the lifetime of the process. That is
 // acceptable: lookup is by pointer (hash/equals = identity) and each entry
 // stores only lightweight pointers.
 using DictToGuardManagersMap =
@@ -1855,6 +2854,25 @@ class LeafGuard {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict());
   }
+  virtual bool supports_subtree_memo() const {
+    return true;
+  }
+  virtual bool emits_subtree_memo_token() const {
+    return false;
+  }
+  virtual bool emits_subtree_memo_token_for_frame_locals() const {
+    return false;
+  }
+  virtual bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
+  }
+  virtual bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
+  }
 
   virtual ~LeafGuard() = default;
 
@@ -1882,6 +2900,7 @@ class LeafGuard {
  */
 class LAMBDA_GUARD : public LeafGuard {
  public:
+
   LAMBDA_GUARD(
       RootGuardManager* root_guard_manager,
       py::object guard_check_fn,
@@ -1928,6 +2947,10 @@ class LAMBDA_GUARD : public LeafGuard {
     return GuardDebugInfo(false, verbose_code_parts(), 0);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   // The user provided lambda function for check_fn.
   py::function _guard_check_fn;
@@ -1935,6 +2958,7 @@ class LAMBDA_GUARD : public LeafGuard {
 
 class TYPE_MATCH : public LeafGuard {
  public:
+
   // type_id = id(type(obj))
   TYPE_MATCH(
       RootGuardManager* root_guard_manager,
@@ -2006,6 +3030,7 @@ class FAKE_SCRIPT_TYPE_MATCH : public LeafGuard {
 
 class ID_MATCH : public LeafGuard {
  public:
+
   // obj_id = id(obj)
   ID_MATCH(
       RootGuardManager* root_guard_manager,
@@ -2078,6 +3103,7 @@ class FALSE_MATCH : public LeafGuard {
 
 class EQUALS_MATCH : public LeafGuard {
  public:
+
   EQUALS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -2116,6 +3142,7 @@ class EQUALS_MATCH : public LeafGuard {
 
 class RANGE_ITERATOR_MATCH : public LeafGuard {
  public:
+
   RANGE_ITERATOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object start,
@@ -2167,6 +3194,7 @@ class RANGE_ITERATOR_MATCH : public LeafGuard {
 
 class TUPLE_ITERATOR_LEN : public LeafGuard {
  public:
+
   TUPLE_ITERATOR_LEN(
       RootGuardManager* root_guard_manager,
       py::object length,
@@ -2201,6 +3229,7 @@ class TUPLE_ITERATOR_LEN : public LeafGuard {
 
 class LENGTH_CHECK : public LeafGuard {
  public:
+
   LENGTH_CHECK(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -2231,6 +3260,7 @@ class LENGTH_CHECK : public LeafGuard {
 
 class DICT_LENGTH : public LeafGuard {
  public:
+
   DICT_LENGTH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -2269,6 +3299,7 @@ class NOT_NONE : public LeafGuard {
 
 class MAPPING_KEYS_MATCH : public LeafGuard {
  public:
+
   MAPPING_KEYS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -2297,6 +3328,7 @@ class MAPPING_KEYS_MATCH : public LeafGuard {
 
 class DEFAULT_DEVICE : public LeafGuard {
  public:
+
   DEFAULT_DEVICE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -2335,7 +3367,43 @@ class DEFAULT_DEVICE : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_default_device(
+            _utils_device_dict.ptr(), _device.ptr()),
+        "<DEFAULT_DEVICE>");
+    return true;
+  }
+
   // Save the current device and the module dict during the guard construction.
   py::object _utils_device_dict;
   py::object _device;
@@ -2343,6 +3411,7 @@ class DEFAULT_DEVICE : public LeafGuard {
 
 class GLOBAL_STATE : public LeafGuard {
  public:
+
   GLOBAL_STATE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -2388,7 +3457,41 @@ class GLOBAL_STATE : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_global_state(_guard),
+        "<GLOBAL_STATE>");
+    return true;
+  }
+
   py::object owner_;
   GlobalStateGuard* _guard;
 };
@@ -2398,6 +3501,7 @@ class GLOBAL_STATE : public LeafGuard {
 // HASATTR guard.
 class NO_HASATTR : public LeafGuard {
  public:
+
   NO_HASATTR(
       RootGuardManager* root_guard_manager,
       py::object attr_name,
@@ -2424,6 +3528,7 @@ class NO_HASATTR : public LeafGuard {
 // being faster.
 class DICT_CONTAINS : public LeafGuard {
  public:
+
   DICT_CONTAINS(
       RootGuardManager* root_guard_manager,
       bool contains,
@@ -2589,6 +3694,7 @@ class DUAL_LEVEL_MATCH : public LeafGuard {
  */
 class RelationalGuard : public LeafGuard {
  public:
+
   RelationalGuard(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -2598,8 +3704,13 @@ class RelationalGuard : public LeafGuard {
             std::move(verbose_code_parts),
             std::move(user_stack)) {}
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
   // reset the relational guard state on guard failure. This is called by the
   // guard manager.
+
   virtual void reset_state() = 0;
 };
 
@@ -2608,6 +3719,7 @@ class RelationalGuard : public LeafGuard {
  */
 class OBJECT_ALIASING : public RelationalGuard {
  public:
+
   OBJECT_ALIASING(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts,
@@ -2630,6 +3742,26 @@ class OBJECT_ALIASING : public RelationalGuard {
     _is_first_call = true;
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_object_aliasing(
+            value, static_cast<const void*>(this)),
+        "<OBJECT_ALIASING>");
+    return true;
+  }
+
  private:
   bool _is_first_call{true};
   PyObject* _first_tensor{nullptr};
@@ -2640,6 +3772,7 @@ class OBJECT_ALIASING : public RelationalGuard {
  */
 class NO_TENSOR_ALIASING : public RelationalGuard {
  public:
+
   NO_TENSOR_ALIASING(
       RootGuardManager* root_guard_manager,
       const py::list& tensor_names,
@@ -2677,6 +3810,26 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     _unique_tensors.clear();
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_no_tensor_aliasing(
+            value, static_cast<const void*>(this)),
+        "<NO_TENSOR_ALIASING>");
+    return true;
+  }
+
  private:
   py::list _tensor_names;
   ska::flat_hash_map<PyObject*, std::nullptr_t> _unique_tensors;
@@ -2695,6 +3848,7 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
  */
 class STORAGE_OVERLAPPING : public RelationalGuard {
  public:
+
   STORAGE_OVERLAPPING(
       RootGuardManager* root_guard_manager,
       bool overlapping,
@@ -2731,6 +3885,7 @@ class STORAGE_OVERLAPPING : public RelationalGuard {
  */
 class SYMBOLIC_SHAPE_GUARD : public RelationalGuard {
  public:
+
   SYMBOLIC_SHAPE_GUARD(
       RootGuardManager* root_guard_manager,
       py::int_ nargs_int,
@@ -3095,6 +4250,10 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
     return GuardDebugInfo(true, 0);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   // Pre-interned attr names + expected values
   std::vector<std::pair<PyObject*, py::object>> _expected_attrs;
@@ -3117,6 +4276,7 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
 
 class DICT_VERSION : public LeafGuard {
  public:
+
   DICT_VERSION(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -3252,12 +4412,20 @@ class GuardAccessor {
     return _guard_manager;
   }
 
+  const std::unique_ptr<GuardManager>& get_guard_manager() const {
+    return _guard_manager;
+  }
+
   bool matches_key(const py::handle& key) const {
     return _accessor_key.equal(key);
   }
 
-  std::string get_source() {
+  const std::string& get_source() const {
     return _source;
+  }
+
+  virtual int framelocals_index() const {
+    return -1;
   }
 
   // matches_dict_tag is used by the DictGetItemGuardAccessor to skip the guard
@@ -3266,6 +4434,10 @@ class GuardAccessor {
   virtual bool check_nopybind(FrameLocalsMapping* map, bool matches_dict_tag) {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
+  }
+  bool check_child_manager_nopybind(PyObject* obj);
+  virtual bool supports_subtree_memo() const {
+    return true;
   }
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
   virtual std::string repr() const = 0;
@@ -3310,6 +4482,7 @@ class GuardAccessor {
   // A string that can be eval'd on f_locals or f_globals to access the variable
   // value. Only used for debugging.
   std::string _source;
+
 };
 
 /**
@@ -3421,6 +4594,7 @@ class GuardManager {
  public:
   // relational guard helpers
   void set_has_object_aliasing_guard() {
+
     _has_object_aliasing_guard = true;
   }
 
@@ -3496,6 +4670,7 @@ class GuardManager {
       std::vector<RecordedTensorMetadata>&& tensor_metadata) {
     _tensor_metadata_pointers[value] = std::move(tensor_metadata);
   }
+
 
   void disable_recursive_dict_tag_optimization() {
     dict_to_guard_managers.withLock([&](DictToGuardManagersMap& map) {
@@ -3606,6 +4781,16 @@ class GuardManager {
   // the code here.
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        append_guard_subtree_memo_token(
+            active_guard_subtree_memo_recorder,
+            active_guard_subtree_memo_relax_global_dicts
+                ? GuardSubtreeEntryToken::make_for_source(value, _source)
+                : GuardSubtreeEntryToken::make(value),
+            _source);
+      }
+    }
 
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
@@ -3673,10 +4858,10 @@ class GuardManager {
 
   virtual bool check_nopybind(PyObject* value) {
     // -----------------------------------------------------------------------------
-    // Recursive Dict‑Tag Matching
+    // Recursive Dict-Tag Matching
     // -----------------------------------------------------------------------------
-    // The GuardManager implements recursive dictionary‑tag matching.
-    // During compilation we pre‑compute every `tag_safe_node` and its
+    // The GuardManager implements recursive dictionary-tag matching.
+    // During compilation we pre-compute every `tag_safe_node` and its
     // corresponding `tag_safe_root` (see `find_tag_safe_nodes` in guards.py).
     // These annotations allow the runtime to validate large subtrees with a
     // single, cheap check.
@@ -3698,58 +4883,64 @@ class GuardManager {
     //      and revalidate recorded tensor metadata.
     //      All checks passing means guard passes with no further traversal.
     //
-    // 2) First‑time `value` pointer
-    //    • Enter recording mode; walk the subtree, each tag safe root collects
+    // 2) First-time `value` pointer
+    //    - Enter recording mode; walk the subtree, each tag safe root collects
     //      dict tag, and cache the new `value` pointer.
-    //    • Future executions with this pointer now hit the fast path above.
+    //    - Future executions with this pointer now hit the fast path above.
     //
     // 3) Supporting multiple pointers
-    //    • We deliberately cache a bounded number of distinct `value` pointers
+    //    - We deliberately cache a bounded number of distinct `value` pointers
     //      to enable regional compilation. Compiling one transformer layer and
     //      reusing it for many identical layers in an LLM requires saving
     //      multiple `value` pointers. This is done by storing `value` pointers
     //      in a dictionary.
-    //    • A small fixed cap prevents unbounded growth of the cache.
+    //    - A small fixed cap prevents unbounded growth of the cache.
     //
-    // 4) Weak‑reference safety
-    //    • Each cached `value` pointer is stored as a weak reference with a
-    //      callback.  When the underlying Python object is garbage‑collected,
-    //      the callback automatically disables dict‑tag matching for the
+    // 4) Weak-reference safety
+    //    - Each cached `value` pointer is stored as a weak reference with a
+    //      callback. When the underlying Python object is garbage-collected,
+    //      the callback automatically disables dict-tag matching for the
     //      entire guard manager.
-    //    • This guards against aliasing bugs: CPython can recycle a freed
+    //    - This guards against aliasing bugs: CPython can recycle a freed
     //      memory address, so a new object might otherwise appear to match an
     //      old pointer.
     //
     // 5) Guard failure
-    //    • If a tag check ever fails for this root, we conservatively disable
-    //      dict‑tag matching for that node. In the common case, failures are
+    //    - If a tag check ever fails for this root, we conservatively disable
+    //      dict-tag matching for that node. In the common case, failures are
     //      rare, so the optimization remains effective.
     //
     // Result
     // ------
-    // This strategy shrinks guard‑evaluation overhead to recursive dict tag
+    // This strategy shrinks guard-evaluation overhead to recursive dict tag
     // matching, instead of a full recursive value check on every invocation,
-    // yielding significant speed‑ups in torch.compile’s Guard Tree.
+    // yielding significant speed-ups in torch.compile's Guard Tree.
     // -----------------------------------------------------------------------------
     bool is_recording = false;
     if (!_disable_dict_tag_matching) {
       if (_is_tag_safe_root) {
         // Check if the `value` object was recorded earlier
         if (_dict_pointers.find(value) != _dict_pointers.end()) {
-          // Check for fast path
-          // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
-          if (check_dict_pointer_tags(value) &&
-              check_tensor_metadata_fast(value)) {
-            if (check_no_tensor_aliasing_guards_fast(value)) {
-              return true;
-            } else {
-              _disable_dict_tag_matching = true;
-              return false;
+          // A receipt recorder must observe the full subtree. The recursive
+          // dict-tag shortcut is a 2.10 optimization that postdates the
+          // actual-partial recorder and would otherwise omit its self tokens.
+          if (active_guard_subtree_memo_recorder == nullptr) {
+            // Check for fast path
+            // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
+            if (check_dict_pointer_tags(value) &&
+                check_tensor_metadata_fast(value)) {
+              if (check_no_tensor_aliasing_guards_fast(value)) {
+                return true;
+              } else {
+                _disable_dict_tag_matching = true;
+                return false;
+              }
             }
+            // Something changed, very likely the dict tag checking will fail
+            // in future. So disable the recursive tag matching.
+            _disable_dict_tag_matching = true;
           }
-          // Something changed, very likely the dict tag checking will fail in
-          // future. So disable the recursive tag matching.
-          _disable_dict_tag_matching = true;
+
         } else if (
             _dict_pointers.size() ==
             _max_saved_pointers_for_recursive_dict_tags_check) {
@@ -3822,6 +5013,7 @@ class GuardManager {
     // Implementation note - Create a capsule object that will be passed on to
     // the weakref callback.  The capsule wraps the ``this`` GuardManager
     // object, so that we can access the C++ object and set
+
     // _disable_dict_tag_matching member in the callback.
 
     // Alternatively, we could have checked that the weakref is valid at
@@ -3874,7 +5066,7 @@ class GuardManager {
     // -----------------
     // In steady state we no longer need to iterate over the recorded
     // dictionaries and compare their `ma_version_tag`s (the
-    // “are-tags-unchanged” loop that used to dominate the fast-path guard
+    // "are-tags-unchanged" loop that used to dominate the fast-path guard
     // evaluation).  The presence of an *active watcher* is itself a guarantee
     // that none of the dicts has mutated; if one **does** mutate, the callback
     // simply flips `_disable_dict_tag_matching = true`, causing the next guard
@@ -3940,21 +5132,77 @@ class GuardManager {
 #endif
   }
 
+  virtual bool supports_subtree_memo_recursive() const {
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->supports_subtree_memo()) {
+        return false;
+      }
+    }
+    for (const auto& accessor : _accessors) {
+      if (!accessor->supports_subtree_memo()) {
+        return false;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool supports_accessor_subtree_memo_recursive(
+      const std::string& source,
+      int* framelocals_index = nullptr) const {
+    if (framelocals_index != nullptr) {
+      *framelocals_index = -1;
+    }
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() != source) {
+        continue;
+      }
+      if (!accessor->supports_subtree_memo()) {
+        return false;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive()) {
+        return false;
+      }
+      if (framelocals_index != nullptr) {
+        *framelocals_index = accessor->framelocals_index();
+      }
+      return true;
+    }
+    return false;
+  }
+
   virtual bool check_nopybind(FrameLocalsMapping* value) {
     return check_nopybind_template(value);
   }
 
   template <typename T>
   bool check_leaf_guards_nopybind(T* value) {
-    // Iterate over leaf guards
     for (const auto& guard : _leaf_guards) {
-      if (!guard->check_nopybind(value)) { // early exit
+      bool result = false;
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        bool emit_subtree_memo_token = false;
+        if constexpr (std::is_same_v<T, PyObject>) {
+          emit_subtree_memo_token = guard->emits_subtree_memo_token();
+        } else {
+          emit_subtree_memo_token =
+              guard->emits_subtree_memo_token_for_frame_locals();
+        }
+        if (emit_subtree_memo_token) {
+          result = guard->append_subtree_memo_token(
+              value, active_guard_subtree_memo_recorder);
+        } else {
+          result = guard->check_nopybind(value);
+        }
+      } else {
+        result = guard->check_nopybind(value);
+      }
+      if (!result) {
         _fail_count += 1;
-        // no need of sorting, just return.
         return false;
       }
     }
-
     return true;
   }
 
@@ -3979,7 +5227,9 @@ class GuardManager {
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
-      if (!accessor->check_nopybind(value, matches_dict_tag)) { // early exit
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (!accessor_result) { // early exit
         _fail_count += 1;
         result = false;
         // need to sort, so break the loop.
@@ -4015,6 +5265,55 @@ class GuardManager {
       // If result is true, reset the _dict_tag. This is useful if there is a
       // mutation on the dict but it does not change the attr values (like
       // swapping).
+      _dict_tag = new_tag;
+    }
+
+    return result;
+  }
+
+  template <typename T>
+  bool check_accessors_nopybind_skipping_source(
+      T* value,
+      const std::string& skip_source) {
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (_is_dict) {
+        new_tag = get_dict_version_unchecked(value);
+        matches_dict_tag = (new_tag == _dict_tag);
+
+      }
+    }
+
+    bool result = true;
+    bool failed_on_first = true;
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() == skip_source) {
+        failed_on_first = false;
+        continue;
+      }
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (!accessor_result) {
+        _fail_count += 1;
+        result = false;
+        break;
+      }
+      failed_on_first = false;
+    }
+
+    if (!result && !failed_on_first) {
+      std::sort(
+          _accessors.begin(),
+          _accessors.end(),
+          [](const std::unique_ptr<GuardAccessor>& a,
+             const std::unique_ptr<GuardAccessor>& b) {
+            return a->get_guard_manager()->fail_count() >
+                b->get_guard_manager()->fail_count();
+          });
+    }
+
+    if (_is_dict && result) {
       _dict_tag = new_tag;
     }
 
@@ -4168,6 +5467,7 @@ class GuardManager {
 
   // GuardAccessors nodes to access the child guards. These guards are
   // shufflable. On a guard failure, they are sorted based on their fail count
+
   // to enable fail fast for the next check.
   std::vector<std::unique_ptr<GuardAccessor>> _accessors;
 
@@ -4215,6 +5515,10 @@ GuardAccessor::GuardAccessor(
 GuardAccessor::GuardAccessor(GuardManager* guard_manager, GuardAccessor* from)
     : _guard_manager(std::unique_ptr<GuardManager>(guard_manager)) {
   from->clone_visitor(this);
+}
+
+inline bool GuardAccessor::check_child_manager_nopybind(PyObject* obj) {
+  return _guard_manager->check_nopybind(obj);
 }
 
 /**
@@ -4281,7 +5585,9 @@ class RootGuardManager : public GuardManager {
 
   // Fast check function.
   template <typename T>
-  bool check_nopybind_template(T* value) { // borrowed ref
+  bool check_nopybind_template(
+      T* value,
+      const std::string* skip_accessor_source = nullptr) { // borrowed ref
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions with GIL.
     PyThreadState* _save = nullptr;
@@ -4297,6 +5603,8 @@ class RootGuardManager : public GuardManager {
       LocalState state;
       _local_state = state;
     }
+    GuardLocalStateScope local_state_scope(&_local_state);
+
 
     if (!GuardManager::check_leaf_guards_nopybind(value)) {
       _reset_relational_guard_state();
@@ -4308,11 +5616,16 @@ class RootGuardManager : public GuardManager {
     // torch function at this point, because if there
     // was a torch function, we should've traced through it
     const at::impl::TorchFunctionDisabledState old_state =
+
         at::impl::PythonTorchFunctionTLS::get_disabled_state();
     at::impl::PythonTorchFunctionTLS::set_disabled_state(
         at::impl::TorchFunctionDisabledState::ALL_DISABLED);
 
-    if (!GuardManager::check_accessors_nopybind(value)) {
+    const bool accessor_result = skip_accessor_source == nullptr
+        ? GuardManager::check_accessors_nopybind(value)
+        : GuardManager::check_accessors_nopybind_skipping_source(
+              value, *skip_accessor_source);
+    if (!accessor_result) {
       at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
       _reset_relational_guard_state();
       return false;
@@ -4340,6 +5653,24 @@ class RootGuardManager : public GuardManager {
     return check_nopybind_template(value);
   }
 
+  bool check_nopybind_skipping_source(
+      FrameLocalsMapping* value,
+      const std::string& skip_accessor_source) {
+    return check_nopybind_template(value, &skip_accessor_source);
+  }
+
+  bool supports_subtree_memo_recursive() const override {
+    if (!GuardManager::supports_subtree_memo_recursive()) {
+      return false;
+    }
+    for (const auto& guard : _epilogue_lambda_guards) {
+      if (!guard->supports_subtree_memo()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // Fast check_verbose function.
   GuardDebugInfo check_verbose_nopybind(
       PyObject* value) override { // borrowed ref
@@ -4349,6 +5680,7 @@ class RootGuardManager : public GuardManager {
     Py_UNBLOCK_THREADS; // ; is added to avoid clang-formatting
     std::lock_guard<std::mutex> lock_guard(_lock);
     Py_BLOCK_THREADS; // ; is added to avoid clang-formatting
+
 
     // Get the local state. This will be used for TENSOR_MATCH guards.
     if (_init_local_state) {
@@ -4591,6 +5923,7 @@ class DictGuardManager : public GuardManager {
         _expected_type(Py_TYPE(example_value.ptr())),
         _is_exact_dict_type(PyDict_CheckExact(example_value.ptr())) {}
 
+
   GuardManager* get_key_manager(
       py::object key_index,
       std::string source,
@@ -4673,6 +6006,7 @@ class DictGuardManager : public GuardManager {
         KeyValueManager& key_value_manager = _key_value_managers[dict_pointer];
         std::unique_ptr<GuardManager>& key_manager = key_value_manager.first;
         if (key_manager && !key_manager->check_nopybind(key)) {
+
           return false;
         }
         std::unique_ptr<GuardManager>& value_manager = key_value_manager.second;
@@ -4807,6 +6141,23 @@ class DictGuardManager : public GuardManager {
     return _is_exact_dict_type;
   }
 
+  bool supports_subtree_memo_recursive() const override {
+    if (!GuardManager::supports_subtree_memo_recursive()) {
+      return false;
+    }
+    for (const auto& item : _key_value_managers) {
+      const auto& key_manager = item.second.first;
+      if (key_manager && !key_manager->supports_subtree_memo_recursive()) {
+        return false;
+      }
+      const auto& value_manager = item.second.second;
+      if (value_manager && !value_manager->supports_subtree_memo_recursive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  public: // cloning functions
   DictGuardManager(
       RootGuardManager* cloned_root,
@@ -4872,6 +6223,7 @@ class DictGuardManager : public GuardManager {
           cloned_mgr->_key_value_managers[index].second =
               std::unique_ptr<GuardManager>(cloned_value_manager);
         }
+
       }
     }
     return cloned_mgr;
@@ -4958,6 +6310,7 @@ std::unique_ptr<GuardManager> make_guard_manager(
 #if IS_PYBIND_2_13_PLUS
   using threeobjects = std::tuple<py::object, py::object, py::object>;
   PYBIND11_CONSTINIT static py::gil_safe_call_once_and_store<threeobjects>
+
       storage;
 
   auto& [guard_manager_enum_class, base_guard_manager_enum, dict_guard_manager_enum] =
@@ -5040,6 +6393,7 @@ const LocalState& get_local_state(RootGuardManager* root) {
 
 class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
  public:
+
   TORCH_FUNCTION_MODE_STACK(
       RootGuardManager* root_guard_manager,
       const py::list& initial_stack,
@@ -5058,7 +6412,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   }
 
   template <typename T>
-  bool check_nopybind_template(T* value) {
+  bool check_nopybind_template(T* value) const {
     // Ignore value arg, only used to satisfy the interface
     const size_t len = (size_t)at::impl::PythonTorchFunctionTLS::stack_len();
     const size_t ref_stack_size = this->_ref_stack.size();
@@ -5088,12 +6442,54 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_torch_function_mode_stack(
+            static_cast<const void*>(this)),
+        "<TORCH_FUNCTION_MODE_STACK>");
+    return true;
+  }
+
   std::vector<PyTypeObject*> _ref_stack;
 };
 
+static bool torch_function_mode_stack_guard_matches(const void* guard) {
+  return guard != nullptr &&
+      static_cast<const TORCH_FUNCTION_MODE_STACK*>(guard)
+          ->check_nopybind_template(static_cast<PyObject*>(nullptr));
+}
+
 class DISPATCH_KEY_SET_MATCH : public LeafGuard {
  public:
+
   DISPATCH_KEY_SET_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -5115,12 +6511,17 @@ class DISPATCH_KEY_SET_MATCH : public LeafGuard {
         _root_guard_manager->_local_state.apply(value_).raw_repr();
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  private:
   uint64_t raw_repr;
 };
 
 class TENSOR_MATCH : public LeafGuard {
  public:
+
   TENSOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -5135,9 +6536,12 @@ class TENSOR_MATCH : public LeafGuard {
             root_guard_manager,
             std::move(verbose_code_parts),
             std::move(user_stack)),
-        _tensor_name(py::cast<std::string>(std::move(tensor_name))) {
+        _tensor_name(py::cast<std::string>(std::move(tensor_name))),
+        _supports_subtree_memo_token(
+            tensor_match_source_supports_subtree_memo(_tensor_name)) {
     root_guard_manager->set_init_local_state_flag();
     PyObject* item = value.ptr();
+
     if (!THPVariable_CheckExact(item) && !THPVariable_Check(item)) {
       PyErr_SetString(PyExc_TypeError, "expected Tensor()");
       return;
@@ -5204,8 +6608,29 @@ class TENSOR_MATCH : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_subtree_memo() const override {
+    return _supports_subtree_memo_token;
+  }
+  bool emits_subtree_memo_token() const override {
+    return _supports_subtree_memo_token;
+  }
+
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    GuardSubtreeEntryToken token;
+    if (!GuardSubtreeEntryToken::make_tensor_match(
+            value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens, std::move(token), _tensor_name);
+    return true;
+  }
+
  private:
   std::string _tensor_name;
+  bool _supports_subtree_memo_token;
   std::unique_ptr<TensorCheck> _tensor_check;
 };
 
@@ -5214,6 +6639,7 @@ class TENSOR_MATCH : public LeafGuard {
  */
 class GetAttrGuardAccessor : public GuardAccessor {
  public:
+
   GetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -5238,7 +6664,7 @@ class GetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -5294,6 +6720,7 @@ class GetAttrGuardAccessor : public GuardAccessor {
  */
 class GenericGetAttrGuardAccessor : public GuardAccessor {
  public:
+
   GenericGetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -5318,7 +6745,7 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -5406,6 +6833,7 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
     bool result = _guard_manager->check_nopybind(x);
     Py_DECREF(x);
     return result;
+
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5524,6 +6952,10 @@ class GetItemGuardAccessor : public GuardAccessor {
  */
 class FrameLocalsGuardAccessor : public GuardAccessor {
  public:
+  int framelocals_index() const override {
+    return _framelocals_idx;
+  }
+
   FrameLocalsGuardAccessor(
       RootGuardManager* root,
       const py::tuple& key,
@@ -5562,6 +6994,7 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
   // Run as a result of calling check(), e.g. from Python
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
+
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
     // This should not cause guard failure.
     // If this error is encountered, it probably means
@@ -5700,6 +7133,7 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   }
 
  public: // cloning functions
+
   DictGetItemGuardAccessor(
       GuardManager* guard_manager,
       DictGetItemGuardAccessor* from)
@@ -6001,6 +7435,7 @@ std::string to_string(TensorProperty prop) {
 template <TensorProperty _prop>
 class TensorPropertyGuardAccessor : public GuardAccessor {
  public:
+
   TensorPropertyGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -6030,6 +7465,7 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
       return false;
     }
     at::Tensor tensor = THPVariable_Unpack(obj);
+
     std::optional<int64_t> opt_value;
     if (_prop == TensorProperty::SIZE) {
       if (_index >= tensor.dim()) {
@@ -6053,7 +7489,7 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
 
     PyObject* py_value =
         PyLong_FromLongLong(opt_value.value()); // New reference
-    bool result = _guard_manager->check_nopybind(py_value);
+    bool result = check_child_manager_nopybind(py_value);
     Py_DECREF(py_value);
     return result;
   }
@@ -6128,6 +7564,7 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
  */
 class IndexedGuardAccessor : public GuardAccessor {
  public:
+
   IndexedGuardAccessor(
       RootGuardManager* root,
       py::int_ index,
@@ -6146,7 +7583,7 @@ class IndexedGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* tuple = PyTuple_Pack(2, _index.ptr(), obj); // New reference
-    bool result = _guard_manager->check_nopybind(tuple);
+    bool result = check_child_manager_nopybind(tuple);
     Py_DECREF(tuple);
     return result;
   }
@@ -6190,6 +7627,7 @@ class IndexedGuardAccessor : public GuardAccessor {
  */
 class GradGuardAccessor : public GuardAccessor {
  public:
+
   GradGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -6213,7 +7651,7 @@ class GradGuardAccessor : public GuardAccessor {
     }
     PyObject* grad =
         THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
-    bool result = _guard_manager->check_nopybind(grad);
+    bool result = check_child_manager_nopybind(grad);
     // For undefined tensor, THPVariable_Wrap returns Py_RETURN_NONE. So, no
     // need of Py_XDECREF.
     Py_DECREF(grad);
@@ -6248,6 +7686,7 @@ class GradGuardAccessor : public GuardAccessor {
   }
 
   GuardAccessor* clone(
+
       RootGuardManager* cloned_root,
       const py::function& clone_filter_fn) override {
     return clone_common<GradGuardAccessor>(cloned_root, clone_filter_fn);
@@ -6259,6 +7698,7 @@ class GradGuardAccessor : public GuardAccessor {
  */
 class FuncDefaultsGuardAccessor : public GuardAccessor {
  public:
+
   FuncDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -6287,7 +7727,7 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -6326,6 +7766,7 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
       const py::function& clone_filter_fn) override {
     return clone_common<FuncDefaultsGuardAccessor>(
         cloned_root, clone_filter_fn);
+
   }
 };
 
@@ -6334,6 +7775,7 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
  */
 class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  public:
+
   FuncKwDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -6362,7 +7804,7 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -6411,6 +7853,7 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  */
 class GlobalsGuardAccessor : public GuardAccessor {
  public:
+
   GlobalsGuardAccessor(
       RootGuardManager* root,
       py::dict globals_dict,
@@ -6431,7 +7874,7 @@ class GlobalsGuardAccessor : public GuardAccessor {
       override { // borrowed ref
     // Ignore the obj arg. This is required to satisfy the function signature.
     // Just pass on the globals dict to the child manager.
-    return _guard_manager->check_nopybind(_globals_dict);
+    return check_child_manager_nopybind(_globals_dict);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -6477,6 +7920,7 @@ class GlobalsGuardAccessor : public GuardAccessor {
  */
 class TypeGuardAccessor : public GuardAccessor {
  public:
+
   // name = __type_accessor__, a unique string used as attribute name.
   TypeGuardAccessor(
       RootGuardManager* root,
@@ -6496,7 +7940,7 @@ class TypeGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* x = (PyObject*)Py_TYPE(obj); // borrowed ref
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -6540,6 +7984,7 @@ class TypeDictGuardAccessor : public GuardAccessor {
             root,
             std::move(name),
             std::move(source),
+
             example_value,
             guard_manager_enum) {}
 
@@ -6647,6 +8092,7 @@ class TypeMROGuardAccessor : public GuardAccessor {
   }
 
  public: // cloning functions
+
   TypeMROGuardAccessor(GuardManager* guard_manager, TypeMROGuardAccessor* from)
       : GuardAccessor(guard_manager, from) {
     from->clone_visitor(this);
@@ -6666,6 +8112,7 @@ class TypeMROGuardAccessor : public GuardAccessor {
  */
 class TupleIteratorGetItemAccessor : public GuardAccessor {
  public:
+
   TupleIteratorGetItemAccessor(
       RootGuardManager* root,
       py::object index,
@@ -6692,7 +8139,7 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     return result;
   }
 
@@ -6745,6 +8192,7 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
  */
 class GlobalWeakRefGuardAccessor : public GuardAccessor {
  public:
+
   GlobalWeakRefGuardAccessor(
       RootGuardManager* root,
       py::object global_name,
@@ -6786,7 +8234,7 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6856,9 +8304,11 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
  */
 class WeakRefCallGuardAccessor : public GuardAccessor {
  public:
+
   WeakRefCallGuardAccessor(
       RootGuardManager* root,
       py::str name,
+
       std::string source,
       py::handle example_value,
       py::handle guard_manager_enum)
@@ -6887,7 +8337,7 @@ class WeakRefCallGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6943,6 +8393,7 @@ class CodeGuardAccessor : public GuardAccessor {
  public:
   // name = __type_mro_accessor__, a unique string used as attribute name.
   CodeGuardAccessor(
+
       RootGuardManager* root,
       py::str name,
       std::string source,
@@ -7093,6 +8544,7 @@ class ClosureGuardAccessor : public GuardAccessor {
  */
 class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  public:
+
   CallFunctionNoArgsGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -7121,7 +8573,7 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
       return false;
     }
 
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -7150,6 +8602,11 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
     return "CallFunctionNoArgsGuardAccessor()";
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
+
  public: // cloning functions
   CallFunctionNoArgsGuardAccessor(
       GuardManager* guard_manager,
@@ -7174,6 +8631,7 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  */
 class PythonLambdaGuardAccessor : public GuardAccessor {
  public:
+
   PythonLambdaGuardAccessor(
       RootGuardManager* root,
       py::function accessor_fn,
@@ -7198,7 +8656,7 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -7221,11 +8679,16 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
     return "PythonLambdaGuardAccessor";
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+
  public: // cloning functions
   PythonLambdaGuardAccessor(
       GuardManager* guard_manager,
       PythonLambdaGuardAccessor* from)
       : GuardAccessor(guard_manager, from) {
+
     from->clone_visitor(this);
   }
 
@@ -7480,6 +8943,104 @@ bool root_guard_manager_has_no_guards(void* root) {
     return false;
   }
   return ((RootGuardManager*)root)->has_no_guards();
+}
+
+
+
+void* create_guard_last_success_receipt() {
+  return new GuardLastSuccessReceipt();
+}
+
+void destroy_guard_last_success_receipt(void* receipt) {
+  delete static_cast<GuardLastSuccessReceipt*>(receipt);
+}
+
+void reset_guard_last_success_receipt(void* receipt) {
+  if (receipt == nullptr) {
+    return;
+  }
+  static_cast<GuardLastSuccessReceipt*>(receipt)->reset();
+}
+
+bool is_guard_last_success_receipt_enabled(void* receipt) {
+  return receipt != nullptr &&
+      static_cast<GuardLastSuccessReceipt*>(receipt)->actual_partial.state ==
+      GuardLastSuccessPartialPlanState::Enabled;
+}
+
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe) {
+  if (receipt == nullptr) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  GuardLastSuccessReceipt* state =
+      static_cast<GuardLastSuccessReceipt*>(receipt);
+  if (is_skip_guard_eval_unsafe || root == nullptr) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
+  static const std::string self_source = "L['self']";
+
+  if (state->actual_partial.is_enabled_for(entry_key, root)) {
+    if (guard_last_success_actual_partial_tokens_match(
+            state->actual_partial, f_locals)) {
+      return root_mgr->check_nopybind_skipping_source(f_locals, self_source);
+    }
+    state->actual_partial.reset();
+  }
+
+  if (!state->actual_partial.should_train()) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  int self_framelocals_index = -1;
+  if (!root_mgr->supports_accessor_subtree_memo_recursive(
+          self_source, &self_framelocals_index)) {
+    state->actual_partial.disable();
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<std::string> debug_paths;
+  {
+    GuardSubtreeMemoRecorderScope recorder(&tokens, &debug_paths);
+    if (!run_root_guard_manager(root, f_locals)) {
+      state->reset();
+      return false;
+    }
+  }
+
+  if (tokens.empty() || debug_paths.size() != tokens.size() ||
+      tokens.size() > kGuardLastSuccessActualMaxTokens) {
+    state->actual_partial.disable();
+    return true;
+  }
+
+  GuardLastSuccessPartialPlanBuild build;
+  if (!guard_last_success_prepare_actual_partial(
+          &state->actual_partial,
+          f_locals,
+          self_framelocals_index,
+          tokens,
+          debug_paths,
+          build)) {
+    state->actual_partial.disable();
+    return true;
+  }
+
+
+  state->actual_partial.observe_successful_training_pass(
+      entry_key,
+      root,
+      std::move(build.stability_tokens),
+      std::move(build.hot_tokens));
+  return true;
 }
 
 PyObject* torch_c_dynamo_guards_init() {
@@ -7849,6 +9410,7 @@ PyObject* torch_c_dynamo_guards_init() {
       GuardAccessor,
       std::unique_ptr<FuncKwDefaultsGuardAccessor>>(
       py_m, "FuncKwDefaultsGuardAccessor");
+
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       GlobalsGuardAccessor,
@@ -8336,6 +9898,7 @@ PyObject* torch_c_dynamo_guards_init() {
           py::arg("source"),
           py::arg("example_value"),
           py::arg("guard_manager_enum"),
+
           py::return_value_policy::reference)
       // return by reference because GuardManager has the ownership of accessors
       // and guard managers
@@ -8537,6 +10100,7 @@ PyObject* torch_c_dynamo_guards_init() {
                 example_value,
                 guard_manager_enum);
           },
+
           py::arg("source"),
           py::arg("example_value"),
           py::arg("guard_manager_enum"),
@@ -8636,6 +10200,7 @@ PyObject* torch_c_dynamo_guards_init() {
                 guard_manager_enum);
           },
           py::arg("source"),
+
           py::arg("example_value"),
           py::arg("guard_manager_enum"),
           py::return_value_policy::reference)
@@ -8845,6 +10410,7 @@ PyObject* torch_c_dynamo_guards_init() {
       "install_storage_overlapping_guard", install_storage_overlapping_guard);
   py_m.def(
       "compute_overlapping_tensors",
+
       [](const std::vector<Tensor> tensors, bool symbolic) {
         // Pick the correct Meta class, depending on whether we are
         // dealing with symbolic values or not.

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -5214,6 +5214,11 @@ class GuardAccessor {
   // matches_dict_tag is used by the DictGetItemGuardAccessor to skip the guard
   // subtree on immutable dict getitems.
   virtual bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) = 0;
+  virtual bool check_nopybind_actual_partial(
+      PyObject* obj,
+      bool matches_dict_tag = false) {
+    return check_nopybind(obj, matches_dict_tag);
+  }
   virtual bool check_nopybind(FrameLocalsMapping* map, bool matches_dict_tag) {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
@@ -5576,6 +5581,10 @@ class GuardManager {
                 ? GuardSubtreeEntryToken::make_for_source(value, _source)
                 : GuardSubtreeEntryToken::make(value),
             _source);
+        if (!this->check_leaf_guards_nopybind(value)) {
+          return false;
+        }
+        return this->check_accessors_nopybind<true>(value);
       }
     }
 
@@ -5583,7 +5592,7 @@ class GuardManager {
       return false;
     }
 
-    return this->check_accessors_nopybind(value);
+    return this->check_accessors_nopybind<false>(value);
   }
 
   bool check_dict_pointer_tags(PyObject* value) {
@@ -6042,7 +6051,7 @@ class GuardManager {
     return true;
   }
 
-  template <typename T>
+  template <bool RecordActualPartial = false, typename T>
   bool check_accessors_nopybind(T* value) {
     bool matches_dict_tag = false;
     uint64_t new_tag = 0;
@@ -6063,16 +6072,19 @@ class GuardManager {
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
-      if constexpr (std::is_same_v<T, PyObject>) {
+      bool accessor_result = false;
+      if constexpr (RecordActualPartial && std::is_same_v<T, PyObject>) {
         if (C10_UNLIKELY(
                 active_guard_actual_partial_supported != nullptr &&
                 is_self_local_source_path(accessor->get_source()) &&
                 !accessor->supports_actual_partial_subtree_memo(value))) {
           *active_guard_actual_partial_supported = false;
         }
+        accessor_result =
+            accessor->check_nopybind_actual_partial(value, matches_dict_tag);
+      } else {
+        accessor_result = accessor->check_nopybind(value, matches_dict_tag);
       }
-      const bool accessor_result =
-          accessor->check_nopybind(value, matches_dict_tag);
       if (!accessor_result) { // early exit
         _fail_count += 1;
         result = false;
@@ -6492,7 +6504,7 @@ class RootGuardManager : public GuardManager {
     });
 
     const bool accessor_result = skip_accessor_source == nullptr
-        ? GuardManager::check_accessors_nopybind(value)
+        ? GuardManager::check_accessors_nopybind<false>(value)
         : GuardManager::check_accessors_nopybind_skipping_source(
               value, *skip_accessor_source);
     if (!accessor_result) {
@@ -7548,17 +7560,13 @@ class GetAttrGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
-    PyObject* x = PyObject_GetAttr(obj, _attr_name); // new ref
-    if (x == nullptr) {
-      // Attribute absent, clear the exception and return false.
-      PyErr_Clear();
-      return false;
-    }
-    guard_actual_partial_record_instance_attr_binding(
-        obj, _attr_name, x, get_source(), true);
-    bool result = check_child_manager_nopybind(x);
-    Py_DECREF(x);
-    return result;
+    return check_nopybind_impl<false>(obj, matches_dict_tag);
+  }
+
+  bool check_nopybind_actual_partial(
+      PyObject* obj,
+      bool matches_dict_tag = false) override {
+    return check_nopybind_impl<true>(obj, matches_dict_tag);
   }
 
   bool supports_actual_partial_subtree_memo(PyObject*) const override {
@@ -7606,6 +7614,22 @@ class GetAttrGuardAccessor : public GuardAccessor {
   }
 
  private:
+  template <bool RecordActualPartial>
+  bool check_nopybind_impl(PyObject* obj, bool matches_dict_tag) {
+    PyObject* x = PyObject_GetAttr(obj, _attr_name); // new ref
+    if (x == nullptr) {
+      // Attribute absent, clear the exception and return false.
+      PyErr_Clear();
+      return false;
+    }
+    if constexpr (RecordActualPartial) {
+      guard_actual_partial_record_instance_attr_binding(
+          obj, _attr_name, x, get_source(), true);
+    }
+    bool result = check_child_manager_nopybind(x);
+    Py_DECREF(x);
+    return result;
+  }
   // no need of py::object here because the attr_name is already passed on to
   // the base class as accessor_key which is a py::object.
   PyObject* _attr_name{nullptr};
@@ -7635,17 +7659,13 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
-    PyObject* x = PyObject_GenericGetAttr(obj, _attr_name); // new ref
-    if (x == nullptr) {
-      // Attribute absent, clear the exception and return false.
-      PyErr_Clear();
-      return false;
-    }
-    guard_actual_partial_record_instance_attr_binding(
-        obj, _attr_name, x, get_source(), false);
-    bool result = check_child_manager_nopybind(x);
-    Py_DECREF(x);
-    return result;
+    return check_nopybind_impl<false>(obj, matches_dict_tag);
+  }
+
+  bool check_nopybind_actual_partial(
+      PyObject* obj,
+      bool matches_dict_tag = false) override {
+    return check_nopybind_impl<true>(obj, matches_dict_tag);
   }
 
   bool supports_actual_partial_subtree_memo(PyObject*) const override {
@@ -7692,6 +7712,23 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
   }
 
  private:
+  template <bool RecordActualPartial>
+  bool check_nopybind_impl(PyObject* obj, bool matches_dict_tag) {
+    PyObject* x = PyObject_GenericGetAttr(obj, _attr_name); // new ref
+    if (x == nullptr) {
+      // Attribute absent, clear the exception and return false.
+      PyErr_Clear();
+      return false;
+    }
+    if constexpr (RecordActualPartial) {
+      guard_actual_partial_record_instance_attr_binding(
+          obj, _attr_name, x, get_source(), false);
+    }
+    bool result = check_child_manager_nopybind(x);
+    Py_DECREF(x);
+    return result;
+  }
+
   // no need of py::object here because the attr_name is already passed on to
   // the base class as accessor_key which is a py::object.
   PyObject* _attr_name{nullptr};
@@ -7719,24 +7756,13 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
-    // NOTE for future guard optimization developers - We tried saving the dict
-    // pointer and weakref of the original object to avoid calling
-    // PyObject_GenericGetDict on a fast path, but this did not lead any
-    // meaningful speedups because of 2 reasons
-    // 1) Once __dict__ is generated, accessing it the second time is fast.
-    // 2) Getting the object from weakref, from 3.13 onwards, requires
-    // Py_DECREF, which further eats into the benefit.
-    PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
-    if (x == nullptr) {
-      // Attribute absent, clear the exception and return false.
-      PyErr_Clear();
-      return false;
-    }
-    guard_actual_partial_record_generic_dict_binding(obj, x, get_source());
-    bool result = _guard_manager->check_nopybind(x);
-    Py_DECREF(x);
-    return result;
+    return check_nopybind_impl<false>(obj, matches_dict_tag);
+  }
 
+  bool check_nopybind_actual_partial(
+      PyObject* obj,
+      bool matches_dict_tag = false) override {
+    return check_nopybind_impl<true>(obj, matches_dict_tag);
   }
 
   bool supports_actual_partial_subtree_memo(PyObject*) const override {
@@ -7775,6 +7801,30 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
       const py::function& clone_filter_fn) override {
     return clone_common<GetGenericDictGuardAccessor>(
         cloned_root, clone_filter_fn);
+  }
+
+ private:
+  template <bool RecordActualPartial>
+  bool check_nopybind_impl(PyObject* obj, bool matches_dict_tag) {
+    // NOTE for future guard optimization developers - We tried saving the dict
+    // pointer and weakref of the original object to avoid calling
+    // PyObject_GenericGetDict on a fast path, but this did not lead any
+    // meaningful speedups because of 2 reasons
+    // 1) Once __dict__ is generated, accessing it the second time is fast.
+    // 2) Getting the object from weakref, from 3.13 onwards, requires
+    // Py_DECREF, which further eats into the benefit.
+    PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
+    if (x == nullptr) {
+      // Attribute absent, clear the exception and return false.
+      PyErr_Clear();
+      return false;
+    }
+    if constexpr (RecordActualPartial) {
+      guard_actual_partial_record_generic_dict_binding(obj, x, get_source());
+    }
+    bool result = _guard_manager->check_nopybind(x);
+    Py_DECREF(x);
+    return result;
   }
 };
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -398,6 +398,9 @@ std::string TensorCheck::check_verbose(
 
 namespace {
 
+class GuardAccessor;
+class RootGuardManager;
+
 typedef std::vector<TensorCheck> ChecksList;
 
 typedef struct {
@@ -2135,6 +2138,7 @@ struct GuardLastSuccessPartialPlan {
     self_weakref = py::object();
     self_type = nullptr;
     self_framelocals_index = -1;
+    self_accessor = nullptr;
     stability_tokens.clear();
     tokens.clear();
     type_proofs.clear();
@@ -2224,6 +2228,7 @@ struct GuardLastSuccessPartialPlan {
   py::object self_weakref;
   PyTypeObject* self_type{nullptr};
   int self_framelocals_index{-1};
+  const GuardAccessor* self_accessor{nullptr};
   std::vector<GuardSubtreeEntryToken> stability_tokens;
   std::vector<GuardSubtreeEntryToken> tokens;
   std::vector<GuardSubtreeTypeProof> type_proofs;
@@ -2489,86 +2494,45 @@ static bool guard_subtree_memo_tokens_match(
   return true;
 }
 
-static bool source_starts_with(const std::string& source, const char* prefix) {
-  const size_t prefix_len = std::strlen(prefix);
-  return source.size() >= prefix_len &&
-      source.compare(0, prefix_len, prefix) == 0;
-}
-
-static bool is_self_local_source_path(const std::string& source) {
-  static constexpr const char* kSelf = "L['self']";
-  if (!source_starts_with(source, kSelf)) {
-    return false;
-  }
-  return source.size() == std::strlen(kSelf) ||
-      source[std::strlen(kSelf)] == '.' || source[std::strlen(kSelf)] == '[';
-}
-
-static bool is_local_source_path(const std::string& source) {
-  return source_starts_with(source, "L[");
-}
-
-static PyObject* guard_last_success_self_key() {
-  static PyObject* key = PyUnicode_InternFromString("self");
-
-  return key;
-}
-
 static PyObject* guard_last_success_get_self(
     FrameLocalsMapping* f_locals,
     int framelocals_index) {
-  if (framelocals_index >= 0) {
-    PyObject* current_self = f_locals->get(framelocals_index);
-    if (current_self != nullptr) {
-      return current_self;
-    }
-  }
-  PyObject* key = guard_last_success_self_key();
-  if (key == nullptr) {
-    PyErr_Clear();
+  if (framelocals_index < 0) {
     return nullptr;
   }
-  return PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+  PyObject* current_self = f_locals->get(framelocals_index);
+  if (current_self == nullptr) {
+    PyErr_Clear();
+  }
+  return current_self;
 }
 
 static bool guard_last_success_extract_self_partial_tokens(
     const std::vector<GuardSubtreeEntryToken>& tokens,
-    const std::vector<std::string>& debug_paths,
+    const std::vector<uint8_t>& self_membership,
     std::vector<GuardSubtreeEntryToken>& partial_tokens) {
   partial_tokens.clear();
-  if (tokens.empty()) {
-    return false;
-  }
-  if (tokens.size() != debug_paths.size()) {
+  if (tokens.empty() || tokens.size() != self_membership.size()) {
     return false;
   }
 
-  size_t start = tokens.size();
-  for (size_t i = 0; i < debug_paths.size(); ++i) {
-    if (debug_paths[i] == "L['self']") {
-      start = i;
-      break;
+  bool saw_self = false;
+  bool closed_self_interval = false;
+  for (size_t i = 0; i < self_membership.size(); ++i) {
+    if (self_membership[i] > 1) {
+      return false;
     }
-  }
-  if (start == tokens.size()) {
-    return false;
-  }
-
-  size_t end = tokens.size();
-  for (size_t i = start + 1; i < debug_paths.size(); ++i) {
-    const auto& path = debug_paths[i];
-    if (is_global_source_path(path) ||
-        (is_local_source_path(path) && !is_self_local_source_path(path))) {
-      end = i;
-      break;
+    if (self_membership[i] == 0) {
+      closed_self_interval |= saw_self;
+      continue;
     }
+    if (closed_self_interval) {
+      return false;
+    }
+    saw_self = true;
+    partial_tokens.push_back(tokens[i]);
   }
-  if (end <= start) {
-    return false;
-  }
-
-  partial_tokens.assign(tokens.begin() + start, tokens.begin() + end);
-  return true;
+  return saw_self && !partial_tokens.empty();
 }
 
 struct GuardLastSuccessPartialPlanBuild {
@@ -2587,16 +2551,18 @@ static bool guard_last_success_prepare_actual_partial(
     GuardLastSuccessPartialPlan* plan,
     FrameLocalsMapping* f_locals,
     int self_framelocals_index,
+    const GuardAccessor* self_accessor,
     const std::vector<GuardSubtreeEntryToken>& tokens,
-    const std::vector<std::string>& debug_paths,
+    const std::vector<uint8_t>& self_membership,
     const std::vector<GuardActualPartialAccessorRecord>& accessor_records,
     GuardLastSuccessPartialPlanBuild& build) {
-  if (accessor_records.size() > kGuardLastSuccessActualMaxAccessorRecords) {
+  if (self_accessor == nullptr ||
+      accessor_records.size() > kGuardLastSuccessActualMaxAccessorRecords) {
     return false;
   }
   std::vector<GuardSubtreeEntryToken> partial_tokens;
   if (!guard_last_success_extract_self_partial_tokens(
-          tokens, debug_paths, partial_tokens)) {
+          tokens, self_membership, partial_tokens)) {
     return false;
   }
   if (partial_tokens.size() > kGuardLastSuccessActualMaxTokens) {
@@ -2623,6 +2589,7 @@ static bool guard_last_success_prepare_actual_partial(
   plan->self_weakref = py::reinterpret_steal<py::object>(weakref);
   plan->self_type = Py_TYPE(current_self);
   plan->self_framelocals_index = self_framelocals_index;
+  plan->self_accessor = self_accessor;
 
   if (!guard_last_success_build_partial_plan_tokens(
           tokens,
@@ -2703,11 +2670,15 @@ static bool guard_last_success_actual_partial_tokens_match(
 
 thread_local std::vector<GuardSubtreeEntryToken>*
     active_guard_subtree_memo_recorder = nullptr;
-thread_local std::vector<std::string>* active_guard_subtree_memo_debug_paths =
+thread_local std::vector<uint8_t>* active_guard_subtree_memo_self_membership =
     nullptr;
 thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
 thread_local std::vector<GuardActualPartialAccessorRecord>*
     active_guard_actual_partial_accessor_records = nullptr;
+thread_local RootGuardManager* active_guard_subtree_memo_root = nullptr;
+thread_local const GuardAccessor* active_guard_actual_partial_self_accessor =
+    nullptr;
+thread_local bool active_guard_actual_partial_in_self = false;
 
 static void guard_actual_partial_mark_unsupported() {
   if (active_guard_actual_partial_supported != nullptr) {
@@ -2731,9 +2702,8 @@ static bool guard_actual_partial_can_record_accessor() {
 
 static void guard_actual_partial_record_generic_dict_binding(
     PyObject* owner,
-    PyObject* dict,
-    const std::string& source) {
-  if (!is_self_local_source_path(source) ||
+    PyObject* dict) {
+  if (!active_guard_actual_partial_in_self ||
       !guard_actual_partial_can_record_accessor()) {
     return;
   }
@@ -2755,9 +2725,8 @@ static void guard_actual_partial_record_instance_attr_binding(
     PyObject* owner,
     PyObject* key,
     PyObject* expected,
-    const std::string& source,
     bool require_default_getattribute) {
-  if (!is_self_local_source_path(source) ||
+  if (!active_guard_actual_partial_in_self ||
       !guard_actual_partial_can_record_accessor()) {
     return;
   }
@@ -2831,10 +2800,8 @@ static void guard_actual_partial_record_instance_attr_binding(
   active_guard_actual_partial_accessor_records->push_back(std::move(record));
 }
 
-static void guard_actual_partial_record_code_accessor(
-    PyObject* parent,
-    const std::string& source) {
-  if (!is_self_local_source_path(source) ||
+static void guard_actual_partial_record_code_accessor(PyObject* parent) {
+  if (!active_guard_actual_partial_in_self ||
       !guard_actual_partial_can_record_accessor()) {
     return;
   }
@@ -2866,49 +2833,92 @@ static void guard_actual_partial_record_code_accessor(
 struct GuardSubtreeMemoRecorderScope {
   explicit GuardSubtreeMemoRecorderScope(
       std::vector<GuardSubtreeEntryToken>* tokens,
-      std::vector<std::string>* debug_paths = nullptr,
+      std::vector<uint8_t>* self_membership,
+      RootGuardManager* root,
+      const GuardAccessor* self_accessor,
       std::vector<GuardActualPartialAccessorRecord>* accessor_records = nullptr,
       bool* actual_partial_supported = nullptr,
       bool relax_global_dicts = false)
       : previous(active_guard_subtree_memo_recorder),
-        previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_self_membership(active_guard_subtree_memo_self_membership),
         previous_accessor_records(active_guard_actual_partial_accessor_records),
         previous_actual_partial_supported(
             active_guard_actual_partial_supported),
         previous_actual_partial_list_items(
             active_guard_actual_partial_list_items),
+        previous_root(active_guard_subtree_memo_root),
+        previous_self_accessor(active_guard_actual_partial_self_accessor),
+        previous_in_self(active_guard_actual_partial_in_self),
         previous_relax_global_dicts(
             active_guard_subtree_memo_relax_global_dicts) {
     active_guard_subtree_memo_recorder = tokens;
-    active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_subtree_memo_self_membership = self_membership;
     active_guard_actual_partial_accessor_records = accessor_records;
     active_guard_actual_partial_supported = actual_partial_supported;
     active_guard_actual_partial_list_items = 0;
+    active_guard_subtree_memo_root = root;
+    active_guard_actual_partial_self_accessor = self_accessor;
+    active_guard_actual_partial_in_self = false;
     active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
+    if (previous != nullptr || tokens == nullptr ||
+        self_membership == nullptr || root == nullptr ||
+        self_accessor == nullptr) {
+      guard_actual_partial_mark_unsupported();
+    }
   }
 
   ~GuardSubtreeMemoRecorderScope() {
     active_guard_subtree_memo_recorder = previous;
-    active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_subtree_memo_self_membership = previous_self_membership;
     active_guard_actual_partial_accessor_records = previous_accessor_records;
     active_guard_actual_partial_supported = previous_actual_partial_supported;
     active_guard_actual_partial_list_items = previous_actual_partial_list_items;
+    active_guard_subtree_memo_root = previous_root;
+    active_guard_actual_partial_self_accessor = previous_self_accessor;
+    active_guard_actual_partial_in_self = previous_in_self;
     active_guard_subtree_memo_relax_global_dicts = previous_relax_global_dicts;
   }
 
   std::vector<GuardSubtreeEntryToken>* previous{nullptr};
-  std::vector<std::string>* previous_debug_paths{nullptr};
+  std::vector<uint8_t>* previous_self_membership{nullptr};
   std::vector<GuardActualPartialAccessorRecord>* previous_accessor_records{
       nullptr};
   bool* previous_actual_partial_supported{nullptr};
   size_t previous_actual_partial_list_items{0};
+  RootGuardManager* previous_root{nullptr};
+  const GuardAccessor* previous_self_accessor{nullptr};
+  bool previous_in_self{false};
   bool previous_relax_global_dicts{false};
+};
+
+struct GuardActualPartialSelfScope {
+  explicit GuardActualPartialSelfScope(bool enter)
+      : previous(active_guard_actual_partial_in_self), entered(enter) {
+    if (!entered) {
+      return;
+    }
+    if (previous || active_guard_subtree_memo_recorder == nullptr ||
+        active_guard_subtree_memo_self_membership == nullptr ||
+        active_guard_subtree_memo_root == nullptr ||
+        active_guard_actual_partial_self_accessor == nullptr) {
+      guard_actual_partial_mark_unsupported();
+    }
+    active_guard_actual_partial_in_self = true;
+  }
+
+  ~GuardActualPartialSelfScope() {
+    if (entered) {
+      active_guard_actual_partial_in_self = previous;
+    }
+  }
+
+  bool previous{false};
+  bool entered{false};
 };
 
 static void append_guard_subtree_memo_token(
     std::vector<GuardSubtreeEntryToken>* tokens,
-    GuardSubtreeEntryToken&& token,
-    const std::string& debug_path) {
+    GuardSubtreeEntryToken&& token) {
   if (active_guard_actual_partial_supported != nullptr &&
       (!*active_guard_actual_partial_supported ||
        tokens->size() >= kGuardLastSuccessActualMaxTokens)) {
@@ -2917,7 +2927,7 @@ static void append_guard_subtree_memo_token(
   }
   if (active_guard_actual_partial_supported != nullptr &&
       token.kind == GuardSubtreeProbeTokenKind::ExactList &&
-      is_self_local_source_path(debug_path)) {
+      active_guard_actual_partial_in_self) {
     const size_t list_size = static_cast<size_t>(token.size);
     if (list_size > kGuardLastSuccessActualMaxListItemsPerToken ||
         active_guard_actual_partial_list_items >
@@ -2932,8 +2942,13 @@ static void append_guard_subtree_memo_token(
     active_guard_actual_partial_list_items += list_size;
   }
   tokens->emplace_back(std::move(token));
-  if (active_guard_subtree_memo_debug_paths != nullptr) {
-    active_guard_subtree_memo_debug_paths->push_back(debug_path);
+  if (active_guard_actual_partial_supported != nullptr) {
+    if (active_guard_subtree_memo_self_membership == nullptr) {
+      guard_actual_partial_mark_unsupported();
+    } else {
+      active_guard_subtree_memo_self_membership->push_back(
+          active_guard_actual_partial_in_self ? 1 : 0);
+    }
   }
 }
 
@@ -3753,7 +3768,6 @@ class GuardDebugInfo {
 };
 
 class GuardManager;
-class RootGuardManager;
 class DictGuardManager;
 
 // Global registry used by the *recursive-dict-tag* optimisation.
@@ -4224,8 +4238,7 @@ class EQUALS_MATCH : public LeafGuard {
     }
     append_guard_subtree_memo_token(
         tokens,
-        GuardSubtreeEntryToken::make_exact_set_equals(value, _value.ptr()),
-        "<EQUALS_EXACT_SET>");
+        GuardSubtreeEntryToken::make_exact_set_equals(value, _value.ptr()));
     return true;
   }
 
@@ -4513,8 +4526,7 @@ class DEFAULT_DEVICE : public LeafGuard {
     append_guard_subtree_memo_token(
         tokens,
         GuardSubtreeEntryToken::make_default_device(
-            _utils_device_dict.ptr(), _device.ptr()),
-        "<DEFAULT_DEVICE>");
+            _utils_device_dict.ptr(), _device.ptr()));
     return true;
   }
 
@@ -4603,9 +4615,7 @@ class GLOBAL_STATE : public LeafGuard {
       return false;
     }
     append_guard_subtree_memo_token(
-        tokens,
-        GuardSubtreeEntryToken::make_global_state(_guard),
-        "<GLOBAL_STATE>");
+        tokens, GuardSubtreeEntryToken::make_global_state(_guard));
     return true;
   }
 
@@ -4924,8 +4934,7 @@ class OBJECT_ALIASING : public RelationalGuard {
     append_guard_subtree_memo_token(
         tokens,
         GuardSubtreeEntryToken::make_object_aliasing(
-            value, static_cast<const void*>(this)),
-        "<OBJECT_ALIASING>");
+            value, static_cast<const void*>(this)));
     return true;
   }
 
@@ -5020,8 +5029,7 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     append_guard_subtree_memo_token(
         tokens,
         GuardSubtreeEntryToken::make_no_tensor_aliasing(
-            value, static_cast<const void*>(this)),
-        "<NO_TENSOR_ALIASING>");
+            value, static_cast<const void*>(this)));
     return true;
   }
 
@@ -5501,8 +5509,7 @@ class DIMENSION_DYNAMIC_MARKING_GUARD : public LeafGuard {
     append_guard_subtree_memo_token(
         tokens,
         GuardSubtreeEntryToken::make_dimension_marking_absent(
-            value, has_marking_str()),
-        "<TENSOR_DIMENSION_MARKING_ABSENT>");
+            value, has_marking_str()));
     return true;
   }
 
@@ -5679,8 +5686,10 @@ class GuardAccessor {
     return _source;
   }
 
-  virtual int framelocals_index() const {
-    return -1;
+  virtual bool matches_framelocals_key(
+      const char* /*key*/,
+      int* /*framelocals_index*/) const {
+    return false;
   }
 
   // matches_dict_tag is used by the DictGetItemGuardAccessor to skip the guard
@@ -6043,13 +6052,14 @@ class GuardManager {
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
     if constexpr (std::is_same_v<T, PyObject>) {
-      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+      if (C10_UNLIKELY(
+              active_guard_subtree_memo_recorder != nullptr &&
+              active_guard_subtree_memo_root == _root)) {
         append_guard_subtree_memo_token(
             active_guard_subtree_memo_recorder,
             active_guard_subtree_memo_relax_global_dicts
                 ? GuardSubtreeEntryToken::make_for_source(value, _source)
-                : GuardSubtreeEntryToken::make(value),
-            _source);
+                : GuardSubtreeEntryToken::make(value));
         if (!this->check_leaf_guards_nopybind(value)) {
           return false;
         }
@@ -6428,51 +6438,33 @@ class GuardManager {
     return true;
   }
 
-  bool supports_accessor_subtree_memo_recursive(
-      const std::string& source,
-      int* framelocals_index = nullptr) const {
-    if (framelocals_index != nullptr) {
-      *framelocals_index = -1;
+  bool find_actual_partial_framelocals_accessor(
+      const char* key,
+      const GuardAccessor** matched_accessor,
+      int* framelocals_index) const {
+    if (key == nullptr || matched_accessor == nullptr ||
+        framelocals_index == nullptr) {
+      return false;
     }
+    *matched_accessor = nullptr;
+    *framelocals_index = -1;
     for (const auto& accessor : _accessors) {
-      if (accessor->get_source() != source) {
+      int candidate_index = -1;
+      if (!accessor->matches_framelocals_key(key, &candidate_index)) {
         continue;
       }
-      if (!accessor->supports_subtree_memo()) {
+      if (*matched_accessor != nullptr || candidate_index < 0) {
         return false;
-      }
-      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive()) {
-        return false;
-      }
-      if (framelocals_index != nullptr) {
-        *framelocals_index = accessor->framelocals_index();
-      }
-      return true;
-    }
-    return false;
-  }
-
-  bool supports_actual_partial_accessor_subtree_memo_recursive(
-      const std::string& source,
-      int* framelocals_index = nullptr) const {
-    if (framelocals_index != nullptr) {
-      *framelocals_index = -1;
-    }
-    for (const auto& accessor : _accessors) {
-      if (accessor->get_source() != source) {
-        continue;
       }
       if (!accessor->supports_subtree_memo() ||
           !accessor->get_guard_manager()
                ->supports_actual_partial_subtree_memo_recursive()) {
         return false;
       }
-      if (framelocals_index != nullptr) {
-        *framelocals_index = accessor->framelocals_index();
-      }
-      return true;
+      *matched_accessor = accessor.get();
+      *framelocals_index = candidate_index;
     }
-    return false;
+    return *matched_accessor != nullptr;
   }
 
   virtual bool check_nopybind(FrameLocalsMapping* value) {
@@ -6483,13 +6475,16 @@ class GuardManager {
   bool check_leaf_guards_nopybind(T* value) {
     for (const auto& guard : _leaf_guards) {
       bool result = false;
-      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+      if (C10_UNLIKELY(
+              active_guard_subtree_memo_recorder != nullptr &&
+              active_guard_subtree_memo_root == _root)) {
         bool emit_subtree_memo_token = false;
         if constexpr (std::is_same_v<T, PyObject>) {
           const bool actual_partial_supported =
               guard->supports_actual_partial_subtree_memo(value);
           if (active_guard_actual_partial_supported != nullptr &&
-              is_self_local_source_path(_source) && !actual_partial_supported) {
+              active_guard_actual_partial_in_self &&
+              !actual_partial_supported) {
             *active_guard_actual_partial_supported = false;
           }
           emit_subtree_memo_token = actual_partial_supported &&
@@ -6521,7 +6516,9 @@ class GuardManager {
   }
 
   template <bool RecordActualPartial = false, typename T>
-  bool check_accessors_nopybind(T* value) {
+  bool check_accessors_nopybind(
+      T* value,
+      const GuardAccessor* record_self_accessor = nullptr) {
     bool matches_dict_tag = false;
     uint64_t new_tag = 0;
     if constexpr (std::is_same_v<T, PyObject>) {
@@ -6542,15 +6539,23 @@ class GuardManager {
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
       bool accessor_result = false;
-      if constexpr (RecordActualPartial && std::is_same_v<T, PyObject>) {
+      if constexpr (
+          RecordActualPartial && std::is_same_v<T, FrameLocalsMapping>) {
+        const bool enter_self = accessor.get() == record_self_accessor &&
+            accessor.get() == active_guard_actual_partial_self_accessor &&
+            active_guard_subtree_memo_root == _root;
+        GuardActualPartialSelfScope self_scope(enter_self);
+        accessor_result = accessor->check_nopybind(value, matches_dict_tag);
+      } else if constexpr (RecordActualPartial && std::is_same_v<T, PyObject>) {
         if (C10_UNLIKELY(
                 active_guard_actual_partial_supported != nullptr &&
-                is_self_local_source_path(accessor->get_source()) &&
+                active_guard_actual_partial_in_self &&
                 !accessor->supports_actual_partial_subtree_memo(value))) {
           *active_guard_actual_partial_supported = false;
         }
-        accessor_result =
-            accessor->check_nopybind_actual_partial(value, matches_dict_tag);
+        accessor_result = active_guard_actual_partial_in_self
+            ? accessor->check_nopybind_actual_partial(value, matches_dict_tag)
+            : accessor->check_nopybind(value, matches_dict_tag);
       } else {
         accessor_result = accessor->check_nopybind(value, matches_dict_tag);
       }
@@ -6597,9 +6602,9 @@ class GuardManager {
   }
 
   template <typename T>
-  bool check_accessors_nopybind_skipping_source(
+  bool check_accessors_nopybind_skipping_accessor(
       T* value,
-      const std::string& skip_source) {
+      const GuardAccessor* skip_accessor) {
     bool matches_dict_tag = false;
     uint64_t new_tag = 0;
     if constexpr (std::is_same_v<T, PyObject>) {
@@ -6612,7 +6617,7 @@ class GuardManager {
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
-      if (accessor->get_source() == skip_source) {
+      if (accessor.get() == skip_accessor) {
         failed_on_first = false;
         continue;
       }
@@ -6908,12 +6913,16 @@ class RootGuardManager : public GuardManager {
   }
 
   // Fast check function.
-  template <bool HasActualPartial = false, typename T>
+  template <
+      bool HasActualPartial = false,
+      bool RecordActualPartial = false,
+      typename T>
   bool check_nopybind_template(
       T* value,
-      const std::string* skip_accessor_source = nullptr,
+      const GuardAccessor* actual_partial_self_accessor = nullptr,
       GuardLastSuccessPartialPlan* actual_partial_plan = nullptr,
       bool* actual_partial_token_miss = nullptr) { // borrowed ref
+    static_assert(!(HasActualPartial && RecordActualPartial));
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions with GIL.
     PyThreadState* _save = nullptr;
@@ -6933,11 +6942,15 @@ class RootGuardManager : public GuardManager {
     }
 
     if constexpr (HasActualPartial) {
-      if (actual_partial_plan == nullptr ||
-          actual_partial_token_miss == nullptr) {
+      if (actual_partial_token_miss == nullptr) {
         return false;
       }
       *actual_partial_token_miss = false;
+      if (actual_partial_plan == nullptr ||
+          actual_partial_self_accessor == nullptr) {
+        *actual_partial_token_miss = true;
+        return false;
+      }
       if (!guard_last_success_actual_partial_tokens_match(
               *actual_partial_plan, value, &_local_state)) {
         *actual_partial_token_miss = true;
@@ -6971,10 +6984,17 @@ class RootGuardManager : public GuardManager {
       at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
     });
 
-    const bool accessor_result = skip_accessor_source == nullptr
-        ? GuardManager::check_accessors_nopybind<false>(value)
-        : GuardManager::check_accessors_nopybind_skipping_source(
-              value, *skip_accessor_source);
+    bool accessor_result = false;
+    if constexpr (RecordActualPartial) {
+      accessor_result = actual_partial_self_accessor != nullptr &&
+          GuardManager::check_accessors_nopybind<true>(
+                            value, actual_partial_self_accessor);
+    } else {
+      accessor_result = actual_partial_self_accessor == nullptr
+          ? GuardManager::check_accessors_nopybind<false>(value)
+          : GuardManager::check_accessors_nopybind_skipping_accessor(
+                value, actual_partial_self_accessor);
+    }
     if (!accessor_result) {
       return false;
     }
@@ -7008,19 +7028,18 @@ class RootGuardManager : public GuardManager {
     return check_nopybind_template(value);
   }
 
-  bool check_nopybind_skipping_source(
+  bool check_nopybind_recording_actual_partial(
       FrameLocalsMapping* value,
-      const std::string& skip_accessor_source) {
-    return check_nopybind_template(value, &skip_accessor_source);
+      const GuardAccessor* self_accessor) {
+    return check_nopybind_template<false, true>(value, self_accessor);
   }
 
   bool check_nopybind_actual_partial(
       FrameLocalsMapping* value,
-      const std::string& skip_accessor_source,
       GuardLastSuccessPartialPlan& plan,
       bool& token_miss) {
     return check_nopybind_template<true>(
-        value, &skip_accessor_source, &plan, &token_miss);
+        value, plan.self_accessor, &plan, &token_miss);
   }
 
   bool supports_subtree_memo_recursive() const override {
@@ -7835,8 +7854,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     append_guard_subtree_memo_token(
         tokens,
         GuardSubtreeEntryToken::make_torch_function_mode_stack(
-            static_cast<const void*>(this)),
-        "<TORCH_FUNCTION_MODE_STACK>");
+            static_cast<const void*>(this)));
     return true;
   }
 
@@ -7987,7 +8005,7 @@ class TENSOR_MATCH : public LeafGuard {
             value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
       return false;
     }
-    append_guard_subtree_memo_token(tokens, std::move(token), _tensor_name);
+    append_guard_subtree_memo_token(tokens, std::move(token));
     return true;
   }
 
@@ -8083,7 +8101,7 @@ class GetAttrGuardAccessor : public GuardAccessor {
     }
     if constexpr (RecordActualPartial) {
       guard_actual_partial_record_instance_attr_binding(
-          obj, _attr_name, x, get_source(), true);
+          obj, _attr_name, x, true);
     }
     bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
@@ -8180,7 +8198,7 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
     }
     if constexpr (RecordActualPartial) {
       guard_actual_partial_record_instance_attr_binding(
-          obj, _attr_name, x, get_source(), false);
+          obj, _attr_name, x, false);
     }
     bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
@@ -8278,7 +8296,7 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
       return false;
     }
     if constexpr (RecordActualPartial) {
-      guard_actual_partial_record_generic_dict_binding(obj, x, get_source());
+      guard_actual_partial_record_generic_dict_binding(obj, x);
     }
     bool result = _guard_manager->check_nopybind(x);
     Py_DECREF(x);
@@ -8371,8 +8389,25 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
     return true;
   }
 
-  int framelocals_index() const override {
-    return _framelocals_idx;
+  bool matches_framelocals_key(const char* key, int* framelocals_index)
+      const override {
+    // Frame-local names are exact Unicode objects. Reject synthetic keys
+    // instead of invoking an arbitrary Python __eq__ while walking accessors.
+    if (key == nullptr || _key == nullptr || !PyUnicode_CheckExact(_key) ||
+        _framelocals_idx < 0) {
+      return false;
+    }
+    const int comparison = PyUnicode_CompareWithASCIIString(_key, key);
+    if (comparison != 0) {
+      if (PyErr_Occurred()) {
+        PyErr_Clear();
+      }
+      return false;
+    }
+    if (framelocals_index != nullptr) {
+      *framelocals_index = _framelocals_idx;
+    }
+    return true;
   }
 
   FrameLocalsGuardAccessor(
@@ -9867,7 +9902,7 @@ class CodeGuardAccessor : public GuardAccessor {
   bool check_nopybind_actual_partial(
       PyObject* obj,
       bool matches_dict_tag = false) override {
-    guard_actual_partial_record_code_accessor(obj, get_source());
+    guard_actual_partial_record_code_accessor(obj);
     return check_nopybind(obj, matches_dict_tag);
   }
 
@@ -10433,12 +10468,11 @@ bool run_root_guard_manager_with_last_success_receipt(
   }
 
   RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
-  static const std::string self_source = "L['self']";
 
   if (state->actual_partial.is_enabled_for(entry_key, root)) {
     bool token_miss = false;
     const bool result = root_mgr->check_nopybind_actual_partial(
-        f_locals, self_source, state->actual_partial, token_miss);
+        f_locals, state->actual_partial, token_miss);
     if (!token_miss) {
       return result;
     }
@@ -10451,21 +10485,28 @@ bool run_root_guard_manager_with_last_success_receipt(
     return run_root_guard_manager(root, f_locals);
   }
 
+  const GuardAccessor* self_accessor = nullptr;
   int self_framelocals_index = -1;
-  if (!root_mgr->supports_actual_partial_accessor_subtree_memo_recursive(
-          self_source, &self_framelocals_index)) {
+  if (!root_mgr->find_actual_partial_framelocals_accessor(
+          "self", &self_accessor, &self_framelocals_index)) {
     state->actual_partial.disable();
     return run_root_guard_manager(root, f_locals);
   }
 
   std::vector<GuardSubtreeEntryToken> tokens;
-  std::vector<std::string> debug_paths;
+  std::vector<uint8_t> self_membership;
   std::vector<GuardActualPartialAccessorRecord> accessor_records;
   bool actual_partial_supported = true;
   {
     GuardSubtreeMemoRecorderScope recorder(
-        &tokens, &debug_paths, &accessor_records, &actual_partial_supported);
-    if (!run_root_guard_manager(root, f_locals)) {
+        &tokens,
+        &self_membership,
+        root_mgr,
+        self_accessor,
+        &accessor_records,
+        &actual_partial_supported);
+    if (!root_mgr->check_nopybind_recording_actual_partial(
+            f_locals, self_accessor)) {
       // Cache lookup probes entries that commonly do not own the current
       // input. Keep this entry's plan and training state on a probe miss.
       return false;
@@ -10477,7 +10518,7 @@ bool run_root_guard_manager_with_last_success_receipt(
     return true;
   }
 
-  if (tokens.empty() || debug_paths.size() != tokens.size() ||
+  if (tokens.empty() || self_membership.size() != tokens.size() ||
       tokens.size() > kGuardLastSuccessActualMaxTokens) {
     state->actual_partial.disable();
     return true;
@@ -10488,8 +10529,9 @@ bool run_root_guard_manager_with_last_success_receipt(
           &state->actual_partial,
           f_locals,
           self_framelocals_index,
+          self_accessor,
           tokens,
-          debug_paths,
+          self_membership,
           accessor_records,
           build)) {
     state->actual_partial.disable();

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -154,6 +154,7 @@ enum class GuardSubtreeProbeTokenKind : uint8_t {
   BoundMethod,
   FrameGlobals,
   TensorDimensionMarkingAbsent,
+  ExactSetEquals,
 };
 
 constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
@@ -1093,6 +1094,25 @@ static bool guard_subtree_type_version_is_valid(PyTypeObject* type) {
 #endif
 }
 
+static bool guard_subtree_ensure_type_version(
+    PyTypeObject* type,
+    PyObject* lookup_key) {
+  if (type == nullptr || lookup_key == nullptr) {
+    return false;
+  }
+  (void)_PyType_Lookup(type, lookup_key);
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    return false;
+  }
+#if PY_VERSION_HEX >= 0x030C0000
+  if (PyUnstable_Type_AssignVersionTag(type) == 0) {
+    return false;
+  }
+#endif
+  return guard_subtree_type_version_is_valid(type);
+}
+
 static bool guard_actual_partial_uses_default_getattribute(PyTypeObject* type) {
   return type != nullptr && type->tp_getattr == nullptr &&
       type->tp_getattro == PyObject_GenericGetAttr;
@@ -1151,6 +1171,10 @@ struct GuardSubtreeTypeProof {
 enum class GuardActualPartialAccessorRecordKind : uint8_t {
   GenericDictBinding,
   InstanceAttrBinding,
+  TypeMethodBinding,
+  StaticModuleAttrBinding,
+  StaticTypeAttrBinding,
+  CodeAccessor,
 };
 
 struct GuardActualPartialAccessorRecord {
@@ -1163,6 +1187,7 @@ struct GuardActualPartialAccessorRecord {
   py::object owner_dict;
   PyTypeObject* owner_type{nullptr};
   bool requires_default_getattribute{false};
+  bool owner_has_dict_slot{false};
 };
 
 struct GuardSubtreeGenericDictOwnerProof {
@@ -1201,6 +1226,65 @@ struct GuardSubtreeInstanceAttrOwnerProof {
     return dictptr != nullptr && *dictptr == dict.ptr() &&
         PyDict_CheckExact(*dictptr) &&
         PyDict_GetItem(*dictptr, key.ptr()) == expected.ptr();
+  }
+};
+
+struct GuardSubtreeCodeAccessorProof {
+  py::object function;
+  py::object code;
+
+  bool matches_current() const {
+    if (!PyFunction_Check(function.ptr())) {
+      return false;
+    }
+    PyObject* current_code = PyFunction_GetCode(function.ptr());
+    if (current_code == nullptr) {
+      PyErr_Clear();
+      return false;
+    }
+    return current_code == code.ptr();
+  }
+};
+
+struct GuardSubtreeTypeMethodProof {
+  py::object owner;
+  PyObject* owner_ptr{nullptr};
+  py::object key;
+  py::object expected;
+  py::object dict;
+  PyTypeObject* owner_type{nullptr};
+  bool owner_is_self{false};
+  bool owner_has_dict_slot{false};
+  unsigned int version{0};
+
+  bool matches_or_refreshes_current(PyObject* current_self) {
+    PyObject* current_owner = owner_is_self ? current_self : owner.ptr();
+    if (current_owner == nullptr || Py_TYPE(current_owner) != owner_type) {
+      return false;
+    }
+    PyObject** dictptr = _PyObject_GetDictPtr(current_owner);
+    if ((dictptr != nullptr) != owner_has_dict_slot) {
+      return false;
+    }
+    if (dictptr != nullptr &&
+        (dict.ptr() == nullptr
+             ? *dictptr != nullptr
+             : *dictptr != dict.ptr() || !PyDict_CheckExact(*dictptr) ||
+                 PyDict_GetItem(*dictptr, key.ptr()) != nullptr)) {
+      return false;
+    }
+    if (guard_subtree_type_version_is_valid(owner_type) &&
+        owner_type->tp_version_tag == version) {
+      return guard_actual_partial_uses_default_getattribute(owner_type);
+    }
+    if (!guard_actual_partial_uses_default_getattribute(owner_type) ||
+        _PyType_Lookup(owner_type, key.ptr()) != expected.ptr() ||
+        !guard_subtree_ensure_type_version(owner_type, key.ptr())) {
+      PyErr_Clear();
+      return false;
+    }
+    version = owner_type->tp_version_tag;
+    return true;
   }
 };
 
@@ -1245,6 +1329,7 @@ struct GuardSubtreeEntryToken {
   PyTypeObject* bound_c_method_class{nullptr};
   int bound_c_method_flags{0};
   PyObject* dimension_marking_key{nullptr};
+  PyObject* expected_value{nullptr};
 
   static GuardSubtreeEntryToken make(PyObject* obj) {
     GuardSubtreeEntryToken token;
@@ -1415,6 +1500,18 @@ struct GuardSubtreeEntryToken {
     return token;
   }
 
+  static GuardSubtreeEntryToken make_exact_set_equals(
+      PyObject* obj,
+      PyObject* expected) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::ExactSetEquals;
+    token.expected_value = expected;
+    token.size = PySet_GET_SIZE(expected);
+    return token;
+  }
+
   bool matches_tensor_current(const LocalState* state) const {
     if (state == nullptr) {
       return false;
@@ -1517,6 +1614,9 @@ struct GuardSubtreeEntryToken {
     }
     if (kind == GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent) {
       return dimension_marking_key == other.dimension_marking_key;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::ExactSetEquals) {
+      return expected_value == other.expected_value && size == other.size;
     }
     return version == other.version && size == other.size &&
         list_items == other.list_items;
@@ -1848,6 +1948,8 @@ static bool guard_last_success_retain_token_objects(
         for (PyObject* item : token.list_items) {
           retain(item);
         }
+      } else if (token.kind == GuardSubtreeProbeTokenKind::ExactSetEquals) {
+        retain(token.expected_value);
       }
     }
   }
@@ -1927,20 +2029,54 @@ static bool guard_last_success_build_accessor_proofs(
       continue;
     }
 
+    const bool instance_binding = record.kind ==
+        GuardActualPartialAccessorRecordKind::InstanceAttrBinding;
+    const bool module_binding = record.kind ==
+        GuardActualPartialAccessorRecordKind::StaticModuleAttrBinding;
+    const bool type_binding = record.kind ==
+        GuardActualPartialAccessorRecordKind::StaticTypeAttrBinding;
+    if (!instance_binding && !module_binding && !type_binding) {
+      continue;
+    }
+
     if (record.key.ptr() == nullptr || record.resolved.ptr() == nullptr ||
         record.owner_dict.ptr() == nullptr ||
         !PyUnicode_Check(record.key.ptr()) ||
         !PyDict_CheckExact(record.owner_dict.ptr()) ||
         PyDict_GetItem(record.owner_dict.ptr(), record.key.ptr()) !=
-            record.resolved.ptr() ||
-        _PyType_Lookup(record.owner_type, record.key.ptr()) != nullptr ||
-        !guard_last_success_add_type_proof(
-            record.owner_type,
-            record.key.ptr(),
-            record.requires_default_getattribute,
-            type_proofs)) {
+            record.resolved.ptr()) {
       PyErr_Clear();
       return false;
+    }
+    if (instance_binding) {
+      if (_PyType_Lookup(record.owner_type, record.key.ptr()) != nullptr ||
+          !guard_last_success_add_type_proof(
+              record.owner_type,
+              record.key.ptr(),
+              record.requires_default_getattribute,
+              type_proofs)) {
+        PyErr_Clear();
+        return false;
+      }
+    } else {
+      PyTypeObject* expected_owner_type =
+          module_binding ? &PyModule_Type : &PyType_Type;
+      PyObject* metatype_attr =
+          _PyType_Lookup(expected_owner_type, record.key.ptr());
+      PyObject** dictptr = _PyObject_GetDictPtr(record.owner_ptr);
+      const bool exact_owner = module_binding
+          ? PyModule_CheckExact(record.owner_ptr)
+          : PyType_Check(record.owner_ptr) &&
+              Py_TYPE(record.owner_ptr) == &PyType_Type;
+      if (PyErr_Occurred() || !exact_owner ||
+          record.owner_type != expected_owner_type || dictptr == nullptr ||
+          *dictptr != record.owner_dict.ptr() ||
+          (metatype_attr != nullptr && PyDescr_IsData(metatype_attr)) ||
+          (type_binding &&
+           Py_TYPE(record.resolved.ptr())->tp_descr_get != nullptr)) {
+        PyErr_Clear();
+        return false;
+      }
     }
     GuardSubtreeInstanceAttrOwnerProof proof;
     proof.owner_is_self = record.owner_ptr == current_self;
@@ -2003,6 +2139,8 @@ struct GuardLastSuccessPartialPlan {
     type_proofs.clear();
     generic_dict_owner_proofs.clear();
     instance_attr_owner_proofs.clear();
+    type_method_proofs.clear();
+    code_accessor_proofs.clear();
     cross_slice_relations.clear();
     retained_token_objects.clear();
   }
@@ -2031,6 +2169,8 @@ struct GuardLastSuccessPartialPlan {
           new_generic_dict_owner_proofs,
       std::vector<GuardSubtreeInstanceAttrOwnerProof>&&
           new_instance_attr_owner_proofs,
+      std::vector<GuardSubtreeTypeMethodProof>&& new_type_method_proofs,
+      std::vector<GuardSubtreeCodeAccessorProof>&& new_code_accessor_proofs,
       std::vector<GuardCrossSliceRelationPlan>&& new_cross_slice_relations,
       std::vector<py::object>&& new_retained_token_objects) {
     const bool same_entry =
@@ -2061,6 +2201,8 @@ struct GuardLastSuccessPartialPlan {
     type_proofs = std::move(new_type_proofs);
     generic_dict_owner_proofs = std::move(new_generic_dict_owner_proofs);
     instance_attr_owner_proofs = std::move(new_instance_attr_owner_proofs);
+    type_method_proofs = std::move(new_type_method_proofs);
+    code_accessor_proofs = std::move(new_code_accessor_proofs);
     cross_slice_relations = std::move(new_cross_slice_relations);
     retained_token_objects = std::move(new_retained_token_objects);
     if (state != GuardLastSuccessPartialPlanState::Enabled &&
@@ -2086,6 +2228,8 @@ struct GuardLastSuccessPartialPlan {
   std::vector<GuardSubtreeTypeProof> type_proofs;
   std::vector<GuardSubtreeGenericDictOwnerProof> generic_dict_owner_proofs;
   std::vector<GuardSubtreeInstanceAttrOwnerProof> instance_attr_owner_proofs;
+  std::vector<GuardSubtreeTypeMethodProof> type_method_proofs;
+  std::vector<GuardSubtreeCodeAccessorProof> code_accessor_proofs;
   std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
   std::vector<py::object> retained_token_objects;
 };
@@ -2097,6 +2241,8 @@ struct GuardLastSuccessReceipt {
 
   GuardLastSuccessPartialPlan actual_partial;
 };
+
+static bool py_equals(PyObject* a, PyObject* b, bool false_on_error);
 
 static bool guard_subtree_exact_list_token_matches_current(
     const GuardSubtreeEntryToken& token,
@@ -2120,6 +2266,117 @@ static bool guard_subtree_exact_list_token_matches_current(
   return true;
 }
 
+static bool guard_last_success_build_type_method_proofs(
+    const std::vector<GuardActualPartialAccessorRecord>& records,
+    PyObject* current_self,
+    std::vector<GuardSubtreeTypeMethodProof>& proofs) {
+  proofs.clear();
+  for (const auto& record : records) {
+    if (record.kind !=
+        GuardActualPartialAccessorRecordKind::TypeMethodBinding) {
+      continue;
+    }
+    if (record.owner_ptr == nullptr || record.key.ptr() == nullptr ||
+        record.resolved.ptr() == nullptr || record.owner_type == nullptr ||
+        Py_TYPE(record.owner_ptr) != record.owner_type ||
+        !guard_actual_partial_uses_default_getattribute(record.owner_type) ||
+        !PyFunction_Check(record.resolved.ptr()) ||
+        _PyType_Lookup(record.owner_type, record.key.ptr()) !=
+            record.resolved.ptr() ||
+        !guard_subtree_ensure_type_version(
+            record.owner_type, record.key.ptr())) {
+      PyErr_Clear();
+      return false;
+    }
+
+    PyObject** dictptr = _PyObject_GetDictPtr(record.owner_ptr);
+    if ((dictptr != nullptr) != record.owner_has_dict_slot ||
+        (dictptr != nullptr && record.owner_dict.ptr() == nullptr &&
+         *dictptr != nullptr) ||
+        (record.owner_dict.ptr() != nullptr &&
+         (dictptr == nullptr || *dictptr != record.owner_dict.ptr() ||
+          !PyDict_CheckExact(*dictptr) ||
+          PyDict_GetItem(*dictptr, record.key.ptr()) != nullptr))) {
+      return false;
+    }
+
+    bool seen = false;
+    for (const auto& proof : proofs) {
+      if (proof.owner_ptr == record.owner_ptr &&
+          proof.key.ptr() == record.key.ptr()) {
+        seen = true;
+        if (proof.expected.ptr() != record.resolved.ptr() ||
+            proof.owner_type != record.owner_type ||
+            proof.dict.ptr() != record.owner_dict.ptr() ||
+            proof.owner_has_dict_slot != record.owner_has_dict_slot) {
+          return false;
+        }
+        break;
+      }
+    }
+    if (!seen) {
+      GuardSubtreeTypeMethodProof proof;
+      proof.owner = record.owner;
+      proof.owner_ptr = record.owner_ptr;
+      proof.key = record.key;
+      proof.expected = record.resolved;
+      proof.dict = record.owner_dict;
+      proof.owner_type = record.owner_type;
+      proof.owner_has_dict_slot = record.owner_has_dict_slot;
+      proof.version = record.owner_type->tp_version_tag;
+      if (record.owner_ptr == current_self) {
+        proof.owner = py::object();
+        proof.owner_is_self = true;
+      }
+      proofs.push_back(std::move(proof));
+    }
+  }
+  return true;
+}
+
+static bool guard_last_success_build_code_accessor_proofs(
+    const std::vector<GuardActualPartialAccessorRecord>& records,
+    std::vector<GuardSubtreeCodeAccessorProof>& proofs) {
+  proofs.clear();
+  std::unordered_map<PyObject*, size_t> proof_index_by_function;
+  proof_index_by_function.reserve(records.size());
+  for (const auto& record : records) {
+    if (record.kind != GuardActualPartialAccessorRecordKind::CodeAccessor) {
+      continue;
+    }
+    if (record.owner_ptr == nullptr || record.resolved.ptr() == nullptr ||
+        !PyFunction_Check(record.owner_ptr) ||
+        PyFunction_GetCode(record.owner_ptr) != record.resolved.ptr()) {
+      PyErr_Clear();
+      return false;
+    }
+    const auto existing = proof_index_by_function.find(record.owner_ptr);
+    if (existing != proof_index_by_function.end()) {
+      if (proofs[existing->second].code.ptr() != record.resolved.ptr()) {
+        return false;
+      }
+      continue;
+    }
+    GuardSubtreeCodeAccessorProof proof;
+    proof.function = record.owner;
+    proof.code = record.resolved;
+    proof_index_by_function.emplace(record.owner_ptr, proofs.size());
+    proofs.push_back(std::move(proof));
+  }
+  return true;
+}
+
+static bool guard_subtree_exact_set_equals_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  if (token.object == nullptr || Py_TYPE(token.object) != token.type ||
+      !PySet_CheckExact(token.object) || token.expected_value == nullptr ||
+      !PySet_CheckExact(token.expected_value) ||
+      PySet_GET_SIZE(token.expected_value) != token.size) {
+    return false;
+  }
+  return py_equals(token.object, token.expected_value, /*false_on_error=*/true);
+}
+
 static bool guard_subtree_memo_tokens_match(
     const std::vector<GuardSubtreeEntryToken>& tokens,
     PyObject* root_value,
@@ -2136,6 +2393,12 @@ static bool guard_subtree_memo_tokens_match(
         GuardSubtreeProbeTokenKind::TensorDimensionMarkingAbsent) {
       if (!guard_subtree_dimension_marking_absent_token_matches_current(
               token)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::ExactSetEquals) {
+      if (!guard_subtree_exact_set_equals_token_matches_current(token)) {
         return false;
       }
       continue;
@@ -2305,6 +2568,8 @@ struct GuardLastSuccessPartialPlanBuild {
   std::vector<GuardSubtreeTypeProof> type_proofs;
   std::vector<GuardSubtreeGenericDictOwnerProof> generic_dict_owner_proofs;
   std::vector<GuardSubtreeInstanceAttrOwnerProof> instance_attr_owner_proofs;
+  std::vector<GuardSubtreeTypeMethodProof> type_method_proofs;
+  std::vector<GuardSubtreeCodeAccessorProof> code_accessor_proofs;
   std::vector<GuardCrossSliceRelationPlan> cross_slice_relations;
   std::vector<py::object> retained_token_objects;
 };
@@ -2361,11 +2626,15 @@ static bool guard_last_success_prepare_actual_partial(
     return false;
   }
   return guard_last_success_build_accessor_proofs(
-      accessor_records,
-      current_self,
-      build.type_proofs,
-      build.generic_dict_owner_proofs,
-      build.instance_attr_owner_proofs);
+             accessor_records,
+             current_self,
+             build.type_proofs,
+             build.generic_dict_owner_proofs,
+             build.instance_attr_owner_proofs) &&
+      guard_last_success_build_type_method_proofs(
+             accessor_records, current_self, build.type_method_proofs) &&
+      guard_last_success_build_code_accessor_proofs(
+             accessor_records, build.code_accessor_proofs);
 }
 
 static bool guard_last_success_actual_partial_tokens_match(
@@ -2406,6 +2675,16 @@ static bool guard_last_success_actual_partial_tokens_match(
   }
   for (auto& proof : plan.type_proofs) {
     if (!proof.matches_or_refreshes_current()) {
+      return false;
+    }
+  }
+  for (auto& proof : plan.type_method_proofs) {
+    if (!proof.matches_or_refreshes_current(current_self)) {
+      return false;
+    }
+  }
+  for (const auto& proof : plan.code_accessor_proofs) {
+    if (!proof.matches_current()) {
       return false;
     }
   }
@@ -2474,30 +2753,104 @@ static void guard_actual_partial_record_instance_attr_binding(
     return;
   }
   if (owner == nullptr || key == nullptr || expected == nullptr ||
-      !PyUnicode_Check(key) ||
-      (require_default_getattribute &&
-       !guard_actual_partial_uses_default_getattribute(Py_TYPE(owner)))) {
+      !PyUnicode_Check(key)) {
     guard_actual_partial_mark_unsupported();
     return;
   }
+
+  GuardActualPartialAccessorRecord record;
+  record.owner = py::reinterpret_borrow<py::object>(owner);
+  record.owner_ptr = owner;
+  record.key = py::reinterpret_borrow<py::object>(key);
+  record.resolved = py::reinterpret_borrow<py::object>(expected);
+  record.owner_type = Py_TYPE(owner);
+
+  const bool default_getattribute = !require_default_getattribute ||
+      guard_actual_partial_uses_default_getattribute(record.owner_type);
   PyObject** dictptr = _PyObject_GetDictPtr(owner);
-  if (dictptr == nullptr || *dictptr == nullptr ||
-      !PyDict_CheckExact(*dictptr) ||
-      PyDict_GetItem(*dictptr, key) != expected ||
-      _PyType_Lookup(Py_TYPE(owner), key) != nullptr) {
+  PyObject* type_attr = _PyType_Lookup(record.owner_type, key);
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  const bool exact_owner_dict =
+      dictptr != nullptr && *dictptr != nullptr && PyDict_CheckExact(*dictptr);
+  record.owner_has_dict_slot = dictptr != nullptr;
+  if (exact_owner_dict) {
+    record.owner_dict = py::reinterpret_borrow<py::object>(*dictptr);
+  }
+
+  const bool direct_instance_binding = default_getattribute &&
+      exact_owner_dict && PyDict_GetItem(*dictptr, key) == expected &&
+      type_attr == nullptr;
+  const bool type_method_binding = default_getattribute &&
+      type_attr != nullptr && PyFunction_Check(type_attr) &&
+      PyMethod_Check(expected) && PyMethod_GET_SELF(expected) == owner &&
+      PyMethod_GET_FUNCTION(expected) == type_attr &&
+      (dictptr == nullptr || *dictptr == nullptr ||
+       (exact_owner_dict && PyDict_GetItem(*dictptr, key) == nullptr));
+  const bool static_module_binding = require_default_getattribute &&
+      !default_getattribute && PyModule_CheckExact(owner) &&
+      record.owner_type == &PyModule_Type && exact_owner_dict &&
+      PyDict_GetItem(*dictptr, key) == expected &&
+      (type_attr == nullptr || !PyDescr_IsData(type_attr));
+  const bool static_type_binding = require_default_getattribute &&
+      !default_getattribute && PyType_Check(owner) &&
+      Py_TYPE(owner) == &PyType_Type && record.owner_type == &PyType_Type &&
+      exact_owner_dict && PyDict_GetItem(*dictptr, key) == expected &&
+      (type_attr == nullptr || !PyDescr_IsData(type_attr)) &&
+      Py_TYPE(expected)->tp_descr_get == nullptr;
+
+  if (direct_instance_binding) {
+    record.kind = GuardActualPartialAccessorRecordKind::InstanceAttrBinding;
+    record.requires_default_getattribute = require_default_getattribute;
+  } else if (
+      type_method_binding &&
+      guard_subtree_ensure_type_version(record.owner_type, key)) {
+    record.kind = GuardActualPartialAccessorRecordKind::TypeMethodBinding;
+    record.resolved = py::reinterpret_borrow<py::object>(type_attr);
+  } else if (static_module_binding) {
+    record.kind = GuardActualPartialAccessorRecordKind::StaticModuleAttrBinding;
+  } else if (static_type_binding) {
+    record.kind = GuardActualPartialAccessorRecordKind::StaticTypeAttrBinding;
+  } else {
+    PyErr_Clear();
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  active_guard_actual_partial_accessor_records->push_back(std::move(record));
+}
+
+static void guard_actual_partial_record_code_accessor(
+    PyObject* parent,
+    const std::string& source) {
+  if (!is_self_local_source_path(source) ||
+      !guard_actual_partial_can_record_accessor()) {
+    return;
+  }
+  PyObject* function = parent;
+  if (PyMethod_Check(parent)) {
+    function = PyMethod_GET_FUNCTION(parent);
+  } else if (PyInstanceMethod_Check(parent)) {
+    function = PyInstanceMethod_GET_FUNCTION(parent);
+  }
+  if (!PyFunction_Check(function)) {
+    guard_actual_partial_mark_unsupported();
+    return;
+  }
+  PyObject* code = PyFunction_GetCode(function);
+  if (code == nullptr) {
     PyErr_Clear();
     guard_actual_partial_mark_unsupported();
     return;
   }
   GuardActualPartialAccessorRecord record;
-  record.kind = GuardActualPartialAccessorRecordKind::InstanceAttrBinding;
-  record.owner = py::reinterpret_borrow<py::object>(owner);
-  record.owner_ptr = owner;
-  record.key = py::reinterpret_borrow<py::object>(key);
-  record.resolved = py::reinterpret_borrow<py::object>(expected);
-  record.owner_dict = py::reinterpret_borrow<py::object>(*dictptr);
-  record.owner_type = Py_TYPE(owner);
-  record.requires_default_getattribute = require_default_getattribute;
+  record.kind = GuardActualPartialAccessorRecordKind::CodeAccessor;
+  record.owner = py::reinterpret_borrow<py::object>(function);
+  record.owner_ptr = function;
+  record.resolved = py::reinterpret_borrow<py::object>(code);
+  record.owner_type = Py_TYPE(function);
   active_guard_actual_partial_accessor_records->push_back(std::move(record));
 }
 
@@ -3823,7 +4176,28 @@ class EQUALS_MATCH : public LeafGuard {
 
   bool supports_actual_partial_subtree_memo(PyObject* value) const override {
     return _actual_partial_safe_constant ||
-        guard_actual_partial_is_deeply_immutable(value);
+        guard_actual_partial_is_deeply_immutable(value) ||
+        (PySet_CheckExact(_value.ptr()) && PySet_CheckExact(value));
+  }
+
+  bool emits_actual_partial_subtree_memo_token() const override {
+    return PySet_CheckExact(_value.ptr());
+  }
+
+  bool append_actual_partial_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    if (!PySet_CheckExact(value) || !PySet_CheckExact(_value.ptr())) {
+      return true;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_exact_set_equals(value, _value.ptr()),
+        "<EQUALS_EXACT_SET>");
+    return true;
   }
 
  private:
@@ -8983,6 +9357,9 @@ class GlobalsGuardAccessor : public GuardAccessor {
  */
 class TypeGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject* parent) const override {
+    return parent != nullptr;
+  }
 
   // name = __type_accessor__, a unique string used as attribute name.
   TypeGuardAccessor(
@@ -9454,6 +9831,19 @@ class WeakRefCallGuardAccessor : public GuardAccessor {
  */
 class CodeGuardAccessor : public GuardAccessor {
  public:
+  bool supports_actual_partial_subtree_memo(PyObject* parent) const override {
+    if (parent == nullptr) {
+      return false;
+    }
+    PyObject* function = parent;
+    if (PyMethod_Check(parent)) {
+      function = PyMethod_GET_FUNCTION(parent);
+    } else if (PyInstanceMethod_Check(parent)) {
+      function = PyInstanceMethod_GET_FUNCTION(parent);
+    }
+    return PyFunction_Check(function);
+  }
+
   // name = __type_mro_accessor__, a unique string used as attribute name.
   CodeGuardAccessor(
 
@@ -9485,6 +9875,13 @@ class CodeGuardAccessor : public GuardAccessor {
       return false;
     }
     return _guard_manager->check_nopybind(x);
+  }
+
+  bool check_nopybind_actual_partial(
+      PyObject* obj,
+      bool matches_dict_tag = false) override {
+    guard_actual_partial_record_code_accessor(obj, get_source());
+    return check_nopybind(obj, matches_dict_tag);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -10126,6 +10523,8 @@ bool run_root_guard_manager_with_last_success_receipt(
       std::move(build.type_proofs),
       std::move(build.generic_dict_owner_proofs),
       std::move(build.instance_attr_owner_proofs),
+      std::move(build.type_method_proofs),
+      std::move(build.code_accessor_proofs),
       std::move(build.cross_slice_relations),
       std::move(build.retained_token_objects));
   return true;

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -12,7 +12,18 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe);
 bool root_guard_manager_has_no_guards(void* root);
+
+void* create_guard_last_success_receipt();
+void destroy_guard_last_success_receipt(void* receipt);
+void reset_guard_last_success_receipt(void* receipt);
+bool is_guard_last_success_receipt_enabled(void* receipt);
 
 extern thread_local bool tls_is_in_mode_without_ignore_compile_internals;
 
@@ -95,6 +106,14 @@ class TensorCheck {
       const LocalState& state,
       const at::Tensor& v,
       const std::string& tensor_name);
+
+  const std::vector<std::optional<c10::SymInt>>& sizes() const {
+    return sizes_;
+  }
+
+  const std::vector<std::optional<c10::SymInt>>& strides() const {
+    return strides_;
+  }
 
   PyTypeObject* pytype;
 

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -476,6 +476,12 @@ void initDynamoBindings(PyObject* torch) {
       .def_readonly("backend", &CacheEntry::backend)
       .def_readonly(
           "isolate_recompiles_id", &CacheEntry::_isolate_recompiles_id)
+      .def_property_readonly(
+          "_debug_fast_guard_enabled",
+          [](const CacheEntry& entry) {
+            return torch::dynamo::is_guard_last_success_receipt_enabled(
+                entry.last_success_receipt);
+          })
       .def(
           "update_diff_guard_root_manager",
           &CacheEntry::update_diff_guard_root_manager);

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -486,8 +486,14 @@ void initDynamoBindings(PyObject* torch) {
           "update_diff_guard_root_manager",
           &CacheEntry::update_diff_guard_root_manager);
 
-  py::class_<PrecompileEntry>(m, "_PrecompileEntry")
-      .def_readonly("guard_manager", &PrecompileEntry::guard_manager);
+  py::class_<PrecompileEntry, std::shared_ptr<PrecompileEntry>>(
+      m, "_PrecompileEntry")
+      .def_readonly("guard_manager", &PrecompileEntry::guard_manager)
+      .def_property_readonly(
+          "_debug_fast_guard_enabled", [](const PrecompileEntry& entry) {
+            return torch::dynamo::is_guard_last_success_receipt_enabled(
+                entry.last_success_receipt);
+          });
 
   py::class_<ExtraState>(m, "_ExtraState")
       .def("invalidate", &ExtraState::invalidate);


### PR DESCRIPTION
## Summary

Ports the hardened Last Successful Guard Memo / actual-partial token plan to current PyTorch `main`.

The experiment is gated by `torch._dynamo.config.enable_guard_lookup_memo` and defaults to **off**. With the flag off, Dynamo keeps the existing guard lookup path: no receipt allocation, no token/accessor recording, no relation tracking, and no precompile receipt snapshot or mutex acquisition for an empty precompile list.

When explicitly enabled, each cache entry may train a conservative flat plan for the stable `L['self']` guard slice. A hit validates the recorded bindings/tokens, skips that covered guard subtree, and evaluates the residual guard path. Unsupported shapes, proof mismatch, invalidation, owner/type changes, or bounded-training failure all fail closed to the original GuardManager path.

## Main-port changes

- Preserve current-main cache buckets, `isolate_recompiles_id`, guardless lookup, and skip-guard-unsafe behavior.
- Own FastGuard receipt state per `CacheEntry`; invalidation and destruction reset only that entry.
- Give precompile entries independent receipt ownership with lifetime-safe snapshots; the ordinary empty-list path uses only an atomic presence hint.
- Record relation operands without adding default-off hot-path work, and preserve all-self, cross-slice, residual, and recursive-dict-tag alias semantics.
- Isolate recording/non-recording accessor templates so the disabled path does not pay source-string or recorder costs.
- Bound token/accessor/list memory and unstable training so unsupported workloads cannot grow state indefinitely.

## Correctness closure

- Fail closed for unsupported leaf guards, accessors, container shapes, tensor subclasses, dimension-marking descriptors, opaque attributes, and free-threaded Python.
- Prove direct instance/generic-dict/static module/static type/method/function-code bindings before publishing a plan.
- Revalidate descriptor slots and type identity on the hot path.
- Retain exact-list/token objects safely and restrict exact-set equality tokens to deeply immutable elements, avoiding user `__eq__` callbacks.
- Preserve local-state transitions, owner lifetime, cache-entry/root/self identity, mutation invalidation, and relation cleanup semantics.

## Scope

- 13 existing source/test files.
- No production statistics or timing counters.
- No design/plan documents or benchmark artifacts.
- No new environment variable; the existing-style Dynamo config flag is the only opt-in control.

## Validation completed

- `git diff --check` and conflict-marker/scope checks.
- Repository-required `clang-format 19.1.4` on the changed C++ ranges.
- Python AST validation for all 5 changed Python/typing files.
- AST validation for all 24 subprocess programs embedded in the focused Dynamo tests.
- MSVC syntax/API probes for the Python 3.12/3.13 conditional set API and the changed precompile implementation.
- Independent parity and correctness reviews found no remaining P0/P1 code issue.

This checkout is sparse and does not have a target-main build whose generated headers/ABI match the new source. Full compilation and focused runtime tests therefore remain CI/entity-card gates; this PR does **not** claim a new performance number from the local static checks.

## Required performance/runtime gates

- Flag off: functional parity and no lookup p50/p99 regression versus current main.
- Flag on: confirm the plan reaches Enabled, the covered `L['self']` subtree is skipped, and report plan coverage plus cache-lookup p50/p99.
- Run mutation, alias/relation, multi-entry, precompile lifetime, local-state, and output-correctness cases.
- Compare card results against the established FastGuard baseline before merge.

Port source/reference: [113xiaoji/pytorch#9](https://github.com/113xiaoji/pytorch/pull/9)

cc @voznesenskym @penguinwu @EikanWang @Guobing-Chen @jgong5 @anijain2305 @williamwen42