### PR TITLE
[inductor] Evaluate compile-time ProcessGroup attrs in overlap estimates

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -101,6 +101,31 @@ def build_collective_info(graph, hiding_annotations):
     return collective_info
 
 
+class TestProcessGroupNameResolution(TestCase):
+    def test_evaluate_compile_time_process_group_get_attr_without_meta_val(self):
+        from torch._inductor.fx_passes.bucketing import _resolve_group_name
+        from torch._inductor.fx_utils import evaluate_compile_time_value
+
+        class ProcessGroupLike:
+            group_name = "fake_group"
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self._test_pg = ProcessGroupLike()
+
+        graph = torch.fx.Graph()
+        pg_node = graph.get_attr("_test_pg")
+        graph.output(pg_node)
+        torch.fx.GraphModule(Root(), graph)
+
+        self.assertNotIn("val", pg_node.meta)
+        self.assertIs(
+            evaluate_compile_time_value(pg_node), graph.owning_module._test_pg
+        )
+        self.assertEqual(_resolve_group_name(pg_node), "fake_group")
+
+
 @requires_accelerator_dist_backend()
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
 @instantiate_parametrized_tests

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -842,6 +842,7 @@ def estimate_nccl_collective_runtime_from_fx_node(
     from torch._inductor.fx_passes.bucketing import _resolve_group_name
 
     group_name = _resolve_group_name(kwargs["group_name"])
+    kwargs["group_name"] = group_name
     group_size = _get_group_size_by_name(group_name)
     if not isinstance(fx_node.target, torch._ops.OpOverload):
         raise AssertionError(

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -18,6 +18,7 @@ from torch._inductor.comm_analysis import (
     NCCL_COLL,
 )
 from torch._inductor.fx_passes.utils import BitsetAncestors
+from torch._inductor.fx_utils import evaluate_compile_time_value
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch._logging import trace_structured
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -36,18 +37,14 @@ overlap_log = torch._logging.getArtifactLogger(__name__, "overlap")
 
 
 def _resolve_group_name(group_name: Any) -> "GroupName":
-    """Resolve group_name to a GroupName string.
-
-    In compile-on-one-rank graphs, collective ops receive their
-    group_name argument as an FX Node reference (pointing to a
-    mesh_get_process_group call) rather than a string literal. For
-    bucketing key purposes we resolve via the ProcessGroup stored in
-    node.meta["val"].
+    """Resolve group_name to a GroupName string. In compile-on-one-rank graphs
+    collective ops can receive group_name as an FX node (a ProcessGroup via
+    meta["val"] or a get_attr) rather than a string literal.
     """
+    group_name = evaluate_compile_time_value(group_name)
     if isinstance(group_name, str):
         return group_name  # pyrefly: ignore [bad-return]
-    pg = group_name.meta["val"]
-    return pg.group_name
+    return group_name.group_name
 
 
 BucketMode: TypeAlias = Literal[

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -38,6 +38,22 @@ from torch.utils.flop_counter import flop_registry
 from .virtualized import V
 
 
+def evaluate_compile_time_value(value: Any) -> Any:
+    """Resolve the compile-time Python value behind an FX node argument: its
+    ``meta["val"]`` or, for a ``get_attr`` node, the GraphModule attribute. Never
+    executes arbitrary FX nodes; non-Node or unresolved inputs pass through.
+    """
+    if not isinstance(value, torch.fx.Node):
+        return value
+    if "val" in value.meta:
+        return value.meta["val"]
+    if value.op == "get_attr" and value.graph.owning_module is not None:
+        from torch.fx.graph_module import _get_attr
+
+        return _get_attr(value.graph.owning_module, value.target)  # type: ignore[arg-type]
+    return value
+
+
 # Check the pattern: (nn.module, F.function/torch.Tensor.method) matched.
 # Works for length 2 patterns with 1 module and 1 function/method.
 def matches_module_function_pattern(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #188059
* #187842
* #188058
* __->__ #188057

Functionalized eager collectives can pass a ProcessGroup to _c10d_functional ops as a
compile-time FX value. In GraphTrainer regional graphs with ATen overlap scheduling it
arrives as a get_attr node with no meta["val"], so the group-name resolver raised
KeyError: "val" and compilation failed.

Resolve it via a small evaluate_compile_time_value helper (torch._inductor.fx_utils)
that reads meta["val"] or a get_attr target without executing arbitrary FX nodes, and
feed the resolved string to the NCCL-timing path.

Test Plan:
  python test/distributed/test_overlap_bucketing_unit.py \
    TestProcessGroupNameResolution.test_evaluate_compile_time_process_group_get_attr_without_meta_val -v

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo