### PR TITLE
[JIT] Skip re-walking already-scripted modules in the prepare pass (#187863)

### DIFF
--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -592,6 +592,42 @@ class TestRecursiveScript(JitTestCase):
         ):
             jit_obj(1, 2, 3, 4)
 
+    def test_prepare_scriptable_already_scripted_with_ignored_child(self):
+        # Scripting a wrapper around an already-scripted child used to re-walk that
+        # child's _modules and re-assign its __jit_ignored_attributes__ submodule (a
+        # non-scripted nn.Module), raising "Cannot re-assign modules in a ScriptModule
+        # with non-scripted module". The _modules loop now skips already-scripted
+        # children, so re-scripting the wrapper succeeds.
+        class IgnoredChild(torch.nn.Module):
+            __jit_ignored_attributes__ = ["sub"]
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.sub = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                if torch.jit.is_scripting():
+                    return torch.zeros_like(x)
+                return self._real(x)
+
+            @torch.jit.ignore
+            def _real(self, x):
+                return self.sub(x)
+
+        class Wrapper(torch.nn.Module):
+            def __init__(self, inner):
+                super().__init__()
+                self.inner = inner
+
+            def forward(self, x):
+                return self.inner.forward(x)
+
+        inner = torch.jit.script(IgnoredChild())
+        self.assertIn("sub", dict(inner.named_children()))
+        scripted = torch.jit.script(Wrapper(inner))
+        t = torch.randn(2, 4)
+        self.assertEqual(scripted(t), torch.zeros_like(t))
+
     def test_attributes(self):
         @torch.jit.script
         class Inner2:

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1077,7 +1077,10 @@ def call_prepare_scriptable_func_impl(obj, memo):
     for name, sub_module in obj.__dict__.items():
         if name == "_modules":
             for k, v in sub_module.items():
-                sub_module[k] = call_prepare_scriptable_func_impl(v, memo)
+                # Mirror the elif below: skip already-scripted children (re-assigning
+                # a jit-ignored grandchild back into a ScriptModule would raise).
+                if isinstance(v, torch.nn.Module) and not isinstance(v, ScriptModule):
+                    sub_module[k] = call_prepare_scriptable_func_impl(v, memo)
             new_obj_dict[name] = sub_module
         elif isinstance(sub_module, torch.nn.Module) and not isinstance(
             sub_module, ScriptModule


### PR DESCRIPTION
Summary:

`torch.jit.script(m)` runs a prepare pass (`call_prepare_scriptable_func_impl`) that recursively walks `m`'s submodules. Its two descent branches disagree: the direct-attribute branch skips children that are already `ScriptModule`s, but the `_modules` branch recurses into and re-assigns every entry unconditionally. So re-walking an already-scripted child -- which happens in two-level scripting, where a child is scripted, nested, and the parent scripted again -- re-runs `child._modules[k] = call_prepare_scriptable_func_impl(v)`; if that child has a `__jit_ignored_attributes__` submodule (left as a live, non-scripted `nn.Module`), re-assigning it into the child's `OrderedModuleDict` raises "Cannot re-assign modules in a ScriptModule with non-scripted module".

It stays latent in ordinary nested scripting because a re-walked subtree's grandchildren are already `ScriptModule`s, so the re-assign is a same-typed no-op. It only fails once a grandchild is deliberately kept non-scripted -- e.g. an export/AOTI-backed leaf that hides an un-scriptable `torch.cond` subtree behind `__jit_ignored_attributes__` (kept real for `torch.export`/eager) and is then scripted inside a larger graph.

Fix: apply the same `not isinstance(v, ScriptModule)` guard to the `_modules` branch. No-op for normal models; it only removes the spurious failure. Non-scripted children are still re-assigned.

Test Plan:
```
buck2 test fbcode//caffe2/test:jit -- test_prepare_scriptable_already_scripted_with_ignored_child
```
Pass 2: https://www.internalfb.com/intern/testinfra/testrun/12103424177378097

Reviewed By: kqfu

Differential Revision: D109222259


