### PR TITLE
Fix RNG state replay in distribution tests to use device-aware get/set_rng_state

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -162,6 +162,18 @@ def is_all_nan(tensor):
     return (tensor != tensor).all()
 
 
+def _get_rng_state_accessors_for_default_device():
+    default_device = torch.device(torch.get_default_device())
+    if default_device.type == "cpu":
+        return torch.get_rng_state, torch.set_rng_state
+
+    device_module = torch.get_device_module(default_device.type)
+    return (
+        lambda: device_module.get_rng_state(default_device),
+        lambda state: device_module.set_rng_state(state, default_device),
+    )
+
+
 Example = namedtuple("Example", ["Dist", "params"])
 
 
@@ -2301,9 +2313,10 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Uniform, (low, 1.0))
         self._gradcheck_log_prob(Uniform, (0.0, high))
 
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         rand = low.new(low.size()).uniform_()
-        torch.set_rng_state(state)
+        set_rng_state(state)
         u = Uniform(low, high).rsample()
         u.backward(torch.ones_like(u))
         self.assertEqual(low.grad, 1 - rand)
@@ -2354,9 +2367,10 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Cauchy, (loc, 1.0))
         self._gradcheck_log_prob(Cauchy, (0.0, scale))
 
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         eps = loc.new(loc.size()).cauchy_()
-        torch.set_rng_state(state)
+        set_rng_state(state)
         c = Cauchy(loc, scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(loc.grad, torch.ones_like(scale))
@@ -2383,9 +2397,10 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(HalfCauchy, (scale,))
         self._gradcheck_log_prob(HalfCauchy, (1.0,))
 
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         eps = scale.new(scale.size()).cauchy_().abs_()
-        torch.set_rng_state(state)
+        set_rng_state(state)
         c = HalfCauchy(scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(scale.grad, eps)
@@ -2770,9 +2785,10 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Normal, (loc, 1.0))
         self._gradcheck_log_prob(Normal, (0.0, scale))
 
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
-        torch.set_rng_state(state)
+        set_rng_state(state)
         z = Normal(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))
@@ -3473,9 +3489,10 @@ class TestDistributions(DistributionsTestCase):
         self.assertEqual(Exponential(50.0).sample((1,)).size(), (1,))
 
         self._gradcheck_log_prob(Exponential, (rate,))
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         eps = rate.new(rate.size()).exponential_()
-        torch.set_rng_state(state)
+        set_rng_state(state)
         z = Exponential(rate).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(rate.grad, -eps / rate**2)
@@ -3541,9 +3558,10 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Laplace, (loc, 1.0))
         self._gradcheck_log_prob(Laplace, (0.0, scale))
 
-        state = torch.get_rng_state()
+        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
+        state = get_rng_state()
         eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
-        torch.set_rng_state(state)
+        set_rng_state(state)
         z = Laplace(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -162,18 +162,6 @@ def is_all_nan(tensor):
     return (tensor != tensor).all()
 
 
-def _get_rng_state_accessors_for_default_device():
-    default_device = torch.device(torch.get_default_device())
-    if default_device.type == "cpu":
-        return torch.get_rng_state, torch.set_rng_state
-
-    device_module = torch.get_device_module(default_device.type)
-    return (
-        lambda: device_module.get_rng_state(default_device),
-        lambda state: device_module.set_rng_state(state, default_device),
-    )
-
-
 Example = namedtuple("Example", ["Dist", "params"])
 
 
@@ -1355,6 +1343,25 @@ class TestDistributions(DistributionsTestCase):
         torch.set_default_device(None)
         super().tearDown()
 
+    def _default_device_rng_accessors(self):
+        default_device = torch.device(torch.get_default_device())
+        if default_device.type == "cpu":
+            return torch.get_rng_state, torch.set_rng_state
+
+        device_module = torch.get_device_module(default_device.type)
+        return (
+            lambda: device_module.get_rng_state(default_device),
+            lambda state: device_module.set_rng_state(state, default_device),
+        )
+
+    def _get_rng_state(self):
+        get_rng_state, _ = self._default_device_rng_accessors()
+        return get_rng_state()
+
+    def _set_rng_state(self, state):
+        _, set_rng_state = self._default_device_rng_accessors()
+        return set_rng_state(state)
+
     def test_default_device(self, device):
         device_type = torch.device(device).type
         self.assertEqual(torch.get_default_device().type, device_type)
@@ -2313,10 +2320,9 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Uniform, (low, 1.0))
         self._gradcheck_log_prob(Uniform, (0.0, high))
 
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         rand = low.new(low.size()).uniform_()
-        set_rng_state(state)
+        self._set_rng_state(state)
         u = Uniform(low, high).rsample()
         u.backward(torch.ones_like(u))
         self.assertEqual(low.grad, 1 - rand)
@@ -2367,10 +2373,9 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Cauchy, (loc, 1.0))
         self._gradcheck_log_prob(Cauchy, (0.0, scale))
 
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         eps = loc.new(loc.size()).cauchy_()
-        set_rng_state(state)
+        self._set_rng_state(state)
         c = Cauchy(loc, scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(loc.grad, torch.ones_like(scale))
@@ -2397,10 +2402,9 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(HalfCauchy, (scale,))
         self._gradcheck_log_prob(HalfCauchy, (1.0,))
 
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         eps = scale.new(scale.size()).cauchy_().abs_()
-        set_rng_state(state)
+        self._set_rng_state(state)
         c = HalfCauchy(scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(scale.grad, eps)
@@ -2785,10 +2789,9 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Normal, (loc, 1.0))
         self._gradcheck_log_prob(Normal, (0.0, scale))
 
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
-        set_rng_state(state)
+        self._set_rng_state(state)
         z = Normal(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))
@@ -3489,10 +3492,9 @@ class TestDistributions(DistributionsTestCase):
         self.assertEqual(Exponential(50.0).sample((1,)).size(), (1,))
 
         self._gradcheck_log_prob(Exponential, (rate,))
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         eps = rate.new(rate.size()).exponential_()
-        set_rng_state(state)
+        self._set_rng_state(state)
         z = Exponential(rate).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(rate.grad, -eps / rate**2)
@@ -3558,10 +3560,9 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Laplace, (loc, 1.0))
         self._gradcheck_log_prob(Laplace, (0.0, scale))
 
-        get_rng_state, set_rng_state = _get_rng_state_accessors_for_default_device()
-        state = get_rng_state()
+        state = self._get_rng_state()
         eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
-        set_rng_state(state)
+        self._set_rng_state(state)
         z = Laplace(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))


### PR DESCRIPTION
Fixes: 
https://github.com/intel/torch-xpu-ops/issues/4020

torch.get_rng_state and torch.set_rng_state operate on CPU RNG state only. The affected distribution tests save RNG state, draw a reference epsilon, then restore RNG state before calling rsample. 

On XPU/CUDA, in-place random ops such as cauchy_, exponential_, and uniform_ consume device RNG state, so restoring CPU RNG state does not replay the same random stream. 

Fix:
Add _get_rng_state_accessors_for_default_device to resolve device-aware get/set RNG state functions from the current default device, and use those accessors.