### PR TITLE
[Inductor][Host-side TMA] Support tensordesc<> in the static Triton launcher

### DIFF
--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -9,6 +9,21 @@ from .triton_compat import ASTSource, CompiledKernel, knobs as triton_knobs
 from .triton_helpers import get_constexprs
 
 
+@functools.lru_cache(None)
+def _tma_arg_helpers():
+    """Cached (make_arg, TensorDescriptor) for host-side TMA arg expansion --
+    avoids re-importing on the hot launch path. ``make_arg(arg, metadata)``
+    returns ``[CUtensorMap, *shape, *strides]``. The nvidia backend's
+    ``make_tensordesc_arg`` ignores its third arg, so we pass None."""
+    from triton.backends.nvidia.driver import make_tensordesc_arg
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    def make_arg(arg, metadata):
+        return make_tensordesc_arg(arg, metadata, None)
+
+    return make_arg, TensorDescriptor
+
+
 class StaticallyLaunchedTritonKernel:
     """
     Parses the metadata of a CompiledKernel from Triton into a structure that can
@@ -109,6 +124,9 @@ class StaticallyLaunchedTritonKernel:
         self.has_profile_scratch = needs_scratch_arg("Profile", "profile_scratch_size")
 
         # pyrefly: ignore [missing-attribute]
+        self.tensordesc_meta = getattr(kernel.metadata, "tensordesc_meta", None)
+        self._has_tensordesc = False
+        # pyrefly: ignore [missing-attribute]
         self.arg_tys = self.arg_ty_from_signature(kernel.src)
         self.function: int | None = None  # Loaded by load_kernel(on the parent process)
         self.module: int | None = None  # Owns the HIP/CUDA module loaded for function
@@ -203,6 +221,29 @@ class StaticallyLaunchedTritonKernel:
             raise NotImplementedError("TMA descriptor kernels are not yet supported")
         return StaticallyLaunchedTritonKernel.type_mappings()[ty]
 
+    def _expand_tensordesc_type(self, ty: str) -> str:
+        """Expand a tensordesc<dtype[shape]> signature entry into the per-arg
+        type chars triton lowers it to (mirrors nvidia driver expand_signature):
+        nvTmaDesc path -> CUtensorMap + shape(i32) + strides(i64); host-decomposed
+        path -> base ptr + shape/strides(i64) + 2 flags + shape(i32) + strides(i64).
+        """
+        import re
+
+        match = re.match(r"tensordesc<([^\[>]*)\[([^\]]*)\]", ty)
+        if match is None:
+            raise NotImplementedError(f"Could not parse tensordesc type: {ty}")
+        ndim = match.group(2).count(",") + 1
+        meta = self.tensordesc_meta
+        idx = self._tensordesc_idx
+        self._tensordesc_idx += 1
+        per_desc_meta = meta[idx] if meta else None
+        if per_desc_meta is None:
+            chars = ["O"] + ["l"] * (2 * ndim) + ["i", "i"]
+        else:
+            chars = ["M"]
+        chars += ["i"] * ndim + ["l"] * ndim
+        return "".join(chars)
+
     def arg_ty_from_signature(self, src: ASTSource) -> str:
         def index_key(i: Any) -> int:
             if isinstance(i, str):
@@ -227,6 +268,7 @@ class StaticallyLaunchedTritonKernel:
         # completely ignores the constexprs passed into it when generating code.
         # So we can ignore them here too
         params = []
+        self._tensordesc_idx = 0
 
         for i in sorted(signature.keys()):
             ty = signature[i]
@@ -235,6 +277,9 @@ class StaticallyLaunchedTritonKernel:
             # so we check both here
             if ty == "constexpr" or i in constants:
                 pass
+            elif isinstance(ty, str) and ty.startswith("tensordesc<"):
+                self._has_tensordesc = True
+                params.append(self._expand_tensordesc_type(ty))
             else:
                 # pyrefly: ignore [bad-argument-type]
                 params.append(self.extract_type(ty))
@@ -249,6 +294,25 @@ class StaticallyLaunchedTritonKernel:
         # and reload them.
         state["cubin_path"] = None
         return state
+
+    def _expand_tma_args(self, args: tuple[object, ...]) -> tuple[object, ...]:
+        """Expand each host-side TMA TensorDescriptor arg into the flat kernel
+        params triton's launcher would produce (CUtensorMap + shape + strides),
+        so the args match the expanded type string from arg_ty_from_signature.
+        """
+        make_tensordesc_arg, TensorDescriptor = _tma_arg_helpers()
+
+        meta = self.tensordesc_meta
+        out: list[object] = []
+        td_idx = 0
+        for arg in args:
+            if isinstance(arg, TensorDescriptor):
+                per_desc_meta = meta[td_idx] if meta else None
+                td_idx += 1
+                out.extend(make_tensordesc_arg(arg, per_desc_meta))
+            else:
+                out.append(arg)
+        return tuple(out)
 
     def run(
         self,
@@ -268,6 +332,9 @@ class StaticallyLaunchedTritonKernel:
         # throw an exception. But if inductor is the only one calling this
         # thing, it should always match.
         # Get rid of constants before passing to cubin launcher
+
+        if self._has_tensordesc:
+            args = self._expand_tma_args(args)
 
         arg_tys = self.arg_tys
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2532,6 +2532,14 @@ class CachingAutotuner(KernelInterface):
         ):
             return None
 
+        # Host-side TMA descriptors are expanded into the flat kernel params
+        # (CUtensorMap + shape + strides) inside StaticallyLaunchedTritonKernel.run;
+        # the _FastCudaLauncher vectorcall bypasses run() and can't do that
+        # variable-length expansion, so use the regular static launcher (which is
+        # still static -- no dynamic-launcher dispatch overhead).
+        if self.inductor_meta.get("host_tma_descriptor_args"):
+            return None
+
         # _FastCudaLauncher binds CUDA/HIP function pointers; XPU static
         # launchers use SYCL kernels stored in PyCapsules.
         if self.device_props.type not in ("cuda", "hip"):
@@ -2678,6 +2686,47 @@ class CompileResult(Generic[_T]):
         self.inductor_meta = inductor_meta
 
     def make_launcher(self) -> LauncherType: ...
+
+    def _host_tma_pre_runner_lines(
+        self, runner_args: list[str], call_args: list[str]
+    ) -> tuple[list[str], list[str]]:
+        """Build host-side TMA descriptors in the launcher and substitute them
+        for the raw tensor args. Shared by the dynamic and static launchers.
+        Returns (pre_runner_lines, updated runner_args).
+        """
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        pre_runner_lines: list[str] = []
+        if not host_tma_args:
+            return pre_runner_lines, runner_args
+        if not has_triton_stable_tma_api():
+            raise RuntimeError(
+                "host-side TMA requires a Triton with the stable TMA API "
+                "(triton.tools.tensor_descriptor.TensorDescriptor)"
+            )
+        cfg_kwargs = self.config.kwargs
+        all_constants = self.compile_meta["constants"]
+        for inner_name, desc_info in host_tma_args.items():
+            if inner_name not in call_args or not isinstance(desc_info, dict):
+                continue
+            block_shape_vals = _resolve_dims(
+                desc_info["block_shape"], cfg_kwargs, all_constants
+            )
+            shape_vals = _resolve_dims(desc_info["shape"], cfg_kwargs, all_constants)
+            stride_vals = _resolve_dims(desc_info["strides"], cfg_kwargs, all_constants)
+            if block_shape_vals is None or shape_vals is None or stride_vals is None:
+                continue
+            desc_var = f"{inner_name}_host_tma_desc"
+            aligned_var = f"{inner_name}_aligned"
+            # _host_tma_aligned clones (warning once) only if misaligned.
+            pre_runner_lines.append(
+                f'{aligned_var} = _host_tma_aligned({inner_name}, "{inner_name}")'
+            )
+            pre_runner_lines.append(
+                f"{desc_var} = TensorDescriptor({aligned_var}, {shape_vals},"
+                f" {stride_vals}, {block_shape_vals})"
+            )
+            runner_args = [desc_var if a == inner_name else a for a in runner_args]
+        return pre_runner_lines, runner_args
 
     def _gen_launcher_code(
         self, scope, def_args, runner_args, pre_runner_lines=None
@@ -2948,7 +2997,18 @@ class StaticTritonCompileResult(CompileResult[_T]):
 
         # StaticallyLaunchedCudaKernel.run takes in order grid_0, grid_1, grid_2, stream, and call_args
         runner_args = ["grid_0", "grid_1", "grid_2", "stream", *call_args]
-        launcher = self._gen_launcher_code(scope, def_args, runner_args)
+        pre_runner_lines, runner_args = self._host_tma_pre_runner_lines(
+            runner_args, call_args
+        )
+        if self.inductor_meta.get("host_tma_descriptor_args"):
+            # _host_tma_pre_runner_lines already validated the stable TMA API.
+            from triton.tools.tensor_descriptor import TensorDescriptor
+
+            scope["_host_tma_aligned"] = _host_tma_aligned
+            scope["TensorDescriptor"] = TensorDescriptor
+        launcher = self._gen_launcher_code(
+            scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
+        )
         launcher.config = self.config  # type: ignore[attr-defined]
         launcher.n_regs = self.kernel.n_regs  # type: ignore[attr-defined]
         launcher.n_spills = self.kernel.n_spills  # type: ignore[attr-defined]
@@ -3146,49 +3206,15 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 *call_args,
             ]
 
-        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
-        pre_runner_lines: list[str] = []
-        if host_tma_args:
-            if not has_triton_stable_tma_api():
-                raise RuntimeError(
-                    "host-side TMA requires a Triton with the stable TMA API "
-                    "(triton.tools.tensor_descriptor.TensorDescriptor)"
-                )
+        pre_runner_lines, runner_args = self._host_tma_pre_runner_lines(
+            runner_args, call_args
+        )
+        if self.inductor_meta.get("host_tma_descriptor_args"):
+            # _host_tma_pre_runner_lines already validated the stable TMA API.
             from triton.tools.tensor_descriptor import TensorDescriptor
 
             scope["_host_tma_aligned"] = _host_tma_aligned
             scope["TensorDescriptor"] = TensorDescriptor
-            cfg_kwargs = cfg.kwargs
-            all_constants = compile_meta["constants"]
-
-            for inner_name, desc_info in host_tma_args.items():
-                if inner_name not in call_args or not isinstance(desc_info, dict):
-                    continue
-                block_shape_vals = _resolve_dims(
-                    desc_info["block_shape"], cfg_kwargs, all_constants
-                )
-                shape_vals = _resolve_dims(
-                    desc_info["shape"], cfg_kwargs, all_constants
-                )
-                stride_vals = _resolve_dims(
-                    desc_info["strides"], cfg_kwargs, all_constants
-                )
-                if (
-                    block_shape_vals is None
-                    or shape_vals is None
-                    or stride_vals is None
-                ):
-                    continue
-                desc_var = f"{inner_name}_host_tma_desc"
-                aligned_var = f"{inner_name}_aligned"
-                pre_runner_lines.append(
-                    f'{aligned_var} = _host_tma_aligned({inner_name}, "{inner_name}")'
-                )
-                pre_runner_lines.append(
-                    f"{desc_var} = TensorDescriptor({aligned_var}, {shape_vals},"
-                    f" {stride_vals}, {block_shape_vals})"
-                )
-                runner_args = [desc_var if a == inner_name else a for a in runner_args]
 
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
@@ -4053,9 +4079,11 @@ def _handle_combo_kernel_per_subkernel_blocks(
             cfgs = pointwise(
                 size_hints_i,
                 triton_meta=triton_meta,
-                tile_hint=TileHint.SQUARE
-                if combo_meta[f"tile_hint_{i}"] == "TileHint.SQUARE"
-                else TileHint.DEFAULT,
+                tile_hint=(
+                    TileHint.SQUARE
+                    if combo_meta[f"tile_hint_{i}"] == "TileHint.SQUARE"
+                    else TileHint.DEFAULT
+                ),
                 filename=filename,
                 min_elem_per_thread=min_elem_per_thread,
                 inductor_meta=inductor_meta_i,

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include <torch/csrc/utils/python_numbers.h>
+#include <cstring>
 #include <filesystem>
 #include <optional>
 #include <utility>
@@ -97,12 +98,46 @@ CUdeviceptr getPointer(PyObject* obj) {
   AT_CUDA_DRIVER_CHECK(hipPointerGetAttribute(
       &dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, data_ptr));
 #else
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuPointerGetAttribute(
-      &dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, data_ptr));
+  AT_CUDA_DRIVER_CHECK(
+      nvrtc().cuPointerGetAttribute(
+          &dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, data_ptr));
 #endif
 
   return dev_ptr;
 }
+
+#if !defined(USE_ROCM)
+// Mirror triton's PyCUtensorMapObject layout (nvidia/driver.c) so we can read
+// the 128-byte CUtensorMap that fill_tma_descriptor_tiled() produces. Host-side
+// TMA kernels take this descriptor as a by-value kernel parameter.
+struct PyCUtensorMapObject {
+  PyObject_HEAD
+  alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
+};
+
+// Return a pointer to the 128-byte CUtensorMap for a host-side TMA descriptor
+// argument. Supports triton's native PyCUtensorMap (fast path) and duck-typed
+// objects exposing tma_desc_cpu_ptr(). The pointer is owned by `obj`, which the
+// caller must keep alive across the synchronous kernel launch (cuLaunchKernel
+// copies the param bytes before returning).
+void* getTmaDescPtr(PyObject* obj) {
+  if (std::strcmp(
+          Py_TYPE(obj)->tp_name, "triton.backends.nvidia.PyCUtensorMap") == 0) {
+    return &reinterpret_cast<PyCUtensorMapObject*>(obj)->tensorMap;
+  }
+  // Duck-typed fallback: tma_desc_cpu_ptr() -> host pointer to a CUtensorMap.
+  THPObjectPtr method{PyObject_GetAttrString(obj, "tma_desc_cpu_ptr")};
+  TORCH_CHECK(
+      method,
+      "tensordesc argument must be a triton PyCUtensorMap or expose "
+      "tma_desc_cpu_ptr()");
+  THPObjectPtr ret{PyObject_CallNoArgs(method)};
+  TORCH_CHECK(ret, "tma_desc_cpu_ptr() call failed");
+  auto host_ptr = static_cast<uintptr_t>(THPUtils_unpackUInt64(ret));
+  TORCH_CHECK(host_ptr != 0, "tma_desc_cpu_ptr() returned NULL");
+  return reinterpret_cast<void*>(host_ptr);
+}
+#endif
 
 #define SHARED_MEM_STATIC_MAX 49152 // 48 KB
 
@@ -148,10 +183,11 @@ std::pair<CUmodule, CUfunction> loadKernel(
   AT_CUDA_DRIVER_CHECK(
       nvrtc().cuModuleGetFunction(&func, mod, funcName.c_str()));
   int shared_optin = 0;
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuDeviceGetAttribute(
-      &shared_optin,
-      CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
-      device));
+  AT_CUDA_DRIVER_CHECK(
+      nvrtc().cuDeviceGetAttribute(
+          &shared_optin,
+          CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+          device));
 
 #endif
 
@@ -208,16 +244,19 @@ std::pair<CUmodule, CUfunction> loadKernel(
     AT_CUDA_DRIVER_CHECK(
         nvrtc().cuFuncSetCacheConfig(func, CU_FUNC_CACHE_PREFER_SHARED));
     int shared_total = 0, shared_static = 0;
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuDeviceGetAttribute(
-        &shared_total,
-        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
-        device));
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuFuncGetAttribute(
-        &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, func));
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuFuncSetAttribute(
-        func,
-        CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-        shared_optin - shared_static));
+    AT_CUDA_DRIVER_CHECK(
+        nvrtc().cuDeviceGetAttribute(
+            &shared_total,
+            CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
+            device));
+    AT_CUDA_DRIVER_CHECK(
+        nvrtc().cuFuncGetAttribute(
+            &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, func));
+    AT_CUDA_DRIVER_CHECK(
+        nvrtc().cuFuncSetAttribute(
+            func,
+            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+            shared_optin - shared_static));
 #endif
   }
   return {mod, func};
@@ -255,18 +294,19 @@ inline void launchKernel(
       nullptr));
 
 #else
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuLaunchKernel(
-      func,
-      gridX,
-      gridY,
-      gridZ,
-      32 * numWarps, // blockDim.x
-      1, // blockDim.y
-      1, // blockDim.z
-      sharedMemBytes,
-      stream,
-      args,
-      nullptr));
+  AT_CUDA_DRIVER_CHECK(
+      nvrtc().cuLaunchKernel(
+          func,
+          gridX,
+          gridY,
+          gridZ,
+          32 * numWarps, // blockDim.x
+          1, // blockDim.y
+          1, // blockDim.z
+          sharedMemBytes,
+          stream,
+          args,
+          nullptr));
 #endif
 }
 
@@ -344,6 +384,16 @@ void parseKernelArgs(
         *reinterpret_cast<CUdeviceptr*>(slot) = ptr;
         break;
       }
+      case 'M': { // host-side TMA descriptor (CUtensorMap, 128-byte by-value)
+#if defined(USE_ROCM)
+        TORCH_CHECK(false, "tensordesc kernel args are not supported on ROCm");
+#else
+        // The descriptor lives in the Python arg (alive for this launch); point
+        // the kernel arg directly at its 128 bytes -- no 8-byte slot needed.
+        kernelArgs[i] = getTmaDescPtr(item);
+        continue;
+#endif
+      }
       default:
         TORCH_CHECK(false, "Unknown type passed in: ", typeChar);
     }
@@ -402,8 +452,9 @@ PyObject* load_kernel(PyObject* self, PyObject* args) {
 #else
   AT_CUDA_DRIVER_CHECK(
       nvrtc().cuFuncGetAttribute(&n_regs, CU_FUNC_ATTRIBUTE_NUM_REGS, func));
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuFuncGetAttribute(
-      &n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, func));
+  AT_CUDA_DRIVER_CHECK(
+      nvrtc().cuFuncGetAttribute(
+          &n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, func));
 
 #endif
   n_spills /= 4;
@@ -851,6 +902,16 @@ static PyObject* fast_launcher_vectorcall(
       case 'O': {
         *reinterpret_cast<CUdeviceptr*>(slot) = getPointerFast(item);
         break;
+      }
+      case 'M': {
+#if defined(USE_ROCM)
+        TORCH_CHECK(false, "tensordesc kernel args are not supported on ROCm");
+#else
+        // Override the pre-bound slot pointer: the kernel arg must point at the
+        // descriptor's 128 bytes (owned by `item`, alive for this launch).
+        self->kernelArgs[i] = getTmaDescPtr(item);
+        continue;
+#endif
       }
       case 'b':
         convertType<int8_t>(THPUtils_unpackInt, "int8", slot, item);


### PR DESCRIPTION
Host-side TMA kernels take their TMA descriptor as a by-value `CUtensorMap` (a `tensordesc<dtype[block]>` signature entry). The static Triton launcher previously raised `NotImplementedError` for that type, so every host-side TMA kernel fell back to the dynamic launcher.

This teaches the static launcher to handle `tensordesc<>`:
- **C++** (`static_launcher/cuda.cpp`): a new `'M'` arg type marshals the 128-byte `CUtensorMap` by value. `getTmaDescPtr` mirrors triton's `extractTmaDesc` (native `PyCUtensorMap` fast path + duck-typed `tma_desc_cpu_ptr()` fallback); the kernel arg points directly at the descriptor's 128 bytes (owned by the Python arg, alive across the synchronous launch).
- **Python** (`static_triton_launcher.py`): `arg_ty_from_signature` expands a `tensordesc<>` entry into the per-arg types triton lowers it to (CUtensorMap + shape + strides), mirroring the nvidia backend's `expand_signature`; `run()` expands each `TensorDescriptor` via `make_tensordesc_arg`.
- The host-side descriptor build is factored into a shared `CompileResult` helper used by both launchers.
- `_FastCudaLauncher` is skipped for host-TMA kernels (it bypasses `run()` and can't do the variable-length expansion); they use the regular static launcher, still static.

**No regressions:** device-side TMA and non-TMA kernels never carry a `tensordesc<>` signature entry, so they never reach the new code path. If static construction fails it raises `NotImplementedError`, which `can_statically_launch` catches and bypasses to the dynamic launcher.

The standalone no-cudagraph win is modest (~3%): the per-call host cost is dominated by `CUtensorMap` encoding, which both launchers pay. This PR is primarily the enabler for descriptor caching (stacked PR), which beats device-side TMA.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo