### PR TITLE
[ROCm][CI] Fail fast on gfx950 pods with broken KFD topology

### DIFF
--- a/.ci/pytorch/rocm_preflight.py
+++ b/.ci/pytorch/rocm_preflight.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Fast ROCm/RCCL pre-flight health check for distributed CI shards.
+
+Some gfx950 runner pods come up with a container that cannot read part of the
+KFD/HSA topology -- RCCL fails every collective init with
+"ncclUnhandledCudaError: Call to CUDA function failed / Could not read node #N"
+(N is a fixed topology-node index for that pod). When a distributed shard lands
+on such a pod, the first collective crashes and a later test hangs the whole
+shard until the 270-minute job timeout. Host-side ``rocminfo`` still enumerates
+the GPUs on these pods, so the existing GPU-count gate does not catch it.
+
+This runs a tiny multi-rank all_reduce inside the test container before the
+suite. If it fails (or is killed by the outer ``timeout``), the job fails in
+seconds with a clear message instead of hanging, and the bad pod can be drained.
+"""
+
+import datetime
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+_PG_TIMEOUT = datetime.timedelta(seconds=60)
+
+
+def _worker(rank: int, world_size: int) -> None:
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29555")
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size, timeout=_PG_TIMEOUT
+    )
+    try:
+        t = torch.ones(16, device=f"cuda:{rank}")
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+    finally:
+        dist.destroy_process_group()
+
+
+def main() -> int:
+    n = torch.cuda.device_count()
+    if n < 1:
+        print("::error::ROCm pre-flight: no GPUs visible to the container")
+        return 1
+    world_size = min(2, n)
+    try:
+        mp.spawn(_worker, args=(world_size,), nprocs=world_size, join=True)
+    except Exception as e:
+        print(
+            "::error::ROCm/RCCL pre-flight failed: the container cannot "
+            f"initialize a {world_size}-rank collective on this runner -- "
+            "likely a broken KFD/HSA topology on this pod (look for "
+            '"Could not read node #N"). Failing fast instead of hanging; '
+            f"re-run to land on a healthy runner. Underlying error: {e}"
+        )
+        return 1
+    print(f"ROCm/RCCL pre-flight passed ({world_size}-rank all_reduce)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -273,7 +273,16 @@ jobs:
           echo "CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
           WORKSPACE_ORIGINAL_OWNER_ID=$(docker exec -t "${container_name}" stat -c '%u' /var/lib/jenkins/workspace | tr -d '\r')
           echo "WORKSPACE_ORIGINAL_OWNER_ID=${WORKSPACE_ORIGINAL_OWNER_ID}" >> "$GITHUB_ENV"
-          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
+          # ROCm/RCCL pre-flight for distributed shards: some gfx950 pods come up
+          # with a container that can't read the KFD topology ("Could not read
+          # node #N"), so every collective init fails and a later test hangs the
+          # whole shard until the 270-min job timeout. Host-side rocminfo still
+          # passes on these pods, so the GPU-count check misses it. Fail fast.
+          PREFLIGHT=""
+          if [[ "${TEST_CONFIG}" == *distributed* ]]; then
+            PREFLIGHT="timeout 180 python .ci/pytorch/rocm_preflight.py && "
+          fi
+          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${PREFLIGHT}${TEST_COMMAND}"
 
       - name: Restore workspace owner (for gfx1100 only)
         if: always() && contains(matrix.runner, 'gfx1100')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188024

Some gfx950 (MI350) 2-GPU runner pods come up with a container that cannot read
part of the KFD/HSA topology. RCCL then fails every collective init with
"ncclUnhandledCudaError: Call to CUDA function failed / Could not read node #N"
(N is a fixed topology-node index for that pod, e.g. #2 or #9). When a
distributed shard lands on such a pod, the first collective crashes and a later
test hangs the whole shard until the 270-minute job timeout. Host-side rocminfo
still enumerates the GPUs on these pods, so the existing "Runner check GPU
count" gate does not catch it -- the failure is the container's deeper topology
read, not agent enumeration.

Diagnosis: the same RCCL error appears across many different distributed tests
and both worker-crash and downstream-hang forms; in the logs it is constant per
pod and present from the very first collective, and world_size is 2 so "node #N"
cannot be a rank -- it is a system topology node. So it is a per-pod container
health problem, not a PyTorch or per-test bug.

Fix: add a fast in-container RCCL pre-flight (.ci/pytorch/rocm_preflight.py) that
spawns a min(2, ngpu)-rank process group and does one all_reduce. For
distributed shards _rocm-test.yml runs it (wrapped in `timeout 180`) before the
suite; on failure or hang the job fails in seconds with a clear message instead
of hanging for 270 minutes, and the bad pod is identifiable for draining.
Non-distributed shards are unchanged.

Test Plan:

```
python -m py_compile .ci/pytorch/rocm_preflight.py
lintrunner -a .ci/pytorch/rocm_preflight.py .github/workflows/_rocm-test.yml
```

Validated the pre-flight directly. Locally on 8x A100 (the nccl backend
exercises the same init/collective path RCCL uses) the script passes:

  ROCm/RCCL pre-flight passed (2-rank all_reduce)

and the failure path is exercised too: when the process group cannot initialize,
mp.spawn raises, the script prints the "::error::" message and exits 1 -- the job
fails fast instead of hanging.

In CI, dispatched the gate on the gfx950.2 distributed pool: the pre-flight ran
inside the container and passed on healthy pods (exit 0, suite proceeded). The
broken-pod case is the same exit-1 fast-fail path; it only reproduces when a pod
with the broken KFD topology is in rotation, and the pool was healthy during
testing, so that specific case was not caught live.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang