### PR TITLE
Add Ascend/pytorch to L2 in CRCR allowlist

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -36,7 +36,6 @@
 #   - org4/downstream-repo4: @oncall1,oncall2
 
 L1:
-  - Ascend/pytorch
   - riseproject-dev/pytorch-ci
   - NVIDIA-dev/pytorch-oot-internal
   - NVIDIA/pytorch-windows-ci
@@ -45,3 +44,4 @@ L2:
   # Canonical test repo for CRCR.
   - pytorch/crcr-test
   - TorchedHat/pytorch-redhat-ci
+  - Ascend/pytorch


### PR DESCRIPTION
As stated in the title, Ascend has reached the criteria of L2 in CRCR. Refer to https://github.com/Ascend/pytorch

cc @fffrog @atalman @albanD 