### PR TITLE
fix(maskedtensor): map each kwarg from its own value in _map_mt_args_kwargs

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 
 from torch.masked import as_masked_tensor, masked_tensor, _combine_input_and_mask
-from torch.masked.maskedtensor.core import _masks_match, _tensors_match
+from torch.masked.maskedtensor.core import _map_mt_args_kwargs, _masks_match, _tensors_match
 from torch.masked.maskedtensor.unary import NATIVE_INPLACE_UNARY_FNS, NATIVE_UNARY_FNS, UNARY_NAMES
 from torch.masked.maskedtensor.binary import NATIVE_BINARY_FNS, NATIVE_INPLACE_BINARY_FNS, BINARY_NAMES
 from torch.masked.maskedtensor.reductions import REDUCE_NAMES
@@ -129,6 +129,23 @@ class TestBasics(TestCase):
             masked_tensor(data, mt)
         with self.assertRaisesRegex(TypeError, "mask must be a Tensor"):
             masked_tensor(data, 0)
+
+    def test_map_mt_args_kwargs_maps_each_kwarg(self, device):
+        # _map_mt_args_kwargs must map every kwarg from its own value. It used to
+        # map all kwargs from `a`, the positional-arg loop variable left over from
+        # the previous loop, so kwargs took the last arg's value (and crashed with
+        # NameError when there were no positional args). passthrough ops feed the
+        # mapped kwargs straight into the op, so this silently used the wrong data.
+        mask = torch.tensor([True, True, True], device=device)
+        first = masked_tensor(torch.ones(3, device=device), mask)
+        keyword = masked_tensor(torch.full((3,), 2.0, device=device), mask)
+
+        _, impl_kwargs = _map_mt_args_kwargs((first,), {"other": keyword}, lambda x: x.get_data())
+        self.assertTrue(torch.equal(impl_kwargs["other"], keyword.get_data()))
+
+        # No positional args: the kwarg must still be mapped (previously NameError).
+        _, impl_kwargs = _map_mt_args_kwargs((), {"other": keyword}, lambda x: x.get_data())
+        self.assertTrue(torch.equal(impl_kwargs["other"], keyword.get_data()))
 
     def test_diff_layouts(self, device):
         data = torch.randn((3, 4), device=device).to_sparse_coo()

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -89,7 +89,7 @@ def _map_mt_args_kwargs(args, kwargs, map_fn):
         impl_args.append(_helper(a, map_fn))
     impl_kwargs = {}
     for k in kwargs:
-        impl_kwargs[k] = _helper(a, map_fn)
+        impl_kwargs[k] = _helper(kwargs[k], map_fn)
     return impl_args, impl_kwargs
 
 


### PR DESCRIPTION
## Summary

`_map_mt_args_kwargs` in `torch/masked/maskedtensor/core.py` maps each keyword argument from the wrong source:

```python
impl_args = []
for a in args:
    impl_args.append(_helper(a, map_fn))
impl_kwargs = {}
for k in kwargs:
    impl_kwargs[k] = _helper(a, map_fn)   # uses `a`, not `kwargs[k]`
```

The kwargs loop calls `_helper(a, ...)`, where `a` is the loop variable left over from the preceding `for a in args` loop, instead of `_helper(kwargs[k], ...)`. So:

- every kwarg is mapped from the **last positional arg's** value, ignoring the actual kwarg value; and
- when there are **no positional args**, `a` is never bound and the function raises `NameError`.

The mapped kwargs are not always discarded. `passthrough.py` feeds them straight into the op:

```python
data_args, data_kwargs = _map_mt_args_kwargs(args, kwargs, lambda x: x.get_data())
result_data = fn(*data_args, **data_kwargs)
```

so a passthrough op invoked with a keyword argument silently runs on the wrong tensor data (or crashes when invoked with keyword args only).

The fix maps each kwarg from its own value, mirroring the positional-arg loop.

## Test

Added `TestBasics.test_map_mt_args_kwargs_maps_each_kwarg`, which feeds a distinct `MaskedTensor` as a kwarg and asserts the mapped kwarg matches that kwarg's data (not the positional arg's), including the no-positional-args case that used to raise `NameError`.

```
pytest test/test_maskedtensor.py -k test_map_mt_args_kwargs_maps_each_kwarg
```

I could not run the suite in my environment (no compiled `torch` build available here), so I verified the control-flow bug with a standalone reduction of the function (`_helper` stubbed, which does not affect the leaked-variable behavior):

- `_map_mt_args_kwargs((1, 2), {"x": 99}, lambda v: v)` → `([1, 2], {"x": 2})` before the fix (should be `{"x": 99}`); `([1, 2], {"x": 99})` after.
- `_map_mt_args_kwargs((), {"x": 99}, lambda v: v)` → `NameError` before the fix; `([], {"x": 99})` after.

Relying on CI to run the added test against a real build.
