### PR TITLE
Fix functional isend/irecv passing a global peer rank to sub-group P2P ops

### DIFF
--- a/test/dynamo/test_fake_distributed.py
+++ b/test/dynamo/test_fake_distributed.py
@@ -450,6 +450,72 @@ class GraphModule(torch.nn.Module):
 
 instantiate_parametrized_tests(TestFakeDistributedP2P)
 
+
+@skipIf(not dist.is_available(), "requires distributed")
+class TestFakeDistributedP2PSubgroup(DynamoTestCase):
+    # Regression test: on a sub-group, the functional P2P helpers must pass a
+    # GROUP-LOCAL peer rank to the _c10d_functional ops (which, like the eager
+    # ProcessGroup send/recv path, expect a group-local rank). Previously a
+    # global rank was passed, which is out of range on a proper sub-group.
+    def setUp(self):
+        super().setUp()
+        dist.init_process_group(backend="fake", rank=0, world_size=4)
+        # Sub-group [0, 2]: group-local rank 1 corresponds to global rank 2.
+        self.subgroup = dist.new_group([0, 2])
+
+    def tearDown(self):
+        dist.destroy_process_group()
+
+    @torch._dynamo.config.patch(enable_p2p_compilation=True)
+    def test_compiled_isend_subgroup_uses_group_local_rank(self):
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(fullgraph=True, backend=backend)
+        def fn(tensor):
+            req = dist.isend(tensor, group_dst=1, group=self.subgroup)
+            req.wait()
+
+        fn(torch.ones(10))
+        self.assertEqual(len(backend.graphs), 1)
+        graph = normalize_graph(backend.graphs[0])
+        self.assertIn("_c10d_functional.isend(l_tensor_, 1,", graph)
+        self.assertNotIn("_c10d_functional.isend(l_tensor_, 2,", graph)
+
+    @torch._dynamo.config.patch(enable_p2p_compilation=True)
+    def test_compiled_irecv_subgroup_uses_group_local_rank(self):
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(fullgraph=True, backend=backend)
+        def fn(tensor):
+            req = dist.irecv(tensor, group_src=1, group=self.subgroup)
+            req.wait()
+
+        fn(torch.zeros(10))
+        self.assertEqual(len(backend.graphs), 1)
+        graph = normalize_graph(backend.graphs[0])
+        self.assertIn("_c10d_functional.irecv(l_tensor_, 1,", graph)
+        self.assertNotIn("_c10d_functional.irecv(l_tensor_, 2,", graph)
+
+    @torch._dynamo.config.patch(enable_p2p_compilation=True)
+    def test_compiled_batch_isend_irecv_subgroup_uses_group_local_rank(self):
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(fullgraph=True, backend=backend)
+        def fn(send_tensor, recv_tensor):
+            ops = [
+                dist.P2POp(dist.isend, send_tensor, group_peer=1, group=self.subgroup),
+                dist.P2POp(dist.irecv, recv_tensor, group_peer=1, group=self.subgroup),
+            ]
+            for w in dist.batch_isend_irecv(ops):
+                w.wait()
+
+        fn(torch.ones(10), torch.zeros(10))
+        self.assertEqual(len(backend.graphs), 1)
+        graph = normalize_graph(backend.graphs[0])
+        self.assertIn("['isend', 'irecv'], [1, 1],", graph)
+        self.assertNotIn("[2, 2]", graph)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2865,7 +2865,9 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
 
                 ops.append(op_var)
                 tensors.append(item.var_getattr(tx, "tensor"))
-                peers.append(item.var_getattr(tx, "peer"))
+                # batch_p2p_ops expects a group-local rank, which is what
+                # P2POp.group_peer provides.
+                peers.append(item.var_getattr(tx, "group_peer"))
                 tags.append(item.var_getattr(tx, "tag"))
                 if group_var is None:
                     group_var = item.var_getattr(tx, "group")

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1813,7 +1813,7 @@ def all_gather_inplace(
 
 def isend_inplace(
     tensor: torch.Tensor,
-    dst: int,
+    dst: int | None = None,
     tag: int = 0,
     group: dist.ProcessGroup | None = None,
     group_dst: int = -1,
@@ -1827,12 +1827,14 @@ def isend_inplace(
             raise ValueError(
                 "Cannot specify both 'dst' and 'group_dst' args as per eager impl"
             )
-        global_dst = c10d.get_global_rank(group, group_dst)
+        local_dst = group_dst
+    elif dst is not None:
+        local_dst = c10d.get_group_rank(group, dst)
     else:
-        global_dst = dst
+        raise ValueError("Must specify either 'dst' or 'group_dst'")
 
     group_name = _resolve_group_name(group)
-    tensor = torch.ops._c10d_functional.isend(tensor, global_dst, tag, group_name)
+    tensor = torch.ops._c10d_functional.isend(tensor, local_dst, tag, group_name)
     if _are_we_tracing():
         return tensor
     return _maybe_wrap_tensor(tensor)
@@ -1840,7 +1842,7 @@ def isend_inplace(
 
 def irecv_inplace(
     tensor: torch.Tensor,
-    src: int,
+    src: int | None = None,
     tag: int = 0,
     group: dist.ProcessGroup | None = None,
     group_src: int = -1,
@@ -1854,11 +1856,13 @@ def irecv_inplace(
             raise ValueError(
                 "Cannot specify both 'src' and 'group_src' args as per eager impl"
             )
-        global_src = c10d.get_global_rank(group, group_src)
+        local_src = group_src
+    elif src is not None:
+        local_src = c10d.get_group_rank(group, src)
     else:
-        global_src = src
+        raise ValueError("Must specify either 'src' or 'group_src'")
     group_name = _resolve_group_name(group)
-    tensor = torch.ops._c10d_functional.irecv(tensor, global_src, tag, group_name)
+    tensor = torch.ops._c10d_functional.irecv(tensor, local_src, tag, group_name)
     return _maybe_wrap_tensor(tensor)
 
 


### PR DESCRIPTION
## Summary

Fix the traceable functional P2P helpers (`isend` / `irecv` / `batch_isend_irecv`) passing a **global** peer rank to the `_c10d_functional` ops, which—like the eager `ProcessGroup` send/recv path—expect a **group-local** rank.

On the `WORLD` group the global and group-local ranks coincide, so the bug is masked. On a proper sub-group (e.g. a context-parallel group carved out of a larger world) the global rank exceeds the sub-group size and the backend aborts. Observed on HCCL as:

```
p2p rank id must be smaller than group size
```

This is a regression from #161213.

## Root cause & fix

**`isend_inplace` / `irecv_inplace`** (`torch/distributed/_functional_collectives.py`)

The helpers converted the peer to a global rank via `get_global_rank` before handing it to `_c10d_functional.isend` / `irecv`, but those ops want a group-local rank. The fix:

- A group-relative `group_dst` / `group_src` is now passed through as-is.
- A global `dst` / `src` is mapped with `get_group_rank` (the inverse of the previous `get_global_rank`).
- `dst` / `src` default to `None` so the group-relative calling convention binds cleanly under `torch.compile`, and a clear `ValueError` is raised if neither form is supplied.

**`batch_isend_irecv`** (`torch/_dynamo/variables/functions.py`)

The Dynamo rewrite collected `P2POp.peer` (a global rank); it now uses `P2POp.group_peer` (already group-local) so `batch_p2p_ops` receives the rank its op expects.

## Test Plan

Added fake-backend regression tests that compile `isend` / `irecv` / `batch_isend_irecv` on a size-2 sub-group (`[0, 2]` of a world of 4) and assert the captured graph passes the group-local peer rank (`1`) to the `_c10d_functional` ops rather than the global rank (`2`):

```
python test/dynamo/test_fake_distributed.py -k Subgroup
```

Also verified end-to-end on Ascend NPU running a context-parallel model (CP degree 2) with `torch.compile` P2P compilation enabled: before this change the run aborts at the functional `isend` with `p2p rank id must be smaller than group size`; after it, the compiled graph passes the `isend` / `irecv` stage.

> The unit tests above were not run locally (no build environment on this host); CI will exercise them.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @kwen2501 @H-Huang @awgu
