### PR TITLE
[inductor] Evaluate compile-time ProcessGroup attrs in overlap estimates

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -101,6 +101,31 @@ def build_collective_info(graph, hiding_annotations):
     return collective_info
 
 
+class TestProcessGroupNameResolution(TestCase):
+    def test_evaluate_compile_time_process_group_get_attr_without_meta_val(self):
+        from torch._inductor.fx_passes.bucketing import _resolve_group_name
+        from torch._inductor.fx_utils import evaluate_compile_time_value
+
+        class ProcessGroupLike:
+            group_name = "fake_group"
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self._test_pg = ProcessGroupLike()
+
+        graph = torch.fx.Graph()
+        pg_node = graph.get_attr("_test_pg")
+        graph.output(pg_node)
+        torch.fx.GraphModule(Root(), graph)
+
+        self.assertNotIn("val", pg_node.meta)
+        self.assertIs(
+            evaluate_compile_time_value(pg_node), graph.owning_module._test_pg
+        )
+        self.assertEqual(_resolve_group_name(pg_node), "fake_group")
+
+
 @requires_accelerator_dist_backend()
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
 @instantiate_parametrized_tests

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -842,6 +842,7 @@ def estimate_nccl_collective_runtime_from_fx_node(
     from torch._inductor.fx_passes.bucketing import _resolve_group_name
 
     group_name = _resolve_group_name(kwargs["group_name"])
+    kwargs["group_name"] = group_name
     group_size = _get_group_size_by_name(group_name)
     if not isinstance(fx_node.target, torch._ops.OpOverload):
         raise AssertionError(

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -18,6 +18,7 @@ from torch._inductor.comm_analysis import (
     NCCL_COLL,
 )
 from torch._inductor.fx_passes.utils import BitsetAncestors
+from torch._inductor.fx_utils import evaluate_compile_time_value
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch._logging import trace_structured
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -41,13 +42,17 @@ def _resolve_group_name(group_name: Any) -> "GroupName":
     In compile-on-one-rank graphs, collective ops receive their
     group_name argument as an FX Node reference (pointing to a
     mesh_get_process_group call) rather than a string literal. For
-    bucketing key purposes we resolve via the ProcessGroup stored in
-    node.meta["val"].
+    bucketing key purposes we evaluate compile-time FX values to get
+    the underlying ProcessGroup object or group-name string.
     """
+    group_name = evaluate_compile_time_value(group_name)
     if isinstance(group_name, str):
         return group_name  # pyrefly: ignore [bad-return]
-    pg = group_name.meta["val"]
-    return pg.group_name
+    if not hasattr(group_name, "group_name"):
+        raise AssertionError(
+            f"could not resolve collective group name from {group_name!r}"
+        )
+    return group_name.group_name
 
 
 BucketMode: TypeAlias = Literal[

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -38,6 +38,26 @@ from torch.utils.flop_counter import flop_registry
 from .virtualized import V
 
 
+def evaluate_compile_time_value(value: Any) -> Any:
+    """Evaluate an FX value that represents a compile-time Python object.
+
+    This intentionally does not execute arbitrary FX nodes. It only reads values
+    that tracing/fake propagation already materialized in node metadata or that
+    FX stores as GraphModule attributes.
+    """
+    if not isinstance(value, torch.fx.Node):
+        return value
+    if "val" in value.meta:
+        return value.meta["val"]
+    if value.op == "get_attr":
+        gm = value.graph.owning_module
+        if gm is not None:
+            from torch.fx.graph_module import _get_attr
+
+            return _get_attr(gm, value.target)  # type: ignore[arg-type]
+    return value
+
+
 # Check the pattern: (nn.module, F.function/torch.Tensor.method) matched.
 # Works for length 2 patterns with 1 module and 1 function/method.
 def matches_module_function_pattern(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187842
* #187965
* __->__ #187964

Functionalized eager collectives can pass a ProcessGroup as a compile-time FX value to _c10d_functional ops. In GraphTrainer regional Inductor graphs with ATen distributed overlap scheduling enabled, that value can appear as a get_attr node instead of a string group name or a node with meta["val"].

Before this change, the overlap scheduler collective estimator assumed an FX ProcessGroup argument either was already a group-name string or had node.meta["val"]. When GraphTrainer passed a get_attr ProcessGroup node without that metadata, compilation failed before scheduling could run:

    torch._inductor.exc.InductorError: KeyError: "val"

    File "torch/_inductor/fx_passes/overlap_scheduling.py", line 1738, in gather_node_runtime_estimations

      estimations[start] = estimate_collective_time(...)

    File "torch/_inductor/comm_analysis.py", line 844, in estimate_nccl_collective_runtime_from_fx_node

      group_name = _resolve_group_name(kwargs["group_name"])

    File "torch/_inductor/fx_passes/bucketing.py", line 49, in _resolve_group_name

      pg = group_name.meta["val"]

Add a conservative evaluate_compile_time_value helper in torch._inductor.fx_utils. It evaluates plain Python values, FX nodes with meta["val"], and GraphModule get_attr nodes, but intentionally does not execute arbitrary FX nodes. Use it when resolving collective group names, so the group-name resolver consumes a common compile-time-value abstraction instead of special-casing one ProcessGroup node shape.

Also replace the estimator normalized group_name kwarg with the resolved group-name string before optional NCCL timing, so the benchmark path does not try to materialize a ProcessGroup FX node as a tensor-like value.

Add a lightweight regression test that builds an FX get_attr ProcessGroup node without meta["val"], verifies compile-time evaluation through the owning GraphModule, and then resolves the group name.

Test Plan:

  python test/distributed/test_overlap_bucketing_unit.py TestProcessGroupNameResolution.test_evaluate_compile_time_process_group_get_attr_without_meta_val -v

  lintrunner -a torch/_inductor/fx_utils.py torch/_inductor/fx_passes/bucketing.py torch/_inductor/comm_analysis.py test/distributed/test_overlap_bucketing_unit.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo