### PR TITLE
[dynamo] Fix non-iterable slice assignment error message for old CPython patches

### DIFF
--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -3,6 +3,8 @@
 # TODO: move set tests from test_functions.py/test_misc.py to this file
 
 
+import sys
+
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import make_dynamo_test
@@ -482,6 +484,55 @@ class ListTests(TupleTests):
         self.assertRaises(TypeError, p.__delitem__)
         self.assertRaises(TypeError, p.__delitem__, 1.1)
         self.assertRaises(TypeError, p.__delitem__, 1, 2)
+
+    @make_dynamo_test
+    def test___setitem___slice_non_iterable(self):
+        # ref: https://github.com/python/cpython/pull/120442 (gh-120384),
+        # which fixed an array-out-of-bounds crash by moving the
+        # PySequence_Fast check ahead of the step==1 branch in
+        # list_ass_subscript. Before this landed, simple (step is None or
+        # 1) slices raised "can only assign an iterable" instead of the
+        # unified extended-slice message. Verified empirically against
+        # real CPython builds (cross-checked via two independent
+        # toolchains): the fix shipped in 3.10.20, 3.11.15, and 3.12.5
+        # (3.12.0 is the first 3.12 release, so 3.12.0-3.12.4 predate it);
+        # 3.13+ never had the bug.
+        v = sys.version_info
+        has_bug = (
+            (v[:2] == (3, 10) and v < (3, 10, 20))
+            or (v[:2] == (3, 11) and v < (3, 11, 15))
+            or (v[:2] == (3, 12) and v < (3, 12, 5))
+        )
+        p = self.thetype("abcdef")
+        if has_bug:
+            self.assertRaisesRegex(
+                TypeError,
+                "can only assign an iterable",
+                p.__setitem__,
+                slice(1, 3),
+                1,
+            )
+        else:
+            self.assertRaisesRegex(
+                TypeError,
+                "must assign iterable to extended slice",
+                p.__setitem__,
+                slice(1, 3),
+                1,
+            )
+
+        # Extended slices (step != 1) always use the extended-slice message.
+        self.assertRaisesRegex(
+            TypeError,
+            "must assign iterable to extended slice",
+            p.__setitem__,
+            slice(1, 5, 2),
+            1,
+        )
+
+        # Valid iterable assignments are unaffected.
+        p[1:3] = ["x", "y"]
+        self.assertEqual(p, ["a", "x", "y", "d", "e", "f"])
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -93,6 +93,26 @@ def pyslice_check(obj: VariableTracker) -> bool:
     return issubclass(obj.python_type(), slice)
 
 
+def _cpython_has_simple_slice_bug() -> bool:
+    # CPython gh-120384 fixed an array-out-of-bounds crash by moving the
+    # PySequence_Fast check ahead of the step==1 branch in
+    # list_ass_subscript, which as a side effect unified the non-iterable
+    # error message for simple and extended slices. Before this landed,
+    # simple slices (step is None or 1) raised "can only assign an
+    # iterable" instead of "must assign iterable to extended slice".
+    # Verified empirically against real CPython builds: the fix shipped in
+    # 3.10.20, 3.11.15, and 3.12.5 (3.12.0 is the first 3.12 release, so
+    # 3.12.0-3.12.4 predate it); 3.13+ never had the bug.
+    v = sys.version_info
+    if v[:2] == (3, 10):
+        return v < (3, 10, 20)
+    if v[:2] == (3, 11):
+        return v < (3, 11, 15)
+    if v[:2] == (3, 12):
+        return v < (3, 12, 5)
+    return False
+
+
 class BaseListVariable(VariableTracker):
     @staticmethod
     def cls_for_instance(obj: Any) -> type["BaseListVariable"]:
@@ -1286,7 +1306,11 @@ class ListVariable(CommonListMethodsVariable):
                 # before the step==1 branch, so this message applies to all
                 # slice forms.
                 if not vt_is_iterable(value):
-                    raise_type_error(tx, "must assign iterable to extended slice")
+                    msg = "must assign iterable to extended slice"
+                    step = key_as_const.step
+                    if step in (None, 1) and _cpython_has_simple_slice_bug():
+                        msg = "can only assign an iterable"
+                    raise_type_error(tx, msg)
 
                 value_unpack = unpack_iterable(tx, value)
                 try:


### PR DESCRIPTION
ListVariable.mp_ass_subscript_impl raised "must assign iterable to extended
slice" for every non-iterable slice assignment (e.g. `lst[1:3] = 1`),
regardless of Python version. That message is correct on most CPython
versions, but not all of them.

CPython gh-120384/PR #120442 fixed an array-out-of-bounds crash by moving
the PySequence_Fast check ahead of the step==1 branch in
list_ass_subscript. Before that landed, simple (step is None or 1) slices
raised "can only assign an iterable" instead of the unified extended-slice
message.

This PR went through two rounds of getting the affected version range
wrong, both now corrected with stronger verification:

1. First attempt gated on `sys.version_info >= (3, 12, 5)`, matching the
   issue's literal text ("3.10, 3.11, 3.12.0-3.12.4"). This is wrong for
   *current* 3.10/3.11 patches: testing against 11 real CPython builds
   (3.10.20, 3.11.15, 3.12.0-3.12.13, 3.13.0, 3.14.5) showed only
   3.12.0-3.12.4 actually have the bug - the fix was separately backported
   into the 3.10 and 3.11 branches at some later patch.

2. Second attempt narrowed the gate to `3.12.0 <= v < 3.12.5` based on
   that finding - which then actually failed CI, because CI's Python 3.10
   (3.10.12) predates the 3.10 backport and still has the bug. The local
   verification only checked recent patches (3.10.20, 3.11.15) and missed
   that the backport landed partway through each release line, not at the
   start of it.

This version bisects the exact backport point per minor version, cross-
checked against two independent sources (`uv python install`, which uses
python-build-standalone, and official `python:X.Y.Z` Docker images) to
avoid relying on a single toolchain:

- 3.10: bug present through 3.10.19, fixed in 3.10.20
- 3.11: bug present through 3.11.14, fixed in 3.11.15
- 3.12: bug present in 3.12.0-3.12.4, fixed in 3.12.5
- 3.13+: never had the bug

The fix now uses `_cpython_has_simple_slice_bug()`, a small helper
documenting this table, plus a single non-nested conditional for the
message choice (incorporating the simplification @jansel's review bot
suggested for the previous version).

Fixes #187774

Generated by my agent.

Test Plan:

test/dynamo/test_list.py::ListTests::test___setitem___slice_non_iterable
runs both eager and torch.compile'd via @make_dynamo_test, computing the
same has-bug condition independently in the test to check the version-
appropriate message for both simple and extended non-iterable slice
assignments, plus a sanity check that valid iterable assignment still
works.

python test/dynamo/test_list.py ListTests.test___setitem___slice_non_iterable -v
python test/dynamo/test_list.py -v
(50/50 tests pass on this machine's Python 3.14.5)

Verified the version-detection table itself against 13 real interpreter
builds spanning 3.10.12 through 3.14.5, cross-checked via both
`uv python install` and official `python:X.Y.Z` Docker images - this is
what caught the 3.10.12 CI failure in the first place (CI's failure log
showed `Python 3.10.12` raising "can only assign an iterable", which
contradicted the previous version's 3.10.20-based assumption).

Since building PyTorch against each affected interpreter to test the
actual Dynamo-traced path isn't practical here, separately verified the
Dynamo-side branch logic by monkeypatching `_cpython_has_simple_slice_bug`
to force `True` and confirming, through a real torch.compile(backend="eager")
call against the build on this machine, that the compiled path raises
"can only assign an iterable" for simple slices and "must assign iterable
to extended slice" for extended slices - so both the version-detection
table and Dynamo's use of it are verified independently.

lintrunner -a: no issues introduced (one pre-existing, unrelated PYREFLY
error in torch/cuda/graphs.py exists identically on the base commit before
these changes).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98