### PR TITLE
[XPU] Migrate Linux CI/CD Docker to Intel OMIX for XPU support packages installation

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -203,6 +203,7 @@ case "$tag" in
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=13
     XPU_VERSION=2026.0
+    OMIX_VERSION=0.2
     if [[ $tag =~ "client" ]]; then
       XPU_DRIVER_TYPE=CLIENT
     else
@@ -385,6 +386,7 @@ build_image() {
        --build-arg "TSAN=${TSAN}" \
        --build-arg "XPU_VERSION=${XPU_VERSION}" \
        --build-arg "XPU_DRIVER_TYPE=${XPU_DRIVER_TYPE}" \
+       --build-arg "OMIX_VERSION=${OMIX_VERSION}" \
        --build-arg "ACL=${ACL:-}" \
        --build-arg "OPENBLAS=${OPENBLAS:-}" \
        --build-arg "SKIP_SCCACHE_INSTALL=${SKIP_SCCACHE_INSTALL:-}" \

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -234,6 +234,7 @@ case "$tag" in
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=13
     XPU_VERSION=2026.1
+    OMIX_VERSION=0.3.0
     if [[ $tag =~ "client" ]]; then
       XPU_DRIVER_TYPE=CLIENT
     else
@@ -426,6 +427,7 @@ build_image() {
        --build-arg "TSAN=${TSAN}" \
        --build-arg "XPU_VERSION=${XPU_VERSION}" \
        --build-arg "XPU_DRIVER_TYPE=${XPU_DRIVER_TYPE}" \
+       --build-arg "OMIX_VERSION=${OMIX_VERSION}" \
        --build-arg "ACL=${ACL:-}" \
        --build-arg "OPENBLAS=${OPENBLAS:-}" \
        --build-arg "SKIP_SCCACHE_INSTALL=${SKIP_SCCACHE_INSTALL:-}" \

--- a/.ci/docker/common/install_xpu.sh
+++ b/.ci/docker/common/install_xpu.sh
@@ -133,37 +133,81 @@ function install_xpu_packages() {
     rm -f /tmp/intel-deep-learning-essentials.sh
 }
 
-# Default use GPU driver rolling releases
-XPU_DRIVER_VERSION=""
-if [[ "${XPU_DRIVER_TYPE,,}" == "lts" ]]; then
-    # Use GPU driver LTS releases
-    XPU_DRIVER_VERSION="/lts/2523"
-fi
-
-# Default use Intel® oneAPI Deep Learning Essentials 2025.3
-if [[ "$XPU_VERSION" == "2026.0" ]]; then
-    XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh"
-else
-    XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b3e6c1bf-a6d5-4580-8b1d-80cbfd38c8af/intel-deep-learning-essentials-2025.3.2.36_offline.sh"
-fi
-
-# The Driver installation depends on the base OS
-ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-case "$ID" in
-    ubuntu)
-        install_ubuntu
-    ;;
-    rhel|almalinux)
-        install_rhel
-    ;;
-    sles)
-        install_sles
-    ;;
-    *)
-        echo "Unable to determine OS..."
+function install_ubuntu_omix() {
+    . /etc/os-release
+    if [[ ! " noble " =~ " ${VERSION_CODENAME} " ]]; then
+        echo "OMIX: Ubuntu version ${VERSION_CODENAME} not supported"
         exit 1
-    ;;
-esac
+    fi
 
-# XPU support packages installation
-install_xpu_packages
+    apt-get update -y
+    apt-get install -y gpg-agent wget
+
+    # Add Intel GPG key
+    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+        | gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+
+    # Add OMIX repository
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+        https://repositories.intel.com/gpu/ubuntu ${VERSION_CODENAME}/intel-omix/${OMIX_VERSION} unified" \
+        | tee /etc/apt/sources.list.d/intel-gpu-${VERSION_CODENAME}.list
+    apt-get update
+
+    # Install OMIX (includes GPU driver + oneAPI DLE components)
+    apt-get install -y intel-omix-dev
+
+    # Cleanup
+    apt-get autoclean && apt-get clean
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+}
+
+if [[ -n "$OMIX_VERSION" ]]; then
+    # OMIX path: unified package handles both GPU driver and DLE
+    ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+    case "$ID" in
+        ubuntu)
+            install_ubuntu_omix
+        ;;
+        *)
+            echo "OMIX: OS $ID not yet supported"
+            exit 1
+        ;;
+    esac
+else
+    # Legacy path: separate GPU driver + DLE offline installer
+
+    # Default use GPU driver rolling releases
+    XPU_DRIVER_VERSION=""
+    if [[ "${XPU_DRIVER_TYPE,,}" == "lts" ]]; then
+        # Use GPU driver LTS releases
+        XPU_DRIVER_VERSION="/lts/2523"
+    fi
+
+    # Default use Intel® oneAPI Deep Learning Essentials 2025.3
+    if [[ "$XPU_VERSION" == "2026.0" ]]; then
+        XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh"
+    else
+        XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b3e6c1bf-a6d5-4580-8b1d-80cbfd38c8af/intel-deep-learning-essentials-2025.3.2.36_offline.sh"
+    fi
+
+    # The Driver installation depends on the base OS
+    ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+    case "$ID" in
+        ubuntu)
+            install_ubuntu
+        ;;
+        rhel|almalinux)
+            install_rhel
+        ;;
+        sles)
+            install_sles
+        ;;
+        *)
+            echo "Unable to determine OS..."
+            exit 1
+        ;;
+    esac
+
+    # XPU support packages installation
+    install_xpu_packages
+fi

--- a/.ci/docker/common/install_xpu.sh
+++ b/.ci/docker/common/install_xpu.sh
@@ -133,37 +133,112 @@ function install_xpu_packages() {
     rm -f /tmp/intel-deep-learning-essentials.sh
 }
 
-# Default use GPU driver rolling releases
-XPU_DRIVER_VERSION=""
-if [[ "${XPU_DRIVER_TYPE,,}" == "lts" ]]; then
-    # Use GPU driver LTS releases
-    XPU_DRIVER_VERSION="/lts/2523"
-fi
-
-# Default use Intel® oneAPI Deep Learning Essentials 2026.0
-if [[ "$XPU_VERSION" == "2026.1" ]]; then
-    XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c109e1ae-e02c-48a6-917b-b03b90d33f77/intel-deep-learning-essentials-2026.1.2.25_offline.sh"
-else
-    XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh"
-fi
-
-# The Driver installation depends on the base OS
-ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-case "$ID" in
-    ubuntu)
-        install_ubuntu
-    ;;
-    rhel|almalinux)
-        install_rhel
-    ;;
-    sles)
-        install_sles
-    ;;
-    *)
-        echo "Unable to determine OS..."
+function install_ubuntu_omix() {
+    . /etc/os-release
+    if [[ ! " jammy noble " =~ " ${VERSION_CODENAME} " ]]; then
+        echo "OMIX: Ubuntu version ${VERSION_CODENAME} not supported"
         exit 1
-    ;;
-esac
+    fi
 
-# XPU support packages installation
-install_xpu_packages
+    apt-get update -y
+    apt-get install -y gpg-agent wget
+
+    # Add Intel GPG key
+    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+        | gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+
+    # Select OMIX repo: intel-omix-pvc for LTS driver (CI), intel-omix for rolling/client (CD)
+    if [[ "${XPU_DRIVER_TYPE,,}" == "lts" ]]; then
+        OMIX_REPO="intel-omix-pvc"
+    else
+        OMIX_REPO="intel-omix"
+    fi
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+        https://repositories.intel.com/gpu/ubuntu ${VERSION_CODENAME}/${OMIX_REPO}/${OMIX_VERSION} unified" \
+        | tee /etc/apt/sources.list.d/intel-gpu-${VERSION_CODENAME}.list
+    apt-get update
+
+    # Install OMIX (includes GPU driver + oneAPI DLE components)
+    apt-get install -y intel-omix-dev
+
+    # Cleanup
+    apt-get autoclean && apt-get clean
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+}
+
+function install_rhel_omix() {
+    . /etc/os-release
+    if [[ ! " 8.10 " =~ " ${VERSION_ID} " ]]; then
+        echo "OMIX: RHEL version ${VERSION_ID} not supported"
+        exit 1
+    fi
+
+    dnf install -y 'dnf-command(config-manager)'
+    dnf config-manager --add-repo \
+        https://repositories.intel.com/gpu/rhel/${VERSION_ID}/intel-omix/${OMIX_VERSION}/unified/intel-gpu-${VERSION_ID}.repo
+
+    # Install OMIX (includes GPU driver + oneAPI DLE components)
+    dnf install -y --refresh intel-omix-devel
+
+    # Cleanup
+    dnf clean all
+    rm -rf /var/cache/yum
+    rm -rf /var/lib/yum/yumdb
+    rm -rf /var/lib/yum/history
+}
+
+if [[ -n "$OMIX_VERSION" ]]; then
+    # OMIX path: unified package handles both GPU driver and DLE
+    ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+    case "$ID" in
+        ubuntu)
+            install_ubuntu_omix
+        ;;
+        rhel|almalinux)
+            install_rhel_omix
+        ;;
+        *)
+            echo "OMIX: OS $ID not yet supported"
+            exit 1
+        ;;
+    esac
+else
+    # Legacy path: separate GPU driver + DLE offline installer
+
+    # Default use GPU driver rolling releases
+    XPU_DRIVER_VERSION=""
+    if [[ "${XPU_DRIVER_TYPE,,}" == "lts" ]]; then
+        # Use GPU driver LTS releases
+        XPU_DRIVER_VERSION="/lts/2523"
+    fi
+
+    # Default use Intel® oneAPI Deep Learning Essentials 2026.0
+    if [[ "$XPU_VERSION" == "2026.1" ]]; then
+        XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c109e1ae-e02c-48a6-917b-b03b90d33f77/intel-deep-learning-essentials-2026.1.2.25_offline.sh"
+    elif [[ "$XPU_VERSION" == "2026.0" ]]; then
+        XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh"
+    else
+        XPU_PACKAGES_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b3e6c1bf-a6d5-4580-8b1d-80cbfd38c8af/intel-deep-learning-essentials-2025.3.2.36_offline.sh"
+    fi
+
+    # The Driver installation depends on the base OS
+    ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+    case "$ID" in
+        ubuntu)
+            install_ubuntu
+        ;;
+        rhel|almalinux)
+            install_rhel
+        ;;
+        sles)
+            install_sles
+        ;;
+        *)
+            echo "Unable to determine OS..."
+            exit 1
+        ;;
+    esac
+
+    # XPU support packages installation
+    install_xpu_packages
+fi

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -209,5 +209,6 @@ RUN python3 -m pip install --upgrade pip && \
     python3 -mpip install cmake==3.28.4
 ADD ./common/install_xpu.sh install_xpu.sh
 ENV XPU_VERSION 2026.1
+ENV OMIX_VERSION 0.3.0
 RUN bash ./install_xpu.sh && rm install_xpu.sh
 RUN pushd /opt/_internal && tar -xJf static-libs-for-embedding-only.tar.xz && popd

--- a/.ci/docker/ubuntu-xpu/Dockerfile
+++ b/.ci/docker/ubuntu-xpu/Dockerfile
@@ -61,6 +61,7 @@ RUN rm install_inductor_benchmark_deps.sh common_utils.sh timm.txt huggingface-r
 # Install XPU Dependencies
 ARG XPU_VERSION
 ARG XPU_DRIVER_TYPE
+ARG OMIX_VERSION
 COPY ./common/install_xpu.sh install_xpu.sh
 RUN bash ./install_xpu.sh && rm install_xpu.sh
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -259,8 +259,10 @@ if [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
     # shellcheck disable=SC1091
     source /opt/intel/oneapi/umf/latest/env/vars.sh
   fi
-  # shellcheck disable=SC1091
-  source /opt/intel/oneapi/tcm/latest/env/vars.sh
+  if [ -f /opt/intel/oneapi/tcm/latest/env/vars.sh ]; then
+    # shellcheck disable=SC1091
+    source /opt/intel/oneapi/tcm/latest/env/vars.sh
+  fi
   # shellcheck disable=SC1091
   source /opt/intel/oneapi/ccl/latest/env/vars.sh
   # shellcheck disable=SC1091


### PR DESCRIPTION
## Summary

Intel OMIX bundles the UMD GPU driver and oneAPI Deep Learning Essentials into one package. This replaces the two-step driver + DLE offline installer with a single OMIX install, for both CI (Ubuntu Noble) and CD (AlmaLinux 8.10 manywheel) images. Please refer https://dgpu-docs.intel.com/installation-guides/installing-omix.html for details.

**Scope: Linux only. Windows CI/CD is not touched by this PR** and continues to use the DLE offline installer via `.ci/pytorch/windows/internal/xpu_install.bat`.

`OMIX_VERSION` gates the install method: set -> OMIX, unset -> legacy DLE path. The legacy path is untouched, so `jammy-xpu-n-1` is unaffected and unsetting the variable is a complete rollback.

OMIX installs to the same `/opt/intel/oneapi/` layout, so all env sourcing in `build.sh`, `test.sh`, `build_env_setup.py` and the inductor oneAPI config stays as-is.

## Changes

| File | Change |
|------|--------|
| `.ci/docker/common/install_xpu.sh` | Add `install_ubuntu_omix()` / `install_rhel_omix()` + `OMIX_VERSION`-gated dispatch |
| `.ci/docker/build.sh` | `OMIX_VERSION=0.3.0` for `noble-xpu-n` images + `--build-arg` pass-through |
| `.ci/docker/ubuntu-xpu/Dockerfile` | `ARG OMIX_VERSION` |
| `.ci/docker/manywheel/Dockerfile_2_28` | `ENV OMIX_VERSION 0.3.0` in the `xpu_final` stage |

## Test Plan

Test XPU CI and CD workflows for this PR

