### PR TITLE
Guard print_sccache_stats() when sccache is not installed

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -382,6 +382,7 @@ function install_cutlass_api() {
 }
 
 function print_sccache_stats() {
+  if ! which sccache &> /dev/null; then echo "sccache not installed, skipping stats"; return; fi
   echo 'PyTorch Build Statistics'
   sccache --show-stats
 


### PR DESCRIPTION
Fixes #188060

Adds a check for sccache availability before calling `sccache --show-stats` in `print_sccache_stats()`.

CC @atalman 