### PR TITLE
Allow associative_scan(combine_mode="pointwise") for PrivateUse1 back…

### DIFF
--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -212,9 +212,13 @@ def associative_scan(
             raise ValueError(
                 f"Combine_mode must either 'pointwise' or 'generic', but got {cm}"
             )
-        if cm == "pointwise" and not all(l.device.type in ("cuda", "xpu") for l in lxs):
+        privateuse1_backend = torch._C._get_privateuse1_backend_name()
+        if cm == "pointwise" and not all(
+            l.device.type in ("cuda", "xpu", privateuse1_backend) for l in lxs
+        ):
             raise ValueError(
-                "For combine_mode='pointwise', all input tensors need to be on CUDA or XPU"
+                "For combine_mode='pointwise', all input tensors need to be on "
+                "CUDA, XPU, or a PrivateUse1 backend"
             )
 
         # Checks for xs


### PR DESCRIPTION
…ends

torch.associative_scan(..., combine_mode="pointwise") currently restricts its inputs to CUDA or XPU tensors. This blocks out-of-tree backends registered through the PrivateUse1 mechanism from using the pointwise path, even when they provide the required scan codegen for torch.compile.

Allow the currently-registered PrivateUse1 backend (via torch._C._get_privateuse1_backend_name()) in addition to CUDA and XPU. The change hardcodes no backend name; it unblocks whatever backend a user has registered via torch.utils.rename_privateuse1_backend(...).