### PR TITLE
[ROCm] Return packed varlen flash-attention LSE to match the CUDA contract

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -307,6 +307,72 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
           softmax_fa_t};// debug_attn_mask
 }
 
+#if !AOTRITON_COMPACT_VARLEN_LSE
+namespace {
+
+// pytorch/pytorch#187872: AOTriton builds without compact-varlen-LSE support
+// make the varlen attention kernel write the log-sum-exp in a per-sequence
+// padded layout (batch_size, num_heads, max_seqlen_q). The CUDA backend and the
+// ROCm CK backend instead return the packed (num_heads, total_q) layout aligned
+// with the packed out (total_q, num_heads, head_size). These helpers convert
+// between the two with a vectorized on-device gather/scatter (no host
+// synchronization), so the ROCm varlen path exposes the same packed contract on
+// every AOTriton version.
+at::Tensor compact_varlen_lse(
+    const at::Tensor& lse_padded, // (batch_size, num_heads, max_seqlen_q)
+    const at::Tensor& cu_seqlens_q, // (batch_size + 1)
+    int64_t total_q) {
+  const int64_t batch_size = lse_padded.size(0);
+  const int64_t num_heads = lse_padded.size(1);
+  const int64_t max_seqlen_q = lse_padded.size(2);
+  // Dtype-cast only; stays on device and avoids the host sync of a .to(kCPU).
+  auto cu = cu_seqlens_q.to(at::kLong);
+  auto opts_idx =
+      at::TensorOptions().dtype(at::kLong).device(lse_padded.device());
+  auto seqlens = cu.slice(0, 1, batch_size + 1) - cu.slice(0, 0, batch_size);
+  // Passing output_size = total_q lets repeat_interleave skip the
+  // data-dependent sum (.item()) that would otherwise force a device-to-host
+  // synchronization.
+  auto batch_id = at::repeat_interleave(
+      at::arange(batch_size, opts_idx), seqlens, 0, total_q);
+  auto pos = at::arange(total_q, opts_idx) - cu.index_select(0, batch_id);
+  auto idx = batch_id * max_seqlen_q + pos;
+  auto src = lse_padded.permute({1, 0, 2}).reshape(
+      {num_heads, batch_size * max_seqlen_q});
+  return src.index_select(1, idx).contiguous(); // (num_heads, total_q)
+}
+
+// Inverse of compact_varlen_lse: re-pad a packed (num_heads, total_q) LSE back
+// to (batch_size, num_heads, max_seqlen_q) for the AOTriton varlen backward
+// kernel, using the same vectorized on-device scatter (no host
+// synchronization). The pad region is zero-initialized so the unused tail is
+// deterministic.
+at::Tensor uncompact_varlen_lse(
+    const at::Tensor& lse_packed, // (num_heads, total_q)
+    const at::Tensor& cu_seqlens_q, // (batch_size + 1)
+    int64_t batch_size,
+    int64_t num_heads,
+    int64_t max_seqlen_q) {
+  const int64_t total_q = lse_packed.size(1);
+  auto cu = cu_seqlens_q.to(at::kLong);
+  auto opts_idx =
+      at::TensorOptions().dtype(at::kLong).device(lse_packed.device());
+  auto seqlens = cu.slice(0, 1, batch_size + 1) - cu.slice(0, 0, batch_size);
+  auto batch_id = at::repeat_interleave(
+      at::arange(batch_size, opts_idx), seqlens, 0, total_q);
+  auto pos = at::arange(total_q, opts_idx) - cu.index_select(0, batch_id);
+  auto idx = batch_id * max_seqlen_q + pos;
+  auto flat =
+      at::zeros({num_heads, batch_size * max_seqlen_q}, lse_packed.options());
+  flat.index_copy_(1, idx, lse_packed);
+  return flat.view({num_heads, batch_size, max_seqlen_q})
+      .permute({1, 0, 2})
+      .contiguous(); // (batch_size, num_heads, max_seqlen_q)
+}
+
+} // namespace
+#endif // !AOTRITON_COMPACT_VARLEN_LSE
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                const at::Tensor &k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
@@ -511,6 +577,14 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
     out.zero_();
     softmax_lse.fill_(std::numeric_limits<float>::infinity());
   }
+
+#if !AOTRITON_COMPACT_VARLEN_LSE
+  // Normalize the per-sequence padded LSE to the packed (num_heads, total_q)
+  // layout that the CUDA and CK backends return, aligned with out
+  // (total_q, num_heads, head_size). The repack is a vectorized on-device
+  // gather with no host synchronization. See pytorch/pytorch#187872.
+  softmax_lse = compact_varlen_lse(softmax_lse, cu_seqlens_q, total_q);
+#endif
 
   return {out, q, k, v, softmax_lse, seed_t, offset_t, softmax_fa_t};
 }
@@ -770,7 +844,14 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
 #if AOTRITON_COMPACT_VARLEN_LSE
   at::Tensor softmax_lse_cont = softmax_lse.view({num_heads, total_q}).contiguous();
 #else
-  at::Tensor softmax_lse_cont = softmax_lse.view({batch_size * num_heads, max_seqlen_q}).contiguous();
+  // pytorch/pytorch#187872: the forward returns the packed (num_heads, total_q)
+  // LSE; re-pad it to (batch_size, num_heads, max_seqlen_q) for the AOTriton
+  // varlen backward kernel with a vectorized on-device scatter (no host sync).
+  at::Tensor softmax_lse_cont =
+      uncompact_varlen_lse(
+          softmax_lse, cu_seqlens_q, batch_size, num_heads, max_seqlen_q)
+          .view({batch_size * num_heads, max_seqlen_q})
+          .contiguous();
 #endif
 
   at::Tensor q_padded, k_padded, v_padded;

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -4879,6 +4879,44 @@ class TestSDPACudaOnly(NNTestCase):
             }
         )
 
+    @unittest.skipIf(not TEST_WITH_ROCM, "ROCm-only: AOTriton varlen flash-attention LSE layout (issue #187872)")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention was not built for this system")
+    def test_flash_attention_varlen_lse_packed_layout(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/187872.
+        # On ROCm the varlen flash-attention path (AOTriton) must return the
+        # packed (num_heads, total_q) log-sum-exp that the CUDA and CK backends
+        # return, aligned with the packed (total_q, num_heads, head_dim) output --
+        # not the per-sequence padded (batch, num_heads, max_seqlen) layout. A 3-D
+        # LSE breaks callers that combine the output with the LSE (e.g.
+        # attention-sink rescaling) on ROCm.
+        dtype = torch.float16
+        num_heads, head_dim = 4, 64
+        seqlens = [128, 64, 192]
+        total_q = sum(seqlens)
+        max_seqlen = max(seqlens)
+        cu_seqlens = torch.tensor(
+            [0, *itertools.accumulate(seqlens)], device=device, dtype=torch.int32
+        )
+        q = torch.randn(total_q, num_heads, head_dim, device=device, dtype=dtype)
+        k = torch.randn(total_q, num_heads, head_dim, device=device, dtype=dtype)
+        v = torch.randn(total_q, num_heads, head_dim, device=device, dtype=dtype)
+        # Pass only the required positional arguments so the call stays portable
+        # across releases (optional kwargs such as scale/window_size/seqused_k
+        # default to None).
+        output, softmax_lse = torch.ops.aten._flash_attention_forward(
+            q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, 0.0, False, False
+        )[:2]
+        self.assertEqual(output.shape, (total_q, num_heads, head_dim))
+        # The packed contract: 2-D (num_heads, total_q), not 3-D per-seq padded.
+        self.assertEqual(
+            softmax_lse.dim(),
+            2,
+            f"varlen flash-attention LSE must be packed 2-D (num_heads, total_q); "
+            f"got {softmax_lse.dim()}-D {tuple(softmax_lse.shape)} "
+            f"(per-sequence padded layout, issue #187872)",
+        )
+        self.assertEqual(softmax_lse.shape, (num_heads, total_q))
+
 class TestSDPAXpuOnly(NNTestCase):
     """ Used to test XPU only functionality of scaled_dot_product_attention
     Mostly migrate from TestSDPACudaOnly in test/test_transformers.py


### PR DESCRIPTION
## Summary

On ROCm, `torch.ops.aten._flash_attention_forward` (the varlen path) returns the
log-sum-exp (LSE) in a **per-sequence padded** layout
`(num_sequences, num_heads, max_seqlen)`, while CUDA returns the **packed**
layout `(num_heads, total_q)`. The attention output `out` is packed
`(total_q, num_heads, head_size)` on *both* backends. The asymmetry breaks any
caller that combines `out` with the LSE (attention sinks, or any softmax-aux
epilogue), because the LSE no longer aligns with the packed token order of `out`.

Fixes #187872.

## Root cause

The varlen LSE shape is backend-dependent:

- CUDA `mha_varlen_fwd` allocates `softmax_lse = empty({num_heads, total_q})` (packed).
- ROCm **CK** `mha_varlen_fwd_ck` also allocates `empty({num_heads, total_q})` (packed).
- ROCm **AOTriton** `mha_varlen_fwd_aot` (the default ROCm FA backend) is gated on
  `AOTRITON_COMPACT_VARLEN_LSE`:
  ```cpp
  #if AOTRITON_COMPACT_VARLEN_LSE
    auto softmax_lse = at::empty({num_heads, total_q}, ...);                 // packed
  #else
    auto softmax_lse = at::empty({batch_size, num_heads, max_seqlen_q}, ...); // padded
  #endif
  ```
  For AOTriton versions without compact-varlen-LSE support, the `#else` padded
  layout is returned — this is what ships in current ROCm wheels, so the default
  ROCm varlen path diverges from CUDA.

`_flash_attention_forward` passes this LSE straight through to callers and to the
backward, so the padded shape is what users observe.

## Fix

Normalize the AOTriton varlen LSE to the packed `(num_heads, total_q)` contract in
the HIP backend glue, only on the non-compact path:

- **Forward** (`mha_varlen_fwd_aot`): repack the padded
  `(batch_size, num_heads, max_seqlen_q)` LSE into `(num_heads, total_q)` using
  `cu_seqlens_q`, before returning.
- **Backward** (`mha_varlen_bwd_aot`): re-pad the now-packed saved LSE back to
  `(batch_size, num_heads, max_seqlen_q)` for the AOTriton backward kernel. The
  repack and re-pad are exact inverses, so gradients are unchanged.

CUDA, the ROCm CK backend, and the compact AOTriton path
(`AOTRITON_COMPACT_VARLEN_LSE == 1`) are untouched — the helpers and the
conversions are compiled only under `#if !AOTRITON_COMPACT_VARLEN_LSE`.

## Validation

On an RDNA4 GPU (gfx1201, RX 9070), torch `2.9.1+rocm7.2`:

- **Repro**: a 3-segment varlen call (`cu_seqlens_q=[0,472,1223,2048]`, 8 heads,
  head_dim 64) returns `out (2048, 8, 64)` (packed) but `lse (3, 8, 825)` =
  `(num_seqs, num_heads, max_seqlen)`.
- **Values are correct, only the layout differs**: the valid per-segment region
  of the padded LSE matches an fp32 per-segment reference exactly
  (max abs diff `0.0`), and the repack to `(8, 2048)` matches the reference
  packed LSE (max abs diff `~1e-6`).
- **Contract fix**: the documented attention-sink reshape
  `lse.transpose(0, 1).reshape(B, L, -1)` succeeds on the packed LSE and fails on
  the 3D LSE with the exact error from the report
  (`shape '[1, 2048, -1]' is invalid for input of size 19800`, where
  `19800 = 3 segments × 8 heads × 825`).
- **Backward round-trip**: re-padding the packed LSE reproduces the original
  padded valid region exactly (max abs diff `0.0`).
- **ATen helpers compile-checked**: the exact `compact_varlen_lse` /
  `uncompact_varlen_lse` bodies were JIT-compiled via
  `torch.utils.cpp_extension.load_inline` against the installed ROCm torch and
  pass the numerical checks above.

A full from-source ROCm rebuild was not run for the in-tree integration (the
integration is a guarded reassignment of the already-validated helpers); the
varlen flash-attention forward/backward tests in `test/test_transformers.py`
should exercise it in CI.

## BC / risk

No behavior change on CUDA or on the compact AOTriton path. On the affected ROCm
AOTriton path the returned LSE shape changes from the (undocumented) padded
`(num_seqs, num_heads, max_seqlen)` to the documented packed `(num_heads, total_q)`
— i.e. it now matches CUDA, which is the intended contract.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang