### PR TITLE
[minifier][inductor] add backend info in minifier repro

### DIFF
--- a/test/dynamo/_triton_extra_import_kernel.py
+++ b/test/dynamo/_triton_extra_import_kernel.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
+# A user-defined Triton kernel at module scope, using an imported Triton
+# helper name other than the usual `triton` or `tl` globals.
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice

--- a/test/dynamo/_triton_extra_import_kernel.py
+++ b/test/dynamo/_triton_extra_import_kernel.py
@@ -1,0 +1,12 @@
+# Owner(s): ["module: dynamo"]
+
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def triton_kernel_with_extra_import(x_ptr, BLOCK: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    values = libdevice.exp2(tl.load(x_ptr + offsets))
+    tl.store(x_ptr + offsets, values)

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -274,31 +274,27 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         with patch.object(sys, "path", [test_inductor_dir, *sys.path]):
             custom_inductor_config = importlib.import_module("custom_inductor_config")
 
-        old_enable_optimisation = custom_inductor_config.enable_optimisation
-        try:
-            # This re-registers the CPU backend with its original scheduling and
-            # wrapper codegen, but adds a third-party backend config module.
-            with patch_inductor_backend(
-                "cpu", custom_backend_config=custom_inductor_config
-            ):
-                custom_inductor_config.enable_optimisation = True
-                args = [torch.randn(4)]
+        # This re-registers the CPU backend with its original scheduling and
+        # wrapper codegen, but adds a third-party backend config module.
+        with (
+            patch_inductor_backend("cpu", custom_backend_config=custom_inductor_config),
+            custom_inductor_config.patch(enable_optimisation=True),
+        ):
+            args = [torch.randn(4)]
 
-                def f(x):
-                    return (x + 1,)
+            def f(x):
+                return (x + 1,)
 
-                gm = make_fx(f)(*args)
-                buf = io.StringIO()
-                save_graph_repro(buf, gm, args, "inductor")
-                repro = buf.getvalue()
+            gm = make_fx(f)(*args)
+            buf = io.StringIO()
+            save_graph_repro(buf, gm, args, "inductor")
+            repro = buf.getvalue()
 
-                self.assertIn(f"import {custom_inductor_config.__name__}", repro)
-                self.assertIn(
-                    f"{custom_inductor_config.__name__}.enable_optimisation = True",
-                    repro,
-                )
-        finally:
-            custom_inductor_config.enable_optimisation = old_enable_optimisation
+            self.assertIn(f"import {custom_inductor_config.__name__}", repro)
+            self.assertIn(
+                f"{custom_inductor_config.__name__}.enable_optimisation = True",
+                repro,
+            )
 
     def import_triton_extra_import_kernel(self):
         test_dynamo_dir = os.path.abspath(os.path.dirname(__file__))

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -271,12 +271,8 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         test_inductor_dir = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "inductor")
         )
-        old_path = list(sys.path)
-        sys.path.insert(0, test_inductor_dir)
-        try:
+        with patch.object(sys, "path", [test_inductor_dir, *sys.path]):
             custom_inductor_config = importlib.import_module("custom_inductor_config")
-        finally:
-            sys.path[:] = old_path
 
         old_enable_optimisation = custom_inductor_config.enable_optimisation
         try:
@@ -306,12 +302,8 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
 
     def import_triton_extra_import_kernel(self):
         test_dynamo_dir = os.path.abspath(os.path.dirname(__file__))
-        old_path = list(sys.path)
-        sys.path.insert(0, test_dynamo_dir)
-        try:
+        with patch.object(sys, "path", [test_dynamo_dir, *sys.path]):
             return importlib.import_module("_triton_extra_import_kernel")
-        finally:
-            sys.path[:] = old_path
 
     @unittest.skipIf(not has_triton(), "requires Triton")
     def test_save_graph_repro_emits_extra_triton_imports(self):

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import importlib
 import io
 import os
 import pickle
@@ -261,6 +262,122 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         save_graph_repro(buf, gm, args, "inductor_accuracy")
         r = buf.getvalue()
         self.assertIn("reader.opaque('__torch__.MyClass')", r)
+
+    def test_save_graph_repro_emits_custom_backend_codegen_config(self):
+        from torch.testing._internal.inductor_utils import patch_inductor_backend
+
+        # Reuse the custom ConfigModule already used by Inductor cache-key tests
+        # instead of creating a second dummy config module for repro coverage.
+        test_inductor_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "inductor")
+        )
+        old_path = list(sys.path)
+        sys.path.insert(0, test_inductor_dir)
+        try:
+            custom_inductor_config = importlib.import_module("custom_inductor_config")
+        finally:
+            sys.path[:] = old_path
+
+        old_enable_optimisation = custom_inductor_config.enable_optimisation
+        try:
+            # This re-registers the CPU backend with its original scheduling and
+            # wrapper codegen, but adds a third-party backend config module.
+            with patch_inductor_backend(
+                "cpu", custom_backend_config=custom_inductor_config
+            ):
+                custom_inductor_config.enable_optimisation = True
+                args = [torch.randn(4)]
+
+                def f(x):
+                    return (x + 1,)
+
+                gm = make_fx(f)(*args)
+                buf = io.StringIO()
+                save_graph_repro(buf, gm, args, "inductor")
+                repro = buf.getvalue()
+
+                self.assertIn(f"import {custom_inductor_config.__name__}", repro)
+                self.assertIn(
+                    f"{custom_inductor_config.__name__}.enable_optimisation = True",
+                    repro,
+                )
+        finally:
+            custom_inductor_config.enable_optimisation = old_enable_optimisation
+
+    def import_triton_extra_import_kernel(self):
+        test_dynamo_dir = os.path.abspath(os.path.dirname(__file__))
+        old_path = list(sys.path)
+        sys.path.insert(0, test_dynamo_dir)
+        try:
+            return importlib.import_module("_triton_extra_import_kernel")
+        finally:
+            sys.path[:] = old_path
+
+    @unittest.skipIf(not has_triton(), "requires Triton")
+    def test_save_graph_repro_emits_extra_triton_imports(self):
+        extra_import_kernel = self.import_triton_extra_import_kernel()
+
+        with (
+            patch.object(kernel_side_table, "id_to_kernel", {}),
+            patch.object(kernel_side_table, "kernel_to_id", {}),
+            patch.object(kernel_side_table, "constant_args", {}),
+        ):
+            # The helper kernel references `libdevice` directly instead of only
+            # `triton` or `tl`, matching user kernels that import helpers from
+            # Triton's extra packages.
+            kernel_side_table.add_kernel(
+                extra_import_kernel.triton_kernel_with_extra_import
+            )
+
+            args = [torch.randn(4)]
+
+            def f(x):
+                return (x + 1,)
+
+            gm = make_fx(f)(*args)
+            buf = io.StringIO()
+            save_graph_repro(buf, gm, args, "inductor")
+            repro = buf.getvalue()
+
+            self.assertIn("import triton.language.extra.libdevice as libdevice", repro)
+
+    @unittest.skipIf(not TEST_CUDA or not has_triton(), "requires CUDA and Triton")
+    def test_after_aot_minifier_emits_extra_triton_imports_integration(self):
+        extra_import_kernel = self.import_triton_extra_import_kernel()
+        from torch._dynamo.debug_utils import minifier_dir
+        from torch._inductor.codegen.simd import SIMDScheduling
+
+        @torch.compile
+        def fn(x):
+            extra_import_kernel.triton_kernel_with_extra_import[(1,)](x, BLOCK=16)
+            return x + 1
+
+        def fail_codegen_node(*args, **kwargs):
+            raise RuntimeError("intentional triton codegen failure")
+
+        with tempfile.TemporaryDirectory() as d:
+            repro_path = None
+            with (
+                torch._dynamo.config.patch(
+                    repro_after="aot",
+                    repro_level=2,
+                    debug_dir_root=d,
+                ),
+                patch.object(
+                    SIMDScheduling,
+                    "codegen_node",
+                    side_effect=fail_codegen_node,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    fn(torch.randn(16, device="cuda"))
+                repro_path = os.path.join(minifier_dir(), "minifier_launcher.py")
+
+            self.assertIsNotNone(repro_path)
+            with open(repro_path) as f:
+                repro = f.read()
+
+        self.assertIn("import triton.language.extra.libdevice as libdevice", repro)
 
     def test_repro_run_accuracy_does_not_reuse_compiled_graph(self):
         class Repro(torch.nn.Module):

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -44,6 +44,7 @@ from torch._dynamo.testing import rand_strided
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._prims_common import is_float_dtype
 from torch.multiprocessing.reductions import StorageWeakRef
+from torch.utils._config_module import ConfigModule
 from torch.utils._content_store import ContentStoreReader, ContentStoreWriter
 
 from . import config
@@ -517,11 +518,24 @@ import os
 def generate_config_string(*, stable_output: bool = False) -> str:
     import torch._functorch.config
     import torch._inductor.config
+    from torch._inductor.codegen import common
 
     if stable_output:
         return "# config omitted due to stable_output=True"
 
+    # Third-party Inductor backends can register their own ConfigModule.
+    # Repros need to replay non-default values from those modules, and
+    # ConfigModule.codegen_config() emits assignments but not the module import.
+    extra_codegen_configs = []
+    for c in common.custom_backend_codegen_configs.values():
+        if isinstance(c, ConfigModule):
+            codegen_config = c.codegen_config()
+            if codegen_config:
+                extra_codegen_configs.append(f"import {c.__name__}\n{codegen_config}")
+    extra_codegen_configs_str = "\n".join(extra_codegen_configs)
+
     experimental_config = torch.fx.experimental._config.codegen_config()  # type: ignore[attr-defined]
+
     return f"""\
 import torch._dynamo.config
 import torch._inductor.config
@@ -531,6 +545,7 @@ import torch.fx.experimental._config
 {torch._inductor.config.codegen_config()}
 {torch._functorch.config.codegen_config()}
 {experimental_config}
+{extra_codegen_configs_str}
 """
 
 

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
+import types
 import typing
 import uuid
 from importlib import import_module
@@ -606,12 +607,40 @@ if "__compile_source__" in globals():
         fn: Any = kernel if isinstance(kernel, JITFunction) else kernel.fn
         return fn.__name__.split(".")[-1]
 
+    def get_triton_import_line(name: str, val: Any) -> str | None:
+        # User-defined Triton kernels are serialized from their source, not from
+        # their original Python module.  If the source references a global
+        # imported from Triton, such as `from triton.language.extra import
+        # libdevice`, the standalone repro must recreate that import.
+        if name in ("triton", "tl"):
+            return None
+
+        if isinstance(val, types.ModuleType):
+            module_name = val.__name__
+            if module_name == "triton" or module_name.startswith("triton."):
+                return f"import {module_name} as {name}"
+            return None
+
+        module_name = getattr(val, "__module__", None)
+        object_name = getattr(val, "__name__", None)
+        if (
+            isinstance(module_name, str)
+            and (module_name == "triton" or module_name.startswith("triton."))
+            and isinstance(object_name, str)
+        ):
+            if name == object_name:
+                return f"from {module_name} import {object_name}"
+            return f"from {module_name} import {object_name} as {name}"
+
+        return None
+
     def write_kernel_dependencies(
         kernel: Any,
         written_constexpr_vars: set[str],
         written_nested_kernels: set[str],
+        written_triton_imports: set[str],
     ) -> str:
-        """Write out global tl.constexpr vars and nested kernel dependencies."""
+        """Write out global triton imports, tl.constexpr vars, and nested kernels."""
         result = ""
         jit_fn = kernel if isinstance(kernel, JITFunction) else kernel.fn
         if not getattr(jit_fn, "fn", None) or not getattr(jit_fn, "src", None):
@@ -629,11 +658,20 @@ if "__compile_source__" in globals():
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
                 called_names.add(node.func.id)
 
-        # Write out global tl.constexpr variables
-        for name in referenced_names:
+        # Only recreate globals that are safe and useful for a standalone
+        # Triton repro: imports anchored in the Triton package and simple
+        # constants.  Other user globals remain unsupported here.
+        for name in sorted(referenced_names):
             if name in written_constexpr_vars:
                 continue
             val = fn_globals.get(name)
+
+            import_line = get_triton_import_line(name, val)
+            if import_line is not None:
+                if import_line not in written_triton_imports:
+                    result += import_line + "\n"
+                    written_triton_imports.add(import_line)
+                continue
 
             if isinstance(val, TritonConstexpr) and getattr(val, "value", None):
                 result += f"{name} = tl.constexpr({val.value})\n"
@@ -654,7 +692,10 @@ if "__compile_source__" in globals():
             # Mark as written before recursing to prevent cycles
             written_nested_kernels.add(nested_fn_name)
             result += write_kernel_dependencies(
-                val, written_constexpr_vars, written_nested_kernels
+                val,
+                written_constexpr_vars,
+                written_nested_kernels,
+                written_triton_imports,
             )
             result += generate_custom_triton_kernel(val)
 
@@ -662,6 +703,10 @@ if "__compile_source__" in globals():
 
     written_nested_kernels: set[str] = set()
     written_constexpr_vars: set[str] = set()
+    written_triton_imports: set[str] = {
+        "import triton",
+        "import triton.language as tl",
+    }
 
     model_str += f"{kernel_side_table_prefix}.reset_table()\n"
 
@@ -670,7 +715,10 @@ if "__compile_source__" in globals():
 
         try:
             model_str += write_kernel_dependencies(
-                kernel, written_constexpr_vars, written_nested_kernels
+                kernel,
+                written_constexpr_vars,
+                written_nested_kernels,
+                written_triton_imports,
             )
             fn_name = get_fn_name(kernel)
 


### PR DESCRIPTION
## Summary

  - Replay registered third-party Inductor backend `ConfigModule` overrides in generated Dynamo repro scripts.
  - Serialize Triton-package imports referenced by user-defined Triton kernels in after-AOT repros.
  - Add regression coverage for custom backend config replay and Triton extra imports in minifier repros.

## Details

  - Extends `generate_config_string()` to include non-default config values from registered custom_backend_codegen_configs.
  - Updates `write_kernel_dependencies()` to detect referenced globals that resolve to triton / triton.* modules
    or objects and emit the needed imports e.g. `from triton.language.extra import libdevice`. Currently only `triton`, and `import triton.language as tl` are added as imports.
  - Adds tests for:
      - replaying an existing custom Inductor backend config module;
      - emitting extra Triton imports in direct `save_graph_repro()` output;
            -  Adds a module-scoped Triton helper kernel using triton.language.extra.libdevice.
      - preserving those imports through an after-AOT minifier integration path.

Generated with codex assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98