### PR TITLE
Add bcomplex32 Support to torch.testing Comparison Module

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -86,6 +86,7 @@ _DTYPE_PRECISIONS = {
     torch.float32: (1.3e-6, 1e-5),
     torch.float64: (1e-7, 1e-7),
     torch.complex32: (0.001, 1e-5),
+    torch.bcomplex32: (0.016, 1e-5),
     torch.complex64: (1.3e-6, 1e-5),
     torch.complex128: (1e-7, 1e-7),
 }
@@ -851,6 +852,13 @@ class TensorLikePair(Pair):
         Returns:
             (Tuple[Tensor, Tensor]): Equalized tensors.
         """
+        # bcomplex32 stores components as bfloat16. Cast to complex64 before device movement
+        # because some backends (e.g. XPU) lack a bcomplex32 D2H copy kernel.
+        if actual.dtype == torch.bcomplex32:
+            actual = actual.to(torch.complex64)
+        if expected.dtype == torch.bcomplex32:
+            expected = expected.to(torch.complex64)
+
         # The comparison logic uses operators currently not supported by the MPS backends.
         #  See https://github.com/pytorch/pytorch/issues/77144 for details.
         # TODO: Remove this conversion as soon as all operations are supported natively by the MPS backend


### PR DESCRIPTION
### Summary
Add support for the `bcomplex32` dtype in PyTorch's testing framework. This enables proper comparison of `bcomplex32` tensors in unit tests and implements the review feedback from torch-xpu-ops PR #4055 to centralize dtype handling.

### Changes
- **Added bcomplex32 precision specification** in `_DTYPE_PRECISIONS` dict with tolerances `(0.016, 1e-5)` to account for bfloat16 component precision
- **Implemented bcomplex32 to complex64 conversion** in `TensorLikePair.equalize_tensors()` to handle backend limitations where certain devices (e.g., XPU) lack native bcomplex32 device-to-host copy kernels

### Context
This change addresses https://github.com/intel/torch-xpu-ops/issues/3994 and implements feedback from torch-xpu-ops PR https://github.com/intel/torch-xpu-ops/pull/4055 which added bcomplex32 support to XPU's fill and where kernels.

### Why This Matters
- **Centralized handling**: Instead of handling bcomplex32 comparison in individual test files, this moves the logic to PyTorch's comparison framework for universal coverage
- **Backend compatibility**: Automatically converts bcomplex32 to complex64 before tensor comparison, working around backends that lack specific copy kernels
- **Consistent precision**: Establishes appropriate default tolerances for bcomplex32 based on bfloat16 component precision

### Testing
This change enables the following tests to work correctly with bcomplex32:
- torch-xpu-ops extended tests for fill and where operations
- Any new tests using `assertEqual` with bcomplex32 tensors

### Files Modified
- `torch/testing/_comparison.py`: Added bcomplex32 support
