### PR TITLE
[Inductor] Add decomposition for prims.uniform

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7709,6 +7709,7 @@ for dtype in (torch.int32, torch.int64):
 
         self.common(fn, [torch.tensor([np.nan, np.inf, -np.inf, 0.0, 1.0, -1.0])])
 
+    @config.patch(fallback_random=True)
     def test_uniform(self):
         def fn(x):
             return aten.uniform.default(x, 0, 1)
@@ -7721,6 +7722,27 @@ for dtype in (torch.int32, torch.int64):
             exact_stride=True,
             reference_in_float=False,
         )
+
+    @config.patch(fallback_random=False)
+    def test_uniform_no_fallback(self):
+        def fn(x):
+            return aten.uniform.default(x, 0, 1)
+
+        a = torch.randn([5, 3]).permute(1, 0)
+
+        compiled = torch.compile(fn, fullgraph=True)
+        res = compiled(a)
+        self.assertEqual(res.shape, a.shape)
+        self.assertEqual(res.dtype, a.dtype)
+        self.assertEqual(res.device.type, a.device.type)
+        self.assertEqual(res.stride(), a.stride())
+
+        # Confirm non-eager compilation
+        torch.manual_seed(0)
+        eager_out = fn(a)
+        torch.manual_seed(0)
+        compiled_out = compiled(a)
+        self.assertNotEqual(eager_out, compiled_out)
 
     def test_complex_from_real_imag(self):
         def fn(x, y):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -374,6 +374,7 @@ inductor_override_kwargs["cpu"] = {
     "empty_strided": {"assert_equal": False},
     "new_empty_strided": {"assert_equal": False},
     "randn": {"assert_equal": False},
+    "nn.functional.rrelu": {"check_gradient": False},
     ("nn.functional.multilabel_soft_margin_loss", f16): {
         "atol": 3e-4,
         "rtol": 0.002,
@@ -411,6 +412,7 @@ inductor_override_kwargs["cuda"] = {
     "empty_strided": {"assert_equal": False},
     "new_empty_strided": {"assert_equal": False},
     "randn": {"assert_equal": False},
+    "nn.functional.rrelu": {"check_gradient": False},
     ("cross", f16): {"reference_in_float": True},
     ("linalg.cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
@@ -529,6 +531,7 @@ inductor_override_kwargs["xpu"] = {
     "empty_strided": {"assert_equal": False},
     "new_empty_strided": {"assert_equal": False},
     "randn": {"assert_equal": False},
+    "nn.functional.rrelu": {"check_gradient": False},
     # XPU
     ("cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -245,6 +245,7 @@ extra_random_decomps = get_decompositions(
         aten.log_normal_,
         aten.rrelu_with_noise,
         aten.rrelu_with_noise_,
+        aten.uniform,
         aten.uniform_,
     ]
 )

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -5,7 +5,7 @@ import math
 import operator
 import sys
 from collections.abc import Callable
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, cast, TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -843,6 +843,30 @@ def randint(
     **kwargs: Any,
 ) -> torch.Tensor:
     return aten.randint.low(0, high, size, **kwargs)
+
+
+@register_decomposition(prims.uniform)
+def uniform(
+    shape: list[int | torch.SymInt],
+    *,
+    low: torch.types.Number,
+    high: torch.types.Number,
+    dtype: torch.dtype,
+    device: torch.device,
+    stride: list[int | torch.SymInt],
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    if generator is None:
+        rand_samples = torch.rand(shape, dtype=dtype, device=device)
+    else:
+        rand_samples = torch.rand(
+            shape, generator=generator, dtype=dtype, device=device
+        )
+    res = (high - low) * rand_samples + low
+
+    if stride != utils.make_contiguous_strides_for(cast(list[int], shape)):
+        return res.as_strided(shape, stride)
+    return res
 
 
 @register_decomposition(quantized.linear_dynamic_fp16_unpacked_weight.default)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -864,7 +864,7 @@ def uniform(
         )
     res = (high - low) * rand_samples + low
 
-    if stride != utils.make_contiguous_strides_for(cast(list[int], shape)):
+    if tuple(stride) != utils.make_contiguous_strides_for(cast(list[int], shape)):
         return res.as_strided(shape, stride)
     return res
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3633,7 +3633,7 @@ make_fallback(aten._scaled_dot_product_attention_math_for_mps)  # @malfet
 
 
 # 1) Easy
-make_fallback(aten.uniform, warn=False)
+make_fallback(aten.uniform, override_decomp=True)
 make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_torch.py)
 make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?


### PR DESCRIPTION
Currently inductor uses an eager fallback for `aten.uniform` and `aten.uniform_`. This PR adds a straight forward decomposition of `prims.uniform` so it can be natively lowered to `prims.rand`.

/cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison, @shunting314, @jansel, @eikanwang