### PR TITLE
[MPS] Migrate prod reduction to a native Metal kernel (core)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1424,3 +1424,148 @@ REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);
+
+// ===== prod kernels (this PR, on top of malfet sum/value migration) =====
+// Product reduction kernels
+// ============================================================================
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+[[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
+kernel void prod_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size [[threads_per_simdgroup]]) {
+  using TA = opmath_t<TO>;
+
+  // input_base is uint32: the host dispatch guard rejects inputs whose largest
+  // element offset exceeds 2^32, so the per-group base (tgid * elems_per_group)
+  // and the accumulated index below cannot wrap a 32-bit offset.
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint32_t rsize = params.reduction_size;
+  const uint32_t stride = tptg * NCHAINS;
+  uint32_t base = tid * NCHAINS;
+
+  if (num_reduced_dims <= 1) {
+    // All indexing here is uint32: input_base, base/idx, and reduction_stride.
+    // The host guard rejects inputs whose largest element offset
+    // (input_base + idx * reduction_stride) could exceed 2^32, so this cannot
+    // wrap.
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[input_base + (base + j) * reduction_stride]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[input_base + idx * reduction_stride]);
+    }
+  } else {
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[get_input_offset(base + j, tgid, params)]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
+    }
+  }
+
+  TA output_val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    output_val *= acc[j];
+
+  auto threads_remaining = tptg;
+  threadgroup TA
+      shared_outputs[MAX_THREADGROUP_SIZE / c10::metal::simdgroup_size];
+
+  while (threads_remaining > 1) {
+    output_val = c10::metal::simd_prod(output_val);
+    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
+    if (threads_remaining > 1) {
+      if (simd_lane_id == 0)
+        shared_outputs[simdgroup_id] = output_val;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (tid < threads_remaining) {
+        output_val = shared_outputs[tid];
+      } else {
+        output_val = static_cast<TA>(1);
+      }
+    }
+  }
+
+  if (tid == 0) {
+    // uint32 output offset: the host guard ensures output.numel() <= 2^32, so
+    // the cross-dimension index*stride sum cannot wrap. reduction_idx is a
+    // tgid-derived id and per-dim sizes/strides stay 32-bit.
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+    output[output_offset] = static_cast<TO>(output_val);
+  }
+}
+
+#define REGISTER_PROD(TI, TO)                               \
+  template [[host_name("prod_reduction_" #TI "_" #TO)]]     \
+  kernel void prod_reduction<TI, TO, SUM_NCHAINS>(          \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      constant NormParams<> & params [[buffer(2)]],         \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size [[threads_per_simdgroup]]);
+
+REGISTER_PROD(float, float);
+REGISTER_PROD(half, half);
+REGISTER_PROD(half, float);
+REGISTER_PROD(bfloat, bfloat);
+REGISTER_PROD(bfloat, float);
+REGISTER_PROD(int, int);
+REGISTER_PROD(int, long);
+REGISTER_PROD(long, long);
+REGISTER_PROD(short, short);
+REGISTER_PROD(short, long);
+REGISTER_PROD(char, char);
+REGISTER_PROD(char, long);
+REGISTER_PROD(uchar, uchar);
+REGISTER_PROD(uchar, long);
+REGISTER_PROD(bool, long);
+REGISTER_PROD(bool, int);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -349,6 +349,266 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
   });
 }
 
+// ============================================================================
+// Metal kernel dispatch helpers for prod
+// ============================================================================
+
+static std::vector<int64_t> get_reduce_dims(const Tensor& input, OptionalIntArrayRef opt_dim) {
+  std::vector<int64_t> dims;
+  if (opt_dim.has_value() && !opt_dim.value().empty()) {
+    for (auto d : opt_dim.value()) {
+      dims.push_back(maybe_wrap_dim(d, input.dim()));
+    }
+  } else {
+    for (int64_t d = 0; d < input.dim(); d++) {
+      dims.push_back(d);
+    }
+  }
+  return dims;
+}
+
+static NormParams<> build_reduce_params(const Tensor& input,
+                                        const std::vector<int64_t>& reduce_dims,
+                                        const Tensor& output,
+                                        bool keepdim) {
+  NormParams params;
+  params.ndim = input.dim();
+  params.p = 0;
+  params.reduction_size = input.numel() / std::max<int64_t>(output.numel(), 1);
+
+  bool is_reduced[c10::metal::max_ndim] = {};
+  for (auto d : reduce_dims)
+    is_reduced[d] = true;
+
+  if (keepdim || output.dim() == input.dim()) {
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      params.output_sizes[d] = output.size(d);
+      params.output_strides[d] = output.stride(d);
+    }
+  } else {
+    uint32_t out_d = 0;
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      if (is_reduced[d]) {
+        params.output_sizes[d] = 1;
+        params.output_strides[d] = 0;
+      } else {
+        params.output_sizes[d] = output.size(out_d);
+        params.output_strides[d] = output.stride(out_d);
+        out_d++;
+      }
+    }
+  }
+
+  return params;
+}
+
+// Native prod kernels are instantiated for same-dtype pairs and the natural
+// accumulation promotions only; an explicit prod(..., dtype=) can request any
+// (input, output) scalar combination.
+static bool prod_kernel_registered(ScalarType in, ScalarType out) {
+  if (in == out) {
+    // Same-dtype kernels are instantiated for these only. uint16/32/64 are not
+    // (and are rejected up front in prod_kernel_mps, since prod is unsupported
+    // for them on CPU too); bool output uses the nonzero path above.
+    return in == kFloat || in == kHalf || in == kBFloat16 || in == kInt || in == kLong || in == kShort || in == kChar ||
+        in == kByte;
+  }
+  if ((in == kHalf || in == kBFloat16) && out == kFloat) {
+    return true;
+  }
+  if ((in == kInt || in == kShort || in == kChar || in == kByte) && out == kLong) {
+    return true;
+  }
+  if (in == kBool && (out == kInt || out == kLong)) {
+    return true;
+  }
+  return false;
+}
+
+static void prod_kernel_mps(const Tensor& input,
+                            const std::vector<int64_t>& reduce_dims,
+                            bool keepdim,
+                            const Tensor& output) {
+  // Complex prod requires complex multiplication semantics not available in
+  // the generic float2 SIMD kernels; fall back to MPSGraph. Pass the output
+  // dtype so a complex input with an explicit real dtype= casts per element
+  // before reducing (matching CPU), instead of silently dropping the dtype.
+  if (c10::isComplexType(input.scalar_type())) {
+    reduction_out_mps(
+        input, reduce_dims, keepdim, output.scalar_type(), output, MPSReductionType::PROD, "prod_kernel_mps");
+    return;
+  }
+  // One threadgroup per output element; Metal caps the grid at ~2^32
+  // threadgroups, so a reduction with more than 2^32 outputs cannot be
+  // dispatched (the generic kernel's 32-bit output index would also wrap).
+  TORCH_CHECK(output.numel() <= std::numeric_limits<uint32_t>::max(),
+              "MPS prod reduction with more than 2^32 output elements is not supported");
+  // bool output: prod(..., dtype=bool) uses nonzero semantics (CPU multiplies
+  // the boolean mask input != 0), so a 0.5 element contributes True, not a
+  // truncated 0. Reduce input.to(kBool) (the nonzero mask as a bool tensor ->
+  // the registered (bool,long) kernel) rather than casting the raw input to the
+  // long accumulator, which would truncate non-integer values. to(kBool) is
+  // used over ne(0) because MPS has no scalar ne for the unsigned uint16/uint32/
+  // uint64 dtypes (ne_..._ushort/uint/ulong are unregistered), which CPU prod
+  // accepts. Metal simd_product has no bool, so the accumulator stays long and
+  // is cast back to bool at the end.
+  if (output.scalar_type() == kBool) {
+    auto long_output = at::empty_like(output, output.options().dtype(kLong));
+    prod_kernel_mps(input.to(kBool), reduce_dims, keepdim, long_output);
+    output.copy_(long_output.to(kBool));
+    return;
+  }
+  // uint16/32/64 have no native prod kernel, and prod is "not implemented" for
+  // them on CPU too. Reject with a clear error rather than recursing forever
+  // below: cast-to-self is a no-op, so the cast-and-recurse path would loop
+  // until the stack overflows.
+  TORCH_CHECK(output.scalar_type() != kUInt16 && output.scalar_type() != kUInt32 && output.scalar_type() != kUInt64,
+              "prod: not implemented for ",
+              output.scalar_type(),
+              " output on MPS");
+  // prod(..., dtype=) accumulates in the output dtype. For an (input, output)
+  // pair with no native kernel, cast the input to the output dtype and recurse
+  // into the same-dtype kernel instead of requesting an unregistered kernel.
+  if (!prod_kernel_registered(input.scalar_type(), output.scalar_type())) {
+    prod_kernel_mps(input.to(output.scalar_type()).contiguous(), reduce_dims, keepdim, output);
+    return;
+  }
+  if (input.numel() == 0) {
+    output.fill_(1);
+    return;
+  }
+  if (output.numel() == 0)
+    return;
+
+  int64_t reduction_size = input.numel() / output.numel();
+  // The native kernel indexes input and output as uint32 (input_base + idx *
+  // stride; output_offset += idx * output_stride) and reads reduction_size as a
+  // uint32 loop bound. Reject tensors whose reduction extent or largest element
+  // offset exceeds 2^32 rather than silently wrapping (the prior int64 NormParams
+  // path handled these but taxed small reductions). Largest offset is
+  // sum_i stride_i * (size_i - 1); a strided out= needs its own check since
+  // output.numel() does not bound a strided output offset.
+  constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+  int64_t max_input_offset = 0;
+  for (const auto i : c10::irange(input.dim()))
+    max_input_offset += static_cast<int64_t>(input.stride(i)) * std::max<int64_t>(input.size(i) - 1, 0);
+  int64_t max_output_offset = 0;
+  for (const auto i : c10::irange(output.dim()))
+    max_output_offset += static_cast<int64_t>(output.stride(i)) * std::max<int64_t>(output.size(i) - 1, 0);
+  TORCH_CHECK(reduction_size <= kU32Max && max_input_offset <= kU32Max && max_output_offset <= kU32Max,
+              "MPS prod: tensor too large for 32-bit indexing (reduction extent or element offset exceeds 2^32)");
+  auto type_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass all-reduce: reshape input to
+  // [num_groups, elems_per_group], reduce dim=1 to per-group partials, then
+  // reduce partials to scalar. Reuses the existing prod_reduction kernel both
+  // passes. Bypasses is_outer's M=1 single-TG-per-output degenerate dispatch.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    // total_N fits uint32 here: the dispatch guard rejects a max element offset
+    // above 2^32, and this contiguous all-reduce's max offset is numel - 1, so
+    // input.numel() <= 2^32. num_groups stays small (<=512), so elems_per_group
+    // also fits uint32 when assigned into the NormParams fields below.
+    int64_t total_N = input.numel();
+    uint32_t num_groups = static_cast<uint32_t>(
+        std::min<int64_t>(512, c10::metal::ceil_div(total_N, static_cast<int64_t>(MAX_THREADGROUP_SIZE) * 4)));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    int64_t elems_per_group = total_N / num_groups;
+
+    auto partials = at::empty({static_cast<int64_t>(num_groups)}, output.options());
+    auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+
+    // Pass 1: input[num_groups, elems_per_group] -> partials[num_groups], reduce dim=1.
+    NormParams<> params1{};
+    params1.reduction_size = elems_per_group;
+    params1.ndim = 2;
+    params1.input_sizes[0] = num_groups;
+    params1.input_strides[0] = elems_per_group;
+    params1.output_sizes[0] = num_groups;
+    params1.output_strides[0] = 1;
+    params1.input_sizes[1] = elems_per_group;
+    params1.input_strides[1] = 1;
+
+    // Pass 2: partials[num_groups] -> output[1], reduce dim=0.
+    NormParams<> params2{};
+    params2.reduction_size = num_groups;
+    params2.ndim = 1;
+    params2.input_sizes[0] = num_groups;
+    params2.input_strides[0] = 1;
+    params2.output_sizes[0] = 1;
+    params2.output_strides[0] = 0;
+
+    auto p2_kernel = fmt::format("prod_reduction_{}_{}", out_str, out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps1 = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps1, "prod_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        mtl_setArgs(enc, input, partials, params1);
+        // Round each pass up to a full simdgroup. prod_reduction's
+        // simd_prod<long> emulates 64-bit simd via simd_shuffle_and_fill_down;
+        // in a partial simdgroup an active lane reads an in-range inactive lane
+        // as garbage (0 on M1/M2 -> corrupted product), which the fill does not
+        // cover. Padding lanes in a full simdgroup carry the identity 1.
+        // Cap to MAX_THREADGROUP_SIZE first (elems_per_group is int64 and may
+        // exceed 2^32 when num_groups==1) so the round_up runs in 32 bits.
+        uint32_t epg_capped = static_cast<uint32_t>(std::min<int64_t>(MAX_THREADGROUP_SIZE, elems_per_group));
+        auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(epg_capped, 32u));
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(p2_kernel);
+        getMPSProfiler().beginProfileKernel(ps2, "prod_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, params2);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(num_groups, 32u));
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+  // The generic NormParams path indexes per-dim arrays sized by max_ndim; a
+  // higher-rank input would index past the struct/stack storage. (The outer/
+  // inner fast paths above use only M/N and are rank-agnostic.)
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              "MPS prod: reductions over more than ",
+              c10::metal::max_ndim,
+              " dimensions are not supported");
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  uint32_t capped_reduction = static_cast<uint32_t>(std::min<int64_t>(MAX_THREADGROUP_SIZE, reduction_size));
+  auto threads_per_group = c10::metal::ceil_div(capped_reduction, 32u) * 32u;
+  // 64-bit total dispatch thread count: one threadgroup per output element, so
+  // output.numel() * threads_per_group can exceed 2^32 (e.g. millions of output
+  // elements * a full threadgroup). threads_per_group stays 32-bit.
+  uint64_t num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "prod_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, params);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
 static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       at::OptionalIntArrayRef dim,
                                       const std::optional<Scalar>& correction,
@@ -1201,8 +1461,14 @@ Tensor trace_mps(const Tensor& self) {
 
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
-  int64_t dims[1] = {dim};
-  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
+  // 0-dim tensor: prod(scalar, dim=0) is a no-op reduction; return scalar.
+  if (input_t.dim() == 0) {
+    output_t.copy_(input_t);
+    return;
+  }
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  std::vector<int64_t> reduce_dims = {dim_};
+  prod_kernel_mps(input_t, reduce_dims, keepdim, output_t);
 }
 
 static void aminmax_kernel_mps(const Tensor& self, int64_t dim, bool keepdim, Tensor& min, Tensor& max) {
@@ -1218,14 +1484,12 @@ static void aminmax_allreduce_kernel_mps(const Tensor& self, Tensor& min, Tensor
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
-  std::vector<int64_t> dims(self.dim());
-  std::iota(dims.begin(), dims.end(), 0);
+  auto reduce_dims = get_reduce_dims(self, std::nullopt);
 
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  reduction_out_mps(
-      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
+  prod_kernel_mps(self, reduce_dims, false, output_t);
 
   return output_t;
 }

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -120,9 +120,11 @@ inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_sum(T val) {
 
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_prod(T val) {
+  // Fill with 1 (product identity) for inactive lanes in partial simdgroups
+  int2 fill = as_type<int2>(T(1));
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
     val *= as_type<T>(
-        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), fill, i));
   }
   return simd_broadcast(val, 0);
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16129,6 +16129,172 @@ class TestMetalLibrary(TestCaseMPS):
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
 # to achieve this.
+
+class TestReduceOpsMetal(TestCaseMPS):
+    """Tests for Metal kernel reduce ops: prod."""
+
+    # =========================================================================
+    # Product reduction
+    # =========================================================================
+    def test_prod_metal_basic(self):
+        for shape in [(4,), (3, 4), (2, 3, 4), (2, 3, 4, 5)]:
+            for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
+                if dtype in (torch.int32, torch.int64):
+                    cpu_x = torch.randint(1, 3, shape, device='cpu', dtype=dtype)
+                else:
+                    cpu_x = torch.randint(1, 4, shape, device='cpu', dtype=dtype)
+                mps_x = cpu_x.to('mps')
+                # Scalar prod
+                self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+                # Per-dim prod
+                for dim in range(len(shape)):
+                    self.assertEqual(torch.prod(mps_x, dim=dim), torch.prod(cpu_x, dim=dim))
+                    self.assertEqual(
+                        torch.prod(mps_x, dim=dim, keepdim=True),
+                        torch.prod(cpu_x, dim=dim, keepdim=True))
+
+    def test_prod_metal_dtype_promotion(self):
+        cpu_x = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.prod(mps_x, dtype=torch.int64),
+            torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_float_types(self):
+        cpu_x = torch.randn(8, 16, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(torch.prod(mx, dim=1), torch.prod(cx, dim=1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(torch.prod(mx, dim=0), torch.prod(cx, dim=0), atol=1e-2, rtol=1e-2)
+
+    def test_prod_metal_empty(self):
+        cpu_x = torch.empty(0, 3, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_scalar(self):
+        cpu_x = torch.tensor(5.0, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_bool(self):
+        cpu_x = torch.tensor([True, True, False, True], device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+        self.assertEqual(torch.prod(mps_x, dtype=torch.int64), torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_large(self):
+        cpu_x = torch.randint(1, 3, (64, 128), device='cpu', dtype=torch.int32)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x, dim=0), torch.prod(cpu_x, dim=0))
+        self.assertEqual(torch.prod(mps_x, dim=1), torch.prod(cpu_x, dim=1))
+
+    def test_prod_metal_partial_simdgroup_allreduce(self):
+        # 2-pass all-reduce prod where pass 2 lands a PARTIAL simdgroup
+        # (N=21000 -> num_groups=6, not a multiple of 32). The 64-bit
+        # simd_prod<long> (used by int/bool prod) emulates simd reduction via
+        # simd_shuffle_and_fill_down, where an active lane reading an in-range
+        # inactive lane gets garbage (0 on M1/M2 -> the product collapses to 0).
+        # The dispatch rounds the threadgroup up to a full simdgroup to avoid it.
+        # Passes on M4 regardless; this guards the M1/M2 path.
+        for dtype in (torch.int64, torch.int32, torch.bool):
+            cpu_x = torch.ones(21000, device='cpu', dtype=dtype)
+            if dtype is not torch.bool:
+                cpu_x[:3] = 2  # product = 8, distinguishable from a 0 corruption
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(mps_x.prod().cpu(), cpu_x.prod(), f"prod all-reduce {dtype}")
+
+    def test_prod_metal_dtype_cast_matrix(self):
+        # prod(..., dtype=) accepts any (input, output) scalar combo, but native
+        # kernels only cover same-dtype + the natural acc promotions. Every other
+        # combo (half->float small-M, float->long, bool->uint8, ...) must cast to
+        # the output dtype rather than request an unregistered Metal kernel.
+        # Covers dim=0 (outer/small-M), dim=1 (inner) and all-reduce.
+        import itertools
+        dts = (torch.bool, torch.uint8, torch.int16, torch.int32, torch.int64,
+               torch.float16, torch.bfloat16, torch.float32)
+        cpu_base = torch.ones(6, 4, device='cpu')
+        cpu_base[0] = 2     # product over dim 0 == 2 per column; small, no overflow
+        cpu_base[2, 1] = 0  # one zero: exercises 0-product and bool AND -> False
+        for in_dt, out_dt in itertools.product(dts, dts):
+            cpu_x = cpu_base.to(in_dt)
+            mps_x = cpu_x.to('mps')
+            for kw in ({'dim': 0}, {'dim': 1}, {}):
+                self.assertEqual(torch.prod(mps_x, dtype=out_dt, **kw).cpu(),
+                                 torch.prod(cpu_x, dtype=out_dt, **kw),
+                                 f"prod {in_dt}->{out_dt} {kw}")
+
+    def test_prod_metal_noncontiguous(self):
+        cpu_x = torch.randint(1, 4, (4, 6), device='cpu', dtype=torch.float32)
+        mps_x = cpu_x.to('mps')
+        # Transpose makes it non-contiguous
+        cpu_t = cpu_x.t()
+        mps_t = mps_x.t()
+        self.assertEqual(torch.prod(mps_t, dim=0), torch.prod(cpu_t, dim=0))
+        self.assertEqual(torch.prod(mps_t, dim=1), torch.prod(cpu_t, dim=1))
+
+    def test_prod_metal_bool_fractional(self):
+        # prod(dtype=bool) uses nonzero semantics: a fractional 0.5 is nonzero
+        # -> True. A float->long truncation would make it 0 -> False.
+        for vals in ([0.5, 0.5], [0.5, 0.0], [0.1, 0.2, 0.3]):
+            x = torch.tensor(vals, device="mps")
+            self.assertEqual(torch.prod(x, dtype=torch.bool).item(),
+                             torch.prod(x.cpu(), dtype=torch.bool).item())
+
+    def test_prod_metal_bool_output_unsigned(self):
+        # prod(..., dtype=bool) must work for uint16/32/64: MPS has no scalar ne
+        # for those dtypes, so the bool path uses to(kBool). Match CPU nonzero
+        # semantics across the unsigned + signed-int + float input dtypes.
+        for dt in (torch.uint16, torch.uint32, torch.uint64,
+                   torch.int32, torch.float32):
+            x = torch.tensor([[0, 2, 3], [1, 1, 1]], dtype=dt, device="mps")
+            self.assertEqual(torch.prod(x, dim=1, dtype=torch.bool).cpu(),
+                             torch.prod(x.cpu(), dim=1, dtype=torch.bool))
+
+    def test_prod_metal_half_float_accumulation(self):
+        # MPS prod accumulates float16 in float (opmath/acc_type), matching CUDA
+        # and the MPS sum/var/std convention -- more accurate than CPU's
+        # half-precision accumulation, which drifts ~20% over a long reduction.
+        # Compare to the float-accumulated reference, not CPU.
+        x = torch.full((4096,), 1.0009765625, dtype=torch.float16)
+        self.assertEqual(torch.prod(x.to("mps")).cpu(), torch.prod(x.float()).half())
+
+    def test_prod_metal_unsigned_same_dtype(self):
+        # uint16/32/64 have no native prod kernel and prod is unsupported for
+        # them on CPU too; MPS must raise a clean error, not crash with a Metal
+        # pipeline error or recurse forever (cast-to-self is a no-op).
+        for dt in (torch.uint16, torch.uint32, torch.uint64):
+            x = torch.tensor([[1, 2, 3], [4, 5, 6]]).to(dt).to("mps")
+            with self.assertRaises(RuntimeError):
+                torch.prod(x, dim=1, dtype=dt)
+
+    def test_prod_metal_complex_dtype(self):
+        # Complex prod with an explicit real dtype casts per element before
+        # reducing (CPU semantics), not complex-product-then-cast.
+        for dt in (torch.float32, torch.float16):
+            x = torch.tensor([1 + 2j, 3 + 4j], device="mps")
+            self.assertEqual(torch.prod(x, dtype=dt).item(),
+                             torch.prod(x.cpu(), dtype=dt).item())
+
+    def test_prod_metal_rank_guard(self):
+        # A rank-17 view (reachable via as_strided past the factory rank check)
+        # hits the generic NormParams path, whose per-dim arrays are sized for
+        # max_ndim=16; ranks above 16 must raise cleanly, not index past storage.
+        x = torch.as_strided(torch.ones(1, device="mps"), (1,) * 17, (0,) * 17)
+        with self.assertRaises(RuntimeError):
+            torch.prod(x)
+
+    def test_prod_metal_reduction_extent_over_uint32_raises(self):
+        # A reduced extent of exactly 2^32 (a zero-stride view, so no large
+        # allocation) exceeds the native kernel's uint32 reduction_size, so the
+        # dispatch guard must reject it cleanly rather than wrap to 0.
+        x = torch.as_strided(torch.ones(1, device="mps"), (2, 1 << 32), (0, 0))
+        with self.assertRaises(RuntimeError):
+            torch.prod(x, dim=1)
+
+instantiate_parametrized_tests(TestReduceOpsMetal)
+
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")


### PR DESCRIPTION
Replaces the MPSGraph-backed `prod` reduction on MPS with a native Metal
kernel, removing prod from the shape-dependent MPSGraph cache. This is the
core migration: the generic `prod_reduction` kernel plus its two-pass
all-reduce dispatch, covering all dtypes (including the bool nonzero-product
and `dtype=` cast paths) and contiguous/non-contiguous reductions.

## Context

Part of #187455. This is the first piece of splitting #187788 ([MPS] Migrate
prod to native Metal kernels, ~1600 lines) into smaller reviewable PRs, at the
reviewer's request. That PR is now closed in favor of this split; this PR is its core. The split:

- the `simd_prod<long>` identity fix -- folded into this PR (it has no consumer
  in main today, and the int/bool prod kernels here are its first);
- **this PR: the core** -- the generic `prod_reduction` kernel + the two-pass
  all-reduce dispatch + the uint32 guard + correctness tests;
- a follow-up (C3) -- the outer/inner/wide/thin shape specializations and the
  prod benchmark.

This PR is correctness-focused: parity with the MPSGraph reduction it replaces,
and it takes prod out of the shape-dependent MPSGraph cache (eliminating the
per-shape graph recompilation). The shape-specialization speedups and the
benchmark script land with the specialization kernels in the follow-up, so this
PR stays a focused, reviewable change.

Indexing is uint32 (input and output element offsets, and the reduction
extent). A reduction whose largest input or output element offset, or whose
extent, would exceed 2^32 is rejected with a clear TORCH_CHECK rather than
silently wrapping: the >2^32 case is rare and an int64 NormParams measurably
taxes every small reduction. The output-offset check covers strided `out=`
tensors, whose offset is not bounded by output.numel().

The `simd_prod<long>` identity fill in c10/metal/reduction_utils.h is fixed
here because the int/bool prod kernels are its first consumers -- an emulated
64-bit simd reduction in a partial simdgroup must fill inactive lanes with
the product identity 1, not 0.

## Test Plan
```
python test/test_mps.py -k test_prod_metal -v
```
17 tests covering dtype coverage, bool nonzero semantics, `dtype=` casts,
non-contiguous reductions, half-float accumulation, the partial-simdgroup
all-reduce (exercising the simd_prod fix), and
`reduction_extent_over_uint32_raises` (the uint32 guard).

The full `--mps` test matrix was run locally on this change (M4 Pro): no prod
regressions.

## Known limitation (shared with sum_reduction / value_reduction)
The per-thread loop `for (; base + NCHAINS <= rsize; base += stride)` uses
uint32 counters, so a reduction extent within `MAX_THREADGROUP_SIZE * NCHAINS`
of 2^32 (reachable only via a crafted zero-stride view) can wrap `base` and
loop forever. This loop is identical to the existing `sum_reduction` and
`value_reduction` kernels, so prod follows the established pattern here; a fix
(a tighter dispatch guard or 64-bit loop counters) would be most consistent
applied across all three reduce kernels in a follow-up rather than diverging
in prod alone.

Authored with Claude.

---
Review history (local-gate findings + dispositions): https://gist.github.com/anagnorisis2peripeteia/bc447c27cb9fd3532ae8c96f57a6b437

