### PR TITLE
[inductor] Prefer successor-unblocking LPMF when allow_peak_memory_increasing_fusion is off

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
@@ -8,6 +9,7 @@ from torch._dynamo.utils import same
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
+from torch.utils._ordered_set import OrderedSet
 from torch.testing._internal.common_utils import serialTest, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
@@ -50,6 +52,61 @@ class Foo(torch.nn.Module):
         return t3.sum() + t4.sum()
 
 
+class TestLPMFMemoryOrdering(TestCase):
+    class Node:
+        def __init__(self, name, index, size):
+            self.name = name
+            self.mpi_node = SimpleNamespace(
+                index=index,
+                size=size,
+                pred_nodes=[],
+                succ_nodes=[],
+                pred_buffers=[],
+            )
+
+        def get_outputs(self):
+            return []
+
+        def get_name(self):
+            return self.name
+
+    @config.patch("allow_peak_memory_increasing_fusion", False)
+    @config.patch("size_threshold_for_succ_based_strategy", 0)
+    def test_lpmf_prefers_earliest_successor_when_ready_nodes_allocate(self):
+        early_root = self.Node("early_root", 0, 100)
+        late_root = self.Node("late_root", 1, 10)
+        early_successor = self.Node("early_successor", 2, 0)
+        late_successor = self.Node("late_successor", 10, 0)
+        early_root.mpi_node.succ_nodes = [early_successor]
+        late_root.mpi_node.succ_nodes = [late_successor]
+        early_successor.mpi_node.pred_nodes = [early_root]
+        late_successor.mpi_node.pred_nodes = [late_root]
+
+        order = memory.topological_sort_lpmf(
+            [early_root, late_root, early_successor, late_successor],
+            {},
+            {},
+            OrderedSet(),
+        )
+
+        self.assertEqual(order[0], early_root)
+
+    @config.patch("allow_peak_memory_increasing_fusion", False)
+    @config.patch("size_threshold_for_succ_based_strategy", 0)
+    def test_lpmf_uses_memory_ordering_when_no_successors(self):
+        larger_root = self.Node("larger_root", 0, 100)
+        smaller_root = self.Node("smaller_root", 1, 10)
+
+        order = memory.topological_sort_lpmf(
+            [larger_root, smaller_root],
+            {},
+            {},
+            OrderedSet(),
+        )
+
+        self.assertEqual(order[0], smaller_root)
+
+
 # The tests in this class uses very small tensors. The default
 # score_fusion_memory threshold will cause different fusion decisions and
 # generate a different wrapper. Override the threshold to make these tests
@@ -64,6 +121,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
         self.inputs = torch.ones((M, 2), device=GPU_TYPE)
         self.orig_reorder_method = memory.reorder_for_peak_memory
 
+    @config.patch("allow_peak_memory_increasing_fusion", False)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory(self):
         outp_corr = self.model(self.inputs)
@@ -79,10 +137,10 @@ class TestOperatorReorderForPeakMemory(TestCase):
         (
             FileCheck()
             .check(call_str)
-            .check("buf1 = ")
             .check("buf0 = ")
             .check("buf2 = ")
             .check("buf4 = ")
+            .check("buf1 = ")
             .check("buf3 = ")
             .check("buf5 = ")
             .check("buf7 = ")
@@ -92,6 +150,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
         outp = compiled_model(self.inputs)
         self.assertTrue(same(outp, outp_corr))
 
+    @config.patch("allow_peak_memory_increasing_fusion", False)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory_lpmf(self):
         outp_corr = self.model(self.inputs)
@@ -128,11 +187,11 @@ class TestOperatorReorderForPeakMemory(TestCase):
             (
                 FileCheck()
                 .check(call_str)
-                .check("buf1 = ")
                 .check("buf0 = ")
+                .check("buf1 = ")
                 .check("buf2 = ")
-                .check("buf4 = ")
                 .check("buf3 = ")
+                .check("buf4 = ")
                 .check("buf5 = ")
                 .check("buf7 = ")
                 .run(code)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -432,11 +432,10 @@ reorder_prefetch_limit: int | None = None
 reorder_for_peak_memory = True
 reorder_for_peak_memory_debug = False
 
-# In some cases, when all the nodes that can be scheduled are quite large,
-# it is beneficial to switch the scheduling strategy. So instead of using
-# size as the criterion, we choose a node that can unlock more nodes to
-# become schedulable by analyzing their successor nodes. The default value
-# is zero, which turns off this optimization.
+# When all schedulable nodes have allocations larger than this threshold and
+# at least one ready node unlocks a successor, prefer the node that unlocks the
+# earliest successor. The original LPMF memory key remains the fallback when
+# no successor information is available.
 size_threshold_for_succ_based_strategy: int = 0
 
 

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -712,33 +712,38 @@ def topological_sort_lpmf(
 
     # schedule nodes one at a time
     schedule: list[BaseSchedulerNode] = []
-    size_threshold = config.size_threshold_for_succ_based_strategy
     num_iters: int = 0
     while num_iters < len(nodes) and nodes_to_schedule:
+        def memory_key(node: BaseSchedulerNode) -> tuple[int, int, int]:
+            return (
+                node.mpi_node.size if node.mpi_node.size > memory_gap else 0,
+                node.mpi_node.size - node_info[node]["memory_to_free"],
+                node.mpi_node.index,
+            )
+
+        def earliest_successor_index(node: BaseSchedulerNode) -> int:
+            return min(
+                (succ_node.mpi_node.index for succ_node in node.mpi_node.succ_nodes),
+                default=len(nodes),
+            )
+
         # select a node to schedule:
-        if (
-            size_threshold > 0
-            and min(node.mpi_node.size for node in nodes_to_schedule) > size_threshold
-        ):
+        successor_indexes = [
+            earliest_successor_index(node) for node in nodes_to_schedule
+        ]
+        use_successor_ordering = (
+            not config.allow_peak_memory_increasing_fusion
+            and min(node.mpi_node.size for node in nodes_to_schedule)
+            > config.size_threshold_for_succ_based_strategy
+            and any(index != len(nodes) for index in successor_indexes)
+        )
+        if use_successor_ordering:
             selected_node = min(
                 nodes_to_schedule,
-                key=lambda node: min(
-                    (
-                        succ_node.mpi_node.index
-                        for succ_node in node.mpi_node.succ_nodes
-                    ),
-                    default=len(nodes),
-                ),
+                key=earliest_successor_index,
             )
         else:
-            selected_node = min(
-                nodes_to_schedule,
-                key=lambda node: (
-                    node.mpi_node.size if node.mpi_node.size > memory_gap else 0,
-                    node.mpi_node.size - node_info[node]["memory_to_free"],
-                    node.mpi_node.index,
-                ),
-            )
+            selected_node = min(nodes_to_schedule, key=memory_key)
         nodes_to_schedule.remove(selected_node)
         schedule.append(selected_node)
         num_iters += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187846
* __->__ #187845
* #187844
* #187843
* #187842
* #187841
* #187840
* #187839
* #187675

Make the LPMF scheduler optionally prefer a ready node that unlocks the earliest successor when all ready nodes are large. This path is active only when allow_peak_memory_increasing_fusion=False, so the default True setting keeps the previous memory ordering.

Example: two roots are ready. A allocates 100 MB and unlocks successor A2 at order 2; B allocates 10 MB and unlocks successor B2 at order 10. Pure memory ordering can pick B first, leaving A's branch blocked and increasing the time multiple branch outputs stay live. In peak-aware mode, A is chosen first because it unblocks earlier downstream work and can finish/free that branch sooner.

If no ready node unlocks a successor, the original LPMF memory key remains the fallback.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo