### PR TITLE
[SymmMem] Skip test_get on ROCm

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
     requires_cuda_p2p_access,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_WITH_ROCM,
 )
 
 
@@ -290,6 +291,9 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             # TODO: remove after we have wait_signal
             dist.barrier()
 
+    @skip_but_pass_in_sandcastle_if(
+        TEST_WITH_ROCM, "nvshmem_get_out not yet implemented for ROCm"
+    )
     def test_get(self) -> None:
         self._init_device()
         group_name = dist.group.WORLD.group_name


### PR DESCRIPTION
`symm_mem::nvshmem_get_out` (added in #182378) has no rocSHMEM/HIP kernel yet, so `test/distributed/test_nvshmem.py::NVSHMEMSymmetricMemoryTest::test_get` raises `NotImplementedError` and consistently reds the `linux-jammy-rocm-py3.10-mi350` distributed trunk shards.

Gate `test_get` on ROCm, matching the NCCL `test_get` gating from the same PR. rocSHMEM support can lift the skip later. This should be safe since `test_get` was introduced in the referenced PR, and other targets also include examples like `@skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")`

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @BenBrock 