### PR TITLE
[TokenSwitch] Add expert-major dispatch layout

### DIFF
--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -362,6 +362,95 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         )
         self.assertEqual(combined, expected)
 
+    @skip_if_lt_x_gpu(2)
+    def test_dispatch_expert_major(self):
+        """Expert-major layout: out_topk_weights is 1-D, out_topk_idx is absent."""
+        self._init()
+        ts = self.get_token_switch()
+        num_recv_tokens = self.world_size * NUM_TOKENS
+
+        topk_idx, topk_weights = _generate_topk(
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+        )
+        routing = ts.create_routing(topk_idx, layout="expert_major")
+
+        token_val = float(self.rank + 1)
+        tokens = torch.full(
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+        )
+        out_tokens = torch.zeros(
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        # 1-D weights: one scalar per received slot (no topk dim).
+        out_topk_weights = torch.zeros(
+            num_recv_tokens, dtype=torch.float32, device=self.device
+        )
+
+        ts.dispatch(
+            routing,
+            tokens,
+            topk_weights,
+            out=(out_tokens, out_topk_weights, None),
+        )
+        torch.cuda.synchronize()
+
+        src_rank = (self.rank - 1) % self.world_size
+        expected_val = float(src_rank + 1)
+        received = out_tokens[:NUM_TOKENS].float()
+        self.assertTrue(
+            received.eq(expected_val).all(),
+            f"rank {self.rank}: expected {expected_val}, got {received[0, 0].item()}",
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_dispatch_combine_roundtrip_expert_major(self):
+        """Expert-major HT roundtrip: user applies 1-D weights before combine."""
+        self._init()
+        ts = self.get_token_switch()
+        num_recv_tokens = self.world_size * NUM_TOKENS
+
+        topk_idx, topk_weights = _generate_topk(
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+        )
+        routing = ts.create_routing(topk_idx, layout="expert_major")
+
+        token_val = float(self.rank + 1)
+        tokens = torch.full(
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+        )
+        out_tokens = torch.zeros(
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        out_topk_weights = torch.zeros(
+            num_recv_tokens, dtype=torch.float32, device=self.device
+        )
+
+        ts.dispatch(
+            routing,
+            tokens,
+            topk_weights,
+            out=(out_tokens, out_topk_weights, None),
+        )
+        torch.cuda.synchronize()
+
+        # HT+expert_major: multiply by weights before combine.
+        # out_topk_weights[:NUM_TOKENS] covers this rank's expert zone.
+        expert_tokens = out_tokens[:NUM_TOKENS].contiguous()
+        expert_weights = out_topk_weights[:NUM_TOKENS]
+        expert_tokens_weighted = (
+            expert_tokens.float().mul_(expert_weights[:, None])
+        ).to(torch.bfloat16).contiguous()
+
+        combined = torch.zeros(
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        ts.combine(routing, expert_tokens_weighted, out=combined)
+        torch.cuda.synchronize()
+
+        # weights are 1/TOP_K = 1.0, so the roundtrip is lossless.
+        expected = torch.full((NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16)
+        self.assertEqual(combined.cpu(), expected)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu
@@ -41,6 +41,19 @@ struct EpTensor {
         TORCH_CHECK(_r == ncclSuccess, "nccl_ep error: ", ncclGetErrorString(_r)); \
     } while (0)
 
+// Translate the header's standalone layout enum to the library enum.
+static ncclEpLayout_t to_nccl_layout(NcclEpLayout layout) {
+    switch (layout) {
+        case NcclEpLayout::Flat:
+            return NCCL_EP_LAYOUT_FLAT;
+        case NcclEpLayout::ExpertMajor:
+            return NCCL_EP_LAYOUT_EXPERT_MAJOR;
+        case NcclEpLayout::RankMajor:
+            return NCCL_EP_LAYOUT_RANK_MAJOR;
+    }
+    TORCH_CHECK(false, "nccl_ep: invalid layout ", static_cast<int64_t>(layout));
+}
+
 static ncclComm_t get_nccl_comm(
     const c10::intrusive_ptr<::c10d::ProcessGroup>& pg) {
     auto* ncclPg = dynamic_cast<c10d::ProcessGroupNCCL*>(
@@ -94,7 +107,8 @@ c10::intrusive_ptr<NcclEpGroup> nccl_ep_create_group(
 c10::intrusive_ptr<NcclEpHandle> nccl_ep_create_handle(
     const c10::intrusive_ptr<NcclEpGroup>& group,
     const at::Tensor& topk_idx,
-    const std::optional<at::Tensor>& recv_expert_counter) {
+    const std::optional<at::Tensor>& recv_expert_counter,
+    NcclEpLayout layout) {
     auto stream = at::cuda::getCurrentCUDAStream();
     auto ep_group = reinterpret_cast<ncclEpGroup_t>(group->group);
 
@@ -116,14 +130,17 @@ c10::intrusive_ptr<NcclEpHandle> nccl_ep_create_handle(
     ncclEpHandle_t ep_handle = nullptr;
     NCCL_EP_CHECK(ncclEpCreateHandle(
         &ep_handle, ep_group,
-        NCCL_EP_LAYOUT_FLAT,
+        to_nccl_layout(layout),
         &topk.desc,
         &layout_info,
         /*config=*/nullptr,
         stream));
 
     return c10::make_intrusive<NcclEpHandle>(
-        ep_handle, topk_idx, std::move(recv_total_counter));
+        ep_handle,
+        layout,
+        topk_idx,
+        std::move(recv_total_counter));
 }
 
 int64_t nccl_ep_handle_get_num_recv_tokens(
@@ -142,8 +159,8 @@ void nccl_ep_dispatch(
     const at::Tensor& tokens,
     const at::Tensor& topk_weights,
     at::Tensor& out_tokens,
-    at::Tensor& out_topk_weights,
-    at::Tensor& out_topk_idx) {
+    std::optional<at::Tensor> out_topk_weights,
+    std::optional<at::Tensor> out_topk_idx) {
     auto stream = at::cuda::getCurrentCUDAStream();
     auto ep_handle = reinterpret_cast<ncclEpHandle_t>(handle->handle);
 
@@ -152,8 +169,9 @@ void nccl_ep_dispatch(
     EpTensor in_tokens(tokens);
     EpTensor in_weights(topk_weights);
     EpTensor out_tok(out_tokens);
-    EpTensor out_wts(out_topk_weights);
-    EpTensor out_idx(out_topk_idx);
+    std::optional<EpTensor> out_wts, out_idx;
+    if (out_topk_weights) out_wts.emplace(*out_topk_weights);
+    if (out_topk_idx) out_idx.emplace(*out_topk_idx);
 
     ncclEpDispatchInputs_t inputs = NCCL_EP_DISPATCH_INPUTS_INIT;
     inputs.tokens = &in_tokens.desc;
@@ -161,8 +179,8 @@ void nccl_ep_dispatch(
 
     ncclEpDispatchOutputs_t outputs = NCCL_EP_DISPATCH_OUTPUTS_INIT;
     outputs.tokens = &out_tok.desc;
-    outputs.topk_weights = &out_wts.desc;
-    outputs.topk_idx = &out_idx.desc;
+    outputs.topk_weights = out_wts ? &out_wts->desc : nullptr;
+    outputs.topk_idx = out_idx ? &out_idx->desc : nullptr;
 
     ncclEpDispatchConfig_t config = NCCL_EP_DISPATCH_CONFIG_INIT;
 
@@ -216,7 +234,8 @@ c10::intrusive_ptr<NcclEpGroup> nccl_ep_create_group(
 c10::intrusive_ptr<NcclEpHandle> nccl_ep_create_handle(
     const c10::intrusive_ptr<NcclEpGroup>&,
     const at::Tensor&,
-    const std::optional<at::Tensor>&) {
+    const std::optional<at::Tensor>&,
+    NcclEpLayout) {
     not_supported();
 }
 
@@ -228,7 +247,7 @@ int64_t nccl_ep_handle_get_num_recv_tokens(
 void nccl_ep_dispatch(
     const c10::intrusive_ptr<NcclEpHandle>&,
     const at::Tensor&, const at::Tensor&,
-    at::Tensor&, at::Tensor&, at::Tensor&) {
+    at::Tensor&, std::optional<at::Tensor>, std::optional<at::Tensor>) {
     not_supported();
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp
@@ -8,6 +8,15 @@
 
 namespace c10d::nccl_ep {
 
+// Dispatch output layout, mirroring ncclEpLayout_t. Kept as a standalone enum
+// (rather than ncclEpLayout_t) so this header stays free of <nccl_ep.h>; the
+// .cu translates it to the library enum.
+enum class NcclEpLayout : int64_t {
+  Flat = 0,
+  ExpertMajor = 1,
+  RankMajor = 2,
+};
+
 struct NcclEpGroup : c10::intrusive_ptr_target {
   void* group{nullptr}; // ncclEpGroup_t, opaque to avoid including nccl_ep.h
 
@@ -17,6 +26,7 @@ struct NcclEpGroup : c10::intrusive_ptr_target {
 
 struct NcclEpHandle : c10::intrusive_ptr_target {
   void* handle{nullptr}; // ncclEpHandle_t, opaque
+  NcclEpLayout layout{NcclEpLayout::Flat}; // for callers to query output shapes
   // The library stashes topk_idx's device pointer on the handle (per nccl_ep.h:
   // "User-owned (do not free). LL reads directly; HT uses cached
   // hybridep.topk_idx"). recv_total_counter is allocated by us and read back
@@ -25,8 +35,13 @@ struct NcclEpHandle : c10::intrusive_ptr_target {
   at::Tensor topk_idx;
   at::Tensor recv_total_counter;
 
-  NcclEpHandle(void* handle, at::Tensor topk_idx, at::Tensor recv_total_counter)
+  NcclEpHandle(
+      void* handle,
+      NcclEpLayout layout,
+      at::Tensor topk_idx,
+      at::Tensor recv_total_counter)
       : handle(handle),
+        layout(layout),
         topk_idx(std::move(topk_idx)),
         recv_total_counter(std::move(recv_total_counter)) {}
   ~NcclEpHandle();
@@ -42,18 +57,22 @@ TORCH_API c10::intrusive_ptr<NcclEpGroup> nccl_ep_create_group(
 TORCH_API c10::intrusive_ptr<NcclEpHandle> nccl_ep_create_handle(
     const c10::intrusive_ptr<NcclEpGroup>& group,
     const at::Tensor& topk_idx,
-    const std::optional<at::Tensor>& recv_expert_counter);
+    const std::optional<at::Tensor>& recv_expert_counter,
+    NcclEpLayout layout);
 
 TORCH_API int64_t nccl_ep_handle_get_num_recv_tokens(
     const c10::intrusive_ptr<NcclEpHandle>& handle);
 
+// out_topk_idx is nullopt for expert-major layouts, which leave it
+// unpopulated; out_topk_weights stays populated (1-D for expert-major, 2-D for
+// flat) and is optional only for API symmetry.
 TORCH_API void nccl_ep_dispatch(
     const c10::intrusive_ptr<NcclEpHandle>& handle,
     const at::Tensor& tokens,
     const at::Tensor& topk_weights,
     at::Tensor& out_tokens,
-    at::Tensor& out_topk_weights,
-    at::Tensor& out_topk_idx);
+    std::optional<at::Tensor> out_topk_weights,
+    std::optional<at::Tensor> out_topk_idx);
 
 TORCH_API void nccl_ep_combine(
     const c10::intrusive_ptr<NcclEpHandle>& handle,

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp
@@ -26,6 +26,11 @@ PYBIND11_MODULE(_nccl_ep, m) {
   setenv("NCCL_HOME", NCCL_EP_JIT_HOME, /*overwrite=*/0);
 #endif
 
+  py::enum_<NcclEpLayout>(m, "Layout")
+      .value("FLAT", NcclEpLayout::Flat)
+      .value("EXPERT_MAJOR", NcclEpLayout::ExpertMajor)
+      .value("RANK_MAJOR", NcclEpLayout::RankMajor);
+
   py::class_<NcclEpGroup, c10::intrusive_ptr<NcclEpGroup>>(m, "_NcclEpGroup")
       .def_static(
           "create",
@@ -42,7 +47,8 @@ PYBIND11_MODULE(_nccl_ep, m) {
           &nccl_ep_create_handle,
           py::arg("group"),
           py::arg("topk_idx"),
-          py::arg("recv_expert_counter") = py::none())
+          py::arg("recv_expert_counter") = py::none(),
+          py::arg("layout"))
       .def("get_num_recv_tokens", &nccl_ep_handle_get_num_recv_tokens);
 
   m.def(

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -105,6 +105,7 @@ def _import_nccl_ep() -> Any:
 class Routing:
     handle: object
     topk_idx: torch.Tensor
+    layout: str = "flat"  # "flat" | "expert_major"
 
 
 class _DispatchAutograd(torch.autograd.Function):
@@ -116,12 +117,12 @@ class _DispatchAutograd(torch.autograd.Function):
         tokens: torch.Tensor,
         topk_weights: torch.Tensor,
         max_recv_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         _N, H = tokens.shape
         K = topk_weights.shape[1]
-        out_tokens = tokens.new_zeros(max_recv_tokens, H)
-        out_topk_weights = topk_weights.new_zeros(max_recv_tokens, K)
-        out_topk_idx = routing.topk_idx.new_zeros(max_recv_tokens, K)
+        out_tokens, out_topk_weights, out_topk_idx = ts._alloc_dispatch_outputs(
+            routing, tokens, topk_weights, max_recv_tokens, H, K
+        )
         ts._dispatch(
             routing, tokens, topk_weights, out_tokens, out_topk_weights, out_topk_idx
         )
@@ -135,8 +136,8 @@ class _DispatchAutograd(torch.autograd.Function):
     def backward(
         ctx: Any,
         grad_out_tokens: torch.Tensor,
-        grad_out_topk_weights: torch.Tensor,
-        grad_out_topk_idx: torch.Tensor,
+        grad_out_topk_weights: torch.Tensor | None,
+        grad_out_topk_idx: torch.Tensor | None,
     ) -> tuple[None, None, torch.Tensor, None, None]:
         grad_tokens = grad_out_tokens.new_zeros(ctx.tokens_shape)
         ctx.ts._combine(ctx.routing, grad_out_tokens.contiguous(), grad_tokens)
@@ -152,7 +153,7 @@ class _CombineAutograd(torch.autograd.Function):
         expert_tokens: torch.Tensor,
     ) -> torch.Tensor:
         N = routing.topk_idx.shape[0]
-        H = expert_tokens.shape[1]
+        H = expert_tokens.shape[-1]
         out_tokens = expert_tokens.new_zeros(N, H)
         ts._combine(routing, expert_tokens, out_tokens)
         ctx.ts = ts
@@ -167,20 +168,21 @@ class _CombineAutograd(torch.autograd.Function):
     def backward(
         ctx: Any, grad_out_tokens: torch.Tensor
     ) -> tuple[None, None, torch.Tensor]:
-        M, H = ctx.expert_shape
+        ts = ctx.ts
+        H = ctx.expert_shape[-1]
         N = grad_out_tokens.shape[0]
         K = ctx.top_k
         dtype = ctx.expert_dtype
-        # ncclEpDispatch requires the output buffer sized to the group's
-        # max_recv_tokens_per_rank, regardless of what shape expert_tokens had
-        # in forward (often a slice like out_tokens[:M]). Allocate full-size,
-        # run dispatch, then slice to ctx.expert_shape so the returned grad
-        # matches the input that produced it.
-        max_recv = ctx.ts._max_recv_tokens_per_rank
-        grad_expert_full = grad_out_tokens.new_zeros(max_recv, H).to(dtype)
+        # Allocate the full-size dispatch output buffer matching the layout's
+        # expected shape, dispatch the gradient into it, then slice back to
+        # ctx.expert_shape so the returned grad matches the combine input.
+        max_recv = ts._max_recv_tokens_per_rank
+        grad_expert_full, dummy_out_weights, dummy_out_idx = ts._alloc_dispatch_outputs(
+            ctx.routing, grad_out_tokens, grad_out_tokens.new_zeros(N, K, dtype=torch.float32),
+            max_recv, H, K,
+        )
+        grad_expert_full = grad_expert_full.to(dtype)
         dummy_weights = grad_out_tokens.new_zeros(N, K, dtype=torch.float32)
-        dummy_out_weights = grad_out_tokens.new_zeros(max_recv, K, dtype=torch.float32)
-        dummy_out_idx = ctx.routing.topk_idx.new_zeros(max_recv, K)
         ctx.ts._dispatch(
             ctx.routing,
             grad_out_tokens.to(dtype).contiguous(),
@@ -189,6 +191,9 @@ class _CombineAutograd(torch.autograd.Function):
             dummy_out_weights,
             dummy_out_idx,
         )
+        # Slice the leading dim back to expert_shape[0] (no-op for LL+EM where
+        # the full buffer was already the right size).
+        M = ctx.expert_shape[0]
         return None, None, grad_expert_full[:M].contiguous()
 
 
@@ -212,14 +217,27 @@ class TokenSwitch(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def _alloc_dispatch_outputs(
+        self,
+        routing: Routing,
+        tokens: torch.Tensor,
+        topk_weights: torch.Tensor,
+        max_recv_tokens: int,
+        H: int,
+        K: int,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        """Allocate dispatch output buffers with shapes matching routing.layout."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def _dispatch(
         self,
         routing: Routing,
         tokens: torch.Tensor,
         topk_weights: torch.Tensor,
         out_tokens: torch.Tensor,
-        out_topk_weights: torch.Tensor,
-        out_topk_idx: torch.Tensor,
+        out_topk_weights: torch.Tensor | None,
+        out_topk_idx: torch.Tensor | None,
     ) -> None:
         raise NotImplementedError
 
@@ -239,16 +257,19 @@ class TokenSwitch(abc.ABC):
         topk_weights: torch.Tensor,
         max_recv_tokens: int | None = None,
         *,
-        out: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        out: tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """Route tokens to experts.
 
-        With ``out=(out_tokens, out_topk_weights, out_topk_idx)``: writes to the provided
-        buffers and returns them; no autograd support.
-        Without ``out``: allocates output buffers and returns
-        ``(out_tokens, out_topk_weights, out_topk_idx)`` with autograd support.
-        ``max_recv_tokens`` is required when ``out`` is not provided.
-        ``topk_weights`` receives no gradient (routing metadata).
+        Returns ``(out_tokens, out_topk_weights, out_topk_idx)``.  For
+        expert-major layouts ``out_topk_idx`` is ``None``; for LL+expert-major
+        ``out_topk_weights`` is also ``None``.
+
+        With ``out=(out_tokens, out_topk_weights, out_topk_idx)``: writes to the
+        provided buffers and returns them; no autograd support.
+        Without ``out``: allocates output buffers and returns the tuple with
+        autograd support.  ``max_recv_tokens`` is required when ``out`` is not
+        provided.  ``topk_weights`` receives no gradient (routing metadata).
         """
         if out is not None:
             self._dispatch(routing, tokens, topk_weights, *out)
@@ -279,7 +300,11 @@ class TokenSwitch(abc.ABC):
 
 
 class TokenSwitchNCCL(TokenSwitch):
-    """Token switch backed by NCCL EP (:func:`ncclEpCreateGroup` / dispatch / combine)."""
+    """Token switch backed by NCCL EP (:func:`ncclEpCreateGroup` / dispatch / combine).
+
+    The dispatch output layout is chosen per routing via
+    :meth:`create_routing`'s ``layout`` argument.
+    """
 
     def __init__(
         self,
@@ -290,8 +315,15 @@ class TokenSwitchNCCL(TokenSwitch):
         max_token_bytes: int,
     ) -> None:
         self._ep = _import_nccl_ep()
+        ep = self._ep
+
+        self._layout_map = {
+            "flat": ep.Layout.FLAT,
+            "expert_major": ep.Layout.EXPERT_MAJOR,
+        }
+
         self._max_recv_tokens_per_rank = max_recv_tokens_per_rank
-        self._group = self._ep._NcclEpGroup.create(
+        self._group = ep._NcclEpGroup.create(
             process_group,
             num_experts,
             max_dispatch_tokens_per_rank,
@@ -299,18 +331,50 @@ class TokenSwitchNCCL(TokenSwitch):
             max_token_bytes,
         )
 
+    def _alloc_dispatch_outputs(
+        self,
+        routing: Routing,
+        tokens: torch.Tensor,
+        topk_weights: torch.Tensor,
+        max_recv_tokens: int,
+        H: int,
+        K: int,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        if routing.layout == "expert_major":
+            # topk_weights is 1D (one scalar weight per recv slot);
+            # topk_idx is not populated (nullptr in NCCL EP).
+            return (
+                tokens.new_zeros(max_recv_tokens, H),
+                topk_weights.new_zeros(max_recv_tokens),
+                None,
+            )
+        # flat: standard 2D outputs
+        return (
+            tokens.new_zeros(max_recv_tokens, H),
+            topk_weights.new_zeros(max_recv_tokens, K),
+            tokens.new_zeros(max_recv_tokens, K, dtype=torch.int32),
+        )
+
     def create_routing(
         self,
         topk_idx: torch.Tensor,
         per_expert_token_counts: torch.Tensor | None = None,
+        layout: str = "flat",
     ) -> Routing:
-        """Create expert routing for this phase; pass to :meth:`dispatch` / :meth:`combine`."""
+        """Create expert routing for this phase; pass to :meth:`dispatch` / :meth:`combine`.
+
+        ``layout`` controls the dispatch output memory layout: ``"flat"`` or
+        ``"expert_major"``.
+        """
+        if layout not in self._layout_map:
+            raise ValueError(f"layout must be one of {list(self._layout_map)}; got {layout!r}")
         handle = self._ep._NcclEpHandle.create(
             self._group,
             topk_idx,
             per_expert_token_counts,
+            self._layout_map[layout],
         )
-        return Routing(handle=handle, topk_idx=topk_idx)
+        return Routing(handle=handle, topk_idx=topk_idx, layout=layout)
 
     def _dispatch(
         self,
@@ -318,8 +382,8 @@ class TokenSwitchNCCL(TokenSwitch):
         tokens: torch.Tensor,
         topk_weights: torch.Tensor,
         out_tokens: torch.Tensor,
-        out_topk_weights: torch.Tensor,
-        out_topk_idx: torch.Tensor,
+        out_topk_weights: torch.Tensor | None,
+        out_topk_idx: torch.Tensor | None,
     ) -> None:
         self._ep._nccl_ep_dispatch(
             routing.handle,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187805
* __->__ #187804

Expose the receive-buffer layout through the token-switch API so callers can
select it (the NCCL EP algorithm stays high_throughput).

Expert-major orders the dispatched tokens so that all tokens routed to the same
local expert are contiguous, which is the layout a grouped GEMM over experts
consumes directly -- no regrouping pass between dispatch and the expert matmul.

- Add a `NcclEpLayout` enum (`Flat` / `ExpertMajor` / `RankMajor`) in the header,
  kept separate from the library's `ncclEpLayout_t` so the header stays free of
  `<nccl_ep.h>`; the `.cu` translates between them via `to_nccl_layout()`.
- `nccl_ep_create_handle` takes a `NcclEpLayout` arg instead of hardcoding
  `NCCL_EP_LAYOUT_FLAT`; the layout is stashed on the handle.
- `nccl_ep_dispatch`'s `out_topk_idx` is now optional, since expert-major
  layouts leave it unpopulated; `out_topk_weights` also becomes optional for API
  symmetry (it stays populated -- 1-D for expert-major, 2-D for flat).
- Python: `create_routing` gains a `layout` arg, with the output-buffer shapes
  chosen per layout.
- pybind binds `NcclEpLayout` as a `Layout` enum object.

Test Plan:
On a node with 2+ GPUs and a `USE_NCCL_EP=1` build:

```
python -m pytest test/distributed/test_token_switch.py -k expert_major -v
```

Covers `test_dispatch_expert_major` and
`test_dispatch_combine_roundtrip_expert_major`. Passed on 8xH100.