### PR TITLE
Add linalg SVD operator benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_other_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_other_test.py
@@ -25,6 +25,7 @@ from pt import (  # noqa: F401
     interpolate_test,
     layernorm_test,
     linear_test,
+    linalg_svd_test,
     matmul_test,
     mm_test,
     nan_to_num_test,

--- a/benchmarks/operator_benchmark/pt/linalg_svd_test.py
+++ b/benchmarks/operator_benchmark/pt/linalg_svd_test.py
@@ -1,0 +1,56 @@
+import operator_benchmark as op_bench
+
+import torch
+
+
+"""Microbenchmarks for torch.linalg.svd and torch.linalg.svdvals."""
+
+
+def linalg_svd(input):
+    return torch.linalg.svd(input, full_matrices=False)
+
+
+ops_list = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["linalg_svd", linalg_svd],
+        ["linalg_svdvals", torch.linalg.svdvals],
+    ],
+)
+
+linalg_svd_short_configs = op_bench.config_list(
+    attr_names=["M", "N", "batch"],
+    attrs=[
+        [2, 3, 1],
+        [64, 32, 1],
+        [128, 64, 1],
+        [64, 128, 1],
+        [96, 48, 2],
+        [128, 128, 1],
+    ],
+    cross_product_configs={"device": ["cpu", "mps"], "dtype": [torch.float32]},
+    tags=["short"],
+)
+
+
+class LinalgSvdBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, batch, device, dtype, op_func):
+        shape = (M, N) if batch == 1 else (batch, M, N)
+        self.inputs = {
+            "input": torch.randn(
+                *shape, device=device, dtype=dtype, requires_grad=self.auto_set()
+            ),
+        }
+        self.op_func = op_func
+
+    def forward(self, input):
+        return self.op_func(input)
+
+
+op_bench.generate_pt_tests_from_op_list(
+    ops_list, linalg_svd_short_configs, LinalgSvdBenchmark
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
This PR dependent from https://github.com/pytorch/pytorch/pull/187796
## Summary
- Add operator benchmarks for `torch.linalg.svd` and `torch.linalg.svdvals`.
- Cover CPU and MPS short configs, including small low-rank shapes, rectangular shapes, batched inputs, and a square boundary case.
- Register the benchmark in the aggregate operator benchmark entrypoint.

## Test plan
- Installed the local operator benchmark extension with `python -m pip install . -v --no-build-isolation` from `benchmarks/operator_benchmark/pt_extension`.
- Ran `python -m pt.linalg_svd_test --list-tests`.
- Ran one CPU benchmark case: `python -m pt.linalg_svd_test --test-name linalg_svd_M2_N3_batch1_cpu_dtypetorch.float32 --iterations 1 --warmup-iterations 1`.
- Ran one MPS benchmark case: `python -m pt.linalg_svd_test --test-name linalg_svdvals_M2_N3_batch1_mps_dtypetorch.float32 --iterations 1 --warmup-iterations 1`.
- Verified aggregate discovery with `python -m benchmark_all_test --operators linalg_svd --list-tests`.

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen @aditvenk @Isalia20