### PR TITLE
[ao][pruning] Add experimental topology-aware modules

### DIFF
--- a/test/ao/sparsity/test_topology_rigorous.py
+++ b/test/ao/sparsity/test_topology_rigorous.py
@@ -1,0 +1,579 @@
+# Owner(s): ["module: sparse"]
+# ruff: noqa: S101
+
+import importlib.util
+import io
+import os
+import pathlib
+import sys
+import unittest
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint
+
+
+try:
+    from torch.testing._internal.common_utils import raise_on_run_directly
+except (ImportError, ModuleNotFoundError):
+    raise_on_run_directly = None
+
+
+try:
+    from torch.ao.pruning._experimental.topology import (
+        LyapunovSpectralGuard,
+        SpectralPrototypeEmbedding,
+        TopologicalSpectralAttention,
+        TopologyGatedLowRankLinear,
+    )
+except ModuleNotFoundError:
+    if os.environ.get("PYTORCH_TEST_TOPOLOGY_SOURCE_FALLBACK") != "1":
+        raise
+    _ROOT = pathlib.Path(__file__).resolve().parents[3]
+    _TOPOLOGY = _ROOT / "torch" / "ao" / "pruning" / "_experimental" / "topology"
+    _SPEC = importlib.util.spec_from_file_location(
+        "topology_under_test",
+        _TOPOLOGY / "__init__.py",
+        submodule_search_locations=[str(_TOPOLOGY)],
+    )
+    _MODULE = importlib.util.module_from_spec(_SPEC)
+    sys.modules["topology_under_test"] = _MODULE
+    assert _SPEC.loader is not None
+    _SPEC.loader.exec_module(_MODULE)
+    LyapunovSpectralGuard = _MODULE.LyapunovSpectralGuard
+    SpectralPrototypeEmbedding = _MODULE.SpectralPrototypeEmbedding
+    TopologicalSpectralAttention = _MODULE.TopologicalSpectralAttention
+    TopologyGatedLowRankLinear = _MODULE.TopologyGatedLowRankLinear
+
+
+def _rank1_linear(in_features=8, out_features=6, bias=True, device="cpu"):
+    linear = torch.nn.Linear(in_features, out_features, bias=bias, device=device)
+    with torch.no_grad():
+        u = torch.linspace(1.0, 2.0, out_features, device=device).unsqueeze(1)
+        v = torch.linspace(-0.5, 0.5, in_features, device=device).unsqueeze(0)
+        linear.weight.copy_(u @ v)
+        if bias:
+            linear.bias.copy_(torch.linspace(-0.1, 0.1, out_features, device=device))
+    return linear
+
+
+def _community_embedding(device="cpu"):
+    embedding = torch.nn.Embedding(8, 3, device=device)
+    with torch.no_grad():
+        embedding.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [-1.0, 0.5, 0.0],
+                    [-1.0, 0.5, 0.0],
+                    [-1.0, 0.5, 0.0],
+                    [-1.0, 0.5, 0.0],
+                ],
+                device=device,
+            )
+        )
+    return embedding
+
+
+class TestTopologyGatedLowRankLinearRigorous(unittest.TestCase):
+    def test_constructor_validation_and_counts(self):
+        with pytest.raises(ValueError, match="energy_threshold"):
+            TopologyGatedLowRankLinear(2, 2, energy_threshold=0.0)
+        with pytest.raises(ValueError, match="max_rank"):
+            TopologyGatedLowRankLinear(2, 2, max_rank=0)
+        with pytest.raises(ValueError, match="min_compression_ratio"):
+            TopologyGatedLowRankLinear(2, 2, min_compression_ratio=1.0)
+        module = TopologyGatedLowRankLinear(3, 4, bias=True)
+        assert module.dense_parameter_count() == 16
+        assert module.compressed_parameter_count(rank=1) == 11
+        assert module.compressed_parameter_count() == 25
+        assert "is_compressed=False" in module.extra_repr()
+        no_bias = TopologyGatedLowRankLinear(3, 4, bias=False)
+        assert no_bias.dense_parameter_count() == 12
+        no_bias.reset_parameters()
+
+    def test_factory_forward_fallback_and_tiny_edge_case(self):
+        dense = torch.nn.Linear(1, 1)
+        module = TopologyGatedLowRankLinear.from_linear(dense)
+        x = torch.empty(0, 1)
+        torch.testing.assert_close(module(x), dense(x))
+        assert not module.try_compress()
+        torch.testing.assert_close(module(torch.ones(2, 1)), dense(torch.ones(2, 1)))
+
+    def test_compressed_forward_matches_rank1_dense_and_is_deterministic(self):
+        torch.manual_seed(123)
+        dense = _rank1_linear()
+        module = TopologyGatedLowRankLinear.from_linear(
+            dense,
+            energy_threshold=0.999,
+            max_rank=1,
+            min_compression_ratio=1.2,
+        )
+        x = torch.randn(4, 8)
+        expected = dense(x)
+        assert module.try_compress()
+        assert module.try_compress()
+        torch.testing.assert_close(module(x), expected, atol=1e-5, rtol=1e-5)
+        assert module.compressed_parameter_count() == 20
+        assert "is_compressed=True" in module.extra_repr()
+
+        torch.manual_seed(123)
+        dense_again = _rank1_linear()
+        module_again = TopologyGatedLowRankLinear.from_linear(
+            dense_again,
+            energy_threshold=0.999,
+            min_compression_ratio=1.2,
+        )
+        assert module_again.try_compress()
+        torch.testing.assert_close(module(x), module_again(x), atol=0, rtol=0)
+
+        full_rank = torch.nn.Linear(4, 4, bias=False)
+        with torch.no_grad():
+            full_rank.weight.copy_(torch.eye(4))
+        clipped = TopologyGatedLowRankLinear.from_linear(
+            full_rank,
+            energy_threshold=0.99,
+            max_rank=1,
+            min_compression_ratio=1.1,
+        )
+        assert not clipped.try_compress()
+
+    def test_gradients_flow_and_training_loss_decreases_after_compression(self):
+        torch.manual_seed(0)
+        teacher = _rank1_linear()
+        module = TopologyGatedLowRankLinear.from_linear(teacher, energy_threshold=0.999, min_compression_ratio=1.2)
+        assert module.try_compress()
+        x = torch.randn(32, 8)
+        target = teacher(x).detach() + 0.1
+        opt = torch.optim.SGD(module.parameters(), lr=0.2)
+        first_loss = None
+        for _ in range(10):
+            opt.zero_grad()
+            loss = F.mse_loss(module(x), target)
+            if first_loss is None:
+                first_loss = loss.detach()
+            loss.backward()
+            assert module.low_rank_left.grad is not None
+            assert module.low_rank_right.grad is not None
+            opt.step()
+        assert loss < first_loss
+
+    def test_optimizer_state_is_rewritten_when_compressing_after_warmup(self):
+        torch.manual_seed(0)
+        teacher = _rank1_linear()
+        module = TopologyGatedLowRankLinear.from_linear(teacher, energy_threshold=0.999, min_compression_ratio=1.2)
+        opt = torch.optim.Adam(module.parameters(), lr=0.01)
+        x = torch.randn(8, 8)
+        F.mse_loss(module(x), teacher(x).detach()).backward()
+        opt.step()
+        old_weight = module.weight
+        assert old_weight in opt.state
+
+        assert module.try_compress(optimizer=opt)
+        assert old_weight not in opt.state
+        assert all(param is not old_weight for group in opt.param_groups for param in group["params"])
+        assert any(param is module.low_rank_left for group in opt.param_groups for param in group["params"])
+        assert any(param is module.low_rank_right for group in opt.param_groups for param in group["params"])
+
+    def test_state_dict_and_torch_save_round_trip_after_compression(self):
+        dense = _rank1_linear()
+        module = TopologyGatedLowRankLinear.from_linear(dense, energy_threshold=0.999, min_compression_ratio=1.2)
+        assert module.try_compress()
+        x = torch.randn(3, 8)
+        expected = module(x)
+
+        loaded = TopologyGatedLowRankLinear(8, 6)
+        loaded.load_state_dict(module.state_dict())
+        assert loaded.is_compressed
+        torch.testing.assert_close(loaded(x), expected)
+
+        buffer = io.BytesIO()
+        torch.save(module.state_dict(), buffer)
+        buffer.seek(0)
+        round_tripped_state = torch.load(buffer)
+        round_tripped = TopologyGatedLowRankLinear(8, 6)
+        round_tripped.load_state_dict(round_tripped_state)
+        torch.testing.assert_close(round_tripped(x), expected)
+
+    def test_internal_edge_paths_and_dense_reload_after_compression(self):
+        dense = _rank1_linear(bias=False)
+        module = TopologyGatedLowRankLinear.from_linear(dense, energy_threshold=0.999, min_compression_ratio=1.2)
+        assert module._target_rank(torch.empty(0)) is None
+        assert module._target_rank(torch.zeros(2)) is None
+        assert module.try_compress()
+        compressed_state = module.state_dict()
+        module.low_rank_left = None
+        with pytest.raises(RuntimeError, match="factors are missing"):
+            module(torch.randn(2, 8))
+
+        dense_state = TopologyGatedLowRankLinear.from_linear(dense).state_dict()
+        module.load_state_dict(dense_state)
+        assert not module.is_compressed
+        x = torch.randn(2, 8)
+        torch.testing.assert_close(module(x), dense(x))
+
+        wrong_shape = TopologyGatedLowRankLinear(2, 2, bias=False)
+        with pytest.raises(RuntimeError, match="size mismatch for low-rank checkpoint"):
+            wrong_shape.load_state_dict(compressed_state)
+
+    def test_half_precision_compression_and_state_load_device_dtype(self):
+        dense = _rank1_linear().half()
+        module = TopologyGatedLowRankLinear.from_linear(dense, energy_threshold=0.999, min_compression_ratio=1.2)
+        assert module.try_compress()
+        assert module.low_rank_left.dtype == torch.float16
+
+        if torch.cuda.is_available():
+            target = TopologyGatedLowRankLinear(8, 6, device="cuda", dtype=torch.float16)
+            target.load_state_dict({name: value.cpu() for name, value in module.state_dict().items()})
+            assert target.low_rank_left.device.type == "cuda"
+            assert target.low_rank_left.dtype == torch.float16
+
+    def test_checkpoint_compile_and_amp_compatibility(self):
+        dense = _rank1_linear()
+        module = TopologyGatedLowRankLinear.from_linear(dense, energy_threshold=0.999, min_compression_ratio=1.2)
+        assert module.try_compress()
+        x = torch.randn(2, 8, requires_grad=True)
+        out = checkpoint(module, x, use_reentrant=False)
+        out.sum().backward()
+        assert x.grad is not None
+
+        compiled = torch.compile(module, backend="eager")
+        torch.testing.assert_close(compiled(x.detach()), module(x.detach()))
+
+        if torch.cuda.is_available():
+            cuda_module = module.cuda()
+            cuda_x = x.detach().cuda()
+            with torch.autocast(device_type="cuda", dtype=torch.float16):
+                amp_out = cuda_module(cuda_x)
+            assert amp_out.dtype == torch.float16
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA memory check requires a GPU")
+    @pytest.mark.skipif(os.environ.get("PYTORCH_TEST_TOPOLOGY_MEMORY") != "1", reason="allocator-sensitive memory check is opt-in")
+    def test_gpu_peak_memory_is_lower_than_dense_baseline(self):
+        device = "cuda"
+        torch.cuda.empty_cache()
+        dense = _rank1_linear(2048, 2048, device=device)
+        x = torch.randn(16, 2048, device=device, requires_grad=True)
+        torch.cuda.reset_peak_memory_stats()
+        dense(x).sum().backward()
+        dense_peak = torch.cuda.max_memory_allocated()
+        del dense, x
+        torch.cuda.empty_cache()
+
+        dense_for_compression = _rank1_linear(2048, 2048, device=device)
+        compressed = TopologyGatedLowRankLinear.from_linear(
+            dense_for_compression,
+            energy_threshold=0.999,
+            min_compression_ratio=10.0,
+        )
+        assert compressed.try_compress()
+        del dense_for_compression
+        torch.cuda.empty_cache()
+        x = torch.randn(16, 2048, device=device, requires_grad=True)
+        torch.cuda.reset_peak_memory_stats()
+        compressed(x).sum().backward()
+        compressed_peak = torch.cuda.max_memory_allocated()
+        assert compressed_peak < dense_peak
+
+
+class TestSpectralPrototypeEmbeddingRigorous(unittest.TestCase):
+    def test_constructor_validation_observation_and_empty_graph_fallback(self):
+        with pytest.raises(ValueError, match="num_prototypes"):
+            SpectralPrototypeEmbedding(4, 2, num_prototypes=0)
+        with pytest.raises(ValueError, match="min_observations"):
+            SpectralPrototypeEmbedding(4, 2, num_prototypes=2, min_observations=0)
+        with pytest.raises(ValueError, match="window_size"):
+            SpectralPrototypeEmbedding(4, 2, num_prototypes=2, window_size=0)
+        module = SpectralPrototypeEmbedding(1000, 4, num_prototypes=4, min_observations=2)
+        module.observe_tokens(torch.empty(0, dtype=torch.long))
+        module.observe_tokens(torch.full((2,), -1, dtype=torch.long))
+        assert not module.try_compress()
+        assert "cooccurrence" not in module.state_dict()
+        assert "edge_index" not in module.state_dict()
+        assert "edge_weight" not in module.state_dict()
+        assert "token_counts" not in module.state_dict()
+        padded = SpectralPrototypeEmbedding(4, 2, num_prototypes=2, padding_idx=0, min_observations=1)
+        assert torch.count_nonzero(padded.weight[0]) == 0
+        padded.observe_tokens(torch.tensor([[0, 1, 0]]))
+        assert padded.token_counts[0] == 0
+        assert padded._spectral_assignments() is None
+
+        options = torch.nn.Embedding(4, 2, max_norm=1.5, scale_grad_by_freq=True, sparse=True)
+        copied = SpectralPrototypeEmbedding.from_embedding(options, num_prototypes=2)
+        assert copied.max_norm == options.max_norm
+        assert copied.scale_grad_by_freq == options.scale_grad_by_freq
+        assert copied.sparse == options.sparse
+
+    def test_compression_forward_numerics_and_fallback(self):
+        embedding = _community_embedding()
+        module = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=2, min_observations=4)
+        tokens = torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]])
+        module.observe_tokens(tokens)
+        assert module.try_compress()
+        assert module.try_compress()
+        assert module.is_compressed
+        torch.testing.assert_close(module(tokens), embedding(tokens), atol=1e-6, rtol=1e-6)
+
+        fallback = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=2, min_observations=100)
+        assert not fallback.try_compress()
+        torch.testing.assert_close(fallback(tokens), embedding(tokens))
+
+    def test_compressed_embedding_preserves_padding_and_index_errors(self):
+        embedding = _community_embedding()
+        embedding.padding_idx = 0
+        with torch.no_grad():
+            embedding.weight[0].zero_()
+        module = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=3, min_observations=4)
+        tokens = torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]])
+        module.observe_tokens(tokens)
+        assert module.try_compress()
+        assert module.edge_index.numel() == 0
+        out = module(tokens)
+        torch.testing.assert_close(out[0, 0], torch.zeros(3))
+        out.sum().backward()
+        torch.testing.assert_close(module.prototype_weight.grad[0], torch.zeros(3))
+        with pytest.raises(IndexError):
+            module(torch.tensor([-1]))
+        with pytest.raises(IndexError):
+            module(torch.tensor([8]))
+
+    def test_embedding_optimizer_state_is_rewritten_when_compressing_after_warmup(self):
+        embedding = _community_embedding()
+        module = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=2, min_observations=4)
+        module.observe_tokens(torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]))
+        opt = torch.optim.Adam(module.parameters(), lr=0.01)
+        tokens = torch.tensor([0, 1, 4, 5])
+        F.mse_loss(module(tokens), embedding(tokens).detach()).backward()
+        opt.step()
+        old_weight = module.weight
+        assert old_weight in opt.state
+
+        assert module.try_compress(optimizer=opt)
+        assert old_weight not in opt.state
+        assert all(param is not old_weight for group in opt.param_groups for param in group["params"])
+        assert any(param is module.prototype_weight for group in opt.param_groups for param in group["params"])
+
+    def test_padding_single_token_rows_runtime_error_and_dense_reload(self):
+        embedding = torch.nn.Embedding(4, 2, padding_idx=0)
+        module = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=2, min_observations=2)
+        module.observe_tokens(torch.tensor([[1], [2]]))
+        assert not module.try_compress()
+
+        compressed = SpectralPrototypeEmbedding.from_embedding(_community_embedding(), num_prototypes=2, min_observations=4)
+        compressed.observe_tokens(torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]))
+        assert compressed.try_compress()
+        compressed.prototype_weight = None
+        with pytest.raises(RuntimeError, match="prototype weights are missing"):
+            compressed(torch.tensor([0]))
+
+        dense_state = SpectralPrototypeEmbedding.from_embedding(_community_embedding(), num_prototypes=2).state_dict()
+        compressed.load_state_dict(dense_state)
+        assert not compressed.is_compressed
+
+    def test_gradients_training_determinism_and_serialization(self):
+        torch.manual_seed(7)
+        embedding = _community_embedding()
+        module = SpectralPrototypeEmbedding.from_embedding(embedding, num_prototypes=2, min_observations=4)
+        module.observe_tokens(torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]))
+        assert module.try_compress()
+        tokens = torch.tensor([0, 1, 4, 5])
+        target = torch.zeros(4, 3)
+        opt = torch.optim.SGD(module.parameters(), lr=0.2)
+        first_loss = None
+        for _ in range(8):
+            opt.zero_grad()
+            loss = F.mse_loss(module(tokens), target)
+            if first_loss is None:
+                first_loss = loss.detach()
+            loss.backward()
+            assert module.prototype_weight.grad is not None
+            opt.step()
+        assert loss < first_loss
+
+        torch.manual_seed(7)
+        module2 = SpectralPrototypeEmbedding.from_embedding(_community_embedding(), num_prototypes=2, min_observations=4)
+        module2.observe_tokens(torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]))
+        assert module2.try_compress()
+        torch.testing.assert_close(module2(tokens), _community_embedding()(tokens))
+
+        loaded = SpectralPrototypeEmbedding(8, 3, num_prototypes=2)
+        loaded.load_state_dict(module.state_dict())
+        assert loaded.is_compressed
+        torch.testing.assert_close(loaded(tokens), module(tokens))
+
+        buffer = io.BytesIO()
+        torch.save(module.state_dict(), buffer)
+        buffer.seek(0)
+        round_tripped_state = torch.load(buffer)
+        round_tripped = SpectralPrototypeEmbedding(8, 3, num_prototypes=2)
+        round_tripped.load_state_dict(round_tripped_state)
+        torch.testing.assert_close(round_tripped(tokens), module(tokens))
+
+    def test_checkpoint_compile_amp_and_zero_length_inputs(self):
+        module = SpectralPrototypeEmbedding.from_embedding(_community_embedding(), num_prototypes=2, min_observations=4)
+        module.observe_tokens(torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]))
+        assert module.try_compress()
+        tokens = torch.tensor([], dtype=torch.long)
+        assert module(tokens).shape == (0, 3)
+
+        tokens = torch.tensor([0, 4])
+        mapped = module.token_to_prototype[tokens]
+        out = checkpoint(lambda weight: F.embedding(mapped, weight).sum(), module.prototype_weight, use_reentrant=False)
+        out.backward()
+        assert module.prototype_weight.grad is not None
+
+        compiled = torch.compile(module, backend="eager")
+        torch.testing.assert_close(compiled(torch.tensor([0, 4])), module(torch.tensor([0, 4])))
+
+        if torch.cuda.is_available():
+            cuda_module = module.cuda()
+            with torch.autocast(device_type="cuda", dtype=torch.float16):
+                out = cuda_module(torch.tensor([0, 4], device="cuda"))
+            assert out.dtype == torch.float32
+
+
+class TestTopologicalSpectralAttentionRigorous(unittest.TestCase):
+    def test_constructor_validation_and_dense_fallbacks(self):
+        with pytest.raises(ValueError, match="min_seq_len"):
+            TopologicalSpectralAttention(min_seq_len=0)
+        with pytest.raises(ValueError, match="num_clusters"):
+            TopologicalSpectralAttention(num_clusters=0)
+        with pytest.raises(ValueError, match="spectral_gap"):
+            TopologicalSpectralAttention(spectral_gap_threshold=-1.0)
+        module = TopologicalSpectralAttention(min_seq_len=8, num_clusters=2)
+        q = torch.randn(1, 2, 0, 4)
+        out = module(q, q, q)
+        assert out.shape == q.shape
+        q = torch.randn(1, 2, 4, 4)
+        mask = torch.zeros(4, 4)
+        torch.testing.assert_close(
+            module(q, q, q, attn_mask=mask),
+            F.scaled_dot_product_attention(q, q, q, attn_mask=mask, dropout_p=0.0),
+        )
+        no_structure = TopologicalSpectralAttention(min_seq_len=1, num_clusters=2)
+        flat = torch.zeros(1, 1, 4, 4)
+        assert no_structure._cluster_assignments(flat) is None
+        too_many_clusters = TopologicalSpectralAttention(min_seq_len=1, num_clusters=4)
+        assert too_many_clusters._cluster_assignments(torch.randn(1, 1, 4, 4)) is None
+        no_gap = TopologicalSpectralAttention(min_seq_len=1, num_clusters=2, spectral_gap_threshold=100.0)
+        assert no_gap._cluster_assignments(torch.randn(1, 1, 5, 4)) is None
+        causal = TopologicalSpectralAttention(min_seq_len=1, num_clusters=2, is_causal=True)
+        torch.testing.assert_close(
+            causal(q, q, q),
+            F.scaled_dot_product_attention(q, q, q, dropout_p=0.0, is_causal=True),
+        )
+
+    def test_eval_disables_attention_dropout(self):
+        module = TopologicalSpectralAttention(min_seq_len=8, dropout_p=0.9).eval()
+        q = torch.randn(1, 2, 4, 4)
+        torch.testing.assert_close(module(q, q, q), F.scaled_dot_product_attention(q, q, q, dropout_p=0.0))
+
+    def test_cluster_size_bias_matches_dense_for_identical_members(self):
+        module = TopologicalSpectralAttention(min_seq_len=1, num_clusters=2).eval()
+        query = torch.tensor([[[[1.0, 0.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [1.0, 0.0], [-1.0, 0.0]]]])
+        value = torch.tensor([[[[2.0, 0.0], [2.0, 0.0], [-4.0, 0.0]]]])
+        assignments = torch.tensor([0, 0, 1])
+        torch.testing.assert_close(
+            module._clustered_attention(query, key, value, assignments, None),
+            F.scaled_dot_product_attention(query, key, value, dropout_p=0.0),
+        )
+
+    def test_clustered_attention_empty_representatives_falls_back(self):
+        module = TopologicalSpectralAttention(min_seq_len=1, num_clusters=2)
+        q = torch.randn(1, 1, 3, 4)
+        assignments = torch.full((3,), 9, dtype=torch.long)
+        torch.testing.assert_close(
+            module._clustered_attention(q, q, q, assignments, None),
+            F.scaled_dot_product_attention(q, q, q, dropout_p=0.0),
+        )
+
+    def test_clustered_path_shape_gradients_determinism_checkpoint_and_compile(self):
+        torch.manual_seed(9)
+        module = TopologicalSpectralAttention(min_seq_len=4, num_clusters=2, spectral_gap_threshold=0.05)
+        base = torch.tensor([[2.0, 0, 0, 0], [2.1, 0, 0, 0], [-2.0, 0, 0, 0], [-2.1, 0, 0, 0]])
+        q = base.view(1, 1, 4, 4).requires_grad_()
+        k = q.clone().detach().requires_grad_()
+        v = torch.arange(16, dtype=torch.float32).view(1, 1, 4, 4).requires_grad_()
+        assert module._cluster_assignments(k) is not None
+        out = module(q, k, v)
+        assert out.shape == v.shape
+        out.sum().backward()
+        assert q.grad is not None
+        assert k.grad is not None
+        assert v.grad is not None
+
+        torch.manual_seed(9)
+        module2 = TopologicalSpectralAttention(min_seq_len=4, num_clusters=2, spectral_gap_threshold=0.05)
+        torch.testing.assert_close(module2(q.detach(), k.detach(), v.detach()), out.detach())
+
+        q2 = q.detach().requires_grad_()
+        checkpoint_out = checkpoint(lambda x: module(x, x, v.detach()), q2, use_reentrant=False)
+        assert checkpoint_out.shape == v.shape
+
+        compile_module = TopologicalSpectralAttention(min_seq_len=8, num_clusters=2)
+        compiled = torch.compile(compile_module, backend="eager", fullgraph=True)
+        torch.testing.assert_close(
+            compiled(q.detach(), k.detach(), v.detach()),
+            F.scaled_dot_product_attention(q.detach(), k.detach(), v.detach(), dropout_p=0.0),
+        )
+
+    def test_amp_dense_path_on_cuda(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA AMP requires a GPU")
+        module = TopologicalSpectralAttention(min_seq_len=8, num_clusters=2).cuda()
+        q = torch.randn(1, 2, 4, 8, device="cuda")
+        with torch.autocast(device_type="cuda", dtype=torch.float16):
+            out = module(q, q, q)
+        assert out.dtype == torch.float16
+
+
+class TestLyapunovSpectralGuardRigorous(unittest.TestCase):
+    def test_constructor_validation_observe_accept_reject_and_relative_math(self):
+        with pytest.raises(ValueError, match="warmup_steps"):
+            LyapunovSpectralGuard(warmup_steps=0)
+        with pytest.raises(ValueError, match="max_loss"):
+            LyapunovSpectralGuard(max_loss_relative_increase=-0.1)
+        with pytest.raises(ValueError, match="max_spectral"):
+            LyapunovSpectralGuard(max_spectral_relative_increase=-0.1)
+        with pytest.raises(ValueError, match="history_size"):
+            LyapunovSpectralGuard(history_size=0)
+        with pytest.raises(ValueError, match="history_size"):
+            LyapunovSpectralGuard(warmup_steps=4, history_size=3)
+        assert LyapunovSpectralGuard._relative_increase(0.0, 1.0) > 0
+        assert not LyapunovSpectralGuard(warmup_steps=2).accept(loss=1.0, spectral_energy=1.0)
+
+        guard = LyapunovSpectralGuard(warmup_steps=2, max_loss_relative_increase=0.1, max_spectral_relative_increase=0.1)
+        assert not guard.observe(loss=1.0, spectral_energy=2.0)
+        assert guard.observe(loss=torch.tensor(1.0), spectral_energy=torch.tensor(2.0))
+        assert guard.accept(loss=1.05, spectral_energy=2.1)
+        assert guard.reject(loss=1.5, spectral_energy=2.1)
+
+    def test_snapshot_rollback_and_state_dict_round_trip(self):
+        module = torch.nn.Linear(3, 2)
+        snapshot = LyapunovSpectralGuard.snapshot_module(module)
+        with torch.no_grad():
+            module.weight.add_(3.0)
+        LyapunovSpectralGuard.rollback_module(module, snapshot)
+        torch.testing.assert_close(module.weight, snapshot["weight"])
+
+        guard = LyapunovSpectralGuard(warmup_steps=1)
+        guard.observe(loss=1.0, spectral_energy=1.0)
+        buffer = io.BytesIO()
+        torch.save(guard.state_dict(), buffer)
+        buffer.seek(0)
+        state = torch.load(buffer)
+        loaded = LyapunovSpectralGuard(warmup_steps=1)
+        loaded.load_state_dict(state)
+        assert loaded.is_ready
+        assert loaded.accept(loss=1.0, spectral_energy=1.0)
+
+
+if __name__ == "__main__":
+    if raise_on_run_directly is not None:
+        raise_on_run_directly("test/test_ao_sparsity.py")
+    unittest.main()

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -55,6 +55,12 @@ from ao.sparsity.test_data_sparsifier import (  # noqa: F401
 
 # Utilities
 from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F401
+from ao.sparsity.test_topology_rigorous import (  # noqa: F401
+    TestLyapunovSpectralGuardRigorous,
+    TestSpectralPrototypeEmbeddingRigorous,
+    TestTopologicalSpectralAttentionRigorous,
+    TestTopologyGatedLowRankLinearRigorous,
+)
 
 
 instantiate_device_type_tests(TestSaliencyPruner, globals())

--- a/torch/ao/pruning/_experimental/topology/__init__.py
+++ b/torch/ao/pruning/_experimental/topology/__init__.py
@@ -1,0 +1,11 @@
+from .attention import TopologicalSpectralAttention
+from .embedding import SpectralPrototypeEmbedding
+from .guard import LyapunovSpectralGuard
+from .low_rank import TopologyGatedLowRankLinear
+
+__all__ = [
+    "LyapunovSpectralGuard",
+    "SpectralPrototypeEmbedding",
+    "TopologicalSpectralAttention",
+    "TopologyGatedLowRankLinear",
+]

--- a/torch/ao/pruning/_experimental/topology/attention.py
+++ b/torch/ao/pruning/_experimental/topology/attention.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class TopologicalSpectralAttention(nn.Module):
+    r"""Scaled dot-product attention with an opt-in clustered approximation gate."""
+
+    def __init__(
+        self,
+        *,
+        min_seq_len: int = 128,
+        num_clusters: int = 4,
+        spectral_gap_threshold: float = 0.10,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+    ) -> None:
+        super().__init__()
+        if min_seq_len <= 0:
+            raise ValueError("min_seq_len must be positive")
+        if num_clusters <= 0:
+            raise ValueError("num_clusters must be positive")
+        if spectral_gap_threshold < 0:
+            raise ValueError("spectral_gap_threshold must be non-negative")
+        self.min_seq_len = min_seq_len
+        self.num_clusters = num_clusters
+        self.spectral_gap_threshold = spectral_gap_threshold
+        self.dropout_p = dropout_p
+        self.is_causal = is_causal
+
+    def _dropout_p(self) -> float:
+        return self.dropout_p if self.training else 0.0
+
+    def _cluster_assignments(self, keys: torch.Tensor) -> torch.Tensor | None:
+        seq_len = keys.shape[-2]
+        if seq_len < self.min_seq_len or seq_len < self.num_clusters:
+            return None
+        features = keys.detach().mean(dim=tuple(range(keys.ndim - 2))).float()
+        centered = features - features.mean(dim=0, keepdim=True)
+        affinity = centered @ centered.T
+        affinity = affinity - affinity.min()
+        affinity.fill_diagonal_(0)
+        degree = affinity.sum(dim=1)
+        if torch.count_nonzero(degree > 0) < self.num_clusters:
+            return None
+        inv_sqrt = torch.rsqrt(degree.clamp_min(1e-12))
+        laplacian = torch.eye(seq_len, device=keys.device) - inv_sqrt[:, None] * affinity * inv_sqrt[None, :]
+        eigenvalues, eigenvectors = torch.linalg.eigh(laplacian)
+        if eigenvalues.numel() <= self.num_clusters:
+            return None
+        gap = eigenvalues[self.num_clusters] - eigenvalues[self.num_clusters - 1]
+        if float(gap.item()) < self.spectral_gap_threshold:
+            return None
+        feature = eigenvectors[:, 1 if eigenvectors.shape[1] > 1 else 0]
+        order = torch.argsort(feature)
+        assignments = torch.empty(seq_len, dtype=torch.long, device=keys.device)
+        for cluster_id, chunk in enumerate(torch.tensor_split(order, self.num_clusters)):
+            assignments[chunk] = cluster_id
+        return assignments
+
+    def _clustered_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        assignments: torch.Tensor,
+        attn_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        representatives_k = []
+        representatives_v = []
+        cluster_sizes = []
+        for cluster_id in range(self.num_clusters):
+            members = assignments == cluster_id
+            if not members.any():
+                continue
+            representatives_k.append(key[..., members, :].mean(dim=-2))
+            representatives_v.append(value[..., members, :].mean(dim=-2))
+            cluster_sizes.append(members.sum())
+        if not representatives_k:
+            return F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                dropout_p=self._dropout_p(),
+                is_causal=self.is_causal,
+            )
+        clustered_key = torch.stack(representatives_k, dim=-2)
+        clustered_value = torch.stack(representatives_v, dim=-2)
+        cluster_bias = torch.stack(cluster_sizes).to(device=query.device, dtype=query.dtype).log().view(1, -1)
+        return F.scaled_dot_product_attention(
+            query,
+            clustered_key,
+            clustered_value,
+            attn_mask=cluster_bias,
+            dropout_p=self._dropout_p(),
+            is_causal=False,
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assignments = None
+        if not torch.compiler.is_compiling() and attn_mask is None and not self.is_causal:
+            assignments = self._cluster_assignments(key)
+        if assignments is None:
+            return F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                dropout_p=self._dropout_p(),
+                is_causal=self.is_causal,
+            )
+        return self._clustered_attention(query, key, value, assignments, attn_mask)

--- a/torch/ao/pruning/_experimental/topology/embedding.py
+++ b/torch/ao/pruning/_experimental/topology/embedding.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .low_rank import _optimizer_contains_parameter, _replace_optimizer_parameters
+
+if TYPE_CHECKING:
+    from torch.optim import Optimizer
+
+
+class SpectralPrototypeEmbedding(nn.Module):
+    r"""Embedding module that compresses token communities into prototypes.
+
+    The module observes token windows, builds a token co-occurrence graph, and
+    uses the Fiedler vector of the normalized graph Laplacian to split tokens
+    into deterministic communities. Compression is opt-in via
+    :meth:`try_compress`; dense embedding lookup remains the default path.
+    """
+
+    is_compressed: bool
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        *,
+        num_prototypes: int,
+        padding_idx: int | None = None,
+        min_observations: int = 32,
+        window_size: int = 2,
+        max_norm: float | None = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        if num_prototypes <= 0 or num_prototypes > num_embeddings:
+            raise ValueError("num_prototypes must be in [1, num_embeddings]")
+        if padding_idx is not None:
+            if padding_idx > 0:
+                if padding_idx >= num_embeddings:
+                    raise AssertionError("padding_idx must be within num_embeddings")
+            elif padding_idx < 0:
+                if padding_idx < -num_embeddings:
+                    raise AssertionError("padding_idx must be within num_embeddings")
+                padding_idx = num_embeddings + padding_idx
+        if min_observations <= 0:
+            raise ValueError("min_observations must be positive")
+        if window_size <= 0:
+            raise ValueError("window_size must be positive")
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.num_prototypes = num_prototypes
+        self.padding_idx = padding_idx
+        self.min_observations = min_observations
+        self.window_size = window_size
+        self.max_norm = max_norm
+        self.norm_type = norm_type
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
+        self.weight = nn.Parameter(torch.empty(num_embeddings, embedding_dim, **factory_kwargs))
+        self.prototype_weight: nn.Parameter | None = None
+        self.edge_index = torch.empty(2, 0, dtype=torch.long, device=device)
+        self.edge_weight = torch.empty(0, device=device)
+        self.token_counts = torch.zeros(num_embeddings, device=device)
+        self.register_buffer("token_to_prototype", torch.zeros(num_embeddings, dtype=torch.long, device=device))
+        self.is_compressed = False
+        self.reset_parameters()
+
+    @classmethod
+    def from_embedding(
+        cls,
+        embedding: nn.Embedding,
+        *,
+        num_prototypes: int,
+        min_observations: int = 32,
+        window_size: int = 2,
+    ) -> SpectralPrototypeEmbedding:
+        module = cls(
+            embedding.num_embeddings,
+            embedding.embedding_dim,
+            num_prototypes=num_prototypes,
+            padding_idx=embedding.padding_idx,
+            min_observations=min_observations,
+            window_size=window_size,
+            max_norm=embedding.max_norm,
+            norm_type=embedding.norm_type,
+            scale_grad_by_freq=embedding.scale_grad_by_freq,
+            sparse=embedding.sparse,
+            device=embedding.weight.device,
+            dtype=embedding.weight.dtype,
+        )
+        with torch.no_grad():
+            module.weight.copy_(embedding.weight)
+        return module
+
+    def reset_parameters(self) -> None:
+        nn.init.normal_(self.weight)
+        if self.padding_idx is not None:
+            with torch.no_grad():
+                self.weight[self.padding_idx].fill_(0)
+
+    @torch.no_grad()
+    def observe_tokens(self, tokens: torch.Tensor) -> None:
+        flat = tokens.detach().reshape(-1).to(device=self.token_counts.device, dtype=torch.long)
+        if flat.numel() == 0:
+            return
+        valid = (flat >= 0) & (flat < self.num_embeddings)
+        if self.padding_idx is not None:
+            valid &= flat != self.padding_idx
+        flat = flat[valid]
+        if flat.numel() == 0:
+            return
+        self.token_counts.index_add_(0, flat, torch.ones_like(flat, dtype=self.token_counts.dtype))
+        rows = tokens.detach().reshape(-1, tokens.shape[-1] if tokens.ndim > 1 else tokens.numel()).to(
+            device=self.token_counts.device, dtype=torch.long
+        )
+        edge_parts = []
+        for row in rows:
+            row = row[(row >= 0) & (row < self.num_embeddings)]
+            if self.padding_idx is not None:
+                row = row[row != self.padding_idx]
+            for index in range(row.numel()):
+                left = max(0, index - self.window_size)
+                right = min(row.numel(), index + self.window_size + 1)
+                center = row[index]
+                neighbors = row[left:right]
+                neighbors = neighbors[neighbors != center]
+                if neighbors.numel() > 0:
+                    centers = center.expand_as(neighbors)
+                    edge_parts.append(torch.stack((centers, neighbors), dim=0))
+                    edge_parts.append(torch.stack((neighbors, centers), dim=0))
+        if not edge_parts:
+            return
+        new_edges = torch.cat(edge_parts, dim=1)
+        new_weights = torch.ones(new_edges.shape[1], dtype=self.token_counts.dtype, device=self.token_counts.device)
+        if self.edge_index.numel() > 0:
+            new_edges = torch.cat((self.edge_index, new_edges), dim=1)
+            new_weights = torch.cat((self.edge_weight, new_weights))
+        edge_ids = new_edges[0] * self.num_embeddings + new_edges[1]
+        unique_ids, inverse = torch.unique(edge_ids, sorted=True, return_inverse=True)
+        coalesced_weights = torch.zeros(unique_ids.numel(), dtype=new_weights.dtype, device=new_weights.device)
+        coalesced_weights.index_add_(0, inverse, new_weights)
+        self.edge_index = torch.stack((unique_ids // self.num_embeddings, unique_ids % self.num_embeddings), dim=0)
+        self.edge_weight = coalesced_weights
+
+    def _spectral_assignments(self) -> torch.Tensor | None:
+        observed = self.token_counts > 0
+        if int(self.token_counts.sum().item()) < self.min_observations or observed.sum() < self.num_prototypes:
+            return None
+        if self.edge_index.numel() == 0:
+            return None
+        adjacency = torch.sparse_coo_tensor(
+            self.edge_index,
+            self.edge_weight,
+            (self.num_embeddings, self.num_embeddings),
+            device=self.token_counts.device,
+        ).coalesce()
+        degree = torch.zeros(self.num_embeddings, dtype=self.edge_weight.dtype, device=self.token_counts.device)
+        degree.index_add_(0, adjacency.indices()[0], adjacency.values())
+        active = observed & (degree > 0)
+        if active.sum() < self.num_prototypes:
+            return None
+        active_indices = active.nonzero(as_tuple=False).flatten()
+        row, col = adjacency.indices()
+        active_edges = active[row] & active[col]
+        if not active_edges.any():
+            return None
+        active_lookup = torch.full((self.num_embeddings,), -1, dtype=torch.long, device=self.token_counts.device)
+        active_lookup[active_indices] = torch.arange(active_indices.numel(), device=self.token_counts.device)
+        sub_indices = torch.stack((active_lookup[row[active_edges]], active_lookup[col[active_edges]]), dim=0)
+        sub_adj = torch.sparse_coo_tensor(
+            sub_indices,
+            adjacency.values()[active_edges],
+            (active_indices.numel(), active_indices.numel()),
+            device=self.token_counts.device,
+        ).to_dense()
+        sub_degree = sub_adj.sum(dim=1).clamp_min(1e-12)
+        inv_sqrt = torch.rsqrt(sub_degree)
+        laplacian = torch.eye(active_indices.numel(), device=sub_adj.device) - inv_sqrt[:, None] * sub_adj * inv_sqrt[None, :]
+        _, eigenvectors = torch.linalg.eigh(laplacian)
+        feature_index = 1 if eigenvectors.shape[1] > 1 else 0
+        feature = eigenvectors[:, feature_index]
+        order = torch.argsort(feature)
+        assignments = torch.zeros(self.num_embeddings, dtype=torch.long, device=self.token_to_prototype.device)
+        for cluster_id, chunk in enumerate(torch.tensor_split(order, self.num_prototypes)):
+            if chunk.numel() > 0:
+                assignments[active_indices[chunk]] = cluster_id
+        inactive = (~active).nonzero(as_tuple=False).flatten()
+        if inactive.numel() > 0:
+            nearest = torch.argmin(torch.cdist(self.weight.detach()[inactive].float(), self.weight.detach()[active_indices].float()), dim=1)
+            assignments[inactive] = assignments[active_indices[nearest]]
+        return assignments
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.edge_index = fn(self.edge_index)
+        self.edge_weight = fn(self.edge_weight)
+        self.token_counts = fn(self.token_counts)
+        return self
+
+    @torch.no_grad()
+    def try_compress(self, optimizer: Optimizer | None = None) -> bool:
+        if self.is_compressed:
+            return True
+        if optimizer is not None and not _optimizer_contains_parameter(optimizer, self.weight):
+            raise ValueError("optimizer does not contain the dense weight parameter")
+        assignments = self._spectral_assignments()
+        if assignments is None:
+            return False
+        prototypes = []
+        if self.padding_idx is not None:
+            prototypes.append(torch.zeros_like(self.weight.detach()[0]))
+        for prototype_id in range(self.num_prototypes):
+            members = assignments == prototype_id
+            if self.padding_idx is not None:
+                members[self.padding_idx] = False
+            if members.any():
+                prototypes.append(self.weight.detach()[members].mean(dim=0))
+            else:
+                prototypes.append(self.weight.detach()[0])
+        prototype_weight = torch.stack(prototypes, dim=0)
+        if self.padding_idx is not None:
+            assignments = assignments + 1
+            assignments[self.padding_idx] = 0
+        old_weight = self.weight
+        del self._parameters["weight"]
+        self.weight = None  # type: ignore[assignment]
+        self.prototype_weight = nn.Parameter(prototype_weight.contiguous())
+        self.token_to_prototype.copy_(assignments)
+        self.edge_index = torch.empty(2, 0, dtype=torch.long, device=self.token_to_prototype.device)
+        self.edge_weight = torch.empty(0, dtype=self.token_counts.dtype, device=self.token_to_prototype.device)
+        self.token_counts.zero_()
+        self.is_compressed = True
+        if optimizer is not None:
+            _replace_optimizer_parameters(optimizer, old_weight, (self.prototype_weight,))
+        return True
+
+    def _checkpoint_factory_kwargs(
+        self,
+        fallback: torch.Tensor | None = None,
+        *,
+        assign: bool = False,
+    ) -> dict[str, torch.device | torch.dtype]:
+        if assign and fallback is not None:
+            return {"device": fallback.device, "dtype": fallback.dtype}
+        reference = None
+        for candidate in (self.weight, self.prototype_weight):
+            if isinstance(candidate, torch.Tensor):
+                reference = candidate
+                break
+        if reference is None:
+            reference = self.token_to_prototype
+        if reference is None:
+            reference = fallback
+        if reference is None:
+            return {}
+        dtype = fallback.dtype if fallback is not None and assign else torch.get_default_dtype()
+        if reference.is_floating_point():
+            dtype = reference.dtype
+        elif fallback is not None:
+            dtype = fallback.dtype
+        return {"device": reference.device, "dtype": dtype}
+
+    def _prepare_dense_parameters(self, weight: torch.Tensor | None = None, *, assign: bool = False) -> None:
+        factory_kwargs = self._checkpoint_factory_kwargs(weight, assign=assign)
+        if "prototype_weight" in self._parameters:
+            del self._parameters["prototype_weight"]
+        self.prototype_weight = None
+        if "weight" not in self._parameters:
+            del self.__dict__["weight"]
+            self.weight = nn.Parameter(torch.empty(self.num_embeddings, self.embedding_dim, **factory_kwargs))
+        self.is_compressed = False
+
+    def _prepare_prototype_parameters(self, prototype_weight: torch.Tensor, *, assign: bool = False) -> None:
+        factory_kwargs = self._checkpoint_factory_kwargs(prototype_weight, assign=assign)
+        if "weight" in self._parameters:
+            del self._parameters["weight"]
+        self.weight = None  # type: ignore[assignment]
+        self.prototype_weight = nn.Parameter(torch.empty(prototype_weight.shape, **factory_kwargs))
+        self.is_compressed = True
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        prototype_weight = state_dict.get(prefix + "prototype_weight")
+        if prototype_weight is not None:
+            expected_rows = self.num_prototypes + (1 if self.padding_idx is not None else 0)
+            if prototype_weight.ndim != 2 or prototype_weight.shape != (expected_rows, self.embedding_dim):
+                error_msgs.append(
+                    "size mismatch for prototype checkpoint: "
+                    f"prototype_weight has shape {tuple(prototype_weight.shape)}, expected "
+                    f"({expected_rows}, {self.embedding_dim})"
+                )
+            else:
+                assign = bool(local_metadata.get("assign_to_params_buffers", False))
+                self._prepare_prototype_parameters(prototype_weight, assign=assign)
+        elif prefix + "weight" in state_dict and self.is_compressed:
+            assign = bool(local_metadata.get("assign_to_params_buffers", False))
+            self._prepare_dense_parameters(state_dict[prefix + "weight"], assign=assign)
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.is_compressed:
+            if self.prototype_weight is None:
+                raise RuntimeError("prototype weights are missing")
+            mapped = self.token_to_prototype.index_select(0, input.reshape(-1)).reshape(input.shape)
+            return F.embedding(
+                mapped,
+                self.prototype_weight,
+                0 if self.padding_idx is not None else None,
+                self.max_norm,
+                self.norm_type,
+                self.scale_grad_by_freq,
+                self.sparse,
+            )
+        return F.embedding(
+            input,
+            self.weight,
+            self.padding_idx,
+            self.max_norm,
+            self.norm_type,
+            self.scale_grad_by_freq,
+            self.sparse,
+        )

--- a/torch/ao/pruning/_experimental/topology/guard.py
+++ b/torch/ao/pruning/_experimental/topology/guard.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class LyapunovSpectralGuard:
+    r"""Tracks warmup stability and rejects compression when metrics drift."""
+
+    def __init__(
+        self,
+        *,
+        warmup_steps: int = 8,
+        max_loss_relative_increase: float = 0.02,
+        max_spectral_relative_increase: float = 0.05,
+        history_size: int = 16,
+    ) -> None:
+        if warmup_steps <= 0:
+            raise ValueError("warmup_steps must be positive")
+        if max_loss_relative_increase < 0:
+            raise ValueError("max_loss_relative_increase must be non-negative")
+        if max_spectral_relative_increase < 0:
+            raise ValueError("max_spectral_relative_increase must be non-negative")
+        if history_size <= 0:
+            raise ValueError("history_size must be positive")
+        if history_size < warmup_steps:
+            raise ValueError("history_size must be greater than or equal to warmup_steps")
+        self.warmup_steps = warmup_steps
+        self.max_loss_relative_increase = max_loss_relative_increase
+        self.max_spectral_relative_increase = max_spectral_relative_increase
+        self.loss_history: deque[float] = deque(maxlen=history_size)
+        self.spectral_history: deque[float] = deque(maxlen=history_size)
+        self.is_ready = False
+
+    @staticmethod
+    def _as_float(value: float | torch.Tensor) -> float:
+        if isinstance(value, torch.Tensor):
+            return float(value.detach().float().item())
+        return float(value)
+
+    @staticmethod
+    def _relative_increase(baseline: float, value: float) -> float:
+        denominator = max(abs(baseline), 1e-12)
+        return (value - baseline) / denominator
+
+    def observe(self, *, loss: float | torch.Tensor, spectral_energy: float | torch.Tensor) -> bool:
+        self.loss_history.append(self._as_float(loss))
+        self.spectral_history.append(self._as_float(spectral_energy))
+        self.is_ready = len(self.loss_history) >= self.warmup_steps
+        return self.is_ready
+
+    def accept(self, *, loss: float | torch.Tensor, spectral_energy: float | torch.Tensor) -> bool:
+        if not self.is_ready:
+            return False
+        current_loss = self._as_float(loss)
+        current_spectral = self._as_float(spectral_energy)
+        baseline_loss = sum(self.loss_history) / len(self.loss_history)
+        baseline_spectral = sum(self.spectral_history) / len(self.spectral_history)
+        loss_increase = self._relative_increase(baseline_loss, current_loss)
+        spectral_increase = self._relative_increase(baseline_spectral, current_spectral)
+        return (
+            loss_increase <= self.max_loss_relative_increase
+            and spectral_increase <= self.max_spectral_relative_increase
+        )
+
+    def reject(self, *, loss: float | torch.Tensor, spectral_energy: float | torch.Tensor) -> bool:
+        return not self.accept(loss=loss, spectral_energy=spectral_energy)
+
+    @staticmethod
+    def snapshot_module(module: nn.Module) -> dict[str, torch.Tensor]:
+        return {name: value.detach().clone() for name, value in module.state_dict().items()}
+
+    @staticmethod
+    def rollback_module(module: nn.Module, snapshot: Mapping[str, torch.Tensor]) -> None:
+        module.load_state_dict(snapshot, strict=True)
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return {
+            "loss_history": torch.tensor(list(self.loss_history), dtype=torch.float64),
+            "spectral_history": torch.tensor(list(self.spectral_history), dtype=torch.float64),
+            "is_ready": torch.tensor(self.is_ready),
+        }
+
+    def load_state_dict(self, state_dict: Mapping[str, torch.Tensor]) -> None:
+        loss_history = state_dict["loss_history"].detach().cpu().tolist()
+        spectral_history = state_dict["spectral_history"].detach().cpu().tolist()
+        if len(loss_history) > self.loss_history.maxlen or len(spectral_history) > self.spectral_history.maxlen:
+            raise ValueError("loaded history is larger than this guard's history_size")
+        self.loss_history.clear()
+        self.spectral_history.clear()
+        self.loss_history.extend(float(value) for value in loss_history)
+        self.spectral_history.extend(float(value) for value in spectral_history)
+        self.is_ready = bool(state_dict["is_ready"].detach().cpu().item())

--- a/torch/ao/pruning/_experimental/topology/low_rank.py
+++ b/torch/ao/pruning/_experimental/topology/low_rank.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+if TYPE_CHECKING:
+    from torch.optim import Optimizer
+
+
+def _optimizer_contains_parameter(optimizer: Optimizer, parameter: nn.Parameter) -> bool:
+    return any(param is parameter for group in optimizer.param_groups for param in group["params"])
+
+
+def _replace_optimizer_parameters(
+    optimizer: Optimizer,
+    old_parameter: nn.Parameter,
+    new_parameters: tuple[nn.Parameter, ...],
+) -> None:
+    found = False
+    inserted = False
+    for group in optimizer.param_groups:
+        params = group["params"]
+        next_params = []
+        for param in params:
+            if param is old_parameter:
+                found = True
+                if not inserted:
+                    next_params.extend(new_parameters)
+                    inserted = True
+            else:
+                next_params.append(param)
+        params[:] = next_params
+    if not found:
+        raise ValueError("optimizer does not contain the parameter being compressed")
+    optimizer.state.pop(old_parameter, None)
+
+
+class TopologyGatedLowRankLinear(nn.Module):
+    r"""Linear layer that only switches to low-rank factors after a spectral gate.
+
+    The module starts as an exact dense copy. Calling :meth:`try_compress` computes
+    an SVD of the dense weight and replaces it with two factors only if the kept
+    singular spectrum preserves enough energy and reduces parameter count by the
+    requested ratio.
+    """
+
+    in_features: int
+    out_features: int
+    is_compressed: bool
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        *,
+        energy_threshold: float = 0.98,
+        max_rank: int | None = None,
+        min_compression_ratio: float = 1.05,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        if not 0.0 < energy_threshold <= 1.0:
+            raise ValueError("energy_threshold must be in (0, 1]")
+        if max_rank is not None and max_rank <= 0:
+            raise ValueError("max_rank must be positive")
+        if min_compression_ratio <= 1.0:
+            raise ValueError("min_compression_ratio must be greater than 1")
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.in_features = in_features
+        self.out_features = out_features
+        self.energy_threshold = energy_threshold
+        self.max_rank = max_rank
+        self.min_compression_ratio = min_compression_ratio
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, **factory_kwargs))
+        self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs)) if bias else None
+        self.low_rank_left: nn.Parameter | None = None
+        self.low_rank_right: nn.Parameter | None = None
+        self.is_compressed = False
+        self.reset_parameters()
+
+    @classmethod
+    def from_linear(
+        cls,
+        linear: nn.Linear,
+        *,
+        energy_threshold: float = 0.98,
+        max_rank: int | None = None,
+        min_compression_ratio: float = 1.05,
+    ) -> TopologyGatedLowRankLinear:
+        module = cls(
+            linear.in_features,
+            linear.out_features,
+            linear.bias is not None,
+            energy_threshold=energy_threshold,
+            max_rank=max_rank,
+            min_compression_ratio=min_compression_ratio,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        with torch.no_grad():
+            module.weight.copy_(linear.weight)
+            if linear.bias is not None and module.bias is not None:
+                module.bias.copy_(linear.bias)
+        return module
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            nn.init.uniform_(self.bias, -bound, bound)
+
+    def dense_parameter_count(self) -> int:
+        bias_count = 0 if self.bias is None else self.bias.numel()
+        return self.out_features * self.in_features + bias_count
+
+    def compressed_parameter_count(self, rank: int | None = None) -> int:
+        if rank is None:
+            if self.low_rank_left is None or self.low_rank_right is None:
+                rank = min(self.out_features, self.in_features)
+            else:
+                rank = self.low_rank_right.shape[0]
+        bias_count = 0 if self.bias is None else self.bias.numel()
+        return rank * (self.out_features + self.in_features) + bias_count
+
+    def _target_rank(self, singular_values: torch.Tensor) -> int | None:
+        if singular_values.numel() == 0:
+            return None
+        energy = singular_values.square()
+        total = energy.sum()
+        if total <= 0:
+            return None
+        cumulative = torch.cumsum(energy, dim=0) / total
+        required_rank = int(torch.searchsorted(cumulative, torch.tensor(self.energy_threshold, device=cumulative.device)).item()) + 1
+        if required_rank <= 0:
+            return None
+        if self.max_rank is not None and self.max_rank < required_rank:
+            return None
+        rank = required_rank
+        if self.compressed_parameter_count(rank) * self.min_compression_ratio >= self.dense_parameter_count():
+            return None
+        return rank
+
+    @torch.no_grad()
+    def try_compress(self, optimizer: Optimizer | None = None) -> bool:
+        if self.is_compressed:
+            return True
+        if optimizer is not None and not _optimizer_contains_parameter(optimizer, self.weight):
+            raise ValueError("optimizer does not contain the dense weight parameter")
+        weight = self.weight.detach()
+        svd_input = weight.float() if weight.dtype in (torch.float16, torch.bfloat16) else weight
+        u, s, vh = torch.linalg.svd(svd_input, full_matrices=False)
+        rank = self._target_rank(s)
+        if rank is None:
+            return False
+        sqrt_s = torch.sqrt(s[:rank])
+        left = (u[:, :rank] * sqrt_s.unsqueeze(0)).to(dtype=weight.dtype)
+        right = (sqrt_s.unsqueeze(1) * vh[:rank, :]).to(dtype=weight.dtype)
+        old_weight = self.weight
+        del self._parameters["weight"]
+        self.weight = None  # type: ignore[assignment]
+        self.low_rank_left = nn.Parameter(left.contiguous())
+        self.low_rank_right = nn.Parameter(right.contiguous())
+        self.is_compressed = True
+        if optimizer is not None:
+            _replace_optimizer_parameters(optimizer, old_weight, (self.low_rank_left, self.low_rank_right))
+        return True
+
+    def _checkpoint_factory_kwargs(
+        self,
+        fallback: torch.Tensor | None = None,
+        *,
+        assign: bool = False,
+    ) -> dict[str, torch.device | torch.dtype]:
+        if assign and fallback is not None:
+            return {"device": fallback.device, "dtype": fallback.dtype}
+        reference = None
+        for candidate in (self.weight, self.low_rank_left, self.low_rank_right, self.bias):
+            if isinstance(candidate, torch.Tensor):
+                reference = candidate
+                break
+        if reference is None:
+            reference = fallback
+        if reference is None:
+            return {}
+        return {"device": reference.device, "dtype": reference.dtype}
+
+    def _prepare_dense_parameters(self, weight: torch.Tensor | None = None, *, assign: bool = False) -> None:
+        factory_kwargs = self._checkpoint_factory_kwargs(weight, assign=assign)
+        if "low_rank_left" in self._parameters:
+            del self._parameters["low_rank_left"]
+        if "low_rank_right" in self._parameters:
+            del self._parameters["low_rank_right"]
+        self.low_rank_left = None
+        self.low_rank_right = None
+        if "weight" not in self._parameters:
+            del self.__dict__["weight"]
+            self.weight = nn.Parameter(torch.empty(self.out_features, self.in_features, **factory_kwargs))
+        self.is_compressed = False
+
+    def _prepare_low_rank_parameters(self, left: torch.Tensor, right: torch.Tensor, *, assign: bool = False) -> None:
+        factory_kwargs = self._checkpoint_factory_kwargs(left, assign=assign)
+        if "weight" in self._parameters:
+            del self._parameters["weight"]
+        self.weight = None  # type: ignore[assignment]
+        self.low_rank_left = nn.Parameter(torch.empty(left.shape, **factory_kwargs))
+        self.low_rank_right = nn.Parameter(torch.empty(right.shape, **factory_kwargs))
+        self.is_compressed = True
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        left = state_dict.get(prefix + "low_rank_left")
+        right = state_dict.get(prefix + "low_rank_right")
+        if left is not None and right is not None:
+            if (
+                left.ndim != 2
+                or right.ndim != 2
+                or left.shape[0] != self.out_features
+                or right.shape[1] != self.in_features
+                or left.shape[1] != right.shape[0]
+            ):
+                error_msgs.append(
+                    "size mismatch for low-rank checkpoint: "
+                    f"low_rank_left has shape {tuple(left.shape)} and "
+                    f"low_rank_right has shape {tuple(right.shape)}, expected "
+                    f"({self.out_features}, rank) and (rank, {self.in_features})"
+                )
+            else:
+                assign = bool(local_metadata.get("assign_to_params_buffers", False))
+                self._prepare_low_rank_parameters(left, right, assign=assign)
+        elif prefix + "weight" in state_dict and self.is_compressed:
+            assign = bool(local_metadata.get("assign_to_params_buffers", False))
+            self._prepare_dense_parameters(state_dict[prefix + "weight"], assign=assign)
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+    def extra_repr(self) -> str:
+        rank = None if self.low_rank_right is None else self.low_rank_right.shape[0]
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"bias={self.bias is not None}, is_compressed={self.is_compressed}, rank={rank}"
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.is_compressed:
+            if self.low_rank_left is None or self.low_rank_right is None:
+                raise RuntimeError("compressed low-rank factors are missing")
+            hidden = F.linear(input, self.low_rank_right)
+            return F.linear(hidden, self.low_rank_left, self.bias)
+        return F.linear(input, self.weight, self.bias)


### PR DESCRIPTION
## Summary

Fixes #187781.

This PR addresses the topology-aware memory optimization prototype by adding an experimental `torch.ao.pruning._experimental.topology` package with four guarded training-time memory primitives:

- `TopologyGatedLowRankLinear`: starts from an exact dense `nn.Linear` copy and switches to low-rank factors only when the singular spectrum satisfies the configured energy gate and parameter-count savings are real.
- `SpectralPrototypeEmbedding`: observes token windows, stores sparse co-occurrence calibration state, and compresses token communities into prototype embeddings after a spectral assignment gate.
- `TopologicalSpectralAttention`: keeps dense SDPA for masked, causal, short, unstructured, or compile-time paths and uses clustered representatives only when the spectral gap gate allows it.
- `LyapunovSpectralGuard`: tracks warmup loss/spectral histories and rejects compression when post-warmup movement exceeds configured stability thresholds.

The issue this solves is that local dtype, checkpointing, quantization, and low-rank choices do not provide an experimental PyTorch surface for module rewrites gated by measured model-state topology. This PR adds explicit opt-in primitives for that direction while keeping dense behavior as the default path until callers run calibration and call `try_compress()`.

## Details

The implementation includes safeguards that are important for a PyTorch-facing prototype:

- optimizer-aware compression APIs that can rewrite optimizer parameter groups after warmup compression;
- `state_dict()` / `load_state_dict()` transitions between dense and compressed layouts;
- shape validation for strict low-rank/prototype checkpoint loading;
- half/bfloat16 SVD handled through a float32 work dtype with factors cast back;
- sparse, non-persistent embedding calibration state so checkpoints do not carry a dense vocabulary graph;
- preserved embedding padding/index semantics in the compressed path;
- eval-mode dropout handling for SDPA;
- dense fallback under `torch.compiler.is_compiling()` for Dynamo-friendly behavior;
- aggregate test wiring through `test/test_ao_sparsity.py`.

## Test Plan

```bash
PYTORCH_TEST_TOPOLOGY_SOURCE_FALLBACK=1 pytest test/ao/sparsity/test_topology_rigorous.py -v --tb=short
```

Result: 24 passed, 1 skipped.

```bash
python -m py_compile torch/ao/pruning/_experimental/topology/__init__.py torch/ao/pruning/_experimental/topology/attention.py torch/ao/pruning/_experimental/topology/embedding.py torch/ao/pruning/_experimental/topology/guard.py torch/ao/pruning/_experimental/topology/low_rank.py test/ao/sparsity/test_topology_rigorous.py
```

Result: passed.

```bash
lintrunner -a --take RUFF,NEWLINE,TESTOWNERS,EXEC,NOQA test/ao/sparsity/test_topology_rigorous.py test/test_ao_sparsity.py torch/ao/pruning/_experimental/topology/__init__.py torch/ao/pruning/_experimental/topology/attention.py torch/ao/pruning/_experimental/topology/embedding.py torch/ao/pruning/_experimental/topology/guard.py torch/ao/pruning/_experimental/topology/low_rank.py
```

Result: passed for the PR files.

```bash
coverage run --rcfile=agent_space/topology.coveragerc -m pytest test/ao/sparsity/test_topology_rigorous.py -q
coverage report --rcfile=agent_space/topology.coveragerc
```

Result: 24 passed, 1 skipped; 92% total topology package coverage.



