### PR TITLE
Migrate inductor-perf-test-nightly-aarch64 to OSDC

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -81,6 +81,7 @@ runner_mapping:
   linux.arm64.m8g.4xlarge: l-arm64g4-16-62                       # m8g.4xlarge
   linux.arm64.r7g.12xlarge.memory: l-arm64g3-61-463              # r7g.12xlarge
   linux.arm64.m7g.metal: l-barm64g3-62-226                       # m7g.metal
+  linux.arm64.m8g.metal-24xl: l-barm64g4-94-344                  # m8g.24xlarge (dedicated)
 
 
   # ---- x86 GPU — A100 (p4de family) ----

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -80,10 +80,11 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "mt-"
       runner: linux.arm64.${{ needs.get-label-type.outputs.runner-config }}.4xlarge
       build-environment: linux-jammy-aarch64-py3.10
       docker-image-name: ci-image:pytorch-linux-jammy-aarch64-py3.10-gcc15-inductor-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "inductor_huggingface_perf_cpu_aarch64", shard: 1, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
@@ -128,6 +129,7 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio torchao"
+      use-arc: true
     secrets: inherit
 
 
@@ -146,6 +148,7 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: true
     secrets: inherit
 
 
@@ -160,4 +163,5 @@ jobs:
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
+      use-arc: true
     secrets: inherit


### PR DESCRIPTION
> [!WARNING]
> **Blocked on pytorch/ci-infra#810** (adds the `l-barm64g4-94-344` runner definition). That must be merged and deployed before this lands, or the perf test jobs target a runner that doesn't exist yet.

Moves the aarch64 inductor CPU perf nightly off AWS Graviton onto OSDC (ARC) arm64 runners.

### Changes
- build + both test jobs set `use-arc: true` and pin `runner_prefix: "mt-"` (straight to OSDC, no `arc` dial-up); build gains `ci-docker-hash`.
- `arc.yaml`: route the perf test runner `linux.arm64.m8g.metal-24xl` -> `l-barm64g4-94-344` (size-matched 96c/384Gi `m8g.24xlarge` OSDC Graviton4 runner added in ci-infra#810). The build runner (`linux.arm64.m8g.4xlarge`) maps to the standard OSDC arm64 build node.

### Validation
```
python3 .github/scripts/map_ec2_to_arc.py --prefix "mt-" '{ include: [ { config: "x", shard: 1, num_shards: 1, runner: "linux.arm64.m8g.metal-24xl" } ]}'
# -> mt-l-barm64g4-94-344
```

Authored with the assistance of an AI coding agent (Claude Code).