### PR TITLE
[ShardedTensor] Make ShardedTensor Device Transfer Methods Hardware-Agnostic

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -595,20 +595,20 @@ class ShardedTensor(ShardedTensorBase):
             device = torch.device(device) if isinstance(device, str) else device
             if not (
                 isinstance(device, torch.device)
-                and device.index == torch.cuda.current_device()
+                and device.index == torch.accelerator.current_device_index()
             ):
                 raise AssertionError(
-                    """Only device without device id (e.g. "cpu" or "cuda") is expected for ShardedTensor!"""
+                    f"Only device without device id (e.g. 'cpu' or '{device.type}') "
+                    f"is expected for ShardedTensor!"
                 )
-
-        current_device = torch.device(torch.cuda.current_device())
-        # returns a copy of ShardedTensor on CUDA current device
+        current_device = torch.device(torch.accelerator.current_device_index())
+        # returns a copy of ShardedTensor on accelerator current device
         list_shards: list[Shard] = []
         # move all local shards to current device, and change metadata
         # if local shards already on the current device, there's no
         # real data movement, only the metadata are copied.
         for shard in self._local_shards:
-            cuda_tensor = shard.tensor.cuda(
+            new_tensor = shard.tensor.to(
                 device=current_device,
                 non_blocking=non_blocking,
                 memory_format=memory_format,
@@ -616,23 +616,22 @@ class ShardedTensor(ShardedTensorBase):
             metadata = copy.deepcopy(shard.metadata)
             metadata.placement._device = current_device  # type: ignore[union-attr]
 
-            list_shards.append(Shard(cuda_tensor, metadata))
+            list_shards.append(Shard(new_tensor, metadata))
 
         st_meta = copy.deepcopy(self.metadata())
         for meta in st_meta.shards_metadata:
-            if meta.placement.device().type != "cuda":  # type: ignore[union-attr]
+            if meta.placement.device().type != current_device.type:  # type: ignore[union-attr]
                 meta.placement._device = current_device  # type: ignore[union-attr]
 
         pg = self._process_group if process_group is None else process_group
         # we need to use `init_from_local_shards` to communicate between ranks
         # and update the sharding spec/shards metadata.
-        st_cuda = ShardedTensor._init_from_local_shards_and_global_metadata(
+        return ShardedTensor._init_from_local_shards_and_global_metadata(
             list_shards,
             sharded_tensor_metadata=st_meta,
             process_group=pg,
             init_rrefs=self._init_rrefs,
         )
-        return st_cuda
 
     def to(self, *args, **kwargs) -> ShardedTensor:
         current_device: torch.device
@@ -667,9 +666,9 @@ class ShardedTensor(ShardedTensorBase):
             torch.device(device_to) if isinstance(device_to, (str, int)) else device_to
         )
 
-        if device_to.type in {"cuda", "xpu"}:
-            # if device_to set to cuda, set to current device even
-            # if user specify the device index.
+        if device_to.type != "cpu":
+            # if device_to set to accelerator, set to current device even
+            # if user specifies the device index.
             current_idx = torch.accelerator.current_device_index()
             if device_to.index != current_idx:
                 warnings.warn(
@@ -692,7 +691,7 @@ class ShardedTensor(ShardedTensorBase):
             # already have correct dtype and device, return itself
             return self
 
-        # returns a copy of ShardedTensor on CUDA current device
+        # returns a copy of ShardedTensor on target device
         list_shards: list[Shard] = []
 
         for shard in self._local_shards:


### PR DESCRIPTION
# Make ShardedTensor Device Transfer Methods Hardware-Agnostic


## Summary

Refactored `ShardedTensor.cuda()` and `ShardedTensor.to()` methods to support third-party accelerator devices (e.g., NPU, XPU) by removing hardcoded CUDA-specific logic. The implementation leverages the `torch.accelerator` API to dynamically determine the current accelerator device.

---

## Problem

### The Gap

The `ShardedTensor` class in `torch/distributed/_shard/sharded_tensor/api.py` contained hardcoded CUDA-specific logic in its device transfer methods, preventing third-party hardware vendors (e.g., Huawei NPU, Intel XPU) from integrating their accelerators into the sharded tensor ecosystem.

### Hardcoded patterns (before fix):

| Location | Original Code | Issue |
|----------|---------------|-------|
| `cuda()` method | `torch.cuda.current_device()` | Direct CUDA API call |
| `cuda()` method | `shard.tensor.cuda(...)` | Calls tensor.cuda() instead of device-agnostic tensor.to() |
| `cuda()` method | `meta.placement.device().type != "cuda"` | Hardcoded string comparison |
| `to()` method | `device_to.type in {"cuda", "xpu"}` | Explicit device type list |

---

## Implementation

The implementation took a simpler approach than originally proposed, modifying the existing methods directly rather than creating a new `_to_device()` abstraction.

### Changes to `cuda()` method

1. **Device index retrieval**: Changed from `torch.cuda.current_device()` to `torch.accelerator.current_device_index()`

2. **Error message**: Made device-type aware:
   ```python
   # Before:
   raise AssertionError(
       'Only device without device id (e.g. "cpu" or "cuda") is expected for ShardedTensor!'
   )
   # After:
   raise AssertionError(
       f"Only device without device id (e.g. 'cpu' or '{device.type}') "
       f"is expected for ShardedTensor!"
   )
   ```

3. **Tensor transfer**: Changed from `shard.tensor.cuda()` to `shard.tensor.to()`:
   ```python
   # Before:
   cuda_tensor = shard.tensor.cuda(
       device=current_device,
       non_blocking=non_blocking,
       memory_format=memory_format,
   )
   # After:
   new_tensor = shard.tensor.to(
       device=current_device,
       non_blocking=non_blocking,
       memory_format=memory_format,
   )
   ```

4. **Metadata comparison**: Changed from hardcoded `"cuda"` to dynamic `current_device.type`:
   ```python
   # Before:
   if meta.placement.device().type != "cuda":
   # After:
   if meta.placement.device().type != current_device.type:
   ```

### Changes to `to()` method

Changed the device type check from an explicit allowlist to a denylist:
```python
# Before:
if device_to.type in {"cuda", "xpu"}:
    # if device_to set to cuda, set to current device even
    # if user specify the device index.

# After:
if device_to.type != "cpu":
    # if device_to set to accelerator, set to current device even
    # if user specifies the device index.
```

This change:
- Removes the need to add each new accelerator type (npu, xpu, etc.) explicitly
- Treats all non-CPU devices uniformly as accelerators
- Uses `torch.accelerator.current_device_index()` to get the current device

---

## Why This Approach

1. **Using `torch.accelerator` API**:
   - `torch.accelerator.current_device_index()` returns the current accelerator device index
   - `torch.device(int)` automatically uses the current accelerator type
   - This abstracts away device-specific calls

2. **Using denylist (`!= "cpu"`) instead of allowlist**:
   - Automatically supports any new accelerator type
   - No need to update the code when adding support for NPU, XPU, etc.
   - Simpler and more maintainable

---

## Backward Compatibility

| API | Change | Impact |
|-----|--------|--------|
| `.cuda()` | Uses accelerator API | No breaking change - identical behavior for CUDA users |
| `.to(device)` | Uses denylist for device check | Extends support to all accelerator types |
| `.cpu()` | No changes | Unaffected |

All existing CUDA workflows remain identical. The only observable change is that `to()` now works correctly with any non-CPU accelerator device.

---

## Test Plan

**Existing tests validate the changes:**

1. `test_sharded_tensor_to_cuda` - validates CUDA transfer behavior
2. `test_sharded_tensor_to_test` - validates `to()` method with various device/dtype combinations
3. `test_sharded_tensor_to_cpu` - validates CPU transfer behavior

The implementation was verified against the existing test suite.

---

## References

- `torch.accelerator` module: `torch/accelerator/__init__.py`
  - `current_device_index()`: returns current accelerator device index
- `_get_preferred_device()` implementation: `torch/distributed/_shard/sharded_tensor/api.py` (preserved for third-party backend support via ProcessGroup)

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @chauhang @penguinwu @H-Huang @kwen2501 @zpcore
