### PR TITLE
[Inductor] Don't always strip compute-capability suffix

### DIFF
--- a/test/inductor/test_compile.py
+++ b/test/inductor/test_compile.py
@@ -325,12 +325,14 @@ class TestStandaloneInductor(TestCase):
         return_value="100a",
     )
     @unittest.skipIf(torch.version.hip is not None, "CUDA-only")
-    def test_aoti_cuda_target_arch_strips_suffix(self, _):
+    def test_aoti_cuda_target_arch_preserves_suffix(self, _):
         from torch._inductor.codegen.cuda import compile_utils
 
-        self.assertEqual(compile_utils._aoti_cuda_target_arch(), "100")
+        self.assertEqual(compile_utils._aoti_cuda_target_arch(), "100a")
+        with config.patch({"cuda.arch": "90"}):
+            self.assertEqual(compile_utils._aoti_cuda_target_arch(), "90a")
         with config.patch({"cuda.arch": "90a"}):
-            self.assertEqual(compile_utils._aoti_cuda_target_arch(), "90")
+            self.assertEqual(compile_utils._aoti_cuda_target_arch(), "90a")
 
     @mock.patch.dict(os.environ, {"TORCH_CUDA_ARCH_LIST": "8.0;8.6"})
     @mock.patch(
@@ -438,7 +440,7 @@ class TestStandaloneInductor(TestCase):
 
         precompile_config.assert_called_once_with(launcher.config, cc_override=90)
         _, params, cubin, bin_type, asm, asm_type = cache_set.call_args.args
-        self.assertEqual(params["cuda_arch"], "90")
+        self.assertEqual(params["cuda_arch"], "90a")
         self.assertEqual(cubin, b"target cubin")
         self.assertEqual(bin_type, "cubin")
         self.assertEqual(asm, "target ptx")
@@ -468,7 +470,7 @@ class TestStandaloneInductor(TestCase):
 
         precompile_config.assert_not_called()
         _, params, cubin, bin_type, asm, asm_type = cache_set.call_args.args
-        self.assertEqual(params["cuda_arch"], "100")
+        self.assertEqual(params["cuda_arch"], "100a")
         self.assertEqual(cubin, b"current cubin")
         self.assertEqual(bin_type, "cubin")
         self.assertEqual(asm, "current ptx")

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -257,7 +257,8 @@ def _cuda_fatbin_command(
     fatbinary: str | None,
     current_arch: str | None = None,
 ) -> list[str]:
-    current_arch = current_arch or cuda_compile_utils._nvcc_arch_as_compile_option()
+    if not current_arch:
+        current_arch = cuda_compile_utils._nvcc_arch_as_compile_option_or_raise()
     gencode_options = cuda_compile_utils._cuda_multi_arch_gencode_options(current_arch)
     if (
         fatbinary is not None

--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -131,8 +131,8 @@ def _nvcc_host_compiler_options() -> list[str]:
     ]
 
 
-def _nvcc_arch_as_compile_option() -> str:
-    arch = cuda_env.get_cuda_arch()
+def _cuda_arch_with_compile_suffix(arch: str) -> str:
+    arch = _normalize_cuda_arch(arch)
     if arch == "90":
         # Required by cutlass compilation.
         return "90a"
@@ -149,6 +149,13 @@ def _nvcc_arch_as_compile_option() -> str:
     if arch == "121":
         return "121a"
     return arch
+
+
+def _nvcc_arch_as_compile_option() -> str:
+    arch = cuda_env.get_cuda_arch()
+    if arch is None:
+        return arch
+    return _cuda_arch_with_compile_suffix(arch)
 
 
 def _normalize_cuda_arch(arch: str) -> str:
@@ -185,14 +192,9 @@ def _cuda_arch_is_compatible_with_current(arch: str, current_arch: str) -> bool:
 
 
 def _aoti_cuda_target_arch() -> str:
-    arch = (
-        _normalize_cuda_arch(str(config.cuda.arch))
-        if config.cuda.arch is not None
-        else _nvcc_arch_as_compile_option()
-    )
-    # Triton cc overrides are numeric compute capabilities. The suffix is only
-    # used for native nvcc compilation, not for the PTX AOTI packages here.
-    return str(_cuda_arch_number(arch))
+    if config.cuda.arch is not None:
+        return _cuda_arch_with_compile_suffix(str(config.cuda.arch))
+    return _nvcc_arch_as_compile_option()
 
 
 def _parse_gencode_options(flags: list[str]) -> OrderedSet[tuple[str, str]]:

--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -151,11 +151,18 @@ def _cuda_arch_with_compile_suffix(arch: str) -> str:
     return arch
 
 
-def _nvcc_arch_as_compile_option() -> str:
+def _nvcc_arch_as_compile_option() -> str | None:
     arch = cuda_env.get_cuda_arch()
     if arch is None:
         return arch
     return _cuda_arch_with_compile_suffix(arch)
+
+
+def _nvcc_arch_as_compile_option_or_raise() -> str:
+    arch = _nvcc_arch_as_compile_option()
+    if arch is None:
+        raise RuntimeError("Unable to determine CUDA architecture")
+    return arch
 
 
 def _normalize_cuda_arch(arch: str) -> str:
@@ -194,7 +201,7 @@ def _cuda_arch_is_compatible_with_current(arch: str, current_arch: str) -> bool:
 def _aoti_cuda_target_arch() -> str:
     if config.cuda.arch is not None:
         return _cuda_arch_with_compile_suffix(str(config.cuda.arch))
-    return _nvcc_arch_as_compile_option()
+    return _nvcc_arch_as_compile_option_or_raise()
 
 
 def _parse_gencode_options(flags: list[str]) -> OrderedSet[tuple[str, str]]:
@@ -231,7 +238,9 @@ def _cuda_multi_arch_gencode_options(current_arch: str | None = None) -> list[st
     ones, so explicit TORCH_CUDA_ARCH_LIST entries below the current target are
     intentionally ignored.
     """
-    current_arch = _normalize_cuda_arch(current_arch or _nvcc_arch_as_compile_option())
+    if not current_arch:
+        current_arch = _nvcc_arch_as_compile_option_or_raise()
+    current_arch = _normalize_cuda_arch(current_arch)
     options: OrderedSet[tuple[str, str]] = OrderedSet()
 
     arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST")
@@ -275,7 +284,9 @@ def _cuda_multi_arch_gencode_options(current_arch: str | None = None) -> list[st
 def _cuda_gencode_options_have_non_current_sass(
     gencode_options: list[str], current_arch: str | None = None
 ) -> bool:
-    current_arch = _normalize_cuda_arch(current_arch or _nvcc_arch_as_compile_option())
+    if not current_arch:
+        current_arch = _nvcc_arch_as_compile_option_or_raise()
+    current_arch = _normalize_cuda_arch(current_arch)
     for kind, arch in _parse_gencode_options(
         [f"-gencode={option}" for option in gencode_options]
     ):
@@ -285,7 +296,7 @@ def _cuda_gencode_options_have_non_current_sass(
 
 
 def _nvcc_compiler_options() -> list[str]:
-    arch = _nvcc_arch_as_compile_option()
+    arch = _nvcc_arch_as_compile_option_or_raise()
     code = [f"sm_{arch}", f"compute_{arch}"]
     if config.cuda.enable_cuda_lto:
         code += [f"lto_{arch}"]


### PR DESCRIPTION
Following #185328 tests such as 

``` 
File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
torch._inductor.exc.InductorError: CalledProcessError: Command '['nvcc', '-fatbin', '/tmp/tmpri_861ie/ce75deix5v2ltuxilvqvbxmlr5qvlqmr22yvpthfi2chjjhlxkcn/cos_triton_poi_fused_cos_0.ptx', '-o', '/tmp/tmpri_861ie/ce75deix5v2ltuxilvqvbxmlr5qvlqmr22yvpthfi2chjjhlxkcn/cos_triton_poi_fused_cos_0.fatbin', '-gencode', 'arch=compute_100,code=sm_100', '-gencode', 'arch=compute_100,code=compute_100', '-gencode', 'arch=compute_110,code=sm_110', '-gencode', 'arch=compute_120,code=sm_120']' returned non-zero exit status 255.

To execute this test, run the following from the base repo dir:
    python test/inductor/test_aot_inductor_package.py TestAOTInductorPackageCpp_cuda.test_compile_standalone_cos
    
    ...
    
    stderr:
ptxas fatal   : PTX with .target 'sm_100a' cannot be compiled for architecture 'sm_100'
    
```

  seem to break due to removed suffixes. This PR does not strip suffixes in `_aoti_cuda_target_arch` which otherwise breaks with e.g., `.target sm_103a` PTX emitted by Trition. 
    

    Authored with codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo