### PR TITLE
Remove dead tensorexpr xref from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,7 +269,6 @@ dependencies as well as the nightly binaries into the repo directory.
   * [cpp](test/cpp) - C++ unit tests for PyTorch C++ frontend.
     * [api](test/cpp/api) - [README](test/cpp/api/README.md)
     * [jit](test/cpp/jit) - [README](test/cpp/jit/README.md)
-    * [tensorexpr](test/cpp/tensorexpr) - [README](test/cpp/tensorexpr/README.md)
   * [expect](test/expect) - Automatically generated "expect" files
     which are used to compare against expected output.
   * [onnx](test/onnx) - Tests for ONNX export functionality,


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` linked to `test/cpp/tensorexpr` and its README, but that directory was deleted in #158928 ("Remove tensorexpr tests"). The nightly `Link checks / lint-xrefs` job scans the whole repo (unlike on PRs, where it only checks the diff) and was failing on these two dead cross-references:

```
FAIL test/cpp/tensorexpr
FAIL test/cpp/tensorexpr/README.md
```

This drops the stale bullet so the cross-reference check passes again. The sibling `test/cpp/{api,jit}` links are unaffected and still resolve.

Surfaced in nightly run [28067407540](https://github.com/pytorch/pytorch/actions/runs/28067407540/job/83094673913).

Note: the sibling `lint-urls` nightly job is also red, but that's a separate, repo-wide link-rot cleanup (~25 files of dead/unreachable URLs) and is intentionally out of scope here.

## Test Plan

Verified the removed targets no longer exist and the remaining `test/cpp/*` link targets are present in the tree.

This PR was authored with the assistance of an AI coding assistant.