### PR TITLE
device_mesh: fall back to new_group when parent backend lacks split s…

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -548,12 +548,28 @@ else:
             # Otherwise, we need to make more than one API call (`new_group`) for subgroup creations. The
             # numbers of API calls are equal to the number of subgroups for each mesh dimension. In a 2 * 4
             # mesh, we need to make two API calls per ranks to create all the subgroups.
+            # The split_group path requires the parent backend to actually
+            # support communicator splitting (e.g. NCCL ncclCommSplit). Some
+            # backends (e.g. XCCL) do not override supportsSplitting() and
+            # would raise inside split_group, so fall back to the new_group
+            # path below when splitting is unsupported. torchcomms handles
+            # splitting independently of supportsSplitting(), so it is exempt.
+            parent_supports_splitting = (
+                dist_config.use_torchcomms
+                or (
+                    torch.accelerator.is_available()
+                    and default_group._get_backend(
+                        torch.accelerator.current_accelerator()  # pyrefly: ignore[bad-argument-type]
+                    ).supports_splitting
+                )
+            )
             if (
                 (
                     getattr(default_group, "bound_device_id", None) is not None
                     or dist_config.use_torchcomms
                 )
                 and torch.accelerator.is_available()
+                and parent_supports_splitting
                 and (
                     backend is None
                     or default_group._get_backend(


### PR DESCRIPTION
…upport

init_device_mesh with eager_init=True sets bound_device_id on the default process group, which routes subgroup creation through split_group(). That call raises 'No backend for the parent process group or its backend does not support splitting' for backends whose supportsSplitting() returns false (e.g. XCCL, which does not override the Backend default).

Gate the split_group() path on the parent backend actually supporting splitting (or torchcomms being enabled, which handles splitting independently). When unsupported, fall through to the existing new_group() loop instead of erroring out. NCCL and torchcomms behavior is unchanged.

Fixes InitDeviceMeshTest.test_backend_override_argument_dict_with_idx_and_backend_eager on XCCL.

topic: not user facing

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy