### PR TITLE
[MPS] Fix int64 amax/amin returning 0 for partial-simdgroup reductions

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -208,6 +208,24 @@ inline c10::metal::pair<ARG_T, IDX_T> simd_argmax(ARG_T val, IDX_T idx_val) {
   return {rc.first, simd_broadcast(idx_val, rc.second)};
 }
 
+template <typename T>
+inline constexpr T max_identity() {
+  if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+    return T(-INFINITY);
+  } else {
+    return ::metal::numeric_limits<T>::lowest();
+  }
+}
+
+template <typename T>
+inline constexpr T min_identity() {
+  if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+    return T(INFINITY);
+  } else {
+    return ::metal::numeric_limits<T>::max();
+  }
+}
+
 // Below algorithms are  written with hardcoded assumption that simdgroup is 32
 // and threadgroup_max is 1024, i.e. reduction can be done in two stages max
 template <typename T>
@@ -293,11 +311,13 @@ T threadgroup_max(threadgroup T* data, T val, unsigned idx, unsigned size) {
   }
   if (size > simdgroup_size) {
     ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
-      auto rc1 = simd_max(data[idx]);
-      if (idx == 0) {
-        data[0] = rc1;
-      }
+    const unsigned n_sg = (size + simdgroup_size - 1) / simdgroup_size;
+    // All lanes must call simd_max (it is simd-wide); pad out-of-range slots
+    // with the op identity so inactive in-range lanes cannot inject undefined
+    // 0 into the emulated long reduction.
+    auto rc1 = simd_max(idx < n_sg ? data[idx] : max_identity<T>());
+    if (idx == 0) {
+      data[0] = rc1;
     }
   }
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
@@ -312,11 +332,13 @@ T threadgroup_min(threadgroup T* data, T val, unsigned idx, unsigned size) {
   }
   if (size > simdgroup_size) {
     ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-    if (idx < ((size + simdgroup_size - 1) / simdgroup_size)) {
-      auto rc1 = simd_min(data[idx]);
-      if (idx == 0) {
-        data[0] = rc1;
-      }
+    const unsigned n_sg = (size + simdgroup_size - 1) / simdgroup_size;
+    // All lanes must call simd_min (it is simd-wide); pad out-of-range slots
+    // with the op identity so inactive in-range lanes cannot inject undefined
+    // 0 into the emulated long reduction.
+    auto rc1 = simd_min(idx < n_sg ? data[idx] : min_identity<T>());
+    if (idx == 0) {
+      data[0] = rc1;
     }
   }
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
@@ -431,11 +453,7 @@ IDX_T threadgroup_argmin(
 template <typename T>
 struct MaxOp {
   static inline constexpr T identity() {
-    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
-      return T(-INFINITY);
-    } else {
-      return ::metal::numeric_limits<T>::lowest();
-    }
+    return max_identity<T>();
   }
 
   // Strict "should-replace" predicate: returns true iff cand strictly beats
@@ -469,11 +487,7 @@ struct MaxOp {
 template <typename T>
 struct MinOp {
   static inline constexpr T identity() {
-    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
-      return T(INFINITY);
-    } else {
-      return ::metal::numeric_limits<T>::max();
-    }
+    return min_identity<T>();
   }
 
   static inline bool replace(T cand, T cur) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15896,7 +15896,48 @@ class TestMetalLibrary(TestCaseMPS):
                 out1[idx] = rc.second;
             }}
 
+            kernel void do_threadgroup_max(device {DTYPE_TO_METAL[dtype]}* out,
+                                           constant {DTYPE_TO_METAL[dtype]}* inp,
+                                           constant uint& size [[buffer(2)]],
+                                           uint tid [[thread_position_in_threadgroup]]) {{
+                threadgroup {DTYPE_TO_METAL[dtype]} data[32];
+                if (tid < 32) {{
+                    data[tid] = static_cast<{DTYPE_TO_METAL[dtype]}>(0);
+                }}
+                ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+                {DTYPE_TO_METAL[dtype]} val =
+                    tid < size ? inp[tid] : c10::metal::max_identity<{DTYPE_TO_METAL[dtype]}>();
+                auto rc = c10::metal::threadgroup_max(data, val, tid, size);
+                if (tid == 0) {{
+                    out[0] = rc;
+                }}
+            }}
+
+            kernel void do_threadgroup_min(device {DTYPE_TO_METAL[dtype]}* out,
+                                           constant {DTYPE_TO_METAL[dtype]}* inp,
+                                           constant uint& size [[buffer(2)]],
+                                           uint tid [[thread_position_in_threadgroup]]) {{
+                threadgroup {DTYPE_TO_METAL[dtype]} data[32];
+                if (tid < 32) {{
+                    data[tid] = static_cast<{DTYPE_TO_METAL[dtype]}>(0);
+                }}
+                ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+                {DTYPE_TO_METAL[dtype]} val =
+                    tid < size ? inp[tid] : c10::metal::min_identity<{DTYPE_TO_METAL[dtype]}>();
+                auto rc = c10::metal::threadgroup_min(data, val, tid, size);
+                if (tid == 0) {{
+                    out[0] = rc;
+                }}
+            }}
         """)
+
+        def check_threadgroup_reduce(kernel, x_cpu, expected):
+            x = x_cpu.to("mps")
+            out = torch.empty(1, device="mps", dtype=dtype)
+            group_size = ((x.numel() + 31) // 32) * 32
+            kernel(out, x, x.numel(), threads=(group_size,), group_size=(group_size,))
+            self.assertEqual(out.cpu()[0], expected)
+
         x = torch.testing.make_tensor(28, device="mps", dtype=dtype)
         y = torch.empty_like(x)
         z0 = torch.empty_like(x)
@@ -15912,6 +15953,20 @@ class TestMetalLibrary(TestCaseMPS):
                         f"results are {z0}, but all elements should have been {x_max.item()}")
         self.assertTrue((z1 == x_max_idx).all().item(),
                         f"results are {z1}, but all elements should have been {x_max_idx.item()}")
+        for n in [17, 33, 64, 1000]:
+            if dtype.is_floating_point:
+                neg_inf = torch.full((n,), -float("inf"), dtype=dtype)
+                pos_inf = torch.full((n,), float("inf"), dtype=dtype)
+                check_threadgroup_reduce(lib.do_threadgroup_max, neg_inf, torch.amax(neg_inf))
+                check_threadgroup_reduce(lib.do_threadgroup_min, pos_inf, torch.amin(pos_inf))
+            else:
+                neg = -torch.arange(1, n + 1, dtype=dtype)
+                pos = torch.arange(1, n + 1, dtype=dtype)
+                check_threadgroup_reduce(lib.do_threadgroup_max, neg, torch.amax(neg))
+                check_threadgroup_reduce(lib.do_threadgroup_min, pos, torch.amin(pos))
+                check_threadgroup_reduce(lib.do_threadgroup_max, pos, torch.amax(pos))
+                check_threadgroup_reduce(lib.do_threadgroup_min, neg, torch.amin(neg))
+
         # Test nan propagation
         if not dtype.is_floating_point:
             return


### PR DESCRIPTION
Part of #187455.

This is an independent correctness fix for the existing MPS `amax`/`amin` value-reduction helper. It does not change the prod or var/std migration order.

## Summary

`torch.amax` / `torch.amin` on int64 MPS tensors can return 0 instead of the true extremum when a multi-simdgroup helper reduction has a partial second simdgroup. The fix keeps every lane active for the second-stage simd-wide min/max call and pads out-of-range slots with the operation identity. The identity is shared with `MaxOp` / `MinOp`, including `-/+INFINITY` for floating types, so the fix does not introduce the `-FLT_MAX` / `+FLT_MAX` floating identity regression called out in review.

## Root cause

`threadgroup_max` / `threadgroup_min` first write one value per simdgroup into threadgroup memory, then combine those per-simdgroup values. The old combine guarded the second-stage `simd_max(data[idx])` / `simd_min(data[idx])` call with `idx < num_simdgroups`. Those calls are simd-wide, so in-range inactive lanes still participate. On the emulated 64-bit path, those lanes can be read as 0, which beats all-negative max inputs and all-positive min inputs.

## Fix

- Add shared `max_identity<T>()` / `min_identity<T>()` helpers.
- Use those helpers in `threadgroup_max` / `threadgroup_min` to pad inactive second-stage lanes instead of guarding the simd-wide call.
- Reuse the same helpers from `MaxOp::identity()` / `MinOp::identity()` so helper reductions and value reductions stay aligned.
- Extend existing `TestMetalLibrary.test_reduction_utils` instead of adding a standalone one-off regression test.

Sibling audit: `sum` / `sum2` have zero as a neutral identity, Welford uses a different helper shape, and public `argmin` / `argmax` use the newer `arg_reduction*` kernels whose stage-two combine already pads values with `Op::identity()` and indices with `UINT_MAX`. The old `threadgroup_arg*` helpers still have the guarded shape but I do not find current call sites for them. `prod` has its own split and is intentionally handled separately.

## Minimal reproducer

```python
import torch
x = -torch.arange(1, 34, dtype=torch.int64, device="mps")
print(torch.amax(x).cpu())
```

Pre-fix MPS returns `tensor(0)`; CPU returns `tensor(-1)`. The symmetric positive-minimum case is `torch.amin(torch.arange(1, 34, dtype=torch.int64, device="mps"))`, which pre-fix returns `0` instead of `1`.

## Test Plan

```
cp c10/metal/reduction_utils.h torch/include/c10/metal/reduction_utils.h
PYTHONPATH="$PWD" /opt/homebrew/bin/python3.11 test/test_mps.py -k test_reduction_utils -v
lintrunner -a -m upstream/main
~/.claude/skills/ask-opencode/bin/autoreview-cascade --base upstream/main --target-repo pytorch/pytorch --target-dir "$PWD"
STRYKER_CXX_BIN=/Users/cameronbeeley/stryker-cxx/bin/stryker-cxx.js \
  marmorkrebs --tool stryker-cxx --dir . \
  --changed-files 'c10/metal/reduction_utils.h:318,c10/metal/reduction_utils.h:339' \
  --max-mutants 30 --threshold-break 0.6 --timeout 1800000 \
  --timeout-factor 1.5 --timeout-constant-ms 5000 \
  --build-command 'cp c10/metal/reduction_utils.h torch/include/c10/metal/reduction_utils.h && ninja -C build torch_cpu && cp build/lib/libtorch_cpu.dylib torch/lib/' \
  --check-command '/opt/homebrew/bin/python3.11 -c "print(\"mutation check command: ok\")"' \
  --test-command 'PYTHONPATH="/Users/cameronbeeley/pytorch-prs/amax-int64-fix" PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/test_mps.py -k test_reduction_utils -v'
PYTHONPATH="$PWD" PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/run_test.py --verbose --mps --keep-going
```

Focused helper test: 6 passed. Mutation: 2/2 line-scoped mutants killed (`idx < n_sg` -> `idx <= n_sg` for max/min). Full `--mps --keep-going` found one failure in `test_metal.py::TestMetalRewritePass::test_conv`; the same failure reproduces on the direct parent `ca983a7651e211593156afa615480d51d6a0d233` after rebuild, so this PR introduces no new local MPS CI failures.

## Perf / Regression Sweep

No speedup is claimed. I ran an amax/amin regression sweep on a local MacBook Pro with Apple M4 Pro, 20-core GPU, and 48 GB memory using `torch.utils.benchmark.Timer.blocked_autorange`, warmup 30, 100 queued iterations per timing block, 5 repeated means, and an isolated subprocess per cell. The local reviewer-evidence script is `agent_space/amax_amin_perf_sweep.py`; it is not intended as a maintained benchmark.

Base: `ca983a7651e2`. Head: `d9b81cddbff1`. Result: 0 regressions across 90 comparable cells at threshold speedup >= 0.95. Worst cells:

| op | shape | dtype | dim | base us | head us | speedup |
|---|---:|---|---:|---:|---:|---:|
| amin | 1000 | int64 | None | 4.9839 | 5.2348 | 0.9521 |
| amax | 128x8192 | float32 | None | 16.9042 | 17.5604 | 0.9626 |
| amax | 1000 | int64 | None | 5.0571 | 5.2316 | 0.9666 |
| amax | 128x8192 | int64 | None | 26.8357 | 27.6860 | 0.9693 |
| amin | 1024x1024 | int32 | None | 14.7521 | 15.1595 | 0.9731 |
| amax | 1024x1024 | int32 | None | 14.7130 | 15.1157 | 0.9734 |
| amax | 128x8192 | int32 | -1 | 8.4826 | 8.7084 | 0.9741 |
| amin | 128x8192 | int32 | 0 | 18.0268 | 18.4685 | 0.9761 |

<details>
<summary>Full amax/amin sweep table</summary>

| op | shape | dtype | dim | base us | head us | speedup |
|---|---:|---|---:|---:|---:|---:|
| amax | 1000 | bfloat16 | None | 5.0716 | 4.8612 | 1.0433 |
| amax | 1000 | float16 | None | 4.9337 | 4.7773 | 1.0327 |
| amax | 1000 | float32 | None | 4.7909 | 4.7575 | 1.0070 |
| amax | 1000 | int32 | None | 4.5600 | 4.4451 | 1.0258 |
| amax | 1000 | int64 | None | 5.0571 | 5.2316 | 0.9666 |
| amax | 1024x1024 | bfloat16 | -1 | 7.8575 | 7.7409 | 1.0151 |
| amax | 1024x1024 | bfloat16 | 0 | 10.3101 | 9.6802 | 1.0651 |
| amax | 1024x1024 | bfloat16 | None | 18.9562 | 18.9624 | 0.9997 |
| amax | 1024x1024 | float16 | -1 | 7.2694 | 7.2988 | 0.9960 |
| amax | 1024x1024 | float16 | 0 | 8.3017 | 8.1224 | 1.0221 |
| amax | 1024x1024 | float16 | None | 17.1029 | 17.1717 | 0.9960 |
| amax | 1024x1024 | float32 | -1 | 7.7571 | 7.7701 | 0.9983 |
| amax | 1024x1024 | float32 | 0 | 9.6492 | 9.5930 | 1.0059 |
| amax | 1024x1024 | float32 | None | 17.0368 | 17.3529 | 0.9818 |
| amax | 1024x1024 | int32 | -1 | 7.7093 | 7.6712 | 1.0050 |
| amax | 1024x1024 | int32 | 0 | 9.5615 | 9.2552 | 1.0331 |
| amax | 1024x1024 | int32 | None | 14.7130 | 15.1157 | 0.9734 |
| amax | 1024x1024 | int64 | -1 | 22.9205 | 22.8621 | 1.0026 |
| amax | 1024x1024 | int64 | 0 | 23.2433 | 22.9749 | 1.0117 |
| amax | 1024x1024 | int64 | None | 27.3836 | 27.2286 | 1.0057 |
| amax | 128x8192 | bfloat16 | -1 | 10.6555 | 10.6564 | 0.9999 |
| amax | 128x8192 | bfloat16 | 0 | 26.8449 | 27.0544 | 0.9923 |
| amax | 128x8192 | bfloat16 | None | 18.7336 | 18.9181 | 0.9902 |
| amax | 128x8192 | float16 | -1 | 8.9035 | 9.0472 | 0.9841 |
| amax | 128x8192 | float16 | 0 | 20.2643 | 19.5344 | 1.0374 |
| amax | 128x8192 | float16 | None | 17.0606 | 17.1483 | 0.9949 |
| amax | 128x8192 | float32 | -1 | 9.5729 | 9.5861 | 0.9986 |
| amax | 128x8192 | float32 | 0 | 20.9501 | 20.4664 | 1.0236 |
| amax | 128x8192 | float32 | None | 16.9042 | 17.5604 | 0.9626 |
| amax | 128x8192 | int32 | -1 | 8.4826 | 8.7084 | 0.9741 |
| amax | 128x8192 | int32 | 0 | 18.0935 | 18.4986 | 0.9781 |
| amax | 128x8192 | int32 | None | 14.9730 | 15.2970 | 0.9788 |
| amax | 128x8192 | int64 | -1 | 22.5739 | 22.0329 | 1.0246 |
| amax | 128x8192 | int64 | 0 | 29.4437 | 29.2996 | 1.0049 |
| amax | 128x8192 | int64 | None | 26.8357 | 27.6860 | 0.9693 |
| amax | 33 | bfloat16 | None | 4.7444 | 4.6592 | 1.0183 |
| amax | 33 | float16 | None | 4.7207 | 4.5539 | 1.0366 |
| amax | 33 | float32 | None | 4.6130 | 4.5894 | 1.0051 |
| amax | 33 | int32 | None | 4.5426 | 4.3593 | 1.0420 |
| amax | 33 | int64 | None | 4.7166 | 4.6222 | 1.0204 |
| amax | 65 | bfloat16 | None | 4.7604 | 4.6300 | 1.0282 |
| amax | 65 | float16 | None | 4.6770 | 4.6046 | 1.0157 |
| amax | 65 | float32 | None | 4.7711 | 4.6383 | 1.0286 |
| amax | 65 | int32 | None | 4.5303 | 4.3685 | 1.0370 |
| amax | 65 | int64 | None | 4.7083 | 4.6324 | 1.0164 |
| amin | 1000 | bfloat16 | None | 4.9476 | 4.7737 | 1.0364 |
| amin | 1000 | float16 | None | 4.7211 | 4.6900 | 1.0066 |
| amin | 1000 | float32 | None | 4.7679 | 4.8212 | 0.9889 |
| amin | 1000 | int32 | None | 4.5268 | 4.4079 | 1.0270 |
| amin | 1000 | int64 | None | 4.9839 | 5.2348 | 0.9521 |
| amin | 1024x1024 | bfloat16 | -1 | 8.0113 | 7.9277 | 1.0105 |
| amin | 1024x1024 | bfloat16 | 0 | 9.6381 | 9.5964 | 1.0043 |
| amin | 1024x1024 | bfloat16 | None | 19.0998 | 18.8655 | 1.0124 |
| amin | 1024x1024 | float16 | -1 | 7.3119 | 7.2875 | 1.0033 |
| amin | 1024x1024 | float16 | 0 | 8.1525 | 8.1798 | 0.9967 |
| amin | 1024x1024 | float16 | None | 16.8548 | 17.1830 | 0.9809 |
| amin | 1024x1024 | float32 | -1 | 7.7833 | 7.7648 | 1.0024 |
| amin | 1024x1024 | float32 | 0 | 9.7593 | 9.7846 | 0.9974 |
| amin | 1024x1024 | float32 | None | 17.0236 | 17.2536 | 0.9867 |
| amin | 1024x1024 | int32 | -1 | 7.7128 | 7.5846 | 1.0169 |
| amin | 1024x1024 | int32 | 0 | 9.4136 | 9.2852 | 1.0138 |
| amin | 1024x1024 | int32 | None | 14.7521 | 15.1595 | 0.9731 |
| amin | 1024x1024 | int64 | -1 | 23.0755 | 22.3602 | 1.0320 |
| amin | 1024x1024 | int64 | 0 | 22.8413 | 22.3849 | 1.0204 |
| amin | 1024x1024 | int64 | None | 27.0038 | 27.0258 | 0.9992 |
| amin | 128x8192 | bfloat16 | -1 | 10.5084 | 10.7447 | 0.9780 |
| amin | 128x8192 | bfloat16 | 0 | 26.6363 | 26.5370 | 1.0037 |
| amin | 128x8192 | bfloat16 | None | 19.0236 | 19.0439 | 0.9989 |
| amin | 128x8192 | float16 | -1 | 9.0779 | 8.8947 | 1.0206 |
| amin | 128x8192 | float16 | 0 | 19.9390 | 19.5933 | 1.0176 |
| amin | 128x8192 | float16 | None | 16.8071 | 17.1361 | 0.9808 |
| amin | 128x8192 | float32 | -1 | 9.6507 | 9.6803 | 0.9969 |
| amin | 128x8192 | float32 | 0 | 21.4744 | 20.7584 | 1.0345 |
| amin | 128x8192 | float32 | None | 17.3656 | 17.3943 | 0.9984 |
| amin | 128x8192 | int32 | -1 | 8.5286 | 8.4830 | 1.0054 |
| amin | 128x8192 | int32 | 0 | 18.0268 | 18.4685 | 0.9761 |
| amin | 128x8192 | int32 | None | 15.0380 | 15.3488 | 0.9798 |
| amin | 128x8192 | int64 | -1 | 22.8776 | 22.7853 | 1.0041 |
| amin | 128x8192 | int64 | 0 | 29.7325 | 29.1092 | 1.0214 |
| amin | 128x8192 | int64 | None | 27.3202 | 27.2964 | 1.0009 |
| amin | 33 | bfloat16 | None | 4.6905 | 4.7792 | 0.9814 |
| amin | 33 | float16 | None | 4.7559 | 4.6200 | 1.0294 |
| amin | 33 | float32 | None | 4.7129 | 4.6117 | 1.0219 |
| amin | 33 | int32 | None | 4.5402 | 4.3823 | 1.0360 |
| amin | 33 | int64 | None | 4.7592 | 4.6483 | 1.0239 |
| amin | 65 | bfloat16 | None | 4.7528 | 4.6432 | 1.0236 |
| amin | 65 | float16 | None | 4.7616 | 4.5458 | 1.0475 |
| amin | 65 | float32 | None | 4.6663 | 4.5952 | 1.0155 |
| amin | 65 | int32 | None | 4.4617 | 4.4156 | 1.0104 |
| amin | 65 | int64 | None | 4.6416 | 4.6855 | 0.9906 |

</details>

## Review history

https://gist.github.com/e351ef96fade7acd5b0cb5c0d5f4b191

## BC-breaking?

No.
