### PR TITLE
Add SSH support and teardown to lint CI workflow

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -23,6 +23,14 @@ jobs:
       image: ${{ inputs.docker-image }}
     timeout-minutes: 120
     steps:
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+          instructions: |
+            All linting is done inside the container, to start an interactive session run:
+              docker exec -it $(docker container ps --format '{{.ID}}') bash
+
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
@@ -47,3 +55,7 @@ jobs:
 
           # Execute the linter script
           bash "${RUNNER_TEMP}/linter_script"
+
+      - name: Teardown Linux
+        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        if: always()


### PR DESCRIPTION
## Author Notes

Trying to debug weird lint behavior, this would be helpful.

## Agent Notes

Adds setup-ssh and teardown-linux steps to the `_lint.yml` reusable workflow, matching the pattern used by `_linux-build.yml`, `_linux-test.yml`, and `_docs.yml`. The setup-ssh action has `fail-silently` defaulting to `true`, so it will no-op gracefully on ARC/container runners where SSH is not available and work when the infrastructure supports it.

This PR was authored with the help of an AI assistant.