### PR TITLE
auto qualify backend strings for comms

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2029,33 +2029,51 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
     def test_parse_backend_string(self):
         from torch.distributed.distributed_c10d import _parse_backend_string
 
-        # Simple form maps to device(s) where the backend is the registered default.
-        self.assertEqual(_parse_backend_string("nccl"), {"cuda": "nccl"})
-        self.assertEqual(_parse_backend_string("NCCL"), {"cuda": "nccl"})
-        # gloo is the default for both cpu and mps in default_device_backend_map.
-        self.assertEqual(_parse_backend_string("gloo"), {"cpu": "gloo", "mps": "gloo"})
+        all_devices = {"cpu", "cuda", "xpu", "mps"}
 
-        # Merged form returns exactly what was named, no synthesized defaults.
+        # Simple form maps to device(s) where the backend is the registered default.
         self.assertEqual(
-            _parse_backend_string("cpu:gloo,cuda:nccl"),
+            _parse_backend_string("nccl", available_devices=all_devices),
+            {"cuda": "nccl"},
+        )
+        self.assertEqual(
+            _parse_backend_string("NCCL", available_devices=all_devices),
+            {"cuda": "nccl"},
+        )
+        # gloo is the default for both cpu and mps in default_device_backend_map.
+        self.assertEqual(
+            _parse_backend_string("gloo", available_devices=all_devices),
+            {"cpu": "gloo", "mps": "gloo"},
+        )
+
+        # Merged form returns exactly what was named, filtered by available_devices.
+        self.assertEqual(
+            _parse_backend_string("cpu:gloo,cuda:nccl", available_devices=all_devices),
             {"cpu": "gloo", "cuda": "nccl"},
         )
         self.assertEqual(
-            _parse_backend_string("CPU:GLOO , CUDA:NCCL"),
+            _parse_backend_string(
+                "CPU:GLOO , CUDA:NCCL", available_devices=all_devices
+            ),
             {"cpu": "gloo", "cuda": "nccl"},
         )
         # Unknown device types in merged form are accepted (no validation here).
-        self.assertEqual(_parse_backend_string("xpu:nccl"), {"xpu": "nccl"})
+        self.assertEqual(
+            _parse_backend_string("xpu:nccl", available_devices=all_devices),
+            {"xpu": "nccl"},
+        )
 
         # Errors.
         with self.assertRaisesRegex(ValueError, "Unknown backend"):
-            _parse_backend_string("definitely_not_a_backend")
+            _parse_backend_string(
+                "definitely_not_a_backend", available_devices=all_devices
+            )
         with self.assertRaisesRegex(ValueError, "Invalid device:backend pairing"):
-            _parse_backend_string("cpu:gloo:extra")
+            _parse_backend_string("cpu:gloo:extra", available_devices=all_devices)
         with self.assertRaisesRegex(ValueError, "Invalid device:backend pairing"):
-            _parse_backend_string("cpu:gloo,bare")
+            _parse_backend_string("cpu:gloo,bare", available_devices=all_devices)
         with self.assertRaisesRegex(ValueError, "Duplicate device type"):
-            _parse_backend_string("cpu:gloo,cpu:dummy")
+            _parse_backend_string("cpu:gloo,cpu:dummy", available_devices=all_devices)
 
     def test_init_process_group_with_multiple_backends(self):
         dist.Backend.register_backend(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1271,7 +1271,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
         # Device type not present in parent.
         with self.assertRaisesRegex(ValueError, "is not present in the parent"):
-            c10d.split_group(pg, [[0, 1]], backend="xpu:nccl")
+            c10d.split_group(pg, [[0, 1]], backend="xpu:xccl")
 
         # Filtering out the parent's default backend (cuda) must raise from C++.
         with self.assertRaises(RuntimeError):

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import os
 import unittest
 
 import torch
@@ -7,7 +8,12 @@ import torch.distributed as dist
 from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import C10dTorchCommsTestBase
-from torch.testing._internal.common_utils import parametrize, run_tests, subtest
+from torch.testing._internal.common_utils import (
+    find_free_port,
+    parametrize,
+    run_tests,
+    subtest,
+)
 
 
 @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
@@ -23,6 +29,15 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
     @property
     def _rank_value(self):
         return self.rank + 1
+
+    def _requires_cuda(self):
+        """Return True when the test variant is NOT cuda.
+
+        MultiProcContinuousTest workers wrap unittest.SkipTest as RuntimeError,
+        so @onlyCUDA / self.skipTest() poison the entire class.  Tests that
+        need NCCL should call this and ``return`` early instead.
+        """
+        return self.device_type != "cuda"
 
     def _skip_if_product_overflows(self, op):
         if op == dist.ReduceOp.PRODUCT and self.world_size > 12:
@@ -228,11 +243,131 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
         with self.assertRaisesRegex(NotImplementedError, "sort_ranks"):
             dist.new_group(ranks=ranks, sort_ranks=False)
 
+    def test_new_group_backend_none_narrows_to_default_device(self):
+        ranks = list(range(self.world_size))
+        ng = dist.new_group(ranks=ranks, backend=None)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=ng)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_new_group_bare_default_backend_is_auto_qualified(self):
+        if self._requires_cuda():
+            return
+        ranks = list(range(self.world_size))
+        ng = dist.new_group(ranks=ranks, backend="nccl")
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=ng)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_new_group_qualified_backend_passes_through(self):
+        if self._requires_cuda():
+            return
+        ranks = list(range(self.world_size))
+        ng = dist.new_group(ranks=ranks, backend="cuda:nccl")
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=ng)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_new_group_with_pg_options(self):
+        if self._requires_cuda():
+            return
+        ranks = list(range(self.world_size))
+        opts = dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+        opts.config.cga_cluster_size = 2
+        opts.config.max_ctas = 16
+        ng = dist.new_group(ranks=ranks, pg_options=opts)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=ng)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_new_group_sequential_pg_options_produce_distinct_groups(self):
+        if self._requires_cuda():
+            return
+        ranks = list(range(self.world_size))
+        opts_a = dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+        opts_a.config.cga_cluster_size = 2
+        opts_b = dist.ProcessGroupNCCL.Options()
+        opts_b.config.cga_cluster_size = 4
+        g_a = dist.new_group(ranks=ranks, pg_options=opts_a)
+        g_b = dist.new_group(ranks=ranks, pg_options=opts_b)
+        self.assertNotEqual(g_a.group_name, g_b.group_name)
+
 
 devices = ["cpu", "cuda", "xpu"]
 instantiate_device_type_tests(
     TestC10dTorchCommsBasic, globals(), only_for=devices, allow_xpu=True
 )
+
+
+@unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+class TestC10dTorchCommsInitAutoQualify(C10dTorchCommsTestBase):
+    """Verify init_process_group auto-qualifies bare backends under torchcomms.
+
+    Overrides ``_init_pg`` to pass ``device_id`` with bare ``"nccl"`` —
+    the auto-qualify logic in ``init_process_group`` should expand it to
+    ``"cpu:gloo,cuda:nccl"`` so both CPU and CUDA backends are available.
+    """
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        torch.distributed.config.use_torchcomms = True
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = rdvz_file
+        os.environ["LOCAL_RANK"] = str(rank)
+
+        store = dist.FileStore(rdvz_file, world_size)
+        device_id = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(rank)
+
+        dist.init_process_group(
+            backend="nccl",
+            world_size=world_size,
+            rank=rank,
+            store=store,
+            device_id=device_id,
+        )
+        cls.pg = dist.distributed_c10d._get_default_group()
+        torch.set_default_device(device_id)
+
+    @property
+    def _rank_value(self):
+        return self.rank + 1
+
+    def test_default_pg_has_cpu_backend(self):
+        default_pg = dist.distributed_c10d._get_default_group()
+        cpu_be = default_pg._get_backend(torch.device("cpu"))
+        self.assertIsNotNone(cpu_be)
+
+    def test_default_pg_has_cuda_backend(self):
+        default_pg = dist.distributed_c10d._get_default_group()
+        cuda_be = default_pg._get_backend(torch.device("cuda"))
+        self.assertIsNotNone(cuda_be)
+
+    def test_allreduce_on_auto_qualified_pg(self):
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=self.pg)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_new_group_from_auto_qualified_parent(self):
+        ranks = list(range(self.world_size))
+        ng = dist.new_group(ranks=ranks)
+        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(tensor, group=ng)
+        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
+
+    def test_bound_device_id_is_set(self):
+        default_pg = dist.distributed_c10d._get_default_group()
+        self.assertIsNotNone(default_pg.bound_device_id)
+        self.assertEqual(default_pg.bound_device_id.type, "cuda")
+
+
+instantiate_device_type_tests(
+    TestC10dTorchCommsInitAutoQualify, globals(), only_for=["cuda"]
+)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -198,6 +198,36 @@ def _use_torchcomms_enabled() -> bool:
     return _TORCHCOMM_AVAILABLE and dist_config.use_torchcomms
 
 
+def _pg_options_to_hints(pg_options: Any) -> dict[str, str] | None:
+    """Convert ProcessGroupNCCL.Options to a torchcomms hints dict."""
+    if pg_options is None:
+        return None
+
+    hints: dict[str, str] = {}
+
+    if hasattr(pg_options, "config"):
+        config = pg_options.config
+        for attr in dir(config):
+            if not attr.startswith("_"):
+                try:
+                    value = getattr(config, attr)
+                    if not callable(value):
+                        hints[attr] = str(value)
+                except Exception:
+                    pass
+
+    for attr in dir(pg_options):
+        if not attr.startswith("_") and attr != "config":
+            try:
+                value = getattr(pg_options, attr)
+                if not callable(value):
+                    hints[attr] = str(value)
+            except Exception:
+                pass
+
+    return hints if hints else None
+
+
 _pickler = pickle.Pickler
 _unpickler = pickle.Unpickler
 
@@ -737,13 +767,23 @@ class BackendConfig:
         return self.device_backend_map
 
 
-def _parse_backend_string(backend: str) -> dict[str, str]:
+def _parse_backend_string(
+    backend: str,
+    available_devices: set[str],
+) -> dict[str, str]:
     """Parse a backend string into a ``{device_type: backend_name}`` dict.
 
     Accepts either the merged form (``"cpu:gloo,cuda:nccl"``) or a simple
     backend name (``"nccl"``). For the simple form, the backend is mapped to
     every device for which it is registered as the default in
     ``Backend.default_device_backend_map``.
+
+    For the simple form, only device types in *available_devices* are
+    included in the result. This prevents bare backend names like ``"gloo"``
+    from expanding to device types not present in the caller's context (e.g.
+    ``"mps"`` on a CUDA-only system). The merged form is returned exactly as
+    named so callers can validate explicitly-requested devices against their
+    own context.
 
     Unlike :class:`BackendConfig`, this does not synthesize defaults for
     unspecified devices — callers get back exactly what was named.
@@ -771,7 +811,7 @@ def _parse_backend_string(backend: str) -> dict[str, str]:
     device_types = [
         device
         for device, be in Backend.default_device_backend_map.items()
-        if be == backend
+        if be == backend and device in available_devices
     ]
     if not device_types:
         raise ValueError(
@@ -2167,6 +2207,28 @@ def init_process_group(
     if backend is None:
         backend = "undefined"
 
+    # TorchComms needs device-qualified backend strings so that split_group
+    # can create subgroups for each device type.  Auto-qualify bare backend
+    # names (e.g. "nccl" → "cpu:gloo,cuda:nccl") so callers don't have to.
+    if (
+        _use_torchcomms_enabled()
+        and device_id is not None
+        and ":" not in backend
+        and backend not in (Backend.UNDEFINED, Backend.MPI, Backend.FAKE)
+    ):
+        bare = backend.lower()
+        qualified: dict[str, str] = {}
+        for dev, be in Backend.default_device_backend_map.items():
+            if be == bare:
+                qualified[dev] = bare
+        if not qualified:
+            qualified[device_id.type] = bare
+        if "cpu" not in qualified:
+            cpu_be = Backend.default_device_backend_map.get("cpu")
+            if cpu_be:
+                qualified["cpu"] = cpu_be
+        backend = ",".join(f"{d}:{b}" for d, b in qualified.items())
+
     # Convert string into `Backend` type
     backend = Backend(backend)
 
@@ -2443,18 +2505,22 @@ def _new_process_group_helper(
                 torch_device,
                 backend_str,
             )
-            # TODO: figure out pg option conversion for torchComms.
             # `persistent_store=true` tells torchcomms to reuse the c10d-side
             # `backend_prefix_store` directly instead of constructing its own
             # TCPStore via StoreManager (which would otherwise require an
             # explicit MASTER_ADDR/MASTER_PORT and conflict with the c10d
             # rendezvous store on rapid re-binds).
+            hints: dict[str, str] = {"persistent_store": "true"}
+            if backend_options is not None:
+                extra = _pg_options_to_hints(backend_options)
+                if extra:
+                    hints.update(extra)
             comm = new_comm(
                 backend_str,
                 torch_device,
                 name=group_name,
                 store=backend_prefix_store,
-                hints={"persistent_store": "true"},
+                hints=hints,
             )
             buffer_size = os.environ.get(
                 "TORCH_FR_BUFFER_SIZE",
@@ -5882,8 +5948,13 @@ def split_group(
     # loop honors this filter so unwanted backends are never split.
     device_types_filter: list[torch.device] | None = None
     if backend is not None:
-        parent_device_backends = _parse_backend_string(parent_backend_str)
-        requested_device_backends = _parse_backend_string(str(backend))
+        parent_devices = {d.type for d in parent_pg._device_types}
+        parent_device_backends = _parse_backend_string(
+            parent_backend_str, available_devices=parent_devices
+        )
+        requested_device_backends = _parse_backend_string(
+            str(backend), available_devices=parent_devices
+        )
         for device_type, requested_be in requested_device_backends.items():
             if device_type not in parent_device_backends:
                 raise ValueError(
@@ -5904,7 +5975,6 @@ def split_group(
         pg_backend = Backend(str(backend))
         backend_config = BackendConfig(pg_backend)
 
-    # TODO: figure out pg option for torchComms
     if pg_options is None and not _use_torchcomms_enabled():
         # default pg_options same as the parent process group
         # A deep copy is needed because if the option will be modified inside split
@@ -6169,6 +6239,45 @@ def _new_group_via_split_group(
         group_ranks = list(range(global_world_size))
     else:
         group_ranks = sorted(ranks)
+
+    # Auto-qualify the requested backend so it always names just the parent's
+    # default device backend (the one matching ``bound_device_id``) plus any
+    # explicitly-requested extra device entry.
+    #
+    # split_group's filter has two requirements:
+    #   (1) it must contain the parent's default device backend, and
+    #   (2) device entries it omits are not included in the new subgroup.
+    #
+    # The naive default (``backend=None``) inherits the parent's full set,
+    # which creates an extra gloo comm per subgroup on every nccl-with-gloo
+    # parent — expensive and racy. Explicitly narrowing to the default
+    # device backend gives every torchcomms caller the same single-backend
+    # subgroup they almost always want, while still letting an explicit
+    # device-qualified string (``"cpu:gloo,cuda:nccl"``) opt back into the
+    # multi-backend behavior
+    bound = default_pg.bound_device_id
+    if bound is not None and (backend is None or ":" not in str(backend)):
+        parent_backend_str, _ = _world.pg_map[default_pg]
+        parent_devices = {d.type for d in default_pg._device_types}
+        parent_device_backends = _parse_backend_string(
+            parent_backend_str, available_devices=parent_devices
+        )
+        default_dev = bound.type
+        default_be = parent_device_backends.get(default_dev)
+        if default_be is not None:
+            if backend is None:
+                # Inherit just the default-device backend, not all parent
+                # device backends.
+                backend = f"{default_dev}:{default_be}"
+            else:
+                bare = str(backend)
+                matched_device = next(
+                    (d for d, be in parent_device_backends.items() if be == bare),
+                    None,
+                )
+                if matched_device is not None:
+                    qualified: dict[str, str] = {matched_device: bare}
+                    backend = ",".join(f"{d}:{b}" for d, b in qualified.items())
 
     # torchcomms backends expect every parent rank to participate in split:
     # members pass their ranks list, non-members pass [] (NCCL_SPLIT_NOCOLOR


### PR DESCRIPTION

Summary:
Optimizes initizialization and subgroup creation by auto-qualifying bare backend strings to minimize downstream changes.

Also enables passing process group options (`pg_options`) to `torchcomms` backends.

Test Plan:
see `test_c10d_torchcomms.py`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/187856).
* #188011
* __->__ #187856