### PR TITLE
Fix Windows libtorch x86_64 and arm64 packages overwriting each other

### DIFF
--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -234,16 +234,23 @@ def create_libtorch_zip(
     return zip_path
 
 
-def compute_zip_prefix(platform: str, desired_cuda: str, libtorch_variant: str) -> str:
+def compute_zip_prefix(
+    platform: str, desired_cuda: str, libtorch_variant: str, arch: str
+) -> str:
     """Compute the zip filename prefix matching existing naming conventions.
 
     Linux:  libtorch-shared-with-deps
     macOS:  libtorch-macos-arm64
     Windows: libtorch-win-shared-with-deps (or libtorch-win-arm64-shared-with-deps)
+
+    The arch component keeps the Windows x86_64 and arm64 packages from
+    sharing a filename and overwriting each other in the upload bucket.
     """
     if platform == "macos":
         return "libtorch-macos-arm64"
     elif platform == "windows":
+        if arch == "arm64":
+            return f"libtorch-win-arm64-{libtorch_variant}"
         return f"libtorch-win-{libtorch_variant}"
     else:
         return f"libtorch-{libtorch_variant}"
@@ -272,6 +279,12 @@ def main() -> None:
         "--libtorch-variant",
         default="shared-with-deps",
         help="Libtorch variant (shared-with-deps, etc.)",
+    )
+    parser.add_argument(
+        "--arch",
+        default="x86_64",
+        choices=["x86_64", "arm64"],
+        help="Target architecture (used to disambiguate Windows package names)",
     )
     parser.add_argument(
         "--git-hash",
@@ -316,7 +329,7 @@ def main() -> None:
 
         # Compute zip prefix
         zip_prefix = compute_zip_prefix(
-            args.platform, args.desired_cuda, args.libtorch_variant
+            args.platform, args.desired_cuda, args.libtorch_variant, args.arch
         )
 
         # Split debug symbols on Linux

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -512,6 +512,7 @@ def generate_libtorch_extraction_configs(
     uses to add an extraction job that depends on that wheel's build job.
     """
     preferred_python = "3.11" if os == "windows-arm64" else "3.10"
+    arch = "arm64" if os == "windows-arm64" else "x86_64"
 
     # Group wheel configs by (gpu_arch_type, gpu_arch_version)
     arch_to_config: dict[tuple[str, str], dict[str, str]] = {}
@@ -528,7 +529,10 @@ def generate_libtorch_extraction_configs(
 
         desired_cuda = source_config["desired_cuda"]
         libtorch_variant = "shared-with-deps"
-        build_name = f"libtorch-{gpu_arch_type}{gpu_arch_version}-{libtorch_variant}-release".replace(
+        # Include arch in the build name so windows x86_64 and arm64 libtorch
+        # packages don't share a name and overwrite each other on upload.
+        arch_tag = f"{arch}-" if os == "windows-arm64" else ""
+        build_name = f"libtorch-{arch_tag}{gpu_arch_type}{gpu_arch_version}-{libtorch_variant}-release".replace(
             ".", "_"
         )
 
@@ -542,6 +546,7 @@ def generate_libtorch_extraction_configs(
                 "desired_cuda": desired_cuda,
                 "gpu_arch_type": gpu_arch_type,
                 "gpu_arch_version": gpu_arch_version,
+                "arch": arch,
             }
         )
 

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -371,7 +371,8 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch !{{ lt_config["arch"] }}
       - uses: !{{ common.upload_artifact_action }}
         if: always()
         with:

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -264,7 +264,7 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-  libtorch-cpu-shared-with-deps-release-extract:
+  libtorch-arm64-cpu-shared-with-deps-release-extract:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
@@ -296,20 +296,21 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch arm64
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
-          name: libtorch-cpu-shared-with-deps-release
+          name: libtorch-arm64-cpu-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ runner.temp }}/libtorch_output/"
-  libtorch-cpu-shared-with-deps-release-upload:  # Uploading
+  libtorch-arm64-cpu-shared-with-deps-release-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
-    needs: libtorch-cpu-shared-with-deps-release-extract
+    needs: libtorch-arm64-cpu-shared-with-deps-release-extract
     with:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: libtorch
@@ -317,7 +318,7 @@ jobs:
       GPU_ARCH_TYPE: cpu
       LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      build_name: libtorch-cpu-shared-with-deps-release
+      build_name: libtorch-arm64-cpu-shared-with-deps-release
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -831,7 +831,8 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch x86_64
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -891,7 +892,8 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch x86_64
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -952,7 +954,8 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch x86_64
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
@@ -1013,7 +1016,8 @@ jobs:
             --output-dir "${{ runner.temp }}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
-            --libtorch-variant "$LIBTORCH_VARIANT"
+            --libtorch-variant "$LIBTORCH_VARIANT" \
+            --arch x86_64
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:


### PR DESCRIPTION
Fixes #187812

## Problem

The Windows libtorch CD packages for x86_64 and arm64 are generated with the **same filename** and uploaded to the **same S3 location**, so the arm64 build clobbers the x86_64 one. Users downloading the Windows x64 libtorch release actually receive Aarch64 binaries (`c10.dll: PE32+ executable (DLL) (GUI) Aarch64`).

## Root cause

`compute_zip_prefix()` in `.ci/libtorch/extract_libtorch_from_wheel.py` returned `libtorch-win-shared-with-deps` for every Windows build regardless of architecture (the docstring even named `libtorch-win-arm64-shared-with-deps`, but the code never produced it). Both x86_64 and arm64 are CPU builds, so the upload subfolder (`DESIRED_CUDA=cpu`) and the zip filename were identical, and the S3 object key is the zip filename.

The arch-blind naming was introduced in #174753 (which added the wheel-extraction approach); the collision became live once the windows-arm64 wheel workflow started running the same extraction in #181586.

## Fix

Thread architecture through the extraction so arm64 produces `libtorch-win-arm64-shared-with-deps-{version}.zip` while x86_64 keeps its existing `libtorch-win-shared-with-deps-{version}.zip` name (preserving the public download URL). `generate_libtorch_extraction_configs` also gives the arm64 job a distinct `build_name` so the GitHub artifact and job names no longer alias.

## Test Plan

Verified prefix logic:

```
x86_64 -> libtorch-win-shared-with-deps
arm64  -> libtorch-win-arm64-shared-with-deps
```

Regenerated the binary build workflows (`python .github/scripts/generate_ci_workflows.py`); the windows-arm64 wheel workflow now passes `--arch arm64` and uploads a distinct `libtorch-arm64-cpu-shared-with-deps-release` artifact, while the x86_64 workflow is unchanged apart from an explicit `--arch x86_64`.

This PR was authored with the assistance of an AI coding assistant (Claude Code).