### PR TITLE
[profiler][cupti] Perfetto-native (.pftrace) export, full chrome-args parity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -132,3 +132,6 @@
 [submodule "third_party/mslk"]
 	path = third_party/mslk
 	url = https://github.com/meta-pytorch/MSLK.git
+[submodule "third_party/perfetto"]
+	path = third_party/perfetto
+	url = https://github.com/google/perfetto.git

--- a/benchmarks/profiler_benchmark/cupti_monitor_bench_export.py
+++ b/benchmarks/profiler_benchmark/cupti_monitor_bench_export.py
@@ -16,6 +16,10 @@ off-thread. Reported per mode:
 Each ``--mode`` runs in its own process so the monitor gets a clean CUPTI subscriber.
 ``--kernels`` scales the eager workload's kernel count -> the trace's event count.
 
+``--pftrace`` (cupti_monitor only) exports the Perfetto-native ``.pftrace`` (encoded from
+the columnar window via protozero) instead of chrome JSON, to compare the two export paths
+(``format`` in the output distinguishes them; trace_events counts SLICE_BEGINs for pftrace).
+
 ``--trace-file PATH`` runs the real ``--mode monitor`` ``export_chrome_trace`` over a
 loaded chrome trace's *exact* events, measuring export at a real trace's scale/shape: a
 stand-in Kineto profiler emits the trace's CPU-side events as the base, a stand-in
@@ -45,15 +49,43 @@ from torch._C._profiler import _ExperimentalConfig
 from torch.profiler import profile, ProfilerActivity
 
 
+def _read_back(out_path: str, pftrace: bool) -> tuple[int, float, str]:
+    """Return (event_count, MB, actual_path) for an exported trace. The monitor backend
+    gzips to ``<path>.gz`` unless the path already ends in .gz; .pftrace is the Perfetto-
+    native variant (event_count is its SLICE_BEGIN count), otherwise chrome JSON."""
+    actual = out_path if out_path.endswith(".gz") else out_path + ".gz"
+    size_mb = os.path.getsize(actual) / 1e6
+    if pftrace:
+        from perfetto.protos.perfetto.trace.perfetto_trace_pb2 import (  # pyrefly: ignore[missing-import]
+            Trace,
+            TrackEvent,
+        )
+
+        t = Trace()
+        with gzip.open(actual, "rb") as f:
+            t.ParseFromString(f.read())
+        n = sum(
+            1
+            for p in t.packet
+            if p.HasField("track_event")
+            and p.track_event.type == TrackEvent.TYPE_SLICE_BEGIN
+        )
+    else:
+        with gzip.open(actual, "rt") as f:
+            n = len(json.load(f)["traceEvents"])
+    return n, size_mb, actual
+
+
 def run_export(
     mode: str,
     kernels: int,
     iters: int,
     trace_file: str | None = None,
     async_export: bool = False,
+    pftrace: bool = False,
 ) -> dict:
     if trace_file is not None:
-        return _run_export_trace_file(mode, trace_file, iters, async_export)
+        return _run_export_trace_file(mode, trace_file, iters, async_export, pftrace)
     use_monitor = mode == "monitor"
     backend: dict = {"backend": "cupti_monitor"} if use_monitor else {}
     if use_monitor and async_export:
@@ -71,7 +103,7 @@ def run_export(
     n_events = 0
     out_mb = 0.0
     with tempfile.TemporaryDirectory() as td:
-        trace_path = str(Path(td) / "trace.json.gz")
+        trace_path = str(Path(td) / ("trace.pftrace" if pftrace else "trace.json.gz"))
         for _ in range(iters):
             with profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
@@ -88,15 +120,14 @@ def run_export(
             prof.wait_for_exports()  # no-op for stock Kineto
             wait_ms.append((time.perf_counter() - t1) * 1e3)
 
-            out_mb = os.path.getsize(trace_path) / 1e6
-            with gzip.open(trace_path, "rt") as f:
-                n_events = len(json.load(f)["traceEvents"])
-            os.remove(trace_path)
+            n_events, out_mb, actual = _read_back(trace_path, pftrace)
+            os.remove(actual)
 
     em = statistics.median(export_ms)
     wm = statistics.median(wait_ms)
     return {
         "mode": mode,
+        "format": "pftrace" if pftrace else "json",
         "kernels": kernels,
         "iters": iters,
         "trace_events": n_events,
@@ -301,7 +332,7 @@ class _LoadedWindowObserver:
 
 
 def _run_export_trace_file(
-    mode: str, path: str, iters: int, async_export: bool = False
+    mode: str, path: str, iters: int, async_export: bool = False, pftrace: bool = False
 ) -> dict:
     """Run the real ``export_chrome_trace`` over a loaded trace's state: a stand-in
     profiler emits its CPU events and a stand-in observer holds its GPU window, so the
@@ -324,7 +355,7 @@ def _run_export_trace_file(
     n_events = 0
     out_mb = 0.0
     with tempfile.TemporaryDirectory() as td:
-        out = str(Path(td) / "trace.json.gz")
+        out = str(Path(td) / ("trace.pftrace" if pftrace else "trace.json.gz"))
         for _ in range(iters):
             prof = types.SimpleNamespace(
                 profiler=_LoadedCpuProfiler(cpu_data),
@@ -342,13 +373,12 @@ def _run_export_trace_file(
             t1 = time.perf_counter()
             profile.wait_for_exports(prof)
             wait_ms.append((time.perf_counter() - t1) * 1e3)
-            out_mb = os.path.getsize(out) / 1e6
-            with gzip.open(out, "rt") as f:
-                n_events = len(json.load(f)["traceEvents"])
+            n_events, out_mb, _ = _read_back(out, pftrace)
     em = statistics.median(export_ms)
     wm = statistics.median(wait_ms)
     return {
         "mode": "monitor",
+        "format": "pftrace" if pftrace else "json",
         "async_export": async_export,
         "trace_file": path,
         "iters": iters,
@@ -381,6 +411,12 @@ def main() -> None:
         help="cupti_monitor only: defer the merge off-thread (export_chrome_trace is just "
         "the handoff; the merge + write is timed under wait_exports_ms).",
     )
+    parser.add_argument(
+        "--pftrace",
+        action="store_true",
+        help="cupti_monitor only: export the Perfetto-native .pftrace (encoded from the "
+        "columnar window via protozero) instead of chrome JSON, to compare the two paths.",
+    )
     args = parser.parse_args()
 
     if args.trace_file and args.mode != "monitor":
@@ -388,6 +424,10 @@ def main() -> None:
             "--trace-file supports --mode monitor only: stock Kineto exports off a live "
             "in-memory profile and cannot re-export a saved trace. For the kineto "
             "baseline, run synthetic --mode trunk."
+        )
+    if args.pftrace and args.mode != "monitor":
+        raise SystemExit(
+            "--pftrace is cupti_monitor only (stock Kineto emits chrome JSON)."
         )
     if not args.trace_file:
         torch.cuda.init()
@@ -399,6 +439,7 @@ def main() -> None:
                 args.iters,
                 trace_file=args.trace_file,
                 async_export=args.async_export,
+                pftrace=args.pftrace,
             ),
             indent=2,
             sort_keys=True,

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -114,6 +114,7 @@ libtorch_profiler_sources = [
     "torch/csrc/autograd/profiler_kineto.cpp",
     "torch/csrc/profiler/collection.cpp",
     "torch/csrc/profiler/cupti/monitor_native.cpp",
+    "torch/csrc/profiler/cupti/monitor_pftrace.cpp",
     "torch/csrc/profiler/cupti/nccl_profiler.cpp",
     "torch/csrc/profiler/data_flow.cpp",
     "torch/csrc/profiler/kineto_shim.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1349,6 +1349,19 @@ target_include_directories(torch_cpu PRIVATE
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/nlohmann/include)
 
+# Perfetto SDK amalgamation: the CUPTI monitor's native .pftrace encoder
+# (monitor_pftrace.cpp) builds traces via protozero. perfetto.cc is one
+# self-contained TU; --gc-sections drops the unused tracing SDK so only the
+# protozero runtime (~15KB) survives in the final binary. Warnings are
+# suppressed for the vendored source (torch_cpu builds with -Werror).
+target_include_directories(torch_cpu PRIVATE
+  ${TORCH_ROOT}/third_party/perfetto/sdk)
+target_sources(torch_cpu PRIVATE
+  ${TORCH_ROOT}/third_party/perfetto/sdk/perfetto.cc)
+set_source_files_properties(
+  ${TORCH_ROOT}/third_party/perfetto/sdk/perfetto.cc
+  PROPERTIES COMPILE_FLAGS "-w")
+
 install(DIRECTORY
   "${TORCH_SRC_DIR}/csrc"
   "${TORCH_SRC_DIR}/headeronly"

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -856,6 +856,74 @@ _cupti_monitor.enable_hes_early()
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     @_isolated
+    def test_cupti_monitor_pftrace_export(self):
+        # A .pftrace output path makes the cupti_monitor backend emit a Perfetto-native
+        # trace (protobuf) instead of chrome JSON: each event becomes a slice on its
+        # (pid, tid) track. Requires the optional perfetto package.
+        try:
+            from perfetto.protos.perfetto.trace.perfetto_trace_pb2 import (  # type: ignore[import]
+                Trace,
+                TrackEvent,
+            )
+        except ImportError:
+            self.skipTest("perfetto package not installed")
+        cfg = _ExperimentalConfig(custom_profiler_config='{"backend":"cupti_monitor"}')
+        with TemporaryFileName(mode="w+", suffix=".pftrace") as path:
+            with profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                experimental_config=cfg,
+            ) as prof:
+                a = torch.randn(128, 128, device="cuda")
+                with torch.autograd.profiler.record_function("region"):
+                    (a @ a).relu().sum().item()
+                torch.cuda.synchronize()
+            prof.export_chrome_trace(path)
+            out = path + ".gz"  # the monitor always gzips
+            self.assertTrue(os.path.exists(out))
+            trace = Trace()
+            with gzip.open(out, "rb") as fh:
+                trace.ParseFromString(fh.read())  # valid protobuf (gzip-wrapped)
+            slices = sum(
+                1
+                for p in trace.packet
+                if p.HasField("track_event")
+                and p.track_event.type == TrackEvent.TYPE_SLICE_BEGIN
+            )
+            tracks = sum(1 for p in trace.packet if p.HasField("track_descriptor"))
+            # names are interned: resolve each slice's name_iid via the InternedData table
+            iid_name = {
+                en.iid: en.name
+                for p in trace.packet
+                if p.HasField("interned_data")
+                for en in p.interned_data.event_names
+            }
+            names = {
+                iid_name.get(p.track_event.name_iid)
+                for p in trace.packet
+                if p.HasField("track_event") and p.track_event.name_iid
+            }
+            self.assertGreater(slices, 0)
+            self.assertGreater(tracks, 0)
+            # the record_function region shows up as a slice
+            self.assertIn("region", names)
+            # full parity: GPU ops carry their args as debug_annotations and an ac2g flow.
+            anno_keys = {
+                a.name
+                for p in trace.packet
+                if p.HasField("track_event")
+                for a in p.track_event.debug_annotations
+            }
+            self.assertIn("correlation", anno_keys)
+            self.assertIn("stream", anno_keys)
+            flows = sum(
+                len(p.track_event.flow_ids)
+                for p in trace.packet
+                if p.HasField("track_event")
+            )
+            self.assertGreater(flows, 0)
+
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    @_isolated
     def test_cupti_monitor_async_export_defers(self):
         # cupti_monitor_async_export=true hands the export off: a background poll thread
         # is spawned and the file is written off-thread, joined by wait_for_exports.

--- a/torch/_C/_profiler.pyi
+++ b/torch/_C/_profiler.pyi
@@ -314,6 +314,12 @@ class _CuptiMonitorModule:
     def current_external_id() -> int: ...
     @staticmethod
     def metadata_put_external(blob: str, external_id: int = 0) -> None: ...
+    @staticmethod
+    def encode_pftrace(
+        tracks: list[tuple[int, int, bool, int, int, str]],
+        name_table: list[str],
+        groups: list[tuple],
+    ) -> bytes: ...
 
 _cupti_monitor: _CuptiMonitorModule
 

--- a/torch/csrc/profiler/cupti/monitor_pftrace.cpp
+++ b/torch/csrc/profiler/cupti/monitor_pftrace.cpp
@@ -1,0 +1,163 @@
+#include <torch/csrc/profiler/cupti/monitor_pftrace.h>
+
+#include <perfetto.h>
+
+#include <nlohmann/json.hpp>
+
+namespace torch::profiler::impl {
+
+namespace {
+namespace pbz = perfetto::protos::pbzero;
+
+// Emit a parsed JSON value into a DebugAnnotation (recursing for object/array),
+// mirroring the chrome path's typed args.
+void emitJsonValue(pbz::DebugAnnotation* a, const nlohmann::json& v) {
+  if (v.is_object()) {
+    for (auto it = v.begin(); it != v.end(); ++it) {
+      auto* d = a->add_dict_entries();
+      d->set_name(it.key());
+      emitJsonValue(d, it.value());
+    }
+  } else if (v.is_array()) {
+    for (const auto& e : v) {
+      emitJsonValue(a->add_array_values(), e);
+    }
+  } else if (v.is_boolean()) {
+    a->set_bool_value(v.get<bool>());
+  } else if (v.is_number_float()) {
+    a->set_double_value(v.get<double>());
+  } else if (v.is_number()) {
+    a->set_int_value(v.get<int64_t>());
+  } else if (v.is_string()) {
+    a->set_string_value(v.get<std::string>());
+  } else { // null
+    a->set_string_value("null");
+  }
+}
+
+// Spread one JSON blob onto a TrackEvent like _annotation_to_args: object ->
+// top-level keys each an annotation; list -> a single "annotation" string
+// (json.dumps); scalar -> a single typed "annotation"; parse failure -> the raw
+// blob as "annotation".
+void emitJsonBlob(pbz::TrackEvent* te, const char* data, size_t len) {
+  auto parsed = nlohmann::json::parse(data, data + len, nullptr, false);
+  if (parsed.is_discarded()) {
+    auto* a = te->add_debug_annotations();
+    a->set_name("annotation");
+    a->set_string_value(data, len);
+  } else if (parsed.is_object()) {
+    for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+      auto* a = te->add_debug_annotations();
+      a->set_name(it.key());
+      emitJsonValue(a, it.value());
+    }
+  } else if (parsed.is_array()) {
+    auto* a = te->add_debug_annotations();
+    a->set_name("annotation");
+    a->set_string_value(parsed.dump());
+  } else {
+    auto* a = te->add_debug_annotations();
+    a->set_name("annotation");
+    emitJsonValue(a, parsed);
+  }
+}
+} // namespace
+
+std::string cuptiMonitorEncodePftrace(
+    const std::vector<PftraceTrack>& tracks,
+    const std::vector<std::string>& name_table,
+    const std::vector<PftraceGroup>& groups) {
+  protozero::HeapBuffered<pbz::Trace> trace;
+
+  for (const auto& tr : tracks) {
+    auto* td = trace->add_packet()->set_track_descriptor();
+    td->set_uuid(tr.uuid);
+    if (tr.parent) {
+      td->set_parent_uuid(tr.parent);
+    }
+    if (tr.is_process) {
+      auto* p = td->set_process();
+      p->set_pid(tr.pid);
+      p->set_process_name(tr.name);
+    } else {
+      auto* th = td->set_thread();
+      th->set_pid(tr.pid);
+      th->set_tid(tr.tid);
+      th->set_thread_name(tr.name);
+    }
+  }
+
+  if (!name_table.empty()) {
+    auto* pkt = trace->add_packet();
+    pkt->set_trusted_packet_sequence_id(1);
+    pkt->set_sequence_flags(pbz::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* interned = pkt->set_interned_data();
+    uint64_t iid = 1;
+    for (const auto& nm : name_table) {
+      auto* en = interned->add_event_names();
+      en->set_iid(iid++);
+      en->set_name(nm);
+    }
+  }
+
+  for (const auto& g : groups) {
+    for (size_t i = 0; i < g.n; ++i) {
+      auto* pkt = trace->add_packet();
+      pkt->set_timestamp(static_cast<uint64_t>(g.ts[i]));
+      pkt->set_trusted_packet_sequence_id(1);
+      pkt->set_sequence_flags(pbz::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+      auto* te = pkt->set_track_event();
+      te->set_type(pbz::TrackEvent::TYPE_SLICE_BEGIN);
+      te->set_track_uuid(g.track_uuid[i]);
+      te->set_name_iid(g.name_iid[i]);
+      if (g.flow && g.flow[i]) {
+        te->add_flow_ids(static_cast<uint64_t>(g.flow[i]));
+      }
+      for (const auto& a : g.int_annos) {
+        if (a.skip_zero && a.vals[i] == 0) {
+          continue;
+        }
+        if (a.present && !a.present[i]) {
+          continue;
+        }
+        auto* da = te->add_debug_annotations();
+        da->set_name(a.key);
+        da->set_int_value(a.vals[i]);
+      }
+      for (const auto& a : g.str_annos) {
+        if (a.idx[i] < 0) {
+          continue;
+        }
+        auto* da = te->add_debug_annotations();
+        da->set_name(a.key);
+        da->set_string_value(a.table[static_cast<size_t>(a.idx[i])]);
+      }
+      for (const auto& a : g.arr_annos) {
+        auto* da = te->add_debug_annotations();
+        da->set_name(a.key);
+        for (const auto* col : a.cols) {
+          da->add_array_values()->set_int_value(col[i]);
+        }
+      }
+      for (const auto& a : g.json_annos) {
+        const int32_t off = a.offsets[i];
+        const int32_t len = a.offsets[i + 1] - off;
+        if (len > 0) {
+          emitJsonBlob(te, a.buffer + off, static_cast<size_t>(len));
+        }
+      }
+    }
+    for (size_t i = 0; i < g.n; ++i) {
+      auto* pkt = trace->add_packet();
+      pkt->set_timestamp(static_cast<uint64_t>(g.end[i]));
+      pkt->set_trusted_packet_sequence_id(1);
+      auto* te = pkt->set_track_event();
+      te->set_type(pbz::TrackEvent::TYPE_SLICE_END);
+      te->set_track_uuid(g.track_uuid[i]);
+    }
+  }
+
+  return trace.SerializeAsString();
+}
+
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/cupti/monitor_pftrace.h
+++ b/torch/csrc/profiler/cupti/monitor_pftrace.h
@@ -1,0 +1,98 @@
+#pragma once
+
+// Perfetto-native (.pftrace) encoder for the CUPTI monitor. The Python side
+// (torch/profiler/_cupti/monitor_trace.py) shapes the columnar trace window
+// into a track list + per-kind groups of flat arrays + annotation specs; the
+// pybind glue in monitor_python.cpp turns those into the plain C++ inputs below
+// and calls cuptiMonitorEncodePftrace, which emits a concatenated stream of
+// perfetto TracePackets via protozero (the perfetto SDK amalgamation under
+// third_party/perfetto). Each slice becomes a SLICE_BEGIN (carrying its
+// debug_annotations + flow) and a SLICE_END. Returns the raw, uncompressed
+// trace bytes; the caller gzips. perfetto.h is pulled in only by the .cpp, and
+// this stays free of any Python/pybind dependency so it can live in torch_cpu.
+
+#include <c10/macros/Macros.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace torch::profiler::impl {
+
+// A trace track: a process track (is_process) carries pid + name; a thread
+// track carries pid + tid + name under parent (its process track's uuid, 0 if
+// none).
+struct PftraceTrack {
+  uint64_t uuid;
+  uint64_t parent;
+  bool is_process;
+  int32_t pid;
+  int32_t tid;
+  std::string name;
+};
+
+// One int debug-annotation column: int_value = vals[i]. Skipped for slice i
+// when skip_zero and vals[i]==0 (matches the chrome path patching ids on only
+// when nonzero), or when present is non-null and present[i]==0 (used for the
+// unmapped half of an enum -- see PftraceStrAnno).
+struct PftraceIntAnno {
+  std::string key;
+  const int64_t* vals;
+  bool skip_zero;
+  const uint8_t* present; // nullable: emit only where present[i] != 0
+};
+
+// One string debug-annotation column: string_value = table[idx[i]], skipped for
+// slice i when idx[i] < 0. Low-cardinality enum names (copy kind, sync kind,
+// ...) are passed as a small table + an index column rather than per-slice
+// strings; idx < 0 marks a value with no name (its raw int is emitted via a
+// paired PftraceIntAnno instead).
+struct PftraceStrAnno {
+  std::string key;
+  const int64_t* idx;
+  std::vector<std::string> table;
+};
+
+// One array debug-annotation column (e.g. grid / block): array_values is the
+// per-slice tuple [cols[0][i], cols[1][i], ...] of int values.
+struct PftraceArrAnno {
+  std::string key;
+  std::vector<const int64_t*> cols;
+};
+
+// One JSON debug-annotation column (annotation / collective-descriptor blob).
+// Slice i's blob is buffer[offsets[i], offsets[i + 1]); empty (offsets equal)
+// means none. Parsed natively and spread like _annotation_to_args: an object's
+// top-level keys each become an annotation, a list/scalar/parse-failure becomes
+// a single "annotation".
+struct PftraceJsonAnno {
+  const int32_t* offsets; // length n + 1
+  const char* buffer;
+};
+
+// One per-kind group of slices sharing an annotation schema. ts / end /
+// track_uuid / name_iid are length-n parallel columns; flow (nullable) is a
+// per- slice ac2g flow id (0 = no flow). name_iid indexes the global name
+// table.
+struct PftraceGroup {
+  const int64_t* ts;
+  const int64_t* end;
+  const uint64_t* track_uuid;
+  const uint64_t* name_iid;
+  size_t n;
+  std::vector<PftraceIntAnno> int_annos;
+  std::vector<PftraceStrAnno> str_annos;
+  std::vector<PftraceArrAnno> arr_annos;
+  std::vector<PftraceJsonAnno> json_annos;
+  const int64_t* flow; // nullable
+};
+
+// tracks -> TrackDescriptor packets; name_table -> one interned EventName table
+// (iid == index + 1). Emits each group's SLICE_BEGINs (with debug_annotations +
+// flow) then SLICE_ENDs. trace_processor reorders by timestamp.
+TORCH_API std::string cuptiMonitorEncodePftrace(
+    const std::vector<PftraceTrack>& tracks,
+    const std::vector<std::string>& name_table,
+    const std::vector<PftraceGroup>& groups);
+
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/cupti/monitor_python.cpp
+++ b/torch/csrc/profiler/cupti/monitor_python.cpp
@@ -1,7 +1,10 @@
 #include <torch/csrc/profiler/cupti/monitor_python.h>
 
 #include <torch/csrc/profiler/cupti/monitor_native.h>
+#include <torch/csrc/profiler/cupti/monitor_pftrace.h>
 #include <torch/csrc/utils/pybind.h>
+
+#include <pybind11/numpy.h>
 
 #include <c10/util/ApproximateClock.h>
 
@@ -266,6 +269,135 @@ void initCuptiMonitorBindings(py::module& m) {
     }
     return py::make_tuple(std::move(out), std::move(ext_meta));
   });
+
+  // Encode the prepared columnar window into a Perfetto-native trace (raw
+  // TracePacket stream, uncompressed) via protozero. See monitor_pftrace.h. The
+  // Python side (monitor_trace.py) shapes the window and gzips the result.
+  //  - tracks: list of (uuid, parent, is_process, pid, tid, name)
+  //  - name_table: list of distinct slice names (iid == index + 1)
+  //  - groups: list of per-kind groups, each a tuple
+  //      (ts, end, track_uuid, name_iid,
+  //       int_annos:  [(key, int64_col, skip_zero), ...],
+  //       str_annos:  [(key, idx_int64_col, [str, ...]), ...],
+  //       arr_annos:  [(key, [int64_col, ...]), ...],
+  //       json_annos: [(int32_offsets_col, blob_bytes), ...],
+  //       flow: int64_col | None)
+  // All columns are numpy arrays; they are kept alive for the encode.
+  cupti_monitor.def(
+      "encode_pftrace",
+      [](const py::list& tracks,
+         const py::list& name_table,
+         const py::list& groups) -> py::bytes {
+        using torch::profiler::impl::PftraceGroup;
+        using torch::profiler::impl::PftraceTrack;
+
+        constexpr auto kFlags = py::array::c_style | py::array::forcecast;
+        using A64 = py::array_t<int64_t, kFlags>;
+        using AU64 = py::array_t<uint64_t, kFlags>;
+        using A32 = py::array_t<int32_t, kFlags>;
+        std::vector<py::object> keepalive;
+        auto i64 = [&](const py::handle& h) -> const int64_t* {
+          A64 a = py::cast<A64>(h);
+          const int64_t* p = a.data();
+          keepalive.push_back(std::move(a));
+          return p;
+        };
+        auto u64 = [&](const py::handle& h) -> const uint64_t* {
+          AU64 a = py::cast<AU64>(h);
+          const uint64_t* p = a.data();
+          keepalive.push_back(std::move(a));
+          return p;
+        };
+        auto i32 = [&](const py::handle& h) -> const int32_t* {
+          A32 a = py::cast<A32>(h);
+          const int32_t* p = a.data();
+          keepalive.push_back(std::move(a));
+          return p;
+        };
+        using AU8 = py::array_t<uint8_t, kFlags>;
+        auto u8 = [&](const py::handle& h) -> const uint8_t* {
+          if (h.is_none()) {
+            return nullptr;
+          }
+          AU8 a = py::cast<AU8>(h);
+          const uint8_t* p = a.data();
+          keepalive.push_back(std::move(a));
+          return p;
+        };
+
+        std::vector<PftraceTrack> track_vec;
+        track_vec.reserve(tracks.size());
+        for (const auto& item : tracks) {
+          auto t = item.cast<py::tuple>();
+          track_vec.push_back(
+              {t[0].cast<uint64_t>(),
+               t[1].cast<uint64_t>(),
+               t[2].cast<bool>(),
+               t[3].cast<int32_t>(),
+               t[4].cast<int32_t>(),
+               t[5].cast<std::string>()});
+        }
+        std::vector<std::string> name_vec;
+        name_vec.reserve(name_table.size());
+        for (const auto& item : name_table) {
+          name_vec.push_back(item.cast<std::string>());
+        }
+
+        std::vector<PftraceGroup> group_vec;
+        group_vec.reserve(groups.size());
+        for (const auto& gobj : groups) {
+          auto g = gobj.cast<py::tuple>();
+          PftraceGroup pg{};
+          pg.ts = i64(g[0]);
+          pg.end = i64(g[1]);
+          pg.track_uuid = u64(g[2]);
+          pg.name_iid = u64(g[3]);
+          pg.n = static_cast<size_t>(py::len(g[0]));
+          for (const auto& s : g[4].cast<py::list>()) {
+            auto t = s.cast<py::tuple>();
+            pg.int_annos.push_back(
+                {t[0].cast<std::string>(),
+                 i64(t[1]),
+                 t[2].cast<bool>(),
+                 u8(t[3])});
+          }
+          for (const auto& s : g[5].cast<py::list>()) {
+            auto t = s.cast<py::tuple>();
+            pg.str_annos.push_back(
+                {t[0].cast<std::string>(),
+                 i64(t[1]),
+                 t[2].cast<std::vector<std::string>>()});
+          }
+          for (const auto& s : g[6].cast<py::list>()) {
+            auto t = s.cast<py::tuple>();
+            std::vector<const int64_t*> cols;
+            for (const auto& col : t[1].cast<py::list>()) {
+              cols.push_back(i64(col));
+            }
+            pg.arr_annos.push_back({t[0].cast<std::string>(), std::move(cols)});
+          }
+          for (const auto& s : g[7].cast<py::list>()) {
+            auto t = s.cast<py::tuple>();
+            const int32_t* offsets = i32(t[0]);
+            auto blob = t[1].cast<py::bytes>();
+            keepalive.push_back(blob);
+            pg.json_annos.push_back({offsets, PyBytes_AS_STRING(blob.ptr())});
+          }
+          pg.flow = g[8].is_none() ? nullptr : i64(g[8]);
+          group_vec.push_back(std::move(pg));
+        }
+
+        std::string out;
+        {
+          py::gil_scoped_release release;
+          out = torch::profiler::impl::cuptiMonitorEncodePftrace(
+              track_vec, name_vec, group_vec);
+        }
+        return py::bytes(out);
+      },
+      py::arg("tracks"),
+      py::arg("name_table"),
+      py::arg("groups"));
 }
 
 } // namespace torch::profiler::impl

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -9,6 +9,8 @@ from typing import Any, cast, TYPE_CHECKING
 
 import numpy as np
 
+import torch
+
 
 # orjson serializes ~3-8x faster than stdlib json on large traces and emits bytes; not a
 # torch dep (absent in CI), so use it when present and fall back to json.
@@ -300,7 +302,7 @@ def _trace_window_entries(
         if linked is not None and linked[0] == process_id:
             return linked[1]
         process_map = thread_resource_map.get(process_id, {})
-        return int(process_map.get(normalized_thread_id, normalized_thread_id))
+        return process_map.get(normalized_thread_id, normalized_thread_id)
 
     # Drop the trailing "Activity Buffer Request" overhead that lands after the last
     # real activity: the cutoff is the max non-overhead end (converted ns).
@@ -771,6 +773,497 @@ def _gpu_user_annotation_events(
     return gpu_user_events
 
 
+# --- Perfetto-native (.pftrace) encoding -------------------------------------
+# The wire encoding is done natively (protozero via the perfetto SDK) in
+# torch/csrc/profiler/cupti/monitor_pftrace.cpp; here we only shape the window into the
+# flat arrays + track list it consumes.
+
+
+def _window_to_pftrace(
+    cpu_data: dict, trace_window: dict, base_ns: int, output_path: str
+) -> None:
+    """Encode the monitor's columnar window straight to a Perfetto-native trace (.pftrace),
+    concatenated with the Kineto CPU events -- NO chrome-dict materialization. Full parity with
+    the chrome path's per-event args, ac2g flows, and collective metadata, emitted as
+    TrackEvent debug_annotations + flow_ids by the native encoder. The GPU kinds are assembled
+    vectorized from their numpy columns into per-kind groups; runtime/driver use a per-record
+    CPU-thread join (as the chrome path does)."""
+    columns = cast("dict[str, dict[str, Any]]", trace_window.get("columns", {}))
+    thread_resource_map = cast(
+        "dict[int, dict[int, int]]", trace_window.get("thread_resource_map", {})
+    )
+    uuids: dict = {}
+    pid_ints: dict = {}
+    proc_name: dict = {}
+    thr_name: dict = {}
+    tracks: list = []
+    groups: list = []  # raw group dicts; name_iid filled in after global name interning
+
+    def _col(ks):
+        c = columns.get(ks)
+        return c if c and len(next(iter(c.values()))) else None
+
+    def pid_int(pid):
+        # int32 descriptor id (cosmetic); map any id to a stable NON-negative value.
+        if isinstance(pid, int):
+            return pid & 0x7FFFFFFF
+        return pid_ints.setdefault(pid, len(pid_ints) + 1)
+
+    def add_track(uuid, parent, is_proc, pid, tid, name):
+        tracks.append((uuid, parent, is_proc, pid_int(pid), pid_int(tid), str(name)))
+
+    def track_for(pid, tid, proc_label="", thr_label=""):
+        if ("p", pid) not in uuids:
+            uuids[("p", pid)] = len(uuids) + 1
+            add_track(
+                uuids[("p", pid)],
+                0,
+                True,
+                pid,
+                0,
+                str(proc_name.get(pid) or proc_label or pid),
+            )
+        key = ("t", pid, tid)
+        if key not in uuids:
+            uuids[key] = len(uuids) + 1
+            add_track(
+                uuids[key],
+                uuids[("p", pid)],
+                False,
+                pid,
+                tid,
+                str(thr_name.get(key) or thr_label or tid),
+            )
+        return uuids[key]
+
+    def gpu_uuids(pid_arr, tid_arr, proc_fmt, thr_fmt):
+        # (pid, tid) -> uuid for whole columns: unique pairs (packed into one int64 key) each
+        # register a track; map back via the inverse index (no per-event Python).
+        key = (pid_arr.astype(np.int64) << np.int64(32)) | (
+            tid_arr.astype(np.int64) & 0xFFFFFFFF
+        )
+        uniq, inv = np.unique(key, return_inverse=True)
+        ids = np.empty(len(uniq), dtype=np.uint64)
+        for j, k in enumerate(uniq.tolist()):
+            pid = int(k >> 32)
+            tid = int(k & 0xFFFFFFFF)
+            if tid >= 0x80000000:  # sign-extend the packed int32 tid
+                tid -= 0x100000000
+            ids[j] = track_for(pid, tid, proc_fmt.format(pid), thr_fmt.format(tid))
+        return ids[inv]
+
+    def int_anno(key, col, skip_zero=False, present=None):
+        # present: optional per-slice uint8 mask (emit the int only where set).
+        return (
+            key,
+            np.ascontiguousarray(col, dtype=np.int64),
+            skip_zero,
+            None if present is None else np.ascontiguousarray(present, dtype=np.uint8),
+        )
+
+    def enum_anno(key, col, mapping):
+        # Match the chrome path's mapping.get(x, x): a name (string) where the value is in
+        # the map, the raw int otherwise. Returns (str_spec, int_spec|None): the string
+        # table covers the mapped values (idx -1 => slice skipped), and the int_spec (present
+        # only on the unmapped slices) carries the raw value, so a column with unmapped
+        # values stays a faithful mix of string + int annotations.
+        col = np.ascontiguousarray(col, dtype=np.int64)
+        uniq, inv = np.unique(col, return_inverse=True)
+        mapped_u = np.array([int(u) in mapping for u in uniq.tolist()], dtype=bool)
+        tab_pos = np.full(len(uniq), -1, dtype=np.int64)
+        table = []
+        for j, u in enumerate(uniq.tolist()):
+            if mapped_u[j]:
+                tab_pos[j] = len(table)
+                table.append(str(mapping[int(u)]))
+        str_spec = (key, tab_pos[inv], table)
+        if mapped_u.all():
+            return str_spec, None
+        return str_spec, int_anno(key, col, present=(~mapped_u)[inv])
+
+    def arr_anno(key, cols):
+        return (key, [np.ascontiguousarray(c, dtype=np.int64) for c in cols])
+
+    def collect_enums(pairs):
+        # (key, col, mapping) specs -> (str_specs, int_specs): each enum yields a string
+        # annotation plus, if any value is unmapped, an int annotation for those slices.
+        strs, ints = [], []
+        for k, col, m in pairs:
+            s, i = enum_anno(k, col, m)
+            strs.append(s)
+            if i is not None:
+                ints.append(i)
+        return strs, ints
+
+    def json_anno(blobs):
+        # blobs: per-slice str/None -> a CSR (offsets, buffer) varlen column; empty for None.
+        enc = [b"" if b is None else b.encode() for b in blobs]
+        lengths = np.fromiter((len(b) for b in enc), dtype=np.int32, count=len(enc))
+        offsets = np.zeros(len(enc) + 1, dtype=np.int32)
+        np.cumsum(lengths, out=offsets[1:])
+        return (offsets, b"".join(enc))
+
+    def graph_meta(c):
+        # graph ids + annotation + collective-metadata, patched onto every GPU op kind
+        # (kernel/memcpy/memset) exactly as the chrome path does -- sparse, present only
+        # where the column carries data.
+        extra, jsons = [], []
+        if c["graph_id"].any():
+            extra.append(int_anno("graph id", c["graph_id"], skip_zero=True))
+        if c["graph_node_id"].any():
+            extra.append(int_anno("graph node id", c["graph_node_id"], skip_zero=True))
+        ann = c.get("annotation")
+        if ann is not None and any(x is not None for x in ann.tolist()):
+            jsons.append(json_anno(ann.tolist()))
+        meta = c.get("metadata")
+        if meta is not None and any(x is not None for x in meta.tolist()):
+            jsons.append(json_anno(meta.tolist()))
+        return extra, jsons
+
+    def add_group(ts, end, uu, names, ints=(), strs=(), arrs=(), jsons=(), flow=None):
+        groups.append(
+            {
+                "ts": np.ascontiguousarray(ts, dtype=np.int64),
+                "end": np.ascontiguousarray(end, dtype=np.int64),
+                "uuid": np.ascontiguousarray(uu, dtype=np.uint64),
+                "names": names,
+                "ints": list(ints),
+                "strs": list(strs),
+                "arrs": list(arrs),
+                "jsons": list(jsons),
+                "flow": None
+                if flow is None
+                else np.ascontiguousarray(flow, dtype=np.int64),
+            }
+        )
+
+    # --- joins shared with the chrome path ---
+    context_to_device: dict = {}
+    for ks in ("kernel", "gpu_memcpy", "gpu_memset", "cuda_event"):
+        c = _col(ks)
+        if c is None or "context_id" not in c:
+            continue
+        for ctx, dev in zip(c["context_id"].tolist(), c["device_id"].tolist()):
+            context_to_device.setdefault(ctx, dev)
+    event_sync_to_corr: dict = {}
+    ce = _col("cuda_event")
+    if ce is not None:
+        event_sync_to_corr = {
+            sid: corr
+            for sid, corr in zip(
+                ce["cuda_event_sync_id"].tolist(), ce["correlation_id"].tolist()
+            )
+            if sid
+        }
+
+    # --- CPU side: Kineto chrome events (M names + X slices with their args) ---
+    for e in cpu_data.get("traceEvents", []):
+        if isinstance(e, dict) and e.get("ph") == "M":
+            a = e.get("args") or {}
+            if e.get("name") == "process_name":
+                proc_name[e.get("pid")] = a.get("name", "")
+            elif e.get("name") == "thread_name":
+                thr_name[("t", e.get("pid"), e.get("tid"))] = a.get("name", "")
+    cpu_thread_by_external_id: dict = {}
+    cpu_ts: list = []
+    cpu_end: list = []
+    cpu_uuid: list = []
+    cpu_names: list = []
+    cpu_args: list = []
+    for e in cpu_data.get("traceEvents", []):
+        if not isinstance(e, dict) or e.get("ph") != "X" or e.get("cat") == "Trace":
+            continue
+        a = e.get("args") if isinstance(e.get("args"), dict) else {}
+        if e.get("cat") in ("cpu_op", "user_annotation") and "External id" in a:
+            try:
+                cpu_thread_by_external_id[int(a["External id"])] = (
+                    e.get("pid"),
+                    e.get("tid"),
+                )
+            except (TypeError, ValueError):
+                pass
+        ts = base_ns + round(_as_float(e.get("ts")) * 1000.0)
+        cpu_ts.append(ts)
+        cpu_end.append(ts + round(_as_float(e.get("dur")) * 1000.0))
+        cpu_uuid.append(track_for(e.get("pid"), e.get("tid")))
+        cpu_names.append(str(e.get("name", "")))
+        cpu_args.append(json.dumps(a) if a else None)
+    if cpu_ts:
+        jsons = [json_anno(cpu_args)] if any(a is not None for a in cpu_args) else ()
+        add_group(cpu_ts, cpu_end, cpu_uuid, cpu_names, jsons=jsons)
+
+    # corr -> CPU thread, for the runtime/driver thread remap (via the external-corr column).
+    cpu_thread_by_correlation_id: dict = {}
+    ext = _col("external_correlation")
+    if ext is not None:
+        for corr, eid in zip(
+            ext["correlation_id"].tolist(), ext["external_id"].tolist()
+        ):
+            if corr and eid in cpu_thread_by_external_id:
+                cpu_thread_by_correlation_id[corr] = cpu_thread_by_external_id[eid]
+
+    # --- kernel: pid=device, tid=stream; full launch args + flow + collective metadata ---
+    c = _col("kernel")
+    if c is not None:
+        uu = gpu_uuids(c["device_id"], c["stream_id"], "GPU {}", "stream {}")
+        ints = [
+            int_anno("device", c["device_id"]),
+            int_anno("context", c["context_id"]),
+            int_anno("stream", c["stream_id"]),
+            int_anno("correlation", c["correlation_id"]),
+            int_anno("registers per thread", c["registers_per_thread"]),
+            int_anno(
+                "shared memory", c["static_shared_memory"] + c["dynamic_shared_memory"]
+            ),
+            int_anno("priority", c["priority"]),
+            int_anno("queued", c["queued"]),
+            int_anno("channel", c["channel"]),
+            int_anno("channel_type", c["channel_type"]),
+        ]
+        arrs = [
+            arr_anno("grid", [c["grid_x"], c["grid_y"], c["grid_z"]]),
+            arr_anno("block", [c["block_x"], c["block_y"], c["block_z"]]),
+        ]
+        extra, jsons = graph_meta(c)
+        add_group(
+            c["start_ns"],
+            c["end_ns"],
+            uu,
+            c["name"].tolist(),
+            ints + extra,
+            (),
+            arrs,
+            jsons,
+            c["correlation_id"],
+        )
+
+    # --- memcpy / memset: pid=device, tid=stream; transfer args + flow ---
+    c = _col("gpu_memcpy")
+    if c is not None:
+        uu = gpu_uuids(c["device_id"], c["stream_id"], "GPU {}", "stream {}")
+        ints = [
+            int_anno("device", c["device_id"]),
+            int_anno("context", c["context_id"]),
+            int_anno("stream", c["stream_id"]),
+            int_anno("correlation", c["correlation_id"]),
+            int_anno("bytes", c["bytes"]),
+            int_anno("flags", c["flags"]),
+        ]
+        strs, enum_ints = collect_enums(
+            [
+                ("copy kind", c["copy_kind"], _MEMCPY_KIND_NAMES),
+                ("src kind", c["src_kind"], _MEMORY_KIND_NAMES),
+                ("dst kind", c["dst_kind"], _MEMORY_KIND_NAMES),
+            ]
+        )
+        extra, jsons = graph_meta(c)
+        names = ["Memcpy"] * len(c["start_ns"])
+        add_group(
+            c["start_ns"],
+            c["end_ns"],
+            uu,
+            names,
+            ints + extra + enum_ints,
+            strs,
+            jsons=jsons,
+            flow=c["correlation_id"],
+        )
+    c = _col("gpu_memset")
+    if c is not None:
+        uu = gpu_uuids(c["device_id"], c["stream_id"], "GPU {}", "stream {}")
+        # "memory kind" is a raw int in the chrome path (it name-maps only memcpy's
+        # src/dst kind, not memset's memory kind), so it stays an int annotation.
+        ints = [
+            int_anno("device", c["device_id"]),
+            int_anno("context", c["context_id"]),
+            int_anno("stream", c["stream_id"]),
+            int_anno("correlation", c["correlation_id"]),
+            int_anno("bytes", c["bytes"]),
+            int_anno("value", c["value"]),
+            int_anno("memory kind", c["memory_kind"]),
+            int_anno("flags", c["flags"]),
+        ]
+        extra, jsons = graph_meta(c)
+        names = ["Memset"] * len(c["start_ns"])
+        add_group(
+            c["start_ns"],
+            c["end_ns"],
+            uu,
+            names,
+            ints + extra,
+            (),
+            jsons=jsons,
+            flow=c["correlation_id"],
+        )
+
+    # --- runtime / driver API: registered names only, remapped onto their CPU thread ---
+    for ks in ("cuda_runtime", "cuda_driver"):
+        c = _col(ks)
+        if c is None:
+            continue
+        is_rt = ks == "cuda_runtime"
+        namer = _runtime_cbid_name if is_rt else _driver_cbid_name
+        is_reg = _runtime_is_registered if is_rt else _driver_is_registered
+        req_flow = _runtime_requires_flow if is_rt else _driver_requires_flow
+        uniq_cb, inv = np.unique(c["cbid"], return_inverse=True)
+        names_u = [namer(int(x)) for x in uniq_cb.tolist()]
+        reg_u = np.array([is_reg(nm) for nm in names_u], dtype=bool)
+        flow_u = np.array([req_flow(nm) for nm in names_u], dtype=bool)
+        keep = np.nonzero(reg_u[inv])[0]
+        if not len(keep):
+            continue
+        pid = c["process_id"][keep].tolist()
+        corr = c["correlation_id"][keep]
+        normtid = (
+            c["thread_id"][keep].astype(np.uint32).astype(np.int32).astype(np.int64)
+        )
+        tid = np.fromiter(
+            (
+                cpu_thread_by_correlation_id[cc][1]
+                if cc in cpu_thread_by_correlation_id
+                and cpu_thread_by_correlation_id[cc][0] == p
+                else thread_resource_map.get(p, {}).get(nt, nt)
+                for p, cc, nt in zip(pid, corr.tolist(), normtid.tolist())
+            ),
+            dtype=np.int64,
+            count=len(keep),
+        )
+        uu = gpu_uuids(c["process_id"][keep], tid, "process {}", "thread {}")
+        names = [names_u[i] for i in inv[keep].tolist()]
+        flow = np.where(flow_u[inv[keep]], corr, 0)
+        ints = [int_anno("cbid", c["cbid"][keep]), int_anno("correlation", corr)]
+        add_group(c["start_ns"][keep], c["end_ns"][keep], uu, names, ints, flow=flow)
+
+    # --- overhead (own lane), dropping the trailing buffer-request artifact ---
+    c = _col("overhead")
+    if c is not None:
+        max_non_overhead_end = 0
+        for ks, col in columns.items():
+            if ks in ("overhead", "external_correlation", "cuda_event"):
+                continue
+            if col and "end_ns" in col and len(col["end_ns"]):
+                max_non_overhead_end = max(
+                    max_non_overhead_end, int(col["end_ns"].max())
+                )
+        name_l = c["name"].tolist()
+        starts = c["start_ns"]
+        keep = np.array(
+            [
+                not (
+                    nm == "Activity Buffer Request"
+                    and max_non_overhead_end > 0
+                    and int(starts[i]) > max_non_overhead_end
+                )
+                for i, nm in enumerate(name_l)
+            ],
+            dtype=bool,
+        )
+        idx = np.nonzero(keep)[0]
+        if len(idx):
+            u = track_for(_OVERHEAD_PID, 0, "Overhead", "Overhead")
+            uu = np.full(len(idx), u, dtype=np.uint64)
+            add_group(
+                starts[idx], c["end_ns"][idx], uu, [name_l[i] for i in idx.tolist()]
+            )
+
+    # --- cuda_sync: device via context, stream via the sync record, wait_on join ---
+    c = _col("cuda_sync")
+    if c is not None:
+        st = c["sync_type"]
+        ctx = c["context_id"]
+        device = np.fromiter(
+            (context_to_device.get(int(x), 0) for x in ctx.tolist()),
+            dtype=np.int64,
+            count=len(ctx),
+        )
+        stream = np.where(c["stream_id"] == _SYNC_INVALID, -1, c["stream_id"]).astype(
+            np.int64
+        )
+        corr = c["correlation_id"]
+        # Split on wait-bearing sync types (Event Sync / Stream Wait Event) so only those rows
+        # carry the wait_on_* annotations, matching the chrome path.
+        wait = np.isin(st, (1, 2))
+        for sub in (np.nonzero(~wait)[0], np.nonzero(wait)[0]):
+            if not len(sub):
+                continue
+            uu = gpu_uuids(device[sub], stream[sub], "GPU {}", "stream {}")
+            names = [
+                _SYNC_TYPE_NAMES.get(int(s), f"sync_{int(s)}") for s in st[sub].tolist()
+            ]
+            ints = [
+                int_anno("stream", stream[sub]),
+                int_anno("correlation", corr[sub]),
+                int_anno("device", device[sub]),
+                int_anno("context", ctx[sub]),
+            ]
+            # cuda_sync_kind is the slice name (string, with the sync_<n> fallback) -- not
+            # the raw-int fallback the copy/memory enums use.
+            uniqn, name_inv = np.unique(
+                np.asarray(names, dtype=object), return_inverse=True
+            )
+            strs = [
+                (
+                    "cuda_sync_kind",
+                    name_inv.astype(np.int64),
+                    [str(n) for n in uniqn.tolist()],
+                )
+            ]
+            if np.isin(st[sub], (1, 2)).all():
+                rec_corr = np.fromiter(
+                    (
+                        event_sync_to_corr.get(int(s), -1)
+                        for s in c["cuda_event_sync_id"][sub].tolist()
+                    ),
+                    dtype=np.int64,
+                    count=len(sub),
+                )
+                ints += [
+                    int_anno("wait_on_stream", np.full(len(sub), -1, dtype=np.int64)),
+                    int_anno("wait_on_cuda_event_id", c["cuda_event_id"][sub]),
+                    int_anno("wait_on_cuda_event_record_corr_id", rec_corr),
+                ]
+            add_group(c["start_ns"][sub], c["end_ns"][sub], uu, names, ints, strs)
+
+    # Global name interning: one EventName table across all groups; each slice carries a
+    # name_iid into it (vectorized via np.unique, no per-event Python).
+    name_cols = [
+        np.asarray(g["names"], dtype=object)
+        if not isinstance(g["names"], np.ndarray)
+        else g["names"].astype(object)
+        for g in groups
+    ]
+    if name_cols:
+        all_names = np.concatenate(name_cols)
+        uniq, inv = np.unique(all_names, return_inverse=True)
+        name_table = [str(x) for x in uniq.tolist()]
+        iid = (inv + 1).astype(np.uint64)
+    else:
+        name_table, iid = [], np.empty(0, dtype=np.uint64)
+    group_tuples = []
+    off = 0
+    for g in groups:
+        n = len(g["ts"])
+        group_tuples.append(
+            (
+                g["ts"],
+                g["end"],
+                g["uuid"],
+                iid[off : off + n],
+                g["ints"],
+                g["strs"],
+                g["arrs"],
+                g["jsons"],
+                g["flow"],
+            )
+        )
+        off += n
+    out = torch._C._profiler._cupti_monitor.encode_pftrace(
+        tracks, name_table, group_tuples
+    )
+    with gzip.open(output_path, "wb", compresslevel=1) as f:
+        f.write(out)
+
+
 def merge_trace_window_into_chrome_trace(
     cpu_trace_path: str | os.PathLike[str],
     output_path: str | os.PathLike[str],
@@ -786,6 +1279,11 @@ def merge_trace_window_into_chrome_trace(
     data = _orjson.loads(raw) if _orjson is not None else json.loads(raw)
 
     base_ns = int(data.get("baseTimeNanoseconds", _default_base_ns()))
+    # Perfetto-native output: encode straight from the columnar window (skip building the
+    # chrome event dicts entirely -- that build dominates the JSON path).
+    if ".pftrace" in output_path:
+        _window_to_pftrace(data, trace_window, base_ns, output_path)
+        return
     original_events = list(data.get("traceEvents", []))
     cpu_thread_by_external_id: dict[int, tuple[int, int]] = {}
     for event in original_events:
@@ -885,12 +1383,13 @@ def merge_trace_window_into_chrome_trace(
     data["traceEvents"] = events
     data["traceName"] = trace_name or output_path
 
-    # Encode once and write the whole buffer (json.dump streaming through gzip's text wrapper
-    # is ~3-5x slower on large traces). compresslevel=1 favors throughput over file size.
+    # (.pftrace is handled earlier, straight from the columnar window.)
     if _orjson is not None:
         payload = _orjson.dumps(data)
     else:
         payload = json.dumps(data, separators=(",", ":")).encode()
+    # Encode once and write the whole buffer, gzipped when the path ends .gz (compresslevel=1
+    # favors throughput over size).
     if output_path.endswith(".gz"):
         with gzip.open(output_path, "wb", compresslevel=1) as f:
             f.write(payload)

--- a/torch/profiler/_cupti/observers/profiler.py
+++ b/torch/profiler/_cupti/observers/profiler.py
@@ -341,7 +341,8 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
             if w is None:
                 return
             w["cpu"] = os.fspath(cpu_trace_path)
-            # Monitor traces are always gzipped; the writer keys gzip off the .gz suffix.
+            # Monitor traces are always gzipped (chrome JSON or .pftrace alike); the writer
+            # keys gzip + format off the suffix.
             out = os.fspath(output_path)
             w["out"] = out if out.endswith(".gz") else out + ".gz"
         self._maybe_write(window_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187892
* #187520
* #187519
* #187517
* #187518
* #186655
* #186802
* #186812
* #187874
* #186855
* #186439
* #187515
* #186811

export_chrome_trace(path) with a .pftrace path makes the cupti_monitor backend emit a
Perfetto-native trace instead of chrome JSON, encoded straight from the observer's columnar
window (no chrome-dict materialization). The .pftrace output is a drop-in replacement for the
chrome-JSON output: every per-event arg (as TrackEvent debug_annotations), the ac2g flows, and
the collective-descriptor metadata are emitted, not just timing slices.

Encoding is native via protozero (the Perfetto SDK), vendored as a submodule at
third_party/perfetto. Only the checked-in SDK amalgamation (sdk/perfetto.{h,cc}) is compiled,
as one isolated TU; with --gc-sections the unused tracing SDK is dropped, leaving ~15KB of
protozero in the final binary and no static initializers. There is no protobuf-runtime or
codegen dependency -- the amalgamation header inlines the pbzero builders.

Review in this order:
- third_party/perfetto submodule + the build wiring (build_variables.bzl,
  caffe2/CMakeLists.txt): perfetto.cc is compiled into torch_cpu with its include dir.
- torch/csrc/profiler/cupti/monitor_pftrace.{h,cpp}: the native encoder (torch_cpu, no
  pybind). It is kind-agnostic -- the Python side passes per-kind groups of numpy columns +
  typed annotation specs (int / interned-string / int-array / sparse-JSON) + a flow column,
  and the encoder emits the TracePackets. JSON blobs (collective metadata + record_function
  annotation) are parsed natively (nlohmann) and spread exactly like _annotation_to_args; an
  enum value with no name is emitted as its raw int, matching the chrome path's get(x, x).
- monitor_python.cpp: the encode_pftrace binding -- extracts the groups, keeps the numpy
  arrays alive, releases the GIL for the encode.
- monitor_trace.py: _window_to_pftrace assembles the groups columnar with full chrome parity
  (per-kind args, grid/block, graph ids, memcpy/memset enum names, runtime/driver registered-
  name filter + correlation->cpu-thread join, cuda_sync wait_on, overhead trailing-drop, CPU
  events with args, flows). Names are interned with np.unique into a name_iid column + a table,
  so nothing that scales with slice count crosses as a Python object.
- the benchmark gains --pftrace to compare the two export paths.

The boundary keeps the per-slice work where it is cheap: Python stays columnar (no per-event
objects -- the cost that dominates the chrome path), and C++ owns the per-slice protobuf
encoding with the GIL released. The previous revision hand-wrote the protobuf wire bytes in
Python (a fixed-varint np.tile template); it was fast but could not grow to debug_annotations
or nested metadata without re-implementing a protobuf encoder, hence vendoring protozero.

Test plan:
```
# unit test: parses the emitted trace under the official perfetto decoder, asserting slices,
# named tracks, interned names, correlation/stream debug_annotations, and ac2g flow_ids
python test/profiler/test_profiler.py -k cupti_monitor_pftrace_export
# no regressions across the monitor suite
python test/profiler/test_profiler.py -k cupti_monitor
```
Both green. Exact parity was verified by exporting the SAME columnar window to both formats and
diffing the decoded (name, ts, dur, args) of every slice as multisets over a real ~220k-event
trace: 121851 / 121851 slices identical, 0 differences. Export latency on that trace (sync):
~530 ms / 2.3 MB for .pftrace vs ~1020 ms / 4.6 MB for chrome JSON.

Run recipe for the monitor: LD_PRELOAD libcupti >= 13.3 so torch and the monitor share one
CUPTI. trace_processor cannot run in CI (it fetches a shell binary), so the parity diff above
uses the perfetto pb2 decoder.

This PR was authored with the assistance of an AI coding assistant.