### PR TITLE
[ROCm] fix wait instructions

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -257,9 +257,12 @@ __device__ inline void cmtdStore(void* address, T value) {
       if constexpr (wait_for_commit)
       {
         __atomic_signal_fence(__ATOMIC_SEQ_CST);
-#ifdef __gfx1250__
-        asm volatile("s_wait_loadcnt(0)" ::: "memory");
+#if defined(__GFX12__)
+        asm volatile("s_wait_storecnt(0)" ::: "memory");
+#elif defined(__GFX10__) || defined(__GFX11__)
+        asm volatile("s_waitcnt_vscnt(0)" ::: "memory");
 #else
+        // Older architectures have only 'vmcnt' counter.
         asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
 #endif
         __atomic_signal_fence(__ATOMIC_SEQ_CST);

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -260,7 +260,7 @@ __device__ inline void cmtdStore(void* address, T value) {
 #if defined(__GFX12__)
         asm volatile("s_wait_storecnt(0)" ::: "memory");
 #elif defined(__GFX10__) || defined(__GFX11__)
-        asm volatile("s_waitcnt_vscnt(0)" ::: "memory");
+        asm volatile("s_waitcnt_vscnt null, 0" ::: "memory");
 #else
         // Older architectures have only 'vmcnt' counter.
         asm volatile("s_waitcnt vmcnt(0)" ::: "memory");

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -604,9 +604,12 @@ struct ReduceJitOp {
         if constexpr (wait_for_commit)
         {
           __atomic_signal_fence(__ATOMIC_SEQ_CST);
-  #ifdef __gfx1250__
-          asm volatile("s_wait_loadcnt(0)" ::: "memory");
+  #if defined(__GFX12__)
+          asm volatile("s_wait_storecnt(0)" ::: "memory");
+  #elif defined(__GFX10__) || defined(__GFX11__)
+          asm volatile("s_waitcnt_vscnt(0)" ::: "memory");
   #else
+          // Older architectures have only 'vmcnt' counter.
           asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
   #endif
           __atomic_signal_fence(__ATOMIC_SEQ_CST);

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -607,7 +607,7 @@ struct ReduceJitOp {
   #if defined(__GFX12__)
           asm volatile("s_wait_storecnt(0)" ::: "memory");
   #elif defined(__GFX10__) || defined(__GFX11__)
-          asm volatile("s_waitcnt_vscnt(0)" ::: "memory");
+          asm volatile("s_waitcnt_vscnt null, 0" ::: "memory");
   #else
           // Older architectures have only 'vmcnt' counter.
           asm volatile("s_waitcnt vmcnt(0)" ::: "memory");


### PR DESCRIPTION
GFX 10-12 architectures have distinct counters for loading/store to/from VGPRs. Older architectures have only one counter for memory operations with VGPR. GFX 12 architecture also changes instructions that wait these counters. Therefore we must call different instructions for different architectures.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang