### PR TITLE
[DO NOT MERGE][debug] Neuter rocm-mi350 to triage gfx950 test_fake_tensor context poisoning

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -254,6 +254,9 @@ jobs:
             -e TESTS_TO_INCLUDE \
             -e HUGGING_FACE_HUB_TOKEN \
             -e DASHBOARD_TAG \
+            -e AMD_SERIALIZE_KERNEL=3 \
+            -e TORCH_SHOW_CPP_STACKTRACES=1 \
+            -e PYTHONUNBUFFERED=1 \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \
             --ulimit stack=10485760:83886080 \
             --ulimit core=0 \

--- a/.github/workflows/rocm-mi350.yml
+++ b/.github/workflows/rocm-mi350.yml
@@ -5,9 +5,11 @@
 name: rocm-mi350
 
 on:
-  #push:
-  #  tags:
-  #    - ciflow/rocm-mi350/*
+  # DEBUG: temporarily enabled to triage gfx950 CUDA-context poisoning in
+  # test_fake_tensor. DO NOT MERGE.
+  push:
+    tags:
+      - ciflow/rocm-mi350/*
   workflow_dispatch:
   #schedule:
   #  - cron: 29 8 * * *  # about 1:29am PDT
@@ -40,26 +42,25 @@ jobs:
 
   linux-noble-rocm-py3_12-build:
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
-    name: linux-noble-rocm-py3.12-mi350
+    name: linux-jammy-rocm-py3.10-mi350
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: ""
-      build-environment: linux-noble-rocm-py3.12-mi350
-      docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      # DEBUG: build trunk's jammy/py3.10-mi350 env so allow-reuse-old-whl finds
+      # a recent prebuilt wheel (no cpp changes) and skips the compile entirely.
+      # Also matches the env where the fault was originally observed.
+      build-environment: linux-jammy-rocm-py3.10-mi350
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      # DEBUG: single shard, test_fake_tensor only (see tests-to-include below).
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
         ]}
     secrets: inherit
 
   linux-noble-rocm-py3_12-test:
-    name: linux-noble-rocm-py3.12-mi350
+    name: linux-jammy-rocm-py3.10-mi350
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-noble-rocm-py3_12-build
@@ -68,4 +69,6 @@ jobs:
       build-environment: ${{ needs.linux-noble-rocm-py3_12-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
+      # DEBUG: only run the test file with the context-poisoning fault.
+      tests-to-include: "test_fake_tensor"
     secrets: inherit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #187975

Throwaway debugging branch. Must not be merged.

On gfx950 (MI350), some op in the test_fake_tensor shard triggers a HIP kernel
fault (hipErrorLaunchFailure / "CUDA error: unspecified launch failure") that
poisons the CUDA context. Because the error is async/sticky, it surfaces later
as a cascade of victim failures (e.g.
PropagateRealTensorsFakeTensorTest::test_index_cuda_with_cpu_int16_propagate_real_tensors
failing in setUp/manual_seed, then passing when re-run alone). Per-test disables
(#187836/867/895/942) only silence victims, not the real trigger.

This neuters rocm-mi350.yml to the minimum needed to localize the trigger:
- single test shard, restricted to test_fake_tensor via tests-to-include
- ciflow/rocm-mi350 push trigger re-enabled (workflow_dispatch also works)

and injects debugging env into the ROCm test container in _rocm-test.yml:
- AMD_SERIALIZE_KERNEL=3: error-check after every kernel so the fault is
  reported at the real triggering test instead of a later victim
- TORCH_SHOW_CPP_STACKTRACES=1: C++ stack to name the faulting op
- PYTHONUNBUFFERED=1: flush the in-flight test nodeid before a possible segfault

Test Plan:

YAML validated locally:

```
python -c "import yaml; yaml.safe_load(open('.github/workflows/rocm-mi350.yml'))"
python -c "import yaml; yaml.safe_load(open('.github/workflows/_rocm-test.yml'))"
lintrunner -a .github/workflows/rocm-mi350.yml .github/workflows/_rocm-test.yml
```

To run: push this branch and workflow_dispatch the rocm-mi350 workflow against
it (or open a draft PR and add the ciflow/rocm-mi350 label). In the raw job log,
the first FAILED test in test_fake_tensor (with its C++ stacktrace) is the real
context-poisoning trigger to disable/fix.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang