### PR TITLE
Require an installed dict watcher for the recursive dict-tag fast path on 3.12+

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1502,6 +1502,13 @@ class TagSafetyChecks(RecursiveDictTagTests):
 
 
 class RecursiveDictGuardTests(RecursiveDictTagTests):
+    # The recursive dict-tag fast path only engages on 3.12+ (it needs
+    # PyDict_Watch); below that it is gated off and stays disabled, so the
+    # runtime enable/disable transitions this test asserts do not apply.
+    @unittest.skipIf(
+        sys.version_info < (3, 12),
+        "recursive dict-tag fast path requires 3.12+ dict watchers",
+    )
     def test_disabling(self):
         class Mod(torch.nn.Module):
             def __init__(self):

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1502,13 +1502,6 @@ class TagSafetyChecks(RecursiveDictTagTests):
 
 
 class RecursiveDictGuardTests(RecursiveDictTagTests):
-    # The recursive dict-tag fast path only engages on 3.12+ (it needs
-    # PyDict_Watch); below that it is gated off and stays disabled, so the
-    # runtime enable/disable transitions this test asserts do not apply.
-    @unittest.skipIf(
-        sys.version_info < (3, 12),
-        "recursive dict-tag fast path requires 3.12+ dict watchers",
-    )
     def test_disabling(self):
         class Mod(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3500,20 +3500,20 @@ class GuardManager {
     return this->check_accessors_nopybind(value);
   }
 
-  bool check_dict_pointer_tags(PyObject* value) {
-    if (_dict_callback_installed) {
-      // This means that for 3.12+, there are callbacks watching dict pointers.
-      return true;
-    }
-    for (auto& kv : _dict_pointers[value]) {
-      PyObject* dict_pointer = kv.first;
-      uint64_t old_tag = kv.second;
-      uint64_t new_tag = get_dict_version_unchecked(dict_pointer);
-      if (old_tag != new_tag) {
-        return false;
-      }
-    }
-    return true;
+  bool dict_watchers_installed() {
+    // Only fast-path recursive dict-tag matching when dict watchers are
+    // installed (3.12+ with a successful PyDict_Watch). The watcher callback
+    // sets _disable_dict_tag_matching on ANY change to a recorded dict, and the
+    // caller only invokes this when !_disable_dict_tag_matching, so reaching
+    // here means no recorded dict changed -- no per-dict version check (and no
+    // dict dereference) is needed.
+    //
+    // Without watchers we would have to read versions off the RAW recorded dict
+    // pointers in _dict_pointers. Those interior dicts can be freed while the
+    // tag-safe-root `value` is still alive (the value weakref callback only
+    // protects `value` itself, not nested dicts), so dereferencing them is a
+    // use-after-free. In that case bail and let the full guard check run.
+    return _dict_callback_installed;
   }
 
   bool check_tensor_metadata_fast(PyObject* value) {
@@ -3623,9 +3623,7 @@ class GuardManager {
         // Check if the `value` object was recorded earlier
         if (_dict_pointers.find(value) != _dict_pointers.end()) {
           // Check for fast path
-          // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
-          if (check_dict_pointer_tags(value) &&
-              check_tensor_metadata_fast(value)) {
+          if (dict_watchers_installed() && check_tensor_metadata_fast(value)) {
             if (check_no_tensor_aliasing_guards_fast(value)) {
               return true;
             } else {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3500,20 +3500,33 @@ class GuardManager {
     return this->check_accessors_nopybind(value);
   }
 
-  bool dict_watchers_installed() {
-    // Only fast-path recursive dict-tag matching when dict watchers are
-    // installed (3.12+ with a successful PyDict_Watch). The watcher callback
-    // sets _disable_dict_tag_matching on ANY change to a recorded dict, and the
-    // caller only invokes this when !_disable_dict_tag_matching, so reaching
-    // here means no recorded dict changed -- no per-dict version check (and no
-    // dict dereference) is needed.
-    //
-    // Without watchers we would have to read versions off the RAW recorded dict
-    // pointers in _dict_pointers. Those interior dicts can be freed while the
-    // tag-safe-root `value` is still alive (the value weakref callback only
-    // protects `value` itself, not nested dicts), so dereferencing them is a
-    // use-after-free. In that case bail and let the full guard check run.
+  bool check_dict_pointer_tags(PyObject* value) {
+#if IS_PYTHON_3_12_PLUS
+    // 3.12+: a successful PyDict_Watch installs callbacks that flip
+    // _disable_dict_tag_matching on ANY change to a recorded dict, and the
+    // caller only reaches here while !_disable_dict_tag_matching -- so an
+    // installed watcher already proves no recorded dict changed, with no dict
+    // dereference. If the watcher failed to install we bail (return false)
+    // rather than fall through to the raw-pointer read below, keeping the
+    // on-by-default 3.12+ path safe.
+    (void)value;
     return _dict_callback_installed;
+#else
+    // Pre-3.12: no PyDict_Watch. Read the version tag off each RAW recorded
+    // dict pointer. This is a use-after-free if an interior dict is freed while
+    // the tag-safe-root `value` is still alive (the value weakref only protects
+    // the root, not the nested dicts), which is why the optimization is off by
+    // default below 3.12 -- opt-in only, for callers who accept the risk.
+    for (auto& kv : _dict_pointers[value]) {
+      PyObject* dict_pointer = kv.first;
+      uint64_t old_tag = kv.second;
+      uint64_t new_tag = get_dict_version_unchecked(dict_pointer);
+      if (old_tag != new_tag) {
+        return false;
+      }
+    }
+    return true;
+#endif
   }
 
   bool check_tensor_metadata_fast(PyObject* value) {
@@ -3623,7 +3636,8 @@ class GuardManager {
         // Check if the `value` object was recorded earlier
         if (_dict_pointers.find(value) != _dict_pointers.end()) {
           // Check for fast path
-          if (dict_watchers_installed() && check_tensor_metadata_fast(value)) {
+          if (check_dict_pointer_tags(value) &&
+              check_tensor_metadata_fast(value)) {
             if (check_no_tensor_aliasing_guards_fast(value)) {
               return true;
             } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #188103
* __->__ #188101
* #187868

The recursive dict-tag fast path (`use_recursive_dict_tags_for_guards`)
validates an entire tag-safe-root subtree with a cheap tag check instead of a
full traversal. Its safety hinges on detecting when a recorded interior dict is
mutated or freed.

On 3.12+ that detection comes from `PyDict_Watch`: a successful watch installs
callbacks that flip `_disable_dict_tag_matching` on any change to a recorded
dict (including dealloc), and the caller only reaches the fast path while
`!_disable_dict_tag_matching`. So `check_dict_pointer_tags` just reports whether
the watcher is installed -- if it is, nothing changed and no dict is
dereferenced. The change here is that if `PyDict_Watch` ever fails to install we
now bail (return false) instead of falling through to the raw-pointer version
read, so the path is safe to enable by default on 3.12+ (next PR in the stack).

Below 3.12 there is no `PyDict_Watch`, and plain dicts cannot be weakref'd, so
there is no cheap, correct way to detect a freed interior dict. The path falls
back to reading version tags off the RAW recorded dict pointers, which is a
use-after-free if an interior dict is freed while the tag-safe-root `value` is
still alive (e.g. a submodule is replaced). This is left as opt-in on purpose:
the optimization stays off by default below 3.12, for callers who want the
speedup and accept the risk.

Test Plan:

```
python -m pytest test/dynamo/test_guard_manager.py -q
# 80 passed
```

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98