### PR TITLE
Implement LU factorization without pivoting on CPU

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -980,7 +980,9 @@ void ldl_solve_kernel(
               [out] the LU decomposition
   * `pivots` - [out] the pivot indices
   * `infos` - [out] error codes, positive values indicate singular matrices
-  * `compute_pivots` - should always be true (can be false only for CUDA)
+  * `compute_pivots` - when true, factor with partial pivoting via LAPACK GETRF.
+                       When false, factor without pivoting (LAPACK has no such
+                       routine, so it is done in place here).
 
   For further details, please see the LAPACK documentation for GETRF.
 */
@@ -992,34 +994,74 @@ void apply_lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& in
       "Calling torch.linalg.lu_factor on a CPU tensor requires compiling ",
       "PyTorch with LAPACK. Please use PyTorch built with LAPACK support.");
 #else
-  TORCH_CHECK(compute_pivots, "linalg.lu_factor: LU without pivoting is not implemented on the CPU");
-
   auto input_data = input.data_ptr<scalar_t>();
-  auto pivots_data = pivots.data_ptr<int>();
   auto infos_data = infos.data_ptr<int>();
   auto input_matrix_stride = matrixStride(input);
-  auto pivots_stride = pivots.size(-1);
   auto batch_size = batchCount(input);
   auto m = input.size(-2);
   auto n = input.size(-1);
   auto leading_dimension = std::max<int64_t>(1, m);
-
-  const auto loop = [&](int64_t start, int64_t end) {
-    for (const auto i : c10::irange(start, end)) {
-      scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
-      int* pivots_working_ptr = &pivots_data[i * pivots_stride];
-      int* infos_working_ptr = &infos_data[i];
-      lapackLu<scalar_t>(
-          m,
-          n,
-          input_working_ptr,
-          leading_dimension,
-          pivots_working_ptr,
-          infos_working_ptr);
-    }
-  };
   // avoid overflow
   auto matrix_rank = std::min(m, n);
+
+  const auto loop = [&](int64_t start, int64_t end) {
+    if (compute_pivots) {
+      auto pivots_data = pivots.data_ptr<int>();
+      auto pivots_stride = pivots.size(-1);
+      for (const auto i : c10::irange(start, end)) {
+        scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
+        int* pivots_working_ptr = &pivots_data[i * pivots_stride];
+        int* infos_working_ptr = &infos_data[i];
+        lapackLu<scalar_t>(
+            m,
+            n,
+            input_working_ptr,
+            leading_dimension,
+            pivots_working_ptr,
+            infos_working_ptr);
+      }
+    } else {
+      // LAPACK GETRF always pivots, so factor without pivoting in place using a
+      // right-looking LU. This matches the unpivoted path supported on CUDA.
+      // pivots is the identity permutation; some callers (e.g. linalg.lu) pass
+      // an empty pivots tensor when not pivoting, so only fill it when sized.
+      const bool fill_pivots = pivots.numel() == batch_size * matrix_rank;
+      int* pivots_data = fill_pivots ? pivots.data_ptr<int>() : nullptr;
+      auto pivots_stride = fill_pivots ? pivots.size(-1) : 0;
+      for (const auto i : c10::irange(start, end)) {
+        scalar_t* A = &input_data[i * input_matrix_stride];
+        int& info = infos_data[i];
+        info = 0;
+        for (const auto j : c10::irange(matrix_rank)) {
+          scalar_t diag = A[j + j * leading_dimension];
+          // A zero pivot means the matrix is singular for this unpivoted
+          // factorization. Skip scaling (as CUDA does) to avoid producing NaNs.
+          if (diag == scalar_t(0)) {
+            if (info == 0) {
+              info = static_cast<int>(j + 1);
+            }
+            continue;
+          }
+          for (const auto row : c10::irange(j + 1, m)) {
+            A[row + j * leading_dimension] /= diag;
+          }
+          for (const auto col : c10::irange(j + 1, n)) {
+            scalar_t u = A[j + col * leading_dimension];
+            for (const auto row : c10::irange(j + 1, m)) {
+              A[row + col * leading_dimension] -=
+                  A[row + j * leading_dimension] * u;
+            }
+          }
+        }
+        if (fill_pivots) {
+          int* pivots_working_ptr = &pivots_data[i * pivots_stride];
+          for (const auto j : c10::irange(matrix_rank)) {
+            pivots_working_ptr[j] = static_cast<int>(j + 1);
+          }
+        }
+      }
+    }
+  };
   // A heuristic tested on a 32 core/socket ICX system
   // https://github.com/pytorch/pytorch/pull/93037#discussion_r1090112948
   int64_t chunk_size_per_thread = static_cast<int64_t>(

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5606,7 +5606,7 @@ class TestLinalg(TestCase):
 
         sizes = ((3, 3), (5, 5), (4, 2), (3, 4), (0, 0), (0, 1), (1, 0))
         batches = ((0,), (), (1,), (2,), (3,), (1, 0), (3, 5))
-        pivots = (True, False) if self.device_type != "cpu" else (True,)
+        pivots = (True, False)
         fns = (partial(torch.lu, get_infos=True), torch.linalg.lu_factor, torch.linalg.lu_factor_ex)
         for ms, batch, pivot, singular, fn in itertools.product(sizes, batches, pivots, (True, False), fns):
             shape = batch + ms
@@ -5628,12 +5628,31 @@ class TestLinalg(TestCase):
         A = torch.ones(5, 3, 3, device=device)
         self.assertTrue((torch.linalg.lu_factor_ex(A, pivot=True).info >= 0).all())
 
-        if self.device_type == 'cpu':
-            # Error checking, no pivoting variant on CPU
-            fns = [torch.lu, torch.linalg.lu_factor, torch.linalg.lu_factor_ex, torch.linalg.lu]
-            for f in fns:
-                with self.assertRaisesRegex(RuntimeError, 'LU without pivoting is not implemented on the CPU'):
-                    f(torch.empty(1, 2, 2), pivot=False)
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(*floating_and_complex_types())
+    def test_lu_factor_no_pivot(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/134459:
+        # LU without pivoting used to raise "LU without pivoting is not
+        # implemented on the CPU" while it worked on CUDA. It now factors in
+        # place on the CPU as well, matching the CUDA behavior.
+        make_arg = partial(make_tensor, dtype=dtype, device=device)
+
+        # The matrix from the issue report.
+        A = torch.tensor([[1, 1, 1], [1, 2, 2], [1, 2, 3]], dtype=dtype, device=device)
+        P, L, U = torch.linalg.lu(A, pivot=False)
+        self.assertEqual(P.numel(), 0)  # no permutation when pivot=False
+        self.assertEqual(L @ U, A)
+
+        LU, pivots = torch.linalg.lu_factor(A, pivot=False)
+        # Pivots encode the identity permutation (1-based, like LAPACK getrf).
+        self.assertEqual(pivots, torch.arange(1, 1 + A.size(-1), device=device, dtype=torch.int32))
+
+        # Square (batched), tall and wide inputs all round-trip to L @ U.
+        for shape in ((5, 4, 4), (6, 3), (3, 6)):
+            M = make_arg(shape)
+            _, L, U = torch.linalg.lu(M, pivot=False)
+            self.assertEqual(L @ U, M)
 
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2})
     @skipCUDAIfNoCusolver

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -41,7 +41,6 @@ from torch.testing._internal.common_utils import (
     slowTest,
     TEST_WITH_ROCM,
     TEST_WITH_TORCHINDUCTOR,
-    TEST_XPU,
 )
 from torch.testing._internal.opinfo.core import (
     clone_sample,
@@ -1926,13 +1925,6 @@ op_db: list[OpInfo] = [
         sample_inputs_func=sample_inputs_linalg_lu,
         decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
         skips=(
-            # linalg.lu_factor: LU without pivoting is not implemented on the CPU
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_compare_cpu",
-                active_if=(not TEST_XPU),
-            ),
             # Exception: Resizing an out= argument with no elements threw a resize warning!
             DecorateInfo(
                 unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
@@ -1961,13 +1953,6 @@ op_db: list[OpInfo] = [
         sample_inputs_func=sample_inputs_linalg_lu,
         decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
         skips=(
-            # linalg.lu_factor: LU without pivoting is not implemented on the CPU
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_compare_cpu",
-                active_if=(not TEST_XPU),
-            ),
             # Exception: Resizing an out= argument with no elements threw a resize warning!
             DecorateInfo(
                 unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
@@ -1997,13 +1982,6 @@ op_db: list[OpInfo] = [
         sample_inputs_func=sample_inputs_linalg_lu,
         decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
         skips=(
-            # linalg.lu_factor: LU without pivoting is not implemented on the CPU
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_compare_cpu",
-                active_if=(not TEST_XPU),
-            ),
             # AssertionError: Resizing an out= argument with no elements threw a resize warning!
             DecorateInfo(
                 unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"


### PR DESCRIPTION
## Issue

Fixes #134459

## Summary

LU without pivoting worked on CUDA but threw `LU without pivoting is not implemented on the CPU` because the CPU path always called LAPACK getrf which pivots. This adds an in-place right-looking unpivoted LU for the `compute_pivots=false` branch (identity pivots first zero pivot reported through info like getrf and scaling skipped on a zero pivot like the CUDA path so singular inputs don't turn into NaNs) and removes the now-dead CPU error checks and `test_compare_cpu` xfails.

## Test plan

Added `test_lu_factor_no_pivot` (CPU, floating and complex) covering the matrix from the issue, identity pivots, and square/tall/wide round-trips

```
python test/test_linalg.py -k "test_lu_factor_no_pivot or test_linalg_lu_family"
python test/test_ops.py -k linalg_lu
```

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. CPU `pivot=False` used to error and it now succeeds, matching CUDA.

I made this with assistance from Claude.