### PR TITLE
Bump lintrunner from 0.12.11 to 0.13.0 in /.ci/docker

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -287,7 +287,8 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 #test that import:
 
 #lintrunner is supported on aarch64-linux only from 0.12.4 version
-lintrunner==0.12.11
+#lintrunner is supported on riscv64-linux only from 0.13.0 version
+lintrunner==0.13.0
 #Description: all about linters!
 #Pinned versions: 0.12.11
 #test that import:


### PR DESCRIPTION
Bumps lintrunner to 0.13.0. That enables builds on RISC-V with minimal diff. Derived from https://github.com/pytorch/pytorch/pull/182278.