### PR TITLE
[inductor] Add autotune_at_compile_time_emit_source to gate the compile-time autotuning docstring

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1937,6 +1937,14 @@ class triton:
     # Setting to None means uninitialized
     autotune_at_compile_time: bool | None = autotune_at_compile_time_default()
 
+    # When autotuning at compile time, also prepend the (no-op) "Compile-time
+    # auto-tuning block" docstring to the emitted output module. The real autotuning
+    # already ran during codegen; this block is debug-only text, so a consumer that
+    # extracts runnable source from the emitted module can disable it to avoid
+    # emitting then stripping it. It affects emitted source, so it stays part of the
+    # FxGraphCache key (hashed via save_config_portable, absent from the ignore lists).
+    autotune_at_compile_time_emit_source: bool = True
+
     # We use random tensors for autotune by default. Setting this as true will let us
     # use inputs from sample inputs to autotune user defined triton kernels.
     # Side effect for this option is increased memory footprint during first pass compilation.

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -3007,7 +3007,14 @@ class GraphLowering(torch.fx.Interpreter):
     ) -> CompiledModule:
         from .codecache import PyCodeCache
 
-        if config.triton.autotune_at_compile_time:
+        # The auto-tuning block below is debug-only text prepended as a docstring (the
+        # real autotuning already ran); gating its emission on
+        # autotune_at_compile_time_emit_source lets a consumer that captures the
+        # emitted module request clean, runnable source.
+        if (
+            config.triton.autotune_at_compile_time
+            and config.triton.autotune_at_compile_time_emit_source
+        ):
             # sanitize docstrings in kernel defs (#155006)
             kernel_autotune_defs = self.wrapper_code.kernel_autotune_defs.getvalue()
             kernel_autotune_defs = kernel_autotune_defs.replace('"""', '\\"\\"\\"')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187848

I'm working on a new precompile python export API and as part of that I want to inline inductor output code without the benchmarking harness. This makes it optional to omit the benchmarking code, which I will use in later PRs.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo