### PR TITLE
[inductor] Attribute cpp_wrapper host C++ compile time under a dedicated timer

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -98,6 +98,27 @@ def _register_fbcode_cpp_wrapper_arg_helper_op(m, device):
 class TestGpuWrapper(InductorTestCase):
     device = GPU_TYPE
 
+    def test_cpp_wrapper_compile_timing_recorded(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        from torch._dynamo.utils import compilation_time_metrics
+        from torch._inductor.utils import fresh_cache
+
+        def fn(x, y):
+            return (x @ y).relu()
+
+        x = torch.randn(64, 64, device=self.device)
+        y = torch.randn(64, 64, device=self.device)
+        compilation_time_metrics.pop("cpp_wrapper_compile", None)
+        with fresh_cache():
+            compiled = torch.compile(options={"cpp_wrapper": True})(fn)
+            result = compiled(x, y)
+        self.assertEqual(result, fn(x, y))
+        self.assertIn("cpp_wrapper_compile", compilation_time_metrics)
+        durations = compilation_time_metrics["cpp_wrapper_compile"]
+        self.assertTrue(any(t > 0 for t in durations))
+
     def test_aoti_debug_printer_works_on_constants(self):
         batch_size = 32
         seq_length = 50

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4168,6 +4168,17 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
     def cache_clear() -> None:
         CppWrapperCodeCache.cache.clear()
 
+    @classmethod
+    def load_pybinding(cls, *args: Any, **kwargs: Any) -> Any:
+        # The cpp_wrapper host glue is compiled synchronously here (in the JIT
+        # torch.compile path this runs while importing the generated wrapper
+        # module, and in AOTI it runs during the autotune pass). Time it under a
+        # dedicated key so the host C++ cold-compile cost is attributed to
+        # cpp_wrapper instead of being hidden inside the generic
+        # PyCodeCache.load_by_key_path timer.
+        with dynamo_timed("cpp_wrapper_compile", log_pt2_compile_event=True):
+            return super().load_pybinding(*args, **kwargs)
+
     cpp_compile_command_flags = {
         "include_pytorch": True,
         "shared": True,


### PR DESCRIPTION
The JIT cpp_wrapper path compiles the generated host glue synchronously when the wrapper module is imported, but that cost was folded into the generic `PyCodeCache.load_by_key_path` timer, so the cpp_wrapper-specific host cold compile was invisible in compilation metrics and PT2 compile-event traces.

Override `CppWrapperCodeCache.load_pybinding` to wrap the synchronous host-glue compile in dynamo_timed("cpp_wrapper_compile", log_pt2_compile_event=True), recording the host C++ cold-compile cost into compilation_time_metrics and the chromium / pt2_compile_events stream, separate from Python module import.

Authored with Claude Opus 4.8 through Cursor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo