### PR TITLE
[Inductor][TEST] Align `test_main_loop_scaling` with H100 support surface

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1162,11 +1162,6 @@ class TestFP8Lowering(TestCase):
         bias = None
 
         am, ak, bn, bk = scaling_block_sizes
-        if IS_SM90 and (bn, bk) == (1, 128):
-            self.skipTest(
-                "SM90 cuBLAS scaled_mm expects non-transposed RHS "
-                "BlockWise1x128 scales"
-            )
         tma_supported = (bn, bk) != (1, 128) and (
             ((am, ak) != (128, 128) and (bn, bk) != (128, 128))
             or ceil_div(K, 128) % 4 == 0
@@ -1177,8 +1172,13 @@ class TestFP8Lowering(TestCase):
             w, dtype_float8, block_outer=bn, block_inner=bk
         )
         w_t_fp8 = w_fp8.t()
+        # cuBLAS expects RHS BlockWise1x128 scales in [N, ceil(K / 128)]
+        # order even though the corresponding weight is passed transposed.
         w_inverse_scale = _prepare_blockwise_scale(
-            w_inverse_scale, bn, bk, transposed=True
+            w_inverse_scale,
+            bn,
+            bk,
+            transposed=(bn, bk) != (1, 128),
         )
 
         # quantize input x

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1154,6 +1154,17 @@ class TestFP8Lowering(TestCase):
         bias = None
 
         am, ak, bn, bk = scaling_block_sizes
+        if IS_SM90:
+            if (bn, bk) == (1, 128):
+                self.skipTest(
+                    "SM90 cuBLAS scaled_mm expects non-transposed RHS "
+                    "BlockWise1x128 scales"
+                )
+            if K < 512 and ((am, ak) == (128, 128) or (bn, bk) == (128, 128)):
+                self.skipTest(
+                    "SM90 cuBLAS pads 128x128 scales when K < 512, which "
+                    "Inductor TMA main-loop scaling does not support"
+                )
 
         # quantize weight (prior to inference)
         w_fp8, w_inverse_scale = _quantize_blockwise(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1108,7 +1108,15 @@ class TestFP8Lowering(TestCase):
     @xfailIf(
         torch.cuda.is_available() and torch.cuda.get_device_capability() != (9, 0)
     )  # cuBLAS 128-element blockwise scaling is only supported for CC 9.0
-    @parametrize("shape", ((16, 256, 256), (1024, 512, 1024), (32768, 4096, 4096)))
+    @parametrize(
+        "shape",
+        (
+            (16, 256, 256),
+            (16, 256, 640),
+            (1024, 512, 1024),
+            (32768, 4096, 4096),
+        ),
+    )
     @parametrize("use_fast_accum", (False, True))
     @parametrize(
         "scaling_block_sizes",
@@ -1154,17 +1162,15 @@ class TestFP8Lowering(TestCase):
         bias = None
 
         am, ak, bn, bk = scaling_block_sizes
-        if IS_SM90:
-            if (bn, bk) == (1, 128):
-                self.skipTest(
-                    "SM90 cuBLAS scaled_mm expects non-transposed RHS "
-                    "BlockWise1x128 scales"
-                )
-            if K < 512 and ((am, ak) == (128, 128) or (bn, bk) == (128, 128)):
-                self.skipTest(
-                    "SM90 cuBLAS pads 128x128 scales when K < 512, which "
-                    "Inductor TMA main-loop scaling does not support"
-                )
+        if IS_SM90 and (bn, bk) == (1, 128):
+            self.skipTest(
+                "SM90 cuBLAS scaled_mm expects non-transposed RHS "
+                "BlockWise1x128 scales"
+            )
+        tma_supported = (bn, bk) != (1, 128) and (
+            ((am, ak) != (128, 128) and (bn, bk) != (128, 128))
+            or ceil_div(K, 128) % 4 == 0
+        )
 
         # quantize weight (prior to inference)
         w_fp8, w_inverse_scale = _quantize_blockwise(
@@ -1241,6 +1247,19 @@ class TestFP8Lowering(TestCase):
             linear_compiled = torch.compile(
                 linear, backend="inductor", mode="max-autotune"
             )
+            if use_fast_accum and not tma_supported:
+                with self.assertRaisesRegex(
+                    RuntimeError, "scaled_gemm doesn't support fast accum"
+                ):
+                    run_and_get_code(
+                        linear_compiled,
+                        x_fp8,
+                        x_inverse_scale,
+                        w_t_fp8,
+                        w_inverse_scale,
+                        bias,
+                    )
+                return
             y_compiled, code = run_and_get_code(
                 linear_compiled,
                 x_fp8,
@@ -1249,6 +1268,13 @@ class TestFP8Lowering(TestCase):
                 w_inverse_scale,
                 bias,
             )
+
+        if not tma_supported:
+            FileCheck().check_not("triton_scaled_mm_device_tma_main_loop_scaling").run(
+                code[0]
+            )
+            self.assertEqual(y_eager, y_compiled, rtol=1e-2, atol=0.05)
+            return
 
         # Verify that Inductor chooses the correct scaling recipes
         check_scale_recipe_a = (

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -985,6 +985,7 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+
     def fallback():
         # contraction_dim is non-optional in the schema.
         fallback_contraction_dim = [] if contraction_dim is None else contraction_dim

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -862,6 +862,17 @@ epilogue_scaling_types = [ScalingType.TensorWise, ScalingType.RowWise]
 main_loop_scaling_types = [ScalingType.BlockWise1x128, ScalingType.BlockWise128x128]
 
 
+def _is_supported_tma_main_loop_scaling(
+    scale_option_a: ScalingType, scale_option_b: ScalingType, k: Any
+) -> bool:
+    if scale_option_b == ScalingType.BlockWise1x128:
+        return False
+    if ScalingType.BlockWise128x128 in (scale_option_a, scale_option_b):
+        k_scale_blocks = ceildiv(k, 128)
+        return V.graph.sizevars.statically_known_multiple_of(k_scale_blocks, 4)
+    return True
+
+
 def _is_tensorwise_scaling(sz: Any) -> bool:
     return (len(sz) == 0) or all(
         V.graph.sizevars.statically_known_equals(d, 1) for d in sz
@@ -974,6 +985,23 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+    def fallback():
+        # contraction_dim is non-optional in the schema.
+        fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
+        return scaled_mm_v2_fallback(
+            mat_a,
+            mat_b,
+            scale_a,
+            recipe_a,
+            swizzle_a,
+            scale_b,
+            recipe_b,
+            swizzle_b,
+            bias,
+            out_dtype,
+            fallback_contraction_dim,
+            use_fast_accum,
+        )
 
     # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
     # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,
@@ -1001,23 +1029,20 @@ def tuned_scaled_mm_v2(
         or not is_single_level_scale
         or scale_a[0].dtype != torch.float32
     ):
-        # contraction_dim is a non-optional int[] in the schema (default []);
-        # this lowering defaults it to None, so coerce before the eager call.
-        fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
-        return scaled_mm_v2_fallback(
-            mat_a,
-            mat_b,
-            scale_a,
-            recipe_a,
-            swizzle_a,
-            scale_b,
-            recipe_b,
-            swizzle_b,
-            bias,
-            out_dtype,
-            fallback_contraction_dim,
-            use_fast_accum,
+        return fallback()
+
+    if len(scale_a) == len(recipe_a) == len(scale_b) == len(recipe_b) == 1:
+        scale_option_a, scale_option_b = (
+            ScalingType(recipe_a[0]),
+            ScalingType(recipe_b[0]),
         )
+        if use_triton_scaling_template(
+            scale_option_a, scale_option_b, main_loop_scaling_types
+        ) and not _is_supported_tma_main_loop_scaling(
+            scale_option_a, scale_option_b, mat_a.get_size()[1]
+        ):
+            return fallback()
+
     # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m, n, k, layout, mat_a, mat_b = mm_args(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
@@ -1101,13 +1126,18 @@ def tuned_scaled_mm_v2(
             elif use_triton_scaling_template(
                 scale_option_a, scale_option_b, main_loop_scaling_types
             ):
-                overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
-                overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
+                if _is_supported_tma_main_loop_scaling(
+                    scale_option_a, scale_option_b, k
+                ):
+                    overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
+                    overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
 
-                templates_to_use.append(scaled_mm_device_tma_main_loop_scaling_template)
-                kwarg_overrides[scaled_mm_device_tma_main_loop_scaling_template.uid] = (
-                    overriders
-                )
+                    templates_to_use.append(
+                        scaled_mm_device_tma_main_loop_scaling_template
+                    )
+                    kwarg_overrides[
+                        scaled_mm_device_tma_main_loop_scaling_template.uid
+                    ] = overriders
             else:
                 raise AssertionError(
                     "Inductor Triton does not support scaling options that are present "
@@ -1278,13 +1308,18 @@ def tuned_scaled_mm(
             elif use_triton_scaling_template(
                 scale_option_a, scale_option_b, main_loop_scaling_types
             ):
-                overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
-                overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
+                if _is_supported_tma_main_loop_scaling(
+                    scale_option_a, scale_option_b, k
+                ):
+                    overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
+                    overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
 
-                templates_to_use.append(scaled_mm_device_tma_main_loop_scaling_template)
-                kwarg_overrides[scaled_mm_device_tma_main_loop_scaling_template.uid] = (
-                    overriders
-                )
+                    templates_to_use.append(
+                        scaled_mm_device_tma_main_loop_scaling_template
+                    )
+                    kwarg_overrides[
+                        scaled_mm_device_tma_main_loop_scaling_template.uid
+                    ] = overriders
             else:
                 raise AssertionError(
                     "Inductor Triton does not support scaling options that are present "


### PR DESCRIPTION
Otherwise fails with e.g.,
```
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 551, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1661, in only_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_fp8.py", line 1133, in test_main_loop_scaling
    y_eager = linear(
              ^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_fp8.py", line 1106, in linear
    y = torch.nn.functional.scaled_mm(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/functional.py", line 7166, in scaled_mm
    out = torch._scaled_mm_v2(
          ^^^^^^^^^^^^^^^^^^^^
ValueError: scale_b must have shape 256 x 2 Float elements, got [2, 256]
```
authored with codex

We might also consider pruning some of these cases are they appear to be skipped on basically all platforms?

cc @ezyang @gchanan @kadeng @msaroufim @ptrblck @tinglvv @nWEIdia @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo