### PR TITLE
[MPS] Migrate prod to native Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.h
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.h
@@ -7,12 +7,12 @@ C10_METAL_CONSTEXPR uint32_t SUM_NCHAINS = 8;
 template <unsigned N = c10::metal::max_ndim>
 struct NormParams {
   float p;
-  uint32_t reduction_size;
+  int64_t reduction_size;
   uint32_t ndim;
 
-  ::c10::metal::array<uint32_t, N> input_sizes;
-  ::c10::metal::array<uint32_t, N> input_strides;
+  ::c10::metal::array<int64_t, N> input_sizes;
+  ::c10::metal::array<int64_t, N> input_strides;
 
-  ::c10::metal::array<uint32_t, N> output_sizes;
-  ::c10::metal::array<uint32_t, N> output_strides;
+  ::c10::metal::array<int64_t, N> output_sizes;
+  ::c10::metal::array<int64_t, N> output_strides;
 };

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -23,11 +23,16 @@ struct norm_abs_functor {
 // `reduction_idx` is the index of a particular batch of input elements that all
 // get reduced to one output element. `reduction_element_idx` is the index of
 // just one input element within its batch.
-static uint32_t get_input_offset(
-    uint32_t reduction_element_idx,
-    uint32_t reduction_idx,
+static ulong get_input_offset(
+    ulong reduction_element_idx,
+    ulong reduction_idx,
     constant NormParams<>& params) {
-  uint32_t input_offset = 0;
+  // 64-bit accumulated global offset: a tensor can have more than 2^32 elements
+  // on high-memory Apple Silicon, so the cross-dimension index*stride sum must
+  // not wrap. The within-dim indices are also 64-bit because reduction_size (and
+  // hence reduction_element_idx) can exceed 2^32 when a single output element
+  // reduces the whole tensor.
+  ulong input_offset = 0;
 
   for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
     auto input_dim_size = params.input_sizes[dim];
@@ -38,14 +43,14 @@ static uint32_t get_input_offset(
     if (input_dim_size == output_dim_size) {
       auto index_in_dim = reduction_idx % input_dim_size;
       reduction_idx /= input_dim_size;
-      input_offset += index_in_dim * params.input_strides[dim];
+      input_offset += static_cast<ulong>(index_in_dim) * params.input_strides[dim];
 
       // Otherwise, this dim is being reduced, so we index by
       // `reduction_element_idx`
     } else {
       auto index_in_dim = reduction_element_idx % input_dim_size;
       reduction_element_idx /= input_dim_size;
-      input_offset += index_in_dim * params.input_strides[dim];
+      input_offset += static_cast<ulong>(index_in_dim) * params.input_strides[dim];
     }
   }
   return input_offset;
@@ -79,8 +84,8 @@ kernel void norm(
   // First, all the input elements assigned to the threadgroup are divided
   // between all the threads in the threadgroup, and each thread reduces those
   // elements down to one partial `output_val`.
-  for (uint32_t reduction_element_idx = tid;
-       reduction_element_idx < params.reduction_size;
+  for (ulong reduction_element_idx = tid;
+       reduction_element_idx < static_cast<ulong>(params.reduction_size);
        reduction_element_idx += tptg) {
     auto input_elem =
         input[get_input_offset(reduction_element_idx, tgid, params)];
@@ -310,7 +315,7 @@ kernel void sum_reduction(
   // For single reduced dim: input_base + k * reduction_stride gives
   // the k-th reduction element — no per-element dim loop needed.
   uint32_t input_base = 0;
-  uint32_t reduction_stride = 1;
+  ulong reduction_stride = 1;
   uint32_t num_reduced_dims = 0;
   {
     uint32_t out_idx = tgid;
@@ -333,9 +338,9 @@ kernel void sum_reduction(
     acc[j] = 0;
   }
 
-  const uint32_t rsize = params.reduction_size;
+  const ulong rsize = params.reduction_size;
   const uint32_t stride = tptg * NCHAINS;
-  uint32_t base = tid * NCHAINS;
+  ulong base = tid * NCHAINS;
 
   if (num_reduced_dims <= 1) {
     // Fast path: direct indexing with base + k * reduction_stride
@@ -345,7 +350,7 @@ kernel void sum_reduction(
             load_val<MODE>(input[input_base + (base + j) * reduction_stride]);
       }
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
+    for (ulong idx = base; idx < rsize; idx++) {
       acc[idx % NCHAINS] +=
           load_val<MODE>(input[input_base + idx * reduction_stride]);
     }
@@ -357,7 +362,7 @@ kernel void sum_reduction(
             load_val<MODE>(input[get_input_offset(base + j, tgid, params)]);
       }
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
+    for (ulong idx = base; idx < rsize; idx++) {
       acc[idx % NCHAINS] +=
           load_val<MODE>(input[get_input_offset(idx, tgid, params)]);
     }
@@ -426,11 +431,11 @@ kernel void sum_reduction_strided_pass1(
     uint tgid [[threadgroup_position_in_grid]]) {
   using TA = ::metal::conditional_t<MODE == LOAD_NONZERO, uint, opmath_t<TO>>;
 
-  const uint32_t E = params.reduction_size;
-  const uint32_t base_flat = tgid * E;
+  const ulong E = params.reduction_size;
+  const ulong base_flat = static_cast<ulong>(tgid) * E;
 
   TA acc = 0;
-  for (uint32_t k = tid; k < E; k += tptg) {
+  for (ulong k = tid; k < E; k += tptg) {
     acc += load_val<MODE>(input[get_input_offset(base_flat + k, 0u, params)]);
   }
 
@@ -823,7 +828,7 @@ kernel void value_reduction(
     uint tptg [[threads_per_threadgroup]],
     uint tgid [[threadgroup_position_in_grid]]) {
   uint32_t input_base = 0;
-  uint32_t reduction_stride = 1;
+  ulong reduction_stride = 1;
   uint32_t num_reduced_dims = 0;
   {
     uint32_t out_idx = tgid;
@@ -847,9 +852,9 @@ kernel void value_reduction(
     acc[j] = identity_val;
   }
 
-  const uint32_t rsize = params.reduction_size;
+  const ulong rsize = params.reduction_size;
   const uint32_t stride = tptg * NCHAINS;
-  uint32_t base = tid * NCHAINS;
+  ulong base = tid * NCHAINS;
 
   if (num_reduced_dims <= 1) {
     for (; base + NCHAINS <= rsize; base += stride) {
@@ -860,7 +865,7 @@ kernel void value_reduction(
                 input[input_base + (base + j) * reduction_stride]));
       }
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
+    for (ulong idx = base; idx < rsize; idx++) {
       acc[idx % NCHAINS] = Op::combine(
           acc[idx % NCHAINS],
           Load::template load<TA>(input[input_base + idx * reduction_stride]));
@@ -874,7 +879,7 @@ kernel void value_reduction(
                 input[get_input_offset(base + j, tgid, params)]));
       }
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
+    for (ulong idx = base; idx < rsize; idx++) {
       acc[idx % NCHAINS] = Op::combine(
           acc[idx % NCHAINS],
           Load::template load<TA>(input[get_input_offset(idx, tgid, params)]));
@@ -1189,7 +1194,7 @@ kernel void arg_reduction(
 
   // Compute input_base and detect reduction pattern (mirrors value_reduction).
   uint32_t input_base = 0;
-  uint32_t reduction_stride = 1;
+  ulong reduction_stride = 1;
   uint32_t num_reduced_dims = 0;
   {
     uint32_t out_idx = tgid;
@@ -1207,24 +1212,28 @@ kernel void arg_reduction(
 
   TA best_val = Op::identity();
   uint32_t best_idx = 0;
-  const uint32_t rsize = params.reduction_size;
+  // rsize is 64-bit so the loop cannot wrap on a >2^32-element reduced dim. The
+  // tracked argmax index stays 32-bit (the simd_arg_reduce / int64-output infra
+  // is 32-bit-indexed); a single reduced dim larger than 2^32 elements is not
+  // supported by arg-reduction and is outside this fix's scope.
+  const ulong rsize = params.reduction_size;
 
   if (num_reduced_dims <= 1) {
-    for (uint32_t idx = tid; idx < rsize; idx += tptg) {
+    for (ulong idx = tid; idx < rsize; idx += tptg) {
       const TA val =
           static_cast<TA>(input[input_base + idx * reduction_stride]);
       if (Op::replace(val, best_val)) {
         best_val = val;
-        best_idx = idx;
+        best_idx = static_cast<uint32_t>(idx);
       }
     }
   } else {
-    for (uint32_t idx = tid; idx < rsize; idx += tptg) {
+    for (ulong idx = tid; idx < rsize; idx += tptg) {
       const TA val =
           static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
       if (Op::replace(val, best_val)) {
         best_val = val;
-        best_idx = idx;
+        best_idx = static_cast<uint32_t>(idx);
       }
     }
   }
@@ -1424,3 +1433,537 @@ REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);
+
+// ===== prod kernels (this PR, on top of malfet sum/value migration) =====
+// Product reduction kernels
+// ============================================================================
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size [[threads_per_simdgroup]]) {
+  using TA = opmath_t<TO>;
+
+  // input_base is 64-bit: for the 2-pass all-reduce the per-group base offset is
+  // tgid * elems_per_group, which can exceed 2^32 for tensors with more than
+  // 2^32 elements. A 32-bit base would wrap and read the wrong region.
+  ulong input_base = 0;
+  ulong reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += static_cast<ulong>(idx) * params.input_strides[dim];
+      }
+    }
+  }
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const ulong rsize = params.reduction_size;
+  const uint32_t stride = tptg * NCHAINS;
+  ulong base = tid * NCHAINS;
+
+  if (num_reduced_dims <= 1) {
+    // 64-bit accumulated global offset: input_base is ulong, base/idx are ulong
+    // (they range over the reduction, which can exceed 2^32 for a single output
+    // element reducing the whole tensor), and the per-element step
+    // idx * reduction_stride stays in 64 bits so stepping through the reduced
+    // dimension of a >2^32-element input cannot wrap. reduction_stride stays
+    // 32-bit (a single stride fits 32 bits).
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *= static_cast<TA>(
+            input[input_base + (base + j) * reduction_stride]);
+      }
+    }
+    for (ulong idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *= static_cast<TA>(
+          input[input_base + idx * reduction_stride]);
+    }
+  } else {
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[get_input_offset(base + j, tgid, params)]);
+      }
+    }
+    for (ulong idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
+    }
+  }
+
+  TA output_val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    output_val *= acc[j];
+
+  auto threads_remaining = tptg;
+  threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE];
+
+  while (threads_remaining > 1) {
+    output_val = c10::metal::simd_prod(output_val);
+    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
+    if (threads_remaining > 1) {
+      if (simd_lane_id == 0)
+        shared_outputs[simdgroup_id] = output_val;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (tid < threads_remaining) {
+        output_val = shared_outputs[tid];
+      } else {
+        output_val = static_cast<TA>(1);
+      }
+    }
+  }
+
+  if (tid == 0) {
+    // 64-bit accumulated output offset: the cross-dimension index*stride sum can
+    // exceed 2^32 for tensors with more than 2^32 elements. reduction_idx is a
+    // tgid-derived id and per-dim sizes/strides stay 32-bit.
+    ulong output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += static_cast<ulong>(index_in_dim) * params.output_strides[dim];
+      }
+    }
+    output[output_offset] = static_cast<TO>(output_val);
+  }
+}
+
+template <
+    typename TI,
+    typename TO,
+    uint TG_X = 32,
+    uint TG_Y = 32,
+    uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  uint rows_per_y = ceil_div(M, TG_Y);
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = min(row_start + rows_per_y, M);
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+  // [M, N] input with more than 2^32 elements. row/col/N stay 32-bit.
+  uint row = row_start;
+  for (; row + NCHAINS <= row_end; row += NCHAINS) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(input[static_cast<ulong>(row + j) * N + col]);
+    }
+  }
+  for (; row < row_end; row++) {
+    acc[row % NCHAINS] *= static_cast<TA>(input[static_cast<ulong>(row) * N + col]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+
+  threadgroup TA shmem[TG_Y][TG_X];
+  shmem[tid_tg.y][tid_tg.x] = prod;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s)
+      shmem[tid_tg.y][tid_tg.x] *= shmem[tid_tg.y + s][tid_tg.x];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    output[static_cast<ulong>(col) * out_stride] = static_cast<TO>(shmem[0][tid_tg.x]);
+  }
+}
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+
+  // One SIMD group reduces one row; num_simd_groups rows share a TG (mirrors
+  // sum_reduction_inner). Avoids one whole TG per row, which idles most threads
+  // and over-subscribes the GPU when there are many short rows.
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+
+  // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+  // [M, N] input with more than 2^32 elements. row/N stay 32-bit.
+  constant TI* row_ptr = input + static_cast<ulong>(row) * N;
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint stride = 32 * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = simd_lane_id * NCHAINS;
+  for (; base < aligned_N; base += stride) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(row_ptr[base + j]);
+    }
+  }
+  for (uint i = aligned_N + simd_lane_id; i < N; i += 32) {
+    acc[0] *= static_cast<TA>(row_ptr[i]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+  // Reduce across the 32 lanes of this SIMD group (no shared memory needed).
+  prod = c10::metal::simd_prod(prod);
+
+  if (simd_lane_id == 0) {
+    output[row] = static_cast<TO>(prod);
+  }
+}
+
+// Wide inner-dim prod: one whole threadgroup (up to 1024 threads) products one
+// row, used for few/huge rows (small M, large N) where the simd-per-row variant
+// leaves only 32 lanes on a giant row and idles most of the GPU (e.g. M=2,
+// N~8M is ~25x slower there). Mirrors welford_reduction_inner_wide.
+template <typename TI, typename TO, int NCHAINS>
+kernel void prod_reduction_inner_wide(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+  uint row = tgid;
+  if (row >= M)
+    return;
+  // 64-bit base: row * N can exceed 2^32 for a >2^32-element input; the in-row
+  // offsets below stay 32-bit (a single row has at most N <= uint32 elements).
+  constant TI* row_ptr = input + static_cast<ulong>(row) * N;
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+  const uint stride = tptg * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = tid;
+  for (uint i = base; i < aligned_N; i += stride) {
+    for (uint c = 0; c < NCHAINS; c++)
+      acc[c] *= static_cast<TA>(row_ptr[i + c * tptg]);
+  }
+  for (uint i = base + aligned_N; i < N; i += tptg)
+    acc[0] *= static_cast<TA>(row_ptr[i]);
+  TA p = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    p *= acc[j];
+
+  // Reduce across the simdgroup, then a shared-memory tree across simdgroups.
+  p = c10::metal::simd_prod(p);
+  threadgroup TA shared[32];
+  if (simd_lane_id == 0)
+    shared[simdgroup_id] = p;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    // Padding lanes (>= num_simd_groups) carry the prod identity 1; the final
+    // simdgroup has 32 active lanes so simd_prod<long>'s shuffle-fill is benign.
+    p = (simd_lane_id < num_simd_groups) ? shared[simd_lane_id] : TA(1);
+    p = c10::metal::simd_prod(p);
+    if (simd_lane_id == 0)
+      output[row] = static_cast<TO>(p);
+  }
+}
+
+// Thin inner-dim prod: ONE thread products a full row, serially over N. For
+// small N the simd-per-row variant leaves 32-N of its 32 lanes idle and pays
+// simd-reduction overhead for under one element of work per lane; thread-per-row
+// has neither. Dispatched for small N with M large enough to fill the GPU.
+template <typename TI, typename TO>
+kernel void prod_reduction_inner_thin(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  if (gid >= M)
+    return;
+  constant TI* row_ptr = input + static_cast<ulong>(gid) * N;
+  TA p = 1;
+  for (uint i = 0; i < N; i++)
+    p *= static_cast<TA>(row_ptr[i]);
+  output[gid] = static_cast<TO>(p);
+}
+
+#define REGISTER_PROD(TI, TO)                               \
+  template [[host_name("prod_reduction_" #TI "_" #TO)]]     \
+  kernel void prod_reduction<TI, TO, SUM_NCHAINS>(          \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      constant NormParams<> & params [[buffer(2)]],         \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size [[threads_per_simdgroup]]);
+
+#define REGISTER_PROD_OUTER(TI, TO)                              \
+  template [[host_name("prod_reduction_outer_" #TI "_" #TO)]]    \
+  kernel void prod_reduction_outer<TI, TO, 32, 32, SUM_NCHAINS>( \
+      constant TI * input [[buffer(0)]],                         \
+      device TO * output [[buffer(1)]],                          \
+      constant uint3 & sizes [[buffer(2)]],                      \
+      uint2 tid_tg [[thread_position_in_threadgroup]],           \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+#define REGISTER_PROD_INNER(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner<TI, TO, SUM_NCHAINS>(      \
+      constant TI * input [[buffer(0)]],                      \
+      device TO * output [[buffer(1)]],                       \
+      constant uint2 & sizes [[buffer(2)]],                   \
+      uint tid [[thread_index_in_threadgroup]],               \
+      uint tptg [[threads_per_threadgroup]],                  \
+      uint tgid [[threadgroup_position_in_grid]],             \
+      uint simd_lane_id [[thread_index_in_simdgroup]],        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_PROD(float, float);
+REGISTER_PROD(half, half);
+REGISTER_PROD(half, float);
+REGISTER_PROD(bfloat, bfloat);
+REGISTER_PROD(bfloat, float);
+REGISTER_PROD(int, int);
+REGISTER_PROD(int, long);
+REGISTER_PROD(long, long);
+REGISTER_PROD(short, short);
+REGISTER_PROD(short, long);
+REGISTER_PROD(char, char);
+REGISTER_PROD(char, long);
+REGISTER_PROD(uchar, uchar);
+REGISTER_PROD(uchar, long);
+REGISTER_PROD(bool, long);
+REGISTER_PROD(bool, int);
+
+REGISTER_PROD_OUTER(float, float);
+REGISTER_PROD_OUTER(half, half);
+REGISTER_PROD_OUTER(half, float);
+REGISTER_PROD_OUTER(bfloat, bfloat);
+REGISTER_PROD_OUTER(bfloat, float);
+REGISTER_PROD_OUTER(int, int);
+REGISTER_PROD_OUTER(int, long);
+REGISTER_PROD_OUTER(long, long);
+REGISTER_PROD_OUTER(short, short);
+REGISTER_PROD_OUTER(short, long);
+REGISTER_PROD_OUTER(char, char);
+REGISTER_PROD_OUTER(char, long);
+REGISTER_PROD_OUTER(uchar, uchar);
+REGISTER_PROD_OUTER(uchar, long);
+REGISTER_PROD_OUTER(bool, long);
+REGISTER_PROD_OUTER(bool, int);
+
+REGISTER_PROD_INNER(float, float);
+REGISTER_PROD_INNER(half, half);
+REGISTER_PROD_INNER(half, float);
+REGISTER_PROD_INNER(bfloat, bfloat);
+REGISTER_PROD_INNER(bfloat, float);
+REGISTER_PROD_INNER(int, int);
+REGISTER_PROD_INNER(int, long);
+REGISTER_PROD_INNER(long, long);
+REGISTER_PROD_INNER(short, short);
+REGISTER_PROD_INNER(short, long);
+REGISTER_PROD_INNER(char, char);
+REGISTER_PROD_INNER(char, long);
+REGISTER_PROD_INNER(uchar, uchar);
+REGISTER_PROD_INNER(uchar, long);
+REGISTER_PROD_INNER(bool, long);
+REGISTER_PROD_INNER(bool, int);
+
+#define REGISTER_PROD_INNER_WIDE(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_wide_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner_wide<TI, TO, SUM_NCHAINS>(      \
+      constant TI * input [[buffer(0)]],                           \
+      device TO * output [[buffer(1)]],                            \
+      constant uint2 & sizes [[buffer(2)]],                        \
+      uint tid [[thread_index_in_threadgroup]],                    \
+      uint tptg [[threads_per_threadgroup]],                       \
+      uint tgid [[threadgroup_position_in_grid]],                  \
+      uint simd_lane_id [[thread_index_in_simdgroup]],             \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_PROD_INNER_WIDE(float, float);
+REGISTER_PROD_INNER_WIDE(half, half);
+REGISTER_PROD_INNER_WIDE(half, float);
+REGISTER_PROD_INNER_WIDE(bfloat, bfloat);
+REGISTER_PROD_INNER_WIDE(bfloat, float);
+REGISTER_PROD_INNER_WIDE(int, int);
+REGISTER_PROD_INNER_WIDE(int, long);
+REGISTER_PROD_INNER_WIDE(long, long);
+REGISTER_PROD_INNER_WIDE(short, short);
+REGISTER_PROD_INNER_WIDE(short, long);
+REGISTER_PROD_INNER_WIDE(char, char);
+REGISTER_PROD_INNER_WIDE(char, long);
+REGISTER_PROD_INNER_WIDE(uchar, uchar);
+REGISTER_PROD_INNER_WIDE(uchar, long);
+REGISTER_PROD_INNER_WIDE(bool, long);
+REGISTER_PROD_INNER_WIDE(bool, int);
+
+#define REGISTER_PROD_INNER_THIN(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_thin_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner_thin<TI, TO>(                   \
+      constant TI * input [[buffer(0)]],                           \
+      device TO * output [[buffer(1)]],                            \
+      constant uint2 & sizes [[buffer(2)]],                        \
+      uint gid [[thread_position_in_grid]]);
+
+REGISTER_PROD_INNER_THIN(float, float);
+REGISTER_PROD_INNER_THIN(half, half);
+REGISTER_PROD_INNER_THIN(half, float);
+REGISTER_PROD_INNER_THIN(bfloat, bfloat);
+REGISTER_PROD_INNER_THIN(bfloat, float);
+REGISTER_PROD_INNER_THIN(int, int);
+REGISTER_PROD_INNER_THIN(int, long);
+REGISTER_PROD_INNER_THIN(long, long);
+REGISTER_PROD_INNER_THIN(short, short);
+REGISTER_PROD_INNER_THIN(short, long);
+REGISTER_PROD_INNER_THIN(char, char);
+REGISTER_PROD_INNER_THIN(char, long);
+REGISTER_PROD_INNER_THIN(uchar, uchar);
+REGISTER_PROD_INNER_THIN(uchar, long);
+REGISTER_PROD_INNER_THIN(bool, long);
+REGISTER_PROD_INNER_THIN(bool, int);
+
+// Small-M variants: prod_outer with TG_Y matching M.
+// Avoids the 75-87% idle-thread waste of TG_Y=32 when M is 8 or 16.
+
+template [[host_name("prod_reduction_outer_8_float_float")]]
+kernel void prod_reduction_outer<float, float, 128, 8>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_8_half_half")]]
+kernel void prod_reduction_outer<half, half, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_8_bfloat_bfloat")]]
+kernel void prod_reduction_outer<bfloat, bfloat, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+template [[host_name("prod_reduction_outer_16_float_float")]]
+kernel void prod_reduction_outer<float, float, 64, 16>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_16_half_half")]]
+kernel void prod_reduction_outer<half, half, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_16_bfloat_bfloat")]]
+kernel void prod_reduction_outer<bfloat, bfloat, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+// Small-M outer prod (M <= 16): grid-stride over columns, each thread reduces
+// COLS columns over all M rows. The generic outer kernel splits the tiny M
+// across TG_Y row-workers and pays a shared-memory barrier tree; that overhead
+// dominates when M is small. One-thread-per-column instead over-subscribes the
+// GPU for large N. sum dim=0 uses a tensor-core simdgemm path that products
+// cannot, so prod needs this dedicated layout. COLS=2 won a config sweep.
+template <typename TI, typename TO, uint COLS = 2>
+kernel void prod_reduction_outer_smallm(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint gsize [[threads_per_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+  for (uint col = gid; col < N; col += gsize) {
+    TA acc = 1;
+    // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+    // [M, N] input with more than 2^32 elements. row/col/N stay 32-bit.
+    for (uint row = 0; row < M; row++) {
+      acc *= static_cast<TA>(input[static_cast<ulong>(row) * N + col]);
+    }
+    output[static_cast<ulong>(col) * out_stride] = static_cast<TO>(acc);
+  }
+}
+
+#define REGISTER_PROD_OUTER_SMALLM(TI, TO)                                  \
+  template                                                                  \
+      [[host_name("prod_reduction_outer_smallm_" #TI "_" #TO)]] kernel void \
+      prod_reduction_outer_smallm<TI, TO, 2>(                               \
+          constant TI * input [[buffer(0)]],                                \
+          device TO * output [[buffer(1)]],                                 \
+          constant uint3 & sizes [[buffer(2)]],                             \
+          uint gid [[thread_position_in_grid]],                             \
+          uint gsize [[threads_per_grid]]);
+REGISTER_PROD_OUTER_SMALLM(float, float);
+REGISTER_PROD_OUTER_SMALLM(half, half);
+REGISTER_PROD_OUTER_SMALLM(bfloat, bfloat);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -349,6 +349,384 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
   });
 }
 
+// ============================================================================
+// Metal kernel dispatch helpers for prod
+// ============================================================================
+
+static std::vector<int64_t> get_reduce_dims(const Tensor& input, OptionalIntArrayRef opt_dim) {
+  std::vector<int64_t> dims;
+  if (opt_dim.has_value() && !opt_dim.value().empty()) {
+    for (auto d : opt_dim.value()) {
+      dims.push_back(maybe_wrap_dim(d, input.dim()));
+    }
+  } else {
+    for (int64_t d = 0; d < input.dim(); d++) {
+      dims.push_back(d);
+    }
+  }
+  return dims;
+}
+
+static NormParams<> build_reduce_params(const Tensor& input,
+                                        const std::vector<int64_t>& reduce_dims,
+                                        const Tensor& output,
+                                        bool keepdim) {
+  NormParams params;
+  params.ndim = input.dim();
+  params.p = 0;
+  params.reduction_size = input.numel() / std::max<int64_t>(output.numel(), 1);
+
+  bool is_reduced[c10::metal::max_ndim] = {};
+  for (auto d : reduce_dims)
+    is_reduced[d] = true;
+
+  if (keepdim || output.dim() == input.dim()) {
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      params.output_sizes[d] = output.size(d);
+      params.output_strides[d] = output.stride(d);
+    }
+  } else {
+    uint32_t out_d = 0;
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      if (is_reduced[d]) {
+        params.output_sizes[d] = 1;
+        params.output_strides[d] = 0;
+      } else {
+        params.output_sizes[d] = output.size(out_d);
+        params.output_strides[d] = output.stride(out_d);
+        out_d++;
+      }
+    }
+  }
+
+  return params;
+}
+
+// Native prod kernels are instantiated for same-dtype pairs and the natural
+// accumulation promotions only; an explicit prod(..., dtype=) can request any
+// (input, output) scalar combination.
+static bool prod_kernel_registered(ScalarType in, ScalarType out) {
+  if (in == out) {
+    // Same-dtype kernels are instantiated for these only. uint16/32/64 are not
+    // (and are rejected up front in prod_kernel_mps, since prod is unsupported
+    // for them on CPU too); bool output uses the nonzero path above.
+    return in == kFloat || in == kHalf || in == kBFloat16 || in == kInt ||
+        in == kLong || in == kShort || in == kChar || in == kByte;
+  }
+  if ((in == kHalf || in == kBFloat16) && out == kFloat) {
+    return true;
+  }
+  if ((in == kInt || in == kShort || in == kChar || in == kByte) && out == kLong) {
+    return true;
+  }
+  if (in == kBool && (out == kInt || out == kLong)) {
+    return true;
+  }
+  return false;
+}
+
+static void prod_kernel_mps(const Tensor& input,
+                            const std::vector<int64_t>& reduce_dims,
+                            bool keepdim,
+                            const Tensor& output) {
+  // Complex prod requires complex multiplication semantics not available in
+  // the generic float2 SIMD kernels; fall back to MPSGraph. Pass the output
+  // dtype so a complex input with an explicit real dtype= casts per element
+  // before reducing (matching CPU), instead of silently dropping the dtype.
+  if (c10::isComplexType(input.scalar_type())) {
+    reduction_out_mps(
+        input, reduce_dims, keepdim, output.scalar_type(), output, MPSReductionType::PROD, "prod_kernel_mps");
+    return;
+  }
+  // One threadgroup per output element; Metal caps the grid at ~2^32
+  // threadgroups, so a reduction with more than 2^32 outputs cannot be
+  // dispatched (the generic kernel's 32-bit output index would also wrap).
+  TORCH_CHECK(output.numel() <= std::numeric_limits<uint32_t>::max(),
+              "MPS prod reduction with more than 2^32 output elements is not supported");
+  // bool output: prod(..., dtype=bool) uses nonzero semantics (CPU multiplies
+  // the boolean mask input != 0), so a 0.5 element contributes True, not a
+  // truncated 0. Reduce input.to(kBool) (the nonzero mask as a bool tensor ->
+  // the registered (bool,long) kernel) rather than casting the raw input to the
+  // long accumulator, which would truncate non-integer values. to(kBool) is
+  // used over ne(0) because MPS has no scalar ne for the unsigned uint16/uint32/
+  // uint64 dtypes (ne_..._ushort/uint/ulong are unregistered), which CPU prod
+  // accepts. Metal simd_product has no bool, so the accumulator stays long and
+  // is cast back to bool at the end.
+  if (output.scalar_type() == kBool) {
+    auto long_output = at::empty_like(output, output.options().dtype(kLong));
+    prod_kernel_mps(input.to(kBool), reduce_dims, keepdim, long_output);
+    output.copy_(long_output.to(kBool));
+    return;
+  }
+  // uint16/32/64 have no native prod kernel, and prod is "not implemented" for
+  // them on CPU too. Reject with a clear error rather than recursing forever
+  // below: cast-to-self is a no-op, so the cast-and-recurse path would loop
+  // until the stack overflows.
+  TORCH_CHECK(output.scalar_type() != kUInt16 &&
+                  output.scalar_type() != kUInt32 &&
+                  output.scalar_type() != kUInt64,
+              "prod: not implemented for ", output.scalar_type(),
+              " output on MPS");
+  // prod(..., dtype=) accumulates in the output dtype. For an (input, output)
+  // pair with no native kernel, cast the input to the output dtype and recurse
+  // into the same-dtype kernel instead of requesting an unregistered kernel.
+  if (!prod_kernel_registered(input.scalar_type(), output.scalar_type())) {
+    prod_kernel_mps(input.to(output.scalar_type()).contiguous(), reduce_dims, keepdim, output);
+    return;
+  }
+  if (input.numel() == 0) {
+    output.fill_(1);
+    return;
+  }
+  if (output.numel() == 0)
+    return;
+
+  // 64-bit: a generic/non-contiguous reduction extent can be an exact 2^32
+  // multiple (reachable via zero-stride views), which would wrap a uint32 to 0
+  // and dispatch a zero-sized threadgroup. The kernel loop bound is read from
+  // the int64 NormParams; this local only feeds the (capped) threadgroup size.
+  int64_t reduction_size = input.numel() / output.numel();
+  auto type_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass all-reduce: reshape input to
+  // [num_groups, elems_per_group], reduce dim=1 to per-group partials, then
+  // reduce partials to scalar. Reuses the existing prod_reduction kernel both
+  // passes. Bypasses is_outer's M=1 single-TG-per-output degenerate dispatch.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    // total_N is 64-bit: input.numel() can exceed 2^32 on high-memory Apple
+    // Silicon. num_groups stays small (<=512), but elems_per_group must stay
+    // 64-bit: a prime total_N forces num_groups==1, so elems_per_group ==
+    // total_N and can exceed 2^32. It flows into NormParams::reduction_size and
+    // input_strides (now int64), and the kernel's per-group base offset
+    // (tgid * elems_per_group) is computed in ulong.
+    int64_t total_N = input.numel();
+    uint32_t num_groups = static_cast<uint32_t>(std::min<int64_t>(
+        512, c10::metal::ceil_div(total_N, static_cast<int64_t>(MAX_THREADGROUP_SIZE) * 4)));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    int64_t elems_per_group = total_N / num_groups;
+
+    auto partials = at::empty({static_cast<int64_t>(num_groups)}, output.options());
+    auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+
+    // Pass 1: input[num_groups, elems_per_group] -> partials[num_groups], reduce dim=1.
+    NormParams<> params1{};
+    params1.reduction_size = elems_per_group;
+    params1.ndim = 2;
+    params1.input_sizes[0] = num_groups;
+    params1.input_strides[0] = elems_per_group;
+    params1.output_sizes[0] = num_groups;
+    params1.output_strides[0] = 1;
+    params1.input_sizes[1] = elems_per_group;
+    params1.input_strides[1] = 1;
+
+    // Pass 2: partials[num_groups] -> output[1], reduce dim=0.
+    NormParams<> params2{};
+    params2.reduction_size = num_groups;
+    params2.ndim = 1;
+    params2.input_sizes[0] = num_groups;
+    params2.input_strides[0] = 1;
+    params2.output_sizes[0] = 1;
+    params2.output_strides[0] = 0;
+
+    auto p2_kernel = fmt::format("prod_reduction_{}_{}", out_str, out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps1 = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps1, "prod_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        mtl_setArgs(enc, input, partials, params1);
+        // Round each pass up to a full simdgroup. prod_reduction's
+        // simd_prod<long> emulates 64-bit simd via simd_shuffle_and_fill_down;
+        // in a partial simdgroup an active lane reads an in-range inactive lane
+        // as garbage (0 on M1/M2 -> corrupted product), which the fill does not
+        // cover. Padding lanes in a full simdgroup carry the identity 1.
+        // Cap to MAX_THREADGROUP_SIZE first (elems_per_group is int64 and may
+        // exceed 2^32 when num_groups==1) so the round_up runs in 32 bits.
+        uint32_t epg_capped = static_cast<uint32_t>(
+            std::min<int64_t>(MAX_THREADGROUP_SIZE, elems_per_group));
+        auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(epg_capped, 32u));
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(p2_kernel);
+        getMPSProfiler().beginProfileKernel(ps2, "prod_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, params2);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(num_groups, 32u));
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  bool is_single = reduce_dims.size() == 1 && output.numel() != 1;
+  bool is_outer = is_single && reduce_dims[0] == 0 && input.is_contiguous() && output.is_contiguous();
+  bool is_inner = is_single && reduce_dims[0] == input.dim() - 1 && input.is_contiguous() && output.is_contiguous();
+
+  // The specialized outer/inner prod kernels carry M and N as 32-bit sizes, so
+  // fall back to the generic 64-bit NormParams path when a single dimension (or
+  // the non-reduced product) exceeds uint32.
+  if (is_single) {
+    constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+    int64_t rd_size = input.size(reduce_dims[0]);
+    if (rd_size > kU32Max || input.numel() / std::max<int64_t>(rd_size, 1) > kU32Max) {
+      is_outer = false;
+      is_inner = false;
+    }
+  }
+
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    uint32_t TG_X, TG_Y;
+    std::string kernel;
+    // Small-M kernels are instantiated same-dtype only; a mixed-dtype
+    // prod(..., dtype=...) request must fall through to the generic outer path
+    // (which covers all input/output combos) to avoid an unregistered kernel.
+    bool small_m_supported = input.scalar_type() == output.scalar_type() &&
+        (input.scalar_type() == at::kFloat || input.scalar_type() == at::kHalf || input.scalar_type() == at::kBFloat16);
+    if (small_m_supported && M <= 16) {
+      // Grid-stride small-M path (COLS=2 columns/thread): no barrier tree, and a
+      // bounded threadgroup count for large N. Wins over the generic outer
+      // kernel and one-thread-per-column for tiny M.
+      constexpr uint32_t COLS = 2, TG = 256;
+      auto sm_kernel = fmt::format("prod_reduction_outer_smallm_{}_{}", type_str, out_str);
+      const uint32_t gthreads = c10::metal::ceil_div(N, COLS * TG) * TG;
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        @autoreleasepool {
+          id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+          auto ps = lib.getPipelineStateForFunc(sm_kernel);
+          getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer_smallm", {input});
+          [enc setComputePipelineState:ps];
+          // Pad to 4 uints: Metal requires 16 bytes for a `constant uint3&`
+          // argument, and a 12-byte struct aborts under MTL_DEBUG_LAYER.
+          const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+          mtl_setArgs(enc, input, output, sizes_s);
+          [enc dispatchThreads:MTLSizeMake(gthreads, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps);
+        }
+      });
+      return;
+    }
+    // M > 16: generic 2D outer kernel (TG_X x TG_Y row-workers + tree reduce).
+    TG_X = 32;
+    TG_Y = 32;
+    kernel = fmt::format("prod_reduction_outer_{}_{}", type_str, out_str);
+    auto num_tg_x = c10::metal::ceil_div(N, TG_X);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer", {input});
+        [enc setComputePipelineState:ps];
+        // Pad to 4 uints: Metal requires 16 bytes for a `constant uint3&`
+        // argument, and a 12-byte struct aborts under MTL_DEBUG_LAYER.
+        const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  if (is_inner) {
+    uint32_t N = input.size(input.dim() - 1);
+    uint32_t M = input.numel() / N;
+    // Enough rows -> one SIMD group per row (pack rows_per_tg rows per TG).
+    // Few rows (small M) -> the "wide" kernel (one whole TG per row, up to 1024
+    // threads), since only M simdgroups on few rows idles most of the GPU. This
+    // gates on M only, not N: unlike welford, prod's simd-per-row still wins at
+    // moderate M with large N (e.g. M=256, N=65536), so a low N cap would
+    // regress it.
+    // Tall-thin (small N, large M) -> one thread per row: a 32-lane SIMD group
+    // on N<=32 leaves most lanes idle and pays simd-reduction overhead for under
+    // one element of work per lane.
+    bool use_thin = (M >= 64 && N <= 32);
+    bool use_simd_per_row = (M >= 64);
+    uint32_t tg_size, num_tgs;
+    std::string kernel;
+    if (use_thin) {
+      kernel = fmt::format("prod_reduction_inner_thin_{}_{}", type_str, out_str);
+      tg_size = 256;
+      num_tgs = c10::metal::ceil_div(M, tg_size); // one thread per row
+    } else if (use_simd_per_row) {
+      kernel = fmt::format("prod_reduction_inner_{}_{}", type_str, out_str);
+      tg_size = (N <= 512) ? 1024u : 256u;
+      num_tgs = c10::metal::ceil_div(M, tg_size / 32);
+    } else {
+      kernel = fmt::format("prod_reduction_inner_wide_{}_{}", type_str, out_str);
+      tg_size = std::min(1024u, c10::metal::ceil_div(N, 32u) * 32u);
+      if (N >= 2048) {
+        tg_size = c10::metal::ceil_div(N / (4u * 16u), 32u) * 32u;
+        tg_size = std::clamp(tg_size, 32u, 1024u);
+      }
+      num_tgs = M; // one TG per row
+    }
+    // 64-bit total dispatch thread count: num_tgs * tg_size can exceed 2^32 for
+    // a tall input (many rows) even though num_tgs and tg_size each fit 32 bits.
+    const uint64_t total_threads = static_cast<uint64_t>(num_tgs) * tg_size;
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(total_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+  // The generic NormParams path indexes per-dim arrays sized by max_ndim; a
+  // higher-rank input would index past the struct/stack storage. (The outer/
+  // inner fast paths above use only M/N and are rank-agnostic.)
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              "MPS prod: reductions over more than ",
+              c10::metal::max_ndim,
+              " dimensions are not supported");
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  uint32_t capped_reduction = static_cast<uint32_t>(std::min<int64_t>(MAX_THREADGROUP_SIZE, reduction_size));
+  auto threads_per_group = c10::metal::ceil_div(capped_reduction, 32u) * 32u;
+  // 64-bit total dispatch thread count: one threadgroup per output element, so
+  // output.numel() * threads_per_group can exceed 2^32 (e.g. millions of output
+  // elements * a full threadgroup). threads_per_group stays 32-bit.
+  uint64_t num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "prod_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, params);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
 static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       at::OptionalIntArrayRef dim,
                                       const std::optional<Scalar>& correction,
@@ -836,7 +1214,9 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
       // Pad per-TG thread count up to a full simdgroup; padding lanes load
       // Op::identity() and skip the per-thread scan, keeping the two-stage
       // SIMD reduction well-defined for all reduction sizes.
-      const auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(params.reduction_size, 32u));
+      const auto threads_per_group = std::min(
+          MAX_THREADGROUP_SIZE,
+          c10::metal::round_up(static_cast<uint32_t>(params.reduction_size), 32u));
       const auto num_threads = static_cast<uint32_t>(output_view.numel()) * threads_per_group;
       [ce dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
       getMPSProfiler().endProfileKernel(ps);
@@ -1201,8 +1581,14 @@ Tensor trace_mps(const Tensor& self) {
 
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
-  int64_t dims[1] = {dim};
-  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
+  // 0-dim tensor: prod(scalar, dim=0) is a no-op reduction; return scalar.
+  if (input_t.dim() == 0) {
+    output_t.copy_(input_t);
+    return;
+  }
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  std::vector<int64_t> reduce_dims = {dim_};
+  prod_kernel_mps(input_t, reduce_dims, keepdim, output_t);
 }
 
 static void aminmax_kernel_mps(const Tensor& self, int64_t dim, bool keepdim, Tensor& min, Tensor& max) {
@@ -1218,14 +1604,12 @@ static void aminmax_allreduce_kernel_mps(const Tensor& self, Tensor& min, Tensor
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
-  std::vector<int64_t> dims(self.dim());
-  std::iota(dims.begin(), dims.end(), 0);
+  auto reduce_dims = get_reduce_dims(self, std::nullopt);
 
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  reduction_out_mps(
-      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
+  prod_kernel_mps(self, reduce_dims, false, output_t);
 
   return output_t;
 }

--- a/benchmarks/bench_mps_reduce.py
+++ b/benchmarks/bench_mps_reduce.py
@@ -1,0 +1,141 @@
+"""Benchmark Metal reduce ops (var, std, prod, argmax, argmin, max, min) on MPS.
+
+Uses torch.utils.benchmark.Timer + blocked_autorange.
+
+Usage:
+    python benchmarks/bench_mps_reduce.py
+    python benchmarks/bench_mps_reduce.py --variable-shapes
+"""
+
+import argparse
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+def fmt(m):
+    return f"{m.median * 1e6:>8.1f} +/- {m.iqr * 1e6:>5.1f}"
+
+
+def bench(stmt, glob, min_run_time=2.0):
+    t = Timer(stmt=stmt, globals=glob)
+    return t.blocked_autorange(min_run_time=min_run_time)
+
+
+def run_fixed(args):
+    print("=" * 72)
+    print("FIXED-SHAPE REDUCTIONS")
+    print("=" * 72)
+
+    cases = [
+        ("prod dim=0", (128, 256), "torch.prod(x, dim=0); torch.mps.synchronize()"),
+        ("prod dim=1", (128, 256), "torch.prod(x, dim=1); torch.mps.synchronize()"),
+        ("var dim=1", (128, 256), "torch.var(x, dim=1); torch.mps.synchronize()"),
+        ("var dim=0", (128, 256), "torch.var(x, dim=0); torch.mps.synchronize()"),
+        ("std dim=1", (128, 256), "torch.std(x, dim=1); torch.mps.synchronize()"),
+        (
+            "var_mean dim=1",
+            (128, 256),
+            "torch.var_mean(x, dim=1); torch.mps.synchronize()",
+        ),
+        (
+            "std_mean dim=1",
+            (128, 256),
+            "torch.std_mean(x, dim=1); torch.mps.synchronize()",
+        ),
+        ("argmax dim=0", (128, 256), "torch.argmax(x, dim=0); torch.mps.synchronize()"),
+        ("argmax dim=1", (128, 256), "torch.argmax(x, dim=1); torch.mps.synchronize()"),
+        ("argmin dim=1", (128, 256), "torch.argmin(x, dim=1); torch.mps.synchronize()"),
+        ("max dim=0", (128, 256), "torch.max(x, dim=0); torch.mps.synchronize()"),
+        ("max dim=1", (128, 256), "torch.max(x, dim=1); torch.mps.synchronize()"),
+        ("min dim=0", (128, 256), "torch.min(x, dim=0); torch.mps.synchronize()"),
+    ]
+
+    header = f"{'op':<24} {'shape':>14} {'med +/- iqr (us)':>22}"
+    print(header)
+    print("-" * len(header))
+
+    for name, shape, stmt in cases:
+        x = torch.randn(shape, device="mps")
+        result = bench(stmt, {"x": x, "torch": torch}, min_run_time=args.min_time)
+        print(f"{name:<24} {str(shape):>14} {fmt(result):>22}")
+
+
+def run_large(args):
+    print()
+    print("=" * 72)
+    print("LARGE REDUCTIONS")
+    print("=" * 72)
+
+    cases = [
+        ("var dim=1", (1024, 4096), "torch.var(x, dim=1); torch.mps.synchronize()"),
+        (
+            "argmax dim=1",
+            (1024, 4096),
+            "torch.argmax(x, dim=1); torch.mps.synchronize()",
+        ),
+        ("max dim=1", (1024, 4096), "torch.max(x, dim=1); torch.mps.synchronize()"),
+        ("prod dim=1", (1024, 4096), "torch.prod(x, dim=1); torch.mps.synchronize()"),
+    ]
+
+    header = f"{'op':<24} {'shape':>14} {'med +/- iqr (us)':>22}"
+    print(header)
+    print("-" * len(header))
+
+    for name, shape, stmt in cases:
+        x = torch.randn(shape, device="mps")
+        result = bench(stmt, {"x": x, "torch": torch}, min_run_time=args.min_time)
+        print(f"{name:<24} {str(shape):>14} {fmt(result):>22}")
+
+
+def run_variable(args):
+    print()
+    print("=" * 72)
+    print("VARIABLE-SHAPE (20 different shapes)")
+    print("=" * 72)
+
+    import random
+
+    random.seed(42)
+    shapes = [(random.randint(32, 512), random.randint(64, 1024)) for _ in range(20)]
+
+    for op_name, op_fn_str in [
+        ("var dim=0", "torch.var(x, dim=0)"),
+        ("argmax dim=0", "torch.argmax(x, dim=0)"),
+    ]:
+        tensors = [torch.randn(s, device="mps") for s in shapes]
+        stmt = f"for x in tensors:\n    {op_fn_str}\ntorch.mps.synchronize()"
+        result = bench(
+            stmt, {"tensors": tensors, "torch": torch}, min_run_time=args.min_time
+        )
+        per_call = result.median * 1e6 / len(shapes)
+        iqr_per = result.iqr * 1e6 / len(shapes)
+        print(
+            f"{op_name:<24} 20 shapes     {per_call:>8.1f} +/- {iqr_per:>5.1f} us/call"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark MPS reduce ops (Metal vs MPSGraph)"
+    )
+    parser.add_argument("--min-time", type=float, default=2.0)
+    parser.add_argument(
+        "--variable-shapes",
+        action="store_true",
+        help="Include variable-shape cache-swelling test",
+    )
+    args = parser.parse_args()
+
+    print(f"PyTorch {torch.__version__}")
+    print("Benchmark: torch.utils.benchmark.Timer + blocked_autorange")
+    print()
+
+    run_fixed(args)
+    run_large(args)
+    if args.variable_shapes:
+        run_variable(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/operator_benchmark/mps/prod_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/prod_reduce_bench.py
@@ -1,0 +1,60 @@
+"""Benchmark for the native Metal prod reduction vs the MPSGraph implementation
+it replaces.
+
+Run on a build WITH the native kernel and on a build WITHOUT it (e.g. the PR
+parent commit) and compare. Reports two regimes:
+
+  * steady-state: a fixed shape benchmarked warm (torch.utils.benchmark median).
+  * shape-varying: many distinct shapes seen once each -- this is where MPSGraph
+    pays a per-shape graph recompilation (~100ms/shape) the native kernel does
+    not.
+
+Methodology note: the per-shape MPS bench has high run-to-run variance; use the
+interleaved 5-trial median below (not a single sweep) when comparing builds.
+"""
+import time
+
+import torch
+import torch.utils.benchmark as benchmark
+
+STEADY_SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((1_000_000, 8), 1),   # tall-thin: thread-per-row kernel
+    ((2, 8_000_000), 1),   # short-wide: wide inner kernel
+]
+
+
+def steady_state():
+    print("# steady-state prod (median us, warm)")
+    for shape, dim in STEADY_SHAPES:
+        x = torch.randn(*shape, device="mps")
+        torch.mps.synchronize()
+        t = benchmark.Timer(stmt="torch.prod(x, dim=dim); torch.mps.synchronize()",
+                            globals={"x": x, "dim": dim, "torch": torch})
+        us = t.blocked_autorange(min_run_time=0.5).median * 1e6
+        print(f"  {str(shape):20} dim={dim}: {us:8.1f} us")
+        del x
+        torch.mps.empty_cache()
+
+
+def shape_varying(n=200):
+    # n distinct shapes, each reduced once -> exercises per-shape compilation.
+    buf = torch.randn(20_000_000, device="mps")
+    torch.prod(torch.as_strided(buf, (64, 500), (500, 1)), dim=1)  # warm
+    torch.mps.synchronize()
+    t0 = time.time()
+    for i in range(n):
+        N = 999 + i * 101
+        torch.prod(torch.as_strided(buf, (64, N), (N, 1)), dim=1)
+    torch.mps.synchronize()
+    dt = time.time() - t0
+    print(f"# shape-varying prod: {n} distinct shapes = {dt * 1e3:.0f} ms "
+          f"({dt / n * 1e3:.2f} ms/shape)")
+
+
+if __name__ == "__main__":
+    steady_state()
+    shape_varying()

--- a/benchmarks/sweep_reduce.py
+++ b/benchmarks/sweep_reduce.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Full reduce-op perf sweep for MPS — isolated-subprocess per cell, dumps JSON.
+
+Lives in the worktree (benchmarks/mps/sweep_reduce.py) so the PR's perf numbers
+stay reproducible. Run on each build (MPSGraph baseline vs Metal PR), then compare.
+
+Usage:
+  # one cell (used internally per-subprocess):
+  python sweep_reduce.py --cell '{"op":"var","shape":[1024,4096],"dim":-1,"dtype":"float32"}'
+  # full sweep (spawns one fresh subprocess per cell -> avoids cross-cell cache/thermal bleed):
+  python sweep_reduce.py --out /tmp/sweep_<tag>.json
+  # compare two result files:
+  python sweep_reduce.py --compare /tmp/sweep_base.json /tmp/sweep_pr.json
+"""
+
+import argparse
+import itertools
+import json
+import subprocess
+import sys
+
+
+OPS = [
+    "sum",
+    "mean",
+    "nansum",
+    "prod",
+    "var",
+    "std",
+    "var_mean",
+    "std_mean",
+    "argmax",
+    "argmin",
+    "amax",
+    "amin",
+    "max",
+    "min",
+]
+SHAPES = [
+    [128, 256],
+    [1024, 4096],
+    [4096, 1024],
+    [1048576],
+    [256, 256, 256],
+    [8, 2048, 4096],
+    [16, 512, 4096],
+]
+DTYPES = ["float32", "float16", "bfloat16"]
+DIMS = [0, -1, None]
+
+
+def _valid(op, shape, dim):
+    if dim is None and op in ("max", "min"):  # max(dim)/min(dim) need a dim
+        return False
+    if dim is not None and dim >= len(shape):
+        return False
+    if len(shape) == 1 and dim == 0:
+        pass  # 1D dim=0 == all-reduce, allow
+    return True
+
+
+def run_cell(cell):
+    import torch
+    from torch.utils.benchmark import Timer
+
+    dt = getattr(torch, cell["dtype"])
+    shape, dim, op = cell["shape"], cell["dim"], cell["op"]
+    torch.manual_seed(0)
+    if op in ("argmax", "argmin", "amax", "amin", "max", "min") and dt in (
+        torch.float16,
+        torch.bfloat16,
+    ):
+        x = torch.randn(*shape).to(dt).to("mps")
+    else:
+        x = (
+            torch.randn(*shape, dtype=torch.float32).to(dt).to("mps")
+            if dt.is_floating_point
+            else torch.randint(0, 8, shape, dtype=dt).to("mps")
+        )
+    fn = getattr(torch, op)
+    stmt = "fn(x) if d is None else fn(x, dim=d); torch.mps.synchronize()"
+    try:
+        Timer(stmt=stmt, globals={"fn": fn, "x": x, "d": dim}).blocked_autorange(
+            min_run_time=0.3
+        )  # warm
+        m = Timer(stmt=stmt, globals={"fn": fn, "x": x, "d": dim}).blocked_autorange(
+            min_run_time=0.5
+        )
+        return round(m.median * 1e6, 3)
+    except Exception as e:
+        return f"ERR:{type(e).__name__}"
+
+
+def sweep(out):
+    cells = [
+        dict(op=o, shape=s, dim=d, dtype=t)
+        for o, s, t, d in itertools.product(OPS, SHAPES, DTYPES, DIMS)
+        if _valid(o, s, d)
+    ]
+    results = {}
+    for i, c in enumerate(cells):
+        key = f"{c['op']}|{c['shape']}|{c['dim']}|{c['dtype']}"
+        r = subprocess.run(
+            [sys.executable, __file__, "--cell", json.dumps(c)],
+            capture_output=True,
+            text=True,
+        )
+        val = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else "ERR:nostdout"
+        try:
+            results[key] = float(val)
+        except ValueError:
+            results[key] = val
+        print(f"[{i + 1}/{len(cells)}] {key} -> {results[key]}", flush=True)
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"wrote {out} ({len(results)} cells)")
+
+
+def compare(base_f, pr_f):
+    with open(base_f) as f:
+        base = json.load(f)
+    with open(pr_f) as f:
+        pr = json.load(f)
+    wins = matched = regr = 0
+    regr_list = []
+    for k in sorted(set(base) & set(pr)):
+        b, p = base[k], pr[k]
+        if not (isinstance(b, float) and isinstance(p, float)):
+            continue
+        sp = b / p  # speedup of PR over baseline (>1 = faster)
+        if sp > 1.05:
+            wins += 1
+        elif sp < 0.95:
+            regr += 1
+            regr_list.append((k, round(sp, 3), b, p))
+        else:
+            matched += 1
+    print(f"wins(>1.05x): {wins}  matched: {matched}  REGRESSIONS(<0.95x): {regr}")
+    print("worst regressions:")
+    for k, sp, b, p in sorted(regr_list, key=lambda r: r[1])[:20]:
+        print(f"  {sp}x  {k}  base={b} pr={p}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cell")
+    ap.add_argument("--out")
+    ap.add_argument("--compare", nargs=2)
+    a = ap.parse_args()
+    if a.cell:
+        print(run_cell(json.loads(a.cell)))
+    elif a.out:
+        sweep(a.out)
+    elif a.compare:
+        compare(a.compare[0], a.compare[1])

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -120,9 +120,11 @@ inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_sum(T val) {
 
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_prod(T val) {
+  // Fill with 1 (product identity) for inactive lanes in partial simdgroups
+  int2 fill = as_type<int2>(T(1));
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
     val *= as_type<T>(
-        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), fill, i));
   }
   return simd_broadcast(val, 0);
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16122,6 +16122,284 @@ class TestMetalLibrary(TestCaseMPS):
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
 # to achieve this.
+
+class TestReduceOpsMetal(TestCaseMPS):
+    """Tests for Metal kernel reduce ops: prod."""
+
+    # =========================================================================
+    # Product reduction
+    # =========================================================================
+    def test_prod_metal_basic(self):
+        for shape in [(4,), (3, 4), (2, 3, 4), (2, 3, 4, 5)]:
+            for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
+                if dtype in (torch.int32, torch.int64):
+                    cpu_x = torch.randint(1, 3, shape, device='cpu', dtype=dtype)
+                else:
+                    cpu_x = torch.randint(1, 4, shape, device='cpu', dtype=dtype)
+                mps_x = cpu_x.to('mps')
+                # Scalar prod
+                self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+                # Per-dim prod
+                for dim in range(len(shape)):
+                    self.assertEqual(torch.prod(mps_x, dim=dim), torch.prod(cpu_x, dim=dim))
+                    self.assertEqual(
+                        torch.prod(mps_x, dim=dim, keepdim=True),
+                        torch.prod(cpu_x, dim=dim, keepdim=True))
+
+    def test_prod_metal_dtype_promotion(self):
+        cpu_x = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.prod(mps_x, dtype=torch.int64),
+            torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_float_types(self):
+        cpu_x = torch.randn(8, 16, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(torch.prod(mx, dim=1), torch.prod(cx, dim=1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(torch.prod(mx, dim=0), torch.prod(cx, dim=0), atol=1e-2, rtol=1e-2)
+
+    def test_prod_metal_empty(self):
+        cpu_x = torch.empty(0, 3, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_scalar(self):
+        cpu_x = torch.tensor(5.0, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_bool(self):
+        cpu_x = torch.tensor([True, True, False, True], device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+        self.assertEqual(torch.prod(mps_x, dtype=torch.int64), torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_large(self):
+        cpu_x = torch.randint(1, 3, (64, 128), device='cpu', dtype=torch.int32)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x, dim=0), torch.prod(cpu_x, dim=0))
+        self.assertEqual(torch.prod(mps_x, dim=1), torch.prod(cpu_x, dim=1))
+
+    def test_prod_metal_partial_simdgroup_allreduce(self):
+        # 2-pass all-reduce prod where pass 2 lands a PARTIAL simdgroup
+        # (N=21000 -> num_groups=6, not a multiple of 32). The 64-bit
+        # simd_prod<long> (used by int/bool prod) emulates simd reduction via
+        # simd_shuffle_and_fill_down, where an active lane reading an in-range
+        # inactive lane gets garbage (0 on M1/M2 -> the product collapses to 0).
+        # The dispatch rounds the threadgroup up to a full simdgroup to avoid it.
+        # Passes on M4 regardless; this guards the M1/M2 path.
+        for dtype in (torch.int64, torch.int32, torch.bool):
+            cpu_x = torch.ones(21000, device='cpu', dtype=dtype)
+            if dtype is not torch.bool:
+                cpu_x[:3] = 2  # product = 8, distinguishable from a 0 corruption
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(mps_x.prod().cpu(), cpu_x.prod(), f"prod all-reduce {dtype}")
+
+    def test_prod_metal_dtype_cast_matrix(self):
+        # prod(..., dtype=) accepts any (input, output) scalar combo, but native
+        # kernels only cover same-dtype + the natural acc promotions. Every other
+        # combo (half->float small-M, float->long, bool->uint8, ...) must cast to
+        # the output dtype rather than request an unregistered Metal kernel.
+        # Covers dim=0 (outer/small-M), dim=1 (inner) and all-reduce.
+        import itertools
+        dts = (torch.bool, torch.uint8, torch.int16, torch.int32, torch.int64,
+               torch.float16, torch.bfloat16, torch.float32)
+        cpu_base = torch.ones(6, 4, device='cpu')
+        cpu_base[0] = 2     # product over dim 0 == 2 per column; small, no overflow
+        cpu_base[2, 1] = 0  # one zero: exercises 0-product and bool AND -> False
+        for in_dt, out_dt in itertools.product(dts, dts):
+            cpu_x = cpu_base.to(in_dt)
+            mps_x = cpu_x.to('mps')
+            for kw in ({'dim': 0}, {'dim': 1}, {}):
+                self.assertEqual(torch.prod(mps_x, dtype=out_dt, **kw).cpu(),
+                                 torch.prod(cpu_x, dtype=out_dt, **kw),
+                                 f"prod {in_dt}->{out_dt} {kw}")
+
+    def test_prod_metal_noncontiguous(self):
+        cpu_x = torch.randint(1, 4, (4, 6), device='cpu', dtype=torch.float32)
+        mps_x = cpu_x.to('mps')
+        # Transpose makes it non-contiguous
+        cpu_t = cpu_x.t()
+        mps_t = mps_x.t()
+        self.assertEqual(torch.prod(mps_t, dim=0), torch.prod(cpu_t, dim=0))
+        self.assertEqual(torch.prod(mps_t, dim=1), torch.prod(cpu_t, dim=1))
+
+    @unittest.skipIf(not torch.backends.mps.is_available() or
+                     torch.mps.recommended_max_memory() < 16 * 1024**3,
+                     "needs >16GB unified memory for a >2^32-element tensor")
+    def test_prod_metal_allreduce_64bit_index(self):
+        # >2^32 elements exercises 64-bit indexing in the prod two-pass
+        # all-reduce: ones with a single 2 past the uint32 wrap -> prod 2.0. A
+        # 32-bit base offset would wrap and miss the 2 (-> 1.0).
+        n = (1 << 32) + 8192
+        x = torch.ones(n, dtype=torch.float16, device="mps")
+        x[n - 1] = 2.0
+        try:
+            self.assertEqual(torch.prod(x).item(), 2.0, atol=0.01, rtol=0)
+        finally:
+            del x
+            torch.mps.empty_cache()
+
+    def test_prod_metal_bool_fractional(self):
+        # prod(dtype=bool) uses nonzero semantics: a fractional 0.5 is nonzero
+        # -> True. A float->long truncation would make it 0 -> False.
+        for vals in ([0.5, 0.5], [0.5, 0.0], [0.1, 0.2, 0.3]):
+            x = torch.tensor(vals, device="mps")
+            self.assertEqual(torch.prod(x, dtype=torch.bool).item(),
+                             torch.prod(x.cpu(), dtype=torch.bool).item())
+
+    def test_prod_metal_bool_output_unsigned(self):
+        # prod(..., dtype=bool) must work for uint16/32/64: MPS has no scalar ne
+        # for those dtypes, so the bool path uses to(kBool). Match CPU nonzero
+        # semantics across the unsigned + signed-int + float input dtypes.
+        for dt in (torch.uint16, torch.uint32, torch.uint64,
+                   torch.int32, torch.float32):
+            x = torch.tensor([[0, 2, 3], [1, 1, 1]], dtype=dt, device="mps")
+            self.assertEqual(torch.prod(x, dim=1, dtype=torch.bool).cpu(),
+                             torch.prod(x.cpu(), dim=1, dtype=torch.bool))
+
+    def test_prod_metal_half_float_accumulation(self):
+        # MPS prod accumulates float16 in float (opmath/acc_type), matching CUDA
+        # and the MPS sum/var/std convention -- more accurate than CPU's
+        # half-precision accumulation, which drifts ~20% over a long reduction.
+        # Compare to the float-accumulated reference, not CPU.
+        x = torch.full((4096,), 1.0009765625, dtype=torch.float16)
+        self.assertEqual(torch.prod(x.to("mps")).cpu(), torch.prod(x.float()).half())
+
+    def test_prod_metal_unsigned_same_dtype(self):
+        # uint16/32/64 have no native prod kernel and prod is unsupported for
+        # them on CPU too; MPS must raise a clean error, not crash with a Metal
+        # pipeline error or recurse forever (cast-to-self is a no-op).
+        for dt in (torch.uint16, torch.uint32, torch.uint64):
+            x = torch.tensor([[1, 2, 3], [4, 5, 6]]).to(dt).to("mps")
+            with self.assertRaises(RuntimeError):
+                torch.prod(x, dim=1, dtype=dt)
+
+    @unittest.skipIf(not torch.backends.mps.is_available() or
+                     torch.mps.recommended_max_memory() < 20 * 1024**3,
+                     "needs >20GB unified memory for a >2^32-offset partial reduce")
+    def test_prod_metal_partial_reduce_64bit_index(self):
+        # Partial reduce whose per-row base offset (row*N) exceeds 2^32: rows of
+        # ones except a single 2 in the last row -> prod over dim=1 is 2 only in
+        # the last row. A 32-bit row*N base would wrap and miss it.
+        M, N = 5, 1 << 30  # row 4 base = 4*2^30 = 2^32
+        x = torch.ones(M, N, dtype=torch.float16, device="mps")
+        x[M - 1, N - 1] = 2.0
+        try:
+            expected = torch.ones(M, dtype=torch.float16, device="mps")
+            expected[M - 1] = 2.0
+            self.assertEqual(torch.prod(x, dim=1), expected, atol=0.01, rtol=0)
+        finally:
+            del x
+            torch.mps.empty_cache()
+
+    @unittest.skipIf(not torch.backends.mps.is_available() or
+                     torch.mps.recommended_max_memory() < 30 * 1024**3,
+                     "needs >30GB unified memory for a >2^32 single dimension")
+    def test_prod_metal_large_dim_64bit(self):
+        # A single reduced dimension > 2^32 must fall back from the 32-bit
+        # specialized inner kernel to the 64-bit generic path.
+        M, N = 2, (1 << 32) + 8192
+        x = torch.ones(M, N, dtype=torch.float16, device="mps")
+        x[1, N - 1] = 2.0
+        try:
+            expected = torch.tensor([1.0, 2.0], dtype=torch.float16, device="mps")
+            self.assertEqual(torch.prod(x, dim=1), expected, atol=0.01, rtol=0)
+        finally:
+            del x
+            torch.mps.empty_cache()
+
+    def test_prod_metal_complex_dtype(self):
+        # Complex prod with an explicit real dtype casts per element before
+        # reducing (CPU semantics), not complex-product-then-cast.
+        for dt in (torch.float32, torch.float16):
+            x = torch.tensor([1 + 2j, 3 + 4j], device="mps")
+            self.assertEqual(torch.prod(x, dtype=dt).item(),
+                             torch.prod(x.cpu(), dtype=dt).item())
+
+    def test_prod_metal_wide_inner_few_rows(self):
+        # Few rows of a huge reduced dim (M < 64) route to the wide inner kernel
+        # (one threadgroup per row); must match CPU. Values near 1 keep the
+        # product in range.
+        torch.manual_seed(0)
+        for M, N in [(2, 2_000_000), (8, 500_000)]:
+            x = (1.0 + 0.001 * torch.randn(M, N)).to("mps")
+            self.assertEqual(torch.prod(x, dim=1).cpu(),
+                             torch.prod(x.cpu(), dim=1), rtol=1e-3, atol=1e-3)
+        # int wide path is exact (long accumulator)
+        xi = torch.ones(2, 1_000_000, dtype=torch.int32)
+        xi[:, ::500] = 2
+        self.assertEqual(torch.prod(xi.to("mps"), dim=1).cpu(),
+                         torch.prod(xi, dim=1))
+
+    def test_prod_metal_thin_inner_small_n(self):
+        # Tall-thin (small N, large M) routes to the thread-per-row thin kernel
+        # (N<=32); must match CPU across dtypes and across the N=32/33 boundary.
+        torch.manual_seed(0)
+        for M, N in [(100000, 8), (20000, 32), (20000, 33)]:
+            for dt in (torch.float32, torch.float16, torch.bfloat16):
+                x = (1.0 + 0.001 * torch.randn(M, N)).to(dt)
+                self.assertEqual(torch.prod(x.to("mps"), dim=1).cpu(),
+                                 torch.prod(x, dim=1), rtol=1e-2, atol=1e-2)
+        # int thin path is exact (long accumulator)
+        xi = torch.ones(100000, 8, dtype=torch.int32)
+        xi[:, ::4] = 2
+        self.assertEqual(torch.prod(xi.to("mps"), dim=1).cpu(), torch.prod(xi, dim=1))
+
+    def test_prod_metal_rank_guard(self):
+        # A rank-17 view (reachable via as_strided past the factory rank check)
+        # hits the generic NormParams path, whose per-dim arrays are sized for
+        # max_ndim=16; ranks above 16 must raise cleanly, not index past storage.
+        x = torch.as_strided(torch.ones(1, device="mps"), (1,) * 17, (0,) * 17)
+        with self.assertRaises(RuntimeError):
+            torch.prod(x)
+
+    def test_prod_metal_zero_stride_exact_2gb_extent(self):
+        # A reduced extent that is an exact 2^32 multiple (here via a zero-stride
+        # view, so no large allocation) must not wrap the threadgroup size to 0
+        # and crash at dispatch. prod of 2^32 ones is 1.
+        x = torch.as_strided(torch.ones(1, device="mps"), (2, 1 << 32), (0, 0))
+        self.assertEqual(torch.prod(x, dim=1), torch.ones(2, device="mps"))
+
+    @unittest.skipIf(not torch.backends.mps.is_available() or
+                     torch.mps.recommended_max_memory() < 12 * 1024**3,
+                     "needs >12GB unified memory for a >2^32 reduced stride")
+    def test_prod_metal_large_reduced_stride_64bit(self):
+        # A reduced-dim stride > 2^32 (via as_strided over a >2^32-element
+        # storage) must not truncate to 32 bits: prod reads base[0]*base[1<<32].
+        n = (1 << 32) + 1
+        base = torch.ones(n, dtype=torch.uint8, device="mps")
+        base[1 << 32] = 2
+        x = torch.as_strided(base, (1, 2), (0, 1 << 32))
+        try:
+            self.assertEqual(torch.prod(x, dim=1).item(), 2)
+        finally:
+            del base, x
+            torch.mps.empty_cache()
+
+    @unittest.skipIf(not torch.backends.mps.is_available() or
+                     torch.mps.recommended_max_memory() < 16 * 1024**3,
+                     "needs >16GB unified memory for a >2^32-element tensor")
+    def test_prod_metal_prime_allreduce_64bit(self):
+        # A prime element count > 2^32 forces num_groups==1 in the two-pass
+        # all-reduce, so elems_per_group == total_N > 2^32 and must not be
+        # truncated to 32 bits (a 32-bit reduction_size / elems_per_group would
+        # wrap and reduce only the low bits, missing the 2 in the last element).
+        n = 4294967311  # smallest prime > 2^32
+        x = torch.ones(n, dtype=torch.float16, device="mps")
+        x[n - 1] = 2.0
+        try:
+            self.assertEqual(torch.prod(x).item(), 2.0, atol=0.01, rtol=0)
+        finally:
+            del x
+            torch.mps.empty_cache()
+
+
+instantiate_parametrized_tests(TestReduceOpsMetal)
+
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")


### PR DESCRIPTION
Part of #187455.

## Summary
Replaces the MPSGraph `prod` reduction on MPS with native Metal kernels (generic + outer/inner + small-M variants) across the full dtype matrix, removing the per-shape MPSGraph graph-cache path for `prod`. var/std, argmax/argmin and min/max stay on the existing path. Split out of #182255 per the request to break it into smaller pieces.

Root cause for the partial-simdgroup fix: `prod_reduction` reduces via `c10::metal::simd_prod<long>` (int and bool route through the 64-bit long accumulator), which emulates the 64-bit simd reduction with `simd_shuffle_and_fill_down`. The fill substitutes only out-of-range source lanes, NOT in-range inactive lanes in a partial simdgroup, which return undefined data (0 on M1/M2, benign on M4) and collapse the product to 0. Fix rounds every `prod_reduction` dispatch's threadgroup count up to a multiple of `simdgroup_size` (`round_up(N, 32)`) so the simdgroup is always full and padding threads carry the prod identity 1 (same round-up min/max already applies).

Additional correctness fixes: 64-bit element addressing throughout the NormParams prod kernels and the int64 NormParams descriptor (no >2^32-element wrap, incl. prime element counts forcing the generic all-reduce path); `prod(..., dtype=bool)` uses `to(bool)` nonzero semantics (also covers unsigned uint16/32/64 which lack a scalar `ne` kernel); complex prod with explicit real `dtype=` casts per element before reducing; uint16/32/64 output (unsupported on CPU too) raises a clear "not implemented" error instead of recursing forever; generic prod path guards `input.dim() <= max_ndim` (16) against a rank-17 as_strided view.

## Checklist
- [ ] Lint clean (`spin fixlint` / `lintrunner -a`)
- [x] Tests added/updated in `test/test_mps.py` (incl. `test_prod_metal_partial_simdgroup_allreduce`; `-k "64bit_index or large_dim or prime_allreduce"` gated on >=16-30GB unified memory) and `test/test_ops.py -k "prod and mps"` (OpInfo consistency)
- [x] Benchmark script committed under `benchmarks/operator_benchmark/mps/`

Test Plan:
```
PYTORCH_TEST_MPS=1 python test/test_mps.py -k prod
PYTORCH_TEST_MPS=1 python test/test_ops.py -k "prod and mps"
PYTORCH_TEST_MPS=1 python test/test_mps.py -k "64bit_index or large_dim or prime_allreduce"
```

## BC-breaking?
Two silent numeric/behavior changes:
- **float16 prod now accumulates in float** (opmath_t / acc_type), matching CUDA and the MPS sum/var/std convention. More accurate than CPU's half-precision accumulation (which drifts ~20% over a long reduction); the half tests compare against a float-accumulated reference, not CPU bit-parity.
- **`prod` with a uint16/32/64 output now raises** a clear "not implemented" error up front (no native kernel; prod is unsupported for those dtypes on CPU too) instead of recursing forever in the cast-and-recurse path.

Otherwise no BC break.

## Perf
Measured vs the MPSGraph reduction this replaces (M4 Pro); benchmark script in `benchmarks/operator_benchmark/mps/`. Per-shape figures present in the current body:
- Shape-varying workloads: ~42x faster (MPSGraph recompiles a graph per unique shape ~124ms/shape; native kernel JIT-compiles once per dtype then runs ~3ms/shape) — the main win for dynamic-shape models.
- Steady-state (warm, fixed shape): 1.7-1.96x on common square/inner/outer/all-reduce shapes; parity (0.96-1.01x median) elsewhere. High run-to-run variance (a shape reads 0.5-1.6x across runs), so 5-trial medians + an interleaved native-vs-MPSGraph harness are used.
- Small-M large-N (e.g. [2, ~8M]): wide inner-dim kernel (one threadgroup/row, up to 1024 threads, mirroring var/std's welford_inner_wide) dispatched when M < 64; drops ~10ms -> ~1ms with no change to common square shapes.
- Tall-thin large-M small-N (e.g. [1M, 8]): thread-per-row thin kernel for N<=32 brings the previously ~11x-slower simd-per-row case to parity-or-win.

Authored by Claude.