### PR TITLE
[SDPA] Fix 32-bit dropout RNG offset overflow in mem-efficient attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -763,9 +763,13 @@ struct AttentionBackwardKernel {
       // Advance pointers that depend on the total concatenated
       // number of queries, as `num_queries` is modified in the block
       // below
+      // `batch_id` is int64_t here, but the `num_heads * num_queries *
+      // num_keys` product is evaluated in 32-bit and wraps once it exceeds
+      // 2^32. Widen it so this matches the forward pass, which indexes the
+      // same dropout RNG sequence.
       dropout_batch_head_rng_offset =
-          batch_id * (num_heads * num_queries * num_keys) +
-          head_id * (num_queries * num_keys);
+          batch_id * int64_t(num_heads) * num_queries * num_keys +
+          int64_t(head_id) * num_queries * num_keys;
       logsumexp_ptr += batch_id * lse_strideB + head_id * lse_strideH;
 
       if (cu_seqlens_q_ptr != nullptr) {

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -203,9 +203,13 @@ struct AttentionKernel {
       auto lse_dim = ceil_div((int32_t)num_queries, kAlignLSE) * kAlignLSE;
 
       if (kSupportsDropout) {
+        // `batch_id`/`head_id` are 32-bit, so compute the per-(batch, head)
+        // RNG offset in 64-bit to avoid wraparound when
+        // num_queries * num_keys > 2^32. The backward pass indexes the same
+        // dropout RNG sequence, so the two must agree (see below).
         dropout_batch_head_rng_offset =
-            batch_id * num_heads * num_queries * num_keys +
-            head_id * num_queries * num_keys;
+            int64_t(batch_id) * num_heads * num_queries * num_keys +
+            int64_t(head_id) * num_queries * num_keys;
       }
 
       int64_t q_start = 0, k_start = 0;

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2234,6 +2234,7 @@ class TestSDPAFailureModes(NNTestCase):
         # before the fix, all rows past 2**32 // seq_len were garbage
         self.assertEqual(out, ref, atol=5e-3, rtol=5e-3)
 
+    @largeTensorTest("12GB", "cuda")
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support Efficient Attention")
     def test_mem_eff_attention_dropout_rng_offset_no_overflow(self):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2234,6 +2234,48 @@ class TestSDPAFailureModes(NNTestCase):
         # before the fix, all rows past 2**32 // seq_len were garbage
         self.assertEqual(out, ref, atol=5e-3, rtol=5e-3)
 
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support Efficient Attention")
+    def test_mem_eff_attention_dropout_rng_offset_no_overflow(self):
+        # The per-(batch, head) dropout RNG offset is
+        #   (batch_id * num_heads + head_id) * num_queries * num_keys
+        # and used to be computed in 32-bit. At seq_len == 65536 the product
+        # num_queries * num_keys is exactly 2**32, so every (batch, head)
+        # offset wraps to 0 and all heads end up drawing the same dropout mask.
+        # Feed the heads identical q/k/v so that any difference in the output
+        # can only come from the dropout RNG: with the overflow the two heads
+        # are masked identically, after the fix they are masked independently.
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+
+        seq_len = 65536  # num_queries * num_keys == 2**32 exactly
+        num_heads = 2
+        head_dim = 8
+        torch.manual_seed(0)
+        qk = torch.randn(1, 1, seq_len, head_dim, device=device, dtype=dtype)
+        query = qk.expand(1, num_heads, seq_len, head_dim).contiguous()
+        key = query.clone()
+        value = (
+            torch.randn(1, 1, seq_len, head_dim, device=device, dtype=dtype)
+            .expand(1, num_heads, seq_len, head_dim)
+            .contiguous()
+        )
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            # Sanity: identical inputs and no dropout -> identical heads.
+            no_dropout = torch.nn.functional.scaled_dot_product_attention(
+                query, key, value, dropout_p=0.0
+            )
+            self.assertEqual(no_dropout[:, 0], no_dropout[:, 1])
+
+            torch.manual_seed(0)
+            out = torch.nn.functional.scaled_dot_product_attention(
+                query, key, value, dropout_p=0.5
+            )
+        # The heads must be dropped independently; with the 32-bit overflow
+        # both offsets wrapped to 0 and the two heads came out identical.
+        self.assertFalse(torch.allclose(out[:, 0], out[:, 1]))
+
 
 def _get_block_size_n(device, head_dim, is_dropout, is_causal):
     # This should match the block sizes in the CUDA kernel


### PR DESCRIPTION
### Summary

`mem_eff_attention` computes the per-`(batch, head)` dropout RNG offset as

```cpp
(batch_id * num_heads + head_id) * num_queries * num_keys
```

in 32-bit. That product wraps once `num_queries * num_keys` reaches `2**32` (`seq_len > 65536`, or sooner once you multiply through several heads/batches, since the head term alone is `num_heads * num_queries * num_keys`).

This is the same overflow class as #187684, which just widened the `attn_bias` offset and the dropout `skipahead` argument on the forward path. This PR covers the remaining dropout RNG offset on both the forward and backward kernels.

### Why it matters

Two separate things break once the offset wraps:

1. The forward pass evaluates the whole expression in 32-bit. The backward pass already has `batch_id` as `int64_t`, but it still forms `num_heads * num_queries * num_keys` in 32-bit, so the two sides land on different offsets at large sizes. The dropout mask reconstructed during backward then no longer matches the one forward applied, and the gradients are silently wrong. That is the same failure mode #187684 was chasing.

2. Distinct `(batch, head)` slots collapse onto the same wrapped offset and end up drawing the same dropout mask instead of being masked independently.

The neighboring pointer math in these kernels (`output_ptr`, `output_accum_ptr`, the `attn_bias` offset from #187684) is already done with explicit `int64_t(...)` casts. The dropout offset was the odd one out.

### Reproduction

At `seq_len == 65536`, `num_queries * num_keys == 2**32` exactly, so every slot's offset is a multiple of `2**32` and wraps to 0:

```python
>>> M, S, H = 1 << 32, 65536, 4
>>> [((b * H + h) * S * S) % M for (b, h) in [(0, 0), (0, 1), (1, 0), (3, 3)]]
[0, 0, 0, 0]
```

Every head shares offset 0, so under dropout they all get the identical mask.

The added test `test_mem_eff_attention_dropout_rng_offset_no_overflow` exercises exactly this: `seq_len == 65536`, two heads fed identical q/k/v, and it asserts the heads come out different under `dropout_p=0.5` (independent masks) while staying identical at `dropout_p=0.0`. Before the fix both heads are byte-identical under dropout; after it they differ.

### Testing note

I verified the offset arithmetic above on CPU, but I don't have a CUDA GPU on hand to run the kernel-level test locally, so I'm leaning on CI for that part. The fix itself is the same `int64` widening #187684 applied a few lines up.

There's one more instance of this pattern I left out on purpose: the forward `logsumexp_ptr` advance (`batch_id * lse_dim * num_heads + ...` near the top of `kernel_forward.h`). It only overflows at much larger sizes and isn't on the dropout path, so I kept this PR scoped to the forward/backward dropout pair that the test covers. Happy to fold it in if you'd rather have it here.


cc @drisspg @liangel-02 @howardzhang-cv