### PR TITLE
Fix #187801

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -533,7 +533,7 @@ inline void validate_sdpa_input(
   if (attn_mask_.has_value()){
     TORCH_CHECK(
       !is_causal,
-      "Explicit attn_mask should not be set when is_causal=True");
+      "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
     auto mask_dtype = attn_mask_->dtype();
     TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == at::kFloat || mask_dtype == query_.dtype(),
       "Expected attn_mask dtype to be bool or float or to match query dtype, but got attn_mask.dtype: ",

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -531,6 +531,9 @@ inline void validate_sdpa_input(
       "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
       query_.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead.");
   if (attn_mask_.has_value()){
+    TORCH_CHECK(
+      !is_causal,
+      "Explicit attn_mask should not be set when is_causal=True");
     auto mask_dtype = attn_mask_->dtype();
     TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == at::kFloat || mask_dtype == query_.dtype(),
       "Expected attn_mask dtype to be bool or float or to match query dtype, but got attn_mask.dtype: ",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12187,8 +12187,9 @@ class TestSDPA(TestCaseMPS):
             attn_mask[1, :, qL // 2:, :] = False
         elif variant == "causal_with_inf":
             attn_mask = torch.zeros(B, NH, qL, kL, dtype=dtype, device="mps")
+            causal_mask = torch.ones(qL, kL, dtype=torch.bool, device="mps").tril()
+            attn_mask.masked_fill_(causal_mask.logical_not(), float("-inf"))
             attn_mask[..., 0, 0] = float("-inf")
-            is_causal = True
         self._run_prefill_test(q, k, v, attn_mask=attn_mask, is_causal=is_causal)
 
     def test_caching_scale(self):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1586,6 +1586,30 @@ class TestSDPAFailureModes(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
+    @parametrize(
+        "backend",
+        [
+            None,
+            SDPBackend.ERROR,
+            SDPBackend.MATH,
+            SDPBackend.FLASH_ATTENTION,
+            SDPBackend.EFFICIENT_ATTENTION,
+            SDPBackend.CUDNN_ATTENTION,
+            SDPBackend.OVERRIDEABLE,
+        ],
+        name_fn=lambda backend: "default" if backend is None else backend.name.lower(),
+    )
+    def test_attn_mask_and_is_causal_errors_before_dispatch(self, device, backend):
+        q = torch.randn(2, 4, 8, 16, device=device)
+        k = torch.randn(2, 4, 8, 16, device=device)
+        v = torch.randn(2, 4, 8, 16, device=device)
+        attn_mask = torch.zeros(8, 8, device=device)
+
+        context = contextlib.nullcontext() if backend is None else sdpa_kernel(backends=[backend])
+        with context:
+            with self.assertRaisesRegex(RuntimeError, "Explicit attn_mask should not be set when is_causal=True"):
+                F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, is_causal=True)
+
     @onlyCUDA
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION or not isSM8XDevice or not isSM120Device,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1605,9 +1605,10 @@ class TestSDPAFailureModes(NNTestCase):
         v = torch.randn(2, 4, 8, 16, device=device)
         attn_mask = torch.zeros(8, 8, device=device)
 
+        expected_error = "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True"
         context = contextlib.nullcontext() if backend is None else sdpa_kernel(backends=[backend])
         with context:
-            with self.assertRaisesRegex(RuntimeError, "Explicit attn_mask should not be set when is_causal=True"):
+            with self.assertRaisesRegex(RuntimeError, expected_error):
                 F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, is_causal=True)
 
     @onlyCUDA


### PR DESCRIPTION
## Human Note
We had existing tests for this  and it just wasnt working correctly for other backends. Simple make sure we invaldiate at the top before dispatch

## Agent Report
# Report: pytorch/pytorch#187801

## Summary

`torch.nn.functional.scaled_dot_product_attention` silently accepted calls with both `attn_mask` and `is_causal=True` when backend dispatch selected a fused/flash path. This contradicted the public docstring and the existing math-backend behavior.

## Root cause

The error check existed inside the math implementation of SDPA, but not in the common public input validation path. As a result, behavior depended on backend selection:

- forced math backend: raised `RuntimeError`
- default CPU dispatch / forced flash backend: returned an output

The existing `TestTransformers.test_scaled_dot_product_attention` did not catch this because it is decorated with `@sdpa_kernel(backends=[SDPBackend.MATH])`, so it only exercised the backend that already had the check.

## Fix

Added the `attn_mask` plus `is_causal` validation to `validate_sdpa_input` in `aten/src/ATen/native/transformers/attention.cpp`, which runs before SDPA backend selection. This makes the public API reject the invalid argument combination consistently across CPU/CUDA and all `sdpa_kernel` backend contexts. The pre-dispatch error preserves the existing math-backend message prefix so existing MPS assertions remain compatible.

Added a regression test in `test/test_transformers.py` under `TestSDPAFailureModes` that is parameterized over default dispatch and every `SDPBackend` enum value. The instantiated CPU and CUDA tests verify the prefixed error is raised before dispatch even for unavailable/unsupported backend contexts.

Updated `test/test_mps.py::TestSDPA.test_prefill_attention_fully_masked_rows` so its `causal_with_inf` variant no longer passes the now-invalid `attn_mask` plus `is_causal=True` combination. The test now materializes the equivalent causal additive mask and keeps `is_causal=False`, preserving the fully masked row coverage while respecting the public SDPA API contract.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F

q = torch.randn(2, 4, 8, 16)
k = torch.randn(2, 4, 8, 16)
v = torch.randn(2, 4, 8, 16)
mask = torch.zeros(8, 8)

out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
print(out.shape)
```

Output after fix:

```text
Traceback (most recent call last):
  File "/home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/repro.py", line 9, in <module>
    out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True
```

</details>

## Validation

Rebuild:

```bash
bash /home/drisspg/.ptq_workspace/scripts/rebuild.sh /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/pytorch
```

Targeted tests:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/pytorch && /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/.venv/bin/python test/test_transformers.py TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_default_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_error_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_math_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_flash_attention_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_efficient_attention_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_cudnn_attention_cpu TestSDPAFailureModesCPU.test_attn_mask_and_is_causal_errors_before_dispatch_overrideable_cpu TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_default_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_error_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_math_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_flash_attention_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_efficient_attention_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_cudnn_attention_cuda TestSDPAFailureModesCUDA.test_attn_mask_and_is_causal_errors_before_dispatch_overrideable_cuda --verbose
```

Result: 14 tests passed across CPU/CUDA and default, ERROR, MATH, FLASH_ATTENTION, EFFICIENT_ATTENTION, CUDNN_ATTENTION, and OVERRIDEABLE backend contexts.

Additional checks:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801 && .venv/bin/python fuzz_sdpa_attn_mask_is_causal.py
```

Result: 112 combinations passed. The script covered CPU/CUDA, default plus every `SDPBackend`, 3D/4D inputs, float/bool masks, and 2D/input-rank masks; every case raised the expected `RuntimeError`.

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/pytorch && /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/.venv/bin/python -m py_compile test/test_mps.py
```

Result: passed.

A CPU smoke check of the materialized causal additive mask produced a finite zero output for the fully masked first query row. Running the exact MPS test locally was not possible in this Linux job environment; `test/test_mps.py` also currently fails to import locally due to an unrelated `common_mps` import mismatch.

Lint/prerequisite checks:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/pytorch && spin quickfix
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187801/pytorch && spin quicklint
```

Result: both passed.

`spin fixlint` was also run because the PTQ instructions requested it before generating `fix.diff`; it failed on unrelated pre-existing lint findings in shell/header files outside this diff. The scoped changed-file checks via `spin quickfix` and `spin quicklint` passed.


Fixes #187801


<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F

q = torch.randn(2, 4, 8, 16)
k = torch.randn(2, 4, 8, 16)
v = torch.randn(2, 4, 8, 16)
mask = torch.zeros(8, 8)

out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
print(out.shape)
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced missing SDPA validation
Created `repro.py` from the issue report and ran it with the job venv. The call to `F.scaled_dot_product_attention(..., attn_mask=mask, is_causal=True)` returned `torch.Size([2, 4, 8, 16])` instead of raising, so the reported behavior reproduces locally.

### Existing test only covers forced math backend
Ran one instantiated CPU variant of `TestTransformers.test_scaled_dot_product_attention`; it passed because the test is decorated with `@sdpa_kernel(backends=[SDPBackend.MATH])`. A separate backend probe showed forced math raises for `attn_mask` + `is_causal`, while forced CPU flash attention returns successfully, matching the issue repro under default backend selection.

### Added pre-dispatch guard and regression test
Added the missing `attn_mask` + `is_causal` check to the common C++ SDPA input validator before backend selection. Added `TestSDPAFailureModes.test_attn_mask_and_is_causal_errors_before_dispatch`, which failed against the old installed binary on CPU, confirming the regression covers the public default/flash path instead of only the math backend.

### Rebuilt and validated CPU/CUDA behavior
Rebuilt PyTorch with the PTQ rebuild script. The issue repro now raises `RuntimeError: Explicit attn_mask should not be set when is_causal=True`; a backend probe shows both forced math and forced flash raise for float and bool masks. The new targeted regression passes on CPU and CUDA. `spin quickfix` and `spin quicklint` pass; full `spin fixlint` hit unrelated pre-existing lint failures in shell/header files outside this diff.

### Fuzzed backend contexts and expanded regression test
Added a local fuzz script covering CPU/CUDA, default plus every `SDPBackend`, 3D/4D inputs, float/bool masks, and 2D/input-rank masks. All 112 combinations raised the expected error. Expanded the durable regression test to parameterize default, ERROR, MATH, FLASH_ATTENTION, EFFICIENT_ATTENTION, CUDNN_ATTENTION, and OVERRIDEABLE backend contexts; all 14 CPU/CUDA instantiated tests passed.

### Addressed MPS error-message compatibility review
Fetched the PR review comment noting that the new pre-dispatch error would break the existing MPS test expecting the math-backend prefix. Updated the new guard to use the existing `_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True` message and tightened the new CPU/CUDA regression test to assert that full message. Rebuilt, reran the 112-combination fuzz script, reran all 14 CPU/CUDA backend-context tests, and reran `spin quicklint`; all passed.

### Investigated failing MPS CI and patched invalid MPS test input
Fetched per-job logs through the GitHub job logs API because `gh run view --log-failed` is still blocked until the full workflow completes. Both MPS failures are `TestSDPA.test_prefill_attention_fully_masked_rows_*_variant_causal_with_inf`, which intentionally combined `attn_mask` with `is_causal=True` and now hits the new public validation. Updated that MPS test variant to materialize the equivalent causal additive mask and call SDPA with `is_causal=False`, preserving the fully masked row coverage without relying on invalid API usage. Validated `test/test_mps.py` compiles, a CPU smoke check produces zero finite output for the fully masked row, all 14 CPU/CUDA backend-context regression tests pass, the 112-combination fuzz script passes, and `spin quicklint` passes. The exact MPS test could not be run locally in this Linux environment; direct import of `test/test_mps.py` also hits an unrelated `common_mps` import mismatch locally.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @liangel-02 @howardzhang-cv