### PR TITLE
Fix inductor_timm eager nondeterminism baselines

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
@@ -34,7 +34,7 @@ inception_v3,pass,6
 
 
 
-mobilenetv2_100,pass,7
+mobilenetv2_100,pass_due_to_skip,7
 
 
 
@@ -58,7 +58,7 @@ swin_base_patch4_window7_224,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass_due_to_skip,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -34,7 +34,7 @@ inception_v3,pass,6
 
 
 
-mobilenetv2_100,pass,7
+mobilenetv2_100,pass_due_to_skip,7
 
 
 
@@ -58,7 +58,7 @@ swin_base_patch4_window7_224,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass_due_to_skip,6
 
 
 

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -98,6 +98,75 @@ class TestDynamoBenchmark(unittest.TestCase):
             output.getvalue(),
         )
 
+    def test_timm_cuda_inductor_amp_skips_eager_nondeterministic_models(
+        self,
+    ) -> None:
+        module_name = "benchmarks.dynamo._timm_models_skip_test"
+        module_path = os.path.join(os.path.dirname(__file__), "timm_models.py")
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None:
+            self.fail("could not load timm_models.py spec")
+        if spec.loader is None:
+            self.fail("could not load timm_models.py loader")
+
+        fake_timm = types.ModuleType("timm")
+        fake_timm.__version__ = "1.0.0"
+        fake_timm_data = types.ModuleType("timm.data")
+        fake_timm_data.resolve_data_config = lambda *args, **kwargs: {}
+        fake_timm_models = types.ModuleType("timm.models")
+        fake_timm_models.create_model = lambda *args, **kwargs: None
+        fake_timm_models.list_models = lambda *args, **kwargs: []
+
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "timm": fake_timm,
+                "timm.data": fake_timm_data,
+                "timm.models": fake_timm_models,
+            },
+        ):
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                sys.modules.pop(module_name, None)
+
+        runner = module.TimmRunner()
+        runner.args = types.SimpleNamespace(
+            accuracy=True,
+            amp=True,
+            backend="inductor",
+            devices=["cpu", "cuda"],
+            training=True,
+        )
+        original_device = module.benchmark_common.current_device
+        try:
+            module.benchmark_common.current_device = "cuda"
+            self.assertIn(
+                "mobilenetv2_100",
+                runner.skip_accuracy_check_as_eager_non_deterministic,
+            )
+            self.assertIn(
+                "tf_efficientnet_b0",
+                runner.skip_accuracy_check_as_eager_non_deterministic,
+            )
+
+            module.benchmark_common.current_device = "cpu"
+            self.assertNotIn(
+                "mobilenetv2_100",
+                runner.skip_accuracy_check_as_eager_non_deterministic,
+            )
+
+            runner.args.amp = False
+            module.benchmark_common.current_device = "cuda"
+            self.assertNotIn(
+                "mobilenetv2_100",
+                runner.skip_accuracy_check_as_eager_non_deterministic,
+            )
+        finally:
+            module.benchmark_common.current_device = original_device
+
     def test_dashboard_performance_uses_warm_peak_memory(self) -> None:
         args = parse_args(
             [

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -10,8 +10,10 @@ import warnings
 
 
 try:
+    from . import common as benchmark_common
     from .common import BenchmarkRunner, download_retry_decorator, load_yaml_file, main
 except ImportError:
+    import common as benchmark_common
     from common import BenchmarkRunner, download_retry_decorator, load_yaml_file, main
 
 import torch
@@ -208,7 +210,24 @@ class TimmRunner(BenchmarkRunner):
     @property
     def skip_accuracy_check_as_eager_non_deterministic(self):
         if self.args.accuracy and self.args.training:
-            return self._accuracy["skip"]["eager_not_deterministic"]
+            skip_models = set(self._accuracy["skip"]["eager_not_deterministic"])
+            active_device = benchmark_common.current_device
+            if not active_device and self.args.devices is not None:
+                devices = self.args.devices
+                if len(devices) == 1:
+                    active_device = devices[0]
+            if (
+                self.args.backend == "inductor"
+                and self.args.amp
+                and torch.version.hip is None
+                and active_device == "cuda"
+            ):
+                skip_models.update(
+                    self._accuracy["skip"].get(
+                        "cuda_inductor_amp_eager_not_deterministic", set()
+                    )
+                )
+            return skip_models
         return set()
 
     @property

--- a/benchmarks/dynamo/timm_models.yaml
+++ b/benchmarks/dynamo/timm_models.yaml
@@ -84,3 +84,8 @@ dtype:
 accuracy:
   skip:
     eager_not_deterministic: []
+    cuda_inductor_amp_eager_not_deterministic:
+      # Eager train-mode AMP is not bitwise deterministic for these models on
+      # CUDA, so the benchmark still compiles them but skips the accuracy diff.
+      - mobilenetv2_100
+      - tf_efficientnet_b0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187954

The inductor_timm CUDA training shards were failing before they ever
compiled `mobilenetv2_100` and `tf_efficientnet_b0`. The benchmark first
runs two eager train-mode AMP executions and compares them with zero
tolerance on CUDA; these two TIMM models are not bitwise deterministic in
that eager precheck, so the run recorded `eager_two_runs_differ` and
exited with zero Dynamo graphs. The later graph-break `0` readings in CI
were therefore early-exit artifacts, not real graph-break improvements.

Teach the TIMM benchmark about a CUDA Inductor AMP-scoped eager
nondeterminism skip list. The skip is keyed off the active device so mixed
CPU/CUDA runs do not hide CPU accuracy, and it only applies to training
accuracy runs on CUDA Inductor AMP. Update the static and dynamic CUDA
TIMM training expected accuracy rows to `pass_due_to_skip` while keeping
the existing graph-break baselines intact, so CI still requires the models
to compile and report their normal graph-break counts.

I considered simply updating the graph-break baselines to zero, as suggested
by the generic checker output, but that would bless the early-exit artifact
caused by the eager/eager failure. Recording the eager nondeterminism is the
narrower fix and preserves graph-break coverage.

Fixes #187951
Generated by my agent

Test Plan:
- python -m unittest benchmarks.dynamo.test.TestDynamoBenchmark.test_timm_auto_install_uses_no_deps benchmarks.dynamo.test.TestDynamoBenchmark.test_prepare_repro_installs_timm_without_deps benchmarks.dynamo.test.TestDynamoBenchmark.test_timm_cuda_inductor_amp_skips_eager_nondeterministic_models
- git diff --cached --check
- bash -lc 'python benchmarks/dynamo/check_accuracy.py --actual <(printf "name,accuracy,graph_breaks\nmobilenetv2_100,pass_due_to_skip,7\ntf_efficientnet_b0,pass_due_to_skip,6\n") --expected benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv && python benchmarks/dynamo/check_graph_breaks.py --actual <(printf "name,accuracy,graph_breaks\nmobilenetv2_100,pass_due_to_skip,7\ntf_efficientnet_b0,pass_due_to_skip,6\n") --expected benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv'
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98