### PR TITLE
Fix Library.define double-prepending namespace for namespaced schema names

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -495,6 +495,29 @@ class TestPythonRegistration(TestCase):
             "into C++) for ops that were never cached on the namespace",
         )
 
+    def test_define_normalizes_namespaced_schema_name(self):
+        # Library.define() takes a bare op name in the schema, but C++ also
+        # accepts a name prefixed with the matching namespace ("ns::foo"). In
+        # that case the qualname recorded in _op_defs must not double-prepend the
+        # namespace. Regression: it used to produce "ns::ns::foo", which later
+        # broke teardown's _clear_torch_ops_cache with "too many values to
+        # unpack (expected 2)".
+        lib = Library(self.test_ns, "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define(f"{self.test_ns}::my_op(Tensor x) -> Tensor")
+        self.assertIn(f"{self.test_ns}::my_op", lib._op_defs)
+        self.assertNotIn(f"{self.test_ns}::{self.test_ns}::my_op", lib._op_defs)
+        # Teardown must not raise.
+        lib._destroy()
+
+    def test_clear_torch_ops_cache_tolerates_malformed_qualname(self):
+        # Defense-in-depth: _clear_torch_ops_cache runs in a shutdown-time
+        # finalizer and must never raise, even on a qualname that does not split
+        # into exactly "namespace::name".
+        from torch.library import _clear_torch_ops_cache
+
+        # Must not raise.
+        _clear_torch_ops_cache({"a::b::c", "no_separator"})
+
     def test_register_check_mem_op_survives_gc(self):
         # Regression guard for the autorevert of #181785: inductor's
         # `register_check_mem_op` is an lru_cache-decorated registration whose

--- a/torch/library.py
+++ b/torch/library.py
@@ -312,7 +312,9 @@ class Library:
 
         result = self.m.define(schema, alias_analysis, tuple(tags))
         name = schema.split("(")[0]
-        qualname = self.ns + "::" + name
+        # C++ accepts a name prefixed with the matching namespace ("ns::foo");
+        # don't double-prepend the namespace in that case.
+        qualname = name if "::" in name else f"{self.ns}::{name}"
 
         # If the OpOverloadPacket exists already, then this means we're adding a
         # new OpOverload for it. Refresh the packet to include the new OpOverload.
@@ -620,7 +622,13 @@ def _clear_torch_ops_cache(op_defs):
     # That's OK - the next time torch.ops.ns.foo gets called, it'll be
     # recomputed to point at the right collection of overloads.
     for qualname in op_defs:
-        ns, name_with_overload = qualname.split("::")
+        splits = qualname.split("::")
+        if len(splits) != 2:
+            # Defense-in-depth: this runs in a shutdown-time finalizer that must
+            # never raise, so tolerate any qualname that isn't a clean
+            # "namespace::name" instead of unpacking blindly.
+            continue
+        ns, name_with_overload = splits
         name = name_with_overload.split(".")[0]
         if not hasattr(torch.ops, ns):
             continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187970

Library.define() builds the op qualname as `self.ns + "::" + name`, where name
is the part of the schema before "(". The C++ schema parser accepts a name that
is already prefixed with the library's own namespace (e.g.
Library("mylib").define("mylib::foo(...) -> ...")) and registers the op
correctly, but the Python side then double-prepends, recording
"mylib::mylib::foo" in _op_defs and the module-global _defs.

That malformed qualname later breaks teardown: _clear_torch_ops_cache does
`ns, name = qualname.split("::")`, which raises "ValueError: too many values to
unpack (expected 2)". Because the cleanup runs from a weakref.finalize
finalizer, in practice this surfaces as an "Exception ignored in" traceback at
interpreter shutdown -- benign (the process still exits 0) but noisy, and it
pollutes CI failure classification (observed inflating "flaky" signal on
otherwise-green jobs).

Root-cause fix: normalize in define -- only prepend the namespace when name does
not already contain "::", mirroring the existing pattern in
register_symm_mem_args. This keeps _op_defs/_defs entries well-formed.

An assert/raise in define was considered and rejected: the genuinely-wrong case
(a namespace that does not match the library) is already caught by C++ with a
clear, actionable error, and the matching-namespace case is one C++ deliberately
accepts -- so rejecting it in Python would be an inconsistent behavior change.

Defense-in-depth: also make _clear_torch_ops_cache skip any qualname that does
not split into exactly "namespace::name" rather than unpacking blindly, since it
runs in a shutdown-time finalizer that must never raise.

Test Plan:

```
# The normalize test fails before the define fix (records "ns::ns::my_op"):
python test/test_python_dispatch.py TestPythonRegistration.test_define_normalizes_namespaced_schema_name

# Full class after the fix: 30 passed
python test/test_python_dispatch.py TestPythonRegistration

lintrunner -a torch/library.py test/test_python_dispatch.py
```

Authored with Claude.