### PR TITLE
[MPS] Fix duplicate kernel names across MetalScheduling instances

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -222,6 +222,28 @@ class MPSBasicTests(TestCase):
         torch._dynamo.mark_dynamic(x, 1)
         self.assertEqual(fn(x), x.var(dim=-1))
 
+    def test_while_loop_kernel_naming(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/187852
+        # while_loop compiles cond and body as separate MetalScheduling instances,
+        # each of which used to reset _kernel_fn_counter to 0, producing duplicate
+        # "generated_kernel_0" names that caused a Metal mangled-name collision.
+        def fn(iterations):
+            def cond(i):
+                return i < iterations
+
+            def body(i):
+                return (i + 2,)
+
+            (out_i,) = torch._higher_order_ops.while_loop(
+                cond, body, (torch.tensor(0, dtype=torch.int32, device=self.device),)
+            )
+            return out_i
+
+        iters = torch.tensor(4, dtype=torch.int32, device=self.device)
+        compiled_fn = torch.compile(fn, backend="inductor")
+        result = compiled_fn(iters)
+        self.assertEqual(result, torch.tensor(4, dtype=torch.int32, device=self.device))
+
     def test_welford_multistage_sibling_redeclare(self):
         # Regression test: BatchNorm2d-train emits two codegen passes on
         # the same multistage reduction root (welford + running-stats

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -1209,7 +1209,6 @@ class MetalKernel(SIMDKernel):
 
 class MetalScheduling(SIMDScheduling):
     kernel_type = MetalKernel  # type: ignore[assignment]
-    _kernel_fn_counter: int = 0
 
     def __init__(self, scheduler: Scheduler | None) -> None:
         super().__init__(scheduler)
@@ -1235,8 +1234,7 @@ class MetalScheduling(SIMDScheduling):
 
         # Python path: register kernel with async_compile; wait() will compile all
         # accumulated Metal kernels into a single library and replace each placeholder.
-        fn_name = f"generated_kernel_{self._kernel_fn_counter}"
-        self._kernel_fn_counter += 1
+        fn_name = f"generated_kernel_{wrapper.next_kernel_suffix()}"
         wrapper.src_to_kernel[src_code] = fn_name
 
         # Extract Metal source from compile_mps_shader('''...''') call


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/187852.

Use the wrapper's existing global `next_kernel_suffix()` counter  (backed by itertools.count() on the wrapper) instead of a per-scheduler field. 

Fixes https://github.com/pytorch/pytorch/issues/187852

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo