### PR TITLE
[Dynamo][Cache] Strengthen isolate_recompiles tests to catch isolation regressions

### DIFF
--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -484,19 +484,33 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         automatic_dynamic_shapes=False,
     )
     def test_isolate_recompiles_basic(self):
-        """A single isolated region respects its per-region recompile limit."""
+        """Each isolated region has its own recompile limit: region A hitting
+        its limit (recompile_limit=1) does not consume region B's budget."""
 
         def f(x):
             return x.sin()
 
-        opt_f = torch.compile(
+        opt_a = torch.compile(
             f, backend="eager", dynamic=False, isolate_recompiles=True
         )
+        opt_b = torch.compile(
+            f, backend="eager", dynamic=False, isolate_recompiles=True
+        )
+        self.assertNotEqual(opt_a._isolate_recompiles_id, opt_b._isolate_recompiles_id)
 
-        opt_f(torch.randn(3))
-
+        opt_a(torch.randn(3))
         with self.assertRaises(FailOnRecompileLimitHit):
-            opt_f(torch.randn(4))
+            opt_a(torch.randn(4))  # region A exhausts its own limit
+
+        # Region B is unaffected: its own budget still allows one compile.
+        opt_b(torch.randn(5))
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_a._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_b._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
 
     @torch._dynamo.config.patch(
         recompile_limit=1,
@@ -638,6 +652,21 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         opt_static(torch.randn(5, 9))
         self.assertEqual(cnt.frame_count, 3)
 
+        # Entries are bucketed per region, not pooled: the static region holds
+        # its 2 shapes, the dynamic region its 1, and nothing leaked to the
+        # default (-1) bucket.
+        self.assertNotEqual(
+            opt_static._isolate_recompiles_id, opt_dynamic._isolate_recompiles_id
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_static._isolate_recompiles_id)), 2
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_dynamic._isolate_recompiles_id)),
+            1,
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
+
     @torch._dynamo.config.patch(automatic_dynamic_shapes=False)
     def test_isolate_recompiles_mark_dynamic_vs_static(self):
         """Two regions: one with mark_static, one with mark_dynamic.
@@ -678,6 +707,20 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         opt_static(x_static3)
         self.assertEqual(cnt_static.frame_count, 2)
 
+        # Per-region buckets: static holds its 2 shapes, dynamic its 1, and the
+        # default (-1) bucket stays empty.
+        self.assertNotEqual(
+            opt_static._isolate_recompiles_id, opt_dynamic._isolate_recompiles_id
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_static._isolate_recompiles_id)), 2
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_dynamic._isolate_recompiles_id)),
+            1,
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
+
     @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
     def test_isolate_recompiles_auto_dynamic_shared_pgo(self):
         """PGO (frame_state) is shared across isolated regions. Region B
@@ -702,6 +745,14 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
         opt_b(torch.randn(9, 4))
         self.assertEqual(cnt_b.frame_count, 1)
+
+        # PGO is shared, but cache entries are bucketed per region: region B's
+        # single entry lives in its own bucket, not the default and not A's.
+        self.assertNotEqual(opt_a._isolate_recompiles_id, opt_b._isolate_recompiles_id)
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_b._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
 
     @torch._dynamo.config.patch(
         recompile_limit=2,
@@ -746,19 +797,32 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
     @torch._dynamo.config.patch(recompile_limit=1)
     def test_isolate_recompiles_fullgraph_raises(self):
-        """With fullgraph=True, hitting the recompile limit raises
-        FailOnRecompileLimitHit regardless of fail_on_recompile_limit_hit."""
+        """With fullgraph=True, hitting a region's recompile limit raises
+        FailOnRecompileLimitHit regardless of fail_on_recompile_limit_hit. The
+        limit is per-region: region A raising does not stop region B from
+        compiling its first graph."""
 
         def f(x):
             return x.sin()
 
-        opt_f = torch.compile(
+        opt_a = torch.compile(
             f, backend="eager", fullgraph=True, dynamic=False, isolate_recompiles=True
         )
+        opt_b = torch.compile(
+            f, backend="eager", fullgraph=True, dynamic=False, isolate_recompiles=True
+        )
+        self.assertNotEqual(opt_a._isolate_recompiles_id, opt_b._isolate_recompiles_id)
 
-        opt_f(torch.randn(3))
+        opt_a(torch.randn(3))
         with self.assertRaisesRegex(FailOnRecompileLimitHit, "fullgraph=True"):
-            opt_f(torch.randn(4))
+            opt_a(torch.randn(4))
+
+        # Region B has its own budget: its first compile must succeed, not raise.
+        opt_b(torch.randn(5))
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_b._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
 
     @torch._dynamo.config.patch(automatic_dynamic_shapes=False)
     def test_isolate_recompiles_graph_break_independent_regions(self):
@@ -970,6 +1034,9 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
         id_a = opt_a._isolate_recompiles_id
         id_b = opt_b._isolate_recompiles_id
+        # The two regions and the default bucket are genuinely distinct.
+        self.assertNotEqual(id_a, id_b)
+        self.assertNotEqual(id_a, -1)
 
         # Region A compiles once, then hits limit
         opt_a(torch.randn(3))
@@ -1051,6 +1118,9 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
         opt_iso = torch.compile(f, backend=cnt, isolate_recompiles=True)
         id_iso = opt_iso._isolate_recompiles_id
+        # A genuine isolated region (distinct from the default bucket) that
+        # nonetheless inherits the global SKIP.
+        self.assertNotEqual(id_iso, -1)
 
         x = torch.randn(3)
         self.assertEqual(opt_iso(x), f(x))
@@ -1104,12 +1174,16 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         )
         id_a = opt_a._isolate_recompiles_id
         id_b = opt_b._isolate_recompiles_id
+        self.assertNotEqual(id_a, id_b)
 
         # Interleave compilations
         opt_a(torch.randn(3))
         opt_b(torch.randn(10))
         opt_a(torch.randn(4))
         opt_b(torch.randn(11))
+
+        # 4 entries total across the two regions (2 each), not pooled into one.
+        self.assertEqual(_get_total_cache_entry_count(f), 4)
 
         # Newest at front in each region
         entries_a = _get_cache_entries_for_region(f, id_a)
@@ -1202,6 +1276,16 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         opt_isolated(torch.randn(3))
         self.assertEqual(cnt.frame_count, 1)
 
+        # The reuse is genuine cross-bucket fallback: opt_isolated is a real
+        # region (not the default), it added no entry of its own, and the reused
+        # entry lives in the default (-1) bucket.
+        self.assertNotEqual(opt_isolated._isolate_recompiles_id, -1)
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_isolated._isolate_recompiles_id)),
+            0,
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 1)
+
     @torch._dynamo.config.patch(recompile_limit=8)
     def test_isolate_recompiles_reasons_include_default_bucket(self):
         """Recompile-reason logging for an isolated region must also walk
@@ -1246,6 +1330,14 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
             default_fails,
             f"default-bucket entries' guard failures dropped from "
             f"recompile reasons (bug): {default_fails}",
+        )
+        # Region and default are separate buckets: only shape-3 is in the
+        # default bucket; the region holds its own shape-4/5 entries.
+        self.assertNotEqual(opt_isolated._isolate_recompiles_id, -1)
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 1)
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_isolated._isolate_recompiles_id)),
+            2,
         )
 
     @torch._dynamo.config.patch(recompile_limit=8)
@@ -1305,6 +1397,10 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
             2,
             f"expected guard failures for both default entries, got {default_fails}",
         )
+        # The two default entries (shapes 3, 4) stay in the default bucket; the
+        # region's shape-5/6 entries live in its own bucket.
+        self.assertNotEqual(opt_iso._isolate_recompiles_id, -1)
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 2)
 
     def test_isolate_recompiles_reset_clears_region_strategy(self):
         """torch._dynamo.reset() must clear region_strategy_map on
@@ -1328,6 +1424,10 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         torch._dynamo.reset()
 
         opt_b = torch.compile(f, backend=cnt, isolate_recompiles=True)
+        # Both are genuine isolated regions (distinct from the default bucket);
+        # the RUN_ONLY persisted for opt_a's region must not survive reset.
+        self.assertNotEqual(opt_a._isolate_recompiles_id, -1)
+        self.assertNotEqual(opt_b._isolate_recompiles_id, -1)
         opt_b(torch.randn(5))
         self.assertEqual(cnt.frame_count, 2)
 
@@ -1432,6 +1532,15 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
         opt_b(torch.randn(4))
         self.assertEqual(cnt_a.frame_count, 1)
         self.assertEqual(cnt_b.frame_count, 1)
+        # Each region owns one entry; nothing leaked to the default bucket.
+        self.assertNotEqual(opt_a._isolate_recompiles_id, opt_b._isolate_recompiles_id)
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_a._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(
+            len(_get_cache_entries_for_region(f, opt_b._isolate_recompiles_id)), 1
+        )
+        self.assertEqual(len(_get_cache_entries_for_region(f, -1)), 0)
 
         torch._dynamo.reset()
 
@@ -1442,8 +1551,11 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
     @torch._dynamo.config.patch(recompile_limit=3)
     def test_isolate_recompiles_resume_function(self):
-        """Resume functions from a graph break inherit the region's
-        isolate_recompiles_id and respect its per-region recompile limit."""
+        """Resume functions from a graph break are bucketed by their region's
+        isolate_recompiles_id, both for cache lookup and for the per-region
+        recompile limit. Region A exhausting its resume-frame limit leaves
+        region B free to compile the same main/resume frames independently
+        (they share the backend, so without isolation B would cache-hit A)."""
         cnt = torch._dynamo.testing.CompileCounter()
 
         mode = {"value": "a"}
@@ -1460,25 +1572,31 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
             else:
                 return a + 1
 
-        opt_f = torch.compile(f, backend=cnt, isolate_recompiles=True)
+        opt_a = torch.compile(f, backend=cnt, isolate_recompiles=True)
+        opt_b = torch.compile(f, backend=cnt, isolate_recompiles=True)
+        self.assertNotEqual(opt_a._isolate_recompiles_id, opt_b._isolate_recompiles_id)
 
-        # First call: main frame (sin) + resume frame (cos) = 2 compiles.
-        opt_f(torch.randn(4))
+        # Region A, first call: main frame (sin) + resume frame (cos) = 2.
+        opt_a(torch.randn(4))
         self.assertEqual(cnt.frame_count, 2)
 
-        # Each new mode recompiles only the resume frame (main is cached).
-        mode["value"] = "b"
-        opt_f(torch.randn(4))
-        self.assertEqual(cnt.frame_count, 3)
+        # Each new mode recompiles only region A's resume frame (main cached).
+        for m, expected in (("b", 3), ("c", 4)):
+            mode["value"] = m
+            opt_a(torch.randn(4))
+            self.assertEqual(cnt.frame_count, expected)
 
-        mode["value"] = "c"
-        opt_f(torch.randn(4))
-        self.assertEqual(cnt.frame_count, 4)
-
-        # Resume function has 3 entries = recompile_limit. Fourth mode blocked.
+        # Region A's resume frame has 3 entries = recompile_limit. A fourth
+        # mode is blocked (runs eager), so no new compile.
         mode["value"] = "d"
-        opt_f(torch.randn(4))
+        opt_a(torch.randn(4))
         self.assertEqual(cnt.frame_count, 4)
+
+        # Region B is independent: mode "a" would cache-hit region A's main and
+        # resume frames without isolation, but here both recompile (+2).
+        mode["value"] = "a"
+        opt_b(torch.randn(4))
+        self.assertEqual(cnt.frame_count, 6)
 
     def test_isolate_recompiles_gc_wrapper(self):
         """When an isolated compile wrapper is GC'd, orphaned cache entries


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187885
* #187884
* #182080

Many isolate_recompiles tests passed even when the feature did nothing: they
discriminated on backend-mismatch (separate CompileCounter instances), differing
guards, single-region behavior, or global state (PGO/SKIP/reset) rather than the
per-region cache bucketing they claimed to exercise. Simulating
isolate_recompiles as a no-op by collapsing every region into the shared default
(-1) bucket, 17 of 33 tests still passed -- 14 of which are named after the
feature.

This strengthens those 14 to fail when isolation regresses, matching the pattern
the already-strong tests use: assert each region owns exactly its entries via
_get_cache_entries_for_region(f, opt._isolate_recompiles_id), that region ids are
distinct, and that the default (-1) bucket is empty for pure-isolated tests (or
holds only its own entries for the mixed fallback/skip/reason tests). The
single-region tests (basic, fullgraph_raises, resume_function) are reworked into
genuine two-region tests; resume_function now shows region B recompiling the same
main and resume frames region A already compiled, which would be a cache hit (a
silent pass) without isolation. Afterward the only tests that pass with isolation
disabled are the three intended non-isolated baselines.

Test Plan:

```
python test/dynamo/test_recompile_ux.py IsolateRecompilesTests
```

Authored with assistance from Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98