### PR TITLE
[inductor][fbcode] Unconditionally add CUDA sdk_lib + stubs to RE link path

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1998,9 +1998,15 @@ def _transform_cuda_paths(lpaths: list[str]) -> None:
 
     # Internal path needs special care, using the SDK lib path directly.
     if config.is_fbcode():
-        stub_dir = Path(build_paths.sdk_lib) / "stubs"
-        if stub_dir.is_dir() and str(stub_dir) not in lpaths:
-            lpaths.append(str(stub_dir))
+        # Add sdk_lib and its stubs/ (which hold the CUDA libs) unconditionally:
+        # an existence gate fails on the not-yet-materialized EdenFS path, and a
+        # nonexistent -L is harmless to the linker.
+        for cuda_lib_dir in (
+            build_paths.sdk_lib,
+            os.path.join(build_paths.sdk_lib, "stubs"),
+        ):
+            if cuda_lib_dir not in lpaths:
+                lpaths.append(cuda_lib_dir)
 
 
 def _transform_rocm_paths(lpaths: list[str]) -> None:


### PR DESCRIPTION
Summary:
In fbcode, cpp_wrapper/AOTI links the generated wrapper `.so` against `-lcuda` on a Remote Execution worker, but the CUDA libs (`libcudart_static.a`, `stubs/libcuda.so`) live under `build_paths.sdk_lib`, not the `-L .../lib64` that cpp_extension adds. `_transform_cuda_paths` gated adding `sdk_lib/stubs` on `.is_dir()`, which is False for the not-yet-materialized EdenFS path, so the link failed with `unable to find library -lcuda`.

Fix: append `sdk_lib` and its `stubs` dir unconditionally; a nonexistent `-L` is harmless to the linker.

Authored with Claude Code.

Test Plan: CI

Differential Revision: D108922550




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo