### PR TITLE
fix: initialize r to prevent uninitialized memory return in Laguerre and Legendre polynomials

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -3148,7 +3148,7 @@ inline C10_HOST_DEVICE T laguerre_polynomial_l_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = T(1.0) - x;
-    T r;
+    T r = q;
 
     for (int64_t k = 1; (k < n) && !std::isnan(q); k++) {
         r = (((k + k) + (T(1.0) - x)) * q - k * p) / (k + 1);
@@ -3188,7 +3188,7 @@ inline C10_HOST_DEVICE T legendre_polynomial_p_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x;
-    T r;
+    T r = q;
 
     for (int64_t k = 1; (k < n) && !std::isnan(q); k++) {
         r = ((k + k + 1) * x * q - k * p) / (k + 1);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -255,6 +255,31 @@ class TestBinaryUfuncs(TestCase):
                 result_nc = op(x_nc, n_nc)
                 self.assertTrue(result_nc.isnan().all())
 
+    def test_laguerre_legendre_polynomial_nan_propagation(self):
+        # Same uninitialized-memory bug as test_chebyshev_polynomial_nan_propagation
+        # above (#187761/#187762), in the two remaining recurrences that guard the
+        # loop with !isnan(q): laguerre_polynomial_l and legendre_polynomial_p. With
+        # a NaN x, q is NaN up front so the loop never runs and `T r` was returned
+        # uninitialized. hermite_polynomial_he has no isnan guard (its loop always
+        # runs once for n >= 2), so it is not affected.
+        nan = float("nan")
+        ops = [
+            torch.special.laguerre_polynomial_l,
+            torch.special.legendre_polynomial_p,
+        ]
+        for op in ops:
+            with self.subTest(op=op.__name__):
+                x = torch.tensor([nan, nan], dtype=torch.float64)
+                n = torch.tensor([5, 5], dtype=torch.float64)
+                # Contiguous input
+                result = op(x, n)
+                self.assertTrue(result.isnan().all())
+                # Non-contiguous input (non-contiguous inputs were the primary repro)
+                x_nc = x[::1].clone().as_strided((1,), (2,))
+                n_nc = n[::1].clone().as_strided((1,), (2,))
+                result_nc = op(x_nc, n_nc)
+                self.assertTrue(result_nc.isnan().all())
+
 
 class TestBinaryUfuncsDevice(TestCase):
     # Generic tests for elementwise binary (AKA binary universal (u) functions (funcs))


### PR DESCRIPTION
## Summary

Follow-up to #187762, which fixed the same uninitialized-memory bug in the seven Chebyshev recurrences. The two remaining `*_forward` recurrences in `aten/src/ATen/native/Math.h` that guard the loop with `!std::isnan(q)` have the identical defect:

- `laguerre_polynomial_l_forward`
- `legendre_polynomial_p_forward`

When `x` is NaN, `q` is NaN before the first iteration (`q = T(1.0) - x` / `q = x`), so the loop `for (...; (k < n) && !std::isnan(q); ...)` is never entered. `T r` was declared without initialization, so for `n >= 2` the functions returned garbage stack memory instead of NaN. As in #187762, non-contiguous inputs were the most reliable way to surface it.

Reproducer on the current code (both return a garbage subnormal instead of NaN):

```python
import torch
x = torch.tensor([float("nan")], dtype=torch.float64)
n = torch.tensor([5], dtype=torch.float64)
torch.special.laguerre_polynomial_l(x, n)  # -> 2.99e-312, want nan
torch.special.legendre_polynomial_p(x, n)  # -> 2.99e-312, want nan
```

The fix initializes `r = q`, matching #187762. If `q` is NaN (because `x` is NaN), `r` starts as NaN and propagates correctly; if the loop runs, `r` is overwritten on the first iteration, so there's no change for valid inputs.

`hermite_polynomial_he_forward` also declares `T r` uninitialized but is **not** affected: its loop has no `!isnan(q)` guard, so for `n >= 2` it always runs at least once and `r` is always assigned. It is left untouched.

## Test plan

Added `test_laguerre_legendre_polynomial_nan_propagation` to `test/test_binary_ufuncs.py`, mirroring the `test_chebyshev_polynomial_nan_propagation` test from #187762 (contiguous and non-contiguous NaN inputs with `n = 5`, which takes the recurrence path). Verified locally that the new assertions fail before the change (the ops return a garbage value, `isnan().all()` is `False`); the build with the fix is covered by CI.


cc @mruberry @kshitij12345