### PR TITLE
Fix margin docstring rendering in HingeEmbeddingLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -870,7 +870,7 @@ class HingeEmbeddingLoss(_Loss):
     where :math:`L = \{l_1,\dots,l_N\}^\top`.
 
     Args:
-        margin (float, optional): Has a default value of `1`.
+        margin (float, optional): Has a default value of :math:`1`.
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
             the losses are averaged over each loss element in the batch. Note that for
             some losses, there are multiple elements per sample. If the field :attr:`size_average`


### PR DESCRIPTION
The margin argument in HingeEmbeddingLoss used a single backtick (`1`), which Sphinx renders as an italic title-reference rather than inline math. This makes it inconsistent with the sibling loss classes (MultiMarginLoss, MarginRankingLoss, TripletMarginLoss, CosineEmbeddingLoss), which all use :math:1``. This aligns the rendering.