### PR TITLE
docs: document FlopCounterMode semantics

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2042,8 +2042,6 @@ coverage_ignore_classes = [
     "DLDeviceType",
     # torch.utils.file_baton
     "FileBaton",
-    # torch.utils.flop_counter
-    "FlopCounterMode",
     # torch.utils.hipify.hipify_python
     "CurrentState",
     "GeneratedFileCleaner",

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -89,6 +89,7 @@
     :toctree: generated
     :nosignatures:
 
+    FlopCounterMode
     baddbmm_flop
     bmm_flop
     conv_backward_flop

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -17,7 +17,8 @@ Counting semantics
 * Counts are produced by formulas in ``flop_registry``. Operators without a
   formula may be decomposed into registered operators; otherwise they add zero
   FLOPs.
-* Formulas receive tensor shapes by default. Use
+* Formula inputs have tensor arguments replaced by their shapes by default.
+  Non-tensor arguments pass through unchanged. Use
   ``register_flop_formula(..., get_raw=True)`` only when the formula needs the
   original tensor arguments or metadata.
 * Forward and backward operations are counted only if they execute while the
@@ -27,6 +28,8 @@ Counting semantics
 * Counts do not automatically adjust for dtype-specific throughput, Tensor
   Cores, sparsity, quantization, masking, skipped elements, memory movement, or
   data-dependent early exits. A formula must explicitly model those semantics.
+  For example, the built-in attention formulas are upper bounds for causal or
+  otherwise masked attention unless the formula explicitly models the mask.
 * Higher-order operators and ``torch.compile`` may expose decomposed or fused
   work differently from eager execution. Custom operators and custom Triton
   kernels need a formula or a decomposition if they should contribute FLOPs.
@@ -55,6 +58,9 @@ Example
 
 Registering a formula for a custom op
 -------------------------------------
+
+Register custom FLOP formulas before constructing ``FlopCounterMode``. The
+mode snapshots the global registry during initialization.
 
 .. code-block:: python
 

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -1,4 +1,82 @@
 # mypy: allow-untyped-defs
+"""Utilities for counting theoretical floating point operations.
+
+``FlopCounterMode`` is a context manager that intercepts PyTorch operators and
+adds up their registered FLOP formulas. The result is a shape-based,
+theoretical FLOP count for the operators that ran inside the context, not a
+hardware performance measurement.
+
+The counter is useful when comparing model graphs, activation checkpointing
+plans, or shape changes with a stable FLOP accounting rule. It should not be
+read as kernel instructions, wall-clock time, memory bandwidth, achieved
+FLOP/s, Tensor Core utilization, or the exact work done by a fused kernel.
+
+Counting semantics
+------------------
+
+* Counts are produced by formulas in ``flop_registry``. Operators without a
+  formula may be decomposed into registered operators; otherwise they add zero
+  FLOPs.
+* Formulas receive tensor shapes by default. Use
+  ``register_flop_formula(..., get_raw=True)`` only when the formula needs the
+  original tensor arguments or metadata.
+* Forward and backward operations are counted only if they execute while the
+  context manager is active.
+* The default formulas use dense, naive mathematical definitions. For example,
+  matrix multiplication counts ``2 * m * n * k`` FLOPs.
+* Counts do not automatically adjust for dtype-specific throughput, Tensor
+  Cores, sparsity, quantization, masking, skipped elements, memory movement, or
+  data-dependent early exits. A formula must explicitly model those semantics.
+* Higher-order operators and ``torch.compile`` may expose decomposed or fused
+  work differently from eager execution. Custom operators and custom Triton
+  kernels need a formula or a decomposition if they should contribute FLOPs.
+* Module attribution is tracked through ``ModuleTracker``. Totals are always
+  available under ``"Global"``; submodule rows are best-effort attribution for
+  module calls observed during the context.
+* The workload still executes normally. Use this mode for a few representative
+  iterations rather than long training runs if overhead or memory use matters.
+
+Example
+-------
+
+.. code-block:: python
+
+    import torch
+    from torch.utils.flop_counter import FlopCounterMode
+
+    model = torch.nn.Linear(16, 32)
+    x = torch.randn(4, 16)
+
+    with FlopCounterMode(display=False) as mode:
+        model(x).sum().backward()
+
+    print(mode.get_total_flops())
+    print(mode.get_flop_counts()["Global"])
+
+Registering a formula for a custom op
+-------------------------------------
+
+.. code-block:: python
+
+    from math import prod
+
+    import torch
+    from torch.utils.flop_counter import FlopCounterMode, register_flop_formula
+
+    @torch.library.custom_op("example::scale", mutates_args=())
+    def scale(x: torch.Tensor) -> torch.Tensor:
+        return x * 2
+
+    @register_flop_formula(torch.ops.example.scale)
+    def scale_flops(x_shape, *, out_shape=None) -> int:
+        return prod(x_shape)
+
+    x = torch.randn(8)
+    with FlopCounterMode(display=False) as mode:
+        scale(x)
+
+    assert mode.get_total_flops() == 8
+"""
 from types import NoneType
 import logging
 import torch
@@ -792,22 +870,29 @@ def _pytreeify_preserve_structure(f):
 
 
 class FlopCounterMode:
-    """
-    ``FlopCounterMode`` is a context manager that counts the number of flops within its context.
+    """Count theoretical FLOPs for operators that run inside the context.
 
-    It does this using a ``TorchDispatchMode``.
+    ``FlopCounterMode`` uses ``TorchDispatchMode`` to intercept operations and
+    apply registered FLOP formulas. Counts are shape-based and formula-defined;
+    unsupported operations contribute zero FLOPs unless they decompose into
+    supported operations.
 
-    It also supports hierarchical output by passing a module (or list of
-    modules) to FlopCounterMode on construction. If you do not need hierarchical
-    output, you do not need to use it with a module.
+    The optional ``mods`` argument is no longer needed for module attribution.
+    When ``display`` is true, exiting the context prints a table. Use
+    ``get_total_flops()`` or ``get_flop_counts()`` to read the same information
+    programmatically.
 
-    Example usage
+    Example usage:
 
     .. code-block:: python
 
         mod = ...
-        with FlopCounterMode(mod) as flop_counter:
-            mod.sum().backward()
+        inp = ...
+
+        with FlopCounterMode(display=False) as flop_counter:
+            mod(inp).sum().backward()
+
+        total = flop_counter.get_total_flops()
 
     """
 


### PR DESCRIPTION
## Issue

Fixes #123800

## Summary

Documents `torch.utils.flop_counter.FlopCounterMode` as a theoretical, formula-based FLOP counter and clarifies common semantic boundaries: unsupported ops, decompositions, custom/Triton kernels, module attribution, backward counting, dense formulas, sparsity/dtype/performance caveats, and expected overhead. Also adds `FlopCounterMode` to the `torch.utils.flop_counter` autosummary.

## Testing

- `python -m py_compile torch/utils/flop_counter.py`
- `git diff --check`
- content smoke check for the new documentation anchors

`lintrunner` is not installed in this local environment, so I could not run `spin fixlint`.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [ ] Added/updated tests
- [x] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.