### PR TITLE
[functorch] Add ViewMetaSequence._from_parts helper

### DIFF
--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -479,6 +479,18 @@ class ViewMetaSequence:
 
         return self.metadata == other.metadata
 
+    @classmethod
+    def _from_parts(
+        cls, sequence: list[object], metadata: MetadataKey
+    ) -> ViewMetaSequence:
+        # Rebuild a ViewMetaSequence directly from its parts, bypassing the
+        # FunctionalTensor-based __init__. This lets the recipe be reconstructed from
+        # plain values rather than from a live FunctionalTensor or an embedded pickle.
+        self = cls.__new__(cls)
+        self.sequence = sequence  # type: ignore[assignment]
+        self.metadata = metadata
+        return self
+
 
 # new_arg and arg here are either:
 # (1) both a FakeTensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187851

ViewMetaSequence.__init__ builds the sequence from a live FunctionalTensor. Add a
_from_parts classmethod that rebuilds an instance directly from its (sequence,
metadata) parts via cls.__new__, bypassing the FunctionalTensor-based constructor.

This lets the view-replay recipe be reconstructed from plain values -- for example
when regenerating it as source or from a serialized form -- instead of requiring a
live FunctionalTensor. It is a small standalone building block for upcoming
standalone-artifact codegen; there is no in-tree caller yet.

Test Plan:

No behavior change to existing paths (adds a new, currently-unused classmethod).
Lint:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a
```

Authored with an AI assistant.