### PR TITLE
Resolve object-aliasing guards in C++ instead of a Python lambda

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -101,6 +101,76 @@ class GuardManagerTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(actual, fn(x))
 
+    def test_object_aliasing_root_guard(self):
+        # The C++ OBJECT_ALIASING_ROOT guard re-reads aliased objects from the
+        # locals and compares identity as a single root epilogue guard (so it
+        # preserves the recursive-dict-tag optimization instead of disabling it
+        # like a relational leaf guard would). Verify it engages, is correct,
+        # and survives a clone. Skips if it is not installed (e.g. globals/
+        # unsupported sources force the python-lambda fallback).
+        import torch._dynamo.guards as dynamo_guards
+
+        class Shared:
+            def __init__(self):
+                self.flag = True
+
+        class Layer(torch.nn.Module):
+            def __init__(self, shared):
+                super().__init__()
+                self.shared = shared
+                self.lin = torch.nn.Linear(8, 8)
+
+            def forward(self, x):
+                if self.shared.flag:
+                    x = x + 1
+                return self.lin(x)
+
+        class Net(torch.nn.Module):
+            def __init__(self, n):
+                super().__init__()
+                shared = Shared()
+                self.layers = torch.nn.ModuleList([Layer(shared) for _ in range(n)])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer(x)
+                return x
+
+        torch._dynamo.reset()
+        installed = []
+        orig = dynamo_guards.install_object_aliasing_root_guard
+
+        def spy(*args, **kwargs):
+            installed.append(True)
+            return orig(*args, **kwargs)
+
+        model = Net(4)
+        with (
+            torch._dynamo.config.patch(use_recursive_dict_tags_for_guards=True),
+            mock.patch.object(dynamo_guards, "install_object_aliasing_root_guard", spy),
+        ):
+            torch.compile(model, backend="eager", fullgraph=True)(torch.randn(8))
+
+        if not installed:
+            self.skipTest("object-aliasing root guard not installed")
+
+        root = _debug_get_cache_entry_list(type(model).forward.__code__)[
+            0
+        ].guard_manager.root
+        f_locals = {"self": model, "x": torch.randn(8)}
+
+        # Valid (all layers share one object) passes, on the tree and a clone.
+        for manager in (root, root.clone_manager(lambda _: True)):
+            self.assertTrue(manager.check(f_locals))
+
+        # Breaking the aliasing (a layer points at a different object) fails,
+        # and restoring it passes again (no stale state).
+        saved = model.layers[1].shared
+        model.layers[1].shared = Shared()
+        self.assertFalse(root.check(f_locals))
+        model.layers[1].shared = saved
+        self.assertTrue(root.check(f_locals))
+
     def test_guard_debug_info_user_stack(self):
         """Test that GuardDebugInfo can store user stack trace information."""
         import traceback

--- a/torch/_C/_dynamo/guards.pyi
+++ b/torch/_C/_dynamo/guards.pyi
@@ -449,6 +449,12 @@ def install_object_aliasing_guard(
     verbose_code_parts: list[str],
     user_stack: traceback.StackSummary | None,
 ) -> None: ...
+def install_object_aliasing_root_guard(
+    root: RootGuardManager,
+    pairs: list[tuple[list[tuple[bool, Any]], list[tuple[bool, Any]]]],
+    verbose_code_parts: list[str],
+    user_stack: traceback.StackSummary | None,
+) -> None: ...
 def install_no_tensor_aliasing_guard(
     guard_managers: list[GuardManager],
     tensor_names: list[str],

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -64,6 +64,7 @@ from torch._C._dynamo.guards import (
     GuardManager,
     install_no_tensor_aliasing_guard,
     install_object_aliasing_guard,
+    install_object_aliasing_root_guard,
     install_storage_overlapping_guard,
     install_symbolic_shape_guard,
     LeafGuard,
@@ -856,6 +857,54 @@ def get_verbose_code_parts(
     return verbose_code_parts
 
 
+def _object_aliasing_source_to_steps(
+    source: Source,
+) -> list[tuple[bool, Any]] | None:
+    """Convert a Source into (is_attr, key) steps applied from the locals dict,
+    for the C++ OBJECT_ALIASING_ROOT guard. is_attr -> getattr(key), else
+    getitem(key). Returns None for anything that is not a simple locals-rooted
+    attr/getitem chain (globals, cells, slices, non-str/int keys, or other
+    source types), so the caller falls back to a python lambda guard.
+    """
+    steps: list[tuple[bool, Any]] = []
+    cur: Source = source
+    while True:
+        if isinstance(cur, LocalSource):
+            if cur.is_derefed_cell_contents:
+                return None
+            steps.append((False, cur.local_name))
+            break
+        elif isinstance(cur, AttrSource):
+            steps.append((True, cur.member))
+            cur = cur.base
+        elif isinstance(cur, DictGetItemSource):
+            if type(cur.index) not in (str, int):
+                return None
+            steps.append((False, cur.index))
+            cur = cur.base
+        elif isinstance(cur, GetItemSource):
+            if cur.index_is_slice or type(cur.index) not in (str, int):
+                return None
+            steps.append((False, cur.index))
+            cur = cur.base
+        elif isinstance(
+            cur,
+            (
+                NNModuleSource,
+                UnspecializedNNModuleSource,
+                UnspecializedBuiltinNNModuleSource,
+                FSDPNNModuleSource,
+            ),
+        ):
+            # Transparent nn.Module source markers: resolve to the same object
+            # as their base, so they add no access step.
+            cur = cur.base
+        else:
+            return None
+    steps.reverse()
+    return steps
+
+
 def _get_closure_var_hint(source: Source | None) -> str | None:
     """
     Walk up the source chain to find a CellContentsSource ancestor.
@@ -1290,7 +1339,8 @@ class GuardBuilder(GuardBuilderBase):
         # Save the guard managers to avoid repeatedly traversing sources.
         self._cached_guard_managers: dict[str, GuardManager] = {}
         self._cached_duplicate_input_guards: set[tuple[str, str]] = set()
-        self.object_aliasing_guard_codes: list[tuple[str, str]] = []
+        # (source_a, source_b, code_part, verbose_code_part) per aliasing pair.
+        self.object_aliasing_guard_codes: list[tuple[Source, Source, str, str]] = []
         self.guard_nn_modules = config.guard_nn_modules and justknobs_check(
             "pytorch/compiler:guard_nn_modules"
         )
@@ -3083,7 +3133,9 @@ class GuardBuilder(GuardBuilderBase):
             # get more information.
             code_part = code[0]
             verbose_code_part = get_verbose_code_parts(code_part, guard)[0]
-            self.object_aliasing_guard_codes.append((code_part, verbose_code_part))
+            self.object_aliasing_guard_codes.append(
+                (guard.originating_source, source_b, code_part, verbose_code_part)
+            )
         else:
             install_object_aliasing_guard(
                 self.get_guard_manager(guard),
@@ -4920,20 +4972,43 @@ class CheckFunctionManager:
         # but that undermined the recursive-dict guard optimization: placing the
         # aliasing guard at a leaf prevented the parent dict node from
         # qualifying as a recursive-dict guard root. Because aliasing guards are
-        # rare, we now emit them as epilogue guards via a small Python lambda.
-        # This repeats the access in Python—adding a bit of work—but the
-        # overhead is outweighed by the gains from enabling recursive-dict guard
-        # optimization.
+        # rare, we emit them as root epilogue guards that re-read the objects.
+        # When both sides resolve to a simple locals-rooted attr/getitem chain,
+        # we install a single C++ epilogue guard (OBJECT_ALIASING_ROOT) that
+        # replays the access in C++; otherwise we fall back to a Python lambda.
+        # Both stay at the root, so the recursive-dict guard optimization is
+        # preserved.
         if (
             config.use_lamba_guard_for_object_aliasing
             and builder.object_aliasing_guard_codes
         ):
-            aliasing_code_parts, aliasing_verbose_code_parts = map(
-                list, zip(*builder.object_aliasing_guard_codes)
-            )
-            builder.add_python_lambda_leaf_guard_to_root(
-                aliasing_code_parts, aliasing_verbose_code_parts
-            )
+            _Steps = list[tuple[bool, Any]]
+            cpp_pairs: list[tuple[_Steps, _Steps]] = []
+            cpp_verbose: list[str] = []
+            lambda_code_parts: list[str] = []
+            lambda_verbose: list[str] = []
+            for (
+                source_a,
+                source_b,
+                code_part,
+                verbose_code_part,
+            ) in builder.object_aliasing_guard_codes:
+                steps_a = _object_aliasing_source_to_steps(source_a)
+                steps_b = _object_aliasing_source_to_steps(source_b)
+                if steps_a is not None and steps_b is not None:
+                    cpp_pairs.append((steps_a, steps_b))
+                    cpp_verbose.append(verbose_code_part)
+                else:
+                    lambda_code_parts.append(code_part)
+                    lambda_verbose.append(verbose_code_part)
+            if cpp_pairs:
+                install_object_aliasing_root_guard(
+                    builder.guard_manager.root, cpp_pairs, cpp_verbose, None
+                )
+            if lambda_code_parts:
+                builder.add_python_lambda_leaf_guard_to_root(
+                    lambda_code_parts, lambda_verbose
+                )
 
         aotautograd_guards: list[GuardEnvExpr] = (
             self.output_graph.aotautograd_guards if self.output_graph else []

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2521,6 +2521,99 @@ class OBJECT_ALIASING : public RelationalGuard {
   PyObject* _first_tensor{nullptr};
 };
 
+// Checks object-aliasing relations ("a is b") entirely from the root locals by
+// re-resolving each side's access path in C++. Installed as a single root
+// epilogue guard (NOT attached to leaf managers), so unlike the relational
+// OBJECT_ALIASING leaf guard it does not disable the recursive-dict-tag
+// optimization: a relational leaf guard breaks if one side's subtree is
+// tag-skipped while the other is traversed, whereas this guard re-reads both
+// sides independently after traversal.
+//
+// Each side is a "path": a sequence of (is_attr, key) steps applied from the
+// root value (the locals dict). is_attr -> PyObject_GetAttr, else
+// PyObject_GetItem. The Python side only builds paths it can resolve this way
+// (locals-rooted attr/getitem chains) and falls back to a python lambda guard
+// for anything else, so unsupported sources never reach here.
+class OBJECT_ALIASING_ROOT : public LeafGuard {
+ public:
+  OBJECT_ALIASING_ROOT(
+      RootGuardManager* root_guard_manager,
+      const py::list& pairs,
+      py::object verbose_code_parts,
+      py::object user_stack)
+      : LeafGuard(
+            root_guard_manager,
+            std::move(verbose_code_parts),
+            std::move(user_stack)) {
+    for (const auto& pair : pairs) {
+      auto t = py::cast<py::tuple>(pair);
+      _pairs.emplace_back(
+          compile_path(py::cast<py::list>(t[0])),
+          compile_path(py::cast<py::list>(t[1])));
+    }
+  }
+
+  bool check_nopybind(PyObject* value) override { // value: locals dict (borrowed)
+    for (const auto& p : _pairs) {
+      PyObject* a = resolve(value, p.first); // new ref or nullptr
+      if (a == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      PyObject* b = resolve(value, p.second); // new ref or nullptr
+      if (b == nullptr) {
+        PyErr_Clear();
+        Py_DECREF(a);
+        return false;
+      }
+      bool same = (a == b);
+      Py_DECREF(a);
+      Py_DECREF(b);
+      if (!same) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  struct Step {
+    bool is_attr;
+    py::object key;
+  };
+  using Path = std::vector<Step>;
+
+  static Path compile_path(const py::list& steps) {
+    Path path;
+    path.reserve(steps.size());
+    for (const auto& step : steps) {
+      auto t = py::cast<py::tuple>(step);
+      path.push_back(
+          Step{py::cast<bool>(t[0]), py::reinterpret_borrow<py::object>(t[1])});
+    }
+    return path;
+  }
+
+  // Returns a new reference to the resolved object, or nullptr with the Python
+  // error set (caller clears it).
+  static PyObject* resolve(PyObject* root, const Path& path) {
+    PyObject* cur = root;
+    Py_INCREF(cur);
+    for (const auto& step : path) {
+      PyObject* nxt = step.is_attr ? PyObject_GetAttr(cur, step.key.ptr())
+                                   : PyObject_GetItem(cur, step.key.ptr());
+      Py_DECREF(cur);
+      if (nxt == nullptr) {
+        return nullptr;
+      }
+      cur = nxt;
+    }
+    return cur;
+  }
+
+  std::vector<std::pair<Path, Path>> _pairs;
+};
+
 /**
  * Checks that none of the tensors alias.
  */
@@ -7122,6 +7215,19 @@ void install_object_aliasing_guard(
   y->add_permitted_leaf_guard(guard);
 }
 
+void install_object_aliasing_root_guard(
+    RootGuardManager* root,
+    const py::list& pairs,
+    py::object verbose_code_parts,
+    py::object user_stack) {
+  // Installs a single root epilogue guard that checks all object-aliasing
+  // relations by re-resolving their access paths from the locals dict. Unlike
+  // install_object_aliasing_guard, it does not touch leaf managers, so it
+  // preserves the recursive-dict-tag optimization.
+  root->add_epilogue_lambda_guard(std::make_unique<OBJECT_ALIASING_ROOT>(
+      root, pairs, std::move(verbose_code_parts), std::move(user_stack)));
+}
+
 void install_no_tensor_aliasing_guard(
     const py::list& guard_managers,
     const py::list& tensor_names,
@@ -8667,6 +8773,8 @@ PyObject* torch_c_dynamo_guards_init() {
           py::return_value_policy::reference);
 
   py_m.def("install_object_aliasing_guard", install_object_aliasing_guard);
+  py_m.def(
+      "install_object_aliasing_root_guard", install_object_aliasing_root_guard);
   py_m.def(
       "install_no_tensor_aliasing_guard", install_no_tensor_aliasing_guard);
   py_m.def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #187882
* #187883
* __->__ #187992
* #187868

Object-aliasing guards (`a is b`, e.g. a config object shared across many
repeated submodules, see #185886) were emitted as a single batched Python
epilogue lambda. The lambda re-reads each object's access path in Python on
every guard evaluation, which scales with the number of aliasing pairs and is a
notable chunk of cache-lookup time for large models.

The lambda lives at the root (rather than as a relational leaf guard) on
purpose: a relational leaf guard breaks if one side's subtree is skipped by the
recursive-dict-tag optimization while the other is traversed, so the objects
must be re-read independently after traversal. This change keeps that property
but does the work in C++: a new root epilogue guard OBJECT_ALIASING_ROOT holds,
per pair, two access "paths" (sequences of (is_attr, key) steps) and replays
them from the locals dict (PyObject_GetAttr / PyObject_GetItem), comparing the
two resolved objects by pointer.

The Python side converts each pair's two Sources into step lists, treating the
transparent nn.Module source markers (NNModuleSource and friends) as
pass-throughs, and falls back to the existing Python lambda for any pair whose
sources are not a simple locals-rooted attr/getitem chain (globals, cells,
slices, non-str/int keys, etc.), so correctness is never at risk. Both paths
stay at the root, so the recursive-dict-tag optimization is preserved.

Measured with a deterministic guard_manager.check() microbenchmark on a model
with N repeated submodules sharing one object, recursive dict tags enabled:

```
        python lambda    C++ root guard
  N=40      17.5us           1.2us
  N=82      32.7us           1.3us
```

Test Plan:

```
python test/dynamo/test_guard_manager.py   # 81 passed
```

Adds test_object_aliasing_root_guard, which spies on
install_object_aliasing_root_guard to confirm the C++ guard engaged (else
skips), then checks guard_manager.check() on the tree and a clone: the valid
(all-aliased) case passes, breaking one submodule's shared object fails, and
restoring it passes again. Also verified test_modules.py (142) and
test_set_aliasing_recompiles unaffected.

This PR was authored with the assistance of an AI coding assistant.