### PR TITLE
Don't fail-fast the nightly update-commit-hashes matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -135,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: update-commit-hash
     strategy:
+      fail-fast: false
       matrix:
         include:
           - repo-name: vision


### PR DESCRIPTION
## Summary

The nightly `update-commit-hashes` job (`.github/workflows/nightly.yml`) runs one matrix leg per tracked repo (vision, audio, triton, vllm, torchtitan, torchcomms). The matrix used the default `fail-fast: true`, so when one leg failed GitHub **cancelled the other in-progress legs**.

In nightly run [28067407540](https://github.com/pytorch/pytorch/actions/runs/28067407540) the `torchcomms` leg crashed and took down the otherwise-healthy `triton` leg with it ([cancelled](https://github.com/pytorch/pytorch/actions/runs/28067407540/job/83094641205)).

Setting `fail-fast: false` makes each repo's hash update independent, so a single repo's failure no longer cancels the rest.

The underlying torchcomms crash is fixed separately in pytorch/test-infra (the `update_commit_hashes.py` script crashed when the old pinned commit was orphaned upstream). This PR just limits the blast radius.

This PR was authored with the assistance of an AI coding assistant.