### PR TITLE
[cuda] Remove global annotation enable; scope it to the graph capture

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -10,11 +10,9 @@ from torch.cuda._graph_annotations import (
     _is_tools_id_unavailable,
     _rekey_annotations,
     clear_kernel_annotations,
-    enable_annotations,
     get_kernel_annotations,
     mark_kernels,
     mark_stream,
-    remap_to_exec_graph,
     resolve_pending_annotations,
 )
 from torch.testing._internal.common_utils import (
@@ -48,7 +46,8 @@ except ImportError:
 class TestMarkKernels(TestCase):
     def setUp(self):
         super().setUp()
-        enable_annotations()
+        # Annotations are enabled per-capture via torch.cuda.graph(..,
+        # enable_annotations=True); there is no global toggle.
         clear_kernel_annotations()
 
     def tearDown(self):
@@ -64,13 +63,12 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             # mark_kernels is the first captured work here, so the entry
             # frontier is empty and the implementation must fall back to
             # newly created graph roots.
             with mark_kernels("phase_a"):
                 _ = x + 1
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -82,12 +80,11 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             with mark_kernels("scope_1"):
                 _ = x + 1
             with mark_kernels("scope_2"):
                 _ = x * 2
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         scope_1_ids = set()
@@ -108,10 +105,9 @@ class TestMarkKernels(TestCase):
         x = torch.randn(8, device="cuda")
 
         annotation = {"name": "all_gather", "Group size": 2, "dtype": "bfloat16"}
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             with mark_kernels(annotation):
                 _ = x + 1
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -123,10 +119,9 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             with mark_kernels("test"):
                 _ = x + 1
-            resolve_pending_annotations()
 
         self.assertGreater(len(get_kernel_annotations()), 0)
         clear_kernel_annotations()
@@ -140,12 +135,11 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             _ = x + 1
             with mark_kernels("empty"):
                 pass
             _ = x * 2
-            resolve_pending_annotations()
 
         for anns in get_kernel_annotations().values():
             for ann in anns:
@@ -155,13 +149,12 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             _ = x + 1
             _ = x * 2
             with mark_kernels("tagged"):
                 _ = x + 3
             _ = x - 1
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         total_annotated = sum(len(anns) for anns in annotations.values())
@@ -175,13 +168,12 @@ class TestMarkKernels(TestCase):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             with mark_kernels("outer"):
                 _ = x + 1  # outer only
                 with mark_kernels("inner"):
                     _ = x * 2  # nested: inner should win
                 _ = x - 1  # outer only
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         outer_ids = set()
@@ -215,13 +207,12 @@ class TestMarkKernels(TestCase):
             "dtype": "bfloat16",
         }
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             with mark_kernels(outer_ann):
                 _ = x + 1  # outer only
                 with mark_kernels(inner_ann):
                     _ = x * 2  # nested
                 _ = x - 1  # outer only
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         outer_only_ids = set()
@@ -257,12 +248,11 @@ class TestMarkKernels(TestCase):
             "dtype": "bfloat16",
         }
 
-        with torch.cuda.graph(graph):
+        with torch.cuda.graph(graph, enable_annotations=True):
             # Both scopes wrap the same kernels; inner exits first.
             with mark_kernels(outer_ann):
                 with mark_kernels(inner_ann):
                     _ = x + 1
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -277,56 +267,20 @@ class TestMarkKernels(TestCase):
             self.assertEqual(ann["In msg nelems"], 1024)
             self.assertEqual(ann["dtype"], "bfloat16")
 
-    def test_remap_to_exec_graph(self):
-        from cuda.bindings import runtime as cuda_runtime
-
-        graph = torch.cuda.CUDAGraph()
-        x = torch.randn(8, device="cuda")
-
-        with torch.cuda.graph(graph):
-            with mark_kernels("test"):
-                _ = x + 1
-            resolve_pending_annotations()
-
-        annotations_before = dict(get_kernel_annotations())
-        self.assertGreater(len(annotations_before), 0)
-
-        exec_handle = cuda_runtime.cudaGraphExec_t(
-            init_value=graph.raw_cuda_graph_exec()
-        )
-        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(exec_handle)
-
-        remap_to_exec_graph(graph)
-
-        annotations_after = get_kernel_annotations()
-        self.assertEqual(len(annotations_after), len(annotations_before))
-        for tools_id in annotations_after:
-            self.assertEqual(tools_id >> 32, exec_graph_id)
-
-    def test_disabled_is_noop(self):
-        from torch.cuda._graph_annotations import disable_annotations
-
-        disable_annotations()
-
+    def test_no_enable_records_nothing(self):
+        # Without enable_annotations=True the capture is un-annotated, so
+        # mark_kernels is a no-op and nothing is recorded.
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
         with torch.cuda.graph(graph):
             with mark_kernels("should_not_appear"):
                 _ = x + 1
-            resolve_pending_annotations()
 
         self.assertEqual(len(get_kernel_annotations()), 0)
 
-        # Re-enable for other tests
-        enable_annotations()
-
     def test_enable_annotations_kwarg(self):
-        """enable_annotations on torch.cuda.graph auto-resolves annotations."""
-        from torch.cuda._graph_annotations import disable_annotations
-
-        # Start with annotations disabled to verify the kwarg enables them.
-        disable_annotations()
+        """enable_annotations=True on torch.cuda.graph records and auto-resolves."""
         clear_kernel_annotations()
 
         graph = torch.cuda.CUDAGraph()
@@ -344,9 +298,6 @@ class TestMarkKernels(TestCase):
 
     def test_enable_annotations_does_not_clear(self):
         """Annotations from a previous graph survive a second capture."""
-        from torch.cuda._graph_annotations import disable_annotations
-
-        disable_annotations()
         clear_kernel_annotations()
 
         graph1 = torch.cuda.CUDAGraph()
@@ -380,10 +331,7 @@ class TestMarkKernels(TestCase):
             with mark_kernels("remap_test"):
                 _ = x + 1
 
-        exec_handle = cuda_runtime.cudaGraphExec_t(
-            init_value=graph.raw_cuda_graph_exec()
-        )
-        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(exec_handle)
+        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(graph.raw_cuda_graph_exec())
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -396,19 +344,6 @@ class TestMarkKernels(TestCase):
                 f"expected exec_graph_id {exec_graph_id}",
             )
 
-    def test_enable_annotations_false_does_not_auto_resolve(self):
-        """Without enable_annotations, pending scopes are not resolved."""
-        graph = torch.cuda.CUDAGraph()
-        x = torch.randn(8, device="cuda")
-
-        # enable_annotations=False (default): no auto-resolve.
-        with torch.cuda.graph(graph):
-            with mark_kernels("unresolved"):
-                _ = x + 1
-
-        # Annotations should be empty because resolve was never called.
-        self.assertEqual(len(get_kernel_annotations()), 0)
-
     def test_mark_stream_snapshots_capture_before_switch(self):
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
@@ -418,7 +353,7 @@ class TestMarkKernels(TestCase):
         aux_done = torch.cuda.Event()
 
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.graph(graph, stream=capture_stream):
+        with torch.cuda.graph(graph, stream=capture_stream, enable_annotations=True):
             _ = x + 1
             aux_ready = capture_stream.record_event()
             with mark_stream(aux_stream, {"name": "aux"}):
@@ -426,7 +361,6 @@ class TestMarkKernels(TestCase):
                 _ = x * 2
                 aux_stream.record_event(aux_done)
             capture_stream.wait_event(aux_done)
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -445,7 +379,7 @@ class TestMarkKernels(TestCase):
         aux_done = torch.cuda.Event()
 
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.graph(graph, stream=capture_stream):
+        with torch.cuda.graph(graph, stream=capture_stream, enable_annotations=True):
             base = x + 1
             fork_event = capture_stream.record_event()
 
@@ -462,7 +396,6 @@ class TestMarkKernels(TestCase):
                 aux_stream.record_event(aux_done)
 
             capture_stream.wait_event(aux_done)
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertGreater(len(annotations), 0)
@@ -475,14 +408,13 @@ class TestMarkKernels(TestCase):
     def _exec_graph_id(self, graph):
         from cuda.bindings import runtime as cuda_runtime
 
-        handle = cuda_runtime.cudaGraphExec_t(init_value=graph.raw_cuda_graph_exec())
-        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(handle)
+        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(graph.raw_cuda_graph_exec())
         return exec_graph_id
 
     @parametrize("keep_graph", [True, False])
     def test_multiple_graphs_in_sequence_each_remapped(self, keep_graph):
-        """Several graphs captured in sequence, then resolved once and
-        remapped each, must all be annotated -- not just the last one.
+        """Several graphs captured in sequence must each be annotated and
+        remapped to their own exec id -- not just the last one.
 
         Covers both keep_graph modes: with keep_graph=True the template
         survives capture, with keep_graph=False it is destroyed -- the capture
@@ -492,24 +424,20 @@ class TestMarkKernels(TestCase):
         graph_b = torch.cuda.CUDAGraph(keep_graph=keep_graph)
         x = torch.randn(8, device="cuda")
 
-        with torch.cuda.graph(graph_a):
+        with torch.cuda.graph(graph_a, enable_annotations=True):
             with mark_kernels("graph_a"):
                 _ = x + 1
 
         # Break in between, then capture a second graph with its own marks.
-        with torch.cuda.graph(graph_b):
+        with torch.cuda.graph(graph_b, enable_annotations=True):
             with mark_kernels("graph_b"):
                 _ = x * 2
 
         if keep_graph:
-            # keep_graph=False auto-instantiates at capture_end.
+            # keep_graph=True defers instantiation (and thus the remap); for
+            # keep_graph=False capture_end already instantiated and remapped.
             graph_a.instantiate()
             graph_b.instantiate()
-
-        # Resolve the whole sequence once, then remap each graph.
-        resolve_pending_annotations()
-        remap_to_exec_graph(graph_a)
-        remap_to_exec_graph(graph_b)
 
         exec_a = self._exec_graph_id(graph_a)
         exec_b = self._exec_graph_id(graph_b)
@@ -598,7 +526,7 @@ class TestMarkKernels(TestCase):
         aux_done = torch.cuda.Event()
 
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.graph(graph, stream=capture_stream):
+        with torch.cuda.graph(graph, stream=capture_stream, enable_annotations=True):
             base = x + 1
             shared_event = capture_stream.record_event()
 
@@ -613,7 +541,6 @@ class TestMarkKernels(TestCase):
                     aux_stream.record_event(aux_done)
 
             capture_stream.wait_event(aux_done)
-            resolve_pending_annotations()
 
         annotations = get_kernel_annotations()
         self.assertEqual(len(annotations), 1)

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -19,25 +19,21 @@ Requires ``cuda.bindings`` package and a CUDA driver that supports
 ``cudaGraphNodeGetToolsId`` (CUDA >= 13.1 or appropriate cuda-compat).
 When unavailable, ``mark_kernels`` silently becomes a no-op.
 
+Annotation recording is enabled per capture via ``torch.cuda.graph``'s
+``enable_annotations`` argument, which also resolves and remaps the recorded
+annotations to the exec graph automatically on context exit.
+
 Usage during capture::
 
-    from torch.cuda._graph_annotations import (
-        enable_annotations,
-        mark_kernels,
-        resolve_pending_annotations,
-        remap_to_exec_graph,
-    )
+    from torch.cuda._graph_annotations import mark_kernels, get_kernel_annotations
 
-    enable_annotations()
-
-    with torch.cuda.graph(graph):
+    with torch.cuda.graph(graph, enable_annotations=True):
         with mark_kernels("phase_A"):
             y = workload_a(x)
         with mark_kernels("phase_B"):
             z = workload_b(y)
-        resolve_pending_annotations()
 
-    remap_to_exec_graph(graph)
+    annotations = get_kernel_annotations()
 """
 
 import importlib.metadata
@@ -75,20 +71,19 @@ _ExistingDirectDependents: TypeAlias = dict[int, set[int]]
 # Deferred to first use to avoid premature CUDA initialization.
 _tools_id_available: bool | None = None
 
-# Global kill switch. When False, mark_kernels and mark_stream are no-ops.
+# Whether annotation recording is active. Scoped to a ``torch.cuda.graph``
+# capture: set by the context manager on entry (from its ``enable_annotations``
+# argument) and cleared on exit. When False, mark_kernels/mark_stream and the
+# capture-id stamp are no-ops. Module-level (not thread-local) because capture
+# can span threads (e.g. autograd).
 _annotations_enabled: bool = False
 
 
-def enable_annotations() -> None:
-    """Enable kernel annotation recording."""
+def _set_annotations_enabled(enabled: bool) -> None:
+    """Set whether annotation recording is active. Used by ``torch.cuda.graph``
+    to scope annotations to a capture; not a public API."""
     global _annotations_enabled
-    _annotations_enabled = True
-
-
-def disable_annotations() -> None:
-    """Disable kernel annotation recording."""
-    global _annotations_enabled
-    _annotations_enabled = False
+    _annotations_enabled = enabled
 
 
 def _probe_tools_id() -> bool:

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -621,10 +621,11 @@ class graph:
         # pyrefly: ignore [missing-attribute]
         torch._C._host_emptyCache()
 
-        if self._enable_annotations:
-            from torch.cuda._graph_annotations import enable_annotations as _enable_ann
+        # Scope annotation recording to this capture: stamp/mark_kernels gate on
+        # this flag, and __exit__ always clears it.
+        from torch.cuda._graph_annotations import _set_annotations_enabled
 
-            _enable_ann()
+        _set_annotations_enabled(self._enable_annotations)
 
         # Stackoverflow seems comfortable with this pattern
         # https://stackoverflow.com/questions/26635684/calling-enter-and-exit-manually#39172487
@@ -640,16 +641,23 @@ class graph:
         )
 
     def __exit__(self, *args: object) -> None:
-        if self._enable_annotations:
-            from torch.cuda._graph_annotations import resolve_pending_annotations
+        from torch.cuda._graph_annotations import (
+            _set_annotations_enabled,
+            resolve_pending_annotations,
+        )
 
-            resolve_pending_annotations()
+        try:
+            if self._enable_annotations:
+                resolve_pending_annotations()
 
-        # capture_end stamps the capture id and, for keep_graph=False,
-        # instantiates (which remaps annotations to the exec id). For
-        # keep_graph=True the remap is owned by the later instantiate()/replay().
-        self.cuda_graph.capture_end()
-        self.stream_ctx.__exit__(*args)
+            # capture_end stamps the capture id and, for keep_graph=False,
+            # instantiates (which remaps annotations to the exec id). For
+            # keep_graph=True the remap is owned by the later instantiate()/replay().
+            self.cuda_graph.capture_end()
+            self.stream_ctx.__exit__(*args)
+        finally:
+            # Annotation recording is capture-scoped; clear it unconditionally.
+            _set_annotations_enabled(False)
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187911
* #187749

The private enable_annotations()/disable_annotations() process-global toggles are
removed. Whether annotation recording is active is now set per capture by
torch.cuda.graph(.., enable_annotations=...) on entry and cleared on exit (via a
private _set_annotations_enabled).

This removes a gating inconsistency: stamp + mark_kernels gated on the global
flag while the context manager's enable/resolve gated on the per-context flag.
Because the global never reset, after any annotated capture they diverged --
e.g. calling mark_kernels in a context declared enable_annotations=False (relying
on the leaked global) recorded scopes that were never resolved/remapped for that
graph. With the flag scoped to the capture, all sites agree and that class of
misuse is structurally impossible. Global mutable enable state was a foot-gun
anyway; the documented API is the per-graph kwarg, and nothing depended on the
global yet.

Tests are rewritten to enable annotations per capture via the kwarg (no global
setUp toggle); the disabled-path tests now assert that an un-annotated capture
records nothing.

Test Plan:
```
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda.py -k graph
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda.py -k keep_graph
```

Authored with assistance from Claude (Anthropic AI assistant).