### PR TITLE
Fix Py_None reference ownership in THPGenerator_reduce

### DIFF
--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -261,7 +261,7 @@ static PyObject* THPGenerator_reduce(PyObject* _self, PyObject* noargs) {
       state.get(),
       1,
       device_type != at::kCPU ? THPGenerator_getOffset(_self, nullptr)
-                              : Py_None);
+                              : Py_NewRef(Py_None));
   PyTuple_SET_ITEM(state.get(), 2, THPGenerator_getState(_self, nullptr));
   PyTuple_SET_ITEM(ret.get(), 2, state.release());
 


### PR DESCRIPTION
Fixes #188032

`PyTuple_SET_ITEM` steals a reference to the inserted object.

In `THPGenerator_reduce`, the CPU path inserts `Py_None` directly into the state tuple:

```cpp
PyTuple_SET_ITEM(
    state.get(),
    1,
    device_type != at::kCPU ? THPGenerator_getOffset(_self, nullptr)
                            : Py_None);
```

This passes a borrowed reference where ownership is transferred to the tuple.

Replace `Py_None` with `Py_NewRef(Py_None)` to satisfy the CPython ownership contract and match existing usage elsewhere in the codebase.

### Testing

```bash
python test/test_torch.py -k test_generator_cpu
python test/test_torch.py -k test_pickle_generator
python test/test_torch.py -k test_generator_reduce_none_refcount
```


cc @albanD