### PR TITLE
[Inductor][Host-side TMA] Cache host-side TMA descriptors across launches

### DIFF
--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -24,6 +24,41 @@ def _tma_arg_helpers():
     return make_arg, TensorDescriptor
 
 
+def expand_host_tma_descriptor(cache, pos, tensor, name, shape, strides, block, meta):
+    """Build the expanded kernel params for one host-side TMA descriptor
+    ([CUtensorMap, *shape, *strides]) and cache them per descriptor position.
+
+    Called from the generated static launcher on the hot path. On a cache hit
+    (same TMA-aligned base address) it returns the previously-encoded
+    CUtensorMap, skipping both the TensorDescriptor construction/validation and
+    cuTensorMapEncodeTiled. The descriptor only encodes addressing (not buffer
+    contents), so reuse is safe whenever the address/shape/strides match.
+
+    A misaligned input is cloned fresh each call (the clone is freed after the
+    launch), so its descriptor must NOT be cached -- we only cache when the base
+    is already TMA-aligned (the assume_aligned_inputs path).
+    """
+    from ..utils import TMA_ALIGNMENT
+    from .triton_heuristics import _host_tma_aligned
+
+    make_tensordesc_arg, TensorDescriptor = _tma_arg_helpers()
+    data_ptr = tensor.data_ptr()
+    aligned = data_ptr % TMA_ALIGNMENT == 0
+    if aligned:
+        cached = cache.get(pos)
+        if cached is not None and cached[0] == data_ptr:
+            return cached[1]
+        base = tensor
+    else:
+        # _host_tma_aligned clones (warning once) -- the clone is uncacheable.
+        base = _host_tma_aligned(tensor, name)
+    desc = TensorDescriptor(base, shape, strides, block)
+    expanded = tuple(make_tensordesc_arg(desc, meta))
+    if aligned:
+        cache[pos] = (data_ptr, expanded)
+    return expanded
+
+
 class StaticallyLaunchedTritonKernel:
     """
     Parses the metadata of a CompiledKernel from Triton into a structure that can
@@ -296,9 +331,12 @@ class StaticallyLaunchedTritonKernel:
         return state
 
     def _expand_tma_args(self, args: tuple[object, ...]) -> tuple[object, ...]:
-        """Expand each host-side TMA TensorDescriptor arg into the flat kernel
-        params triton's launcher would produce (CUtensorMap + shape + strides),
-        so the args match the expanded type string from arg_ty_from_signature.
+        """Fallback expansion of host-side TMA TensorDescriptor args into the
+        flat kernel params (CUtensorMap + shape + strides). The static launcher
+        normally pre-expands (with caching) in the generated launcher via
+        expand_host_tma_descriptor, so by the time run() is reached the args are
+        already expanded and this is a no-op; it only fires if a TensorDescriptor
+        reaches run() directly.
         """
         make_tensordesc_arg, TensorDescriptor = _tma_arg_helpers()
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2728,6 +2728,62 @@ class CompileResult(Generic[_T]):
             runner_args = [desc_var if a == inner_name else a for a in runner_args]
         return pre_runner_lines, runner_args
 
+    def _host_tma_static_pre_runner_lines(
+        self, runner_args: list[str], call_args: list[str]
+    ) -> tuple[list[str], list[str], dict[str, Any]]:
+        """Static-launcher variant of host-side TMA descriptor setup. Instead of
+        rebuilding a TensorDescriptor every call, emit a cached expander
+        (expand_host_tma_descriptor) that returns the flat kernel params
+        (CUtensorMap + shape + strides) and reuses the encoded CUtensorMap when
+        the input address is unchanged -- skipping the descriptor build and
+        cuTensorMapEncodeTiled on the hot path. The expanded params are spliced
+        into the runner call. Returns (pre_runner_lines, runner_args, scope).
+        """
+        from .static_triton_launcher import expand_host_tma_descriptor
+
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        pre_runner_lines: list[str] = []
+        scope_additions: dict[str, Any] = {}
+        if not host_tma_args:
+            return pre_runner_lines, runner_args, scope_additions
+        # See _host_tma_pre_runner_lines: fail clearly on a too-old Triton.
+        if not has_triton_stable_tma_api():
+            raise RuntimeError(
+                "host-side TMA requires a Triton with the stable TMA API "
+                "(triton.tools.tensor_descriptor.TensorDescriptor)"
+            )
+        cfg_kwargs = self.config.kwargs
+        all_constants = self.compile_meta["constants"]
+        meta = getattr(self.kernel, "tensordesc_meta", None)
+        pos = 0
+        for inner_name, desc_info in host_tma_args.items():
+            if inner_name not in call_args or not isinstance(desc_info, dict):
+                continue
+            block_shape_vals = _resolve_dims(
+                desc_info["block_shape"], cfg_kwargs, all_constants
+            )
+            shape_vals = _resolve_dims(desc_info["shape"], cfg_kwargs, all_constants)
+            stride_vals = _resolve_dims(desc_info["strides"], cfg_kwargs, all_constants)
+            if block_shape_vals is None or shape_vals is None or stride_vals is None:
+                continue
+            desc_var = f"{inner_name}_host_tma_desc"
+            pre_runner_lines.append(
+                f"{desc_var} = expand_host_tma_descriptor(_tma_cache, {pos}, "
+                f'{inner_name}, "{inner_name}", {shape_vals}, {stride_vals}, '
+                f"{block_shape_vals}, _tma_meta[{pos}])"
+            )
+            runner_args = [
+                f"*{desc_var}" if a == inner_name else a for a in runner_args
+            ]
+            pos += 1
+        if pre_runner_lines:
+            scope_additions = {
+                "expand_host_tma_descriptor": expand_host_tma_descriptor,
+                "_tma_cache": {},
+                "_tma_meta": list(meta) if meta else [None] * pos,
+            }
+        return pre_runner_lines, runner_args, scope_additions
+
     def _gen_launcher_code(
         self, scope, def_args, runner_args, pre_runner_lines=None
     ) -> LauncherType:
@@ -2997,15 +3053,10 @@ class StaticTritonCompileResult(CompileResult[_T]):
 
         # StaticallyLaunchedCudaKernel.run takes in order grid_0, grid_1, grid_2, stream, and call_args
         runner_args = ["grid_0", "grid_1", "grid_2", "stream", *call_args]
-        pre_runner_lines, runner_args = self._host_tma_pre_runner_lines(
-            runner_args, call_args
+        pre_runner_lines, runner_args, tma_scope = (
+            self._host_tma_static_pre_runner_lines(runner_args, call_args)
         )
-        if self.inductor_meta.get("host_tma_descriptor_args"):
-            # _host_tma_pre_runner_lines already validated the stable TMA API.
-            from triton.tools.tensor_descriptor import TensorDescriptor
-
-            scope["_host_tma_aligned"] = _host_tma_aligned
-            scope["TensorDescriptor"] = TensorDescriptor
+        scope.update(tma_scope)
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
         )


### PR DESCRIPTION
Stacked on #187917.

Host-side TMA kernels build a `TensorDescriptor` and encode a `CUtensorMap` (`cuTensorMapEncodeTiled`) on every launch. For a repeated call on the same buffer this is redundant: a `CUtensorMap` encodes addressing (base address, shape, strides, block), not buffer contents, so it stays valid across calls while the address/shape/strides are unchanged.

This adds a per-launcher cache for the static launcher. `make_launcher` emits calls to `expand_host_tma_descriptor`, which returns the expanded kernel params (`CUtensorMap` + shape + strides) and caches them per descriptor position keyed by `data_ptr`. On a hit it skips both the `TensorDescriptor` construction/validation and the encode.

**Correctness:**
- Cache key is the base `data_ptr`; a different address (fresh allocation) misses and re-encodes. Verified with 20 distinct input tensors and interleaved same/different inputs -- all match eager.
- Only 16-byte-aligned inputs are cached. A misaligned input is cloned fresh each call (clone freed after launch), so it always rebuilds.
- An address reused by a later same-shape/stride tensor (the launcher is shape-specialized) is still described correctly by the cached descriptor.
- The cache lives in the generated launcher scope and is never pickled.

## Result (B200, bf16 SiLU 1.05M, locked 900MHz, no-cudagraph, wall/call)
| mode | us/call |
|---|---|
| no-TMA | 21.3 |
| device-TMA | 27.5 |
| host-TMA (no cache) | 28.9 |
| **host-TMA (cached)** | **24.5** |

Caching makes host-side TMA **beat device-side TMA** in the no-cudagraph path: the device-side in-kernel descriptor prologue cannot be cached, but the host-side descriptor work now is. The benefit grows with the number of descriptors per kernel (e.g. GEMM A/B/output). Under cudagraph all modes are equal (launcher + encoding run once at capture).

Device-side TMA and non-TMA kernels carry no `tensordesc<>` args and are unaffected.

## Test Plan
```
python -m pytest test/inductor/test_torchinductor_strided_blocks.py -k "TritonHostSideTMATestCUDA"  # 95 passed, 7 xfailed
python -m pytest test/inductor/test_torchinductor_strided_blocks.py -k "(TritonTensorDescriptorTestCUDA and not TritonHostSide) or TritonBlockPointerTestGPU"  # 177 passed, 1 pre-existing fail
```

Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo