### PR TITLE
[fix] torch.where silently overflows fp16 scalars (issue #187429)

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -715,8 +715,32 @@ Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
   return ret;
 }
 
+// scalar_tensor for reduced-precision types uses a relaxed cast (no overflow
+// check) to match torch.tensor() semantics. Verify the scalar is in range here
+// so torch.where raises consistently with fill_/full_like on non-scalar
+// tensors, which go through the kernel path that does use checked_convert. The
+// guard is limited to Half/BFloat16 -- the domain of
+// AT_DISPATCH_REDUCED_FLOATING_TYPES -- so float8/float4 result types keep
+// their existing behavior instead of falling through to the dispatch default
+// and raising. Symbolic scalars are skipped: their value is unknown at trace
+// time (so there is nothing to range-check), and calling Scalar::to<scalar_t>()
+// would force a guard_float specialization on an otherwise data-dependent
+// value.
+static void check_scalar_in_reduced_float_range(
+    const Scalar& scalar,
+    ScalarType result_type) {
+  if ((result_type == kHalf || result_type == kBFloat16) &&
+      !scalar.isSymbolic()) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(
+        result_type, "where_scalar_bounds_check", [&] {
+          (void)scalar.to<scalar_t>();
+        });
+  }
+}
+
 Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
   auto result_type = at::native::result_type(other, self);
+  check_scalar_in_reduced_float_range(self, result_type);
   auto self_converted =
       at::scalar_tensor(self, other.options().dtype(result_type));
   auto other_converted = other.to(result_type);
@@ -725,6 +749,7 @@ Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
 
 Tensor where(const Tensor& condition, const Tensor& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
+  check_scalar_in_reduced_float_range(other, result_type);
   auto other_converted =
       at::scalar_tensor(other, self.options().dtype(result_type));
   auto self_converted = self.to(result_type);

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -646,8 +646,32 @@ Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
   return ret;
 }
 
+// scalar_tensor for reduced-precision types uses a relaxed cast (no overflow
+// check) to match torch.tensor() semantics. Verify the scalar is in range here
+// so torch.where raises consistently with fill_/full_like on non-scalar
+// tensors, which go through the kernel path that does use checked_convert. The
+// guard is limited to Half/BFloat16 -- the domain of
+// AT_DISPATCH_REDUCED_FLOATING_TYPES -- so float8/float4 result types keep
+// their existing behavior instead of falling through to the dispatch default
+// and raising. Symbolic scalars are skipped: their value is unknown at trace
+// time (so there is nothing to range-check), and calling Scalar::to<scalar_t>()
+// would force a guard_float specialization on an otherwise data-dependent
+// value.
+static void check_scalar_in_reduced_float_range(
+    const Scalar& scalar,
+    ScalarType result_type) {
+  if ((result_type == kHalf || result_type == kBFloat16) &&
+      !scalar.isSymbolic()) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(
+        result_type, "where_scalar_bounds_check", [&] {
+          (void)scalar.to<scalar_t>();
+        });
+  }
+}
+
 Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
   auto result_type = at::native::result_type(other, self);
+  check_scalar_in_reduced_float_range(self, result_type);
   auto self_converted =
       at::scalar_tensor(self, other.options().dtype(result_type));
   auto other_converted = other.to(result_type);
@@ -656,6 +680,7 @@ Tensor where(const Tensor& condition, const Scalar& self, const Tensor& other) {
 
 Tensor where(const Tensor& condition, const Tensor& self, const Scalar& other) {
   auto result_type = at::native::result_type(self, other);
+  check_scalar_in_reduced_float_range(other, result_type);
   auto other_converted =
       at::scalar_tensor(other, self.options().dtype(result_type));
   auto self_converted = self.to(result_type);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6434,6 +6434,49 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(torch.ne(a, b).tolist(), [False, False, True])
 
 
+    @onlyNativeDeviceTypes
+    def test_where_scalar_fp16_overflow(self, device):
+        # torch.where(cond, overflowing_scalar, fp16_tensor) previously
+        # silently produced +/-Inf because scalar_tensor uses a relaxed cast
+        # for numel==1 tensors. The where implementation now checks for
+        # overflow explicitly to stay consistent with fill_/full_like.
+        cond = torch.tensor([True, False, True], device=device)
+        fp16 = torch.zeros(3, dtype=torch.float16, device=device)
+        overflow = 65507.0  # > float16 max (~65504)
+        err = "cannot be converted to type"
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, overflow, fp16)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, fp16, overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, -overflow, fp16)
+
+        # Values within float16 range must still work
+        result = torch.where(cond, 100.0, fp16)
+        self.assertEqual(result.dtype, torch.float16)
+        result = torch.where(cond, fp16, 100.0)
+        self.assertEqual(result.dtype, torch.float16)
+
+        # bfloat16 is the other half of the guard's domain (bf16 max ~3.39e38).
+        bf16 = torch.zeros(3, dtype=torch.bfloat16, device=device)
+        bf16_overflow = 1e39  # > bfloat16 max
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, bf16_overflow, bf16)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, bf16, bf16_overflow)
+        result = torch.where(cond, 100.0, bf16)
+        self.assertEqual(result.dtype, torch.bfloat16)
+
+        # Reduced-precision types outside AT_DISPATCH_REDUCED_FLOATING_TYPES
+        # (float8) must keep working: the bounds check only covers Half/BFloat16,
+        # so these still go through the existing relaxed cast rather than raising.
+        f8 = torch.zeros(3, dtype=torch.float8_e4m3fn, device=device)
+        result = torch.where(cond, 1.0, f8)
+        self.assertEqual(result.dtype, torch.float8_e4m3fn)
+        result = torch.where(cond, f8, 1.0)
+        self.assertEqual(result.dtype, torch.float8_e4m3fn)
+
     @skipIfTorchInductor("FIXME")
     def test_hook_remove(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/58354

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6287,6 +6287,49 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(torch.ne(a, b).tolist(), [False, False, True])
 
 
+    @onlyNativeDeviceTypes
+    def test_where_scalar_fp16_overflow(self, device):
+        # torch.where(cond, overflowing_scalar, fp16_tensor) previously
+        # silently produced +/-Inf because scalar_tensor uses a relaxed cast
+        # for numel==1 tensors. The where implementation now checks for
+        # overflow explicitly to stay consistent with fill_/full_like.
+        cond = torch.tensor([True, False, True], device=device)
+        fp16 = torch.zeros(3, dtype=torch.float16, device=device)
+        overflow = 65507.0  # > float16 max (~65504)
+        err = "cannot be converted to type"
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, overflow, fp16)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, fp16, overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, -overflow, fp16)
+
+        # Values within float16 range must still work
+        result = torch.where(cond, 100.0, fp16)
+        self.assertEqual(result.dtype, torch.float16)
+        result = torch.where(cond, fp16, 100.0)
+        self.assertEqual(result.dtype, torch.float16)
+
+        # bfloat16 is the other half of the guard's domain (bf16 max ~3.39e38).
+        bf16 = torch.zeros(3, dtype=torch.bfloat16, device=device)
+        bf16_overflow = 1e39  # > bfloat16 max
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, bf16_overflow, bf16)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.where(cond, bf16, bf16_overflow)
+        result = torch.where(cond, 100.0, bf16)
+        self.assertEqual(result.dtype, torch.bfloat16)
+
+        # Reduced-precision types outside AT_DISPATCH_REDUCED_FLOATING_TYPES
+        # (float8) must keep working: the bounds check only covers Half/BFloat16,
+        # so these still go through the existing relaxed cast rather than raising.
+        f8 = torch.zeros(3, dtype=torch.float8_e4m3fn, device=device)
+        result = torch.where(cond, 1.0, f8)
+        self.assertEqual(result.dtype, torch.float8_e4m3fn)
+        result = torch.where(cond, f8, 1.0)
+        self.assertEqual(result.dtype, torch.float8_e4m3fn)
+
     @skipIfTorchInductor("FIXME")
     def test_hook_remove(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/58354


### PR DESCRIPTION
Fixes #187429

## Root cause

Commit `0eae6b68f42` ("Unify torch.tensor and torch.ops.aten.scalar_tensor behavior") intentionally relaxed the cast in `fill_inplace<Half>` for `numel==1` tensors: it switched from `checked_convert` to `static_cast` so `scalar_tensor` matches `torch.tensor()` semantics.

That change had an unintended side-effect on the scalar overloads of `torch.where`:

```python
fp16 = torch.zeros(3, dtype=torch.float16)
torch.where(cond, 65507.0, fp16)   # silently produces +Inf
torch.where(cond, fp16, 65507.0)   # silently produces +Inf
```

The scalar is promoted to an fp16 tensor via `scalar_tensor`, which now uses the relaxed cast, so an out-of-range value becomes `+/-Inf` instead of raising `RuntimeError`. The equivalent `full_like`/`fill_` on a multi-element tensor still raises because that path goes through `fill_non_native_type<Half>` → `checked_convert`.

## Fix

Add an explicit range check in `where.ScalarSelf` and `where.ScalarOther` (in `TensorCompare.cpp`) **before** the `scalar_tensor` call, factored into a file-local helper `check_scalar_in_reduced_float_range`. When the result type is `Half` or `BFloat16`, the scalar is routed through `Scalar::to<scalar_t>()` via `AT_DISPATCH_REDUCED_FLOATING_TYPES`, which uses `checked_convert` and raises on overflow - matching `fill_`/`full_like`. The relaxed-cast behavior of `scalar_tensor` itself is left unchanged.

Two refinements from review:

- **Guard limited to Half/BFloat16**, not `isReducedFloatingType`. The latter also matches float8/float4, which `AT_DISPATCH_REDUCED_FLOATING_TYPES` does not emit cases for - so using it would send those result types to the dispatch default and turn a currently-working `torch.where(cond, 1.0, float8_tensor)` into a `NotImplementedError`. Narrowing keeps float8/float4 behavior unchanged.
- **Symbolic scalars skipped** (`!scalar.isSymbolic()`). These overloads are `CompositeImplicitAutograd` and run on Meta during tracing/export; a symbolic scalar's value is unknown at trace time (nothing to range-check), and calling `Scalar::to<scalar_t>()` would otherwise force a `guard_float` specialization on a data-dependent value. Concrete scalars are unaffected, and `scalar_tensor` performs the same conversion on that path regardless.

## Test Plan

```bash
python test/test_torch.py \
    TestTorchDeviceTypeCPU.test_where_scalar_fp16_overflow_cpu \
    TestTorchDeviceTypeCUDA.test_where_scalar_fp16_overflow_cuda
```

Passes on CPU and ROCm. The test covers float16 and bfloat16 overflow (both argument orders) plus in-range values, and float8 coverage guarding against the dispatch-default regression.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No - turns a silent `+/-Inf` for out-of-range fp16/bf16 scalars into a `RuntimeError`, matching `fill_`/`full_like`. float8/float4 and symbolic-scalar behavior is unchanged.