### PR TITLE
Fix #187985

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -6,6 +6,7 @@ import math
 import re
 import unittest
 from importlib import import_module
+from types import SimpleNamespace
 
 import torch
 import torch._dynamo.config
@@ -21,13 +22,21 @@ from functorch.compile import (
     nop,
 )
 from torch._dynamo.backends.common import aot_autograd
+from torch._dynamo.source import ConstantSource
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
     CompileCounterWithBackend,
     normalize_gm,
 )
+from torch._functorch.partitioners import has_recomputable_rng_ops, is_rng_op
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+from torch.fx.experimental.sym_node import SymNode
+from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, parametrize, skipIfHpu
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
@@ -2772,6 +2781,190 @@ def forward(self, arg0_1, arg1_1):
             "Activation checkpoint rematerialization in `forward-loss-backward` graph does not support RNG ops in recompute regions.",
         ):
             self._compile_and_capture(fwd_bwd_with_rng, True, (x,))
+
+    def test_ac_rematerialize_sdpa_rng_classification(self):
+        sdpa_ops = [
+            torch.ops.aten.scaled_dot_product_attention.default,
+            torch.ops.aten._scaled_dot_product_attention_math_for_mps.default,
+            torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+            torch.ops.aten._scaled_dot_product_cudnn_attention_backward.default,
+            torch.ops.aten._scaled_dot_product_flash_attention.default,
+            torch.ops.aten._scaled_dot_product_flash_attention.quantized,
+            torch.ops.aten._scaled_dot_product_efficient_attention.default,
+            torch.ops.aten._scaled_dot_product_efficient_attention_backward.default,
+            torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
+            torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default,
+            torch.ops.aten._flash_attention_forward.default,
+            torch.ops.aten._flash_attention_forward.quantized,
+            torch.ops.aten._flash_attention_forward_no_dropout_inplace.default,
+            torch.ops.aten._efficient_attention_forward.default,
+            torch.ops.aten._cudnn_attention_forward.default,
+        ]
+        shape_env = ShapeEnv()
+        zero_symbol = shape_env.create_symbol(
+            0.0,
+            source=ConstantSource("dropout_zero"),
+            dynamic_dim=DimDynamic.DUCK,
+            constraint_dim=None,
+        )
+        nonzero_symbol = shape_env.create_symbol(
+            0.1,
+            source=ConstantSource("dropout_nonzero"),
+            dynamic_dim=DimDynamic.DUCK,
+            constraint_dim=None,
+        )
+        symfloat_zero = torch.SymFloat(SymNode(zero_symbol, shape_env, float, hint=0.0))
+        symfloat_nonzero = torch.SymFloat(
+            SymNode(nonzero_symbol, shape_env, float, hint=0.1)
+        )
+        dropout_cases = [
+            (0, False),
+            (0.0, False),
+            (-0.0, False),
+            (1e-12, True),
+            (0.1, True),
+            (float("nan"), True),
+        ]
+
+        for op in sdpa_ops:
+            dropout_arg_idx = next(
+                idx
+                for idx, arg in enumerate(op._schema.arguments)
+                if arg.name == "dropout_p"
+            )
+            for dropout_p, expected in dropout_cases:
+                with self.subTest(op=op, dropout_p=dropout_p):
+                    graph = torch.fx.Graph()
+                    q = graph.placeholder("q")
+                    args = [q] * (dropout_arg_idx + 1)
+                    args[dropout_arg_idx] = dropout_p
+                    node = graph.call_function(op, tuple(args), {})
+                    node.meta["recompute"] = (
+                        torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+                    )
+                    graph.output(node)
+                    gm = torch.fx.GraphModule({}, graph)
+
+                    self.assertEqual(has_recomputable_rng_ops(gm), expected)
+
+            with self.subTest(op=op, dropout_p="dynamic"):
+                graph = torch.fx.Graph()
+                q = graph.placeholder("q")
+                dropout_p = graph.placeholder("dropout_p")
+                args = [q] * (dropout_arg_idx + 1)
+                args[dropout_arg_idx] = dropout_p
+                node = graph.call_function(op, tuple(args), {})
+                node.meta["recompute"] = (
+                    torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+                )
+                graph.output(node)
+                gm = torch.fx.GraphModule({}, graph)
+
+                self.assertTrue(has_recomputable_rng_ops(gm))
+
+            for dropout_p, expected in dropout_cases:
+                with self.subTest(op=op, kwarg_dropout_p=dropout_p):
+                    graph = torch.fx.Graph()
+                    q = graph.placeholder("q")
+                    node = graph.call_function(
+                        op, tuple([q] * dropout_arg_idx), {"dropout_p": dropout_p}
+                    )
+                    node.meta["recompute"] = (
+                        torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+                    )
+                    graph.output(node)
+                    gm = torch.fx.GraphModule({}, graph)
+
+                    self.assertEqual(has_recomputable_rng_ops(gm), expected)
+
+            for dropout_p, expected in [
+                (symfloat_zero, False),
+                (symfloat_nonzero, True),
+            ]:
+                with self.subTest(op=op, symfloat_dropout_p=dropout_p):
+                    args = [None] * (dropout_arg_idx + 1)
+                    args[dropout_arg_idx] = dropout_p
+                    node = SimpleNamespace(target=op, args=tuple(args), kwargs={})
+
+                    self.assertEqual(is_rng_op(node), expected)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_ac_rematerialize_with_sdpa_dropout_zero(self):
+        from torch.nn.attention import sdpa_kernel, SDPBackend
+
+        cases = []
+        if PLATFORM_SUPPORTS_MEM_EFF_ATTENTION:
+            cases.append((SDPBackend.EFFICIENT_ATTENTION, torch.float32))
+        if PLATFORM_SUPPORTS_FLASH_ATTENTION:
+            cases.append((SDPBackend.FLASH_ATTENTION, torch.float16))
+        if PLATFORM_SUPPORTS_CUDNN_ATTENTION:
+            cases.append((SDPBackend.CUDNN_ATTENTION, torch.float16))
+        if not cases:
+            self.skipTest("No fused SDPA backends available")
+        sdpa_ops = {
+            torch.ops.aten.scaled_dot_product_attention.default,
+            torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+            torch.ops.aten._scaled_dot_product_flash_attention.default,
+            torch.ops.aten._scaled_dot_product_efficient_attention.default,
+            torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
+        }
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op in sdpa_ops:
+                return torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+            return torch.utils.checkpoint.CheckpointPolicy.PREFER_SAVE
+
+        context_fn = functools.partial(
+            torch.utils.checkpoint.create_selective_checkpoint_contexts, policy_fn
+        )
+
+        for backend, dtype in cases:
+            with self.subTest(backend=backend, dtype=dtype):
+                torch._dynamo.reset()
+                q = torch.randn(
+                    2, 4, 128, 64, device="cuda", dtype=dtype, requires_grad=True
+                )
+                k = torch.randn(
+                    2, 4, 128, 64, device="cuda", dtype=dtype, requires_grad=True
+                )
+                v = torch.randn(
+                    2, 4, 128, 64, device="cuda", dtype=dtype, requires_grad=True
+                )
+
+                def fwd_bwd_with_sdpa(q, k, v):
+                    with sdpa_kernel(backend):
+                        z = torch.utils.checkpoint.checkpoint(
+                            lambda q, k, v: F.scaled_dot_product_attention(
+                                q, k, v, dropout_p=0.0
+                            ),
+                            q,
+                            k,
+                            v,
+                            use_reentrant=False,
+                            context_fn=context_fn,
+                        )
+                    loss = z.sum()
+                    dq, dk, dv = _grad(loss, (q, k, v))
+
+                    return z.detach(), dq, dk, dv
+
+                result_with, gm_with = self._compile_and_capture(
+                    fwd_bwd_with_sdpa, True, (q, k, v)
+                )
+                torch._dynamo.reset()
+                result_without, _ = self._compile_and_capture(
+                    fwd_bwd_with_sdpa, False, (q, k, v)
+                )
+                eager_inputs = tuple(
+                    t.detach().clone().requires_grad_(True) for t in (q, k, v)
+                )
+                result_eager = fwd_bwd_with_sdpa(*eager_inputs)
+
+                for actual, expected in zip(result_with, result_without):
+                    self.assertEqual(actual, expected)
+                for actual, expected in zip(result_with, result_eager):
+                    self.assertEqual(actual, expected)
+                self.assertEqual(sum(self.count_op(gm_with, op) for op in sdpa_ops), 2)
 
     def test_ac_rematerialize_with_no_annotations(self):
         x = torch.randn(4, 4, requires_grad=True)

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2943,8 +2943,8 @@ def forward(self, arg0_1, arg1_1):
                             use_reentrant=False,
                             context_fn=context_fn,
                         )
-                    loss = z.sum()
-                    dq, dk, dv = _grad(loss, (q, k, v))
+                        loss = z.sum()
+                        dq, dk, dv = _grad(loss, (q, k, v))
 
                     return z.detach(), dq, dk, dv
 

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -2255,7 +2255,9 @@ main()
 
     def test_trace_run_with_rng_state(self):
         def sdpa(xq, xk):
-            return F.scaled_dot_product_attention(xq, xk, xk, is_causal=True)
+            return F.scaled_dot_product_attention(
+                xq, xk, xk, dropout_p=0.1, is_causal=True
+            )
 
         def g(xq_1, xk_1, xq_2, xk_2):
             # xq: (bs, n_local_heads, seqlen, head_dim)
@@ -2308,7 +2310,7 @@ main()
                 run_with_rng_state = torch.ops.higher_order.run_with_rng_state(
                     getitem_8,
                     torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default,
-                    getitem_3, getitem_4, getitem_4, 0.0, True,
+                    getitem_3, getitem_4, getitem_4, 0.1, True,
                 )
                 ...
         ```

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -21,7 +21,6 @@ from unittest import mock
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-import torch.nn.functional as F
 from torch import _inductor as inductor
 from torch._dynamo import compiled_autograd, config
 from torch._dynamo.backends.debugging import aot_eager
@@ -2254,54 +2253,29 @@ main()
         )
 
     def test_trace_run_with_rng_state(self):
-        def sdpa(xq, xk):
-            return F.scaled_dot_product_attention(
-                xq, xk, xk, dropout_p=0.1, is_causal=True
-            )
+        rng_state = torch.get_rng_state()
 
-        def g(xq_1, xk_1, xq_2, xk_2):
-            # xq: (bs, n_local_heads, seqlen, head_dim)
-            # xk: (bs, n_local_heads, cache_len + seqlen, head_dim)
-            y1 = sdpa(xq_1, xk_1)
-            y2 = torch.utils.checkpoint.checkpoint(
-                sdpa, xq_2, xk_2, use_reentrant=False
-            )
-            y = torch.mul(y1, y2)
-            z = torch.matmul(y, y)
-            return z
+        def g(x):
+            return (x * x).sum()
 
         def f():
-            bs = 1
-            n_local_heads = 1
-            seqlen = 2
-            head_dim = 2
-            cache_len = 2
-            xq_list = [
-                torch.ones(
-                    (bs, n_local_heads, seqlen, head_dim),
-                    requires_grad=True,
-                    device="cpu",
+            x = torch.ones((2, 2), requires_grad=True, device="cpu")
+
+            def hook(grad):
+                return torch._prims.rng_prims.run_with_rng_state(
+                    rng_state, torch.ops.aten.rand_like.default, grad
                 )
-                for _ in range(2)
-            ]
-            xk_list = [
-                torch.ones(
-                    (bs, n_local_heads, cache_len + seqlen, head_dim),
-                    requires_grad=True,
-                    device="cpu",
-                )
-                for _ in range(2)
-            ]
-            out = torch.compile(g, fullgraph=True)(
-                xq_list[0], xk_list[0], xq_list[1], xk_list[1]
-            )
-            out.sum().backward()
-            return out, *[x.grad for x in xq_list + xk_list]
+
+            x.register_hook(hook)
+            out = torch.compile(g, fullgraph=True)(x)
+            out.backward()
+            return out, x.grad
 
         """
         Walkthrough of what happens with `run_with_rng_state`:
-        1. `run_with_rng_state` only shows up in the backward graph (this op is inserted by the partitioner).
-        2. The Dynamo graph captured by Compiled Autograd looks like:
+        1. The tensor hook calls `run_with_rng_state` during backward.
+        2. Compiled Autograd captures the backward graph with the hook call.
+        3. The Dynamo graph captured by Compiled Autograd looks like:
         ```
         ===== __compiled_fn_3 =====
         torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
@@ -2309,44 +2283,34 @@ main()
                 ...
                 run_with_rng_state = torch.ops.higher_order.run_with_rng_state(
                     getitem_8,
-                    torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default,
-                    getitem_3, getitem_4, getitem_4, 0.1, True,
+                    torch.ops.aten.rand_like.default,
+                    aot0_add,
                 )
                 ...
         ```
-        3. We want to preserve this `run_with_rng_state` op when going through AOTAutograd. We do it by having special handling
+        4. We want to preserve this `run_with_rng_state` op when going through AOTAutograd. We do it by having special handling
         in `run_with_rng_state` op's py_functionalize_impl.
         """
 
+        saw_run_with_rng_state = False
+
         def _run_with_rng_state_op_check(inductor_post_grad_graph):
-            # Checks that `run_with_rng_state` op exists in Compiled Autograd's Inductor post-grad graph.
+            # Checks that `run_with_rng_state` op exists in one of Compiled Autograd's Inductor post-grad graphs.
+            nonlocal saw_run_with_rng_state
             op_set = {node.target for node in inductor_post_grad_graph.nodes}
-            if torch.ops.higher_order.run_and_save_rng_state not in op_set:
-                # This is backward graph, so check existence of `run_with_rng_state` op
-                self.assertTrue(torch.ops.higher_order.run_with_rng_state in op_set)
+            saw_run_with_rng_state = (
+                saw_run_with_rng_state
+                or torch.ops.higher_order.run_with_rng_state in op_set
+            )
 
         with torch._inductor.config.patch(
             post_grad_custom_post_pass=_run_with_rng_state_op_check
         ):
-            compiler_fn = make_compiler_fn(fullgraph=True)
-
-            def make_compiler_fn_with_op_check():
-                def _compiler_fn(gm):
-                    # Checks that `run_with_rng_state` op exists in Compiled Autograd's Dynamo graph.
-                    self.assertTrue(
-                        any(
-                            node.target is torch.ops.higher_order.run_with_rng_state
-                            for node in gm.graph.nodes
-                        )
-                    )
-                    return compiler_fn(gm)
-
-                return _compiler_fn
-
-            compiler_fn_with_op_check = make_compiler_fn_with_op_check()
             self.check_output_and_recompiles(
-                f, compiler_fn=compiler_fn_with_op_check, compile_fn=False
+                f, compiler_fn=make_compiler_fn(fullgraph=True), compile_fn=False
             )
+
+        self.assertTrue(saw_run_with_rng_state)
 
     @torch._inductor.config.patch(enable_auto_functionalized_v2=True)
     def test_trace_auto_functionalized_v2(self):

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -170,6 +170,55 @@ def must_recompute(node: fx.Node) -> bool:
     ]
 
 
+def is_tagged_nondeterministic_seeded(node: fx.Node) -> bool:
+    """Return True for operators tagged as consuming seeded randomness."""
+    return (
+        hasattr(node.target, "tags")
+        and torch.Tag.nondeterministic_seeded in node.target.tags
+    )
+
+
+def get_schema_arg_idx(target: object, arg_name: str) -> int | None:
+    """Return the positional schema index for an operator argument name."""
+    if not isinstance(target, torch._ops.OpOverload):
+        return None
+    for idx, arg in enumerate(target._schema.arguments):
+        if arg.name == arg_name:
+            return idx
+    return None
+
+
+def get_sdpa_dropout_p(node: fx.Node) -> object | None:
+    """Return an SDPA-family op's schema-level dropout_p value when it has one."""
+    dropout_arg_idx = get_schema_arg_idx(node.target, "dropout_p")
+    if dropout_arg_idx is None:
+        return None
+
+    dropout_arg = node.target._schema.arguments[dropout_arg_idx]
+    if len(node.args) > dropout_arg_idx:
+        return node.args[dropout_arg_idx]
+    if "dropout_p" in node.kwargs:
+        return node.kwargs["dropout_p"]
+    return dropout_arg.default_value
+
+
+def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
+    """Return True unless SDPA-family dropout is statically known to be disabled."""
+    dropout_p = get_sdpa_dropout_p(node)
+    return dropout_p is None or not statically_known_true(dropout_p == 0.0)
+
+
+def is_rng_op(node: fx.Node) -> bool:
+    """Return True when a node's seeded nondeterminism cannot be statically ruled out."""
+    if not is_tagged_nondeterministic_seeded(node):
+        return False
+
+    if get_schema_arg_idx(node.target, "dropout_p") is not None:
+        return is_nonzero_dropout_sdpa(node)
+
+    return True
+
+
 def _is_assert_only_symbool(node: fx.Node) -> bool:
     return (
         isinstance(node.meta.get("val"), torch.SymBool)
@@ -189,11 +238,7 @@ def has_recomputable_ops(fx_g: fx.GraphModule) -> bool:
 
 def has_recomputable_rng_ops(fx_g: fx.GraphModule) -> bool:
     for node in fx_g.graph.nodes:
-        if (
-            must_recompute(node)
-            and hasattr(node.target, "tags")
-            and torch.Tag.nondeterministic_seeded in node.target.tags
-        ):
+        if must_recompute(node) and is_rng_op(node):
             return True
     return False
 
@@ -1772,11 +1817,7 @@ def functionalize_rng_ops(
     def get_rng_ops(gmod: fx.GraphModule) -> dict[str, fx.Node]:
         random_nodes: dict[str, fx.Node] = {}
         for node in gmod.graph.nodes:
-            if (
-                node.op == "call_function"
-                and hasattr(node.target, "tags")
-                and torch.Tag.nondeterministic_seeded in node.target.tags
-            ):
+            if node.op == "call_function" and is_rng_op(node):
                 random_nodes[node.name] = node
         return random_nodes
 
@@ -1815,11 +1856,7 @@ def functionalize_rng_ops(
     bw_graph_rng_ops = get_rng_ops(bw_module)
     recomputable_rng_ops_map = {}
     for node in joint_module.graph.nodes:
-        if (
-            must_recompute(node)
-            and hasattr(node.target, "tags")
-            and torch.Tag.nondeterministic_seeded in node.target.tags
-        ):
+        if must_recompute(node) and is_rng_op(node):
             # Skip if the node doesn't exist in both forward and backward graphs.
             # This can happen when the RNG op's output is not needed for gradient
             # computation and gets eliminated by dead code elimination.

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -180,24 +180,22 @@ def get_schema_arg_idx(target: object, arg_name: str) -> int | None:
     return None
 
 
-def get_sdpa_dropout_p(node: fx.Node) -> object | None:
-    """Return an SDPA-family op's schema-level dropout_p value when it has one."""
+def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
+    """Return True unless SDPA-family dropout is statically known to be disabled."""
     dropout_arg_idx = get_schema_arg_idx(node.target, "dropout_p")
     if dropout_arg_idx is None:
-        return None
+        return True
 
     dropout_arg = node.target._schema.arguments[dropout_arg_idx]
     if len(node.args) > dropout_arg_idx:
-        return node.args[dropout_arg_idx]
-    if "dropout_p" in node.kwargs:
-        return node.kwargs["dropout_p"]
-    return dropout_arg.default_value
-
-
-def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
-    """Return True unless SDPA-family dropout is statically known to be disabled."""
-    dropout_p = get_sdpa_dropout_p(node)
-    return dropout_p is None or not statically_known_true(dropout_p == 0.0)
+        dropout_p = node.args[dropout_arg_idx]
+    elif "dropout_p" in node.kwargs:
+        dropout_p = node.kwargs["dropout_p"]
+    elif dropout_arg.default_value is not None:
+        dropout_p = dropout_arg.default_value
+    else:
+        return True
+    return not statically_known_true(dropout_p == 0.0)
 
 
 def is_rng_op(node: fx.Node) -> bool:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -15,7 +15,7 @@ import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 import torch._inductor.inductor_prims
@@ -182,11 +182,15 @@ def get_schema_arg_idx(target: object, arg_name: str) -> int | None:
 
 def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
     """Return True unless SDPA-family dropout is statically known to be disabled."""
-    dropout_arg_idx = get_schema_arg_idx(node.target, "dropout_p")
+    target = node.target
+    if not isinstance(target, torch._ops.OpOverload):
+        return True
+
+    dropout_arg_idx = get_schema_arg_idx(target, "dropout_p")
     if dropout_arg_idx is None:
         return True
 
-    dropout_arg = node.target._schema.arguments[dropout_arg_idx]
+    dropout_arg = target._schema.arguments[dropout_arg_idx]
     if len(node.args) > dropout_arg_idx:
         dropout_p = node.args[dropout_arg_idx]
     elif "dropout_p" in node.kwargs:
@@ -195,7 +199,8 @@ def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
         dropout_p = dropout_arg.default_value
     else:
         return True
-    return not statically_known_true(dropout_p == 0.0)
+
+    return not statically_known_true(cast(bool | torch.SymBool, dropout_p == 0.0))
 
 
 def is_rng_op(node: fx.Node) -> bool:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -170,14 +170,6 @@ def must_recompute(node: fx.Node) -> bool:
     ]
 
 
-def is_tagged_nondeterministic_seeded(node: fx.Node) -> bool:
-    """Return True for operators tagged as consuming seeded randomness."""
-    return (
-        hasattr(node.target, "tags")
-        and torch.Tag.nondeterministic_seeded in node.target.tags
-    )
-
-
 def get_schema_arg_idx(target: object, arg_name: str) -> int | None:
     """Return the positional schema index for an operator argument name."""
     if not isinstance(target, torch._ops.OpOverload):
@@ -210,7 +202,10 @@ def is_nonzero_dropout_sdpa(node: fx.Node) -> bool:
 
 def is_rng_op(node: fx.Node) -> bool:
     """Return True when a node's seeded nondeterminism cannot be statically ruled out."""
-    if not is_tagged_nondeterministic_seeded(node):
+    if not (
+        hasattr(node.target, "tags")
+        and torch.Tag.nondeterministic_seeded in node.target.tags
+    ):
         return False
 
     if get_schema_arg_idx(node.target, "dropout_p") is not None:


### PR DESCRIPTION
## Human Note
This fixes: https://github.com/pytorch/pytorch/issues/187985. Right now ops are tagged with nondeterministic_seeded whole sale. For sdpa this is a lil overkill. When dropout is == 0 we dont do anything with philox and are compeltely determnistic. And infact dropout is getting less and less popular anways. Added some regression tests and we dynmaically check whether dropout is set to know if we need to set te tag. 


You will see I had to make a larger change to `   def test_trace_run_with_rng_state(self):`

This is intentionally and ill explain why.
1. this is a badly written test IMO. Or at least it relied on behavior we are changing. So the goal was to show that `run_with_rng_state` is preserved all thew way down to inductor. It relied on the fact that partioner happend to be inserting this for sdap_flash_on_cpu. The rewrite using the hook I think is more direct and relies less on implicit system behavior.
2. Cool, so I should be able to just set dropout equals 0.1 and still get the same behavior, right? No good sir you can not. That is because on cpu sdpa_flash does not support dropout != 0.0 and we go to the composite implicit version :/
3. Why not just only run on gpu? This changes from  `run_with_rng_state` to `graphsafe_run_with_rng_state` rip.

Okay so I updated it and used hooks. QED


## Agent Report
# Report: pytorch/pytorch#187985

## Summary

Selective activation checkpointing in forward-loss-backward graphs rejected dropout-free SDPA recomputation because SDPA operator overloads carry `torch.Tag.nondeterministic_seeded` unconditionally. The fix makes the RNG predicate dropout-aware for seeded ops with a schema `dropout_p` argument: statically known `dropout_p == 0.0` is treated as deterministic, while nonzero, NaN, and dynamic/symbolic-unknown dropout remains classified as RNG.

## Root cause

`torch._functorch.partitioners.has_recomputable_rng_ops` treated every recomputable node with `torch.Tag.nondeterministic_seeded` as an RNG op. CUDA SDPA fused overloads include that tag even when `dropout_p=0.0`, where no randomness is consumed. The forward-loss-backward remat pass therefore raised its unsupported-RNG error before it could rematerialize deterministic SDPA nodes.

## Fix

- Added `is_rng_op(node)` in `torch/_functorch/partitioners.py`.
- For general nondeterministic-seeded ops without a `dropout_p` schema argument, behavior is unchanged.
- For seeded ops with a schema `dropout_p` argument, the op is treated as RNG unless `statically_known_true(dropout_p == 0.0)`.
- The dropout argument is discovered from the operator schema instead of a hard-coded SDPA op-to-index table, covering cuDNN, quantized flash, MPS math, and related tagged attention variants without index drift.
- Updated `has_recomputable_rng_ops` and `functionalize_rng_ops` RNG discovery to share this predicate.
- Added tests for positional and keyword dropout, literal zero, nonzero, NaN, dynamic placeholder, and SymFloat known-zero/nonzero dropout classification.
- Added CUDA forward-loss-backward correctness coverage for forced efficient attention (`float32`), forced flash attention (`float16`), and forced cuDNN attention (`float16`) when the platform supports them, comparing remat-enabled compile against remat-disabled compile and eager output/gradients.
- Updated the existing compiled-autograd RNG-state test to use `dropout_p=0.1`, because dropout-free SDPA is now intentionally not an RNG op.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.fx.experimental.proxy_tensor import make_fx
from torch._functorch.partitioners import has_recomputable_rng_ops

print("device", torch.cuda.get_device_name(0))

def run(dropout_p):
    def f(q, k, v):
        return F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)

    q = torch.randn(2, 4, 512, 64, device="cuda", requires_grad=True)
    k = torch.randn(2, 4, 512, 64, device="cuda", requires_grad=True)
    v = torch.randn(2, 4, 512, 64, device="cuda", requires_grad=True)
    gm = make_fx(f)(q, k, v)

    for node in gm.graph.nodes:
        if node.op == "call_function" and "scaled_dot_product" in str(node.target):
            print("mark", dropout_p, node.target, node.args, node.kwargs)
            node.meta["recompute"] = torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE

    print("dropout_p", dropout_p, "has_recomputable_rng_ops", has_recomputable_rng_ops(gm))

run(0.0)
run(0.1)
```

Output after the fix:

```text
device NVIDIA GB200
mark 0.0 aten._scaled_dot_product_efficient_attention.default (q_1, k_1, v_1, None, True) {}
dropout_p 0.0 has_recomputable_rng_ops False
mark 0.1 aten._scaled_dot_product_efficient_attention.default (q_1, k_1, v_1, None, True, 0.1) {}
dropout_p 0.1 has_recomputable_rng_ops True
```

Before the fix, the `dropout_p=0.0` case returned `True` and caused the forward-loss-backward remat pass to reject the graph.

</details>

## Review follow-up

A parallel subagent review (`run-20260623-222547-19be6fd6`) found one substantive maintainability issue: the original hard-coded SDPA op-to-dropout-index map missed cuDNN and quantized attention variants and could drift with schemas. The implementation was simplified to use schema lookup for `dropout_p`, and classification tests were expanded to include those variants.

## Validation

Tests:

```text
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/pytorch
/home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/.venv/bin/python test/dynamo/test_activation_checkpointing.py RematerializeACNodesPassTests.test_ac_rematerialize_with_rng_ops_raises_error RematerializeACNodesPassTests.test_ac_rematerialize_sdpa_rng_classification RematerializeACNodesPassTests.test_ac_rematerialize_with_sdpa_dropout_zero
```

Result after review follow-up and formatting:

```text
Ran 3 tests in 0.651s

OK
```

Additional diagnostics:

- Local classification fuzz covered 1,435 constant dropout cases and 7 dynamic dropout cases across SDPA-family op targets.
- CUDA remat diagnostics on `NVIDIA GB200` showed remat-enabled graphs contain two SDPA ops versus one without remat.
- For efficient attention `float32`, output, `dq`, `dk`, and `dv` matched remat-disabled compile and eager exactly (`max_abs=0.0`, `torch.equal=True`).
- For flash attention `float16`/`bfloat16`, output and gradients also matched exactly in diagnostics.
- cuDNN attention was unavailable in this build. A CI run with cuDNN support showed the test needed to keep `sdpa_kernel(backend)` active through `_grad`, because checkpoint recompute runs during backward and otherwise falls back to the default backend selection. The test has been updated accordingly and keeps the cuDNN subcase.
- Math SDPA decomposes and is covered by ordinary RNG/dropout handling rather than this fused-SDPA tag path.

CI follow-up tests:

```text
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/pytorch
ATEN_CPU_CAPABILITY=default /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/.venv/bin/python agent_space/run_compiled_autograd_method.py
/home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/.venv/bin/python test/dynamo/test_activation_checkpointing.py RematerializeACNodesPassTests.test_ac_rematerialize_with_sdpa_dropout_zero
```

Result: both commands exited 0; the SDPA test reported `Ran 1 test ... OK`. The compiled-autograd check used a temporary direct method-invocation script because this aarch64 job reports `HAS_CPU=False`, so the file-level test command can exit 0 without running `TestCompiledAutograd` locally. Direct invocation reproduced the CI assertion before the latest test rewrite and passed after it.

Latest PR CI triage:

```text
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985
~/dotfiles/scripts/github_ci_triage https://github.com/pytorch/pytorch/pull/187995
```

Result: current PR failures still include repeated `TestCompiledAutograd.test_trace_run_with_rng_state` failures at commit `fd70172`, with `torch.ops.higher_order.run_with_rng_state` missing from the Inductor post-grad `op_set`. The latest uncommitted fix rewrites that test to stop using SDPA as the RNG-HOP source; it now explicitly exercises `torch._prims.rng_prims.run_with_rng_state` from a backward hook and asserts that an Inductor post-grad graph sees `run_with_rng_state`.

Prerequisite checks:

```text
cd /home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/pytorch
spin quicklint
```

Result: `spin quicklint` passed. Full `spin fixlint` was attempted earlier and failed on unrelated pre-existing shellcheck issues in `.ci/pytorch/test.sh`.

## Artifacts

- Diff: `/home/drisspg/.ptq_workspace/jobs/20260623-pytorch-187985/fix.diff`


Fixes #187985


<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.fx.experimental.proxy_tensor import make_fx
from torch._functorch.partitioners import has_recomputable_rng_ops

def f(q, k, v):
    return F.scaled_dot_product_attention(q, k, v, dropout_p=0.0)

q = k = v = torch.randn(2, 4, 512, 64, requires_grad=True)
gm = make_fx(f)(q, k, v)

# Mark the SDPA node as must-recompute (what selective AC does), then check:
for node in gm.graph.nodes:
    if node.op == "call_function" and "scaled_dot_product_attention" in str(node.target):
        node.meta["recompute"] = torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE

print(has_recomputable_rng_ops(gm))   # -> True, despite dropout_p=0.0
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Primed context and reproduced RNG classification
- Read `prime.md`, PTQ context, system prompt, existing worklog, and PyTorch repo instructions.
- Ran the provided `repro.py` with the job venv; it printed `False` because its string match does not mark the CPU flash SDPA target.
- Adjusted the local repro to mark targets containing `scaled_dot_product`; `aten._scaled_dot_product_flash_attention_for_cpu.default` has `Tag.nondeterministic_seeded`, and `has_recomputable_rng_ops(gm)` returned `True` for `dropout_p=0.0`.

### Confirmed CUDA repro
- Ran the repro with CUDA tensors on `NVIDIA GB200` using the job venv.
- `dropout_p=0.0` traced to `aten._scaled_dot_product_efficient_attention.default` with `Tag.nondeterministic_seeded`; after marking it recomputable, `has_recomputable_rng_ops(gm)` returned `True`.
- `dropout_p=0.1` also returned `True`, as expected for real dropout RNG.

### Implemented SDPA dropout-aware RNG classification
- Added `is_rng_op` in `torch/_functorch/partitioners.py` so seeded ops with a schema `dropout_p` argument and statically zero dropout are not treated as RNG, while nonzero, NaN, or dynamic dropout remains RNG.
- Updated `has_recomputable_rng_ops` and functionalized RNG op discovery to use the same predicate.
- Switched the zero-dropout check to `statically_known_true(dropout_p == 0.0)`, so guarded/symbolic known-zero dropout is accepted while truly dynamic dropout remains RNG.
- After review, replaced the hard-coded SDPA op-to-dropout-index table with schema lookup, which also covers cuDNN, quantized flash, MPS math, and related tagged attention ops without index drift.

### Added fuzz-style classification and output correctness tests
- Added a deterministic classification test over tagged attention ops with schema `dropout_p`, covering positional and keyword dropout, zero, nonzero, NaN, dynamic, and SymFloat known-zero/nonzero inputs.
- Strengthened the CUDA forward-loss-backward SDPA test to return the attention output plus gradients and compare against both remat-disabled compile and eager.
- Extended the CUDA correctness test to cover available fused backends selected by forced `sdpa_kernel`: efficient attention with `float32`, flash attention with `float16`, and cuDNN attention with `float16` when the platform supports them.
- Ran an additional local fuzz script over 1,435 constant dropout cases and 7 dynamic dropout cases; all matched expected RNG classification.
- Focused tests passed: `RematerializeACNodesPassTests.test_ac_rematerialize_with_rng_ops_raises_error`, `test_ac_rematerialize_sdpa_rng_classification`, and `test_ac_rematerialize_with_sdpa_dropout_zero`.

### Inspected actual remat outputs
- Ran CUDA diagnostics with fixed seed on `NVIDIA GB200` comparing remat-enabled compile, remat-disabled compile, and eager.
- Remat graph contains two SDPA ops versus one without remat, so the SDPA is actually recomputed for backward.
- For default/efficient `float32`, output, `dq`, `dk`, and `dv` all matched exactly: max_abs `0.0` and `torch.equal=True` for remat vs non-remat and remat vs eager.
- For forced flash attention with `float16`/`bfloat16`, output and gradients also matched exactly. cuDNN attention is unavailable in this build; math SDPA decomposes and is covered by ordinary RNG/dropout handling rather than this SDPA tag path.
- The compiled remat graph feeds recomputed SDPA outputs/logsumexp/philox seed/offset into `_scaled_dot_product_efficient_attention_backward` with dropout `0.0`, which is the expected structure.

### Review pass and follow-up
- Ran parallel subagent review (`scout`, `reviewer`, `validator`) with run id `run-20260623-222547-19be6fd6`; all children completed and no handoff requests were emitted.
- Consensus finding: the hard-coded op map was the main maintainability risk and missed cuDNN/quantized attention variants.
- Addressed the finding with schema lookup and expanded tests accordingly.
- Refactored `is_rng_op` into clearer internal predicates: tagged nondeterministic-seeded detection and the SDPA dropout exception.
- Moved SymFloat test helper imports to module scope.

### Additional test discovery and validation
- Ran an 8-child GPT-5.5 subagent sweep (`run-20260623-225430-c4c0a9f8`) to find existing tests worth running; all children completed and no handoff requests were emitted.
- Ran adjacent remat tests: `test_ac_rematerialize_simple_forward_backward`, `test_ac_rematerialize_with_no_annotations`, and `test_ac_rematerialize_with_selective_checkpoint_policy`; these passed. Two initial ViaTags class names were invalid and not counted.
- Ran correct ViaTags CUDA SAC tests: `test_compile_selective_checkpoint_must_recompute_partition_fn0_cuda`, `partition_fn1_cuda`, `test_compile_selective_checkpoint_must_not_recompute_gemm_partition_fn0_cuda`, and `partition_fn1_cuda`; all passed.
- Ran RNG functionalization tests: `TestFunctionalizationRngOpsCUDA.test_checkpoint_cuda_float32`, `test_checkpoint_with_unused_rng_in_backward_cuda_float32`, and `test_dropout_decomp_cuda_float32`; all passed.
- Ran symbolic-shape checks: `TestPySymInt.test_statically_known_true`, `TestUnbacked.test_deferred_symfloat_assert_backend_eager`, and `test_deferred_symfloat_eq_assert_backend_eager`; all passed. An earlier command used uninstantiated parameterized names and was not counted.
- Ran SDPA backend-choice smoke tests: CPU dense dropout `0.0`/`0.7` float32 and CUDA dense fused choice; all passed. An earlier command used uninstantiated class names and was not counted.

### CI pyrefly follow-up
- The saved CI log path from the prompt was not present locally, but the current code matched the reported pyrefly narrowing issue.
- Applied a minimal pyrefly follow-up: locally narrow `node.target` before reading `_schema` and cast the schema-level dropout comparison for `statically_known_true`.
- Reverted optional `is_rng_op` refactoring so the follow-up diff stays small.
- Verified `uvx --python 3.10 lintrunner@0.12.7 --take PYREFLY torch/_functorch/partitioners.py` passes.

### Full rerun after pyrefly follow-up
- Reran the full validation set in one command: focused six remat tests, four ViaTags CUDA SAC tests, three RNG functionalization tests, three symbolic-shape checks, three SDPA backend-choice smoke tests, targeted PYREFLY, and `spin quicklint`.
- All behavioral tests passed: 6 + 4 + 3 + 3 + 3 tests all OK.
- Targeted PYREFLY and `spin quicklint` both passed.

### MUST_RECOMPUTE SDPA check
- Ran an ad hoc CUDA forward-loss-backward compile using selective checkpoint policy `MUST_RECOMPUTE` for SDPA ops.
- With `dropout_p=0.0`, compile succeeded and the captured graph had two SDPA ops, confirming actual recomputation.
- With `dropout_p=0.1`, compile raised `BackendCompilerFailed`, confirming true dropout RNG is still rejected.

### Lint and validation
- `spin quickfix` applied formatting changes, and `spin quicklint` passed.
- Re-ran the focused three-test command after formatting; all passed.

### Fetched PR #187995 failing CI
- Ran `github_ci_triage` for https://github.com/pytorch/pytorch/pull/187995 and saved logs under `agent_space/ci_logs_187995_refetch/`.
- The initial GitHub log fetch hid several failures because the runs were still in progress; Dr. CI's PR comment exposed exact failing tests.
- Refetched the exact failing jobs from S3 under `agent_space/ci_logs_187995_rng/`.
- Confirmed two consistent related failures: `test/inductor/test_compiled_autograd.py::TestCompiledAutograd::test_trace_run_with_rng_state` no longer saw `run_with_rng_state`, and `test/dynamo/test_activation_checkpointing.py::RematerializeACNodesPassTests::test_ac_rematerialize_with_sdpa_dropout_zero` failed only for the forced cuDNN subcase with `aten._scaled_dot_product_flash_attention.default encountered during backward but not found in storage`.
- Also confirmed the completed torchtitan failure is broken trunk: flavor `FSDP+CP+PP+compile with torchcomms` fails during model initialization in `nn.init.trunc_normal_` on a DTensor with `RuntimeError: Unsupported tensor data type for NCCL`.

### Fixed CI follow-ups
- Updated `test_trace_run_with_rng_state` to use `dropout_p=0.1`; the test is specifically checking the RNG-state HOP preservation path, and dropout-free SDPA is now intentionally classified as non-RNG.
- Kept the cuDNN forced-backend correctness subcase and fixed the test to keep `sdpa_kernel(backend)` active through `_grad`. The CI failure happened because checkpoint recompute runs during backward after the original backend context had exited; the recompute therefore used the default backend selection and hit flash while the original forward had been forced to cuDNN.
- Re-ran the exact failing tests locally: `TestCompiledAutograd.test_trace_run_with_rng_state` passed with exit 0, and `RematerializeACNodesPassTests.test_ac_rematerialize_with_sdpa_dropout_zero` passed with exit 0.
- Dropped an extra local `partitioners.py` cleanup because it was not needed for the CI follow-up and the committed PR branch already passes lint there.
- Ran `spin quicklint`; it completed with no lint issues.

### Latest CI follow-up after PR rerun
- Re-read `prime.md`, `PTQ_CONTEXT.md`, `system_prompt.md`, `worklog.md`, `report.md`, and `pytorch/AGENTS.md` before further edits.
- Fetched fresh PR CI with `~/dotfiles/scripts/github_ci_triage https://github.com/pytorch/pytorch/pull/187995`; latest failures still include repeated `TestCompiledAutograd.test_trace_run_with_rng_state` failures at commit `fd70172`, with `torch.ops.higher_order.run_with_rng_state` missing from `op_set` in `_run_with_rng_state_op_check`.
- Confirmed the worktree started clean at `fd7017250ff` (`origin/ptq/187985`), meaning the earlier two-test follow-up had already been committed/pushed.
- Found the prior local validation command for `test_compiled_autograd.py` was misleading on this aarch64 job because `HAS_CPU` is false, so the file runner exited 0 without running the method. Directly instantiating `TestCompiledAutograd.test_trace_run_with_rng_state` reproduced the CI assertion locally.
- Reworked `test_trace_run_with_rng_state` so it no longer uses SDPA as the source of `run_with_rng_state`. The test now explicitly calls `torch._prims.rng_prims.run_with_rng_state` from a tensor backward hook, keeps the compiled-autograd/Inductor preservation coverage, and asserts that an Inductor post-grad graph actually contains `run_with_rng_state`.
- Validated the compiled-autograd test by direct method invocation with `ATEN_CPU_CAPABILITY=default` to avoid the local aarch64 compiler `-march` issue: exit 0.
- Re-ran `RematerializeACNodesPassTests.test_ac_rematerialize_with_sdpa_dropout_zero`: `Ran 1 test ... OK`.
- Ran `spin quicklint`: no lint issues.
- Regenerated `fix.diff`; it now contains only the uncommitted compiled-autograd test rewrite.

### Historical check for compiled-autograd test
- Ran `codewalk` on `test_trace_run_with_rng_state`; the test was added by Will Feng in PR #127247 (`c07a799ed552`, `[Traceable FSDP2] Add Dynamo support for run_with_rng_state HOP`) to verify Dynamo/compiled-autograd tracing of the `run_with_rng_state` HOP and its functionalization path.
- Locally swapped `test_compiled_autograd.py` and `partitioners.py` to historical refs and directly invoked the test method with `ATEN_CPU_CAPABILITY=default`.
- `origin/main` original state (`dropout_p` implicit 0.0, old partitioner) passed locally.
- Core PR state `3b8579b52e6` (`dropout_p` implicit 0.0, dropout-aware partitioner) failed locally with the same missing-`run_with_rng_state` assertion, confirming this is the expected consequence of no longer treating zero-dropout SDPA as RNG.
- Follow-up state `fd7017250ff` (`dropout_p=0.1`) also failed locally. The reason is CPU SDPA with nonzero dropout no longer stays on the fused `_scaled_dot_product_flash_attention_for_cpu` path that the old test used; it decomposes to math/random operations and Inductor random primitives instead of preserving the `run_with_rng_state` HOP.
- Checked alternatives to the hook rewrite after review concern: CUDA forced-flash SDPA with dropout uses `graphsafe_run_with_rng_state`, not regular `run_with_rng_state`, and compiled autograd then hit an unrelated Dynamo `ObservedIndexError` at `call_aot_bwd_prologue[11]`.
- Tried preserving the original checkpoint/SDPA shape by explicitly wrapping CPU flash SDPA in `run_with_rng_state`; that failed because checkpoint's caching dispatch mode has no HOP rule for user-authored `run_with_rng_state` inside the checkpointed function.
- Kept the hook-based test but restored more of the original explanatory walkthrough/comment style so the test's purpose remains clear.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @liangel-02 @howardzhang-cv