### PR TITLE
Title: [BE] Enable ruff FURB122 lint rule and fix violations

### DIFF
--- a/benchmarks/dynamo/launch_compile_op_numerics.py
+++ b/benchmarks/dynamo/launch_compile_op_numerics.py
@@ -891,8 +891,7 @@ async def runner(args):
         f"/workspace/result_{args.gpu[0]}_{args.pytorch_version}_{args.cuda_version}.jsonl",
         "a+",
     ) as result:
-        for r in results:
-            result.write(r)
+        result.writelines(results)
 
 
 def main():

--- a/caffe2/perfkernels/hp_emblookup_codegen.py
+++ b/caffe2/perfkernels/hp_emblookup_codegen.py
@@ -566,9 +566,7 @@ for o in options:
 code.append("} // namespace caffe2")
 
 with open(filename, "w", encoding="utf8") as fout:
-    for c in code:
-        # print(c, file = fout)
-        fout.write(c + "\n")
+    fout.writelines(c + "\n" for c in code)
 
 
 print("Created " + filename)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2373,8 +2373,7 @@ def coverage_post_process(app, exception):
 
     if output:
         with open(output_file, "a") as f:
-            for o in output:
-                f.write(o)
+            f.writelines(output)
 
 
 def process_docstring(app, what_, name, obj, options, lines):

--- a/docs/source/scripts/build_opsets.py
+++ b/docs/source/scripts/build_opsets.py
@@ -62,13 +62,11 @@ def main():
 
     with open(os.path.join(BUILD_DIR, ATEN_OPS_CSV_FILE), "w") as f:
         f.write("Operator,Schema\n")
-        for name, schema in aten_ops_list:
-            f.write(f'"``{name}``","{schema}"\n')
+        f.writelines(f'"``{name}``","{schema}"\n' for name, schema in aten_ops_list)
 
     with open(os.path.join(BUILD_DIR, PRIMS_OPS_CSV_FILE), "w") as f:
         f.write("Operator,Schema\n")
-        for name, schema in prims_ops_list:
-            f.write(f'"``{name}``","{schema}"\n')
+        f.writelines(f'"``{name}``","{schema}"\n' for name, schema in prims_ops_list)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ ignore = [
     "E741",
     "EXE001",
     "F405",
-    "FURB122", # writelines
     # these ignores are from ruff NPY; please fix!
     "NPY002",
     # these ignores are from ruff PERF; please fix!

--- a/scripts/release_notes/remove_cherry_picks.py
+++ b/scripts/release_notes/remove_cherry_picks.py
@@ -130,8 +130,7 @@ def main():
 
     # Write log file
     with open(log_path, "w") as f:
-        for entry in log_entries:
-            f.write(entry + "\n")
+        f.writelines(entry + "\n" for entry in log_entries)
     logger.info(f"Wrote removal log to {log_path}")
 
 

--- a/test/mobile/lightweight_dispatch/tests_setup.py
+++ b/test/mobile/lightweight_dispatch/tests_setup.py
@@ -150,8 +150,7 @@ if __name__ == "__main__":
         ]
         shutil.copyfile(ops_yaml, backup)
         with open(ops_yaml, "a") as f:
-            for op in _OPERATORS:
-                f.write(f"- {op}\n")
+            f.writelines(f"- {op}\n" for op in _OPERATORS)
     elif command == "shutdown":
         for file in _MODELS:
             if os.path.isfile(file):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9991,8 +9991,7 @@ class TestLinalgCudaOnly(TestCase):
             results_filename = torch.cuda.tunable.get_filename()
             validators = torch.cuda.tunable.get_validators()
             with open(results_filename, "w") as file:
-                for key, value in validators:
-                    file.write(f"Validator,{key},{value}\n")
+                file.writelines(f"Validator,{key},{value}\n" for key, value in validators)
                 file.write(
                     "GemmTunableOp_Half_NN,nn_96_128_256_ld_96_256_96,"
                     "Gemm_Cublaslt_id_999999_tile_999999_stages_999999_"

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -198,8 +198,7 @@ for hip_platform_file in hip_platform_files:
             print(f"{hip_platform_file} skipped")
         else:
             with open(hip_platform_file, "w") as sources:
-                for line in newlines:
-                    sources.write(line)
+                sources.writelines(newlines)
             print(f"{hip_platform_file} updated")
 
 # NOTE: MSLK sources needing hipify
@@ -279,8 +278,7 @@ for hipify_v1_to_v2_file in hipify_v1_to_v2_files:
             print(f"{hipify_v1_to_v2_file} skipped")
         else:
             with open(hipify_v1_to_v2_file, "w") as sources:
-                for line in newlines:
-                    sources.write(line)
+                sources.writelines(newlines)
             print(f"{hipify_v1_to_v2_file} updated")
 
 
@@ -316,6 +314,5 @@ if not buck_build:
             do_write = False
     if do_write:
         with open(mslk_move_dst, "w") as dst:
-            for line in src_lines:
-                dst.write(line)
+            dst.writelines(src_lines)
         print(f"{mslk_move_dst} updated")

--- a/tools/linter/adapters/stable_shim_usage_linter.py
+++ b/tools/linter/adapters/stable_shim_usage_linter.py
@@ -129,8 +129,10 @@ def write_shim_function_versions(
         )
         f.write("# DO NOT EDIT MANUALLY.\n\n")
 
-        for func_name, (major, minor, patch) in sorted_functions:
-            f.write(f"{func_name}: TORCH_VERSION_{major}_{minor}_{patch}\n")
+        f.writelines(
+            f"{func_name}: TORCH_VERSION_{major}_{minor}_{patch}\n"
+            for func_name, (major, minor, patch) in sorted_functions
+        )
 
 
 def check_file(

--- a/tools/setup_helpers/gen_version_header.py
+++ b/tools/setup_helpers/gen_version_header.py
@@ -61,8 +61,7 @@ def main(args: argparse.Namespace) -> None:
 
     with open(args.template_path) as input:
         with open(args.output_path, "w") as output:
-            for line in input:
-                output.write(apply_replacements(replacements, line))
+            output.writelines(apply_replacements(replacements, line) for line in input)
 
 
 if __name__ == "__main__":

--- a/tools/setup_helpers/generate_linker_script.py
+++ b/tools/setup_helpers/generate_linker_script.py
@@ -41,8 +41,7 @@ def gen_linker_script(
         for lineid, line in enumerate(linker_script_lines):
             if lineid == text_line_start + 2:
                 f.write("    *(\n")
-                for plines in prioritized_text:
-                    f.write(f"      .text.{plines}\n")
+                f.writelines(f"      .text.{plines}\n" for plines in prioritized_text)
                 f.write("    )\n")
             f.write(f"{line}\n")
 


### PR DESCRIPTION
Body:
## Summary

Enables the ruff `FURB122` rule (prefer `f.writelines(...)` over a for-loop of
`f.write(...)`) by fixing all existing violations and removing `FURB122` from
the `[tool.ruff.lint] ignore` list in `pyproject.toml`.

Most violations were fixed with ruff's autofix. The one manual change is in
`caffe2/perfkernels/hp_emblookup_codegen.py`, where an inline comment in the
loop body blocked the autofix; that file is excluded from CI lint, so the edit
is kept minimal with no reformatting.

Non-user-facing, mechanical cleanup. No behavior change.

## Test plan

`FURB122` reports no violations across the repo:

\`\`\`
ruff check . --select FURB122
\`\`\`

Changed files are format-clean under the CI-pinned ruff 0.14.4:

\`\`\`
lintrunner --skip PYREFLY   # ok, no lint issues
\`\`\`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98