### PR TITLE
[ROCm][CI] Restore workspace owner for all ROCm test runners, not just gfx1100

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -275,8 +275,8 @@ jobs:
           echo "WORKSPACE_ORIGINAL_OWNER_ID=${WORKSPACE_ORIGINAL_OWNER_ID}" >> "$GITHUB_ENV"
           docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
 
-      - name: Restore workspace owner (for gfx1100 only)
-        if: always() && contains(matrix.runner, 'gfx1100')
+      - name: Restore workspace owner
+        if: always()
         shell: bash
         run: |
           docker exec -t "${CONTAINER_NAME}" sh -c \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187968

The _rocm-test.yml reusable workflow runs tests inside a container started with
`--user jenkins` over a bind-mounted ${GITHUB_WORKSPACE}. Files written inside
the container are owned by the container's uid, which differs from the host
runner's uid. PR #185444 added a "Restore workspace owner" step that chowns the
workspace back to its original owner so the host-side post-steps can read it,
but gated it to gfx1100 (navi31) runners only.

On every other ROCm container runner (gfx950/MI350, gfx942/MI300, mi210) the
chown never runs, so the workspace is left owned by the container uid and the
host-side post-steps fail with "Permission denied" -- e.g. "Print remaining
test logs" (cat of *_toprint.log), "Upload test artifacts" (zip), and the
submodule/checkout cleanup during teardown. On a reused workspace this also
corrupts the next job's checkout, which can surface as bare exit-code-255 test
crashes with no test report.

The uid mismatch is generic to all ROCm container runners, not specific to
gfx1100. Since _rocm-test.yml is ROCm-only and the chown-back is idempotent
when ownership already matches, run the restore unconditionally (always())
instead of gating on the runner architecture.

Test Plan:

Validated locally:

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_rocm-test.yml'))"
lintrunner -a .github/workflows/_rocm-test.yml
```

End-to-end validation requires a real ROCm GPU runner (the change only takes
effect there). Dispatch trunk-rocm-sandbox.yml (MI210) against this branch, or
open a PR with the ciflow/rocm-mi300 label, and confirm:
- the "Restore workspace owner" step now executes (previously skipped on
  non-gfx1100 runners), and
- "Print remaining test logs" and "Upload test artifacts" no longer report
  "Permission denied".

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang