### PR TITLE
fix(autograd): sinc_backward NaN for second derivative at x=0

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5366,7 +5366,7 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
   auto self_pi = self * M_PI;
-  auto self_squared_pi = self * self * M_PI;
+  auto self_squared_pi = self_pi * self;
   auto mask = (self_squared_pi == 0.0);
   // Prevent NaN from entering the graph at x=0; even though those positions
   // are overridden below, 0*NaN = NaN during higher-order grad computation.
@@ -5375,7 +5375,7 @@ Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
       grad * ((self_pi * self_pi.cos() - self_pi.sin()) / safe_denom).conj();
   // Use -pi^2*x/3 (first Taylor term of sinc') as the x=0 branch so that
   // autograd can trace through it and recover sinc''(0) = -pi^2/3 correctly.
-  return at::where(mask, grad * (-self_pi * M_PI / 3.0).conj(), out);
+  return at::where(mask, grad * (-self_pi * (M_PI / 3.0)).conj(), out);
 }
 
 // Because the backward of pad(input, pads) is just pad(grad_output, [-p for p

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5367,10 +5367,16 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
   auto self_pi = self * M_PI;
   auto self_squared_pi = self * self * M_PI;
-  auto out = grad *
-      ((self_pi * self_pi.cos() - self_pi.sin()) / self_squared_pi).conj();
+  // Safe denom prevents NaN from entering the autograd graph at x=0;
+  // at::where alone does not block it from poisoning higher-order grads.
+  auto safe_denom = at::where(
+      self_squared_pi == 0.0, at::ones_like(self_squared_pi), self_squared_pi);
+  auto out =
+      grad * ((self_pi * self_pi.cos() - self_pi.sin()) / safe_denom).conj();
+  // Use -pi^2*x/3 (first Taylor term of sinc') as the x=0 branch so that
+  // autograd can trace through it and recover sinc''(0) = -pi^2/3 correctly.
   return at::where(
-      self_squared_pi == 0.0, at::scalar_tensor(0.0, grad.options()), out);
+      self_squared_pi == 0.0, grad * (-self_pi * M_PI / 3.0).conj(), out);
 }
 
 // Because the backward of pad(input, pads) is just pad(grad_output, [-p for p

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5367,16 +5367,15 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
   auto self_pi = self * M_PI;
   auto self_squared_pi = self * self * M_PI;
-  // Safe denom prevents NaN from entering the autograd graph at x=0;
-  // at::where alone does not block it from poisoning higher-order grads.
-  auto safe_denom = at::where(
-      self_squared_pi == 0.0, at::ones_like(self_squared_pi), self_squared_pi);
+  auto mask = (self_squared_pi == 0.0);
+  // Prevent NaN from entering the graph at x=0; even though those positions
+  // are overridden below, 0*NaN = NaN during higher-order grad computation.
+  auto safe_denom = self_squared_pi.masked_fill(mask, 1.0);
   auto out =
       grad * ((self_pi * self_pi.cos() - self_pi.sin()) / safe_denom).conj();
   // Use -pi^2*x/3 (first Taylor term of sinc') as the x=0 branch so that
   // autograd can trace through it and recover sinc''(0) = -pi^2/3 correctly.
-  return at::where(
-      self_squared_pi == 0.0, grad * (-self_pi * M_PI / 3.0).conj(), out);
+  return at::where(mask, grad * (-self_pi * M_PI / 3.0).conj(), out);
 }
 
 // Because the backward of pad(input, pads) is just pad(grad_output, [-p for p


### PR DESCRIPTION
`sinc_backward` divided directly by `self_squared_pi`, which is zero at x=0. Since `sinc'(x) = (pi*x*cos(pi*x) - sin(pi*x)) / (pi*x^2)` has a 0/0 singularity there, NaN entered the autograd graph and sinc''(0) came out NaN instead of -pi^2/3.

The fix introduces a safe denominator (`ones_like` where `self_squared_pi == 0`) to block NaN in the general branch, and replaces the `scalar_tensor(0.0)` true-branch of the outer `at::where` with `grad * (-self_pi * M_PI / 3.0)` — the first Taylor term of `sinc'(x) = -pi^2*x/3`. This evaluates to 0 at x=0 (correct: `sinc'(0) = 0`) and lets autograd trace through it to recover `sinc''(0) = -pi^2/3`. Using a constant scalar as the true-branch blocks higher-order gradients from flowing through it entirely.

Fixes: #89459 

Test Plan:
- `python test/test_unary_ufuncs.py -k sinc` — 554 passed, 18 skipped
- `lintrunner -a torch/csrc/autograd/FunctionsManual.cpp` — no issues in changed lines



cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93