### PR TITLE
[ROCm] Fix libdrm readlink buffer bounds

### DIFF
--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -84,11 +84,11 @@ index cd8ee596..3e453ecd 100644
 +	// if it doesn't exist, search
 +	if (!fp) {
 +
-+	char self_path[ PATH_MAX ];
++	char self_path[ PATH_MAX + 1 ];
 +	ssize_t count;
 +	ssize_t i;
 +
-+	count = readlink( "/proc/self/exe", self_path, PATH_MAX );
++	count = readlink( "/proc/self/exe", self_path, sizeof(self_path) - 1 );
 +	if (count > 0) {
 +		self_path[count] = '\0';
 +


### PR DESCRIPTION
Summary:
- Leave room for the terminating NUL byte when the ROCm libdrm patch reads /proc/self/exe
- Bound readlink() with sizeof(self_path) - 1 so self_path[count] remains in bounds

Test Plan:
- bash -n .ci/docker/common/install_rocm_drm.sh

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang