### PR TITLE
Fix uninitialized embedding indices in test_embedding_meta_indices

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1709,11 +1709,14 @@ def forward(self, x_1):
     def test_embedding_meta_indices(self):
         with FakeTensorMode():
             weight = torch.empty(20, 8)
-            indices = torch.empty(2, 3, dtype=torch.long, device="meta")
+            # Indices must be in range: under propagate_real_tensors the real
+            # embedding gather runs, and uninitialized (torch.empty) indices read
+            # out of bounds -- a hard GPU fault on some backends (e.g. ROCm).
+            indices = torch.zeros(2, 3, dtype=torch.long, device="meta")
             out = torch.nn.functional.embedding(indices, weight)
 
             meta_weight = torch.empty(20, 8, dtype=torch.float64, device="meta")
-            cpu_indices = torch.empty(4, 5, dtype=torch.long)
+            cpu_indices = torch.zeros(4, 5, dtype=torch.long)
             meta_weight_out = torch.nn.functional.embedding(cpu_indices, meta_weight)
 
             run_cuda_cases = (
@@ -1722,7 +1725,7 @@ def forward(self, x_1):
             )
             if run_cuda_cases:
                 cuda_weight = torch.empty(20, 8, device="cuda")
-                cuda_indices = torch.empty(2, 3, dtype=torch.long, device="cuda")
+                cuda_indices = torch.zeros(2, 3, dtype=torch.long, device="cuda")
                 cuda_out = torch.nn.functional.embedding(cuda_indices, cuda_weight)
 
         self.assertIsInstance(out, FakeTensor)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188002

test_embedding_meta_indices built its embedding index tensors with
torch.empty(..., dtype=torch.long), i.e. uninitialized memory. The values
never mattered for the FakeTensorMode metadata assertions, but under
PropagateRealTensorsFakeTensorTest (fake_tensor_propagate_real_tensors) the
real embedding gather actually executes on the device with those garbage
indices. Garbage longs are almost always far outside the 20-row weight table,
so the real gather reads out of bounds.

On CUDA this is silently tolerated (index_select/embedding does not bounds
check; the OOB read returns garbage), which is why the test was always green on
NVIDIA CI. On ROCm gfx950 the same OOB read raises a hard GPU hardware
exception (HSA_STATUS_ERROR_EXCEPTION, surfaced as "CUDA error: unspecified
launch failure"), which poisons the HIP context for the rest of the process.
Subsequent tests then fail at their first CUDA call (e.g. in setUp's
manual_seed), so the failures were misattributed to unrelated tests
(test_index_cuda_with_cpu_* for int16/float8), and the per-test disables
#187836/#187867/#187895/#187942 were treating victims, not the cause.

The fault was nondeterministic because torch.empty returns recycled allocator
memory: in a fresh process it is often small/in-range, but after other tests
churn the allocator it holds large/OOB values. It was localized by running only
test_fake_tensor on gfx950 with AMD_SERIALIZE_KERNEL=3, which reports the fault
at the actual launching test instead of a later victim.

Fix: use in-range indices (torch.zeros) for the index tensors. Weights stay
uninitialized since their contents are irrelevant. This removes the out-of-
bounds access on every backend.

Follow-up (separate change): with the trigger fixed, the int16/float8
test_index_cuda_with_cpu_* disables should be re-enabled and confirmed.

Test Plan:

```
python test/test_fake_tensor.py -v -k embedding_meta_indices
lintrunner -a test/test_fake_tensor.py
```

All embedding_meta_indices variants pass locally on CUDA, including
test_embedding_meta_indices_propagate_real_tensors. The no-fault behavior is
inherently gfx950-specific (CUDA tolerates the OOB read), so end-to-end
confirmation is via re-running test_fake_tensor on an MI350 runner.

Authored with Claude.