### PR TITLE
[BE] Remove dead executorch jobs from trunk

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -392,40 +392,6 @@ jobs:
       compiler: gcc11
     secrets: inherit
 
-  linux-jammy-py3-clang18-executorch-build:
-#    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3-clang18-executorch ') }}
-    name: linux-jammy-py3-clang18-executorch
-    uses: ./.github/workflows/_linux-build.yml
-    needs:
-      - get-label-type
-      - job-filter
-    if: false # Has been broken for a while
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3-clang18-executorch
-      docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-executorch
-      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      test-matrix: |
-        { include: [
-          { config: "executorch", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-        ]}
-    secrets: inherit
-
-  linux-jammy-py3-clang18-executorch-test:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3-clang18-executorch ') }}
-    name: linux-jammy-py3-clang18-executorch
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - get-label-type
-      - linux-jammy-py3-clang18-executorch-build
-      - job-filter
-    with:
-      build-environment: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.test-matrix }}
-      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-    secrets: inherit
-
   linux-jammy-py3_10-gcc11-full-debug-build-only:
     if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11-full-debug-build-only ') }}
     name: linux-jammy-py3.10-gcc11-full-debug-build-only


### PR DESCRIPTION
Deletes the `linux-jammy-py3-clang18-executorch` build and test jobs from `trunk.yml`. The build was already disabled (`if: false # Has been broken for a while`) and the pair hasn't run for a long time, so they provide no signal.

### Validation
```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/trunk.yml'))"
grep -n executorch .github/workflows/trunk.yml   # -> no matches
```

Authored with the assistance of an AI coding agent (Claude Code).