### PR TITLE
Build mi350 ROCm workflows on OSDC, keep tests on ROCm hardware

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -111,6 +111,10 @@ runner_mapping:
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
+  # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
+  # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
+  amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
+  amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -89,6 +89,9 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
+      runner_prefix: "mt-"
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi350
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |

--- a/.github/workflows/inductor-rocm-mi350.yml
+++ b/.github/workflows/inductor-rocm-mi350.yml
@@ -45,7 +45,9 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: ""
+      runner_prefix: "mt-"
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/periodic-rocm-mi350.yml
+++ b/.github/workflows/periodic-rocm-mi350.yml
@@ -51,7 +51,9 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: ""
+      runner_prefix: "mt-"
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/rocm-mi350.yml
+++ b/.github/workflows/rocm-mi350.yml
@@ -44,7 +44,9 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: ""
+      runner_prefix: "mt-"
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |


### PR DESCRIPTION
Migrates the build jobs of the four **mi350** ROCm workflows (`rocm-mi350`, `inductor-rocm-mi350`, `periodic-rocm-mi350`, `inductor-perf-test-nightly-rocm-mi350`) off AWS onto OSDC (ARC) x86 runners, tests staying on the gfx950 ROCm GPU runners. Completes the ROCm build-on-OSDC migration (the other 11 are in a separate PR).

Per build job: `use-arc: true`, `runner_prefix: "mt-"`, add `ci-docker-hash`.

These were deferred because their test labels carry the amd-do experiment prefix (`${{ amd-do-label-type }}linux.rocm.gpu.gfx950.x`). When amd-do is on, the label is `amd-do-linux.rocm.gpu.gfx950.1`, which the OSDC build's `map_ec2_to_arc.py` would otherwise fail to resolve. They're added to `arc.yaml` as passthrough (identity) entries next to the plain gfx950 labels, so the mapper keeps them unprefixed and amd-do routing is preserved. No mapper code change. `_rocm-test.yml` jobs unchanged.

### Validation
```
python3 .github/scripts/map_ec2_to_arc.py --prefix "mt-" '{ include: [ { config: "x", shard: 1, num_shards: 1, runner: "amd-do-linux.rocm.gpu.gfx950.1" } ]}'
# -> amd-do-linux.rocm.gpu.gfx950.1 (passthrough)
```

### Testing

https://github.com/pytorch/pytorch/actions/runs/28066712352

Authored with the assistance of an AI coding agent (Claude Code).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang