### PR TITLE
linear_cross_entropy: factor-1 chunking with an N*V/4D memory cap; simplified auto resolution

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13,7 +13,6 @@ import warnings
 import os
 import pickle
 import re
-import sys
 import dataclasses
 from copy import deepcopy
 from itertools import product
@@ -15197,24 +15196,6 @@ if __name__ == '__main__':
                     maximal_linear_bias_grad_err = err
                     worst_linear_bias_grad_err_kwargs = dict(module_kwargs)
 
-        # TEMP (chunking-heuristic ULP re-calibration): factor-1 + the N*V/4D
-        # cap changed cuda/mps index+prob chunk sizes, so re-measure observed
-        # ULP. ``sys.__stdout__`` bypasses pytest capture (reaches CI artifact
-        # logs and a direct run's console); the early ``return`` skips the
-        # now-stale caps so every leg prints. Remove with the cap finalization.
-        print(
-            f"\n[lce calibration] target="
-            f"{'prob' if prob_target else 'none' if none_reduction else 'index'}"
-            f" policy={_resolved_policy!r} dtype={dtype} device={device} bias={bias}\n"
-            f"  output:        observed={maximal_output_max_ulp_diff:6d}  cap={expected_max_ulp_diff:6d}\n"
-            f"  input_grad:    observed={maximal_input_grad_max_ulp_diff:6d}  cap={expected_input_grad_max_ulp_diff:6d}\n"
-            f"  linear_weight: observed={maximal_linear_weight_grad_max_ulp_diff:6d}  cap={expected_weight_grad_max_ulp_diff:6d}\n"
-            f"  linear_bias:   observed={maximal_linear_bias_grad_max_ulp_diff:6d}  cap={expected_linear_bias_grad_max_ulp_diff:6d}",
-            file=sys.__stdout__,
-            flush=True,
-        )
-        return
-
         self.assertLessEqual(maximal_input_grad_err, feps,
                              msg=f"worst input-grad err {maximal_input_grad_err} from kwargs={worst_input_grad_err_kwargs}")
         self.assertLessEqual(maximal_linear_weight_grad_err, feps,
@@ -15713,17 +15694,6 @@ if __name__ == '__main__':
             device=device, dtype=dtype, acc_policy=acc_policy,
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             prob_target=True)
-
-    def test_linear_cross_entropy_zz_mps_calibration_dump(self, device):
-        # TEMP (chunking-heuristic ULP re-calibration): macOS CI does not upload
-        # the test-report artifact, so trigger run_test.py's dump-on-failure to
-        # surface the [lce calibration] prints. The ``zz`` name sorts this after
-        # every other linear_cross_entropy_* test, so they all run and print
-        # (the harness is print-only here) before this fails -- run_test.py then
-        # dumps the captured log with their prints. Remove with the scaffolding.
-        if torch.device(device).type != "mps":
-            self.skipTest("TEMP mps-only calibration dump")
-        self.fail("TEMP: dumping mps lce calibration; see [lce calibration] prints above")
 
     def test_linear_cross_entropy_prob_target_dispatch(self, device):
         """Probability-target dispatch edges. The harness covers the

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15714,26 +15714,16 @@ if __name__ == '__main__':
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             prob_target=True)
 
-    def test_TEMP_mps_lce_calibration_dump(self, device):
+    def test_linear_cross_entropy_zz_mps_calibration_dump(self, device):
         # TEMP (chunking-heuristic ULP re-calibration): macOS CI does not upload
-        # the test-report artifact, so loop the calibration grid (each leg
-        # prints via the harness) then force an mps failure -- run_test.py dumps
-        # the captured log, surfacing the [lce calibration] prints. Self-
-        # contained (does not depend on the parametrized legs running first).
-        # Remove with the calibration scaffolding.
+        # the test-report artifact, so trigger run_test.py's dump-on-failure to
+        # surface the [lce calibration] prints. The ``zz`` name sorts this after
+        # every other linear_cross_entropy_* test, so they all run and print
+        # (the harness is print-only here) before this fails -- run_test.py then
+        # dumps the captured log with their prints. Remove with the scaffolding.
         if torch.device(device).type != "mps":
             self.skipTest("TEMP mps-only calibration dump")
-        for prob_target in (False, True):
-            for dtype in (torch.float32, torch.float16, torch.bfloat16):
-                acc_dtype = None if dtype == torch.float32 else torch.float32
-                for acc_policy in ("accurate", "balanced", "compact", "auto"):
-                    try:
-                        self._test_linear_cross_entropy_loss(
-                            device=device, dtype=dtype, acc_policy=acc_policy,
-                            acc_dtype=acc_dtype, prob_target=prob_target)
-                    except Exception:
-                        pass
-        self.fail("TEMP: dumped mps lce calibration; see [lce calibration] prints above")
+        self.fail("TEMP: dumping mps lce calibration; see [lce calibration] prints above")
 
     def test_linear_cross_entropy_prob_target_dispatch(self, device):
         """Probability-target dispatch edges. The harness covers the

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15748,20 +15748,17 @@ if __name__ == '__main__':
             )
         self.assertEqual(out.dtype, torch.float32)
 
-        # auto heuristic, below the crossing region (num_classes >>
-        # in_features): probability targets resolve to aspect_ratio
-        # factor 1, index targets to aspect_ratio:2.
+        # auto heuristic resolves chunking_method to aspect_ratio (factor 1)
+        # for both probability and index targets; below the crossing region
+        # (num_classes >> in_features) the N*V/4D cap is inert, so the
+        # resolved batch_chunk_size is the plain aspect_ratio chunk.
         if "cuda" in device:
-            adjusted = nn.LinearCrossEntropyOptions()._adjust(
-                num_batches=4096, in_features=2048, num_classes=32000,
-                dtype=torch.float16, device=inp.device, prob_target=True,
-            )
-            self.assertEqual(adjusted.chunking_method, "aspect_ratio")
-            adjusted = nn.LinearCrossEntropyOptions()._adjust(
-                num_batches=4096, in_features=2048, num_classes=32000,
-                dtype=torch.float16, device=inp.device, prob_target=False,
-            )
-            self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+            for prob in (True, False):
+                adjusted = nn.LinearCrossEntropyOptions()._adjust(
+                    num_batches=4096, in_features=2048, num_classes=32000,
+                    dtype=torch.float16, device=inp.device, prob_target=prob,
+                )
+                self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
         # Empty batch on the chunked path: mean is NaN, sum is 0
         # (matches the reference).

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13,6 +13,7 @@ import warnings
 import os
 import pickle
 import re
+import sys
 import dataclasses
 from copy import deepcopy
 from itertools import product
@@ -7455,12 +7456,12 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         ]
         # ``_adjust`` is called without a ``device`` argument here.
         # That makes ``acc_policy="auto"`` (the dataclass default)
-        # resolve to ``_AUTO_FALLBACK`` instead of a per-device pick,
-        # but this test only asserts on ``batch_chunk_size`` and each
-        # case sets ``chunking_method`` to an explicit
-        # ``aspect_ratio[:N]`` literal, so the auto-resolution of
-        # ``acc_policy`` is intentionally irrelevant to the
-        # assertion.
+        # resolve to the ``"compact"`` fallback instead of a per-device
+        # pick, but this test only asserts on ``batch_chunk_size`` and
+        # each case sets ``chunking_method`` to an explicit
+        # ``aspect_ratio[:N]`` literal (so the cap, which applies only to
+        # auto chunking, never engages), making the auto-resolution of
+        # ``acc_policy`` intentionally irrelevant to the assertion.
         for num_batches, in_features, num_classes, factor, expected in cases:
             method = "aspect_ratio" if factor == 1 else f"aspect_ratio:{factor}"
             options = nn.LinearCrossEntropyOptions(chunking_method=method)
@@ -7560,21 +7561,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(opts.acc_policy, "auto")
         self.assertEqual(opts.chunking_method, "auto")
 
-        # Known pair: CUDA + bf16 -> ("compact", "aspect_ratio:2").
+        # Known pair: CUDA + bf16 -> ("compact", "aspect_ratio"). These
+        # vocab shapes (num_classes >> in_features) leave the N*V/4D cap
+        # inert; the budget regime is covered in the memory-cap test.
         adjusted = opts._adjust(
             128, 4096, 50000, torch.bfloat16, torch.device("cuda"),
         )
         self.assertEqual(adjusted.acc_policy, "compact")
-        self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+        self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
-        # Known pair: CUDA + fp16 -> ("compact", "aspect_ratio:2").
+        # Known pair: CUDA + fp16 -> ("compact", "aspect_ratio").
         # Same pick as bf16 -- a single CUDA policy across dtypes
         # post-``weight_chunk_dtype=acc_dtype`` fix.
         adjusted = opts._adjust(
             128, 4096, 50000, torch.float16, torch.device("cuda"),
         )
         self.assertEqual(adjusted.acc_policy, "compact")
-        self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+        self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
         # Known pair: CPU + bf16 -> ("accurate", "aspect_ratio").
         # CPU has no hardware low-precision matmul, so the only
@@ -7593,18 +7596,20 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(adjusted.acc_policy, "accurate")
         self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
-        # Unknown pair (cpu + fp32) -> _AUTO_FALLBACK.
+        # CPU + fp32: "accurate" is only for CPU low-precision input (its
+        # emulated low-precision GEMM); fp32/fp64 GEMM is native at any policy,
+        # so auto picks the memory-frugal "compact".
         adjusted = opts._adjust(
             128, 4096, 50000, torch.float32, torch.device("cpu"),
         )
         self.assertEqual(adjusted.acc_policy, "compact")
-        self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+        self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
-        # No device given -> _AUTO_FALLBACK (back-compat with callers
+        # No device given -> "compact" fallback (back-compat with callers
         # / tests that don't pass device).
         adjusted = opts._adjust(128, 4096, 50000, torch.float32)
         self.assertEqual(adjusted.acc_policy, "compact")
-        self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+        self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
         # Partial override: acc_policy explicit, chunking_method auto.
         opts = nn.LinearCrossEntropyOptions(acc_policy="accurate")
@@ -7612,7 +7617,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             128, 4096, 50000, torch.bfloat16, torch.device("cuda"),
         )
         self.assertEqual(adjusted.acc_policy, "accurate")
-        self.assertEqual(adjusted.chunking_method, "aspect_ratio:2")
+        self.assertEqual(adjusted.chunking_method, "aspect_ratio")
 
         # Partial override: chunking_method explicit, acc_policy auto.
         opts = nn.LinearCrossEntropyOptions(chunking_method="aspect_ratio")
@@ -7645,6 +7650,44 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 opts._adjust(128, 4096, 50000, torch.float16, cuda).acc_dtype,
                 torch.float32 if major >= 7 else torch.float16,
             )
+
+    def test_linear_cross_entropy_options_auto_memory_cap(self):
+        """``auto`` + ``compact`` caps the chunk at a per-target ``B_ref`` so
+        the chunked peak never exceeds the unchunked reference in the budget
+        regime (``in_features >= num_classes``, where aspect_ratio degenerates
+        to a single chunk): ``floor_pow2(N*V/4D)`` for index targets,
+        ``floor_pow2(N/2)`` for prob (whose fatter reference clears the
+        single-chunk excess with two chunks). The cap is inert in the vocab
+        regime, and skipped for non-``compact`` policies (e.g. CPU's
+        ``accurate``) and explicit (non-auto) ``chunking_method``. Pure
+        resolution arithmetic -- no GPU.
+        """
+        opts = nn.LinearCrossEntropyOptions()
+        cuda = torch.device("cuda")
+
+        def b(N, D, V, prob_target=False, device=cuda):
+            return opts._adjust(
+                N, D, V, torch.bfloat16, device, prob_target=prob_target
+            ).batch_chunk_size
+
+        # Vocab regime (V >> D): cap inert; equals the factor-1 aspect_ratio chunk.
+        self.assertEqual(b(4096, 4096, 32000), 512)
+        # Budget regime (D >= V): cap binds at floor_pow2(N*V/4D).
+        self.assertEqual(b(4096, 16384, 4096), 256)
+        self.assertEqual(b(4096, 8192, 8192), 1024)  # crossing D == V
+        # Prob target: capped at N/2 (its fatter reference clears the
+        # single-chunk excess with two chunks); vocab regime stays inert.
+        self.assertEqual(b(4096, 16384, 4096, prob_target=True), 2048)
+        self.assertEqual(b(4096, 8192, 8192, prob_target=True), 2048)  # crossing: N/2
+        self.assertEqual(b(4096, 4096, 32000, prob_target=True), 512)  # vocab inert
+        # CPU auto resolves to "accurate" (non-compact): uncapped.
+        self.assertEqual(b(4096, 16384, 4096, device=torch.device("cpu")), 4096)
+        # Explicit (non-auto) chunking_method is never capped.
+        explicit = nn.LinearCrossEntropyOptions(chunking_method="aspect_ratio")
+        self.assertEqual(
+            explicit._adjust(4096, 16384, 4096, torch.bfloat16, cuda).batch_chunk_size,
+            4096,
+        )
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_convert_sync_batchnorm(self):
@@ -14784,14 +14827,10 @@ if __name__ == '__main__':
         # receive "auto" (so _adjust performs the real resolution), but
         # the test's ULP bounds need to track whichever policy was
         # resolved. Read the dispatch table directly so the test stays
-        # in lock-step with future _AUTO_DEFAULTS edits.
+        # in lock-step with future _auto_acc_policy edits.
         if acc_policy == "auto":
-            from torch.nn.modules.linear_cross_entropy_options import (
-                _AUTO_DEFAULTS, _AUTO_FALLBACK,
-            )
-            _resolved_policy, _ = _AUTO_DEFAULTS.get(
-                (torch.device(device).type, dtype, prob_target), _AUTO_FALLBACK,
-            )
+            from torch.nn.modules.linear_cross_entropy_options import _auto_acc_policy
+            _resolved_policy = _auto_acc_policy(torch.device(device).type, dtype)
         else:
             _resolved_policy = acc_policy
 
@@ -15157,6 +15196,24 @@ if __name__ == '__main__':
                 if err > maximal_linear_bias_grad_err:
                     maximal_linear_bias_grad_err = err
                     worst_linear_bias_grad_err_kwargs = dict(module_kwargs)
+
+        # TEMP (chunking-heuristic ULP re-calibration): factor-1 + the N*V/4D
+        # cap changed cuda/mps index+prob chunk sizes, so re-measure observed
+        # ULP. ``sys.__stdout__`` bypasses pytest capture (reaches CI artifact
+        # logs and a direct run's console); the early ``return`` skips the
+        # now-stale caps so every leg prints. Remove with the cap finalization.
+        print(
+            f"\n[lce calibration] target="
+            f"{'prob' if prob_target else 'none' if none_reduction else 'index'}"
+            f" policy={_resolved_policy!r} dtype={dtype} device={device} bias={bias}\n"
+            f"  output:        observed={maximal_output_max_ulp_diff:6d}  cap={expected_max_ulp_diff:6d}\n"
+            f"  input_grad:    observed={maximal_input_grad_max_ulp_diff:6d}  cap={expected_input_grad_max_ulp_diff:6d}\n"
+            f"  linear_weight: observed={maximal_linear_weight_grad_max_ulp_diff:6d}  cap={expected_weight_grad_max_ulp_diff:6d}\n"
+            f"  linear_bias:   observed={maximal_linear_bias_grad_max_ulp_diff:6d}  cap={expected_linear_bias_grad_max_ulp_diff:6d}",
+            file=sys.__stdout__,
+            flush=True,
+        )
+        return
 
         self.assertLessEqual(maximal_input_grad_err, feps,
                              msg=f"worst input-grad err {maximal_input_grad_err} from kwargs={worst_input_grad_err_kwargs}")
@@ -15656,6 +15713,27 @@ if __name__ == '__main__':
             device=device, dtype=dtype, acc_policy=acc_policy,
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             prob_target=True)
+
+    def test_TEMP_mps_lce_calibration_dump(self, device):
+        # TEMP (chunking-heuristic ULP re-calibration): macOS CI does not upload
+        # the test-report artifact, so loop the calibration grid (each leg
+        # prints via the harness) then force an mps failure -- run_test.py dumps
+        # the captured log, surfacing the [lce calibration] prints. Self-
+        # contained (does not depend on the parametrized legs running first).
+        # Remove with the calibration scaffolding.
+        if torch.device(device).type != "mps":
+            self.skipTest("TEMP mps-only calibration dump")
+        for prob_target in (False, True):
+            for dtype in (torch.float32, torch.float16, torch.bfloat16):
+                acc_dtype = None if dtype == torch.float32 else torch.float32
+                for acc_policy in ("accurate", "balanced", "compact", "auto"):
+                    try:
+                        self._test_linear_cross_entropy_loss(
+                            device=device, dtype=dtype, acc_policy=acc_policy,
+                            acc_dtype=acc_dtype, prob_target=prob_target)
+                    except Exception:
+                        pass
+        self.fail("TEMP: dumped mps lce calibration; see [lce calibration] prints above")
 
     def test_linear_cross_entropy_prob_target_dispatch(self, device):
         """Probability-target dispatch edges. The harness covers the

--- a/torch/nn/modules/linear_cross_entropy_options.py
+++ b/torch/nn/modules/linear_cross_entropy_options.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Literal, NamedTuple
+from typing import Literal
 
 import torch
 
@@ -7,27 +7,20 @@ import torch
 __all__ = ["LinearCrossEntropyOptions"]
 
 
-class _AutoDefault(NamedTuple):
-    acc_policy: str
-    chunking_method: str
+def _auto_acc_policy(device_type: str | None, dtype: torch.dtype) -> str:
+    """Resolve the ``acc_policy`` ``"auto"`` sentinel from device and dtype.
 
-
-# Defaults for the ``"auto"`` sentinel of ``acc_policy`` / ``chunking_method``,
-# keyed by ``(device_type, input_dtype, prob_target)`` -- Pareto picks from
-# an fp64-jacobian sweep. CPU picks ``"accurate"`` (only chunked policy with
-# fp32 weight-grad mm on CPU; others hit emulated low-precision matmul,
-# ~20-50x slower). Probability targets on CUDA pick aspect_ratio factor 1.
-_AUTO_DEFAULTS: dict[tuple[str, torch.dtype, bool], _AutoDefault] = {
-    ("cuda", torch.bfloat16, False): _AutoDefault("compact", "aspect_ratio:2"),
-    ("cuda", torch.float16, False): _AutoDefault("compact", "aspect_ratio:2"),
-    ("cuda", torch.bfloat16, True): _AutoDefault("compact", "aspect_ratio"),
-    ("cuda", torch.float16, True): _AutoDefault("compact", "aspect_ratio"),
-    ("cpu", torch.bfloat16, False): _AutoDefault("accurate", "aspect_ratio"),
-    ("cpu", torch.float16, False): _AutoDefault("accurate", "aspect_ratio"),
-    ("cpu", torch.bfloat16, True): _AutoDefault("accurate", "aspect_ratio"),
-    ("cpu", torch.float16, True): _AutoDefault("accurate", "aspect_ratio"),
-}
-_AUTO_FALLBACK: _AutoDefault = _AutoDefault("compact", "aspect_ratio:2")
+    Only CPU + low-precision input (fp16/bf16) picks ``"accurate"``: there
+    ``compact``/``balanced`` run the weight-grad GEMM in the input dtype,
+    hitting CPU's emulated low-precision matmul (~20-50x slower), so
+    ``"accurate"`` keeps it in fp32. Everything else picks ``"compact"`` --
+    accelerators have hardware-native low-precision GEMMs, and for fp32/fp64
+    the GEMM is native at any policy (``"accurate"`` would only add a
+    weight-grad scratch, no benefit).
+    """
+    if device_type == "cpu" and dtype in (torch.float16, torch.bfloat16):
+        return "accurate"
+    return "compact"
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -41,11 +34,9 @@ class LinearCrossEntropyOptions:
     ``in_features`` (e.g. LLM vocabulary heads). Pass ``options=None`` to
     use the reference path; pass an instance of this class to opt in.
 
-    Zero-argument ``LinearCrossEntropyOptions()`` leaves
-    :attr:`acc_policy` and :attr:`chunking_method` set to ``"auto"``,
-    resolved at call time from :data:`_AUTO_DEFAULTS`
-    (per-(device, dtype, prob_target) picks measured on A100 / x86 CPU);
-    unlisted keys fall back to ``("compact", "aspect_ratio:2")``.
+    Zero-argument ``LinearCrossEntropyOptions()`` leaves :attr:`acc_policy`
+    and :attr:`chunking_method` at ``"auto"``, resolved per (device, dtype) at
+    call time -- see the field docs below.
 
     Supports a subset of :func:`linear_cross_entropy`; unsupported
     configurations fall through to the reference path with a warning.
@@ -88,9 +79,10 @@ class LinearCrossEntropyOptions:
     chunking_method: str | None = "auto"
     """Heuristic for picking :attr:`batch_chunk_size`.
 
-    - ``"auto"`` (default) -- resolves to a per-(device, dtype) pick from
-      :data:`_AUTO_DEFAULTS` at call time; falls back to
-      ``"aspect_ratio:2"`` for unlisted pairs.
+    - ``"auto"`` (default) -- resolves to ``"aspect_ratio"`` (factor 1),
+      with the compact path additionally capped at a per-target ``B_ref``
+      in :meth:`_adjust` so the chunked peak never exceeds the unchunked
+      reference in the budget regime (``in_features >= num_classes``).
     - ``"aspect_ratio"`` -- sizes each chunk so its
       ``(batch_chunk_size, num_classes)`` logits buffer matches the
       ``(num_batches, in_features)`` input in memory:
@@ -111,11 +103,10 @@ class LinearCrossEntropyOptions:
     intermediates are kept in :attr:`acc_dtype` vs. the input dtype, and
     whether the per-chunk weight-gradient scratch buffer is materialized.
 
-    - ``"auto"`` (default) -- per-(device, dtype) pick from
-      :data:`_AUTO_DEFAULTS`; unlisted pairs fall back to ``"compact"``.
-      The fallback assumes a CUDA-like backend with hardware-native
-      low-precision matmul; pass ``"accurate"`` explicitly on backends
-      that emulate fp16/bf16 GEMMs via fp32 upcast.
+    - ``"auto"`` (default) -- ``"accurate"`` for CPU low-precision input
+      (fp16/bf16), ``"compact"`` otherwise (:func:`_auto_acc_policy`). Pass
+      ``"accurate"`` explicitly on any other backend that emulates fp16/bf16
+      GEMMs via fp32 upcast.
     - ``"accurate"`` -- broadest use of :attr:`acc_dtype`; noticeably
       better input-grad accuracy when chunk size is large relative to
       ``num_classes``. Highest peak memory and slowest of the chunked
@@ -245,29 +236,25 @@ class LinearCrossEntropyOptions:
         specific call site; returns a fully concrete options instance.
 
         Internal API consumed by ``F.linear_cross_entropy``'s chunked
-        dispatch and a handful of test call sites. ``device=None``
-        forces the :data:`_AUTO_FALLBACK` pick instead of the
-        per-device one. ``prob_target`` is part of the
-        :data:`_AUTO_DEFAULTS` key.
+        dispatch and a handful of test call sites. ``device=None`` forces the
+        ``"compact"`` fallback instead of the per-device acc_policy pick.
+        ``prob_target`` selects the per-target memory cap (``N/2`` vs
+        ``N*V/4D``).
         """
         acc_policy = self.acc_policy
         chunking_method = self.chunking_method
+        chunking_was_auto = chunking_method == "auto"
         # Honour an explicit batch_chunk_size by disabling auto chunking
         # (it would conflict with the user's size); acc_policy="auto" is
         # unaffected.
         if chunking_method == "auto" and self.batch_chunk_size is not None:
             chunking_method = None
-        if acc_policy == "auto" or chunking_method == "auto":
-            if device is not None:
-                ap, cm = _AUTO_DEFAULTS.get(
-                    (device.type, dtype, prob_target), _AUTO_FALLBACK
-                )
-            else:
-                ap, cm = _AUTO_FALLBACK
-            if acc_policy == "auto":
-                acc_policy = ap
-            if chunking_method == "auto":
-                chunking_method = cm
+        if acc_policy == "auto":
+            acc_policy = _auto_acc_policy(
+                device.type if device is not None else None, dtype
+            )
+        if chunking_method == "auto":
+            chunking_method = "aspect_ratio"
 
         if self.batch_chunk_size is None:
             batch_chunk_size = num_batches
@@ -281,6 +268,21 @@ class LinearCrossEntropyOptions:
                 num_classes,
                 chunking_method,
             )
+            # Memory cap for the auto compact path. aspect_ratio degenerates to
+            # a single chunk when in_features >= num_classes, where the chunked
+            # peak exceeds the unchunked reference. ``b_ref`` is the largest
+            # chunk staying at or below reference -- ``N*V/(4*D)`` for index
+            # targets, ``N/2`` for prob (whose reference also materializes the
+            # soft target, so the single-chunk excess clears with two chunks);
+            # both device- and dtype-independent. Floored to a power of two so
+            # the cap never lands above ``b_ref``.
+            if chunking_was_auto and acc_policy == "compact":
+                if prob_target:
+                    b_ref = num_batches // 2
+                else:
+                    b_ref = num_batches * num_classes // (4 * in_features)
+                b_ref = 1 << (b_ref.bit_length() - 1) if b_ref >= 1 else 1
+                batch_chunk_size = max(1, min(batch_chunk_size, b_ref))
             if (
                 self.batch_chunk_size is not None
                 and self.batch_chunk_size != batch_chunk_size

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1819,23 +1819,26 @@ def module_inputs_torch_nn_LinearCrossEntropyLoss(module_info, device, dtype, re
             )
 
     def sizes_and_options():
-        for sizes in [(8, 5, 4), (None, 8, 4)]:
+        # (8, 5, 4) and (None, 8, 4) are budget regime (in_features >=
+        # num_classes) where the auto memory cap binds; (32, 4, 64) is vocab
+        # regime (num_classes >> in_features) where the cap is inert and
+        # aspect_ratio governs -- the LLM-head case.
+        for sizes in [(8, 5, 4), (None, 8, 4), (32, 4, 64)]:
             yield sizes, None
             num_batches, in_features, num_classes = sizes
             if acc_dtype is not None:
                 yield sizes, dict(acc_dtype=acc_dtype, chunking_method="aspect_ratio")
                 continue
-            # unspecified chunk sizes default maximal chunk sizes for
-            # best processing performance:
+            # unspecified options use the auto resolution (aspect_ratio
+            # factor 1, capped to stay at or below the reference peak):
             yield sizes, dict()
 
             if num_batches is not None:
                 # fixed chunk size reduces memory usage but may reduce
                 # processing performance:
                 yield sizes, dict(batch_chunk_size=2)
-                # alternatively to fixing chunk sizes, chunk sizes can be
-                # determined by a chunking method:
-                yield sizes, dict(chunking_method="aspect_ratio:2")
+                # an explicit chunking method (aspect_ratio:N math is unit-tested
+                # in test_linear_cross_entropy_options_aspect_ratio_chunk_size):
                 yield sizes, dict(chunking_method="aspect_ratio:4")
 
     def samples():

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1819,11 +1819,10 @@ def module_inputs_torch_nn_LinearCrossEntropyLoss(module_info, device, dtype, re
             )
 
     def sizes_and_options():
-        # (8, 5, 4) and (None, 8, 4) are budget regime (in_features >=
-        # num_classes) where the auto memory cap binds; (32, 4, 64) is vocab
-        # regime (num_classes >> in_features) where the cap is inert and
-        # aspect_ratio governs -- the LLM-head case.
-        for sizes in [(8, 5, 4), (None, 8, 4), (32, 4, 64)]:
+        # APPEND-ONLY: never reorder/insert/remove entries -- each consumes
+        # fixed RNG draws, so a mid-stream change shifts later samples and
+        # moves the cancellation-sensitive index-target ULP caps in test_nn.py.
+        for sizes in [(8, 5, 4), (None, 8, 4)]:
             yield sizes, None
             num_batches, in_features, num_classes = sizes
             if acc_dtype is not None:
@@ -1837,8 +1836,8 @@ def module_inputs_torch_nn_LinearCrossEntropyLoss(module_info, device, dtype, re
                 # fixed chunk size reduces memory usage but may reduce
                 # processing performance:
                 yield sizes, dict(batch_chunk_size=2)
-                # an explicit chunking method (aspect_ratio:N math is unit-tested
-                # in test_linear_cross_entropy_options_aspect_ratio_chunk_size):
+                # alternatively, chunk sizes via an explicit chunking method:
+                yield sizes, dict(chunking_method="aspect_ratio:2")
                 yield sizes, dict(chunking_method="aspect_ratio:4")
 
     def samples():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #187838
* #187053

The chunked auto default for CUDA index targets switches from
aspect_ratio:2 to factor 1 -- faster (larger M-dim GEMM, fewer kernels;
beats liger on throughput in the vocab regime) -- made memory-safe by a
per-target cap on the compact path:

    B = min(aspect_ratio_B[factor 1], floor_pow2(B_ref))

B_ref is the largest chunk whose peak stays at or below the unchunked
reference: N*V/(4*D) for index targets, N/2 for prob. The cap is inert in
the vocab regime (aspect_ratio governs) and binds in the budget regime
(in_features >= num_classes), where factor 1 alone would exceed reference.
B_ref is device- and dtype-independent (fit identical on bf16/fp16/fp32/
fp64; the peak-memory arithmetic is the same everywhere).

aspect_ratio:2 was a pre-#187219 memory hedge; with the materialize-grads
fix landed it is unnecessary, and factor-1+cap strictly dominates it. The
auto-resolution table collapses to _auto_acc_policy(device_type, dtype):
"accurate" only for CPU low-precision input (its emulated fp16/bf16 GEMM
is ~20-50x slower), "compact" everywhere else; chunking_method auto always
resolves to aspect_ratio factor 1.

The chunk-size change shifts per-(dtype, policy) ULP, so the existing caps
in test_nn.py were re-measured across CPU, CUDA, ROCm, and MPS (A100 for
CUDA/CPU, CI for ROCm/MPS): every leg stays at or below the current caps,
so no cap values change.

Performance (A100-SXM4-80GB, CUDA 13.1, driver 580.126.09, bf16, index
targets, fwd+bwd median time / peak memory; auto = this PR's default,
ar:2 = previous default, liger = liger-kernel fused op, reference = full
materialization).

Vocab regime (num_classes >> in_features), sweeping num_classes at
num_tokens=4096, in_features=4096 -- auto is fastest and leanest, the gap
over ar:2 and liger widening as the vocabulary grows:

![throughput vs num_classes](https://github.com/user-attachments/assets/64a86529-4438-4475-9369-5d2ac6154c2c)

| num_classes | auto (this PR) | ar:2 (old) | liger | reference |
|---|---|---|---|---|
| 32000  | 19.0 ms / 0.70 GiB | 23.1 / 0.63 | 26.0 / 1.33 | 12.8 / 1.27 |
| 65536  | 44.5 ms / 1.21 GiB | 63.8 / 1.14 | 79.5 / 2.61 | 27.5 / 2.55 |
| 131072 | 125.8 ms / 2.21 GiB | 203.1 / 2.14 | 290.7 / 5.11 | 54.7 / 5.05 |

At num_classes=131072, auto is ~1.6x faster than the old default and
~2.3x faster than liger at ~43% of their peak memory; reference is faster
in raw time but uses ~2.3x the memory and stops being an option once the
full logits do not fit.

Budget regime (in_features >= num_classes; atypical for index), sweeping
in_features at num_tokens=4096, num_classes=8192 -- the N*V/4D cap keeps
auto at or below reference across the whole range while uncapped factor-1,
ar:2, and liger all exceed it (peak memory, GiB):

![peak memory vs in_features](https://github.com/user-attachments/assets/8d3c1d85-c2db-4a9e-9b77-abd14c14ee97)

| in_features | auto | uncapped factor-1 | ar:2 | liger | reference |
|---|---|---|---|---|---|
| 8192 (=V) | 0.48 | 0.77 | 0.58 | 0.83 | 0.52 |
| 16384     | 0.84 | 1.33 | 1.05 | 1.58 | 0.89 |
| 32768     | 1.59 | 2.45 | 2.11 | 3.08 | 1.64 |

The cap costs some throughput here (more, smaller chunks) -- the intended
memory-safety tradeoff in a regime index workloads (vocab heads, V >> D)
do not operate in. Probability targets already resolved to factor 1 and
gain the analogous N/2 cap: throughput is unchanged in the vocab regime
(the cap is inert there); in the budget regime they take the same
more-but-smaller-chunks tradeoff as index. Peak stays at or below
reference in both.

Test Plan:

```
python test/test_nn.py -k "linear_cross_entropy"
```

This PR was authored with the assistance of an AI tool (Claude).