### PR TITLE
[TokenSwitch] Add symmetric-memory zero-copy dispatch/combine

### DIFF
--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -5,6 +5,7 @@ import logging
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed._token_switch import _import_nccl_ep, TokenSwitchNCCL
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
@@ -362,6 +363,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         )
         self.assertEqual(combined, expected)
 
+
     @skip_if_lt_x_gpu(2)
     def test_dispatch_expert_major(self):
         """Expert-major layout: out_topk_weights is 1-D, out_topk_idx is absent."""
@@ -450,6 +452,170 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         # weights are 1/TOP_K = 1.0, so the roundtrip is lossless.
         expected = torch.full((NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16)
         self.assertEqual(combined.cpu(), expected)
+
+    @skip_if_lt_x_gpu(2)
+    def test_dispatch_symm_mem_tokens(self):
+        """Dispatch with symm_mem-backed tokens exercises the zero-copy window path."""
+        self._init()
+        ts = self.get_token_switch()
+        pg = dist.distributed_c10d._get_default_group()
+        num_recv_tokens = self.world_size * NUM_TOKENS
+
+        # Allocate the token buffer in symmetric memory so NCCL EP can address
+        # it via the registered ncclWindow without an extra device-side copy.
+        symm_tokens = symm_mem.empty(
+            NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=self.device
+        )
+        symm_mem.rendezvous(symm_tokens, group=pg)
+
+        token_val = float(self.rank + 1)
+        symm_tokens.fill_(token_val)
+
+        topk_idx, topk_weights = _generate_topk(
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+        )
+        routing = ts.create_routing(topk_idx)
+
+        out_tokens = symm_mem.empty(
+            num_recv_tokens, HIDDEN, dtype=torch.bfloat16, device=self.device
+        )
+        symm_mem.rendezvous(out_tokens, group=pg)
+
+        out_topk_weights = torch.zeros(
+            (num_recv_tokens, TOP_K), dtype=torch.float32, device=self.device
+        )
+        out_topk_idx = torch.zeros(
+            (num_recv_tokens, TOP_K), dtype=torch.int64, device=self.device
+        )
+
+        ts.dispatch(
+            routing,
+            symm_tokens,
+            topk_weights,
+            out=(out_tokens, out_topk_weights, out_topk_idx),
+        )
+        torch.cuda.synchronize()
+
+        src_rank = (self.rank - 1) % self.world_size
+        expected_val = float(src_rank + 1)
+        received = out_tokens[:NUM_TOKENS].float()
+        self.assertTrue(
+            received.eq(expected_val).all(),
+            f"rank {self.rank}: expected {expected_val}, got {received[0, 0].item()}",
+        )
+
+
+    @skip_if_lt_x_gpu(2)
+    def test_combine_symm_mem_tokens(self):
+        """Combine with symm_mem-backed expert tokens exercises the zero-copy window path."""
+        self._init()
+        ts = self.get_token_switch()
+        pg = dist.distributed_c10d._get_default_group()
+        num_recv_tokens = self.world_size * NUM_TOKENS
+
+        topk_idx, topk_weights = _generate_topk(
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+        )
+        routing = ts.create_routing(topk_idx)
+
+        token_val = float(self.rank + 1)
+        tokens = torch.full(
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+        )
+        out_tokens = torch.zeros(
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        out_topk_weights = torch.zeros(
+            (num_recv_tokens, TOP_K), dtype=torch.float32, device=self.device
+        )
+        out_topk_idx = torch.zeros(
+            (num_recv_tokens, TOP_K), dtype=torch.int64, device=self.device
+        )
+
+        ts.dispatch(
+            routing,
+            tokens,
+            topk_weights,
+            out=(out_tokens, out_topk_weights, out_topk_idx),
+        )
+        torch.cuda.synchronize()
+
+        # Allocate expert_tokens in symmetric memory for zero-copy combine path.
+        symm_expert_tokens = symm_mem.empty(
+            NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=self.device
+        )
+        symm_mem.rendezvous(symm_expert_tokens, group=pg)
+        symm_expert_tokens.copy_(out_tokens[:NUM_TOKENS])
+
+        combined = torch.zeros(
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        ts.combine(routing, symm_expert_tokens, out=combined)
+        torch.cuda.synchronize()
+
+        expected = torch.full((NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16)
+        self.assertEqual(combined.cpu(), expected)
+
+    @skip_if_lt_x_gpu(2)
+    def test_dispatch_group_gemm_combine_symm_mem(self):
+        """Full pipeline: dispatch (symm_mem) -> group_gemm -> weight mul -> combine (symm_mem)."""
+        self._init()
+        ts = self.get_token_switch()
+        pg = dist.distributed_c10d._get_default_group()
+        num_recv_tokens = self.world_size * NUM_TOKENS
+
+        token_val = float(self.rank + 1)
+        tokens = torch.full(
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+        )
+
+        topk_idx, topk_weights = _generate_topk(
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+        )
+        routing = ts.create_routing(topk_idx, layout="expert_major")
+
+        out_tokens = symm_mem.empty(
+            num_recv_tokens, HIDDEN, dtype=torch.bfloat16, device=self.device
+        )
+        symm_mem.rendezvous(out_tokens, group=pg)
+        out_topk_weights = torch.zeros(
+            num_recv_tokens, dtype=torch.float32, device=self.device
+        )
+
+        ts.dispatch(
+            routing,
+            tokens,
+            topk_weights,
+            out=(out_tokens, out_topk_weights, None),
+        )
+        torch.cuda.synchronize()
+
+        # group_gemm: simulate with a scaled identity weight matrix.
+        GEMM_SCALE = 2.0
+        expert_tokens = out_tokens[:NUM_TOKENS].contiguous()
+        weight = torch.eye(HIDDEN, dtype=torch.float32, device=self.device) * GEMM_SCALE
+        gemm_out = expert_tokens.float().mm(weight).to(torch.bfloat16)
+
+        # weight mul + allocate directly into symm_mem pool to avoid a copy.
+        expert_weights = out_topk_weights[:NUM_TOKENS]
+        with torch.cuda.use_mem_pool(symm_mem.get_mem_pool(self.device)):
+            gemm_weighted = (
+                gemm_out.float().mul_(expert_weights[:, None])
+            ).to(torch.bfloat16).contiguous()
+        symm_mem.rendezvous(gemm_weighted, group=pg)
+
+        combined = torch.zeros(
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=self.device
+        )
+        ts.combine(routing, gemm_weighted, out=combined)
+        torch.cuda.synchronize()
+
+        # weights are 1/TOP_K = 1.0 and GEMM_SCALE applied, so expected = token_val * GEMM_SCALE.
+        expected_val = token_val * GEMM_SCALE
+        expected = torch.full(
+            (NUM_TOKENS, HIDDEN), expected_val, dtype=torch.bfloat16, device=self.device
+        )
+        self.assertEqual(combined, expected)
 
 
 if __name__ == "__main__":

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -483,7 +483,7 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
     Python_add_library(_nccl_ep MODULE WITH_SOABI
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep.cu"
       "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_ep_pybind.cpp")
-    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL)
+    target_compile_definitions(_nccl_ep PRIVATE USE_NCCL_EP USE_C10D_NCCL USE_NCCL)
     # torch_python: pybind + Tensor/ProcessGroup casters; torch_cuda:
     # ProcessGroupNCCL::getCommPtr, getNcclDataType, CUDA stream, embedded NCCL;
     # __caffe2_nccl_ep: libnccl_ep (static .a or shared .so) + nccl_ep headers.

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu
@@ -6,6 +6,8 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 #include <nccl_ep.h>
 
 namespace c10d::nccl_ep {
@@ -33,7 +35,48 @@ struct EpTensor {
         desc.sizes = const_cast<size_t*>(
             reinterpret_cast<const size_t*>(t.sizes().data()));
     }
+
+    // Window-backed constructor: NCCL-EP reads via RDMA from the registered
+    // ncclWindow instead of a plain device pointer (zero-copy path).
+    EpTensor(ncclWindow_t win, uint64_t win_offset, at::Tensor tensor)
+        : t(std::move(tensor)) {
+        TORCH_CHECK_VALUE(
+            t.is_contiguous(),
+            "nccl_ep tensors must be memory-contiguous (call .contiguous())");
+        TORCH_CHECK_VALUE(t.dim() > 0, "nccl_ep tensor must have rank >= 1");
+        desc.ndim = static_cast<unsigned int>(t.dim());
+        desc.datatype = c10d::getNcclDataType(t.scalar_type());
+        desc.data = nullptr;
+        desc.win_hdl = win;
+        desc.win_offset = win_offset;
+        static_assert(sizeof(size_t) == sizeof(int64_t));
+        desc.sizes = const_cast<size_t*>(
+            reinterpret_cast<const size_t*>(t.sizes().data()));
+    }
 };
+
+// Returns an EpTensor for t. If t is backed by NCCLSymmetricMemory registered
+// under group_name, uses the window + offset (zero-copy RDMA path); otherwise
+// falls back to the plain device-pointer path.
+static EpTensor make_ep_tensor(
+    const at::Tensor& t,
+    const std::string& group_name) {
+    namespace sm = c10d::symmetric_memory;
+    if (sm::is_symm_mem_tensor(t)) {
+        // rendezvous() is cached after the first collective call — cheap here.
+        auto symm_mem = sm::rendezvous(t, group_name);
+        auto* nccl_sm =
+            dynamic_cast<sm::NCCLSymmetricMemory*>(symm_mem.get());
+        if (nccl_sm != nullptr) {
+            ncclWindow_t win = nccl_sm->get_window();
+            void* base = nccl_sm->get_buffer_ptrs()[nccl_sm->get_rank()];
+            uint64_t offset = static_cast<uint8_t*>(t.data_ptr()) -
+                              static_cast<uint8_t*>(base);
+            return EpTensor(win, offset, t);
+        }
+    }
+    return EpTensor(t);
+}
 
 #define NCCL_EP_CHECK(expr)                                             \
     do {                                                                \
@@ -101,6 +144,7 @@ c10::intrusive_ptr<NcclEpGroup> nccl_ep_create_group(
 
     auto result = c10::make_intrusive<NcclEpGroup>();
     result->group = ep_group;
+    result->group_name = pg->getGroupName();
     return result;
 }
 
@@ -139,6 +183,7 @@ c10::intrusive_ptr<NcclEpHandle> nccl_ep_create_handle(
     return c10::make_intrusive<NcclEpHandle>(
         ep_handle,
         layout,
+        group->group_name,
         topk_idx,
         std::move(recv_total_counter));
 }
@@ -166,7 +211,7 @@ void nccl_ep_dispatch(
 
     // topk_idx is bound to the handle at nccl_ep_create_handle time; the new
     // ncclEpDispatch API doesn't take it as a per-call input.
-    EpTensor in_tokens(tokens);
+    EpTensor in_tokens = make_ep_tensor(tokens, handle->group_name);
     EpTensor in_weights(topk_weights);
     EpTensor out_tok(out_tokens);
     std::optional<EpTensor> out_wts, out_idx;
@@ -197,7 +242,7 @@ void nccl_ep_combine(
     auto stream = at::cuda::getCurrentCUDAStream();
     auto ep_handle = reinterpret_cast<ncclEpHandle_t>(handle->handle);
 
-    EpTensor in_tok(expert_tokens);
+    EpTensor in_tok = make_ep_tensor(expert_tokens, handle->group_name);
     EpTensor out_tok(out_tokens);
 
     ncclEpCombineInputs_t inputs = NCCL_EP_COMBINE_INPUTS_INIT;

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_ep.hpp
@@ -19,6 +19,7 @@ enum class NcclEpLayout : int64_t {
 
 struct NcclEpGroup : c10::intrusive_ptr_target {
   void* group{nullptr}; // ncclEpGroup_t, opaque to avoid including nccl_ep.h
+  std::string group_name;
 
   NcclEpGroup() = default;
   ~NcclEpGroup();
@@ -27,6 +28,7 @@ struct NcclEpGroup : c10::intrusive_ptr_target {
 struct NcclEpHandle : c10::intrusive_ptr_target {
   void* handle{nullptr}; // ncclEpHandle_t, opaque
   NcclEpLayout layout{NcclEpLayout::Flat}; // for callers to query output shapes
+  std::string group_name; // for symm_mem zero-copy rendezvous lookup
   // The library stashes topk_idx's device pointer on the handle (per nccl_ep.h:
   // "User-owned (do not free). LL reads directly; HT uses cached
   // hybridep.topk_idx"). recv_total_counter is allocated by us and read back
@@ -38,10 +40,12 @@ struct NcclEpHandle : c10::intrusive_ptr_target {
   NcclEpHandle(
       void* handle,
       NcclEpLayout layout,
+      std::string group_name,
       at::Tensor topk_idx,
       at::Tensor recv_total_counter)
       : handle(handle),
         layout(layout),
+        group_name(std::move(group_name)),
         topk_idx(std::move(topk_idx)),
         recv_total_counter(std::move(recv_total_counter)) {}
   ~NcclEpHandle();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187805
* #187804

When a dispatch/combine tensor is backed by `NCCLSymmetricMemory` registered
under the process group's name, address it via the registered `ncclWindow` +
offset (RDMA zero-copy path) instead of a plain device pointer, avoiding a
staging copy into a regular device buffer.

- `EpTensor` gains a window-backed constructor (`win_hdl` + `win_offset`).
- `make_ep_tensor()` looks up the symm_mem rendezvous for a tensor and uses the
  window path when available, falling back to the device-pointer path.
- `NcclEpGroup` / `NcclEpHandle` carry the `group_name` needed for that lookup.
- `torch/CMakeLists.txt`: add `USE_NCCL` to the `_nccl_ep` compile definitions
  so `NCCL_HAS_SYMMEM_SUPPORT` is defined and `NCCLSymmetricMemory` is a
  complete type.

Test Plan:
On a node with 2+ GPUs and a `USE_NCCL_EP=1` build:

```
python -m pytest test/distributed/test_token_switch.py -k symm_mem -v
```

Covers `test_dispatch_symm_mem_tokens`, `test_combine_symm_mem_tokens`, and
`test_dispatch_group_gemm_combine_symm_mem` (a full dispatch -> group_gemm ->
weight-mul -> combine pipeline with symm_mem on both ends). Passed on 8xH100.