### PR TITLE
[CI] Rename RISC-V cross-compilation image to include "cross" suffix

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -76,8 +76,8 @@ elif [[ "$image" == *cuda*linter* ]]; then
 elif [[ "$image" == *linter* ]]; then
   # Use a separate Dockerfile for linter to keep a small image size
   DOCKERFILE="linter/Dockerfile"
-elif [[ "$image" == *riscv* ]]; then
-  # Use RISC-V specific Dockerfile
+elif [[ "$image" == *riscv*cross* ]]; then
+  # Use RISC-V cross-compilation specific Dockerfile
   DOCKERFILE="ubuntu-cross-riscv/Dockerfile"
 fi
 
@@ -467,7 +467,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 fi
 
 if [ -n "$GCC_VERSION" ]; then
-  if [[ "$image" == *riscv* ]]; then
+  if [[ "$image" == *riscv*cross* ]]; then
     # Check RISC-V cross-compilation toolchain version
     if !(drun riscv64-linux-gnu-gcc-${GCC_VERSION} --version 2>&1 | grep -q " $GCC_VERSION\\W"); then
       echo "RISC-V GCC_VERSION=$GCC_VERSION, but:"

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -76,7 +76,7 @@ if [[ "$BUILD_ENVIRONMENT" == *aarch64* ]]; then
   export ACL_ROOT_DIR=/acl
 fi
 
-if [[ "$BUILD_ENVIRONMENT" == *riscv64* ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *riscv64*cross* ]]; then
   if [[ -f /opt/riscv-cross-env/bin/activate ]]; then
     # shellcheck disable=SC1091
     source /opt/riscv-cross-env/bin/activate
@@ -224,7 +224,7 @@ fi
 
 # Do not change workspace permissions for ROCm and s390x CI jobs
 # as it can leave workspace with bad permissions for cancelled jobs
-if [[ "$BUILD_ENVIRONMENT" != *rocm* && "$BUILD_ENVIRONMENT" != *s390x* && "$BUILD_ENVIRONMENT" != *riscv64* && -d /var/lib/jenkins/workspace ]]; then
+if [[ "$BUILD_ENVIRONMENT" != *rocm* && "$BUILD_ENVIRONMENT" != *s390x* && "$BUILD_ENVIRONMENT" != *riscv64*cross* && -d /var/lib/jenkins/workspace ]]; then
   # Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
   WORKSPACE_ORIGINAL_OWNER_ID=$(stat -c '%u' "/var/lib/jenkins/workspace")
   cleanup_workspace() {
@@ -432,6 +432,6 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
   PYTHONPATH=. python tools/stats/export_test_times.py
 fi
 # don't do this for s390x or riscv64 as they don't use sccache
-if [[ "$BUILD_ENVIRONMENT" != *s390x* && "$BUILD_ENVIRONMENT" != *riscv64* ]]; then
+if [[ "$BUILD_ENVIRONMENT" != *s390x* && "$BUILD_ENVIRONMENT" != *riscv64*cross* ]]; then
   print_sccache_stats
 fi

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -73,7 +73,7 @@ jobs:
           # TODO: Re-enable me when docker pin update happens
           # pytorch-linux-jammy-py3-clang18-executorch,
           pytorch-linux-jammy-py3.12-triton-cpu,
-          pytorch-linux-noble-riscv64-py3.12-gcc14
+          pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
         ]
         include:
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc15

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-noble-riscv64-py3.12-gcc14
-      docker-image-name: ci-image:pytorch-linux-noble-riscv64-py3.12-gcc14
+      docker-image-name: ci-image:pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       runner: linux.c7i.2xlarge
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}


### PR DESCRIPTION
The RISC-V CI docker image name is renamed from `pytorch-linux-noble-riscv64-py3.12-gcc14` to `pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build` to make it explicit that this is a cross-compilation setup, not a native build.

All `*riscv*` pattern matches in the CI build scripts are updated to `*riscv*cross*` so that future native RISC-V builds won't accidentally match the cross-compilation code paths.

## Test Plan:
```
cd .ci/docker
CI=1 ./build.sh pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
```