### PR TITLE
[inductor] Downgrade standalone_compile no-artifact log from warning to debug

### DIFF
--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -557,9 +557,16 @@ def standalone_compile(
             return AOTCompiledArtifact(compiled_fn)
         artifacts = torch.compiler.save_cache_artifacts()
         if artifacts is None:
-            log.warning(
-                "standalone_compile artifact generation failed, cannot save. "
-                "Run with TORCH_LOGS=+torch._inductor.codecache to identify the problem"
+            # A None artifact is benign: it just means there is no bundled cache to
+            # persist, so a later reload re-runs normal compilation instead of taking a
+            # cache hit. It is also the EXPECTED outcome for several legitimate cases --
+            # caches intentionally disabled (force_disable_caches / fx_graph_cache), and
+            # uncacheable graphs such as control-flow HOPs (torch.cond / while_loop) whose
+            # lowering produces no bundled artifact even with caches on. Log at debug.
+            log.debug(
+                "standalone_compile produced no cache artifact. This is expected when "
+                "caches are disabled (force_disable_caches / fx_graph_cache) or for "
+                "uncacheable graphs such as control-flow HOPs (torch.cond / while_loop)"
             )
 
     return CacheCompiledArtifact(compiled_fn, artifacts)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187849

When standalone_compile cannot produce a bundled cache artifact, save_cache_artifacts
returns None and the result is logged at warning level. A None artifact is benign:
the returned CacheCompiledArtifact still works, and a later reload simply re-runs
normal compilation instead of taking a cache hit. It is also the expected outcome for
several legitimate cases -- caches intentionally disabled (force_disable_caches /
fx_graph_cache), and uncacheable graphs such as control-flow HOPs (torch.cond /
while_loop) whose lowering produces no bundled artifact even with caches on.

Logging this at warning is noisy and misleading (it reads as a failure). Downgrade it
to debug and reword the message to describe the expected causes instead of pointing at
a codecache log to "identify the problem".

Test Plan:

Behavior-only change to a log call (severity + message text); no functional change.
Verified lint-clean on the changed lines:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo