### PR TITLE
Speed up all_gather_offset writes with a shared unrolled copy helper

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_gather_offset.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_gather_offset.cu
@@ -6,6 +6,7 @@
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh>
 #include <cstdint>
 
 // All-gather a rank-local bucket of parameter shards into a "parameter-
@@ -140,12 +141,8 @@ __global__ void all_gather_offset_push_kernel(
         static_cast<size_t>(tile_off);
     char* dst = reinterpret_cast<char*>(
         ncclGetLsaPointer(out_window, dst_byte, dst_peer));
-    const int64_t nvec = tile_len / AG_ALIGN;
-    for (int64_t k = threadIdx.x; k < nvec; k += blockDim.x) {
-      const int64_t b = k * AG_ALIGN;
-      at::native::memory::st_vec<AG_ALIGN>(
-          dst + b, at::native::memory::ld_vec<AG_ALIGN>(src + b));
-    }
+    copy_bytes_vec16_aligned(
+        src, dst, static_cast<size_t>(tile_len), threadIdx.x, blockDim.x);
   }
 
   // Publish this rank's writes (release) and observe all peers' writes

--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_to_all_nd.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_to_all_nd.cu
@@ -7,6 +7,7 @@
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh>
 
 // Permute-free all-to-all for Ulysses-style sequence parallelism.
 //
@@ -26,42 +27,6 @@ namespace c10d::nccl_extension {
 using namespace c10d::symmetric_memory;
 
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
-
-namespace {
-
-// Caller must ensure 16-byte aligned addresses and nbytes divisible by 16.
-__device__ inline void copy_bytes_vec16_aligned(
-    const char* src,
-    char* dst,
-    size_t nbytes,
-    size_t tid,
-    size_t stride) {
-  const size_t n_vec = nbytes / 16;
-  constexpr int kUnroll = 4;
-  size_t vec_idx = tid;
-  for (; vec_idx + static_cast<size_t>(kUnroll - 1) * stride < n_vec;
-       vec_idx += static_cast<size_t>(kUnroll) * stride) {
-    at::native::memory::Vec<16> chunk[kUnroll];
-#pragma unroll 4
-    for (int u = 0; u < kUnroll; ++u) {
-      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
-      chunk[u] = at::native::memory::ld_vec<16>(src + i * 16);
-    }
-#pragma unroll 4
-    for (int u = 0; u < kUnroll; ++u) {
-      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
-      at::native::memory::st_vec<16>(dst + i * 16, chunk[u]);
-    }
-  }
-  for (; vec_idx < n_vec; vec_idx += stride) {
-    const char* src_ptr = src + vec_idx * 16;
-    char* dst_ptr = dst + vec_idx * 16;
-    auto v = at::native::memory::ld_vec<16>(src_ptr);
-    at::native::memory::st_vec<16>(dst_ptr, v);
-  }
-}
-
-} // namespace
 
 constexpr int A2A_MAX_SLOTS = 64;           // max group size (p)
 constexpr int A2A_MAX_CTAS_PER_SLOT = 16;   // max CTAs assigned to one slot's rows

--- a/torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ATen/native/cuda/MemoryAccess.cuh>
+
+namespace c10d::symmetric_memory {
+
+// Cooperative 16-byte-vectorized copy of `nbytes` from `src` to `dst`.  Caller
+// must ensure both pointers are 16-byte aligned and nbytes is a multiple of 16.
+// `tid`/`stride` are this thread's rank and the cooperating thread count (e.g.
+// threadIdx.x / blockDim.x for a CTA-wide copy).  Loads are batched kUnroll-deep
+// before the stores so several loads stay in flight (memory-level parallelism),
+// which is what hides latency when occupancy is low (few CTAs).
+__device__ inline void copy_bytes_vec16_aligned(
+    const char* src,
+    char* dst,
+    size_t nbytes,
+    size_t tid,
+    size_t stride) {
+  const size_t n_vec = nbytes / 16;
+  constexpr int kUnroll = 4;
+  size_t vec_idx = tid;
+  for (; vec_idx + static_cast<size_t>(kUnroll - 1) * stride < n_vec;
+       vec_idx += static_cast<size_t>(kUnroll) * stride) {
+    at::native::memory::Vec<16> chunk[kUnroll];
+#pragma unroll 4
+    for (int u = 0; u < kUnroll; ++u) {
+      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
+      chunk[u] = at::native::memory::ld_vec<16>(src + i * 16);
+    }
+#pragma unroll 4
+    for (int u = 0; u < kUnroll; ++u) {
+      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
+      at::native::memory::st_vec<16>(dst + i * 16, chunk[u]);
+    }
+  }
+  for (; vec_idx < n_vec; vec_idx += stride) {
+    const char* src_ptr = src + vec_idx * 16;
+    char* dst_ptr = dst + vec_idx * 16;
+    auto v = at::native::memory::ld_vec<16>(src_ptr);
+    at::native::memory::st_vec<16>(dst_ptr, v);
+  }
+}
+
+} // namespace c10d::symmetric_memory

--- a/torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/symm_mem_copy.cuh
@@ -6,13 +6,18 @@ namespace c10d::symmetric_memory {
 
 // Cooperative 16-byte-vectorized copy of `nbytes` from `src` to `dst`.  Caller
 // must ensure both pointers are 16-byte aligned and nbytes is a multiple of 16.
+// `src` and `dst` are `__restrict__`: the two regions must not overlap, which
+// lets the compiler pipeline loads ahead of stores.  Overlapping ranges are
+// undefined behavior and are NOT diagnosed (the contract is unchecked), so only
+// use this for distinct buffers -- both callers copy between separate input and
+// output windows, never in place.
 // `tid`/`stride` are this thread's rank and the cooperating thread count (e.g.
 // threadIdx.x / blockDim.x for a CTA-wide copy).  Loads are batched kUnroll-deep
 // before the stores so several loads stay in flight (memory-level parallelism),
 // which is what hides latency when occupancy is low (few CTAs).
 __device__ inline void copy_bytes_vec16_aligned(
-    const char* src,
-    char* dst,
+    const char* __restrict__ src,
+    char* __restrict__ dst,
     size_t nbytes,
     size_t tid,
     size_t stride) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187778
* __->__ #187776

Factor the 16-byte-vectorized copy used by `nccl_all_to_all_nd` into a shared header (`symm_mem_copy.cuh`) and use it
for the `all_gather_offset` push kernel, which previously copied each tile with a plain `ld_vec`/`st_vec` grid-stride
loop.

The helper batches `kUnroll=4` loads before issuing the stores, so several loads stay in flight per thread (memory-level
parallelism). `all_gather_offset` caps the grid at `AG_MAX_CTAS=32`, so it runs at low occupancy where there are too few
warps to hide load latency on their own -- the batched loads are what hide it. The multimem path is unchanged (it uses
`ncclMultimemCopy`, not the copy loop).

Effective output bandwidth on the push path (8x H100, bf16, GB/s):

| shape | plain | unrolled | delta |
| --- | --- | --- | --- |
| 1 x 16MB | 288 | 337 | +17% |
| 2 x 8MB | 288 | 335 | +16% |
| 8 x 2MB | 288 | 332 | +15% |
| 1 x 64MB + 8 x 8KB (skew) | 299 | 334 | +12% |
| 64 x 64KB | 251 | 286 | +14% |
| 256 x 4KB | 74 | 65 | -12% |

The 256 x 4KB case regresses: each 4KB shard is exactly `blockDim.x` vectors, so the unrolled body never runs and only
the extra register pressure remains; that shape is launch-latency-bound and not a realistic bucket.

## Test Plan

Built and ran on an H100 node with 4 ranks: `all_gather_offset` (16 cases, both the multimem and `NCCL_NVLS_ENABLE=0`
push paths) and `all_to_all_nd` (8 cases) all pass. Push bandwidth A/B measured on 8 ranks with the numbers above.

```
CUDA_VISIBLE_DEVICES=0,1,2,3 \
  python test/distributed/test_nccl.py -v -k all_gather_offset
CUDA_VISIBLE_DEVICES=0,1,2,3 \
  python test/distributed/test_nccl.py -v -k all_to_all_nd
```
