### PR TITLE
[MPS] Move mish to Metal kernel instead of MPSGraph

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -230,6 +230,36 @@ REGISTER_BINARY_OP(silu_backward, float, float);
 REGISTER_BINARY_OP(silu_backward, half, half);
 REGISTER_BINARY_OP(silu_backward, bfloat, bfloat);
 
+struct mish_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    float xf = float(x);
+    return static_cast<T>(
+        xf *
+        ::metal::precise::tanh(::c10::metal::log1p(::metal::precise::exp(xf))));
+  }
+};
+
+REGISTER_UNARY_OP(mish, float, float);
+REGISTER_UNARY_OP(mish, half, half);
+REGISTER_UNARY_OP(mish, bfloat, bfloat);
+
+struct mish_backward_functor {
+  template <typename T>
+  inline T operator()(const T grad_output, const T self) {
+    float sf = float(self);
+    float sig = 1.0f / (1.0f + ::metal::precise::exp(-sf));
+    float tsp =
+        ::metal::precise::tanh(::c10::metal::log1p(::metal::precise::exp(sf)));
+    return static_cast<T>(
+        float(grad_output) * (tsp + sf * sig * (1.0f - tsp * tsp)));
+  }
+};
+
+REGISTER_BINARY_OP(mish_backward, float, float);
+REGISTER_BINARY_OP(mish_backward, half, half);
+REGISTER_BINARY_OP(mish_backward, bfloat, bfloat);
+
 template <typename T>
 static inline float gelu_dispatch_tanh(float x) {
   if IF_CONSTEXPR (::metal::is_same_v<T, float>) {

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -17,8 +17,6 @@
 #include <ATen/ops/glu_backward_native.h>
 #include <ATen/ops/glu_native.h>
 #include <ATen/ops/hardtanh_backward_native.h>
-#include <ATen/ops/mish_backward_native.h>
-#include <ATen/ops/mish_native.h>
 #include <ATen/ops/relu_native.h>
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
@@ -540,124 +538,6 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
       cachedGraph->thresholdTensor_ : getMPSGraphTensorFromScalar(stream, threshold_scalar),
     };
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(mish_out_mps)
-(const Tensor& self, const Tensor& result) {
-  using namespace mps;
-  TORCH_CHECK(self.is_mps());
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()), "Mish for complex is not supported for MPS");
-
-  if (result.numel() == 0)
-    return;
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-  };
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  bool executeGatherOp =
-      !(self.is_contiguous(MemoryFormat::Contiguous) || self.is_contiguous(MemoryFormat::ChannelsLast) ||
-        self.is_contiguous(MemoryFormat::ChannelsLast3d));
-  Tensor result_ = at::empty_like(self, executeGatherOp ? MemoryFormat::Contiguous : MemoryFormat::Preserve);
-
-  @autoreleasepool {
-    std::string key = "mish_out_mps:" + getTensorsStringKey({self});
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:inputTensor name:nil];
-      MPSGraphTensor* softplusTensor = at::native::mps::log1p(mpsGraph, expTensor);
-      MPSGraphTensor* tanhTensor = [mpsGraph tanhWithTensor:softplusTensor name:nil];
-      MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:tanhTensor
-                                                                          name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->outputTensor_, executeGatherOp ? result_ : result, nil, false);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-  if (executeGatherOp) {
-    result.copy_(result_);
-  }
-}
-
-Tensor mish_backward_mps(const Tensor& grad_output, const Tensor& self) {
-  using namespace mps;
-  TORCH_CHECK(self.is_mps());
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()), "Mish for complex is not supported for MPS");
-
-  Tensor grad_input = at::empty_like(self, self.suggest_memory_format());
-  if (grad_input.numel() == 0)
-    return grad_input;
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* gradOutputTensor_ = nil;
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* gradInputTensor_ = nil;
-  };
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "mish_backward_out_mps:" + getTensorsStringKey({grad_output, self});
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      // grad_input = grad_output * (tanh(softplus(x)) + input * sigmoid(x) * (1 - tanh(softplus(x)) ^ 2)
-
-      MPSGraphTensor* sigmoidTensor = [mpsGraph sigmoidWithTensor:inputTensor name:nil];
-
-      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:inputTensor name:nil];
-      MPSGraphTensor* softplusTensor = at::native::mps::log1p(mpsGraph, expTensor);
-      MPSGraphTensor* tanhSPTensor = [mpsGraph tanhWithTensor:softplusTensor name:nil];
-
-      MPSGraphTensor* tanhSPSquaredTensor = [mpsGraph multiplicationWithPrimaryTensor:tanhSPTensor
-                                                                      secondaryTensor:tanhSPTensor
-                                                                                 name:nil];
-      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-      MPSGraphTensor* oneMinusTanhSPSquaredTensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                           secondaryTensor:tanhSPSquaredTensor
-                                                                                      name:nil];
-      MPSGraphTensor* xSigmoidTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                 secondaryTensor:sigmoidTensor
-                                                                            name:nil];
-      MPSGraphTensor* partialResultTensor = [mpsGraph multiplicationWithPrimaryTensor:xSigmoidTensor
-                                                                      secondaryTensor:oneMinusTanhSPSquaredTensor
-                                                                                 name:nil];
-      MPSGraphTensor* mishGradTensor = [mpsGraph additionWithPrimaryTensor:partialResultTensor
-                                                           secondaryTensor:tanhSPTensor
-                                                                      name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                  secondaryTensor:mishGradTensor
-                                                                             name:nil];
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
-    return grad_input;
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -129,6 +129,14 @@ static void silu_backward_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "silu_backward");
 }
 
+static void mish_kernel(TensorIteratorBase& iter) {
+  lib.exec_unary_kernel(iter, "mish");
+}
+
+static void mish_backward_kernel(TensorIterator& iter) {
+  lib.exec_binary_kernel(iter, "mish_backward");
+}
+
 static void leaky_relu_kernel(TensorIteratorBase& iter, const Scalar& negative_slope) {
   lib.exec_unary_kernel(iter, "leaky_relu", negative_slope);
 }
@@ -203,6 +211,8 @@ REGISTER_DISPATCH(leaky_relu_stub, leaky_relu_kernel);
 REGISTER_DISPATCH(leaky_relu_backward_stub, leaky_relu_backward_kernel);
 REGISTER_DISPATCH(silu_stub, silu_kernel);
 REGISTER_DISPATCH(silu_backward_stub, silu_backward_kernel);
+REGISTER_DISPATCH(mish_stub, mish_kernel);
+REGISTER_DISPATCH(mish_backward_stub, mish_backward_kernel);
 REGISTER_DISPATCH(GeluKernel, gelu_kernel);
 REGISTER_DISPATCH(GeluBackwardKernel, gelu_backward_kernel);
 REGISTER_DISPATCH(sigmoid_backward_stub, sigmoid_backward_kernel);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5332,14 +5332,12 @@
   structured_inherits: TensorIteratorBase
   python_module: nn
   dispatch:
-    CPU, CUDA, XPU: mish_out
-    MPS: mish_out_mps
+    CPU, CUDA, MPS, XPU: mish_out
 
 - func: mish_backward(Tensor grad_output, Tensor self) -> Tensor
   python_module: nn
   dispatch:
-    CPU, CUDA, XPU: mish_backward
-    MPS: mish_backward_mps
+    CPU, CUDA, MPS, XPU: mish_backward
     CompositeImplicitAutograd: math_mish_backward
 
 - func: sigmoid(Tensor self) -> Tensor


### PR DESCRIPTION
## Summary

`mish` and `mish_backward` were the only elementwise activations on MPS still implemented through MPSGraph (`Activation.mm`). `silu`, `gelu`, `elu`, `hardswish`, `leaky_relu` and the rest already run as Metal kernels registered through the `*_stub` dispatch path in `ActivationKernel.mm` / `ActivationKernel.metal`.

The MPSGraph path builds and caches a graph per call, and for non-contiguous inputs it stages the data through a gather plus a copy back into the output. That makes `mish` slower than its siblings, and disproportionately slow on strided tensors.

This PR registers `mish_stub` / `mish_backward_stub` for MPS with Metal functors that mirror `silu`, and drops the two MPSGraph implementations. Net change is 39 insertions, 124 deletions.

One signature subtlety: `mish_backward_stub` is an `activation_backward_fn` (`void(*)(TensorIterator&)`), whereas `silu_backward_stub` is a `structured_activation_backward_fn` (`void(*)(TensorIteratorBase&)`), so the backward kernel takes `TensorIterator&`.

## Benchmarks

Measured on an M-series GPU, MPSGraph path vs the Metal kernel:

| case | MPSGraph | Metal | speedup |
|---|---|---|---|
| forward 2048x2048 contiguous | 1.243 ms | 0.296 ms | 4.2x |
| forward 2048x2048 strided | 4.518 ms | 0.297 ms | 15.2x |
| forward 4096x4096 strided | 3.135 ms | 0.768 ms | 4.1x |
| fwd+bwd 2048x2048 contiguous | 2.894 ms | 0.913 ms | 3.2x |
| fwd+bwd 2048x2048 strided | 9.048 ms | 0.947 ms | 9.6x |
| fwd+bwd 4096x4096 strided | 18.80 ms | 5.62 ms | 3.3x |

With the Metal kernel a strided input costs the same as a contiguous one (0.297 vs 0.296 ms), whereas MPSGraph was ~3.6x slower on strided. The contiguous gain comes from dropping the per-call graph build/cache overhead.

## Correctness

Compared against the CPU float64 reference (forward and backward):

| dtype | forward max\|Δ\| | backward max\|Δ\| |
|---|---|---|
| float32 | 5.3e-07 | 6.4e-07 |
| float16 | 1.9e-03 | 4.9e-04 |
| bfloat16 | 7.8e-03 | 3.9e-03 |

Strided output is bit-identical to contiguous (max\|Δ\| = 0), and `mish` backward works on strided inputs. The forward functor uses `x * tanh(log1p(exp(x)))` and the backward uses `dy * (t + x*s*(1 - t^2))` with `s = sigmoid(x)`, `t = tanh(log1p(exp(x)))`, matching the CPU/CUDA kernels.
