### PR TITLE
Make expandable-segment Handle a move-only RAII owner and exception-safe

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -521,10 +521,7 @@ struct ExpandableSegment {
 #endif
         // Roll back the handles created in this call (none are mapped yet)
         // and report no progress so the caller treats it as OOM.
-        for (auto j : c10::irange(begin, i)) {
-          handles_.at(j).release();
-        }
-        trimHandles();
+        releaseHandles(begin, i);
         return rangeFromHandles(begin, begin);
       }
       // Throws on any other error; a no-op on success.
@@ -888,9 +885,7 @@ struct ExpandableSegment {
             ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
 #endif
       }
-      for (auto i : c10::irange(begin, end)) {
-        handles_.at(i).release();
-      }
+      releaseHandles(begin, end);
     });
     for (auto i : c10::irange(begin, end)) {
       auto& handle = handles_.at(i);
@@ -934,6 +929,11 @@ struct ExpandableSegment {
     C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
         ptr_ + segment_size_ * begin, (end - begin) * segment_size_));
 #endif
+    releaseHandles(begin, end);
+  }
+  // Release the handles in [begin, end) and drop trailing empty slots. Callers
+  // must have unmapped any mapped slots in the range first (see release()).
+  void releaseHandles(size_t begin, size_t end) {
     for (auto i : c10::irange(begin, end)) {
       handles_.at(i).release();
     }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -506,12 +506,21 @@ struct ExpandableSegment {
         {
           size_t device_free = 0;
           size_t device_total = 0;
-          (void)cudaMemGetInfo(&device_free, &device_total);
-          LOG(WARNING)
-              << "expandable_segments: memory mapping failed with OOM on device "
-              << static_cast<int>(device_) << " while trying to map "
-              << segment_size_ << " bytes (free: " << device_free
-              << ", total: " << device_total << ").";
+          const cudaError_t info_status =
+              cudaMemGetInfo(&device_free, &device_total);
+          if (info_status == cudaSuccess) {
+            LOG(WARNING)
+                << "expandable_segments: memory mapping failed with OOM on device "
+                << static_cast<int>(device_) << " while trying to map "
+                << segment_size_ << " bytes (free: " << device_free
+                << ", total: " << device_total << ").";
+          } else {
+            LOG(WARNING)
+                << "expandable_segments: memory mapping failed with OOM on device "
+                << static_cast<int>(device_) << " while trying to map "
+                << segment_size_ << " bytes; cudaMemGetInfo failed: "
+                << cudaGetErrorString(info_status) << ".";
+          }
         }
 #ifdef USE_ROCM
         // hipMemCreate above returned hipErrorOutOfMemory and treated it
@@ -872,11 +881,11 @@ struct ExpandableSegment {
     auto rollback = c10::make_scope_exit([&] {
       if (mapped > begin) {
 #ifdef USE_ROCM
-        C10_CUDA_IGNORE_ERROR(hipMemUnmap(
+        C10_CUDA_CHECK_WARN(hipMemUnmap(
             ptr() + begin * segment_size_, (mapped - begin) * segment_size_));
 #else
-        (void)DriverAPI::get()->cuMemUnmap_(
-            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
+        C10_CUDA_DRIVER_WARN(DriverAPI::get()->cuMemUnmap_(
+            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_));
 #endif
       }
       releaseHandles(begin, end);
@@ -1018,9 +1027,9 @@ struct ExpandableSegment {
       }
 #endif
 #ifdef USE_ROCM
-      C10_CUDA_IGNORE_ERROR(hipMemRelease(*handle));
+      C10_CUDA_CHECK_WARN(hipMemRelease(*handle));
 #else
-      (void)DriverAPI::get()->cuMemRelease_(*handle);
+      C10_CUDA_DRIVER_WARN(DriverAPI::get()->cuMemRelease_(*handle));
 #endif
       handle = std::nullopt;
       shareable_handle = std::nullopt;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -467,7 +467,7 @@ struct ExpandableSegment {
       handles_.resize(end);
     }
     for (auto i : c10::irange(begin, end)) {
-      TORCH_INTERNAL_ASSERT(!handles_.at(i));
+      TORCH_INTERNAL_ASSERT(!handles_.at(i).active());
       CUmemGenericAllocationHandle handle = 0;
       CUmemAllocationProp prop = {};
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
@@ -502,45 +502,38 @@ struct ExpandableSegment {
       auto status =
           DriverAPI::get()->cuMemCreate_(&handle, segment_size_, &prop, 0);
 #endif
-      if (status != CUDA_SUCCESS) {
-        if (status == CUDA_ERROR_OUT_OF_MEMORY) {
-          {
-            size_t device_free = 0;
-            size_t device_total = 0;
-            (void)cudaMemGetInfo(&device_free, &device_total);
-            LOG(WARNING)
-                << "expandable_segments: memory mapping failed with OOM on device "
-                << static_cast<int>(device_) << " while trying to map "
-                << segment_size_ << " bytes (free: " << device_free
-                << ", total: " << device_total << ").";
-          }
-#ifdef USE_ROCM
-          // hipMemCreate above returned hipErrorOutOfMemory and treated it
-          // like a sticky runtime error. Which means we need to clear it.
-          // Unlike the corresponding CUDA Driver API.
-          (void)hipGetLastError();
-#endif
-          for (auto j : c10::irange(begin, i)) {
-            auto& maybe_handle = handles_.at(j);
-            TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-            auto h = *maybe_handle;
-            maybe_handle = std::nullopt;
-#ifdef USE_ROCM
-            C10_CUDA_CHECK(hipMemRelease(h.handle));
-#else
-            C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemRelease_(h.handle));
-#endif
-          }
-          trimHandles();
-          return rangeFromHandles(begin, begin);
+      if (status == CUDA_ERROR_OUT_OF_MEMORY) {
+        {
+          size_t device_free = 0;
+          size_t device_total = 0;
+          (void)cudaMemGetInfo(&device_free, &device_total);
+          LOG(WARNING)
+              << "expandable_segments: memory mapping failed with OOM on device "
+              << static_cast<int>(device_) << " while trying to map "
+              << segment_size_ << " bytes (free: " << device_free
+              << ", total: " << device_total << ").";
         }
 #ifdef USE_ROCM
-        C10_CUDA_CHECK(status);
-#else
-        C10_CUDA_DRIVER_CHECK(status);
+        // hipMemCreate above returned hipErrorOutOfMemory and treated it
+        // like a sticky runtime error. Which means we need to clear it.
+        // Unlike the corresponding CUDA Driver API.
+        (void)hipGetLastError();
 #endif
+        // Roll back the handles created in this call (none are mapped yet)
+        // and report no progress so the caller treats it as OOM.
+        for (auto j : c10::irange(begin, i)) {
+          handles_.at(j).release();
+        }
+        trimHandles();
+        return rangeFromHandles(begin, begin);
       }
-      handles_.at(i) = Handle{.handle = handle};
+      // Throws on any other error; a no-op on success.
+#ifdef USE_ROCM
+      C10_CUDA_CHECK(status);
+#else
+      C10_CUDA_DRIVER_CHECK(status);
+#endif
+      handles_.at(i) = Handle(handle, std::nullopt);
     }
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
@@ -594,18 +587,17 @@ struct ExpandableSegment {
 
     buf.write(reinterpret_cast<const char*>(&header), sizeof(ShareHeader));
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-      auto& handle = *maybe_handle;
+      auto& handle = handles_.at(i);
+      TORCH_INTERNAL_ASSERT(handle.active());
       if (handle_type_ != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
         if (!handle.shareable_handle) {
           int fd = 0;
 #ifdef USE_ROCM
           C10_CUDA_CHECK(hipMemExportToShareableHandle(
-              &fd, handle.handle, hipMemHandleTypePosixFileDescriptor, 0));
+              &fd, handle.get(), hipMemHandleTypePosixFileDescriptor, 0));
 #else
           C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemExportToShareableHandle_(
-              &fd, handle.handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+              &fd, handle.get(), CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
 #endif
           handle.shareable_handle = fd;
           LOG(INFO) << "use posix fd to share expandable segments.";
@@ -624,7 +616,7 @@ struct ExpandableSegment {
         if (!handle.shareable_handle) {
           CUmemFabricHandle fabric_handle;
           C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemExportToShareableHandle_(
-              &fabric_handle, handle.handle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
+              &fabric_handle, handle.get(), CU_MEM_HANDLE_TYPE_FABRIC, 0));
           handle.shareable_handle = fabric_handle;
           LOG(INFO) << "use fabric handle to share expandable segments.";
         }
@@ -687,6 +679,8 @@ struct ExpandableSegment {
 #define SYS_pidfd_getfd 438
 #endif
 #endif // !_WIN32
+    std::vector<Handle> imported;
+    imported.reserve(header.num_handles);
     if (header.handle_type != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
 #ifdef _WIN32
       TORCH_CHECK(
@@ -706,17 +700,7 @@ struct ExpandableSegment {
         if (myfd == -1) {
           auto err = errno;
           close(static_cast<int>(pidfd));
-          for (auto& h : segment->handles_) {
-            TORCH_INTERNAL_ASSERT(h.has_value());
-            const Handle& handle = *h;
-#ifdef USE_ROCM
-            C10_CUDA_CHECK(hipMemRelease(handle.handle));
-#else
-            C10_CUDA_DRIVER_CHECK(
-                DriverAPI::get()->cuMemRelease_(handle.handle));
-#endif
-            h = std::nullopt;
-          }
+          // `imported` releases handles imported so far via ~Handle on throw.
           TORCH_CHECK(
               err != ENOSYS,
               "The kernel on this machine does not support the pidfd_getfd syscall needed to use IPC for CUDA tensors when expandable_segments:True is set. "
@@ -746,7 +730,7 @@ struct ExpandableSegment {
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
         close(static_cast<int>(myfd));
-        segment->handles_.emplace_back(handle);
+        imported.emplace_back(handle, std::nullopt);
       }
       close(static_cast<int>(pidfd));
 #endif // !_WIN32
@@ -771,10 +755,14 @@ struct ExpandableSegment {
             get_nvml_fabric_info(device),
             "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
-        segment->handles_.emplace_back(handle);
+        imported.emplace_back(handle, std::nullopt);
       }
 #endif
     }
+    // Publish imported handles only after every import succeeds; on any throw
+    // above, `imported` releases them via ~Handle and the segment stays empty,
+    // so no partial state is mapped or leaked.
+    segment->handles_ = std::move(imported);
     segment->mapAndSetAccess(0, header.num_handles);
     return segment;
   }
@@ -885,30 +873,43 @@ struct ExpandableSegment {
   }
 
   void mapAndSetAccess(size_t begin, size_t end) {
+    // Map/setAccess can fail partway. On failure, unmap the prefix we mapped
+    // and release every handle in [begin, end) so no active-but-unmapped slot
+    // survives; otherwise teardown would later unmap a never-mapped range.
+    // Non-throwing: runs during unwinding.
+    size_t mapped = begin;
+    auto rollback = c10::make_scope_exit([&] {
+      for (auto i : c10::irange(begin, mapped)) {
+#ifdef USE_ROCM
+        C10_CUDA_IGNORE_ERROR(
+            hipMemUnmap(ptr() + i * segment_size_, segment_size_));
+#else
+        (void)DriverAPI::get()->cuMemUnmap_(
+            ptr_ + i * segment_size_, segment_size_);
+#endif
+      }
+      for (auto i : c10::irange(begin, end)) {
+        handles_.at(i).release();
+      }
+    });
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
+      auto& handle = handles_.at(i);
+      TORCH_INTERNAL_ASSERT(handle.active());
 #ifdef USE_ROCM
       C10_CUDA_CHECK(hipMemMap(
-          ptr() + i * segment_size_,
-          segment_size_,
-          0,
-          maybe_handle->handle,
-          0ULL));
+          ptr() + i * segment_size_, segment_size_, 0, handle.get(), 0ULL));
 #else
       C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemMap_(
-          ptr_ + i * segment_size_,
-          segment_size_,
-          0,
-          maybe_handle->handle,
-          0ULL));
+          ptr_ + i * segment_size_, segment_size_, 0, handle.get(), 0ULL));
 #endif
+      mapped = i + 1;
     }
-    mapped_size_ += (end - begin) * segment_size_;
     setAccess(device_, begin, end);
     for (auto p : peers_) {
       setAccess(p, begin, end);
     }
+    mapped_size_ += (end - begin) * segment_size_;
+    rollback.release();
   }
 
   void unmapHandles(size_t begin, size_t end) {
@@ -925,43 +926,33 @@ struct ExpandableSegment {
       cuda::CUDAGuard device_guard(device_);
       C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
+    // Unmap the whole contiguous range in one call, then release each handle.
+#ifdef USE_ROCM
+    C10_CUDA_CHECK(hipMemUnmap(
+        ptr() + segment_size_ * begin, (end - begin) * segment_size_));
+#else
+    C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
+        ptr_ + segment_size_ * begin, (end - begin) * segment_size_));
+#endif
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-      Handle h = *maybe_handle;
-      maybe_handle = std::nullopt;
-#ifdef USE_ROCM
-      C10_CUDA_CHECK(hipMemUnmap(ptr() + segment_size_ * i, segment_size_));
-#else
-      C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
-          ptr_ + segment_size_ * i, segment_size_));
-#endif
-      if (h.shareable_handle) {
-#ifndef _WIN32
-        close(std::get<int>(*h.shareable_handle));
-#endif
-      }
-#ifdef USE_ROCM
-      C10_CUDA_CHECK(hipMemRelease(h.handle));
-#else
-      C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemRelease_(h.handle));
-#endif
+      handles_.at(i).release();
     }
     trimHandles();
   }
   void trimHandles() {
     auto it = std::ranges::find_if(
         std::views::reverse(handles_),
-        [](const std::optional<Handle>& opt) { return opt.has_value(); });
+        [](const Handle& h) { return h.active(); });
     handles_.erase(it.base(), handles_.end());
   }
   void forEachAllocatedRange(const std::function<void(size_t, size_t)>& fn) {
     size_t start = 0;
     for (auto i : c10::irange(handles_.size())) {
-      if (handles_.at(i) && (i == 0 || !handles_.at(i - 1))) {
+      if (handles_.at(i).active() && (i == 0 || !handles_.at(i - 1).active())) {
         start = i;
       }
-      if (handles_.at(i) && (i + 1 == handles_.size() || !handles_.at(i + 1))) {
+      if (handles_.at(i).active() &&
+          (i + 1 == handles_.size() || !handles_.at(i + 1).active())) {
         fn(start, i + 1);
       }
     }
@@ -987,9 +978,66 @@ struct ExpandableSegment {
   size_t segment_size_;
   size_t mapped_size_;
   size_t max_handles_;
+  // An engaged `handle` marks ownership; a default-constructed Handle is an
+  // empty slot. `shareable_handle` is a separate, producer-only export artifact
+  // (a POSIX fd or fabric handle) that coexists with `handle` and must also be
+  // closed.
   struct Handle {
-    CUmemGenericAllocationHandle handle;
+    std::optional<CUmemGenericAllocationHandle> handle;
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
+
+    Handle() = default;
+    Handle(
+        CUmemGenericAllocationHandle h,
+        std::optional<std::variant<int, CUmemFabricHandle>> s)
+        : handle(h), shareable_handle(std::move(s)) {}
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    Handle(Handle&& other) noexcept
+        : handle(std::exchange(other.handle, std::nullopt)),
+          shareable_handle(
+              std::exchange(other.shareable_handle, std::nullopt)) {}
+    Handle& operator=(Handle&& other) noexcept {
+      // Swap so `other` carries away our previous resources and releases them
+      // when it is destroyed.
+      handle.swap(other.handle);
+      shareable_handle.swap(other.shareable_handle);
+      return *this;
+    }
+    ~Handle() {
+      release();
+    }
+
+    // Whether this slot owns a physical handle.
+    bool active() const {
+      return handle.has_value();
+    }
+    // The owned physical handle; valid only when active().
+    CUmemGenericAllocationHandle get() const {
+      return handle.value();
+    }
+    // Free the physical handle (and close the shareable fd) and reset to an
+    // empty slot; callers must unmap the slot first. No-op when inactive. Must
+    // not throw: may run during unwinding, so release errors are ignored.
+    void release() noexcept {
+      if (!active()) {
+        return;
+      }
+#ifndef _WIN32
+      if (shareable_handle) {
+        if (const int* fd = std::get_if<int>(&*shareable_handle)) {
+          close(*fd);
+        }
+      }
+#endif
+#ifdef USE_ROCM
+      C10_CUDA_IGNORE_ERROR(hipMemRelease(*handle));
+#else
+      (void)DriverAPI::get()->cuMemRelease_(*handle);
+#endif
+      handle = std::nullopt;
+      shareable_handle = std::nullopt;
+    }
   };
   struct ShareHeader {
     // All fields have in-class default initializers so that
@@ -1005,7 +1053,7 @@ struct ExpandableSegment {
     Expandable_Segments_Handle_Type handle_type =
         Expandable_Segments_Handle_Type::UNSPECIFIED;
   };
-  std::vector<std::optional<Handle>> handles_;
+  std::vector<Handle> handles_;
   // devices on which this memory should be mapped in addition
   // to the device where the physical memory lives (device_).
   std::vector<c10::DeviceIndex> peers_;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -519,8 +519,7 @@ struct ExpandableSegment {
         // Unlike the corresponding CUDA Driver API.
         (void)hipGetLastError();
 #endif
-        // Roll back the handles created in this call (none are mapped yet)
-        // and report no progress so the caller treats it as OOM.
+        // Roll back unmapped handles created here; no progress signals OOM.
         releaseHandles(begin, i);
         return rangeFromHandles(begin, begin);
       }
@@ -756,9 +755,7 @@ struct ExpandableSegment {
       }
 #endif
     }
-    // Publish imported handles only after every import succeeds; on any throw
-    // above, `imported` releases them via ~Handle and the segment stays empty,
-    // so no partial state is mapped or leaked.
+    // Publish after all imports succeed; `imported` releases on throw.
     segment->handles_ = std::move(imported);
     segment->mapAndSetAccess(0, header.num_handles);
     return segment;
@@ -870,10 +867,7 @@ struct ExpandableSegment {
   }
 
   void mapAndSetAccess(size_t begin, size_t end) {
-    // Map/setAccess can fail partway. On failure, unmap the prefix we mapped
-    // and release every handle in [begin, end) so no active-but-unmapped slot
-    // survives; otherwise teardown would later unmap a never-mapped range.
-    // Non-throwing: runs during unwinding.
+    // On failure, unmap the prefix and release the range.
     size_t mapped = begin;
     auto rollback = c10::make_scope_exit([&] {
       if (mapped > begin) {
@@ -931,8 +925,7 @@ struct ExpandableSegment {
 #endif
     releaseHandles(begin, end);
   }
-  // Release the handles in [begin, end) and drop trailing empty slots. Callers
-  // must have unmapped any mapped slots in the range first (see release()).
+  // Release handles in [begin, end) and trim; caller must unmap first.
   void releaseHandles(size_t begin, size_t end) {
     for (auto i : c10::irange(begin, end)) {
       handles_.at(i).release();
@@ -978,10 +971,7 @@ struct ExpandableSegment {
   size_t segment_size_;
   size_t mapped_size_;
   size_t max_handles_;
-  // An engaged `handle` marks ownership; a default-constructed Handle is an
-  // empty slot. `shareable_handle` is a separate, producer-only export artifact
-  // (a POSIX fd or fabric handle) that coexists with `handle` and must also be
-  // closed.
+  // Move-only RAII owner; closes shareable_handle on free.
   struct Handle {
     std::optional<CUmemGenericAllocationHandle> handle;
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
@@ -998,8 +988,7 @@ struct ExpandableSegment {
           shareable_handle(
               std::exchange(other.shareable_handle, std::nullopt)) {}
     Handle& operator=(Handle&& other) noexcept {
-      // Swap so `other` carries away our previous resources and releases them
-      // when it is destroyed.
+      // Swap so `other` releases our old resources on destruction.
       handle.swap(other.handle);
       shareable_handle.swap(other.shareable_handle);
       return *this;
@@ -1016,9 +1005,7 @@ struct ExpandableSegment {
     CUmemGenericAllocationHandle get() const {
       return handle.value();
     }
-    // Free the physical handle (and close the shareable fd) and reset to an
-    // empty slot; callers must unmap the slot first. No-op when inactive. Must
-    // not throw: may run during unwinding, so release errors are ignored.
+    // Free handle + shareable fd (caller must unmap first).
     void release() noexcept {
       if (!active()) {
         return;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -879,13 +879,13 @@ struct ExpandableSegment {
     // Non-throwing: runs during unwinding.
     size_t mapped = begin;
     auto rollback = c10::make_scope_exit([&] {
-      for (auto i : c10::irange(begin, mapped)) {
+      if (mapped > begin) {
 #ifdef USE_ROCM
-        C10_CUDA_IGNORE_ERROR(
-            hipMemUnmap(ptr() + i * segment_size_, segment_size_));
+        C10_CUDA_IGNORE_ERROR(hipMemUnmap(
+            ptr() + begin * segment_size_, (mapped - begin) * segment_size_));
 #else
         (void)DriverAPI::get()->cuMemUnmap_(
-            ptr_ + i * segment_size_, segment_size_);
+            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
 #endif
       }
       for (auto i : c10::irange(begin, end)) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -562,7 +562,7 @@ struct ExpandableSegment {
       handles_.resize(end);
     }
     for (auto i : c10::irange(begin, end)) {
-      TORCH_INTERNAL_ASSERT(!handles_.at(i));
+      TORCH_INTERNAL_ASSERT(!handles_.at(i).active());
       CUmemGenericAllocationHandle handle = 0;
       CUmemAllocationProp prop = {};
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
@@ -597,45 +597,38 @@ struct ExpandableSegment {
       auto status =
           DriverAPI::get()->cuMemCreate_(&handle, segment_size_, &prop, 0);
 #endif
-      if (status != CUDA_SUCCESS) {
-        if (status == CUDA_ERROR_OUT_OF_MEMORY) {
-          {
-            size_t device_free = 0;
-            size_t device_total = 0;
-            (void)cudaMemGetInfo(&device_free, &device_total);
-            LOG(WARNING)
-                << "expandable_segments: memory mapping failed with OOM on device "
-                << static_cast<int>(device_) << " while trying to map "
-                << segment_size_ << " bytes (free: " << device_free
-                << ", total: " << device_total << ").";
-          }
-#ifdef USE_ROCM
-          // hipMemCreate above returned hipErrorOutOfMemory and treated it
-          // like a sticky runtime error. Which means we need to clear it.
-          // Unlike the corresponding CUDA Driver API.
-          (void)hipGetLastError();
-#endif
-          for (auto j : c10::irange(begin, i)) {
-            auto& maybe_handle = handles_.at(j);
-            TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-            auto h = *maybe_handle;
-            maybe_handle = std::nullopt;
-#ifdef USE_ROCM
-            C10_CUDA_CHECK(hipMemRelease(h.handle));
-#else
-            C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemRelease_(h.handle));
-#endif
-          }
-          trimHandles();
-          return rangeFromHandles(begin, begin);
+      if (status == CUDA_ERROR_OUT_OF_MEMORY) {
+        {
+          size_t device_free = 0;
+          size_t device_total = 0;
+          (void)cudaMemGetInfo(&device_free, &device_total);
+          LOG(WARNING)
+              << "expandable_segments: memory mapping failed with OOM on device "
+              << static_cast<int>(device_) << " while trying to map "
+              << segment_size_ << " bytes (free: " << device_free
+              << ", total: " << device_total << ").";
         }
 #ifdef USE_ROCM
-        C10_CUDA_CHECK(status);
-#else
-        C10_CUDA_DRIVER_CHECK(status);
+        // hipMemCreate above returned hipErrorOutOfMemory and treated it
+        // like a sticky runtime error. Which means we need to clear it.
+        // Unlike the corresponding CUDA Driver API.
+        (void)hipGetLastError();
 #endif
+        // Roll back the handles created in this call (none are mapped yet)
+        // and report no progress so the caller treats it as OOM.
+        for (auto j : c10::irange(begin, i)) {
+          handles_.at(j).release();
+        }
+        trimHandles();
+        return rangeFromHandles(begin, begin);
       }
-      handles_.at(i) = Handle{.handle = handle};
+      // Throws on any other error; a no-op on success.
+#ifdef USE_ROCM
+      C10_CUDA_CHECK(status);
+#else
+      C10_CUDA_DRIVER_CHECK(status);
+#endif
+      handles_.at(i) = Handle(handle, std::nullopt);
     }
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
@@ -685,18 +678,17 @@ struct ExpandableSegment {
 
     buf.write(reinterpret_cast<const char*>(&header), sizeof(ShareHeader));
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-      auto& handle = *maybe_handle;
+      auto& handle = handles_.at(i);
+      TORCH_INTERNAL_ASSERT(handle.active());
       if (handle_type_ != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
         if (!handle.shareable_handle) {
           int fd = 0;
 #ifdef USE_ROCM
           C10_CUDA_CHECK(hipMemExportToShareableHandle(
-              &fd, handle.handle, hipMemHandleTypePosixFileDescriptor, 0));
+              &fd, handle.get(), hipMemHandleTypePosixFileDescriptor, 0));
 #else
           C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemExportToShareableHandle_(
-              &fd, handle.handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+              &fd, handle.get(), CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
 #endif
           handle.shareable_handle = fd;
           LOG(INFO) << "use posix fd to share expandable segments.";
@@ -715,7 +707,7 @@ struct ExpandableSegment {
         if (!handle.shareable_handle) {
           CUmemFabricHandle fabric_handle;
           C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemExportToShareableHandle_(
-              &fabric_handle, handle.handle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
+              &fabric_handle, handle.get(), CU_MEM_HANDLE_TYPE_FABRIC, 0));
           handle.shareable_handle = fabric_handle;
           LOG(INFO) << "use fabric handle to share expandable segments.";
         }
@@ -778,6 +770,8 @@ struct ExpandableSegment {
 #define SYS_pidfd_getfd 438
 #endif
 #endif // !_WIN32
+    std::vector<Handle> imported;
+    imported.reserve(header.num_handles);
     if (header.handle_type != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
 #ifdef _WIN32
       TORCH_CHECK(
@@ -798,6 +792,8 @@ struct ExpandableSegment {
         auto myfd = syscall(SYS_pidfd_getfd, pidfd, fd, 0);
         if (myfd == -1) {
           auto err = errno;
+          // close_pidfd (scope_exit above) and `imported` (releases handles
+          // imported so far via ~Handle) both fire on this throw.
           TORCH_CHECK(
               err != ENOSYS,
               "The kernel on this machine does not support the pidfd_getfd syscall needed to use IPC for CUDA tensors when expandable_segments:True is set. "
@@ -829,7 +825,8 @@ struct ExpandableSegment {
             "}");
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
-        segment->handles_.emplace_back(handle);
+        // close_myfd (scope_exit above) closes myfd; don't double-close it here.
+        imported.emplace_back(handle, std::nullopt);
       }
 #endif // !_WIN32
     } else {
@@ -856,10 +853,14 @@ struct ExpandableSegment {
             get_nvml_fabric_info(device),
             "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
-        segment->handles_.emplace_back(handle);
+        imported.emplace_back(handle, std::nullopt);
       }
 #endif
     }
+    // Publish imported handles only after every import succeeds; on any throw
+    // above, `imported` releases them via ~Handle and the segment stays empty,
+    // so no partial state is mapped or leaked.
+    segment->handles_ = std::move(imported);
     segment->mapAndSetAccess(0, header.num_handles);
     return segment;
   }
@@ -976,31 +977,43 @@ struct ExpandableSegment {
   }
 
   void mapAndSetAccess(size_t begin, size_t end) {
+    // Map/setAccess can fail partway. On failure, unmap the prefix we mapped
+    // and release every handle in [begin, end) so no active-but-unmapped slot
+    // survives; otherwise teardown would later unmap a never-mapped range.
+    // Non-throwing: runs during unwinding.
+    size_t mapped = begin;
+    auto rollback = c10::make_scope_exit([&] {
+      for (auto i : c10::irange(begin, mapped)) {
+#ifdef USE_ROCM
+        C10_CUDA_IGNORE_ERROR(
+            hipMemUnmap(ptr() + i * segment_size_, segment_size_));
+#else
+        (void)DriverAPI::get()->cuMemUnmap_(
+            ptr_ + i * segment_size_, segment_size_);
+#endif
+      }
+      for (auto i : c10::irange(begin, end)) {
+        handles_.at(i).release();
+      }
+    });
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
+      auto& handle = handles_.at(i);
+      TORCH_INTERNAL_ASSERT(handle.active());
 #ifdef USE_ROCM
       C10_CUDA_CHECK(hipMemMap(
-          ptr() + i * segment_size_,
-          segment_size_,
-          0,
-          maybe_handle->handle,
-          0ULL));
+          ptr() + i * segment_size_, segment_size_, 0, handle.get(), 0ULL));
 #else
       C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemMap_(
-          ptr_ + i * segment_size_,
-          segment_size_,
-          0,
-          maybe_handle->handle,
-          0ULL));
+          ptr_ + i * segment_size_, segment_size_, 0, handle.get(), 0ULL));
 #endif
-      maybe_handle->mapped = true;
+      mapped = i + 1;
     }
-    mapped_size_ += (end - begin) * segment_size_;
     setAccess(device_, begin, end);
     for (auto p : peers_) {
       setAccess(p, begin, end);
     }
+    mapped_size_ += (end - begin) * segment_size_;
+    rollback.release();
   }
 
   void unmapHandles(size_t begin, size_t end) {
@@ -1017,49 +1030,33 @@ struct ExpandableSegment {
       cuda::CUDAGuard device_guard(device_);
       C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
+    // Unmap the whole contiguous range in one call, then release each handle.
+#ifdef USE_ROCM
+    C10_CUDA_CHECK(hipMemUnmap(
+        ptr() + segment_size_ * begin, (end - begin) * segment_size_));
+#else
+    C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
+        ptr_ + segment_size_ * begin, (end - begin) * segment_size_));
+#endif
     for (auto i : c10::irange(begin, end)) {
-      auto& maybe_handle = handles_.at(i);
-      TORCH_INTERNAL_ASSERT(maybe_handle.has_value());
-      Handle h = *maybe_handle;
-      maybe_handle = std::nullopt;
-      if (h.mapped) {
-#ifdef USE_ROCM
-        C10_CUDA_CHECK(hipMemUnmap(ptr() + segment_size_ * i, segment_size_));
-#else
-        C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
-            ptr_ + segment_size_ * i, segment_size_));
-#endif
-      }
-      if (h.shareable_handle) {
-#ifndef _WIN32
-        // shareable_handle also holds CUmemFabricHandle for fabric segments;
-        // std::get_if skips those (no fd to close) instead of throwing.
-        if (auto* fd = std::get_if<int>(&*h.shareable_handle)) {
-          close(*fd);
-        }
-#endif
-      }
-#ifdef USE_ROCM
-      C10_CUDA_CHECK(hipMemRelease(h.handle));
-#else
-      C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemRelease_(h.handle));
-#endif
+      handles_.at(i).release();
     }
     trimHandles();
   }
   void trimHandles() {
     auto it = std::ranges::find_if(
         std::views::reverse(handles_),
-        [](const std::optional<Handle>& opt) { return opt.has_value(); });
+        [](const Handle& h) { return h.active(); });
     handles_.erase(it.base(), handles_.end());
   }
   void forEachAllocatedRange(const std::function<void(size_t, size_t)>& fn) {
     size_t start = 0;
     for (auto i : c10::irange(handles_.size())) {
-      if (handles_.at(i) && (i == 0 || !handles_.at(i - 1))) {
+      if (handles_.at(i).active() && (i == 0 || !handles_.at(i - 1).active())) {
         start = i;
       }
-      if (handles_.at(i) && (i + 1 == handles_.size() || !handles_.at(i + 1))) {
+      if (handles_.at(i).active() &&
+          (i + 1 == handles_.size() || !handles_.at(i + 1).active())) {
         fn(start, i + 1);
       }
     }
@@ -1085,12 +1082,68 @@ struct ExpandableSegment {
   size_t segment_size_;
   size_t mapped_size_;
   size_t max_handles_;
+  // An engaged `handle` marks ownership; a default-constructed Handle is an
+  // empty slot. `shareable_handle` is a separate, producer-only export artifact
+  // (a POSIX fd or fabric handle) that coexists with `handle` and must also be
+  // closed.
   struct Handle {
-    CUmemGenericAllocationHandle handle;
+    std::optional<CUmemGenericAllocationHandle> handle;
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
-    // False for handles imported via fromShared but not yet cuMemMap'd, so
-    // unmapHandles can skip cuMemUnmap on ranges that were never mapped.
-    bool mapped = false;
+
+    Handle() = default;
+    Handle(
+        CUmemGenericAllocationHandle h,
+        std::optional<std::variant<int, CUmemFabricHandle>> s)
+        : handle(h), shareable_handle(std::move(s)) {}
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    Handle(Handle&& other) noexcept
+        : handle(std::exchange(other.handle, std::nullopt)),
+          shareable_handle(
+              std::exchange(other.shareable_handle, std::nullopt)) {}
+    Handle& operator=(Handle&& other) noexcept {
+      if (this == &other) {
+        return *this;
+      }
+      release();
+      handle = std::exchange(other.handle, std::nullopt);
+      shareable_handle = std::exchange(other.shareable_handle, std::nullopt);
+      return *this;
+    }
+    ~Handle() {
+      release();
+    }
+
+    // Whether this slot owns a physical handle.
+    bool active() const {
+      return handle.has_value();
+    }
+    // The owned physical handle; valid only when active().
+    CUmemGenericAllocationHandle get() const {
+      return handle.value();
+    }
+    // Free the physical handle (and close the shareable fd) and reset to an
+    // empty slot; callers must unmap the slot first. No-op when inactive. Must
+    // not throw: may run during unwinding, so release errors are ignored.
+    void release() noexcept {
+      if (!active()) {
+        return;
+      }
+#ifndef _WIN32
+      if (shareable_handle) {
+        if (const int* fd = std::get_if<int>(&*shareable_handle)) {
+          close(*fd);
+        }
+      }
+#endif
+#ifdef USE_ROCM
+      C10_CUDA_IGNORE_ERROR(hipMemRelease(*handle));
+#else
+      (void)DriverAPI::get()->cuMemRelease_(*handle);
+#endif
+      handle = std::nullopt;
+      shareable_handle = std::nullopt;
+    }
   };
   struct ShareHeader {
     // All fields have in-class default initializers so that
@@ -1106,7 +1159,7 @@ struct ExpandableSegment {
     Expandable_Segments_Handle_Type handle_type =
         Expandable_Segments_Handle_Type::UNSPECIFIED;
   };
-  std::vector<std::optional<Handle>> handles_;
+  std::vector<Handle> handles_;
   // devices on which this memory should be mapped in addition
   // to the device where the physical memory lives (device_).
   std::vector<c10::DeviceIndex> peers_;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -759,6 +759,13 @@ struct ExpandableSegment {
           "on the producer, or disable expandable_segments.");
     }
 #endif
+    // segment_size divides every address/size computation below (starting
+    // with numSegments() in the constructor); a zero from a corrupted or
+    // malicious peer would be a division by zero.
+    TORCH_CHECK(
+        header.segment_size != 0,
+        "expandable_segments IPC: received a zero segment_size in the share "
+        "header");
     auto segment = std::make_unique<ExpandableSegment>(
         device,
         std::nullopt,
@@ -775,6 +782,16 @@ struct ExpandableSegment {
 #define SYS_pidfd_getfd 438
 #endif
 #endif // !_WIN32
+    // num_handles is attacker/peer-controlled and sizes this reserve()
+    // upfront, before a single handle has been validated; bound it against
+    // the segment's own capacity, which comes from the local device's
+    // reserved virtual address space rather than the wire payload.
+    TORCH_CHECK(
+        header.num_handles <= segment->max_handles_,
+        "expandable_segments IPC: share header claims ",
+        header.num_handles,
+        " handles, more than this segment's capacity of ",
+        segment->max_handles_);
     std::vector<Handle> imported;
     imported.reserve(header.num_handles);
     if (header.handle_type != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -561,6 +561,13 @@ struct ExpandableSegment {
     if (end > handles_.size()) {
       handles_.resize(end);
     }
+    // On failure (throw or early return), release handles created here but
+    // not yet handed to mapAndSetAccess -- they were never cuMemMap'd, so
+    // unmapHandles (which unconditionally unmaps its whole range) must never
+    // see them as part of an allocated range.
+    size_t created = begin;
+    auto rollback =
+        c10::make_scope_exit([&] { releaseHandles(begin, created); });
     for (auto i : c10::irange(begin, end)) {
       TORCH_INTERNAL_ASSERT(!handles_.at(i).active());
       CUmemGenericAllocationHandle handle = 0;
@@ -619,18 +626,20 @@ struct ExpandableSegment {
         // Unlike the corresponding CUDA Driver API.
         (void)hipGetLastError();
 #endif
-        // Roll back unmapped handles created here; no progress signals OOM.
-        releaseHandles(begin, i);
+        // rollback (scope_exit above) releases handles created so far.
         return rangeFromHandles(begin, begin);
       }
-      // Throws on any other error; a no-op on success.
+      // Throws on any other error; rollback (scope_exit above) releases
+      // handles created so far.
 #ifdef USE_ROCM
       C10_CUDA_CHECK(status);
 #else
       C10_CUDA_DRIVER_CHECK(status);
 #endif
       handles_.at(i) = Handle(handle);
+      created = i + 1;
     }
+    rollback.release();
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
   }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -603,19 +603,15 @@ struct ExpandableSegment {
           size_t device_total = 0;
           const cudaError_t info_status =
               cudaMemGetInfo(&device_free, &device_total);
-          if (info_status == cudaSuccess) {
-            LOG(WARNING)
-                << "expandable_segments: memory mapping failed with OOM on device "
-                << static_cast<int>(device_) << " while trying to map "
-                << segment_size_ << " bytes (free: " << device_free
-                << ", total: " << device_total << ").";
-          } else {
-            LOG(WARNING)
-                << "expandable_segments: memory mapping failed with OOM on device "
-                << static_cast<int>(device_) << " while trying to map "
-                << segment_size_ << " bytes; cudaMemGetInfo failed: "
-                << cudaGetErrorString(info_status) << ".";
-          }
+          const std::string detail = (info_status == cudaSuccess)
+              ? " bytes (free: " + std::to_string(device_free) +
+                  ", total: " + std::to_string(device_total) + ")."
+              : std::string(" bytes; cudaMemGetInfo failed: ") +
+                  cudaGetErrorString(info_status) + ".";
+          LOG(WARNING)
+              << "expandable_segments: memory mapping failed with OOM on device "
+              << static_cast<int>(device_) << " while trying to map "
+              << segment_size_ << detail;
         }
 #ifdef USE_ROCM
         // hipMemCreate above returned hipErrorOutOfMemory and treated it
@@ -633,7 +629,7 @@ struct ExpandableSegment {
 #else
       C10_CUDA_DRIVER_CHECK(status);
 #endif
-      handles_.at(i) = Handle(handle, std::nullopt);
+      handles_.at(i) = Handle(handle);
     }
     mapAndSetAccess(begin, end);
     return rangeFromHandles(begin, end);
@@ -847,8 +843,9 @@ struct ExpandableSegment {
             "}");
 #endif
         LOG(INFO) << "use posix fd to import expandable segments.";
-        // close_myfd (scope_exit above) closes myfd; don't double-close it here.
-        imported.emplace_back(handle, std::nullopt);
+        // close_myfd (scope_exit above) closes myfd; don't double-close it
+        // here.
+        imported.emplace_back(handle);
       }
 #endif // !_WIN32
     } else {
@@ -875,7 +872,7 @@ struct ExpandableSegment {
             get_nvml_fabric_info(device),
             "}");
         LOG(INFO) << "use fabric handle to import expandable segments.";
-        imported.emplace_back(handle, std::nullopt);
+        imported.emplace_back(handle);
       }
 #endif
     }
@@ -1107,10 +1104,7 @@ struct ExpandableSegment {
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
 
     Handle() = default;
-    Handle(
-        CUmemGenericAllocationHandle h,
-        std::optional<std::variant<int, CUmemFabricHandle>> s)
-        : handle(h), shareable_handle(std::move(s)) {}
+    explicit Handle(CUmemGenericAllocationHandle h) : handle(h) {}
     Handle(const Handle&) = delete;
     Handle& operator=(const Handle&) = delete;
     Handle(Handle&& other) noexcept

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -983,13 +983,13 @@ struct ExpandableSegment {
     // Non-throwing: runs during unwinding.
     size_t mapped = begin;
     auto rollback = c10::make_scope_exit([&] {
-      for (auto i : c10::irange(begin, mapped)) {
+      if (mapped > begin) {
 #ifdef USE_ROCM
-        C10_CUDA_IGNORE_ERROR(
-            hipMemUnmap(ptr() + i * segment_size_, segment_size_));
+        C10_CUDA_IGNORE_ERROR(hipMemUnmap(
+            ptr() + begin * segment_size_, (mapped - begin) * segment_size_));
 #else
         (void)DriverAPI::get()->cuMemUnmap_(
-            ptr_ + i * segment_size_, segment_size_);
+            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
 #endif
       }
       for (auto i : c10::irange(begin, end)) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -614,8 +614,7 @@ struct ExpandableSegment {
         // Unlike the corresponding CUDA Driver API.
         (void)hipGetLastError();
 #endif
-        // Roll back the handles created in this call (none are mapped yet)
-        // and report no progress so the caller treats it as OOM.
+        // Roll back unmapped handles created here; no progress signals OOM.
         releaseHandles(begin, i);
         return rangeFromHandles(begin, begin);
       }
@@ -854,9 +853,7 @@ struct ExpandableSegment {
       }
 #endif
     }
-    // Publish imported handles only after every import succeeds; on any throw
-    // above, `imported` releases them via ~Handle and the segment stays empty,
-    // so no partial state is mapped or leaked.
+    // Publish after all imports succeed; `imported` releases on throw.
     segment->handles_ = std::move(imported);
     segment->mapAndSetAccess(0, header.num_handles);
     return segment;
@@ -974,10 +971,7 @@ struct ExpandableSegment {
   }
 
   void mapAndSetAccess(size_t begin, size_t end) {
-    // Map/setAccess can fail partway. On failure, unmap the prefix we mapped
-    // and release every handle in [begin, end) so no active-but-unmapped slot
-    // survives; otherwise teardown would later unmap a never-mapped range.
-    // Non-throwing: runs during unwinding.
+    // On failure, unmap the prefix and release the range.
     size_t mapped = begin;
     auto rollback = c10::make_scope_exit([&] {
       if (mapped > begin) {
@@ -1035,8 +1029,7 @@ struct ExpandableSegment {
 #endif
     releaseHandles(begin, end);
   }
-  // Release the handles in [begin, end) and drop trailing empty slots. Callers
-  // must have unmapped any mapped slots in the range first (see release()).
+  // Release handles in [begin, end) and trim; caller must unmap first.
   void releaseHandles(size_t begin, size_t end) {
     for (auto i : c10::irange(begin, end)) {
       handles_.at(i).release();
@@ -1082,10 +1075,7 @@ struct ExpandableSegment {
   size_t segment_size_;
   size_t mapped_size_;
   size_t max_handles_;
-  // An engaged `handle` marks ownership; a default-constructed Handle is an
-  // empty slot. `shareable_handle` is a separate, producer-only export artifact
-  // (a POSIX fd or fabric handle) that coexists with `handle` and must also be
-  // closed.
+  // Move-only RAII owner; closes shareable_handle on free.
   struct Handle {
     std::optional<CUmemGenericAllocationHandle> handle;
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
@@ -1122,9 +1112,7 @@ struct ExpandableSegment {
     CUmemGenericAllocationHandle get() const {
       return handle.value();
     }
-    // Free the physical handle (and close the shareable fd) and reset to an
-    // empty slot; callers must unmap the slot first. No-op when inactive. Must
-    // not throw: may run during unwinding, so release errors are ignored.
+    // Free handle + shareable fd (caller must unmap first).
     void release() noexcept {
       if (!active()) {
         return;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -601,12 +601,21 @@ struct ExpandableSegment {
         {
           size_t device_free = 0;
           size_t device_total = 0;
-          (void)cudaMemGetInfo(&device_free, &device_total);
-          LOG(WARNING)
-              << "expandable_segments: memory mapping failed with OOM on device "
-              << static_cast<int>(device_) << " while trying to map "
-              << segment_size_ << " bytes (free: " << device_free
-              << ", total: " << device_total << ").";
+          const cudaError_t info_status =
+              cudaMemGetInfo(&device_free, &device_total);
+          if (info_status == cudaSuccess) {
+            LOG(WARNING)
+                << "expandable_segments: memory mapping failed with OOM on device "
+                << static_cast<int>(device_) << " while trying to map "
+                << segment_size_ << " bytes (free: " << device_free
+                << ", total: " << device_total << ").";
+          } else {
+            LOG(WARNING)
+                << "expandable_segments: memory mapping failed with OOM on device "
+                << static_cast<int>(device_) << " while trying to map "
+                << segment_size_ << " bytes; cudaMemGetInfo failed: "
+                << cudaGetErrorString(info_status) << ".";
+          }
         }
 #ifdef USE_ROCM
         // hipMemCreate above returned hipErrorOutOfMemory and treated it
@@ -976,11 +985,11 @@ struct ExpandableSegment {
     auto rollback = c10::make_scope_exit([&] {
       if (mapped > begin) {
 #ifdef USE_ROCM
-        C10_CUDA_IGNORE_ERROR(hipMemUnmap(
+        C10_CUDA_CHECK_WARN(hipMemUnmap(
             ptr() + begin * segment_size_, (mapped - begin) * segment_size_));
 #else
-        (void)DriverAPI::get()->cuMemUnmap_(
-            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
+        C10_CUDA_DRIVER_WARN(DriverAPI::get()->cuMemUnmap_(
+            ptr_ + begin * segment_size_, (mapped - begin) * segment_size_));
 #endif
       }
       releaseHandles(begin, end);
@@ -1125,9 +1134,9 @@ struct ExpandableSegment {
       }
 #endif
 #ifdef USE_ROCM
-      C10_CUDA_IGNORE_ERROR(hipMemRelease(*handle));
+      C10_CUDA_CHECK_WARN(hipMemRelease(*handle));
 #else
-      (void)DriverAPI::get()->cuMemRelease_(*handle);
+      C10_CUDA_DRIVER_WARN(DriverAPI::get()->cuMemRelease_(*handle));
 #endif
       handle = std::nullopt;
       shareable_handle = std::nullopt;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -616,10 +616,7 @@ struct ExpandableSegment {
 #endif
         // Roll back the handles created in this call (none are mapped yet)
         // and report no progress so the caller treats it as OOM.
-        for (auto j : c10::irange(begin, i)) {
-          handles_.at(j).release();
-        }
-        trimHandles();
+        releaseHandles(begin, i);
         return rangeFromHandles(begin, begin);
       }
       // Throws on any other error; a no-op on success.
@@ -992,9 +989,7 @@ struct ExpandableSegment {
             ptr_ + begin * segment_size_, (mapped - begin) * segment_size_);
 #endif
       }
-      for (auto i : c10::irange(begin, end)) {
-        handles_.at(i).release();
-      }
+      releaseHandles(begin, end);
     });
     for (auto i : c10::irange(begin, end)) {
       auto& handle = handles_.at(i);
@@ -1038,6 +1033,11 @@ struct ExpandableSegment {
     C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemUnmap_(
         ptr_ + segment_size_ * begin, (end - begin) * segment_size_));
 #endif
+    releaseHandles(begin, end);
+  }
+  // Release the handles in [begin, end) and drop trailing empty slots. Callers
+  // must have unmapped any mapped slots in the range first (see release()).
+  void releaseHandles(size_t begin, size_t end) {
     for (auto i : c10::irange(begin, end)) {
       handles_.at(i).release();
     }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -561,10 +561,8 @@ struct ExpandableSegment {
     if (end > handles_.size()) {
       handles_.resize(end);
     }
-    // On failure (throw or early return), release handles created here but
-    // not yet handed to mapAndSetAccess -- they were never cuMemMap'd, so
-    // unmapHandles (which unconditionally unmaps its whole range) must never
-    // see them as part of an allocated range.
+    // On failure, release handles created so far; they were never cuMemMap'd,
+    // and unmapHandles's bulk cuMemUnmap must never see them as allocated.
     size_t created = begin;
     auto rollback =
         c10::make_scope_exit([&] { releaseHandles(begin, created); });
@@ -629,8 +627,7 @@ struct ExpandableSegment {
         // rollback (scope_exit above) releases handles created so far.
         return rangeFromHandles(begin, begin);
       }
-      // Throws on any other error; rollback (scope_exit above) releases
-      // handles created so far.
+      // Throws on any other error; rollback handles that too.
 #ifdef USE_ROCM
       C10_CUDA_CHECK(status);
 #else
@@ -764,9 +761,7 @@ struct ExpandableSegment {
           "on the producer, or disable expandable_segments.");
     }
 #endif
-    // segment_size divides every address/size computation below (starting
-    // with numSegments() in the constructor); a zero from a corrupted or
-    // malicious peer would be a division by zero.
+    // Zero would divide-by-zero in numSegments() below.
     TORCH_CHECK(
         header.segment_size != 0,
         "expandable_segments IPC: received a zero segment_size in the share "
@@ -787,10 +782,8 @@ struct ExpandableSegment {
 #define SYS_pidfd_getfd 438
 #endif
 #endif // !_WIN32
-    // num_handles is attacker/peer-controlled and sizes this reserve()
-    // upfront, before a single handle has been validated; bound it against
-    // the segment's own capacity, which comes from the local device's
-    // reserved virtual address space rather than the wire payload.
+    // num_handles is peer-controlled; bound it against the segment's own
+    // capacity before sizing reserve() with it.
     TORCH_CHECK(
         header.num_handles <= segment->max_handles_,
         "expandable_segments IPC: share header claims ",

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -37,6 +37,21 @@
   } while (0)
 // clang-format on
 
+// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
+// it is safe to call from noexcept teardown / unwinding paths.
+#define C10_CUDA_DRIVER_WARN(EXPR)                                           \
+  do {                                                                       \
+    CUresult __err = EXPR;                                                   \
+    if (__err != CUDA_SUCCESS) {                                             \
+      const char* err_str = nullptr;                                         \
+      if (c10::cuda::DriverAPI::get()->cuGetErrorString_(__err, &err_str) != \
+          CUDA_SUCCESS) {                                                    \
+        err_str = "unknown error";                                           \
+      }                                                                      \
+      TORCH_WARN("CUDA driver error: ", err_str);                            \
+    }                                                                        \
+  } while (0)
+
 #define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT)                             \
   do {                                                                     \
     CUresult __err = EXPR;                                                 \

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -49,21 +49,20 @@
   } while (0)
 // clang-format on
 
-// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
-// it is safe to call from noexcept teardown / unwinding paths. Takes an
-// already-evaluated CUresult (not a call expression) so callers that also
-// need the result -- see C10_CUDA_DRIVER_CHECK_GOTO below -- don't evaluate
-// the driver call twice.
-#define C10_CUDA_DRIVER_WARN(RESULT)                                          \
+// Shared by C10_CUDA_DRIVER_WARN and C10_CUDA_DRIVER_CHECK_GOTO below: given a
+// CUresult already evaluated under an active CUDAErrorLogCapture, warn if it
+// failed. Not usable on its own -- the capture object must be constructed
+// immediately before the driver call runs (its constructor resets the
+// thread-local log buffer that a driver callback appends to during the
+// call), so callers each construct their own and evaluate their own call.
+#define C10_CUDA_DRIVER_WARN_RESULT(RESULT, LOG_CAPTURE)                      \
   do {                                                                        \
-    c10::cuda::CUDAErrorLogCapture __cuda_error_log;                          \
-    CUresult __err = RESULT;                                                  \
-    if (__err != CUDA_SUCCESS) {                                              \
+    if ((RESULT) != CUDA_SUCCESS) {                                           \
       const auto __cuda_error_log_message =                                   \
-          __cuda_error_log.get_error_log_suffix();                            \
+          (LOG_CAPTURE).get_error_log_suffix();                               \
       const char* err_str;                                                    \
       CUresult get_error_str_err [[maybe_unused]] =                           \
-          c10::cuda::DriverAPI::get()->cuGetErrorString_(__err, &err_str);    \
+          c10::cuda::DriverAPI::get()->cuGetErrorString_((RESULT), &err_str); \
       if (get_error_str_err != CUDA_SUCCESS) {                                \
         TORCH_WARN(                                                           \
             "CUDA driver error: unknown error", __cuda_error_log_message);    \
@@ -73,13 +72,23 @@
     }                                                                         \
   } while (0)
 
-#define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT) \
-  do {                                         \
-    CUresult __err_for_goto = EXPR;            \
-    C10_CUDA_DRIVER_WARN(__err_for_goto);      \
-    if (__err_for_goto != CUDA_SUCCESS) {      \
-      goto NEXT;                               \
-    }                                          \
+// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
+// it is safe to call from noexcept teardown / unwinding paths.
+#define C10_CUDA_DRIVER_WARN(EXPR)                        \
+  do {                                                    \
+    c10::cuda::CUDAErrorLogCapture __cuda_error_log;      \
+    CUresult __err = EXPR;                                \
+    C10_CUDA_DRIVER_WARN_RESULT(__err, __cuda_error_log); \
+  } while (0)
+
+#define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT)                              \
+  do {                                                                      \
+    c10::cuda::CUDAErrorLogCapture __cuda_error_log_for_goto;               \
+    CUresult __err_for_goto = EXPR;                                         \
+    C10_CUDA_DRIVER_WARN_RESULT(__err_for_goto, __cuda_error_log_for_goto); \
+    if (__err_for_goto != CUDA_SUCCESS) {                                   \
+      goto NEXT;                                                            \
+    }                                                                       \
   } while (0)
 
 // The integer in the second column specifies the requested CUDA Driver API

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -49,10 +49,15 @@
   } while (0)
 // clang-format on
 
-#define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT)                                \
+// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
+// it is safe to call from noexcept teardown / unwinding paths. Takes an
+// already-evaluated CUresult (not a call expression) so callers that also
+// need the result -- see C10_CUDA_DRIVER_CHECK_GOTO below -- don't evaluate
+// the driver call twice.
+#define C10_CUDA_DRIVER_WARN(RESULT)                                          \
   do {                                                                        \
     c10::cuda::CUDAErrorLogCapture __cuda_error_log;                          \
-    CUresult __err = EXPR;                                                    \
+    CUresult __err = RESULT;                                                  \
     if (__err != CUDA_SUCCESS) {                                              \
       const auto __cuda_error_log_message =                                   \
           __cuda_error_log.get_error_log_suffix();                            \
@@ -65,29 +70,16 @@
       } else {                                                                \
         TORCH_WARN("CUDA driver error: ", err_str, __cuda_error_log_message); \
       }                                                                       \
-      goto NEXT;                                                              \
     }                                                                         \
   } while (0)
 
-// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
-// it is safe to call from noexcept teardown / unwinding paths.
-#define C10_CUDA_DRIVER_WARN(EXPR)                                           \
-  do {                                                                       \
-    c10::cuda::CUDAErrorLogCapture __cuda_error_log;                         \
-    CUresult __err = EXPR;                                                   \
-    if (__err != CUDA_SUCCESS) {                                             \
-      const auto __cuda_error_log_message =                                  \
-          __cuda_error_log.get_error_log_suffix();                           \
-      const char* err_str;                                                   \
-      CUresult get_error_str_err [[maybe_unused]] =                          \
-          c10::cuda::DriverAPI::get()->cuGetErrorString_(__err, &err_str);   \
-      if (get_error_str_err != CUDA_SUCCESS) {                               \
-        TORCH_WARN(                                                          \
-            "CUDA driver error: unknown error", __cuda_error_log_message);   \
-      } else {                                                               \
-        TORCH_WARN("CUDA driver error: ", err_str, __cuda_error_log_message);\
-      }                                                                      \
-    }                                                                        \
+#define C10_CUDA_DRIVER_CHECK_GOTO(EXPR, NEXT) \
+  do {                                         \
+    CUresult __err_for_goto = EXPR;            \
+    C10_CUDA_DRIVER_WARN(__err_for_goto);      \
+    if (__err_for_goto != CUDA_SUCCESS) {      \
+      goto NEXT;                               \
+    }                                          \
   } while (0)
 
 // The integer in the second column specifies the requested CUDA Driver API

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -49,12 +49,10 @@
   } while (0)
 // clang-format on
 
-// Shared by C10_CUDA_DRIVER_WARN and C10_CUDA_DRIVER_CHECK_GOTO below: given a
-// CUresult already evaluated under an active CUDAErrorLogCapture, warn if it
-// failed. Not usable on its own -- the capture object must be constructed
-// immediately before the driver call runs (its constructor resets the
-// thread-local log buffer that a driver callback appends to during the
-// call), so callers each construct their own and evaluate their own call.
+// Shared by C10_CUDA_DRIVER_WARN and C10_CUDA_DRIVER_CHECK_GOTO below. Not
+// usable on its own: LOG_CAPTURE must be constructed immediately before RESULT
+// is evaluated, since its constructor resets the log buffer a driver callback
+// writes to during the call.
 #define C10_CUDA_DRIVER_WARN_RESULT(RESULT, LOG_CAPTURE)                      \
   do {                                                                        \
     if ((RESULT) != CUDA_SUCCESS) {                                           \

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -69,6 +69,27 @@
     }                                                                         \
   } while (0)
 
+// Non-throwing variant of C10_CUDA_DRIVER_CHECK: warns instead of throwing, so
+// it is safe to call from noexcept teardown / unwinding paths.
+#define C10_CUDA_DRIVER_WARN(EXPR)                                           \
+  do {                                                                       \
+    c10::cuda::CUDAErrorLogCapture __cuda_error_log;                         \
+    CUresult __err = EXPR;                                                   \
+    if (__err != CUDA_SUCCESS) {                                             \
+      const auto __cuda_error_log_message =                                  \
+          __cuda_error_log.get_error_log_suffix();                           \
+      const char* err_str;                                                   \
+      CUresult get_error_str_err [[maybe_unused]] =                          \
+          c10::cuda::DriverAPI::get()->cuGetErrorString_(__err, &err_str);   \
+      if (get_error_str_err != CUDA_SUCCESS) {                               \
+        TORCH_WARN(                                                          \
+            "CUDA driver error: unknown error", __cuda_error_log_message);   \
+      } else {                                                               \
+        TORCH_WARN("CUDA driver error: ", err_str, __cuda_error_log_message);\
+      }                                                                      \
+    }                                                                        \
+  } while (0)
+
 // The integer in the second column specifies the requested CUDA Driver API
 // version. The dynamic loader will accept a driver with a newer version, but it
 // ensures that the requested symbol exists in *at least* the specified version


### PR DESCRIPTION
`ExpandableSegment::Handle` becomes a move-only RAII owner: its destructor frees the physical handle and closes the shareable fd, so the `map()` / `unmap()` / `fromShared()` error paths can no longer leak handles. `mapAndSetAccess` is made exception-safe (a partial map/setAccess failure rolls back), keeping the `active() <=> mapped` invariant so teardown never unmaps a never-mapped range. `handles_` collapses from `vector<optional<Handle>>` to `vector<Handle>`.


Fixes #188008.
