### PR TITLE
Add privateuse1 backend support to has_triton()

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -208,7 +208,7 @@ def has_triton() -> bool:
 
     # Dynamically add privateuse1 backend if registered.
     pu1_backend = torch._C._get_privateuse1_backend_name()
-    if pu1_backend:
+    if pu1_backend and pu1_backend != "privateuseone":
         try:
             get_interface_for_device(pu1_backend)
             triton_supported_devices[pu1_backend] = _return_true

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -204,6 +204,17 @@ def has_triton() -> bool:
         "mtia": _return_true,
     }
 
+    import torch
+
+    # Dynamically add privateuse1 backend if registered.
+    pu1_backend = torch._C._get_privateuse1_backend_name()
+    if pu1_backend:
+        try:
+            get_interface_for_device(pu1_backend)
+            triton_supported_devices[pu1_backend] = _return_true
+        except NotImplementedError:
+            pass
+
     def is_device_compatible_with_triton() -> bool:
         for device, extra_check in triton_supported_devices.items():
             device_interface = get_interface_for_device(device)


### PR DESCRIPTION
## Motivation
PrivateUse1 backends may provide Triton support through their own Triton integrations. However, `has_triton()` currently only recognizes a fixed set of built-in device types.
Many Triton-related tests rely on has_triton(). Since registered PrivateUse1 backends are not recognized by this check, existing test coverage cannot be reused even when the backend supports Triton through its own integration.
This limits test reuse for out-of-tree backends.

## Changes
Update `torch/utils/_triton.py::has_triton()` to dynamically recognize a registered PrivateUse1 backend.

## Notes
This change uses the registered PrivateUse1 device interface only as an availability gate. The actual Triton support is expected to be provided by the backend's own Triton integration.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD