### PR TITLE
[inductor] Add allow_peak_memory_increasing_fusion config

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -956,6 +956,13 @@ loop_index_inversion_in_fusion: bool = True
 # For the cases loop ordering after fusion does not help, we don't lose much.
 score_fusion_memory_threshold = 10
 
+# Allow choices that Inductor's peak-memory heuristics would otherwise block.
+# This is intentionally on by default so existing fusion behavior stays unchanged
+# unless a caller explicitly opts into peak-memory-aware restrictions.
+allow_peak_memory_increasing_fusion = (
+    os.environ.get("TORCHINDUCTOR_ALLOW_PEAK_MEMORY_INCREASING_FUSION", "1") == "1"
+)
+
 # For Triton Templates, select fastest of best template + epilogue vs best template + separate epilogue kernel
 benchmark_epilogue_fusion = (
     os.environ.get("TORCHINDUCTOR_BENCHMARK_EPILOGUE_FUSION", "1") == "1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187846
* #187845
* #187844
* #187843
* #187842
* #187841
* __->__ #187840
* #187839
* #187675

Add a single config switch for the peak-memory-aware choices in this stack. The flag defaults to True so the old/aggressive fusion and memory-planning behavior remains unchanged unless tests or users explicitly opt into the more conservative mode with allow_peak_memory_increasing_fusion=False.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo