### PR TITLE
Fix `pytorchbot merge -r` grafting trunk commits onto PRs

### DIFF
--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -13,6 +13,20 @@ def mocked_rev_parse(branch: str) -> str:
 
 MAIN_BRANCH = "refs/remotes/origin/main"
 VIABLE_STRICT_BRANCH = "refs/remotes/origin/viable/strict"
+# A full 40-char hex SHA, as `git merge-base` actually outputs; value is opaque
+# to the code (passed through verbatim to the rebase call).
+FORK_POINT = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def make_mocked_run_git(push_result: str = "") -> Any:
+    """_run_git stub: merge-base yields a fork point, everything else push_result."""
+
+    def run_git(*args: str) -> str:
+        if args and args[0] == "merge-base":
+            return FORK_POINT
+        return push_result
+
+    return run_git
 
 
 class TestRebase(TestCase):
@@ -28,12 +42,15 @@ class TestRebase(TestCase):
         mocked_gql: Any,
     ) -> None:
         "Tests rebase successfully"
+        mocked_run_git.side_effect = make_mocked_run_git()
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
         rebase_onto(pr, repo, MAIN_BRANCH)
+        base_ref = f"refs/remotes/origin/{pr.base_ref()}"
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", MAIN_BRANCH, "pull/31093/head"),
+            mock.call("merge-base", base_ref, "pull/31093/head"),
+            mock.call("rebase", "--onto", MAIN_BRANCH, FORK_POINT, "pull/31093/head"),
             mock.call(
                 "push",
                 "-f",
@@ -59,12 +76,17 @@ class TestRebase(TestCase):
         mocked_gql: Any,
     ) -> None:
         "Tests rebase to viable/strict successfully"
+        mocked_run_git.side_effect = make_mocked_run_git()
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
         rebase_onto(pr, repo, VIABLE_STRICT_BRANCH, False)
+        base_ref = f"refs/remotes/origin/{pr.base_ref()}"
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", VIABLE_STRICT_BRANCH, "pull/31093/head"),
+            mock.call("merge-base", base_ref, "pull/31093/head"),
+            mock.call(
+                "rebase", "--onto", VIABLE_STRICT_BRANCH, FORK_POINT, "pull/31093/head"
+            ),
             mock.call(
                 "push",
                 "-f",
@@ -79,7 +101,7 @@ class TestRebase(TestCase):
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
-    @mock.patch("gitutils.GitRepo._run_git", return_value="Everything up-to-date")
+    @mock.patch("gitutils.GitRepo._run_git")
     @mock.patch("gitutils.GitRepo.rev_parse", side_effect=mocked_rev_parse)
     @mock.patch("tryrebase.gh_post_comment")
     def test_no_need_to_rebase(
@@ -90,12 +112,15 @@ class TestRebase(TestCase):
         mocked_gql: Any,
     ) -> None:
         "Tests branch already up to date"
+        mocked_run_git.side_effect = make_mocked_run_git("Everything up-to-date")
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
         rebase_onto(pr, repo, MAIN_BRANCH)
+        base_ref = f"refs/remotes/origin/{pr.base_ref()}"
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", MAIN_BRANCH, "pull/31093/head"),
+            mock.call("merge-base", base_ref, "pull/31093/head"),
+            mock.call("rebase", "--onto", MAIN_BRANCH, FORK_POINT, "pull/31093/head"),
             mock.call(
                 "push",
                 "-f",
@@ -163,6 +188,45 @@ class TestRebase(TestCase):
         )
         additional_msg = additional_rebase_failure_info(Exception(error))
         self.assertTrue("This is likely because" in additional_msg)
+
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("gitutils.GitRepo._run_git")
+    @mock.patch("gitutils.GitRepo.rev_parse", side_effect=mocked_rev_parse)
+    @mock.patch("tryrebase.gh_post_comment")
+    def test_rebase_does_not_replay_trunk_commits(
+        self,
+        mocked_post_comment: Any,
+        mocked_rp: Any,
+        mocked_run_git: Any,
+        mocked_gql: Any,
+    ) -> None:
+        """#187374: rebase must anchor on the fork point (--onto) and never use
+        the 2-arg form, which grafts trunk commits onto the PR."""
+        mocked_run_git.side_effect = make_mocked_run_git()
+        pr = GitHubPR("pytorch", "pytorch", 31093)
+        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        rebase_onto(pr, repo, VIABLE_STRICT_BRANCH)
+        base_ref = f"refs/remotes/origin/{pr.base_ref()}"
+
+        self.assertIn(
+            mock.call("merge-base", base_ref, "pull/31093/head"),
+            mocked_run_git.call_args_list,
+        )
+        rebase_calls = [
+            c for c in mocked_run_git.call_args_list if c.args and c.args[0] == "rebase"
+        ]
+        self.assertEqual(
+            rebase_calls,
+            [
+                mock.call(
+                    "rebase",
+                    "--onto",
+                    VIABLE_STRICT_BRANCH,
+                    FORK_POINT,
+                    "pull/31093/head",
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -59,7 +59,14 @@ def rebase_onto(
     refspec = f"{branch}:{pr.head_ref()}"
 
     repo.fetch(branch, branch)
-    repo._run_git("rebase", onto_branch, branch)
+    # Rebase only the PR's own commits. The 2-arg `git rebase <onto_branch>
+    # <branch>` form replays all of onto_branch..branch, which grafts in trunk
+    # commits when the PR has merged its base in and onto_branch (e.g.
+    # viable/strict) lags that base. Anchoring on the fork point from the PR's
+    # base branch excludes anything already on the base. See #187374.
+    base_branch = f"refs/remotes/{repo.remote}/{pr.base_ref()}"
+    fork_point = repo.get_merge_base(base_branch, branch)
+    repo._run_git("rebase", "--onto", onto_branch, fork_point, branch)
 
     if repo.rev_parse(branch) == repo.rev_parse(onto_branch):
         raise Exception(SAME_SHA_ERROR)  # noqa: TRY002


### PR DESCRIPTION
`rebase_onto` used `git rebase <onto_branch> <branch>`, replaying all of onto_branch..branch. When a PR has merged its base in and the target lags that base (the `-r` default, viable/strict, is behind trunk), that range includes the merged-in base commits, which get re-applied and force-pushed onto the PR (#187374, e.g. #187022).

Anchor the replay at the PR's fork point from its base branch and use `--onto`, so only the PR's own commits land on the target:

    git rebase --onto <onto_branch> $(merge-base <base_branch> <branch>) <branch>

Anchoring on `base_ref()` is correct for any base (it equals the default branch for normal PRs). ghstack path unchanged.

Note: this does change behavior in one case. For a PR already ahead of viable/strict (based on newer main) that did not merge main in, the old code no-op'd with 'already up to date'; now a true rebase onto viable/strict occurs. This might trigger additional CI overhead, but may reflect what's desired when `pytorchbot merge -r` is invoked.

Test Plan: 
- Added unit tests 
- Verification on canary cases PRs with the `--dry-run` flag running from local:
    - PR behind viable/strict --> rebase to v/s
    - PR on viable/strict --> no change
    - PR ahead of viable/strict --> true rebase back to v/s
    - PR ahead of viable/strict, merges from main --> updates only commits from PR
