### PR TITLE
[SymmMem] Add barrier implementation for NCCL symmetric memory backend

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -342,6 +342,30 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @skip_if_lt_x_gpu(2)
+    def test_nccl_symmem_barrier(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        numel = 64
+        t = symm_mem.empty(numel, dtype=torch.float32, device=self.device).fill_(
+            self.rank
+        )
+        handle = symm_mem.rendezvous(t, group=group_name)
+        self.assertEqual(handle.rank, self.rank)
+        self.assertEqual(handle.world_size, self.world_size)
+
+        handle.barrier()
+        for peer in range(self.world_size):
+            buf = handle.get_buffer(peer, (numel,), torch.float32)
+            self.assertTrue(buf.eq(peer).all())
+        handle.barrier()
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_subgroup(self):
         symm_mem.set_backend("NCCL")

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
@@ -108,6 +108,71 @@ __device__ __forceinline__ void wait_signal(uint32_t* addr) {
     ;
 }
 
+// Validates the channel argument for barrier(), put_signal() and
+// wait_signal(). Shared by the CUDA and NCCL symmetric-memory backends.
+// ``signal_pad_size`` is passed in (rather than calling get_signal_pad_size()
+// here) so this header doesn't need to include SymmetricMemory.hpp.
+inline void check_channel(int channel, int world_size, size_t signal_pad_size) {
+  TORCH_CHECK(
+      channel >= 0,
+      "channel for barrier(), put_signal() and wait_signal() ",
+      "must be greater than 0 (got ",
+      channel,
+      ")");
+  const size_t num_channels =
+      signal_pad_size / sizeof(uint32_t) * world_size;
+  TORCH_CHECK(
+      static_cast<size_t>(channel) < num_channels,
+      "The maximum supported channel for barrier(), put_signal() and wait_signal() is ",
+      num_channels - 1,
+      " (got ",
+      channel,
+      ")");
+}
+
+// All-to-all signal barrier over the symmetric-memory signal pads, shared by
+// the CUDA and NCCL backends. Each rank sets a flag in every peer's signal pad
+// (at its own slot) and waits for every peer to set the matching flag in its
+// own pad. The try_put_signal/try_wait_signal CAS protocol toggles each slot
+// 0->1 then 1->0, so the pads return to zero and the barrier is reusable.
+[[maybe_unused]] static __global__ void barrier_kernel(
+    uint32_t** signal_pads,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms) {
+  if (threadIdx.x < world_size) {
+    auto target_rank = threadIdx.x;
+    if (target_rank == rank) {
+      return;
+    }
+    auto put_success = try_put_signal<std::memory_order_release>(
+        signal_pads[target_rank] + world_size * channel + rank, timeout_ms);
+    if (!put_success) {
+      printf(
+          "[FATAL] SymmetricMemory::barrier: rank %d failed to send signal "
+          "to rank %d on channel %d after %lu milliseconds\n",
+          rank,
+          target_rank,
+          channel,
+          timeout_ms);
+      trap();
+    }
+    auto wait_success = try_wait_signal<std::memory_order_acquire>(
+        signal_pads[rank] + world_size * channel + target_rank, timeout_ms);
+    if (!wait_success) {
+      printf(
+          "[FATAL] SymmetricMemory::barrier: rank %d failed to receive signal "
+          "from rank %d on channel %d after %lu milliseconds\n",
+          rank,
+          target_rank,
+          channel,
+          timeout_ms);
+      trap();
+    }
+  }
+}
+
 // Synchronizes blocks with matching blockIdx across participating devices.
 // Note: sync_remote_block itself is not a system level barrier/fence. It is a
 // building block for expressing different synchronization patterns.

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -156,64 +156,8 @@ size_t CUDASymmetricMemory::get_offset() {
   return offset_;
 }
 
-void check_channel(int channel, int world_size) {
-  TORCH_CHECK(
-      channel >= 0,
-      "channel for barrier(), put_signal() and wait_signal() ",
-      "must be greater than 0 (got ",
-      channel,
-      ")");
-  const size_t num_channels = c10d::symmetric_memory::get_signal_pad_size() /
-      sizeof(uint32_t) * world_size;
-  TORCH_CHECK(
-      static_cast<size_t>(channel) < num_channels,
-      "The maximum supported channel for barrier(), put_signal() and wait_signal() is ",
-      num_channels - 1,
-      " (got ",
-      channel,
-      ")");
-}
-
-static __global__ void barrier_kernel(
-    uint32_t** signal_pads,
-    int channel,
-    int rank,
-    int world_size,
-    size_t timeout_ms) {
-  if (threadIdx.x < world_size) {
-    auto target_rank = threadIdx.x;
-    if (target_rank == rank) {
-      return;
-    }
-    auto put_success = try_put_signal<std::memory_order_release>(
-        signal_pads[target_rank] + world_size * channel + rank, timeout_ms);
-    if (!put_success) {
-      printf(
-          "[FATAL] CUDASymmetricMemory::barrier: rank %d failed to send signal "
-          "to rank %d on channel %d after %lu microseconds\n",
-          rank,
-          target_rank,
-          channel,
-          timeout_ms);
-      trap();
-    }
-    auto wait_success = try_wait_signal<std::memory_order_acquire>(
-        signal_pads[rank] + world_size * channel + target_rank, timeout_ms);
-    if (!wait_success) {
-      printf(
-          "[FATAL] CUDASymmetricMemory::barrier: rank %d failed to receive signal "
-          "from rank %d on channel %d after %lu microseconds\n",
-          rank,
-          target_rank,
-          channel,
-          timeout_ms);
-      trap();
-    }
-  }
-}
-
 void CUDASymmetricMemory::barrier(int channel, size_t timeout_ms) {
-  check_channel(channel, world_size_);
+  check_channel(channel, world_size_, get_signal_pad_size());
   auto pg = c10d::resolve_process_group(pai_->group_name_);
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(0),
@@ -269,7 +213,7 @@ void CUDASymmetricMemory::put_signal(
     int dst_rank,
     int channel,
     size_t timeout_ms) {
-  check_channel(channel, world_size_);
+  check_channel(channel, world_size_, get_signal_pad_size());
   auto pg = c10d::resolve_process_group(pai_->group_name_);
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(0),
@@ -331,7 +275,7 @@ void CUDASymmetricMemory::wait_signal(
     int src_rank,
     int channel,
     size_t timeout_ms) {
-  check_channel(channel, world_size_);
+  check_channel(channel, world_size_, get_signal_pad_size());
   auto pg = c10d::resolve_process_group(pai_->group_name_);
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(0),

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -378,7 +378,28 @@ void* NCCLSymmetricMemory::get_multicast_ptr() {
 }
 
 void NCCLSymmetricMemory::barrier(int channel, size_t timeout_ms) {
+#ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+  TORCH_CHECK(
+      pai_->signal_pads_dev_ != nullptr,
+      "NCCLSymmetricMemory::barrier requires peer signal pad pointers, which "
+      "are only populated when peers are accessible over the symmetric-memory "
+      "(LSA/NVLink) domain.");
+  check_channel(channel, world_size_, get_signal_pad_size());
+  c10::cuda::CUDAGuard device_guard(device_idx_);
+  barrier_kernel<<<
+      1,
+      std::max(at::cuda::warp_size(), world_size_),
+      0,
+      at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<uint32_t**>(pai_->signal_pads_dev_),
+      channel,
+      rank_,
+      world_size_,
+      timeout_ms);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+#else
   TORCH_CHECK(false, "NYI");
+#endif
 }
 
 void NCCLSymmetricMemory::put_signal(int dst_rank, int channel, size_t timeout_ms) {
@@ -476,10 +497,16 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // A single window is registered over the whole region at rendezvous
     // time, so only the base pointer (already granularity-aligned by
     // ncclMemAlloc) needs to satisfy NCCL's window-alignment requirement.
+    const size_t aligned_buffer_size = at::round_up(size, 16UL);
     const size_t signal_pad_size = get_signal_pad_size();
-    const size_t total_size = at::round_up(size, 16UL) + signal_pad_size;
+    const size_t total_size = aligned_buffer_size + signal_pad_size;
     void* ptr;
     C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
+    // ncclMemAlloc does not zero memory. Zero the signal pad so the CAS-based
+    // barrier() protocol starts from a known (all-zero) state on first use
+    // (CUDASymmetricMemory zeroes its whole allocation for the same reason).
+    C10_CUDA_CHECK(cudaMemset(
+        static_cast<char*>(ptr) + aligned_buffer_size, 0, signal_pad_size));
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.emplace(


### PR DESCRIPTION
## Summary

`NCCLSymmetricMemory::barrier()` was previously unimplemented — it just did
`TORCH_CHECK(false, "NYI")`. Any code path that calls `hdl.barrier()` on a
symmetric-memory handle while the NCCL backend is selected
(`symm_mem.set_backend("NCCL")`) therefore failed at runtime.

This PR implements it by exposing the existing CUDA-backend barrier kernel to
the NCCL backend as well, instead of duplicating it:

In addition, `signal_pad` wasnt zero'ed out so `barrier` couldn't work anyway. We fix that so `barrier` starts with a known all-zero state in `signal_pad`

## Test plan

```
pytest test/distributed/test_nccl.py -k test_nccl_symmem_barrier -vvs
```