### PR TITLE
Fix THPStream_richcompare reading off the end of non-Stream objects

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10787,6 +10787,21 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(y1, y1_expect.tolist())
         self.assertEqual(y2, y1_expect.imag.tolist())
 
+    def test_stream_compare_with_non_stream(self):
+        # Comparing a Stream against a non-Stream (including None) has to be
+        # safe and well defined: a Stream is never equal to a non-Stream, and
+        # != is its negation. Regression test for #188033, where richcompare
+        # reinterpret_cast `other` to THPStream* without checking its type
+        # first (reading off the end of a foreign object) and the None branch
+        # returned False for every op, so `stream != None` was wrongly False.
+        s = torch.Stream()
+        for other in (None, 42, "x", 3.14, object(), [s]):
+            self.assertFalse(s == other)
+            self.assertTrue(s != other)
+        # A Stream still compares equal to itself.
+        self.assertTrue(s == s)
+        self.assertFalse(s != s)
+
     @unittest.skipIf(torch.backends.cuda.is_built(), "Skipped for cuda-enabled build")
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -435,8 +435,23 @@ static PyObject* THPStream_richcompare(
     PyObject* other,
     int op) {
   PyObject* result = nullptr;
-  if (Py_IsNone(other)) {
-    result = Py_False;
+  // `other` can be any Python object. Only reinterpret_cast it to THPStream*
+  // once we know it really is a Stream; doing so for a foreign object and
+  // reading stream_id/device_index/device_type walks off the end of it (an
+  // out-of-bounds read). A non-Stream, including None, is never equal to a
+  // Stream, so equality is well defined and ordering is unsupported.
+  if (!THPStream_Check(other)) {
+    switch (op) {
+      case Py_EQ:
+        result = Py_False;
+        break;
+      case Py_NE:
+        result = Py_True;
+        break;
+      default:
+        result = Py_False;
+        break;
+    }
   } else {
     switch (op) {
       case Py_EQ:


### PR DESCRIPTION
Fixes #188033.

`THPStream_richcompare` casts its `other` argument straight to `THPStream*`
and reads `stream_id` / `device_index` / `device_type` off it for any
comparison except against `None`:

```c++
if (Py_IsNone(other)) {
  result = Py_False;
} else {
  switch (op) {
    case Py_EQ:
      result = THPStream_eq(
          reinterpret_cast<THPStream*>(self),
          reinterpret_cast<THPStream*>(other));   // other may not be a Stream
      ...
```

When `other` is any non-Stream object, those field reads run past the end
of it — an out-of-bounds read (UB, and ASAN flags it). The `None` branch is
also wrong on its own: it returns `Py_False` for *every* op, so
`stream != None` comes back `False` instead of `True`.

The fix gates on `THPStream_Check(other)` (the helper already in `Stream.h`)
before the cast. A non-Stream — `None` included — is never equal to a
Stream, so `==` is `False`, `!=` is `True`, and ordering stays unsupported.
The Stream-vs-Stream path is untouched.

## Test

Added `test_stream_compare_with_non_stream` in `test/test_torch.py`. It
builds a `torch.Stream()` and checks `==`/`!=` against `None`, an int, a
str, a float, a bare `object()`, and a list, plus self-comparison.

I reproduced the `!=` half deterministically on the released `2.12.0+cpu`
wheel — `torch.Stream() != None` returns `False` there — so the new test
fails before this change and passes after. I haven't built this branch
locally; the C++ side is left to CI.
