### PR TITLE
Clean up mentions of deprecated nvidia-docker in README files

### DIFF
--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -17,7 +17,7 @@ See `build.sh` for valid build environments (it's the giant switch).
 * `build.sh` -- dispatch script to launch all builds
 * `common` -- scripts used to execute individual Docker build stages
 * `ubuntu` -- Dockerfile for Ubuntu image for CPU build and test jobs
-* `ubuntu-cuda` -- Dockerfile for Ubuntu image with CUDA support for nvidia-docker
+* `ubuntu-cuda` -- Dockerfile for Ubuntu image with CUDA support
 * `ubuntu-rocm` -- Dockerfile for Ubuntu image with ROCm support
 * `ubuntu-xpu` -- Dockerfile for Ubuntu image with XPU support
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ docker run --gpus all --rm -ti --ipc=host pytorch/pytorch:latest
 
 Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
 for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you
-should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `nvidia-docker run`.
+should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `docker run`.
 
 #### Building the image yourself
 


### PR DESCRIPTION
`nvidia-docker` has been deprecated as of Docker version 19.03 [(2019)](https://www.pugetsystems.com/labs/hpc/Workstation-Setup-for-Docker-with-the-New-NVIDIA-Container-Toolkit-nvidia-docker2-is-deprecated-1568/)

this PR removes or replaces confusing mentions of `nvidia-docker` in the README files