### PR TITLE
Allow meta-codesync GitHub App to issue revert commands

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2062,6 +2062,7 @@ def validate_revert(
     allowed_apps = {
         "https://github.com/apps/pytorch-auto-revert",
         "https://github.com/apps/facebook-github-tools",
+        "https://github.com/apps/meta-codesync",
     }
     if comment.author_url in allowed_apps:
         allowed_reverters.append("NONE")


### PR DESCRIPTION
## Summary

`meta-codesync[bot]` authenticates via a GitHub App installation, not as a repo collaborator, so its comments have `authorAssociation == NONE`. `validate_revert` only allows `COLLABORATOR`/`MEMBER`/`OWNER` (plus an allowlist of trusted apps), so revert commands from this bot are rejected.

This adds `https://github.com/apps/meta-codesync` to the `allowed_apps` set, matching the existing treatment of `pytorch-auto-revert` and `facebook-github-tools`.

## Companion change

This only covers the **revert** path. The `@pytorchbot merge -i` rejection seen on e.g. #187360 is gated separately by `hasWritePermissions` in `pytorch/test-infra` (`torchci/lib/bot/utils.ts`), which keys off the bot **username** (`meta-codesync[bot]`) rather than the app URL. That fix is a separate PR against test-infra.

## Context

`meta-codesync[bot]` collaborator permission resolves to `none` (it's a GitHub App, so installation scopes are not surfaced as collaborator permission or author association), which is why the explicit allowlist entry is required.

---
This PR was authored with the assistance of an AI coding assistant.