### PR TITLE
[inductor] Fix cpp wrapper handling for python-only inputs

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -54,7 +54,11 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    has_cpp_wrapper_for_device,
+    HAS_GPU,
+)
 from torch.utils._import_utils import import_dill
 
 
@@ -3764,6 +3768,33 @@ class GraphModule(torch.nn.Module):
         compiled = compile_fx_inner(gm, [m, x])
         result = compiled([m, x])
         self.assertEqual(result, (x * 2,))
+
+    @unittest.skipIf(
+        not has_cpp_wrapper_for_device("cpu"),
+        "requires CPU cpp wrapper",
+    )
+    @inductor_config.patch(cpp_wrapper=True)
+    def test_cpp_wrapper_opaque_object_state_input_slot(self):
+        m = OpaqueMultiplier(2.0)
+        x = torch.ones(3)
+        y = torch.arange(3, dtype=torch.float32)
+
+        graph = torch.fx.Graph()
+        fake_mode = FakeTensorMode()
+        x_node = graph.placeholder("x")
+        x_node.meta["val"] = fake_mode.from_tensor(x)
+        m_node = graph.placeholder("m")
+        m_node.meta["val"] = m
+        y_node = graph.placeholder("y")
+        y_node.meta["val"] = fake_mode.from_tensor(y)
+        out = graph.call_function(torch.ops.aten.add.Tensor, (x_node, y_node))
+        out.meta["val"] = fake_mode.from_tensor(x + y)
+        graph.output((out,))
+
+        gm = torch.fx.GraphModule({}, graph)
+        compiled = compile_fx_inner(gm, [x, m, y], cpp_wrapper=True)
+        result = compiled([x, m, y])
+        self.assertEqual(result, (x + y,))
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_benchmark_harness_no_pickle_for_opaque_inputs(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4179,8 +4179,19 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
             size_t result_len = PyList_GET_SIZE(pyvec);
             result.reserve(result_len);
             for (size_t i = 0; i < result_len; i++) {{
+                PyObject* item = PyList_GET_ITEM(pyvec, i);
+                if (item == Py_None) {{
+                    result.push_back(nullptr);
+                    continue;
+                }}
                 // AtenTensorHandle is essentially a pointer
-                void* elem = PyCapsule_GetPointer(PyList_GET_ITEM(pyvec, i), NULL);
+                void* elem = PyCapsule_GetPointer(item, NULL);
+                if (elem == nullptr && PyErr_Occurred()) {{
+                    PyErr_Clear();
+                    throw std::runtime_error(
+                        "expected input handle to be a PyCapsule or None"
+                    );
+                }}
                 result.push_back(reinterpret_cast<AtenTensorHandle>(elem));
             }}
             return result;

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -751,8 +751,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 codegen_symbol(size, name, sizeof, dim)
             for dim, stride in enumerate(value.get_stride()):
                 codegen_symbol(stride, name, strideof, dim)
-        elif isinstance(value, ir.TorchBindObject):
-            # torchbind objects are loaded in proxy executor
+        elif isinstance(
+            value, (ir.TorchBindObject, ir.GeneratorState, ir.OpaqueObjectState)
+        ):
+            # Python-only inputs do not define C++ shape symbols.
             pass
         else:
             raise AssertionError(f"Unknown value type: {type(value)}")
@@ -1710,7 +1712,34 @@ class CppWrapperCpu(PythonWrapperCodegen):
             )
             """)
 
-        wrapper_body = "input_tensors = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg, device='cpu') for arg in args]"
+        input_python_indices = [
+            idx
+            for idx, value in enumerate(V.graph.graph_inputs.values())
+            if isinstance(
+                value,
+                (ir.TorchBindObject, ir.GeneratorState, ir.OpaqueObjectState),
+            )
+        ]
+        python_only_input_indices = (
+            "set()"
+            if not input_python_indices
+            else "{" + ", ".join(map(str, input_python_indices)) + "}"
+        )
+        wrapper_body = f"""
+                    python_only_input_indices = {python_only_input_indices}
+                    input_tensors = []
+                    input_handle_positions = []
+                    # Preserve graph input slots: Python-only inputs stay None
+                    # and are unpacked as nullptrs by the JIT cpp wrapper.
+                    input_handles = [None] * len(args)
+                    for idx, arg in enumerate(args):
+                        if idx in python_only_input_indices:
+                            continue
+                        input_handle_positions.append(idx)
+                        input_tensors.append(
+                            arg if isinstance(arg, torch.Tensor) else torch.tensor(arg, device='cpu')
+                        )
+        """
         if V.graph.constants:
             # Append constants to the input args for cpp wrapper.
             # Python wrapper directly gets the value inside the wrapper call
@@ -1723,16 +1752,25 @@ class CppWrapperCpu(PythonWrapperCodegen):
             constants_str = f"[{', '.join(V.graph.constants.keys())}]"
             wrapper_body += f"""
                     constants_tensor = {constants_str}
+                    constants_start_idx = len(input_handles)
+                    input_handles.extend([None] * len(constants_tensor))
+                    input_handle_positions.extend(
+                        range(constants_start_idx, constants_start_idx + len(constants_tensor))
+                    )
                     input_tensors.extend(constants_tensor)
             """
         # Convert vector of at::Tensor to vector of AtenTensorHandle.
         # If we pass at::Tensor, the compilation will be too slow.
         wrapper_body += """
-                    input_handles = torch._C._aoti.unsafe_alloc_void_ptrs_from_tensors(input_tensors)
+                    packed_input_handles = torch._C._aoti.unsafe_alloc_void_ptrs_from_tensors(input_tensors)
+                    for idx, handle in zip(input_handle_positions, packed_input_handles):
+                        input_handles[idx] = handle
         """
         # Release the inputs for memory reuse.
         wrapper_body += """
                     args.clear()
+                    del input_handle_positions
+                    del packed_input_handles
                     del input_tensors
         """
 


### PR DESCRIPTION
Summary:
- Skip Python-only graph inputs when packing tensors into AtenTensorHandle values for the JIT cpp wrapper.
- Preserve the original input slots so later tensor inputs and appended constants keep the indices expected by generated C++ code.
- Add a regression test with an OpaqueObjectState input between two tensor inputs.

Tests:
- python test/test_opaque_obj_v2.py -k test_cpp_wrapper_opaque_object_state_input_slot

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo