### PR TITLE
fix(nn): raise ValueError instead of ZeroDivisionError for norm_type=0 in lp_pool1d/2d/3d and LPPool modules

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1136,6 +1136,8 @@ def lp_pool3d(
             stride=stride,
             ceil_mode=ceil_mode,
         )
+    if norm_type == 0:
+        raise ValueError("norm_type must be non-zero")
     kd, kw, kh = _triple(kernel_size)
     if isinstance(norm_type, (int, float)):
         if norm_type == float("inf"):
@@ -1183,6 +1185,8 @@ def lp_pool2d(
             stride=stride,
             ceil_mode=ceil_mode,
         )
+    if norm_type == 0:
+        raise ValueError("norm_type must be non-zero")
     kw, kh = _pair(kernel_size)
     if isinstance(norm_type, (int, float)):
         if norm_type == float("inf"):
@@ -1233,6 +1237,8 @@ def lp_pool1d(
         if norm_type == -float("inf"):
             return -max_pool1d(-input.abs(), kernel_size, stride, 0, 1, ceil_mode)
 
+    if norm_type == 0:
+        raise ValueError("norm_type must be non-zero")
     if stride is not None:
         out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1110,6 +1110,8 @@ class _LPPoolNd(Module):
         ceil_mode: bool = False,
     ) -> None:
         super().__init__()
+        if norm_type == 0:
+            raise ValueError("norm_type must be non-zero")
         self.norm_type = norm_type
         self.kernel_size = kernel_size
         self.stride = stride


### PR DESCRIPTION
### Summary

Fixes #187743

`F.lp_pool1d`, `F.lp_pool2d`, and `F.lp_pool3d` all compute `.pow(1.0 / norm_type)` in their return expression. When `norm_type=0` this produces a bare `ZeroDivisionError: division by zero` with no indication of which argument is invalid or what the valid range is.

`nn.LPPool1d` / `LPPool2d` / `LPPool3d` compound the problem: their constructors silently accepted `norm_type=0`, so the error was deferred to forward-time — an even more confusing failure site.

### Changes

**`torch/nn/functional.py`** — add early validation in `lp_pool1d`, `lp_pool2d`, and `lp_pool3d`:
```python
if norm_type == 0:
    raise ValueError("norm_type must be non-zero")
```
(inserted after the `has_torch_function` dispatch block so the error is raised before any tensor work)

**`torch/nn/modules/pooling.py`** — add the same guard in `_LPPoolNd.__init__` so the module constructors also fail fast.

### Before / After

```python
# Before
F.lp_pool2d(torch.randn(2, 1, 9, 1), norm_type=0, kernel_size=1)
# ZeroDivisionError: division by zero

# After
F.lp_pool2d(torch.randn(2, 1, 9, 1), norm_type=0, kernel_size=1)
# ValueError: norm_type must be non-zero
```

Same fix applies to `lp_pool1d`, `lp_pool3d`, and all three `LPPool*` module classes.

### Testing

- Existing tests unchanged; no new tests for now (validation is trivial, but happy to add if the team prefers).

cc @malfet @mikaylagawarecki