### PR TITLE
Add guard-eval benchmarks for models with many repeated nn.Modules

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py
+++ b/benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import torch
 import torch._dynamo.config
+from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 
 
 # to satisfy linter complaining about undefined variable
@@ -38,8 +39,72 @@ def bench(name, fn):
     print(f"{name} {np.median(results) * 1000:.1f}us (warmup={end - start:.1f}s)")
 
 
+# Models with many repeated submodules (e.g. decoder stacks) exercise guard
+# evaluation that scales with the number of inlined nn.Modules: per-layer scalar
+# attribute guards, object-aliasing guards from shared objects, and relational
+# symbolic-shape guards. See https://github.com/pytorch/pytorch/issues/185886.
+class _Shared:
+    def __init__(self):
+        self.flag = True
+
+
+class _RepeatedLayer(torch.nn.Module):
+    def __init__(self, idx, hidden, shared):
+        super().__init__()
+        self.eps = 1e-6
+        self.scale = 0.5 + idx * 1e-3
+        self.register_buffer("bias", torch.randn(hidden))
+        self.shared = shared
+
+    def forward(self, x):
+        if self.shared.flag:
+            x = x + self.eps
+        return x * self.scale + self.bias
+
+
+class _RepeatedModules(torch.nn.Module):
+    def __init__(self, n_layers, hidden):
+        super().__init__()
+        shared = _Shared()
+        self.layers = torch.nn.ModuleList(
+            [_RepeatedLayer(i, hidden, shared) for i in range(n_layers)]
+        )
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def bench_guard_check(name, n_layers, hidden=64):
+    # Time the compiled guard tree in isolation (guard_manager.check) so the
+    # measurement reflects guard-eval cost, not the trivial per-layer compute.
+    torch._dynamo.reset()
+    model = _RepeatedModules(n_layers, hidden)
+    compiled = torch.compile(model, fullgraph=True, dynamic=True)
+    x = torch.randn(128, hidden)[:64]  # a view, so it has a ._base
+
+    start = time.perf_counter()
+    compiled(x)
+    end = time.perf_counter()
+
+    guard_manager = _debug_get_cache_entry_list(type(model).forward.__code__)[
+        0
+    ].guard_manager
+    f_locals = {"self": model, "x": x}
+    if not guard_manager.check(f_locals):
+        raise RuntimeError("guard check failed; cannot benchmark guard eval")
+
+    results = timeit.repeat(
+        lambda: guard_manager.check(f_locals), number=1000, repeat=20
+    )
+    print(f"{name} {np.median(results) * 1000:.1f}us (warmup={end - start:.1f}s)")
+
+
 def main():
     bench("compiled", torch.compile(foo, dynamic=False))  # type: ignore[F821]
+    for n_layers in (10, 40, 80):
+        bench_guard_check(f"repeated_modules[{n_layers}]", n_layers)
 
 
 if __name__ == "__main__":

--- a/benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py
+++ b/benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py
@@ -43,6 +43,10 @@ def bench(name, fn):
 # evaluation that scales with the number of inlined nn.Modules: per-layer scalar
 # attribute guards, object-aliasing guards from shared objects, and relational
 # symbolic-shape guards. See https://github.com/pytorch/pytorch/issues/185886.
+#
+# The same module pattern is mirrored in
+# benchmarks/dynamo/pr_time_benchmarks/benchmarks/nn_module_guard_eval.py; keep
+# the two in sync.
 class _Shared:
     def __init__(self):
         self.flag = True
@@ -57,6 +61,10 @@ class _RepeatedLayer(torch.nn.Module):
         self.shared = shared
 
     def forward(self, x):
+        # Load-bearing: reading the shared object is what makes Dynamo emit the
+        # object-aliasing guards (layers[i].shared is layers[j].shared) this
+        # benchmark exercises. `flag` is always True, so do not "simplify" the
+        # branch away -- doing so silently removes those guards.
         if self.shared.flag:
             x = x + self.eps
         return x * self.scale + self.bias

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nn_module_guard_eval.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nn_module_guard_eval.py
@@ -12,6 +12,9 @@ from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 # attribute guards, object-aliasing guards from shared objects, and relational
 # symbolic-shape guards. This benchmark guards against regressions in that
 # runtime guard-eval cost. See https://github.com/pytorch/pytorch/issues/185886.
+#
+# The same module pattern is mirrored in
+# benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py; keep the two in sync.
 class Shared:
     def __init__(self):
         self.flag = True
@@ -26,6 +29,10 @@ class GuardEvalLayer(nn.Module):
         self.shared = shared
 
     def forward(self, x):
+        # Load-bearing: reading the shared object is what makes Dynamo emit the
+        # object-aliasing guards (layers[i].shared is layers[j].shared) this
+        # benchmark exercises. `flag` is always True, so do not "simplify" the
+        # branch away -- doing so silently removes those guards.
         if self.shared.flag:
             x = x + self.eps
         return x * self.scale + self.bias
@@ -69,15 +76,21 @@ class Benchmark(BenchmarkBase):
     def _prepare_once(self):
         torch._dynamo.reset()
         self._model = RepeatedModules(self.N_LAYERS, self.HIDDEN)
-        compiled = torch.compile(
-            self._model,
-            fullgraph=True,
-            backend=self.backend(),
-            dynamic=self.is_dynamic(),
-        )
-        # a view, so the input has a ._base (exercises relational shape guards)
-        self._x = torch.randn(2 * self.HIDDEN, self.HIDDEN)[: self.HIDDEN]
-        compiled(self._x)
+        # Pin enable_cpp_symbolic_shape_guards so the dynamic baseline is robust
+        # to a future default flip: with it True the symbolic-shape guards move
+        # into a compiled C++ guard, shifting the instruction count with no
+        # change to expected_results.csv. (The static variant has no
+        # symbolic-shape guards and is unaffected.)
+        with torch._dynamo.config.patch(enable_cpp_symbolic_shape_guards=False):
+            compiled = torch.compile(
+                self._model,
+                fullgraph=True,
+                backend=self.backend(),
+                dynamic=self.is_dynamic(),
+            )
+            # a view, so the input has a ._base (exercises relational shape guards)
+            self._x = torch.randn(2 * self.HIDDEN, self.HIDDEN)[: self.HIDDEN]
+            compiled(self._x)
 
         self._guard_manager = _debug_get_cache_entry_list(
             type(self._model).forward.__code__

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nn_module_guard_eval.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nn_module_guard_eval.py
@@ -1,0 +1,107 @@
+import sys
+
+from benchmark_base import BenchmarkBase
+
+import torch
+import torch.nn as nn
+from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+
+# Guard evaluation for models with many repeated submodules (e.g. decoder
+# stacks) scales with the number of inlined nn.Modules: per-layer scalar
+# attribute guards, object-aliasing guards from shared objects, and relational
+# symbolic-shape guards. This benchmark guards against regressions in that
+# runtime guard-eval cost. See https://github.com/pytorch/pytorch/issues/185886.
+class Shared:
+    def __init__(self):
+        self.flag = True
+
+
+class GuardEvalLayer(nn.Module):
+    def __init__(self, idx, hidden, shared):
+        super().__init__()
+        self.eps = 1e-6
+        self.scale = 0.5 + idx * 1e-3
+        self.register_buffer("bias", torch.randn(hidden))
+        self.shared = shared
+
+    def forward(self, x):
+        if self.shared.flag:
+            x = x + self.eps
+        return x * self.scale + self.bias
+
+
+class RepeatedModules(nn.Module):
+    def __init__(self, n_layers, hidden):
+        super().__init__()
+        shared = Shared()
+        self.layers = nn.ModuleList(
+            [GuardEvalLayer(i, hidden, shared) for i in range(n_layers)]
+        )
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class Benchmark(BenchmarkBase):
+    N_LAYERS = 20
+    HIDDEN = 64
+
+    def __init__(self, dynamic):
+        super().__init__(
+            category="nn_module_guard_eval",
+            backend="eager",
+            device="cpu",
+            dynamic=dynamic,
+        )
+
+    def name(self):
+        prefix = self.category()
+        if self.is_dynamic():
+            prefix += "_dynamic"
+        return prefix
+
+    def description(self):
+        return "runtime guard-eval cost for a stack of repeated nn.Modules"
+
+    def _prepare_once(self):
+        torch._dynamo.reset()
+        self._model = RepeatedModules(self.N_LAYERS, self.HIDDEN)
+        compiled = torch.compile(
+            self._model,
+            fullgraph=True,
+            backend=self.backend(),
+            dynamic=self.is_dynamic(),
+        )
+        # a view, so the input has a ._base (exercises relational shape guards)
+        self._x = torch.randn(2 * self.HIDDEN, self.HIDDEN)[: self.HIDDEN]
+        compiled(self._x)
+
+        self._guard_manager = _debug_get_cache_entry_list(
+            type(self._model).forward.__code__
+        )[0].guard_manager
+        self._f_locals = {"self": self._model, "x": self._x}
+        if not self._guard_manager.check(self._f_locals):
+            raise RuntimeError("guard check failed; cannot benchmark guard eval")
+
+    def _prepare(self):
+        pass
+
+    def _work(self):
+        # Time guard evaluation in isolation so the metric reflects guard-eval
+        # cost rather than the trivial per-layer compute.
+        self._guard_manager.check(self._f_locals)
+
+
+def main():
+    result_path = sys.argv[1]
+    for dynamic in (False, True):
+        Benchmark(dynamic).enable_instruction_count().collect_all().append_results(
+            result_path
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -122,8 +122,8 @@ dtensor_dispatch_custom_handler,instruction_count,34910,0.1
 
 
 
-nn_module_guard_eval,instruction_count,82620,0.1
+nn_module_guard_eval,instruction_count,80120,0.1
 
 
 
-nn_module_guard_eval_dynamic,instruction_count,98899,0.1
+nn_module_guard_eval_dynamic,instruction_count,111714,0.1

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -119,3 +119,11 @@ dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 dtensor_dispatch_custom_handler,instruction_count,34910,0.1
+
+
+
+nn_module_guard_eval,instruction_count,82620,0.1
+
+
+
+nn_module_guard_eval_dynamic,instruction_count,98899,0.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #188103
* #188101
* __->__ #187868

Dynamo cache-lookup / guard-evaluation cost scales with the number of
inlined nn.Modules: each repeated submodule contributes per-layer scalar
attribute guards, object-aliasing guards from shared objects, and
relational symbolic-shape guards. For deep stacks (e.g. many-layer decoder
models) this dominates the pre-graph runtime overhead, but no benchmark
exercised it -- existing nn.Module benchmarks measure compile time, and the
existing guard-eval microbenchmark uses a flat function rather than repeated
modules. See https://github.com/pytorch/pytorch/issues/185886.

This adds two benchmarks over a stack of repeated user-defined nn.Modules
carrying those guard patterns:

- A pr_time_benchmarks regression gate (nn_module_guard_eval.py) that measures
  runtime instruction count of guard_manager.check() in isolation, so the
  metric reflects guard-eval cost rather than graph execution. Deterministic
  instruction counts make it suitable for CI gating.
- A repeated_modules[N] case in the dynamo_guard_eval microbenchmark for quick
  local inspection of how guard eval scales with depth.

The expected_results.csv values are the instruction counts measured by the
trunk pr_time_benchmarks CI runner (nn_module_guard_eval 80120,
nn_module_guard_eval_dynamic 111714).

Test Plan:

pr_time benchmark passes against the recorded baseline:

```
cd benchmarks/dynamo/pr_time_benchmarks
PYTHONPATH=./benchmarks python benchmarks/nn_module_guard_eval.py result.csv
PYTHONPATH=./benchmarks python check_results.py expected_results.csv result.csv new.csv
# -> All benchmarks passed
```

Microbenchmark runs and shows the expected linear scaling:

```
python benchmarks/dynamo/microbenchmarks/dynamo_guard_eval.py
# repeated_modules[10] 11.9us
# repeated_modules[40] 34.3us
# repeated_modules[80] 69.8us
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98