### PR TITLE
Fix MPS fused RMSNorm: do the weight multiply in fp32 to match CPU/CUDA

### DIFF
--- a/aten/src/ATen/native/mps/kernels/RMSNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/RMSNorm.metal
@@ -3,12 +3,20 @@
 // Copyright © 2024 Apple Inc.
 
 #include <c10/metal/common.h>
+#include <c10/metal/utils.h>
 #include <metal_common>
 #include <metal_simdgroup>
 #include <metal_stdlib>
 
 using namespace metal;
+using c10::metal::opmath_t;
 using c10::metal::simdgroup_size;
+
+template <typename T>
+inline T rms_norm_apply(T x, opmath_t<T> inv, T w) {
+  using op_T = opmath_t<T>;
+  return static_cast<T>((static_cast<op_T>(x) * inv) * static_cast<op_T>(w));
+}
 
 template <typename T>
 [[kernel]] void rms_single_row(
@@ -69,16 +77,12 @@ template <typename T>
   out += gid * size_t(axis_size) + lid * N_READS;
   if (lid * N_READS + N_READS <= axis_size) {
     for (int i = 0; i < N_READS; i++) {
-      out[i] = static_cast<T>(
-          (static_cast<float>(x[i]) * local_inv_mean[0]) *
-          static_cast<float>(w[w_stride * i]));
+      out[i] = rms_norm_apply(x[i], local_inv_mean[0], w[w_stride * i]);
     }
   } else {
     for (int i = 0; i < N_READS; i++) {
       if ((lid * N_READS + i) < axis_size) {
-        out[i] = static_cast<T>(
-            (static_cast<float>(x[i]) * local_inv_mean[0]) *
-            static_cast<float>(w[w_stride * i]));
+        out[i] = rms_norm_apply(x[i], local_inv_mean[0], w[w_stride * i]);
       }
     }
   }
@@ -146,16 +150,14 @@ template <typename T>
   for (uint r = 0; r < axis_size; r += lsize * N_READS) {
     if (r + lid * N_READS + N_READS <= axis_size) {
       for (int i = 0; i < N_READS; i++) {
-        out[r + i] = static_cast<T>(
-            (static_cast<float>(x[r + i]) * local_inv_mean[0]) *
-            static_cast<float>(w[w_stride * (i + r)]));
+        out[r + i] =
+            rms_norm_apply(x[r + i], local_inv_mean[0], w[w_stride * (i + r)]);
       }
     } else {
       for (int i = 0; i < N_READS; i++) {
         if ((r + lid * N_READS + i) < axis_size) {
-          out[r + i] = static_cast<T>(
-              (static_cast<float>(x[r + i]) * local_inv_mean[0]) *
-              static_cast<float>(w[w_stride * (i + r)]));
+          out[r + i] = rms_norm_apply(
+              x[r + i], local_inv_mean[0], w[w_stride * (i + r)]);
         }
       }
     }

--- a/aten/src/ATen/native/mps/kernels/RMSNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/RMSNorm.metal
@@ -69,12 +69,16 @@ template <typename T>
   out += gid * size_t(axis_size) + lid * N_READS;
   if (lid * N_READS + N_READS <= axis_size) {
     for (int i = 0; i < N_READS; i++) {
-      out[i] = w[w_stride * i] * static_cast<T>(x[i] * local_inv_mean[0]);
+      out[i] = static_cast<T>(
+          (static_cast<float>(x[i]) * local_inv_mean[0]) *
+          static_cast<float>(w[w_stride * i]));
     }
   } else {
     for (int i = 0; i < N_READS; i++) {
       if ((lid * N_READS + i) < axis_size) {
-        out[i] = w[w_stride * i] * static_cast<T>(x[i] * local_inv_mean[0]);
+        out[i] = static_cast<T>(
+            (static_cast<float>(x[i]) * local_inv_mean[0]) *
+            static_cast<float>(w[w_stride * i]));
       }
     }
   }
@@ -142,14 +146,16 @@ template <typename T>
   for (uint r = 0; r < axis_size; r += lsize * N_READS) {
     if (r + lid * N_READS + N_READS <= axis_size) {
       for (int i = 0; i < N_READS; i++) {
-        out[r + i] = w[w_stride * (i + r)] *
-            static_cast<T>(x[r + i] * local_inv_mean[0]);
+        out[r + i] = static_cast<T>(
+            (static_cast<float>(x[r + i]) * local_inv_mean[0]) *
+            static_cast<float>(w[w_stride * (i + r)]));
       }
     } else {
       for (int i = 0; i < N_READS; i++) {
         if ((r + lid * N_READS + i) < axis_size) {
-          out[r + i] = w[w_stride * (i + r)] *
-              static_cast<T>(x[r + i] * local_inv_mean[0]);
+          out[r + i] = static_cast<T>(
+              (static_cast<float>(x[r + i]) * local_inv_mean[0]) *
+              static_cast<float>(w[w_stride * (i + r)]));
         }
       }
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9630,6 +9630,21 @@ class TestMPS(TestCaseMPS):
         y = x / 64
         self.assertEqual(y, torch.tensor([0., 1023.9844], device="mps"))
 
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("N", [4095, 4097])
+    def test_fused_rms_norm_weight_multiply_in_fp32(self, dtype, N):
+        # Keep x*inv*weight in fp32 and cast once, like the CPU composite
+        # (#147203). Compare the half path to the same fused kernel run in fp32.
+        if dtype == torch.bfloat16 and MACOS_VERSION < 15.0:
+            self.skipTest("bfloat16 requires macOS 15+")
+        torch.manual_seed(0)
+        x = torch.randn(2, N, dtype=dtype, device="mps")
+        w = (torch.randn(N, dtype=torch.float32, device="mps") * 8).to(dtype)
+        with torch.inference_mode():
+            y = torch.ops.aten._fused_rms_norm(x, [N], w, 1e-5)[0]
+            ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
+        self.assertEqual(y, ref, atol=0, rtol=0)
+
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
## What does this PR do?

The MPS fused RMSNorm kernel casts the normalized value to the half dtype before multiplying by the weight (`out = w * static_cast<T>(x * inv)`), so its output diverges from PyTorch's CPU composite and CUDA fused/reference behavior, which keep the `x * inv * weight` product in fp32 and cast once at the end (the CPU side was aligned in #147203). This affects half/bfloat16 inference on MPS whenever `RMSNorm`/`rms_norm` dispatches to the fused affine kernel (weight present, matching dtype, no grad).

Fix: do the weight multiply in fp32 in the same order as the reference (`(x * inv) * weight`) and cast once. Adds an MPS regression test that runs the fused kernel in fp16/bf16 and in fp32 with the same inputs (identical reduction) and asserts they agree, so only the weight-multiply precision is checked (N = 4095, 4097, covering both shader paths).

Reproduced on Apple Silicon; the kernel recompile (a full source build) is left to CI.
