### PR TITLE
[inductor] add cat_linear as a group_batch_fusion fusion

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import collections
+import operator
 import unittest
 
 import torch
@@ -1536,6 +1537,181 @@ class TestFindIndependentSubsetGreedy(TestCase):
         self.assertEqual(next(i), [lookup[n] for n in ["n4"]])
         self.assertEqual(next(i), [lookup[n] for n in ["n0", "n1"]])
         self.assertRaises(StopIteration, lambda: next(i))
+
+
+class CatLinearMod(torch.nn.Module):
+    # linear(cat(parts, dim=cat_dim)). cat_dim=-1 is the matchable shape.
+    def __init__(self, widths, out_features, has_bias=True, cat_dim=-1, device="cpu"):
+        super().__init__()
+        self.cat_dim = cat_dim
+        # when the cat is not on the last dim the feature width is unchanged,
+        # so the linear contracts a single part's width
+        in_features = sum(widths) if cat_dim == -1 else widths[0]
+        self.lin = torch.nn.Linear(in_features, out_features, bias=has_bias).to(device)
+
+    def forward(self, parts):
+        x = torch.cat(parts, dim=self.cat_dim)
+        return self.lin(x)
+
+
+class CatLinearTwoUserMod(torch.nn.Module):
+    # the cat feeds the linear *and* a second consumer, so it can't be erased.
+    def __init__(self, widths, out_features, device="cpu"):
+        super().__init__()
+        self.lin = torch.nn.Linear(sum(widths), out_features).to(device)
+
+    def forward(self, parts):
+        x = torch.cat(parts, dim=-1)
+        return self.lin(x), x.sum()
+
+
+@torch._inductor.config.patch(
+    pre_grad_fusion_options={"cat_linear": {}},
+    post_grad_fusion_options={},
+)
+class TestCatLinearFusion(TestCase):
+    def _fires(self, module, parts):
+        counters.clear()
+        traced = torch.compile(module)
+        traced(parts)
+        n = counters["inductor"]["cat_linear"]
+        counters.clear()
+        return n
+
+    def _fuse_and_get_graph(self, module, parts):
+        # run the pre-grad pass on the dynamo graph and hand the rewritten
+        # GraphModule back so we can check the cat is really gone, not just that
+        # the counter bumped (the counter increments inside fuse, before DCE).
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            group_batch_fusion_passes,
+        )
+
+        captured = {}
+
+        def backend(gm, example_inputs):
+            group_batch_fusion_passes(gm.graph, pre_grad=True)
+            # the rewrite drops the linear's only use of the cat; DCE is what
+            # actually deletes the now-dead cat, same as the real pre-grad path.
+            gm.graph.eliminate_dead_code()
+            gm.graph.lint()
+            gm.recompile()
+            captured["gm"] = gm
+            return gm.forward
+
+        counters.clear()
+        torch._dynamo.reset()
+        torch.compile(module, backend=backend)(parts)
+        return captured["gm"]
+
+    def _node_counts(self, gm):
+        cats = linears = adds = 0
+        for n in gm.graph.nodes:
+            if n.op != "call_function":
+                continue
+            if n.target is torch.cat:
+                cats += 1
+            elif n.target in (torch.nn.functional.linear, torch._C._nn.linear):
+                linears += 1
+            elif n.target is operator.add:
+                adds += 1
+        return cats, linears, adds
+
+    def test_cat_linear_removes_cat_two_part(self):
+        m = CatLinearMod([16, 16], 32)
+        parts = [torch.randn(4, 16), torch.randn(4, 16)]
+        gm = self._fuse_and_get_graph(m, parts)
+        self.assertEqual(counters["inductor"]["cat_linear"], 1)
+        cats, linears, adds = self._node_counts(gm)
+        self.assertEqual(cats, 0)
+        self.assertEqual(linears, 2)
+        self.assertEqual(adds, 1)
+        counters.clear()
+
+    def test_cat_linear_removes_cat_three_part(self):
+        m = CatLinearMod([16, 16, 16], 32)
+        parts = [torch.randn(4, 16) for _ in range(3)]
+        gm = self._fuse_and_get_graph(m, parts)
+        self.assertEqual(counters["inductor"]["cat_linear"], 1)
+        cats, linears, adds = self._node_counts(gm)
+        self.assertEqual(cats, 0)
+        self.assertEqual(linears, 3)
+        self.assertEqual(adds, 2)
+        counters.clear()
+
+    def test_cat_linear_keeps_cat_when_rejected(self):
+        # a rejected case (too many parts) must leave the cat untouched
+        m = CatLinearMod([16, 16, 16, 16], 32)
+        parts = [torch.randn(4, 16) for _ in range(4)]
+        gm = self._fuse_and_get_graph(m, parts)
+        self.assertEqual(counters["inductor"]["cat_linear"], 0)
+        cats, _, _ = self._node_counts(gm)
+        self.assertEqual(cats, 1)
+        counters.clear()
+
+    def test_cat_linear_two_part(self):
+        m = CatLinearMod([16, 16], 32)
+        parts = [torch.randn(4, 16), torch.randn(4, 16)]
+        self.assertEqual(self._fires(m, parts), 1)
+
+    def test_cat_linear_three_part(self):
+        m = CatLinearMod([16, 16, 16], 32)
+        parts = [torch.randn(4, 16) for _ in range(3)]
+        self.assertEqual(self._fires(m, parts), 1)
+
+    def test_cat_linear_rejects_non_last_dim(self):
+        m = CatLinearMod([16, 16], 16, cat_dim=0)
+        parts = [torch.randn(4, 16), torch.randn(4, 16)]
+        self.assertEqual(self._fires(m, parts), 0)
+
+    def test_cat_linear_rejects_too_many_parts(self):
+        m = CatLinearMod([16, 16, 16, 16], 32)
+        parts = [torch.randn(4, 16) for _ in range(4)]
+        self.assertEqual(self._fires(m, parts), 0)
+
+    def test_cat_linear_rejects_over_width(self):
+        m = CatLinearMod([256, 256], 32)
+        parts = [torch.randn(4, 256), torch.randn(4, 256)]
+        self.assertEqual(self._fires(m, parts), 0)
+
+    def test_cat_linear_rejects_thin_piece(self):
+        m = CatLinearMod([4, 16], 32)
+        parts = [torch.randn(4, 4), torch.randn(4, 16)]
+        self.assertEqual(self._fires(m, parts), 0)
+
+    def test_cat_linear_rejects_multi_user_cat(self):
+        m = CatLinearTwoUserMod([16, 16], 32)
+        parts = [torch.randn(4, 16), torch.randn(4, 16)]
+        self.assertEqual(self._fires(m, parts), 0)
+
+    @requires_gpu()
+    def test_cat_linear_numerics(self):
+        for has_bias in [True, False]:
+            counters.clear()
+            torch._dynamo.reset()
+            module = CatLinearMod(
+                [176, 176], 256, has_bias=has_bias, device=GPU_TYPE
+            ).to(torch.bfloat16)
+            parts = [
+                torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
+            ]
+            ref = module(parts)
+            res = torch.compile(module)(parts)
+            self.assertEqual(counters["inductor"]["cat_linear"], 1)
+            self.assertEqual(ref, res, rtol=1.6e-2, atol=1e-2)
+            counters.clear()
+
+    def test_cat_linear_numerics_cpu(self):
+        for has_bias in [True, False]:
+            counters.clear()
+            torch._dynamo.reset()
+            module = CatLinearMod([24, 24], 32, has_bias=has_bias)
+            parts = [torch.randn(8, 24), torch.randn(8, 24)]
+            ref = module(parts)
+            res = torch.compile(module)(parts)
+            self.assertEqual(counters["inductor"]["cat_linear"], 1)
+            self.assertEqual(ref, res)
+            counters.clear()
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -1570,10 +1570,19 @@ class CatLinearTwoUserMod(torch.nn.Module):
     post_grad_fusion_options={},
 )
 class TestCatLinearFusion(TestCase):
-    def _fires(self, module, parts):
+    def _fires(self, module, parts, traffic_floor=0):
+        # unit-test tensors never reach the real 512 MiB floor, so unless a test
+        # is exercising the floor, drop it to 0 and let the shape gates decide.
+        from unittest import mock
+
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
         counters.clear()
-        traced = torch.compile(module)
-        traced(parts)
+        torch._dynamo.reset()
+        with mock.patch.object(
+            gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", traffic_floor
+        ):
+            torch.compile(module)(parts)
         n = counters["inductor"]["cat_linear"]
         counters.clear()
         return n
@@ -1582,9 +1591,12 @@ class TestCatLinearFusion(TestCase):
         # run the pre-grad pass on the dynamo graph and hand the rewritten
         # GraphModule back so we can check the cat is really gone, not just that
         # the counter bumped (the counter increments inside fuse, before DCE).
+        from unittest import mock
+
         from torch._inductor.fx_passes.group_batch_fusion import (
             group_batch_fusion_passes,
         )
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
 
         captured = {}
 
@@ -1600,7 +1612,8 @@ class TestCatLinearFusion(TestCase):
 
         counters.clear()
         torch._dynamo.reset()
-        torch.compile(module, backend=backend)(parts)
+        with mock.patch.object(gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", 0):
+            torch.compile(module, backend=backend)(parts)
         return captured["gm"]
 
     def _node_counts(self, gm):
@@ -1668,10 +1681,24 @@ class TestCatLinearFusion(TestCase):
         parts = [torch.randn(4, 16) for _ in range(4)]
         self.assertEqual(self._fires(m, parts), 0)
 
-    def test_cat_linear_rejects_over_width(self):
-        m = CatLinearMod([256, 256], 32)
-        parts = [torch.randn(4, 256), torch.randn(4, 256)]
+    def test_cat_linear_rejects_wide_output(self):
+        # N=128 is past the N<=96 ceiling; a wide output is compute-bound.
+        m = CatLinearMod([64, 64], 128)
+        parts = [torch.randn(4, 64), torch.randn(4, 64)]
         self.assertEqual(self._fires(m, parts), 0)
+
+    def test_cat_linear_rejects_small_traffic(self):
+        # all shape gates pass; at the real 512 MiB floor this concat is too small.
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
+        m = CatLinearMod([16, 16], 32)
+        parts = [torch.randn(4, 16), torch.randn(4, 16)]
+        self.assertEqual(
+            self._fires(
+                m, parts, traffic_floor=gbf.CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES
+            ),
+            0,
+        )
 
     def test_cat_linear_rejects_thin_piece(self):
         m = CatLinearMod([4, 16], 32)
@@ -1685,30 +1712,40 @@ class TestCatLinearFusion(TestCase):
 
     @requires_gpu()
     def test_cat_linear_numerics(self):
+        from unittest import mock
+
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
         for has_bias in [True, False]:
             counters.clear()
             torch._dynamo.reset()
             module = CatLinearMod(
-                [176, 176], 256, has_bias=has_bias, device=GPU_TYPE
+                [176, 176], 64, has_bias=has_bias, device=GPU_TYPE
             ).to(torch.bfloat16)
             parts = [
                 torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
                 torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
             ]
             ref = module(parts)
-            res = torch.compile(module)(parts)
+            with mock.patch.object(gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", 0):
+                res = torch.compile(module)(parts)
             self.assertEqual(counters["inductor"]["cat_linear"], 1)
             self.assertEqual(ref, res, rtol=1.6e-2, atol=1e-2)
             counters.clear()
 
     def test_cat_linear_numerics_cpu(self):
+        from unittest import mock
+
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
         for has_bias in [True, False]:
             counters.clear()
             torch._dynamo.reset()
             module = CatLinearMod([24, 24], 32, has_bias=has_bias)
             parts = [torch.randn(8, 24), torch.randn(8, 24)]
             ref = module(parts)
-            res = torch.compile(module)(parts)
+            with mock.patch.object(gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", 0):
+                res = torch.compile(module)(parts)
             self.assertEqual(counters["inductor"]["cat_linear"], 1)
             self.assertEqual(ref, res)
             counters.clear()

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -1593,10 +1593,10 @@ class TestCatLinearFusion(TestCase):
         # the counter bumped (the counter increments inside fuse, before DCE).
         from unittest import mock
 
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
         from torch._inductor.fx_passes.group_batch_fusion import (
             group_batch_fusion_passes,
         )
-        from torch._inductor.fx_passes import group_batch_fusion as gbf
 
         captured = {}
 
@@ -1694,9 +1694,7 @@ class TestCatLinearFusion(TestCase):
         m = CatLinearMod([16, 16], 32)
         parts = [torch.randn(4, 16), torch.randn(4, 16)]
         self.assertEqual(
-            self._fires(
-                m, parts, traffic_floor=gbf.CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES
-            ),
+            self._fires(m, parts, traffic_floor=gbf.CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES),
             0,
         )
 

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -1731,6 +1731,51 @@ class TestCatLinearFusion(TestCase):
             self.assertEqual(ref, res, rtol=1.6e-2, atol=1e-2)
             counters.clear()
 
+    @requires_gpu()
+    def test_cat_linear_numerics_backward(self):
+        # forward is not enough: the rewrite has to keep the backward correct too.
+        # grads reach the shared weight through the differentiable slices (one
+        # slice per piece), and the bias grad flows only through out_0 since bias
+        # rides on the first piece. Compare W.grad, bias.grad, and the per-part
+        # input grads eager-vs-compiled at the same bf16 tol as the fwd test.
+        from unittest import mock
+
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
+        for has_bias in [True, False]:
+            counters.clear()
+            torch._dynamo.reset()
+            module = CatLinearMod(
+                [176, 176], 64, has_bias=has_bias, device=GPU_TYPE
+            ).to(torch.bfloat16)
+            base = [
+                torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randn(64, 176, device=GPU_TYPE, dtype=torch.bfloat16),
+            ]
+
+            def run(compiled):
+                module.zero_grad(set_to_none=True)
+                parts = [p.detach().clone().requires_grad_(True) for p in base]
+                fn = torch.compile(module) if compiled else module
+                fn(parts).sum().backward()
+                return (
+                    module.lin.weight.grad.detach().clone(),
+                    module.lin.bias.grad.detach().clone() if has_bias else None,
+                    [p.grad.detach().clone() for p in parts],
+                )
+
+            w_ref, b_ref, in_ref = run(False)
+            with mock.patch.object(gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", 0):
+                w_res, b_res, in_res = run(True)
+
+            self.assertEqual(counters["inductor"]["cat_linear"], 1)
+            self.assertEqual(w_ref, w_res, rtol=1.6e-2, atol=1e-2)
+            if has_bias:
+                self.assertEqual(b_ref, b_res, rtol=1.6e-2, atol=1e-2)
+            for gr, gs in zip(in_ref, in_res):
+                self.assertEqual(gr, gs, rtol=1.6e-2, atol=1e-2)
+            counters.clear()
+
     def test_cat_linear_numerics_cpu(self):
         from unittest import mock
 
@@ -1746,6 +1791,46 @@ class TestCatLinearFusion(TestCase):
                 res = torch.compile(module)(parts)
             self.assertEqual(counters["inductor"]["cat_linear"], 1)
             self.assertEqual(ref, res)
+            counters.clear()
+
+    def test_cat_linear_numerics_backward_cpu(self):
+        # fp32 pin for the backward. forward alone can't catch a wrong weight
+        # column offset or a misplaced bias, both only show up in the grads:
+        # the shared weight grad comes through the differentiable slices (one
+        # per piece) and the bias grad flows only through out_0 since the bias
+        # rides the first piece. fp32 at the default (tight) tol so a subtle
+        # slice/bias error can't hide under a loose bf16 tolerance.
+        from unittest import mock
+
+        from torch._inductor.fx_passes import group_batch_fusion as gbf
+
+        for has_bias in [True, False]:
+            counters.clear()
+            torch._dynamo.reset()
+            module = CatLinearMod([24, 24], 32, has_bias=has_bias)
+            base = [torch.randn(8, 24), torch.randn(8, 24)]
+
+            def run(compiled):
+                module.zero_grad(set_to_none=True)
+                parts = [p.detach().clone().requires_grad_(True) for p in base]
+                fn = torch.compile(module) if compiled else module
+                fn(parts).sum().backward()
+                return (
+                    module.lin.weight.grad.detach().clone(),
+                    module.lin.bias.grad.detach().clone() if has_bias else None,
+                    [p.grad.detach().clone() for p in parts],
+                )
+
+            w_ref, b_ref, in_ref = run(False)
+            with mock.patch.object(gbf, "CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES", 0):
+                w_res, b_res, in_res = run(True)
+
+            self.assertEqual(counters["inductor"]["cat_linear"], 1)
+            self.assertEqual(w_ref, w_res)
+            if has_bias:
+                self.assertEqual(b_ref, b_res)
+            for gr, gs in zip(in_ref, in_res):
+                self.assertEqual(gr, gs)
             counters.clear()
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -346,6 +346,7 @@ batch_fusion = True
 # batch fusion options:
 # batch_linear
 # batch_linear_lhs
+# cat_linear
 # batch_layernorm
 # batch_tanh
 # batch_relu

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -932,11 +932,13 @@ class CatLinearFusion(BatchFusion):
                         # slice is a differentiable view of the full weight; the
                         # clone makes each GEMM operand contiguous. Folds to a const
                         # when frozen; in training it's a cheap weight-only op.
+                        # pyrefly: ignore [not-callable]
                         with graph.inserting_after(anchor):
                             w_slice = graph.call_function(  # type: ignore[operator]
                                 aten.slice.Tensor,
                                 args=(weight, 1, offsets[i], offsets[i + 1]),
                             )
+                        # pyrefly: ignore [not-callable]
                         with graph.inserting_after(w_slice):
                             w_cont = graph.call_function(  # type: ignore[operator]
                                 aten.clone.default,

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -944,11 +944,11 @@ class CatLinearFusion(BatchFusion):
                                 kwargs={"memory_format": torch.contiguous_format},
                             )
                         if weight_val is not None:
-                            sv = aten.slice.Tensor(
+                            sv = aten.slice.Tensor(  # type: ignore[operator]
                                 weight_val, 1, offsets[i], offsets[i + 1]
                             )
                             w_slice.meta["example_value"] = sv
-                            w_cont.meta["example_value"] = sv.contiguous()
+                            w_cont.meta["example_value"] = sv.contiguous()  # type: ignore[operator]
                         cache[key] = w_cont
                     # bias rides on the first piece only; folding it into the
                     # reduce-add would just be an extra node.

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -9,6 +9,7 @@ from typing import Any
 import torch
 from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._logging import trace_structured
+from torch.fx.experimental.symbolic_shapes import free_symbols
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.utils._ordered_set import OrderedSet
 
@@ -741,6 +742,185 @@ class PreGradBatchLinearFusion(BatchFusion):
                 getitem.meta.update(linear.meta)
                 graph.erase_node(linear)  # type: ignore[operator]
         counters["inductor"]["batch_linear"] += 1
+
+
+# Cap the contracted width we are willing to split. Past this the original
+# linear is compute-bound enough that the cat it removes is in the noise, while
+# the split still pays N launches plus the partial-sum adds, so it tends to lose.
+CAT_LINEAR_MAX_TOTAL_WIDTH = 384
+# Skip slivers: a piece this thin turns into a launch-bound matmul whose own
+# overhead outweighs the slice of the cat traffic it saves.
+CAT_LINEAR_MIN_PIECE_WIDTH = 8
+# Keep the fan-out small. More pieces means more kernel launches and more
+# operator.add nodes in the reduce, which eats the cat saving.
+CAT_LINEAR_MAX_PARTS = 3
+
+
+def _meta_shape(node):
+    if not isinstance(node, torch.fx.Node) or not is_node_meta_valid(node):
+        return None
+    val = node.meta.get("example_value")
+    if val is None:
+        val = node.meta.get("val")
+    if val is None or not hasattr(val, "shape"):
+        return None
+    shape = val.shape
+    # static shapes only: bail on symbolic so we never specialize a backed
+    # SymInt or trip over an unbacked one (same free_symbols guard split_cat uses)
+    if free_symbols(shape):
+        return None
+    return tuple(int(s) for s in shape)
+
+
+def match_cat_linear(node: torch.fx.Node):
+    """Match linear(cat([parts...], dim=-1), weight, bias).
+
+    Returns (parts, weight, bias, offsets) or None. Conservative on purpose:
+    last-dim cat only, total width and part count capped, no thin slivers, and
+    a weight whose contraction dim lines up with the cat. The cat must have a
+    single user so it can actually be erased once the linear is rewritten.
+    """
+    cat_in = get_arg_value(node, 0, "input")
+    weight = get_arg_value(node, 1, "weight")
+    bias = get_arg_value(node, 2, "bias")
+    if not isinstance(cat_in, torch.fx.Node) or not CallFunctionVarArgs(
+        [torch.cat]
+    ).match(cat_in):
+        return None
+    if len(cat_in.users) != 1:
+        return None
+
+    parts = get_arg_value(cat_in, 0, "tensors")
+    if not isinstance(parts, (list, tuple)) or not (
+        2 <= len(parts) <= CAT_LINEAR_MAX_PARTS
+    ):
+        return None
+    if not all(isinstance(p, torch.fx.Node) for p in parts):
+        return None
+
+    cat_shape = _meta_shape(cat_in)
+    if cat_shape is None or len(cat_shape) < 2:
+        return None
+    rank = len(cat_shape)
+    cat_dim = get_arg_value(cat_in, 1, "dim")
+    if cat_dim is None:
+        cat_dim = 0
+    if not isinstance(cat_dim, int):
+        return None
+    if (cat_dim + rank if cat_dim < 0 else cat_dim) != rank - 1:
+        return None
+
+    k_total = int(cat_shape[-1])
+    if k_total > CAT_LINEAR_MAX_TOTAL_WIDTH:
+        return None
+
+    offsets = [0]
+    for p in parts:
+        sh = _meta_shape(p)
+        if sh is None or len(sh) != rank:
+            return None
+        k_i = int(sh[-1])
+        if k_i < CAT_LINEAR_MIN_PIECE_WIDTH:
+            return None
+        offsets.append(offsets[-1] + k_i)
+    if offsets[-1] != k_total:
+        return None
+
+    w_shape = _meta_shape(weight)
+    if w_shape is None or len(w_shape) != 2 or int(w_shape[-1]) != k_total:
+        return None
+
+    return parts, weight, bias, offsets
+
+
+@register_fusion("cat_linear")
+class CatLinearFusion(BatchFusion):
+    """
+    Rewrite linear(cat([x0, x1, ...], dim=-1), weight, bias) into a sum of
+    per-piece linears on contiguous last-dim weight slices, so the concatenated
+    activation is never materialised in forward or backward.
+
+    Unlike the other fusions here this is a per-node rewrite (one linear(cat)
+    splits into several smaller linears) rather than a batch of like-shaped ops,
+    so every match forms its own group of one. Off by default; opt in via
+    pre_grad_fusion_options["cat_linear"].
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.graph_search_options = {
+            **self.graph_search_options,
+            "min_fuse_set_size": 1,
+        }
+
+    def match(self, node: torch.fx.Node):
+        if not CallFunctionVarArgs(
+            [torch.nn.functional.linear, torch._C._nn.linear]
+        ).match(node):
+            return None
+        if not is_node_meta_valid(node):
+            return None
+        matched = match_cat_linear(node)
+        if matched is None:
+            return None
+        # stash so fuse() doesn't recompute the whole match per candidate; the
+        # same node object is what apply_group_batch_fusion hands back to fuse.
+        node.meta["cat_linear_match"] = matched
+        return ("cat_linear", node)
+
+    def fuse(self, graph: torch.fx.GraphModule, subset: list[torch.fx.Node]):
+        for node in subset:
+            matched = node.meta.pop("cat_linear_match", None)
+            if matched is None:
+                matched = match_cat_linear(node)
+            if matched is None:
+                continue
+            parts, weight, bias, offsets = matched
+            node_val = node.meta.get("example_value", node.meta.get("val"))
+            weight_val = weight.meta.get("example_value", weight.meta.get("val"))
+
+            with graph.inserting_before(node):  # type: ignore[operator]
+                partials = []
+                for i, part in enumerate(parts):
+                    # slice+clone gives each piece a contiguous weight. In the
+                    # frozen/inference path these fold to constants; in the
+                    # training/non-frozen path the params are lifted to inputs so
+                    # the slice+clone re-run every forward. That cost is weight-
+                    # only (no activation) and is already in the measured win, so
+                    # we keep it here rather than hoisting.
+                    w_slice = graph.call_function(  # type: ignore[operator]
+                        aten.slice.Tensor, args=(weight, 1, offsets[i], offsets[i + 1])
+                    )
+                    w_cont = graph.call_function(  # type: ignore[operator]
+                        aten.clone.default,
+                        args=(w_slice,),
+                        kwargs={"memory_format": torch.contiguous_format},
+                    )
+                    if weight_val is not None:
+                        sv = aten.slice.Tensor(
+                            weight_val, 1, offsets[i], offsets[i + 1]
+                        )
+                        w_slice.meta["example_value"] = sv
+                        w_cont.meta["example_value"] = sv.contiguous()
+                    # bias rides on the first piece only; folding it into the
+                    # reduce-add would just be an extra node.
+                    out_i = graph.call_function(  # type: ignore[operator]
+                        torch.nn.functional.linear,
+                        args=(part, w_cont, bias if i == 0 else None),
+                    )
+                    if node_val is not None:
+                        out_i.meta["example_value"] = node_val
+                    partials.append(out_i)
+
+                acc = partials[0]
+                for out_i in partials[1:]:
+                    acc = graph.call_function(operator.add, args=(acc, out_i))  # type: ignore[operator]
+                    if node_val is not None:
+                        acc.meta["example_value"] = node_val
+
+            node.replace_all_uses_with(acc)
+            graph.erase_node(node)  # type: ignore[operator]
+            counters["inductor"]["cat_linear"] += 1
 
 
 @register_fusion("batch_layernorm")

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -744,16 +744,35 @@ class PreGradBatchLinearFusion(BatchFusion):
         counters["inductor"]["batch_linear"] += 1
 
 
-# Cap the contracted width we are willing to split. Past this the original
-# linear is compute-bound enough that the cat it removes is in the noise, while
-# the split still pays N launches plus the partial-sum adds, so it tends to lose.
-CAT_LINEAR_MAX_TOTAL_WIDTH = 384
-# Skip slivers: a piece this thin turns into a launch-bound matmul whose own
-# overhead outweighs the slice of the cat traffic it saves.
+# Profitability gates for cat_linear (opt-in; numbers come from the sweep in the
+# PR description). The split only wins for a narrow output fed by a large,
+# memory-bound concat, so gate on output width and concat traffic.
+# Widest win output is 96; first loss at N=128.
+CAT_LINEAR_MAX_OUTPUT_WIDTH = 96
+# Only the concat's M*K_total*dtype_bytes of HBM traffic is removed, so it has to
+# cover the per-piece launch + reduce. Bytes, so fp32 trips it at half the bf16
+# element count.
+CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES = 512 * 1024 * 1024
+# Width isn't the profit lever (every win has K_total >= 512); kept as a backstop.
+CAT_LINEAR_MAX_TOTAL_WIDTH = 1 << 30
+# Skip slivers: a piece this thin is a launch-bound matmul with no upside.
 CAT_LINEAR_MIN_PIECE_WIDTH = 8
-# Keep the fan-out small. More pieces means more kernel launches and more
-# operator.add nodes in the reduce, which eats the cat saving.
+# More parts means more launches and reduce-adds; >3 lost in the sweep.
 CAT_LINEAR_MAX_PARTS = 3
+
+
+def _weight_hoist_anchor(graph, weight):
+    # Insert hoisted slices after the weight's own def, or after the last
+    # placeholder when it's a lifted input (can't insert a call between placeholders).
+    if weight.op == "placeholder":
+        anchor = weight
+        for n in graph.nodes:
+            if n.op == "placeholder":
+                anchor = n
+            else:
+                break
+        return anchor
+    return weight
 
 
 def _meta_shape(node):
@@ -830,6 +849,22 @@ def match_cat_linear(node: torch.fx.Node):
     if w_shape is None or len(w_shape) != 2 or int(w_shape[-1]) != k_total:
         return None
 
+    # N is the profit variable; wide outputs are compute-bound and lose the split.
+    n_out = int(w_shape[0])
+    if n_out > CAT_LINEAR_MAX_OUTPUT_WIDTH:
+        return None
+
+    # traffic = prod(leading dims) * k_total * dtype_bytes.
+    cat_val = cat_in.meta.get("example_value")
+    if cat_val is None:
+        cat_val = cat_in.meta.get("val")
+    item_bytes = getattr(getattr(cat_val, "dtype", None), "itemsize", 2)
+    m_lead = 1
+    for d in cat_shape[:-1]:
+        m_lead *= int(d)
+    if m_lead * k_total * item_bytes < CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES:
+        return None
+
     return parts, weight, bias, offsets
 
 
@@ -869,6 +904,14 @@ class CatLinearFusion(BatchFusion):
         return ("cat_linear", node)
 
     def fuse(self, graph: torch.fx.GraphModule, subset: list[torch.fx.Node]):
+        # Slice+clone each weight once per graph and hoist to entry, so a weight
+        # matched by several cat_linears (weight-tied blocks) isn't re-sliced at
+        # every site. Keyed per graph: the fusion object is reused across compiles.
+        if getattr(self, "_piece_gid", None) != id(graph):
+            self._piece_gid = id(graph)
+            self._piece_cache = {}
+        cache = self._piece_cache
+
         for node in subset:
             matched = node.meta.pop("cat_linear_match", None)
             if matched is None:
@@ -878,30 +921,35 @@ class CatLinearFusion(BatchFusion):
             parts, weight, bias, offsets = matched
             node_val = node.meta.get("example_value", node.meta.get("val"))
             weight_val = weight.meta.get("example_value", weight.meta.get("val"))
+            anchor = _weight_hoist_anchor(graph, weight)
 
             with graph.inserting_before(node):  # type: ignore[operator]
                 partials = []
                 for i, part in enumerate(parts):
-                    # slice+clone gives each piece a contiguous weight. In the
-                    # frozen/inference path these fold to constants; in the
-                    # training/non-frozen path the params are lifted to inputs so
-                    # the slice+clone re-run every forward. That cost is weight-
-                    # only (no activation) and is already in the measured win, so
-                    # we keep it here rather than hoisting.
-                    w_slice = graph.call_function(  # type: ignore[operator]
-                        aten.slice.Tensor, args=(weight, 1, offsets[i], offsets[i + 1])
-                    )
-                    w_cont = graph.call_function(  # type: ignore[operator]
-                        aten.clone.default,
-                        args=(w_slice,),
-                        kwargs={"memory_format": torch.contiguous_format},
-                    )
-                    if weight_val is not None:
-                        sv = aten.slice.Tensor(
-                            weight_val, 1, offsets[i], offsets[i + 1]
-                        )
-                        w_slice.meta["example_value"] = sv
-                        w_cont.meta["example_value"] = sv.contiguous()
+                    key = (weight, offsets[i], offsets[i + 1])
+                    w_cont = cache.get(key)
+                    if w_cont is None:
+                        # slice is a differentiable view of the full weight; the
+                        # clone makes each GEMM operand contiguous. Folds to a const
+                        # when frozen; in training it's a cheap weight-only op.
+                        with graph.inserting_after(anchor):
+                            w_slice = graph.call_function(  # type: ignore[operator]
+                                aten.slice.Tensor,
+                                args=(weight, 1, offsets[i], offsets[i + 1]),
+                            )
+                        with graph.inserting_after(w_slice):
+                            w_cont = graph.call_function(  # type: ignore[operator]
+                                aten.clone.default,
+                                args=(w_slice,),
+                                kwargs={"memory_format": torch.contiguous_format},
+                            )
+                        if weight_val is not None:
+                            sv = aten.slice.Tensor(
+                                weight_val, 1, offsets[i], offsets[i + 1]
+                            )
+                            w_slice.meta["example_value"] = sv
+                            w_cont.meta["example_value"] = sv.contiguous()
+                        cache[key] = w_cont
                     # bias rides on the first piece only; folding it into the
                     # reduce-add would just be an extra node.
                     out_i = graph.call_function(  # type: ignore[operator]

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -753,8 +753,6 @@ CAT_LINEAR_MAX_OUTPUT_WIDTH = 96
 # cover the per-piece launch + reduce. Bytes, so fp32 trips it at half the bf16
 # element count.
 CAT_LINEAR_CAT_TRAFFIC_FLOOR_BYTES = 512 * 1024 * 1024
-# Width isn't the profit lever (every win has K_total >= 512); kept as a backstop.
-CAT_LINEAR_MAX_TOTAL_WIDTH = 1 << 30
 # Skip slivers: a piece this thin is a launch-bound matmul with no upside.
 CAT_LINEAR_MIN_PIECE_WIDTH = 8
 # More parts means more launches and reduce-adds; >3 lost in the sweep.
@@ -830,8 +828,6 @@ def match_cat_linear(node: torch.fx.Node):
         return None
 
     k_total = int(cat_shape[-1])
-    if k_total > CAT_LINEAR_MAX_TOTAL_WIDTH:
-        return None
 
     offsets = [0]
     for p in parts:
@@ -887,6 +883,11 @@ class CatLinearFusion(BatchFusion):
             **self.graph_search_options,
             "min_fuse_set_size": 1,
         }
+        # Dedup hoisted weight slices across the several fuse() calls this rule
+        # makes on one graph (weight-tied blocks match at multiple sites). A fresh
+        # rule instance is built per compile in generate_fusion_from_config and
+        # only ever runs on a single graph, so an instance-level cache is safe.
+        self._piece_cache: dict = {}
 
     def match(self, node: torch.fx.Node):
         if not CallFunctionVarArgs(
@@ -895,32 +896,27 @@ class CatLinearFusion(BatchFusion):
             return None
         if not is_node_meta_valid(node):
             return None
-        matched = match_cat_linear(node)
-        if matched is None:
+        # match() runs on every linear during the candidate BFS, including nodes
+        # that never fuse, so keep it side-effect-free: recompute in fuse() rather
+        # than stashing on node.meta (which would leave stale meta behind).
+        if match_cat_linear(node) is None:
             return None
-        # stash so fuse() doesn't recompute the whole match per candidate; the
-        # same node object is what apply_group_batch_fusion hands back to fuse.
-        node.meta["cat_linear_match"] = matched
         return ("cat_linear", node)
 
     def fuse(self, graph: torch.fx.GraphModule, subset: list[torch.fx.Node]):
-        # Slice+clone each weight once per graph and hoist to entry, so a weight
-        # matched by several cat_linears (weight-tied blocks) isn't re-sliced at
-        # every site. Keyed per graph: the fusion object is reused across compiles.
-        if getattr(self, "_piece_gid", None) != id(graph):
-            self._piece_gid = id(graph)
-            self._piece_cache = {}
+        # Slice+clone each weight once and hoist to entry, so a weight matched by
+        # several cat_linears (weight-tied blocks) isn't re-sliced at every site.
         cache = self._piece_cache
 
         for node in subset:
-            matched = node.meta.pop("cat_linear_match", None)
-            if matched is None:
-                matched = match_cat_linear(node)
+            matched = match_cat_linear(node)
             if matched is None:
                 continue
             parts, weight, bias, offsets = matched
-            node_val = node.meta.get("example_value", node.meta.get("val"))
             weight_val = weight.meta.get("example_value", weight.meta.get("val"))
+            bias_val = None
+            if bias is not None:
+                bias_val = bias.meta.get("example_value", bias.meta.get("val"))
             anchor = _weight_hoist_anchor(graph, weight)
 
             with graph.inserting_before(node):  # type: ignore[operator]
@@ -958,15 +954,27 @@ class CatLinearFusion(BatchFusion):
                         torch.nn.functional.linear,
                         args=(part, w_cont, bias if i == 0 else None),
                     )
-                    if node_val is not None:
-                        out_i.meta["example_value"] = node_val
+                    # Each synthesized node gets its own fake val computed from its
+                    # own operands, the way BatchLinearLHSFusion does. The old code
+                    # aliased the whole linear's fake tensor onto every piece and
+                    # every reduce-add, sharing one FakeTensor object across
+                    # distinct nodes.
+                    part_val = part.meta.get("example_value", part.meta.get("val"))
+                    w_cont_val = w_cont.meta.get("example_value")
+                    if part_val is not None and w_cont_val is not None:
+                        out_i.meta["example_value"] = torch.nn.functional.linear(
+                            part_val, w_cont_val, bias_val if i == 0 else None
+                        )
                     partials.append(out_i)
 
                 acc = partials[0]
                 for out_i in partials[1:]:
-                    acc = graph.call_function(operator.add, args=(acc, out_i))  # type: ignore[operator]
-                    if node_val is not None:
-                        acc.meta["example_value"] = node_val
+                    prev = acc
+                    acc = graph.call_function(operator.add, args=(prev, out_i))  # type: ignore[operator]
+                    prev_val = prev.meta.get("example_value")
+                    out_val = out_i.meta.get("example_value")
+                    if prev_val is not None and out_val is not None:
+                        acc.meta["example_value"] = torch.add(prev_val, out_val)
 
             node.replace_all_uses_with(acc)
             graph.erase_node(node)  # type: ignore[operator]


### PR DESCRIPTION
Supersedes #187074 (the previous PR was auto-closed after a force-push to the branch; same change, same branch).

Adds an opt-in `cat_linear` fusion to the group_batch_fusion registry. It rewrites `linear(cat([x0, x1, ...], dim=-1), W, b)` into a sum of per-piece linears on contiguous last-dim slices of `W`, so the concatenated activation is never materialised in forward or backward. This `cat(...)`-into-`linear` shape is common in recommender and multimodal models (concatenated feature blocks fed straight into a single linear). When the model concats a handful of features and immediately runs one linear over them, in the memory-bound regime this drops the cat's `[M, K_total]` HBM write/read and lets each per-piece linear keep its own epilogue fusion instead of feeding one big opaque matmul.

It is registered like the other linear fusions and gated through `pre_grad_fusion_options`, so it is off by default and only runs when a user opts in with `pre_grad_fusion_options["cat_linear"] = {}`, exactly like `batch_linear_lhs`. Matches both `torch.nn.functional.linear` and the inlined `torch._C._nn.linear`.

## Gating

The rewrite keeps FLOPs identical but trades one cat-fed GEMM for N smaller GEMMs plus an N-1 reduce, so it only pays when the cat is the dominant traffic and the fused output is narrow. The two gates that actually track that are the output width and the cat's HBM traffic; the gates are set from a shape sweep (numbers in the perf section):

- output-width ceiling `N <= 96`: the fused linear's `out_features`. Wide outputs are compute-bound and the split loses GEMM efficiency. 96 is the widest output in the measured win set; the first loss is at N=128, so 96 keeps every win with a \~33% margin.
- cat-traffic floor `>= 512 MiB`: `prod(leading dims) * K_total * dtype_bytes`. The only saving is the eliminated cat traffic, so it has to be large enough to clear the per-piece launch + reduce overhead. 512 MiB sits between the smallest measured win (676 MB) and the largest measured-neutral corner (491 MB), and because it is in bytes, fp32 reaches it at half the element count of bf16.
- `2 <= parts <= 3`: 4- and 8-way splits lost +26..+35% in the sweep.
- each part `>= 8` wide: thinner pieces are launch-bound GEMMs with no upside.
- last-dim cat only, the weight's contraction dim must line up with the cat, and the cat must have a single user (`len(cat.users) == 1`) so it can actually be erased once the linear is rewritten. If the cat feeds another consumer the rewrite would add N linears on top of an unchanged cat, so it is declined.
- shapes must be statically known; symbolic shapes are skipped via the same `free_symbols` guard `split_cat` uses (no specialization on a backed SymInt, no trip on an unbacked one).

The contracted-width cap is kept only as a loose sanity backstop. An earlier revision gated on a hard total-width cap of 384, but width is not the profitability lever: that cap blocked the entire win region (every win has `K_total >= 512`) and only fenced off the slow corners by coincidence. Output width + cat traffic gate the right cases directly.

Bias rides on the first per-piece linear. The per-piece weight slice is a differentiable view of the full weight (grads flow back to `W`) and the contiguous clone is hoisted to graph entry and shared across matches over the same weight, so a weight-tied / repeated structure is split once per graph.

Unlike the batch/group fusions this is a per-node rewrite rather than a batch of like-shaped ops, so the fusion uses `min_fuse_set_size = 1` and a per-node match key to form single-node groups; the shared search/observer machinery is otherwise untouched. `match` is side-effect-free and `fuse` recomputes the rewrite plan on the nodes it actually rewrites, so a node that matches but never fuses leaves no stale meta behind.

## Perf

Numerically neutral fwd and bwd (eager vs compiled checked on every model below). AMD Instinct MI355X (gfx950), ROCm 7.2, bf16; full train step, clock-locked, multi-rep with the per-rep spread reported.

Public models at large batch (M\~960k), controlled single-harness A/B, per-side median:

| model | shape (K_total x N) | off (ms) | on (ms) | delta |
|---|---|---|---|---|
| multimodal late-fusion (ConcatBERT/MMBT) | 1024 x 2 | 4.888 | 4.517 | -7.6% |
| Wide&Deep | 768 x 1 | 5.281 | 5.112 | -3.2% |
| DCN-V2 | 752 x 1 | 15.69 | 15.40 | -1.8% |

All three on/off rep ranges are fully separated and fwd+bwd are numerically neutral. These wins are large-batch (M\~960k) and memory-bound; at a realistic mid batch every candidate is launch-bound and the pass is unmeasurable, so this is explicitly a large-batch, memory-bound, small-output optimization, not a universal speedup.

- microbench shape sweep: the profitable corner is a wide concat (`K_total >= 512`) feeding a small output (`N <~ 128`) at large batch (`M >= ~524k`); the win deepens from \~-25% at K=512 to \~-49% at K=4096 (N=16), and is neutral outside that corner. That trend is what the two gates encode.
- TorchBench: 1 of 63 models matches the pattern (dlrm), widening the caps adds 0 matches, no behavior change, no numeric change, negligible compile overhead (+0.29 s median). Opt-in and inert where it does not match.

## Test plan

`test/inductor/test_group_batch_fusion.py`:

| test | checks |
|---|---|
| `test_cat_linear_two_part` / `_three_part` | matcher fires on a 2- / 3-part last-dim cat |
| `test_cat_linear_removes_cat_two_part` / `_three_part` | cat gone, per-piece linears + reduce-adds left behind |
| `test_cat_linear_keeps_cat_when_rejected` | a rejected case keeps its cat live |
| `test_cat_linear_rejects_non_last_dim` | non-last-dim cat declined |
| `test_cat_linear_rejects_too_many_parts` | parts > 3 declined |
| `test_cat_linear_rejects_thin_piece` | sub-8-wide piece declined |
| `test_cat_linear_rejects_multi_user_cat` | multi-user cat declined |
| `test_cat_linear_rejects_wide_output` | N=128 > 96 ceiling declined |
| `test_cat_linear_rejects_small_traffic` | sub-512 MiB traffic declined |
| `test_cat_linear_numerics` / `_cpu` | GPU bf16 and CPU, eager == compiled, counter increments once |
| `test_cat_linear_numerics_backward` / `_cpu` | GPU bf16 and CPU fp32, eager == compiled grads: `W.grad`, `bias.grad`, per-part input grads |

The shape-gate and numerics tests drop the traffic floor to 0 (unit-test tensors never reach 512 MiB) so the shape gates are what they exercise; the dedicated `rejects_small_traffic` test keeps the real floor and asserts a tiny concat is declined.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
