### PR TITLE
Guard CuTeDSL topk override against non-current CUDA device

### DIFF
--- a/test/python_native/test_topk_cutedsl.py
+++ b/test/python_native/test_topk_cutedsl.py
@@ -243,6 +243,33 @@ class TestCuTeDSLTopK(TestCase):
         expected.scatter_(-1, i, 1.0)
         self.assertEqual(x.grad, expected)
 
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "requires at least 2 visible CUDA devices",
+    )
+    def test_non_current_device(self) -> None:
+        """The override must launch on the input's device even when it isn't
+        the current device. The Python-native dispatch path gets no automatic
+        CUDA device guard, so without the guard the CuTeDSL kernel launches on
+        the current device's stream and rejects the off-device input (mirrors
+        the bmm override regression fixed in #187983)."""
+        k = 32  # register kernel; _test_n(k) keeps the override in range
+        old_device = torch.cuda.current_device()
+        try:
+            torch.cuda.set_device(0)
+            x = torch.randn(256, _test_n(k), device="cuda:1", dtype=torch.float32)
+            pn = torch.backends.python_native
+            with pn.cutedsl.disabled():
+                ref_v, _ = torch.topk(x, k, dim=-1)
+            got_v, got_i = torch.topk(x, k, dim=-1)
+            # current device unchanged; result stays on the input's device
+            self.assertEqual(torch.cuda.current_device(), 0)
+            self.assertEqual(got_v.device, torch.device("cuda:1"))
+            self.assertEqual(got_v, ref_v)
+            self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        finally:
+            torch.cuda.set_device(old_device)
+
 
 instantiate_parametrized_tests(TestCuTeDSLTopK)
 

--- a/torch/_native/ops/topk/cutedsl_impl.py
+++ b/torch/_native/ops/topk/cutedsl_impl.py
@@ -162,14 +162,28 @@ def _run(self: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     self_2d = flatten_last_dim(self)
     N = self_2d.shape[-1]
     kernel = _kernel_for(k, N)
-    if kernel == "register":
-        values_2d, indices_2d = topk_register(self_2d, k)
-    else:
+
+    def _launch() -> tuple[torch.Tensor, torch.Tensor]:
+        if kernel == "register":
+            return topk_register(self_2d, k)
         # Pick the deterministic kernel under torch.use_deterministic_algorithms
         # (kept off by default for perf; the non-det kernel still produces
         # correct top-K values but indices may differ on ties).
         deterministic = torch.are_deterministic_algorithms_enabled()
-        values_2d, indices_2d = topk_radix(self_2d, k, deterministic=deterministic)
+        return topk_radix(self_2d, k, deterministic=deterministic)
+
+    # The Python-native dispatch path does not get an automatic CUDA device
+    # guard before launching the kernel (unlike the generated C++ ATen path),
+    # so the CuTeDSL kernel runs on the current device's stream. Guard the
+    # launch when the input is not already on the current device, while leaving
+    # the common already-current path direct to avoid the context-manager
+    # overhead. See #187983 for the same fix on the bmm override.
+    device = self.get_device()
+    if device == torch.cuda.current_device():
+        values_2d, indices_2d = _launch()
+    else:
+        with torch.cuda.device(device):
+            values_2d, indices_2d = _launch()
     return unflatten_last_dim(values_2d, indices_2d, self, k)
 
 


### PR DESCRIPTION
The Python-native `topk` override launches a CuTeDSL kernel for eligible CUDA
inputs. Unlike the generated C++ ATen CUDA path, this Python dispatch path does
not get an automatic CUDA device guard before launching the kernel, so the
CuTeDSL kernel runs on the *current* device's stream. When the input lives on a
device other than the current one (e.g. model hooks running buffers on `cuda:1`
while the process current device is still `cuda:0`), the kernel launches on the
wrong device and rejects the off-device pointers.

This is the same root cause that #187983 just fixed for the `bmm` outer-product
override. The output of `_run` is allocated on the input's device (inside the
kernels), but the launch goes to the current device's stream, so a non-current
input mismatches.

The fix guards the kernel launch with the input's device when it isn't already
current, and leaves the common already-current path direct to avoid the
context-manager overhead (mirroring the conditional guard in #187983). Both the
functional and `.out` variants route through `_run`, so a single guard covers
them.

The same missing-guard pattern also affects the other Python-native overrides
that launch on the current/env stream — `scatter_add` and `_fused_rms_norm`
(CuTeDSL), and the nvmath path of `_foreach_mm` (which uses
`torch.cuda.current_stream()` directly). I kept this PR scoped to `topk` because
it has a dedicated override test I can extend with a clean repro; happy to send
the same guard for the others as a follow-up, or fold them in here if you'd
prefer one sweep.

## Test Plan

Adds `test_non_current_device` to `TestCuTeDSLTopK`. It reuses the existing
`_test_n(k)` shape helper (so the override actually fires rather than falling
through to aten), allocates the input on `cuda:1` with the current device set to
`cuda:0`, and checks the result lands on `cuda:1` and matches the aten reference.
It is gated on `torch.cuda.device_count() >= 2`.

Note: I don't have a 2-GPU machine, so I could not execute this test locally;
the change is verified by code inspection against the #187983 precedent and is
arch/device-gated for CI. `python -m py_compile` and `ruff check` / `ruff
format --check` pass on both files.
