### PR TITLE
Fix torch.compile validation for random ops

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19043,6 +19043,35 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(out.stride(), (1,))
         self.assertTrue(out._is_zerotensor())
 
+    @parametrize("invalid_p", (-0.1, 2.0))
+    def test_bernoulli_invalid_probabilities_raise(self, invalid_p):
+        if torch.device(self.device).type != "cpu":
+            raise unittest.SkipTest("CPU validation contract")
+
+        def fn(p):
+            return torch.bernoulli(p)
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        p = torch.full((4,), invalid_p, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
+            opt_fn(p)
+
+    def test_normal_negative_std_tensor_raises(self):
+        if torch.device(self.device).type != "cpu":
+            raise unittest.SkipTest("CPU validation contract")
+
+        def fn(mean, std):
+            return torch.normal(mean, std)
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        mean = torch.zeros((4,), device=self.device)
+        std = torch.full((4,), -1.0, device=self.device)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "normal expects all elements of std >= 0.0"
+        ):
+            opt_fn(mean, std)
+
     # end of class CommonTemplate - add new tests here
 
 
@@ -19147,30 +19176,6 @@ if RUN_CPU:
 
             _, code_vec = run_and_get_cpp_code(opt_f, x_vec)
             FileCheck().check_not(".abs()").run(code_vec)
-
-        def test_bernoulli_invalid_probabilities_raise(self):
-            def fn(p):
-                return torch.bernoulli(p)
-
-            opt_fn = torch.compile(fn)
-
-            for invalid_p in (-0.1, 2.0):
-                p = torch.full((4,), invalid_p)
-                with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
-                    opt_fn(p)
-
-        def test_normal_negative_std_tensor_raises(self):
-            def fn(mean, std):
-                return torch.normal(mean, std)
-
-            opt_fn = torch.compile(fn)
-            mean = torch.zeros((4,))
-            std = torch.full((4,), -1.0)
-
-            with self.assertRaisesRegex(
-                RuntimeError, "normal expects all elements of std >= 0.0"
-            ):
-                opt_fn(mean, std)
 
     copy_tests(CommonTemplate, CpuTests, "cpu")
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19525,6 +19525,30 @@ if RUN_CPU:
             _, code_vec = run_and_get_cpp_code(opt_f, x_vec)
             FileCheck().check_not(".abs()").run(code_vec)
 
+        def test_bernoulli_invalid_probabilities_raise(self):
+            def fn(p):
+                return torch.bernoulli(p)
+
+            opt_fn = torch.compile(fn)
+
+            for invalid_p in (-0.1, 2.0):
+                p = torch.full((4,), invalid_p)
+                with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
+                    opt_fn(p)
+
+        def test_normal_negative_std_tensor_raises(self):
+            def fn(mean, std):
+                return torch.normal(mean, std)
+
+            opt_fn = torch.compile(fn)
+            mean = torch.zeros((4,))
+            std = torch.full((4,), -1.0)
+
+            with self.assertRaisesRegex(
+                RuntimeError, "normal expects all elements of std >= 0.0"
+            ):
+                opt_fn(mean, std)
+
     copy_tests(CommonTemplate, CpuTests, "cpu")
 
 if RUN_GPU or HAS_MPS:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19420,6 +19420,35 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         for _ in range(4):
             self.assertEqual(compiled(x, a, b), fn(x, a, b))
 
+    @parametrize("invalid_p", (-0.1, 2.0))
+    def test_bernoulli_invalid_probabilities_raise(self, invalid_p):
+        if torch.device(self.device).type != "cpu":
+            raise unittest.SkipTest("CPU validation contract")
+
+        def fn(p):
+            return torch.bernoulli(p)
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        p = torch.full((4,), invalid_p, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
+            opt_fn(p)
+
+    def test_normal_negative_std_tensor_raises(self):
+        if torch.device(self.device).type != "cpu":
+            raise unittest.SkipTest("CPU validation contract")
+
+        def fn(mean, std):
+            return torch.normal(mean, std)
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        mean = torch.zeros((4,), device=self.device)
+        std = torch.full((4,), -1.0, device=self.device)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "normal expects all elements of std >= 0.0"
+        ):
+            opt_fn(mean, std)
+
     # end of class CommonTemplate - add new tests here
 
 
@@ -19524,30 +19553,6 @@ if RUN_CPU:
 
             _, code_vec = run_and_get_cpp_code(opt_f, x_vec)
             FileCheck().check_not(".abs()").run(code_vec)
-
-        def test_bernoulli_invalid_probabilities_raise(self):
-            def fn(p):
-                return torch.bernoulli(p)
-
-            opt_fn = torch.compile(fn)
-
-            for invalid_p in (-0.1, 2.0):
-                p = torch.full((4,), invalid_p)
-                with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
-                    opt_fn(p)
-
-        def test_normal_negative_std_tensor_raises(self):
-            def fn(mean, std):
-                return torch.normal(mean, std)
-
-            opt_fn = torch.compile(fn)
-            mean = torch.zeros((4,))
-            std = torch.full((4,), -1.0)
-
-            with self.assertRaisesRegex(
-                RuntimeError, "normal expects all elements of std >= 0.0"
-            ):
-                opt_fn(mean, std)
 
     copy_tests(CommonTemplate, CpuTests, "cpu")
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19148,6 +19148,30 @@ if RUN_CPU:
             _, code_vec = run_and_get_cpp_code(opt_f, x_vec)
             FileCheck().check_not(".abs()").run(code_vec)
 
+        def test_bernoulli_invalid_probabilities_raise(self):
+            def fn(p):
+                return torch.bernoulli(p)
+
+            opt_fn = torch.compile(fn)
+
+            for invalid_p in (-0.1, 2.0):
+                p = torch.full((4,), invalid_p)
+                with self.assertRaisesRegex(RuntimeError, "Expected p_in"):
+                    opt_fn(p)
+
+        def test_normal_negative_std_tensor_raises(self):
+            def fn(mean, std):
+                return torch.normal(mean, std)
+
+            opt_fn = torch.compile(fn)
+            mean = torch.zeros((4,))
+            std = torch.full((4,), -1.0)
+
+            with self.assertRaisesRegex(
+                RuntimeError, "normal expects all elements of std >= 0.0"
+            ):
+                opt_fn(mean, std)
+
     copy_tests(CommonTemplate, CpuTests, "cpu")
 
 if RUN_GPU or HAS_MPS:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5970,10 +5970,11 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
-    aten._assert_async.msg(
-        torch.all((self >= 0) & (self <= 1)),
-        "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
-    )
+    if not self.is_meta and self.device.type != "cuda":
+        aten._assert_async.msg(
+            torch.all((self >= 0) & (self <= 1)),
+            "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
+        )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5971,10 +5971,11 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
-    aten._assert_async.msg(
-        torch.all((self >= 0) & (self <= 1)),
-        "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
-    )
+    if not self.is_meta and self.device.type != "cuda":
+        aten._assert_async.msg(
+            torch.all((self >= 0) & (self <= 1)),
+            "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
+        )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5971,6 +5971,10 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
+    aten._assert_async.msg(
+        torch.all((self >= 0) & (self <= 1)),
+        "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
+    )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5970,6 +5970,10 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
+    aten._assert_async.msg(
+        torch.all((self >= 0) & (self <= 1)),
+        "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
+    )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -437,6 +437,7 @@ def register_backend_for_device(
 class BackendFeature(Enum):
     FOREACH = auto()
     BUCKETIZE = auto()
+    DEVICE_ASSERT_ASYNC = auto()
     INPLACE_BUFFERS = auto()
     MASKED_SCATTER_WITH_INDEX = auto()
     SCAN = auto()

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -440,6 +440,7 @@ def register_backend_for_device(
 class BackendFeature(Enum):
     FOREACH = auto()
     BUCKETIZE = auto()
+    DEVICE_ASSERT_ASYNC = auto()
     INPLACE_BUFFERS = auto()
     MASKED_SCATTER_WITH_INDEX = auto()
     SCAN = auto()

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5113,6 +5113,7 @@ class CppScheduling(BaseScheduling):
     MAX_FUSED_KERNEL_ARGS_NUM = 500
     backend_features = OrderedSet(
         [
+            BackendFeature.DEVICE_ASSERT_ASYNC,
             BackendFeature.INPLACE_BUFFERS,
             BackendFeature.REDUCE_TO_SINGLE_ELEMENT,
         ]

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5115,6 +5115,7 @@ class CppScheduling(BaseScheduling):
     MAX_FUSED_KERNEL_ARGS_NUM = 500
     backend_features = OrderedSet(
         [
+            BackendFeature.DEVICE_ASSERT_ASYNC,
             BackendFeature.INPLACE_BUFFERS,
             BackendFeature.REDUCE_TO_SINGLE_ELEMENT,
         ]

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -22,6 +22,7 @@ from torch.utils._sympy.value_ranges import ValueRanges
 from ..utils import ceildiv, get_bounds_index_expr, get_kernel_metadata
 from ..virtualized import ops, OpsWrapper, V
 from .common import (
+    BackendFeature,
     CSEVariable,
     DeferredLine,
     DTYPE_TO_COMPUTATION_DTYPE,
@@ -1212,6 +1213,11 @@ class MetalKernel(SIMDKernel):
 
 class MetalScheduling(SIMDScheduling):
     kernel_type = MetalKernel  # type: ignore[assignment]
+    backend_features = OrderedSet([BackendFeature.DEVICE_ASSERT_ASYNC])
+
+    @classmethod
+    def get_backend_features(cls, device: torch.device) -> OrderedSet[BackendFeature]:
+        return cls.backend_features
 
     def __init__(self, scheduler: Scheduler | None) -> None:
         super().__init__(scheduler)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7786,14 +7786,15 @@ class TritonScheduling(SIMDScheduling):
 
     @classmethod
     def get_backend_features(cls, device: torch.device):
+        backend_features = cls.backend_features.copy()
+        if device.type != "cpu":
+            backend_features.add(BackendFeature.DEVICE_ASSERT_ASYNC)
         if (
             config.triton.cooperative_reductions
             or config.triton.force_cooperative_reductions
         ):
-            return OrderedSet(
-                [*cls.backend_features, BackendFeature.REDUCE_TO_SINGLE_ELEMENT]
-            )
-        return cls.backend_features
+            backend_features.add(BackendFeature.REDUCE_TO_SINGLE_ELEMENT)
+        return backend_features
 
     def codegen_comment(self, node_schedule, kernel_name=None):
         wrapper = V.graph.wrapper_code

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8001,14 +8001,15 @@ class TritonScheduling(SIMDScheduling):
 
     @classmethod
     def get_backend_features(cls, device: torch.device):
+        backend_features = cls.backend_features.copy()
+        if device.type != "cpu":
+            backend_features.add(BackendFeature.DEVICE_ASSERT_ASYNC)
         if (
             config.triton.cooperative_reductions
             or config.triton.force_cooperative_reductions
         ):
-            return OrderedSet(
-                [*cls.backend_features, BackendFeature.REDUCE_TO_SINGLE_ELEMENT]
-            )
-        return cls.backend_features
+            backend_features.add(BackendFeature.REDUCE_TO_SINGLE_ELEMENT)
+        return backend_features
 
     def codegen_comment(self, node_schedule, kernel_name=None):
         wrapper = V.graph.wrapper_code

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1916,6 +1916,10 @@ def _assert_async(cond, msg):
 
 @register_lowering(aten._assert_async.msg)
 def lower_assert_async(cond, msg):
+    if not V.graph.has_feature(cond, BackendFeature.DEVICE_ASSERT_ASYNC):
+        return fallback_handler(aten._assert_async.msg, add_to_fallback_set=False)(
+            cond, msg
+        )
     return _assert_async(cond, msg)
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1955,6 +1955,10 @@ def _assert_async(cond, msg):
 
 @register_lowering(aten._assert_async.msg)
 def lower_assert_async(cond, msg):
+    if not V.graph.has_feature(cond, BackendFeature.DEVICE_ASSERT_ASYNC):
+        return fallback_handler(aten._assert_async.msg, add_to_fallback_set=False)(
+            cond, msg
+        )
     return _assert_async(cond, msg)
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6699,6 +6699,11 @@ def normal(
         torch._check(
             std >= 0, lambda: f"normal expects std >= 0.0, but found std {std}"
         )
+    elif not std.is_meta:
+        aten._assert_async.msg(
+            torch.all(std >= 0),
+            "normal expects all elements of std >= 0.0",
+        )
 
     if size is None:
         tensors = tuple(t for t in (mean, std) if isinstance(t, TensorLike))

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6641,6 +6641,11 @@ def normal(
         torch._check(
             std >= 0, lambda: f"normal expects std >= 0.0, but found std {std}"
         )
+    elif not std.is_meta:
+        aten._assert_async.msg(
+            torch.all(std >= 0),
+            "normal expects all elements of std >= 0.0",
+        )
 
     if size is None:
         tensors = tuple(t for t in (mean, std) if isinstance(t, TensorLike))


### PR DESCRIPTION
Fixes #185246.
Fixes #185248.

Summary
- Preserve eager-style runtime validation for tensor probabilities in the compiled torch.bernoulli decomposition.
- Preserve eager-style runtime validation for tensor std inputs in the compiled torch.normal reference path.
- Add CPU Inductor regression coverage for invalid Bernoulli probabilities and negative tensor std values.

Validation
- Rebased onto current main.
- python -m compileall -q torch/_decomp/decompositions.py torch/_refs/__init__.py test/inductor/test_torchinductor.py
- lintrunner -m upstream/main --take RUFF,NOQA,NEWLINE,EXEC,PYFMT
- git diff --check upstream/main...HEAD

Notes
- Targeted CPU Inductor runtime tests require a built PyTorch development environment and can run in CI after the fork workflows are approved.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo