### PR TITLE
Add FX graph cache custom guard replay test

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1522,6 +1522,8 @@ class TestFxGraphCache(TestCase):
     def test_cache_hit_replays_custom_guard_evaluator(self):
         class CacheEntry:
             guards_expr = "exact_guard_expr"
+            guards_expr_with_source = [object()]
+            guards_expr_with_source_arg_count = 0
             extern_libs_key = None
 
         shape_env = ShapeEnv()

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1519,6 +1519,51 @@ class TestFxGraphCache(TestCase):
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_hit_replays_custom_guard_evaluator(self):
+        class CacheEntry:
+            guards_expr = "exact_guard_expr"
+            extern_libs_key = None
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        guard_evaluations = []
+
+        def exact_guard_match(guard_expr, _hints):
+            guard_evaluations.append(guard_expr)
+            return guard_expr == CacheEntry.guards_expr
+
+        with (
+            torch._guards.tracing(torch._guards.TracingContext(fake_mode)),
+            mock.patch.object(
+                FxGraphCache,
+                "find_guarded_entry",
+                return_value=(
+                    CacheEntry(),
+                    b"",
+                    {"cache_status_detailed": "hit"},
+                ),
+            ),
+            mock.patch.object(
+                FxGraphCache,
+                "cache_hit_post_compile",
+                side_effect=lambda graph, cache_info, _constants: (graph, cache_info),
+            ),
+        ):
+            graph, cache_info = FxGraphCache._lookup_graph(
+                "key",
+                [],
+                local=True,
+                remote_cache=None,
+                constants=mock.Mock(),
+                evaluate_guards=exact_guard_match,
+            )
+
+        self.assertIsInstance(graph, CacheEntry)
+        self.assertEqual(cache_info["cache_status_detailed"], "hit")
+        self.assertEqual(guard_evaluations, [CacheEntry.guards_expr])
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
     @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     def test_cache_load_with_guards_static_bounds(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188050

AOTAutograd passes a custom guard evaluator into the FX graph cache so it can enforce its exact-match guard contract. A previous guard-provenance change accidentally bypassed that evaluator during cache-hit post-load guard replay, which regressed vLLM through the AOTAutograd cache path.

Add a focused cache-hit test that mocks a stored graph and verifies FxGraphCache._lookup_graph invokes the caller-supplied guard evaluator when replaying guards after load.

Test Plan:

PYTHONPATH=. python test/inductor/test_codecache.py TestFxGraphCache.test_cache_hit_replays_custom_guard_evaluator

lintrunner -a

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo