### PR TITLE
Drop `noexcept` from  `TensorMaker::computeStorageSize` 

### DIFF
--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -80,7 +80,7 @@ class TORCH_API TensorMaker {
   explicit TensorMaker(void* data, IntArrayRef sizes) noexcept
       : data_{data}, sizes_{sizes} {}
 
-  std::size_t computeStorageSize() const noexcept;
+  std::size_t computeStorageSize() const C10_NOEXCEPT_ON_MOBILE;
 
   DataPtr makeDataPtrFromDeleter() noexcept;
 

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -80,7 +80,7 @@ class TORCH_API TensorMaker {
   explicit TensorMaker(void* data, IntArrayRef sizes) noexcept
       : data_{data}, sizes_{sizes} {}
 
-  std::size_t computeStorageSize() const C10_NOEXCEPT_ON_MOBILE;
+  std::size_t computeStorageSize() const;
 
   DataPtr makeDataPtrFromDeleter() noexcept;
 

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -58,7 +58,7 @@ Tensor TensorMaker::make_tensor() {
   return tensor;
  }
 
- std::size_t TensorMaker::computeStorageSize() const noexcept {
+ std::size_t TensorMaker::computeStorageSize() const C10_NOEXCEPT_ON_MOBILE {
    std::size_t itemsize = opts_.dtype().itemsize();
 
    if (strides_) {

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -58,7 +58,7 @@ Tensor TensorMaker::make_tensor() {
   return tensor;
  }
 
- std::size_t TensorMaker::computeStorageSize() const C10_NOEXCEPT_ON_MOBILE {
+ std::size_t TensorMaker::computeStorageSize() const {
    std::size_t itemsize = opts_.dtype().itemsize();
 
    if (strides_) {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -12,6 +12,7 @@ struct THFloatTensor;
 
 #include <iostream>
 #include <chrono>
+#include <limits>
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <string.h>
 #include <sstream>
@@ -535,3 +536,14 @@ TEST(BasicTest, TestForBlobStridesResizeCPU) {
   auto te = *at::expand_size(t, {3, 3});
   ASSERT_EQ(te[1][1].item<int32_t>(), 5);
 }
+
+#ifndef C10_MOBILE
+TEST(BasicTest, TestForBlobStridesOverflowCPU) {
+  // Strides large enough to overflow the storage size computation must throw.
+  // Overflow checks are compiled out on mobile, hence the guard above.
+  std::array<int32_t, 6> storage;
+  const auto huge = std::numeric_limits<int64_t>::max();
+  ASSERT_THROWS(
+      at::for_blob(storage.data(), {2,}).strides({huge,}).options(c10::TensorOptions(kInt)).make_tensor());
+}
+#endif

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -537,13 +537,16 @@ TEST(BasicTest, TestForBlobStridesResizeCPU) {
   ASSERT_EQ(te[1][1].item<int32_t>(), 5);
 }
 
-#ifndef C10_MOBILE
-TEST(BasicTest, TestForBlobStridesOverflowCPU) {
-  // Strides large enough to overflow the storage size computation must throw.
-  // Overflow checks are compiled out on mobile, hence the guard above.
+TEST(BasicTest, TestForBlobStridesOverflow) {
   std::array<int32_t, 6> storage;
+  // Mismatched sizes/strides dimensionality throws on all builds.
+  ASSERT_THROWS(
+      at::for_blob(storage.data(), {2, 3}).strides({1,}).options(c10::TensorOptions(kInt)).make_tensor());
+#ifndef C10_MOBILE
+  // Strides large enough to overflow the storage size computation also throw;
+  // overflow checks are compiled out on mobile.
   const auto huge = std::numeric_limits<int64_t>::max();
   ASSERT_THROWS(
       at::for_blob(storage.data(), {2,}).strides({huge,}).options(c10::TensorOptions(kInt)).make_tensor());
-}
 #endif
+}

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -608,12 +608,8 @@ __host__ __device__
 
 #if defined(C10_MOBILE) && C10_MOBILE
 #define C10_ALWAYS_INLINE_UNLESS_MOBILE inline
-// Mobile builds skip storage size overflow checks, so the relevant routines
-// cannot throw and may be marked noexcept.
-#define C10_NOEXCEPT_ON_MOBILE noexcept
 #else
 #define C10_ALWAYS_INLINE_UNLESS_MOBILE C10_ALWAYS_INLINE
-#define C10_NOEXCEPT_ON_MOBILE
 #endif
 
 #if !defined(FBCODE_CAFFE2) && !defined(C10_NODEPRECATED)

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -608,8 +608,12 @@ __host__ __device__
 
 #if defined(C10_MOBILE) && C10_MOBILE
 #define C10_ALWAYS_INLINE_UNLESS_MOBILE inline
+// Mobile builds skip storage size overflow checks, so the relevant routines
+// cannot throw and may be marked noexcept.
+#define C10_NOEXCEPT_ON_MOBILE noexcept
 #else
 #define C10_ALWAYS_INLINE_UNLESS_MOBILE C10_ALWAYS_INLINE
+#define C10_NOEXCEPT_ON_MOBILE
 #endif
 
 #if !defined(FBCODE_CAFFE2) && !defined(C10_NODEPRECATED)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188062

It was marked as but it calls `computeStorageNbytes()`, which raises via `TORCH_CHECK` on storage-size overflow on non-mobile builds and on mismatch on length of sizes and strides array. 
A throwing noexcept function terminates the process, so an overflowing for_blob() call crashed hard instead of propagating the exception, see https://github.com/pytorch/pytorch/issues/188023 for example.

Drop `noexcept` and add `BasicTest::TestForBlobStridesOverflow`, which calls for_blob with an overflowing stride and asserts it throws.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>