### PR TITLE
[CI] Make sccache install script architecture-agnostic

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -3,6 +3,8 @@
 set -ex
 
 install_ubuntu() {
+  ARCH=$(uname -m)
+  FEATURES="dist-client dist-server" # may vary based on the architecture we are building for
   echo "Installing pkg-config and libssl-dev"
   apt-get update && apt-get install -y pkg-config libssl-dev curl
   echo "Installing rust"
@@ -10,12 +12,14 @@ install_ubuntu() {
   echo "Checking out sccache repo"
   git clone https://github.com/mozilla/sccache -b v0.13.0
   cd sccache
-  echo "Patch dist build on aarch64"
-  sed -i '/all(target_os = "linux", target_arch = "x86_64"),/{ p; s/x86_64/aarch64/; }' src/bin/sccache-dist/main.rs
+  echo "Patch dist build on ${ARCH}"
+  sed -i "/all(target_os = \"linux\", target_arch = \"x86_64\"),/{ p; s/x86_64/${ARCH}/; }" src/bin/sccache-dist/main.rs
   echo "Building sccache"
-  . "$HOME/.cargo/env" && cargo build --release --features="dist-client dist-server"
+  . "$HOME/.cargo/env" && cargo build --release --features="${FEATURES}"
   cp target/release/sccache /opt/cache/bin
-  cp target/release/sccache-dist /opt/cache/bin
+  if [[ "${FEATURES}" =~ *dist-server* ]]; then
+    cp target/release/sccache-dist /opt/cache/bin
+  fi
   echo "Cleaning up"
   cd ..
   rm -rf sccache


### PR DESCRIPTION
The sccache build patch was hardcoded to `aarch64`, requiring a manual edit each time a new architecture is added. This change detects the architecture at build time via `uname -m` and applies the patch generically, so any future arch get the same fix without code duplication.

The `sccache-dist` binary copy is also made conditional on whether `dist-server` is included in `FEATURES`, avoiding a build failure when dist-server support is disabled for a given architecture.

Test Plan:
```
cd .ci/docker
CI=1 bash -x ./build.sh pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
```