### PR TITLE
Migrate x86 CPU inductor perf nightly workflows to OSDC

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
@@ -81,9 +81,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "mt-"
       build-environment: linux-jammy-py3.10-gcc11-build
       docker-image-name: ci-image:pytorch-linux-jammy-py3-gcc11-inductor-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "inductor_huggingface_perf_cpu_x86_zen", shard: 1, num_shards: 3, runner: "linux.24xlarge.amd" },
@@ -100,6 +101,9 @@ jobs:
           { config: "inductor_torchbench_perf_cpu_x86_zen", shard: 4, num_shards: 4, runner: "linux.24xlarge.amd" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit
 
   inductor-test-nightly:
@@ -117,6 +121,9 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit
 
   inductor-test:
@@ -133,4 +140,7 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -81,9 +81,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "mt-"
       build-environment: linux-jammy-py3.10-gcc11-build
       docker-image-name: ci-image:pytorch-linux-jammy-py3-gcc11-inductor-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "inductor_huggingface_perf_cpu_x86", shard: 1, num_shards: 3, runner: "linux.24xl.spr-metal" },
@@ -101,6 +102,9 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio torchao"
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit
 
   inductor-test-nightly-freezing:
@@ -118,6 +122,9 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit
 
   inductor-test:
@@ -135,4 +142,7 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: true
+      python-version: "3.10"
+      compiler: gcc11
     secrets: inherit


### PR DESCRIPTION
Moves `inductor-perf-test-nightly-x86` and `inductor-perf-test-nightly-x86-zen` straight onto OSDC (ARC) runners, without opting into the gradual `arc` dial-up experiment. Each build/test job sets `use-arc: true`.

### Changes (both workflows)
- build pins `runner_prefix: "mt-"` directly (the prefix OSDC ARC runners are registered under), instead of deriving it from the determinator's `arc` experiment. No `check_experiments: arc`.
- build adds `ci-docker-hash` (so the OSDC container image tag resolves), `use-arc: true`, `python-version: "3.10"`, `compiler: gcc11`.
- tests add `use-arc: true`, `python-version`, `compiler`.
- `get-label-type` is retained only to supply `ci-docker-hash`.

### Runner mapping
The CPU perf runners are already in `.github/arc.yaml`:
- `linux.24xl.spr-metal` -> `l-bx86iamx-92-167`
- `linux.24xlarge.amd` -> `l-x86aavx512-125-463`

With `runner_prefix: "mt-"`, `map_ec2_to_arc.py` rewrites the test matrix to `mt-l-...` labels automatically in the OSDC build job, so no test-matrix edits are needed.

Validation is the workflows scheduling on `mt-`-prefixed OSDC runners once landed (nightly cron / ciflow tag).

Authored with the assistance of an AI coding agent (Claude Code).