### PR TITLE
Fix #153344

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7465,6 +7465,47 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
             self.assertIsNone(block_mask.full_q_indices)
 
     @supported_platform
+    def test_from_kv_blocks_unpadded_kv_indices_with_seq_lengths(self, device):
+        kv_num_blocks = torch.ones((1, 1, 3), dtype=torch.int32, device=device)
+        kv_indices = torch.arange(3, dtype=torch.int32, device=device).view(1, 1, 3, 1)
+
+        block_mask = BlockMask.from_kv_blocks(
+            kv_num_blocks,
+            kv_indices,
+            BLOCK_SIZE=32,
+            seq_lengths=(96, 96),
+        )
+
+        self.assertEqual(block_mask.shape, (1, 1, 96, 96))
+        torch.testing.assert_close(block_mask.kv_num_blocks, kv_num_blocks)
+        torch.testing.assert_close(block_mask.kv_indices, kv_indices)
+        torch.testing.assert_close(block_mask.q_num_blocks, kv_num_blocks)
+        torch.testing.assert_close(block_mask.q_indices[..., :1], kv_indices)
+
+    @supported_platform
+    def test_from_kv_blocks_fullgraph_compile_with_inferred_seq_lengths(self, device):
+        def from_kv_blocks_q_metadata(kv_num_blocks, kv_indices):
+            block_mask = BlockMask.from_kv_blocks(kv_num_blocks, kv_indices)
+            return block_mask.q_num_blocks, block_mask.q_indices
+
+        kv_num_blocks, kv_indices, _, _ = self.generate_test_inputs(False, device)
+        counter = CompileCounterWithBackend("aot_eager")
+        q_num_blocks, q_indices = torch.compile(
+            from_kv_blocks_q_metadata, backend=counter, fullgraph=True
+        )(kv_num_blocks, kv_indices)
+
+        self.assertEqual(counter.frame_count, 1)
+        self.assertEqual(len(counter.graphs), 1)
+        torch.testing.assert_close(
+            q_num_blocks,
+            torch.tensor([1, 1], dtype=torch.int32, device=device).view(1, 1, 2),
+        )
+        torch.testing.assert_close(
+            q_indices,
+            torch.tensor([0, 0], dtype=torch.int32, device=device).view(1, 1, 2, 1),
+        )
+
+    @supported_platform
     def test_block_size(self, device):
         kv_num_blocks, kv_indices, _, _ = self.generate_test_inputs(False, device)
         block_mask = BlockMask.from_kv_blocks(kv_num_blocks, kv_indices)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -433,9 +433,13 @@ def _dense_to_ordered(dense_mask: Tensor) -> tuple[Tensor, Tensor]:
 
 
 def _transpose_ordered(
-    num_blocks_in_row: Tensor, col_indices: Tensor
+    num_blocks_in_row: Tensor, col_indices: Tensor, num_cols: int | None = None
 ) -> tuple[Tensor, Tensor]:
-    dense = _ordered_to_dense(num_blocks_in_row, col_indices, col_indices.shape[-1])
+    dense = _ordered_to_dense(
+        num_blocks_in_row,
+        col_indices,
+        col_indices.shape[-1] if num_cols is None else num_cols,
+    )
     return _dense_to_ordered(dense.transpose(-2, -1))
 
 
@@ -1011,21 +1015,6 @@ class BlockMask:
                 "full_kv_num_blocks and full_kv_indices must be both provided or omitted"
             )
 
-        # Generate q_num_blocks and q_indices
-        if compute_q_blocks:
-            q_num_blocks, q_indices = _transpose_ordered(kv_num_blocks, kv_indices)
-            if full_kv_num_blocks is not None:
-                if full_kv_indices is None:
-                    raise AssertionError("full_kv_indices must not be None")
-                full_q_num_blocks, full_q_indices = _transpose_ordered(
-                    full_kv_num_blocks, full_kv_indices
-                )
-            else:
-                full_q_num_blocks, full_q_indices = None, None
-        else:
-            q_num_blocks, q_indices = None, None
-            full_q_num_blocks, full_q_indices = None, None
-
         if isinstance(BLOCK_SIZE, int):
             BLOCK_SIZE = (BLOCK_SIZE, BLOCK_SIZE)
 
@@ -1034,6 +1023,24 @@ class BlockMask:
             q_length = kv_indices.shape[-2] * BLOCK_SIZE[0]
             kv_length = kv_indices.shape[-1] * BLOCK_SIZE[1]
             seq_lengths = (q_length, kv_length)
+        kv_num_cols = (seq_lengths[1] + BLOCK_SIZE[1] - 1) // BLOCK_SIZE[1]
+
+        # Generate q_num_blocks and q_indices
+        if compute_q_blocks:
+            q_num_blocks, q_indices = _transpose_ordered(
+                kv_num_blocks, kv_indices, kv_num_cols
+            )
+            if full_kv_num_blocks is not None:
+                if full_kv_indices is None:
+                    raise AssertionError("full_kv_indices must not be None")
+                full_q_num_blocks, full_q_indices = _transpose_ordered(
+                    full_kv_num_blocks, full_kv_indices, kv_num_cols
+                )
+            else:
+                full_q_num_blocks, full_q_indices = None, None
+        else:
+            q_num_blocks, q_indices = None, None
+            full_q_num_blocks, full_q_indices = None, None
 
         if dq_kv_order is not None and not isinstance(dq_kv_order, (bool, Tensor)):
             raise ValueError("dq_kv_order must be a bool, Tensor, or None")


### PR DESCRIPTION
## Human Note
Fixes 153344, if a users expliclty passes in a seqlen we will honor this and that will allow for indxing up to seqlen // blocksize, i was going to warn if not passed  seqlen but that wont ever really be hit cause of compile and reordable logs. The problem was in the backward metadata construciton, we properly use seqlens if passsed in. 


Fixes #153344


<details>
<summary>Repro Script</summary>

```python
import torch
from torch.nn.attention.flex_attention import BlockMask

kv_num_blocks = torch.tensor([1, 1, 1])
kv_indices = torch.tensor([[0], [1], [2]])
# Note: Error doesn't arise if kv_indices is sufficiently padded:
# kv_indices = torch.tensor([[0, -1, -1], [1, -1, -1], [2, -1, -1]])


kv_num_blocks = kv_num_blocks[None, None, ...]
kv_indices = kv_indices[None, None, ...]

BlockMask.from_kv_blocks(kv_num_blocks, kv_indices, BLOCK_SIZE=32)
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

- Investigated issue #153344. The raw repro without `seq_lengths` is internally inconsistent because `from_kv_blocks` infers KV length from `kv_indices.shape[-1]`, but the compact indices contain block id 2 with width 1.
- Confirmed compact/unpadded `kv_indices` still failed even when `seq_lengths=(96, 96)` was passed, because `_transpose_ordered` ignored the explicit logical KV length and used `col_indices.shape[-1]` as the dense transpose width.
- Patched `torch/nn/attention/flex_attention.py` so `BlockMask.from_kv_blocks` normalizes `BLOCK_SIZE` and `seq_lengths` before q-metadata construction, then passes the KV block count from `seq_lengths` into `_transpose_ordered`.
- Preserved existing inference behavior when `seq_lengths` is omitted. No new warning is emitted for the inferred path because this API is expected to be used under `torch.compile` and we want to avoid warning/logging side effects.
- Checked PyTorch/Dynamo warning patterns: `torch._dynamo.config.reorderable_logging_functions={warnings.warn}` exists but is opt-in compiler config with reordering constraints; in-tree public APIs often use `torch.compiler.is_compiling()` guards for warning emission, but we chose not to add a warning here.
- Added regression coverage in `test/inductor/test_flex_attention.py` for explicit `seq_lengths` with compact indices and `torch.compile(..., fullgraph=True)` with inferred `seq_lengths`.
- Validation:
  - `../.venv/bin/python -m pytest -q test/inductor/test_flex_attention.py::TestBlockMaskCUDA::test_from_kv_blocks_unpadded_kv_indices_with_seq_lengths_cuda test/inductor/test_flex_attention.py::TestBlockMaskCUDA::test_from_kv_blocks_fullgraph_compile_with_inferred_seq_lengths_cuda --tb=short` -> 2 passed.
  - `../.venv/bin/python -m pytest -q test/inductor/test_flex_attention.py -k "TestBlockMask and from_kv_blocks" --tb=short` -> 7 passed, 805 deselected.
  - `../.venv/bin/python -m compileall -q torch/nn/attention/flex_attention.py test/inductor/test_flex_attention.py` -> passed.
  - `git diff --check` -> passed.
  - `PATH="$PWD/../.venv/bin:$PATH" lintrunner -a torch/nn/attention/flex_attention.py test/inductor/test_flex_attention.py` -> passed.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv