### PR TITLE
fix(dynamo): match CPython str semantics

### DIFF
--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -730,7 +730,7 @@ def forward(self, L_x_ : torch.Tensor):
         with compiled_autograd._enable(compiler_fn):
             dynamo_out = torch.compile(mod, backend="inductor", fullgraph=True)(x2, obj)
             with self.assertRaisesRegex(
-                torch._dynamo.exc.Unsupported, "Failed to trace builtin operator"
+                torch._dynamo.exc.Unsupported, r"repr\(\) on tensor"
             ):
                 dynamo_out[0].backward(torch.ones(4))
 

--- a/test/dynamo/test_str_protocol.py
+++ b/test/dynamo/test_str_protocol.py
@@ -1,8 +1,16 @@
 # Owner(s): ["module: dynamo"]
-"""Tests for tp_str / generic_str foundation behavior in Dynamo."""
+"""Tests for tp_str / generic_str behavior in Dynamo."""
 
+import collections
+import typing
+
+import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import make_dynamo_test
+
+
+class _OpaqueStrDescriptorObject:
+    __str__ = str.upper
 
 
 class TpStrTests(TestCase):
@@ -54,6 +62,338 @@ class TpStrTests(TestCase):
     @make_dynamo_test
     def test_str_list_falls_back_to_repr(self):
         assert str([1, 2, 3]) == "[1, 2, 3]"  # noqa: S101
+
+    @make_dynamo_test
+    def test_object_dunder_str_on_string_uses_repr(self):
+        assert object.__str__("hello") == "'hello'"  # noqa: S101
+        assert object.__str__("") == "''"  # noqa: S101
+
+    @make_dynamo_test
+    def test_object_dunder_str_on_list_uses_repr(self):
+        assert object.__str__([1, 2, 3]) == "[1, 2, 3]"  # noqa: S101
+
+
+class TpStrUserDefinedTests(TestCase):
+    def test_counter_str(self):
+        def fn(x):
+            return str(collections.Counter("aba"))
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_user_defined_str(self):
+        class MyObj:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return f"MyObj({self.value!r})"
+
+        def fn(x, obj):
+            return str(obj)
+
+        obj = MyObj("value")
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, obj), compiled(x, obj))
+
+    def test_user_defined_dunder_str(self):
+        class MyObj:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return f"MyObj({self.value!r})"
+
+        def fn(x, obj):
+            return obj.__str__()
+
+        obj = MyObj("value")
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, obj), compiled(x, obj))
+
+    def test_user_defined_default_object_str(self):
+        class Plain:
+            pass
+
+        def fn(x, obj):
+            return str(obj)
+
+        obj = Plain()
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, obj), compiled(x, obj))
+
+    def test_user_defined_repr_fallback_for_str(self):
+        class MyObj:
+            def __init__(self, value):
+                self.value = value
+
+            def __repr__(self):
+                return f"MyObj({self.value!r})"
+
+        def fn(x, obj):
+            return str(obj)
+
+        obj = MyObj("value")
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, obj), compiled(x, obj))
+
+    def test_object_dunder_str_on_plain_instance(self):
+        class Plain:
+            pass
+
+        def fn(x, obj):
+            return object.__str__(obj)
+
+        obj = Plain()
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x, obj), compiled(x, obj))
+
+    def test_object_dunder_str_ignores_user_defined_str(self):
+        class MyObj:
+            def __str__(self):
+                return "MyObj"
+
+        def fn(x, obj):
+            return object.__str__(obj)
+
+        obj = MyObj()
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        out = compiled(x, obj)
+        self.assertEqual(fn(x, obj), out)
+        self.assertEqual(out, repr(obj))
+        self.assertNotEqual(out, str(obj))
+
+    def test_object_dunder_str_uses_user_defined_repr(self):
+        class MyObj:
+            def __repr__(self):
+                return "MyObjRepr"
+
+            def __str__(self):
+                return "MyObjStr"
+
+        def fn(x, obj):
+            return object.__str__(obj)
+
+        obj = MyObj()
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        out = compiled(x, obj)
+        self.assertEqual(fn(x, obj), out)
+        self.assertEqual(out, repr(obj))
+        self.assertNotEqual(out, str(obj))
+
+    def test_str_returning_non_string_raises(self):
+        class BadStr:
+            def __str__(self):
+                return 3  # noqa: PLE0307
+
+        def fn(x, obj):
+            try:
+                return str(obj)
+            except TypeError as e:
+                return str(e)
+
+        obj = BadStr()
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        out = compiled(x, obj)
+        self.assertEqual(fn(x, obj), out)
+        self.assertIn("__str__ returned non-string", out)
+
+    def test_user_defined_opaque_str_descriptor_raises_type_error(self):
+        def fn(x, obj):
+            try:
+                return str(obj)
+            except TypeError as e:
+                return str(e)
+
+        x = torch.randn(4)
+        eager_result = fn(x, _OpaqueStrDescriptorObject())
+        self.assertIn(
+            "descriptor 'upper' for 'str' objects doesn't apply",
+            eager_result,
+        )
+
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(eager_result, compiled(x, _OpaqueStrDescriptorObject()))
+
+    def test_metaclass_str(self):
+        class Meta(type):
+            def __repr__(cls):
+                return f"<MetaRepr {cls.__name__}>"
+
+            def __str__(cls):
+                return f"<MetaStr {cls.__name__}>"
+
+        class MyClass(metaclass=Meta):
+            pass
+
+        def fn(x):
+            return str(MyClass)
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_type_dunder_str_on_class(self):
+        class Meta(type):
+            def __repr__(cls):
+                return f"<MetaRepr {cls.__name__}>"
+
+            def __str__(cls):
+                return f"<MetaStr {cls.__name__}>"
+
+        class MyClass(metaclass=Meta):
+            pass
+
+        def fn(x):
+            return type.__str__(MyClass)
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+        self.assertEqual(compiled(x), type.__str__(MyClass))
+
+    def test_user_function_str(self):
+        def helper(y):
+            return y + 1
+
+        def fn(x):
+            return str(helper)
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_lambda_str(self):
+        helper = lambda: None  # noqa: E731
+
+        def fn(x):
+            return str(helper)
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_defaultdict_str(self):
+        def fn(x):
+            return str(collections.defaultdict(int, {"a": 1}))
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_defaultdict_str_with_nested_function_factory_unsupported(self):
+        def fn(x):
+            def factory():
+                return x
+
+            return str(collections.defaultdict(factory, {"a": 1}))
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            r"repr\(\) on nested function with non-constructible closure",
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(4))
+
+    def test_ordereddict_and_namedtuple_str_track_nested_repr(self):
+        class Obj:
+            def __init__(self, val):
+                self.val = val
+
+            def __repr__(self):
+                return f"Obj({self.val})"
+
+        class Named(typing.NamedTuple):
+            obj: object
+
+        def fn(x, obj):
+            ordered = collections.OrderedDict([("obj", obj)])
+            named = Named(obj)
+            y = x + 1
+            s1 = (str(ordered), str(named))
+            obj.val.append(0)
+            s2 = (str(ordered), str(named))
+            return y, s1, s2
+
+        x = torch.randn(4)
+        eager_result = fn(x, Obj([1, 2]))
+        compiled_result = torch.compile(fn, backend="eager", fullgraph=True)(
+            x, Obj([1, 2])
+        )
+        self.assertEqual(eager_result[0], compiled_result[0])
+        self.assertEqual(eager_result[1:], compiled_result[1:])
+
+    def test_structseq_str_with_tensor_graph_breaks(self):
+        def fn(x):
+            return str(torch.max(x, dim=0))
+
+        x = torch.randn(3, 2)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+        compiled = torch.compile(fn, backend="eager")
+        self.assertEqual(compiled(x), str(torch.max(x, dim=0)))
+
+
+class TpStrExceptionTests(TestCase):
+    @make_dynamo_test
+    def test_exception_no_args(self):
+        assert str(ValueError()) == ""  # noqa: S101
+
+    @make_dynamo_test
+    def test_exception_one_arg(self):
+        assert str(ValueError("oops")) == "oops"  # noqa: S101
+
+    @make_dynamo_test
+    def test_exception_one_int_arg(self):
+        assert str(ValueError(42)) == "42"  # noqa: S101
+
+    @make_dynamo_test
+    def test_exception_multiple_args(self):
+        assert str(ValueError("error", 42)) == "('error', 42)"  # noqa: S101
+
+    @make_dynamo_test
+    def test_exception_dunder(self):
+        assert TypeError("bad type").__str__() == "bad type"  # noqa: S101
+
+    @make_dynamo_test
+    def test_exception_unbound_dunder(self):
+        assert ValueError.__str__(ValueError("oops")) == "oops"  # noqa: S101
+
+    @make_dynamo_test
+    def test_runtime_error(self):
+        assert str(RuntimeError("runtime failure")) == "runtime failure"  # noqa: S101
+
+    def test_user_defined_exception_subclass_str(self):
+        class MyError(ValueError):
+            pass
+
+        def fn(x):
+            return str(MyError("oops"))
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
+
+    def test_user_defined_exception_subclass_custom_str(self):
+        class MyError(ValueError):
+            def __str__(self):
+                return f"MyError({self.args[0]!r})"
+
+        def fn(x):
+            return str(MyError("oops"))
+
+        x = torch.randn(4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), compiled(x))
 
 
 class FStringMutationTests(TestCase):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -395,6 +395,20 @@ class BaseBuiltinVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        if name == "__str__" and len(args) == 1 and not kwargs:
+            arg = args[0]
+            if self.as_python_constant() is object:
+                return generic_repr(tx, arg)
+            if self.as_python_constant() is type:
+                if isinstance(arg, variables.UserDefinedClassVariable):
+                    return VariableTracker.build(tx, type.__str__(arg.value))
+                if arg.is_python_constant() and isinstance(
+                    arg.as_python_constant(), type
+                ):
+                    return VariableTracker.build(
+                        tx, type.__str__(arg.as_python_constant())
+                    )
+            return generic_str(tx, arg)
         if name == "__repr__" and len(args) == 1 and not kwargs:
             arg = args[0]
             if self.as_python_constant() is object and isinstance(
@@ -1708,8 +1722,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             return generic_len(tx, args[0])
 
         if name == "__str__" and len(args) == 1 and not kwargs:
-            # type.__str__(instance) → str(instance)
-            return generic_str(tx, args[0])
+            return super().call_method(tx, name, args, kwargs)
 
         if name == "__repr__" and len(args) == 1 and not kwargs:
             return super().call_method(tx, name, args, kwargs)
@@ -1781,24 +1794,7 @@ class BuiltinVariable(BaseBuiltinVariable):
     def call_str(
         self, tx: "InstructionTranslatorBase", arg: VariableTracker
     ) -> VariableTracker | None:
-        if isinstance(
-            arg,
-            (variables.ExceptionVariable, variables.UserDefinedExceptionObjectVariable),
-        ):
-            if len(arg.args) == 0:
-                return VariableTracker.build(tx, "")
-            elif len(arg.args) == 1:
-                return BuiltinVariable(str).call_function(tx, [arg.args[0]], {})
-            else:
-                tuple_var = variables.TupleVariable(list(arg.args))
-                return BuiltinVariable(str).call_function(tx, [tuple_var], {})
-
-        # Handle `str` on a user defined function or object
-        if isinstance(arg, (variables.UserFunctionVariable)):
-            return VariableTracker.build(tx, str(arg.fn))
-        elif isinstance(arg, (variables.UserDefinedObjectVariable)):
-            return generic_str(tx, arg)
-        return None
+        return generic_str(tx, arg)
 
     def call___build_class__(self, tx, *args, **kwargs):
         def fail(args, kwargs) -> NoReturn:

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -75,6 +75,7 @@ from ..utils import (
 from .base import AsPythonConstantNotImplementedError, NO_SUCH_SUBOBJ, VariableTracker
 from .constant import ConstantVariable
 from .functions import NestedUserFunctionVariable, UserFunctionVariable
+from .object_protocol import generic_str
 from .user_defined import call_random_fn, is_standard_setattr, UserDefinedObjectVariable
 
 
@@ -728,6 +729,18 @@ class ExceptionVariable(VariableTracker):
                 source=self.source and AttrSource(self.source, "args"),
             )
         return super().var_getattr(tx, name)
+
+    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/exceptions.c#L118-L129
+        if len(self.args) == 0:
+            return VariableTracker.build(tx, "")
+        elif len(self.args) == 1:
+            return generic_str(tx, self.args[0])
+        else:
+            from . import TupleVariable
+
+            tuple_var = TupleVariable(list(self.args))
+            return generic_str(tx, tuple_var)
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.exc_type})"

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -455,17 +455,24 @@ def generic_str(
 
     Resolution order: str identity check -> tp_str (str_impl) -> tp_repr fallback.
     """
+    from ..exc import TorchDynamoException
+
     if maybe_get_python_type(obj) is str:
         return obj
 
     obj_type = maybe_get_python_type(obj)
-    if (
-        type_implements_tp_str(obj_type)
-        and type(obj).str_impl is not VariableTracker.str_impl
-    ):
-        result = obj.str_impl(tx)
-    else:
-        result = generic_repr(tx, obj)
+    try:
+        if (
+            type_implements_tp_str(obj_type)
+            and type(obj).str_impl is not VariableTracker.str_impl
+        ):
+            result = obj.str_impl(tx)
+        else:
+            result = generic_repr(tx, obj)
+    except TorchDynamoException:
+        raise
+    except Exception as exc:
+        raise_observed_exception(type(exc), tx, args=list(exc.args))
 
     result_type = maybe_get_python_type(result)
     if not issubclass(result_type, str):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -112,7 +112,11 @@ from .base import (
 )
 from .dicts import ConstDictVariable, pydict_check
 from .hashable import HashableTracker
-from .object_protocol import is_nb_not_implemented, type_implements_nb_slot
+from .object_protocol import (
+    generic_repr,
+    is_nb_not_implemented,
+    type_implements_nb_slot,
+)
 from .sets import SetVariable
 
 
@@ -485,13 +489,23 @@ class UserDefinedClassVariable(UserDefinedVariable):
     def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L2379-L2408
         metaclass = type(self.value)
-        if metaclass is type or type(self.value).__repr__ is type.__repr__:
+        if metaclass is type or metaclass.__repr__ is type.__repr__:
             return VariableTracker.build(tx, repr(self.value))
 
         type_attr = self.lookup_metaclass_attr("__repr__")
         if type_attr is None:
             raise_type_error(tx, "'NoneType' object is not callable")
         return self.call_method(tx, "__repr__", [], {})
+
+    def str_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        metaclass = type(self.value)
+        if metaclass is type or metaclass.__str__ is type.__str__:
+            return generic_repr(tx, self)
+
+        type_attr = self.lookup_metaclass_attr("__str__")
+        if type_attr is None:
+            raise_type_error(tx, "'NoneType' object is not callable")
+        return self.call_method(tx, "__str__", [], {})
 
     def nb_or_impl(
         self,
@@ -1897,8 +1911,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         self,
         tx: "InstructionTranslatorBase",
     ) -> VariableTracker:
-        from .object_protocol import generic_repr
-
         type_attr = self.lookup_class_mro_attr("__str__")
         if type_attr is NO_SUCH_SUBOBJ:
             return super().str_impl(tx)
@@ -4329,6 +4341,12 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
         if type(self.value).__repr__ is not BaseException.__repr__:
             return super().repr_impl(tx)
         return self.exc_vt.repr_impl(tx)
+
+    def str_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+        # ref: BaseException_str in https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L118-L129
+        if type(self.value).__str__ is not BaseException.__str__:
+            return super().str_impl(tx)
+        return self.exc_vt.str_impl(tx)
 
     @python_stack.setter
     def python_stack(self, value: traceback.StackSummary) -> None:


### PR DESCRIPTION
In this PR I routed Dynamo's `str()` / `__str__()` handling through `generic_str` so tracing follows CPython `tp_str` / `tp_repr` fallback behavior. Added dedicated `str_impl` handling for exceptions, user-defined classes, and wrapped exception objects, including `object.__str__` and `type.__str__` special cases.
Relevant test cases were also added around the changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98