### PR TITLE
Improve distribute_module docstring

### DIFF
--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -1139,34 +1139,122 @@ def distribute_module(
     output_fn: Callable[[nn.Module, Any, DeviceMesh], None] | None = None,
 ) -> nn.Module:
     """
-    This function expose three functions to control the parameters/inputs/outputs of the module:
+    Convert a module's parameters/buffers to :class:`DTensor` s, and optionally
+    convert its inputs/outputs at runtime, using the three user-provided callbacks.
 
-    1. To perform sharding on the module before runtime execution by specifying the
-    ``partition_fn`` (i.e. allow user to convert Module parameters to :class:`DTensor`
-    parameters according to the `partition_fn` specified).
-    2. To control the inputs or outputs of the module during runtime execution by
-    specifying the ``input_fn`` and ``output_fn``. (i.e. convert the input to
-    :class:`DTensor`, convert the output back to ``torch.Tensor``)
+    The behavior of the three callbacks:
+
+    1. ``partition_fn`` shards the module's parameters/buffers *before* runtime
+       execution (i.e. it converts plain ``torch.Tensor`` parameters into
+       :class:`DTensor` parameters). Any parameter/buffer not converted by
+       ``partition_fn`` is replicated across ``device_mesh`` afterwards. If
+       ``partition_fn`` is ``None``, *all* parameters/buffers are replicated.
+    2. ``input_fn`` / ``output_fn`` convert the module's inputs/outputs *during*
+       runtime execution (e.g. convert plain tensor inputs into :class:`DTensor`,
+       or convert :class:`DTensor` outputs back into plain ``torch.Tensor``).
 
     Args:
         module (:class:`nn.Module`): user module to be partitioned.
-        device_mesh (:class:`DeviceMesh`): the device mesh to place the module.
-        partition_fn (Callable): the function to partition parameters (i.e. shard certain
-            parameters across the ``device_mesh``). If ``partition_fn`` is not specified,
-            by default we replicate all module parameters of ``module`` across the mesh.
-        input_fn (Callable): specify the input distribution, i.e. could control how the
-            input of the module is sharded. ``input_fn`` will be installed as a module
-            ``forward_pre_hook`` (pre forward hook).
-        output_fn (Callable): specify the output distribution, i.e. could control how the
-            output is sharded, or convert it back to torch.Tensor. ``output_fn`` will be
-            installed as a module ``forward_hook`` (post forward hook).
+        device_mesh (:class:`DeviceMesh`): the device mesh to place the module. If
+            ``None``, the current mesh from the ambient mesh context is used.
+        partition_fn (Callable): a function with signature
+            ``partition_fn(name: str, module: nn.Module, device_mesh: DeviceMesh) -> None``.
+            It is called once for *every* submodule (including ``module`` itself),
+            where ``name`` is the submodule's fully-qualified name (``""`` for the
+            top-level module) as returned by :meth:`nn.Module.named_modules`. The
+            function is expected to mutate ``module`` in place, typically by calling
+            :func:`distribute_tensor` and :meth:`register_parameter` to replace
+            selected parameters with :class:`DTensor` parameters. Its return value
+            is ignored. If not specified, all module parameters are replicated
+            across ``device_mesh``.
+        input_fn (Callable): a function with signature
+            ``input_fn(module: nn.Module, inputs: Inputs, device_mesh: DeviceMesh) -> Inputs``,
+            where ``Inputs`` is the tuple of positional arguments to ``forward`` (one
+            entry per positional argument, e.g. ``(x,)`` for ``forward(self, x)``;
+            keyword arguments are not forwarded to ``input_fn``). Installed on the
+            top-level ``module`` as a ``forward_pre_hook``, it returns the new
+            argument tuple -- the same structure as ``inputs``, typically with each
+            ``torch.Tensor`` entry converted to a :class:`DTensor` -- which replaces
+            ``inputs`` for the actual ``forward`` call.
+        output_fn (Callable): a function with signature
+            ``output_fn(module: nn.Module, outputs: Outputs, device_mesh: DeviceMesh) -> Outputs``,
+            where ``Outputs`` is the return type of ``module.forward`` (a single
+            tensor, or any nested structure of tensors such as a tuple/dict), with the
+            tensors typically being :class:`DTensor` s. Installed on the top-level
+            ``module`` as a ``forward_hook``, it returns the replacement output of the
+            same structure -- typically with each :class:`DTensor` converted back to a
+            plain ``torch.Tensor`` via :meth:`DTensor.to_local` or
+            :meth:`DTensor.full_tensor`, or redistributed to different placements.
 
     Returns:
-        A module that contains parameters/buffers that are all ``DTensor`` s.
+        A module whose parameters/buffers are all :class:`DTensor` s (the same
+        ``module`` object, mutated in place).
+
+    .. warning::
+        ``input_fn`` and ``output_fn`` previously took two arguments
+        ``(inputs, device_mesh)`` / ``(outputs, device_mesh)``. That form is
+        deprecated; use the three-argument form documented above.
+
+    Example::
+
+        import torch.nn as nn
+        from torch.distributed.tensor import (
+            DTensor,
+            Replicate,
+            Shard,
+            distribute_module,
+            distribute_tensor,
+            init_device_mesh,
+        )
+
+
+        class MyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fc = nn.Linear(8, 8)
+
+            def forward(self, x):
+                return self.fc(x)
+
+
+        mesh = init_device_mesh("cuda", (4,))
+
+
+        def shard_params(name, mod, mesh):
+            if isinstance(mod, nn.Linear):
+                for pname, param in mod.named_parameters(recurse=False):
+                    mod.register_parameter(
+                        pname, nn.Parameter(distribute_tensor(param, mesh, [Shard(0)]))
+                    )
+
+
+        # Replicate the input across the mesh before forward.
+        def to_replicated(mod, inputs, mesh):
+            return tuple(
+                distribute_tensor(x, mesh, [Replicate()])
+                if isinstance(x, torch.Tensor)
+                else x
+                for x in inputs
+            )
+
+
+        # Convert the DTensor output back to a plain torch.Tensor after forward.
+        def to_local(mod, outputs, mesh):
+            return outputs.full_tensor() if isinstance(outputs, DTensor) else outputs
+
+
+        sharded = distribute_module(
+            MyModule(),
+            mesh,
+            partition_fn=shard_params,
+            input_fn=to_replicated,
+            output_fn=to_local,
+        )
 
     .. note::
-        When initialize the DeviceMesh with the ``xla`` device_type, ``distribute_module``
-        return nn.Module with PyTorch/XLA SPMD annotated parameters. See
+        When initializing the ``DeviceMesh`` with the ``xla`` device_type,
+        ``distribute_module`` returns an ``nn.Module`` with PyTorch/XLA SPMD
+        annotated parameters. See
         `this issue <https://github.com/pytorch/pytorch/issues/92909>`__
         for more details. The XLA integration is experimental and subject to change.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188071

The previous docstring described partition_fn/input_fn/output_fn only as
"Callable" without their argument or return signatures, so users could not
tell what those callbacks receive or must return. Rewrite it to:

- give the exact signature of each callback, grounded in the implementation
  (partition_fn is called once per submodule via named_modules and mutates
  in place returning None; input_fn/output_fn are forward_pre_hook/
  forward_hook installed on the top-level module whose return value replaces
  the inputs/outputs);
- describe input_fn/output_fn as Inputs -> Inputs and Outputs -> Outputs
  respectively, making clear the callback returns the same structure it
  receives with tensor entries converted to/from DTensor, rather than a
  bare Any;
- note that keyword arguments are not forwarded to input_fn;
- surface the deprecated two-argument callback form as a warning;
- add a runnable Example exercising all three callbacks.

Docstring-only change; no behavior changes.

Test Plan:
Docstring-only change. Verified the file lints cleanly:

```
lintrunner -a torch/distributed/tensor/_api.py
```

(Reported pyrefly errors are pre-existing in unrelated files
torch/storage.py and torch/testing/_creation.py.)

Authored-with: Claude (Anthropic AI assistant)