### PR TITLE
[arch_deps migration] Convert OSS caffe/caffe2 arch_deps/exported_arch_deps to select()

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,13 +1,14 @@
 def get_blas_gomp_arch_deps():
-    return [
-        ("x86_64", [
+    return select({
+        "ovr_config//cpu:x86_64": [
             "fbsource//third-party/mkl:{}".format(native.read_config("fbcode", "mkl_lp64", "mkl_lp64_omp")),
-        ]),
-        ("aarch64", [
+        ],
+        "ovr_config//cpu:arm64": [
             "third-party//Arm-Performance-Libraries:armpl_lp64_mp",
             "third-party//openmp:omp",
-        ]),
-    ]
+        ],
+        "DEFAULT": [],
+    })
 
 default_compiler_flags = [
     "-Wall",


### PR DESCRIPTION
Summary:
Phase 2 of migrating the legacy `arch_deps` / `exported_arch_deps` Buck attributes to `select()`, covering the OSS shipit-synced caffe and caffe2 files. Legacy `[("x86_64", [...]), ("aarch64", [...])]` arch-tuple lists become `select({"DEFAULT": [], "ovr_config//cpu:x86_64": [...], "ovr_config//cpu:arm64": [...]})` merged DIRECTLY into the non-arch counterpart (`deps` / `exported_deps` / `propagated_pp_flags`) — no separate arch-specific variables.

Files:
- `caffe/caffe-trunk/src/caffe/BUCK`: arch deps folded directly into `global_deps` (`global_deps = [...] + select(...)`); arch preprocessor flags folded directly into `global_pp_flags` (`global_pp_flags = [...] + select(...)`). The separate `global_arch_deps` / `global_arch_pp_flags` variables are eliminated.
- `caffe/defs.bzl`: `make_mode()` loses its `arch_pp_flags` / `arch_deps` params entirely (no longer needed).
- `caffe/caffe-trunk/src/caffe/defs.bzl`: `libraries_for_modes` drops the `exported_arch_deps` / `arch_propagated_pp_flags` forwarding — the arch values now ride in `mode.deps` -> `exported_deps` and `mode.pp_flags` -> `propagated_pp_flags`.
- `caffe2/defs.bzl`: `get_blas_gomp_arch_deps()` returns a `select()` (shared helper, appended directly to `exported_deps` at each callsite).
- `caffe2/TARGETS`: 3 `exported_arch_deps` migrated — `cpukernel_*` and `_ATen-cpu` append `get_blas_gomp_arch_deps()` (+ a cpukernel/mkl `select`) directly to `exported_deps`; `_ATen-cu`'s per-arch cusparselt select uses `selects.apply` (nested selects are disallowed). Adds the `selects` load.
- `xplat/caffe2/TARGETS`, `xplat/caffe2/defs.bzl`: identical mirror edits.

This also folds caffe's `arch_propagated_pp_flags` into `propagated_pp_flags` via `select()`, completing caffe's migration off all legacy arch attrs. faiss/BUCK is intentionally NOT included (the faiss code-owner rule mandates `exported_arch_deps`; raised separately).

No functional change expected — `select()` reproduces the same per-architecture dependency/flag resolution.

Test Plan:
`arc f` on all 7 files: ok No lint issues.
`buck2 cquery` on `fbcode//caffe/caffe-trunk/src/caffe:{caffe,caffe_cpp,caffe_common,caffe_slim_cpu}` and `fbcode//caffe2:{_ATen-cpu,_ATen-cu}`: all configure cleanly — `select()` / `selects.apply` / `get_blas_gomp_arch_deps()`-as-select resolve with valid `DEFAULT`/`ovr_config//cpu:x86_64`/`ovr_config//cpu:arm64` keys.
Confirmed zero remaining `arch_deps` / `exported_arch_deps` / `arch_propagated_pp_flags` / separate arch-variable references in the caffe files.

Differential Revision: D109244488


