### PR TITLE
[Inductor][XPU] Unfuse addmm for all half-dtype inputs on XPU

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1486,6 +1486,10 @@ class TestPatternMatcher(TestCase):
             "keep_addmm_fused_for_half_dtypes": True,
         }
     )
+    @unittest.skipIf(
+        GPU_TYPE == "xpu",
+        "XPU prefers unfuse for half-dtype addmm; CUDA/ROCm keep fused",
+    )
     def test_unfuse_bias_addmm_half_dtypes(self, dtype):
         args = [
             torch.randn(20, device=GPU_TYPE, dtype=dtype),
@@ -1532,12 +1536,9 @@ class TestPatternMatcher(TestCase):
     )
     @unittest.skipIf(
         GPU_TYPE != "xpu",
-        "narrowing-cast unfuse is XPU-only; CUDA/ROCm keep addmm fused",
+        "XPU prefers unfuse for half-dtype addmm; CUDA/ROCm keep fused",
     )
-    def test_unfuse_bias_addmm_half_dtypes_narrowing_cast(self, dtype):
-        # When bias is fp32 and cast to a half dtype (e.g. AMP), unfusing
-        # lets the Triton pointwise kernel load the fp32 bias directly,
-        # preserving precision instead of truncating before fused addmm.
+    def test_unfuse_bias_addmm_half_dtypes_xpu(self, dtype):
         bias_fp32 = torch.randn(20, device=GPU_TYPE, dtype=torch.float32)
         args = [
             torch.randn(10, 15, device=GPU_TYPE, dtype=dtype),
@@ -1550,20 +1551,8 @@ class TestPatternMatcher(TestCase):
             return torch.nn.functional.gelu(torch.ops.aten.addmm(bias_half, a, b))
 
         _, (code) = run_and_get_code(fn, bias_fp32, args[0], args[1])
-        # Should be unfused (mm, not addmm) because bias is a narrowing cast
         FileCheck().check_not("extern_kernels.addmm(").run(code[0])
 
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @inductor_config.patch(
-        {
-            "fx_graph_remote_cache": False,
-            "keep_addmm_fused_for_half_dtypes": True,
-        }
-    )
-    def test_unfuse_bias_addmm_half_dtypes_narrowing_cast_numerics(self, dtype):
-        # Verify that unfusing a narrowing-cast bias produces results whose
-        # RMSE vs fp64 stays within 3x of eager's RMSE (the torchbench
-        # accuracy check threshold for half dtypes).
         torch.manual_seed(42)
 
         class Model(torch.nn.Module):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1759,18 +1759,9 @@ def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
         torch.bfloat16,
         torch.float16,
     ):
-        # Narrowing-cast unfuse (PR #183680) is XPU-only: it preserves
-        # precision on XPU pointwise but regresses accuracy on ROCm
-        # (basic_gnn_edgecnn training+amp fails on gfx950 otherwise).
+        # CUDA/ROCm keep addmm fused for half dtypes; XPU prefers unfuse
+        # so the pointwise kernel absorbs the bias add directly.
         if inp.meta["val"].device.type != "xpu":
-            return
-        if not (
-            inp.op == "call_function"
-            and inp.target is torch.ops.prims.convert_element_type.default
-            and inp.args[0].meta["val"].dtype.is_floating_point
-            and torch.finfo(inp.args[0].meta["val"].dtype).bits
-            > torch.finfo(inp.meta["val"].dtype).bits
-        ):
             return
 
     def repl(inp, x1, x2, alpha, beta):


### PR DESCRIPTION
The narrow-cast unfuse approach (PR #183680) only helps when bias is explicitly cast via convert_element_type, missing the common case where bias is already half dtype (e.g., AMP). On XPU, prefer to unfuse all half-dtype addmm so the pointwise kernel absorbs the bias add directly. CUDA/ROCm continue to keep addmm fused (existing behavior unchanged).

Test Plan:
- test_unfuse_bias_addmm_half_dtypes: unchanged, now skipped on XPU
- test_unfuse_bias_addmm_half_dtypes_xpu: merged codegen + numerics, XPU-only

Model:
python benchmarks/dynamo/timm_models.py --accuracy -d xpu -n10 --backend=inductor --cold-start-latency --inference --amp --amp-dtype float16 --only pit_b_224
 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo