### PR TITLE
Cleanup persistent cuBLASLt workspaces before test_mempool_ctx_multiеhread

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8007,12 +8007,9 @@ class TestMemPool(TestCase):
             num_expandable_segments, 1, "Expected to have 1 expandable segment only"
         )
 
-    @unittest.skipIf(
-        IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW,
-        "https://github.com/pytorch/pytorch/issues/153460",
-    )
     @serialTest()
     def test_mempool_ctx_multithread(self):
+        torch._C._cuda_clearCublasWorkspaces()
         torch.cuda.empty_cache()
         segments = torch.cuda.memory._snapshot()["segments"]
         self.assertEqual(len(segments), 0, "Expected empty pool in the beginning")


### PR DESCRIPTION
`test_cuda.py::TestMemPool::test_mempool_ctx_multithread` assumes the device allocator snapshot is empty after empty_cache(), but earlier tests in the same process can leave inactive segments behind. 

Call `torch._C._cuda_clearCublasWorkspaces()` at the start of the test (before empty_cache()) so prior tests do not pollute the initial segment count. This matches the pattern already used in other tests

Reproducer (fails without the fix):
```bash
python test_cuda.py TestCuda.test_matmul_device_mismatch TestMemPool.test_mempool_ctx_multithread
```
test_matmul_device_mismatch leaves reserved segments. test_mempool_ctx_multithread then fails with `Expected 0 but got N` on the opening assertion. The test passes in isolation.

Fixes https://github.com/pytorch/pytorch/issues/153460