### PR TITLE
[Inductor][CPU] Fix CppKernel load/compute placement when the load mask lives in compute

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2265,7 +2265,15 @@ class CppKernel(Kernel):
             return
 
         indirect = free_symbol_is_type(expr, SymT.TMP)
-        if indirect:
+        # When the load is masked, indirect_assert references the load mask in
+        # the generated assert.  If the mask was CSE'd into the compute buffer
+        # (and not loads), placing the assert in loads would be a forward
+        # reference to an undeclared variable, so emit it in compute instead.
+        mask = self._load_mask
+        mask_in_compute = isinstance(mask, CppCSEVariable) and not re.search(
+            rf"\b{re.escape(mask.name)}\b", self.loads.getvalue()
+        )
+        if indirect or mask_in_compute:
             # indexing in compute
             csevar = ops.index_expr(expr, torch.int64).value
             buffer = V.kernel.compute


### PR DESCRIPTION
When `CppKernel` decides whether an indirect index expression should be emitted in `loads` versus `compute`, the existing check only considers whether the index references a `TMP` symbol. If the load is masked and the mask itself was CSE'd into the `compute` buffer rather than `loads`, the indirect-index assertion that references the mask ends up as a forward reference to an undeclared variable, producing the `error: 'tmp2' was not declared in this scope` failure reported for the CPP backend.

This change adds a second condition: when `_load_mask` is a `CppCSEVariable` that does not appear in the current `loads` text, the indexing is also emitted in `compute`. This keeps the indirect-index assertion valid regardless of where the mask buffer was placed.

Resolves #187335

- In `torch/_inductor/codegen/cpp.py`, extend the `indirect` check in `CppKernel._check_bounds` to also trigger when the load mask is a CSE variable that lives in `compute`.
- Avoids the forward-reference compile error in the generated `main.cpp` for masked indirect indexing on the CPP backend.
