### PR TITLE
[forward AD] Remove obsolete __debug__ guard when loading JVP decompositions

### DIFF
--- a/torch/autograd/forward_ad.py
+++ b/torch/autograd/forward_ad.py
@@ -70,7 +70,7 @@ def exit_dual_level(*, level=None):
 
 
 def _maybe_load_decompositions():
-    if os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__:
+    if os.environ.get("PYTORCH_JIT", "1") == "1":
         from torch._decomp import decompositions_for_jvp  # noqa: F401
 
 
@@ -103,19 +103,7 @@ def make_dual(tensor, tangent, *, level=None):
     # Import from torch._decomp import decompositions_for_jvp to register
     # decompositions for jvp to the jit registry
     #
-    # FIXME: We specify that __debug__ must be True because
-    # if python is run with -OO or -O flags (i.e., __debug__ is False), we encounter the
-    # following error:
-    #
-    # Return value was annotated as having type Tuple[NoneType, NoneType] but is actually of
-    # type Tuple[Tensor, Tensor]:
-    #   File ".../torch/_decomp/__init__.py", line 1585
-    #     else:
-    #         buffer = z
-    #     return min - torch.log1p(z), buffer
-    #     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
     _maybe_load_decompositions()
-
     if level is None:
         level = _current_level
 


### PR DESCRIPTION
## Summary

Remove the `__debug__` guard from `torch.autograd.forward_ad._maybe_load_decompositions()` and delete the associated FIXME.

The FIXME was added in 2022 to avoid a TorchScript type annotation error when importing `torch._decomp.decompositions_for_jvp` under `python -O/-OO`.

After investigating the current codepath, I was unable to reproduce the reported error on current `main`.

## Investigation

While looking into this codepath:

* Verified that `_maybe_load_decompositions()` is still executed during forward AD operations.
* Added instrumentation to confirm that `_maybe_load_decompositions()` is reached during a simple `torch.func.jvp` call.
* Confirmed that with the current implementation, `torch._decomp.decompositions_for_jvp` is not imported under `python -O` because the import is gated on `__debug__`.
* Added instrumentation to `torch._decomp.decompositions_for_jvp` and verified that removing the `__debug__` condition causes the module to be imported successfully under `python -O`.
* Searched for other callsites and import paths related to `_maybe_load_decompositions()` and `decompositions_for_jvp`.
* Reviewed the commit that introduced the FIXME (2022), but could not find a reproducer for the reported issue.

Despite forcing the import under `python -O`, I was unable to reproduce the TorchScript error described in the FIXME:

```text
Return value was annotated as having type Tuple[NoneType, NoneType]
but is actually of type Tuple[Tensor, Tensor]
```

## Testing

Manual repro:

```bash
python -O - <<'PY'
import torch
from torch.func import jvp

x = torch.randn(4)

jvp(
    torch.nn.functional.logsigmoid,
    (x,),
    (torch.ones_like(x),)
)
PY
```

Verified that `torch._decomp.decompositions_for_jvp` is imported successfully under `python -O` after removing the guard.

Forward AD test coverage:

```bash
python -O test/functorch/test_ops.py -k logsigmoid
```

Result:

```text
Ran 14 tests in 1.646s

OK
```


cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93