### PR TITLE
Fix scaled_dot_product_attention: explicitly check for both attn_mask…

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -531,6 +531,9 @@ inline void validate_sdpa_input(
       "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
       query_.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead.");
   if (attn_mask_.has_value()){
+    TORCH_CHECK(
+        !is_causal,
+        "scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
     auto mask_dtype = attn_mask_->dtype();
     TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == at::kFloat || mask_dtype == query_.dtype(),
       "Expected attn_mask dtype to be bool or float or to match query dtype, but got attn_mask.dtype: ",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11937,7 +11937,7 @@ class TestSDPA(TestCaseMPS):
         with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
             with self.assertRaisesRegex(
                 RuntimeError,
-                r"_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True",
+                r"Explicit attn_mask should not be set when is_causal=True",
             ):
                 F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
 


### PR DESCRIPTION
Fixes #187801

### Summary
The `scaled_dot_product_attention` function's documentation specifies that passing both an explicit `attn_mask` and `is_causal=True` is not allowed. Previously, this constraint was only being checked inside specific backend implementations (like the math path), which could cause the function to either silently ignore arguments or crash unexpectedly when dispatched to fast paths like FlashAttention or Memory-Efficient Attention.

This PR adds a centralized `TORCH_CHECK` directly inside `validate_sdpa_input` (in `aten/src/ATen/native/transformers/attention.cpp`). By checking this at the top-level ATen entry point, we ensure that an appropriate `RuntimeError` is raised uniformly and early across all backend implementations. 

### Changes Made
- Added a validation check in `attention.cpp` to reject `is_causal=True` when `attn_mask` has a value.
- Updated the `assertRaisesRegex` check in `test/test_mps.py` to match the newly centralized error message (removed the backend-specific `_` prefix).

### Testing
Ran the transformers and MPS test suites. The CI should successfully verify that the exception is caught correctly across all SDP implementations.
