### PR TITLE
[inductor] Extract CompiledArtifact._to_binary_bytes from save()

### DIFF
--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -144,51 +144,82 @@ class CacheCompiledArtifact(CompiledArtifact):
         # (we only expect one)
         return len(cache_info.aot_autograd_artifacts) == 1
 
+    def _to_binary_bytes(self) -> bytes:
+        """Serialize this artifact to the in-memory ``binary`` byte format.
+
+        Produces exactly the bytes that ``save(format="binary")`` writes to disk, so
+        callers that only need the bytes (rather than a file on disk) can reuse this
+        without going through ``save``. The byte layout is the one
+        ``load(format="binary")`` reads back: header, ``torch_key``, the autograd-cache
+        ``key`` string, then the opaque ``artifact_bytes``.
+        """
+        if self._artifacts is None:
+            raise RuntimeError(
+                "CompiledArtifact.save failed to save since there's no artifact to save"
+            )
+        artifact_bytes, cache_info = self._artifacts
+        if len(cache_info.aot_autograd_artifacts) == 0:
+            raise RuntimeError(
+                f"CompiledArtifact.save failed to save due to no aot_autograd artifacts. "
+                f"This likely means there was something that was not serializable in the "
+                f"graph passed to standalone_compile. This can generally be fixed by "
+                f"ensuring that your model only uses constructs that are serializable. "
+                f"{cache_info}"
+            )
+        if len(cache_info.aot_autograd_artifacts) > 1:
+            raise AssertionError(
+                f"CompiledArtifact.save failed to save because there was more than one "
+                f"artifact but we only expected one. {cache_info}"
+            )
+        key = cache_info.aot_autograd_artifacts[0]
+
+        from torch.utils._appending_byte_serializer import BytesWriter
+
+        from .codecache import torch_key
+
+        writer = BytesWriter()
+        writer.write_bytes(CacheCompiledArtifact.CACHE_HEADER)
+        writer.write_bytes(torch_key())
+        writer.write_str(key)
+        writer.write_bytes(artifact_bytes)
+        return writer.to_bytes()
+
     def save(
         self, *, path: str, format: Literal["binary", "unpacked"] = "binary"
     ) -> None:
         with dynamo_timed("CompiledArtifact.save"):
-            if self._artifacts is None:
-                raise RuntimeError(
-                    "CompiledArtifact.save failed to save since there's no artifact to save"
-                )
-            artifact_bytes, cache_info = self._artifacts
-            if len(cache_info.aot_autograd_artifacts) == 0:
-                raise RuntimeError(
-                    f"CompiledArtifact.save failed to save due to no aot_autograd artifacts. "
-                    f"This likely means there was something that was not serializable in the "
-                    f"graph passed to standalone_compile. This can generally be fixed by "
-                    f"ensuring that your model only uses constructs that are serializable. "
-                    f"{cache_info}"
-                )
-            if len(cache_info.aot_autograd_artifacts) > 1:
-                raise AssertionError(
-                    f"CompiledArtifact.save failed to save because there was more than one "
-                    f"artifact but we only expected one. {cache_info}"
-                )
-            key = cache_info.aot_autograd_artifacts[0]
-
             if format == "binary":
                 # can't assert that it is a file since it might not exist yet
                 if os.path.isdir(path):
                     raise AssertionError(f"expected path to not be a dir: {path}")
 
-                from torch.utils._appending_byte_serializer import BytesWriter
-
-                from .codecache import torch_key
-
-                writer = BytesWriter()
-                writer.write_bytes(CacheCompiledArtifact.CACHE_HEADER)
-                writer.write_bytes(torch_key())
-                writer.write_str(key)
-                writer.write_bytes(artifact_bytes)
-
                 from torch._inductor.codecache import write_atomic
 
-                write_atomic(path, writer.to_bytes())
+                # ``_to_binary_bytes`` is the single source of the None / empty /
+                # multiple aot_autograd_artifacts validation, so the binary branch
+                # does not repeat those checks here.
+                write_atomic(path, self._to_binary_bytes())
             else:
                 if format != "unpacked":
                     raise AssertionError(f"expected format == 'unpacked', got {format}")
+                if self._artifacts is None:
+                    raise RuntimeError(
+                        "CompiledArtifact.save failed to save since there's no artifact to save"
+                    )
+                artifact_bytes, cache_info = self._artifacts
+                if len(cache_info.aot_autograd_artifacts) == 0:
+                    raise RuntimeError(
+                        f"CompiledArtifact.save failed to save due to no aot_autograd artifacts. "
+                        f"This likely means there was something that was not serializable in the "
+                        f"graph passed to standalone_compile. This can generally be fixed by "
+                        f"ensuring that your model only uses constructs that are serializable. "
+                        f"{cache_info}"
+                    )
+                if len(cache_info.aot_autograd_artifacts) > 1:
+                    raise AssertionError(
+                        f"CompiledArtifact.save failed to save because there was more than one "
+                        f"artifact but we only expected one. {cache_info}"
+                    )
                 if os.path.exists(path):
                     if not os.path.isdir(path):
                         raise AssertionError(f"expected path to be a dir: {path}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #188377
* #187859
* #188376
* #188367
* #188366
* #187858
* __->__ #187850

Pull the binary serialization of a CacheCompiledArtifact (validate the bundled
aot_autograd artifact, then write header / torch_key / key / artifact_bytes) out of
CacheCompiledArtifact.save into a reusable _to_binary_bytes method that returns the
bytes directly. The binary save branch now calls it, so a caller that only needs the
bytes (rather than a file on disk) can reuse this without going through save.

This is behavior-preserving. The only observable reordering is in the binary branch:
the "path must not be a dir" assertion now runs before artifact validation (previously
the validation ran first, at the top of save). The unpacked branch keeps its own copy
of the artifact validation since it consumes artifact_bytes directly; the duplication
is intentional to keep _to_binary_bytes self-contained.

Test Plan:

Behavior-preserving refactor of the save(format="binary") path -- the extracted body
is identical to the code save() previously ran inline. Covered by the existing
standalone-compile save/load tests:

```
python test/inductor/test_codecache.py -k TestStandaloneCompile
```

Lint:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo