### PR TITLE
[dynamo] Skip guard creation for unused function inputs

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9095,6 +9095,110 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertEqual(out, opt_out)
         self.assertEqual(guard_failure, None)
 
+    def test_no_guard_for_unused_input(self):
+        def fn(x, y):
+            return x + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, dynamic=False)
+        opt_fn(torch.randn(3), torch.randn(3))
+        opt_fn(torch.randn(3), torch.randn(5))
+        opt_fn(torch.randn(3), 42)
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_no_guard_for_unused_scalar_input(self):
+        def fn(x, n):
+            return x + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, dynamic=False)
+        opt_fn(torch.randn(3), 5)
+        opt_fn(torch.randn(3), 99)
+        opt_fn(torch.randn(3), "hello")
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_no_guard_for_unused_input_when_locals_called(self):
+        # locals() can observe the full namespace without LOAD_FAST, so we
+        # must keep all inputs and accept the resulting recompiles.
+        def fn(x, y):
+            return locals()["x"] + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, dynamic=False)
+        opt_fn(torch.randn(3), torch.randn(3))
+        opt_fn(torch.randn(3), torch.randn(5))
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_locals_dict_access_of_unused_param_works(self):
+        def fn(x, y):
+            return locals()["y"] + x
+
+        opt_fn = torch.compile(fn, backend="eager")
+        x, y = torch.randn(3), torch.randn(3)
+        self.assertEqual(opt_fn(x, y), fn(x, y))
+
+    def test_no_guard_for_unused_input_varargs(self):
+        def fn(x, *args, **kwargs):
+            return x + 1
+
+        opt_fn = torch.compile(fn, backend="eager")
+        x = torch.randn(3)
+        result = opt_fn(x, torch.randn(2), extra=torch.randn(1))
+        self.assertEqual(result, fn(x))
+
+    def test_no_guard_for_unused_input_still_recompiles_on_used(self):
+        def fn(x, y):
+            return x + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, dynamic=False)
+        opt_fn(torch.randn(3), torch.randn(3))
+        opt_fn(torch.randn(3), torch.randn(5))
+        self.assertEqual(cnt.frame_count, 1)
+        opt_fn(torch.randn(4), torch.randn(3))
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_no_guard_for_unused_input_with_graph_break(self):
+        def fn(x, y):
+            z = x + 1
+            torch._dynamo.graph_break()
+            return z + 2
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, dynamic=False)
+        opt_fn(torch.randn(3), torch.randn(3))
+        after_first = cnt.frame_count
+        opt_fn(torch.randn(3), torch.randn(5))
+        self.assertEqual(cnt.frame_count, after_first)
+
+    def test_no_guard_for_input_unused_before_graph_break(self):
+        # y is not read before the break, so the first subgraph must not
+        # guard on it. Only the resume function (which reads y) should guard.
+        def fn(x, y):
+            z = x + 1
+            torch._dynamo.graph_break()
+            return z + y.sum()
+
+        recompiled_names = []
+
+        def guard_failures(failure):
+            recompiled_names.append(failure.orig_code.co_name)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(
+            cnt, nopython=False, guard_fail_fn=guard_failures
+        )(fn)
+
+        x = torch.randn(3)
+        y1, y2, y3 = torch.randn(3), torch.randn(5), torch.randn(9)
+        self.assertEqual(opt_fn(x, y1), fn(x, y1))
+
+        self.assertEqual(opt_fn(x, y2), fn(x, y2))
+        self.assertEqual(opt_fn(x, y3), fn(x, y3))
+        # Resume function recompiled (y's shape changed), base frame did not.
+        self.assertTrue(recompiled_names)
+        self.assertNotIn(fn.__code__.co_name, recompiled_names)
+
     def test_guard_sym_node_fstring_when_used(self):
         def fn(x):
             # assign fstring to a variable causes the fstring to be used,

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9118,8 +9118,9 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertEqual(cnt.frame_count, 1)
 
     def test_no_guard_for_unused_input_when_locals_called(self):
-        # locals() can observe the full namespace without LOAD_FAST, so we
-        # must keep all inputs and accept the resulting recompiles.
+        # locals() is handled at trace time by _call_frame_locals_snapshot, which
+        # adds pruned locals back from tx.f_locals and installs guards on them.
+        # So y still causes a recompile when its shape changes.
         def fn(x, y):
             return locals()["x"] + 1
 
@@ -9132,6 +9133,18 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
     def test_locals_dict_access_of_unused_param_works(self):
         def fn(x, y):
             return locals()["y"] + x
+
+        opt_fn = torch.compile(fn, backend="eager")
+        x, y = torch.randn(3), torch.randn(3)
+        self.assertEqual(opt_fn(x, y), fn(x, y))
+
+    def test_locals_alias_access_of_unused_param_works(self):
+        # locals() called via an alias (locals2 = locals in global scope) must
+        # still expose pruned locals; _call_frame_locals_snapshot adds them back.
+        locals2 = locals
+
+        def fn(x, y):
+            return locals2()["y"] + x
 
         opt_fn = torch.compile(fn, backend="eager")
         x, y = torch.randn(3), torch.randn(3)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5490,6 +5490,20 @@ class InstructionTranslatorBase(
         linecache.lazycache(f_code.co_filename, f_globals)
 
 
+# Builtins that can observe the entire locals namespace without producing
+# a LOAD_FAST for each name (e.g. locals(), vars(d), exec(s), eval(s)).
+# If any of these is referenced via LOAD_GLOBAL, livevars_analysis would
+# under-approximate which locals are observable and we must keep them all.
+_LOCALS_EXPOSING_GLOBALS = frozenset({"locals", "vars", "exec", "eval"})
+
+
+def _function_exposes_locals(instructions: list[Instruction]) -> bool:
+    for inst in instructions:
+        if inst.opname == "LOAD_GLOBAL" and inst.argval in _LOCALS_EXPOSING_GLOBALS:
+            return True
+    return False
+
+
 class InstructionTranslator(InstructionTranslatorBase):
     @staticmethod
     def current_tx() -> InstructionTranslator:
@@ -5596,9 +5610,27 @@ class InstructionTranslator(InstructionTranslatorBase):
             if f_code.co_flags & CO_VARKEYWORDS:
                 varkw_name = f_code.co_varnames[_vararg_idx]
 
+            # Skip inputs never read anywhere in the function: they cannot
+            # affect the graph or any resume suffix, so guards on them are
+            # wasteful. Export mode must keep all locals because realize_all()
+            # below needs them.
+            if export or _function_exposes_locals(self.instructions):
+                function_live_names: set[str] | None = None
+            else:
+                function_live_names = livevars_analysis(
+                    self.instructions, self.instructions[0]
+                )
+
             dynamism = code_context.get_context(f_code).get("dynamism", None)
             for name, value in f_locals.items():
                 if name not in cell_and_freevars:
+                    if (
+                        function_live_names is not None
+                        and name not in function_live_names
+                        and name != varargs_name
+                        and name != varkw_name
+                    ):
+                        continue
                     local_dynamism = None
                     if dynamism:
                         local_dynamism = frozenset(dynamism.get(name, {}).items())

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5490,20 +5490,6 @@ class InstructionTranslatorBase(
         linecache.lazycache(f_code.co_filename, f_globals)
 
 
-# Builtins that can observe the entire locals namespace without producing
-# a LOAD_FAST for each name (e.g. locals(), vars(d), exec(s), eval(s)).
-# If any of these is referenced via LOAD_GLOBAL, livevars_analysis would
-# under-approximate which locals are observable and we must keep them all.
-_LOCALS_EXPOSING_GLOBALS = frozenset({"locals", "vars", "exec", "eval"})
-
-
-def _function_exposes_locals(instructions: list[Instruction]) -> bool:
-    for inst in instructions:
-        if inst.opname == "LOAD_GLOBAL" and inst.argval in _LOCALS_EXPOSING_GLOBALS:
-            return True
-    return False
-
-
 class InstructionTranslator(InstructionTranslatorBase):
     @staticmethod
     def current_tx() -> InstructionTranslator:
@@ -5613,8 +5599,9 @@ class InstructionTranslator(InstructionTranslatorBase):
             # Skip inputs never read anywhere in the function: they cannot
             # affect the graph or any resume suffix, so guards on them are
             # wasteful. Export mode must keep all locals because realize_all()
-            # below needs them.
-            if export or _function_exposes_locals(self.instructions):
+            # below needs them. locals()/vars() are handled in _call_frame_locals_snapshot
+            # which adds pruned entries back from tx.f_locals on demand.
+            if export:
                 function_live_names: set[str] | None = None
             else:
                 function_live_names = livevars_analysis(

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -59,6 +59,7 @@ from ..source import (
     GetItemSource,
     GlobalSource,
     is_constant_source,
+    LocalSource,
     Source,
     TypeSource,
 )
@@ -1462,6 +1463,8 @@ class BuiltinVariable(BaseBuiltinVariable):
 
     @staticmethod
     def _call_frame_locals_snapshot(tx: "InstructionTranslatorBase") -> VariableTracker:
+        from .builder import VariableBuilder
+
         frame_local_names = set(tx.f_code.co_varnames) | set(tx.cell_and_freevars())
         cell_and_freevars = set(tx.cell_and_freevars())
         frame_locals = {}
@@ -1475,6 +1478,16 @@ class BuiltinVariable(BaseBuiltinVariable):
             ):
                 continue
             frame_locals[ConstantVariable.create(name)] = value
+        # Include locals pruned from symbolic_locals by the unused-input optimisation.
+        # locals()/vars() observes the entire namespace, so build VTs (installing
+        # guards) for any pruned entry that still has a runtime value.
+        for name in frame_local_names:
+            if name in frame_locals or name in cell_and_freevars:
+                continue
+            if name not in tx.f_locals:
+                continue
+            vt = VariableBuilder(tx, LocalSource(name))(tx.f_locals[name])
+            frame_locals[ConstantVariable.create(name)] = vt
         return ConstDictVariable(
             frame_locals,
             mutation_type=ValueMutationNew(),


### PR DESCRIPTION
Fixes #187593.

## Summary

When `InstructionTranslator` sets up a frame it adds every `f_locals` entry to `symbolic_locals` as a `LazyVariableTracker`. If that tracker is ever realized (e.g. by iteration inside `compile_subgraph` or side-effects replay), a guard is installed even for inputs the compiled graph never touches. This produces unnecessary `TENSOR_MATCH` / `TYPE_MATCH` guards on pass-through inputs, causing spurious recompiles when callers vary those arguments.

**Fix:** run `livevars_analysis` from the function's first instruction to compute the set of names read anywhere in the function body. Skip adding a `symbolic_locals` entry for any `f_locals` name absent from that set. Because `create_resume` uses the same analysis for resume-function argnames, an input dead at function entry is also absent from every resume suffix, so skipping it is safe.

Two exceptions keep all locals:
- `export=True`: `realize_all()` iterates `symbolic_locals` unconditionally.
- The function body loads `locals` / `vars` / `exec` / `eval` via `LOAD_GLOBAL`: these builtins can expose the full locals namespace without per-name `LOAD_FAST`, so `livevars_analysis` would under-approximate.

`*args` / `**kwargs` are also never pruned regardless of liveness.

## Test Plan

```bash
# New tests
python test/dynamo/test_misc.py -k "test_no_guard_for_unused" -v
# 7 tests, all OK

# Regression
python test/dynamo/test_misc.py -k "guard" -v
# 41 tests, OK (1 expected failure, pre-existing)

# Lint
python -m ruff check torch/_dynamo/symbolic_convert.py test/dynamo/test_misc.py --ignore E501
# All checks passed
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @williamwen42