### PR TITLE
[BE][Ez]: Optimize ForEach map grouping

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -353,42 +353,33 @@ inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
         "Tensors of the same index must be on the same device and the same dtype "
         "except `step` tensors that can be CPU and float32/64, and optimizer "
         "states that can be bfloat16 for mixed-precision training");
-    grouped_tensors_with_indices.try_emplace(
-        key,
-        TensorsAndIndicesT{
-            [&]() -> nested_optional_tensorvec_t {
-              nested_optional_tensorvec_t nested_tensorvec;
-              nested_tensorvec.reserve(num_lists);
-              for (const auto& i : c10::irange(num_lists)) {
-                std::vector<std::optional<at::Tensor>> tensors;
-                if (!nested_tensorlist[i].empty()) {
-                  // NB: num_tensors is the max possible length for any of
-                  // the inner lists of tensor references. Reserving the max
-                  // trades memory for perf. This should not have significant
-                  // impact.
-                  tensors.reserve(num_tensors);
-                }
-                nested_tensorvec.emplace_back(std::move(tensors));
-              }
-              return nested_tensorvec;
-            }(),
-            [&]() -> IndicesT {
-              if (!with_indices) {
-                return {};
-              } else {
-                IndicesT indices;
-                indices.reserve(num_tensors);
-                return indices;
-              }
-            }()});
+    auto [it, inserted] = grouped_tensors_with_indices.try_emplace(key);
+    auto& tensors_and_indices = it->second;
+    if (inserted) {
+      auto& nested_tensorvec = tensors_and_indices.first;
+      nested_tensorvec.reserve(num_lists);
+      for (const auto& i : c10::irange(num_lists)) {
+        std::vector<std::optional<at::Tensor>> tensors;
+        if (!nested_tensorlist[i].empty()) {
+          // NB: num_tensors is the max possible length for any of the inner
+          // lists of tensor references. Reserving the max trades memory for
+          // perf. This should not have significant impact.
+          tensors.reserve(num_tensors);
+        }
+        nested_tensorvec.emplace_back(std::move(tensors));
+      }
+      if (with_indices) {
+        tensors_and_indices.second.reserve(num_tensors);
+      }
+    }
     for (const auto& list_index : c10::irange(num_lists)) {
       if (!nested_tensorlist[list_index].empty()) {
-        grouped_tensors_with_indices[key].first[list_index].emplace_back(
+        tensors_and_indices.first[list_index].emplace_back(
             nested_tensorlist[list_index][tensor_index]);
       }
     }
     if (with_indices) {
-      grouped_tensors_with_indices[key].second.emplace_back(tensor_index);
+      tensors_and_indices.second.emplace_back(tensor_index);
     }
   }
 


### PR DESCRIPTION
* Reuse pointer given by try_emplace, prevent duplicate map lookups in a loop
* Previous code eagerly reserved vectors for the map value even if they were not inserted, now those values are NOOP if nothing is inserted.
* Also cleans up the code by removing unnecessary lambdas that are immediately called etc

Inspired by review of: https://github.com/pytorch/pytorch/pull/187786 Given there aren't many DeviceDtype and that we are removing expensive allocation calls from the hot path this should speed things up quite a bit. This is a hot path called on every optimizer step and would introduce quite a bit of unnecessary allocation churn.