### PR TITLE
[not for land] CODA backward epilogue fusion prototype

### DIFF
--- a/coda_backward_epilogue_fusion.py
+++ b/coda_backward_epilogue_fusion.py
@@ -1,0 +1,678 @@
+"""
+[not for land] Prototype: backward epilogue fusion across autograd.Function nodes.
+
+A UX prototype for CODA-style backward epilogue fusion ("CODA: Rewriting
+Transformer Blocks as GEMM-Epilogue Programs", arXiv:2605.19269). The problem:
+the backward of an autograd.Function is not self-contained -- for a chain
+mm -> epilogue -> mm, the epilogue's backward wants to fuse as the epilogue of
+the *next* matmul's backward (grad_a = (grad_c @ W^T) * f'(a) is a matmul with a
+pointwise epilogue). A single Function can't express that, since its backward
+runs inside one node.
+
+The approach: the user writes a "1-to-many" op that decomposes into two autograd
+nodes (a matmul node and an epilogue marker node), plus a fusion rule. Before
+backward, apply_epilogue_fusion() walks the graph and arms the matmul node to
+defer its activation gradient into the previous epilogue's backward (no graph
+rewriting; deferral rides a placeholder grad along the existing edge).
+
+The user's forward receives TWO ctxs and saves into each explicitly:
+
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)      # tensors the matmul backward needs
+        epilogue_ctx.save_for_backward(a)     # tensors the pointwise epilogue needs
+        return relu(a)
+
+The framework saves each set on the corresponding autograd node, so:
+  * `main_backward(main_ctx, grad)` reads `main_ctx.saved_tensors`, honors
+    `main_ctx.needs_input_grad`, and returns a grad per forward input. When this
+    node defers, the framework sets needs_input_grad[activation] = False, so the
+    user simply returns None for that slot (as for any not-needed grad) and the
+    fused kernel produces it instead;
+  * `epilogue_backward(epilogue_ctx, ...)` reads `epilogue_ctx.saved_tensors`;
+  * saved sets are partitioned per node (the epilogue tensor `a` lives only on the
+    epilogue node), and the deferred producer's placeholder carries only its main
+    set -- never the epilogue set.
+
+The fused backward kernel receives the producer's main saved set (a plain tuple)
+and the consumer ctx, each exposing only its own subset:
+
+    fused_impl(grad_producer_out, main_saved_tensors, consumer_ctx) -> grad_consumer_main_out
+        main_saved_tensors          # the producer op's main set (e.g. x, w)
+        consumer_ctx.saved_tensors  # the consumer op's epilogue set (e.g. a)
+
+Fusion rules are passed explicitly (no global registry) as a list of
+(producer.main_backward, consumer.epilogue_backward, fused_impl) and applied in
+a single step:
+
+    apply_epilogue_fusion(loss.grad_fn, rules, expect_num_fusions=2)
+    loss.backward()
+
+Each op below is self-contained with its own backwards.
+
+Run:
+    python coda_backward_epilogue_fusion.py
+"""
+
+from collections import deque
+from dataclasses import dataclass
+
+import torch
+from torch.autograd import Function
+
+
+class _Log:
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.c = dict(main_full=0, main_params_only=0, fused_impl=0, epilogue_unfused=0)
+
+    def hit(self, k):
+        self.c[k] += 1
+
+    def __repr__(self):
+        return repr(self.c)
+
+
+LOG = _Log()
+
+
+class DeferredGradTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, shape, dtype, device, main_grad_out, main_saved_tensors):
+        r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+            cls,
+            shape,
+            dtype=dtype,
+            device=device,
+            requires_grad=False,
+        )
+        r._main_grad_out = main_grad_out
+        r._main_saved_tensors = main_saved_tensors
+        return r
+
+    __torch_function__ = torch._C._disabled_torch_function_impl  # type: ignore[attr-defined]
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise RuntimeError(
+            f"DeferredGradTensor is a metadata-only placeholder for a deferred "
+            f"grad_input and must not be used in a real op (got {func}). The "
+            f"consumer epilogue node should detect it and unwrap `._main_grad_out`; "
+            f"reaching __torch_dispatch__ means the placeholder leaked into "
+            f"computation."
+        )
+
+
+class _WrappedCtx:
+    """Forwards every attribute to an inner ctx except the overridden ones, so a
+    backward can be handed a ctx that differs in just one field. Mirrors the
+    WrappedCtx pattern in torch/_functorch/autograd_function.py."""
+
+    _reserved = ("_inner_ctx",)
+
+    def __init__(self, ctx):
+        self._inner_ctx = ctx
+
+    def __getattr__(self, name):
+        return getattr(self._inner_ctx, name)
+
+    def __setattr__(self, name, value):
+        if name in type(self)._reserved:
+            self.__dict__[name] = value
+        else:
+            setattr(self._inner_ctx, name, value)
+
+
+class _MainBackwardCtx(_WrappedCtx):
+    """The ctx handed to main_backward: overrides needs_input_grad (deferred
+    activation slot forced to False) and saved_tensors (served from a set read once
+    in _MainNode.backward, since a checkpoint region errors on a second unpack)."""
+
+    _reserved = ("_needs", "_saved", *_WrappedCtx._reserved)
+
+    def __init__(self, ctx, needs_input_grad, saved_tensors):
+        super().__init__(ctx)
+        self._needs = needs_input_grad
+        self._saved = saved_tensors
+
+    @property
+    def needs_input_grad(self):
+        return self._needs
+
+    @property
+    def saved_tensors(self):
+        return self._saved
+
+
+class _StagingCtx:
+    def __init__(self):
+        self.saved = ()
+        self.output_meta = None
+
+    def save_for_backward(self, *tensors):
+        self.saved = tensors
+
+    def set_output_meta(self, like):
+        # We need the user to explicitly set this because the forward is fused;
+        # we don't know what the metadata for the intermediate is.
+        self.output_meta = (like.shape, like.dtype, like.device)
+
+
+_MAIN_BACKWARD = "_MainNodeBackward"
+_EPILOGUE_BACKWARD = "_EpilogueNodeBackward"
+
+
+def _is_main(node):
+    return type(node).__name__ == _MAIN_BACKWARD
+
+
+def _is_epilogue(node):
+    return type(node).__name__ == _EPILOGUE_BACKWARD
+
+
+class _MainNode(Function):
+    @staticmethod
+    def forward(ctx, cls, meta, main_saved, *inps):
+        ctx.cls = cls
+        ctx.in_metas = tuple((t.shape, t.dtype, t.device) for t in inps)
+        ctx.save_for_backward(*main_saved)
+        ctx.defer_input_idx = None  # set by the plan; None means do not defer
+        shape, dtype, device = meta
+        return torch.empty(shape, dtype=dtype, device=device)
+
+    @staticmethod
+    def backward(ctx, grad_main_out):
+        cls = ctx.cls
+        saved = ctx.saved_tensors
+        needs_input_grad = list(ctx.needs_input_grad[3:])
+        k = ctx.defer_input_idx
+        if k is not None:
+            needs_input_grad[k] = False
+        bw_ctx = _MainBackwardCtx(ctx, tuple(needs_input_grad), saved)
+        LOG.hit("main_params_only" if k is not None else "main_full")
+        grads = list(cls.main_backward(bw_ctx, grad_main_out))
+        if k is not None:
+            shape, dtype, device = ctx.in_metas[k]
+            grads[k] = DeferredGradTensor(shape, dtype, device, grad_main_out, saved)
+        return (None, None, None) + tuple(grads)
+
+
+class _EpilogueNode(Function):
+    @staticmethod
+    def forward(ctx, cls, epilogue_saved, out_holder, main_out):
+        ctx.cls = cls
+        ctx.save_for_backward(*epilogue_saved)
+        ctx.fused_impl = None  # set by the plan when this node fuses
+        (out,) = out_holder
+        return out.view_as(out)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        cls = ctx.cls
+        if isinstance(grad_out, DeferredGradTensor):
+            LOG.hit("fused_impl")
+            grad_main_out = ctx.fused_impl(
+                grad_out._main_grad_out, grad_out._main_saved_tensors, ctx
+            )
+        else:
+            LOG.hit("epilogue_unfused")
+            grad_main_out = cls.epilogue_backward(ctx, grad_out)
+        return (None, None, None, grad_main_out)
+
+
+class FusibleFunction:
+    r"""A fusible op: one forward that decomposes into two autograd nodes -- a "main"
+    node (the matmul) and an "epilogue" node (the pointwise tail) -- so the epilogue's
+    backward can later be fused into the next op's matmul backward by
+    :func:`apply_epilogue_fusion`. Used on its own (without fusion) it behaves like an
+    ordinary autograd Function.
+
+    Subclasses implement three staticmethods:
+
+    ``forward(main_ctx, epilogue_ctx, *inputs) -> output``
+        Runs the full forward. Saves the tensors each backward needs into the
+        corresponding ctx (``main_ctx.save_for_backward(...)`` for the matmul backward,
+        ``epilogue_ctx.save_for_backward(...)`` for the pointwise backward), and MUST
+        call ``main_ctx.set_output_meta(a)`` to declare the intermediate ``a`` (the
+        GEMM output flowing between the two nodes). That metadata cannot be inferred
+        from the final output (e.g. SwiGLU is dim-reducing), and ``apply`` raises if
+        it is missing.
+
+    ``main_backward(main_ctx, grad_main_out) -> grads``
+        The matmul backward; reads ``main_ctx.saved_tensors`` and returns one grad per
+        forward input, honoring ``main_ctx.needs_input_grad``. Compute the weight grad
+        (dW) unconditionally first and guard the activation grad (dx) with
+        ``needs_input_grad``. When this op's activation grad is deferred into a fused
+        kernel, the framework sets ``needs_input_grad`` to ``False`` at the activation
+        slot, so ``main_backward`` returns ``None`` there and the fused kernel produces
+        it instead.
+
+    ``epilogue_backward(epilogue_ctx, grad_out) -> grad_main_out``
+        The pointwise backward; reads ``epilogue_ctx.saved_tensors``.
+
+    Examples::
+
+        >>> import torch
+        >>> class MMRelu(FusibleFunction):
+        ...     @staticmethod
+        ...     def forward(main_ctx, epilogue_ctx, x, w):
+        ...         a = x @ w
+        ...         main_ctx.save_for_backward(x, w)
+        ...         main_ctx.set_output_meta(a)        # REQUIRED: boundary meta (else apply raises)
+        ...         epilogue_ctx.save_for_backward(a)
+        ...         return torch.relu(a)
+        ...     @staticmethod
+        ...     def main_backward(main_ctx, grad_a):   # the matmul backward
+        ...         x, w = main_ctx.saved_tensors
+        ...         # dW first (always local); dx (input 0) is guarded by needs_input_grad
+        ...         # and skipped when deferred into the fused kernel.
+        ...         gw = x.T @ grad_a if main_ctx.needs_input_grad[1] else None
+        ...         gx = grad_a @ w.T if main_ctx.needs_input_grad[0] else None
+        ...         return gx, gw
+        ...     @staticmethod
+        ...     def epilogue_backward(epilogue_ctx, grad_out):   # the pointwise backward
+        ...         (a,) = epilogue_ctx.saved_tensors
+        ...         return grad_out * (a > 0).to(a.dtype)
+        >>>
+        >>> x = torch.randn(4, 6, requires_grad=True)
+        >>> w1 = torch.randn(6, 6, requires_grad=True)
+        >>> w2 = torch.randn(6, 6, requires_grad=True)
+        >>> out = MMRelu.apply(MMRelu.apply(x, w1), w2)   # works as a normal op
+        >>> out.sum().backward()
+
+    To fuse each epilogue's backward into the next matmul's backward, pass a rule to
+    :func:`apply_epilogue_fusion` before calling ``backward``::
+
+        >>> def mm_bw_relu_bw_fused(grad_producer_out, main_saved_tensors, consumer_ctx):
+        ...     _x, w = main_saved_tensors             # producer's matmul weight
+        ...     (a,) = consumer_ctx.saved_tensors      # consumer's preactivation
+        ...     return (grad_producer_out @ w.T) * (a > 0).to(a.dtype)
+        >>>
+        >>> rules = [(MMRelu.main_backward, MMRelu.epilogue_backward, mm_bw_relu_bw_fused)]
+        >>> out = MMRelu.apply(MMRelu.apply(x, w1), w2)
+        >>> loss = out.sum()
+        >>> apply_epilogue_fusion(loss, rules, expect_num_fusions=1)
+        >>> loss.backward()   # relu1's backward runs fused into mm2's grad_input GEMM
+    """
+
+    @classmethod
+    def apply(cls, *inputs):
+        # Run the user's forward once, outside both nodes, against staging ctxs.
+        main_staging = _StagingCtx()
+        epilogue_staging = _StagingCtx()
+        with torch.no_grad():
+            out = cls.forward(main_staging, epilogue_staging, *inputs)
+        # The intermediate may differ in shape from `out` (e.g. SwiGLU is
+        # dim-reducing), so the user must declare its metadata; we can't infer it.
+        if main_staging.output_meta is None:
+            raise RuntimeError(
+                f"{cls.__name__}.forward must call main_ctx.set_output_meta(...) to "
+                f"declare the intermediate (main output) metadata"
+            )
+        # cls and the saved sets pass explicitly into the module-level nodes; `out`
+        # rides in a 1-tuple to stay a non-autograd input to the epilogue.
+        main_out = _MainNode.apply(
+            cls, main_staging.output_meta, main_staging.saved, *inputs
+        )
+        return _EpilogueNode.apply(cls, epilogue_staging.saved, (out,), main_out)
+
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, *inputs):
+        raise NotImplementedError
+
+    @staticmethod
+    def main_backward(main_ctx, grad_main_out):
+        raise NotImplementedError
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, grad_out):
+        raise NotImplementedError
+
+
+@dataclass
+class _PlannedPair:
+    producer: object
+    consumer: object
+    unfused_reason: str | None  # None when fusion is armed; else why no rule matched
+
+    @property
+    def fused(self):
+        return self.unfused_reason is None
+
+    def _label(self):
+        return (
+            f"{self.producer.cls.__name__}.main_backward -> "
+            f"{self.consumer.cls.__name__}.epilogue_backward"
+        )
+
+
+class _InternalDebugFusionPlan:
+    def __init__(self, fused, missing_rules):
+        self._pairs_fused = fused
+        self._pairs_missing_rules = missing_rules
+
+    def assert_num_fusions(self, expected):
+        got = len(self._pairs_fused)
+        if got != expected:
+            lines = [f"expected {expected} backward fusions, planned {got}"]
+            if self._pairs_missing_rules:
+                lines.append(
+                    f"{len(self._pairs_missing_rules)} fusible main -> epilogue "
+                    f"adjacency(ies) have no registered rule:"
+                )
+                lines += [f"  - {p._label()}" for p in self._pairs_missing_rules]
+                lines.append(
+                    "Did you forget to pass a rule for these to "
+                    "apply_epilogue_fusion(rules=...)?"
+                )
+            raise AssertionError("\n".join(lines))
+        return self
+
+    def __repr__(self):
+        all_pairs = self._pairs_fused + self._pairs_missing_rules
+        name = type(self).__name__
+        if not all_pairs:
+            return f"{name}(no candidates)"
+        return (
+            f"{name}(\n  "
+            + "\n  ".join(
+                f"{p.producer.cls.__name__}.main -> "
+                f"{p.consumer.cls.__name__}.epilogue: "
+                f"{'FUSE' if p.fused else 'bail:' + p.unfused_reason}"
+                for p in all_pairs
+            )
+            + "\n)"
+        )
+
+
+def apply_epilogue_fusion(
+    root, rules, *, expect_num_fusions=None, _internal_debug=False
+):
+    r"""Applies epilogue fusion rules to :class:`FusibleFunction` nodes in the autograd graph.
+
+    Each rule in :attr:`rules` specifies a pair of ``main_backward`` and
+    ``epilogue_backward`` methods together with the fused implementation that should run
+    in their place. This function traverses the autograd graph starting from
+    :attr:`root`, and for each adjacent pair of nodes matching a rule, mutates those
+    nodes in place so the fused implementation runs instead.
+
+    This function should be called after the forward pass and before :meth:`backward`,
+    on every iteration.
+
+    It only operates on :class:`FusibleFunction` subclasses; see that class for more
+    details.
+
+    Args:
+        root (Tensor or Node): the loss tensor (or its ``grad_fn``) to traverse
+            back from.
+        rules (list): fusion rules, each a tuple
+            ``(producer_cls.main_backward, consumer_cls.epilogue_backward, fused_impl)``.
+            ``fused_impl(grad_producer_out, main_saved_tensors, consumer_ctx)`` returns
+            the grad of the consumer's main output, computing the producer's deferred
+            ``grad_input`` GEMM with the consumer's epilogue fused on. Only registered
+            pairs fuse.
+        expect_num_fusions (int, optional): if given, assert exactly this many
+            fusions were planned, raising a diagnostic that names any fusible
+            adjacency lacking a rule. This is the supported way to check coverage.
+            Default: ``None``.
+
+    Returns:
+        None. (For debugging only, passing ``_internal_debug=True`` returns an
+        internal plan object describing the planned fusions; its shape is not stable
+        and not part of the public API.)
+
+    Examples::
+
+        >>> import torch
+        >>> class MMRelu(FusibleFunction):
+        ...     @staticmethod
+        ...     def forward(main_ctx, epilogue_ctx, x, w):
+        ...         a = x @ w
+        ...         main_ctx.save_for_backward(x, w)
+        ...         main_ctx.set_output_meta(a)        # REQUIRED: boundary meta (else apply raises)
+        ...         epilogue_ctx.save_for_backward(a)
+        ...         return torch.relu(a)
+        ...     @staticmethod
+        ...     def main_backward(main_ctx, grad_a):   # the matmul backward
+        ...         x, w = main_ctx.saved_tensors
+        ...         gw = x.T @ grad_a if main_ctx.needs_input_grad[1] else None
+        ...         gx = grad_a @ w.T if main_ctx.needs_input_grad[0] else None
+        ...         return gx, gw
+        ...     @staticmethod
+        ...     def epilogue_backward(epilogue_ctx, grad_out):   # the pointwise backward
+        ...         (a,) = epilogue_ctx.saved_tensors
+        ...         return grad_out * (a > 0).to(a.dtype)
+        >>>
+        >>> def mm_bw_relu_bw_fused(grad_producer_out, main_saved_tensors, consumer_ctx):
+        ...     _x, w = main_saved_tensors             # producer's matmul weight
+        ...     (a,) = consumer_ctx.saved_tensors      # consumer's preactivation
+        ...     return (grad_producer_out @ w.T) * (a > 0).to(a.dtype)
+        >>>
+        >>> rules = [(MMRelu.main_backward, MMRelu.epilogue_backward, mm_bw_relu_bw_fused)]
+        >>> x = torch.randn(4, 6, requires_grad=True)
+        >>> w1 = torch.randn(6, 6, requires_grad=True)
+        >>> w2 = torch.randn(6, 6, requires_grad=True)
+        >>> out = MMRelu.apply(MMRelu.apply(x, w1), w2)      # mm1 -> relu -> mm2 -> relu
+        >>> loss = out.sum()
+        >>> apply_epilogue_fusion(loss, rules, expect_num_fusions=1)
+        >>> loss.backward()   # relu1's backward runs fused into mm2's grad_input GEMM
+    """
+    if isinstance(root, torch.Tensor):
+        root = root.grad_fn
+
+    rule_map = {(p, c): impl for p, c, impl in rules}
+
+    nodes, in_degree, seen = [], {}, set()
+    q = deque()
+    if root is not None:
+        seen.add(root)
+        q.append(root)
+    while q:
+        node = q.popleft()
+        nodes.append(node)
+        for fn, _ in node.next_functions:
+            if fn is None:
+                continue
+            in_degree[fn] = in_degree.get(fn, 0) + 1
+            if fn not in seen:
+                seen.add(fn)
+                q.append(fn)
+
+    fused, missing_rules = [], []
+    for n in nodes:
+        if not _is_main(n):
+            continue
+        candidates = [
+            (i, c)
+            for i, (c, _) in enumerate(n.next_functions)
+            if c is not None and _is_epilogue(c)
+        ]
+        if len(candidates) > 1:
+            raise RuntimeError(
+                f"{type(n).__name__}: {len(candidates)} inputs feed epilogue nodes; "
+                f"deferring more than one grad_input is not supported"
+            )
+        if not candidates:
+            continue
+        idx, consumer = candidates[0]
+        impl = rule_map.get((n.cls.main_backward, consumer.cls.epilogue_backward))
+        if impl is None:
+            # Structural candidate (a main feeds an epilogue) but no rule given.
+            missing_rules.append(_PlannedPair(n, consumer, "no rule registered"))
+            continue
+        if in_degree.get(consumer, 0) > 1:
+            raise RuntimeError(
+                f"Cannot fuse {n.cls.__name__}.main_backward into "
+                f"{consumer.cls.__name__}.epilogue_backward: the epilogue output "
+                f"feeds {in_degree[consumer]} downstream main nodes, so its backward "
+                f"grad is accumulated across those branches. Deferral rides a single "
+                f"placeholder along one edge and cannot represent that accumulation. "
+                f"Backward epilogue fusion requires the epilogue output to have "
+                f"exactly one consumer."
+            )
+        n.defer_input_idx = idx
+        consumer.fused_impl = impl
+        fused.append(_PlannedPair(n, consumer, None))  # None == fusion armed
+
+    plan = _InternalDebugFusionPlan(fused, missing_rules)
+    if expect_num_fusions is not None:
+        plan.assert_num_fusions(expect_num_fusions)
+    if _internal_debug:
+        return plan
+    return None
+
+
+# ===========================================================================
+# Example user code: two self-contained ops, each with its own backwards.
+# ===========================================================================
+class MMRelu(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)  # REQUIRED (else apply raises): boundary metadata
+        epilogue_ctx.save_for_backward(a)
+        return torch.relu(a)
+
+    @staticmethod
+    def main_backward(main_ctx, grad_main_out):
+        x, w = main_ctx.saved_tensors
+        # dW first (always local); dx (input 0) is guarded and skipped when deferred.
+        grad_w = (
+            x.transpose(-1, -2) @ grad_main_out
+            if main_ctx.needs_input_grad[1]
+            else None
+        )
+        grad_x = (
+            grad_main_out @ w.transpose(-1, -2)
+            if main_ctx.needs_input_grad[0]
+            else None
+        )
+        return grad_x, grad_w
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, grad_out):
+        (a,) = epilogue_ctx.saved_tensors
+        return grad_out * (a > 0).to(a.dtype)
+
+
+class MMTanh(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)  # REQUIRED (else apply raises): boundary metadata
+        epilogue_ctx.save_for_backward(a)
+        return torch.tanh(a)
+
+    @staticmethod
+    def main_backward(main_ctx, grad_main_out):
+        x, w = main_ctx.saved_tensors
+        # dW first (always local); dx is guarded and skipped when deferred.
+        grad_w = (
+            x.transpose(-1, -2) @ grad_main_out
+            if main_ctx.needs_input_grad[1]
+            else None
+        )
+        grad_x = (
+            grad_main_out @ w.transpose(-1, -2)
+            if main_ctx.needs_input_grad[0]
+            else None
+        )
+        return grad_x, grad_w
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, grad_out):
+        (a,) = epilogue_ctx.saved_tensors
+        return grad_out * (1 - torch.tanh(a) ** 2)
+
+
+def mm_relu_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
+    _x_p, w_p = main_saved_tensors
+    (a_c,) = consumer_ctx.saved_tensors
+    grad_main_input = grad_producer_out @ w_p.transpose(-1, -2)
+    return grad_main_input * (a_c > 0).to(a_c.dtype)
+
+
+def mm_tanh_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
+    _x_p, w_p = main_saved_tensors
+    (a_c,) = consumer_ctx.saved_tensors
+    grad_main_input = grad_producer_out @ w_p.transpose(-1, -2)
+    return grad_main_input * (1 - torch.tanh(a_c) ** 2)
+
+
+# One rule per (producer.main_backward, consumer.epilogue_backward) pair, passed
+# explicitly to apply_epilogue_fusion. The fused impl depends only on the
+# consumer's epilogue, so both producers reuse the same impl.
+RULES = [
+    (MMRelu.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
+    (MMTanh.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
+    (MMRelu.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
+    (MMTanh.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
+]
+
+
+# ===========================================================================
+# Verification.
+# ===========================================================================
+def _check(name, ins, refs, atol=1e-9):
+    ok = True
+    print(f"=== gradient check: {name} ===")
+    labels = ["x"] + [f"w{i}" for i in range(1, len(ins))]
+    for nm, t, r in zip(labels, ins, refs):
+        err = (t.grad - r).abs().max().item()
+        good = torch.allclose(t.grad, r, atol=atol)
+        ok &= good
+        print(f"  grad_{nm}: max_abs_err={err:.2e} ok={good}")
+    assert ok, f"{name}: gradients do not match reference"
+
+
+def scenario_mixed_chain():
+    """x -> MMTanh -> MMRelu -> MMTanh -> sum.
+
+    Fusions:
+      ep1 (MMTanh) <- main2 (MMRelu): key (MMRelu.main, MMTanh.epilogue) -> tanh rule
+      ep2 (MMRelu) <- main3 (MMTanh): key (MMTanh.main, MMRelu.epilogue) -> relu rule
+    """
+    print("\n########## scenario: mixed chain ##########")
+    torch.manual_seed(0)
+    B, K = 4, 6
+
+    def make():
+        return [
+            torch.randn(B if i == 0 else K, K, dtype=torch.double, requires_grad=True)
+            for i in range(4)
+        ]
+
+    ref = make()
+    x, w1, w2, w3 = ref
+    torch.tanh(torch.relu(torch.tanh(x @ w1) @ w2) @ w3).sum().backward()
+    refs = [t.grad.clone() for t in ref]
+
+    ins = make()
+    for t, r in zip(ins, ref):
+        t.data.copy_(r.data)
+    x, w1, w2, w3 = ins
+
+    LOG.reset()
+    loss = MMTanh.apply(MMRelu.apply(MMTanh.apply(x, w1), w2), w3).sum()
+    plan = apply_epilogue_fusion(
+        loss.grad_fn, RULES, expect_num_fusions=2, _internal_debug=True
+    )
+    print(plan)
+    loss.backward()
+
+    _check("mixed", ins, refs)
+    print("kernel paths:", LOG)
+    assert LOG.c["fused_impl"] == 2
+    assert LOG.c["epilogue_unfused"] == 1
+    assert LOG.c["main_params_only"] == 2
+    assert LOG.c["main_full"] == 1
+    print("PASS: both epilogues fused across the mixed chain.")
+
+
+if __name__ == "__main__":
+    scenario_mixed_chain()
+    print("\nALL SCENARIOS PASSED")

--- a/coda_backward_epilogue_fusion.py
+++ b/coda_backward_epilogue_fusion.py
@@ -60,18 +60,19 @@ splitter has collected them:
 
     fused_multiuse(((grad1, saved1), (grad2, saved2)), consumer_ctx)
 
-Fusion rules are passed explicitly (no global registry) as a list of
-(producer.main_backward, consumer.epilogue_backward, fused_impl) and applied in
-a single step. AccumulateGrad rules separately identify the main-backward output
-by forward input index:
+Fusion rules are passed explicitly (no global registry) as ``(pattern,
+replacement)`` pairs and applied in a single step. AccumulateGrad patterns
+separately identify the main-backward output by forward input index:
 
     accumulate_grad_rules = [
-        (producer.main_backward, input_idx, fused_accumulate),
+        ((producer.main_backward, input_idx), fused_accumulate),
     ]
     rules.append(
         (
-            (producer1.main_backward, producer2.main_backward),
-            consumer.epilogue_backward,
+            (
+                (producer1.main_backward, producer2.main_backward),
+                consumer.epilogue_backward,
+            ),
             fused_multiuse,
         )
     )
@@ -443,7 +444,8 @@ class FusibleFunction:
         ...     (a,) = consumer_ctx.saved_tensors      # consumer's preactivation
         ...     return (grad_producer_out @ w.T) * (a > 0).to(a.dtype)
         >>>
-        >>> rules = [(MMRelu.main_backward, MMRelu.epilogue_backward, mm_bw_relu_bw_fused)]
+        >>> pattern = (MMRelu.main_backward, MMRelu.epilogue_backward)
+        >>> rules = [(pattern, mm_bw_relu_bw_fused)]
         >>> out = MMRelu.apply(MMRelu.apply(x, w1), w2)
         >>> loss = out.sum()
         >>> apply_epilogue_fusion(loss, rules, expect_num_fusions=1)
@@ -613,10 +615,10 @@ def apply_epilogue_fusion(
 ):
     r"""Applies epilogue fusion rules to :class:`FusibleFunction` nodes in the autograd graph.
 
-    Each rule in :attr:`rules` specifies either one ``main_backward`` method or an
-    ordered tuple of methods, an ``epilogue_backward`` method, and the fused
-    implementation that should run in their place. This function traverses the
-    autograd graph starting from :attr:`root` and arms matching nodes in place.
+    Each rule in :attr:`rules` is a ``(pattern, replacement)`` pair. The pattern
+    contains either one ``main_backward`` method or an ordered tuple of methods,
+    followed by an ``epilogue_backward`` method. This function traverses the autograd
+    graph starting from :attr:`root` and arms matching nodes in place.
 
     This function should be called after the forward pass and before :meth:`backward`,
     on every iteration.
@@ -638,18 +640,21 @@ def apply_epilogue_fusion(
     Args:
         root (Tensor or Node): the loss tensor (or its ``grad_fn``) to traverse
             back from.
-        rules (list): fusion rules, each a tuple whose first item is either
-            ``producer_cls.main_backward`` or an ordered tuple of producer methods.
-            For one producer, ``fused_impl(grad_producer_out, main_saved_tensors,
-            consumer_ctx)`` returns the grad of the consumer's main output. For an
-            explicit multi-use splitter, ``fused_impl(terms, consumer_ctx)`` receives
-            ordered ``(grad_producer_out, main_saved_tensors)`` terms. Only registered
-            patterns fuse.
-        accumulate_grad_rules (list): fusion rules, each a tuple
-            ``(producer_cls.main_backward, input_idx, fused_impl)``. When that main
-            backward input feeds a unique leaf ``AccumulateGrad``, the normal gradient
-            is deferred and ``fused_impl(grad_producer_out, main_saved_tensors,
-            variable)`` must accumulate directly into ``variable.grad`` and return
+        rules (list): fusion rules expressed as ``(pattern, replacement)`` pairs.
+            A pattern is ``(producer_cls.main_backward,
+            consumer_cls.epilogue_backward)`` for one producer, or an ordered tuple
+            of producer methods in the first position for an explicit multi-use
+            splitter. A single-use replacement receives ``(grad_producer_out,
+            main_saved_tensors, consumer_ctx)``; a multi-use replacement receives
+            ``(terms, consumer_ctx)``, where terms are ordered
+            ``(grad_producer_out, main_saved_tensors)`` pairs. Only registered patterns
+            fuse.
+        accumulate_grad_rules (list): fusion rules expressed as ``(pattern,
+            replacement)`` pairs, where the pattern is
+            ``(producer_cls.main_backward, input_idx)``. When that main backward input
+            feeds a unique leaf ``AccumulateGrad``, the normal gradient is deferred and
+            the replacement receives ``(grad_producer_out, main_saved_tensors,
+            variable)``. It must accumulate directly into ``variable.grad`` and return
             ``None``. Default: ``()``.
         expect_num_fusions (int, optional): if given, assert exactly this many
             fusions were planned, raising a diagnostic that names any fusible
@@ -691,7 +696,8 @@ def apply_epilogue_fusion(
         ...     (a,) = consumer_ctx.saved_tensors      # consumer's preactivation
         ...     return (grad_producer_out @ w.T) * (a > 0).to(a.dtype)
         >>>
-        >>> rules = [(MMRelu.main_backward, MMRelu.epilogue_backward, mm_bw_relu_bw_fused)]
+        >>> pattern = (MMRelu.main_backward, MMRelu.epilogue_backward)
+        >>> rules = [(pattern, mm_bw_relu_bw_fused)]
         >>> x = torch.randn(4, 6, requires_grad=True)
         >>> w1 = torch.randn(6, 6, requires_grad=True)
         >>> w2 = torch.randn(6, 6, requires_grad=True)
@@ -703,11 +709,8 @@ def apply_epilogue_fusion(
     if isinstance(root, torch.Tensor):
         root = root.grad_fn
 
-    rule_map = {(p, c): impl for p, c, impl in rules}
-    accumulate_grad_rule_map = {
-        (producer, input_idx): impl
-        for producer, input_idx, impl in accumulate_grad_rules
-    }
+    rule_map = dict(rules)
+    accumulate_grad_rule_map = dict(accumulate_grad_rules)
 
     nodes, in_degree, edge_in_degree, seen = [], {}, {}, set()
     q = deque()
@@ -1019,13 +1022,27 @@ def mm_weight_accumulate_fused_backward(
 # epilogue. Single-use implementations depend only on the consumer epilogue, so
 # both producer classes reuse the same implementation.
 RULES = [
-    (MMRelu.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
-    (MMTanh.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
-    (MMRelu.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
-    (MMTanh.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
     (
-        (MMRelu.main_backward, MMRelu.main_backward),
-        MMRelu.epilogue_backward,
+        (MMRelu.main_backward, MMRelu.epilogue_backward),
+        mm_relu_fused_backward,
+    ),
+    (
+        (MMTanh.main_backward, MMRelu.epilogue_backward),
+        mm_relu_fused_backward,
+    ),
+    (
+        (MMRelu.main_backward, MMTanh.epilogue_backward),
+        mm_tanh_fused_backward,
+    ),
+    (
+        (MMTanh.main_backward, MMTanh.epilogue_backward),
+        mm_tanh_fused_backward,
+    ),
+    (
+        (
+            (MMRelu.main_backward, MMRelu.main_backward),
+            MMRelu.epilogue_backward,
+        ),
         mm_relu_multiuse_fused_backward,
     ),
 ]
@@ -1033,10 +1050,10 @@ RULES = [
 # These rules identify a main-backward output by its forward input index. They
 # apply only when that edge leads directly to a unique leaf AccumulateGrad.
 ACCUMULATE_GRAD_RULES = [
-    (MMRelu.main_backward, 0, mm_input_accumulate_fused_backward),
-    (MMRelu.main_backward, 1, mm_weight_accumulate_fused_backward),
-    (MMTanh.main_backward, 0, mm_input_accumulate_fused_backward),
-    (MMTanh.main_backward, 1, mm_weight_accumulate_fused_backward),
+    ((MMRelu.main_backward, 0), mm_input_accumulate_fused_backward),
+    ((MMRelu.main_backward, 1), mm_weight_accumulate_fused_backward),
+    ((MMTanh.main_backward, 0), mm_input_accumulate_fused_backward),
+    ((MMTanh.main_backward, 1), mm_weight_accumulate_fused_backward),
 ]
 
 

--- a/coda_backward_epilogue_fusion.py
+++ b/coda_backward_epilogue_fusion.py
@@ -20,7 +20,8 @@ also fuse a main-backward output with a leaf AccumulateGrad, so the GEMM writes
 or adds directly into the leaf's .grad instead of materializing a separate grad.
 For multi-use activations, split_multi_use() explicitly writes out one aliased
 output per use. Their gradients occupy distinct splitter InputBuffer slots, so
-the splitter can package all deferred GEMM terms for one registered fused rule.
+the splitter can either fuse their accumulation directly or package all deferred
+GEMM terms for a rule that also replaces an upstream epilogue.
 
 The user's forward receives TWO ctxs and saves into each explicitly:
 
@@ -55,8 +56,12 @@ its grad directly:
         variable.grad = ...                         # first backward
         addmm(variable.grad, ..., out=variable.grad) # subsequent accumulation
 
-A multi-use epilogue rule receives all ordered branch terms after the explicit
-splitter has collected them:
+A splitter-only replacement receives all ordered branch terms and returns the
+accumulated activation gradient:
+
+    fused_multiuse_accumulate(((grad1, saved1), (grad2, saved2)))
+
+A multi-use epilogue replacement additionally receives the consumer context:
 
     fused_multiuse(((grad1, saved1), (grad2, saved2)), consumer_ctx)
 
@@ -71,6 +76,7 @@ separately identify the main-backward output by forward input index:
         (
             (
                 (producer1.main_backward, producer2.main_backward),
+                split_multi_use,
                 consumer.epilogue_backward,
             ),
             fused_multiuse,
@@ -109,6 +115,7 @@ class _Log:
             main_fully_deferred=0,
             fused_impl=0,
             multiuse_fused=0,
+            splitter_fused=0,
             splitter_deferred=0,
             splitter_unfused=0,
             accumulate_fused=0,
@@ -315,6 +322,7 @@ class _SplitterNode(Function):
         ctx.input_meta = (tensor.shape, tensor.dtype, tensor.device)
         ctx.num_uses = num_uses
         ctx.defer_fusion = False
+        ctx.fused_impl = None
         ctx.set_materialize_grads(False)
         return tuple(tensor.view_as(tensor) for _ in range(num_uses))
 
@@ -328,8 +336,12 @@ class _SplitterNode(Function):
                 )
             LOG.hit("splitter_deferred")
             terms = [term for grad in grads for term in grad._main_grad_terms]
-            shape, dtype, device = ctx.input_meta
-            grad_input = DeferredGradTensor.from_terms(shape, dtype, device, terms)
+            if ctx.fused_impl is None:
+                shape, dtype, device = ctx.input_meta
+                grad_input = DeferredGradTensor.from_terms(shape, dtype, device, terms)
+            else:
+                LOG.hit("splitter_fused")
+                grad_input = ctx.fused_impl(terms)
         else:
             if any(deferred):
                 raise RuntimeError(
@@ -346,9 +358,9 @@ class _SplitterNode(Function):
 def split_multi_use(tensor, num_uses):
     """Returns one aliased output per downstream use of ``tensor``.
 
-    In backward, each output has a distinct InputBuffer slot. With a matching fusion
-    rule the splitter packages the deferred branch terms for the upstream epilogue;
-    without one it explicitly sums the ordinary gradients.
+    In backward, each output has a distinct InputBuffer slot. A matching rule can
+    replace just the branch-gradient accumulation or compose it with an upstream
+    epilogue. Without one, the splitter explicitly sums the ordinary gradients.
     """
     return _SplitterNode.apply(tensor, num_uses)
 
@@ -522,6 +534,7 @@ class _PlannedMultiUsePair:
     splitter: object
     consumer: object
     unfused_reason: str | None
+    includes_epilogue: bool = True
 
     @property
     def fused(self):
@@ -531,10 +544,10 @@ class _PlannedMultiUsePair:
         producers = ", ".join(
             f"{producer.cls.__name__}.main_backward" for producer in self.producers
         )
-        return (
-            f"({producers}) -> split_multi_use -> "
-            f"{self.consumer.cls.__name__}.epilogue_backward"
-        )
+        label = f"({producers}) -> split_multi_use"
+        if self.includes_epilogue:
+            label += f" -> {self.consumer.cls.__name__}.epilogue_backward"
+        return label
 
 
 class _InternalDebugFusionPlan:
@@ -615,10 +628,11 @@ def apply_epilogue_fusion(
 ):
     r"""Applies epilogue fusion rules to :class:`FusibleFunction` nodes in the autograd graph.
 
-    Each rule in :attr:`rules` is a ``(pattern, replacement)`` pair. The pattern
-    contains either one ``main_backward`` method or an ordered tuple of methods,
-    followed by an ``epilogue_backward`` method. This function traverses the autograd
-    graph starting from :attr:`root` and arms matching nodes in place.
+    Each rule in :attr:`rules` is a ``(pattern, replacement)`` pair. A pattern can
+    replace a main-backward/epilogue pair, the accumulation at an explicit splitter,
+    or the splitter accumulation composed with an upstream epilogue. This function
+    traverses the autograd graph starting from :attr:`root` and arms matching nodes in
+    place.
 
     This function should be called after the forward pass and before :meth:`backward`,
     on every iteration.
@@ -630,25 +644,28 @@ def apply_epilogue_fusion(
     prehooks and would observe the placeholder; post-accumulate hooks remain supported.
 
     Multi-use fusion requires callers to pass each use through :func:`split_multi_use`.
-    Every declared output must feed exactly one main backward, and the splitter must be
-    the epilogue output's only consumer. The output order selects the ordered producer
-    tuple in the rule.
+    Every declared output must feed exactly one main backward. The output order selects
+    the ordered producer tuple in the rule. A splitter-only replacement returns a real
+    accumulated gradient to any upstream autograd node. A replacement that also
+    includes an epilogue requires the splitter to be that epilogue output's only
+    consumer.
 
-    It only operates on :class:`FusibleFunction` subclasses; see that class for more
-    details.
+    Matched main-backward producers must be :class:`FusibleFunction` subclasses, but a
+    splitter-only replacement can return its gradient to any upstream autograd node.
 
     Args:
         root (Tensor or Node): the loss tensor (or its ``grad_fn``) to traverse
             back from.
         rules (list): fusion rules expressed as ``(pattern, replacement)`` pairs.
-            A pattern is ``(producer_cls.main_backward,
-            consumer_cls.epilogue_backward)`` for one producer, or an ordered tuple
-            of producer methods in the first position for an explicit multi-use
-            splitter. A single-use replacement receives ``(grad_producer_out,
-            main_saved_tensors, consumer_ctx)``; a multi-use replacement receives
-            ``(terms, consumer_ctx)``, where terms are ordered
-            ``(grad_producer_out, main_saved_tensors)`` pairs. Only registered patterns
-            fuse.
+            Supported patterns are ``(producer.main_backward,
+            consumer.epilogue_backward)``, ``((producer1.main_backward, ...),
+            split_multi_use)``, and ``((producer1.main_backward, ...),
+            split_multi_use, consumer.epilogue_backward)``. A single-use replacement
+            receives ``(grad_producer_out, main_saved_tensors, consumer_ctx)``. A
+            splitter-only replacement receives ``terms`` and returns the accumulated
+            activation gradient. A splitter-plus-epilogue replacement receives
+            ``(terms, consumer_ctx)``. Terms are ordered ``(grad_producer_out,
+            main_saved_tensors)`` pairs. Only registered patterns fuse.
         accumulate_grad_rules (list): fusion rules expressed as ``(pattern,
             replacement)`` pairs, where the pattern is
             ``(producer_cls.main_backward, input_idx)``. When that main backward input
@@ -743,8 +760,7 @@ def apply_epilogue_fusion(
     multiuse_fused, multiuse_unfused = [], []
     for splitter, entries in splitter_producers.items():
         consumer = splitter.next_functions[0][0]
-        if consumer is None or not _is_epilogue(consumer):
-            continue
+        has_epilogue = consumer is not None and _is_epilogue(consumer)
 
         by_output = {}
         for output_nr, producer, input_idx in entries:
@@ -769,6 +785,7 @@ def apply_epilogue_fusion(
                     splitter,
                     consumer,
                     "each splitter output must feed exactly one main backward",
+                    includes_epilogue=has_epilogue,
                 )
             )
             continue
@@ -779,6 +796,7 @@ def apply_epilogue_fusion(
                     splitter,
                     consumer,
                     "one main backward consumes multiple splitter outputs",
+                    includes_epilogue=has_epilogue,
                 )
             )
             continue
@@ -789,32 +807,61 @@ def apply_epilogue_fusion(
                     splitter,
                     consumer,
                     "a main backward already participates in another fusion",
+                    includes_epilogue=has_epilogue,
                 )
             )
             continue
-        if in_degree.get(consumer, 0) != 1:
+        producer_methods = tuple(
+            producer.cls.main_backward for producer, _ in ordered_entries
+        )
+        splitter_impl = rule_map.get((producer_methods, split_multi_use))
+        epilogue_impl = None
+        if has_epilogue:
+            epilogue_impl = rule_map.get(
+                (
+                    producer_methods,
+                    split_multi_use,
+                    consumer.cls.epilogue_backward,
+                )
+            )
+        if (
+            epilogue_impl is not None
+            and in_degree.get(consumer, 0) != 1
+            and splitter_impl is None
+        ):
             multiuse_unfused.append(
                 _PlannedMultiUsePair(
                     producers,
                     splitter,
                     consumer,
                     "the splitter must be the epilogue output's only consumer",
+                    includes_epilogue=True,
                 )
             )
             continue
 
-        producer_methods = tuple(
-            producer.cls.main_backward for producer, _ in ordered_entries
+        includes_epilogue = (
+            epilogue_impl is not None and in_degree.get(consumer, 0) == 1
         )
-        impl = rule_map.get((producer_methods, consumer.cls.epilogue_backward))
-        pair = _PlannedMultiUsePair(producers, splitter, consumer, None)
+        impl = epilogue_impl if includes_epilogue else splitter_impl
+        pair = _PlannedMultiUsePair(
+            producers,
+            splitter,
+            consumer,
+            None,
+            includes_epilogue=includes_epilogue,
+        )
         if impl is None:
             pair.unfused_reason = "no rule registered"
+            pair.includes_epilogue = has_epilogue
             multiuse_unfused.append(pair)
             continue
 
         splitter.defer_fusion = True
-        consumer.multiuse_fused_impl = impl
+        if includes_epilogue:
+            consumer.multiuse_fused_impl = impl
+        else:
+            splitter.fused_impl = impl
         for producer, input_idx in ordered_entries:
             producer.defer_input_idx = input_idx
         multiuse_fused.append(pair)
@@ -987,7 +1034,7 @@ def mm_tanh_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
     return grad_main_input * (1 - torch.tanh(a_c) ** 2)
 
 
-def mm_relu_multiuse_fused_backward(terms, consumer_ctx):
+def mm_multiuse_accumulate_backward(terms):
     grad_main_input = None
     for grad_producer_out, main_saved_tensors in terms:
         _x, w = main_saved_tensors
@@ -995,6 +1042,11 @@ def mm_relu_multiuse_fused_backward(terms, consumer_ctx):
         grad_main_input = (
             branch_grad if grad_main_input is None else grad_main_input + branch_grad
         )
+    return grad_main_input
+
+
+def mm_relu_multiuse_fused_backward(terms, consumer_ctx):
+    grad_main_input = mm_multiuse_accumulate_backward(terms)
     (a,) = consumer_ctx.saved_tensors
     return grad_main_input * (a > 0).to(a.dtype)
 
@@ -1018,9 +1070,8 @@ def mm_weight_accumulate_fused_backward(
     _mm_accumulate_grad(variable, x.transpose(-1, -2), grad_producer_out)
 
 
-# Rules are keyed by one producer or an ordered producer tuple plus the consumer
-# epilogue. Single-use implementations depend only on the consumer epilogue, so
-# both producer classes reuse the same implementation.
+# Rules map graph patterns to replacements. The splitter marker distinguishes
+# activation-gradient accumulation from ordinary main-to-epilogue fusion.
 RULES = [
     (
         (MMRelu.main_backward, MMRelu.epilogue_backward),
@@ -1041,6 +1092,14 @@ RULES = [
     (
         (
             (MMRelu.main_backward, MMRelu.main_backward),
+            split_multi_use,
+        ),
+        mm_multiuse_accumulate_backward,
+    ),
+    (
+        (
+            (MMRelu.main_backward, MMRelu.main_backward),
+            split_multi_use,
             MMRelu.epilogue_backward,
         ),
         mm_relu_multiuse_fused_backward,
@@ -1122,10 +1181,60 @@ def scenario_mixed_chain():
     print("PASS: epilogues and leaf gradient accumulation fused across the chain.")
 
 
-def scenario_multi_use():
-    """One activation explicitly split across two downstream matmuls."""
-    print("\n########## scenario: explicit multi-use ##########")
+def scenario_activation_grad_accumulation():
+    """Fuse branch gradient accumulation at a split native activation."""
+    print("\n########## scenario: activation gradient accumulation ##########")
     torch.manual_seed(1)
+
+    def make():
+        return [
+            torch.randn(4 if i == 0 else 6, 6, dtype=torch.double, requires_grad=True)
+            for i in range(3)
+        ]
+
+    ref = make()
+    x, wa, wb = ref
+    h = torch.sigmoid(x)
+    (torch.relu(h @ wa).sum() + torch.relu(h @ wb).sum()).backward()
+    refs = [tensor.grad.clone() for tensor in ref]
+
+    ins = make()
+    for tensor, reference in zip(ins, ref):
+        tensor.data.copy_(reference.data)
+    x, wa, wb = ins
+
+    h = torch.sigmoid(x)
+    ha, hb = split_multi_use(h, 2)
+    loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
+    pattern = (
+        (MMRelu.main_backward, MMRelu.main_backward),
+        split_multi_use,
+    )
+    replacement = mm_multiuse_accumulate_backward
+    LOG.reset()
+    plan = apply_epilogue_fusion(
+        loss,
+        [(pattern, replacement)],
+        expect_num_fusions=1,
+        _internal_debug=True,
+    )
+    print(plan)
+    loss.backward()
+
+    _check("activation accumulation", ins, refs)
+    print("kernel paths:", LOG)
+    assert LOG.c["splitter_fused"] == 1  # noqa: S101
+    assert LOG.c["splitter_deferred"] == 1  # noqa: S101
+    assert LOG.c["multiuse_fused"] == 0  # noqa: S101
+    assert LOG.c["fused_impl"] == 0  # noqa: S101
+    assert LOG.c["accumulate_fused"] == 0  # noqa: S101
+    print("PASS: only the two branch activation gradients were fused and accumulated.")
+
+
+def scenario_multi_use_end_to_end():
+    """Compose splitter accumulation, an upstream epilogue, and AccumulateGrad."""
+    print("\n########## scenario: explicit multi-use end to end ##########")
+    torch.manual_seed(2)
 
     def make():
         return [
@@ -1159,15 +1268,17 @@ def scenario_multi_use():
     print(plan)
     loss.backward()
 
-    _check("multi-use", ins, refs)
+    _check("multi-use end to end", ins, refs)
     print("kernel paths:", LOG)
     assert LOG.c["multiuse_fused"] == 1  # noqa: S101
     assert LOG.c["splitter_deferred"] == 1  # noqa: S101
+    assert LOG.c["splitter_fused"] == 0  # noqa: S101
     assert LOG.c["accumulate_fused"] == 4  # noqa: S101
     print("PASS: branch GEMMs, InputBuffer accumulation, and epilogue fused.")
 
 
 if __name__ == "__main__":
     scenario_mixed_chain()
-    scenario_multi_use()
+    scenario_activation_grad_accumulation()
+    scenario_multi_use_end_to_end()
     print("\nALL SCENARIOS PASSED")

--- a/coda_backward_epilogue_fusion.py
+++ b/coda_backward_epilogue_fusion.py
@@ -7,7 +7,9 @@ the backward of an autograd.Function is not self-contained -- for a chain
 mm -> epilogue -> mm, the epilogue's backward wants to fuse as the epilogue of
 the *next* matmul's backward (grad_a = (grad_c @ W^T) * f'(a) is a matmul with a
 pointwise epilogue). A single Function can't express that, since its backward
-runs inside one node.
+runs inside one node. A multi-use activation adds another boundary: the autograd
+engine normally accumulates its branch gradients in the consumer's InputBuffer
+before running the epilogue backward.
 
 The approach: the user writes a "1-to-many" op that decomposes into two autograd
 nodes (a matmul node and an epilogue marker node), plus a fusion rule. Before
@@ -16,6 +18,9 @@ defer its activation gradient into the previous epilogue's backward (no graph
 rewriting; deferral rides a placeholder grad along the existing edge). It can
 also fuse a main-backward output with a leaf AccumulateGrad, so the GEMM writes
 or adds directly into the leaf's .grad instead of materializing a separate grad.
+For multi-use activations, split_multi_use() explicitly writes out one aliased
+output per use. Their gradients occupy distinct splitter InputBuffer slots, so
+the splitter can package all deferred GEMM terms for one registered fused rule.
 
 The user's forward receives TWO ctxs and saves into each explicitly:
 
@@ -50,6 +55,11 @@ its grad directly:
         variable.grad = ...                         # first backward
         addmm(variable.grad, ..., out=variable.grad) # subsequent accumulation
 
+A multi-use epilogue rule receives all ordered branch terms after the explicit
+splitter has collected them:
+
+    fused_multiuse(((grad1, saved1), (grad2, saved2)), consumer_ctx)
+
 Fusion rules are passed explicitly (no global registry) as a list of
 (producer.main_backward, consumer.epilogue_backward, fused_impl) and applied in
 a single step. AccumulateGrad rules separately identify the main-backward output
@@ -58,6 +68,13 @@ by forward input index:
     accumulate_grad_rules = [
         (producer.main_backward, input_idx, fused_accumulate),
     ]
+    rules.append(
+        (
+            (producer1.main_backward, producer2.main_backward),
+            consumer.epilogue_backward,
+            fused_multiuse,
+        )
+    )
     apply_epilogue_fusion(
         loss.grad_fn,
         rules,
@@ -90,6 +107,9 @@ class _Log:
             main_partial=0,
             main_fully_deferred=0,
             fused_impl=0,
+            multiuse_fused=0,
+            splitter_deferred=0,
+            splitter_unfused=0,
             accumulate_fused=0,
             epilogue_unfused=0,
         )
@@ -105,17 +125,28 @@ LOG = _Log()
 
 
 class DeferredGradTensor(torch.Tensor):
-    @staticmethod
-    def __new__(cls, shape, dtype, device, main_grad_out, main_saved_tensors):
-        r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+    @classmethod
+    def _new_wrapper(cls, shape, dtype, device):
+        return torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
             cls,
             shape,
             dtype=dtype,
             device=device,
             requires_grad=False,
         )
+
+    @staticmethod
+    def __new__(cls, shape, dtype, device, main_grad_out, main_saved_tensors):
+        r = cls._new_wrapper(shape, dtype, device)
         r._main_grad_out = main_grad_out
         r._main_saved_tensors = main_saved_tensors
+        r._main_grad_terms = ((main_grad_out, main_saved_tensors),)
+        return r
+
+    @classmethod
+    def from_terms(cls, shape, dtype, device, terms):
+        r = cls._new_wrapper(shape, dtype, device)
+        r._main_grad_terms = tuple(terms)
         return r
 
     __torch_function__ = torch._C._disabled_torch_function_impl  # type: ignore[attr-defined]
@@ -125,7 +156,7 @@ class DeferredGradTensor(torch.Tensor):
         raise RuntimeError(
             f"DeferredGradTensor is a metadata-only placeholder for a deferred "
             f"grad_input and must not be used in a real op (got {func}). The "
-            f"consumer epilogue node should detect it and unwrap `._main_grad_out`; "
+            f"consumer epilogue or explicit splitter should detect and unwrap it; "
             f"reaching __torch_dispatch__ means the placeholder leaked into "
             f"computation."
         )
@@ -188,6 +219,7 @@ class _StagingCtx:
 
 _MAIN_BACKWARD = "_MainNodeBackward"
 _EPILOGUE_BACKWARD = "_EpilogueNodeBackward"
+_SPLITTER_BACKWARD = "_SplitterNodeBackward"
 _ACCUMULATE_GRAD = "AccumulateGrad"
 
 
@@ -197,6 +229,10 @@ def _is_main(node):
 
 def _is_epilogue(node):
     return type(node).__name__ == _EPILOGUE_BACKWARD
+
+
+def _is_splitter(node):
+    return type(node).__name__ == _SPLITTER_BACKWARD
 
 
 def _is_accumulate_grad(node):
@@ -245,6 +281,7 @@ class _EpilogueNode(Function):
         ctx.cls = cls
         ctx.save_for_backward(*epilogue_saved)
         ctx.fused_impl = None  # set by the plan when this node fuses
+        ctx.multiuse_fused_impl = None
         (out,) = out_holder
         return out.view_as(out)
 
@@ -252,14 +289,67 @@ class _EpilogueNode(Function):
     def backward(ctx, grad_out):
         cls = ctx.cls
         if isinstance(grad_out, DeferredGradTensor):
-            LOG.hit("fused_impl")
-            grad_main_out = ctx.fused_impl(
-                grad_out._main_grad_out, grad_out._main_saved_tensors, ctx
-            )
+            terms = grad_out._main_grad_terms
+            if len(terms) == 1:
+                LOG.hit("fused_impl")
+                grad_main_out = ctx.fused_impl(*terms[0], ctx)
+            else:
+                if ctx.multiuse_fused_impl is None:
+                    raise RuntimeError(
+                        "A multi-use DeferredGradTensor reached an unarmed epilogue"
+                    )
+                LOG.hit("multiuse_fused")
+                grad_main_out = ctx.multiuse_fused_impl(terms, ctx)
         else:
             LOG.hit("epilogue_unfused")
             grad_main_out = cls.epilogue_backward(ctx, grad_out)
         return (None, None, None, grad_main_out)
+
+
+class _SplitterNode(Function):
+    @staticmethod
+    def forward(ctx, tensor, num_uses):
+        if num_uses < 2:
+            raise RuntimeError("split_multi_use requires at least two uses")
+        ctx.input_meta = (tensor.shape, tensor.dtype, tensor.device)
+        ctx.num_uses = num_uses
+        ctx.defer_fusion = False
+        ctx.set_materialize_grads(False)
+        return tuple(tensor.view_as(tensor) for _ in range(num_uses))
+
+    @staticmethod
+    def backward(ctx, *grads):
+        deferred = [isinstance(grad, DeferredGradTensor) for grad in grads]
+        if ctx.defer_fusion:
+            if not all(deferred):
+                raise RuntimeError(
+                    "A fused splitter expected one DeferredGradTensor per explicit use"
+                )
+            LOG.hit("splitter_deferred")
+            terms = [term for grad in grads for term in grad._main_grad_terms]
+            shape, dtype, device = ctx.input_meta
+            grad_input = DeferredGradTensor.from_terms(shape, dtype, device, terms)
+        else:
+            if any(deferred):
+                raise RuntimeError(
+                    "A DeferredGradTensor reached an unarmed explicit splitter"
+                )
+            LOG.hit("splitter_unfused")
+            present_grads = [grad for grad in grads if grad is not None]
+            grad_input = (
+                None if not present_grads else sum(present_grads[1:], present_grads[0])
+            )
+        return grad_input, None
+
+
+def split_multi_use(tensor, num_uses):
+    """Returns one aliased output per downstream use of ``tensor``.
+
+    In backward, each output has a distinct InputBuffer slot. With a matching fusion
+    rule the splitter packages the deferred branch terms for the upstream epilogue;
+    without one it explicitly sums the ordinary gradients.
+    """
+    return _SplitterNode.apply(tensor, num_uses)
 
 
 def _make_fused_accumulate_grad_prehook(impl, variable):
@@ -270,8 +360,12 @@ def _make_fused_accumulate_grad_prehook(impl, variable):
                 "A fused AccumulateGrad expected a DeferredGradTensor from its "
                 f"producer, but got {type(grad).__name__}"
             )
+        if len(grad._main_grad_terms) != 1:
+            raise RuntimeError(
+                "A fused AccumulateGrad cannot consume a multi-use deferred gradient"
+            )
         LOG.hit("accumulate_fused")
-        result = impl(grad._main_grad_out, grad._main_saved_tensors, variable)
+        result = impl(*grad._main_grad_terms[0], variable)
         if result is not None:
             raise RuntimeError(
                 "An AccumulateGrad fused implementation must update variable.grad "
@@ -420,14 +514,44 @@ class _PlannedAccumulateGrad:
         )
 
 
+@dataclass
+class _PlannedMultiUsePair:
+    producers: tuple
+    splitter: object
+    consumer: object
+    unfused_reason: str | None
+
+    @property
+    def fused(self):
+        return self.unfused_reason is None
+
+    def _label(self):
+        producers = ", ".join(
+            f"{producer.cls.__name__}.main_backward" for producer in self.producers
+        )
+        return (
+            f"({producers}) -> split_multi_use -> "
+            f"{self.consumer.cls.__name__}.epilogue_backward"
+        )
+
+
 class _InternalDebugFusionPlan:
-    def __init__(self, fused, missing_rules, accumulate_grad_fused):
+    def __init__(
+        self,
+        fused,
+        missing_rules,
+        multiuse_fused,
+        multiuse_unfused,
+        accumulate_grad_fused,
+    ):
         self._pairs_fused = fused
         self._pairs_missing_rules = missing_rules
+        self._multiuse_pairs_fused = multiuse_fused
+        self._multiuse_pairs_unfused = multiuse_unfused
         self._accumulate_grad_fused = accumulate_grad_fused
 
     def assert_num_fusions(self, expected):
-        got = len(self._pairs_fused)
+        got = len(self._pairs_fused) + len(self._multiuse_pairs_fused)
         if got != expected:
             lines = [f"expected {expected} backward fusions, planned {got}"]
             if self._pairs_missing_rules:
@@ -440,6 +564,12 @@ class _InternalDebugFusionPlan:
                     "Did you forget to pass a rule for these to "
                     "apply_epilogue_fusion(rules=...)?"
                 )
+            if self._multiuse_pairs_unfused:
+                lines.append("Explicit multi-use candidate(s) did not fuse:")
+                lines += [
+                    f"  - {pair._label()}: {pair.unfused_reason}"
+                    for pair in self._multiuse_pairs_unfused
+                ]
             raise AssertionError("\n".join(lines))
         return self
 
@@ -454,13 +584,19 @@ class _InternalDebugFusionPlan:
     def __repr__(self):
         all_pairs = self._pairs_fused + self._pairs_missing_rules
         name = type(self).__name__
-        if not all_pairs and not self._accumulate_grad_fused:
+        all_multiuse = self._multiuse_pairs_fused + self._multiuse_pairs_unfused
+        if not all_pairs and not all_multiuse and not self._accumulate_grad_fused:
             return f"{name}(no candidates)"
         lines = [
             f"{p.producer.cls.__name__}.main -> "
             f"{p.consumer.cls.__name__}.epilogue: "
             f"{'FUSE' if p.fused else 'bail:' + p.unfused_reason}"
             for p in all_pairs
+        ]
+        lines += [
+            f"{pair._label()}: "
+            f"{'FUSE' if pair.fused else 'bail:' + pair.unfused_reason}"
+            for pair in all_multiuse
         ]
         lines += [f"{p._label()}: FUSE" for p in self._accumulate_grad_fused]
         return f"{name}(\n  " + "\n  ".join(lines) + "\n)"
@@ -477,11 +613,10 @@ def apply_epilogue_fusion(
 ):
     r"""Applies epilogue fusion rules to :class:`FusibleFunction` nodes in the autograd graph.
 
-    Each rule in :attr:`rules` specifies a pair of ``main_backward`` and
-    ``epilogue_backward`` methods together with the fused implementation that should run
-    in their place. This function traverses the autograd graph starting from
-    :attr:`root`, and for each adjacent pair of nodes matching a rule, mutates those
-    nodes in place so the fused implementation runs instead.
+    Each rule in :attr:`rules` specifies either one ``main_backward`` method or an
+    ordered tuple of methods, an ``epilogue_backward`` method, and the fused
+    implementation that should run in their place. This function traverses the
+    autograd graph starting from :attr:`root` and arms matching nodes in place.
 
     This function should be called after the forward pass and before :meth:`backward`,
     on every iteration.
@@ -492,18 +627,24 @@ def apply_epilogue_fusion(
     Tensor backward hooks are rejected because they run before the accumulator's
     prehooks and would observe the placeholder; post-accumulate hooks remain supported.
 
+    Multi-use fusion requires callers to pass each use through :func:`split_multi_use`.
+    Every declared output must feed exactly one main backward, and the splitter must be
+    the epilogue output's only consumer. The output order selects the ordered producer
+    tuple in the rule.
+
     It only operates on :class:`FusibleFunction` subclasses; see that class for more
     details.
 
     Args:
         root (Tensor or Node): the loss tensor (or its ``grad_fn``) to traverse
             back from.
-        rules (list): fusion rules, each a tuple
-            ``(producer_cls.main_backward, consumer_cls.epilogue_backward, fused_impl)``.
-            ``fused_impl(grad_producer_out, main_saved_tensors, consumer_ctx)`` returns
-            the grad of the consumer's main output, computing the producer's deferred
-            ``grad_input`` GEMM with the consumer's epilogue fused on. Only registered
-            pairs fuse.
+        rules (list): fusion rules, each a tuple whose first item is either
+            ``producer_cls.main_backward`` or an ordered tuple of producer methods.
+            For one producer, ``fused_impl(grad_producer_out, main_saved_tensors,
+            consumer_ctx)`` returns the grad of the consumer's main output. For an
+            explicit multi-use splitter, ``fused_impl(terms, consumer_ctx)`` receives
+            ordered ``(grad_producer_out, main_saved_tensors)`` terms. Only registered
+            patterns fuse.
         accumulate_grad_rules (list): fusion rules, each a tuple
             ``(producer_cls.main_backward, input_idx, fused_impl)``. When that main
             backward input feeds a unique leaf ``AccumulateGrad``, the normal gradient
@@ -568,7 +709,7 @@ def apply_epilogue_fusion(
         for producer, input_idx, impl in accumulate_grad_rules
     }
 
-    nodes, in_degree, seen = [], {}, set()
+    nodes, in_degree, edge_in_degree, seen = [], {}, {}, set()
     q = deque()
     if root is not None:
         seen.add(root)
@@ -576,13 +717,104 @@ def apply_epilogue_fusion(
     while q:
         node = q.popleft()
         nodes.append(node)
-        for fn, _ in node.next_functions:
+        for fn, output_nr in node.next_functions:
             if fn is None:
                 continue
             in_degree[fn] = in_degree.get(fn, 0) + 1
+            edge = (fn, output_nr)
+            edge_in_degree[edge] = edge_in_degree.get(edge, 0) + 1
             if fn not in seen:
                 seen.add(fn)
                 q.append(fn)
+
+    splitter_producers = {}
+    for node in nodes:
+        if not _is_main(node):
+            continue
+        for input_idx, (next_node, output_nr) in enumerate(node.next_functions):
+            if next_node is not None and _is_splitter(next_node):
+                splitter_producers.setdefault(next_node, []).append(
+                    (output_nr, node, input_idx)
+                )
+
+    multiuse_fused, multiuse_unfused = [], []
+    for splitter, entries in splitter_producers.items():
+        consumer = splitter.next_functions[0][0]
+        if consumer is None or not _is_epilogue(consumer):
+            continue
+
+        by_output = {}
+        for output_nr, producer, input_idx in entries:
+            by_output.setdefault(output_nr, []).append((producer, input_idx))
+        ordered_entries = []
+        invalid_outputs = False
+        for output_nr in range(splitter.num_uses):
+            matches = by_output.get(output_nr, [])
+            if len(matches) != 1 or edge_in_degree.get((splitter, output_nr), 0) != 1:
+                invalid_outputs = True
+                break
+            producer, input_idx = matches[0]
+            ordered_entries.append((producer, input_idx))
+
+        producers = tuple(
+            producer for _, producer, _ in sorted(entries, key=lambda entry: entry[0])
+        )
+        if invalid_outputs or len(entries) != splitter.num_uses:
+            multiuse_unfused.append(
+                _PlannedMultiUsePair(
+                    producers,
+                    splitter,
+                    consumer,
+                    "each splitter output must feed exactly one main backward",
+                )
+            )
+            continue
+        if len({producer for producer, _ in ordered_entries}) != len(ordered_entries):
+            multiuse_unfused.append(
+                _PlannedMultiUsePair(
+                    producers,
+                    splitter,
+                    consumer,
+                    "one main backward consumes multiple splitter outputs",
+                )
+            )
+            continue
+        if any(producer.defer_input_idx is not None for producer, _ in ordered_entries):
+            multiuse_unfused.append(
+                _PlannedMultiUsePair(
+                    producers,
+                    splitter,
+                    consumer,
+                    "a main backward already participates in another fusion",
+                )
+            )
+            continue
+        if in_degree.get(consumer, 0) != 1:
+            multiuse_unfused.append(
+                _PlannedMultiUsePair(
+                    producers,
+                    splitter,
+                    consumer,
+                    "the splitter must be the epilogue output's only consumer",
+                )
+            )
+            continue
+
+        producer_methods = tuple(
+            producer.cls.main_backward for producer, _ in ordered_entries
+        )
+        impl = rule_map.get((producer_methods, consumer.cls.epilogue_backward))
+        pair = _PlannedMultiUsePair(producers, splitter, consumer, None)
+        if impl is None:
+            pair.unfused_reason = "no rule registered"
+            multiuse_unfused.append(pair)
+            continue
+
+        splitter.defer_fusion = True
+        consumer.multiuse_fused_impl = impl
+        for producer, input_idx in ordered_entries:
+            producer.defer_input_idx = input_idx
+        multiuse_fused.append(pair)
 
     fused, missing_rules, accumulate_grad_fused = [], [], []
     for n in nodes:
@@ -630,6 +862,11 @@ def apply_epilogue_fusion(
                 f"{type(n).__name__}: {len(candidates)} inputs feed epilogue nodes; "
                 f"deferring more than one grad_input is not supported"
             )
+        if candidates and n.defer_input_idx is not None:
+            raise RuntimeError(
+                f"{type(n).__name__}: multiple inputs feed fusible nodes; "
+                "deferring more than one grad_input is not supported"
+            )
         if not candidates:
             continue
         idx, consumer = candidates[0]
@@ -652,7 +889,13 @@ def apply_epilogue_fusion(
         consumer.fused_impl = impl
         fused.append(_PlannedPair(n, consumer, None))  # None == fusion armed
 
-    plan = _InternalDebugFusionPlan(fused, missing_rules, accumulate_grad_fused)
+    plan = _InternalDebugFusionPlan(
+        fused,
+        missing_rules,
+        multiuse_fused,
+        multiuse_unfused,
+        accumulate_grad_fused,
+    )
     if expect_num_fusions is not None:
         plan.assert_num_fusions(expect_num_fusions)
     if expect_num_accumulate_grad_fusions is not None:
@@ -741,6 +984,18 @@ def mm_tanh_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
     return grad_main_input * (1 - torch.tanh(a_c) ** 2)
 
 
+def mm_relu_multiuse_fused_backward(terms, consumer_ctx):
+    grad_main_input = None
+    for grad_producer_out, main_saved_tensors in terms:
+        _x, w = main_saved_tensors
+        branch_grad = grad_producer_out @ w.transpose(-1, -2)
+        grad_main_input = (
+            branch_grad if grad_main_input is None else grad_main_input + branch_grad
+        )
+    (a,) = consumer_ctx.saved_tensors
+    return grad_main_input * (a > 0).to(a.dtype)
+
+
 def _mm_accumulate_grad(variable, mat1, mat2):
     if variable.grad is None:
         variable.grad = mat1 @ mat2
@@ -760,14 +1015,19 @@ def mm_weight_accumulate_fused_backward(
     _mm_accumulate_grad(variable, x.transpose(-1, -2), grad_producer_out)
 
 
-# One rule per (producer.main_backward, consumer.epilogue_backward) pair, passed
-# explicitly to apply_epilogue_fusion. The fused impl depends only on the
-# consumer's epilogue, so both producers reuse the same impl.
+# Rules are keyed by one producer or an ordered producer tuple plus the consumer
+# epilogue. Single-use implementations depend only on the consumer epilogue, so
+# both producer classes reuse the same implementation.
 RULES = [
     (MMRelu.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
     (MMTanh.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
     (MMRelu.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
     (MMTanh.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
+    (
+        (MMRelu.main_backward, MMRelu.main_backward),
+        MMRelu.epilogue_backward,
+        mm_relu_multiuse_fused_backward,
+    ),
 ]
 
 # These rules identify a main-backward output by its forward input index. They
@@ -845,6 +1105,52 @@ def scenario_mixed_chain():
     print("PASS: epilogues and leaf gradient accumulation fused across the chain.")
 
 
+def scenario_multi_use():
+    """One activation explicitly split across two downstream matmuls."""
+    print("\n########## scenario: explicit multi-use ##########")
+    torch.manual_seed(1)
+
+    def make():
+        return [
+            torch.randn(4 if i == 0 else 6, 6, dtype=torch.double, requires_grad=True)
+            for i in range(4)
+        ]
+
+    ref = make()
+    x, w1, wa, wb = ref
+    h = torch.relu(x @ w1)
+    (torch.relu(h @ wa).sum() + torch.relu(h @ wb).sum()).backward()
+    refs = [tensor.grad.clone() for tensor in ref]
+
+    ins = make()
+    for tensor, reference in zip(ins, ref):
+        tensor.data.copy_(reference.data)
+    x, w1, wa, wb = ins
+
+    h = MMRelu.apply(x, w1)
+    ha, hb = split_multi_use(h, 2)
+    loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
+    LOG.reset()
+    plan = apply_epilogue_fusion(
+        loss,
+        RULES,
+        accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+        expect_num_fusions=1,
+        expect_num_accumulate_grad_fusions=4,
+        _internal_debug=True,
+    )
+    print(plan)
+    loss.backward()
+
+    _check("multi-use", ins, refs)
+    print("kernel paths:", LOG)
+    assert LOG.c["multiuse_fused"] == 1  # noqa: S101
+    assert LOG.c["splitter_deferred"] == 1  # noqa: S101
+    assert LOG.c["accumulate_fused"] == 4  # noqa: S101
+    print("PASS: branch GEMMs, InputBuffer accumulation, and epilogue fused.")
+
+
 if __name__ == "__main__":
     scenario_mixed_chain()
+    scenario_multi_use()
     print("\nALL SCENARIOS PASSED")

--- a/coda_backward_epilogue_fusion.py
+++ b/coda_backward_epilogue_fusion.py
@@ -13,7 +13,9 @@ The approach: the user writes a "1-to-many" op that decomposes into two autograd
 nodes (a matmul node and an epilogue marker node), plus a fusion rule. Before
 backward, apply_epilogue_fusion() walks the graph and arms the matmul node to
 defer its activation gradient into the previous epilogue's backward (no graph
-rewriting; deferral rides a placeholder grad along the existing edge).
+rewriting; deferral rides a placeholder grad along the existing edge). It can
+also fuse a main-backward output with a leaf AccumulateGrad, so the GEMM writes
+or adds directly into the leaf's .grad instead of materializing a separate grad.
 
 The user's forward receives TWO ctxs and saves into each explicitly:
 
@@ -25,10 +27,10 @@ The user's forward receives TWO ctxs and saves into each explicitly:
 
 The framework saves each set on the corresponding autograd node, so:
   * `main_backward(main_ctx, grad)` reads `main_ctx.saved_tensors`, honors
-    `main_ctx.needs_input_grad`, and returns a grad per forward input. When this
-    node defers, the framework sets needs_input_grad[activation] = False, so the
-    user simply returns None for that slot (as for any not-needed grad) and the
-    fused kernel produces it instead;
+    `main_ctx.needs_input_grad`, and returns a grad per forward input. When an
+    output is deferred, the framework sets needs_input_grad[input] = False, so
+    the user simply returns None for that slot (as for any not-needed grad) and
+    the fused kernel produces it instead;
   * `epilogue_backward(epilogue_ctx, ...)` reads `epilogue_ctx.saved_tensors`;
   * saved sets are partitioned per node (the epilogue tensor `a` lives only on the
     epilogue node), and the deferred producer's placeholder carries only its main
@@ -41,11 +43,27 @@ and the consumer ctx, each exposing only its own subset:
         main_saved_tensors          # the producer op's main set (e.g. x, w)
         consumer_ctx.saved_tensors  # the consumer op's epilogue set (e.g. a)
 
+A fused accumulation kernel instead receives the destination leaf and updates
+its grad directly:
+
+    fused_accumulate(grad_producer_out, main_saved_tensors, variable) -> None
+        variable.grad = ...                         # first backward
+        addmm(variable.grad, ..., out=variable.grad) # subsequent accumulation
+
 Fusion rules are passed explicitly (no global registry) as a list of
 (producer.main_backward, consumer.epilogue_backward, fused_impl) and applied in
-a single step:
+a single step. AccumulateGrad rules separately identify the main-backward output
+by forward input index:
 
-    apply_epilogue_fusion(loss.grad_fn, rules, expect_num_fusions=2)
+    accumulate_grad_rules = [
+        (producer.main_backward, input_idx, fused_accumulate),
+    ]
+    apply_epilogue_fusion(
+        loss.grad_fn,
+        rules,
+        accumulate_grad_rules=accumulate_grad_rules,
+        expect_num_fusions=2,
+    )
     loss.backward()
 
 Each op below is self-contained with its own backwards.
@@ -66,7 +84,15 @@ class _Log:
         self.reset()
 
     def reset(self):
-        self.c = dict(main_full=0, main_params_only=0, fused_impl=0, epilogue_unfused=0)
+        self.c = dict(
+            main_full=0,
+            main_params_only=0,
+            main_partial=0,
+            main_fully_deferred=0,
+            fused_impl=0,
+            accumulate_fused=0,
+            epilogue_unfused=0,
+        )
 
     def hit(self, k):
         self.c[k] += 1
@@ -126,9 +152,9 @@ class _WrappedCtx:
 
 
 class _MainBackwardCtx(_WrappedCtx):
-    """The ctx handed to main_backward: overrides needs_input_grad (deferred
-    activation slot forced to False) and saved_tensors (served from a set read once
-    in _MainNode.backward, since a checkpoint region errors on a second unpack)."""
+    """The ctx handed to main_backward: overrides needs_input_grad (deferred input
+    slots forced to False) and saved_tensors (served from a set read once in
+    _MainNode.backward, since a checkpoint region errors on a second unpack)."""
 
     _reserved = ("_needs", "_saved", *_WrappedCtx._reserved)
 
@@ -162,6 +188,7 @@ class _StagingCtx:
 
 _MAIN_BACKWARD = "_MainNodeBackward"
 _EPILOGUE_BACKWARD = "_EpilogueNodeBackward"
+_ACCUMULATE_GRAD = "AccumulateGrad"
 
 
 def _is_main(node):
@@ -172,6 +199,10 @@ def _is_epilogue(node):
     return type(node).__name__ == _EPILOGUE_BACKWARD
 
 
+def _is_accumulate_grad(node):
+    return type(node).__name__ == _ACCUMULATE_GRAD
+
+
 class _MainNode(Function):
     @staticmethod
     def forward(ctx, cls, meta, main_saved, *inps):
@@ -179,6 +210,7 @@ class _MainNode(Function):
         ctx.in_metas = tuple((t.shape, t.dtype, t.device) for t in inps)
         ctx.save_for_backward(*main_saved)
         ctx.defer_input_idx = None  # set by the plan; None means do not defer
+        ctx.defer_accumulate_input_idxs = ()
         shape, dtype, device = meta
         return torch.empty(shape, dtype=dtype, device=device)
 
@@ -188,14 +220,22 @@ class _MainNode(Function):
         saved = ctx.saved_tensors
         needs_input_grad = list(ctx.needs_input_grad[3:])
         k = ctx.defer_input_idx
+        deferred_input_idxs = set(ctx.defer_accumulate_input_idxs)
         if k is not None:
-            needs_input_grad[k] = False
+            deferred_input_idxs.add(k)
+        for input_idx in deferred_input_idxs:
+            needs_input_grad[input_idx] = False
         bw_ctx = _MainBackwardCtx(ctx, tuple(needs_input_grad), saved)
-        LOG.hit("main_params_only" if k is not None else "main_full")
+        if ctx.defer_accumulate_input_idxs:
+            LOG.hit("main_partial" if any(needs_input_grad) else "main_fully_deferred")
+        else:
+            LOG.hit("main_params_only" if k is not None else "main_full")
         grads = list(cls.main_backward(bw_ctx, grad_main_out))
-        if k is not None:
-            shape, dtype, device = ctx.in_metas[k]
-            grads[k] = DeferredGradTensor(shape, dtype, device, grad_main_out, saved)
+        for input_idx in deferred_input_idxs:
+            shape, dtype, device = ctx.in_metas[input_idx]
+            grads[input_idx] = DeferredGradTensor(
+                shape, dtype, device, grad_main_out, saved
+            )
         return (None, None, None) + tuple(grads)
 
 
@@ -222,6 +262,26 @@ class _EpilogueNode(Function):
         return (None, None, None, grad_main_out)
 
 
+def _make_fused_accumulate_grad_prehook(impl, variable):
+    def prehook(grads):
+        (grad,) = grads
+        if not isinstance(grad, DeferredGradTensor):
+            raise RuntimeError(
+                "A fused AccumulateGrad expected a DeferredGradTensor from its "
+                f"producer, but got {type(grad).__name__}"
+            )
+        LOG.hit("accumulate_fused")
+        result = impl(grad._main_grad_out, grad._main_saved_tensors, variable)
+        if result is not None:
+            raise RuntimeError(
+                "An AccumulateGrad fused implementation must update variable.grad "
+                "and return None"
+            )
+        return (None,)
+
+    return prehook
+
+
 class FusibleFunction:
     r"""A fusible op: one forward that decomposes into two autograd nodes -- a "main"
     node (the matmul) and an "epilogue" node (the pointwise tail) -- so the epilogue's
@@ -243,11 +303,11 @@ class FusibleFunction:
     ``main_backward(main_ctx, grad_main_out) -> grads``
         The matmul backward; reads ``main_ctx.saved_tensors`` and returns one grad per
         forward input, honoring ``main_ctx.needs_input_grad``. Compute the weight grad
-        (dW) unconditionally first and guard the activation grad (dx) with
-        ``needs_input_grad``. When this op's activation grad is deferred into a fused
-        kernel, the framework sets ``needs_input_grad`` to ``False`` at the activation
-        slot, so ``main_backward`` returns ``None`` there and the fused kernel produces
-        it instead.
+        (dW) and activation grad (dx) only when their corresponding
+        ``needs_input_grad`` entries are true. The framework sets an entry to ``False``
+        when that output is deferred into either an epilogue or AccumulateGrad fused
+        kernel, so ``main_backward`` returns ``None`` there and the fused kernel
+        produces it instead.
 
     ``epilogue_backward(epilogue_ctx, grad_out) -> grad_main_out``
         The pointwise backward; reads ``epilogue_ctx.saved_tensors``.
@@ -266,8 +326,7 @@ class FusibleFunction:
         ...     @staticmethod
         ...     def main_backward(main_ctx, grad_a):   # the matmul backward
         ...         x, w = main_ctx.saved_tensors
-        ...         # dW first (always local); dx (input 0) is guarded by needs_input_grad
-        ...         # and skipped when deferred into the fused kernel.
+        ...         # Both outputs honor needs_input_grad and may be deferred.
         ...         gw = x.T @ grad_a if main_ctx.needs_input_grad[1] else None
         ...         gx = grad_a @ w.T if main_ctx.needs_input_grad[0] else None
         ...         return gx, gw
@@ -348,10 +407,24 @@ class _PlannedPair:
         )
 
 
+@dataclass
+class _PlannedAccumulateGrad:
+    producer: object
+    input_idx: int
+    accumulator: object
+
+    def _label(self):
+        return (
+            f"{self.producer.cls.__name__}.main_backward input {self.input_idx} -> "
+            "AccumulateGrad"
+        )
+
+
 class _InternalDebugFusionPlan:
-    def __init__(self, fused, missing_rules):
+    def __init__(self, fused, missing_rules, accumulate_grad_fused):
         self._pairs_fused = fused
         self._pairs_missing_rules = missing_rules
+        self._accumulate_grad_fused = accumulate_grad_fused
 
     def assert_num_fusions(self, expected):
         got = len(self._pairs_fused)
@@ -370,25 +443,37 @@ class _InternalDebugFusionPlan:
             raise AssertionError("\n".join(lines))
         return self
 
+    def assert_num_accumulate_grad_fusions(self, expected):
+        got = len(self._accumulate_grad_fused)
+        if got != expected:
+            raise AssertionError(
+                f"expected {expected} AccumulateGrad fusions, planned {got}"
+            )
+        return self
+
     def __repr__(self):
         all_pairs = self._pairs_fused + self._pairs_missing_rules
         name = type(self).__name__
-        if not all_pairs:
+        if not all_pairs and not self._accumulate_grad_fused:
             return f"{name}(no candidates)"
-        return (
-            f"{name}(\n  "
-            + "\n  ".join(
-                f"{p.producer.cls.__name__}.main -> "
-                f"{p.consumer.cls.__name__}.epilogue: "
-                f"{'FUSE' if p.fused else 'bail:' + p.unfused_reason}"
-                for p in all_pairs
-            )
-            + "\n)"
-        )
+        lines = [
+            f"{p.producer.cls.__name__}.main -> "
+            f"{p.consumer.cls.__name__}.epilogue: "
+            f"{'FUSE' if p.fused else 'bail:' + p.unfused_reason}"
+            for p in all_pairs
+        ]
+        lines += [f"{p._label()}: FUSE" for p in self._accumulate_grad_fused]
+        return f"{name}(\n  " + "\n  ".join(lines) + "\n)"
 
 
 def apply_epilogue_fusion(
-    root, rules, *, expect_num_fusions=None, _internal_debug=False
+    root,
+    rules,
+    *,
+    accumulate_grad_rules=(),
+    expect_num_fusions=None,
+    expect_num_accumulate_grad_fusions=None,
+    _internal_debug=False,
 ):
     r"""Applies epilogue fusion rules to :class:`FusibleFunction` nodes in the autograd graph.
 
@@ -400,6 +485,12 @@ def apply_epilogue_fusion(
 
     This function should be called after the forward pass and before :meth:`backward`,
     on every iteration.
+
+    AccumulateGrad fusion requires the matched leaf to have exactly one incoming edge
+    in the traversed graph. It is intended for ``backward()`` calls that execute leaf
+    accumulators, not ``autograd.grad()`` calls that return gradients directly. Leaf
+    Tensor backward hooks are rejected because they run before the accumulator's
+    prehooks and would observe the placeholder; post-accumulate hooks remain supported.
 
     It only operates on :class:`FusibleFunction` subclasses; see that class for more
     details.
@@ -413,9 +504,18 @@ def apply_epilogue_fusion(
             the grad of the consumer's main output, computing the producer's deferred
             ``grad_input`` GEMM with the consumer's epilogue fused on. Only registered
             pairs fuse.
+        accumulate_grad_rules (list): fusion rules, each a tuple
+            ``(producer_cls.main_backward, input_idx, fused_impl)``. When that main
+            backward input feeds a unique leaf ``AccumulateGrad``, the normal gradient
+            is deferred and ``fused_impl(grad_producer_out, main_saved_tensors,
+            variable)`` must accumulate directly into ``variable.grad`` and return
+            ``None``. Default: ``()``.
         expect_num_fusions (int, optional): if given, assert exactly this many
             fusions were planned, raising a diagnostic that names any fusible
             adjacency lacking a rule. This is the supported way to check coverage.
+            Default: ``None``.
+        expect_num_accumulate_grad_fusions (int, optional): if given, assert exactly
+            this many main-backward to ``AccumulateGrad`` fusions were planned.
             Default: ``None``.
 
     Returns:
@@ -463,6 +563,10 @@ def apply_epilogue_fusion(
         root = root.grad_fn
 
     rule_map = {(p, c): impl for p, c, impl in rules}
+    accumulate_grad_rule_map = {
+        (producer, input_idx): impl
+        for producer, input_idx, impl in accumulate_grad_rules
+    }
 
     nodes, in_degree, seen = [], {}, set()
     q = deque()
@@ -480,10 +584,42 @@ def apply_epilogue_fusion(
                 seen.add(fn)
                 q.append(fn)
 
-    fused, missing_rules = [], []
+    fused, missing_rules, accumulate_grad_fused = [], [], []
     for n in nodes:
         if not _is_main(n):
             continue
+        for input_idx, (accumulator, _) in enumerate(n.next_functions):
+            impl = accumulate_grad_rule_map.get((n.cls.main_backward, input_idx))
+            if (
+                impl is None
+                or accumulator is None
+                or not _is_accumulate_grad(accumulator)
+            ):
+                continue
+            num_producers = in_degree.get(accumulator, 0)
+            if num_producers > 1:
+                raise RuntimeError(
+                    f"Cannot fuse {n.cls.__name__}.main_backward input {input_idx} "
+                    f"into AccumulateGrad: the leaf receives gradients from "
+                    f"{num_producers} backward edges. Deferred accumulation requires "
+                    f"exactly one producer."
+                )
+            if accumulator.variable._backward_hooks:
+                raise RuntimeError(
+                    f"Cannot fuse {n.cls.__name__}.main_backward input {input_idx} "
+                    "into AccumulateGrad: leaf Tensor backward hooks would observe "
+                    "the deferred gradient placeholder"
+                )
+            n.defer_accumulate_input_idxs = (
+                *n.defer_accumulate_input_idxs,
+                input_idx,
+            )
+            accumulator.register_prehook(
+                _make_fused_accumulate_grad_prehook(impl, accumulator.variable)
+            )
+            accumulate_grad_fused.append(
+                _PlannedAccumulateGrad(n, input_idx, accumulator)
+            )
         candidates = [
             (i, c)
             for i, (c, _) in enumerate(n.next_functions)
@@ -516,9 +652,11 @@ def apply_epilogue_fusion(
         consumer.fused_impl = impl
         fused.append(_PlannedPair(n, consumer, None))  # None == fusion armed
 
-    plan = _InternalDebugFusionPlan(fused, missing_rules)
+    plan = _InternalDebugFusionPlan(fused, missing_rules, accumulate_grad_fused)
     if expect_num_fusions is not None:
         plan.assert_num_fusions(expect_num_fusions)
+    if expect_num_accumulate_grad_fusions is not None:
+        plan.assert_num_accumulate_grad_fusions(expect_num_accumulate_grad_fusions)
     if _internal_debug:
         return plan
     return None
@@ -539,7 +677,7 @@ class MMRelu(FusibleFunction):
     @staticmethod
     def main_backward(main_ctx, grad_main_out):
         x, w = main_ctx.saved_tensors
-        # dW first (always local); dx (input 0) is guarded and skipped when deferred.
+        # Both outputs honor needs_input_grad and may be deferred.
         grad_w = (
             x.transpose(-1, -2) @ grad_main_out
             if main_ctx.needs_input_grad[1]
@@ -570,7 +708,7 @@ class MMTanh(FusibleFunction):
     @staticmethod
     def main_backward(main_ctx, grad_main_out):
         x, w = main_ctx.saved_tensors
-        # dW first (always local); dx is guarded and skipped when deferred.
+        # Both outputs honor needs_input_grad and may be deferred.
         grad_w = (
             x.transpose(-1, -2) @ grad_main_out
             if main_ctx.needs_input_grad[1]
@@ -603,6 +741,25 @@ def mm_tanh_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
     return grad_main_input * (1 - torch.tanh(a_c) ** 2)
 
 
+def _mm_accumulate_grad(variable, mat1, mat2):
+    if variable.grad is None:
+        variable.grad = mat1 @ mat2
+    else:
+        torch.addmm(variable.grad, mat1, mat2, out=variable.grad)
+
+
+def mm_input_accumulate_fused_backward(grad_producer_out, main_saved_tensors, variable):
+    _x, w = main_saved_tensors
+    _mm_accumulate_grad(variable, grad_producer_out, w.transpose(-1, -2))
+
+
+def mm_weight_accumulate_fused_backward(
+    grad_producer_out, main_saved_tensors, variable
+):
+    x, _w = main_saved_tensors
+    _mm_accumulate_grad(variable, x.transpose(-1, -2), grad_producer_out)
+
+
 # One rule per (producer.main_backward, consumer.epilogue_backward) pair, passed
 # explicitly to apply_epilogue_fusion. The fused impl depends only on the
 # consumer's epilogue, so both producers reuse the same impl.
@@ -611,6 +768,15 @@ RULES = [
     (MMTanh.main_backward, MMRelu.epilogue_backward, mm_relu_fused_backward),
     (MMRelu.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
     (MMTanh.main_backward, MMTanh.epilogue_backward, mm_tanh_fused_backward),
+]
+
+# These rules identify a main-backward output by its forward input index. They
+# apply only when that edge leads directly to a unique leaf AccumulateGrad.
+ACCUMULATE_GRAD_RULES = [
+    (MMRelu.main_backward, 0, mm_input_accumulate_fused_backward),
+    (MMRelu.main_backward, 1, mm_weight_accumulate_fused_backward),
+    (MMTanh.main_backward, 0, mm_input_accumulate_fused_backward),
+    (MMTanh.main_backward, 1, mm_weight_accumulate_fused_backward),
 ]
 
 
@@ -626,7 +792,7 @@ def _check(name, ins, refs, atol=1e-9):
         good = torch.allclose(t.grad, r, atol=atol)
         ok &= good
         print(f"  grad_{nm}: max_abs_err={err:.2e} ok={good}")
-    assert ok, f"{name}: gradients do not match reference"
+    assert ok, f"{name}: gradients do not match reference"  # noqa: S101
 
 
 def scenario_mixed_chain():
@@ -635,6 +801,7 @@ def scenario_mixed_chain():
     Fusions:
       ep1 (MMTanh) <- main2 (MMRelu): key (MMRelu.main, MMTanh.epilogue) -> tanh rule
       ep2 (MMRelu) <- main3 (MMTanh): key (MMTanh.main, MMRelu.epilogue) -> relu rule
+      each leaf edge (x, w1, w2, w3) fuses its GEMM with AccumulateGrad
     """
     print("\n########## scenario: mixed chain ##########")
     torch.manual_seed(0)
@@ -659,18 +826,23 @@ def scenario_mixed_chain():
     LOG.reset()
     loss = MMTanh.apply(MMRelu.apply(MMTanh.apply(x, w1), w2), w3).sum()
     plan = apply_epilogue_fusion(
-        loss.grad_fn, RULES, expect_num_fusions=2, _internal_debug=True
+        loss.grad_fn,
+        RULES,
+        accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+        expect_num_fusions=2,
+        expect_num_accumulate_grad_fusions=4,
+        _internal_debug=True,
     )
     print(plan)
     loss.backward()
 
     _check("mixed", ins, refs)
     print("kernel paths:", LOG)
-    assert LOG.c["fused_impl"] == 2
-    assert LOG.c["epilogue_unfused"] == 1
-    assert LOG.c["main_params_only"] == 2
-    assert LOG.c["main_full"] == 1
-    print("PASS: both epilogues fused across the mixed chain.")
+    assert LOG.c["fused_impl"] == 2  # noqa: S101
+    assert LOG.c["accumulate_fused"] == 4  # noqa: S101
+    assert LOG.c["epilogue_unfused"] == 1  # noqa: S101
+    assert LOG.c["main_fully_deferred"] == 3  # noqa: S101
+    print("PASS: epilogues and leaf gradient accumulation fused across the chain.")
 
 
 if __name__ == "__main__":

--- a/coda_backward_epilogue_fusion_lowlevel_demo.py
+++ b/coda_backward_epilogue_fusion_lowlevel_demo.py
@@ -1,0 +1,236 @@
+"""
+[not for land] Low-level demo: drive the CODA backward epilogue-fusion machinery
+by hand, using the private plumbing directly instead of the front door
+(FusibleFunction.apply / apply_epilogue_fusion).
+
+This is exactly the mechanism the public API wraps, unrolled step by step so the
+moving parts are visible:
+
+  _StagingCtx        collects each node's saved tensors (and the main node's
+                     intermediate metadata) during a single no_grad forward
+  _MainNode          the "matmul" autograd node; its forward returns a PHANTOM
+                     output shaped like the intermediate (GEMM output), carrying
+                     the graph edge to the inputs and the saved set
+  _EpilogueNode      the "pointwise" autograd node; attaches the real output to
+                     the graph and, in backward, either runs the epilogue or the
+                     fused kernel
+  DeferredGradTensor a metadata-only placeholder grad that rides the existing
+                     backward edge from the deferring main node to the epilogue,
+                     carrying the producer's grad and main saved set (a plain tuple,
+                     captured in the producer's backward) to the fused kernel
+
+Run:
+    python coda_backward_epilogue_fusion_lowlevel_demo.py
+"""
+
+import os
+import sys
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import coda_backward_epilogue_fusion as coda  # noqa: F401
+from coda_backward_epilogue_fusion import (  # noqa: F401
+    _EpilogueNode,
+    _is_epilogue,
+    _is_main,
+    _MainNode,
+    _StagingCtx,
+    DeferredGradTensor,  # imported for narration/reference
+    FusibleFunction,
+    LOG,
+)
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# User code: the op (a self-contained forward + its main/epilogue backwards) and
+# the fused backward kernel. This is everything the user writes; everything
+# imported above is framework plumbing. The framework only needs cls.forward /
+# cls.main_backward / cls.epilogue_backward to exist.
+# ---------------------------------------------------------------------------
+class MMRelu(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)  # REQUIRED: declares the intermediate metadata
+        epilogue_ctx.save_for_backward(a)
+        return torch.relu(a)
+
+    @staticmethod
+    def main_backward(main_ctx, grad_main_out):
+        x, w = main_ctx.saved_tensors
+        need_x, need_w = main_ctx.needs_input_grad[0], main_ctx.needs_input_grad[1]
+        # dW is always local; dx (input 0) is guarded by needs_input_grad and
+        # skipped when this op's activation grad is deferred into the fused kernel.
+        grad_w = x.transpose(-1, -2) @ grad_main_out if need_w else None
+        grad_x = grad_main_out @ w.transpose(-1, -2) if need_x else None
+        return grad_x, grad_w
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, grad_out):
+        (a,) = epilogue_ctx.saved_tensors
+        return grad_out * (a > 0).to(a.dtype)
+
+
+def mm_relu_fused_backward(grad_producer_out, main_saved_tensors, consumer_ctx):
+    # The producer main node's deferred grad_input GEMM with the consumer relu
+    # epilogue fused on: dL/dh = (dL/da @ w^T) then * relu'(a).
+    _x_p, w_p = main_saved_tensors
+    (a_c,) = consumer_ctx.saved_tensors
+    grad_main_input = grad_producer_out @ w_p.transpose(-1, -2)
+    return grad_main_input * (a_c > 0).to(a_c.dtype)
+
+
+def _edge_names(node):
+    return [("None" if f is None else type(f).__name__) for f, _ in node.next_functions]
+
+
+def _eager_relu_chain_grads(values):
+    # Reference: grads of relu(...relu(x @ w1)... @ wn).sum() over fresh leaves.
+    leaves = [v.detach().clone().requires_grad_(True) for v in values]
+    acc = leaves[0]
+    for w in leaves[1:]:
+        acc = torch.relu(acc @ w)
+    acc.sum().backward()
+    return [leaf.grad for leaf in leaves]
+
+
+def section_1_build_one_op_by_hand():
+    print("=" * 72)
+    print("SECTION 1: build one op (y = relu(x @ w)) by hand -- no fusion")
+    print("=" * 72)
+    torch.manual_seed(0)
+    x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+    w = torch.randn(6, 5, dtype=torch.double, requires_grad=True)
+
+    # STEP 1 -- run the op's forward ONCE under no_grad against two staging ctxs.
+    # The forward saves into each (main_ctx gets x, w + the intermediate meta;
+    # epilogue_ctx gets the preactivation a). Nothing is on the autograd graph yet.
+    main_staging = _StagingCtx()
+    epilogue_staging = _StagingCtx()
+    with torch.no_grad():
+        out = MMRelu.forward(main_staging, epilogue_staging, x, w)
+    msaved = tuple(t.shape for t in main_staging.saved)
+    esaved = tuple(t.shape for t in epilogue_staging.saved)
+    meta_shape = tuple(main_staging.output_meta[0])
+    print("\n[step 1] no_grad forward populated the staging ctxs:")
+    print("  main_staging.saved    :", msaved, "(x, w)")
+    print("  main_staging.meta     :", meta_shape, "(a = x @ w)")
+    print("  epilogue_staging.saved:", esaved, "(a)")
+
+    # STEP 2 -- the MAIN node. Pass cls, the declared intermediate meta, and the
+    # main saved set explicitly (these are non-tensors / a nested tuple, so they
+    # add no graph edges). Its forward returns a PHANTOM tensor shaped like the
+    # intermediate: its value is unused, it exists only to own the grad_fn whose
+    # next edges are (x, w).
+    main_out = _MainNode.apply(
+        MMRelu, main_staging.output_meta, main_staging.saved, x, w
+    )
+    edges = _edge_names(main_out.grad_fn)
+    print("\n[step 2] _MainNode.apply -> phantom intermediate carrier:")
+    print("  grad_fn   :", type(main_out.grad_fn).__name__)
+    print("  next edges:", edges, "(only the tensor inputs x, w)")
+
+    # STEP 3 -- the EPILOGUE node. main_out (phantom) requires grad, so a fresh
+    # view of the no_grad `out` picks up THIS node's grad_fn and becomes the real
+    # output. `out` rides inside a 1-tuple so it is not an autograd input.
+    y = _EpilogueNode.apply(MMRelu, epilogue_staging.saved, (out,), main_out)
+    print("\n[step 3] _EpilogueNode.apply -> real output attached to graph:")
+    print("  grad_fn      :", type(y.grad_fn).__name__)
+    print("  value matches:", torch.allclose(y, torch.relu(x @ w)))
+
+    # BACKWARD with nothing armed: the epilogue node sees a REAL grad (not a
+    # placeholder) and runs MMRelu.epilogue_backward; the main node runs the full
+    # MMRelu.main_backward (both dx and dw).
+    LOG.reset()
+    y.sum().backward()
+    ref_x, ref_w = _eager_relu_chain_grads([x, w])
+    matches = torch.allclose(x.grad, ref_x) and torch.allclose(w.grad, ref_w)
+    print("\n[backward] unfused path; grads match eager autograd:", matches)
+    print("  kernel paths:", LOG, "(main_full + epilogue_unfused, no fusion)")
+
+
+def section_2_two_op_chain_fused_by_hand():
+    print("\n" + "=" * 72)
+    print("SECTION 2: chain y = relu(relu(x @ w1) @ w2), arm ONE fusion by hand")
+    print("=" * 72)
+    torch.manual_seed(0)
+    x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+    w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+    w2 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+
+    def build(cls, *inputs):
+        # The three private steps of FusibleFunction.apply, inlined. Returns the
+        # real output and the phantom main output (so we can reach the main node).
+        ms, es = _StagingCtx(), _StagingCtx()
+        with torch.no_grad():
+            out = cls.forward(ms, es, *inputs)
+        main_out = _MainNode.apply(cls, ms.output_meta, ms.saved, *inputs)
+        final = _EpilogueNode.apply(cls, es.saved, (out,), main_out)
+        return final, main_out
+
+    h, main1_out = build(MMRelu, x, w1)  # h = relu(x @ w1)
+    y, main2_out = build(MMRelu, h, w2)  # y = relu(h @ w2)
+    print("\n[built] two ops on one graph:")
+    print("  y.grad_fn:", type(y.grad_fn).__name__, "(epilogue of op2)")
+    print("  h.grad_fn:", type(h.grad_fn).__name__, "(epilogue of op1)")
+
+    # The pair to fuse. PRODUCER = op2's main node: it will defer the grad of its
+    # activation input. CONSUMER = op1's epilogue node: it produced that
+    # activation (h) and will run the fused kernel. They are adjacent because op2's
+    # main node consumes h, whose grad_fn IS op1's epilogue node.
+    producer_main = main2_out.grad_fn  # _MainNodeBackward (op2)
+    consumer_epi = h.grad_fn  # _EpilogueNodeBackward (op1)
+    assert _is_main(producer_main) and _is_epilogue(consumer_epi)
+    edge0 = producer_main.next_functions[0][0]
+    print(
+        "\n[adjacency] producer_main input 0 ->",
+        type(edge0).__name__,
+        "is consumer_epi:",
+        edge0 is consumer_epi,
+    )
+
+    # ARM the fusion -- exactly what apply_epilogue_fusion does for this one pair:
+    #  (a) defer input 0 (the activation h) on the producer main node: instead of
+    #      computing h's grad GEMM it will emit a DeferredGradTensor on that edge.
+    #  (b) stamp the fused kernel onto the consumer epilogue node.
+    # The producer's saved set is NOT snapshotted here -- the producer's backward
+    # captures it (still alive there) and rides it on the DeferredGradTensor to the
+    # consumer, since by the time the consumer's fused kernel runs the producer's
+    # real saved_tensors are already freed.
+    producer_main.defer_input_idx = 0
+    consumer_epi.fused_impl = mm_relu_fused_backward
+    print("\n[armed] defer_input_idx=0 on producer; fused_impl on consumer")
+
+    # BACKWARD. The narrated flow:
+    #  * op2 epilogue receives a REAL grad (dL/dy) -> epilogue_backward (unfused)
+    #  * op2 main is armed -> returns dW2 locally and a DeferredGradTensor for h
+    #  * op1 epilogue receives that placeholder -> runs the fused kernel:
+    #        dL/dh = (dL/da2 @ w2^T)  then  * relu'(a1)   -- one fused pass
+    #  * op1 main receives the resulting real grad -> full main_backward
+    LOG.reset()
+    y.sum().backward()
+    print("\n[backward] done. kernel paths:", LOG)
+
+    rx, rw1, rw2 = _eager_relu_chain_grads([x, w1, w2])
+    ok = all(
+        [
+            torch.allclose(x.grad, rx),
+            torch.allclose(w1.grad, rw1),
+            torch.allclose(w2.grad, rw2),
+        ]
+    )
+    print("  grads match eager autograd:", ok)
+    assert ok
+    assert LOG.c["fused_impl"] == 1 and LOG.c["epilogue_unfused"] == 1
+    assert LOG.c["main_params_only"] == 1 and LOG.c["main_full"] == 1
+    print("  PASS: one epilogue fused by hand through the private machinery.")
+
+
+if __name__ == "__main__":
+    section_1_build_one_op_by_hand()
+    section_2_two_op_chain_fused_by_hand()
+    print("\nDEMO COMPLETE")

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -1,0 +1,517 @@
+"""Tests for the CODA backward epilogue-fusion prototype.
+
+Run:
+    python coda_backward_epilogue_fusion_test.py
+"""
+
+import os
+import sys
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import coda_backward_epilogue_fusion as coda
+from coda_backward_epilogue_fusion import (
+    apply_epilogue_fusion,
+    DeferredGradTensor,
+    FusibleFunction,
+    LOG,
+    MMRelu,
+    MMTanh,
+    RULES,
+)
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+# An op with no fusion rule registered for any pair, used to exercise the
+# "forgot to register" diagnostics.
+class MMSquare(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)
+        epilogue_ctx.save_for_backward(a)
+        return a * a
+
+    @staticmethod
+    def main_backward(main_ctx, g):
+        x, w = main_ctx.saved_tensors
+        gx = g @ w.transpose(-1, -2) if main_ctx.needs_input_grad[0] else None
+        gw = x.transpose(-1, -2) @ g if main_ctx.needs_input_grad[1] else None
+        return gx, gw
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, g):
+        (a,) = epilogue_ctx.saved_tensors
+        return g * 2 * a
+
+
+# A two-activation-input op, used to exercise the "more than one fusible input"
+# guard. Both inputs can be epilogue outputs.
+class Add2(FusibleFunction):
+    # Only forward is needed: its test raises at planning time (two fusible inputs),
+    # before any backward runs.
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, a, b):
+        main_ctx.set_output_meta(a)
+        return a + b
+
+
+# Same matmul+relu, but the activation is the SECOND input (input 0 is the
+# weight). Used to check the fusible edge is found at a non-zero position.
+class MMReluRHS(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, w, x):
+        a = x @ w
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)
+        epilogue_ctx.save_for_backward(a)
+        return torch.relu(a)
+
+    @staticmethod
+    def main_backward(main_ctx, g):  # inputs are (w, x): weight 0, activation 1
+        x, w = main_ctx.saved_tensors
+        grad_w = x.transpose(-1, -2) @ g if main_ctx.needs_input_grad[0] else None
+        grad_x = g @ w.transpose(-1, -2) if main_ctx.needs_input_grad[1] else None
+        return grad_w, grad_x
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, g):
+        (a,) = epilogue_ctx.saved_tensors
+        return g * (a > 0).to(a.dtype)
+
+
+# A shape-CHANGING epilogue (GLU): a = x @ w is [.., 2K]; the epilogue gates the
+# two halves into [.., K]. The intermediate (a) is wider than the output, so this
+# only works because the user declares the intermediate metadata.
+class MMGlu(FusibleFunction):
+    @staticmethod
+    def forward(main_ctx, epilogue_ctx, x, w):
+        a = x @ w  # [.., 2K]
+        main_ctx.save_for_backward(x, w)
+        main_ctx.set_output_meta(a)  # intermediate is [.., 2K], wider than the output
+        epilogue_ctx.save_for_backward(a)
+        d = a.shape[-1] // 2
+        return a[..., :d] * torch.sigmoid(a[..., d:])  # [.., K]
+
+    @staticmethod
+    def main_backward(main_ctx, grad_a):
+        x, w = main_ctx.saved_tensors
+        grad_x = grad_a @ w.transpose(-1, -2) if main_ctx.needs_input_grad[0] else None
+        grad_w = x.transpose(-1, -2) @ grad_a if main_ctx.needs_input_grad[1] else None
+        return grad_x, grad_w
+
+    @staticmethod
+    def epilogue_backward(epilogue_ctx, grad_out):
+        (a,) = epilogue_ctx.saved_tensors
+        d = a.shape[-1] // 2
+        u, g = a[..., :d], a[..., d:]
+        sig = torch.sigmoid(g)
+        grad_u = grad_out * sig
+        grad_g = grad_out * u * sig * (1 - sig)
+        return torch.cat([grad_u, grad_g], dim=-1)  # [.., 2K] = grad_a (dim-expanding)
+
+
+# Eager reference activation for each op type.
+ACT = {MMRelu: torch.relu, MMTanh: torch.tanh, MMSquare: lambda t: t * t}
+
+CHAINS = {
+    "single_relu": [MMRelu],
+    "relu3": [MMRelu, MMRelu, MMRelu],
+    "tanh3": [MMTanh, MMTanh, MMTanh],
+    "mixed": [MMTanh, MMRelu, MMTanh],
+}
+
+
+def _rule_keys(rules):
+    return {(producer, consumer) for producer, consumer, _ in rules}
+
+
+def _grads(tensors):
+    return [t.grad for t in tensors]
+
+
+def _run_coda(ops, x, ws, do_fuse=True):
+    LOG.reset()
+    out = x
+    for op, w in zip(ops, ws):
+        out = op.apply(out, w)
+    loss = out.sum()
+    plan = (
+        apply_epilogue_fusion(loss.grad_fn, RULES, _internal_debug=True)
+        if do_fuse
+        else None
+    )
+    loss.backward()
+    return plan
+
+
+def _run_eager(ops, x, ws):
+    out = x
+    for op, w in zip(ops, ws):
+        out = ACT[op](out @ w)
+    out.sum().backward()
+
+
+def _fresh_inputs(ops, device, dtype=torch.double, seed=0):
+    torch.manual_seed(seed)
+    base_x = torch.randn(4, 6, dtype=dtype, device=device)
+    base_ws = [torch.randn(6, 6, dtype=dtype, device=device) for _ in ops]
+    return base_x, base_ws
+
+
+class TestCodaBwdFusionNumerics(TestCase):
+    """Fused backward must match plain eager autograd, on any device."""
+
+    @parametrize("chain", list(CHAINS))
+    def test_matches_eager(self, device, chain):
+        ops = CHAINS[chain]
+        base_x, base_ws = _fresh_inputs(ops, device)
+
+        x = base_x.clone().requires_grad_()
+        ws = [w.clone().requires_grad_() for w in base_ws]
+        _run_coda(ops, x, ws, do_fuse=True)
+
+        ex = base_x.clone().requires_grad_()
+        ews = [w.clone().requires_grad_() for w in base_ws]
+        _run_eager(ops, ex, ews)
+
+        self.assertEqual(x.grad, ex.grad)
+        for w, ew in zip(ws, ews):
+            self.assertEqual(w.grad, ew.grad)
+
+    @parametrize("chain", list(CHAINS))
+    def test_fusion_changes_no_numerics(self, device, chain):
+        """Same op chain, with and without applying the fusion plan, agrees."""
+        ops = CHAINS[chain]
+        base_x, base_ws = _fresh_inputs(ops, device)
+
+        x = base_x.clone().requires_grad_()
+        ws = [w.clone().requires_grad_() for w in base_ws]
+        _run_coda(ops, x, ws, do_fuse=True)
+
+        nx = base_x.clone().requires_grad_()
+        nws = [w.clone().requires_grad_() for w in base_ws]
+        _run_coda(ops, nx, nws, do_fuse=False)
+
+        self.assertEqual(x.grad, nx.grad)
+        for w, nw in zip(ws, nws):
+            self.assertEqual(w.grad, nw.grad)
+
+
+class TestCodaBwdFusionPlanning(TestCase):
+    """Structural behavior of the fusion planner and kernel-path accounting."""
+
+    def _inputs(self, n):
+        torch.manual_seed(0)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        ws = [
+            torch.randn(6, 6, dtype=torch.double, requires_grad=True) for _ in range(n)
+        ]
+        return x, ws
+
+    def test_chain_fuses_all_but_tail(self):
+        ops = [MMRelu, MMRelu, MMRelu]
+        x, ws = self._inputs(len(ops))
+        plan = _run_coda(ops, x, ws)
+        # ep1<-main2, ep2<-main3 fuse; the tail epilogue (ep3) has no producer main.
+        self.assertEqual(len(plan._pairs_fused), 2)
+        self.assertEqual(LOG.c["fused_impl"], 2)
+        self.assertEqual(LOG.c["epilogue_unfused"], 1)
+        self.assertEqual(LOG.c["main_params_only"], 2)
+        self.assertEqual(LOG.c["main_full"], 1)  # main1's input is a leaf
+
+    def test_no_duplicate_grad_input_matmul(self):
+        """A deferred producer must not also compute grad_input (no wasted matmul)."""
+        ops = [MMRelu, MMRelu, MMRelu]
+        x, ws = self._inputs(len(ops))
+        _run_coda(ops, x, ws)
+        # Each deferred producer runs params-only; the grad_input matmul happens
+        # exactly once, inside the fused kernel.
+        self.assertEqual(LOG.c["main_params_only"], 2)
+        self.assertEqual(LOG.c["fused_impl"], 2)
+
+    def test_saved_tensors_partitioned_per_node(self):
+        x, ws = self._inputs(1)
+        out = MMRelu.apply(x, ws[0])
+        epi_node = out.grad_fn  # _EpilogueNode
+        main_node = epi_node.next_functions[0][0]  # _MainNode
+        self.assertEqual(len(main_node.saved_tensors), 2)  # x, w
+        self.assertEqual(len(epi_node.saved_tensors), 1)  # preactivation a
+
+    def test_no_reference_cycle_leak(self):
+        import gc
+        import weakref
+
+        refs = []
+
+        def run():
+            x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+            ws = [
+                torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+                for _ in range(3)
+            ]
+            refs.append(weakref.ref(x))
+            refs.extend(weakref.ref(w) for w in ws)
+            out = MMRelu.apply(MMRelu.apply(MMRelu.apply(x, ws[0]), ws[1]), ws[2])
+            loss = out.sum()
+            apply_epilogue_fusion(loss, RULES, expect_num_fusions=2)
+            loss.backward()
+
+        # With gc off, surviving tensors mean a reference cycle is pinning them
+        # (not refcount-freed), which would accumulate activations across a loop.
+        gc.disable()
+        try:
+            run()
+            alive = sum(r() is not None for r in refs)
+        finally:
+            gc.collect()
+            gc.enable()
+        self.assertEqual(
+            alive,
+            0,
+            f"{alive} input/weight tensors still alive after backward "
+            f"(held by a reference cycle, not freed by refcount)",
+        )
+
+    def test_branching_consumer_raises(self):
+        # An epilogue output consumed by more than one main node cannot be fused:
+        # its backward grad accumulates across the branches, which a single deferral
+        # placeholder cannot represent. The planner must reject it loudly.
+        torch.manual_seed(1)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        wa = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        wb = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+
+        b = MMRelu.apply(x, w1)
+        loss = MMRelu.apply(b, wa).sum() + MMRelu.apply(b, wb).sum()
+        with self.assertRaisesRegex(RuntimeError, "exactly one consumer"):
+            apply_epilogue_fusion(loss, RULES)
+
+    def test_unregistered_pair_not_fused(self):
+        self.assertNotIn(
+            (MMSquare.main_backward, MMSquare.epilogue_backward), _rule_keys(RULES)
+        )
+
+        x, ws = self._inputs(2)
+        LOG.reset()
+        out = MMSquare.apply(MMSquare.apply(x, ws[0]), ws[1])
+        loss = out.sum()
+        plan = apply_epilogue_fusion(loss, RULES, _internal_debug=True)
+        self.assertEqual(len(plan._pairs_fused), 0)
+        # The one main->epilogue adjacency is recorded as a missing-rule candidate.
+        self.assertEqual(len(plan._pairs_missing_rules), 1)
+        loss.backward()
+        self.assertEqual(LOG.c["fused_impl"], 0)
+
+        ex = x.detach().clone().requires_grad_()
+        ew0 = ws[0].detach().clone().requires_grad_()
+        ew1 = ws[1].detach().clone().requires_grad_()
+        a1 = ex @ ew0
+        a2 = (a1 * a1) @ ew1
+        (a2 * a2).sum().backward()
+        self.assertEqual(x.grad, ex.grad)
+        self.assertEqual(ws[0].grad, ew0.grad)
+        self.assertEqual(ws[1].grad, ew1.grad)
+
+    def test_missing_rule_reported_in_assert(self):
+        """A fusible adjacency with no rule is surfaced when the count falls short."""
+        x, ws = self._inputs(2)
+        # The MMRelu main feeds MMSquare's epilogue, and the pair
+        # (MMRelu.main_backward, MMSquare.epilogue_backward) is not in RULES.
+        loss = MMRelu.apply(MMSquare.apply(x, ws[0]), ws[1]).sum()
+        plan = apply_epilogue_fusion(loss, RULES, _internal_debug=True)
+        self.assertEqual(len(plan._pairs_fused), 0)
+        self.assertEqual(len(plan._pairs_missing_rules), 1)
+        self.assertEqual(
+            plan._pairs_missing_rules[0]._label(),
+            "MMRelu.main_backward -> MMSquare.epilogue_backward",
+        )
+        with self.assertRaisesRegex(AssertionError, "forget to pass a rule"):
+            plan.assert_num_fusions(1)
+        # The pair label appears in the message too.
+        with self.assertRaisesRegex(
+            AssertionError, r"MMRelu\.main_backward -> MMSquare\.epilogue_backward"
+        ):
+            plan.assert_num_fusions(1)
+
+    def test_mixed_chain_fuses_both(self):
+        """Self-contained ops; the mixed chain fuses both epilogues across types."""
+        self.assertIn(
+            (MMTanh.main_backward, MMRelu.epilogue_backward), _rule_keys(RULES)
+        )
+        self.assertIn(
+            (MMRelu.main_backward, MMTanh.epilogue_backward), _rule_keys(RULES)
+        )
+
+        ops = [MMTanh, MMRelu, MMTanh]
+        x, ws = self._inputs(len(ops))
+        plan = _run_coda(ops, x, ws)
+        self.assertEqual(len(plan._pairs_fused), 2)
+        producers = {p.producer.cls for p in plan._pairs_fused}
+        self.assertEqual(producers, {MMRelu, MMTanh})  # both op types fuse as producers
+        self.assertEqual(LOG.c["fused_impl"], 2)
+
+    def test_assert_num_fusions_contract(self):
+        ops = [MMRelu, MMRelu, MMRelu]
+        x, ws = self._inputs(len(ops))
+        out = x
+        for op, w in zip(ops, ws):
+            out = op.apply(out, w)
+        plan = apply_epilogue_fusion(out.sum(), RULES, _internal_debug=True)
+        self.assertIs(plan.assert_num_fusions(2), plan)  # returns self on success
+        with self.assertRaises(AssertionError):
+            plan.assert_num_fusions(3)
+
+    def test_placeholder_rejects_real_ops(self):
+        # The placeholder must never be computed on; any dispatched op errors.
+        t = DeferredGradTensor(
+            (4, 6),
+            torch.double,
+            torch.device("cpu"),
+            torch.zeros(4, 6, dtype=torch.double),
+            (),
+        )
+        with self.assertRaisesRegex(RuntimeError, "metadata-only placeholder"):
+            _ = t + 1
+        # The happy-path tests above already assert the engine never dispatches on
+        # it (they'd raise here otherwise), so the placeholder truly just rides the
+        # edge in normal backward.
+
+    def test_shape_changing_epilogue(self):
+        """A dim-changing epilogue (GLU): intermediate [.., 2K] wider than output."""
+        torch.manual_seed(0)
+        K = 6
+        x = torch.randn(4, K, dtype=torch.double, requires_grad=True)
+        w = torch.randn(K, 2 * K, dtype=torch.double, requires_grad=True)
+
+        out = MMGlu.apply(x, w)
+        self.assertEqual(out.shape, (4, K))  # output is narrower than the intermediate
+        out.sum().backward()
+
+        ex = x.detach().clone().requires_grad_()
+        ew = w.detach().clone().requires_grad_()
+        a = ex @ ew
+        d = a.shape[-1] // 2
+        (a[..., :d] * torch.sigmoid(a[..., d:])).sum().backward()
+        self.assertEqual(x.grad, ex.grad)
+        self.assertEqual(w.grad, ew.grad)
+
+    def test_multiple_fusible_inputs_errors(self):
+        torch.manual_seed(0)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        w2 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        # Add2's two inputs are both epilogue outputs (MMRelu): two fusible edges.
+        out = Add2.apply(MMRelu.apply(x, w1), MMRelu.apply(x, w2))
+        with self.assertRaisesRegex(RuntimeError, "deferring more than one grad_input"):
+            apply_epilogue_fusion(out.sum(), RULES)
+
+    def test_epilogue_input_not_first(self):
+        """The fusible activation edge can be at a non-zero input position."""
+        torch.manual_seed(0)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        w2 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        rules = RULES + [
+            (
+                MMReluRHS.main_backward,
+                MMRelu.epilogue_backward,
+                coda.mm_relu_fused_backward,
+            ),
+        ]
+
+        a = MMRelu.apply(x, w1)
+        out = MMReluRHS.apply(w2, a)  # activation `a` is the 2nd input
+        loss = out.sum()
+        plan = apply_epilogue_fusion(loss, rules, _internal_debug=True)
+        self.assertEqual(len(plan._pairs_fused), 1)
+        self.assertEqual(plan._pairs_fused[0].producer.defer_input_idx, 1)
+        loss.backward()
+
+        ex = x.detach().clone().requires_grad_()
+        ew1 = w1.detach().clone().requires_grad_()
+        ew2 = w2.detach().clone().requires_grad_()
+        torch.relu(torch.relu(ex @ ew1) @ ew2).sum().backward()
+        self.assertEqual(x.grad, ex.grad)
+        self.assertEqual(w1.grad, ew1.grad)
+        self.assertEqual(w2.grad, ew2.grad)
+
+    def test_expect_num_fusions_kwarg(self):
+        ops = [MMRelu, MMRelu, MMRelu]
+        x, ws = self._inputs(len(ops))
+
+        out = x
+        for op, w in zip(ops, ws):
+            out = op.apply(out, w)
+        plan = apply_epilogue_fusion(
+            out.sum(), RULES, expect_num_fusions=2, _internal_debug=True
+        )
+        self.assertEqual(len(plan._pairs_fused), 2)
+
+        # A wrong expectation raises during apply, on a fresh graph.
+        out2 = x
+        for op, w in zip(ops, ws):
+            out2 = op.apply(out2, w)
+        with self.assertRaises(AssertionError):
+            apply_epilogue_fusion(out2.sum(), RULES, expect_num_fusions=3)
+
+    def test_works_with_nonreentrant_checkpoint(self):
+        """Fusion composes with torch.utils.checkpoint(use_reentrant=False).
+
+        Two AC regions, (M1 E1) and (M2 E2), one op each. Non-reentrant checkpoint
+        builds the real autograd graph -- our main/epilogue nodes are visible to the
+        planner -- and recomputes saved tensors lazily in each node's backward. The
+        planner is purely structural (it never reads saved_tensors), so arming does
+        not force a premature recompute; the producer (main2, region 2) still defers
+        its activation grad into the consumer (epilogue1, region 1) across the region
+        boundary, and the producer's saved set rides the placeholder to the fused
+        kernel even though region 2's tensors are recomputed independently.
+        """
+        from torch.utils.checkpoint import checkpoint
+
+        torch.manual_seed(0)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        w2 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+
+        LOG.reset()
+        h = checkpoint(MMRelu.apply, x, w1, use_reentrant=False)  # region 1: M1 E1
+        out = checkpoint(MMRelu.apply, h, w2, use_reentrant=False)  # region 2: M2 E2
+        loss = out.sum()
+        plan = apply_epilogue_fusion(loss, RULES, _internal_debug=True)
+        self.assertEqual(
+            len(plan._pairs_fused), 1
+        )  # epilogue1 (region 1) <- main2 (region 2)
+        loss.backward()
+        self.assertEqual(LOG.c["fused_impl"], 1)
+        self.assertEqual(LOG.c["epilogue_unfused"], 1)  # the tail epilogue (region 2)
+        self.assertEqual(
+            LOG.c["main_params_only"], 1
+        )  # main2 deferred its activation grad
+        self.assertEqual(LOG.c["main_full"], 1)  # main1's input is a leaf
+
+        ex = x.detach().clone().requires_grad_()
+        ew1 = w1.detach().clone().requires_grad_()
+        ew2 = w2.detach().clone().requires_grad_()
+        torch.relu(torch.relu(ex @ ew1) @ ew2).sum().backward()
+        self.assertEqual(x.grad, ex.grad)
+        self.assertEqual(w1.grad, ew1.grad)
+        self.assertEqual(w2.grad, ew2.grad)
+
+
+instantiate_parametrized_tests(TestCodaBwdFusionPlanning)
+instantiate_device_type_tests(TestCodaBwdFusionNumerics, globals())
+
+if __name__ == "__main__":
+    run_tests()

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -135,7 +135,7 @@ CHAINS = {
 
 
 def _rule_keys(rules):
-    return {(producer, consumer) for producer, consumer, _ in rules}
+    return {pattern for pattern, _replacement in rules}
 
 
 def _grads(tensors):
@@ -268,16 +268,21 @@ class TestCodaBwdFusionNumerics(TestCase):
         ha, hb = split_multi_use(h, 2)
         loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
 
-        rules = [
-            (
-                (MMRelu.main_backward, MMRelu.main_backward),
-                MMRelu.epilogue_backward,
-                coda.mm_relu_multiuse_fused_backward,
-            ),
-        ]
+        pattern = (
+            (MMRelu.main_backward, MMRelu.main_backward),
+            MMRelu.epilogue_backward,
+        )
+        replacement = coda.mm_relu_multiuse_fused_backward
+        rules = [(pattern, replacement)]
         accumulate_grad_rules = [
-            (MMRelu.main_backward, 0, coda.mm_input_accumulate_fused_backward),
-            (MMRelu.main_backward, 1, coda.mm_weight_accumulate_fused_backward),
+            (
+                (MMRelu.main_backward, 0),
+                coda.mm_input_accumulate_fused_backward,
+            ),
+            (
+                (MMRelu.main_backward, 1),
+                coda.mm_weight_accumulate_fused_backward,
+            ),
         ]
 
         LOG.reset()
@@ -403,7 +408,7 @@ class TestCodaBwdFusionPlanning(TestCase):
         h = MMRelu.apply(x, w1)
         ha, hb = split_multi_use(h, 2)
         loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
-        single_use_rules = [rule for rule in RULES if not isinstance(rule[0], tuple)]
+        single_use_rules = [rule for rule in RULES if not isinstance(rule[0][0], tuple)]
 
         LOG.reset()
         plan = apply_epilogue_fusion(loss, single_use_rules, _internal_debug=True)
@@ -619,8 +624,7 @@ class TestCodaBwdFusionPlanning(TestCase):
         w2 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
         rules = RULES + [
             (
-                MMReluRHS.main_backward,
-                MMRelu.epilogue_backward,
+                (MMReluRHS.main_backward, MMRelu.epilogue_backward),
                 coda.mm_relu_fused_backward,
             ),
         ]

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -255,7 +255,54 @@ class TestCodaBwdFusionNumerics(TestCase):
         if grad_ptrs is not None:
             self.assertEqual([t.grad.data_ptr() for t in tensors], grad_ptrs)
 
-    def test_multi_use_splitter_fusion(self, device):
+    def test_splitter_activation_grad_accumulation(self, device):
+        torch.manual_seed(0)
+        base_x = torch.randn(4, 6, dtype=torch.double, device=device)
+        base_wa = torch.randn(6, 6, dtype=torch.double, device=device)
+        base_wb = torch.randn(6, 6, dtype=torch.double, device=device)
+
+        x = base_x.clone().requires_grad_()
+        wa = base_wa.clone().requires_grad_()
+        wb = base_wb.clone().requires_grad_()
+        h = torch.sigmoid(x)
+        self.assertIsNotNone(h.grad_fn)
+        ha, hb = split_multi_use(h, 2)
+        loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
+
+        pattern = (
+            (MMRelu.main_backward, MMRelu.main_backward),
+            split_multi_use,
+        )
+        replacement = coda.mm_multiuse_accumulate_backward
+        rules = [(pattern, replacement)]
+
+        LOG.reset()
+        plan = apply_epilogue_fusion(
+            loss,
+            rules,
+            expect_num_fusions=1,
+            _internal_debug=True,
+        )
+        loss.backward()
+
+        ex = base_x.clone().requires_grad_()
+        ewa = base_wa.clone().requires_grad_()
+        ewb = base_wb.clone().requires_grad_()
+        eh = torch.sigmoid(ex)
+        (torch.relu(eh @ ewa).sum() + torch.relu(eh @ ewb).sum()).backward()
+
+        self.assertEqual(_grads([x, wa, wb]), _grads([ex, ewa, ewb]))
+        self.assertEqual(len(plan._multiuse_pairs_fused), 1)
+        self.assertFalse(plan._multiuse_pairs_fused[0].includes_epilogue)
+        self.assertEqual(LOG.c["splitter_fused"], 1)
+        self.assertEqual(LOG.c["splitter_deferred"], 1)
+        self.assertEqual(LOG.c["multiuse_fused"], 0)
+        self.assertEqual(LOG.c["fused_impl"], 0)
+        self.assertEqual(LOG.c["accumulate_fused"], 0)
+        self.assertEqual(LOG.c["main_params_only"], 2)
+        self.assertEqual(LOG.c["epilogue_unfused"], 2)
+
+    def test_multi_use_splitter_end_to_end(self, device):
         torch.manual_seed(0)
         base_x = torch.randn(4, 6, dtype=torch.double, device=device)
         base_ws = [
@@ -270,6 +317,7 @@ class TestCodaBwdFusionNumerics(TestCase):
 
         pattern = (
             (MMRelu.main_backward, MMRelu.main_backward),
+            split_multi_use,
             MMRelu.epilogue_backward,
         )
         replacement = coda.mm_relu_multiuse_fused_backward
@@ -305,6 +353,7 @@ class TestCodaBwdFusionNumerics(TestCase):
         self.assertEqual(len(plan._multiuse_pairs_fused), 1)
         self.assertEqual(LOG.c["multiuse_fused"], 1)
         self.assertEqual(LOG.c["splitter_deferred"], 1)
+        self.assertEqual(LOG.c["splitter_fused"], 0)
         self.assertEqual(LOG.c["accumulate_fused"], 4)
         self.assertEqual(LOG.c["main_fully_deferred"], 3)
 

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -20,6 +20,7 @@ from coda_backward_epilogue_fusion import (
     MMRelu,
     MMTanh,
     RULES,
+    split_multi_use,
 )
 
 import torch
@@ -254,6 +255,42 @@ class TestCodaBwdFusionNumerics(TestCase):
         if grad_ptrs is not None:
             self.assertEqual([t.grad.data_ptr() for t in tensors], grad_ptrs)
 
+    def test_multi_use_splitter_fusion(self, device):
+        torch.manual_seed(0)
+        base_x = torch.randn(4, 6, dtype=torch.double, device=device)
+        base_ws = [
+            torch.randn(6, 6, dtype=torch.double, device=device) for _ in range(3)
+        ]
+
+        x = base_x.clone().requires_grad_()
+        w1, wa, wb = [w.clone().requires_grad_() for w in base_ws]
+        h = MMRelu.apply(x, w1)
+        ha, hb = split_multi_use(h, 2)
+        loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
+
+        LOG.reset()
+        plan = apply_epilogue_fusion(
+            loss,
+            RULES,
+            accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+            expect_num_fusions=1,
+            expect_num_accumulate_grad_fusions=4,
+            _internal_debug=True,
+        )
+        loss.backward()
+
+        ex = base_x.clone().requires_grad_()
+        ew1, ewa, ewb = [w.clone().requires_grad_() for w in base_ws]
+        eh = torch.relu(ex @ ew1)
+        (torch.relu(eh @ ewa).sum() + torch.relu(eh @ ewb).sum()).backward()
+
+        self.assertEqual(_grads([x, w1, wa, wb]), _grads([ex, ew1, ewa, ewb]))
+        self.assertEqual(len(plan._multiuse_pairs_fused), 1)
+        self.assertEqual(LOG.c["multiuse_fused"], 1)
+        self.assertEqual(LOG.c["splitter_deferred"], 1)
+        self.assertEqual(LOG.c["accumulate_fused"], 4)
+        self.assertEqual(LOG.c["main_fully_deferred"], 3)
+
 
 class TestCodaBwdFusionPlanning(TestCase):
     """Structural behavior of the fusion planner and kernel-path accounting."""
@@ -331,9 +368,9 @@ class TestCodaBwdFusionPlanning(TestCase):
         )
 
     def test_branching_consumer_raises(self):
-        # An epilogue output consumed by more than one main node cannot be fused:
-        # its backward grad accumulates across the branches, which a single deferral
-        # placeholder cannot represent. The planner must reject it loudly.
+        # An implicit multi-use cannot be fused because InputBuffer would add the
+        # placeholders before the epilogue runs. split_multi_use makes those slots
+        # explicit; without it the planner must reject the pattern loudly.
         torch.manual_seed(1)
         x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
         w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
@@ -344,6 +381,56 @@ class TestCodaBwdFusionPlanning(TestCase):
         loss = MMRelu.apply(b, wa).sum() + MMRelu.apply(b, wb).sum()
         with self.assertRaisesRegex(RuntimeError, "exactly one consumer"):
             apply_epilogue_fusion(loss, RULES)
+
+    def test_multi_use_splitter_without_rule_stays_unfused(self):
+        torch.manual_seed(0)
+        x = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w1 = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        wa = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        wb = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        h = MMRelu.apply(x, w1)
+        ha, hb = split_multi_use(h, 2)
+        loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
+        single_use_rules = [rule for rule in RULES if not isinstance(rule[0], tuple)]
+
+        LOG.reset()
+        plan = apply_epilogue_fusion(loss, single_use_rules, _internal_debug=True)
+        self.assertEqual(len(plan._multiuse_pairs_fused), 0)
+        self.assertEqual(len(plan._multiuse_pairs_unfused), 1)
+        self.assertEqual(
+            plan._multiuse_pairs_unfused[0].unfused_reason,
+            "no rule registered",
+        )
+        with self.assertRaisesRegex(AssertionError, "no rule registered"):
+            plan.assert_num_fusions(1)
+        loss.backward()
+        self.assertEqual(LOG.c["splitter_unfused"], 1)
+
+        ex = x.detach().clone().requires_grad_()
+        ew1 = w1.detach().clone().requires_grad_()
+        ewa = wa.detach().clone().requires_grad_()
+        ewb = wb.detach().clone().requires_grad_()
+        eh = torch.relu(ex @ ew1)
+        (torch.relu(eh @ ewa).sum() + torch.relu(eh @ ewb).sum()).backward()
+        self.assertEqual(_grads([x, w1, wa, wb]), _grads([ex, ew1, ewa, ewb]))
+
+    def test_multi_use_splitter_requires_one_consumer_per_output(self):
+        x, ws = self._inputs(4)
+        h = MMRelu.apply(x, ws[0])
+        ha, hb = split_multi_use(h, 2)
+        loss = (
+            MMRelu.apply(ha, ws[1]).sum()
+            + MMRelu.apply(ha, ws[2]).sum()
+            + MMRelu.apply(hb, ws[3]).sum()
+        )
+
+        plan = apply_epilogue_fusion(loss, RULES, _internal_debug=True)
+        self.assertEqual(len(plan._multiuse_pairs_fused), 0)
+        self.assertEqual(
+            plan._multiuse_pairs_unfused[0].unfused_reason,
+            "each splitter output must feed exactly one main backward",
+        )
+        loss.backward()
 
     def test_accumulate_grad_multiple_producers_raises(self):
         torch.manual_seed(0)

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -268,11 +268,23 @@ class TestCodaBwdFusionNumerics(TestCase):
         ha, hb = split_multi_use(h, 2)
         loss = MMRelu.apply(ha, wa).sum() + MMRelu.apply(hb, wb).sum()
 
+        rules = [
+            (
+                (MMRelu.main_backward, MMRelu.main_backward),
+                MMRelu.epilogue_backward,
+                coda.mm_relu_multiuse_fused_backward,
+            ),
+        ]
+        accumulate_grad_rules = [
+            (MMRelu.main_backward, 0, coda.mm_input_accumulate_fused_backward),
+            (MMRelu.main_backward, 1, coda.mm_weight_accumulate_fused_backward),
+        ]
+
         LOG.reset()
         plan = apply_epilogue_fusion(
             loss,
-            RULES,
-            accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+            rules,
+            accumulate_grad_rules=accumulate_grad_rules,
             expect_num_fusions=1,
             expect_num_accumulate_grad_fusions=4,
             _internal_debug=True,

--- a/coda_backward_epilogue_fusion_test.py
+++ b/coda_backward_epilogue_fusion_test.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import coda_backward_epilogue_fusion as coda
 from coda_backward_epilogue_fusion import (
+    ACCUMULATE_GRAD_RULES,
     apply_epilogue_fusion,
     DeferredGradTensor,
     FusibleFunction,
@@ -207,6 +208,52 @@ class TestCodaBwdFusionNumerics(TestCase):
         for w, nw in zip(ws, nws):
             self.assertEqual(w.grad, nw.grad)
 
+    @parametrize("preexisting_grad", [False, True])
+    def test_accumulate_grad_fusion(self, device, preexisting_grad):
+        ops = CHAINS["mixed"]
+        base_x, base_ws = _fresh_inputs(ops, device)
+
+        x = base_x.clone().requires_grad_()
+        ws = [w.clone().requires_grad_() for w in base_ws]
+        ex = base_x.clone().requires_grad_()
+        ews = [w.clone().requires_grad_() for w in base_ws]
+        tensors = [x, *ws]
+        eager_tensors = [ex, *ews]
+
+        grad_ptrs = None
+        if preexisting_grad:
+            torch.manual_seed(1)
+            initial_grads = [torch.randn_like(t) for t in tensors]
+            for tensor, eager_tensor, grad in zip(
+                tensors, eager_tensors, initial_grads
+            ):
+                tensor.grad = grad.clone()
+                eager_tensor.grad = grad.clone()
+            grad_ptrs = [t.grad.data_ptr() for t in tensors]
+
+        LOG.reset()
+        out = x
+        for op, w in zip(ops, ws):
+            out = op.apply(out, w)
+        loss = out.sum()
+        plan = apply_epilogue_fusion(
+            loss,
+            RULES,
+            accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+            expect_num_fusions=2,
+            expect_num_accumulate_grad_fusions=4,
+            _internal_debug=True,
+        )
+        loss.backward()
+        _run_eager(ops, ex, ews)
+
+        self.assertEqual(_grads(tensors), _grads(eager_tensors))
+        self.assertEqual(len(plan._accumulate_grad_fused), 4)
+        self.assertEqual(LOG.c["accumulate_fused"], 4)
+        self.assertEqual(LOG.c["main_fully_deferred"], 3)
+        if grad_ptrs is not None:
+            self.assertEqual([t.grad.data_ptr() for t in tensors], grad_ptrs)
+
 
 class TestCodaBwdFusionPlanning(TestCase):
     """Structural behavior of the fusion planner and kernel-path accounting."""
@@ -297,6 +344,54 @@ class TestCodaBwdFusionPlanning(TestCase):
         loss = MMRelu.apply(b, wa).sum() + MMRelu.apply(b, wb).sum()
         with self.assertRaisesRegex(RuntimeError, "exactly one consumer"):
             apply_epilogue_fusion(loss, RULES)
+
+    def test_accumulate_grad_multiple_producers_raises(self):
+        torch.manual_seed(0)
+        x1 = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        x2 = torch.randn(4, 6, dtype=torch.double, requires_grad=True)
+        w = torch.randn(6, 6, dtype=torch.double, requires_grad=True)
+        loss = MMRelu.apply(x1, w).sum() + MMRelu.apply(x2, w).sum()
+
+        with self.assertRaisesRegex(RuntimeError, "exactly one producer"):
+            apply_epilogue_fusion(
+                loss,
+                RULES,
+                accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+            )
+
+    def test_accumulate_grad_post_hook_runs(self):
+        x, (w,) = self._inputs(1)
+        observed_grads = []
+        handle = w.register_post_accumulate_grad_hook(
+            lambda variable: observed_grads.append(variable.grad.clone())
+        )
+        try:
+            loss = MMRelu.apply(x, w).sum()
+            apply_epilogue_fusion(
+                loss,
+                RULES,
+                accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+                expect_num_accumulate_grad_fusions=2,
+            )
+            loss.backward()
+        finally:
+            handle.remove()
+
+        self.assertEqual(observed_grads, [w.grad])
+
+    def test_accumulate_grad_tensor_hook_raises(self):
+        x, (w,) = self._inputs(1)
+        handle = x.register_hook(lambda grad: grad)
+        try:
+            loss = MMRelu.apply(x, w).sum()
+            with self.assertRaisesRegex(RuntimeError, "backward hooks"):
+                apply_epilogue_fusion(
+                    loss,
+                    RULES,
+                    accumulate_grad_rules=ACCUMULATE_GRAD_RULES,
+                )
+        finally:
+            handle.remove()
 
     def test_unregistered_pair_not_fused(self):
         self.assertNotIn(


### PR DESCRIPTION
**Not for land - RFC / prototype.**

A UX prototype for CODA-style backward epilogue fusion across `autograd.Function`
nodes (see "CODA: Rewriting Transformer Blocks as GEMM-Epilogue Programs",
arXiv:2605.19269).

## Problem
The backward of an `autograd.Function` isn't self-contained: for a chain
`mm -> epilogue -> mm`, the epilogue's backward wants to fuse as the epilogue of
the *next* matmul's backward (`grad_a = (grad_c @ W^T) * f'(a)` is a matmul with a
pointwise epilogue), which a single Function can't express since its backward runs
inside one node. A main-backward GEMM followed by leaf gradient accumulation has
the same issue: eager materializes the GEMM result before `AccumulateGrad` adds it
to `.grad`. An implicitly multi-used activation has another boundary: autograd's
`InputBuffer` combines its branch gradients before the upstream node runs.

## Approach
The user writes a "1-to-many" op that decomposes into two autograd nodes (a matmul
node + an epilogue marker node), plus explicit `(pattern, replacement)` fusion
rules. Before backward, `apply_epilogue_fusion()` walks the graph and arms matching
main-backward outputs:

- For a main-backward -> epilogue-backward pair, the activation gradient is
  deferred into the previous epilogue's backward.
- For a main-backward -> `AccumulateGrad` pair, the output is deferred into an
  accumulator prehook, where the user's fused GEMM writes or adds directly into
  the leaf's `.grad`.
- For explicit multi-use, `split_multi_use(tensor, num_uses)` returns one alias
  per declared use. Distinct splitter output numbers give each branch its own
  `InputBuffer` slot. A pattern ending at `split_multi_use` replaces only the
  ordered branch-gradient accumulation and returns a real gradient to any upstream
  autograd node. A longer pattern can additionally replace an upstream CODA
  epilogue.

There is no graph rewrite: deferral rides a metadata-only placeholder along the
existing edge, carrying the producer's saved set while it is still alive. Leaf
accumulation fusion requires a unique producer so the engine never combines
placeholders. Leaf Tensor backward hooks bail out; post-accumulate hooks still run.
Multi-use fusion requires every declared splitter output to feed exactly one main
backward. A rule that also replaces an epilogue requires the splitter to be that
epilogue output's only consumer. Missing rules or invalid structures stay unfused,
and the splitter performs the ordinary sum; implicit multi-use without a splitter
continues to fail loudly.

## Files (top-level; the prototype lives out of tree)
- `coda_backward_epilogue_fusion.py` -- framework + example ops (MMRelu, MMTanh)
- `coda_backward_epilogue_fusion_test.py` -- device-generic numerics + planner tests
- `coda_backward_epilogue_fusion_lowlevel_demo.py` -- step-by-step demo of the plumbing

## Test plan
```
python coda_backward_epilogue_fusion.py
python coda_backward_epilogue_fusion_lowlevel_demo.py
python coda_backward_epilogue_fusion_test.py
```

Demos + 44 tests pass (CPU and CUDA). Coverage includes eager-equivalent numerics,
isolated activation-gradient accumulation at a split non-leaf native sigmoid,
end-to-end splitter accumulation composed with a CODA epilogue and leaf
accumulation, missing multi-use rules and invalid-use fallback, fresh and
pre-existing `.grad` (the latter retains its storage), activation and weight
outputs, shape-changing epilogues (GLU), shared-leaf / branching / missing-rule
bail-outs, post-accumulate hooks, a reference-cycle leak check, and composition
with `torch.utils.checkpoint(use_reentrant=False)` across two AC regions.

Authored with the assistance of AI coding assistants (Claude and OpenAI Codex).
