### PR TITLE
[inductor] Realize reused pointwise add when allow_peak_memory_increasing_fusion is off

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -13,6 +13,7 @@ import torch.utils.flop_counter
 from torch._dynamo.utils import counters
 from torch._inductor.choices import InductorChoices
 from torch._inductor.dependencies import Dep, MemoryDep, ReadWrites
+from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import GraphPartitionSignature
 from torch._inductor.loop_body import MemoryEntry, MemoryUsageType
 from torch._inductor.scheduler import (
@@ -26,6 +27,7 @@ from torch._inductor.scheduler import (
 from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.utils import fresh_inductor_cache, snode_args_kwargs
 from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_cuda import SM70OrLater
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -895,6 +897,191 @@ class TestScheduler(TestCase):
 
         scheduler.fusion_would_materialize_disjoint_branches.assert_not_called()
 
+    @inductor_config.patch("allow_peak_memory_increasing_fusion", False)
+    def test_reused_add_reaching_reduction_like_output_realizes(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            return add * c, add.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        self.assertTrue(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                add, self._create_reused_pointwise_result()
+            )
+        )
+
+    def test_reused_add_realization_respects_peak_memory_config(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            return add * c, add.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        with inductor_config.patch("allow_peak_memory_increasing_fusion", True):
+            self.assertFalse(
+                GraphLowering._should_realize_reused_pointwise_for_reduction(
+                    add, self._create_reused_pointwise_result()
+                )
+            )
+
+    @inductor_config.patch("allow_peak_memory_increasing_fusion", False)
+    def test_reused_add_reaching_indirect_reduction_like_output_realizes(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            mul = torch.ops.aten.mul.Tensor(add, c)
+            return add - c, mul.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        self.assertTrue(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                add, self._create_reused_pointwise_result()
+            )
+        )
+
+    def test_reused_add_reaching_small_slice_reduction_does_not_realize(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            small = add[:, :1]
+            return add * c, small.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        self.assertFalse(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                add, self._create_reused_pointwise_result()
+            )
+        )
+
+    def test_reused_pointwise_realization_requires_add(self):
+        def fn(a, b, c):
+            mul = torch.ops.aten.mul.Tensor(a, b)
+            return mul + c, mul.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        mul = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.mul.Tensor)
+
+        self.assertFalse(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                mul, self._create_reused_pointwise_result()
+            )
+        )
+
+    def test_reused_add_realization_requires_reduction_like_user(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            return add * c, add - c
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        self.assertFalse(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                add, self._create_reused_pointwise_result()
+            )
+        )
+
+    def test_reused_add_realization_requires_reused_pointwise_reads(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            return add * c, add.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+
+        self.assertFalse(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(
+                add, self._create_reused_pointwise_result(nontrivial_read_count=1)
+            )
+        )
+
+    @inductor_config.patch("allow_peak_memory_increasing_fusion", False)
+    def test_reused_add_realization_unwraps_mutablebox(self):
+        def fn(a, b, c):
+            add = torch.ops.aten.add.Tensor(a, b)
+            return add * c, add.sum(dim=1, keepdim=True)
+
+        gm = make_fx(fn)(torch.randn(4, 8), torch.randn(4, 8), torch.randn(4, 8))
+        add = next(n for n in gm.graph.nodes if n.target is torch.ops.aten.add.Tensor)
+        pointwise = self._create_mock_pointwise_result()
+        result = ir.TensorBox(ir.MutableBox(ir.StorageBox(pointwise)))
+
+        self.assertTrue(
+            GraphLowering._should_realize_reused_pointwise_for_reduction(add, result)
+        )
+
+    def test_output_metadata_shrink_is_reduction_like_without_tag(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten._fused_rms_norm.default)
+        node.meta["val"] = (torch.empty(4, 8), torch.empty(4, 1))
+
+        self.assertFalse(
+            GraphLowering._target_is_reduction_like(
+                torch.ops.aten._fused_rms_norm.default
+            )
+        )
+        self.assertTrue(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_reduction_tag_is_reduction_like_without_output_metadata(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten.sum.default)
+
+        self.assertTrue(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_nested_output_metadata_shrink_is_reduction_like_without_tag(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten._fused_rms_norm.default)
+        node.meta["val"] = {"full": torch.empty(4, 8), "small": [torch.empty(4, 1)]}
+
+        self.assertTrue(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_multiple_full_size_outputs_are_not_reduction_like(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten.alias.default)
+        node.meta["val"] = (torch.empty(4, 8), torch.empty(4, 8))
+
+        self.assertFalse(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_single_output_metadata_shrink_is_not_reduction_like(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten.slice.Tensor)
+        node.meta["val"] = torch.empty(4, 4)
+
+        self.assertFalse(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_partition_metadata_shrink_is_not_reduction_like(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten.split.Tensor)
+        node.meta["val"] = (torch.empty(2, 8), torch.empty(2, 8))
+
+        self.assertFalse(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
+    def test_full_and_empty_split_is_not_reduction_like(self):
+        graph = torch.fx.Graph()
+        node = graph.call_function(torch.ops.aten.split_with_sizes.default)
+        node.meta["val"] = (torch.empty(4, 8), torch.empty(4, 0))
+
+        self.assertFalse(
+            GraphLowering._call_has_reduction_like_output(node, input_numel=32)
+        )
+
     def test_fusion_would_materialize_late_outputs_from_shared_producer_prevents_fusion(
         self,
     ):
@@ -1208,6 +1395,23 @@ class TestScheduler(TestCase):
 
         check = scheduler.fusion_would_materialize_late_outputs_from_shared_producer
         check.assert_not_called()
+
+    def _create_reused_pointwise_result(
+        self, nontrivial_read_count: int = 2
+    ) -> ir.TensorBox:
+        pointwise = self._create_mock_pointwise_result(nontrivial_read_count)
+        return ir.TensorBox(ir.StorageBox(pointwise))
+
+    def _create_mock_pointwise_result(
+        self, nontrivial_read_count: int = 2
+    ) -> ir.Pointwise:
+        pointwise = object.__new__(ir.Pointwise)
+        object.__setattr__(
+            pointwise,
+            "inner_fn_opcount",
+            Mock(return_value=Mock(nontrivial_read_count=nontrivial_read_count)),
+        )
+        return pointwise
 
     def _mock_dep(self, name: str) -> Mock:
         dep = Mock(spec=Dep)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -21,6 +21,7 @@ from sympy import Expr
 import torch
 import torch._logging
 import torch.fx
+import torch.utils._pytree as pytree
 from torch import device, Tensor
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
@@ -48,6 +49,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
     SympyBoolean,
     SymTypes,
+    statically_known_true,
 )
 from torch.fx.node import Node
 from torch.fx.passes.reinplace import _is_view_op
@@ -1861,6 +1863,108 @@ class GraphLowering(torch.fx.Interpreter):
             if isinstance(ir_value, ir.TensorBox):
                 ir_value.realize()
 
+    @staticmethod
+    def _target_is_reduction_like(target: object) -> bool:
+        if not isinstance(target, torch._ops.OpOverload):
+            return False
+        if torch.Tag.reduction in target.tags:
+            return True
+        return False
+
+    @staticmethod
+    def _target_may_return_reduction_like_metadata(target: object) -> bool:
+        if not isinstance(target, torch._ops.OpOverload):
+            return False
+        return "norm" in target.overloadpacket.__name__
+
+    @classmethod
+    def _call_has_reduction_like_output(
+        cls, n: torch.fx.Node, input_numel: int | torch.SymInt
+    ) -> bool:
+        if n.op != "call_function":
+            return False
+        if cls._target_is_reduction_like(n.target):
+            return True
+        if not cls._target_may_return_reduction_like_metadata(n.target):
+            return False
+        tensor_outputs = [
+            output
+            for output in pytree.tree_leaves(n.meta.get("val"))
+            if isinstance(output, torch.Tensor)
+        ]
+        has_full_size_output = any(
+            statically_known_true(output.numel() == input_numel)
+            for output in tensor_outputs
+        )
+        has_smaller_output = any(
+            statically_known_true(output.numel() < input_numel)
+            for output in tensor_outputs
+        )
+        return len(tensor_outputs) > 1 and has_full_size_output and has_smaller_output
+
+    @staticmethod
+    def _node_has_full_size_tensor_value(
+        n: torch.fx.Node, input_numel: int | torch.SymInt
+    ) -> bool:
+        return any(
+            isinstance(output, torch.Tensor)
+            and statically_known_true(output.numel() == input_numel)
+            for output in pytree.tree_leaves(n.meta.get("val"))
+        )
+
+    @classmethod
+    def _user_reaches_reduction_like_output(cls, n: torch.fx.Node) -> bool:
+        cache_key = "_inductor_user_reaches_reduction_like_output"
+        cached = n.meta.get(cache_key)
+        if cached is not None:
+            return cached
+        val = n.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            return False
+        input_numel = val.numel()
+        worklist = [(n, user) for user in n.users]
+        seen: set[torch.fx.Node] = set()
+        while worklist:
+            parent, user = worklist.pop()
+            if user in seen:
+                continue
+            seen.add(user)
+            if cls._call_has_reduction_like_output(
+                user, input_numel
+            ) and cls._node_has_full_size_tensor_value(parent, input_numel):
+                n.meta[cache_key] = True
+                return True
+            if cls._node_has_full_size_tensor_value(user, input_numel):
+                worklist.extend((user, next_user) for next_user in user.users)
+        n.meta[cache_key] = False
+        return False
+
+    @classmethod
+    def _should_realize_reused_pointwise_for_reduction(
+        cls, n: torch.fx.Node, result: object
+    ) -> bool:
+        if (
+            config.allow_peak_memory_increasing_fusion
+            or n.op != "call_function"
+            or n.target is not torch.ops.aten.add.Tensor
+            or len(OrderedSet(n.users)) <= 1
+            or not isinstance(result, TensorBox)
+            or not cls._user_reaches_reduction_like_output(n)
+        ):
+            return False
+
+        data = result.data
+        while not isinstance(data, StorageBox) and isinstance(
+            data, (ir.BaseView, ir.MutableBox)
+        ):
+            data = data.data
+
+        return (
+            isinstance(data, StorageBox)
+            and isinstance(data.data, Pointwise)
+            and data.data.inner_fn_opcount().nontrivial_read_count > 1
+        )
+
     def run_node(self, n: torch.fx.Node) -> object:
         """Lower and execute a single FX node into Inductor IR."""
 
@@ -2072,6 +2176,10 @@ class GraphLowering(torch.fx.Interpreter):
             # already too many reads and rematerializing can be bad.
             num_users = len(OrderedSet(n.users))
             if num_users > 1 and isinstance(result, TensorBox):
+                if self._should_realize_reused_pointwise_for_reduction(n, result):
+                    result = maybe_apply_channels_last_stride_order(result, n)
+                    result.realize()
+
                 for user in n.users:
                     if user.target in needs_realized_inputs:
                         result.realize_hint()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187846
* #187845
* __->__ #187844
* #187843
* #187842
* #187841
* #187840
* #187839
* #187675

Realize a reused aten.add pointwise result before reduction-like branches in peak-aware mode. The behavior is disabled when allow_peak_memory_increasing_fusion=True, so the default path preserves the previous rematerializing behavior.

Example: add = a + b feeds both a full-size pointwise branch and a reduction-like branch such as add.sum(dim=1). If add is inlined into both users, the reduction branch can reread and recompute the full-size add while the pointwise branch also keeps full-size data live. In peak-aware mode, materializing the reused pointwise add once gives the scheduler an explicit buffer and avoids duplicating that full-size work into the reduction branch.

The trigger remains intentionally narrow: the FX node must be aten.add.Tensor, the lowered IR must be Pointwise, the value must have multiple users, and one user must reach a reduction-like output. This avoids broadly realizing arbitrary pointwise nodes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo