### PR TITLE
[inductor] Resolve ProcessGroup attrs in overlap estimates

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1000,6 +1000,44 @@ class TestOverlapPreservingBucketing(InductorTestCase):
         # Should not error in deterministic mode (would have errored before fix)
         schedule_overlap_bucketing(gm)
 
+    @torch._inductor.config.patch(deterministic=True)
+    def test_overlap_scheduler_resolves_get_attr_process_group(self):
+        """
+        Functionalized eager collectives can pass ProcessGroup get_attr nodes to
+        _c10d_functional ops. Overlap scheduling should resolve those without
+        requiring node.meta["val"] on the get_attr node.
+        """
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        def func(a, b):
+            group_name = "0"
+            ar = torch.ops._c10d_functional.all_reduce(a.sum(), "sum", group_name)
+            mm_result = torch.mm(a, b)
+            ar_out = torch.ops._c10d_functional.wait_tensor(ar)
+            return mm_result + ar_out
+
+        with FakeTensorMode():
+            a = torch.randn(16, 16, device=self.device)
+            b = torch.randn(16, 16, device=self.device)
+            gm = make_fx(func)(a, b)
+
+        ar = gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_reduce.default,
+        )[0]
+        gm._test_pg = dist.distributed_c10d._get_default_group()
+        with gm.graph.inserting_before(ar):
+            pg_node = gm.graph.create_node("get_attr", "_test_pg")
+        ar.args = (ar.args[0], ar.args[1], pg_node)
+
+        self.assertNotIn("val", pg_node.meta)
+        gm.graph.lint()
+        gm.recompile()
+
+        schedule_overlap_bucketing(gm, pre_bucketing_fsdp_collectives=False)
+
     def test_assume_bucketed_latency_exceeds_exposed_time(self):
         """
         When assume_bucketing_reduces_latency is True and two same-type

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -842,6 +842,7 @@ def estimate_nccl_collective_runtime_from_fx_node(
     from torch._inductor.fx_passes.bucketing import _resolve_group_name
 
     group_name = _resolve_group_name(kwargs["group_name"])
+    kwargs["group_name"] = group_name
     group_size = _get_group_size_by_name(group_name)
     if not isinstance(fx_node.target, torch._ops.OpOverload):
         raise AssertionError(

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -42,11 +42,24 @@ def _resolve_group_name(group_name: Any) -> "GroupName":
     group_name argument as an FX Node reference (pointing to a
     mesh_get_process_group call) rather than a string literal. For
     bucketing key purposes we resolve via the ProcessGroup stored in
-    node.meta["val"].
+    node.meta["val"] or, for functionalized eager collectives, via the
+    owning module's get_attr value.
     """
     if isinstance(group_name, str):
         return group_name  # pyrefly: ignore [bad-return]
-    pg = group_name.meta["val"]
+    pg = group_name
+    if isinstance(group_name, torch.fx.Node):
+        pg = group_name.meta.get("val")
+        if pg is None and group_name.op == "get_attr":
+            gm = group_name.graph.owning_module
+            if gm is not None:
+                from torch.fx.graph_module import _get_attr
+
+                pg = _get_attr(gm, group_name.target)  # type: ignore[arg-type]
+    if isinstance(pg, str):
+        return pg  # pyrefly: ignore [bad-return]
+    if not hasattr(pg, "group_name"):
+        raise AssertionError(f"could not resolve collective group name from {pg!r}")
     return pg.group_name
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187846
* #187845
* #187844
* #187843
* #187842
* #187841
* #187840
* __->__ #187839
* #187675

Functionalized eager collectives can pass a ProcessGroup get_attr node to _c10d_functional ops. The overlap scheduler's collective estimator resolved only string group names or FX nodes with meta["val"], so Rigi overlap-scheduling experiments failed during compilation with KeyError: 'val' before scheduling could run.

Resolve get_attr ProcessGroup nodes through the owning GraphModule when meta["val"] is absent, and replace the estimator's normalized group_name kwarg with the resolved group-name string before optional NCCL timing. This keeps the benchmark path from trying to materialize a ProcessGroup FX node as a tensor-like value. The regression test builds the same get_attr shape and runs overlap scheduling with deterministic estimates.

Rigi metrics: E149/E150 failed before metrics with KeyError: 'val'. With this fix, E151 and E152 completed. The overlap configurations themselves are not memory wins: E151 was 3517.6 ms, 24.793 GiB active, 27.156 GiB reserved with default pre-bucketing; E152 was 3555.4 ms, 24.626 GiB active, 26.102 GiB reserved without pre-bucketing, versus E145 auto-residual reference at 3519.6 ms, 20.659 GiB active, 21.570 GiB reserved. The fix is a compatibility improvement, not an overlap-scheduling memory improvement for Rigi.

Test Plan:

```

python test/distributed/test_overlap_bucketing_unit.py TestOverlapPreservingBucketing -v

lintrunner -a

```

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo