### PR TITLE
Build remaining B200 workflows on OSDC

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -99,6 +99,10 @@ runner_mapping:
 
   # ---- Partner hardwares ----
 
+  # 8-GPU B200 has OSDC runners, but not enough capacity there yet, so keep it as
+  # a passthrough for now: OSDC builds can run while tests stay on the existing
+  # linux.dgx.b200.8 runner until OSDC capacity is available.
+  linux.dgx.b200.8: linux.dgx.b200.8
   linux.idc.xpu: linux.idc.xpu
   linux.google.tpuv7x.1: linux.google.tpuv7x.1
   linux.rocm.gpu.2: linux.rocm.gpu.2

--- a/.github/workflows/b200-distributed.yml
+++ b/.github/workflows/b200-distributed.yml
@@ -38,8 +38,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.r7i.4xlarge
+      runner_prefix: "mt-"
+      runner: l-x86iavx512-16-128
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-distributed-b200
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11
       cuda-arch-list: '10.0'

--- a/.github/workflows/b200-symm-mem.yml
+++ b/.github/workflows/b200-symm-mem.yml
@@ -38,8 +38,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.r7i.4xlarge
+      runner_prefix: "mt-"
+      runner: l-x86iavx512-16-128
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm100-symm
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11
       cuda-arch-list: '10.0'

--- a/.github/workflows/inductor-perf-test-b200.yml
+++ b/.github/workflows/inductor-perf-test-b200.yml
@@ -84,12 +84,14 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "mt-"
       # Use a bigger runner here because CUDA_ARCH 9.0 is only built for H100
       # or newer GPUs, so it doesn't benefit much from existing compiler cache
       # from trunk. Also use a memory-intensive runner here because memory is
       # usually the bottleneck
-      runner: linux.12xlarge.memory
+      runner: l-x86iavx512-48-384
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm100
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-inductor-benchmarks
       cuda-arch-list: '10.0'
@@ -113,6 +115,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      use-arc: true
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       timeout-minutes: 720
       disable-monitor: false
@@ -132,6 +135,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      use-arc: true
       timeout-minutes: 1440
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       disable-monitor: false
@@ -150,6 +154,7 @@ jobs:
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      use-arc: true
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       timeout-minutes: 720
       export-profiler-trace: "1"


### PR DESCRIPTION
Migrates the build jobs of the three remaining B200 workflows (`b200-distributed`, `b200-symm-mem`, `inductor-perf-test-b200`) off AWS onto OSDC (ARC) x86 runners. Each build: `use-arc: true`, `runner_prefix: "mt-"`, `ci-docker-hash`, and the OSDC equivalent build runner (`l-x86iavx512-16-128` for `r7i.4xlarge`, `l-x86iavx512-48-384` for `12xlarge.memory`).

Tests differ by the B200 test runner:

- **`b200-distributed` / `b200-symm-mem`** run on the 8-GPU `linux.dgx.b200.8`. OSDC has these runners but not enough capacity there yet, so `linux.dgx.b200.8` is added to `arc.yaml` as a passthrough (identity) entry: the build's `map_ec2_to_arc.py` keeps the label and tests stay on the existing runner until OSDC capacity is available. Their test jobs are unchanged.
- **`inductor-perf-test-b200`** runs on the 1-GPU `linux.dgx.b200`, already a `meta_only` runner that remaps to the OSDC B200 runner (`mt-l-x86iamx-22-225-b200`), consistent with the already-migrated `test-b200`. Its test jobs get `use-arc: true` to run on that ARC runner; no `arc.yaml` change.

Same-repo branch (not a fork) so `workflow_dispatch` runs get the full `id-token: write` token for OIDC. Supersedes #188007.

### Validation
```
python3 .github/scripts/map_ec2_to_arc.py --prefix "mt-" '{ include: [ { config: "a", shard: 1, num_shards: 1, runner: "linux.dgx.b200.8" }, { config: "b", shard: 1, num_shards: 1, runner: "linux.dgx.b200" } ]}'
# -> linux.dgx.b200.8 (passthrough); mt-l-x86iamx-22-225-b200 (meta_only remap)
```

Authored with the assistance of an AI coding agent (Claude Code).