### PR TITLE
Fix nullable-to-nonnull conversions for Xcode 26.6 (#187979)

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -120,7 +120,7 @@ void PRINT_TENSOR(std::string name, const at::Tensor& tensor) {
     for (int i = 0; i < t.numel(); ++i) {
       NSString* sf =
           [NSString stringWithFormat:@"%.2f", t.data_ptr<float>()[i]];
-      str += sf.UTF8String;
+      str += sf.UTF8String ?: "";
       str += ", ";
     }
     std::cout << str << std::endl;


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/20466


Xcode 26.x errors under `-Werror` on implicit conversions from nullable `NSString.UTF8String` results to non-nullable `const char *` / `std::string` parameters. Guard each affected site with a `?: ""` fallback (these paths are non-null in practice, so behavior is unchanged). Fixed sites (both the `fbcode` and `xplat` mirror copies):

- `caffe2/.../mpscnn/tests/MPSCNNTests.mm`: the `sf.UTF8String` append in the tensor-printing helper.
- `executorch/.../ExecuTorchLLMTextRunner.mm`: `token.UTF8String` (special tokens), `_modelPath`/`_tokenizerPath` (runner creation), and `prompt.UTF8String` (generate).
- `executorch/.../ExecuTorchLLMMultimodalRunner.mm`: `_modelPath`/`_tokenizerPath` (runner creation) and `input.text.UTF8String` (text input).

___

Test Plan:
Affected targets build clean under the Apple SDK:

```
buck2 build fbobjc/mode/buck2/ios-tests -c 'facebook-dt#apple.xcode_sdk_version=xcode_26.4.1_17e202' --skip-incompatible-targets --skip-missing-targets fbsource//xplat/caffe2:aten_metal_testsApple
buck2 build fbobjc/mode/buck2/ios-tests -c 'facebook-dt#apple.xcode_sdk_version=xcode_26.4.1_17e202' --skip-incompatible-targets --skip-missing-targets fbsource//xplat/executorch/extension/llm/apple:ExecuTorchLLMTests
```

Differential Revision: D109459540


