### PR TITLE
[Inductor] Support non-Triton fused kernels in the FX backend via a high-order-operator

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -13,15 +13,16 @@ import sympy
 import torch
 import torch._inductor.codegen.common as common
 import torch.utils._pytree as pytree
-from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.utils import same
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_wrapper_mutation,
+)
 from torch._higher_order_ops.triton_kernel_wrap import (
     kernel_side_table,
     triton_kernel_wrapper_mutation,
 )
 from torch._inductor import config
 from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
-from torch._inductor.codegen.cpp import CppScheduling
 from torch._inductor.codegen.triton import TritonScheduling
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.codegen.wrapper_fxir import (
@@ -737,27 +738,6 @@ class FxirTestCase(InductorTestCase):
         pred_tensor = torch.tensor([pred], device=self.device)
         self._compile_and_check(foo, [pred_tensor], expected_num_triton_kernels=2)
 
-    def test_cpp_raises(self):
-        """
-        Test the C++ CPU backend. C++ kernels are not yet supported, so for now check
-        that we get the expected exception.
-        """
-
-        def foo(x, y):
-            return x + y * 5
-
-        device = torch.device("cpu")
-        args = [torch.randn(5, device=device) for _ in range(2)]
-
-        cpp_backend = common.DeviceCodegen(CppScheduling, WrapperFxCodegen, None)
-        with (
-            unittest.mock.patch.dict(
-                common.device_codegens, {device.type: cpp_backend}
-            ),
-            self.assertRaisesRegex(BackendCompilerFailed, "Triton"),
-        ):
-            self._compile_and_check(foo, args)
-
     @parametrize("enable_tuning", (False, True))
     @parametrize("use_dynamic_shapes", (False, True))
     def test_autotune(self, use_dynamic_shapes: bool, enable_tuning: bool):
@@ -1460,6 +1440,55 @@ class TestReplaceFloorDiv(InductorTestCase):
         x, y = sympy.symbols("x y")
         expr = sympy.floor(-FloorDiv(x * y, 2) / FloorDiv(-x * y, 131070))
         self._check(expr)
+
+
+@config.patch({**test_config, "fx_wrapper": True})
+class FxirCpuCompiledKernelTestCase(InductorTestCase):
+    """The FX backend embeds non-Triton CPU cpp_fused_* kernels as
+    compiled_kernel_wrapper_mutation HOP nodes instead of raising on them."""
+
+    def _compile_and_capture(self, func, args):
+        gms = []
+        orig_generate = FxConverter.generate
+
+        def generate(self):
+            gm = orig_generate(self)
+            gms.append(gm)
+            return gm
+
+        with unittest.mock.patch.object(FxConverter, "generate", generate):
+            result = torch.compile(func)(*args)
+
+        num_hop = sum(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=compiled_kernel_wrapper_mutation
+                )
+            )
+            for gm in gms
+        )
+        return result, num_hop
+
+    def test_cpp_fused_kernel(self):
+        # x + y fuses with relu and the * 2 into a single cpp_fused_* kernel,
+        # which becomes a compiled_kernel_wrapper_mutation HOP node.
+        def foo(x, y):
+            return (x + y).relu() * 2.0
+
+        args = [torch.randn(8, 8) for _ in range(2)]  # cpu
+        result, num_hop = self._compile_and_capture(foo, args)
+        self.assertTrue(same(foo(*args), result))
+        self.assertGreater(num_hop, 0)
+
+    def test_cpp_fused_kernel_with_extern(self):
+        # a @ b stays an aten extern; the pointwise tail fuses into a cpp kernel.
+        def foo(a, b):
+            return torch.relu(a @ b + a) * 2.0
+
+        args = [torch.randn(16, 16) for _ in range(2)]  # cpu
+        result, num_hop = self._compile_and_capture(foo, args)
+        self.assertTrue(same(foo(*args), result))
+        self.assertGreater(num_hop, 0)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -14,15 +14,16 @@ import sympy
 import torch
 import torch._inductor.codegen.common as common
 import torch.utils._pytree as pytree
-from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.utils import same
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_wrapper_mutation,
+)
 from torch._higher_order_ops.triton_kernel_wrap import (
     kernel_side_table,
     triton_kernel_wrapper_mutation,
 )
 from torch._inductor import config
 from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
-from torch._inductor.codegen.cpp import CppScheduling
 from torch._inductor.codegen.triton import TritonScheduling
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen, UnbackedSymbolDefsLine
 from torch._inductor.codegen.wrapper_fxir import (
@@ -775,27 +776,6 @@ class FxirTestCase(InductorTestCase):
 
         pred_tensor = torch.tensor([pred], device=self.device)
         self._compile_and_check(foo, [pred_tensor], expected_num_triton_kernels=2)
-
-    def test_cpp_raises(self):
-        """
-        Test the C++ CPU backend. C++ kernels are not yet supported, so for now check
-        that we get the expected exception.
-        """
-
-        def foo(x, y):
-            return x + y * 5
-
-        device = torch.device("cpu")
-        args = [torch.randn(5, device=device) for _ in range(2)]
-
-        cpp_backend = common.DeviceCodegen(CppScheduling, WrapperFxCodegen, None)
-        with (
-            unittest.mock.patch.dict(
-                common.device_codegens, {device.type: cpp_backend}
-            ),
-            self.assertRaisesRegex(BackendCompilerFailed, "Triton"),
-        ):
-            self._compile_and_check(foo, args)
 
     @parametrize("enable_tuning", (False, True))
     @parametrize("use_dynamic_shapes", (False, True))
@@ -1613,6 +1593,55 @@ class TestUnbackedSymbolDefs(InductorTestCase):
         line.output_name = "buf0"
         line.unbacked_bindings = {}
         self.assertIsNone(FxConverter._generate_unbacked_symbol_defs(conv, line))
+
+
+@config.patch({**test_config, "fx_wrapper": True})
+class FxirCpuCompiledKernelTestCase(InductorTestCase):
+    """The FX backend embeds non-Triton CPU cpp_fused_* kernels as
+    compiled_kernel_wrapper_mutation HOP nodes instead of raising on them."""
+
+    def _compile_and_capture(self, func, args):
+        gms = []
+        orig_generate = FxConverter.generate
+
+        def generate(self):
+            gm = orig_generate(self)
+            gms.append(gm)
+            return gm
+
+        with unittest.mock.patch.object(FxConverter, "generate", generate):
+            result = torch.compile(func)(*args)
+
+        num_hop = sum(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=compiled_kernel_wrapper_mutation
+                )
+            )
+            for gm in gms
+        )
+        return result, num_hop
+
+    def test_cpp_fused_kernel(self):
+        # x + y fuses with relu and the * 2 into a single cpp_fused_* kernel,
+        # which becomes a compiled_kernel_wrapper_mutation HOP node.
+        def foo(x, y):
+            return (x + y).relu() * 2.0
+
+        args = [torch.randn(8, 8) for _ in range(2)]  # cpu
+        result, num_hop = self._compile_and_capture(foo, args)
+        self.assertTrue(same(foo(*args), result))
+        self.assertGreater(num_hop, 0)
+
+    def test_cpp_fused_kernel_with_extern(self):
+        # a @ b stays an aten extern; the pointwise tail fuses into a cpp kernel.
+        def foo(a, b):
+            return torch.relu(a @ b + a) * 2.0
+
+        args = [torch.randn(16, 16) for _ in range(2)]  # cpu
+        result, num_hop = self._compile_and_capture(foo, args)
+        self.assertTrue(same(foo(*args), result))
+        self.assertGreater(num_hop, 0)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -172,11 +172,15 @@ def reset() -> None:
 
         # Reset cudagraph trees unconditionally since they are global state
         # not tied to a specific backend instance
+        from torch._higher_order_ops.compiled_kernel_wrap import (
+            compiled_kernel_side_table,
+        )
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
         from torch._higher_order_ops.wrap import inductor_code_side_table
 
         kernel_side_table.reset_table()
         inductor_code_side_table.reset_table()
+        compiled_kernel_side_table.reset_table()
 
         if torch.cuda.is_available():
             from torch._inductor.cudagraph_trees import reset_cudagraph_trees

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -172,11 +172,15 @@ def reset() -> None:
 
         # Reset cudagraph trees unconditionally since they are global state
         # not tied to a specific backend instance
+        from torch._higher_order_ops.compiled_kernel_wrap import (
+            compiled_kernel_side_table,
+        )
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
         from torch._higher_order_ops.wrap import inductor_code_side_table
 
         kernel_side_table.reset_table()
         inductor_code_side_table.reset_table()
+        compiled_kernel_side_table.reset_table()
 
         # The fake tensor dispatch cache is process-global (shared across
         # FakeTensorMode instances), so it survives into later compiles. That

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -10,6 +10,10 @@ from torch._higher_order_ops.auto_functionalize import (
     auto_functionalized_v2,
 )
 from torch._higher_order_ops.base_hop import BaseHOP
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_wrapper_functional,
+    compiled_kernel_wrapper_mutation,
+)
 from torch._higher_order_ops.cond import cond
 from torch._higher_order_ops.effects import with_effects
 from torch._higher_order_ops.executorch_call_delegate import executorch_call_delegate
@@ -47,6 +51,8 @@ from torch._higher_order_ops.wrap import (
 
 
 __all__ = [
+    "compiled_kernel_wrapper_functional",
+    "compiled_kernel_wrapper_mutation",
     "cond",
     "while_loop",
     "invoke_subgraph",

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -10,6 +10,10 @@ from torch._higher_order_ops.auto_functionalize import (
     auto_functionalized_v2,
 )
 from torch._higher_order_ops.base_hop import BaseHOP
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_wrapper_functional,
+    compiled_kernel_wrapper_mutation,
+)
 from torch._higher_order_ops.cond import cond
 from torch._higher_order_ops.effects import with_effects
 from torch._higher_order_ops.executorch_call_delegate import executorch_call_delegate
@@ -48,6 +52,8 @@ from torch._higher_order_ops.wrap import (
 
 
 __all__ = [
+    "compiled_kernel_wrapper_functional",
+    "compiled_kernel_wrapper_mutation",
     "cond",
     "switch",
     "while_loop",

--- a/torch/_higher_order_ops/compiled_kernel_wrap.py
+++ b/torch/_higher_order_ops/compiled_kernel_wrap.py
@@ -1,0 +1,239 @@
+"""HOPs for embedding a non-Triton compiled fused kernel into an FX graph.
+
+The Inductor FX backend (``config.fx_wrapper``) embeds Triton kernel launches as
+``triton_kernel_wrapper_mutation`` nodes. Non-Triton fused kernels -- e.g. an
+Inductor CPU ``cpp_fused_*`` pybinding -- are plain callables that take a flat
+positional tensor list and write their outputs in place, so they cannot be
+launched through the Triton HOP. ``compiled_kernel_wrapper_mutation`` is the
+analog for them: the callable is stored in a global side table (callables are not
+graphable) and the HOP carries an integer index plus ``mutated_arg_indices``, the
+positions in ``args`` the kernel writes. Inductor knows the kernel's output
+buffers, so unlike Triton (which parses the kernel's TTIR) the mutated set is
+supplied by the producer and functionalization needs no source analysis.
+
+Dispatch parity with ``triton_kernel_wrapper_mutation``: dense
+(CompositeExplicitAutograd), FakeTensorMode, Meta, ProxyTorchDispatchMode, and
+functionalize, plus a functional sibling ``compiled_kernel_wrapper_functional``.
+"""
+
+import threading
+from collections.abc import Callable
+
+import torch.utils._pytree as pytree
+from torch import Tensor
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import redirect_to_mode, register_fake
+from torch._ops import HigherOrderOperator
+from torch._prims_common import clone_preserve_strides
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
+
+
+class CompiledKernelSideTable:
+    """Global idx <-> compiled-callable table, mirroring KernelSideTable."""
+
+    def __init__(self) -> None:
+        self.id_to_kernel: dict[int, Callable] = {}
+        self.kernel_to_id: dict[Callable, int] = {}
+        self.lock = threading.Lock()
+
+    def add_kernel(self, kernel: Callable) -> int:
+        with self.lock:
+            if kernel in self.kernel_to_id:
+                return self.kernel_to_id[kernel]
+            idx = len(self.id_to_kernel)
+            self.id_to_kernel[idx] = kernel
+            self.kernel_to_id[kernel] = idx
+            return idx
+
+    def get_kernel(self, idx: int) -> Callable:
+        if idx not in self.id_to_kernel:
+            raise AssertionError(f"Compiled kernel index {idx} not found")
+        return self.id_to_kernel[idx]
+
+    def reset_table(self) -> None:
+        self.id_to_kernel = {}
+        self.kernel_to_id = {}
+
+
+compiled_kernel_side_table = CompiledKernelSideTable()
+
+
+class CompiledKernelWrapperMutation(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("compiled_kernel_wrapper_mutation", cacheable=True)
+
+    def __call__(
+        self, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+    ) -> None:
+        return super().__call__(
+            kernel_idx=kernel_idx,
+            mutated_arg_indices=mutated_arg_indices,
+            args=args,
+        )
+
+
+class CompiledKernelWrapperFunctional(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("compiled_kernel_wrapper_functional", cacheable=True)
+
+    def __call__(
+        self, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+    ) -> dict[int, Tensor]:
+        return super().__call__(
+            kernel_idx=kernel_idx,
+            mutated_arg_indices=mutated_arg_indices,
+            args=args,
+        )
+
+
+compiled_kernel_wrapper_mutation = CompiledKernelWrapperMutation()
+compiled_kernel_wrapper_functional = CompiledKernelWrapperFunctional()
+
+
+def _trace(proxy_mode, func_overload, node_args):
+    with disable_proxy_modes_tracing():
+        out = func_overload(**node_args)
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
+    out_proxy = proxy_mode.tracer.create_proxy(
+        "call_function",
+        func_overload,
+        (),
+        proxy_args,
+        name=func_overload.__name__ + "_proxy",
+    )
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+
+@compiled_kernel_wrapper_mutation.py_impl(DispatchKey.CompositeExplicitAutograd)
+def _mutation_dense(
+    *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> None:
+    compiled_kernel_side_table.get_kernel(kernel_idx)(*args)
+    return None
+
+
+@register_fake(compiled_kernel_wrapper_mutation, skip_cache=True)
+def _mutation_fake(
+    *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> None:
+    return None
+
+
+@compiled_kernel_wrapper_mutation.py_impl(DispatchKey.Meta)
+def _mutation_meta(
+    *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> None:
+    return None
+
+
+@compiled_kernel_wrapper_mutation.py_impl(ProxyTorchDispatchMode)
+def _mutation_proxy(
+    mode, *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> None:
+    _trace(
+        mode,
+        compiled_kernel_wrapper_mutation,
+        {
+            "kernel_idx": kernel_idx,
+            "mutated_arg_indices": mutated_arg_indices,
+            "args": args,
+        },
+    )
+    return None
+
+
+@compiled_kernel_wrapper_mutation.py_functionalize_impl
+def _mutation_functionalize(
+    ctx, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> None:
+    unwrapped_args = ctx.unwrap_tensors(args)
+    with ctx.redispatch_to_next():
+        new_vals = compiled_kernel_wrapper_functional(
+            kernel_idx=kernel_idx,
+            mutated_arg_indices=mutated_arg_indices,
+            args=unwrapped_args,
+        )
+    for i, output_arg in new_vals.items():
+        input_arg = args[i]
+        ctx.replace(input_arg, output_arg)
+        ctx.mark_mutation_hidden_from_autograd(input_arg)
+        ctx.commit_update(input_arg)
+        ctx.sync(input_arg)
+    return None
+
+
+def _run_functional(kernel_idx, mutated_arg_indices, args):
+    new_args = list(args)
+    clones: dict[int, Tensor] = {}
+    for i in mutated_arg_indices:
+        clones[i] = clone_preserve_strides(args[i])
+        new_args[i] = clones[i]
+    compiled_kernel_side_table.get_kernel(kernel_idx)(*new_args)
+    return clones
+
+
+@compiled_kernel_wrapper_functional.py_impl(DispatchKey.CompositeExplicitAutograd)
+def _functional_dense(
+    *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> dict[int, Tensor]:
+    return _run_functional(kernel_idx, mutated_arg_indices, args)
+
+
+@register_fake(compiled_kernel_wrapper_functional, skip_cache=True)
+def _functional_fake(
+    *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> dict[int, Tensor]:
+    return {i: clone_preserve_strides(args[i]) for i in mutated_arg_indices}
+
+
+@compiled_kernel_wrapper_functional.py_impl(ProxyTorchDispatchMode)
+def _functional_proxy(
+    mode, *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> dict[int, Tensor]:
+    return _trace(
+        mode,
+        compiled_kernel_wrapper_functional,
+        {
+            "kernel_idx": kernel_idx,
+            "mutated_arg_indices": mutated_arg_indices,
+            "args": args,
+        },
+    )
+
+
+@compiled_kernel_wrapper_functional.py_functionalize_impl
+def _functional_functionalize(
+    ctx, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple
+) -> dict[int, Tensor]:
+    unwrapped_args = ctx.unwrap_tensors(args)
+    with ctx.redispatch_to_next():
+        outputs = compiled_kernel_wrapper_functional(
+            kernel_idx=kernel_idx,
+            mutated_arg_indices=mutated_arg_indices,
+            args=unwrapped_args,
+        )
+    return ctx.wrap_tensors(outputs)
+
+
+# Fall through the keys these HOPs do not implement so the dispatcher reaches the
+# dense / functionalize impls, mirroring triton_kernel_wrapper_mutation.
+for _hop in (compiled_kernel_wrapper_mutation, compiled_kernel_wrapper_functional):
+    _hop.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
+    _hop.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
+    _hop.fallthrough(DispatchKey.ADInplaceOrView)
+    _hop.fallthrough(DispatchKey.BackendSelect)
+    _hop.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
+    _hop.fallthrough(DispatchKey.AutocastCUDA)  # type: ignore[attr-defined]
+    _hop.fallthrough(DispatchKey.AutogradCUDA)
+    _hop.fallthrough(DispatchKey.AutogradCPU)
+
+
+# Redirect the mutation HOP through activation-checkpoint caching modes so it is
+# handled under torch.utils.checkpoint, mirroring triton_kernel_wrapper_mutation.
+redirect_to_mode(compiled_kernel_wrapper_mutation, _CachingTorchDispatchMode)
+redirect_to_mode(compiled_kernel_wrapper_mutation, _CachedTorchDispatchMode)

--- a/torch/_higher_order_ops/compiled_kernel_wrap.py
+++ b/torch/_higher_order_ops/compiled_kernel_wrap.py
@@ -109,6 +109,11 @@ def _trace(proxy_mode, func_overload, node_args):
     return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
 
 
+# The mutation HOP returns None; its only effect is the in-place write into args.
+# Like triton_kernel_wrapper_mutation it is not registered as side-effectful, so a
+# bare eliminate_dead_code() would drop it -- but the Inductor FX backend's output
+# graph (where these nodes live) is never DCE'd: the eliminate_dead_code passes run
+# on the pre-codegen aten graph, not on the converted GraphModule.
 @compiled_kernel_wrapper_mutation.py_impl(DispatchKey.CompositeExplicitAutograd)
 def _mutation_dense(
     *, kernel_idx: int, mutated_arg_indices: tuple[int, ...], args: tuple

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1,3 +1,4 @@
+import abc
 import dataclasses
 import functools
 import logging
@@ -13,6 +14,10 @@ import torch
 from torch._export.passes._node_metadata_hook import (
     _node_metadata_hook,
     _set_node_metadata_hook,
+)
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_side_table,
+    compiled_kernel_wrapper_mutation,
 )
 from torch._higher_order_ops.triton_kernel_wrap import (
     TraceableTritonKernelWrapper,
@@ -112,6 +117,84 @@ class TritonKernel:
 
     tuner: CachingAutotuner
     wrapped: TraceableTritonKernelWrapper
+
+
+class CompiledKernelBackend(abc.ABC):
+    """Teaches FxConverter how to embed one class of non-Triton compiled fused
+    kernel as a compiled_kernel_wrapper_mutation HOP node.
+
+    A backend claims a kernel-definition line (handles_definition), compiles it to
+    a callable (compile_kernel), and reports which call args the kernel writes
+    (mutated_arg_indices). The mutation rule is backend-specific -- a CPU cpp
+    kernel encodes write-ness in its arg_types (non-const pointers), but another
+    compiler's call line may not -- so it is injected here rather than hardcoded
+    in the converter. Out-of-tree backends register via
+    register_compiled_kernel_backend; CppCompiledKernelBackend is the built-in.
+    """
+
+    @abc.abstractmethod
+    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+        """True if this backend owns the given kernel definition."""
+
+    @abc.abstractmethod
+    def compile_kernel(
+        self, converter: "FxConverter", line: "KernelDefinitionLine"
+    ) -> Callable[..., Any]:
+        """Compile the kernel to a callable taking the flat positional args and
+        writing its outputs in place (the contract the HOP's dense impl calls)."""
+
+    @abc.abstractmethod
+    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+        """Positions in the call args the kernel writes (for functionalization)."""
+
+
+_compiled_kernel_backends: list[CompiledKernelBackend] = []
+
+
+def register_compiled_kernel_backend(backend: CompiledKernelBackend) -> None:
+    """Register a CompiledKernelBackend. The first registered backend that claims
+    a kernel wins, so register more specific backends before more general ones."""
+    _compiled_kernel_backends.append(backend)
+
+
+def _select_compiled_kernel_backend(
+    line: "KernelDefinitionLine",
+) -> CompiledKernelBackend | None:
+    for backend in _compiled_kernel_backends:
+        if backend.handles_definition(line):
+            return backend
+    return None
+
+
+class CppCompiledKernelBackend(CompiledKernelBackend):
+    """Built-in backend for CPU cpp_fused_* pybinding kernels."""
+
+    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+        return not line.gpu
+
+    def compile_kernel(
+        self, converter: "FxConverter", line: "KernelDefinitionLine"
+    ) -> Callable[..., Any]:
+        kernel_code = PythonWrapperCodegen._format_kernel_definition(
+            line.kernel_name, line.kernel_body, metadata=line.metadata
+        )
+        mod = PyCodeCache.load("\n".join([converter.prologue, kernel_code]))
+        kernel = getattr(mod, line.kernel_name)
+        if isinstance(kernel, LambdaFuture):
+            kernel = kernel.result()
+        return kernel
+
+    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+        # cpp_argdefs() emits writeable buffers (inplace + output) as non-const
+        # pointers and read-only inputs as 'const T*'; sizevars have no '*'.
+        return tuple(
+            i
+            for i, t in enumerate(line.arg_types)
+            if isinstance(t, str) and "*" in t and not t.strip().startswith("const")
+        )
+
+
+register_compiled_kernel_backend(CppCompiledKernelBackend())
 
 
 def replace_floor_div(expr: sympy.Expr) -> sympy.Expr:
@@ -299,6 +382,8 @@ class FxConverter:
             str | None, torch.fx.Node
         ] = {}  # Symbol table for codegen.
         self.kernels: dict[str, TritonKernel] = {}  # Table to store Triton kernels.
+        # Non-Triton compiled kernels: name -> (side-table idx, owning backend).
+        self.compiled_kernels: dict[str, tuple[int, CompiledKernelBackend]] = {}
         self._unique_symbol_ids: Counter[str] = Counter()
         self.tracer = torch.fx.proxy.GraphAppendingTracer(graph)
         self.expr_to_proxy: dict[sympy.Expr, torch.fx.Proxy] = {}
@@ -1237,21 +1322,48 @@ class FxConverter:
     def _generate_kernel_call(self, line: WrapperLine) -> None:
         if not isinstance(line, KernelCallLine):
             raise AssertionError(f"expected KernelCallLine, got {type(line)}")
+        if line.kernel_name in self.compiled_kernels:
+            self._generate_compiled_kernel_call(line)
+            return
         if not line.triton:
             raise NotImplementedError("FX conversion only supports Triton kernels.")
 
         self._generate_triton_call(line)
 
+    def _generate_compiled_kernel_call(self, line: KernelCallLine) -> None:
+        """Emit a compiled_kernel_wrapper_mutation node for a non-Triton compiled
+        kernel. The kernel writes its outputs in place; the owning backend reports
+        which call args it writes."""
+        kernel_idx, backend = self.compiled_kernels[line.kernel_name]
+        self.gm.graph.call_function(
+            compiled_kernel_wrapper_mutation,
+            kwargs={
+                "kernel_idx": kernel_idx,
+                "mutated_arg_indices": tuple(backend.mutated_arg_indices(line)),
+                "args": tuple(self._lookup_args(line.call_args)),
+            },
+        )
+
     def _generate_kernel_definition(self, line: WrapperLine) -> None:
         if not isinstance(line, KernelDefinitionLine):
             raise AssertionError(f"expected KernelDefinitionLine, got {type(line)}")
 
-        # Generate code for the kernel.
+        # A non-Triton compiled kernel (e.g. CPU cpp_fused_*) claimed by a
+        # registered backend: compile it to a callable, store it in the global
+        # side table, and remember the owning backend so the call line can become
+        # a compiled_kernel_wrapper_mutation HOP node with the backend's mutation
+        # rule.
+        backend = _select_compiled_kernel_backend(line)
+        if backend is not None:
+            kernel = backend.compile_kernel(self, line)
+            idx = compiled_kernel_side_table.add_kernel(kernel)
+            self.compiled_kernels[line.kernel_name] = (idx, backend)
+            return
+
+        # Generate code for the Triton kernel, then import and store the JIT kernel.
         kernel_code = PythonWrapperCodegen._format_kernel_definition(
             line.kernel_name, line.kernel_body, metadata=line.metadata
         )
-
-        # Import the module and store the JIT kernel.
         tuner = self._import_kernel(kernel_code, line.kernel_name)
         wrapped = wrap_triton(tuner.fn)
         self.kernels[line.kernel_name] = TritonKernel(tuner, wrapped)

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -133,18 +133,18 @@ class CompiledKernelBackend(abc.ABC):
     """
 
     @abc.abstractmethod
-    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+    def handles_definition(self, line: KernelDefinitionLine) -> bool:
         """True if this backend owns the given kernel definition."""
 
     @abc.abstractmethod
     def compile_kernel(
-        self, converter: "FxConverter", line: "KernelDefinitionLine"
+        self, converter: "FxConverter", line: KernelDefinitionLine
     ) -> Callable[..., Any]:
         """Compile the kernel to a callable taking the flat positional args and
         writing its outputs in place (the contract the HOP's dense impl calls)."""
 
     @abc.abstractmethod
-    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+    def mutated_arg_indices(self, line: KernelCallLine) -> tuple[int, ...]:
         """Positions in the call args the kernel writes (for functionalization)."""
 
 
@@ -158,7 +158,7 @@ def register_compiled_kernel_backend(backend: CompiledKernelBackend) -> None:
 
 
 def _select_compiled_kernel_backend(
-    line: "KernelDefinitionLine",
+    line: KernelDefinitionLine,
 ) -> CompiledKernelBackend | None:
     for backend in _compiled_kernel_backends:
         if backend.handles_definition(line):
@@ -169,11 +169,11 @@ def _select_compiled_kernel_backend(
 class CppCompiledKernelBackend(CompiledKernelBackend):
     """Built-in backend for CPU cpp_fused_* pybinding kernels."""
 
-    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+    def handles_definition(self, line: KernelDefinitionLine) -> bool:
         return not line.gpu
 
     def compile_kernel(
-        self, converter: "FxConverter", line: "KernelDefinitionLine"
+        self, converter: "FxConverter", line: KernelDefinitionLine
     ) -> Callable[..., Any]:
         kernel_code = PythonWrapperCodegen._format_kernel_definition(
             line.kernel_name, line.kernel_body, metadata=line.metadata
@@ -184,9 +184,11 @@ class CppCompiledKernelBackend(CompiledKernelBackend):
             kernel = kernel.result()
         return kernel
 
-    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
-        # cpp_argdefs() emits writeable buffers (inplace + output) as non-const
-        # pointers and read-only inputs as 'const T*'; sizevars have no '*'.
+    def mutated_arg_indices(self, line: KernelCallLine) -> tuple[int, ...]:
+        # cpp_argdefs() emits writeable buffers (inplace + output) as 'T*' and
+        # read-only inputs with a leading-const 'const T*'; sizevars have no '*'.
+        # This classification keys on that leading-'const' form and must stay
+        # consistent with what cpp_argdefs() produces.
         return tuple(
             i
             for i, t in enumerate(line.arg_types)

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1,3 +1,4 @@
+import abc
 import dataclasses
 import functools
 import logging
@@ -13,6 +14,10 @@ import torch
 from torch._export.passes._node_metadata_hook import (
     _node_metadata_hook,
     _set_node_metadata_hook,
+)
+from torch._higher_order_ops.compiled_kernel_wrap import (
+    compiled_kernel_side_table,
+    compiled_kernel_wrapper_mutation,
 )
 from torch._higher_order_ops.triton_kernel_wrap import (
     TraceableTritonKernelWrapper,
@@ -118,6 +123,84 @@ class TritonKernel:
 
     tuner: CachingAutotuner
     wrapped: TraceableTritonKernelWrapper
+
+
+class CompiledKernelBackend(abc.ABC):
+    """Teaches FxConverter how to embed one class of non-Triton compiled fused
+    kernel as a compiled_kernel_wrapper_mutation HOP node.
+
+    A backend claims a kernel-definition line (handles_definition), compiles it to
+    a callable (compile_kernel), and reports which call args the kernel writes
+    (mutated_arg_indices). The mutation rule is backend-specific -- a CPU cpp
+    kernel encodes write-ness in its arg_types (non-const pointers), but another
+    compiler's call line may not -- so it is injected here rather than hardcoded
+    in the converter. Out-of-tree backends register via
+    register_compiled_kernel_backend; CppCompiledKernelBackend is the built-in.
+    """
+
+    @abc.abstractmethod
+    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+        """True if this backend owns the given kernel definition."""
+
+    @abc.abstractmethod
+    def compile_kernel(
+        self, converter: "FxConverter", line: "KernelDefinitionLine"
+    ) -> Callable[..., Any]:
+        """Compile the kernel to a callable taking the flat positional args and
+        writing its outputs in place (the contract the HOP's dense impl calls)."""
+
+    @abc.abstractmethod
+    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+        """Positions in the call args the kernel writes (for functionalization)."""
+
+
+_compiled_kernel_backends: list[CompiledKernelBackend] = []
+
+
+def register_compiled_kernel_backend(backend: CompiledKernelBackend) -> None:
+    """Register a CompiledKernelBackend. The first registered backend that claims
+    a kernel wins, so register more specific backends before more general ones."""
+    _compiled_kernel_backends.append(backend)
+
+
+def _select_compiled_kernel_backend(
+    line: "KernelDefinitionLine",
+) -> CompiledKernelBackend | None:
+    for backend in _compiled_kernel_backends:
+        if backend.handles_definition(line):
+            return backend
+    return None
+
+
+class CppCompiledKernelBackend(CompiledKernelBackend):
+    """Built-in backend for CPU cpp_fused_* pybinding kernels."""
+
+    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+        return not line.gpu
+
+    def compile_kernel(
+        self, converter: "FxConverter", line: "KernelDefinitionLine"
+    ) -> Callable[..., Any]:
+        kernel_code = PythonWrapperCodegen._format_kernel_definition(
+            line.kernel_name, line.kernel_body, metadata=line.metadata
+        )
+        mod = PyCodeCache.load("\n".join([converter.prologue, kernel_code]))
+        kernel = getattr(mod, line.kernel_name)
+        if isinstance(kernel, LambdaFuture):
+            kernel = kernel.result()
+        return kernel
+
+    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+        # cpp_argdefs() emits writeable buffers (inplace + output) as non-const
+        # pointers and read-only inputs as 'const T*'; sizevars have no '*'.
+        return tuple(
+            i
+            for i, t in enumerate(line.arg_types)
+            if isinstance(t, str) and "*" in t and not t.strip().startswith("const")
+        )
+
+
+register_compiled_kernel_backend(CppCompiledKernelBackend())
 
 
 def replace_floor_div(expr: sympy.Expr) -> sympy.Expr:
@@ -307,6 +390,8 @@ class FxConverter:
             str | None, torch.fx.Node
         ] = {}  # Symbol table for codegen.
         self.kernels: dict[str, TritonKernel] = {}  # Table to store Triton kernels.
+        # Non-Triton compiled kernels: name -> (side-table idx, owning backend).
+        self.compiled_kernels: dict[str, tuple[int, CompiledKernelBackend]] = {}
         self._unique_symbol_ids: Counter[str] = Counter()
         self.tracer = torch.fx.proxy.GraphAppendingTracer(graph)
         self.expr_to_proxy: dict[sympy.Expr, torch.fx.Proxy] = {}
@@ -1321,21 +1406,48 @@ class FxConverter:
     def _generate_kernel_call(self, line: WrapperLine) -> None:
         if not isinstance(line, KernelCallLine):
             raise AssertionError(f"expected KernelCallLine, got {type(line)}")
+        if line.kernel_name in self.compiled_kernels:
+            self._generate_compiled_kernel_call(line)
+            return
         if not line.triton:
             raise NotImplementedError("FX conversion only supports Triton kernels.")
 
         self._generate_triton_call(line)
 
+    def _generate_compiled_kernel_call(self, line: KernelCallLine) -> None:
+        """Emit a compiled_kernel_wrapper_mutation node for a non-Triton compiled
+        kernel. The kernel writes its outputs in place; the owning backend reports
+        which call args it writes."""
+        kernel_idx, backend = self.compiled_kernels[line.kernel_name]
+        self.gm.graph.call_function(
+            compiled_kernel_wrapper_mutation,
+            kwargs={
+                "kernel_idx": kernel_idx,
+                "mutated_arg_indices": tuple(backend.mutated_arg_indices(line)),
+                "args": tuple(self._lookup_args(line.call_args)),
+            },
+        )
+
     def _generate_kernel_definition(self, line: WrapperLine) -> None:
         if not isinstance(line, KernelDefinitionLine):
             raise AssertionError(f"expected KernelDefinitionLine, got {type(line)}")
 
-        # Generate code for the kernel.
+        # A non-Triton compiled kernel (e.g. CPU cpp_fused_*) claimed by a
+        # registered backend: compile it to a callable, store it in the global
+        # side table, and remember the owning backend so the call line can become
+        # a compiled_kernel_wrapper_mutation HOP node with the backend's mutation
+        # rule.
+        backend = _select_compiled_kernel_backend(line)
+        if backend is not None:
+            kernel = backend.compile_kernel(self, line)
+            idx = compiled_kernel_side_table.add_kernel(kernel)
+            self.compiled_kernels[line.kernel_name] = (idx, backend)
+            return
+
+        # Generate code for the Triton kernel, then import and store the JIT kernel.
         kernel_code = PythonWrapperCodegen._format_kernel_definition(
             line.kernel_name, line.kernel_body, metadata=line.metadata
         )
-
-        # Import the module and store the JIT kernel.
         tuner = self._import_kernel(kernel_code, line.kernel_name)
         wrapped = wrap_triton(tuner.fn)
         self.kernels[line.kernel_name] = TritonKernel(tuner, wrapped)

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -139,18 +139,18 @@ class CompiledKernelBackend(abc.ABC):
     """
 
     @abc.abstractmethod
-    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+    def handles_definition(self, line: KernelDefinitionLine) -> bool:
         """True if this backend owns the given kernel definition."""
 
     @abc.abstractmethod
     def compile_kernel(
-        self, converter: "FxConverter", line: "KernelDefinitionLine"
+        self, converter: "FxConverter", line: KernelDefinitionLine
     ) -> Callable[..., Any]:
         """Compile the kernel to a callable taking the flat positional args and
         writing its outputs in place (the contract the HOP's dense impl calls)."""
 
     @abc.abstractmethod
-    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
+    def mutated_arg_indices(self, line: KernelCallLine) -> tuple[int, ...]:
         """Positions in the call args the kernel writes (for functionalization)."""
 
 
@@ -164,7 +164,7 @@ def register_compiled_kernel_backend(backend: CompiledKernelBackend) -> None:
 
 
 def _select_compiled_kernel_backend(
-    line: "KernelDefinitionLine",
+    line: KernelDefinitionLine,
 ) -> CompiledKernelBackend | None:
     for backend in _compiled_kernel_backends:
         if backend.handles_definition(line):
@@ -175,11 +175,11 @@ def _select_compiled_kernel_backend(
 class CppCompiledKernelBackend(CompiledKernelBackend):
     """Built-in backend for CPU cpp_fused_* pybinding kernels."""
 
-    def handles_definition(self, line: "KernelDefinitionLine") -> bool:
+    def handles_definition(self, line: KernelDefinitionLine) -> bool:
         return not line.gpu
 
     def compile_kernel(
-        self, converter: "FxConverter", line: "KernelDefinitionLine"
+        self, converter: "FxConverter", line: KernelDefinitionLine
     ) -> Callable[..., Any]:
         kernel_code = PythonWrapperCodegen._format_kernel_definition(
             line.kernel_name, line.kernel_body, metadata=line.metadata
@@ -190,9 +190,11 @@ class CppCompiledKernelBackend(CompiledKernelBackend):
             kernel = kernel.result()
         return kernel
 
-    def mutated_arg_indices(self, line: "KernelCallLine") -> tuple[int, ...]:
-        # cpp_argdefs() emits writeable buffers (inplace + output) as non-const
-        # pointers and read-only inputs as 'const T*'; sizevars have no '*'.
+    def mutated_arg_indices(self, line: KernelCallLine) -> tuple[int, ...]:
+        # cpp_argdefs() emits writeable buffers (inplace + output) as 'T*' and
+        # read-only inputs with a leading-const 'const T*'; sizevars have no '*'.
+        # This classification keys on that leading-'const' form and must stay
+        # consistent with what cpp_argdefs() produces.
         return tuple(
             i
             for i, t in enumerate(line.arg_types)


### PR DESCRIPTION
## Summary

This is an implementation for the issues [#187649](https://github.com/pytorch/pytorch/issues/187649)

The Inductor FX backend (`config.fx_wrapper` / `WrapperFxCodegen`) wraps a graph to a `torch.fx.GraphModule`, embedding Triton launches as `triton_kernel_wrapper_mutation` nodes. But it supported **only** Triton kernels:

```python
# torch/_inductor/codegen/wrapper_fxir.py
if not line.triton:
    raise NotImplementedError("FX conversion only supports Triton kernels.")
```

So a CPU graph whose pointwise/reduction nodes Inductor fuses into a `cpp_fused_*` kernel could not be exported through the FX backend at all — it raised the moment anything fused. This PR adds a non-Triton analog so fused non-Triton kernels survive in the FX graph as nodes, the same way Triton kernels do.

## What this PR does

**1. A new HOP** (`torch/_higher_order_ops/compiled_kernel_wrap.py`):
`compiled_kernel_wrapper_mutation` and its functional sibling `compiled_kernel_wrapper_functional`. A compiled fused kernel is a plain callable that writes its outputs in place; it is stored in a global side table (callables are not graphable) and the HOP carries an integer index plus `mutated_arg_indices`.

Because Inductor knows the kernel's output buffers, the mutated set is supplied by the producer — no TTIR/source parsing for functionalization.

Dispatch mirrors `triton_kernel_wrapper_mutation` exactly (dense / `register_fake(skip_cache=True)` / Meta / proxy / functionalize, the autograd/autocast fallthroughs, and the activation-checkpoint `redirect_to_mode`s).

**2. FxConverter integration** (`torch/_inductor/codegen/wrapper_fxir.py`):
replace the `not line.triton` raise so a claimed non-Triton kernel definition is compiled to a callable, stored in the side table, and its call line becomes a `compiled_kernel_wrapper_mutation` node.

Which kernels are claimed and which args they mutate are injected through a small `CompiledKernelBackend` registry (`register_compiled_kernel_backend`), rather than hardcoding a cpp-only convention into the converter — a cpp kernel encodes write-ness in its `arg_types` (non-const pointers), but another compiler's call line may not.

`CppCompiledKernelBackend` is the built-in default for CPU `cpp_fused_*` kernels;

`pallas` and `halide` work in the same way, not implemented yet to make the first PR simpler. Out-of-tree compilers register their own.

**3. Test** (`test/inductor/test_fxir_backend.py`): 
`test_cpp_raises` (which asserted the old Triton-only limitation) is replaced by `FxirCpuCompiledKernelTestCase`.

### Example: the resulting FX graph

`relu(a @ b + a) * 2` on CPU under `config.fx_wrapper=True`:

```python
class GraphModule(torch.nn.Module):
    def forward(self, arg0_1: "f32[8, 8]", arg1_1: "f32[8, 8]"):
        buf0: "f32[8, 8]" = torch.empty_strided([8, 8], [8, 1], dtype=torch.float32, device='cpu')
        addmm_out = torch.ops.aten.addmm.out(arg0_1, arg0_1, arg1_1, alpha=1, beta=1, out=buf0)
        compiled_kernel_wrapper_mutation = torch.ops.higher_order.compiled_kernel_wrapper_mutation(
            kernel_idx=0, mutated_arg_indices=(0,), args=(buf0,))
        return buf0
```

`a @ b + a` stays an aten extern; `relu(...) * 2` fuses into a `cpp_fused_*` kernel embedded as the HOP node (in-place on `buf0`, hence `mutated_arg_indices=(0,)`).

## Validation on torchbench models

Compiled on CPU under `config.fx_wrapper=True`, capturing the host FX GraphModule(s) and checking that the compiled output matches eager.

`cpp_hop` is the number of embedded `compiled_kernel_wrapper_mutation` nodes — every one of these would have raised "FX conversion only supports Triton kernels" before this change.

```shell
BERT_pytorch     fx_graphs=1   cpp_kernels=87   numerics_ok=True
demucs           fx_graphs=3   cpp_kernels=25   numerics_ok=True
dcgan            fx_graphs=1   cpp_kernels=6    numerics_ok=True
```

test script:

```python
import importlib
import unittest.mock

import torch
import torch._inductor.config as inductor_config
from torch._dynamo.utils import same
from torch._higher_order_ops.compiled_kernel_wrap import (
    compiled_kernel_wrapper_mutation,
)
from torch._inductor.codegen.wrapper_fxir import FxConverter

MODELS = ["BERT_pytorch", "demucs", "dcgan"]


def run(name):
    module = importlib.import_module(f"torchbenchmark.models.{name}")
    model, example = module.Model(test="eval", device="cpu").get_module()

    def call(m):
        return m(**example) if isinstance(example, dict) else m(*example)

    gms = []
    gen = FxConverter.generate

    def capture(self):
        gms.append(gen(self))
        return gms[-1]

    with torch.no_grad(), inductor_config.patch(
        {"fx_wrapper": True}
    ), unittest.mock.patch.object(FxConverter, "generate", capture):
        out = call(torch.compile(model))

    hop = sum(
        len(
            g.graph.find_nodes(
                op="call_function", target=compiled_kernel_wrapper_mutation
            )
        )
        for g in gms
    )
    print(
        f"{name:<16} fx_graphs={len(gms):<3} cpp_kernels={hop:<4} "
        f"numerics_ok={same(call(model), out)}"
    )


for name in MODELS:
    run(name)
```

## Test Plan

```
python test/inductor/test_fxir_backend.py -k FxirCpuCompiledKernel
```

`FxirCpuCompiledKernelTestCase` compiles a CPU function whose pointwise tail fuses into a `cpp_fused_*` kernel under `config.fx_wrapper`, and checks that the captured FX graph contains a `compiled_kernel_wrapper_mutation` node and that numerics match eager (with and without an interleaved aten extern).
The torchbench models above were validated end to end with the same capture + numerics check.
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98