### PR TITLE
Remove dead grad_input_ variables in slow_conv_dilated backward

### DIFF
--- a/aten/src/ATen/native/NaiveDilatedConvolution.cpp
+++ b/aten/src/ATen/native/NaiveDilatedConvolution.cpp
@@ -666,9 +666,6 @@ static std::tuple<Tensor, Tensor, Tensor> slow_conv_dilated2d_backward_cpu(
       (output_mask[1] ? at::empty(weight.sizes(), options.memory_format(memory_format)) : undefined);
   Tensor grad_bias =
       (output_mask[2] ? at::empty(weight.size(0), options) : undefined);
-  Tensor grad_input_ =
-      (output_mask[0] ? (is_batch ? grad_input : grad_input.unsqueeze(0))
-                      : undefined);
   slow_conv_dilated_all_cpu_template<2>(
       undefined,
       input_,
@@ -722,9 +719,6 @@ static std::tuple<Tensor, Tensor, Tensor> slow_conv_dilated3d_backward_cpu(
       (output_mask[1] ? at::empty(weight.sizes(), options) : undefined);
   Tensor grad_bias =
       (output_mask[2] ? at::empty(weight.size(0), options) : undefined);
-  Tensor grad_input_ =
-      (output_mask[0] ? (is_batch ? grad_input : grad_input.unsqueeze(0))
-                      : undefined);
   slow_conv_dilated_all_cpu_template<3>(
       undefined,
       input_,

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -483,9 +483,6 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_dilated2d_backward_cuda(
       (output_mask[1] ? at::empty(weight.sizes(), options) : undefined);
   Tensor grad_bias =
       (output_mask[2] ? at::empty(weight.size(0), options) : undefined);
-  Tensor grad_input_ =
-      (output_mask[0] ? (is_batch ? grad_input : grad_input.unsqueeze(0))
-                      : undefined);
   slow_conv_dilated_all_cuda_template<2>(
       undefined,
       input_,
@@ -589,9 +586,6 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_dilated3d_backward_cuda(
       (output_mask[1] ? at::empty(weight.sizes(), options) : undefined);
   Tensor grad_bias =
       (output_mask[2] ? at::empty(weight.size(0), options) : undefined);
-  Tensor grad_input_ =
-      (output_mask[0] ? (is_batch ? grad_input : grad_input.unsqueeze(0))
-                      : undefined);
   slow_conv_dilated_all_cuda_template<3>(
       undefined,
       input_,


### PR DESCRIPTION
Removes the `grad_input_` locals in the `slow_conv_dilated` 2d/3d backward (CPU and CUDA). These unsqueezed views have been unused since they were introduced in #20983 (2019): the backward template unpacks `grad_input` through a raw `data_ptr` in `col2hvol`/`col2vol`, sizing the write from `nInputPlane`/`input_size` rather than the tensor shape, so the batched view was never required and the plain `grad_input` was always passed. Flagged by clang-tidy.

No functional change.

Authored with the assistance of an AI assistant.