### PR TITLE
[MPS] Add native ctc_loss / ctc_loss_backward (float and half)

### DIFF
--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -543,8 +543,13 @@ Tensor ctc_loss_impl(const Tensor& log_probs_, const Tensor& targets, LengthsTyp
     }
   }
   if (reduction == at::Reduction::Mean) {
-    auto target_lengths_t = get_clamped_target_length(target_lengths, res.options());
-    return (res / target_lengths_t).mean();
+    // For a half loss, do the division in float and cast back: half is a valid
+    // loss dtype on MPS, but at::tensor (and the division) have no Half kernel
+    // on some backends. float/double are unchanged. Half ctc_loss only reaches
+    // here on MPS; CPU/CUDA never dispatch half to a native kernel.
+    auto compute_dtype = res.scalar_type() == at::kHalf ? at::kFloat : res.scalar_type();
+    auto target_lengths_t = get_clamped_target_length(target_lengths, res.options().dtype(compute_dtype));
+    return (res.to(compute_dtype) / target_lengths_t).mean().to(res.scalar_type());
   } else if (reduction == at::Reduction::Sum) {
     return res.sum();
   }

--- a/aten/src/ATen/native/mps/kernels/LossCTC.h
+++ b/aten/src/ATen/native/mps/kernels/LossCTC.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Strides and sizes shared by the CTC alpha/beta/collect kernels. Targets are
+// passed as the augmented sequence l' (BLANK l_0 BLANK l_1 ... BLANK), so the
+// label axis runs over 2 * target_length + 1 entries.
+struct CTCLossParams {
+  long batch_size;
+  long max_input_length;
+  long max_target_length;
+  long num_labels;
+  long BLANK;
+  long lp_input_stride;
+  long lp_batch_stride;
+  long lp_char_stride;
+  long la_batch_stride;
+  long la_input_stride;
+  long la_target_stride;
+  long tg_target_stride;
+  bool zero_infinity;
+};

--- a/aten/src/ATen/native/mps/kernels/LossCTC.metal
+++ b/aten/src/ATen/native/mps/kernels/LossCTC.metal
@@ -1,0 +1,410 @@
+#include <ATen/native/mps/kernels/LossCTC.h>
+#include <metal_stdlib>
+
+using namespace metal;
+
+// CTC loss on Metal, a direct port of the CUDA forward-backward algorithm in
+// aten/src/ATen/native/cuda/LossCTC.cu (Graves et al., section 4.1). All log
+// quantities use the log-sum-exp trick for numerical stability.
+//
+// One threadgroup handles one batch item; the label axis s of the augmented
+// target l' (length 2 * target_length + 1) is split across the threads. Both
+// alpha and beta march along the time axis sequentially, so every timestep is
+// separated by a threadgroup_barrier. log_alpha / log_beta live in device
+// memory exactly as in the CUDA version, so threads only need the barrier to
+// observe each other's previous-timestep writes.
+//
+// scalar_t is the input/output dtype (float or half); acc_t is the accumulation
+// dtype, always float, used for the DP tables and the log-space gradient. This
+// keeps the half path full-precision; only inputs/outputs are half.
+
+// l' maps even indices to BLANK and odd indices to the real target label.
+template <typename target_t>
+static inline long get_target_prime(
+    constant target_t* target,
+    long offset,
+    long stride,
+    long idx,
+    long BLANK) {
+  if (idx % 2 == 0) {
+    return BLANK;
+  }
+  return target[offset + stride * (idx / 2)];
+}
+
+template <typename scalar_t, typename acc_t, typename target_t>
+kernel void ctc_loss_alpha(
+    device acc_t* log_alpha [[buffer(0)]],
+    constant scalar_t* log_probs [[buffer(1)]],
+    constant target_t* targets [[buffer(2)]],
+    constant long* input_lengths [[buffer(3)]],
+    constant long* target_lengths [[buffer(4)]],
+    constant long* tg_batch_offsets [[buffer(5)]],
+    device acc_t* neg_log_likelihood [[buffer(6)]],
+    constant CTCLossParams& p [[buffer(7)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint ltid [[thread_position_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]]) {
+  const acc_t neginf = -INFINITY;
+  const long b = tg_id;
+  if (b >= p.batch_size) {
+    return;
+  }
+
+  const long input_length = input_lengths[b];
+  const long target_length = target_lengths[b];
+  const long lp_batch_offset = b * p.lp_batch_stride;
+  const long la_batch_offset = b * p.la_batch_stride;
+  const long tg_batch_offset = tg_batch_offsets[b];
+  const long la_size = 2 * p.max_target_length + 1;
+
+  // Empty input: likelihood is 0 iff the target is also empty, else -inf.
+  if (input_length == 0) {
+    if (ltid == 0) {
+      neg_log_likelihood[b] = (target_length == 0) ? 0 : INFINITY;
+    }
+    return;
+  }
+
+  // t = 0 initialization (the equations for alpha_1 above eq (6)).
+  for (long s = ltid; s < la_size; s += tg_size) {
+    acc_t la;
+    if (s == 0) {
+      la = log_probs[lp_batch_offset + p.lp_char_stride * p.BLANK];
+    } else if (s == 1) {
+      la = target_length == 0 ? neginf
+                              : log_probs
+                                    [lp_batch_offset +
+                                     p.lp_char_stride *
+                                         get_target_prime(
+                                             targets,
+                                             tg_batch_offset,
+                                             p.tg_target_stride,
+                                             1,
+                                             p.BLANK)];
+    } else {
+      la = neginf;
+    }
+    log_alpha[la_batch_offset + p.la_target_stride * s] = la;
+  }
+
+  for (long s = ltid; s < la_size; s += tg_size) {
+    // current_char and have_three only depend on s, so compute them once.
+    long current_char;
+    bool have_three;
+    if (s < 2 * target_length + 1 && target_length > 0) {
+      current_char = get_target_prime(
+          targets, tg_batch_offset, p.tg_target_stride, s, p.BLANK);
+      have_three = (s > 1) &&
+          (get_target_prime(
+               targets, tg_batch_offset, p.tg_target_stride, s - 2, p.BLANK) !=
+           current_char);
+    } else {
+      current_char = p.BLANK;
+      have_three = false;
+    }
+    for (long t = 1; t < p.max_input_length; t++) {
+      threadgroup_barrier(mem_flags::mem_device);
+      if (t < input_length && s < 2 * target_length + 1) {
+        // eq (6)/(7): la1, la2, la3 are the three summands, lamax the max for
+        // the log-sum-exp trick.
+        acc_t la1 = log_alpha
+            [la_batch_offset + p.la_input_stride * (t - 1) +
+             p.la_target_stride * s];
+        acc_t lamax = la1;
+        acc_t la2, la3;
+        if (s > 0) {
+          la2 = log_alpha
+              [la_batch_offset + p.la_input_stride * (t - 1) +
+               p.la_target_stride * (s - 1)];
+          lamax = max(lamax, la2);
+        } else {
+          la2 = neginf;
+        }
+        if (have_three) {
+          la3 = log_alpha
+              [la_batch_offset + p.la_input_stride * (t - 1) +
+               p.la_target_stride * (s - 2)];
+          lamax = max(lamax, la3);
+        } else {
+          la3 = neginf;
+        }
+        // All summands -inf: pretend lamax is 0, the result stays -inf.
+        if (lamax == neginf) {
+          lamax = 0;
+        }
+        log_alpha
+            [la_batch_offset + p.la_input_stride * t + p.la_target_stride * s] =
+                precise::log(
+                    precise::exp(la1 - lamax) + precise::exp(la2 - lamax) +
+                    precise::exp(la3 - lamax)) +
+            lamax +
+            log_probs
+                [lp_batch_offset + t * p.lp_input_stride +
+                 p.lp_char_stride * current_char];
+      } else if (s < la_size) {
+        log_alpha
+            [la_batch_offset + p.la_input_stride * t + p.la_target_stride * s] =
+                neginf;
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_device);
+
+  // eq (8): combine the two valid final states into the loss.
+  if (ltid == 0) {
+    acc_t l1 = log_alpha
+        [la_batch_offset + p.la_input_stride * (input_length - 1) +
+         p.la_target_stride * (target_length * 2)];
+    acc_t l2 = target_length > 0
+        ? log_alpha
+              [la_batch_offset + p.la_input_stride * (input_length - 1) +
+               p.la_target_stride * (target_length * 2 - 1)]
+        : neginf;
+    acc_t m = max(l1, l2);
+    m = (m == neginf) ? 0 : m;
+    acc_t log_likelihood =
+        precise::log(precise::exp(l1 - m) + precise::exp(l2 - m)) + m;
+    neg_log_likelihood[b] = -log_likelihood;
+  }
+}
+
+// beta recursion ((10)/(11)), the time-reversed counterpart of alpha. log_beta
+// is laid out like log_alpha (la_* strides are reused for it).
+template <typename scalar_t, typename acc_t, typename target_t>
+kernel void ctc_loss_beta(
+    device acc_t* log_beta [[buffer(0)]],
+    constant scalar_t* log_probs [[buffer(1)]],
+    constant target_t* targets [[buffer(2)]],
+    constant long* input_lengths [[buffer(3)]],
+    constant long* target_lengths [[buffer(4)]],
+    constant long* tg_batch_offsets [[buffer(5)]],
+    constant CTCLossParams& p [[buffer(6)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint ltid [[thread_position_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]]) {
+  const acc_t neginf = -INFINITY;
+  const long b = tg_id;
+  if (b >= p.batch_size) {
+    return;
+  }
+
+  const long input_length = input_lengths[b];
+  const long target_length = target_lengths[b];
+  const long lp_batch_offset = b * p.lp_batch_stride;
+  const long lb_batch_offset = b * p.la_batch_stride;
+  const long tg_batch_offset = tg_batch_offsets[b];
+  const long la_size = 2 * p.max_target_length + 1;
+
+  if (input_length == 0) {
+    return;
+  }
+
+  // beta initialization at t = input_length - 1 (before eq (10)).
+  for (long s = ltid; s < la_size; s += tg_size) {
+    acc_t lb;
+    if (s == 2 * target_length) {
+      lb = log_probs
+          [lp_batch_offset + (input_length - 1) * p.lp_input_stride +
+           p.lp_char_stride * p.BLANK];
+    } else if (s == 2 * target_length - 1) { // false when target_length == 0
+      long current = get_target_prime(
+          targets, tg_batch_offset, p.tg_target_stride, s, p.BLANK);
+      lb = log_probs
+          [lp_batch_offset + (input_length - 1) * p.lp_input_stride +
+           p.lp_char_stride * current];
+    } else {
+      lb = neginf;
+    }
+    log_beta
+        [lb_batch_offset + (input_length - 1) * p.la_input_stride +
+         p.la_target_stride * s] = lb;
+  }
+
+  for (long s = ltid; s < la_size; s += tg_size) {
+    long current_target_prime;
+    bool have_three;
+    if (s < 2 * target_length + 1 && target_length > 0) {
+      current_target_prime = get_target_prime(
+          targets, tg_batch_offset, p.tg_target_stride, s, p.BLANK);
+      have_three = (s < 2 * target_length - 1) &&
+          (get_target_prime(
+               targets, tg_batch_offset, p.tg_target_stride, s + 2, p.BLANK) !=
+           current_target_prime);
+    } else {
+      current_target_prime = p.BLANK;
+      have_three = false;
+    }
+    // Go backward in t, skipping the last timestep initialized above.
+    for (long t = p.max_input_length - 2; t >= 0; t--) {
+      threadgroup_barrier(mem_flags::mem_device);
+      if (t < input_length - 1 && s < 2 * target_length + 1) {
+        acc_t lb1 = log_beta
+            [lb_batch_offset + p.la_input_stride * (t + 1) +
+             p.la_target_stride * s];
+        acc_t lbmax = lb1;
+        acc_t lb2, lb3;
+        if (s < 2 * target_length) {
+          lb2 = log_beta
+              [lb_batch_offset + p.la_input_stride * (t + 1) +
+               p.la_target_stride * (s + 1)];
+          lbmax = max(lbmax, lb2);
+        } else {
+          lb2 = neginf;
+        }
+        if (have_three) {
+          lb3 = log_beta
+              [lb_batch_offset + p.la_input_stride * (t + 1) +
+               p.la_target_stride * (s + 2)];
+          lbmax = max(lbmax, lb3);
+        } else {
+          lb3 = neginf;
+        }
+        if (lbmax == neginf) {
+          lbmax = 0;
+        }
+        log_beta
+            [lb_batch_offset + p.la_input_stride * t + p.la_target_stride * s] =
+                precise::log(
+                    precise::exp(lb1 - lbmax) + precise::exp(lb2 - lbmax) +
+                    precise::exp(lb3 - lbmax)) +
+            lbmax +
+            log_probs
+                [lp_batch_offset + t * p.lp_input_stride +
+                 p.lp_char_stride * current_target_prime];
+      } else if (
+          s < la_size &&
+          (((target_length == 0) && (s > 0)) || (s >= 2 * target_length + 1) ||
+           (t >= input_length))) {
+        log_beta
+            [lb_batch_offset + p.la_input_stride * t + p.la_target_stride * s] =
+                neginf;
+      }
+    }
+  }
+}
+
+// Gradient collection, the naive variant of eq (16): parallel over (b, t) with
+// a sequential loop over s, so each gradient element is owned by exactly one
+// thread and no atomics are needed. The CUDA code keeps an atomic
+// large-alphabet path too; MPS always uses this race-free version. gradient
+// (acc_t) first accumulates log(alpha*beta), then is rewritten to the gradient.
+template <typename scalar_t, typename acc_t, typename target_t>
+kernel void ctc_loss_collect(
+    device acc_t* gradient [[buffer(0)]],
+    constant scalar_t* grad_out [[buffer(1)]],
+    constant acc_t* log_alpha [[buffer(2)]],
+    constant acc_t* log_beta [[buffer(3)]],
+    constant scalar_t* log_probs [[buffer(4)]],
+    constant target_t* targets [[buffer(5)]],
+    constant long* input_lengths [[buffer(6)]],
+    constant long* target_lengths [[buffer(7)]],
+    constant long* tg_batch_offsets [[buffer(8)]],
+    constant acc_t* neg_log_likelihood [[buffer(9)]],
+    constant long* gr_strides [[buffer(10)]], // {batch, input, char}
+    constant long& grad_out_batch_stride [[buffer(11)]],
+    constant CTCLossParams& p [[buffer(12)]],
+    uint2 tid [[thread_position_in_grid]]) {
+  const acc_t neginf = -INFINITY;
+  const long t = tid.x;
+  const long b = tid.y;
+  if (t >= p.max_input_length || b >= p.batch_size) {
+    return;
+  }
+
+  const long input_length = input_lengths[b];
+  const long target_length = target_lengths[b];
+  const long gr_batch_offset = b * gr_strides[0];
+  const long lp_batch_offset = b * p.lp_batch_stride;
+  const long la_batch_offset = b * p.la_batch_stride;
+  const long tg_batch_offset = tg_batch_offsets[b];
+
+  // collected[b, t, l'[s]] "log+=" log_alpha[t, s] + log_beta[t, s].
+  for (long s = 0; s < 2 * p.max_target_length + 1; s++) {
+    if (s < 2 * target_length + 1) { // if target_length == 0 then only s == 0
+      long current_target_prime = get_target_prime(
+          targets, tg_batch_offset, p.tg_target_stride, s, p.BLANK);
+      acc_t log_alpha_beta = log_alpha
+                                 [la_batch_offset + p.la_input_stride * t +
+                                  p.la_target_stride * s] +
+          log_beta[la_batch_offset + p.la_input_stride * t +
+                   p.la_target_stride * s];
+      long idx = gr_batch_offset + t * gr_strides[1] +
+          gr_strides[2] * current_target_prime;
+      acc_t lcab = gradient[idx];
+      if (lcab == neginf) {
+        gradient[idx] = log_alpha_beta;
+      } else {
+        acc_t m = max(lcab, log_alpha_beta);
+        gradient[idx] =
+            precise::log(
+                precise::exp(lcab - m) + precise::exp(log_alpha_beta - m)) +
+            m;
+      }
+    }
+  }
+
+  acc_t nll = neg_log_likelihood[b];
+  acc_t gr = grad_out[b * grad_out_batch_stride];
+
+  for (long c = 0; c < p.num_labels; c++) {
+    long idx = gr_batch_offset + t * gr_strides[1] + gr_strides[2] * c;
+    if (t < input_length && (!p.zero_infinity || nll != INFINITY)) {
+      acc_t lp = log_probs
+          [lp_batch_offset + t * p.lp_input_stride + p.lp_char_stride * c];
+      gradient[idx] =
+          (precise::exp(lp) - precise::exp(gradient[idx] + nll - lp)) * gr;
+    } else {
+      gradient[idx] = 0;
+    }
+  }
+}
+
+#define INSTANTIATE_CTC(DTYPE, ADTYPE, TDTYPE)                                \
+  template [[host_name("ctc_loss_alpha_" #DTYPE "_" #TDTYPE)]] kernel void    \
+  ctc_loss_alpha<DTYPE, ADTYPE, TDTYPE>(                                      \
+      device ADTYPE*,                                                         \
+      constant DTYPE*,                                                        \
+      constant TDTYPE*,                                                       \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      device ADTYPE*,                                                         \
+      constant CTCLossParams&,                                                \
+      uint,                                                                   \
+      uint,                                                                   \
+      uint);                                                                  \
+  template [[host_name("ctc_loss_beta_" #DTYPE "_" #TDTYPE)]] kernel void     \
+  ctc_loss_beta<DTYPE, ADTYPE, TDTYPE>(                                       \
+      device ADTYPE*,                                                         \
+      constant DTYPE*,                                                        \
+      constant TDTYPE*,                                                       \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      constant CTCLossParams&,                                                \
+      uint,                                                                   \
+      uint,                                                                   \
+      uint);                                                                  \
+  template [[host_name("ctc_loss_collect_" #DTYPE "_" #TDTYPE)]] kernel void  \
+  ctc_loss_collect<DTYPE, ADTYPE, TDTYPE>(                                    \
+      device ADTYPE*,                                                         \
+      constant DTYPE*,                                                        \
+      constant ADTYPE*,                                                       \
+      constant ADTYPE*,                                                       \
+      constant DTYPE*,                                                        \
+      constant TDTYPE*,                                                       \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      constant long*,                                                         \
+      constant ADTYPE*,                                                       \
+      constant long*,                                                         \
+      constant long&,                                                         \
+      constant CTCLossParams&,                                                \
+      uint2);
+
+// (scalar_t, acc_t, target_t); acc_t is float for both, so half accumulates in float.
+INSTANTIATE_CTC(float, float, int);
+INSTANTIATE_CTC(float, float, long);
+INSTANTIATE_CTC(half, float, int);
+INSTANTIATE_CTC(half, float, long);

--- a/aten/src/ATen/native/mps/operations/LossCTC.mm
+++ b/aten/src/ATen/native/mps/operations/LossCTC.mm
@@ -1,0 +1,268 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TensorUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/LossCTC.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_ctc_loss_backward_native.h>
+#include <ATen/ops/_ctc_loss_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/full_like.h>
+#include <ATen/ops/tensor.h>
+#endif
+
+namespace at::native {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/LossCTC_metallib.h>
+#endif
+
+namespace {
+
+// Build the per-batch offset into the targets tensor. Targets come either as a
+// 2D (batch x max_target_length) tensor or as a 1D concatenation of all targets;
+// in both cases we precompute where each batch item starts, on the host, exactly
+// like the CPU/CUDA implementations.
+static Tensor make_tg_batch_offsets(const Tensor& targets,
+                                    IntArrayRef target_lengths,
+                                    int64_t batch_size,
+                                    int64_t& tg_target_stride,
+                                    int64_t& max_target_length) {
+  auto tg_batch_offsets = at::empty({batch_size}, at::device(at::kCPU).dtype(at::kLong));
+  auto tg_batch_offsets_data = tg_batch_offsets.mutable_data_ptr<int64_t>();
+  max_target_length = 0;
+  if (targets.dim() == 1) { // concatenated targets
+    int64_t pos = 0;
+    for (const auto i : c10::irange(batch_size)) {
+      tg_batch_offsets_data[i] = pos;
+      pos += target_lengths[i];
+      max_target_length = std::max(max_target_length, target_lengths[i]);
+    }
+    tg_target_stride = targets.stride(0);
+  } else { // batch x max_target_length
+    int64_t tg_batch_stride = targets.stride(0);
+    for (const auto i : c10::irange(batch_size)) {
+      tg_batch_offsets_data[i] = i * tg_batch_stride;
+      max_target_length = std::max(max_target_length, target_lengths[i]);
+    }
+    tg_target_stride = targets.stride(1);
+  }
+  return tg_batch_offsets;
+}
+
+static std::string ctc_kernel_suffix(const Tensor& log_probs, ScalarType target_scalar_type) {
+  return mps::scalarToMetalTypeString(log_probs) + "_" + (target_scalar_type == kInt ? "int" : "long");
+}
+
+} // anonymous namespace
+
+std::tuple<Tensor, Tensor> ctc_loss_mps(const Tensor& log_probs,
+                                        const Tensor& targets,
+                                        IntArrayRef input_lengths,
+                                        IntArrayRef target_lengths,
+                                        int64_t BLANK,
+                                        bool zero_infinity) {
+  (void)zero_infinity; // forward loss does not depend on zero_infinity
+  TORCH_CHECK(log_probs.numel() > 0, "log_probs tensor must not be empty");
+  TORCH_CHECK(log_probs.dim() == 3, "log_probs has to be a 3D tensor");
+  // float and half only (Metal has no double).
+  TORCH_CHECK(log_probs.scalar_type() == kFloat || log_probs.scalar_type() == kHalf,
+              "ctc_loss: MPS only supports float32 or float16 log_probs, got ",
+              log_probs.scalar_type());
+  auto target_scalar_type = targets.scalar_type();
+  TORCH_CHECK(target_scalar_type == kInt || target_scalar_type == kLong,
+              "targets must be int32 or int64, got ",
+              target_scalar_type);
+
+  int64_t batch_size = log_probs.size(1);
+  int64_t num_labels = log_probs.size(2);
+  int64_t max_input_length = log_probs.size(0);
+  TORCH_CHECK((0 <= BLANK) && (BLANK < num_labels), "blank must be in label range");
+  TORCH_CHECK(input_lengths.size() == static_cast<size_t>(batch_size), "input_lengths must be of size batch_size");
+  TORCH_CHECK(target_lengths.size() == static_cast<size_t>(batch_size), "target_lengths must be of size batch_size");
+
+  int64_t tg_target_stride = 0;
+  int64_t max_target_length = 0;
+  auto tg_batch_offsets =
+      make_tg_batch_offsets(targets, target_lengths, batch_size, tg_target_stride, max_target_length);
+
+  for (const auto b : c10::irange(batch_size)) {
+    TORCH_CHECK(input_lengths[b] >= 0, "input_lengths must be non-negative");
+    TORCH_CHECK(input_lengths[b] <= max_input_length,
+                "Expected input_lengths to have value at most ",
+                max_input_length,
+                ", but got ",
+                input_lengths[b]);
+    TORCH_CHECK(target_lengths[b] >= 0, "target_lengths must be non-negative");
+  }
+
+  auto input_lengths_t = at::tensor(input_lengths, targets.options().dtype(kLong)).to(log_probs.device());
+  auto target_lengths_t = at::tensor(target_lengths, targets.options().dtype(kLong)).to(log_probs.device());
+  tg_batch_offsets = tg_batch_offsets.to(log_probs.device());
+
+  // DP table and loss accumulate in float (acc_t); see LossCTC.metal.
+  auto acc_options = log_probs.options().dtype(kFloat);
+  Tensor log_alpha = at::empty({batch_size, max_input_length, 2 * max_target_length + 1}, acc_options);
+  Tensor neg_log_likelihood = at::empty({batch_size}, acc_options);
+
+  CTCLossParams params{batch_size,
+                       max_input_length,
+                       max_target_length,
+                       num_labels,
+                       BLANK,
+                       log_probs.stride(0),
+                       log_probs.stride(1),
+                       log_probs.stride(2),
+                       log_alpha.stride(0),
+                       log_alpha.stride(1),
+                       log_alpha.stride(2),
+                       tg_target_stride,
+                       zero_infinity};
+
+  // One threadgroup per batch item; threads cover the label axis (capped at the
+  // device limit, the kernel strides over s if the axis is longer).
+  const int64_t la_size = 2 * max_target_length + 1;
+  using namespace mps;
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+      auto PSO = lib.getPipelineStateForFunc("ctc_loss_alpha_" + ctc_kernel_suffix(log_probs, target_scalar_type));
+      uint64_t tg_threads = std::min<uint64_t>(la_size, PSO.maxTotalThreadsPerThreadgroup);
+      getMPSProfiler().beginProfileKernel(PSO, "ctc_loss_alpha", {log_probs, targets});
+      [computeEncoder setComputePipelineState:PSO];
+      mtl_setArgs(computeEncoder,
+                  log_alpha,
+                  log_probs,
+                  targets,
+                  input_lengths_t,
+                  target_lengths_t,
+                  tg_batch_offsets,
+                  neg_log_likelihood,
+                  params);
+      [computeEncoder dispatchThreadgroups:MTLSizeMake(batch_size, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(tg_threads, 1, 1)];
+      getMPSProfiler().endProfileKernel(PSO);
+    }
+  });
+  // Cast the loss back to the input dtype; log_alpha stays float for backward.
+  return std::make_tuple(neg_log_likelihood.to(log_probs.scalar_type()), log_alpha);
+}
+
+Tensor ctc_loss_backward_mps(const Tensor& grad_out,
+                             const Tensor& log_probs,
+                             const Tensor& targets,
+                             IntArrayRef input_lengths,
+                             IntArrayRef target_lengths,
+                             const Tensor& neg_log_likelihood,
+                             const Tensor& log_alpha,
+                             int64_t BLANK,
+                             bool zero_infinity) {
+  constexpr double neginf = -std::numeric_limits<double>::infinity();
+  TORCH_CHECK(log_probs.scalar_type() == kFloat || log_probs.scalar_type() == kHalf,
+              "ctc_loss_backward: MPS only supports float32 or float16 log_probs, got ",
+              log_probs.scalar_type());
+  auto target_scalar_type = targets.scalar_type();
+  int64_t batch_size = log_probs.size(1);
+  int64_t num_labels = log_probs.size(2);
+  int64_t max_input_length = log_probs.size(0);
+
+  int64_t tg_target_stride = 0;
+  int64_t max_target_length = 0;
+  auto tg_batch_offsets =
+      make_tg_batch_offsets(targets, target_lengths, batch_size, tg_target_stride, max_target_length);
+  // For 2D targets the alpha width is authoritative (targets.size(1) may be larger).
+  if (targets.dim() != 1) {
+    max_target_length = log_alpha.size(2) / 2;
+  }
+
+  auto input_lengths_t = at::tensor(input_lengths, targets.options().dtype(kLong)).to(log_probs.device());
+  auto target_lengths_t = at::tensor(target_lengths, targets.options().dtype(kLong)).to(log_probs.device());
+  tg_batch_offsets = tg_batch_offsets.to(log_probs.device());
+
+  // Normalize to the kernel's buffer dtypes (float accumulators, input-dtype
+  // grad_out) in case autograd handed us promoted tensors.
+  auto log_alpha_acc = log_alpha.to(kFloat);
+  auto nll_acc = neg_log_likelihood.to(kFloat);
+  auto grad_out_in = grad_out.to(log_probs.scalar_type());
+
+  Tensor log_beta = at::empty_like(log_alpha_acc, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  // gradient accumulates log(sum(alpha*beta)) in float, then is rewritten in place.
+  auto acc_options = log_probs.options().dtype(kFloat);
+  Tensor grad = at::full_like(log_probs, neginf, acc_options, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  CTCLossParams params{batch_size,
+                       max_input_length,
+                       max_target_length,
+                       num_labels,
+                       BLANK,
+                       log_probs.stride(0),
+                       log_probs.stride(1),
+                       log_probs.stride(2),
+                       log_alpha_acc.stride(0),
+                       log_alpha_acc.stride(1),
+                       log_alpha_acc.stride(2),
+                       tg_target_stride,
+                       zero_infinity};
+  // grad is (T, N, C); the kernel expects {batch, input, char} order.
+  std::array<int64_t, 3> gr_strides = {grad.stride(1), grad.stride(0), grad.stride(2)};
+  int64_t grad_out_batch_stride = grad_out_in.stride(0);
+  const int64_t la_size = 2 * max_target_length + 1;
+  const std::string suffix = ctc_kernel_suffix(log_probs, target_scalar_type);
+
+  using namespace mps;
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+
+      // beta: one threadgroup per batch item, threads over the label axis.
+      auto betaPSO = lib.getPipelineStateForFunc("ctc_loss_beta_" + suffix);
+      uint64_t tg_threads = std::min<uint64_t>(la_size, betaPSO.maxTotalThreadsPerThreadgroup);
+      getMPSProfiler().beginProfileKernel(betaPSO, "ctc_loss_beta", {log_probs, targets});
+      [computeEncoder setComputePipelineState:betaPSO];
+      mtl_setArgs(
+          computeEncoder, log_beta, log_probs, targets, input_lengths_t, target_lengths_t, tg_batch_offsets, params);
+      [computeEncoder dispatchThreadgroups:MTLSizeMake(batch_size, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(tg_threads, 1, 1)];
+      getMPSProfiler().endProfileKernel(betaPSO);
+
+      // collect (naive, race-free): parallel over (t, b), sequential over s.
+      auto collectPSO = lib.getPipelineStateForFunc("ctc_loss_collect_" + suffix);
+      getMPSProfiler().beginProfileKernel(collectPSO, "ctc_loss_collect", {log_probs, targets});
+      [computeEncoder setComputePipelineState:collectPSO];
+      mtl_setArgs(computeEncoder,
+                  grad,
+                  grad_out_in,
+                  log_alpha_acc,
+                  log_beta,
+                  log_probs,
+                  targets,
+                  input_lengths_t,
+                  target_lengths_t,
+                  tg_batch_offsets,
+                  nll_acc,
+                  gr_strides,
+                  grad_out_batch_stride,
+                  params);
+      [computeEncoder dispatchThreads:MTLSizeMake(max_input_length, batch_size, 1)
+                threadsPerThreadgroup:MTLSizeMake(std::min<uint64_t>(max_input_length,
+                                                                     collectPSO.maxTotalThreadsPerThreadgroup),
+                                                  1,
+                                                  1)];
+      getMPSProfiler().endProfileKernel(collectPSO);
+    }
+  });
+  // grad was accumulated in float; return it in the input dtype.
+  return grad.to(log_probs.scalar_type());
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2024,6 +2024,7 @@
     CPU: ctc_loss_cpu
     CUDA: ctc_loss_gpu
     Meta: ctc_loss_meta
+    MPS: ctc_loss_mps
     XPU: ctc_loss_xpu
   autogen: _ctc_loss.out
   tags: dynamic_output_shape  # the shape of second output is data dependent
@@ -2038,6 +2039,7 @@
   dispatch:
     CPU: ctc_loss_backward_cpu
     CUDA: ctc_loss_backward_gpu
+    MPS: ctc_loss_backward_mps
     XPU: ctc_loss_backward_xpu
   autogen: _ctc_loss_backward.out
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10529,6 +10529,98 @@ class TestNLLLoss(TestCaseMPS):
             torch.ops.aten.nll_loss_backward(grad_out, inp, label, None, 1, -100, total_weight)
 
 
+class TestCTCLoss(TestCaseMPS):
+    def _ctc_loss_helper(self, T, C, N, target_lengths, input_lengths, *,
+                         targets_1d, target_dtype, dtype=torch.float, blank=0,
+                         zero_infinity=False, reduction="mean"):
+        # CPU is the reference; MPS is a clone of it. log_probs is (T, N, C).
+        # The CPU reference always runs in float (it has no Half kernel); for the
+        # half case MPS runs in half and is compared to the float reference, so
+        # assertEqual uses the dtype-aware fp16 tolerance.
+        log_probs = torch.randn(T, C, N, device="cpu").log_softmax(2).transpose(1, 2).detach()
+        log_probs = log_probs.contiguous().requires_grad_()
+        log_probs_mps = log_probs.detach().clone().to(device="mps", dtype=dtype).requires_grad_()
+
+        if targets_1d:
+            targets = torch.randint(1, C, (sum(target_lengths),), dtype=target_dtype, device="cpu")
+        else:
+            max_tl = max(target_lengths) if len(target_lengths) else 0
+            targets = torch.randint(1, C, (N, max_tl), dtype=target_dtype, device="cpu")
+        targets_mps = targets.detach().clone().to("mps")
+
+        il = torch.tensor(input_lengths, dtype=torch.long)
+        tl = torch.tensor(target_lengths, dtype=torch.long)
+
+        loss_cpu = F.ctc_loss(log_probs, targets, il, tl, blank=blank,
+                              reduction=reduction, zero_infinity=zero_infinity)
+        loss_mps = F.ctc_loss(log_probs_mps, targets_mps, il, tl, blank=blank,
+                              reduction=reduction, zero_infinity=zero_infinity)
+        # The CPU reference is always float. For the half case compare values
+        # only (exact_dtype=False) with an explicit fp16 tolerance, since the MPS
+        # output is half while the reference is float.
+        if dtype == torch.float:
+            tol = {}
+        else:
+            tol = {"exact_dtype": False, "atol": 1e-3, "rtol": 1e-2}
+        self.assertEqual(loss_cpu, loss_mps.to("cpu"), **tol)
+
+        loss_cpu.sum().backward()
+        loss_mps.sum().backward()
+        self.assertEqual(log_probs.grad, log_probs_mps.grad.to("cpu"), **tol)
+
+    def test_ctc_loss_basic(self):
+        # 1D (concatenated) and 2D (padded) targets, int32 and int64.
+        for targets_1d in (True, False):
+            for target_dtype in (torch.int, torch.long):
+                self._ctc_loss_helper(
+                    T=50, C=20, N=16,
+                    target_lengths=[30, 25, 20, 15, 30, 25, 20, 15, 30, 25, 20, 15, 30, 25, 20, 15],
+                    input_lengths=[50] * 16,
+                    targets_1d=targets_1d, target_dtype=target_dtype)
+
+    def test_ctc_loss_reductions(self):
+        for reduction in ("none", "mean", "sum"):
+            self._ctc_loss_helper(
+                T=40, C=15, N=8,
+                target_lengths=[20, 18, 16, 14, 20, 18, 16, 14],
+                input_lengths=[40] * 8,
+                targets_1d=True, target_dtype=torch.long, reduction=reduction)
+
+    def test_ctc_loss_varying_input_lengths(self):
+        # input_lengths shorter than T exercises the t >= input_length tail.
+        self._ctc_loss_helper(
+            T=50, C=20, N=4,
+            target_lengths=[10, 12, 8, 15],
+            input_lengths=[40, 35, 50, 45],
+            targets_1d=True, target_dtype=torch.long)
+
+    def test_ctc_loss_zero_infinity(self):
+        # target longer than input forces an infinite loss; zero_infinity zeroes it.
+        self._ctc_loss_helper(
+            T=10, C=10, N=3,
+            target_lengths=[15, 8, 20],
+            input_lengths=[10, 10, 10],
+            targets_1d=True, target_dtype=torch.long, zero_infinity=True)
+
+    def test_ctc_loss_empty_target(self):
+        # target_length == 0: loss is just the all-blank path.
+        self._ctc_loss_helper(
+            T=20, C=10, N=4,
+            target_lengths=[0, 5, 0, 8],
+            input_lengths=[20] * 4,
+            targets_1d=True, target_dtype=torch.long)
+
+    def test_ctc_loss_half(self):
+        # half MPS vs the float CPU reference. Accumulation is float internally,
+        # so the result tracks the reference within fp16 tolerance (assertEqual
+        # picks the tolerance from the half output dtype).
+        self._ctc_loss_helper(
+            T=50, C=20, N=8,
+            target_lengths=[20, 18, 16, 14, 20, 18, 16, 14],
+            input_lengths=[50] * 8,
+            targets_1d=True, target_dtype=torch.long, dtype=torch.half)
+
+
 class TestTopK(TestCase):
     def _test_topk(self, shape, largest):
         cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)


### PR DESCRIPTION
## Summary

CTC loss has no MPS dispatch, so on MPS it goes through the CPU fallback (`PYTORCH_ENABLE_MPS_FALLBACK=1`): the inputs are copied to the CPU, the forward-backward runs there, and the results are copied back. This adds a native Metal implementation so `_ctc_loss` / `_ctc_loss_backward` stay on the GPU, with no fallback env var and no host round-trip.

The kernels are a direct port of the CUDA forward-backward algorithm in `aten/src/ATen/native/cuda/LossCTC.cu` (Graves et al., section 4.1):

- `ctc_loss_alpha` — forward alpha recursion and the loss (eq 8)
- `ctc_loss_beta` — backward beta recursion
- `ctc_loss_collect` — gradient assembly (eq 16)

Each kernel uses one threadgroup per batch item, splits the augmented-target label axis across threads, and puts a `threadgroup_barrier` between the sequential time steps. The alpha/beta DP tables live in device memory, exactly as in the CUDA version.

## dtypes: float and half

The kernels are templated on `<scalar_t, acc_t, target_t>`. `scalar_t` is the input/output dtype (`float` or `half`); `acc_t` is the accumulation dtype, always `float`. The alpha/beta DP tables and the log-space gradient accumulator are `acc_t`, so the half path runs the full log-sum-exp recursion in float and only the user-visible inputs and outputs are half. The forward casts the loss back to the input dtype and keeps `log_alpha` in float for backward; backward casts the final gradient back to the input dtype.

This matters because the recursion reads and writes the DP table every timestep. Accumulating that in half would round-trip through fp16 at every step and drift over long sequences; keeping the buffers in float avoids that. CPU/CUDA never hit this: `ctc_loss` is registered fp32-only in autocast (`KERNEL_CPU(ctc_loss, IntList, fp32)`) and the native CUDA kernel only instantiates float/double via `AT_DISPATCH_FLOATING_TYPES`, so half CTC there runs through cuDNN. MPS has no cuDNN equivalent, so the native kernel handles half directly and the float-accumulation split is explicit.

`double` is not supported (Metal has no double); a half or float input is required, checked in `ctc_loss_mps` / `ctc_loss_backward_mps`.

## Gradient: naive path only

For the gradient I ported only the naive, race-free `collect` variant: it is parallel over `(t, b)` and sequential over the label axis, so each gradient element is written by exactly one thread and no atomics are needed. The CUDA code also keeps an `atomicAdd`-based path for large alphabets; I left that out because Metal's float atomics require a CAS loop, and it can be added later if a benchmark shows the naive path is a bottleneck. Both variants compute the same result.

## Numerical stability

`exp`/`log` in the log-sum-exp steps use the `precise::` variants. They mirror CUDA's `std::exp`/`std::log`; the `fast::` variants lose too much precision across the per-timestep accumulation. The DP tables being float (above) is the other half of this.

## Correctness

Tests in `test/test_mps.py` (`TestCTCLoss`) compare against the CPU reference for float and half, 1D concatenated and 2D padded targets, int32/int64 targets, the three reductions, variable input lengths, `zero_infinity`, and empty targets. Forward loss and backward gradient are both checked. The half case compares MPS half against the float CPU reference (the CPU kernel has no Half), so it relies on the fp16 tolerance in `assertEqual`.

## Benchmarks

On an M-series GPU, the native kernels vs the CPU fallback they replace (copy to CPU, run, copy back), `reduction="sum"`, float:

| case | CPU fallback | MPS native | speedup |
|---|---|---|---|
| forward T200 N16 C32 S40 | 1.566 ms | 1.064 ms | 1.5x |
| forward T400 N32 C60 S80 | 6.552 ms | 1.583 ms | 4.1x |
| forward T1000 N16 C40 S100 | 9.920 ms | 2.892 ms | 3.4x |
| fwd+bwd T200 N16 C32 S40 | 3.434 ms | 2.400 ms | 1.4x |
| fwd+bwd T400 N32 C60 S80 | 17.629 ms | 5.446 ms | 3.2x |
| fwd+bwd T1000 N16 C40 S100 | 27.296 ms | 9.116 ms | 3.0x |

The gap widens with sequence length and batch as the host round-trip the fallback pays grows. `precise::` math is used throughout, so the speedup is not from trading away accuracy.

## Notes

This covers the `IntArrayRef` `_ctc_loss` path that `nn.CTCLoss` uses. The `_ctc_loss.Tensor` overload (Tensor-valued lengths) still falls back.
