### PR TITLE
autograd: fix PyObject* refcount leak in setup_context path

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -978,6 +978,32 @@ class TestAutograd(TestCase):
         test(torch.randn(24, requires_grad=True), (3, 8), 7, 11)
         test(torch.randn(2, 3, 4, requires_grad=True), (6, 4), -1, 2)
 
+    def test_custom_function_setup_context_no_refcount_leak(self):
+        # Verify that the PyObject* returned by setup_context is Py_DECREF'd.
+        # Before the fix, THPObjectPtr was not used, so every call leaked one
+        # reference to the return value.
+        sentinel = object()
+        initial_rc = sys.getrefcount(sentinel)
+
+        class MyFunc(Function):
+            @staticmethod
+            def forward(x):
+                return x.clone()
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                return sentinel
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad
+
+        x = torch.randn(3, requires_grad=True)
+        for _ in range(5):
+            MyFunc.apply(x).sum().backward()
+
+        self.assertEqual(sys.getrefcount(sentinel), initial_rc)
+
     def test_multiple_insert_removal_caching(self):
         torch._C._set_cached_tensors_enabled(True)
         try:

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1607,8 +1607,8 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* args, PyObject* kwargs) {
       }
       THPObjectPtr setup_context_fn(
           PyObject_GetAttrString(cls, "setup_context"));
-      auto result =
-          PyObject_CallObject(setup_context_fn, ctx_input_output_tuple);
+      THPObjectPtr result(
+          PyObject_CallObject(setup_context_fn, ctx_input_output_tuple));
       if (!result) {
         return nullptr;
       }


### PR DESCRIPTION
## Summary

- `python_function.cpp`: In `_call_function_forward`, the return value of `PyObject_CallObject` for the `setup_context` call was stored as `auto result` (raw `PyObject*`), so `Py_DECREF` was never called on the success path, leaking one reference per invocation.
- Changed declaration to `THPObjectPtr result(...)` for RAII cleanup, consistent with every other `PyObject_CallObject` call in the same file.
- Added a regression test that returns a sentinel object from `setup_context` and asserts `sys.getrefcount` is unchanged after repeated forward+backward passes.

Fixes #188034

## Test plan

- [ ] `python test/test_autograd.py TestAutograd.test_custom_function_setup_context_no_refcount_leak`
- [ ] Existing `test_custom_function_setup_context_*` tests pass