### PR TITLE
[inductor] Include custom op schema in FxGraph cache key

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -530,6 +530,55 @@ class TestFxGraphCache(TestCase):
         torch._dynamo.reset()
         clear_caches()
 
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @config.patch({"compile_threads": 1})
+    def test_cache_key_custom_op_schema(self):
+        # Custom ops registered under the same name but with different
+        # schemas (here, different mutates_args) must not share a cache
+        # entry, otherwise a stale graph is silently reused.
+        # https://github.com/pytorch/pytorch/issues/187319
+        def fn(x, y):
+            out = torch.empty_like(x)
+            torch.ops.test_schema_cache.foo(x, y, out=out)
+            return out
+
+        def register(lib, mutates_args):
+            def foo(x: torch.Tensor, y: torch.Tensor, *, out: torch.Tensor) -> None:
+                torch.mul(torch.mul(x, y), x, out=out)
+
+            def foo_fake(
+                x: torch.Tensor, y: torch.Tensor, *, out: torch.Tensor
+            ) -> None:
+                return None
+
+            schema = "foo" + torch.library.infer_schema(foo, mutates_args=mutates_args)
+            lib.define(schema)
+            lib.impl("foo", foo, "CPU")
+            lib._register_fake("foo", foo_fake)
+
+        x = torch.randn(8)
+        y = torch.randn(8)
+        expected = x * y * x
+
+        # First registration declares the op non-mutating, so Inductor may
+        # eliminate it. This populates the cache.
+        with torch.library._scoped_library("test_schema_cache", "FRAGMENT") as lib:
+            register(lib, [])
+            torch.compile(fn, fullgraph=True)(x, y)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        # Re-register the same op as mutating out. The differing schema must
+        # force a recompile rather than reuse the stale cache entry.
+        torch._dynamo.reset()
+        with torch.library._scoped_library("test_schema_cache", "FRAGMENT") as lib:
+            register(lib, ["out"])
+            result = torch.compile(fn, fullgraph=True)(x, y)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+        self.assertEqual(result, expected)
+
     def _find_triton_kernel_binaries(self):
         found = []
         triton_dir = os.path.join(cache_dir(), "triton")

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1489,6 +1489,29 @@ class FxGraphHashDetails:
                         (kernel_source, constant_args, configs)
                     )
 
+        # The op name recorded in the FX graph (e.g.
+        # "torch.ops.mylib.foo.default") does not capture the op's schema, so
+        # two custom ops registered under the same name but with different
+        # schemas (for example differing mutability / mutates_args) would
+        # otherwise produce the same graph and share a cache entry. Hash the
+        # schemas so such ops are distinguished. Handle both OpOverload (post
+        # AOTAutograd graphs) and OpOverloadPacket (pre-dispatch dynamo graphs).
+        op_schemas: OrderedSet[str] = OrderedSet()
+        if gm is not None:
+            for module in gm.modules():
+                if not isinstance(module, torch.fx.GraphModule):
+                    continue
+                for node in module.graph.nodes:
+                    if node.op != "call_function":
+                        continue
+                    target = node.target
+                    if isinstance(target, torch._ops.OpOverload):
+                        op_schemas.add(str(target._schema))
+                    elif isinstance(target, torch._ops.OpOverloadPacket):
+                        for overload in target.overloads():
+                            op_schemas.add(str(getattr(target, overload)._schema))
+        self.op_schemas = sorted(op_schemas)
+
         no_tensor_inputs = not any(isinstance(x, torch.Tensor) for x in example_inputs)
         # This device index is usually already encoded by the device of the inputs
         # but fx graphs don't necessarily have tensor inputs. If there aren't any,


### PR DESCRIPTION
Fixes #187319

Custom ops registered under the same name but with different schemas (for
example differing mutates_args) produced the same FX graph, so they shared an
FxGraph/AOTAutograd cache entry. After correcting an op mutates_args, the stale
compiled graph could be reused, silently returning wrong results.

This hashes each call_function op schema (OpOverload and OpOverloadPacket
targets) in FxGraphHashDetails, so ops that differ only in schema hash
differently. Cache hits are preserved when the schema is unchanged.

Test: python test/inductor/test_codecache.py TestFxGraphCache.test_cache_key_custom_op_schema


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo