### PR TITLE
[MPS] prod reduction: outer/inner shape specializations (perf)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1569,3 +1569,354 @@ REGISTER_PROD(uchar, uchar);
 REGISTER_PROD(uchar, long);
 REGISTER_PROD(bool, long);
 REGISTER_PROD(bool, int);
+
+// ---- prod shape specializations: outer/inner/wide/thin + small-M (C3) ----
+template <
+    typename TI,
+    typename TO,
+    uint TG_X = 32,
+    uint TG_Y = 32,
+    uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  // 64-bit: M may be up to kU32Max, so ceil_div(M, TG_Y) would wrap to 0 (the
+  // kernel then processes no rows and returns the identity), and row_start +
+  // rows_per_y can exceed 2^32 on the last y-worker before the min clamps it.
+  // Compute both in ulong; rows_per_y and row_end (<= M) fit 32 bits.
+  uint rows_per_y = ceil_div<ulong>(M, TG_Y);
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = min((ulong)row_start + rows_per_y, (ulong)M);
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+  // [M, N] input with more than 2^32 elements. row/col/N stay 32-bit.
+  uint row = row_start;
+  for (; row + NCHAINS <= row_end; row += NCHAINS) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(input[static_cast<ulong>(row + j) * N + col]);
+    }
+  }
+  for (; row < row_end; row++) {
+    acc[row % NCHAINS] *=
+        static_cast<TA>(input[static_cast<ulong>(row) * N + col]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+
+  threadgroup TA shmem[TG_Y][TG_X];
+  shmem[tid_tg.y][tid_tg.x] = prod;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s)
+      shmem[tid_tg.y][tid_tg.x] *= shmem[tid_tg.y + s][tid_tg.x];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    output[static_cast<ulong>(col) * out_stride] =
+        static_cast<TO>(shmem[0][tid_tg.x]);
+  }
+}
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+
+  // One SIMD group reduces one row; num_simd_groups rows share a TG (mirrors
+  // sum_reduction_inner). Avoids one whole TG per row, which idles most threads
+  // and over-subscribes the GPU when there are many short rows.
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+
+  // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+  // [M, N] input with more than 2^32 elements. row/N stay 32-bit.
+  constant TI* row_ptr = input + static_cast<ulong>(row) * N;
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint stride = 32 * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = simd_lane_id * NCHAINS;
+  for (; base < aligned_N; base += stride) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(row_ptr[base + j]);
+    }
+  }
+  for (uint i = aligned_N + simd_lane_id; i < N; i += 32) {
+    acc[0] *= static_cast<TA>(row_ptr[i]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+  // Reduce across the 32 lanes of this SIMD group (no shared memory needed).
+  prod = c10::metal::simd_prod(prod);
+
+  if (simd_lane_id == 0) {
+    output[row] = static_cast<TO>(prod);
+  }
+}
+
+// Wide inner-dim prod: one whole threadgroup (up to 1024 threads) products one
+// row, used for few/huge rows (small M, large N) where the simd-per-row variant
+// leaves only 32 lanes on a giant row and idles most of the GPU (e.g. M=2,
+// N~8M is ~25x slower there). Mirrors welford_reduction_inner_wide.
+template <typename TI, typename TO, int NCHAINS>
+kernel void prod_reduction_inner_wide(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+  uint row = tgid;
+  if (row >= M)
+    return;
+  // 64-bit base: row * N can exceed 2^32 for a >2^32-element input; the in-row
+  // offsets below stay 32-bit (a single row has at most N <= uint32 elements).
+  constant TI* row_ptr = input + static_cast<ulong>(row) * N;
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+  const uint stride = tptg * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = tid;
+  for (uint i = base; i < aligned_N; i += stride) {
+    for (uint c = 0; c < NCHAINS; c++)
+      acc[c] *= static_cast<TA>(row_ptr[i + c * tptg]);
+  }
+  for (uint i = base + aligned_N; i < N; i += tptg)
+    acc[0] *= static_cast<TA>(row_ptr[i]);
+  TA p = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    p *= acc[j];
+
+  // Reduce across the simdgroup, then a shared-memory tree across simdgroups.
+  p = c10::metal::simd_prod(p);
+  threadgroup TA shared[32];
+  if (simd_lane_id == 0)
+    shared[simdgroup_id] = p;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    // Padding lanes (>= num_simd_groups) carry the prod identity 1; the final
+    // simdgroup has 32 active lanes so simd_prod<long>'s shuffle-fill is
+    // benign.
+    p = (simd_lane_id < num_simd_groups) ? shared[simd_lane_id] : TA(1);
+    p = c10::metal::simd_prod(p);
+    if (simd_lane_id == 0)
+      output[row] = static_cast<TO>(p);
+  }
+}
+
+// Thin inner-dim prod: ONE thread products a full row, serially over N. For
+// small N the simd-per-row variant leaves 32-N of its 32 lanes idle and pays
+// simd-reduction overhead for under one element of work per lane;
+// thread-per-row has neither. Dispatched for small N with M large enough to
+// fill the GPU.
+template <typename TI, typename TO>
+kernel void prod_reduction_inner_thin(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  if (gid >= M)
+    return;
+  constant TI* row_ptr = input + static_cast<ulong>(gid) * N;
+  TA p = 1;
+  for (uint i = 0; i < N; i++)
+    p *= static_cast<TA>(row_ptr[i]);
+  output[gid] = static_cast<TO>(p);
+}
+
+#define REGISTER_PROD_OUTER(TI, TO)                              \
+  template [[host_name("prod_reduction_outer_" #TI "_" #TO)]]    \
+  kernel void prod_reduction_outer<TI, TO, 32, 32, SUM_NCHAINS>( \
+      constant TI * input [[buffer(0)]],                         \
+      device TO * output [[buffer(1)]],                          \
+      constant uint3 & sizes [[buffer(2)]],                      \
+      uint2 tid_tg [[thread_position_in_threadgroup]],           \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+#define REGISTER_PROD_INNER(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner<TI, TO, SUM_NCHAINS>(      \
+      constant TI * input [[buffer(0)]],                      \
+      device TO * output [[buffer(1)]],                       \
+      constant uint2 & sizes [[buffer(2)]],                   \
+      uint tid [[thread_index_in_threadgroup]],               \
+      uint tptg [[threads_per_threadgroup]],                  \
+      uint tgid [[threadgroup_position_in_grid]],             \
+      uint simd_lane_id [[thread_index_in_simdgroup]],        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_PROD_OUTER(float, float);
+REGISTER_PROD_OUTER(half, half);
+REGISTER_PROD_OUTER(half, float);
+REGISTER_PROD_OUTER(bfloat, bfloat);
+REGISTER_PROD_OUTER(bfloat, float);
+REGISTER_PROD_OUTER(int, int);
+REGISTER_PROD_OUTER(int, long);
+REGISTER_PROD_OUTER(long, long);
+REGISTER_PROD_OUTER(short, short);
+REGISTER_PROD_OUTER(short, long);
+REGISTER_PROD_OUTER(char, char);
+REGISTER_PROD_OUTER(char, long);
+REGISTER_PROD_OUTER(uchar, uchar);
+REGISTER_PROD_OUTER(uchar, long);
+REGISTER_PROD_OUTER(bool, long);
+REGISTER_PROD_OUTER(bool, int);
+
+REGISTER_PROD_INNER(float, float);
+REGISTER_PROD_INNER(half, half);
+REGISTER_PROD_INNER(half, float);
+REGISTER_PROD_INNER(bfloat, bfloat);
+REGISTER_PROD_INNER(bfloat, float);
+REGISTER_PROD_INNER(int, int);
+REGISTER_PROD_INNER(int, long);
+REGISTER_PROD_INNER(long, long);
+REGISTER_PROD_INNER(short, short);
+REGISTER_PROD_INNER(short, long);
+REGISTER_PROD_INNER(char, char);
+REGISTER_PROD_INNER(char, long);
+REGISTER_PROD_INNER(uchar, uchar);
+REGISTER_PROD_INNER(uchar, long);
+REGISTER_PROD_INNER(bool, long);
+REGISTER_PROD_INNER(bool, int);
+
+#define REGISTER_PROD_INNER_WIDE(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_wide_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner_wide<TI, TO, SUM_NCHAINS>(      \
+      constant TI * input [[buffer(0)]],                           \
+      device TO * output [[buffer(1)]],                            \
+      constant uint2 & sizes [[buffer(2)]],                        \
+      uint tid [[thread_index_in_threadgroup]],                    \
+      uint tptg [[threads_per_threadgroup]],                       \
+      uint tgid [[threadgroup_position_in_grid]],                  \
+      uint simd_lane_id [[thread_index_in_simdgroup]],             \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_PROD_INNER_WIDE(float, float);
+REGISTER_PROD_INNER_WIDE(half, half);
+REGISTER_PROD_INNER_WIDE(half, float);
+REGISTER_PROD_INNER_WIDE(bfloat, bfloat);
+REGISTER_PROD_INNER_WIDE(bfloat, float);
+REGISTER_PROD_INNER_WIDE(int, int);
+REGISTER_PROD_INNER_WIDE(int, long);
+REGISTER_PROD_INNER_WIDE(long, long);
+REGISTER_PROD_INNER_WIDE(short, short);
+REGISTER_PROD_INNER_WIDE(short, long);
+REGISTER_PROD_INNER_WIDE(char, char);
+REGISTER_PROD_INNER_WIDE(char, long);
+REGISTER_PROD_INNER_WIDE(uchar, uchar);
+REGISTER_PROD_INNER_WIDE(uchar, long);
+REGISTER_PROD_INNER_WIDE(bool, long);
+REGISTER_PROD_INNER_WIDE(bool, int);
+
+#define REGISTER_PROD_INNER_THIN(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_thin_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner_thin<TI, TO>(                   \
+      constant TI * input [[buffer(0)]],                           \
+      device TO * output [[buffer(1)]],                            \
+      constant uint2 & sizes [[buffer(2)]],                        \
+      uint gid [[thread_position_in_grid]]);
+
+REGISTER_PROD_INNER_THIN(float, float);
+REGISTER_PROD_INNER_THIN(half, half);
+REGISTER_PROD_INNER_THIN(half, float);
+REGISTER_PROD_INNER_THIN(bfloat, bfloat);
+REGISTER_PROD_INNER_THIN(bfloat, float);
+REGISTER_PROD_INNER_THIN(int, int);
+REGISTER_PROD_INNER_THIN(int, long);
+REGISTER_PROD_INNER_THIN(long, long);
+REGISTER_PROD_INNER_THIN(short, short);
+REGISTER_PROD_INNER_THIN(short, long);
+REGISTER_PROD_INNER_THIN(char, char);
+REGISTER_PROD_INNER_THIN(char, long);
+REGISTER_PROD_INNER_THIN(uchar, uchar);
+REGISTER_PROD_INNER_THIN(uchar, long);
+REGISTER_PROD_INNER_THIN(bool, long);
+REGISTER_PROD_INNER_THIN(bool, int);
+
+// Small-M outer prod (M <= 16): grid-stride over columns, each thread reduces
+// COLS columns over all M rows. The generic outer kernel splits the tiny M
+// across TG_Y row-workers and pays a shared-memory barrier tree; that overhead
+// dominates when M is small. One-thread-per-column instead over-subscribes the
+// GPU for large N. sum dim=0 uses a tensor-core simdgemm path that products
+// cannot, so prod needs this dedicated layout. COLS=2 won a config sweep.
+template <typename TI, typename TO, uint COLS = 2>
+kernel void prod_reduction_outer_smallm(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint gsize [[threads_per_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+  for (uint col = gid; col < N; col += gsize) {
+    TA acc = 1;
+    // 64-bit accumulated global offset: row * N can exceed 2^32 for a logically
+    // [M, N] input with more than 2^32 elements. row/col/N stay 32-bit.
+    for (uint row = 0; row < M; row++) {
+      acc *= static_cast<TA>(input[static_cast<ulong>(row) * N + col]);
+    }
+    output[static_cast<ulong>(col) * out_stride] = static_cast<TO>(acc);
+  }
+}
+
+#define REGISTER_PROD_OUTER_SMALLM(TI, TO)                                  \
+  template                                                                  \
+      [[host_name("prod_reduction_outer_smallm_" #TI "_" #TO)]] kernel void \
+      prod_reduction_outer_smallm<TI, TO, 2>(                               \
+          constant TI * input [[buffer(0)]],                                \
+          device TO * output [[buffer(1)]],                                 \
+          constant uint3 & sizes [[buffer(2)]],                             \
+          uint gid [[thread_position_in_grid]],                             \
+          uint gsize [[threads_per_grid]]);
+REGISTER_PROD_OUTER_SMALLM(float, float);
+REGISTER_PROD_OUTER_SMALLM(half, half);
+REGISTER_PROD_OUTER_SMALLM(bfloat, bfloat);

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1424,3 +1424,148 @@ REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);
+
+// ===== prod kernels (this PR, on top of malfet sum/value migration) =====
+// Product reduction kernels
+// ============================================================================
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+[[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
+kernel void prod_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size [[threads_per_simdgroup]]) {
+  using TA = opmath_t<TO>;
+
+  // input_base is uint32: the host dispatch guard rejects inputs whose largest
+  // element offset exceeds 2^32, so the per-group base (tgid * elems_per_group)
+  // and the accumulated index below cannot wrap a 32-bit offset.
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint32_t rsize = params.reduction_size;
+  const uint32_t stride = tptg * NCHAINS;
+  uint32_t base = tid * NCHAINS;
+
+  if (num_reduced_dims <= 1) {
+    // All indexing here is uint32: input_base, base/idx, and reduction_stride.
+    // The host guard rejects inputs whose largest element offset
+    // (input_base + idx * reduction_stride) could exceed 2^32, so this cannot
+    // wrap.
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[input_base + (base + j) * reduction_stride]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[input_base + idx * reduction_stride]);
+    }
+  } else {
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[get_input_offset(base + j, tgid, params)]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
+    }
+  }
+
+  TA output_val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    output_val *= acc[j];
+
+  auto threads_remaining = tptg;
+  threadgroup TA
+      shared_outputs[MAX_THREADGROUP_SIZE / c10::metal::simdgroup_size];
+
+  while (threads_remaining > 1) {
+    output_val = c10::metal::simd_prod(output_val);
+    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
+    if (threads_remaining > 1) {
+      if (simd_lane_id == 0)
+        shared_outputs[simdgroup_id] = output_val;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (tid < threads_remaining) {
+        output_val = shared_outputs[tid];
+      } else {
+        output_val = static_cast<TA>(1);
+      }
+    }
+  }
+
+  if (tid == 0) {
+    // uint32 output offset: the host guard ensures output.numel() <= 2^32, so
+    // the cross-dimension index*stride sum cannot wrap. reduction_idx is a
+    // tgid-derived id and per-dim sizes/strides stay 32-bit.
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+    output[output_offset] = static_cast<TO>(output_val);
+  }
+}
+
+#define REGISTER_PROD(TI, TO)                               \
+  template [[host_name("prod_reduction_" #TI "_" #TO)]]     \
+  kernel void prod_reduction<TI, TO, SUM_NCHAINS>(          \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      constant NormParams<> & params [[buffer(2)]],         \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size [[threads_per_simdgroup]]);
+
+REGISTER_PROD(float, float);
+REGISTER_PROD(half, half);
+REGISTER_PROD(half, float);
+REGISTER_PROD(bfloat, bfloat);
+REGISTER_PROD(bfloat, float);
+REGISTER_PROD(int, int);
+REGISTER_PROD(int, long);
+REGISTER_PROD(long, long);
+REGISTER_PROD(short, short);
+REGISTER_PROD(short, long);
+REGISTER_PROD(char, char);
+REGISTER_PROD(char, long);
+REGISTER_PROD(uchar, uchar);
+REGISTER_PROD(uchar, long);
+REGISTER_PROD(bool, long);
+REGISTER_PROD(bool, int);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -349,6 +349,266 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
   });
 }
 
+// ============================================================================
+// Metal kernel dispatch helpers for prod
+// ============================================================================
+
+static std::vector<int64_t> get_reduce_dims(const Tensor& input, OptionalIntArrayRef opt_dim) {
+  std::vector<int64_t> dims;
+  if (opt_dim.has_value() && !opt_dim.value().empty()) {
+    for (auto d : opt_dim.value()) {
+      dims.push_back(maybe_wrap_dim(d, input.dim()));
+    }
+  } else {
+    for (int64_t d = 0; d < input.dim(); d++) {
+      dims.push_back(d);
+    }
+  }
+  return dims;
+}
+
+static NormParams<> build_reduce_params(const Tensor& input,
+                                        const std::vector<int64_t>& reduce_dims,
+                                        const Tensor& output,
+                                        bool keepdim) {
+  NormParams params;
+  params.ndim = input.dim();
+  params.p = 0;
+  params.reduction_size = input.numel() / std::max<int64_t>(output.numel(), 1);
+
+  bool is_reduced[c10::metal::max_ndim] = {};
+  for (auto d : reduce_dims)
+    is_reduced[d] = true;
+
+  if (keepdim || output.dim() == input.dim()) {
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      params.output_sizes[d] = output.size(d);
+      params.output_strides[d] = output.stride(d);
+    }
+  } else {
+    uint32_t out_d = 0;
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      if (is_reduced[d]) {
+        params.output_sizes[d] = 1;
+        params.output_strides[d] = 0;
+      } else {
+        params.output_sizes[d] = output.size(out_d);
+        params.output_strides[d] = output.stride(out_d);
+        out_d++;
+      }
+    }
+  }
+
+  return params;
+}
+
+// Native prod kernels are instantiated for same-dtype pairs and the natural
+// accumulation promotions only; an explicit prod(..., dtype=) can request any
+// (input, output) scalar combination.
+static bool prod_kernel_registered(ScalarType in, ScalarType out) {
+  if (in == out) {
+    // Same-dtype kernels are instantiated for these only. uint16/32/64 are not
+    // (and are rejected up front in prod_kernel_mps, since prod is unsupported
+    // for them on CPU too); bool output uses the nonzero path above.
+    return in == kFloat || in == kHalf || in == kBFloat16 || in == kInt || in == kLong || in == kShort || in == kChar ||
+        in == kByte;
+  }
+  if ((in == kHalf || in == kBFloat16) && out == kFloat) {
+    return true;
+  }
+  if ((in == kInt || in == kShort || in == kChar || in == kByte) && out == kLong) {
+    return true;
+  }
+  if (in == kBool && (out == kInt || out == kLong)) {
+    return true;
+  }
+  return false;
+}
+
+static void prod_kernel_mps(const Tensor& input,
+                            const std::vector<int64_t>& reduce_dims,
+                            bool keepdim,
+                            const Tensor& output) {
+  // Complex prod requires complex multiplication semantics not available in
+  // the generic float2 SIMD kernels; fall back to MPSGraph. Pass the output
+  // dtype so a complex input with an explicit real dtype= casts per element
+  // before reducing (matching CPU), instead of silently dropping the dtype.
+  if (c10::isComplexType(input.scalar_type())) {
+    reduction_out_mps(
+        input, reduce_dims, keepdim, output.scalar_type(), output, MPSReductionType::PROD, "prod_kernel_mps");
+    return;
+  }
+  // One threadgroup per output element; Metal caps the grid at ~2^32
+  // threadgroups, so a reduction with more than 2^32 outputs cannot be
+  // dispatched (the generic kernel's 32-bit output index would also wrap).
+  TORCH_CHECK(output.numel() <= std::numeric_limits<uint32_t>::max(),
+              "MPS prod reduction with more than 2^32 output elements is not supported");
+  // bool output: prod(..., dtype=bool) uses nonzero semantics (CPU multiplies
+  // the boolean mask input != 0), so a 0.5 element contributes True, not a
+  // truncated 0. Reduce input.to(kBool) (the nonzero mask as a bool tensor ->
+  // the registered (bool,long) kernel) rather than casting the raw input to the
+  // long accumulator, which would truncate non-integer values. to(kBool) is
+  // used over ne(0) because MPS has no scalar ne for the unsigned uint16/uint32/
+  // uint64 dtypes (ne_..._ushort/uint/ulong are unregistered), which CPU prod
+  // accepts. Metal simd_product has no bool, so the accumulator stays long and
+  // is cast back to bool at the end.
+  if (output.scalar_type() == kBool) {
+    auto long_output = at::empty_like(output, output.options().dtype(kLong));
+    prod_kernel_mps(input.to(kBool), reduce_dims, keepdim, long_output);
+    output.copy_(long_output.to(kBool));
+    return;
+  }
+  // uint16/32/64 have no native prod kernel, and prod is "not implemented" for
+  // them on CPU too. Reject with a clear error rather than recursing forever
+  // below: cast-to-self is a no-op, so the cast-and-recurse path would loop
+  // until the stack overflows.
+  TORCH_CHECK(output.scalar_type() != kUInt16 && output.scalar_type() != kUInt32 && output.scalar_type() != kUInt64,
+              "prod: not implemented for ",
+              output.scalar_type(),
+              " output on MPS");
+  // prod(..., dtype=) accumulates in the output dtype. For an (input, output)
+  // pair with no native kernel, cast the input to the output dtype and recurse
+  // into the same-dtype kernel instead of requesting an unregistered kernel.
+  if (!prod_kernel_registered(input.scalar_type(), output.scalar_type())) {
+    prod_kernel_mps(input.to(output.scalar_type()).contiguous(), reduce_dims, keepdim, output);
+    return;
+  }
+  if (input.numel() == 0) {
+    output.fill_(1);
+    return;
+  }
+  if (output.numel() == 0)
+    return;
+
+  int64_t reduction_size = input.numel() / output.numel();
+  // The native kernel indexes input and output as uint32 (input_base + idx *
+  // stride; output_offset += idx * output_stride) and reads reduction_size as a
+  // uint32 loop bound. Reject tensors whose reduction extent or largest element
+  // offset exceeds 2^32 rather than silently wrapping (the prior int64 NormParams
+  // path handled these but taxed small reductions). Largest offset is
+  // sum_i stride_i * (size_i - 1); a strided out= needs its own check since
+  // output.numel() does not bound a strided output offset.
+  constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+  int64_t max_input_offset = 0;
+  for (const auto i : c10::irange(input.dim()))
+    max_input_offset += static_cast<int64_t>(input.stride(i)) * std::max<int64_t>(input.size(i) - 1, 0);
+  int64_t max_output_offset = 0;
+  for (const auto i : c10::irange(output.dim()))
+    max_output_offset += static_cast<int64_t>(output.stride(i)) * std::max<int64_t>(output.size(i) - 1, 0);
+  TORCH_CHECK(reduction_size <= kU32Max && max_input_offset <= kU32Max && max_output_offset <= kU32Max,
+              "MPS prod: tensor too large for 32-bit indexing (reduction extent or element offset exceeds 2^32)");
+  auto type_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass all-reduce: reshape input to
+  // [num_groups, elems_per_group], reduce dim=1 to per-group partials, then
+  // reduce partials to scalar. Reuses the existing prod_reduction kernel both
+  // passes. Bypasses is_outer's M=1 single-TG-per-output degenerate dispatch.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    // total_N fits uint32 here: the dispatch guard rejects a max element offset
+    // above 2^32, and this contiguous all-reduce's max offset is numel - 1, so
+    // input.numel() <= 2^32. num_groups stays small (<=512), so elems_per_group
+    // also fits uint32 when assigned into the NormParams fields below.
+    int64_t total_N = input.numel();
+    uint32_t num_groups = static_cast<uint32_t>(
+        std::min<int64_t>(512, c10::metal::ceil_div(total_N, static_cast<int64_t>(MAX_THREADGROUP_SIZE) * 4)));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    int64_t elems_per_group = total_N / num_groups;
+
+    auto partials = at::empty({static_cast<int64_t>(num_groups)}, output.options());
+    auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+
+    // Pass 1: input[num_groups, elems_per_group] -> partials[num_groups], reduce dim=1.
+    NormParams<> params1{};
+    params1.reduction_size = elems_per_group;
+    params1.ndim = 2;
+    params1.input_sizes[0] = num_groups;
+    params1.input_strides[0] = elems_per_group;
+    params1.output_sizes[0] = num_groups;
+    params1.output_strides[0] = 1;
+    params1.input_sizes[1] = elems_per_group;
+    params1.input_strides[1] = 1;
+
+    // Pass 2: partials[num_groups] -> output[1], reduce dim=0.
+    NormParams<> params2{};
+    params2.reduction_size = num_groups;
+    params2.ndim = 1;
+    params2.input_sizes[0] = num_groups;
+    params2.input_strides[0] = 1;
+    params2.output_sizes[0] = 1;
+    params2.output_strides[0] = 0;
+
+    auto p2_kernel = fmt::format("prod_reduction_{}_{}", out_str, out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps1 = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps1, "prod_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        mtl_setArgs(enc, input, partials, params1);
+        // Round each pass up to a full simdgroup. prod_reduction's
+        // simd_prod<long> emulates 64-bit simd via simd_shuffle_and_fill_down;
+        // in a partial simdgroup an active lane reads an in-range inactive lane
+        // as garbage (0 on M1/M2 -> corrupted product), which the fill does not
+        // cover. Padding lanes in a full simdgroup carry the identity 1.
+        // Cap to MAX_THREADGROUP_SIZE first (elems_per_group is int64 and may
+        // exceed 2^32 when num_groups==1) so the round_up runs in 32 bits.
+        uint32_t epg_capped = static_cast<uint32_t>(std::min<int64_t>(MAX_THREADGROUP_SIZE, elems_per_group));
+        auto tpg1 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(epg_capped, 32u));
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(p2_kernel);
+        getMPSProfiler().beginProfileKernel(ps2, "prod_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, params2);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(num_groups, 32u));
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+  // The generic NormParams path indexes per-dim arrays sized by max_ndim; a
+  // higher-rank input would index past the struct/stack storage. (The outer/
+  // inner fast paths above use only M/N and are rank-agnostic.)
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              "MPS prod: reductions over more than ",
+              c10::metal::max_ndim,
+              " dimensions are not supported");
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  uint32_t capped_reduction = static_cast<uint32_t>(std::min<int64_t>(MAX_THREADGROUP_SIZE, reduction_size));
+  auto threads_per_group = c10::metal::ceil_div(capped_reduction, 32u) * 32u;
+  // 64-bit total dispatch thread count: one threadgroup per output element, so
+  // output.numel() * threads_per_group can exceed 2^32 (e.g. millions of output
+  // elements * a full threadgroup). threads_per_group stays 32-bit.
+  uint64_t num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "prod_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, params);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
 static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       at::OptionalIntArrayRef dim,
                                       const std::optional<Scalar>& correction,
@@ -1201,8 +1461,14 @@ Tensor trace_mps(const Tensor& self) {
 
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
-  int64_t dims[1] = {dim};
-  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
+  // 0-dim tensor: prod(scalar, dim=0) is a no-op reduction; return scalar.
+  if (input_t.dim() == 0) {
+    output_t.copy_(input_t);
+    return;
+  }
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  std::vector<int64_t> reduce_dims = {dim_};
+  prod_kernel_mps(input_t, reduce_dims, keepdim, output_t);
 }
 
 static void aminmax_kernel_mps(const Tensor& self, int64_t dim, bool keepdim, Tensor& min, Tensor& max) {
@@ -1218,14 +1484,12 @@ static void aminmax_allreduce_kernel_mps(const Tensor& self, Tensor& min, Tensor
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
-  std::vector<int64_t> dims(self.dim());
-  std::iota(dims.begin(), dims.end(), 0);
+  auto reduce_dims = get_reduce_dims(self, std::nullopt);
 
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  reduction_out_mps(
-      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
+  prod_kernel_mps(self, reduce_dims, false, output_t);
 
   return output_t;
 }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -579,6 +579,139 @@ static void prod_kernel_mps(const Tensor& input,
     return;
   }
 
+  bool is_single = reduce_dims.size() == 1 && output.numel() != 1;
+  bool is_outer = is_single && reduce_dims[0] == 0 && input.is_contiguous() && output.is_contiguous();
+  bool is_inner = is_single && reduce_dims[0] == input.dim() - 1 && input.is_contiguous() && output.is_contiguous();
+
+  // The specialized outer/inner prod kernels carry M and N as 32-bit sizes, so
+  // fall back to the generic 64-bit NormParams path when a single dimension (or
+  // the non-reduced product) exceeds uint32.
+  if (is_single) {
+    constexpr int64_t kU32Max = std::numeric_limits<uint32_t>::max();
+    int64_t rd_size = input.size(reduce_dims[0]);
+    if (rd_size > kU32Max || input.numel() / std::max<int64_t>(rd_size, 1) > kU32Max) {
+      is_outer = false;
+      is_inner = false;
+    }
+  }
+
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    uint32_t TG_X, TG_Y;
+    std::string kernel;
+    // Small-M kernels are instantiated same-dtype only; a mixed-dtype
+    // prod(..., dtype=...) request must fall through to the generic outer path
+    // (which covers all input/output combos) to avoid an unregistered kernel.
+    bool small_m_supported = input.scalar_type() == output.scalar_type() &&
+        (input.scalar_type() == at::kFloat || input.scalar_type() == at::kHalf || input.scalar_type() == at::kBFloat16);
+    if (small_m_supported && M <= 16) {
+      // Grid-stride small-M path (COLS=2 columns/thread): no barrier tree, and a
+      // bounded threadgroup count for large N. Wins over the generic outer
+      // kernel and one-thread-per-column for tiny M.
+      constexpr uint32_t COLS = 2, TG = 256;
+      auto sm_kernel = fmt::format("prod_reduction_outer_smallm_{}_{}", type_str, out_str);
+      // 64-bit grid: N may be up to kU32Max, so ceil_div(N, ...) * TG would wrap
+      // a uint32 to 0 (silently dispatching nothing) for N near 2^32.
+      const int64_t gthreads = c10::metal::ceil_div<int64_t>(N, COLS * TG) * TG;
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        @autoreleasepool {
+          id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+          auto ps = lib.getPipelineStateForFunc(sm_kernel);
+          getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer_smallm", {input});
+          [enc setComputePipelineState:ps];
+          // Pad to 4 uints: Metal requires 16 bytes for a `constant uint3&`
+          // argument, and a 12-byte struct aborts under MTL_DEBUG_LAYER.
+          const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+          mtl_setArgs(enc, input, output, sizes_s);
+          [enc dispatchThreads:MTLSizeMake(gthreads, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps);
+        }
+      });
+      return;
+    }
+    // M > 16: generic 2D outer kernel (TG_X x TG_Y row-workers + tree reduce).
+    TG_X = 32;
+    TG_Y = 32;
+    kernel = fmt::format("prod_reduction_outer_{}_{}", type_str, out_str);
+    // 64-bit: ceil_div(N, TG_X) and the num_tg_x * TG_X grid width below would
+    // both wrap a uint32 to 0 for N near 2^32.
+    const int64_t num_tg_x = c10::metal::ceil_div<int64_t>(N, TG_X);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer", {input});
+        [enc setComputePipelineState:ps];
+        // Pad to 4 uints: Metal requires 16 bytes for a `constant uint3&`
+        // argument, and a 12-byte struct aborts under MTL_DEBUG_LAYER.
+        const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  if (is_inner) {
+    uint32_t N = input.size(input.dim() - 1);
+    uint32_t M = input.numel() / N;
+    // Enough rows -> one SIMD group per row (pack rows_per_tg rows per TG).
+    // Few rows (small M) -> the "wide" kernel (one whole TG per row, up to 1024
+    // threads), since only M simdgroups on few rows idles most of the GPU. This
+    // gates on M only, not N: unlike welford, prod's simd-per-row still wins at
+    // moderate M with large N (e.g. M=256, N=65536), so a low N cap would
+    // regress it.
+    // Tall-thin (small N, large M) -> one thread per row: a 32-lane SIMD group
+    // on N<=32 leaves most lanes idle and pays simd-reduction overhead for under
+    // one element of work per lane.
+    bool use_thin = (M >= 64 && N <= 32);
+    bool use_simd_per_row = (M >= 64);
+    uint32_t tg_size;
+    // 64-bit: M may be up to kU32Max, so ceil_div(M, ...) would wrap a uint32 to
+    // 0 for M near 2^32, dispatching no threadgroups.
+    int64_t num_tgs;
+    std::string kernel;
+    if (use_thin) {
+      kernel = fmt::format("prod_reduction_inner_thin_{}_{}", type_str, out_str);
+      tg_size = 256;
+      num_tgs = c10::metal::ceil_div<int64_t>(M, tg_size); // one thread per row
+    } else if (use_simd_per_row) {
+      kernel = fmt::format("prod_reduction_inner_{}_{}", type_str, out_str);
+      tg_size = (N <= 512) ? 1024u : 256u;
+      num_tgs = c10::metal::ceil_div<int64_t>(M, tg_size / 32);
+    } else {
+      kernel = fmt::format("prod_reduction_inner_wide_{}_{}", type_str, out_str);
+      tg_size = std::min(1024u, c10::metal::ceil_div(N, 32u) * 32u);
+      if (N >= 2048) {
+        tg_size = c10::metal::ceil_div(N / (4u * 16u), 32u) * 32u;
+        tg_size = std::clamp(tg_size, 32u, 1024u);
+      }
+      num_tgs = M; // one TG per row
+    }
+    // 64-bit total dispatch thread count: num_tgs * tg_size can exceed 2^32 for
+    // a tall input (many rows).
+    const int64_t total_threads = num_tgs * tg_size;
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(total_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
   auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
   // The generic NormParams path indexes per-dim arrays sized by max_ndim; a
   // higher-rank input would index past the struct/stack storage. (The outer/

--- a/benchmarks/operator_benchmark/mps/prod_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/prod_reduce_bench.py
@@ -1,0 +1,68 @@
+"""Benchmark for the native Metal prod reduction vs the MPSGraph implementation
+it replaces.
+
+Run on a build WITH the native kernel and on a build WITHOUT it (e.g. the PR
+parent commit) and compare. Reports two regimes:
+
+  * steady-state: a fixed shape benchmarked warm (torch.utils.benchmark median).
+  * shape-varying: many distinct shapes seen once each -- this is where MPSGraph
+    pays a per-shape graph recompilation (~100ms/shape) the native kernel does
+    not.
+
+Methodology note: the per-shape MPS bench has high run-to-run variance; use the
+interleaved 5-trial median below (not a single sweep) when comparing builds.
+"""
+
+import time
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+STEADY_SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((1_000_000, 8), 1),  # tall-thin: thread-per-row kernel
+    ((2, 8_000_000), 1),  # short-wide: wide inner kernel
+]
+
+
+def steady_state():
+    print("# steady-state prod (median us, warm)")
+    for shape, dim in STEADY_SHAPES:
+        x = torch.randn(*shape, device="mps")
+        torch.mps.synchronize()
+        stmt = (
+            "torch.prod(x); torch.mps.synchronize()"
+            if dim is None
+            else "torch.prod(x, dim=dim); torch.mps.synchronize()"
+        )
+        t = benchmark.Timer(stmt=stmt, globals={"x": x, "dim": dim, "torch": torch})
+        us = t.blocked_autorange(min_run_time=0.5).median * 1e6
+        print(f"  {str(shape):20} dim={dim}: {us:8.1f} us")
+        del x
+        torch.mps.empty_cache()
+
+
+def shape_varying(n=200):
+    # n distinct shapes, each reduced once -> exercises per-shape compilation.
+    buf = torch.randn(20_000_000, device="mps")
+    torch.prod(torch.as_strided(buf, (64, 500), (500, 1)), dim=1)  # warm
+    torch.mps.synchronize()
+    t0 = time.time()
+    for i in range(n):
+        N = 999 + i * 101
+        torch.prod(torch.as_strided(buf, (64, N), (N, 1)), dim=1)
+    torch.mps.synchronize()
+    dt = time.time() - t0
+    print(
+        f"# shape-varying prod: {n} distinct shapes = {dt * 1e3:.0f} ms "
+        f"({dt / n * 1e3:.2f} ms/shape)"
+    )
+
+
+if __name__ == "__main__":
+    steady_state()
+    shape_varying()

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -120,9 +120,11 @@ inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_sum(T val) {
 
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_prod(T val) {
+  // Fill with 1 (product identity) for inactive lanes in partial simdgroups
+  int2 fill = as_type<int2>(T(1));
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
     val *= as_type<T>(
-        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), fill, i));
   }
   return simd_broadcast(val, 0);
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16293,6 +16293,35 @@ class TestReduceOpsMetal(TestCaseMPS):
         with self.assertRaises(RuntimeError):
             torch.prod(x, dim=1)
 
+    def test_prod_metal_wide_inner_few_rows(self):
+        # Few rows of a huge reduced dim (M < 64) route to the wide inner kernel
+        # (one threadgroup per row); must match CPU. Values near 1 keep the
+        # product in range.
+        torch.manual_seed(0)
+        for M, N in [(2, 2_000_000), (8, 500_000)]:
+            x = (1.0 + 0.001 * torch.randn(M, N)).to("mps")
+            self.assertEqual(torch.prod(x, dim=1).cpu(),
+                             torch.prod(x.cpu(), dim=1), rtol=1e-3, atol=1e-3)
+        # int wide path is exact (long accumulator)
+        xi = torch.ones(2, 1_000_000, dtype=torch.int32)
+        xi[:, ::500] = 2
+        self.assertEqual(torch.prod(xi.to("mps"), dim=1).cpu(),
+                         torch.prod(xi, dim=1))
+
+    def test_prod_metal_thin_inner_small_n(self):
+        # Tall-thin (small N, large M) routes to the thread-per-row thin kernel
+        # (N<=32); must match CPU across dtypes and across the N=32/33 boundary.
+        torch.manual_seed(0)
+        for M, N in [(100000, 8), (20000, 32), (20000, 33)]:
+            for dt in (torch.float32, torch.float16, torch.bfloat16):
+                x = (1.0 + 0.001 * torch.randn(M, N)).to(dt)
+                self.assertEqual(torch.prod(x.to("mps"), dim=1).cpu(),
+                                 torch.prod(x, dim=1), rtol=1e-2, atol=1e-2)
+        # int thin path is exact (long accumulator)
+        xi = torch.ones(100000, 8, dtype=torch.int32)
+        xi[:, ::4] = 2
+        self.assertEqual(torch.prod(xi.to("mps"), dim=1).cpu(), torch.prod(xi, dim=1))
+
 instantiate_parametrized_tests(TestReduceOpsMetal)
 
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16129,6 +16129,172 @@ class TestMetalLibrary(TestCaseMPS):
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
 # to achieve this.
+
+class TestReduceOpsMetal(TestCaseMPS):
+    """Tests for Metal kernel reduce ops: prod."""
+
+    # =========================================================================
+    # Product reduction
+    # =========================================================================
+    def test_prod_metal_basic(self):
+        for shape in [(4,), (3, 4), (2, 3, 4), (2, 3, 4, 5)]:
+            for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
+                if dtype in (torch.int32, torch.int64):
+                    cpu_x = torch.randint(1, 3, shape, device='cpu', dtype=dtype)
+                else:
+                    cpu_x = torch.randint(1, 4, shape, device='cpu', dtype=dtype)
+                mps_x = cpu_x.to('mps')
+                # Scalar prod
+                self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+                # Per-dim prod
+                for dim in range(len(shape)):
+                    self.assertEqual(torch.prod(mps_x, dim=dim), torch.prod(cpu_x, dim=dim))
+                    self.assertEqual(
+                        torch.prod(mps_x, dim=dim, keepdim=True),
+                        torch.prod(cpu_x, dim=dim, keepdim=True))
+
+    def test_prod_metal_dtype_promotion(self):
+        cpu_x = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.prod(mps_x, dtype=torch.int64),
+            torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_float_types(self):
+        cpu_x = torch.randn(8, 16, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(torch.prod(mx, dim=1), torch.prod(cx, dim=1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(torch.prod(mx, dim=0), torch.prod(cx, dim=0), atol=1e-2, rtol=1e-2)
+
+    def test_prod_metal_empty(self):
+        cpu_x = torch.empty(0, 3, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_scalar(self):
+        cpu_x = torch.tensor(5.0, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_bool(self):
+        cpu_x = torch.tensor([True, True, False, True], device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+        self.assertEqual(torch.prod(mps_x, dtype=torch.int64), torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_large(self):
+        cpu_x = torch.randint(1, 3, (64, 128), device='cpu', dtype=torch.int32)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x, dim=0), torch.prod(cpu_x, dim=0))
+        self.assertEqual(torch.prod(mps_x, dim=1), torch.prod(cpu_x, dim=1))
+
+    def test_prod_metal_partial_simdgroup_allreduce(self):
+        # 2-pass all-reduce prod where pass 2 lands a PARTIAL simdgroup
+        # (N=21000 -> num_groups=6, not a multiple of 32). The 64-bit
+        # simd_prod<long> (used by int/bool prod) emulates simd reduction via
+        # simd_shuffle_and_fill_down, where an active lane reading an in-range
+        # inactive lane gets garbage (0 on M1/M2 -> the product collapses to 0).
+        # The dispatch rounds the threadgroup up to a full simdgroup to avoid it.
+        # Passes on M4 regardless; this guards the M1/M2 path.
+        for dtype in (torch.int64, torch.int32, torch.bool):
+            cpu_x = torch.ones(21000, device='cpu', dtype=dtype)
+            if dtype is not torch.bool:
+                cpu_x[:3] = 2  # product = 8, distinguishable from a 0 corruption
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(mps_x.prod().cpu(), cpu_x.prod(), f"prod all-reduce {dtype}")
+
+    def test_prod_metal_dtype_cast_matrix(self):
+        # prod(..., dtype=) accepts any (input, output) scalar combo, but native
+        # kernels only cover same-dtype + the natural acc promotions. Every other
+        # combo (half->float small-M, float->long, bool->uint8, ...) must cast to
+        # the output dtype rather than request an unregistered Metal kernel.
+        # Covers dim=0 (outer/small-M), dim=1 (inner) and all-reduce.
+        import itertools
+        dts = (torch.bool, torch.uint8, torch.int16, torch.int32, torch.int64,
+               torch.float16, torch.bfloat16, torch.float32)
+        cpu_base = torch.ones(6, 4, device='cpu')
+        cpu_base[0] = 2     # product over dim 0 == 2 per column; small, no overflow
+        cpu_base[2, 1] = 0  # one zero: exercises 0-product and bool AND -> False
+        for in_dt, out_dt in itertools.product(dts, dts):
+            cpu_x = cpu_base.to(in_dt)
+            mps_x = cpu_x.to('mps')
+            for kw in ({'dim': 0}, {'dim': 1}, {}):
+                self.assertEqual(torch.prod(mps_x, dtype=out_dt, **kw).cpu(),
+                                 torch.prod(cpu_x, dtype=out_dt, **kw),
+                                 f"prod {in_dt}->{out_dt} {kw}")
+
+    def test_prod_metal_noncontiguous(self):
+        cpu_x = torch.randint(1, 4, (4, 6), device='cpu', dtype=torch.float32)
+        mps_x = cpu_x.to('mps')
+        # Transpose makes it non-contiguous
+        cpu_t = cpu_x.t()
+        mps_t = mps_x.t()
+        self.assertEqual(torch.prod(mps_t, dim=0), torch.prod(cpu_t, dim=0))
+        self.assertEqual(torch.prod(mps_t, dim=1), torch.prod(cpu_t, dim=1))
+
+    def test_prod_metal_bool_fractional(self):
+        # prod(dtype=bool) uses nonzero semantics: a fractional 0.5 is nonzero
+        # -> True. A float->long truncation would make it 0 -> False.
+        for vals in ([0.5, 0.5], [0.5, 0.0], [0.1, 0.2, 0.3]):
+            x = torch.tensor(vals, device="mps")
+            self.assertEqual(torch.prod(x, dtype=torch.bool).item(),
+                             torch.prod(x.cpu(), dtype=torch.bool).item())
+
+    def test_prod_metal_bool_output_unsigned(self):
+        # prod(..., dtype=bool) must work for uint16/32/64: MPS has no scalar ne
+        # for those dtypes, so the bool path uses to(kBool). Match CPU nonzero
+        # semantics across the unsigned + signed-int + float input dtypes.
+        for dt in (torch.uint16, torch.uint32, torch.uint64,
+                   torch.int32, torch.float32):
+            x = torch.tensor([[0, 2, 3], [1, 1, 1]], dtype=dt, device="mps")
+            self.assertEqual(torch.prod(x, dim=1, dtype=torch.bool).cpu(),
+                             torch.prod(x.cpu(), dim=1, dtype=torch.bool))
+
+    def test_prod_metal_half_float_accumulation(self):
+        # MPS prod accumulates float16 in float (opmath/acc_type), matching CUDA
+        # and the MPS sum/var/std convention -- more accurate than CPU's
+        # half-precision accumulation, which drifts ~20% over a long reduction.
+        # Compare to the float-accumulated reference, not CPU.
+        x = torch.full((4096,), 1.0009765625, dtype=torch.float16)
+        self.assertEqual(torch.prod(x.to("mps")).cpu(), torch.prod(x.float()).half())
+
+    def test_prod_metal_unsigned_same_dtype(self):
+        # uint16/32/64 have no native prod kernel and prod is unsupported for
+        # them on CPU too; MPS must raise a clean error, not crash with a Metal
+        # pipeline error or recurse forever (cast-to-self is a no-op).
+        for dt in (torch.uint16, torch.uint32, torch.uint64):
+            x = torch.tensor([[1, 2, 3], [4, 5, 6]]).to(dt).to("mps")
+            with self.assertRaises(RuntimeError):
+                torch.prod(x, dim=1, dtype=dt)
+
+    def test_prod_metal_complex_dtype(self):
+        # Complex prod with an explicit real dtype casts per element before
+        # reducing (CPU semantics), not complex-product-then-cast.
+        for dt in (torch.float32, torch.float16):
+            x = torch.tensor([1 + 2j, 3 + 4j], device="mps")
+            self.assertEqual(torch.prod(x, dtype=dt).item(),
+                             torch.prod(x.cpu(), dtype=dt).item())
+
+    def test_prod_metal_rank_guard(self):
+        # A rank-17 view (reachable via as_strided past the factory rank check)
+        # hits the generic NormParams path, whose per-dim arrays are sized for
+        # max_ndim=16; ranks above 16 must raise cleanly, not index past storage.
+        x = torch.as_strided(torch.ones(1, device="mps"), (1,) * 17, (0,) * 17)
+        with self.assertRaises(RuntimeError):
+            torch.prod(x)
+
+    def test_prod_metal_reduction_extent_over_uint32_raises(self):
+        # A reduced extent of exactly 2^32 (a zero-stride view, so no large
+        # allocation) exceeds the native kernel's uint32 reduction_size, so the
+        # dispatch guard must reject it cleanly rather than wrap to 0.
+        x = torch.as_strided(torch.ones(1, device="mps"), (2, 1 << 32), (0, 0))
+        with self.assertRaises(RuntimeError):
+            torch.prod(x, dim=1)
+
+instantiate_parametrized_tests(TestReduceOpsMetal)
+
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")


### PR DESCRIPTION
Adds shape-specialized Metal prod kernels on top of the native generic
prod_reduction kernel from #188046 (the core migration). A single-dim
contiguous reduction is routed by shape to a specialization -- reduce over
dim 0 (outer), reduce over the last dim (inner), few rows of a huge reduced
dim (inner_wide), tall-thin small reduced dim (inner_thin), small outer M
(outer_smallm) -- and falls back to the generic kernel otherwise. The
specializations carry M and N as uint32, so a reduction whose dimension or
non-reduced product exceeds 2^32 falls to the guarded generic path. The host
grid (ceil_div + threadgroup-count multiply) and the outer kernel's per-y row
range are computed in 64-bit, so M or N immediately below 2^32 cannot wrap a
uint32 to zero and silently dispatch nothing / skip the reduction loop.

## Context
Part of #187455. Second piece of splitting #187788 (the ~1600-line native
prod migration) into reviewable PRs at the reviewer's request; stacks on
#188046 (prod-core). #188046 is correctness-focused (parity with the MPSGraph
reduction + removes prod from the shape-dependent MPSGraph cache); this PR
adds the steady-state speedups from the shape specializations.

## Perf (M4 Pro, single-dim contiguous prod, torch.utils.benchmark median,
vs the generic kernel from #188046)
  (4096, 4096) dim=0  (outer):       1032 us -> 428 us   (2.4x)
  (1000000, 8) dim=1  (inner_thin):  3215 us -> 358 us   (9.0x)
  (2, 8000000) dim=1  (inner_wide):  1536 us -> 1058 us  (1.45x)
  (4096, 4096) dim=1, (1024, 16384) dim=1, all-reduce: parity. The steady-state
  bench's per-iter synchronize floors fast shapes at ~400 us, so the specialized
  inner kernel reads as parity here; it is never a regression.
No regressions. Bench script: benchmarks/operator_benchmark/mps/prod_reduce_bench.py
(run on a build with and without this PR and compare).

## Test Plan
```
python test/test_mps.py -k test_prod_metal -v
```
19 tests, including test_prod_metal_wide_inner_few_rows and
test_prod_metal_thin_inner_small_n which exercise the inner_wide / inner_thin
specializations against the CPU reference. The existing outer/inner shapes in
the suite now route through the specialized kernels. (The >2^32 grid-overflow
path is not unit-tested: it needs a real ~17GB contiguous allocation, the same
constraint as the prod-core uint32 guard.)

## Known limitation (shared with sum_reduction / value_reduction)
The specialization kernels do not support a reduced extent or non-reduced product
within a threadgroup stride of 2^32 (reachable only via a crafted ~17GB contiguous
tensor). Two coupled uint32 overflows exist in that regime: the reduction loops use
uint32 induction (`row += NCHAINS`, `base += stride`, `i += tptg`), which wraps below
the loop bound and never terminates; and the outer kernel's flat index computes
`row + j` in uint32 before the ulong cast, so it too wraps near 2^32. Both patterns
mirror the existing sum_reduction / value_reduction specialization kernels (prod
already 64-bit-casts the row*N offset multiply, hardening it beyond the siblings,
but the inner `row + j` still wraps pre-cast), so the limitation is shared; the
remaining fix -- 64-bit loop induction and casting `row` before the `+ j` -- is
most consistent applied across all the reduce kernels in a follow-up rather than
diverging in prod alone. The host grid math is computed in
64-bit, so the oversized case does not silently no-op via an empty dispatch; because
the loop never terminates the net effect is a GPU hang, not a wrong-but-returned
result.

Review history (local-gate findings + dispositions): https://gist.github.com/anagnorisis2peripeteia/84aacf7575b484ab85bce4d5e1da165a

Authored with Claude.
