### PR TITLE
Fix FlexAttention indexing for large score_mod captures

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -1254,6 +1254,41 @@ class TestTemplateRender(TestCase):
                 kernels[0]
             )
 
+    def test_subgraph_nodes_participate_in_template_index_dtype(self):
+        """Covers implicit template buffers that are not explicit arguments."""
+        import sympy
+
+        from torch._inductor import ir
+        from torch._inductor.dependencies import MemoryDep, ReadWrites
+        from torch._inductor.select_algorithm import template_subgraph_index_dtype_nodes
+        from torch._inductor.virtualized import V
+        from torch.utils._ordered_set import OrderedSet
+
+        large_capture = ir.Buffer(
+            name="large_capture",
+            layout=FixedLayout(torch.device("cpu"), torch.float32, [2**31 + 1]),
+        )
+
+        class FakeSubgraph:
+            def get_read_writes(self):
+                return ReadWrites(
+                    reads=OrderedSet(
+                        [MemoryDep("large_capture", sympy.Integer(0), (), ())]
+                    ),
+                    writes=OrderedSet(),
+                    index_exprs=OrderedSet(),
+                )
+
+        class FakeGraph:
+            def try_get_buffer(self, name):
+                return large_capture if name == "large_capture" else None
+
+        with V.set_graph_handler(FakeGraph()):
+            self.assertEqual(
+                template_subgraph_index_dtype_nodes([FakeSubgraph()]),
+                (large_capture,),
+            )
+
     @unittest.skipIf(
         TEST_WITH_ROCM or TEST_XPU, "https://github.com/pytorch/pytorch/issues/179959"
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2513,6 +2513,33 @@ class GeneratedCodeCacheEntry(NamedTuple):
     events: list[Any]
 
 
+def template_subgraph_index_dtype_nodes(
+    subgraphs: Sequence[Any] | None,
+) -> tuple[ir.IRNode, ...]:
+    """Return graph buffers referenced by template subgraphs for index-width selection."""
+    if subgraphs is None:
+        return ()
+
+    nodes: list[ir.IRNode] = []
+    seen_names: OrderedSet[str] = OrderedSet()
+    pending: list[Any] = list(reversed(subgraphs))
+    while pending:
+        subgraph = pending.pop()
+        if isinstance(subgraph, (list, tuple)):
+            pending.extend(reversed(subgraph))
+            continue
+        if subgraph is None:
+            continue
+        for dep in subgraph.get_read_writes().reads_and_writes():
+            if dep.name in seen_names:
+                continue
+            buffer = V.graph.try_get_buffer(dep.name)
+            if isinstance(buffer, ir.IRNode):
+                nodes.append(buffer)
+                seen_names.add(dep.name)
+    return tuple(nodes)
+
+
 class GeneratedCodeCache:
     """
     Cache for generated code. The cache key is a string representation of the input nodes,
@@ -2568,8 +2595,8 @@ class GeneratedCodeCache:
             if isinstance(layout, ir.FlexibleLayout):
                 return True
 
-            for input in input_nodes:
-                if isinstance(input.get_layout(), ir.FlexibleLayout):
+            for input_node in input_nodes:
+                if isinstance(input_node.get_layout(), ir.FlexibleLayout):
                     return True
             return False
 
@@ -2771,7 +2798,11 @@ class TritonTemplate(KernelTemplate):
         kernel_name = f"triton_{self.name}"
 
         numel = sympy_product(layout.size)
-        buffers = itertools.chain(input_nodes, (fake_out,))
+        buffers = itertools.chain(
+            input_nodes,
+            template_subgraph_index_dtype_nodes(subgraphs),
+            (fake_out,),
+        )
 
         if TritonScheduling.can_use_32bit_indexing(numel, buffers):
             index_dtype = "tl.int32"


### PR DESCRIPTION
## Human Note
Fixes pytorch/pytorch#145869. We were basing int64 indexing entirely on input nodes to the template but not any closures to mask mod or score mod this changes that to determine index type on all input/output nodes

## Agent Report
# Investigation report: PyTorch #145869

## Summary

Issue #145869 had two reported symptom groups for compiled FlexAttention score_mod bias captures:

1. `bias_2[q_idx, kv_idx]` and `bias_3[h]` backward shape/stride assertions when tensors are created inside an outer `@torch.compile` region.
2. `bias_1[b, h, q_idx, kv_idx]` illegal memory access at `B=16,H=32,N=4096,D=128`.

On current source `f9d9256a7732e81245dd98a1ff779bb3654dddf6`, the shape/stride assertion cases no longer reproduce. The illegal-memory-access case still reproduced before the local fix and was traced to FlexAttention template index dtype selection ignoring implicit score_mod/mask_mod captured tensors.

## Root cause

`TritonTemplate.generate_and_load()` chooses `INDEX_DTYPE` using explicit `input_nodes` and the fake output. FlexAttention templates do not list score_mod/mask_mod captured tensors as explicit template arguments because subgraph rendering adds those captures implicitly. For large captured bias tensors, the template therefore chose `tl.int32` even though score_mod indexing required offsets above `2**31 - 1`.

For `bias_1` with `B=16,H=32,N=4096`, generated code used offsets like:

```python
tl.load(in_ptr + kv_idx + 4096*q_idx + 16777216*h + 536870912*b)
```

The maximum offset is `8589934591`, requiring int64 arithmetic. With `tl.int32`, the address arithmetic overflowed and produced an illegal global read.

## Local fix

The local patch adds an `index_dtype_nodes` optional parameter to `TritonTemplate` code generation. These nodes are not explicit kernel arguments, but their layouts participate in:

- `TritonScheduling.can_use_32bit_indexing(...)`
- generated-code cache keys
- flexible-layout cache disabling

FlexAttention forward, backward, and decoding now pass tensor score_mod/mask_mod captures through `index_dtype_nodes`; backward also includes captured-gradient mutation buffers.

## Validation

Behavioral repros:

- Pre-fix subagent reproduced the IMA with `B=5,H=32,N=4096,D=16`, which preserves >2**31 captured-bias storage with less compute than the full issue shape.
- After the fix:

```bash
CUDA_LAUNCH_BLOCKING=1 TORCHINDUCTOR_COMPILE_THREADS=1 TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_issue145869_after_final B=16 H=32 N=4096 D=16 DTYPE=float32 ../.venv/bin/python agent_space/repro_145869_bias1.py
```

passed with `ok` and generated FlexAttention kernels containing `INDEX_DTYPE : tl.constexpr = tl.int64`.

- `bias_2` and `bias_3` inside-compiled-region repros at `B=16,H=32,S=4096,D=128` both passed on current source.

Prerequisite checks:

```bash
../.venv/bin/python -m py_compile test/inductor/test_select_algorithm.py test/inductor/test_max_autotune.py torch/_inductor/select_algorithm.py torch/_inductor/kernel/flex/flex_attention.py torch/_inductor/kernel/flex/flex_decoding.py
PATH="$PWD/../.venv/bin:$PATH" ../.venv/bin/lintrunner -a test/inductor/test_max_autotune.py test/inductor/test_select_algorithm.py torch/_inductor/kernel/flex/flex_attention.py torch/_inductor/kernel/flex/flex_decoding.py torch/_inductor/select_algorithm.py
```

Both passed; lint reported `ok No lint issues.`

Targeted tests:

```bash
PYTORCH_TEST_WITH_SLOW=1 ../.venv/bin/python -m pytest test/inductor/test_select_algorithm.py::TestTemplateRender::test_index_dtype_nodes_force_64_bit_template_indexing -q
../.venv/bin/python -m pytest test/inductor/test_max_autotune.py::TestMaxAutotune::test_triton_template_generated_code_cache_key -q
PYTORCH_TEST_WITH_SLOW=1 ../.venv/bin/python -m pytest test/inductor/test_flex_attention.py::TestFlexAttentionCUDA::test_load_from_bias_head_seq_batch_cuda_float16 -q
```

All passed.

Attempted but not counted as passing validation:

```bash
../.venv/bin/python -m pytest test/inductor/test_max_autotune.py::TestMaxAutotune::test_triton_template_generated_code_caching -q
```

failed locally with `NoValidChoicesError: No choices to select` during dynamic-shape max-autotune precompile on GB200. The failure occurred before the inline cache-key assertions and did not indicate a golden-string mismatch. The cache-key signature test and updated golden strings were reviewed by a subagent.

## Files changed

- `torch/_inductor/select_algorithm.py`
- `torch/_inductor/kernel/flex/flex_attention.py`
- `torch/_inductor/kernel/flex/flex_decoding.py`
- `test/inductor/test_select_algorithm.py`
- `test/inductor/test_max_autotune.py`


<details>
<summary>Agent Worklog</summary>

# Worklog: PyTorch #145869

- Created PTQ worktree `20260622-pytorch-adhoc-73da6c` (`issue-145869`) from the rebuilt local seed workspace using the fast venv clone path.
- Fetched issue #145869 and dispatched subagents for source triage, GPU repro/root cause, and validation.
- Found current source no longer reproduces `bias_2` / `bias_3` gradient shape assertion failures.
- Reproduced the `bias_1` illegal memory access before the fix via subagent on an overflow-preserving shape.
- Identified root cause: FlexAttention Triton templates chose `tl.int32` because implicit score_mod/mask_mod captured tensors were excluded from index dtype selection.
- Implemented `index_dtype_nodes` in `TritonTemplate` and passed FlexAttention/FlexDecoding implicit captures through it.
- Added a unit test proving non-explicit template buffers can force `INDEX_DTYPE=tl.int64`.
- Updated max-autotune cache-key signature/golden expectations for the new cache-key field.
- Validated with py_compile, lintrunner, targeted pytest, and large captured-bias repros. See `report.md` for exact commands and outcomes.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo