### PR TITLE
Generalize memory viz and cycle detection

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -8,6 +8,7 @@ from contextlib import nullcontext
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    IS_LINUX,
     NoTest,
     run_tests,
     TEST_ACCELERATOR,
@@ -269,6 +270,50 @@ class TestAccelerator(TestCase):
         free_bytes, total_bytes = torch.accelerator.get_memory_info()
         self.assertGreaterEqual(free_bytes, 0)
         self.assertGreaterEqual(total_bytes, 0)
+
+    @unittest.skipIf(TEST_MPS, "MPS doesn't support torch.accelerator memory API!")
+    @unittest.skipUnless(IS_LINUX, "cpp contexts are linux only")
+    def test_tensor_cycles(self):
+        from torch.utils.viz._cycles import observe_tensor_cycles
+
+        acc = torch.accelerator.current_accelerator()
+        mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+        if mem_mod is None or not hasattr(mem_mod, "_record_memory_history"):
+            self.skipTest("Backend doesn't support memory history")
+
+        fired = False
+
+        def observer(html):
+            nonlocal fired
+            fired = True
+            self.assertIn("torch.Tensor", html)
+            self.assertIn("cell_contents", html)
+
+        disarm = observe_tensor_cycles(observer)
+
+        def noop():
+            pass
+
+        try:
+
+            def create():
+                x = torch.empty(3, 4, device=acc)
+
+                def foo(p):
+                    if p:
+                        return foo(not p)
+                    else:
+                        return x
+
+                return foo
+
+            create()
+            gc.collect()
+            # the callback fires outside of the collect call, not during it
+            noop()
+            self.assertTrue(fired)
+        finally:
+            disarm()
 
     @unittest.skipIf(
         TEST_XPU,

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -52,11 +52,11 @@ def observe_garbage(observer):
                         # we have to re-run GC to clean up the cycles
                         # we saved from before.
                         gc.set_debug(0)
-                        before = torch.cuda.memory_allocated()
+                        before = torch.accelerator.memory_allocated()
                         gc.collect()
-                        after = torch.cuda.memory_allocated()
+                        after = torch.accelerator.memory_allocated()
                         if before != after:
-                            logger.warning("CUDA Memory changed during GC, %d bytes freed.", before - after)
+                            logger.warning("Accelerator Memory changed during GC, %d bytes freed.", before - after)
                     finally:
                         enabled = True
                 if orig_trace is not None:
@@ -249,7 +249,7 @@ def object_annotation(obj):
         if len(filename) > FRAME_FILENAME_LIMIT:
             filename = "..." + filename[-(FRAME_FILENAME_LIMIT - 3):]
         return f"frame\n{filename}:{obj.f_lineno}"
-    elif is_cuda_tensor(obj):
+    elif is_accelerator_tensor(obj):
         return f"object\n{type(obj).__module__}.{type(obj).__name__} ({obj.shape})"
     else:
         return f"object\n{type(obj).__module__}.{type(obj).__name__}"
@@ -264,9 +264,9 @@ class Node(NamedTuple):
 
 def create_graph(objects, *, context=None, filter=None):
     if context is None:
-        context = cuda_allocation_context()
+        context = accelerator_allocation_context()
     if filter is None:
-        filter = is_cuda_tensor
+        filter = is_accelerator_tensor
 
     objects = [obj for obj in objects if not isinstance(obj, weakref.ProxyTypes)]
     nodes = [Node(object_annotation(obj), context(obj), filter(obj), []) for obj in objects]
@@ -312,15 +312,15 @@ def escape(n):
     return json.dumps(n)
 
 
-def is_cuda_tensor(obj):
+def is_accelerator_tensor(obj):
     return (
         isinstance(obj, torch.Tensor) and
-        obj.device.type == "cuda" and
+        obj.device.type != "cpu" and
         not torch._subclasses.fake_tensor.is_fake_tensor(obj)
     )
 
-def cuda_allocation_context():
-    snapshot = torch.cuda.memory._snapshot()
+def accelerator_allocation_context():
+    snapshot = torch.accelerator.memory._snapshot()
     addr_to_frame = {}
     for seg in snapshot['segments']:
         addr = seg['address']
@@ -331,7 +331,7 @@ def cuda_allocation_context():
             addr += blk['size']
 
     def object_context(obj):
-        if is_cuda_tensor(obj):
+        if is_accelerator_tensor(obj):
             addr = obj.untyped_storage().data_ptr()
             frames = addr_to_frame.get(addr)
             if frames is not None:
@@ -472,12 +472,12 @@ def to_html(nodes):
     return _template.replace('$DOT', repr(dot)).replace('$LISTENERS', '\n'.join(listeners))
 
 def observe_tensor_cycles(callback):
-    torch.cuda.memory._record_memory_history(max_entries=100000)
+    torch.accelerator.memory._record_memory_history(max_entries=100000)
 
     def observer(garbage) -> None:
         if garbage:
-            if not any(is_cuda_tensor(obj) for obj in garbage):
-                logger.info("No CUDA Tensors found in garbage")
+            if not any(is_accelerator_tensor(obj) for obj in garbage):
+                logger.info("No accelerator Tensors found in garbage")
                 return
             callback(to_html(create_graph(garbage)))
     return observe_garbage(observer)
@@ -485,21 +485,21 @@ def observe_tensor_cycles(callback):
 
 def warn_tensor_cycles():
     """
-    Install a warning that reports whenever a cycle that is holding CUDA memory is observed.
+    Install a warning that reports whenever a cycle that is holding accelerator memory is observed.
 
     The warning produces an .html file that visualizes the cycle,
-    and links it to the stack frame that allocated the CUDA tensor.
+    and links it to the stack frame that allocated the tensor.
 
     Reference cycles are freed by the cycle collector rather than being cleaned up
     when the objects in the cycle first become unreachable. If a cycle points to a tensor,
-    the CUDA memory for that tensor will not be freed until garbage collection runs.
-    Accumulation of CUDA allocations can lead to out of memory errors (OOMs), as well as
+    the accelerator memory for that tensor will not be freed until garbage collection runs.
+    Accumulation of allocations can lead to out of memory errors (OOMs), as well as
     non-deterministic allocation behavior which is harder to debug.
     """
-    logger.info("Watching Python reference cycles for CUDA Tensors.")
+    logger.info("Watching Python reference cycles for accelerator Tensors.")
 
     def write_and_log(html) -> None:
         with NamedTemporaryFile('w', suffix='.html') as f:
             f.write(html)
-            logger.warning('Reference cycle includes a CUDA Tensor see visualization of cycle %s', f.name)
+            logger.warning('Reference cycle includes an accelerator Tensor, see visualization of cycle %s', f.name)
     return observe_tensor_cycles(write_and_log)


### PR DESCRIPTION
## Summary

Generalize memory viz and cycle detection to work with any accelerator.
`torch/utils/viz/_cycles.py` was previously hard-coded to CUDA. This PR
replaces all CUDA-specific calls with their `torch.accelerator` equivalents:

- `memory_allocated()` now uses `torch.accelerator.memory_allocated()`
- `_snapshot()` and `_record_memory_history()` now go through `torch.accelerator.memory`
- `is_cuda_tensor()` renamed to `is_accelerator_tensor()` using `device.type != "cpu"`
  so it correctly detects tensors on any accelerator (CUDA, XPU, MPS, PrivateUse1)
- `cuda_allocation_context()` renamed to `accelerator_allocation_context()`

**Depends on #187205** (adds `torch.accelerator.get_device_name()` and
`torch.accelerator.memory._record_memory_history/dump_snapshot`).

cc @albanD @guangyey @EikanWang