### PR TITLE
Enable recursive dict-tag guard optimization by default on 3.12+ non-free-threaded

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -491,7 +491,15 @@ assume_dunder_attributes_remain_unchanged = True
 
 # Speedup guard execution of nested nn modules by recursively checking for dict
 # tags to avoid full guard execution.
-use_recursive_dict_tags_for_guards = False
+#
+# Enabled by default only on CPython 3.12+ non-free-threaded builds. The fast
+# path relies on PyDict_Watch (3.12+) to invalidate recorded dict tags, and on
+# the GIL to serialize the dict-watcher / weakref callbacks that gate it: the
+# gate flag is read on the hot path without atomics, so free-threading is
+# excluded. Pre-3.12 the fast path does not engage regardless (no watchers).
+use_recursive_dict_tags_for_guards = (
+    sys.version_info >= (3, 12) and sysconfig.get_config_var("Py_GIL_DISABLED") != 1
+)
 
 # Maximum number of objects for which we check dict pointers tags. This is
 # useful for regional compilation.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188103
* #188101
* #187868

`use_recursive_dict_tags_for_guards` short-circuits per-module guard subtrees
via a dict tag instead of a full recursive check, and is the dominant lever for
guard-eval cost on models with many repeated nn.Modules (pytorch/pytorch#185886
-- ~2.7x on an 82-layer stack). It has been off by default due to a
use-after-free risk in the fast path.

The preceding PR in this stack gated the fast path on dict watchers, removing
the pre-3.12 raw interior-dict-pointer dereference. With that in place the 3.12+
fast path performs no raw dereference of recorded state: recorded value/dict
pointers are only ever compared as addresses in hash maps (default
`std::hash<PyObject*>`), recorded tensors are reached through `PyWeakref_GetRef`,
and three monotonic invalidations set `_disable_dict_tag_matching` before any
stale memory can be observed -- PyDict_Watch fires on any change to a recorded
dict (including dealloc), a value weakref callback fires when a recorded root is
GC'd (defending against address recycling), and dead tensors are caught by the
weakref null check.

This flips the default to enabled on CPython 3.12+ non-free-threaded builds.
The safety argument relies on the GIL serializing those callbacks against the
hot-path read of `_disable_dict_tag_matching`, which is non-atomic, so
free-threading is excluded (mirrors the `run_gc_after_compile` gating). Pre-3.12
the fast path does not engage regardless (watchers are unavailable), so the
default stays off there to avoid the record-then-disable overhead.

The existing justknob kill-switch (`pytorch/compiler:use_recursive_dict_tags_for_guards`,
checked at the call site in guards.py) and `config.patch` remain available to
disable it without a code change. This being a default flip for a
correctness-sensitive path, broad CI is the real soak.

Test Plan:

```
python -m pytest test/dynamo/test_guard_manager.py test/dynamo/test_modules.py test/dynamo/test_misc.py -q
# test_guard_manager.py + test_modules.py: 222 passed, 8 subtests passed
# test_misc.py: 793 passed, 12 skipped, 4 xfailed, 9 subtests passed
```

Confirmed the default resolves as intended on a 3.13 non-free-threaded build:

```
python -c "import torch._dynamo.config as c; print(c.use_recursive_dict_tags_for_guards)"
# True
```

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98