### PR TITLE
[inductor] Avoid disjoint horizontal fusion when allow_peak_memory_increasing_fusion is off

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 from unittest import skipIf
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import sympy
 
@@ -11,6 +11,7 @@ import torch._inductor.ir as ir
 import torch._inductor.metrics as metrics
 import torch.utils.flop_counter
 from torch._dynamo.utils import counters
+from torch._inductor.choices import InductorChoices
 from torch._inductor.dependencies import Dep, MemoryDep, ReadWrites
 from torch._inductor.ir import GraphPartitionSignature
 from torch._inductor.loop_body import MemoryEntry, MemoryUsageType
@@ -629,11 +630,163 @@ class TestScheduler(TestCase):
         # Assert: Fusion should be allowed (4 unique buffers <= 5 threshold)
         self.assertFalse(result)
 
-    def _create_mock_node(self, name: str, reads: list[str], writes: list[str]) -> Mock:
+    def test_fusion_would_materialize_disjoint_branches_prevents_fusion(self):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.mutation_renames = {}
+        scheduler.can_buffer_be_removed_through_fusion = Mock(return_value=False)
+        scheduler._materialized_external_outputs = (
+            Scheduler._materialized_external_outputs.__get__(scheduler, Scheduler)
+        )
+        scheduler._materialized_external_output_info = (
+            Scheduler._materialized_external_output_info.__get__(scheduler, Scheduler)
+        )
+        scheduler.dep_size_hint = Mock(
+            side_effect=lambda dep: {"B": 200, "C": 200}[dep.name]
+        )
+        scheduler.name_to_buf = {
+            "B": self._create_mock_buffer_users(["use_b"]),
+            "C": self._create_mock_buffer_users(["use_c"]),
+        }
+
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        self.assertTrue(
+            Scheduler.fusion_would_materialize_disjoint_branches(
+                scheduler, node1, node2, shared_data_score=100
+            )
+        )
+
+    def test_fusion_would_materialize_disjoint_branches_allows_internal_output(self):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.mutation_renames = {}
+        scheduler.can_buffer_be_removed_through_fusion = Mock(
+            side_effect=lambda name, fused_node_names: name == "B"
+        )
+        scheduler._materialized_external_outputs = (
+            Scheduler._materialized_external_outputs.__get__(scheduler, Scheduler)
+        )
+        scheduler._materialized_external_output_info = (
+            Scheduler._materialized_external_output_info.__get__(scheduler, Scheduler)
+        )
+        scheduler.dep_size_hint = Mock(side_effect=lambda dep: {"C": 200}[dep.name])
+        scheduler.name_to_buf = {
+            "C": self._create_mock_buffer_users(["use_c"]),
+        }
+
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        self.assertFalse(
+            Scheduler.fusion_would_materialize_disjoint_branches(
+                scheduler, node1, node2, shared_data_score=100
+            )
+        )
+
+    def test_fusion_would_materialize_disjoint_branches_allows_shared_user(self):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.mutation_renames = {}
+        scheduler.can_buffer_be_removed_through_fusion = Mock(return_value=False)
+        scheduler._materialized_external_outputs = (
+            Scheduler._materialized_external_outputs.__get__(scheduler, Scheduler)
+        )
+        scheduler._materialized_external_output_info = (
+            Scheduler._materialized_external_output_info.__get__(scheduler, Scheduler)
+        )
+        scheduler.dep_size_hint = Mock(
+            side_effect=lambda dep: {"B": 200, "C": 200}[dep.name]
+        )
+        scheduler.name_to_buf = {
+            "B": self._create_mock_buffer_users(["join"]),
+            "C": self._create_mock_buffer_users(["join"]),
+        }
+
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        self.assertFalse(
+            Scheduler.fusion_would_materialize_disjoint_branches(
+                scheduler, node1, node2, shared_data_score=100
+            )
+        )
+
+    @inductor_config.patch("allow_peak_memory_increasing_fusion", False)
+    def test_can_fuse_horizontal_blocks_disjoint_branch_materialization(self):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.are_long_distant_nodes = Mock(return_value=False)
+        scheduler.fusion_would_materialize_disjoint_branches = Mock(return_value=True)
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        with patch(
+            "torch._inductor.choices.MixOrderReduction.can_fuse", return_value=False
+        ):
+            self.assertFalse(
+                InductorChoices.can_fuse_horizontal(
+                    scheduler, node1, node2, shared_data_score=1_000_000
+                )
+            )
+
+        scheduler.fusion_would_materialize_disjoint_branches.assert_called_once_with(
+            node1, node2, 1_000_000
+        )
+
+    def test_can_fuse_horizontal_allows_peak_memory_increasing_fusion_when_configured(
+        self,
+    ):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.are_long_distant_nodes = Mock(return_value=False)
+        scheduler.fusion_would_materialize_disjoint_branches = Mock(return_value=True)
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        with (
+            inductor_config.patch("allow_peak_memory_increasing_fusion", True),
+            patch(
+                "torch._inductor.choices.MixOrderReduction.can_fuse",
+                return_value=False,
+            ),
+        ):
+            self.assertTrue(
+                InductorChoices.can_fuse_horizontal(
+                    scheduler, node1, node2, shared_data_score=1_000_000
+                )
+            )
+
+        scheduler.are_long_distant_nodes.assert_called_once_with(node1, node2)
+        scheduler.fusion_would_materialize_disjoint_branches.assert_not_called()
+
+    def test_can_fuse_horizontal_keeps_mix_order_reduction_fast_path(self):
+        scheduler = Mock(spec=Scheduler)
+        scheduler.fusion_would_materialize_disjoint_branches = Mock(return_value=True)
+        node1 = self._create_mock_node(name="node1", reads=["A"], writes=["B"])
+        node2 = self._create_mock_node(name="node2", reads=["A"], writes=["C"])
+
+        with patch(
+            "torch._inductor.choices.MixOrderReduction.can_fuse", return_value=True
+        ):
+            self.assertTrue(
+                InductorChoices.can_fuse_horizontal(
+                    scheduler, node1, node2, shared_data_score=1
+                )
+            )
+
+        scheduler.fusion_would_materialize_disjoint_branches.assert_not_called()
+
+    def _create_mock_node(
+        self,
+        name: str,
+        reads: list[str],
+        writes: list[str],
+        is_reduction: bool = False,
+    ) -> Mock:
         """Helper method to create a mock scheduler node with specified reads/writes"""
         node = Mock(spec=BaseSchedulerNode)
         node.get_name = Mock(return_value=name)
         node.get_nodes = Mock(return_value=[node])
+        node.is_reduction = Mock(return_value=is_reduction)
+        node.is_template = Mock(return_value=False)
+        node.is_foreach = Mock(return_value=False)
 
         # Create mock Dep objects for reads and writes
         read_deps = OrderedSet()
@@ -655,6 +808,19 @@ class TestScheduler(TestCase):
 
         node.read_writes = read_writes
         return node
+
+    def _create_mock_buffer_users(self, names: list[str]) -> Mock:
+        buf = Mock()
+        buf.users = []
+        for name in names:
+            user_node = Mock(spec=BaseSchedulerNode)
+            user_node.get_name = Mock(return_value=name)
+            user = Mock()
+            user.node = user_node
+            user.is_weak = False
+            user.get_name = Mock(return_value=name)
+            buf.users.append(user)
+        return buf
 
     def test_prologue_fusion_uses_template_aliasing_hook(self):
         def make_prologue_and_template(hook_blocks: bool):

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -666,6 +666,14 @@ class InductorChoices:
                 "Nodes are too far away. Fusing them may increase peak memory."
             )
             return False
+        if not config.allow_peak_memory_increasing_fusion:
+            if scheduler.fusion_would_materialize_disjoint_branches(
+                node1, node2, shared_data_score
+            ):
+                WhyNoFuse(node1, node2)(
+                    "Fusion materializes disjoint branch outputs and may increase peak memory."
+                )
+                return False
         return True
 
     @staticmethod

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -958,6 +958,13 @@ loop_index_inversion_in_fusion: bool = True
 # For the cases loop ordering after fusion does not help, we don't lose much.
 score_fusion_memory_threshold = 10
 
+# Allow choices that Inductor's peak-memory heuristics would otherwise block.
+# This is intentionally on by default so existing fusion behavior stays unchanged
+# unless a caller explicitly opts into peak-memory-aware restrictions.
+allow_peak_memory_increasing_fusion = (
+    os.environ.get("TORCHINDUCTOR_ALLOW_PEAK_MEMORY_INCREASING_FUSION", "1") == "1"
+)
+
 # For Triton Templates, select fastest of best template + epilogue vs best template + separate epilogue kernel
 benchmark_epilogue_fusion = (
     os.environ.get("TORCHINDUCTOR_BENCHMARK_EPILOGUE_FUSION", "1") == "1"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6843,6 +6843,92 @@ class Scheduler:
 
         return len(unique_io_buffers) > threshold
 
+    def fusion_would_materialize_disjoint_branches(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        shared_data_score: int,
+    ) -> bool:
+        if (
+            shared_data_score <= 0
+            or node1.is_reduction()
+            or node2.is_reduction()
+            or node1.is_template()
+            or node2.is_template()
+        ):
+            return False
+
+        fused_node_names = OrderedSet(
+            [node.get_name() for node in node1.get_nodes()]
+            + [node.get_name() for node in node2.get_nodes()]
+        )
+
+        node1_output_bytes, node1_external_users, node1_output_count = (
+            self._materialized_external_output_info(node1, fused_node_names)
+        )
+        node2_output_bytes, node2_external_users, node2_output_count = (
+            self._materialized_external_output_info(node2, fused_node_names)
+        )
+        if node1_output_count == 0 or node2_output_count == 0:
+            return False
+
+        if node1_external_users & node2_external_users:
+            return False
+
+        return min(node1_output_bytes, node2_output_bytes) >= shared_data_score
+
+    def _materialized_external_outputs(
+        self,
+        node: BaseSchedulerNode,
+        fused_node_names: OrderedSet[str],
+    ) -> list[tuple[int, OrderedSet[str]]]:
+        outputs: list[tuple[int, OrderedSet[str]]] = []
+        seen_writes: OrderedSet[str] = OrderedSet()
+        for snode in node.get_nodes():
+            for write in snode.read_writes.writes:
+                write_name = self.mutation_renames.get(write.name, write.name)
+                if write_name in seen_writes:
+                    continue
+                seen_writes.add(write_name)
+
+                if self.can_buffer_be_removed_through_fusion(
+                    write_name, fused_node_names
+                ):
+                    continue
+
+                buf = self.name_to_buf.get(write_name)
+                if buf is None:
+                    continue
+
+                users = OrderedSet(
+                    user.get_name()
+                    for user in buf.users
+                    if not user.is_weak
+                    and user.get_name() not in fused_node_names
+                    and not isinstance(user.node, OutputNode)
+                )
+                if not users:
+                    continue
+
+                output_bytes = self.dep_size_hint(write)
+                if output_bytes <= 0:
+                    return []
+
+                outputs.append((output_bytes, users))
+        return outputs
+
+    def _materialized_external_output_info(
+        self,
+        node: BaseSchedulerNode,
+        fused_node_names: OrderedSet[str],
+    ) -> tuple[int, OrderedSet[str], int]:
+        outputs = self._materialized_external_outputs(node, fused_node_names)
+        total_bytes = sum(output_bytes for output_bytes, _ in outputs)
+        external_users: OrderedSet[str] = OrderedSet()
+        for _, users in outputs:
+            external_users.update(users)
+        return total_bytes, external_users, len(outputs)
+
     def are_long_distant_nodes(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #187842
* __->__ #187965
* #187964

# [inductor] Avoid disjoint horizontal fusion when allow_peak_memory_increasing_fusion is off

## Summary

Add a fusion guard that rejects horizontal (consumer/consumer) fusion of two pointwise
nodes when each side materializes a separate external output to a disjoint set of users and
the smaller materialized output is at least the shared-data score. Fusing such nodes keeps
both large outputs live together and lengthens their lifetimes for little reuse benefit.

The guard is active only when `allow_peak_memory_increasing_fusion=False`. The config
defaults to `True`, so default `torch.compile` behavior is unchanged; peak-memory-conscious
callers (e.g. full-graph GraphTrainer compilation) opt in by setting it `False`.

## Motivation

Under full-graph compilation the scheduler may horizontally fuse two pointwise branches that
each produce a large external output consumed by disjoint downstream users. The shared input
read saved by the fusion is small, but the fusion forces both outputs to be materialized and
live simultaneously, raising the active-memory peak.

## Benchmark

GraphTrainer full Inductor, 8-GPU local Rigi, no fuse regions, **default Inductor buffer
reuse ON**, `TORCHINDUCTOR_ALLOW_PEAK_MEMORY_INCREASING_FUSION=0`, `nsteps=10 warmup=3`.
Marginal active / reserved peak vs the parent commit:

| config | active before -> after | reserved before -> after |
|---|---|---|
| d2 w2048 v256 (small vocab) | 4202 -> 3691 (**-511 MiB**) | 4414 -> 3934 (-480 MiB) |
| d8 w2048 v256 (small vocab) | 6412 -> 5899 (**-513 MiB**) | 6624 -> 6142 (-482 MiB) |
| d8 w7168 full vocab | 20899 -> 19636 (**-1263 MiB**) | 23274 -> 21656 (-1618 MiB) |

The savings scale with the materialized output size and are consistent across depth and
vocab size, so this is a generic peak-memory fusion heuristic rather than a workload-specific
hack. Final loss is unchanged.

## Test plan

```bash
# Unit tests for the new guard
python -m pytest test/inductor/test_inductor_scheduler.py -k "disjoint_branches" -v

# Rigi full-graph GraphTrainer reproduction (per row above), e.g. d8 w7168 full vocab:
cd <rigi>
TORCHINDUCTOR_ALLOW_PEAK_MEMORY_INCREASING_FUSION=0 \
RIGI_RESEARCH_DISABLE_FUSE_REGIONS=all \
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 NCCL_SOCKET_IFNAME=lo \
  bv2/tools/_local_run bv2.train nsteps=10 warmup_nsteps=3 evals=None \
  c.model.txt_unemb.chunksz=4096 c.data.min_nouns=256 c.data.max_nouns=256 \
  c.model.depth=8 c.model.dim=7168 use_graph_trainer=True
```

---
Authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo