### PR TITLE
Support int step tensors in foreach optimizer implementations

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -335,14 +335,18 @@ inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
                 if (key.first == d) {
                   return key.second == s || s == at::ScalarType::Float ||
                       s == at::ScalarType::Double ||
-                      s == at::ScalarType::BFloat16;
+                      s == at::ScalarType::BFloat16 ||
+                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Long;
                 } else if (d.is_cpu()) {
                   // note(crcrpar): There are some test cases (e.g.
                   // TestOptim::test_adam) where state_steps are on CPU and the
                   // others are on CUDA. Currently a state_step Tensor has the
                   // dtype of float.
                   return s == at::ScalarType::Float ||
-                      s == at::ScalarType::Double;
+                      s == at::ScalarType::Double ||
+                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Long;
                 } else {
                   return false;
                 }

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -336,16 +336,14 @@ inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
                   return key.second == s || s == at::ScalarType::Float ||
                       s == at::ScalarType::Double ||
                       s == at::ScalarType::BFloat16 ||
-                      s == at::ScalarType::Int ||
-                      s == at::ScalarType::Long;
+                      s == at::ScalarType::Int || s == at::ScalarType::Long;
                 } else if (d.is_cpu()) {
                   // note(crcrpar): There are some test cases (e.g.
                   // TestOptim::test_adam) where state_steps are on CPU and the
                   // others are on CUDA. Currently a state_step Tensor has the
                   // dtype of float.
                   return s == at::ScalarType::Float ||
-                      s == at::ScalarType::Double ||
-                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Double || s == at::ScalarType::Int ||
                       s == at::ScalarType::Long;
                 } else {
                   return false;

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -340,16 +340,14 @@ inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
                   return key.second == s || s == at::ScalarType::Float ||
                       s == at::ScalarType::Double ||
                       s == at::ScalarType::BFloat16 ||
-                      s == at::ScalarType::Int ||
-                      s == at::ScalarType::Long;
+                      s == at::ScalarType::Int || s == at::ScalarType::Long;
                 } else if (d.is_cpu()) {
                   // note(crcrpar): There are some test cases (e.g.
                   // TestOptim::test_adam) where state_steps are on CPU and the
                   // others are on CUDA. Currently a state_step Tensor has the
                   // dtype of float.
                   return s == at::ScalarType::Float ||
-                      s == at::ScalarType::Double ||
-                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Double || s == at::ScalarType::Int ||
                       s == at::ScalarType::Long;
                 } else {
                   return false;

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -339,14 +339,18 @@ inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
                 if (key.first == d) {
                   return key.second == s || s == at::ScalarType::Float ||
                       s == at::ScalarType::Double ||
-                      s == at::ScalarType::BFloat16;
+                      s == at::ScalarType::BFloat16 ||
+                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Long;
                 } else if (d.is_cpu()) {
                   // note(crcrpar): There are some test cases (e.g.
                   // TestOptim::test_adam) where state_steps are on CPU and the
                   // others are on CUDA. Currently a state_step Tensor has the
                   // dtype of float.
                   return s == at::ScalarType::Float ||
-                      s == at::ScalarType::Double;
+                      s == at::ScalarType::Double ||
+                      s == at::ScalarType::Int ||
+                      s == at::ScalarType::Long;
                 } else {
                   return false;
                 }

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -517,7 +517,9 @@ def _multi_tensor_adafactor(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1.0)

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -518,8 +518,8 @@ def _multi_tensor_adafactor(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1.0)

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -517,8 +517,8 @@ def _multi_tensor_adafactor(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1.0)

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -516,7 +516,9 @@ def _multi_tensor_adafactor(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1.0)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -366,7 +366,9 @@ def _multi_tensor_adadelta(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -367,8 +367,8 @@ def _multi_tensor_adadelta(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -368,8 +368,8 @@ def _multi_tensor_adadelta(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -367,7 +367,9 @@ def _multi_tensor_adadelta(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -508,8 +508,8 @@ def _multi_tensor_adagrad(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -507,7 +507,9 @@ def _multi_tensor_adagrad(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -508,7 +508,9 @@ def _multi_tensor_adagrad(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -509,8 +509,8 @@ def _multi_tensor_adagrad(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -680,7 +680,9 @@ def _multi_tensor_adam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -681,8 +681,8 @@ def _multi_tensor_adam(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -681,7 +681,9 @@ def _multi_tensor_adam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
-                device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                device_state_steps,
+                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -682,8 +682,8 @@ def _multi_tensor_adam(
         if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps,
-                    torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=device_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -373,8 +373,8 @@ def _multi_tensor_adamax(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -372,7 +372,9 @@ def _multi_tensor_adamax(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -373,7 +373,9 @@ def _multi_tensor_adamax(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -374,8 +374,8 @@ def _multi_tensor_adamax(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -348,7 +348,9 @@ def _multi_tensor_asgd(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -349,8 +349,8 @@ def _multi_tensor_asgd(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -353,7 +353,9 @@ def _multi_tensor_asgd(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -354,8 +354,8 @@ def _multi_tensor_asgd(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -456,8 +456,8 @@ def _multi_tensor_nadam(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -455,7 +455,9 @@ def _multi_tensor_nadam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -458,7 +458,9 @@ def _multi_tensor_nadam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -459,8 +459,8 @@ def _multi_tensor_nadam(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -420,7 +420,9 @@ def _multi_tensor_radam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -421,8 +421,8 @@ def _multi_tensor_radam(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -421,7 +421,9 @@ def _multi_tensor_radam(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -422,8 +422,8 @@ def _multi_tensor_radam(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -417,7 +417,9 @@ def _multi_tensor_rmsprop(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -418,8 +418,8 @@ def _multi_tensor_rmsprop(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -418,7 +418,9 @@ def _multi_tensor_rmsprop(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -419,8 +419,8 @@ def _multi_tensor_rmsprop(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -348,8 +348,8 @@ def _multi_tensor_rprop(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -347,7 +347,9 @@ def _multi_tensor_rprop(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -348,7 +348,9 @@ def _multi_tensor_rprop(
         # wrapped it once now. The alpha is required to assure we go to the right overload.
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
-                grouped_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
+                grouped_state_steps,
+                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                    alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -349,8 +349,8 @@ def _multi_tensor_rprop(
         if not torch.compiler.is_compiling() and grouped_state_steps[0].is_cpu:
             torch._foreach_add_(
                 grouped_state_steps,
-                    torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
-                    alpha=1,
+                torch.tensor(1, device="cpu", dtype=grouped_state_steps[0].dtype),
+                alpha=1,
             )
         else:
             torch._foreach_add_(grouped_state_steps, 1)


### PR DESCRIPTION
Fixes #142378

The foreach (multi-tensor) optimizer path rejects integer step tensors at two layers:

1. **C++ grouping** (`ForeachUtils.h`): `_group_tensors_by_first_tensors_device_and_dtype` only allows Float/Double/BFloat16 for step tensor dtypes, rejecting Int/Long
2. **Python CPU increment**: All foreach optimizers hardcode `torch.tensor(1.0, device="cpu")` for the step increment, creating a float tensor that fails to add to an int step tensor

**Fix:**
- `aten/src/ATen/native/ForeachUtils.h`: Add `Int` and `Long` to allowed step dtypes in both same-device and cross-device branches
- All 10 optimizer foreach paths (`adam`, `adamw` (via adam), `radam`, `nadam`, `adagrad`, `adamax`, `rmsprop`, `adadelta`, `rprop`, `asgd`, `_adafactor`): Use `dtype=steps[0].dtype` so the increment tensor matches the step tensor's dtype

A prior attempt (PR #148956) only fixed adam.py and ForeachUtils.h. This PR applies the same fix comprehensively across all optimizers.

**Files changed:** 11 (1 C++ header + 10 Python optimizer files)

cc @janeyx99 @albanD @crcrpar