### PR TITLE
 [XPU] Relax tolerance for test_combo_kernel_no_bench_persistent_reduction on XPU

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -866,7 +866,7 @@ class ComboKernelTests(TestCase):
             # XPU eager uses 32 threads with strided access while Triton uses
             # 256 threads with contiguous access. Due to float32 non-associativity,
             # different element-to-thread mappings produce slightly different sums.
-            torch.testing.assert_close(out_eager, out_compiled, atol=2e-5, rtol=1e-5)
+            self.assertEqual(out_eager, out_compiled, atol=2e-5, rtol=1e-5)
         else:
             self.assertEqual(out_eager, out_compiled)
         combined = " ".join(code)

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -863,8 +863,9 @@ class ComboKernelTests(TestCase):
         torch._inductor.metrics.reset()
         out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
         if GPU_TYPE == "xpu":
-            # XPU eager uses 32 threads with strided access while Triton uses
-            # 256 threads with contiguous access. Due to float32 non-associativity,
+            # For this shape (64, 1024), XPU eager uses fewer threads (e.g. 32)
+            # with strided access while Triton uses more threads (e.g. 256)
+            # with contiguous access. Due to float32 non-associativity,
             # different element-to-thread mappings produce slightly different sums.
             self.assertEqual(out_eager, out_compiled, atol=2e-5, rtol=1e-5)
         else:

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -862,7 +862,13 @@ class ComboKernelTests(TestCase):
         torch._dynamo.reset()
         torch._inductor.metrics.reset()
         out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
-        self.assertEqual(out_eager, out_compiled)
+        if GPU_TYPE == "xpu":
+            # XPU eager uses 32 threads with strided access while Triton uses
+            # 256 threads with contiguous access. Due to float32 non-associativity,
+            # different element-to-thread mappings produce slightly different sums.
+            torch.testing.assert_close(out_eager, out_compiled, atol=2e-5, rtol=1e-5)
+        else:
+            self.assertEqual(out_eager, out_compiled)
         combined = " ".join(code)
         self.assertEqual(combined.count("async_compile.triton("), 1)
 


### PR DESCRIPTION
## Summary

Relax tolerance for `test_combo_kernel_no_bench_persistent_reduction` on XPU (`atol=2e-5, rtol=1e-5`), enabling the test to validate correctness instead of being skipped.

## Root Cause

XPU eager reduction uses 32 threads with strided access (each thread accumulates 32 elements via vec_size=4), while Triton compiled reduction uses 256 threads with contiguous access (each thread accumulates ~4 elements). Since float32 addition is non-associative, partitioning the same 1024 elements differently produces slightly different sums (~1.9e-5 max gap). This is expected numerical behavior, not a correctness bug.


## Verification

- Triton kernel mimicking eager's strided pattern produces **bit-identical** results to eager, confirming the mapping difference is the sole source.
- Triton's result is actually **more accurate** vs float64 ground truth (4.5e-6) than eager (1.3e-5).
- Statistical analysis (100 seeds, shape 64×1024): max gap = 1.907e-05, bounded and well-understood.

Neither side should change: eager's strided pattern is optimal for general-purpose reduction, Triton's contiguous pattern is fundamental to its compilation model.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey