### PR TITLE
Build XPU workflows on OSDC, keep tests on XPU hardware

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -100,6 +100,7 @@ runner_mapping:
   # ---- Partner hardwares ----
 
   linux.idc.xpu: linux.idc.xpu
+  linux.client.xpu: linux.client.xpu
   linux.google.tpuv7x.1: linux.google.tpuv7x.1
   linux.rocm.gpu.2: linux.rocm.gpu.2
   linux.rocm.gpu.mi210.1: linux.rocm.gpu.mi210.1

--- a/.github/workflows/inductor-perf-test-nightly-xpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-xpu.yml
@@ -86,10 +86,12 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "mt-"
       build-environment: linux-noble-xpu-n-py3.10
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-inductor-benchmarks
-      runner: linux.c7i.12xlarge
+      runner: l-x86iavx512-48-384
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       test-matrix: |
         { include: [
           { config: "inductor_huggingface_perf_xpu", shard: 1, num_shards: 5, runner: "linux.idc.xpu" },

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -38,10 +38,12 @@ jobs:
     needs: get-label-type
     with:
       sync-tag: linux-xpu-n-1-build
-      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+      runner_prefix: "mt-"
       build-environment: linux-jammy-xpu-n-1-py3.10
       docker-image-name: ci-image:pytorch-linux-jammy-xpu-n-1-py3
-      runner: linux.c7i.12xlarge
+      runner: l-x86iavx512-48-384
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.idc.xpu" },
@@ -59,10 +61,12 @@ jobs:
     needs: get-label-type
     with:
       sync-tag: linux-xpu-n-build
-      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+      runner_prefix: "mt-"
       build-environment: linux-noble-xpu-n-py3.10
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3
-      runner: linux.c7i.12xlarge
+      runner: l-x86iavx512-48-384
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 12, runner: "linux.idc.xpu" },
@@ -96,10 +100,12 @@ jobs:
     needs: get-label-type
     with:
       sync-tag: linux-xpu-n-client-build
-      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+      runner_prefix: "mt-"
       build-environment: linux-noble-xpu-n-py3.10-client
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-client
-      runner: linux.c7i.12xlarge
+      runner: l-x86iavx512-48-384
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       test-matrix: |
         { include: [
           { config: "smoke_xpu", shard: 1, num_shards: 1, runner: "linux.client.xpu" },


### PR DESCRIPTION
Migrates the Linux build jobs in `xpu` and `inductor-perf-test-nightly-xpu` onto OSDC (ARC) runners while keeping tests on the Intel GPU (XPU) hardware: build on a regular Linux OSDC runner, test on the custom hardware.

Per build job: `use-arc: true` + `runner_prefix: "mt-"` (straight to OSDC, no dial-up), `ci-docker-hash` so the OSDC image tag resolves, and build runner `linux.c7i.12xlarge` -> `l-x86iavx512-48-384` (OSDC equivalent, preserves capacity).

`arc.yaml`: add `linux.client.xpu` as a passthrough entry (the build's `map_ec2_to_arc.py` step needs it mapped; it stays unprefixed so the test runs on XPU hardware). `_xpu-test.yml` jobs and the Windows XPU builds are unchanged.

Authored with the assistance of an AI coding agent (Claude Code).