### PR TITLE
compile-on-one-rank: move the flag to torch.compiler.config (deprecate distributed alias)

### DIFF
--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -35,6 +35,7 @@ __all__ = [
     "wrap_top_frame",
     "reorderable_logging_functions",
     "force_disable_caches",
+    "compile_on_one_rank",
 ]
 
 
@@ -104,6 +105,19 @@ force_disable_caches: bool = Config(
 )
 """
 Force disables all caching -- This will take precedence over and override any other caching flag
+"""
+
+compile_on_one_rank: bool = Config(
+    default=False,
+    env_name_default=[
+        "TORCH_COMPILE_ON_ONE_RANK",
+        "TORCH_DISTRIBUTED_COMPILE_ON_ONE_RANK",
+    ],
+)
+"""
+When enabled, device- and rank-specific values (devices, process groups) are computed at
+runtime via custom ops rather than baked in at compile time, so a graph can be compiled on
+one rank and run on all ranks. Read across the stack: make_fx, inductor, and distributed.
 """
 
 dynamic_sources: str = Config(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any, cast, TYPE_CHECKING
 
 import torch
+import torch.compiler.config
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
 from torch._utils import _maybe_view_chunk_cat
@@ -1275,7 +1276,7 @@ def _resolve_group(
             raise AssertionError(
                 "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
             )
-        if dist.config.compile_on_one_rank:
+        if torch.compiler.config.compile_on_one_rank:
             return torch.ops._dtensor.mesh_get_process_group(group, 0)
         return group._dim_group_names[0]
     elif isinstance(group, tuple):
@@ -1286,7 +1287,7 @@ def _resolve_group(
         ):
             dmesh = group[0]
             dim = group[1]
-            if dist.config.compile_on_one_rank:
+            if torch.compiler.config.compile_on_one_rank:
                 return torch.ops._dtensor.mesh_get_process_group(dmesh, dim)
             return dmesh._dim_group_names[dim]
         else:
@@ -1891,7 +1892,7 @@ def _group_or_group_name(
 ) -> dist.ProcessGroup | c10d.GroupName:
     if isinstance(group, str):
         return group
-    elif dist.config.compile_on_one_rank:
+    elif torch.compiler.config.compile_on_one_rank:
         return group
     else:
         return group.group_name

--- a/torch/distributed/config.py
+++ b/torch/distributed/config.py
@@ -4,7 +4,6 @@
 Global configuration flags for torch.distributed
 """
 
-import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -13,11 +12,13 @@ from torch.utils._config_module import Config, install_config_module
 
 __all__ = ["compile_on_one_rank", "use_torchcomms", "pipeline_per_direction_p2p"]
 
-# When enabled, coordinates are computed at runtime via a custom op rather
-# than being baked in at compile time. This allows compiling on one rank
-# and running on multiple ranks.
-compile_on_one_rank: bool = bool(
-    os.environ.get("TORCH_DISTRIBUTED_COMPILE_ON_ONE_RANK", False)
+# Deprecated alias. The canonical flag now lives in torch.compiler.config -- it is read
+# across the compiler stack (make_fx, inductor) not just by distributed. Kept here for
+# back-compat (reads, writes, and .patch forward to the canonical flag).
+compile_on_one_rank: bool = Config(
+    alias="torch.compiler.config.compile_on_one_rank",
+    deprecated=True,
+    deprecation_message="use torch.compiler.config.compile_on_one_rank instead",
 )
 
 # When enabled, uses TorchComms for communication backend instead of the

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1238,7 +1238,7 @@ else:
             return self._coordinate_on_dim
 
         def _sym_get_coordinate(self, index: int) -> IntLikeType:
-            import torch.distributed.config as config
+            import torch.compiler.config as config
             from torch._guards import detect_fake_mode
 
             if (

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -318,7 +318,9 @@ def _get_flattened_mesh_by_layout(
     input) rather than as a get_attr constant holding an unpicklable
     ProcessGroup.
     """
-    if _are_we_tracing() and torch.distributed.config.compile_on_one_rank:
+    import torch.compiler.config
+
+    if _are_we_tracing() and torch.compiler.config.compile_on_one_rank:
         # Pre-check: the custom op can't return None (torch.library doesn't
         # support Optional opaque return types), so guard here first.
         if _get_flattened_mesh_by_layout_impl(mesh, mesh_dims) is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187870
* #186892
* __->__ #187869

compile_on_one_rank is read across the compiler stack (make_fx, inductor), not just by
distributed, which had forced a sys.modules hack in the gate to avoid importing
torch.distributed from core. Move the canonical flag to torch.compiler.config -- the module
for cross-cutting compiler options -- and leave torch.distributed.config.compile_on_one_rank
as a deprecated forwarding alias so existing setters (torchtitan, the
TORCH_DISTRIBUTED_COMPILE_ON_ONE_RANK env var) keep working unchanged, with a one-time
FutureWarning.

_coor_enabled() now reads the canonical flag directly (dropping the sys.modules hack and the
unused sys import), and the in-tree distributed readers (_functional_collectives,
device_mesh, _redistribute) read the canonical flag so normal users never trip the
deprecation warning on a hot read.

The flag accepts two env names: the new neutral TORCH_COMPILE_ON_ONE_RANK (preferred) and
the back-compat TORCH_DISTRIBUTED_COMPILE_ON_ONE_RANK. Switching from
bool(os.environ.get(...)) to Config(env_name_default=...) also fixes a footgun where the old
parsing made any non-empty value (including "0") evaluate truthy.

Internal test files still patch via the deprecated alias (they pass with a one-time
warning); migrating them is a follow-up.

Test Plan:
  python test/distributed/tensor/test_compile_on_one_rank.py TestCompileOnOneRankDeviceAsParameter
  # 11/12 pass; only test_inductor_output_identical_across_devices fails (the not-yet-built
  # Layer-3 codegen identity), unrelated to this change.

Verified manually:
  - alias forwards reads/writes/.patch and warns once (FutureWarning)
  - both env names work, new takes precedence; TORCH_DISTRIBUTED_COMPILE_ON_ONE_RANK=0 -> False
  - _coor_enabled honors torch.compiler.config.patch; no import cycle
  - lintrunner -a on the changed files: clean

Authored with Claude.