### PR TITLE
Fix MPS baddbmm/addbmm crash on size-0 tensors 

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -795,34 +795,14 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
 
   if (opType == ADDBMM_OP_TYPE) {
     result.resize_as_(input);
-    // addbmm sums across batches into a 2D output, so B=0 doesn't make
-    // result.numel()==0 the way it does for baddbmm; needs its own guard.
-    if (batch1.size(0) == 0) {
-      if (beta.toComplexDouble() == 0.0) {
-        result.zero_();
-      } else {
-        at::mul_out(result, input, wrapped_scalar_tensor(beta));
-      }
-      return result;
-    }
-  } else if (result.numel() == 0) {
-    // Empty baddbmm output (e.g. a zero-sized batch dim): nothing to compute,
-    // avoid feeding empty buffers to the MPSGraph / Metal kernel paths.
-    return result;
   }
 
   // Empty tensors would hit the Placeholder [srcBuf length] > 0 assertion.
   if (result.numel() == 0) {
     return result;
   }
-  if (batch1.size(2) == 0) {
-    if (beta.toComplexDouble() == 0.0) {
-      result.zero_();
-    } else if (opType == ADDBMM_OP_TYPE) {
-      at::mul_out(result, input, wrapped_scalar_tensor(beta));
-    } else {
-      result.mul_(beta);
-    }
+  if ((opType == ADDBMM_OP_TYPE && batch1.size(0) == 0) || batch1.size(2) == 0) {
+    at::mul_out(result, input, wrapped_scalar_tensor(beta));
     return result;
   }
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -17,6 +17,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ScalarOps.h>
 #include <ATen/ops/_cholesky_solve_helper_native.h>
 #include <ATen/ops/_linalg_eigh.h>
 #include <ATen/ops/_linalg_solve_ex_native.h>
@@ -43,6 +44,7 @@
 #include <ATen/ops/lu_unpack_native.h>
 #include <ATen/ops/matmul.h>
 #include <ATen/ops/mm_native.h>
+#include <ATen/ops/mul.h>
 #include <ATen/ops/orgqr_native.h>
 #include <ATen/ops/real.h>
 #include <ATen/ops/slice.h>
@@ -793,18 +795,13 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
 
   if (opType == ADDBMM_OP_TYPE) {
     result.resize_as_(input);
-    // addbmm's result isn't populated by a meta function (unlike baddbmm),
-    // so copy input now so that beta-scaling guards below work correctly.
-    if (beta.toComplexDouble() != 0.0) {
-      result.copy_(input);
-    }
     // addbmm sums across batches into a 2D output, so B=0 doesn't make
     // result.numel()==0 the way it does for baddbmm; needs its own guard.
     if (batch1.size(0) == 0) {
       if (beta.toComplexDouble() == 0.0) {
         result.zero_();
       } else {
-        result.mul_(beta);
+        at::mul_out(result, input, wrapped_scalar_tensor(beta));
       }
       return result;
     }
@@ -821,6 +818,8 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
   if (batch1.size(2) == 0) {
     if (beta.toComplexDouble() == 0.0) {
       result.zero_();
+    } else if (opType == ADDBMM_OP_TYPE) {
+      at::mul_out(result, input, wrapped_scalar_tensor(beta));
     } else {
       result.mul_(beta);
     }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -793,16 +793,37 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
 
   if (opType == ADDBMM_OP_TYPE) {
     result.resize_as_(input);
-
-    const int64_t num_batches = batch1.size(0);
-
-    if (num_batches == 0) {
-      result.zero_();
+    // addbmm's result isn't populated by a meta function (unlike baddbmm),
+    // so copy input now so that beta-scaling guards below work correctly.
+    if (beta.toComplexDouble() != 0.0) {
+      result.copy_(input);
+    }
+    // addbmm sums across batches into a 2D output, so B=0 doesn't make
+    // result.numel()==0 the way it does for baddbmm; needs its own guard.
+    if (batch1.size(0) == 0) {
+      if (beta.toComplexDouble() == 0.0) {
+        result.zero_();
+      } else {
+        result.mul_(beta);
+      }
       return result;
     }
   } else if (result.numel() == 0) {
     // Empty baddbmm output (e.g. a zero-sized batch dim): nothing to compute,
     // avoid feeding empty buffers to the MPSGraph / Metal kernel paths.
+    return result;
+  }
+
+  // Empty tensors would hit the Placeholder [srcBuf length] > 0 assertion.
+  if (result.numel() == 0) {
+    return result;
+  }
+  if (batch1.size(2) == 0) {
+    if (beta.toComplexDouble() == 0.0) {
+      result.zero_();
+    } else {
+      result.mul_(beta);
+    }
     return result;
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1491,57 +1491,6 @@ class TestMPS(TestCaseMPS):
                 self.assertFalse(out_a.isnan().any() or out_a.isinf().any(),
                                  f"addbmm beta=0 propagated {bad} for dtype={dtype}")
 
-    def test_baddbmm_empty_tensors(self):
-        # baddbmm crashes on MPS with size-0 dimensions due to empty
-        # MTLBuffer assertion in Placeholder.
-        cases = [
-            # (input_shape, batch1_shape, batch2_shape, label)
-            ((0, 3, 5), (0, 3, 4), (0, 4, 5), "B=0"),
-            ((2, 0, 5), (2, 0, 4), (2, 4, 5), "M=0"),
-            ((2, 3, 0), (2, 3, 4), (2, 4, 0), "N=0"),
-            ((2, 0, 1), (2, 0, 3), (2, 3, 1), "M=0,N=1"),
-            ((2, 3, 5), (2, 3, 0), (2, 0, 5), "K=0"),
-        ]
-        for inp_shape, b1_shape, b2_shape, label in cases:
-            for beta in [0.0, 0.5, 1.0]:
-                inp_cpu = torch.randn(inp_shape)
-                b1_cpu = torch.randn(b1_shape)
-                b2_cpu = torch.randn(b2_shape)
-                expected = torch.baddbmm(inp_cpu, b1_cpu, b2_cpu, beta=beta, alpha=1.2)
-
-                inp_mps = inp_cpu.to("mps")
-                b1_mps = b1_cpu.to("mps")
-                b2_mps = b2_cpu.to("mps")
-                result = torch.baddbmm(inp_mps, b1_mps, b2_mps, beta=beta, alpha=1.2)
-
-                self.assertEqual(result.shape, expected.shape, msg=f"baddbmm {label} beta={beta}")
-                self.assertEqual(result.cpu(), expected, msg=f"baddbmm {label} beta={beta}")
-
-    def test_addbmm_empty_tensors(self):
-        # addbmm hits the same crash path as baddbmm for size-0
-        # dimensions on MPS.
-        cases = [
-            # (input_shape, batch1_shape, batch2_shape, label)
-            ((3, 5), (0, 3, 4), (0, 4, 5), "B=0"),
-            ((0, 5), (2, 0, 4), (2, 4, 5), "M=0"),
-            ((3, 0), (2, 3, 4), (2, 4, 0), "N=0"),
-            ((3, 5), (2, 3, 0), (2, 0, 5), "K=0"),
-        ]
-        for inp_shape, b1_shape, b2_shape, label in cases:
-            for beta in [0.0, 0.5, 1.0]:
-                inp_cpu = torch.randn(inp_shape)
-                b1_cpu = torch.randn(b1_shape)
-                b2_cpu = torch.randn(b2_shape)
-                expected = torch.addbmm(inp_cpu, b1_cpu, b2_cpu, beta=beta, alpha=1.2)
-
-                inp_mps = inp_cpu.to("mps")
-                b1_mps = b1_cpu.to("mps")
-                b2_mps = b2_cpu.to("mps")
-                result = torch.addbmm(inp_mps, b1_mps, b2_mps, beta=beta, alpha=1.2)
-
-                self.assertEqual(result.shape, expected.shape, msg=f"addbmm {label} beta={beta}")
-                self.assertEqual(result.cpu(), expected, msg=f"addbmm {label} beta={beta}")
-
     def test_local_scalar_dense_mps(self):
         x_cpu = torch.randn(1)
         y_mps = x_cpu.to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1491,6 +1491,57 @@ class TestMPS(TestCaseMPS):
                 self.assertFalse(out_a.isnan().any() or out_a.isinf().any(),
                                  f"addbmm beta=0 propagated {bad} for dtype={dtype}")
 
+    def test_baddbmm_empty_tensors(self):
+        # baddbmm crashes on MPS with size-0 dimensions due to empty
+        # MTLBuffer assertion in Placeholder.
+        cases = [
+            # (input_shape, batch1_shape, batch2_shape, label)
+            ((0, 3, 5), (0, 3, 4), (0, 4, 5), "B=0"),
+            ((2, 0, 5), (2, 0, 4), (2, 4, 5), "M=0"),
+            ((2, 3, 0), (2, 3, 4), (2, 4, 0), "N=0"),
+            ((2, 0, 1), (2, 0, 3), (2, 3, 1), "M=0,N=1"),
+            ((2, 3, 5), (2, 3, 0), (2, 0, 5), "K=0"),
+        ]
+        for inp_shape, b1_shape, b2_shape, label in cases:
+            for beta in [0.0, 0.5, 1.0]:
+                inp_cpu = torch.randn(inp_shape)
+                b1_cpu = torch.randn(b1_shape)
+                b2_cpu = torch.randn(b2_shape)
+                expected = torch.baddbmm(inp_cpu, b1_cpu, b2_cpu, beta=beta, alpha=1.2)
+
+                inp_mps = inp_cpu.to("mps")
+                b1_mps = b1_cpu.to("mps")
+                b2_mps = b2_cpu.to("mps")
+                result = torch.baddbmm(inp_mps, b1_mps, b2_mps, beta=beta, alpha=1.2)
+
+                self.assertEqual(result.shape, expected.shape, msg=f"baddbmm {label} beta={beta}")
+                self.assertEqual(result.cpu(), expected, msg=f"baddbmm {label} beta={beta}")
+
+    def test_addbmm_empty_tensors(self):
+        # addbmm hits the same crash path as baddbmm for size-0
+        # dimensions on MPS.
+        cases = [
+            # (input_shape, batch1_shape, batch2_shape, label)
+            ((3, 5), (0, 3, 4), (0, 4, 5), "B=0"),
+            ((0, 5), (2, 0, 4), (2, 4, 5), "M=0"),
+            ((3, 0), (2, 3, 4), (2, 4, 0), "N=0"),
+            ((3, 5), (2, 3, 0), (2, 0, 5), "K=0"),
+        ]
+        for inp_shape, b1_shape, b2_shape, label in cases:
+            for beta in [0.0, 0.5, 1.0]:
+                inp_cpu = torch.randn(inp_shape)
+                b1_cpu = torch.randn(b1_shape)
+                b2_cpu = torch.randn(b2_shape)
+                expected = torch.addbmm(inp_cpu, b1_cpu, b2_cpu, beta=beta, alpha=1.2)
+
+                inp_mps = inp_cpu.to("mps")
+                b1_mps = b1_cpu.to("mps")
+                b2_mps = b2_cpu.to("mps")
+                result = torch.addbmm(inp_mps, b1_mps, b2_mps, beta=beta, alpha=1.2)
+
+                self.assertEqual(result.shape, expected.shape, msg=f"addbmm {label} beta={beta}")
+                self.assertEqual(result.cpu(), expected, msg=f"addbmm {label} beta={beta}")
+
     def test_local_scalar_dense_mps(self):
         x_cpu = torch.randn(1)
         y_mps = x_cpu.to("mps")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1341,6 +1341,8 @@ def sample_inputs_addmv(op_info, device, dtype, requires_grad, **kwargs):
 
 def sample_inputs_addbmm(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    beta_f = 0.5 if dtype.is_floating_point or dtype.is_complex else 2
+    alpha_f = 1.2 if dtype.is_floating_point or dtype.is_complex else 1
 
     # input_shape, batch1_shape, batch2_shape, beta_val, alpha_val, is_broadcasting
     test_cases = [((S, M), (S, S, S), (S, S, M), 1, 1, False),
@@ -1349,6 +1351,9 @@ def sample_inputs_addbmm(op_info, device, dtype, requires_grad, **kwargs):
                   ((1,), (S, S, S), (S, S, M), 0.6, 0.2, True),
                   ((), (S, S, S), (S, S, M), 1, 1, True),
                   ((), (S, S, S), (S, S, M), 0.6, 0.2, True),
+                  ((0, M), (S, 0, S), (S, S, M), 1, 1, False),
+                  ((S, M), (S, S, 0), (S, 0, M), beta_f, alpha_f, False),
+                  ((S, M), (S, S, 0), (S, 0, M), 0, 1, False),
                   ]
 
     for input_shape, batch1_shape, batch2_shape, beta, alpha, is_broadcasting in test_cases:


### PR DESCRIPTION
`torch.baddbmm` and `torch.addbmm` crash on MPS with size-0 tensor dimensions, hitting `INTERNAL ASSERT FAILED` in the Placeholder constructor because empty tensors have zero-length MTLBuffers.
The shared function `addbmm_or_baddbmm_out_mps_impl` had no empty-tensor guard for `baddbmm`, and the existing `addbmm` guard only covered `num_batches == 0` with incorrect beta handling (unconditional `zero_()` instead of beta-aware scaling).

The fix adds guards matching CPU/CUDA semantics:
  - `result.numel() == 0`: return immediately (covers B=0, M=0, N=0)
  - `batch1.size(2) == 0` (contraction dim K=0): zero if beta==0, otherwise scale result by beta
  - `addbmm-specific batch1.size(0) == 0`: needed separately because addbmm sums across batches into a 2D output, so B=0 doesn't make `result.numel() == 0`
  - addbmm-specific `result.copy_(input)` before guards: unlike baddbmm (where the meta function copies input into result), addbmm's result is uninitialized after resize

Fixes #187551