### PR TITLE
[FX][Dynamo] Add tests for nn_module_stack and source_fn_stack metadata contracts

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1375,7 +1375,7 @@ def forward(self, x, y):
 
             return Root()
 
-        for depth in range(3, 10):
+        for depth in (3, 6, 9):
             with self.subTest(depth=depth):
                 m = model_creator(depth)
                 exported = torch._dynamo.export(m, aten_graph=False)(inp)
@@ -1396,13 +1396,14 @@ def forward(self, x, y):
                             elif clean == "L['self']":
                                 clean = ""
                             paths.append(clean)
-                    # Each successive entry should be at least as deep (more dots)
-                    depths = [p.count(".") if p else -1 for p in paths]
-                    for k in range(1, len(depths)):
-                        self.assertGreaterEqual(
-                            depths[k],
-                            depths[k - 1],
-                            f"nn_module_stack not ordered outermost->innermost: {paths}",
+                    # Prefix-chain invariant: each path extends its predecessor
+                    for k in range(1, len(paths)):
+                        if not paths[k - 1]:
+                            # Root (empty string) is prefix of everything
+                            continue
+                        self.assertTrue(
+                            paths[k].startswith(paths[k - 1] + "."),
+                            f"Path {paths[k]!r} is not a child of {paths[k - 1]!r}",
                         )
                 # The deepest node should reflect the full nesting chain
                 self.assertGreaterEqual(

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1193,6 +1193,272 @@ def forward(self, x, y):
                 self.assertTrue(node.meta["nn_module_stack"] is not None)
         self.assertEqual(attr_access_count, 2)
 
+    def test_export_nn_module_stack_contains_module_path_prefix(self):
+        """nn_module_stack paths from Dynamo use the L['self']. prefix format.
+
+        Any downstream pass that reconstructs module hierarchy from
+        nn_module_stack (e.g. ONNX export, custom hardware backends,
+        quantisation) must know how to strip the L['self']. prefix to
+        get clean dotted module paths.  This test ensures Dynamo
+        continues to produce that format so such consumers can rely on
+        it.
+        """
+        inp = torch.randn(4, 4)
+
+        class Inner(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = Inner()
+
+            def forward(self, x):
+                return self.inner(x)
+
+        m = Outer()
+        exported = torch._dynamo.export(m, aten_graph=False)(inp)
+        out_graph = exported[0]
+
+        found_prefixed = False
+        for node in out_graph.graph.nodes:
+            stack = node.meta.get("nn_module_stack") or {}
+            for _key, (path, _cls) in stack.items():
+                if isinstance(path, str) and path.startswith("L['self']."):
+                    found_prefixed = True
+                    # After prefix, should have valid dotted module path
+                    clean = path[len("L['self']."):]
+                    self.assertTrue(
+                        len(clean) > 0,
+                        "Module path after L['self']. prefix should not be empty",
+                    )
+        self.assertTrue(
+            found_prefixed,
+            "Expected at least one nn_module_stack entry using L['self']. prefix",
+        )
+
+    def test_export_nn_module_stack_class_is_type(self):
+        """nn_module_stack class entries are actual types with __name__.
+
+        Passes that render module names (ONNX, debugging tools, custom
+        backends) access cls.__name__ on nn_module_stack entries.
+        This test ensures the class values remain real type objects,
+        not serialised strings.
+        """
+        inp = torch.randn(4, 4)
+
+        class MyBlock(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class MyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = MyBlock()
+
+            def forward(self, x):
+                return self.block(x)
+
+        m = MyModel()
+        exported = torch._dynamo.export(m, aten_graph=False)(inp)
+        out_graph = exported[0]
+
+        found_class = False
+        for node in out_graph.graph.nodes:
+            stack = node.meta.get("nn_module_stack") or {}
+            for _key, (_path, cls) in stack.items():
+                found_class = True
+                self.assertTrue(
+                    isinstance(cls, type),
+                    f"Expected a type in nn_module_stack, got {type(cls)}: {cls}",
+                )
+        self.assertTrue(found_class)
+
+    def test_export_nn_module_stack_nested_module_list(self):
+        """nn_module_stack reflects ModuleList child indices in paths.
+
+        Models with nn.ModuleList (e.g. transformer layers) produce
+        numeric path components like 'layers.0', 'layers.1'.  Passes
+        that detect repeated identical blocks rely on these numeric
+        components being present and structurally consistent across
+        repeated children.
+        """
+        n_blocks = 3
+        inp = torch.randn(4, 4)
+
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block() for _ in range(n_blocks)])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer(x)
+                return x
+
+        m = Model()
+        exported = torch._dynamo.export(m, aten_graph=False)(inp)
+        out_graph = exported[0]
+
+        # Collect all module paths that reference layers.N
+        layer_indices = set()
+        for node in out_graph.graph.nodes:
+            stack = node.meta.get("nn_module_stack") or {}
+            for _key, (path, _cls) in stack.items():
+                if not isinstance(path, str):
+                    continue
+                # Strip L['self']. if present
+                clean = path
+                if clean.startswith("L['self']."):
+                    clean = clean[len("L['self']."):]
+                # Match "layers.N" components
+                if clean.startswith("layers."):
+                    parts = clean.split(".")
+                    if len(parts) >= 2 and parts[1].isdigit():
+                        layer_indices.add(int(parts[1]))
+
+        self.assertEqual(
+            layer_indices, set(range(n_blocks)),
+            f"Expected all {n_blocks} ModuleList children to appear in nn_module_stack paths",
+        )
+
+    def test_export_nn_module_stack_ordering_outermost_to_innermost(self):
+        """nn_module_stack entries are ordered outermost to innermost.
+
+        Consumers that reconstruct module trees iterate nn_module_stack
+        in insertion order (dict ordering) to walk from the root toward
+        the leaf.  This test validates that deeper modules always appear
+        later in the ordered dict.
+        """
+        inp = torch.randn(4, 4)
+
+        def model_creator(depth: int) -> torch.nn.Module:
+            class Chain(torch.nn.Module):
+                def __init__(self, level: int):
+                    super().__init__()
+                    # For depth N, chain of modules is Root.level_0..level_{N-2}; final leaf is .linear
+                    if level == depth - 2:
+                        self.linear = torch.nn.Linear(4, 4)
+                    else:
+                        self._next_name = f"level_{level + 1}"
+                        setattr(self, self._next_name, Chain(level + 1))
+
+                def forward(self, x):
+                    if hasattr(self, "linear"):
+                        return self.linear(x)
+                    return getattr(self, self._next_name)(x)
+
+            class Root(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.level_0 = Chain(level=0)
+
+                def forward(self, x):
+                    return self.level_0(x)
+
+            return Root()
+
+        for depth in range(3, 10):
+            with self.subTest(depth=depth):
+                m = model_creator(depth)
+                exported = torch._dynamo.export(m, aten_graph=False)(inp)
+                out_graph = exported[0]
+
+                max_stack_len = 0
+                for node in out_graph.graph.nodes:
+                    stack = node.meta.get("nn_module_stack") or {}
+                    if len(stack) < 2:
+                        continue
+                    max_stack_len = max(max_stack_len, len(stack))
+                    paths = []
+                    for _key, (path, _cls) in stack.items():
+                        if isinstance(path, str):
+                            clean = path
+                            if clean.startswith("L['self']."):
+                                clean = clean[len("L['self']."):]
+                            elif clean == "L['self']":
+                                clean = ""
+                            paths.append(clean)
+                    # Each successive entry should be at least as deep (more dots)
+                    depths = [p.count(".") if p else -1 for p in paths]
+                    for k in range(1, len(depths)):
+                        self.assertGreaterEqual(
+                            depths[k], depths[k - 1],
+                            f"nn_module_stack not ordered outermost→innermost: {paths}",
+                        )
+                # The deepest node should reflect the full nesting chain
+                self.assertGreaterEqual(
+                    max_stack_len, depth,
+                    f"Expected max nn_module_stack depth >= {depth} for model with depth={depth}",
+                )
+
+    def test_export_source_fn_stack_entries_are_named_callable_pairs(self):
+        """source_fn_stack entries are indexable sequences starting with (str, callable-with-__name__, ...).
+
+        Downstream passes use source_fn_stack[-1][1].__name__ to
+        identify the originating function or module class for an
+        operation.  This test ensures each entry is a list or tuple
+        with at least two elements, where the first is a string and
+        the second carries a __name__ attribute.
+        """
+        inp = torch.randn(4, 4)
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        m = MyModule()
+        exported = torch._dynamo.export(m, aten_graph=False)(inp)
+        out_graph = exported[0]
+
+        found_stack = False
+        for node in out_graph.graph.nodes:
+            if node.op in {"placeholder", "output"}:
+                continue
+            sfn_stack = node.meta.get("source_fn_stack", [])
+            if not sfn_stack:
+                continue
+            found_stack = True
+
+            # Must be a list/tuple of list/tuple entries
+            self.assertIsInstance(sfn_stack, (list, tuple))
+            for entry in sfn_stack:
+                self.assertIsInstance(entry, (list, tuple))
+                self.assertGreaterEqual(
+                    len(entry), 2,
+                    f"source_fn_stack entry should have >= 2 elements: {entry}",
+                )
+                # First element is a string name
+                self.assertIsInstance(entry[0], str)
+                # Second element should have __name__ (function or class)
+                fn_or_cls = entry[1]
+                self.assertTrue(
+                    hasattr(fn_or_cls, "__name__"),
+                    f"source_fn_stack entry[1] ({fn_or_cls}) lacks __name__",
+                )
+        self.assertTrue(found_stack, "Expected at least one source_fn_stack entry")
+
     def test_export_compare_optimize_with_make_fx(self):
         inp = torch.tensor([0.1, 0.1])
         linear = torch.nn.Linear(2, 2)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1228,11 +1228,11 @@ def forward(self, x, y):
         found_prefixed = False
         for node in out_graph.graph.nodes:
             stack = node.meta.get("nn_module_stack") or {}
-            for _key, (path, _cls) in stack.items():
+            for path, _cls in stack.values():
                 if isinstance(path, str) and path.startswith("L['self']."):
                     found_prefixed = True
                     # After prefix, should have valid dotted module path
-                    clean = path[len("L['self']."):]
+                    clean = path[len("L['self'].") :]
                     self.assertTrue(
                         len(clean) > 0,
                         "Module path after L['self']. prefix should not be empty",
@@ -1275,7 +1275,7 @@ def forward(self, x, y):
         found_class = False
         for node in out_graph.graph.nodes:
             stack = node.meta.get("nn_module_stack") or {}
-            for _key, (_path, cls) in stack.items():
+            for _path, cls in stack.values():
                 found_class = True
                 self.assertTrue(
                     isinstance(cls, type),
@@ -1321,13 +1321,12 @@ def forward(self, x, y):
         layer_indices = set()
         for node in out_graph.graph.nodes:
             stack = node.meta.get("nn_module_stack") or {}
-            for _key, (path, _cls) in stack.items():
+            for path, _cls in stack.values():
                 if not isinstance(path, str):
                     continue
                 # Strip L['self']. if present
                 clean = path
-                if clean.startswith("L['self']."):
-                    clean = clean[len("L['self']."):]
+                clean = clean.removeprefix("L['self'].")
                 # Match "layers.N" components
                 if clean.startswith("layers."):
                     parts = clean.split(".")
@@ -1335,7 +1334,8 @@ def forward(self, x, y):
                         layer_indices.add(int(parts[1]))
 
         self.assertEqual(
-            layer_indices, set(range(n_blocks)),
+            layer_indices,
+            set(range(n_blocks)),
             f"Expected all {n_blocks} ModuleList children to appear in nn_module_stack paths",
         )
 
@@ -1388,11 +1388,11 @@ def forward(self, x, y):
                         continue
                     max_stack_len = max(max_stack_len, len(stack))
                     paths = []
-                    for _key, (path, _cls) in stack.items():
+                    for path, _cls in stack.values():
                         if isinstance(path, str):
                             clean = path
                             if clean.startswith("L['self']."):
-                                clean = clean[len("L['self']."):]
+                                clean = clean[len("L['self'].") :]
                             elif clean == "L['self']":
                                 clean = ""
                             paths.append(clean)
@@ -1400,12 +1400,14 @@ def forward(self, x, y):
                     depths = [p.count(".") if p else -1 for p in paths]
                     for k in range(1, len(depths)):
                         self.assertGreaterEqual(
-                            depths[k], depths[k - 1],
-                            f"nn_module_stack not ordered outermost→innermost: {paths}",
+                            depths[k],
+                            depths[k - 1],
+                            f"nn_module_stack not ordered outermost->innermost: {paths}",
                         )
                 # The deepest node should reflect the full nesting chain
                 self.assertGreaterEqual(
-                    max_stack_len, depth,
+                    max_stack_len,
+                    depth,
                     f"Expected max nn_module_stack depth >= {depth} for model with depth={depth}",
                 )
 
@@ -1446,7 +1448,8 @@ def forward(self, x, y):
             for entry in sfn_stack:
                 self.assertIsInstance(entry, (list, tuple))
                 self.assertGreaterEqual(
-                    len(entry), 2,
+                    len(entry),
+                    2,
                     f"source_fn_stack entry should have >= 2 elements: {entry}",
                 )
                 # First element is a string name

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1229,14 +1229,21 @@ def forward(self, x, y):
         for node in out_graph.graph.nodes:
             stack = node.meta.get("nn_module_stack") or {}
             for path, _cls in stack.values():
-                if isinstance(path, str) and path.startswith("L['self']."):
-                    found_prefixed = True
-                    # After prefix, should have valid dotted module path
-                    clean = path[len("L['self'].") :]
-                    self.assertTrue(
-                        len(clean) > 0,
-                        "Module path after L['self']. prefix should not be empty",
-                    )
+                if not isinstance(path, str):
+                    continue
+                if path == "L['self']":
+                    continue
+                self.assertTrue(
+                    path.startswith("L['self']."),
+                    f"Unexpected nn_module_stack path format: {path}",
+                )
+                found_prefixed = True
+                # After prefix, should have valid dotted module path
+                clean = path[len("L['self'].") :]
+                self.assertTrue(
+                    len(clean) > 0,
+                    "Module path after L['self']. prefix should not be empty",
+                )
         self.assertTrue(
             found_prefixed,
             "Expected at least one nn_module_stack entry using L['self']. prefix",
@@ -1412,14 +1419,11 @@ def forward(self, x, y):
                     f"Expected max nn_module_stack depth >= {depth} for model with depth={depth}",
                 )
 
-    def test_export_source_fn_stack_entries_are_named_callable_pairs(self):
-        """source_fn_stack entries are indexable sequences starting with (str, callable-with-__name__, ...).
+    def test_export_source_fn_stack_entries_have_valid_targets(self):
+        """source_fn_stack entries are indexable sequences starting with (str, target, ...).
 
-        Downstream passes use source_fn_stack[-1][1].__name__ to
-        identify the originating function or module class for an
-        operation.  This test ensures each entry is a list or tuple
-        with at least two elements, where the first is a string and
-        the second carries a __name__ attribute.
+        The target is either a string method name or an object with a
+        __name__ attribute, depending on the operation kind.
         """
         inp = torch.randn(4, 4)
 
@@ -1429,7 +1433,7 @@ def forward(self, x, y):
                 self.linear = torch.nn.Linear(4, 4)
 
             def forward(self, x):
-                return torch.relu(self.linear(x))
+                return self.linear(x).relu()
 
         m = MyModule()
         exported = torch._dynamo.export(m, aten_graph=False)(inp)
@@ -1455,11 +1459,11 @@ def forward(self, x, y):
                 )
                 # First element is a string name
                 self.assertIsInstance(entry[0], str)
-                # Second element should have __name__ (function or class)
+                # Method targets are strings; function and class targets have __name__.
                 fn_or_cls = entry[1]
                 self.assertTrue(
-                    hasattr(fn_or_cls, "__name__"),
-                    f"source_fn_stack entry[1] ({fn_or_cls}) lacks __name__",
+                    isinstance(fn_or_cls, str) or hasattr(fn_or_cls, "__name__"),
+                    f"source_fn_stack entry[1] ({fn_or_cls}) is neither a str nor named",
                 )
         self.assertTrue(found_stack, "Expected at least one source_fn_stack entry")
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2180,6 +2180,154 @@ class TestFX(JitTestCase):
         stack_list = list(mod_stack.items())
         self.assertEqual(stack_list, expected_stack)
 
+    def test_nn_module_stack_deep_nesting(self):
+        """nn_module_stack records every level for ≥3 nesting depths.
+
+        Many downstream passes (e.g. ONNX exporter, quantisation, custom
+        backends) reconstruct a module tree from nn_module_stack.  They
+        rely on every intermediate level being present and ordered from
+        outermost to innermost.  The test_nn_module_stack only
+        covers 2 levels; this test ensures 3+ levels work correctly.
+        """
+        def model_creator(depth: int) -> torch.nn.Module:
+            class Chain(torch.nn.Module):
+                def __init__(self, level: int):
+                    super().__init__()
+                    # For depth N, chain of modules is Root.level_0..level_{N-2}; final leaf is .linear
+                    if level == depth - 2:
+                        self.linear = torch.nn.Linear(4, 4)
+                    else:
+                        self._next_name = f"level_{level + 1}"
+                        setattr(self, self._next_name, Chain(level + 1))
+
+                def forward(self, x):
+                    if hasattr(self, "linear"):
+                        return self.linear(x)
+                    return getattr(self, self._next_name)(x)
+
+            class Root(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.level_0 = Chain(level=0)
+
+                def forward(self, x):
+                    return self.level_0(x)
+
+            return Root()
+
+        def expected_paths(depth: int) -> list[str]:
+            module_paths = [
+                ".".join(f"level_{i}" for i in range(level + 1))
+                for level in range(depth - 1)
+            ]
+            return [*module_paths, f"{module_paths[-1]}.linear"]
+
+        for depth in range(3, 10):
+            with self.subTest(depth=depth):
+                m = model_creator(depth)
+                gm = torch.fx.symbolic_trace(m)
+
+                deepest_stack = {}
+                for node in gm.graph.nodes:
+                    s = node.meta.get("nn_module_stack") or {}
+                    if len(s) > len(deepest_stack):
+                        deepest_stack = s
+
+                paths = [path for _key, (path, _cls) in deepest_stack.items()]
+                self.assertEqual(paths, expected_paths(depth))
+
+                # Outermost-to-innermost ordering: paths should be monotonically
+                # increasing in depth (number of dot-separated components)
+                path_depths = [p.count(".") for p in paths]
+                self.assertEqual(path_depths, sorted(path_depths))
+
+    def test_nn_module_stack_module_list(self):
+        """nn_module_stack produces numeric path components for ModuleList children.
+
+        nn.ModuleList is widely used for repeated identical blocks (e.g.
+        transformer layers).  Downstream consumers that collapse repeated
+        sub-trees rely on each child appearing with a numeric path suffix
+        (e.g. "layers.0", "layers.1") and having structurally identical
+        nn_module_stack entries.  This test ensures ModuleList children
+        are correctly reflected in the metadata.
+        """
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4, bias=False)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Model(torch.nn.Module):
+            def __init__(self, n_blocks):
+                super().__init__()
+                self.blocks = torch.nn.ModuleList(
+                    [Block() for _ in range(n_blocks)]
+                )
+
+            def forward(self, x):
+                for blk in self.blocks:
+                    x = blk(x)
+                return x
+
+        n_blocks = 3
+        m = Model(n_blocks)
+        gm = torch.fx.symbolic_trace(m)
+
+        # Collect nn_module_stack for every node that has one
+        stacks_by_node = {}
+        for node in gm.graph.nodes:
+            s = node.meta.get("nn_module_stack") or {}
+            if s and node.op not in ("placeholder", "output"):
+                stacks_by_node[node.name] = s
+
+        # There should be at least n_blocks nodes with stacks (one per block)
+        self.assertGreaterEqual(len(stacks_by_node), n_blocks)
+
+        # Verify numeric indices appear in the paths
+        numeric_paths_seen = set()
+        for _name, stack in stacks_by_node.items():
+            for _key, (path, _cls) in stack.items():
+                # Look for "blocks.0", "blocks.1", "blocks.2" style paths
+                if "blocks." in path:
+                    parts = path.split(".")
+                    idx = parts.index("blocks")
+                    if idx + 1 < len(parts) and parts[idx + 1].isdigit():
+                        numeric_paths_seen.add(int(parts[idx + 1]))
+
+        self.assertEqual(numeric_paths_seen, set(range(n_blocks)))
+
+    def test_nn_module_stack_class_entries_are_types(self):
+        """nn_module_stack class entries are real types (not strings).
+
+        Several consumers (ONNX export, quantisation utilities, custom
+        compiler backends) access ``cls.__name__`` on nn_module_stack
+        entries.  This requires that the class value is an actual type
+        object, not a serialised string or other placeholder.
+        """
+        class UserModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        m = UserModule()
+        gm = torch.fx.symbolic_trace(m)
+
+        found_any_stack = False
+        for node in gm.graph.nodes:
+            stack = node.meta.get("nn_module_stack") or {}
+            for _key, (_path, cls) in stack.items():
+                found_any_stack = True
+                self.assertTrue(
+                    isinstance(cls, type),
+                    f"nn_module_stack class entry should be a type, got {type(cls)}: {cls}",
+                )
+        self.assertTrue(found_any_stack, "Expected at least one nn_module_stack entry")
+
     def test_transformer_preserves_nn_module_stack_for_get_attr(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2222,7 +2222,7 @@ class TestFX(JitTestCase):
             ]
             return [*module_paths, f"{module_paths[-1]}.linear"]
 
-        for depth in range(3, 10):
+        for depth in (3, 6, 9):
             with self.subTest(depth=depth):
                 m = model_creator(depth)
                 gm = torch.fx.symbolic_trace(m)
@@ -2234,12 +2234,12 @@ class TestFX(JitTestCase):
                         deepest_stack = s
 
                 paths = [path for _key, (path, _cls) in deepest_stack.items()]
-                self.assertEqual(paths, expected_paths(depth))
-
                 # Outermost-to-innermost ordering: paths should be monotonically
                 # increasing in depth (number of dot-separated components)
                 path_depths = [p.count(".") for p in paths]
                 self.assertEqual(path_depths, sorted(path_depths))
+                # Exact expected paths (also verifies completeness).
+                self.assertEqual(paths, expected_paths(depth))
 
     def test_nn_module_stack_module_list(self):
         """nn_module_stack produces numeric path components for ModuleList children.

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2181,7 +2181,7 @@ class TestFX(JitTestCase):
         self.assertEqual(stack_list, expected_stack)
 
     def test_nn_module_stack_deep_nesting(self):
-        """nn_module_stack records every level for ≥3 nesting depths.
+        """nn_module_stack records every level for >=3 nesting depths.
 
         Many downstream passes (e.g. ONNX exporter, quantisation, custom
         backends) reconstruct a module tree from nn_module_stack.  They
@@ -2287,8 +2287,8 @@ class TestFX(JitTestCase):
 
         # Verify numeric indices appear in the paths
         numeric_paths_seen = set()
-        for _name, stack in stacks_by_node.items():
-            for _key, (path, _cls) in stack.items():
+        for stack in stacks_by_node.values():
+            for path, _cls in stack.values():
                 # Look for "blocks.0", "blocks.1", "blocks.2" style paths
                 if "blocks." in path:
                     parts = path.split(".")
@@ -2320,7 +2320,7 @@ class TestFX(JitTestCase):
         found_any_stack = False
         for node in gm.graph.nodes:
             stack = node.meta.get("nn_module_stack") or {}
-            for _key, (_path, cls) in stack.items():
+            for _path, cls in stack.values():
                 found_any_stack = True
                 self.assertTrue(
                     isinstance(cls, type),


### PR DESCRIPTION
## Summary

Adds targeted tests for the `nn_module_stack` and `source_fn_stack` node
metadata that FX tracing and Dynamo attach to graph nodes.  These metadata
are consumed by multiple downstream systems (ONNX export, quantisation,
torch.export serialisation, custom compiler backends), but the existing
test coverage only validates basic 2-level nesting with symbolic_trace
and checks for metadata *presence* rather than *structure*.

This PR adds 8 tests that lock down the metadata contracts:

**test/test_fx.py** (symbolic_trace path):
- `test_nn_module_stack_deep_nesting` — dynamically tests depths 3–9 via `subTest`, verifying all intermediate levels are fully recorded and ordered outermost→innermost.
- `test_nn_module_stack_module_list` — `nn.ModuleList` children appear with numeric path components (`blocks.0`, `blocks.1`, …).
- `test_nn_module_stack_class_entries_are_types` — class entries in `nn_module_stack` are real types (not strings) for both user-defined and built-in modules.

**test/dynamo/test_export.py** (Dynamo export path):
- `test_export_nn_module_stack_contains_module_path_prefix` — Dynamo paths use the `L['self'].` prefix format.
- `test_export_nn_module_stack_class_is_type` — class entries remain real `type` objects (not serialised strings) with `__name__`.
- `test_export_nn_module_stack_nested_module_list` — `ModuleList` numeric indices appear in Dynamo-prefixed paths.
- `test_export_nn_module_stack_ordering_outermost_to_innermost` — dynamically tests depths 3–9 via `subTest`, verifying dict iteration order is outermost module first and the deepest stack reflects the full nesting chain.
- `test_export_source_fn_stack_entries_are_named_callable_pairs` — validates the `list[tuple[str, callable]]` schema where `entry[1]` carries `__name__`.

## Motivation

Several components rely on undocumented structural invariants of these
metadata fields:
- **ONNX exporter** reads `nn_module_stack` to map FX nodes to ONNX node
  metadata.
- **Quantisation** (`torch.ao.quantization.pt2e.qat_utils`) inspects
  `source_fn_stack` class entries to identify BatchNorm operations.
- **torch.export** normalises `L['self'].` prefixes during serialisation
  (`_normalize_nn_module_stack` in `torch/export/_trace.py`).
- **Custom compiler backends** reconstruct module hierarchies from
  `nn_module_stack` to map operations back to user-written module
  structure.

Without explicit tests, changes to the tracing infrastructure can silently
break these consumers.  These tests make the implicit contracts explicit.

## Test Plan

All 8 new tests pass locally:

```
python test/test_fx.py 
TestFX.test_nn_module_stack_deep_nesting
TestFX.test_nn_module_stack_module_list
TestFX.test_nn_module_stack_class_entries_are_types

python test/dynamo/test_export.py 
ExportTests.test_export_nn_module_stack_contains_module_path_prefix
ExportTests.test_export_nn_module_stack_class_is_type
ExportTests.test_export_nn_module_stack_nested_module_list
ExportTests.test_export_nn_module_stack_ordering_outermost_to_innermost
ExportTests.test_export_source_fn_stack_entries_are_named_callable_pairs
```

Existing tests unaffected (no production code changes).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98