### PR TITLE
Migrate torch_export_python to ShapesSpec API

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -2204,6 +2204,19 @@ class GraphLowering(torch.fx.Interpreter):
         ):
             new_unbacked_defs.add(result)
 
+        # A tensor placeholder also defines the unbacked symints in its
+        # shape -- the placeholder IS the def-site, mirroring what
+        # ``torch.export._trace._add_input_unbacked_bindings`` records on
+        # the fx side. Without this, ShapesSpec-style inputs (whose dims
+        # are unbacked symbols rather than backed s0/s1) trip the
+        # (inductor >= fx) check below.
+        if n.op == "placeholder":
+            val = n.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                for dim in val.shape:
+                    if isinstance(dim, (torch.SymInt, torch.SymFloat)):
+                        new_unbacked_defs |= free_unbacked_symbols(dim.node._expr)
+
         def format_new_defs() -> str:
             r = [
                 f"unbacked_symbol_defs={buf.get_unbacked_symbol_defs()} in:\n{buf}\n"


### PR DESCRIPTION
Summary:
Switch torch_export_python's dynamic-shapes surface from the legacy
`torch.export.Dim` + dict-of-tuples form to the new
`torch.fx.experimental.dynamic_spec.ShapesSpec` API.

Public surface:
  Before:  dynamic_shapes={"x": (Dim("B"), Dim.STATIC)}

  After:   
dynamic_shapes={"x": TensorSpec([ShapeVar("B"), STATIC])} or
dynamic_shapes={"x": TensorSpec([ShapeVar("B"), 128])}

The new API is unbacked first, (no hidden silent specializations, it allows 
passing assumptions to specialize generated kernels). 

dynamic_shapes=ShapesSpec(
        params={
            "x": TensorSpec([B, STATIC, STATIC]),
        },
        assumptions = [B%16==0]
)

Snapshot specs (rms_norm, xsa_fwd), README, and end-to-end tests
(test_export.py) updated to the new API.

Test Plan:
added tests
run exisiting tests

Differential Revision: D109085691




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo