### PR TITLE
Revert "Advertise Python 3.15 support in wheel metadata (#186244)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.15",
 ]
 dynamic = [
     "entry-points",


### PR DESCRIPTION
We are not ready to officially release python 3.15 yet. 