### PR TITLE
Remove inductor-pallas CPU CI

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -238,11 +238,6 @@ case "$tag" in
     HALIDE=yes
     TRITON=yes
     ;;
-  pytorch-linux-jammy-py3.12-pallas)
-    ANACONDA_PYTHON_VERSION=3.12
-    GCC_VERSION=11
-    PALLAS=yes
-    ;;
   pytorch-linux-jammy-cuda12.8-py3.12-pallas)
     CUDA_VERSION=12.8.1
     ANACONDA_PYTHON_VERSION=3.12

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -61,7 +61,6 @@ jobs:
           pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-clang18,
           pytorch-linux-jammy-py3-gcc11-inductor-benchmarks,
           pytorch-linux-jammy-py3.12-halide,
-          pytorch-linux-jammy-py3.12-pallas,
           pytorch-linux-jammy-cuda13.0-py3.12-pallas,
           pytorch-linux-jammy-tpu-py3.12-pallas,
           pytorch-linux-jammy-xpu-n-1-py3,

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -107,39 +107,6 @@ jobs:
       compiler: gcc11
     secrets: inherit
 
-  inductor-pallas-cpu-build:
-    name: inductor-pallas-cpu-build
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-jammy-py3.12-gcc11-pallas
-      docker-image-name: ci-image:pytorch-linux-jammy-py3.12-pallas
-      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor-pallas-cpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge" },
-        ]}
-      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
-      python-version: "3.12"
-      compiler: gcc11
-    secrets: inherit
-
-  inductor-pallas-cpu-test:
-    name: inductor-pallas-cpu-test
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - inductor-pallas-cpu-build
-      - get-label-type
-    with:
-      build-environment: ${{ needs.inductor-pallas-cpu-build.outputs.build-environment }}
-      docker-image: ${{ needs.inductor-pallas-cpu-build.outputs.docker-image }}
-      test-matrix: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix }}
-      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
-      python-version: "3.12"
-      compiler: gcc11
-    secrets: inherit
-
   inductor-triton-cpu-build:
     name: inductor-triton-cpu-build
     uses: ./.github/workflows/_linux-build.yml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188104

Drops the inductor-pallas-cpu build/test jobs from inductor-unittest,
the matching pytorch-linux-jammy-py3.12-pallas docker image build, and
the corresponding case in .ci/docker/build.sh. The pallas backends are
experimental and likely to be replaced by Helion's pallas backend, so
the CPU CI surface is being retired. The GPU (cuda13.0) and TPU pallas
images and the inductor-pallas workflow are intentionally kept.

See https://github.com/pytorch/pytorch/issues/187963#issuecomment-4791929220.

Test Plan: CI - the affected jobs should no longer run, and other jobs
sharing the docker-builds matrix should be unaffected.

Authored with assistance from Claude Code.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>