### PR TITLE
[Inductor] Make ALLOW_TF32 decision device-aware for XPU

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2094,14 +2094,21 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         if not isinstance(kernel_inputs, MMKernelInputs):
             raise AssertionError(f"Expected MMKernelInputs, got {type(kernel_inputs)}")
         m, n, k = kernel_inputs.mnk_symbolic()
-        # allow_tf32 alignment heuristics based on reverse engineering
-        # H100 CUDA 12.8 behavior
-        size_threshold = V.graph.sizevars.statically_known_true(
-            sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
-        )
-        allow_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32" and (
-            size_threshold
-        )
+        device_type = kernel_inputs.device_type
+        if device_type == "xpu":
+            # XPU eager matmul takes TF32 from the oneDNN flag, not the CUDA one.
+            allow_tf32 = torch._C._get_onednn_allow_tf32()
+        elif device_type == "cuda":
+            # allow_tf32 alignment heuristics based on reverse engineering
+            # H100 CUDA 12.8 behavior
+            size_threshold = V.graph.sizevars.statically_known_true(
+                sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
+            )
+            allow_tf32 = (
+                torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
+            )
+        else:
+            allow_tf32 = False
 
         return {
             "ALLOW_TF32": allow_tf32,

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2097,7 +2097,7 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         device_type = kernel_inputs.device_type
         if device_type == "xpu":
             # XPU eager matmul takes TF32 from the oneDNN flag, not the CUDA one.
-            allow_tf32 = torch._C._get_onednn_allow_tf32()
+            allow_tf32 = torch.backends.mkldnn.allow_tf32
         elif device_type == "cuda":
             # allow_tf32 alignment heuristics based on reverse engineering
             # H100 CUDA 12.8 behavior


### PR DESCRIPTION
The mm template derived ALLOW_TF32 from torch.backends.cuda.matmul.fp32_precision on all devices. On XPU this enabled TF32 in compiled matmul while eager stayed fp32 (eager reads allowTF32OneDNN), so compiled and eager diverged. Read the device own flag instead: XPU uses the oneDNN allow_tf32 flag, CUDA is unchanged.

Fixes #187947

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo