### PR TITLE
[MPS] Migrate var/std to native Metal kernels (Welford)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -278,139 +278,35 @@ inline T finalize_val(T v) {
   return static_cast<T>(::precise::sqrt(v));
 }
 
-// Sum reduction kernel with multiple independent accumulation chains (ILP).
-// Each thread maintains NCHAINS independent accumulators to hide ALU latency
-// and keep the memory pipeline saturated.
-//
-// Two internal paths selected per-threadgroup (not per-element):
-//   - Single reduced dim (or full reduction): compute input_base + k * stride
-//     once per TG, then direct indexing — no per-element dim loop.
-//   - Multiple reduced dims: fall back to get_input_offset per element.
-// MODE: LOAD_IDENTITY (sum), LOAD_NAN_TO_ZERO (nansum),
-// LOAD_NONZERO (count_nonzero — contributes 1 per nonzero element).
-// The compiler eliminates dead branches per instantiation.
-template <
-    typename TI,
-    typename TO,
-    uint NCHAINS = SUM_NCHAINS,
-    LoadMode MODE = LOAD_IDENTITY>
-kernel void sum_reduction(
-    constant TI* input [[buffer(0)]],
-    device TO* output [[buffer(1)]],
-    constant NormParams<>& params [[buffer(2)]],
-    uint tid [[thread_position_in_threadgroup]],
-    uint tptg [[threads_per_threadgroup]],
-    uint tgid [[threadgroup_position_in_grid]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
-    uint simdgroup_size [[threads_per_simdgroup]]) {
-  using TA = ::metal::conditional_t<MODE == LOAD_NONZERO, uint, opmath_t<TO>>;
-
-  // Compute input_base (once per TG) and detect reduction pattern.
-  // For single reduced dim: input_base + k * reduction_stride gives
-  // the k-th reduction element — no per-element dim loop needed.
-  uint32_t input_base = 0;
-  uint32_t reduction_stride = 1;
-  uint32_t num_reduced_dims = 0;
-  {
-    uint32_t out_idx = tgid;
-    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
-      if (params.input_sizes[dim] != params.output_sizes[dim]) {
-        num_reduced_dims++;
-        reduction_stride = params.input_strides[dim];
-      } else {
-        auto idx = out_idx % params.output_sizes[dim];
-        out_idx /= params.output_sizes[dim];
-        input_base += idx * params.input_strides[dim];
-      }
-    }
+// Load functors decide how an input element is converted into the accumulator
+// type. IdentityLoad casts; PredicateLoad maps nonzero (and NaN) -> 1, zero ->
+// 0 (any/all, count_nonzero); NanToZeroLoad replaces NaN with 0 (nansum).
+// Shared by sum_reduction and value_reduction (both route sum/prod/min/max
+// through the same Op + Load abstraction).
+struct IdentityLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    return static_cast<TA>(v);
   }
+};
 
-  // Load helper: cast to accumulator type, optionally replacing NaN with zero
-
-  metal::array<TA, NCHAINS> acc;
-  for (uint j = 0; j < NCHAINS; j++) {
-    acc[j] = 0;
+struct PredicateLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    return load_is_nonzero(v) ? TA(1) : TA(0);
   }
+};
 
-  const uint32_t rsize = params.reduction_size;
-  const uint32_t stride = tptg * NCHAINS;
-  uint32_t base = tid * NCHAINS;
-
-  if (num_reduced_dims <= 1) {
-    // Fast path: direct indexing with base + k * reduction_stride
-    for (; base + NCHAINS <= rsize; base += stride) {
-      for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] +=
-            load_val<MODE>(input[input_base + (base + j) * reduction_stride]);
-      }
+struct NanToZeroLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    TA r = static_cast<TA>(v);
+    if (::metal::isnan(static_cast<float>(r))) {
+      r = TA(0);
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] +=
-          load_val<MODE>(input[input_base + idx * reduction_stride]);
-    }
-  } else {
-    // Generic path: per-element strided offset for multi-dim reductions
-    for (; base + NCHAINS <= rsize; base += stride) {
-      for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] +=
-            load_val<MODE>(input[get_input_offset(base + j, tgid, params)]);
-      }
-    }
-    for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] +=
-          load_val<MODE>(input[get_input_offset(idx, tgid, params)]);
-    }
+    return r;
   }
-
-  // Collapse chains into a single value
-  TA output_val = acc[0];
-  for (uint j = 1; j < NCHAINS; j++) {
-    output_val += acc[j];
-  }
-
-  // SIMD + threadgroup tree reduction
-  auto threads_remaining = tptg;
-  threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE];
-
-  while (threads_remaining > 1) {
-    output_val = c10::metal::simd_sum(output_val);
-    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
-
-    if (threads_remaining > 1) {
-      if (simd_lane_id == 0) {
-        shared_outputs[simdgroup_id] = output_val;
-      }
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-      if (tid < threads_remaining) {
-        output_val = shared_outputs[tid];
-      } else {
-        return;
-      }
-    }
-  }
-
-  if (tid == 0) {
-    uint32_t output_offset = 0;
-    uint32_t reduction_idx = tgid;
-
-    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
-      auto output_dim_size = params.output_sizes[dim];
-      if (output_dim_size > 1) {
-        auto index_in_dim = reduction_idx % output_dim_size;
-        reduction_idx /= output_dim_size;
-        output_offset += index_in_dim * params.output_strides[dim];
-      }
-    }
-    // params.p > 0 means "divide the accumulator by p before casting"
-    // (used by mean to keep the division in opmath_t precision so the
-    // fp32 accumulation isn't lost when TO is fp16/bf16/half2).
-    if (params.p > 0) {
-      output_val /= static_cast<TA>(params.p);
-    }
-    output[output_offset] = static_cast<TO>(output_val);
-  }
-}
+};
 
 template <
     typename TI,
@@ -661,18 +557,15 @@ REGISTER_NORM_INNER(float, float);
 REGISTER_NORM_INNER(half, half);
 REGISTER_NORM_INNER(bfloat, bfloat);
 
-#define REGISTER_SUM_IMPL(TI, TO, PREFIX, MODE)             \
-  template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]   \
-  kernel void sum_reduction<TI, TO, SUM_NCHAINS, MODE>(     \
-      constant TI * input [[buffer(0)]],                    \
-      device TO * output [[buffer(1)]],                     \
-      constant NormParams<> & params [[buffer(2)]],         \
-      uint tid [[thread_position_in_threadgroup]],          \
-      uint tptg [[threads_per_threadgroup]],                \
-      uint tgid [[threadgroup_position_in_grid]],           \
-      uint simd_lane_id [[thread_index_in_simdgroup]],      \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
-      uint simdgroup_size [[threads_per_simdgroup]]);
+#define REGISTER_SUM_IMPL(TI, TO, PREFIX, LOAD, TA)                  \
+  template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]            \
+  kernel void value_reduction<SumOp, LOAD, TI, TO, SUM_NCHAINS, TA>( \
+      constant TI * input [[buffer(0)]],                             \
+      device TO * output [[buffer(1)]],                              \
+      constant NormParams<> & params [[buffer(2)]],                  \
+      uint tid [[thread_position_in_threadgroup]],                   \
+      uint tptg [[threads_per_threadgroup]],                         \
+      uint tgid [[threadgroup_position_in_grid]]);
 
 #define REGISTER_SUM_STRIDED_IMPL(TI, TO, PREFIX, MODE)               \
   template [[host_name(PREFIX "reduction_strided_" #TI "_" #TO)]]     \
@@ -684,43 +577,17 @@ REGISTER_NORM_INNER(bfloat, bfloat);
       uint tptg [[threads_per_threadgroup]],                          \
       uint tgid [[threadgroup_position_in_grid]]);
 
-#define REGISTER_SUM(TI, TO)                       \
-  REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY) \
+#define REGISTER_SUM(TI, TO)                                    \
+  REGISTER_SUM_IMPL(TI, TO, "sum_", IdentityLoad, opmath_t<TO>) \
   REGISTER_SUM_STRIDED_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
-#define REGISTER_NANSUM(TI, TO)                          \
-  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO) \
+#define REGISTER_NANSUM(TI, TO)                                     \
+  REGISTER_SUM_IMPL(TI, TO, "nansum_", NanToZeroLoad, opmath_t<TO>) \
   REGISTER_SUM_STRIDED_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
-#define REGISTER_COUNT_NONZERO(TI)                            \
-  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
+#define REGISTER_COUNT_NONZERO(TI)                                   \
+  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", PredicateLoad, uint) \
   REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
 
-REGISTER_SUM(float, float);
-REGISTER_SUM(float, half);
-REGISTER_SUM(float, bfloat);
-REGISTER_SUM(half, half);
-REGISTER_SUM(half, float);
-REGISTER_SUM(bfloat, bfloat);
-REGISTER_SUM(bfloat, float);
-REGISTER_SUM(int, int);
-REGISTER_SUM(int, long);
-REGISTER_SUM(long, long);
-REGISTER_SUM(short, short);
-REGISTER_SUM(short, long);
-REGISTER_SUM(char, char);
-REGISTER_SUM(char, long);
-REGISTER_SUM(uchar, uchar);
-REGISTER_SUM(uchar, long);
-REGISTER_SUM(bool, long);
-REGISTER_SUM(bool, int);
-REGISTER_SUM(float2, float2);
-REGISTER_SUM(half2, half2);
-
 // nansum variants (floating-point only — integers can't have NaN)
-REGISTER_NANSUM(float, float);
-REGISTER_NANSUM(half, half);
-REGISTER_NANSUM(half, float);
-REGISTER_NANSUM(bfloat, bfloat);
-REGISTER_NANSUM(bfloat, float);
 
 REGISTER_NANSUM_OUTER(float, float);
 REGISTER_NANSUM_OUTER(half, half);
@@ -736,17 +603,6 @@ REGISTER_NANSUM_INNER(bfloat, float);
 
 // count_nonzero: output is always long; reuses sum-reduction machinery
 // with LOAD_NONZERO mode (1 per nonzero element, 0 otherwise).
-REGISTER_COUNT_NONZERO(float);
-REGISTER_COUNT_NONZERO(half);
-REGISTER_COUNT_NONZERO(bfloat);
-REGISTER_COUNT_NONZERO(long);
-REGISTER_COUNT_NONZERO(int);
-REGISTER_COUNT_NONZERO(short);
-REGISTER_COUNT_NONZERO(char);
-REGISTER_COUNT_NONZERO(uchar);
-REGISTER_COUNT_NONZERO(bool);
-REGISTER_COUNT_NONZERO(float2);
-REGISTER_COUNT_NONZERO(half2);
 
 REGISTER_COUNT_NONZERO_OUTER(float);
 REGISTER_COUNT_NONZERO_OUTER(half);
@@ -784,25 +640,8 @@ REGISTER_COUNT_NONZERO_INNER(half2);
 // inductor MPS codegen can reuse the same identity/replace pair; both are
 // pulled in via the file-scope `using namespace c10::metal`.
 
-// Load functors decide how an input element is converted into the
-// accumulator type. IdentityLoad casts (min/max keep the value unchanged);
-// PredicateLoad maps nonzero (and NaN) -> 1, zero -> 0 (any/all).
-struct IdentityLoad {
-  template <typename TA, typename TI>
-  static inline TA load(TI v) {
-    return static_cast<TA>(v);
-  }
-};
-
-struct PredicateLoad {
-  template <typename TA, typename TI>
-  static inline TA load(TI v) {
-    return load_is_nonzero(v) ? TA(1) : TA(0);
-  }
-};
-
-// General value reduction: same 2D-via-NormParams layout as sum_reduction,
-// parameterised on the reduction op and load mode. For min/max, TI == TO
+// General value reduction over the 2D-via-NormParams layout, parameterised
+// on the reduction op and load mode. For min/max, TI == TO
 // and Load = IdentityLoad. For all/any, TO = uchar (a 1-byte alias for the
 // bool output buffer) and Load = PredicateLoad. The
 // max_total_threads_per_threadgroup hint lets the compiler bound the
@@ -813,7 +652,8 @@ template <
     typename Load,
     typename TI,
     typename TO,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 [[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
 kernel void value_reduction(
     constant TI* input [[buffer(0)]],
@@ -839,7 +679,6 @@ kernel void value_reduction(
     }
   }
 
-  using TA = TO;
   using Op = OpFn<TA>;
   const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
@@ -900,7 +739,13 @@ kernel void value_reduction(
         output_offset += index_in_dim * params.output_strides[dim];
       }
     }
-    output[output_offset] = output_val;
+    // params.p > 0 means "divide the accumulator by p before casting" (mean:
+    // keeps the division in TA precision so fp32 accumulation isn't lost when
+    // TO is fp16/bf16). p == 0 for max/min/all/any, so this is a no-op there.
+    if (params.p > 0) {
+      output_val /= static_cast<TA>(params.p);
+    }
+    output[output_offset] = static_cast<TO>(output_val);
   }
 }
 
@@ -915,7 +760,8 @@ template <
     typename TO,
     uint TG_X = 32,
     uint TG_Y = 32,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 [[max_total_threads_per_threadgroup(TG_X * TG_Y)]]
 kernel void value_reduction_outer(
     constant TI* input [[buffer(0)]],
@@ -923,7 +769,6 @@ kernel void value_reduction_outer(
     constant uint3& sizes [[buffer(2)]], // [M, N, output_stride]
     uint2 tid_tg [[thread_position_in_threadgroup]],
     uint2 tg_pos [[threadgroup_position_in_grid]]) {
-  using TA = TO;
   using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
@@ -975,7 +820,7 @@ kernel void value_reduction_outer(
   }
 
   if (tid_tg.y == 0) {
-    output[col * out_stride] = shmem[0][tid_tg.x];
+    output[col * out_stride] = static_cast<TO>(shmem[0][tid_tg.x]);
   }
 }
 
@@ -988,7 +833,8 @@ template <
     typename Load,
     typename TI,
     typename TO,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 kernel void value_reduction_inner(
     constant TI* input [[buffer(0)]],
     device TO* output [[buffer(1)]],
@@ -997,7 +843,6 @@ kernel void value_reduction_inner(
     uint tgid [[threadgroup_position_in_grid]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
-  using TA = TO;
   using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
@@ -1036,7 +881,7 @@ kernel void value_reduction_inner(
   val = Op::simd_reduce(val);
 
   if (simd_lane_id == 0) {
-    output[row] = val;
+    output[row] = static_cast<TO>(val);
   }
 }
 
@@ -1424,3 +1269,43 @@ REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);
+
+// Generic sum / nansum / count_nonzero route through the shared
+// value_reduction kernel (SumOp + Load), instantiated after value_reduction
+// is defined above.
+REGISTER_SUM(float, float);
+REGISTER_SUM(float, half);
+REGISTER_SUM(float, bfloat);
+REGISTER_SUM(half, half);
+REGISTER_SUM(half, float);
+REGISTER_SUM(bfloat, bfloat);
+REGISTER_SUM(bfloat, float);
+REGISTER_SUM(int, int);
+REGISTER_SUM(int, long);
+REGISTER_SUM(long, long);
+REGISTER_SUM(short, short);
+REGISTER_SUM(short, long);
+REGISTER_SUM(char, char);
+REGISTER_SUM(char, long);
+REGISTER_SUM(uchar, uchar);
+REGISTER_SUM(uchar, long);
+REGISTER_SUM(bool, long);
+REGISTER_SUM(bool, int);
+REGISTER_SUM(float2, float2);
+REGISTER_SUM(half2, half2);
+REGISTER_NANSUM(float, float);
+REGISTER_NANSUM(half, half);
+REGISTER_NANSUM(half, float);
+REGISTER_NANSUM(bfloat, bfloat);
+REGISTER_NANSUM(bfloat, float);
+REGISTER_COUNT_NONZERO(float);
+REGISTER_COUNT_NONZERO(half);
+REGISTER_COUNT_NONZERO(bfloat);
+REGISTER_COUNT_NONZERO(long);
+REGISTER_COUNT_NONZERO(int);
+REGISTER_COUNT_NONZERO(short);
+REGISTER_COUNT_NONZERO(char);
+REGISTER_COUNT_NONZERO(uchar);
+REGISTER_COUNT_NONZERO(bool);
+REGISTER_COUNT_NONZERO(float2);
+REGISTER_COUNT_NONZERO(half2);

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -611,6 +611,91 @@ REGISTER_NORM_INNER(bfloat, bfloat);
   REGISTER_SUM_IMPL(TI, long, "count_nonzero_", PredicateLoad, uint) \
   REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
 
+// prod routes through the shared value_reduction kernel with ProdOp (identity
+// 1, combine *), reusing the generic + outer/inner shape specializations the
+// same way min/max do (REGISTER_VALUE_REDUCTION_IMPL). The opmath_t<TO>
+// accumulator keeps fp32 precision for fp16/bf16 prod. The strided 2-pass is a
+// deferred follow-up, as for sum.
+#define REGISTER_PROD(TI, TO)                                                 \
+  template [[host_name("prod_reduction_" #TI "_" #TO)]]                       \
+  kernel void                                                                 \
+  value_reduction<ProdOp, IdentityLoad, TI, TO, SUM_NCHAINS, opmath_t<TO>>(   \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant NormParams<> & params [[buffer(2)]],                           \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint tptg [[threads_per_threadgroup]],                                  \
+      uint tgid [[threadgroup_position_in_grid]]);                            \
+  template [[host_name("prod_reduction_outer_" #TI "_" #TO)]]                 \
+  kernel void value_reduction_outer<                                          \
+      ProdOp,                                                                 \
+      IdentityLoad,                                                           \
+      TI,                                                                     \
+      TO,                                                                     \
+      32,                                                                     \
+      32,                                                                     \
+      SUM_NCHAINS,                                                            \
+      opmath_t<TO>>(                                                          \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint3 & sizes [[buffer(2)]],                                   \
+      uint2 tid_tg [[thread_position_in_threadgroup]],                        \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);                         \
+  template [[host_name("prod_reduction_inner_" #TI "_" #TO)]]                 \
+  kernel void value_reduction_inner<                                          \
+      ProdOp,                                                                 \
+      IdentityLoad,                                                           \
+      TI,                                                                     \
+      TO,                                                                     \
+      SUM_NCHAINS,                                                            \
+      opmath_t<TO>>(                                                          \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint2 & sizes [[buffer(2)]],                                   \
+      uint tptg [[threads_per_threadgroup]],                                  \
+      uint tgid [[threadgroup_position_in_grid]],                             \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);                  \
+  template [[host_name("prod_reduction_inner_wide_" #TI "_" #TO)]]            \
+  kernel void value_reduction_inner_wide<                                     \
+      ProdOp,                                                                 \
+      IdentityLoad,                                                           \
+      TI,                                                                     \
+      TO,                                                                     \
+      SUM_NCHAINS,                                                            \
+      opmath_t<TO>>(                                                          \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint2 & sizes [[buffer(2)]],                                   \
+      uint tid [[thread_index_in_threadgroup]],                               \
+      uint tptg [[threads_per_threadgroup]],                                  \
+      uint tgid [[threadgroup_position_in_grid]],                             \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);                  \
+  template [[host_name("prod_reduction_inner_thin_" #TI "_" #TO)]]            \
+  kernel void                                                                 \
+  value_reduction_inner_thin<ProdOp, IdentityLoad, TI, TO, opmath_t<TO>>(     \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint2 & sizes [[buffer(2)]],                                   \
+      uint gid [[thread_position_in_grid]]);                                  \
+  template [[host_name("prod_reduction_outer_thin_" #TI "_" #TO)]]            \
+  kernel void                                                                 \
+  value_reduction_outer_thin<ProdOp, IdentityLoad, TI, TO, opmath_t<TO>>(     \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint2 & sizes [[buffer(2)]],                                   \
+      uint gid [[thread_position_in_grid]]);                                  \
+  template [[host_name("prod_reduction_outer_bucketed_" #TI "_" #TO)]]        \
+  kernel void                                                                 \
+  value_reduction_outer_bucketed<ProdOp, IdentityLoad, TI, TO, opmath_t<TO>>( \
+      constant TI * input [[buffer(0)]],                                      \
+      device TO * output [[buffer(1)]],                                       \
+      constant uint3 & sizes [[buffer(2)]],                                   \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint tptg [[threads_per_threadgroup]],                                  \
+      uint tgid [[threadgroup_position_in_grid]]);
+
 // nansum variants (floating-point only — integers can't have NaN)
 
 REGISTER_NANSUM_OUTER(float, float);
@@ -901,6 +986,199 @@ kernel void value_reduction_inner(
 
   if (simd_lane_id == 0) {
     output[row] = static_cast<TO>(val);
+  }
+}
+
+// Wide inner-dim variant: one whole threadgroup (up to 1024 threads) reduces
+// one row, for few/huge rows (small M, large N). The simd-per-row variant gives
+// each giant row only 32 lanes and idles most of the GPU (e.g. M=2, N~8M); this
+// gives the row a full TG. Mirrors value_reduction_inner otherwise.
+template <
+    template <typename> class OpFn,
+    typename Load,
+    typename TI,
+    typename TO,
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
+kernel void value_reduction_inner_wide(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // [M, N]
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using Op = OpFn<TA>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / simdgroup_size;
+  uint row = tgid;
+  if (row >= M) {
+    return;
+  }
+  // 64-bit row base: row * N can exceed 2^32; in-row offsets stay 32-bit.
+  constant TI* row_ptr = input + static_cast<ulong>(row) * N;
+
+  const TA identity_val = Op::identity();
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++) {
+    acc[j] = identity_val;
+  }
+  const uint stride = tptg * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  for (uint i = tid; i < aligned_N; i += stride) {
+    for (uint c = 0; c < NCHAINS; c++) {
+      acc[c] =
+          Op::combine(acc[c], Load::template load<TA>(row_ptr[i + c * tptg]));
+    }
+  }
+  for (uint i = tid + aligned_N; i < N; i += tptg) {
+    acc[0] = Op::combine(acc[0], Load::template load<TA>(row_ptr[i]));
+  }
+  TA val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++) {
+    val = Op::combine(val, acc[j]);
+  }
+
+  // Reduce across the simdgroup, then a shared-memory tree across simdgroups.
+  val = Op::simd_reduce(val);
+  threadgroup TA shared[32];
+  if (simd_lane_id == 0) {
+    shared[simdgroup_id] = val;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    // Padding lanes (>= num_simd_groups) carry the identity so the final reduce
+    // runs over a full simdgroup of valid values (also keeps the complex
+    // simd_reduce well-formed -- no inactive-lane reads).
+    val =
+        (simd_lane_id < num_simd_groups) ? shared[simd_lane_id] : identity_val;
+    val = Op::simd_reduce(val);
+    if (simd_lane_id == 0) {
+      output[row] = static_cast<TO>(val);
+    }
+  }
+}
+
+// Thin inner-dim variant: ONE thread reduces a full row, serially over N. For
+// small N the simd-per-row variant idles 32-N of its lanes and pays simd
+// overhead for under one element of work per lane; thread-per-row has neither.
+template <
+    template <typename> class OpFn,
+    typename Load,
+    typename TI,
+    typename TO,
+    typename TA = TO>
+kernel void value_reduction_inner_thin(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // [M, N]
+    uint gid [[thread_position_in_grid]]) {
+  using Op = OpFn<TA>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  if (gid >= M) {
+    return;
+  }
+  constant TI* row_ptr = input + static_cast<ulong>(gid) * N;
+  TA val = Op::identity();
+  for (uint i = 0; i < N; i++) {
+    val = Op::combine(val, Load::template load<TA>(row_ptr[i]));
+  }
+  output[gid] = static_cast<TO>(val);
+}
+
+// Thin outer-dim variant: ONE thread reduces a full output column, serially
+// over the M reduced rows (strided by N). For a short reduced dim (small M)
+// over many columns (large N), the TG-tiled outer kernel launches a tiny
+// mostly-idle threadgroup per 32-column tile (TG_Y rows idle when M < TG_Y);
+// thread-per- column reads coalesced across adjacent gid and fills the GPU.
+template <
+    template <typename> class OpFn,
+    typename Load,
+    typename TI,
+    typename TO,
+    typename TA = TO>
+kernel void value_reduction_outer_thin(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // [M, N]
+    uint gid [[thread_position_in_grid]]) {
+  using Op = OpFn<TA>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  if (gid >= N) {
+    return;
+  }
+  TA val = Op::identity();
+  for (uint i = 0; i < M; i++) {
+    val = Op::combine(
+        val, Load::template load<TA>(input[static_cast<ulong>(i) * N + gid]));
+  }
+  output[gid] = static_cast<TO>(val);
+}
+
+// Bucketed outer reduce (pass 1 of the outer two-pass for a tall-thin [M, N]
+// with very small N). Reads the flat M*N input fully coalesced -- adjacent
+// threads read adjacent elements -- and folds each into its column bucket
+// (idx % N), unlike the column-per-thread outer kernel which only fills N of
+// 32 lanes per row. Each threadgroup reduces a contiguous N-aligned slice into
+// N partials; pass 2 collapses the per-threadgroup partials. N is capped at
+// MAXN (the dispatch gates N <= 8): a small per-thread bucket array keeps
+// register pressure low so the coalesced read stays bandwidth-bound.
+template <
+    template <typename> class OpFn,
+    typename Load,
+    typename TI,
+    typename TO,
+    typename TA = TO>
+kernel void value_reduction_outer_bucketed(
+    constant TI* input [[buffer(0)]],
+    device TO* partials [[buffer(1)]], // [num_tgs, N]
+    constant uint3& sizes [[buffer(2)]], // [total = M*N, N, num_tgs]
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  using Op = OpFn<TA>;
+  constexpr uint MAXN = 8;
+  const ulong total = sizes.x;
+  const uint N = sizes.y;
+  const ulong num_tgs = sizes.z;
+  // contiguous slice for this threadgroup, rounded up to a multiple of N so
+  // idx % N stays the column index across the whole slice. Keep the slice math
+  // in 64-bit even though the host-level tensor bound is UINT32_MAX: the final
+  // threadgroup's start + per_tg can exceed that bound before it is clamped.
+  const ulong per_tg =
+      ceil_div(ceil_div(total, num_tgs), static_cast<ulong>(N)) * N;
+  const ulong start64 = static_cast<ulong>(tgid) * per_tg;
+  const ulong end64 = min(start64 + per_tg, total);
+  const uint start = static_cast<uint>(min(start64, total));
+  const uint end = static_cast<uint>(end64);
+  const uint span = end - start;
+
+  TA acc[MAXN];
+  for (uint j = 0; j < N; j++) {
+    acc[j] = Op::identity();
+  }
+  uint col = tid % N;
+  const uint col_step = tptg % N;
+  for (uint offset = tid; offset < span; offset += tptg) {
+    const uint idx = start + offset;
+    acc[col] = Op::combine(acc[col], Load::template load<TA>(input[idx]));
+    col += col_step;
+    if (col >= N) {
+      col -= N;
+    }
+  }
+
+  threadgroup TA shared[MAX_THREADGROUP_SIZE / simdgroup_size];
+  for (uint j = 0; j < N; j++) {
+    const TA red = Op::threadgroup_reduce(shared, acc[j], tid, tptg);
+    if (tid == 0) {
+      partials[tgid * N + j] = static_cast<TO>(red);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 }
 
@@ -1328,3 +1606,30 @@ REGISTER_COUNT_NONZERO(uchar);
 REGISTER_COUNT_NONZERO(bool);
 REGISTER_COUNT_NONZERO(float2);
 REGISTER_COUNT_NONZERO(half2);
+
+// prod: generic value_reduction<ProdOp>. int/short/char/uchar -> long for the
+// dtype= upcast; bool -> long/int for the nonzero-product (mask) path.
+REGISTER_PROD(float, float);
+REGISTER_PROD(half, half);
+REGISTER_PROD(half, float);
+REGISTER_PROD(bfloat, bfloat);
+REGISTER_PROD(bfloat, float);
+// fp32 -> half/bfloat: the two-pass uses opmath (fp32) partials so a long-dim
+// half/bfloat reduction stays lossless (a per-chunk product can overflow the
+// 16-bit range while the full product is finite). Pass 2 narrows fp32 ->
+// output.
+REGISTER_PROD(float, half);
+REGISTER_PROD(float, bfloat);
+REGISTER_PROD(int, int);
+REGISTER_PROD(int, long);
+REGISTER_PROD(long, long);
+REGISTER_PROD(short, short);
+REGISTER_PROD(short, long);
+REGISTER_PROD(char, char);
+REGISTER_PROD(char, long);
+REGISTER_PROD(uchar, uchar);
+REGISTER_PROD(uchar, long);
+REGISTER_PROD(bool, long);
+REGISTER_PROD(bool, int);
+REGISTER_PROD(float2, float2);
+REGISTER_PROD(half2, half2);

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -185,8 +185,9 @@ REGISTER_NORM(half2, half);
 
 #include <c10/metal/reduction_utils.h>
 
-// Load modes for sum_reduction: identity (sum), nan-to-zero (nansum),
-// nonzero-as-one (count_nonzero), abs (L1 norm), or square (L2 norm).
+// Load modes for the specialized strided/outer/inner sum kernels and norm
+// kernels: identity (sum), nan-to-zero (nansum), nonzero-as-one
+// (count_nonzero), abs (L1 norm), or square (L2 norm).
 enum LoadMode : uint {
   LOAD_IDENTITY = 0,
   LOAD_NAN_TO_ZERO = 1,
@@ -279,10 +280,9 @@ inline T finalize_val(T v) {
 }
 
 // Load functors decide how an input element is converted into the accumulator
-// type. IdentityLoad casts; PredicateLoad maps nonzero (and NaN) -> 1, zero ->
-// 0 (any/all, count_nonzero); NanToZeroLoad replaces NaN with 0 (nansum).
-// Shared by sum_reduction and value_reduction (both route sum/prod/min/max
-// through the same Op + Load abstraction).
+// type for value_reduction instantiations. IdentityLoad casts; PredicateLoad
+// maps nonzero (and NaN) -> 1, zero -> 0 (any/all, count_nonzero);
+// NanToZeroLoad replaces NaN with 0 (nansum).
 struct IdentityLoad {
   template <typename TA, typename TI>
   static inline TA load(TI v) {
@@ -305,6 +305,30 @@ struct NanToZeroLoad {
       r = TA(0);
     }
     return r;
+  }
+};
+
+template <template <typename> class OpFn, typename Load, typename TA>
+struct ValueAccumulator {
+  template <typename TI>
+  static inline void accumulate(thread TA& acc, TI v) {
+    acc = OpFn<TA>::combine(acc, Load::template load<TA>(v));
+  }
+
+  static inline TA combine(TA a, TA b) {
+    return OpFn<TA>::combine(a, b);
+  }
+};
+
+template <typename Load, typename TA>
+struct ValueAccumulator<c10::metal::SumOp, Load, TA> {
+  template <typename TI>
+  static inline void accumulate(thread TA& acc, TI v) {
+    acc += Load::template load<TA>(v);
+  }
+
+  static inline TA combine(TA a, TA b) {
+    return a + b;
   }
 };
 
@@ -680,6 +704,7 @@ kernel void value_reduction(
   }
 
   using Op = OpFn<TA>;
+  using Acc = ValueAccumulator<OpFn, Load, TA>;
   const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
@@ -693,36 +718,30 @@ kernel void value_reduction(
   if (num_reduced_dims <= 1) {
     for (; base + NCHAINS <= rsize; base += stride) {
       for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] = Op::combine(
-            acc[j],
-            Load::template load<TA>(
-                input[input_base + (base + j) * reduction_stride]));
+        Acc::accumulate(
+            acc[j], input[input_base + (base + j) * reduction_stride]);
       }
     }
     for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] = Op::combine(
-          acc[idx % NCHAINS],
-          Load::template load<TA>(input[input_base + idx * reduction_stride]));
+      Acc::accumulate(
+          acc[idx % NCHAINS], input[input_base + idx * reduction_stride]);
     }
   } else {
     for (; base + NCHAINS <= rsize; base += stride) {
       for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] = Op::combine(
-            acc[j],
-            Load::template load<TA>(
-                input[get_input_offset(base + j, tgid, params)]));
+        Acc::accumulate(
+            acc[j], input[get_input_offset(base + j, tgid, params)]);
       }
     }
     for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] = Op::combine(
-          acc[idx % NCHAINS],
-          Load::template load<TA>(input[get_input_offset(idx, tgid, params)]));
+      Acc::accumulate(
+          acc[idx % NCHAINS], input[get_input_offset(idx, tgid, params)]);
     }
   }
 
   TA output_val = acc[0];
   for (uint j = 1; j < NCHAINS; j++) {
-    output_val = Op::combine(output_val, acc[j]);
+    output_val = Acc::combine(output_val, acc[j]);
   }
 
   threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE / simdgroup_size];

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1633,3 +1633,712 @@ REGISTER_PROD(bool, long);
 REGISTER_PROD(bool, int);
 REGISTER_PROD(float2, float2);
 REGISTER_PROD(half2, half2);
+
+// ===== welford kernels (this PR, on top of malfet sum/value migration) =====
+// ============================================================================
+// Welford reduction kernels (var / std / var_mean / std_mean)
+// ============================================================================
+
+inline float3 simd_welford_combine(float3 stats) {
+  for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
+    float3 other;
+    other.x = ::metal::simd_shuffle_and_fill_down(stats.x, 0.0f, i);
+    other.y = ::metal::simd_shuffle_and_fill_down(stats.y, 0.0f, i);
+    other.z = ::metal::simd_shuffle_and_fill_down(stats.z, 0.0f, i);
+    stats = welford_combine(stats, other);
+  }
+  return stats;
+}
+
+struct WelfordConfig {
+  // Host-computed max(reduction_count - correction, 0). Computed on the host in
+  // int64/double so it stays exact: a float element count loses integer
+  // precision above 2^24, which corrupted this divisor when correction was
+  // close to N for large reductions (var returned inf instead of a finite
+  // value).
+  float denom;
+  float compute_std;
+  float write_mean;
+};
+
+template <typename TI, typename TO>
+kernel void welford_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant NormParams<>& params [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size_val [[threads_per_simdgroup]]) {
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  float w_mean = 0, w_m2 = 0, w_count = 0;
+  const uint32_t rsize = params.reduction_size;
+
+  if (num_reduced_dims <= 1) {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      float val = static_cast<float>(input[input_base + k * reduction_stride]);
+      w_count += 1;
+      float delta = val - w_mean;
+      w_mean += delta / w_count;
+      w_m2 += delta * (val - w_mean);
+    }
+  } else {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      float val = static_cast<float>(input[get_input_offset(k, tgid, params)]);
+      w_count += 1;
+      float delta = val - w_mean;
+      w_mean += delta / w_count;
+      w_m2 += delta * (val - w_mean);
+    }
+  }
+
+  float3 stats = simd_welford_combine(float3(w_mean, w_m2, w_count));
+
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, simdgroup_size_val);
+
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+
+  if (tid == 0) {
+    // Clamp M2 to >= 0 before sqrt: cancellation can round it slightly negative
+    // for a near-constant input, which would yield NaN std.
+    float m2 = ::metal::isnan(stats.y) ? stats.y : max(stats.y, 0.0f);
+    float denom = config.denom;
+    float var = (denom > 0)
+        ? m2 / denom
+        : (m2 > 0 ? INFINITY : NAN); // denom==0 (correction>=N): match CPU
+                                     // IEEE (inf), not Metal fast-math nan
+
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+
+    output[output_offset] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[output_offset] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+template <typename TI, typename TO, uint TG_X = 32, uint TG_Y = 32>
+kernel void welford_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  uint rows_per_y = ceil_div(M, TG_Y);
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = min(row_start + rows_per_y, M);
+
+  float w_mean = 0, w_m2 = 0, w_count = 0;
+  for (uint row = row_start; row < row_end; row++) {
+    float val = static_cast<float>(input[row * N + col]);
+    w_count += 1;
+    float delta = val - w_mean;
+    w_mean += delta / w_count;
+    w_m2 += delta * (val - w_mean);
+  }
+
+  threadgroup float3 shmem[TG_Y][TG_X];
+  shmem[tid_tg.y][tid_tg.x] = float3(w_mean, w_m2, w_count);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s)
+      shmem[tid_tg.y][tid_tg.x] = welford_combine(
+          shmem[tid_tg.y][tid_tg.x], shmem[tid_tg.y + s][tid_tg.x]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    float3 stats = shmem[0][tid_tg.x];
+    // Clamp M2 to >= 0 before sqrt (cancellation guard, see pass2).
+    float m2 = ::metal::isnan(stats.y) ? stats.y : max(stats.y, 0.0f);
+    float denom = config.denom;
+    float var = (denom > 0)
+        ? m2 / denom
+        : (m2 > 0 ? INFINITY : NAN); // denom==0 (correction>=N): match CPU
+                                     // IEEE (inf), not Metal fast-math nan
+    output[col * out_stride] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[col * out_stride] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+template <typename TI, typename TO>
+kernel void welford_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+
+  // One SIMD group (32 lanes) reduces one row; num_simd_groups rows share a TG.
+  // This keeps every lane busy on small rows and bounds the threadgroup count
+  // (M/num_simd_groups) instead of launching one whole TG per row, which idles
+  // most threads and over-subscribes the GPU for many short rows.
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+
+  constant TI* row_ptr = input + row * N;
+
+  constexpr uint NCHAINS = 4;
+  float w_mean[NCHAINS] = {0}, w_m2[NCHAINS] = {0}, w_count[NCHAINS] = {0};
+  // Each lane reads NCHAINS consecutive elements, blocks strided by 32*NCHAINS
+  // (coalesced across the SIMD group), matching sum_reduction_inner.
+  const uint stride = 32 * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = simd_lane_id * NCHAINS;
+  for (; base < aligned_N; base += stride) {
+    for (uint c = 0; c < NCHAINS; c++) {
+      float val = static_cast<float>(row_ptr[base + c]);
+      w_count[c] += 1;
+      float delta = val - w_mean[c];
+      w_mean[c] += delta / w_count[c];
+      w_m2[c] += delta * (val - w_mean[c]);
+    }
+  }
+  // Tail: leftover elements after the last full block, one per lane.
+  for (uint i = aligned_N + simd_lane_id; i < N; i += 32) {
+    float val = static_cast<float>(row_ptr[i]);
+    w_count[0] += 1;
+    float delta = val - w_mean[0];
+    w_mean[0] += delta / w_count[0];
+    w_m2[0] += delta * (val - w_mean[0]);
+  }
+  // Merge chains
+  float3 merged = float3(w_mean[0], w_m2[0], w_count[0]);
+  for (uint c = 1; c < NCHAINS; c++) {
+    merged = welford_combine(merged, float3(w_mean[c], w_m2[c], w_count[c]));
+  }
+  // Reduce across the 32 lanes of this SIMD group (no shared memory needed).
+  float3 stats = simd_welford_combine(merged);
+
+  if (simd_lane_id == 0) {
+    // Clamp M2 to >= 0 before sqrt (cancellation guard, see pass2).
+    float m2 = ::metal::isnan(stats.y) ? stats.y : max(stats.y, 0.0f);
+    float denom = config.denom;
+    float var = (denom > 0)
+        ? m2 / denom
+        : (m2 > 0 ? INFINITY : NAN); // denom==0 (correction>=N): match CPU
+                                     // IEEE (inf), not Metal fast-math nan
+    output[row] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[row] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+// ============================================================================
+// Welford 2-pass for all-reduce: pass1 writes per-TG (mean, M2, count)
+// triplet; pass2 combines triplets and produces final var/std/mean.
+// Used when output.numel() == 1 and N is large enough to benefit from
+// multiple threadgroups working in parallel.
+// ============================================================================
+
+template <typename TI>
+kernel void welford_reduction_pass1(
+    constant TI* input [[buffer(0)]],
+    device float3* partials [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // .x = elems_per_group, .y = total N
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint elems_per_group = sizes.x;
+  const uint total_N = sizes.y;
+  const uint group_start = tgid * elems_per_group;
+  const uint group_end = min(group_start + elems_per_group, total_N);
+
+  // Accumulate this thread's local sum / sum-of-squares (cheap FMAs, no
+  // per-element division), shifted by a data value so the sum-of-squares stays
+  // numerically safe regardless of the true mean. Convert to a Welford triplet
+  // with a single division; the cross-thread combine below uses the stable
+  // Welford merge. This avoids ~N per-element divisions in the hot loop, which
+  // is what made the Welford all-reduce slower than the plain sum all-reduce.
+  float shift = (group_start + tid < group_end)
+      ? static_cast<float>(input[group_start + tid])
+      : 0.0f;
+  if (!::metal::isfinite(shift)) {
+    shift = 0.0f;
+  }
+  float w_sum = 0, w_sumsq = 0, w_count = 0;
+  for (uint k = group_start + tid; k < group_end; k += tptg) {
+    float d = static_cast<float>(input[k]) - shift;
+    w_sum += d;
+    w_sumsq += d * d;
+    w_count += 1;
+  }
+  float w_mean = 0, w_m2 = 0;
+  if (w_count > 0) {
+    float meand = w_sum / w_count;
+    w_mean = shift + meand;
+    w_m2 = w_sumsq - w_sum * meand; // sum((x - mean)^2)
+  }
+
+  float3 stats = simd_welford_combine(float3(w_mean, w_m2, w_count));
+
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, 32u);
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+
+  if (tid == 0) {
+    partials[tgid] = stats;
+  }
+}
+
+// Pass2: reduce N partial triplets to one final triplet, then write
+// var (or std) and optionally mean. Runs as a single threadgroup.
+template <typename TO>
+kernel void welford_reduction_pass2(
+    device const float3* partials [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint& num_partials [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  float3 acc = float3(0, 0, 0);
+  for (uint32_t i = tid; i < num_partials; i += tptg) {
+    acc = welford_combine(acc, partials[i]);
+  }
+  float3 stats = simd_welford_combine(acc);
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, 32u);
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+  if (tid == 0) {
+    // Clamp M2 to >= 0: under catastrophic cancellation in the Welford combine
+    // a near-constant input can round w_m2 slightly negative, which would make
+    // precise::sqrt return NaN for std.
+    float m2 = ::metal::isnan(stats.y) ? stats.y : max(stats.y, 0.0f);
+    float denom = config.denom;
+    float var = (denom > 0)
+        ? m2 / denom
+        : (m2 > 0 ? INFINITY : NAN); // denom==0 (correction>=N): match CPU
+                                     // IEEE (inf), not Metal fast-math nan
+    output[0] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[0] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+// Wide inner-dim welford: one whole threadgroup (up to 1024 threads) reduces
+// one row, via per-thread streaming Welford + shared-memory tree. Used when N
+// is large / M is small (few but huge rows), where the simd-per-row variant
+// would leave only 32 threads on a giant row (slow AND loses precision from a
+// deep per-lane streaming accumulation). Matches the original reduction order.
+template <typename TI, typename TO>
+kernel void welford_reduction_inner_wide(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+  uint row = tgid;
+  if (row >= M)
+    return;
+  constant TI* row_ptr = input + row * N;
+  constexpr uint NCHAINS = 4;
+  float w_mean[NCHAINS] = {0}, w_m2[NCHAINS] = {0}, w_count[NCHAINS] = {0};
+  uint stride = tptg * NCHAINS;
+  uint base = tid;
+  // Vectorize only over full stride-aligned blocks; the scalar tail below
+  // handles [aligned_N, N). Gating on `i + (NCHAINS-1)*tptg < N` instead would
+  // let the last vectorized block overlap the tail start and double-count it.
+  uint aligned_N = (N / stride) * stride;
+  for (uint i = base; i < aligned_N; i += stride) {
+    for (uint c = 0; c < NCHAINS; c++) {
+      float val = static_cast<float>(row_ptr[i + c * tptg]);
+      w_count[c] += 1;
+      float delta = val - w_mean[c];
+      w_mean[c] += delta / w_count[c];
+      w_m2[c] += delta * (val - w_mean[c]);
+    }
+  }
+  for (uint i = base + aligned_N; i < N; i += tptg) {
+    float val = static_cast<float>(row_ptr[i]);
+    w_count[0] += 1;
+    float delta = val - w_mean[0];
+    w_mean[0] += delta / w_count[0];
+    w_m2[0] += delta * (val - w_mean[0]);
+  }
+  float3 merged = float3(w_mean[0], w_m2[0], w_count[0]);
+  for (uint c = 1; c < NCHAINS; c++) {
+    merged = welford_combine(merged, float3(w_mean[c], w_m2[c], w_count[c]));
+  }
+  float3 stats = simd_welford_combine(merged);
+  threadgroup float3 shared_stats[32];
+  if (simd_lane_id == 0) {
+    shared_stats[simdgroup_id] = stats;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    stats = (simd_lane_id < num_simd_groups) ? shared_stats[simd_lane_id]
+                                             : float3(0, 0, 0);
+    stats = simd_welford_combine(stats);
+    if (simd_lane_id == 0) {
+      // Clamp M2 to >= 0 before sqrt (cancellation guard, see pass2).
+      float m2 = ::metal::isnan(stats.y) ? stats.y : max(stats.y, 0.0f);
+      float denom = config.denom;
+      float var = (denom > 0) ? m2 / denom : (m2 > 0 ? INFINITY : NAN);
+      output[row] =
+          static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+      if (config.write_mean > 0) {
+        output_mean[row] = static_cast<TO>(stats.x);
+      }
+    }
+  }
+}
+
+#define REGISTER_WELFORD_INNER_WIDE(TI, TO)                 \
+  template [[host_name("welford_inner_wide_" #TI "_" #TO)]] \
+  kernel void welford_reduction_inner_wide<TI, TO>(         \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      device TO * output_mean [[buffer(2)]],                \
+      constant uint2 & sizes [[buffer(3)]],                 \
+      constant WelfordConfig & config [[buffer(4)]],        \
+      uint tid [[thread_index_in_threadgroup]],             \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+REGISTER_WELFORD_INNER_WIDE(float, float);
+REGISTER_WELFORD_INNER_WIDE(half, half);
+REGISTER_WELFORD_INNER_WIDE(half, float);
+REGISTER_WELFORD_INNER_WIDE(bfloat, bfloat);
+REGISTER_WELFORD_INNER_WIDE(bfloat, float);
+
+#define REGISTER_WELFORD(TI, TO)                            \
+  template [[host_name("welford_" #TI "_" #TO)]]            \
+  kernel void welford_reduction<TI, TO>(                    \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      device TO * output_mean [[buffer(2)]],                \
+      constant NormParams<> & params [[buffer(3)]],         \
+      constant WelfordConfig & config [[buffer(4)]],        \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size_val [[threads_per_simdgroup]]);
+
+#define REGISTER_WELFORD_OUTER(TI, TO)                 \
+  template [[host_name("welford_outer_" #TI "_" #TO)]] \
+  kernel void welford_reduction_outer<TI, TO, 32, 32>( \
+      constant TI * input [[buffer(0)]],               \
+      device TO * output [[buffer(1)]],                \
+      device TO * output_mean [[buffer(2)]],           \
+      constant uint3 & sizes [[buffer(3)]],            \
+      constant WelfordConfig & config [[buffer(4)]],   \
+      uint2 tid_tg [[thread_position_in_threadgroup]], \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+// Thin inner-dim welford: ONE thread reduces a full row, serially over N. For
+// small N the simd-per-row variant leaves 32-N of its 32 lanes idle and pays
+// simd-reduction overhead for under one element of work per lane; a plain
+// thread-per-row loop has no idle lanes and no cross-lane reduction. Dispatched
+// for small N with M large enough that one thread per row fills the GPU.
+template <typename TI, typename TO>
+kernel void welford_reduction_inner_thin(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint gid [[thread_position_in_grid]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  if (gid >= M)
+    return;
+  constant TI* row_ptr = input + gid * N;
+  float mean = 0, m2 = 0, count = 0;
+  for (uint i = 0; i < N; i++) {
+    float val = static_cast<float>(row_ptr[i]);
+    count += 1;
+    float delta = val - mean;
+    mean += delta / count;
+    m2 += delta * (val - mean);
+  }
+  float m2c = ::metal::isnan(m2) ? m2 : max(m2, 0.0f);
+  float denom = config.denom;
+  float var = (denom > 0) ? m2c / denom : (m2c > 0 ? INFINITY : NAN);
+  output[gid] =
+      static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+  if (config.write_mean > 0)
+    output_mean[gid] = static_cast<TO>(mean);
+}
+
+#define REGISTER_WELFORD_INNER(TI, TO)                 \
+  template [[host_name("welford_inner_" #TI "_" #TO)]] \
+  kernel void welford_reduction_inner<TI, TO>(         \
+      constant TI * input [[buffer(0)]],               \
+      device TO * output [[buffer(1)]],                \
+      device TO * output_mean [[buffer(2)]],           \
+      constant uint2 & sizes [[buffer(3)]],            \
+      constant WelfordConfig & config [[buffer(4)]],   \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint tgid [[threadgroup_position_in_grid]],      \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_WELFORD(float, float);
+REGISTER_WELFORD(half, half);
+REGISTER_WELFORD(half, float);
+REGISTER_WELFORD(bfloat, bfloat);
+REGISTER_WELFORD(bfloat, float);
+
+REGISTER_WELFORD_OUTER(float, float);
+
+// 2-pass welford registrations (pass1 templated on TI; pass2 templated on TO).
+#define REGISTER_WELFORD_PASS1(TI)                     \
+  template [[host_name("welford_pass1_" #TI)]]         \
+  kernel void welford_reduction_pass1<TI>(             \
+      constant TI * input [[buffer(0)]],               \
+      device float3 * partials [[buffer(1)]],          \
+      constant uint2 & sizes [[buffer(2)]],            \
+      uint tid [[thread_position_in_threadgroup]],     \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint tgid [[threadgroup_position_in_grid]],      \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define REGISTER_WELFORD_PASS2(TO)                     \
+  template [[host_name("welford_pass2_" #TO)]]         \
+  kernel void welford_reduction_pass2<TO>(             \
+      device const float3* partials [[buffer(0)]],     \
+      device TO* output [[buffer(1)]],                 \
+      device TO* output_mean [[buffer(2)]],            \
+      constant uint& num_partials [[buffer(3)]],       \
+      constant WelfordConfig& config [[buffer(4)]],    \
+      uint tid [[thread_position_in_threadgroup]],     \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_WELFORD_PASS1(float);
+REGISTER_WELFORD_PASS1(half);
+REGISTER_WELFORD_PASS1(bfloat);
+
+REGISTER_WELFORD_PASS2(float);
+REGISTER_WELFORD_PASS2(half);
+REGISTER_WELFORD_PASS2(bfloat);
+
+REGISTER_WELFORD_OUTER(half, half);
+REGISTER_WELFORD_OUTER(half, float);
+REGISTER_WELFORD_OUTER(bfloat, bfloat);
+REGISTER_WELFORD_OUTER(bfloat, float);
+
+REGISTER_WELFORD_INNER(float, float);
+REGISTER_WELFORD_INNER(half, half);
+REGISTER_WELFORD_INNER(half, float);
+REGISTER_WELFORD_INNER(bfloat, bfloat);
+REGISTER_WELFORD_INNER(bfloat, float);
+
+#define REGISTER_WELFORD_INNER_THIN(TI, TO)                 \
+  template [[host_name("welford_inner_thin_" #TI "_" #TO)]] \
+  kernel void welford_reduction_inner_thin<TI, TO>(         \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      device TO * output_mean [[buffer(2)]],                \
+      constant uint2 & sizes [[buffer(3)]],                 \
+      constant WelfordConfig & config [[buffer(4)]],        \
+      uint gid [[thread_position_in_grid]]);
+
+REGISTER_WELFORD_INNER_THIN(float, float);
+REGISTER_WELFORD_INNER_THIN(half, half);
+REGISTER_WELFORD_INNER_THIN(half, float);
+REGISTER_WELFORD_INNER_THIN(bfloat, bfloat);
+REGISTER_WELFORD_INNER_THIN(bfloat, float);
+
+// Small-M variants: welford_outer with TG_Y matching M.
+// Avoids the 75-87% idle-thread waste of TG_Y=32 when M is 8 or 16.
+
+template [[host_name("welford_outer_8_float_float")]]
+kernel void welford_reduction_outer<float, float, 128, 8>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_half_half")]]
+kernel void welford_reduction_outer<half, half, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    device half* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_half_float")]]
+kernel void welford_reduction_outer<half, float, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_bfloat_bfloat")]]
+kernel void welford_reduction_outer<bfloat, bfloat, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device bfloat* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_bfloat_float")]]
+kernel void welford_reduction_outer<bfloat, float, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_16_float_float")]]
+kernel void welford_reduction_outer<float, float, 64, 16>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_half_half")]]
+kernel void welford_reduction_outer<half, half, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    device half* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_half_float")]]
+kernel void welford_reduction_outer<half, float, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_bfloat_bfloat")]]
+kernel void welford_reduction_outer<bfloat, bfloat, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device bfloat* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_bfloat_float")]]
+kernel void welford_reduction_outer<bfloat, float, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -869,6 +869,9 @@ struct ReductionDispatch {
   std::optional<float> divisor; // sum/mean only; appended as a float buffer
                                 // to the outer/inner kernel signatures, and
                                 // passed via NormParams.p elsewhere.
+  bool inner_specializations = false; // op registers inner_thin/inner_wide
+                                      // kernels for degenerate inner shapes
+                                      // (prod); others use the generic inner.
 };
 
 static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch& opts) {
@@ -894,6 +897,16 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
   const auto in_str = scalarToMetalTypeString(opts.input_kernel_dtype);
   const auto out_str = scalarToMetalTypeString(opts.output_kernel_dtype);
   const auto partial_str = scalarToMetalTypeString(opts.partial_dtype);
+  // Two-pass reductions accumulate per-chunk partials in opmath (fp32 for
+  // half/bfloat) so a chunk product can exceed the narrow output range without
+  // overflowing -- the full product is finite. Pass 2 narrows opmath -> output.
+  const ScalarType opmath_pdt =
+      (opts.partial_dtype == kHalf || opts.partial_dtype == kBFloat16) ? kFloat : opts.partial_dtype;
+  const auto opmath_str = scalarToMetalTypeString(opmath_pdt);
+  // complexHalf opmath (float2) partials are not wired for the two-pass; those
+  // keep the fp32-accumulating single-pass kernels.
+  const auto out_dt = output.scalar_type();
+  const bool two_pass_ok = out_dt != kComplexHalf;
 
   // Outer-dim (dim=0 on contiguous input) and inner-dim (last dim on
   // contiguous input) specializations: handle the dim-reduction case with
@@ -910,6 +923,84 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     if (num_reduced == 1 && reduced_dim == 0 && input_orig.dim() >= 2) {
       uint32_t M = input_orig.size(0);
       uint32_t N = input_orig.numel() / M;
+      // Outer bucketed two-pass: few output columns (small N) over a long
+      // reduced dim (large M). The single-pass outer kernel launches
+      // ceil(N/32) threadgroups -- one for N<=32 -- with TG_Y=32 lanes each
+      // serially walking M/32 rows, leaving the GPU idle. Pass 1 instead splits
+      // the flat M*N input into contiguous N-aligned slices, folds each element
+      // into its column bucket, and writes num_tgs*N opmath partials; pass 2
+      // reduces those partials per column. Only worth it for very few output
+      // columns over a very long reduced dim; the two-pass overhead loses on
+      // moderate shapes the single-pass kernel already parallelizes adequately.
+      if (opts.inner_specializations && two_pass_ok && N <= 8 && M >= (1u << 18) && !opts.divisor.has_value()) {
+        // The bucketed kernel folds elements into N column buckets in a fixed
+        // acc[MAXN=8] register array; routing N > 8 here would index out of
+        // bounds, so the gate's N <= 8 is a hard kernel-domain invariant.
+        TORCH_INTERNAL_ASSERT(N <= 8, "bucketed prod kernel handles at most 8 columns");
+        // pass 1: bucketed coalesced read of the flat M*N input -> num_tgs*N
+        // opmath partials; pass 2: the single-pass outer kernel collapses the
+        // num_tgs partials per column (num_tgs is small, so it is fast there).
+        const uint64_t total = (uint64_t)M * N;
+        constexpr uint32_t TG = 256;
+        // Fewer, larger threadgroups: each does one N-bucket reduce over a big
+        // contiguous slice, so the reduce cost is amortized over more reads (the
+        // reduce, not bandwidth, is the floor here). Still enough TGs to fill the
+        // GPU.
+        const uint32_t num_tgs = std::clamp<uint32_t>(static_cast<uint32_t>(total / 32768u), 64u, 1024u);
+        auto partials = at::empty({(int64_t)num_tgs * N}, output.options().dtype(opmath_pdt));
+        auto p1 = fmt::format("{}reduction_outer_bucketed_{}_{}", opts.prefix, in_str, opmath_str);
+        auto p2 = fmt::format("{}reduction_outer_{}_{}", opts.pass2_prefix, opmath_str, out_str);
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          @autoreleasepool {
+            id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+            auto ps1 = lib.getPipelineStateForFunc(p1);
+            getMPSProfiler().beginProfileKernel(ps1, opts.prefix + "reduction_outer_bucketed", {input_orig});
+            // 4th element pads the bind to 16 bytes: Metal's uint3 is 16-byte
+            // aligned even though the kernel reads only 12 (as the outer path does).
+            const std::array<uint32_t, 4> sizes1{static_cast<uint32_t>(total), N, num_tgs, 0};
+            [ce setComputePipelineState:ps1];
+            mtl_setArgs(ce, input_orig, partials, sizes1);
+            [ce dispatchThreads:MTLSizeMake((int64_t)num_tgs * TG, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+            getMPSProfiler().endProfileKernel(ps1);
+
+            // pass 2: (num_tgs, N) reduce dim=0 -> output[N] via the outer kernel
+            auto ps2 = lib.getPipelineStateForFunc(p2);
+            getMPSProfiler().beginProfileKernel(ps2, opts.prefix + "reduction_outer_pass2", {partials});
+            constexpr uint32_t TG_X = 32, TG_Y = 32;
+            const std::array<uint32_t, 4> sizes2{num_tgs, N, 1, 0};
+            [ce setComputePipelineState:ps2];
+            mtl_setArgs(ce, partials, output, sizes2);
+            const auto num_tg_x = c10::metal::ceil_div(N, TG_X);
+            [ce dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+            getMPSProfiler().endProfileKernel(ps2);
+          }
+        });
+        return;
+      }
+      // Thin outer: a short reduced dim (small M) over many output columns
+      // (large N). The TG-tiled outer kernel idles TG_Y-M of its 32 row-workers
+      // and still launches ceil(N/32) threadgroups; one thread per column reads
+      // coalesced across adjacent gid and fully occupies the GPU.
+      if (opts.inner_specializations && M <= 32 && N >= 1024 && !opts.divisor.has_value()) {
+        auto thin_kernel = fmt::format("{}reduction_outer_thin_{}_{}", opts.prefix, in_str, out_str);
+        constexpr uint32_t TG = 256;
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          @autoreleasepool {
+            id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+            auto ps = lib.getPipelineStateForFunc(thin_kernel);
+            getMPSProfiler().beginProfileKernel(ps, opts.prefix + "reduction_outer_thin", {input_orig});
+            struct {
+              uint32_t M, N;
+            } sizes_s = {M, N};
+            [ce setComputePipelineState:ps];
+            mtl_setArgs(ce, input_orig, output, sizes_s);
+            [ce dispatchThreads:MTLSizeMake(c10::metal::ceil_div(N, TG) * TG, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+            getMPSProfiler().endProfileKernel(ps);
+          }
+        });
+        return;
+      }
       auto outer_kernel = fmt::format("{}reduction_outer_{}_{}", opts.prefix, in_str, out_str);
       constexpr uint32_t TG_X = 32, TG_Y = 32;
       const auto num_tg_x = c10::metal::ceil_div(N, TG_X);
@@ -937,10 +1028,99 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     if (num_reduced == 1 && reduced_dim == input_orig.dim() - 1) {
       uint32_t N = input_orig.size(input_orig.dim() - 1);
       uint32_t M = input_orig.numel() / N;
-      auto inner_kernel = fmt::format("{}reduction_inner_{}_{}", opts.prefix, in_str, out_str);
-      constexpr uint32_t TG_SIZE = 256;
-      constexpr uint32_t rows_per_tg = TG_SIZE / 32;
-      const auto num_tgs = c10::metal::ceil_div(M, rows_per_tg);
+      // Super-wide: few rows (small M) with a huge reduced dim. One TG per row
+      // (inner_wide) leaves most of the GPU idle and is bandwidth-starved. Split
+      // each row into K chunks -> M*K parallel partials (pass 1), then reduce the
+      // K partials per row (pass 2). Reuses the generic NormParams value_reduction
+      // kernel, mirroring the full-reduce two-pass but keeping the M batch dim.
+      // Partials are stored at opmath (fp32 for half/bfloat, via opmath_pdt) so
+      // a per-chunk product stays lossless even when it would overflow the
+      // narrow output range (the full product is finite). complexHalf opmath
+      // (float2) is not wired for the two-pass, so it keeps inner_wide (one
+      // TG/row, fp32 accumulator).
+      if (opts.inner_specializations && two_pass_ok && M < 32 && N >= 4096 && !opts.divisor.has_value()) {
+        uint32_t K = std::clamp<uint32_t>(512u / std::max<uint32_t>(M, 1u), 1u, 512u);
+        while (K > 1 && N % K != 0) {
+          K--;
+        }
+        if (K > 1) {
+          const uint32_t chunkN = N / K;
+          auto input_c = input_orig.contiguous();
+          auto partials = at::empty({(int64_t)M * K}, output.options().dtype(opmath_pdt));
+          auto p1 = fmt::format("{}reduction_{}_{}", opts.prefix, in_str, opmath_str);
+          auto p2 = fmt::format("{}reduction_{}_{}", opts.pass2_prefix, opmath_str, out_str);
+          // pass 1: [M*K, chunkN] reduce dim=1 -> partials[M*K]
+          NormParams params1{};
+          params1.ndim = 2;
+          params1.reduction_size = chunkN;
+          params1.input_sizes[0] = M * K;
+          params1.input_strides[0] = chunkN;
+          params1.input_sizes[1] = chunkN;
+          params1.input_strides[1] = 1;
+          params1.output_sizes[0] = M * K;
+          params1.output_strides[0] = 1;
+          // pass 2: partials[M, K] reduce dim=1 -> output[M]
+          NormParams params2{};
+          params2.ndim = 2;
+          params2.reduction_size = K;
+          params2.input_sizes[0] = M;
+          params2.input_strides[0] = K;
+          params2.input_sizes[1] = K;
+          params2.input_strides[1] = 1;
+          params2.output_sizes[0] = M;
+          params2.output_strides[0] = 1;
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            @autoreleasepool {
+              id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+              auto ps1 = lib.getPipelineStateForFunc(p1);
+              getMPSProfiler().beginProfileKernel(ps1, opts.prefix + "reduction_wide_pass1", {input_c});
+              [ce setComputePipelineState:ps1];
+              mtl_setArgs(ce, input_c, partials, params1);
+              auto tpg1 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, c10::metal::round_up(chunkN, 32u));
+              [ce dispatchThreads:MTLSizeMake((int64_t)M * K * tpg1, 1, 1)
+                  threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+              getMPSProfiler().endProfileKernel(ps1);
+
+              auto ps2 = lib.getPipelineStateForFunc(p2);
+              getMPSProfiler().beginProfileKernel(ps2, opts.prefix + "reduction_wide_pass2", {partials});
+              [ce setComputePipelineState:ps2];
+              mtl_setArgs(ce, partials, output, params2);
+              auto tpg2 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, c10::metal::round_up(K, 32u));
+              [ce dispatchThreads:MTLSizeMake((int64_t)M * tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+              getMPSProfiler().endProfileKernel(ps2);
+            }
+          });
+          return;
+        }
+      }
+      // Shape-specialized inner kernels, only for ops that register them
+      // (inner_specializations): thin = one thread per row for a tiny reduced
+      // dim; wide = one whole TG per row for few huge rows; else the generic
+      // simd-per-row kernel. Non-specialized ops keep the generic path.
+      std::string inner_kernel;
+      uint32_t tg_size;
+      int64_t num_tgs;
+      if (opts.inner_specializations && M >= 64 && N <= 128) {
+        inner_kernel = fmt::format("{}reduction_inner_thin_{}_{}", opts.prefix, in_str, out_str);
+        tg_size = 256;
+        num_tgs = c10::metal::ceil_div<int64_t>(M, tg_size); // one thread per row
+      } else if (!opts.inner_specializations || M >= 64) {
+        inner_kernel = fmt::format("{}reduction_inner_{}_{}", opts.prefix, in_str, out_str);
+        // One simdgroup (32 lanes) per row, 8 rows per 256-thread TG. A larger TG
+        // would pack more rows per TG and shrink num_tgs (ceil(M/(tg/32))),
+        // under-utilizing the GPU for moderate M, so keep 256 for all ops.
+        tg_size = 256u;
+        num_tgs = c10::metal::ceil_div<int64_t>(M, tg_size / 32);
+      } else {
+        inner_kernel = fmt::format("{}reduction_inner_wide_{}_{}", opts.prefix, in_str, out_str);
+        tg_size = std::min<uint32_t>(1024u, c10::metal::ceil_div(N, 32u) * 32u);
+        if (N >= 2048) {
+          tg_size = c10::metal::ceil_div(N / (4u * 16u), 32u) * 32u;
+          tg_size = std::clamp<uint32_t>(tg_size, 32u, 1024u);
+        }
+        num_tgs = M; // one TG per row
+      }
+      const int64_t total_threads = num_tgs * tg_size;
       dispatch_sync_with_rethrow(stream->queue(), ^() {
         @autoreleasepool {
           id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
@@ -955,7 +1135,7 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
           } else {
             mtl_setArgs(ce, input_orig, output, sizes_s);
           }
-          [ce dispatchThreads:MTLSizeMake(num_tgs * TG_SIZE, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG_SIZE, 1, 1)];
+          [ce dispatchThreads:MTLSizeMake(total_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
           getMPSProfiler().endProfileKernel(ps);
         }
       });
@@ -964,10 +1144,22 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
   }
 
   // Two-pass for large full reductions: pass 1 splits input into <=512
-  // contiguous slices, each TG reduces one slice to a partial; pass 2
-  // collapses the num_groups partials into the final scalar.
-  if (output.numel() == 1 && reduction_size > MAX_THREADGROUP_SIZE * NCHAINS) {
-    auto num_groups = std::min(512u, c10::metal::ceil_div(reduction_size, MAX_THREADGROUP_SIZE * NCHAINS));
+  // contiguous slices, each TG reduces one slice to a partial; pass 2 collapses
+  // the num_groups partials into the final scalar. prod's complexHalf is excluded
+  // (its float2 opmath partials are not wired here, and half2 partials would
+  // overflow on a long slice); it falls to the fp32-accumulating single-pass.
+  if (output.numel() == 1 && reduction_size > MAX_THREADGROUP_SIZE * NCHAINS &&
+      !(opts.inner_specializations && output.scalar_type() == kComplexHalf)) {
+    // Keep pass-2 overhead proportional to input size. Small full reductions are
+    // latency-bound and prefer fewer partials; large ones need enough pass-1
+    // parallelism to stay bandwidth-bound.
+    uint32_t max_num_groups = 384u;
+    if (reduction_size <= (1u << 20)) {
+      max_num_groups = 32u;
+    } else if (reduction_size <= (1u << 22)) {
+      max_num_groups = 192u;
+    }
+    auto num_groups = std::min(max_num_groups, c10::metal::ceil_div(reduction_size, MAX_THREADGROUP_SIZE * NCHAINS));
     while (num_groups > 1 && reduction_size % num_groups != 0) {
       num_groups--;
     }
@@ -978,11 +1170,17 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
       auto input = (!is_contig && !opts.has_strided_pass1) ? input_orig.contiguous() : input_orig;
       const bool use_strided = !is_contig && opts.has_strided_pass1;
       const uint32_t elems_per_group = reduction_size / num_groups;
-      auto partials = at::empty({(int64_t)num_groups}, output.options().dtype(opts.partial_dtype));
+      // prod stores opmath (fp32 for half/bfloat) pass-1 partials so a per-slice
+      // product can exceed the narrow output range without overflowing -- the
+      // full product is finite. Other ops keep output-dtype partials; gated on
+      // inner_specializations because only prod registers the opmath fp32->out
+      // pass-2 kernel.
+      const auto sc_pdt = opts.inner_specializations ? opmath_pdt : opts.partial_dtype;
+      const auto sc_str = opts.inner_specializations ? opmath_str : partial_str;
+      auto partials = at::empty({(int64_t)num_groups}, output.options().dtype(sc_pdt));
 
-      auto p1_kernel =
-          fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "", in_str, partial_str);
-      auto p2_kernel = fmt::format("{}reduction_{}_{}", opts.pass2_prefix, partial_str, out_str);
+      auto p1_kernel = fmt::format("{}reduction{}_{}_{}", opts.prefix, use_strided ? "_strided" : "", in_str, sc_str);
+      auto p2_kernel = fmt::format("{}reduction_{}_{}", opts.pass2_prefix, sc_str, out_str);
 
       NormParams params1{};
       params1.reduction_size = elems_per_group;
@@ -1199,10 +1397,85 @@ Tensor trace_mps(const Tensor& self) {
   return self.diagonal().sum();
 }
 
+// (input, output) dtype pairs with a registered prod value_reduction kernel.
+static bool prod_kernel_registered(ScalarType in, ScalarType out) {
+  if (in == out) {
+    return in == kFloat || in == kHalf || in == kBFloat16 || in == kInt || in == kLong || in == kShort || in == kChar ||
+        in == kByte || in == kComplexFloat || in == kComplexHalf;
+  }
+  if ((in == kHalf || in == kBFloat16) && out == kFloat) {
+    return true;
+  }
+  if ((in == kInt || in == kShort || in == kChar || in == kByte) && out == kLong) {
+    return true;
+  }
+  if (in == kBool && (out == kInt || out == kLong)) {
+    return true;
+  }
+  return false;
+}
+
+// prod via the shared value_reduction<ProdOp> kernel: route the dtype semantics
+// (dtype= cast, bool nonzero-product, uint rejection), then dispatch through the
+// same reduction_dispatch_mps sum/min/max use. pass-2 multiplies the partials.
+static void prod_kernel_mps(const Tensor& input, IntArrayRef dims, bool keepdim, const Tensor& output) {
+  // bool output: prod(..., dtype=bool) is nonzero-product (CPU multiplies the
+  // input != 0 mask). Reduce input.to(kBool) via the (bool,long) kernel, cast
+  // the long accumulator back to bool.
+  if (output.scalar_type() == kBool) {
+    auto long_output = at::empty_like(output, output.options().dtype(kLong));
+    prod_kernel_mps(input.to(kBool), dims, keepdim, long_output);
+    output.copy_(long_output.to(kBool));
+    return;
+  }
+  TORCH_CHECK(output.scalar_type() != kUInt16 && output.scalar_type() != kUInt32 && output.scalar_type() != kUInt64,
+              "prod: not implemented for ",
+              output.scalar_type(),
+              " output on MPS");
+  // dtype=: cast the input to the output dtype and recurse into the same-dtype
+  // kernel rather than requesting an unregistered (in, out) pair.
+  if (!prod_kernel_registered(input.scalar_type(), output.scalar_type())) {
+    if (input.scalar_type() == output.scalar_type()) {
+      TORCH_CHECK(false, "prod for ", output.scalar_type(), " is not implemented on MPS");
+    }
+    prod_kernel_mps(input.to(output.scalar_type()).contiguous(), dims, keepdim, output);
+    return;
+  }
+  if (input.numel() == 0) {
+    output.fill_(1);
+    return;
+  }
+  if (output.numel() == 0) {
+    return;
+  }
+  // The native kernel indexes with uint32; reject tensors that would overflow.
+  TORCH_CHECK(
+      input.numel() <= std::numeric_limits<uint32_t>::max() && output.numel() <= std::numeric_limits<uint32_t>::max(),
+      "MPS prod: tensor too large for 32-bit indexing");
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              "prod: tensor rank > ",
+              c10::metal::max_ndim,
+              " is not supported on MPS");
+  // in_dtype == input's dtype (routing above already cast for dtype=), so
+  // make_reduction does not re-cast; dispatch on the shared kernel.
+  Tensor result = output;
+  auto iter = make_reduction("prod", result, input, dims, keepdim, input.scalar_type(), output.scalar_type());
+  reduction_dispatch_mps(iter,
+                         ReductionDispatch{
+                             .prefix = "prod_",
+                             .input_kernel_dtype = input.scalar_type(),
+                             .output_kernel_dtype = output.scalar_type(),
+                             .partial_dtype = output.scalar_type(),
+                             .pass2_prefix = "prod_",
+                             .has_strided_pass1 = false,
+                             .inner_specializations = true,
+                         });
+}
+
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
   int64_t dims[1] = {dim};
-  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
+  prod_kernel_mps(input_t, IntArrayRef(dims, 1), keepdim, output_t);
 }
 
 static void aminmax_kernel_mps(const Tensor& self, int64_t dim, bool keepdim, Tensor& min, Tensor& max) {
@@ -1224,8 +1497,7 @@ Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  reduction_out_mps(
-      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
+  prod_kernel_mps(self, IntArrayRef(dims), false, output_t);
 
   return output_t;
 }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/ExpandUtils.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/ReduceOps.h>
 #include <ATen/native/ReduceOpsUtils.h>
@@ -23,17 +24,22 @@
 #include <ATen/ops/any_native.h>
 #include <ATen/ops/argmax_native.h>
 #include <ATen/ops/argmin_native.h>
+#include <ATen/ops/complex.h>
 #include <ATen/ops/count_nonzero_native.h>
+#include <ATen/ops/imag.h>
 #include <ATen/ops/max_native.h>
+#include <ATen/ops/mean.h>
 #include <ATen/ops/mean_native.h>
 #include <ATen/ops/min_native.h>
 #include <ATen/ops/nansum_native.h>
 #include <ATen/ops/prod_native.h>
+#include <ATen/ops/real.h>
 #include <ATen/ops/std_mean_native.h>
 #include <ATen/ops/std_native.h>
 #include <ATen/ops/sum.h>
 #include <ATen/ops/sum_native.h>
 #include <ATen/ops/trace_native.h>
+#include <ATen/ops/var.h>
 #include <ATen/ops/var_mean_native.h>
 #include <ATen/ops/var_native.h>
 #endif
@@ -349,177 +355,339 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
   });
 }
 
+// ============================================================================
+// Metal kernel dispatch helpers for welford
+// ============================================================================
+
+struct WelfordConfig {
+  float denom; // host-computed max(reduction_count - correction, 0); see kernel
+  float compute_std;
+  float write_mean;
+};
+
+static std::vector<int64_t> get_reduce_dims(const Tensor& input, OptionalIntArrayRef opt_dim) {
+  std::vector<int64_t> dims;
+  if (opt_dim.has_value() && !opt_dim.value().empty()) {
+    // Raises on duplicate dims, matching CPU ("dim N appears multiple times").
+    at::dim_list_to_bitset(opt_dim.value(), input.dim());
+    for (auto d : opt_dim.value()) {
+      dims.push_back(maybe_wrap_dim(d, input.dim()));
+    }
+  } else {
+    for (int64_t d = 0; d < input.dim(); d++) {
+      dims.push_back(d);
+    }
+  }
+  return dims;
+}
+
+static NormParams<> build_reduce_params(const Tensor& input,
+                                        const std::vector<int64_t>& reduce_dims,
+                                        const Tensor& output,
+                                        bool keepdim) {
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              "MPS var/std supports tensors with at most ",
+              c10::metal::max_ndim,
+              " dimensions, but got ",
+              input.dim());
+  NormParams params;
+  params.ndim = input.dim();
+  params.p = 0;
+  constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+  auto checked_u32 = [&](int64_t value, const char* field) -> uint32_t {
+    TORCH_CHECK(value >= 0 && value <= kU32Max, "MPS var/std ", field, " exceeds the uint32 indexing domain");
+    return static_cast<uint32_t>(value);
+  };
+  params.reduction_size = checked_u32(input.numel() / std::max<int64_t>(output.numel(), 1), "reduction size");
+
+  bool is_reduced[c10::metal::max_ndim] = {};
+  for (auto d : reduce_dims)
+    is_reduced[d] = true;
+
+  if (keepdim || output.dim() == input.dim()) {
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = checked_u32(input.size(d), "input size");
+      params.input_strides[d] = checked_u32(input.stride(d), "input stride");
+      params.output_sizes[d] = checked_u32(output.size(d), "output size");
+      params.output_strides[d] = checked_u32(output.stride(d), "output stride");
+    }
+  } else {
+    uint32_t out_d = 0;
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = checked_u32(input.size(d), "input size");
+      params.input_strides[d] = checked_u32(input.stride(d), "input stride");
+      if (is_reduced[d]) {
+        params.output_sizes[d] = 1;
+        params.output_strides[d] = 0;
+      } else {
+        params.output_sizes[d] = checked_u32(output.size(out_d), "output size");
+        params.output_strides[d] = checked_u32(output.stride(out_d), "output stride");
+        out_d++;
+      }
+    }
+  }
+
+  return params;
+}
+
+static void welford_kernel_mps(const Tensor& input,
+                               const std::vector<int64_t>& reduce_dims,
+                               bool keepdim,
+                               double correction_value,
+                               bool compute_std,
+                               const Tensor& output,
+                               const Tensor* output_mean = nullptr) {
+  if (input.numel() == 0 || output.numel() == 0)
+    return;
+
+  auto in_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+  int64_t reduction_size = input.numel() / output.numel();
+  constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+  TORCH_CHECK(input.numel() <= kU32Max, "MPS var/std reduction with more than 2^32 input elements is not supported");
+  TORCH_CHECK(output.numel() <= kU32Max, "MPS var/std reduction with more than 2^32 output elements is not supported");
+  TORCH_CHECK(reduction_size <= kU32Max, "MPS var/std reduction over more than 2^32 elements is not supported");
+  const auto reduction_size_u32 = static_cast<uint32_t>(reduction_size);
+
+  WelfordConfig config;
+  // Compute the divisor on the host in double so it stays exact for large
+  // reductions: a float element count loses integer precision above 2^24, which
+  // corrupted denom when correction was close to N (var returned inf).
+  config.denom = static_cast<float>(std::max(static_cast<double>(reduction_size) - correction_value, 0.0));
+  config.compute_std = compute_std ? 1.0f : 0.0f;
+  config.write_mean = output_mean ? 1.0f : 0.0f;
+
+  Tensor mean_placeholder;
+  const Tensor& mean_tensor = output_mean ? *output_mean : (mean_placeholder = at::empty({1}, output.options()));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass for all-reduce (single-output) when N is large enough to give
+  // multiple TGs useful work. Single-pass welford is bottlenecked by the
+  // 1024-thread single-TG limit for any-shape reduce.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    uint32_t total_N = static_cast<uint32_t>(input.numel());
+    uint32_t num_groups = std::min<uint32_t>(512, c10::metal::ceil_div(total_N, MAX_THREADGROUP_SIZE * 8u));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    uint32_t elems_per_group = total_N / num_groups;
+
+    // 4 floats/group, not 3: the pass1/pass2 kernels index partials as
+    // device float3*, which Metal gives a 16-byte (4-float) array stride.
+    // Allocating only 3 floats/group overruns the buffer in pass1's last group.
+    auto partials = at::empty({static_cast<int64_t>(num_groups) * 4}, input.options().dtype(at::kFloat));
+
+    auto kernel_p1 = fmt::format("welford_pass1_{}", in_str);
+    auto kernel_p2 = fmt::format("welford_pass2_{}", out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+
+        auto ps1 = lib.getPipelineStateForFunc(kernel_p1);
+        getMPSProfiler().beginProfileKernel(ps1, "welford_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        struct {
+          uint32_t elems_per_group, total_N;
+        } sizes_p1 = {elems_per_group, total_N};
+        mtl_setArgs(enc, input, partials, sizes_p1);
+        // Round to a full simdgroup: both passes call simd_welford_combine,
+        // whose simd_shuffle_and_fill_down reads undefined data from inactive
+        // lanes in a partial simdgroup (0 on M1/M2 -> corrupt combine). Padding
+        // threads carry the welford identity (count 0), so over-dispatching is
+        // safe.
+        auto tpg1 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(elems_per_group, 32u) * 32u);
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(kernel_p2);
+        getMPSProfiler().beginProfileKernel(ps2, "welford_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, mean_tensor, num_groups, config);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(num_groups, 32u) * 32u);
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  // is_outer / is_inner are designed for shapes where one of M/N is large.
+  // For output.numel() == 1 (all-reduce) either pass goes through the 2-pass
+  // block above; if 2-pass didn't fire (N below its threshold), fall through
+  // to the generic kernel which uses up to 1024 threads in one TG.
+  bool is_single = reduce_dims.size() == 1 && output.numel() != 1;
+  bool is_outer = is_single && reduce_dims[0] == 0 && input.is_contiguous() && output.is_contiguous();
+  bool is_inner = is_single && reduce_dims[0] == input.dim() - 1 && input.is_contiguous() && output.is_contiguous();
+
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    uint32_t TG_X, TG_Y;
+    std::string kernel;
+    if (M <= 8) {
+      TG_X = 128;
+      TG_Y = 8;
+      kernel = fmt::format("welford_outer_8_{}_{}", in_str, out_str);
+    } else if (M <= 16) {
+      TG_X = 64;
+      TG_Y = 16;
+      kernel = fmt::format("welford_outer_16_{}_{}", in_str, out_str);
+    } else {
+      TG_X = 32;
+      TG_Y = 32;
+      kernel = fmt::format("welford_outer_{}_{}", in_str, out_str);
+    }
+    auto num_tg_x = c10::metal::ceil_div(N, TG_X);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "welford_outer", {input});
+        [enc setComputePipelineState:ps];
+        // Pad to 4 uints: welford_reduction_outer takes `constant uint3&`,
+        // which Metal sizes at 16 bytes; a 12-byte struct fails validation.
+        const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+        mtl_setArgs(enc, input, output, mean_tensor, sizes_s, config);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  if (is_inner) {
+    uint32_t N = input.size(input.dim() - 1);
+    uint32_t M = input.numel() / N;
+    // Tall-thin (small N, large M) -> one thread per row: a 32-lane SIMD group
+    // on N<=32 leaves most lanes idle and pays simd-reduction overhead for under
+    // one element of work per lane. Many short-but-not-tiny rows -> one SIMD
+    // group per row (8 rows/TG). Few/huge rows (small M, large N) -> the "wide"
+    // kernel (one whole TG per row, up to 1024 threads): 32 lanes on a giant row
+    // is both slow and loses precision from a deep per-lane streaming Welford
+    // (e.g. GroupNorm's M=2, N~19M).
+    bool use_thin = (M >= 64 && N <= 32);
+    bool use_simd_per_row = (M >= 64 && N <= 16384);
+    uint32_t tg_size, num_tgs;
+    std::string kernel;
+    if (use_thin) {
+      kernel = fmt::format("welford_inner_thin_{}_{}", in_str, out_str);
+      tg_size = 256;
+      num_tgs = c10::metal::ceil_div(M, tg_size); // one thread per row
+    } else if (use_simd_per_row) {
+      kernel = fmt::format("welford_inner_{}_{}", in_str, out_str);
+      tg_size = 256; // 8 SIMD groups = 8 rows per TG
+      num_tgs = c10::metal::ceil_div(M, tg_size / 32);
+    } else {
+      kernel = fmt::format("welford_inner_wide_{}_{}", in_str, out_str);
+      tg_size = std::min(1024u, c10::metal::ceil_div(N, 32u) * 32u);
+      if (N >= 2048) {
+        tg_size = c10::metal::ceil_div(N / (4u * 16u), 32u) * 32u;
+        tg_size = std::clamp(tg_size, 32u, 1024u);
+      }
+      num_tgs = M; // one TG per row
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "welford_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output, mean_tensor, sizes_s, config);
+        // 64-bit total dispatch thread count: num_tgs*tg_size can exceed 2^32
+        // (one TG per row for many rows). num_tgs/tg_size stay 32-bit.
+        [enc dispatchThreads:MTLSizeMake(static_cast<uint64_t>(num_tgs) * tg_size, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("welford_{}_{}", in_str, out_str);
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  uint32_t threads_per_group =
+      std::min<uint32_t>(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(reduction_size_u32, 32u) * 32u);
+  // 64-bit total dispatch thread count: output.numel() * threads_per_group can
+  // exceed 2^32 (one threadgroup per output element, many output elements).
+  uint64_t num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "welford_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, mean_tensor, params, config);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
 static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       at::OptionalIntArrayRef dim,
                                       const std::optional<Scalar>& correction,
                                       bool keepdim,
                                       StdVarType stdVarType) {
-  TORCH_CHECK_TYPE(input_t.is_floating_point() || input_t.is_complex(),
-                   "std and var only support floating point and complex dtypes");
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
-
-  bool use_dim = dim.has_value();
-  IntArrayRef dim_value = use_dim ? dim.value() : NULL;
-
-  if (use_dim) {
-    std::string errMessage = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
-    errMessage += ": reduction dim must be in the range of input shape";
-    for (const auto dim : dim_value) {
-      auto wrap_dim = maybe_wrap_dim(dim, num_input_dims);
-      TORCH_CHECK(wrap_dim < (num_input_dims ? num_input_dims : 1), errMessage.c_str())
+  if (input_t.dim() == 0) {
+    // Validate the user dim against the scalar before remapping to {0}; CPU
+    // raises IndexError for e.g. dim=1 on a 0-d input, and dim_list_to_bitset
+    // additionally raises on duplicate dims (e.g. dim=(0, 0)).
+    if (dim.has_value()) {
+      (void)at::dim_list_to_bitset(dim.value(), input_t.dim());
     }
+    auto input_1d = input_t.unsqueeze(0);
+    auto result = std_var_common_impl_mps(input_1d, IntArrayRef({0}), correction, false, stdVarType);
+    return result.squeeze();
   }
 
-  bool use_correction = !(correction.has_value() && correction.value().toDouble() == 0);
+  TORCH_CHECK(c10::isFloatingType(input_t.scalar_type()) || c10::isComplexType(input_t.scalar_type()),
+              "std and var only support floating point and complex dtypes");
+  if (c10::isComplexType(input_t.scalar_type())) {
+    // Var(complex) = Var(real) + Var(imag) (same correction); std = sqrt.
+    // Output is real-valued. Routes through the real welford kernels (no
+    // complex Metal kernel), matching CPU/MPSGraph semantics.
+    auto v = at::var(at::real(input_t).contiguous(), dim, correction, keepdim)
+                 .add(at::var(at::imag(input_t).contiguous(), dim, correction, keepdim));
+    return (stdVarType == STANDARD_DEVIATION) ? v.sqrt() : v;
+  }
+
+  auto reduce_dims = get_reduce_dims(input_t, dim);
   const auto correction_value = correction.value_or(1.0).toDouble();
-  int64_t correction_n = 1;
 
-  NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_t.sizes(), dim);
-
-  int64_t num_output_dims = 0;
-  NSMutableArray<NSNumber*>* axes = nil;
-  NSMutableArray<NSNumber*>* apparent_output_shape = nil;
-  NSMutableArray<NSNumber*>* apparent_input_shape = nil;
   std::vector<int64_t> output_shape;
-
-  if ((!keepdim && !use_dim) || (!keepdim && use_dim && dim_value.size() <= 0)) {
-    // Flatten the input tensor to reduce it to one value
-    apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = c10::multiply_integers(input_shape);
-    apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
-
-    // Output is a single value
-    apparent_output_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    apparent_output_shape[0] = @1;
-
-    num_output_dims = 0;
-
-    correction_n = num_in_elements;
-
-    // Reduction axes
-    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    axes[0] = @0;
-  } else if (!keepdim && use_dim && !dim_value.empty()) {
-    int64_t num_reduce_dims = dim_value.size();
-    num_output_dims = num_input_dims;
-
-    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-
-    num_output_dims = (num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0; // num_input_dims;
-
-    unsigned int curr_i = 0;
-    for (const auto i : c10::irange(num_input_dims)) {
-      bool found = false;
-      for (const auto j : c10::irange(num_reduce_dims)) {
-        if (i == maybe_wrap_dim(dim_value[j], num_input_dims)) {
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        continue;
-      }
-      output_shape.push_back(input_shape[i]);
-      curr_i += 1;
-      // End loop when output shape is filled
-      if (curr_i == num_output_dims) {
+  for (int64_t d = 0; d < input_t.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
         break;
       }
     }
-
-    for (const auto dim : dim_value) {
-      auto wrap_dim = maybe_wrap_dim(dim, input_shape.size());
-      correction_n *= input_shape[wrap_dim];
-    }
-    // (3, 4, 5) --> (3, 5)
-  } else if ((keepdim && !use_dim) || (keepdim && use_dim && dim_value.empty())) {
-    num_output_dims = 0;
-    int64_t num_reduce_dims = 0;
-    set_axes(axes, num_reduce_dims, dim_value, input_shape.size());
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-    num_output_dims = num_input_dims;
-    for (const auto i : c10::irange(num_input_dims)) {
-      output_shape.push_back((int64_t)1);
-      correction_n *= input_shape[i];
-    }
-    // scalar --> vector case [[1.0034567]]
-  } else if (keepdim && use_dim && !dim_value.empty()) {
-    int64_t num_reduce_dims = dim_value.size();
-    num_output_dims = num_input_dims;
-
-    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-
-    num_output_dims = num_input_dims; //(num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0;
-
-    for (const int i : c10::irange(num_reduce_dims)) {
-      auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
-      correction_n *= input_shape[wrap_dim];
-    }
-
-    for (const int i : c10::irange(num_input_dims)) {
-      output_shape.push_back([apparent_output_shape[i] longValue]);
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(input_t.size(d));
     }
   }
 
-  Tensor output_t = at::empty(IntArrayRef(output_shape.data(), num_output_dims),
-                              input_t.scalar_type(),
-                              std::nullopt,
-                              kMPS,
-                              std::nullopt,
-                              std::nullopt);
+  Tensor output_t = at::empty(output_shape, input_t.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     output_t.fill_(std::numeric_limits<float>::quiet_NaN());
     return output_t;
   }
 
-  double dof = std::max(0.0, correction_n - correction_value);
-  double bessel_correction = correction_n / dof;
-  auto stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string op_key = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
-    NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];
-    std::string bessel_corrected = (use_correction && correction_value) ? "unbiased " : "biased ";
-    std::string use_dim_info = (use_dim) ? "use_dim=1:" + std::to_string(dim_value.size()) : "use_dim=0";
-    std::string keepdim_info = (keepdim) ? "keepdim=1" : "keepdim=0";
-    std::string key = op_key + ":" + getTensorsStringKey(input_t) + ":" + use_dim_info + ":" + keepdim_info + ":" +
-        std::string([ns_key UTF8String]) + ":" + bessel_corrected + ":" + std::to_string(correction_value);
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-      MPSGraphTensor* outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
-      MPSGraphTensor* outputTensor = nil;
-
-      if (use_correction && correction_value) {
-        MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction dataType:getMPSDataType(input_t)];
-        MPSGraphTensor* correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
-                                                                    secondaryTensor:besselTensor
-                                                                               name:nil];
-        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:correctedTensor name:nil]
-                                                          : correctedTensor;
-      } else {
-        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:outputVarTensor name:nil]
-                                                          : outputVarTensor;
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
+  welford_kernel_mps(input_t, reduce_dims, keepdim, correction_value, stdVarType == STANDARD_DEVIATION, output_t);
 
   return output_t;
 }
@@ -1579,22 +1747,116 @@ std::tuple<Tensor, Tensor> std_mean_mps(const Tensor& self,
                                         at::OptionalIntArrayRef dim,
                                         const std::optional<Scalar>& correction,
                                         bool keepdim) {
-  // TODO: Refactor it into a proper std_var_mean composite function
-  auto std = std_mps(self, dim, correction, keepdim);
-  auto mean = at::empty(std.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
-  return {std, mean};
+  if (self.dim() == 0) {
+    if (dim.has_value()) {
+      (void)at::dim_list_to_bitset(dim.value(), self.dim());
+    }
+    auto self_1d = self.unsqueeze(0);
+    auto [s, m] = std_mean_mps(self_1d, IntArrayRef({0}), correction, false);
+    return {s.squeeze(), m.squeeze()};
+  }
+  TORCH_CHECK(c10::isFloatingType(self.scalar_type()) || c10::isComplexType(self.scalar_type()),
+              "std_mean only support floating point and complex dtypes");
+  if (c10::isComplexType(self.scalar_type())) {
+    auto re = at::real(self).contiguous();
+    auto im = at::imag(self).contiguous();
+    auto var = at::var(re, dim, correction, keepdim).add(at::var(im, dim, correction, keepdim));
+    auto mean = at::complex(at::mean(re, dim, keepdim), at::mean(im, dim, keepdim));
+    return {var.sqrt(), mean};
+  }
+  auto reduce_dims = get_reduce_dims(self, dim);
+  const auto correction_value = correction.value_or(1.0).toDouble();
+
+  std::vector<int64_t> output_shape;
+  for (int64_t d = 0; d < self.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(self.size(d));
+    }
+  }
+
+  auto std_out = at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto mean_out =
+      at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
+
+  if (std_out.numel() > 0) {
+    if (self.numel() == 0) {
+      // std/mean of an empty reduction is NaN (matches CPU and the std-out path).
+      std_out.fill_(std::numeric_limits<float>::quiet_NaN());
+      mean_out.fill_(std::numeric_limits<float>::quiet_NaN());
+    } else {
+      welford_kernel_mps(self, reduce_dims, keepdim, correction_value, true, std_out, &mean_out);
+    }
+  }
+
+  return {std_out, mean_out};
 }
 
 std::tuple<Tensor, Tensor> var_mean_mps(const Tensor& self,
                                         at::OptionalIntArrayRef dim,
                                         const std::optional<Scalar>& correction,
                                         bool keepdim) {
-  // TODO: Refactor it into a proper std_var_mean composite function
-  auto var = var_mps(self, dim, correction, keepdim);
-  auto mean = at::empty(var.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
-  return {var, mean};
+  if (self.dim() == 0) {
+    if (dim.has_value()) {
+      (void)at::dim_list_to_bitset(dim.value(), self.dim());
+    }
+    auto self_1d = self.unsqueeze(0);
+    auto [v, m] = var_mean_mps(self_1d, IntArrayRef({0}), correction, false);
+    return {v.squeeze(), m.squeeze()};
+  }
+  TORCH_CHECK(c10::isFloatingType(self.scalar_type()) || c10::isComplexType(self.scalar_type()),
+              "var_mean only support floating point and complex dtypes");
+  if (c10::isComplexType(self.scalar_type())) {
+    auto re = at::real(self).contiguous();
+    auto im = at::imag(self).contiguous();
+    auto var = at::var(re, dim, correction, keepdim).add(at::var(im, dim, correction, keepdim));
+    auto mean = at::complex(at::mean(re, dim, keepdim), at::mean(im, dim, keepdim));
+    return {var, mean};
+  }
+  auto reduce_dims = get_reduce_dims(self, dim);
+  const auto correction_value = correction.value_or(1.0).toDouble();
+
+  std::vector<int64_t> output_shape;
+  for (int64_t d = 0; d < self.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(self.size(d));
+    }
+  }
+
+  auto var_out = at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto mean_out =
+      at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
+
+  if (var_out.numel() > 0) {
+    if (self.numel() == 0) {
+      // var/mean of an empty reduction is NaN (matches CPU and the var-out path).
+      var_out.fill_(std::numeric_limits<float>::quiet_NaN());
+      mean_out.fill_(std::numeric_limits<float>::quiet_NaN());
+    } else {
+      welford_kernel_mps(self, reduce_dims, keepdim, correction_value, false, var_out, &mean_out);
+    }
+  }
+
+  return {var_out, mean_out};
 }
 
 REGISTER_DISPATCH(norm_stub, &norm_kernel_mps)

--- a/benchmarks/mps/prod_reduce_bench.py
+++ b/benchmarks/mps/prod_reduce_bench.py
@@ -1,0 +1,112 @@
+"""Benchmark for the native Metal prod reduction vs the MPSGraph implementation
+it replaces.
+
+Run on a build WITH the native kernel and on a build WITHOUT it (e.g. the PR
+parent commit) and compare. Reports two regimes:
+
+  * steady-state: a fixed shape benchmarked warm (mean of 5
+    torch.utils.benchmark blocked_autorange trials).
+  * shape-varying: many distinct shapes seen once each -- this is where MPSGraph
+    pays a per-shape graph recompilation (~100ms/shape) the native kernel does
+    not.
+
+Methodology note: the per-shape MPS bench has high run-to-run variance; compare
+the same script on the baseline and candidate builds, using the mean of 5 warm
+blocked_autorange trials rather than a single sweep.
+"""
+
+import time
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+STEADY_SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((1_000_000, 8), 1),  # tall-thin: thread-per-row kernel
+    ((2, 8_000_000), 1),  # short-wide: wide inner kernel
+    ((1_000_000, 8), 0),  # dim=0 outer_bucketed: few columns, long reduced dim
+    ((2, 8_000_000), 0),  # dim=0 outer_thin: short reduced dim, many columns
+]
+
+
+def bench_us(stmt, globals_):
+    for _ in range(30):
+        exec(stmt, globals_)
+    torch.mps.synchronize()
+    trials = []
+    for _ in range(5):
+        t = benchmark.Timer(stmt=stmt, globals=globals_)
+        trials.append(t.blocked_autorange(min_run_time=0.5).mean * 1e6)
+    return sum(trials) / len(trials)
+
+
+def steady_state():
+    print("# steady-state prod (mean us, 5 warm blocked_autorange trials)")
+    for shape, dim in STEADY_SHAPES:
+        x = torch.randn(*shape, device="mps")
+        torch.mps.synchronize()
+        stmt = (
+            "torch.prod(x); torch.mps.synchronize()"
+            if dim is None
+            else "torch.prod(x, dim=dim); torch.mps.synchronize()"
+        )
+        us = bench_us(stmt, {"x": x, "dim": dim, "torch": torch})
+        print(f"  {str(shape):20} dim={dim}: {us:8.1f} us")
+        del x
+        torch.mps.empty_cache()
+
+
+def shape_varying(n=200):
+    # n distinct shapes, each reduced once -> exercises per-shape compilation.
+    buf = torch.randn(20_000_000, device="mps")
+    torch.prod(torch.as_strided(buf, (64, 500), (500, 1)), dim=1)  # warm
+    torch.mps.synchronize()
+    t0 = time.time()
+    for i in range(n):
+        N = 999 + i * 101
+        torch.prod(torch.as_strided(buf, (64, N), (N, 1)), dim=1)
+    torch.mps.synchronize()
+    dt = time.time() - t0
+    print(
+        f"# shape-varying prod: {n} distinct shapes = {dt * 1e3:.0f} ms "
+        f"({dt / n * 1e3:.2f} ms/shape)"
+    )
+
+
+def rss_stability(n=2000):
+    """The point of the migration: the native kernel has no per-shape graph
+    cache, so process peak RSS stays bounded across distinct shapes, unlike the
+    MPSGraph prod (which grows its graph cache per shape). Reports the peak-RSS
+    growth across n distinct shapes -- a few MB on the native build, steadily
+    climbing on the MPSGraph build."""
+    import resource
+    import sys
+
+    def peak_rss_mb():
+        ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # ru_maxrss is bytes on macOS, kB on Linux
+        return ru / (1 << 20) if sys.platform == "darwin" else ru / (1 << 10)
+
+    buf = torch.randn(20_000_000, device="mps")
+    torch.prod(torch.as_strided(buf, (64, 500), (500, 1)), dim=1)  # warm
+    torch.mps.synchronize()
+    before = peak_rss_mb()
+    for i in range(n):
+        N = 999 + i * 101
+        torch.prod(torch.as_strided(buf, (64, N), (N, 1)), dim=1)
+    torch.mps.synchronize()
+    after = peak_rss_mb()
+    print(
+        f"# RSS stability: {n} distinct shapes, peak RSS {before:.0f} -> {after:.0f} MB "
+        f"(+{after - before:.0f} MB; native has no per-shape graph cache)"
+    )
+
+
+if __name__ == "__main__":
+    steady_state()
+    shape_varying()
+    rss_stability()

--- a/benchmarks/mps/welford_reduce_bench.py
+++ b/benchmarks/mps/welford_reduce_bench.py
@@ -1,0 +1,107 @@
+"""Benchmark native Metal var/std Welford reductions vs the MPSGraph path.
+
+Run this script on the PR parent build and on the candidate build, then compare
+the same rows. It reports:
+
+  * steady-state: fixed shapes, warm mean of 5 blocked_autorange trials.
+  * shape-varying: many distinct shapes, reduced once each.
+  * RSS stability: peak RSS growth while visiting many distinct shapes.
+
+MPS dispatch is asynchronous, so the timed statements synchronize inside the
+statement. Without that, Timer mostly measures enqueue latency.
+"""
+
+import time
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+STEADY_SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((1_000_000, 8), 1),  # tall-thin: thread-per-row kernel
+    ((8, 1_000_000), 1),  # short-wide: wide inner kernel
+    ((8, 1_000_000), 0),  # dim=0 outer small-M kernel
+]
+
+
+def _fn(op, x, dim):
+    f = torch.var if op == "var" else torch.std
+    return f(x, dim=dim) if dim is not None else f(x)
+
+
+def bench_us(stmt, globals_):
+    for _ in range(30):
+        exec(stmt, globals_)
+    torch.mps.synchronize()
+    trials = []
+    for _ in range(5):
+        t = benchmark.Timer(stmt=stmt, globals=globals_)
+        trials.append(t.blocked_autorange(min_run_time=0.5).mean * 1e6)
+    return sum(trials) / len(trials)
+
+
+def steady_state(op="var"):
+    print(f"# steady-state {op} (mean us, 5 warm blocked_autorange trials)")
+    for shape, dim in STEADY_SHAPES:
+        x = torch.randn(*shape, device="mps")
+        torch.mps.synchronize()
+        us = bench_us(
+            "_fn(op, x, dim); torch.mps.synchronize()",
+            {"_fn": _fn, "op": op, "x": x, "dim": dim, "torch": torch},
+        )
+        print(f"  {str(shape):20} dim={dim}: {us:8.1f} us")
+        del x
+        torch.mps.empty_cache()
+
+
+def shape_varying(op="var", n=200):
+    # n distinct shapes, each reduced once -> exercises per-shape compilation.
+    buf = torch.randn(20_000_000, device="mps")
+    _fn(op, torch.as_strided(buf, (64, 500), (500, 1)), 1)  # warm the machinery
+    torch.mps.synchronize()
+    t0 = time.time()
+    for i in range(n):
+        N = 999 + i * 101
+        _fn(op, torch.as_strided(buf, (64, N), (N, 1)), 1)
+    torch.mps.synchronize()
+    dt = time.time() - t0
+    print(
+        f"# shape-varying {op}: {n} distinct shapes = {dt * 1e3:.0f} ms "
+        f"({dt / n * 1e3:.2f} ms/shape)"
+    )
+
+
+def rss_stability(op="var", n=2000):
+    """The migration removes MPSGraph graph-cache growth for shape-varying
+    var/std. Reports peak-RSS growth across n distinct shapes."""
+    import resource
+    import sys
+
+    def peak_rss_mb():
+        ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return ru / (1 << 20) if sys.platform == "darwin" else ru / (1 << 10)
+
+    buf = torch.randn(20_000_000, device="mps")
+    _fn(op, torch.as_strided(buf, (64, 500), (500, 1)), 1)
+    torch.mps.synchronize()
+    before = peak_rss_mb()
+    for i in range(n):
+        N = 999 + i * 101
+        _fn(op, torch.as_strided(buf, (64, N), (N, 1)), 1)
+    torch.mps.synchronize()
+    after = peak_rss_mb()
+    print(
+        f"# RSS stability {op}: {n} distinct shapes, peak RSS {before:.0f} -> {after:.0f} MB "
+        f"(+{after - before:.0f} MB; native has no per-shape graph cache)"
+    )
+
+
+if __name__ == "__main__":
+    for op in ("var", "std"):
+        steady_state(op)
+        shape_varying(op)
+        rss_stability(op)

--- a/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
@@ -1,0 +1,76 @@
+"""Benchmark for the consolidated sum / mean / nansum / count_nonzero reductions,
+which now route through the shared two-pass value_reduction<SumOp> Metal kernel
+(the same kernel min/max/all/any already use) instead of a separate sum_reduction
+kernel.
+
+Run this on a build WITH the change and on the parent commit (without it) and
+compare. The consolidation is behavior-preserving, so the expectation is parity
+(no regression), not a speedup. amax / amin are included as an unchanged-kernel
+control: their kernel is identical on both builds, so any apparent amax/amin
+delta is pure machine drift and can be divided out of the sum delta
+(corrected = (mine_sum / base_sum) / (mine_amax / base_amax)).
+
+Methodology note: the per-shape MPS bench has high run-to-run variance and is
+sensitive to machine load/thermal. Run this script on each build back-to-back on
+an otherwise-idle machine and compare medians; do not compare a fresh run against
+a stored baseline taken under different load.
+"""
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+# Large shapes so the kernel cost dominates the ~110us MPS dispatch/sync floor.
+SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((8192, 1024), 0),
+    ((1_000_000, 8), 1),
+]
+DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+# sum/mean/nansum migrate onto value_reduction<SumOp>; amax/amin are the
+# unchanged-kernel control.
+OPS = {
+    "sum": torch.sum,
+    "mean": torch.mean,
+    "nansum": torch.nansum,
+    "amax": torch.amax,
+    "amin": torch.amin,
+}
+
+
+def steady_state():
+    print("# steady-state reduction (median us, warm)")
+    for name, fn in OPS.items():
+        for dtype in DTYPES:
+            for shape, dim in SHAPES:
+                x = torch.randn(*shape, device="mps").to(dtype)
+                torch.mps.synchronize()
+                if dim is None:
+                    t = benchmark.Timer(
+                        stmt="fn(x); torch.mps.synchronize()",
+                        globals={"fn": fn, "x": x, "torch": torch},
+                    )
+                else:
+                    t = benchmark.Timer(
+                        stmt="fn(x, dim=dim); torch.mps.synchronize()",
+                        globals={"fn": fn, "x": x, "dim": dim, "torch": torch},
+                    )
+                # Median of 5 trials: a single blocked_autorange has up to ~2x
+                # run-to-run spikes at large float32 shapes (verified -- even the
+                # unchanged amax/amin kernel spikes that much), so a 5-trial
+                # median is required to compare builds meaningfully.
+                trials = sorted(
+                    t.blocked_autorange(min_run_time=0.3).median for _ in range(5)
+                )
+                us = trials[2] * 1e6
+                dt = str(dtype).replace("torch.", "")
+                print(f"  {name:7} {dt:9} {str(shape):16} dim={dim}: {us:9.1f} us")
+                del x
+                torch.mps.empty_cache()
+
+
+if __name__ == "__main__":
+    steady_state()

--- a/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
@@ -1,37 +1,53 @@
-"""Benchmark for the consolidated sum / mean / nansum / count_nonzero reductions,
-which now route through the shared two-pass value_reduction<SumOp> Metal kernel
-(the same kernel min/max/all/any already use) instead of a separate sum_reduction
-kernel.
+"""Benchmark for the consolidated generic sum / mean / nansum reductions.
+
+The changed kernel registrations route the generic `{sum,nansum}_reduction_*`
+entry points through the shared value_reduction<SumOp> Metal kernel instead of
+the old standalone sum_reduction kernel. The dedicated inner/outer
+specializations are intentionally not measured here; they keep their existing
+kernels and are not the behavior this PR changes.
 
 Run this on a build WITH the change and on the parent commit (without it) and
-compare. The consolidation is behavior-preserving, so the expectation is parity
-(no regression), not a speedup. amax / amin are included as an unchanged-kernel
-control: their kernel is identical on both builds, so any apparent amax/amin
-delta is pure machine drift and can be divided out of the sum delta
-(corrected = (mine_sum / base_sum) / (mine_amax / base_amax)).
+compare. The correctness intent is behavior preservation; the performance bar is
+no regression, with any speedup coming from the generic tail implementation now
+used by value_reduction. amax / amin are included as an unchanged-kernel context
+for the existing generic value_reduction path rather than as the primary
+pass/fail signal.
 
 Methodology note: the per-shape MPS bench has high run-to-run variance and is
 sensitive to machine load/thermal. Run this script on each build back-to-back on
-an otherwise-idle machine and compare medians; do not compare a fresh run against
-a stored baseline taken under different load.
+an otherwise-idle machine and compare means across independent measurements;
+do not compare a fresh run against a stored baseline taken under different load.
 """
+
+from collections.abc import Callable
 
 import torch
 import torch.utils.benchmark as benchmark
 
 
-# Large shapes so the kernel cost dominates the ~110us MPS dispatch/sync floor.
-SHAPES = [
-    ((1 << 24,), None),
-    ((4096, 4096), 1),
-    ((4096, 4096), 0),
-    ((1024, 16384), 1),
-    ((8192, 1024), 0),
-    ((1_000_000, 8), 1),
+# These cases hit the changed generic entry points:
+# - full_reduce_1d: large full reduction, two-pass generic kernel
+# - middle_dim_contig: contiguous input, single reduced dim that is neither
+#   dim=0 nor last dim, so it bypasses the inner/outer specializations
+# - multi_dim_noncontig: generic multi-dim + non-contiguous fallback
+# - strided_full_reduce: non-contiguous full reduction using strided pass1 +
+#   generic pass2
+CASES: list[
+    tuple[
+        str,
+        tuple[int, ...],
+        int | tuple[int, ...] | None,
+        Callable[[torch.Tensor], torch.Tensor],
+    ]
+] = [
+    ("full_reduce_1d", (1 << 24,), None, lambda x: x),
+    ("middle_dim_contig", (256, 128, 256), 1, lambda x: x),
+    ("multi_dim_noncontig", (16, 64, 16, 64), (1, 3), lambda x: x[:, ::2, :, :]),
+    ("strided_full_reduce", (4096, 4096), None, lambda x: x.t()),
 ]
 DTYPES = [torch.float32, torch.float16, torch.bfloat16]
-# sum/mean/nansum migrate onto value_reduction<SumOp>; amax/amin are the
-# unchanged-kernel control.
+# sum/mean/nansum generic entry points migrate onto value_reduction<SumOp>;
+# amax/amin show the existing generic value_reduction path for context.
 OPS = {
     "sum": torch.sum,
     "mean": torch.mean,
@@ -39,14 +55,17 @@ OPS = {
     "amax": torch.amax,
     "amin": torch.amin,
 }
+TRIALS = 5
+MIN_RUN_TIME = 0.3
 
 
 def steady_state():
-    print("# steady-state reduction (median us, warm)")
-    for name, fn in OPS.items():
+    print("# steady-state reduction (mean us across independent warm samples)")
+    for op_idx, (name, fn) in enumerate(OPS.items()):
         for dtype in DTYPES:
-            for shape, dim in SHAPES:
-                x = torch.randn(*shape, device="mps").to(dtype)
+            for case_idx, (case_name, shape, dim, transform) in enumerate(CASES):
+                torch.manual_seed(op_idx * 1000 + case_idx)
+                x = transform(torch.randn(*shape, device="mps").to(dtype))
                 torch.mps.synchronize()
                 if dim is None:
                     t = benchmark.Timer(
@@ -58,16 +77,20 @@ def steady_state():
                         stmt="fn(x, dim=dim); torch.mps.synchronize()",
                         globals={"fn": fn, "x": x, "dim": dim, "torch": torch},
                     )
-                # Median of 5 trials: a single blocked_autorange has up to ~2x
-                # run-to-run spikes at large float32 shapes (verified -- even the
-                # unchanged amax/amin kernel spikes that much), so a 5-trial
-                # median is required to compare builds meaningfully.
-                trials = sorted(
-                    t.blocked_autorange(min_run_time=0.3).median for _ in range(5)
-                )
-                us = trials[2] * 1e6
+                # MPS execution is asynchronous; synchronizing inside the timed
+                # statement makes Timer measure kernel execution rather than
+                # enqueue latency.
+                trials_us = [
+                    t.blocked_autorange(min_run_time=MIN_RUN_TIME).mean * 1e6
+                    for _ in range(TRIALS)
+                ]
+                us = sum(trials_us) / len(trials_us)
                 dt = str(dtype).replace("torch.", "")
-                print(f"  {name:7} {dt:9} {str(shape):16} dim={dim}: {us:9.1f} us")
+                print(
+                    f"  {case_name:20} {name:7} {dt:9} {str(tuple(x.shape)):18} "
+                    f"dim={dim}: {us:9.1f} us "
+                    f"(min={min(trials_us):.1f} max={max(trials_us):.1f})"
+                )
                 del x
                 torch.mps.empty_cache()
 

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -501,5 +501,31 @@ struct MinOp {
   }
 };
 
+// Sum / product reduction op functors, sharing the identity / combine /
+// simd_reduce / threadgroup_reduce concept with MaxOp / MinOp so sum_reduction
+// can route through the same two-pass value_reduction kernel. T is the
+// accumulator type (opmath_t<TO> for sum, keeping the fp32 accumulation from
+// being lost when TO is fp16/bf16). No `replace`
+// member: that is arg-reduction-only (argmax/argmin reuse MaxOp/MinOp).
+template <typename T>
+struct SumOp {
+  static inline constexpr T identity() {
+    return T(0);
+  }
+  static inline T combine(T a, T b) {
+    return a + b;
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_sum(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_sum(shared, val, tid, tptg);
+  }
+};
+
 } // namespace metal
 } // namespace c10

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -501,12 +501,12 @@ struct MinOp {
   }
 };
 
-// Sum / product reduction op functors, sharing the identity / combine /
-// simd_reduce / threadgroup_reduce concept with MaxOp / MinOp so sum_reduction
-// can route through the same two-pass value_reduction kernel. T is the
-// accumulator type (opmath_t<TO> for sum, keeping the fp32 accumulation from
-// being lost when TO is fp16/bf16). No `replace`
-// member: that is arg-reduction-only (argmax/argmin reuse MaxOp/MinOp).
+// Sum reduction op functor, sharing the identity / combine / simd_reduce /
+// threadgroup_reduce concept with MaxOp / MinOp so sum and mean can route
+// through the same value_reduction kernels. T is the accumulator type
+// (opmath_t<TO> for sum, keeping fp32 accumulation from being lost when TO is
+// fp16/bf16). No `replace` member: that is arg-reduction-only (argmax/argmin
+// reuse MaxOp/MinOp).
 template <typename T>
 struct SumOp {
   static inline constexpr T identity() {

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -274,11 +274,47 @@ opmath_t<T> threadgroup_prod(
   }
   if (size > simdgroup_size) {
     ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
-      auto rc1 = simd_prod(data[idx]);
-      if (idx == 0) {
-        data[0] = rc1;
+    // simd_prod is a manual shuffle (no hardware simd product); run over a
+    // partial final simdgroup it folds in inactive lanes that read as 0,
+    // zeroing the result -- this hits the emulated simd_prod<long> that all
+    // integer prod (int64 default output) routes through. Reduce the
+    // per-simdgroup partials serially on lane 0 instead (as the float2 overload
+    // below does for complex).
+    if (idx == 0) {
+      unsigned nsg = (size + simdgroup_size - 1) / simdgroup_size;
+      opmath_t<T> acc = data[0];
+      for (unsigned j = 1; j < nsg; ++j) {
+        acc *= data[j];
       }
+      data[0] = acc;
+    }
+  }
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  return data[0];
+}
+
+// Complex product: simd_prod uses a manual shuffle (complex multiply is not a
+// hardware simd reduction), which folds in inactive lanes that read as (0, 0)
+// when the second level has fewer than a full simdgroup of partials. Reduce the
+// per-simdgroup partials serially on lane 0 instead.
+inline float2 threadgroup_prod(
+    threadgroup float2* data,
+    float2 val,
+    unsigned idx,
+    unsigned size) {
+  auto rc = simd_prod(val);
+  if (idx % simdgroup_size == 0) {
+    data[idx / simdgroup_size] = rc;
+  }
+  if (size > simdgroup_size) {
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+    if (idx == 0) {
+      unsigned nsg = (size + simdgroup_size - 1) / simdgroup_size;
+      float2 acc = data[0];
+      for (unsigned j = 1; j < nsg; ++j) {
+        acc = c10::metal::mul(acc, data[j]);
+      }
+      data[0] = acc;
     }
   }
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
@@ -502,8 +538,8 @@ struct MinOp {
 };
 
 // Sum reduction op functor, sharing the identity / combine / simd_reduce /
-// threadgroup_reduce concept with MaxOp / MinOp so sum and mean can route
-// through the same value_reduction kernels. T is the accumulator type
+// threadgroup_reduce concept with MaxOp / MinOp so mean and sum route through
+// the same value_reduction kernels. T is the accumulator type
 // (opmath_t<TO> for sum, keeping fp32 accumulation from being lost when TO is
 // fp16/bf16). No `replace` member: that is arg-reduction-only (argmax/argmin
 // reuse MaxOp/MinOp).
@@ -524,6 +560,48 @@ struct SumOp {
       uint tid,
       uint tptg) {
     return c10::metal::threadgroup_sum(shared, val, tid, tptg);
+  }
+};
+
+template <typename T>
+struct ProdOp {
+  static inline constexpr T identity() {
+    return T(1);
+  }
+  static inline T combine(T a, T b) {
+    return a * b;
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_prod(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_prod(shared, val, tid, tptg);
+  }
+};
+
+// Complex prod: identity is (1, 0) and combine is a complex multiply. The
+// simd/threadgroup reduce already delegate to the complex-correct simd_prod.
+template <>
+struct ProdOp<float2> {
+  static inline constexpr float2 identity() {
+    return float2(1, 0);
+  }
+  static inline float2 combine(float2 a, float2 b) {
+    return c10::metal::mul(a, b);
+  }
+  static inline float2 simd_reduce(float2 val) {
+    return c10::metal::simd_prod(val);
+  }
+  static inline float2 threadgroup_reduce(
+      threadgroup float2* shared,
+      float2 val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_prod(shared, val, tid, tptg);
   }
 };
 

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -376,13 +376,30 @@ float3 threadgroup_welford_reduce(threadgroup T* data, unsigned size) {
 // Each vec3type is tuple of mean, m2 and weight
 template <typename T>
 float3 welford_combine(T a, T b) {
+  // A zero-weight operand (e.g. a simd padding lane filled with 0) is a no-op.
+  // Skipping it before computing delta keeps a valid +/-inf mean from being
+  // corrupted to nan via (inf - 0) * 0 = nan.
+  if (b.z == 0) {
+    return float3(a.x, a.y, a.z);
+  }
+  if (a.z == 0) {
+    return float3(b.x, b.y, b.z);
+  }
   float delta = b.x - a.x;
   float new_weight = a.z + b.z;
   auto w2_over_w = new_weight != 0 ? b.z / new_weight : 0.0;
-  return float3(
-      a.x + delta * w2_over_w,
-      a.y + b.y + delta * delta * a.z * w2_over_w,
-      new_weight);
+  // The delta form is precise for finite means but yields inf - inf = nan when
+  // combining an infinite mean; fall back to the weighted average there so a
+  // valid +/-inf mean is preserved (variance is still nan). NOTE: for inputs
+  // containing infinities, the fused mean here is the mathematically-sensible
+  // value (any same-signed inf -> +/-inf, mixed -> nan) but does NOT match CPU
+  // bit-for-bit, because CPU's serial Welford mean is order-dependent
+  // (var_mean([0,0,inf]) -> inf but var_mean([inf,0,0]) -> nan). A parallel
+  // reduction cannot reproduce that ordering; this matches other parallel
+  // backends rather than the serial reference for this degenerate case.
+  float mean = ::metal::isfinite(delta) ? a.x + delta * w2_over_w
+                                        : (a.x * a.z + b.x * b.z) / new_weight;
+  return float3(mean, a.y + b.y + delta * delta * a.z * w2_over_w, new_weight);
 }
 
 template <typename T>

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -13126,7 +13126,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         ]
         self.common(forward, args, atol=1e-5, rtol=1e-5)
 
-    @xfail_if_mps_unimplemented  # embedding bag
     @requires_gpu()
     @skip_if_halide  # cascading accuracy issues due rsqrt fallback
     def test_tmp_not_defined_issue3(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5498,6 +5498,25 @@ class TestMPS(TestCaseMPS):
             for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
                 self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
 
+    def test_sum_family_generic_reduction(self):
+        cpu = (torch.arange(2 * 4 * 3 * 5, dtype=torch.float32).reshape(2, 4, 3, 5) - 37) / 10
+        cpu = cpu[:, ::2, :, :]
+        self.assertFalse(cpu.is_contiguous())
+        mps = cpu.to("mps")
+        dims = (1, 3)
+
+        for keepdim in (False, True):
+            kw = {"dim": dims, "keepdim": keepdim}
+            self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
+            self.assertEqual(mps.mean(**kw).cpu(), cpu.mean(**kw))
+
+            nans_cpu = cpu.clone()
+            nans_cpu[nans_cpu > 2] = torch.nan
+            nans_mps = nans_cpu.to("mps")
+            self.assertEqual(torch.nansum(nans_mps, **kw).cpu(), torch.nansum(nans_cpu, **kw))
+
+        self.assertEqual(torch.count_nonzero(mps, dim=dims).cpu(), torch.count_nonzero(cpu, dim=dims))
+
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497
         torch.manual_seed(42)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6061,6 +6061,127 @@ class TestMPS(TestCaseMPS):
         for dtype in [torch.float32, torch.int32, torch.int64, torch.bool]:
             helper((2, 3), dtype)
 
+    def test_prod_reduction_boundaries(self):
+        # Regression for the prod -> value_reduction<ProdOp> migration: pins the
+        # dispatch boundaries this change fixes against CPU. prod's simd_prod is
+        # a manual shuffle (no hardware simd product); run over a partial final
+        # simdgroup it folded in inactive lanes (0), zeroing the result -- this
+        # hit complex full-reduce of N in 33-512 and, via the emulated
+        # simd_prod<long>, ALL integer prod (int64 default output) of >32
+        # elements. Also covers the inner thin/wide specializations (N=32/33,
+        # M=63/64) and the super-wide batched two-pass (M<32, N>=4096). Float
+        # inputs are bounded near 1 with the CPU ref built from the same values
+        # upcast so it measures accumulation; integer inputs are mostly ones with
+        # a couple of small factors so the product is exact and never overflows.
+        def check(shape, dtype, dim):
+            if dtype.is_complex:
+                x_t = torch.complex(1.0 + 0.02 * torch.randn(shape),
+                                    0.02 * torch.randn(shape)).to(dtype)
+                ref_dtype = torch.complex64
+                tol = 2e-2 if dtype == torch.complex32 else 1e-4
+            elif dtype.is_floating_point:
+                x_t = (1.0 + 0.02 * torch.randn(shape)).to(dtype)
+                ref_dtype = torch.float32
+                tol = 2e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
+            else:
+                x_t = torch.ones(shape, dtype=dtype)
+                if dtype != torch.bool:
+                    flat = x_t.view(-1)
+                    flat[3], flat[7] = 2, 3
+                ref_dtype = dtype
+                tol = 0
+            cpu_ref = x_t.to(ref_dtype)
+            x_mps = x_t.to("mps")
+            res = torch.prod(x_mps) if dim is None else torch.prod(x_mps, dim=dim)
+            ref = torch.prod(cpu_ref) if dim is None else torch.prod(cpu_ref, dim=dim)
+            self.assertEqual(res.cpu().to(ref.dtype), ref, atol=tol, rtol=tol,
+                             msg=f"prod {tuple(shape)} {dtype} dim={dim}")
+
+        for n in (32, 33, 64, 100, 255, 256, 384, 512, 1024):
+            for dtype in (torch.complex64, torch.complex32,
+                          torch.int32, torch.int64, torch.bool):
+                check((n,), dtype, None)
+        for shape in ((64, 32), (64, 33), (63, 64), (64, 64), (128, 16),
+                      (2, 8192), (4, 16384), (1, 65536)):
+            for dtype in (torch.float32, torch.float16, torch.bfloat16,
+                          torch.int64, torch.complex64, torch.complex32):
+                for dim in (None, 0, -1):
+                    check(shape, dtype, dim)
+        # dim=0 outer specializations the shapes above do not reach: the bucketed
+        # two-pass (M >= 262144, N <= 8) and outer_thin (M <= 32, N >= 1024).
+        # Integer dtypes give a bit-exact product (ones with small factors) at
+        # these large reduction lengths where a random float product overflows.
+        for dtype in (torch.int32, torch.int64):
+            check((262144, 8), dtype, 0)
+            for shape in ((2, 4096), (16, 2048)):
+                check(shape, dtype, 0)
+        # Scalar full-reduce two-pass (output.numel() == 1, large reduction):
+        # prod stores opmath partials, so a slice whose product overflows the
+        # half range is not corrupted when the full product is finite. complexHalf
+        # is excluded from the two-pass (falls to the fp32 single-pass).
+        for dtype in (torch.float16, torch.bfloat16, torch.float32,
+                      torch.complex64, torch.complex32):
+            x = torch.ones(32768, dtype=dtype)
+            x[:30] = 2  # an early slice: product 2^30, overflows the half range
+            x[16384:16414] = 0.5  # a later slice: product 2^-30; full product 1
+            ref_dt = torch.complex64 if dtype.is_complex else torch.float32
+            res = torch.prod(x.to("mps")).cpu().to(ref_dt)
+            self.assertEqual(res, torch.prod(x.to(ref_dt)), atol=2e-2, rtol=2e-2,
+                             msg=f"scalar two-pass overflow {dtype}")
+        # dtype routing: each registered (in, out) prod kernel pair plus the
+        # cast-and-recurse fallback for unregistered pairs, so a mutation to
+        # prod_kernel_registered / the dtype guards mis-routes and is caught.
+        for in_dt, out_dt in (
+            (torch.float16, torch.float32), (torch.bfloat16, torch.float32),
+            (torch.int32, torch.int64), (torch.int16, torch.int64),
+            (torch.int8, torch.int64), (torch.uint8, torch.int64),
+            (torch.bool, torch.int64), (torch.bool, torch.int32),
+            (torch.int32, torch.float32), (torch.float32, torch.float16),
+            (torch.float32, torch.float32), (torch.int64, torch.int64),
+        ):
+            x = torch.ones(64, dtype=in_dt)
+            if in_dt != torch.bool:
+                x[0] = 2
+            res = torch.prod(x.to("mps"), dtype=out_dt).cpu()
+            self.assertEqual(res, torch.prod(x, dtype=out_dt),
+                             msg=f"prod dtype {in_dt}->{out_dt}")
+        # bool output: nonzero-product (True with no zeros, False with a zero).
+        b = torch.ones(64)
+        self.assertEqual(torch.prod(b.to("mps"), dtype=torch.bool).cpu(), torch.tensor(True))
+        b[5] = 0
+        self.assertEqual(torch.prod(b.to("mps"), dtype=torch.bool).cpu(), torch.tensor(False))
+        # uint outputs are rejected (the explicit TORCH_CHECK), not silently
+        # miscomputed -- pin the intended message, not just any exception.
+        for ud in (torch.uint16, torch.uint32, torch.uint64):
+            with self.assertRaisesRegex(RuntimeError, "not implemented for"):
+                torch.prod(torch.ones(8, device="mps"), dtype=ud)
+        # Unsupported dtype=float64 should terminate on the normal MPS dtype
+        # error instead of recursing indefinitely through the cast-and-recurse
+        # fallback.
+        with self.assertRaisesRegex(TypeError, "doesn't support float64"):
+            torch.prod(torch.ones(8, device="mps"), dtype=torch.float64)
+        # The native Metal reduction parameter block supports up to max_ndim.
+        # Higher-rank prod should fail cleanly before filling fixed-size arrays.
+        high_rank = torch.ones(1, device="mps").as_strided((1,) * 17, (0,) * 17)
+        with self.assertRaisesRegex(RuntimeError, "tensor rank >"):
+            torch.prod(high_rank)
+        # bucketed kernel domain: N > 8 with M >= 262144 (dim=0) must route to the
+        # fallback, not the acc[MAXN=8] bucketed kernel.
+        for dtype in (torch.int32, torch.int64):
+            check((262144, 16), dtype, 0)
+        # non-contiguous large reductions: the outer/inner specializations require
+        # contiguous I/O, so a transposed input reaches the general strided path
+        # and exercises the scalar two-pass gate (output.numel() vs 1) and the
+        # has_strided_pass1 routing.
+        for rows, cols, dim in ((8192, 48, 0), (48, 8192, 1), (16384, 24, 0)):
+            x = torch.ones(cols, rows, dtype=torch.int64)
+            x[0, 0] = 2
+            x[0, 1] = 3
+            xt = x.t()  # non-contiguous view, shape (rows, cols)
+            res = torch.prod(xt.to("mps"), dim=dim).cpu()
+            self.assertEqual(res, torch.prod(xt, dim=dim),
+                             msg=f"non-contig prod ({rows},{cols}) dim={dim}")
+
     # Test forward mean
     def test_mean(self):
         def helper(n, c, h, w):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16269,6 +16269,251 @@ class TestMetalLibrary(TestCaseMPS):
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
 # to achieve this.
+
+class TestReduceOpsMetal(TestCaseMPS):
+    """Tests for Metal kernel reduce ops: var / std / var_mean / std_mean."""
+
+    # =========================================================================
+    # Variance and standard deviation
+    # =========================================================================
+    def test_var_metal_basic(self):
+        for shape in [(8,), (4, 8), (2, 4, 8), (2, 3, 4, 5)]:
+            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float32)
+            mps_x = cpu_x.to('mps')
+            # Scalar var
+            self.assertEqual(torch.var(mps_x), torch.var(cpu_x), atol=1e-4, rtol=1e-4)
+            self.assertEqual(torch.var(mps_x, correction=0), torch.var(cpu_x, correction=0), atol=1e-4, rtol=1e-4)
+            # Per-dim
+            for dim in range(len(shape)):
+                self.assertEqual(
+                    torch.var(mps_x, dim=dim), torch.var(cpu_x, dim=dim), atol=1e-4, rtol=1e-4)
+                self.assertEqual(
+                    torch.var(mps_x, dim=dim, keepdim=True),
+                    torch.var(cpu_x, dim=dim, keepdim=True), atol=1e-4, rtol=1e-4)
+
+    def test_std_metal_basic(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float32)
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(torch.std(mps_x), torch.std(cpu_x), atol=1e-4, rtol=1e-4)
+            for dim in range(len(shape)):
+                self.assertEqual(
+                    torch.std(mps_x, dim=dim), torch.std(cpu_x, dim=dim), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_correction(self):
+        cpu_x = torch.randn(10, 20, device='cpu')
+        mps_x = cpu_x.to('mps')
+        for corr in [0, 1, 2]:
+            self.assertEqual(
+                torch.var(mps_x, dim=1, correction=corr),
+                torch.var(cpu_x, dim=1, correction=corr), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_multidim(self):
+        cpu_x = torch.randn(3, 4, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.var(mps_x, dim=[0, 2]),
+            torch.var(cpu_x, dim=[0, 2]), atol=1e-4, rtol=1e-4)
+        self.assertEqual(
+            torch.var(mps_x, dim=[0, 2], keepdim=True),
+            torch.var(cpu_x, dim=[0, 2], keepdim=True), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_half(self):
+        cpu_x = torch.randn(16, 32, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(
+                torch.var(mx, dim=1),
+                torch.var(cx, dim=1), atol=1e-1, rtol=1e-1)
+
+    def test_var_metal_integral_dtype_error(self):
+        for dtype in (torch.int32, torch.int64):
+            x = torch.arange(6, dtype=dtype, device='mps').reshape(2, 3)
+            for fn in (torch.var, torch.std, torch.var_mean, torch.std_mean):
+                with self.assertRaisesRegex(RuntimeError, "only support floating point and complex dtypes"):
+                    fn(x, dim=1)
+
+    def test_var_metal_empty(self):
+        cpu_x = torch.randn(0, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.var(mps_x, dim=0).shape, torch.var(cpu_x, dim=0).shape)
+
+    def test_var_metal_scalar(self):
+        cpu_x = torch.tensor(3.14, device='cpu')
+        mps_x = cpu_x.to('mps')
+        # var of scalar with correction=1 is NaN (dof=0); test correction=0
+        self.assertTrue(torch.isnan(torch.var(mps_x)))
+        self.assertEqual(
+            torch.var(mps_x, correction=0), torch.var(cpu_x, correction=0))
+
+    def test_var_metal_allreduce_large_and_outer(self):
+        # The 2-pass all-reduce Welford indexes partials as device float3*
+        # (16B/group); allocating 3 floats/group overruns the buffer for inputs
+        # past ~4096. The dim=0 outer path binds a uint3 sizes constant. Both
+        # are validated under MTL_DEBUG_LAYER/MTL_SHADER_VALIDATION in CI; here
+        # we check correctness across both paths.
+        for fn in (torch.var, torch.std):
+            for n in (8192, 100003):
+                cpu_x = torch.randn(n, device='cpu')
+                self.assertEqual(fn(cpu_x.to('mps')).cpu(), fn(cpu_x), atol=2e-4, rtol=2e-4)
+        cpu_x = torch.randn(64, 130, device='cpu')  # dim=0 outer welford, uint3 sizes
+        self.assertEqual(torch.var(cpu_x.to('mps'), dim=0).cpu(),
+                         torch.var(cpu_x, dim=0), atol=2e-4, rtol=2e-4)
+
+    def test_var_mean_metal_inf_mean(self):
+        # Welford combine must skip zero-weight padding lanes before delta, else
+        # a valid +/-inf mean is corrupted to nan via (inf - 0) * 0.
+        for fn in (torch.var_mean, torch.std_mean):
+            cpu_x = torch.tensor([0., 0., float('inf')])
+            self.assertEqual(fn(cpu_x.to('mps'))[1].cpu(), fn(cpu_x)[1], equal_nan=True)
+            cpu_x2 = torch.tensor([[0., float('inf')], [1., 2.]])
+            self.assertEqual(fn(cpu_x2.to('mps'), dim=1)[1].cpu(),
+                             fn(cpu_x2, dim=1)[1], equal_nan=True)
+            for inf_value in (float('inf'), float('-inf')):
+                cpu_x3 = torch.zeros(8192)
+                cpu_x3[-1] = inf_value
+                mps_stat, mps_mean = fn(cpu_x3.to('mps'), correction=0)
+                cpu_stat, cpu_mean = fn(cpu_x3, correction=0)
+                self.assertEqual(mps_mean.cpu(), cpu_mean, equal_nan=True)
+                self.assertEqual(mps_stat.cpu(), cpu_stat, equal_nan=True)
+
+    def test_var_metal_inf_propagates_nan(self):
+        # A tensor containing inf has NaN variance (inf-inf); the M2 clamp must
+        # preserve NaN, not clamp it to 0. var/std must match CPU (nan), through
+        # the all-reduce, outer, inner, and generic paths.
+        for shape, dim in (((3,), None), ((2, 4), 1), ((4, 2), 0)):
+            cpu_x = torch.zeros(shape)
+            cpu_x.view(-1)[0] = float('inf')
+            for fn in (torch.var, torch.std):
+                self.assertEqual(fn(cpu_x.to('mps'), dim=dim, correction=0).cpu(),
+                                 fn(cpu_x, dim=dim, correction=0), equal_nan=True)
+
+    def test_var_metal_thin_inner_small_n(self):
+        # Tall-thin (small N, large M) routes to the thread-per-row thin kernel
+        # (N<=32); must match CPU across dtypes and across the N=32/33 boundary.
+        torch.manual_seed(0)
+        for M, N in [(100000, 8), (50000, 16), (20000, 32), (20000, 33)]:
+            for dt in (torch.float32, torch.float16, torch.bfloat16):
+                x = torch.randn(M, N, dtype=dt)
+                for fn in (torch.var, torch.std):
+                    self.assertEqual(fn(x.to("mps"), dim=1).cpu(), fn(x, dim=1),
+                                     rtol=2e-2, atol=2e-2)
+
+    def test_var_metal_large_n_correction_near_n(self):
+        # For N > 2^24 a float element count loses integer precision; the divisor
+        # (N - correction) is computed exactly on the host, so var/std with
+        # correction close to N matches CPU instead of returning inf.
+        N = (1 << 24) + 1
+        x = torch.zeros(N, dtype=torch.float32)
+        x[-1] = 1.0
+        for fn in (torch.var, torch.std):
+            self.assertEqual(fn(x.to("mps"), correction=N - 1).cpu(),
+                             fn(x, correction=N - 1))
+
+    def test_var_metal_partial_simdgroup_allreduce(self):
+        # A 2-pass all-reduce whose pass1/pass2 threadgroup is not a multiple of
+        # 32 must round up to a full simdgroup, else simd_welford_combine reads
+        # undefined data from inactive lanes (0 on M1/M2 -> corrupt). Passes on
+        # M4 (benign fill) regardless; guards the M1/M2 path on CI. The sizes
+        # span the 2-pass threshold so num_groups lands non-multiple-of-32.
+        for N in [4099, 6151, 99991, 1 << 20]:
+            x = torch.randn(N)
+            for fn in (torch.var, torch.std):
+                self.assertEqual(fn(x.to("mps")).cpu(), fn(x), rtol=1e-3, atol=1e-4)
+
+    def test_var_metal_max_rank(self):
+        # 16 is MPS's maximum tensor rank and the exact size of the NormParams
+        # buffers; the generic Welford path must accept it (a tighter bound
+        # would wrongly reject a valid 16-D reduction).
+        cpu_x = torch.randn([2] + [1] * 15, device='cpu')  # 16 dims
+        self.assertEqual(torch.var(cpu_x.to('mps')).cpu(), torch.var(cpu_x),
+                         atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_outer_large_offset(self):
+        # Large mean + small variance catastrophically cancels in a
+        # sum-of-squares formula (negative variance, nan std); the streaming
+        # Welford outer path must stay stable. These shapes hit the M<=8 / M<=16
+        # outer kernels with N>=256.
+        torch.manual_seed(0)
+        for M, N in ((8, 512), (16, 1024)):
+            cpu_x = 1.0e6 + torch.randn(M, N)
+            for fn in (torch.var, torch.std):
+                mv = fn(cpu_x.to('mps'), dim=0).cpu()
+                self.assertFalse(torch.isnan(mv).any())
+                self.assertEqual(mv, fn(cpu_x, dim=0), atol=5e-2, rtol=5e-2)
+            self.assertTrue((torch.var(cpu_x.to('mps'), dim=0).cpu() >= 0).all())
+
+    def test_var_metal_duplicate_dim_raises(self):
+        # Duplicate reduction dims are invalid; MPS must raise like CPU.
+        x = torch.randn(3, 4, 5, device='mps')
+        for fn in (torch.var, torch.std, torch.var_mean, torch.std_mean):
+            with self.assertRaisesRegex(RuntimeError, "appears multiple times"):
+                fn(x, dim=(0, 0))
+
+    def test_var_metal_inner_wide_tail(self):
+        # welford_inner_wide vectorizes NCHAINS elements/thread; a tail-boundary
+        # bug double-counted the last vector block for non-stride-aligned N.
+        torch.manual_seed(0)
+        for N in (4095, 4097, 6000, 8191):
+            cpu_x = torch.randn(2, N)
+            for fn in (torch.var, torch.std):
+                self.assertEqual(fn(cpu_x.to('mps'), dim=1).cpu(),
+                                 fn(cpu_x, dim=1), atol=1e-3, rtol=1e-3)
+
+    def test_var_metal_scalar_invalid_dim_raises(self):
+        # An invalid dim on a 0-d input must raise like CPU, not silently return.
+        x = torch.tensor(3.14, device='mps')
+        for fn in (torch.var, torch.std, torch.var_mean, torch.std_mean):
+            with self.assertRaisesRegex(IndexError, r"Dimension out of range \(expected to be in range of \[-1, 0\], but got 1\)"):
+                fn(x, dim=1)
+
+    def test_var_metal_scalar_duplicate_dim_raises(self):
+        # A duplicate dim on a 0-d input must raise like CPU (dim appears
+        # multiple times), not silently return nan.
+        x = torch.tensor(3.14, device='mps')
+        for fn in (torch.var, torch.std, torch.var_mean, torch.std_mean):
+            with self.assertRaisesRegex(RuntimeError, "dim 0 appears multiple times in the list of dims"):
+                fn(x, dim=(0, 0))
+
+    # =========================================================================
+    # var_mean / std_mean (fused)
+    # =========================================================================
+    def test_var_mean_metal(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            cpu_x = torch.randn(shape, device='cpu')
+            mps_x = cpu_x.to('mps')
+            # Scalar
+            mv, mm = torch.var_mean(mps_x)
+            cv, cm = torch.var_mean(cpu_x)
+            self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+            self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+            # Per-dim
+            for dim in range(len(shape)):
+                mv, mm = torch.var_mean(mps_x, dim=dim)
+                cv, cm = torch.var_mean(cpu_x, dim=dim)
+                self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+                self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+    def test_std_mean_metal(self):
+        cpu_x = torch.randn(4, 8, device='cpu')
+        mps_x = cpu_x.to('mps')
+        ms, mm = torch.std_mean(mps_x, dim=1)
+        cs, cm = torch.std_mean(cpu_x, dim=1)
+        self.assertEqual(ms, cs, atol=1e-4, rtol=1e-4)
+        self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+    def test_var_mean_metal_keepdim(self):
+        cpu_x = torch.randn(3, 4, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        mv, mm = torch.var_mean(mps_x, dim=1, keepdim=True)
+        cv, cm = torch.var_mean(cpu_x, dim=1, keepdim=True)
+        self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+        self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+
+instantiate_parametrized_tests(TestReduceOpsMetal)
+
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15431,6 +15431,9 @@ op_db: list[OpInfo] = [
     OpInfo('var_mean',
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+           dtypesIfMPS=floating_and_complex_types_and(
+               torch.half, torch.bfloat16
+           ),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: some signatures of var_mean do support out
            supports_out=False,
@@ -15447,6 +15450,9 @@ op_db: list[OpInfo] = [
            variant_test_name='unbiased',
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+           dtypesIfMPS=floating_and_complex_types_and(
+               torch.half, torch.bfloat16
+           ),
            sample_inputs_func=sample_inputs_std_var_unbiased,
            # TODO: some signatures of var_mean do support out
            supports_out=False,
@@ -15462,6 +15468,9 @@ op_db: list[OpInfo] = [
     OpInfo('std_mean',
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+           dtypesIfMPS=floating_and_complex_types_and(
+               torch.half, torch.bfloat16
+           ),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: some signatures of std_mean do support out
            supports_out=False,
@@ -15476,6 +15485,9 @@ op_db: list[OpInfo] = [
            variant_test_name='unbiased',
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+           dtypesIfMPS=floating_and_complex_types_and(
+               torch.half, torch.bfloat16
+           ),
            sample_inputs_func=sample_inputs_std_var_unbiased,
            # TODO: some signatures of var_mean do support out
            supports_out=False,
@@ -17021,6 +17033,7 @@ op_db: list[OpInfo] = [
            aliases=('group_norm',),
            ref=reference_group_norm,
            dtypes=floating_types_and(torch.float16, torch.bfloat16),
+           dtypesIfMPS=floating_types_and(torch.float16, torch.bfloat16),
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
@@ -23251,15 +23264,6 @@ op_db: list[OpInfo] = [
                 device_type='xpu',
                 dtypes=[torch.float64]),
             # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # The operator 'aten::std.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -23284,15 +23288,6 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
             # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     ReductionOpInfo(
@@ -23322,15 +23317,6 @@ op_db: list[OpInfo] = [
             # NumPy is giving NaN for this
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_large_input'),
             # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # NotImplementedError: The operator 'aten::var.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -23355,8 +23341,6 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
             # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
         ),
     ),
     ReductionOpInfo(
@@ -27243,12 +27227,6 @@ python_ref_db = [
                 device_type='xpu',
                 dtypes=[torch.float64]),
             # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     # std_mean and var_mean are not ReductionInfos
@@ -27257,10 +27235,9 @@ python_ref_db = [
         torch_opinfo_name="std_mean",
         skips=(
             # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
             DecorateInfo(
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
+                device_type='mps', dtypes=(torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32)
             ),
         ),
     ),
@@ -27357,11 +27334,6 @@ python_ref_db = [
             DecorateInfo(
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
             # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     PythonRefInfo(
@@ -27370,10 +27342,18 @@ python_ref_db = [
         validate_view_consistency=False,
         skips=(
             # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
+            # RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype
             DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
+                unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps',
+                dtypes=(torch.uint8, torch.int8, torch.int32, torch.int16, torch.bool)
+            ),
+            DecorateInfo(
+                unittest.expectedFailure, 'TestCommon', 'test_python_ref_meta', device_type='mps',
+                dtypes=(torch.uint8, torch.int8, torch.int32, torch.int16, torch.bool)
+            ),
+            DecorateInfo(
+                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='mps',
+                dtypes=(torch.uint8, torch.int8, torch.int32, torch.int16, torch.bool)
             ),
         ),
     ),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -20,6 +20,14 @@ if torch.backends.mps.is_available():
 
         # Supported complex OPS
         SUPPORTED_COMPLEX_OPS = {
+            "std",
+            "std_mean",
+            "var",
+            "var_mean",
+            "stdunbiased",
+            "std_meanunbiased",
+            "varunbiased",
+            "var_meanunbiased",
             "__radd__",
             "__rmul__",
             "__rsub__",


### PR DESCRIPTION
Part of #187455.

## Stack Position / Review Order

This is the third reduce-family split and should be reviewed after:

1. #188156: shared `value_reduction<Op, Load, TA>` base for the sum family.
2. #188333: `prod` on top of that shared base.
3. This PR: `var` / `std` / `var_mean` / `std_mean` native Metal Welford kernels.

This rebuild intentionally drops the stale shared `uint32 -> int64` reduction-indexing migration from the earlier #187787 draft. The native Welford path keeps uint32 indexing in the existing `NormParams` domain and rejects unsupported `>2^32` input/output/reduction cases with explicit errors instead of widening the shared reduction infrastructure in this PR.

## Summary

Replaces the MPSGraph-backed `var`, `std`, `var_mean`, and `std_mean` reductions on MPS with native Metal Welford kernels. The implementation keeps Welford-specific kernels separate from the shared sum/prod/value reduction path, preserving the reduce-family stack split while removing another per-shape MPSGraph graph-cache path.

The branch includes:

- generic Welford reduction for arbitrary dims using existing uint32 `NormParams` indexing;
- specialized all-reduce, outer-dim, inner-dim, wide-inner, and thin-inner Welford kernels for representative normalization shapes;
- complex input handling through real/imag component reductions, preserving real-valued variance/std plus complex mean semantics without adding complex Welford Metal kernels;
- OpInfo/common_mps updates for the newly supported MPS var/std dtype surface;
- focused MPS regression coverage for correction, duplicate dims, scalar dims, partial-simdgroup dispatch, large-offset numerical stability, non-stride-aligned wide tails, and GroupNorm-relevant shapes.

Coverage owners: OpInfo / `common_methods_invocations.py` and `torch/testing/_internal/common_mps.py` own the newly supported var/std dtype and xfail/skip surface; focused `test/test_mps.py` Welford cases own kernel-specific numerical, shape, duplicate-dim, partial-simdgroup, and GroupNorm-relevant regressions; the Inductor MPS selectors own the stale expected-failure removal.

## Scope Notes

- No shared `NormParams` widening is included.
- The only Inductor test metadata change is removing the stale MPS expected-failure marker from `test_tmp_not_defined_issue3`; native `var_mean` support makes the test pass on MPS, and the selector plus its dynamic-shapes variant were verified locally after the removal.
- No generic reduction-dispatch change outside the Welford path is included.
- Benchmark evidence lives in `benchmarks/mps/welford_reduce_bench.py` because it is a standalone MPS reviewer-evidence script using `torch.utils.benchmark`, not an `operator_benchmark` framework case.

## Performance / Memory Stability

Benchmark script: `benchmarks/mps/welford_reduce_bench.py`.

Methodology: same script on the parent build (`1dc5b578e448e411c854983fd1ee983a1d6a80eb`, MPSGraph var/std path) and this head (`cd01523561027511bffff9c99b844a65e693be7b`, native Welford path). Steady rows report mean microseconds over five warm `torch.utils.benchmark.Timer.blocked_autorange` trials and synchronize MPS inside the timed statement. Shape-varying/RSS rows visit 200 distinct shapes to expose graph-cache behavior.

### Steady-State Var

| Shape | Dim | Parent us | This PR us | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `(16777216,)` | `None` | 758.3 | 436.5 | 1.74x |
| `(4096, 4096)` | 1 | 747.7 | 406.4 | 1.84x |
| `(4096, 4096)` | 0 | 787.2 | 421.2 | 1.87x |
| `(1024, 16384)` | 1 | 749.2 | 406.3 | 1.84x |
| `(1000000, 8)` | 1 | 450.5 | 259.2 | 1.74x |
| `(8, 1000000)` | 1 | 426.0 | 327.8 | 1.30x |
| `(8, 1000000)` | 0 | 582.9 | 435.7 | 1.34x |

### Steady-State Std

| Shape | Dim | Parent us | This PR us | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `(16777216,)` | `None` | 757.6 | 426.7 | 1.78x |
| `(4096, 4096)` | 1 | 742.5 | 406.5 | 1.83x |
| `(4096, 4096)` | 0 | 783.0 | 418.6 | 1.87x |
| `(1024, 16384)` | 1 | 747.4 | 403.9 | 1.85x |
| `(1000000, 8)` | 1 | 448.8 | 258.9 | 1.73x |
| `(8, 1000000)` | 1 | 423.0 | 326.5 | 1.30x |
| `(8, 1000000)` | 0 | 599.9 | 434.7 | 1.38x |

### Shape-Varying / RSS

| Op | Parent shape-varying | This PR shape-varying | Parent RSS growth | This PR RSS growth |
| --- | ---: | ---: | ---: | ---: |
| `var` | 878 ms / 200 shapes (4.39 ms/shape) | 6 ms / 200 shapes (0.03 ms/shape) | +2370 MB | +0 MB |
| `std` | 760 ms / 200 shapes (3.80 ms/shape) | 6 ms / 200 shapes (0.03 ms/shape) | +437 MB | +0 MB |

## Test Plan

Current local gate head: `cd01523561027511bffff9c99b844a65e693be7b`.

```bash
/opt/homebrew/bin/python3.11 -m py_compile benchmarks/mps/welford_reduce_bench.py test/test_mps.py torch/testing/_internal/common_methods_invocations.py torch/testing/_internal/common_mps.py
/opt/homebrew/bin/lintrunner -a -m 1dc5b578e448e411c854983fd1ee983a1d6a80eb
# Metal compiler preflight for changed ReduceOps.metal under metal3.1 and metal4.0

rm -f build/caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mps/operations/ReduceOps.mm.o
ninja -C build torch_cpu && cp build/lib/libtorch_cpu.dylib torch/lib/libtorch_cpu.dylib

PYTHONPATH=$PWD PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/test_mps.py TestMPS.test_std TestReduceOpsMetal -v
PYTHONPATH=$PWD PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/test_mps.py TestMPS.test_var_simple -v
PYTHONPATH=$PWD PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/test_mps.py \
  TestConsistencyMPS.test_output_match_var_mps_float32 \
  TestConsistencyMPS.test_output_match_var_mps_complex64 \
  TestConsistencyMPS.test_output_match_std_mps_float32 \
  TestConsistencyMPS.test_output_match_std_mps_complex64 \
  TestConsistencyMPS.test_output_match_var_mean_mps_float32 \
  TestConsistencyMPS.test_output_match_var_mean_mps_complex64 \
  TestConsistencyMPS.test_output_match_std_mean_mps_float32 \
  TestConsistencyMPS.test_output_match_std_mean_mps_complex64 \
  TestConsistencyMPS.test_output_grad_match_var_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_std_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_var_mean_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_std_mean_mps_float32 \
  TestConsistencyMPS.test_output_match_nn_functional_group_norm_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_nn_functional_group_norm_mps_float32 \
  TestCommonMPS.test_numpy_ref_mps_nn_functional_group_norm_mps_float32 \
  -v
PYTHONPATH=$PWD PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 -m pytest -q \
  test/inductor/test_torchinductor.py::GPUTests::test_tmp_not_defined_issue3_mps \
  test/inductor/test_torchinductor_dynamic_shapes.py::DynamicShapesGPUTests::test_tmp_not_defined_issue3_dynamic_shapes_mps

PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 PYTHONPATH=/Users/cameronbeeley/pytorch-prs/varstd-rebuild-187787 /opt/homebrew/bin/python3.11 test/run_test.py --verbose --mps --keep-going
```

Full `--mps` local CI result: all PR-relevant var/std, OpInfo/common_mps, `test_mps`, `test_ops`, `test_modules`, and Inductor MPS selectors passed. The runner exited non-zero only because `test/test_metal.py::TestMetalRewritePass::test_conv` fails with `Schema not found for node` for `metal_prepack::conv2d_prepack(...)`; the same selector reproduces on the parent build (`1dc5b578e448e411c854983fd1ee983a1d6a80eb`) with the same error, so this is not a new failure from this PR.

Mutation:

```bash
STRYKER_CXX_BIN=/Users/cameronbeeley/stryker-cxx/bin/stryker-cxx.js \
marmorkrebs --tool stryker-cxx --dir . \
  --changed-files aten/src/ATen/native/mps/operations/ReduceOps.mm:635-690 \
  --max-mutants 12 --threshold-break 0.6 \
  --build-command 'rm -f build/caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mps/operations/ReduceOps.mm.o && ninja -C build torch_cpu && cp build/lib/libtorch_cpu.dylib torch/lib/libtorch_cpu.dylib' \
  --test-command 'PYTHONPATH=$PWD PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 .pr-gates/artifacts/welford_complex_empty_check.py'
```

Mutation result: canonical `marmorkrebs` scalar/complex/empty slice scored 0.92 (`12` mutants, `11` killed, `1` equivalent scalar-recursion survivor, threshold `high`). Direct `stryker-cxx` Welford host-line evidence is also preserved: broad lines 368-690 (`56` mutants, `27` killed, remaining survivors dispositioned as equivalent/static-domain/route-perf noise), supplemental dim/shape lines 368-416 (`11` mutants, `6` killed; max-rank and output-stride loop mutants killed), and supplemental complex/empty lines 635-690 (`12` mutants, `11` killed).

## Review History

Review history and per-finding dispositions: https://gist.github.com/2b6a49d1102755c253b0eabb4d2f1694

## BC-breaking?

No. Unsupported `>2^32` MPS var/std indexing domains now fail explicitly; supported dtype/shape behavior is covered against CPU and OpInfo/common_mps.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo