### PR TITLE
Don't print discovered test cases during iteration

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1175,7 +1175,6 @@ def discover_test_cases_recursively(suite_or_case):
         return [suite_or_case]
     rc = []
     for element in suite_or_case:
-        print(element)
         rc.extend(discover_test_cases_recursively(element))
     return rc
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #188100
* #188098
* #188070
* __->__ #187980

#67819 added an extra print statement that runs during test case iteration and results in `--discover-tests` printing test names **twice**. This PR fixes this to only print test case names *after* full discovery :)