### PR TITLE
Add regression test for torch.from_dlpack() with negative strides

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TEST_WITH_ROCM,
     TestCase,
+    xfailIfTorchDynamo,
 )
 from torch.utils.dlpack import (
     DLDeviceType,
@@ -414,6 +415,29 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(z.shape, (1,))
         # Stride normalization has been removed, strides should be preserved
         self.assertEqual(z.stride(), (3,))
+
+    @xfailIfTorchDynamo
+    @skipMeta
+    @onlyCPU
+    def test_from_dlpack_negative_strides(self, device):
+        # torch.from_dlpack() on a NumPy array with negative strides used to
+        # abort the process instead of raising a catchable Python exception.
+        # See https://github.com/pytorch/pytorch/issues/188023.
+        import numpy as np
+
+        # 1-D negative stride
+        a1 = np.arange(8.0)[::-1]
+        with self.assertRaisesRegex(
+            RuntimeError, "Storage size calculation overflowed"
+        ):
+            torch.from_dlpack(a1)
+
+        # 2-D, one negative axis
+        a2 = np.arange(12.0).reshape(3, 4)[:, ::-1]
+        with self.assertRaisesRegex(
+            RuntimeError, "Storage size calculation overflowed"
+        ):
+            torch.from_dlpack(a2)
 
     @skipMeta
     @onlyNativeDeviceTypes


### PR DESCRIPTION
Fixes #188023

`torch.from_dlpack()` on a NumPy array with negative strides (e.g. `arr[::-1]`) used to abort the whole Python process instead of raising a catchable exception, because `TensorMaker::computeStorageSize()` was declared `noexcept` while calling `TORCH_CHECK` internally.

That `noexcept` has since been removed on trunk, so the abort no longer happens: the negative stride now trips the overflow check in `computeStorageNbytes()` and surfaces as a normal Python `RuntimeError`.

```
RuntimeError: Storage size calculation overflowed with sizes=[8] and strides=[-1]
```

This PR therefore drops the C++ changes it originally carried and keeps only a regression test, covering a 1-D negative stride and a 2-D array with one negative axis.

The positive non-unit stride and Fortran-order cases are already covered by `test_from_dlpack_noncontinguous` (via `x[:, 0]` and `x.t()`), so they are not duplicated here.

The test is marked `@xfailIfTorchDynamo` since Dynamo does not surface the exception.