### PR TITLE
Pin FA3 ABI-stable H100 test to Meta ARC fleet

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -87,3 +87,4 @@ self-hosted-runner:
     # OSDC ARC (multi-tenant) runners
     - mt-l-x86iavx512-2-4
     - mt-rel-l-x86iavx512-8-64
+    - mt-l-x86iamx-22-225-h100

--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -33,11 +33,6 @@ on:
         required: false
         type: string
         default: "gha-artifacts"
-      runner_prefix:
-        required: false
-        type: string
-        default: ""
-        description: Prefix for runner label.
       use-arc:
         required: false
         type: boolean
@@ -281,7 +276,7 @@ jobs:
   test-osdc:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch' && inputs.use-arc
-    runs-on: ${{ inputs.runner_prefix }}l-x86iamx-22-225-h100
+    runs-on: mt-l-x86iamx-22-225-h100
     container:
       image: ${{ inputs.docker-image }}
       options: "--gpus all"

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -85,7 +85,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.docker-image }}
       timeout-minutes: 30
       s3-bucket: gha-artifacts
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11


### PR DESCRIPTION
H100 hardware only exists on the Meta ARC fleet, but the FA3 ABI-stable test job requested it from the LF fleet (e.g. `lf-l-x86iamx-22-225-h100`, see [this run](https://github.com/pytorch/pytorch/actions/runs/27944985756/job/82691188896)), where no such nodes exist.

The `meta_only_runners` guard from #187534 only covers the matrix-based path in `_linux-test.yml`. This workflow has no matrix and hardcoded `${{ inputs.runner_prefix }}l-x86iamx-22-225-h100`, so it inherited `lf-` from the build's fleet. Pinned it to `mt-` instead.

---
This PR was authored with the assistance of an AI coding assistant.