### PR TITLE
Reject factor=0 in ConstantLR to avoid later ZeroDivisionError

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -475,6 +475,11 @@ class TestLRScheduler(TestCase):
         with self.assertRaises(ValueError):
             LinearLR(self.opt, start_factor=start_factor, total_iters=iters)
 
+    @parametrize("factor", [0.0, 1.1])
+    def test_constantlr_factor_limits(self, factor):
+        with self.assertRaises(ValueError):
+            ConstantLR(self.opt, factor=factor, total_iters=4)
+
     def test_constantlr_with_epoch(self):
         # lr = 0.025     if epoch < 5
         # lr = 0.005    if 5 <= epoch

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -810,9 +810,9 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
-                "Constant multiplicative factor expected to be between 0 and 1."
+                "Constant multiplicative factor expected to be greater than 0 and less or equal to 1."
             )
 
         self.factor = factor


### PR DESCRIPTION
Fixes #185006

### Summary

`ConstantLR` validated its multiplicative `factor` with `factor < 0`, so `factor=0` was accepted at construction time. Once `total_iters` is reached, `get_lr()` scales the learning rate by `1.0 / factor`, so a zero factor surfaced as a bare `ZeroDivisionError` several steps later — far from the offending argument and with no indication of which value was invalid.

```python
import torch
opt = torch.optim.SGD([torch.randn(1)], lr=0.1)
sched = torch.optim.lr_scheduler.ConstantLR(opt, factor=0.0, total_iters=2)
sched.step()  # OK
sched.step()  # ZeroDivisionError: float division by zero
```

### Fix

Reject `factor <= 0` at construction, mirroring how `LinearLR` already validates `start_factor`, and update the message to describe the expected `(0, 1]` range. Now:

```
ValueError: Constant multiplicative factor expected to be greater than 0 and less or equal to 1.
```

Valid factors are unaffected.

### Test plan

Added a parametrized `test_constantlr_factor_limits` covering `factor=0.0` and `factor=1.1`, as requested in review.

```
python -m pytest test/optim/test_lrscheduler.py -k test_constantlr_factor_limits -v
python -m pytest test/optim/test_lrscheduler.py -q   # 193 passed, 1 xfailed
```
