### PR TITLE
[partitioner] Fix memory-budget short-circuit emitting non-saveable tuple node

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7127,6 +7127,61 @@ def forward(self, primals_1, tangents_1):
         x = torch.randn(4, requires_grad=True)
         fn(x).sum().backward()
 
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_multi_output_must_save_budget(self):
+        """MUST_SAVE on a multi-output (tuple) producer under a fractional
+        activation_memory_budget must not crash and must be honored.
+
+        With a low budget, choose_saved_values_set can reach the branch where
+        there is nothing left for the knapsack to trade off (every banned node
+        is must-save). That branch used to return inputs + must_save_nodes, which
+        leaked the non-saveable tuple producer node into saved_values and tripped
+        a downstream "expected all ... to be Tensors" assertion. It must instead
+        return a real min-cut, saving the producer's getitem tensors.
+        """
+        import torch._functorch.config as functorch_config
+        from torch.utils.checkpoint import CheckpointPolicy
+
+        producer = torch.ops.aten.topk.default
+
+        def f(x):
+            vals, idx = torch.topk(x.sin(), k=4, dim=1)
+            return (vals.cos() * idx.float().sin()).sum()
+
+        def mark_producer_must_save(gm, joint_inputs):
+            for node in gm.graph.nodes:
+                if node.op == "call_function" and node.target is producer:
+                    node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+            return gm
+
+        bw_graph = {}
+
+        def bw_compiler(gm, _):
+            bw_graph["gm"] = gm
+            return gm
+
+        compiled = aot_function(
+            f,
+            fw_compiler=lambda gm, _: gm,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+
+        x = torch.randn(64, 64, requires_grad=True)
+        with functorch_config.patch(
+            activation_memory_budget=0.1,
+            joint_custom_pass=mark_producer_must_save,
+        ):
+            compiled(x).backward()
+
+        x_ref = x.detach().clone().requires_grad_()
+        f(x_ref).backward()
+        self.assertEqual(x.grad, x_ref.grad)
+
+        # MUST_SAVE on the producer is honored: it is saved, not recomputed,
+        # so the producer op does not appear in the backward graph.
+        self.assertNotIn("topk", bw_graph["gm"].code)
+
     def test_disable_functionalization_ignores_effect_token_metadata(self):
         def fn(args):
             (x,) = args

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3223,7 +3223,9 @@ def choose_saved_values_set(
         recomputable_banned_nodes, key=_size_of, reverse=True
     )
     if len(all_recomputable_banned_nodes) == 0:
-        return node_info.inputs + must_save_nodes
+        # Nothing left for the knapsack to trade off, so this is the same cut the
+        # knapsack would return with an empty dont_ban.
+        return aggressive_recomputation_saved_values
     memories_banned_nodes = [
         get_normalized_size(_size_of(i)) for i in all_recomputable_banned_nodes
     ]


### PR DESCRIPTION
## Summary

In `choose_saved_values_set` (the activation-memory-budget path), there is a
short-circuit for when the knapsack has nothing to trade off: every banned node
is either a graph input or marked `MUST_SAVE`, so `dont_ban` would be empty.
That branch returned `node_info.inputs + must_save_nodes`.

**Root cause:** for a multi-output (tuple-returning) producer marked
`MUST_SAVE`, `must_save_nodes` contains the producer node itself, which is not a
saveable tensor -- in `solve_min_cut` its `in -> out` edge has capacity `inf`
with reason `"non-tensor output"`. Emitting that node into `saved_values` sends
a tuple where a Tensor is expected, tripping a downstream assertion:
`expected all tensors_saved_with_vc_check to be Tensors, got [Tensor, tuple]`.
The manually-built list also drops required-for-backward saves (the sink-edge
mechanism), since those are never in `banned_nodes`.

**Fix:** return `aggressive_recomputation_saved_values`, which is already
computed just above. When `all_recomputable_banned_nodes` is empty, the knapsack
would pick an empty `dont_ban`, so `solve_min_cut(..., aggressive_options, {})`
is definitionally this value -- the same answer the non-degenerate path would
produce, with no extra solve. Because it is a real min-cut, `MUST_SAVE` is
honored through the source-ban inf-chain (the producer is pinned to the source
side, forcing the cut onto its getitem tensors rather than the tuple node), and
required-for-backward values are included. It is also the correct best-effort
result here: we only reach this branch after proving even the most aggressive
recompute exceeds the budget, so the lowest-memory cut is what we want.

## Test Plan

```
python -c "import sys; sys.modules['torchvision']=None; import pytest; \
sys.exit(pytest.main(['test/functorch/test_aotdispatch.py', \
'-k','test_min_cut_partitioner_multi_output_must_save_budget','-x','-q']))"
```

The new test marks a multi-output `torch.topk` producer `MUST_SAVE` under
`activation_memory_budget=0.1` (which drives `all_recomputable_banned_nodes == 0`),
and asserts the run does not crash, gradients match eager, and the producer is
saved (not recomputed). It fails without the fix (`AssertionError`) and passes
with it. The full `TestPartitioning` class was also run on the built tree with
no new failures.

---
This PR was authored with the assistance of an AI coding assistant.