### PR TITLE
Fix cartesian_prod returning inconsistent shape for single tensor input

### DIFF
--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -48,7 +48,7 @@ Tensor cartesian_prod(TensorList tensors) {
     TORCH_CHECK(t.dim() == 1, "Expect a 1D vector, but got shape ", t.sizes());
   }
   if (tensors.size() == 1) {
-    return tensors[0];
+    return tensors[0].unsqueeze(-1);
   }
   std::vector<Tensor> grids = at::meshgrid(tensors, "ij");
   for(Tensor &t : grids) {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1562,7 +1562,7 @@ class TestTensorCreation(TestCase):
 
         # test single input
         prod = torch.cartesian_prod(b)
-        self.assertEqual(b, prod)
+        self.assertEqual(b.unsqueeze(-1), prod)
 
     def test_combinations(self, device):
         a = torch.tensor([1, 2, 3], device=device)


### PR DESCRIPTION
Fixes: 
- #116465.

When `cartesian_prod` receives multiple tensors, the multi-tensor path returns shape (N, num_tensors) via `at::stack(grids, 1)`. But the single-tensor early return just returned the input as-is with shape (N,), which is inconsistent with both the multi-tensor case and `itertools.product` (which returns (N, 1)).

The fix adds `.unsqueeze(-1`) to the single-tensor early return, so it produces (N, 1), matching the (N, num_tensors) contract.

Test Plan:
`python test/test_tensor_creation_ops.py -k test_cartesian_prod`

cc @ezyang @gchanan