### PR TITLE
Add CUDAGraph cloning for live user outputs

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_cudagraph_trees.md
@@ -322,6 +322,12 @@ are wrong, you can mark the start of a new iteration with
 [torch.compiler.cudagraph_mark_step_begin()](https://pytorch.org/docs/stable/generated/torch.compiler.cudagraph_mark_step_begin.html), or clone
 tensors of a prior iteration (outside of torch.compile) before you begin the next run.
 
+If a user-visible output must remain live across iterations, you can instead set
+`torch._inductor.config.triton.cudagraph_trees_generation_cloning = "user_visible"`.
+With this opt-in behavior, CUDAGraph Trees clone live user-visible output storages
+out of the CUDAGraph memory pool before starting a new generation. This does not
+apply to gradients, saved activations, or other internal tensors.
+
 ### Comparisons
 
 | Footguns      | Separate CudaGraph                                         | CUDAGraph Trees                                                        |

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -22,7 +22,11 @@ from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._inductor import config
 from torch._inductor.codecache import FxGraphCache
 from torch._inductor.compile_fx import compile_fx_inner
-from torch._inductor.cudagraph_trees import cudagraphify_impl as tree_cudagraphify_impl
+from torch._inductor.cudagraph_trees import (
+    AliasesPriorGraphOutput,
+    cudagraphify_impl as tree_cudagraphify_impl,
+    ExecutionState,
+)
 from torch._inductor.cudagraph_utils import PlaceholderInfo
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
@@ -227,6 +231,33 @@ if HAS_CUDA_AND_TRITON:
         def run_twc(fn, *args, **kwargs):
             fn(*args, **kwargs)
             return fn(*args, **kwargs)
+
+        @staticmethod
+        def run_next_generation(fn, *args, **kwargs):
+            torch.compiler.cudagraph_mark_step_begin()
+            return fn(*args, **kwargs)
+
+        def replay_next_generation(self, fn, *args, **kwargs):
+            out = self.run_next_generation(fn, *args, **kwargs)
+            self.assertEqual(self.get_manager().path_state, ExecutionState.EXECUTION)
+            return out
+
+        def _iter_tensor_outputs(self, outputs):
+            if isinstance(outputs, torch.Tensor):
+                yield outputs
+                return
+            if isinstance(outputs, (list, tuple)):
+                for out in outputs:
+                    yield from self._iter_tensor_outputs(out)
+                return
+            if outputs is not None:
+                raise AssertionError(f"expected tensor output, got {type(outputs)}")
+
+        def save_live_outputs(self, live_outputs, *outputs):
+            for out in self._iter_tensor_outputs(outputs):
+                live_outputs.append((out, out.detach().clone()))
+            for out, expected in live_outputs:
+                self.assertEqual(out, expected)
 
         def num_checkpoints(self):
             return self.get_manager().debug_checkpointing_counter
@@ -2202,6 +2233,81 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(self.get_root_children(), [2])
 
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        @torch._inductor.config.patch(
+            "triton.cudagraph_managed_input_rerecord_limit", 2
+        )
+        def test_demote_changing_cudagraph_managed_input_to_copy(self):
+            def producer(args):
+                x = args[0]
+                args.clear()
+                return tuple(x + i for i in range(5))
+
+            def consumer(args):
+                x = args[0]
+                args.clear()
+                return [x * x + 1]
+
+            inp = torch.rand([4], device="cuda")
+            producer_cg = self.cudagraphify_impl(producer, [inp], ())
+            consumer_cg = self.cudagraphify_impl(consumer, [inp], ())
+
+            def run_pair(idx):
+                torch.compiler.cudagraph_mark_step_begin()
+                producer_outputs = producer_cg([inp])
+                result = consumer_cg([producer_outputs[idx]])[0]
+                self.assertEqual(result, consumer([producer_outputs[idx]])[0])
+                del result, producer_outputs
+
+            for idx in range(3):
+                run_pair(idx)
+
+            root = next(self.get_roots())
+            children = next(iter(root.children.values()))
+            self.assertEqual(len(children), 3)
+            self.assertEqual(children[-1].cudagraph_managed_idxs, [])
+            self.assertEqual(children[-1].non_static_input_idx, [0])
+
+            for idx in range(3, 5):
+                run_pair(idx)
+
+            self.assertEqual(len(children), 3)
+
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        @torch._inductor.config.patch(
+            "triton.cudagraph_managed_input_rerecord_limit", 1
+        )
+        def test_does_not_demote_aliased_cudagraph_managed_input(self):
+            def producer(args):
+                x = args[0]
+                args.clear()
+                return tuple(x + i for i in range(3))
+
+            def consumer(args):
+                x = args[0]
+                args.clear()
+                return [x]
+
+            inp = torch.rand([4], device="cuda")
+            producer_cg = self.cudagraphify_impl(producer, [inp], ())
+            consumer_cg = self.cudagraphify_impl(consumer, [inp], ())
+
+            def run_pair(idx):
+                torch.compiler.cudagraph_mark_step_begin()
+                producer_outputs = producer_cg([inp])
+                result = consumer_cg([producer_outputs[idx]])[0]
+                self.assertEqual(result, producer_outputs[idx])
+                del result, producer_outputs
+
+            for idx in range(3):
+                run_pair(idx)
+
+            root = next(self.get_roots())
+            children = next(iter(root.children.values()))
+            self.assertEqual(len(children), 3)
+            for child in children:
+                self.assertEqual(child.cudagraph_managed_idxs, [0])
+
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_rerecording_logs_reason(self):
             import logging
 
@@ -2451,16 +2557,494 @@ if HAS_CUDA_AND_TRITON:
             with self.assertRaises(Exception) as exc:
                 out + out
 
-            FileCheck().check("overwritten").check("x * x * x").run(repr(exc.exception))
+            FileCheck().check("overwritten").check("x * x * x").check(
+                "cudagraph_trees_generation_cloning"
+            ).run(repr(exc.exception))
 
             foo(inp)
 
             with self.assertRaises(Exception) as exc:
                 out2 + out2
 
-            FileCheck().check("overwritten").check("x * x * x").run(repr(exc.exception))
+            FileCheck().check("overwritten").check("x * x * x").check(
+                "cudagraph_trees_generation_cloning"
+            ).run(repr(exc.exception))
 
-        def test_grad_accumulation_dealloc_error_message(self):
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        @parametrize(
+            "variant", ("default", "no_graph_partition", "no_keep_output_stride")
+        )
+        def test_clone_live_output_on_new_generation(self, variant):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            patches = {
+                "no_graph_partition": {"graph_partition": False},
+                "no_keep_output_stride": {"keep_output_stride": False},
+            }.get(variant, {})
+            with config.patch(patches):
+                inputs = [
+                    torch.randn(4, device="cuda", dtype=torch.float32) + i
+                    for i in range(4)
+                ]
+                live_outputs = []
+                free_calls = 0
+                orig_free = torch._C._free_And_Remove_DeleterFn
+
+                def spy_free(storage_ptr):
+                    nonlocal free_calls
+                    self.assertTrue(torch._C._has_Standard_Deleter(storage_ptr))
+                    free_calls += 1
+                    return orig_free(storage_ptr)
+
+                with unittest.mock.patch.object(
+                    torch._C, "_free_And_Remove_DeleterFn", spy_free
+                ):
+                    out = self.run_next_generation(foo, inputs[0])
+                    expected = out.detach().clone()
+                    old_data_ptr = out.untyped_storage().data_ptr()
+                    self.save_live_outputs(live_outputs, out)
+
+                    record_out = self.run_next_generation(foo, inputs[1])
+                    record_expected = record_out.detach().clone()
+                    record_old_data_ptr = record_out.untyped_storage().data_ptr()
+                    self.save_live_outputs(live_outputs, record_out)
+                    self.assertEqual(free_calls, 1)
+                    self.assertTrue(torch._C._has_Standard_Deleter(cdata(out)))
+
+                    replay_out = self.replay_next_generation(foo, inputs[2])
+                    node = self.curr_node()
+                    self.assertEqual(free_calls, 2)
+                    self.assertTrue(torch._C._has_Standard_Deleter(cdata(record_out)))
+                    self.assertIs(replay_out, node.cached_tensor_outputs[0])
+                    self.assertTrue(torch._C._is_cached_tensor(replay_out))
+                    replay_old_data_ptr = replay_out.untyped_storage().data_ptr()
+                    self.save_live_outputs(live_outputs, replay_out)
+                    next_out = self.replay_next_generation(foo, inputs[3])
+                    self.save_live_outputs(live_outputs, next_out)
+                    self.assertEqual(free_calls, 2)
+                    self.assertTrue(torch._C._has_Standard_Deleter(cdata(replay_out)))
+
+            self.assertEqual(out, expected)
+            self.assertEqual(out + out, expected + expected)
+            self.assertNotEqual(out.untyped_storage().data_ptr(), old_data_ptr)
+            self.assertEqual(record_out, record_expected)
+            self.assertNotEqual(
+                record_out.untyped_storage().data_ptr(), record_old_data_ptr
+            )
+            self.assertNotEqual(
+                replay_out.untyped_storage().data_ptr(), replay_old_data_ptr
+            )
+            self.assertEqual(replay_out, inputs[2] * inputs[2] * inputs[2])
+            self.assertEqual(next_out, inputs[3] * inputs[3] * inputs[3])
+            self.assertIsNone(node.cached_tensor_outputs[0])
+            self.assertFalse(torch._C._is_cached_tensor(replay_out))
+            self.assertIsNot(out, replay_out)
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_live_output_keeps_cache_when_output_dead(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            inputs = [
+                torch.randn(4, device="cuda", dtype=torch.float32) + i for i in range(4)
+            ]
+            out = self.run_next_generation(foo, inputs[0])
+            del out
+
+            self.run_next_generation(foo, inputs[1])
+            replay_out = self.replay_next_generation(foo, inputs[2])
+            node = self.curr_node()
+            self.assertIs(replay_out, node.cached_tensor_outputs[0])
+            self.assertTrue(torch._C._is_cached_tensor(replay_out))
+            cached_id = id(replay_out)
+            cached_data_ptr = replay_out.untyped_storage().data_ptr()
+            del replay_out
+
+            next_out = self.replay_next_generation(foo, inputs[3])
+            self.assertIs(next_out, node.cached_tensor_outputs[0])
+            self.assertEqual(id(next_out), cached_id)
+            self.assertEqual(next_out.untyped_storage().data_ptr(), cached_data_ptr)
+            self.assertTrue(torch._C._is_cached_tensor(next_out))
+            self.assertEqual(next_out, inputs[3] * inputs[3] * inputs[3])
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_live_aliased_output_storage_on_new_generation(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                y = x * x
+                return y, y[1:]
+
+            inputs = [
+                torch.randn(4, 4, device="cuda", dtype=torch.float32) + i
+                for i in range(4)
+            ]
+            live_outputs = []
+            out, out_view = self.run_next_generation(foo, inputs[0])
+            expected = out.detach().clone()
+            expected_view = out_view.detach().clone()
+            old_data_ptr = out.untyped_storage().data_ptr()
+            view_size = out_view.size()
+            view_stride = out_view.stride()
+            view_storage_offset = out_view.storage_offset()
+            self.assertEqual(cdata(out), cdata(out_view))
+            self.save_live_outputs(live_outputs, out, out_view)
+
+            record_out, record_view = self.run_next_generation(foo, inputs[1])
+            self.save_live_outputs(live_outputs, record_out, record_view)
+            replay_out, replay_view = self.replay_next_generation(foo, inputs[2])
+            self.save_live_outputs(live_outputs, replay_out, replay_view)
+            next_out, next_view = self.replay_next_generation(foo, inputs[3])
+            self.save_live_outputs(live_outputs, next_out, next_view)
+
+            self.assertEqual(out, expected)
+            self.assertEqual(out_view, expected_view)
+            self.assertEqual(cdata(out), cdata(out_view))
+            self.assertNotEqual(out.untyped_storage().data_ptr(), old_data_ptr)
+            self.assertEqual(out_view.size(), view_size)
+            self.assertEqual(out_view.stride(), view_stride)
+            self.assertEqual(out_view.storage_offset(), view_storage_offset)
+            self.assertEqual(replay_out, inputs[2] * inputs[2])
+            self.assertEqual(replay_view, (inputs[2] * inputs[2])[1:])
+            self.assertEqual(next_out, inputs[3] * inputs[3])
+            self.assertEqual(next_view, (inputs[3] * inputs[3])[1:])
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        def test_clone_live_retargets_non_user_visible_output_alias(self):
+            def foo(args):
+                x = args[0]
+                args.clear()
+                y = x * x
+                return y, y[1:]
+
+            inputs = [
+                torch.randn(4, 4, device="cuda", dtype=torch.float32) + i
+                for i in range(4)
+            ]
+            live_outputs = []
+            foo_cg = self.cudagraphify_impl(
+                foo,
+                [inputs[0]],
+                (),
+                stack_traces=[None, None],
+                user_visible_output_idxs=(0,),
+            )
+            out, out_view = self.run_next_generation(foo_cg, [inputs[0]])
+            expected_view = out_view.detach().clone()
+            old_data_ptr = out_view.untyped_storage().data_ptr()
+            self.save_live_outputs(live_outputs, out, out_view)
+
+            replay_out, replay_view = self.replay_next_generation(foo_cg, [inputs[1]])
+            replay_expected_view = replay_view.detach().clone()
+            replay_old_data_ptr = replay_view.untyped_storage().data_ptr()
+            self.save_live_outputs(live_outputs, replay_out, replay_view)
+            next_out, next_view = self.replay_next_generation(foo_cg, [inputs[2]])
+            self.save_live_outputs(live_outputs, next_out, next_view)
+            steady_out, steady_view = self.replay_next_generation(foo_cg, [inputs[3]])
+            self.save_live_outputs(live_outputs, steady_out, steady_view)
+
+            self.assertEqual(cdata(out), cdata(out_view))
+            self.assertEqual(out_view, expected_view)
+            self.assertNotEqual(out_view.untyped_storage().data_ptr(), old_data_ptr)
+            self.assertEqual(cdata(replay_out), cdata(replay_view))
+            self.assertEqual(replay_view, replay_expected_view)
+            self.assertNotEqual(
+                replay_view.untyped_storage().data_ptr(), replay_old_data_ptr
+            )
+            self.assertEqual(cdata(next_out), cdata(next_view))
+            self.assertEqual(cdata(steady_out), cdata(steady_view))
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        def test_clone_live_prior_graph_output_alias(self):
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return (x * x,)
+
+            def foo2(args):
+                x = args[0]
+                args.clear()
+                return (x[1:],)
+
+            inputs = [
+                torch.randn(4, 4, device="cuda", dtype=torch.float32) + i
+                for i in range(4)
+            ]
+            live_outputs = []
+            foo_cg = self.cudagraphify_impl(foo, [inputs[0]], (), stack_traces=[None])
+            foo2_cg = self.cudagraphify_impl(
+                foo2,
+                [inputs[0]],
+                (),
+                stack_traces=[None],
+                user_visible_output_idxs=(0,),
+            )
+
+            def run_pair(x):
+                torch.compiler.cudagraph_mark_step_begin()
+                base = foo_cg([x])[0]
+                view = foo2_cg([base])[0]
+                return base, view
+
+            out, out_view = run_pair(inputs[0])
+            self.assertIsInstance(
+                self.curr_node().output_storage_alias[0], AliasesPriorGraphOutput
+            )
+
+            expected = out.detach().clone()
+            expected_view = out_view.detach().clone()
+            old_data_ptr = out.untyped_storage().data_ptr()
+            self.save_live_outputs(live_outputs, out, out_view)
+
+            record_out, record_view = run_pair(inputs[1])
+            self.save_live_outputs(live_outputs, record_out, record_view)
+            replay_out, replay_view = run_pair(inputs[2])
+            self.save_live_outputs(live_outputs, replay_out, replay_view)
+            next_out, next_view = run_pair(inputs[3])
+            self.save_live_outputs(live_outputs, next_out, next_view)
+
+            self.assertEqual(out, expected)
+            self.assertEqual(out_view, expected_view)
+            self.assertEqual(cdata(out), cdata(out_view))
+            self.assertNotEqual(out.untyped_storage().data_ptr(), old_data_ptr)
+            self.assertEqual(replay_view, replay_out[1:])
+            self.assertEqual(next_view, next_out[1:])
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_live_output_storage_with_only_user_view_live(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x
+
+            inputs = [
+                torch.randn(4, 4, device="cuda", dtype=torch.float32) + i
+                for i in range(4)
+            ]
+            live_outputs = []
+            out = self.run_next_generation(foo, inputs[0])
+            out_view = out[1:]
+            expected_view = out_view.detach().clone()
+            old_data_ptr = out_view.untyped_storage().data_ptr()
+            del out
+            self.save_live_outputs(live_outputs, out_view)
+
+            record_out = self.run_next_generation(foo, inputs[1])
+            self.save_live_outputs(live_outputs, record_out)
+            replay_out = self.replay_next_generation(foo, inputs[2])
+            self.save_live_outputs(live_outputs, replay_out)
+            next_out = self.replay_next_generation(foo, inputs[3])
+            self.save_live_outputs(live_outputs, next_out)
+
+            self.assertEqual(out_view, expected_view)
+            self.assertNotEqual(out_view.untyped_storage().data_ptr(), old_data_ptr)
+            self.assertEqual(replay_out, inputs[2] * inputs[2])
+            self.assertEqual(next_out, inputs[3] * inputs[3])
+
+        def test_clone_live_output_used_as_next_generation_input(self):
+            @torch.compile(mode="reduce-overhead")
+            def step(x, bias):
+                return x * 0.99 + bias
+
+            @torch.compile(mode="reduce-overhead")
+            def producer(x):
+                return x * x + 1
+
+            @torch.compile(mode="reduce-overhead")
+            def consumer(x):
+                return x * 2 - 3
+
+            with config.patch(
+                "triton.cudagraph_trees_generation_cloning", "user_visible"
+            ):
+                live_outputs = []
+                inp = torch.randn(4, device="cuda", dtype=torch.float32)
+                biases = [
+                    torch.randn(4, device="cuda", dtype=torch.float32) * 0.01 + i
+                    for i in range(5)
+                ]
+                x = inp
+                expected = inp
+                old_data_ptr = None
+                for i in range(3):
+                    x = self.run_next_generation(step, x, biases[i])
+                    expected = expected * 0.99 + biases[i]
+                    old_data_ptr = x.untyped_storage().data_ptr()
+                    self.save_live_outputs(live_outputs, x)
+
+                out = self.replay_next_generation(step, x, biases[3])
+                expected_out = expected * 0.99 + biases[3]
+                out_data_ptr = out.untyped_storage().data_ptr()
+                self.save_live_outputs(live_outputs, out)
+                next_out = self.replay_next_generation(step, out, biases[4])
+                self.save_live_outputs(live_outputs, next_out)
+
+                self.assertEqual(x, expected)
+                self.assertNotEqual(x.untyped_storage().data_ptr(), old_data_ptr)
+                self.assertEqual(out, expected_out)
+                self.assertNotEqual(out.untyped_storage().data_ptr(), out_data_ptr)
+                self.assertEqual(next_out, expected_out * 0.99 + biases[4])
+
+                producer_inputs = [
+                    torch.randn(8, device="cuda", dtype=torch.float32) + i
+                    for i in range(5)
+                ]
+                for i in range(3):
+                    torch.compiler.cudagraph_mark_step_begin()
+                    producer_out = producer(producer_inputs[i])
+                    producer_out_data_ptr = producer_out.untyped_storage().data_ptr()
+                    consumer_out = consumer(producer_out)
+                    self.assertEqual(
+                        producer_out.untyped_storage().data_ptr(),
+                        producer_out_data_ptr,
+                    )
+                    self.save_live_outputs(live_outputs, producer_out, consumer_out)
+
+                torch.compiler.cudagraph_mark_step_begin()
+                producer_out = producer(producer_inputs[3])
+                producer_out_data_ptr = producer_out.untyped_storage().data_ptr()
+                self.save_live_outputs(live_outputs, producer_out)
+
+                torch.compiler.cudagraph_mark_step_begin()
+                consumer_out = consumer(producer_out)
+                self.save_live_outputs(live_outputs, consumer_out)
+                self.assertNotEqual(
+                    producer_out.untyped_storage().data_ptr(), producer_out_data_ptr
+                )
+
+                torch.compiler.cudagraph_mark_step_begin()
+                self.save_live_outputs(live_outputs, producer(producer_inputs[4]))
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        @parametrize("graph_partition", (True, False))
+        def test_clone_live_output_saved_for_backward_on_mark_step(
+            self, graph_partition
+        ):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return torch.sigmoid(x)
+
+            with config.patch("graph_partition", graph_partition):
+                live_outputs = []
+                inp = torch.randn(
+                    4, device="cuda", dtype=torch.float32
+                ).requires_grad_()
+                out = self.run_next_generation(foo, inp)
+                expected = out.detach().clone()
+                expected_grad = expected * (1 - expected)
+                old_data_ptr = out.untyped_storage().data_ptr()
+                self.save_live_outputs(live_outputs, out)
+
+                inp2 = (
+                    torch.randn(4, device="cuda", dtype=torch.float32) + 1
+                ).requires_grad_()
+                out2 = self.run_next_generation(foo, inp2)
+                self.save_live_outputs(live_outputs, out2)
+                inp3 = (
+                    torch.randn(4, device="cuda", dtype=torch.float32) + 2
+                ).requires_grad_()
+                out3 = self.replay_next_generation(foo, inp3)
+                self.save_live_outputs(live_outputs, out3)
+                inp4 = (
+                    torch.randn(4, device="cuda", dtype=torch.float32) + 3
+                ).requires_grad_()
+                out4 = self.replay_next_generation(foo, inp4)
+                self.save_live_outputs(live_outputs, out4)
+
+            self.assertEqual(out, expected)
+            self.assertNotEqual(out.untyped_storage().data_ptr(), old_data_ptr)
+            out.sum().backward()
+            self.assertEqual(inp.grad, expected_grad)
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_live_output_saved_for_backward_with_only_user_view_live(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return torch.sigmoid(x)
+
+            live_outputs = []
+            inp = torch.randn(4, device="cuda", dtype=torch.float32).requires_grad_()
+            out = self.run_next_generation(foo, inp)
+            out_view = out[1:]
+            expected_view = out_view.detach().clone()
+            old_data_ptr = out_view.untyped_storage().data_ptr()
+            del out
+            self.save_live_outputs(live_outputs, out_view)
+
+            inp2 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 1
+            ).requires_grad_()
+            out2 = self.run_next_generation(foo, inp2)
+            self.save_live_outputs(live_outputs, out2)
+            inp3 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 2
+            ).requires_grad_()
+            out3 = self.replay_next_generation(foo, inp3)
+            self.save_live_outputs(live_outputs, out3)
+            inp4 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 3
+            ).requires_grad_()
+            out4 = self.replay_next_generation(foo, inp4)
+            self.save_live_outputs(live_outputs, out4)
+
+            self.assertEqual(out_view, expected_view)
+            self.assertNotEqual(out_view.untyped_storage().data_ptr(), old_data_ptr)
+
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_live_view_output_saved_for_backward_on_mark_step(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return torch.sigmoid(x)[1:]
+
+            live_outputs = []
+            inp = torch.randn(4, device="cuda", dtype=torch.float32).requires_grad_()
+            out = self.run_next_generation(foo, inp)
+            expected = out.detach().clone()
+            old_data_ptr = out.untyped_storage().data_ptr()
+            self.save_live_outputs(live_outputs, out)
+
+            inp2 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 1
+            ).requires_grad_()
+            out2 = self.run_next_generation(foo, inp2)
+            self.save_live_outputs(live_outputs, out2)
+            inp3 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 2
+            ).requires_grad_()
+            out3 = self.replay_next_generation(foo, inp3)
+            self.save_live_outputs(live_outputs, out3)
+            inp4 = (
+                torch.randn(4, device="cuda", dtype=torch.float32) + 3
+            ).requires_grad_()
+            out4 = self.replay_next_generation(foo, inp4)
+            self.save_live_outputs(live_outputs, out4)
+
+            self.assertEqual(out, expected)
+            self.assertNotEqual(out.untyped_storage().data_ptr(), old_data_ptr)
+
+        @parametrize("generation_cloning", (None, "user_visible"))
+        def test_grad_accumulation_dealloc_error_message(self, generation_cloning):
             model = torch.nn.Linear(10, 1, device="cuda")
             compiled_model = torch.compile(
                 model, fullgraph=True, mode="reduce-overhead"
@@ -2474,10 +3058,15 @@ if HAS_CUDA_AND_TRITON:
                 loss = compiled_model(x).clone().sum().clone()
                 loss.backward()
 
-            run_iter()
-
-            with self.assertRaises(RuntimeError) as exc:
+            with config.patch(
+                {
+                    "triton.cudagraph_trees_generation_cloning": generation_cloning,
+                }
+            ):
                 run_iter()
+
+                with self.assertRaises(RuntimeError) as exc:
+                    run_iter()
 
             FileCheck().check("gradient tensor output of CUDAGraphs").check(
                 "gradient accumulation"

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -65,6 +65,7 @@ from torch._functorch.aot_autograd import (
 from torch._inductor.codecache import code_hash, FxGraphCache, output_code_log
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
+    cudagraph_trees_clone_live_user_visible_outputs,
     cudagraphs_log,
     format_default_skip_message,
     log_cudagraph_skip_and_bump_counter,
@@ -306,6 +307,10 @@ def _recursive_record_user_visible_output_idxs(gm: GraphModule) -> None:
                 if isinstance(node.args[0][idx], torch.fx.Node)
             ]
         _recursive_record_user_visible_output_idxs(subgraph)
+
+
+def _cudagraph_trees_clone_live_user_outputs() -> bool:
+    return cudagraph_trees_clone_live_user_visible_outputs()
 
 
 @functools.lru_cache(None)
@@ -1958,6 +1963,7 @@ def cudagraphify(
     placeholders: Sequence[PlaceholderInfo] = (),
     mutated_input_idxs: tuple[int, ...] = (),
     kernel_free_cudagraph: bool = False,
+    user_visible_output_idxs: tuple[int, ...] = (),
 ) -> Callable[..., Any]:
     from torch._inductor.cudagraph_trees import (
         cudagraphify_impl as new_cudagraphify_impl,
@@ -1975,6 +1981,7 @@ def cudagraphify(
             placeholders=placeholders,
             mutated_input_idxs=mutated_input_idxs,
             kernel_free_cudagraph=kernel_free_cudagraph,
+            user_visible_output_idxs=user_visible_output_idxs,
             compile_id=torch._guards.CompileContext.current_compile_id(),
         )
     else:
@@ -2592,7 +2599,10 @@ def compile_fx_forward(
     )
 
     model_outputs_node = output_node(gm)
-    if config.keep_output_stride:
+    clone_live_user_outputs = _cudagraph_trees_clone_live_user_outputs()
+    model_outputs = None
+    user_visible_output_idxs: list[int] = []
+    if config.keep_output_stride or clone_live_user_outputs:
         model_outputs = pytree.arg_tree_leaves(*model_outputs_node.args)
         num_model_outputs = len(model_outputs)
 
@@ -2633,11 +2643,14 @@ def compile_fx_forward(
                 f"<= num_model_outputs ({num_model_outputs})"
             )
 
-        model_outputs_node.meta["user_visible_output_idxs"] = [
+        user_visible_output_idxs = [
             idx
             for idx in range(original_output_start_index, orig_output_end_idx)
             if isinstance(model_outputs[idx], torch.fx.Node)
         ]
+
+    if config.keep_output_stride or clone_live_user_outputs:
+        model_outputs_node.meta["user_visible_output_idxs"] = user_visible_output_idxs
     else:
         model_outputs_node.meta["user_visible_output_idxs"] = []
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1850,6 +1850,15 @@ class triton:
     # Emit objgraph backref dumps for leaked cudagraph pool tensors
     cudagraph_trees_objgraph = False
 
+    # Which live cudagraph tree storages to clone before starting a new
+    # generation. None keeps the existing stale-output error behavior.
+    # "user_visible" clones live user-visible output storages out of
+    # the graph pool. Backward graph outputs are not selected for cloning.
+    # This mode can add overhead because live outputs that cross generations
+    # are explicitly copied and stop using cached TensorImpl outputs. Users
+    # can leave this unset and manually clone/copy those outputs instead.
+    cudagraph_trees_generation_cloning: Literal["user_visible"] | None = None
+
     # Enable cudagraph support for mutated inputs from prior cudagraph pool
     cudagraph_support_input_mutation = not is_fbcode()
 
@@ -1859,6 +1868,11 @@ class triton:
     # i.e., allow num_recording <= cudagraph_unexpected_rerecord_limit
     # note: we are conservative here and choose a large limit.
     cudagraph_unexpected_rerecord_limit = 128
+
+    # Number of cudagraph-managed input pointer-change re-records allowed for
+    # a parent/function edge before future recordings copy that input instead
+    # of specializing on its graph-pool address.
+    cudagraph_managed_input_rerecord_limit = 3
 
     # Warn loudly when the number of cudagraphs due to dynamic shape
     # exceeds this limit

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -99,7 +99,7 @@ from torch.utils.weak import TensorWeakRef
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterator, Sequence
+    from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 
     from torch._guards import CompileId
     from torch._inductor.utils import InputType
@@ -507,6 +507,7 @@ def cudagraphify(
     placeholders: tuple[PlaceholderInfo, ...] = (),
     mutated_input_idxs: tuple[int, ...] = (),
     kernel_free_cudagraph: bool = False,
+    user_visible_output_idxs: tuple[int, ...] = (),
     compile_id: CompileId | None = None,
 ) -> tuple[ModelType, OutputType]:
     if is_backward and is_inference:
@@ -530,6 +531,7 @@ def cudagraphify(
         placeholders,
         mutated_input_idxs,
         kernel_free_cudagraph,
+        user_visible_output_idxs,
         compile_id,
     )
 
@@ -681,6 +683,14 @@ def map_to_ref(t: Tensor | None) -> StorageWeakRefWrapper | None:
 # A path index of (depth, offset) indices into a graph that is `depth`` number of nodes from the root
 # at graph output offset
 PathOutputIndex = tuple[int, int]
+# Cached per-node lists and output index to check for user-visible output cloning.
+PathUserVisibleOutputEntry = tuple[
+    list[StorageWeakRefWrapper | None],
+    list[TensorWeakRef | None],
+    list[Tensor | None] | None,
+    int,
+]
+PathUserVisibleStorageGroup = tuple[PathUserVisibleOutputEntry, ...]
 
 # For each node in the path, for each output, is the output alive
 PathLiveness = list[list[bool]]
@@ -720,6 +730,7 @@ class CUDAWarmupNode:
         id: GraphID,
     ) -> None:
         self.wrapped_function = wrapped_function
+        self.user_visible_output_idxs = wrapped_function.user_visible_output_idxs
         self.parent: CUDAGraphNode | CUDAWarmupNode | None = parent
         self.cuda_graphs_pool = cuda_graphs_pool
         self.outputs_weakrefs: list[StorageWeakRefWrapper | None] = []
@@ -731,6 +742,12 @@ class CUDAWarmupNode:
         self.stream = stream
         self.already_warm = already_warm
         self.id = id
+
+    @functools.cached_property
+    def path_user_visible_storage_groups(
+        self,
+    ) -> tuple[PathUserVisibleStorageGroup, ...]:
+        return collect_path_user_visible_storage_groups(tuple(self._path_from_root))
 
     def run(self, new_inputs: Any) -> OutputType:
         if self.has_run:
@@ -915,6 +932,7 @@ class CUDAGraphNode:
         stream: torch.cuda.Stream,
         mode: CompilationMode | None,
         compile_id: CompileId | None,
+        copy_cudagraph_managed_idxs: Sequence[int] = (),
     ) -> None:
         if not isinstance(inputs, (list, tuple)):
             raise AssertionError(
@@ -922,6 +940,7 @@ class CUDAGraphNode:
             )
 
         self.wrapped_function = wrapped_function
+        self.user_visible_output_idxs = wrapped_function.user_visible_output_idxs
         self.id = id
         self.device = device_index
         self.stack_traces = stack_traces
@@ -962,11 +981,14 @@ class CUDAGraphNode:
         ]
         self.tensor_weakrefs: OutputList[TensorWeakRef | None] = []
 
+        copy_cudagraph_managed_idxs_set = OrderedSet(copy_cudagraph_managed_idxs)
         # tensors which are outputs of previous graphs in the tree
         self.cudagraph_managed_idxs: list[int] = [
             idx
             for idx, t in enumerate(inputs)
-            if isinstance(t, torch.Tensor) and self._is_cuda_graph_recorded_tensor(t)
+            if isinstance(t, torch.Tensor)
+            and self._is_cuda_graph_recorded_tensor(t)
+            and idx not in copy_cudagraph_managed_idxs_set
         ]
 
         # (depth, offset) of live tensors which are alias of previous graph outputs
@@ -998,7 +1020,10 @@ class CUDAGraphNode:
         opaque_input_idxs = OrderedSet(
             i for i, inp in enumerate(inputs) if is_opaque_value(inp)
         )
-        static_input_idxs = OrderedSet(wrapped_function.static_input_idxs)
+        static_input_idxs = (
+            OrderedSet(wrapped_function.static_input_idxs)
+            - copy_cudagraph_managed_idxs_set
+        )
         cudagraph_managed_idxs = OrderedSet(self.cudagraph_managed_idxs)
 
         self.static_input_idxs: list[int] = list(
@@ -1130,8 +1155,6 @@ class CUDAGraphNode:
         self.output_storage_alias: OutputList[OutputAliasInfo | None] = []
 
         # is the output Storage unaliased in subsequent outputs, of all subsequent paths
-        # if it is, we cached the output tensor and adjust storage liveness tracking to also
-        # check if the output tensor does not have an additional python reference.
         # If a descendant node discovers it has an alias of a prior output, then the output
         # will no longer be cached in the ancestor.
         # The large majority of tensors are unaliased, and preserving aliased output tensors would add
@@ -1170,6 +1193,12 @@ class CUDAGraphNode:
 
         if self.graph is not None:
             self.graph.replay()
+
+    @functools.cached_property
+    def path_user_visible_storage_groups(
+        self,
+    ) -> tuple[PathUserVisibleStorageGroup, ...]:
+        return collect_path_user_visible_storage_groups(tuple(self._path_from_root))
 
     def _copy_inputs_and_remove_from_src(
         self, dsts: list[InputType], srcs: list[InputType]
@@ -1260,6 +1289,7 @@ class CUDAGraphNode:
             self._initialize_cached_tensors()
 
         outputs: OutputType = []
+        user_visible_output_idxs = self.user_visible_output_idxs
 
         for i, (storage_info, metadata) in enumerate(
             zip(self.output_storage_alias, self.outputs_metadata)
@@ -1311,6 +1341,8 @@ class CUDAGraphNode:
             if w is None:
                 raise AssertionError("expected w to not be None")
             w.swap_weakref(out.untyped_storage()._weak_ref())
+            if user_visible_output_idxs and i in user_visible_output_idxs:
+                self.tensor_weakrefs[i] = TensorWeakRef(out)
 
         return outputs
 
@@ -1371,11 +1403,9 @@ class CUDAGraphNode:
         "Record the model"
 
         def static_input_iter() -> Generator[torch.Tensor, None, None]:
-            for i in self.wrapped_function.static_input_idxs:
+            for i in self.non_managed_static_input_idxs:
                 _inp = inputs[i]
-                if isinstance(
-                    _inp, torch.Tensor
-                ) and not self._is_cuda_graph_recorded_tensor(_inp):
+                if isinstance(_inp, torch.Tensor):
                     yield _inp
 
         # see: output_is_alias_of_persistent_static_inputs above
@@ -1581,7 +1611,6 @@ class CUDAGraphNode:
             raise AssertionError(
                 "expected len(outputs_weakrefs) == len(outputs_metadata)"
             )
-
         for i, (storage_info, metadata, make_cached) in enumerate(
             zip(
                 self.output_storage_alias,
@@ -1913,6 +1942,25 @@ class CUDAGraphNode:
 
         return recording_inputs
 
+    def get_cudagraph_managed_mismatched_idxs(
+        self, inputs: list[InputType]
+    ) -> OrderedSet[int]:
+        mismatched_idxs: OrderedSet[int] = OrderedSet()
+        for idx in self.cudagraph_managed_idxs:
+            inp = inputs[idx]
+            if (
+                isinstance(inp, torch.Tensor)
+                and inp.data_ptr() != self.static_input_data_ptrs[idx]
+            ):
+                mismatched_idxs.add(idx)
+        return mismatched_idxs
+
+    def can_copy_cudagraph_managed_input(self, idx: int) -> bool:
+        return (
+            idx not in self.wrapped_function.mutated_input_idxs
+            and not self.preserved_aliased_inputs[idx]
+        )
+
     def check_invariants(
         self, inputs: list[InputType]
     ) -> tuple[CheckInvariantStatus, Callable[..., str]]:
@@ -1994,6 +2042,85 @@ class CUDAGraphNode:
                 num_desc += 1
                 num_desc += child.num_descendants()
         return num_desc
+
+
+def canonical_path_output_index(
+    node: CUDAGraphNode | CUDAWarmupNode, depth: int, idx: int
+) -> PathOutputIndex:
+    if isinstance(node, CUDAGraphNode):
+        alias_info = node.output_storage_alias[idx]
+        if isinstance(alias_info, AliasesPriorGraphOutput):
+            return alias_info.index
+        if isinstance(alias_info, AliasesNewOutput):
+            return (depth, alias_info.index)
+    return (depth, idx)
+
+
+def collect_path_user_visible_storage_groups(
+    path: tuple[CUDAGraphNode | CUDAWarmupNode, ...],
+) -> tuple[PathUserVisibleStorageGroup, ...]:
+    """Return path storage-alias groups for user-visible output cloning.
+
+    Starts from user-visible outputs, then includes outputs on the same path
+    that may alias those outputs by recorded storage pointer or alias metadata.
+    This is cached per node path so aliases discovered on a different tree path
+    do not affect the current generation transition.
+    """
+    selected_outputs: OrderedSet[PathOutputIndex] = OrderedSet()
+    selected_alias_outputs: OrderedSet[PathOutputIndex] = OrderedSet()
+    selected_data_ptrs: OrderedSet[int] = OrderedSet()
+
+    # First, collect storage pointers and canonical outputs referenced by
+    # user-visible outputs.
+    for depth, node in enumerate(path):
+        for idx in node.user_visible_output_idxs:
+            if idx >= len(node.outputs_weakrefs):
+                raise AssertionError(
+                    "expected user_visible_output_idxs to index outputs_weakrefs"
+                )
+            selected_outputs.add((depth, idx))
+            selected_alias_outputs.add(canonical_path_output_index(node, depth, idx))
+
+            storage_ref = node.outputs_weakrefs[idx]
+            if storage_ref is not None:
+                selected_data_ptrs.add(storage_ref.data_ptr())
+
+    # Then, collect outputs that may alias a user-visible output.
+    for depth, node in enumerate(path):
+        for idx, storage_ref in enumerate(node.outputs_weakrefs):
+            output_index = (depth, idx)
+
+            alias_index = canonical_path_output_index(node, depth, idx)
+            if (
+                output_index in selected_outputs
+                or alias_index in selected_alias_outputs
+                or storage_ref is not None
+                and storage_ref.data_ptr() in selected_data_ptrs
+            ):
+                selected_outputs.add(output_index)
+
+    entries_by_data_ptr: dict[int, list[PathUserVisibleOutputEntry]] = {}
+    for depth, idx in selected_outputs:
+        node = path[depth]
+        output_weakrefs = node.outputs_weakrefs
+        storage_ref = output_weakrefs[idx]
+        if storage_ref is None:
+            continue
+
+        cached_tensor_outputs = (
+            node.cached_tensor_outputs if isinstance(node, CUDAGraphNode) else None
+        )
+        data_ptr = storage_ref.data_ptr()
+        entries_by_data_ptr.setdefault(data_ptr, []).append(
+            (
+                output_weakrefs,
+                node.tensor_weakrefs,
+                cached_tensor_outputs,
+                idx,
+            )
+        )
+
+    return tuple(tuple(entries) for entries in entries_by_data_ptr.values())
 
 
 def get_cudagraph_segments(pool_id: tuple[int, int]) -> Any:
@@ -2232,6 +2359,14 @@ class CUDAGraphTreeManager:
         self.num_rerecord: dict[GraphID | None, dict[FunctionID, int]] = defaultdict(
             lambda: defaultdict(lambda: 0)
         )
+        # Per parent/function edge, track changing cudagraph-managed input
+        # slots. Once a slot crosses the limit, new children copy it.
+        self.cudagraph_managed_input_rerecord: dict[
+            GraphID | None, dict[FunctionID, dict[int, int]]
+        ] = {}
+        self.demoted_cudagraph_managed_idxs: dict[
+            GraphID | None, dict[FunctionID, OrderedSet[int]]
+        ] = {}
 
         # whether we the current node is in a state of warmup, recording, execution. If
         # there is no current node the state will be ExecutionState.None.
@@ -2257,6 +2392,7 @@ class CUDAGraphTreeManager:
 
         self.id_to_mode: dict[FunctionID, CompilationMode] = {}
         self.id_to_compile_id: dict[FunctionID, CompileId | None] = {}
+        self.has_live_user_visible_output_cloning = False
 
         # Note: [Backward Generation Handling]
         # We generally perform a sequence of forward executions followed by backward executions.
@@ -2346,6 +2482,38 @@ class CUDAGraphTreeManager:
             > torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
         )
 
+    def _update_demoted_cudagraph_managed_idxs(
+        self,
+        node_id: GraphID | None,
+        function_id: FunctionID,
+        mismatched_idxs: OrderedSet[int],
+    ) -> None:
+        demoted_idxs = self.demoted_cudagraph_managed_idxs.setdefault(
+            node_id, {}
+        ).setdefault(function_id, OrderedSet())
+        rerecord_counts = self.cudagraph_managed_input_rerecord.setdefault(
+            node_id, {}
+        ).setdefault(function_id, {})
+        for idx in mismatched_idxs - demoted_idxs:
+            rerecord_counts[idx] = rerecord_counts.get(idx, 0) + 1
+            if (
+                rerecord_counts[idx]
+                >= config.triton.cudagraph_managed_input_rerecord_limit
+            ):
+                demoted_idxs.add(idx)
+
+    def _get_demoted_cudagraph_managed_idxs(
+        self, function_id: FunctionID
+    ) -> tuple[int, ...]:
+        node_id = self._get_node_id()
+        return tuple(
+            sorted(
+                self.demoted_cudagraph_managed_idxs.get(node_id, {}).get(
+                    function_id, ()
+                )
+            )
+        )
+
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
         # we will try to end the current execution lazily, since
         # we don't want to do unnecessary checking of the existing outputs
@@ -2356,6 +2524,20 @@ class CUDAGraphTreeManager:
 
         if self.in_warmup:
             self.try_end_curr_warmup(function_id)
+
+        if (
+            self.has_live_user_visible_output_cloning
+            and self.path_state == ExecutionState.EXECUTION
+        ):
+            curr_generation = self.get_curr_generation()
+            # current_node is cleared lazily, so the first invocation in a new
+            # generation may still see children from the previous generation.
+            # Enforce the existing generation boundary before matching children.
+            if self.in_new_torch_compile_invocation(curr_generation):
+                self.try_end_curr_execution(
+                    curr_generation,
+                    skip_dead_output_cleanup=True,
+                )
 
         node_id = self._get_node_id()
         if function_id not in self.non_cudagraph_managed_mutation_hint[node_id]:
@@ -2401,6 +2583,8 @@ class CUDAGraphTreeManager:
         if not self.in_recording:
             unexpected_rerecord = False
             unexpected_rerecord_reason = None
+            cudagraph_managed_mismatched_idxs: OrderedSet[int] = OrderedSet()
+            non_demotable_cudagraph_managed_idxs: OrderedSet[int] = OrderedSet()
             for child in child_nodes[function_id]:
                 # here we are checking memory consistency between recording and execution,
                 # as well as things like stability of tensor locations, etc
@@ -2418,6 +2602,16 @@ class CUDAGraphTreeManager:
                     # other mismatch reasons do count.
                     if status != CheckInvariantStatus.StaticInputIdxMismatch:
                         unexpected_rerecord = True
+                    if status == CheckInvariantStatus.CudagraphManagedIdxMismatch:
+                        mismatched_idxs = child.get_cudagraph_managed_mismatched_idxs(
+                            new_inputs
+                        )
+                        cudagraph_managed_mismatched_idxs.update(mismatched_idxs)
+                        non_demotable_cudagraph_managed_idxs.update(
+                            idx
+                            for idx in mismatched_idxs
+                            if not child.can_copy_cudagraph_managed_input(idx)
+                        )
                     # Only compute detailed reason when debug logging is enabled
                     if log.isEnabledFor(logging.DEBUG):
                         unexpected_rerecord_reason = status_logger()
@@ -2449,6 +2643,16 @@ class CUDAGraphTreeManager:
                     function_id
                 ]:
                     return self.ids_to_funcs[function_id].model(new_inputs)
+
+            demotable_cudagraph_managed_idxs = (
+                cudagraph_managed_mismatched_idxs - non_demotable_cudagraph_managed_idxs
+            )
+            if demotable_cudagraph_managed_idxs:
+                self._update_demoted_cudagraph_managed_idxs(
+                    self._get_node_id(),
+                    function_id,
+                    demotable_cudagraph_managed_idxs,
+                )
 
             # nb: run before checkpointing because checkpointing is slow, and we will
             # be using the eager caching allocator pool which does not require live
@@ -2538,6 +2742,7 @@ class CUDAGraphTreeManager:
                 self.stream,
                 self.mode,
                 self.compile_id,
+                self._get_demoted_cudagraph_managed_idxs(function_id),
             )
             if self.current_node is None:
                 self.roots[function_id].append(node)
@@ -2614,12 +2819,18 @@ class CUDAGraphTreeManager:
         placeholders: tuple[PlaceholderInfo, ...],
         mutated_input_idxs: tuple[int, ...],
         kernel_free_cudagraph: bool,
+        user_visible_output_idxs: tuple[int, ...],
         compile_id: CompileId | None,
     ) -> tuple[
         ModelType,
         OutputType,
     ]:
         id = self.new_func_id()
+        if mode == CompilationMode.BACKWARD:
+            user_visible_output_idxs = ()
+        user_visible_output_idxs_set = frozenset(user_visible_output_idxs)
+        if user_visible_output_idxs_set:
+            self.has_live_user_visible_output_cloning = True
         self.ids_to_stack_traces[id] = stack_traces
         self.ids_to_funcs[id] = WrappedFunction(
             model,
@@ -2629,6 +2840,7 @@ class CUDAGraphTreeManager:
             placeholders,
             mutated_input_idxs,
             kernel_free_cudagraph,
+            user_visible_output_idxs_set,
         )
         self.id_to_mode[id] = mode
         self.id_to_compile_id[id] = compile_id
@@ -2674,8 +2886,8 @@ class CUDAGraphTreeManager:
     def user_invoked_mark_step() -> bool:
         return MarkStepBox.mark_step_counter != 0
 
-    def can_start_new_generation(self) -> bool:
-        if not self.in_new_torch_compile_invocation():
+    def can_start_new_generation(self, curr_generation: int | None = None) -> bool:
+        if not self.in_new_torch_compile_invocation(curr_generation):
             return False
 
         if self.user_invoked_mark_step():
@@ -2683,8 +2895,116 @@ class CUDAGraphTreeManager:
 
         return not self.running_forwards_with_pending_backwards
 
-    def in_new_torch_compile_invocation(self) -> bool:
-        return self.current_gen != self.get_curr_generation()
+    def in_new_torch_compile_invocation(
+        self, curr_generation: int | None = None
+    ) -> bool:
+        if curr_generation is None:
+            curr_generation = self.get_curr_generation()
+        return self.current_gen != curr_generation
+
+    def _clone_current_path_live_user_visible_outputs(self) -> None:
+        if self.current_node is None:
+            raise AssertionError("expected current_node to not be None")
+        path_user_visible_storage_groups = (
+            self.current_node.path_user_visible_storage_groups
+        )
+        if not path_user_visible_storage_groups:
+            return
+
+        storages_to_clone: list[
+            tuple[StorageWeakRefPointer, PathUserVisibleStorageGroup]
+        ] = []
+
+        for output_entries in path_user_visible_storage_groups:
+            for (
+                output_weakrefs,
+                _tensor_weakrefs,
+                _cached_tensor_outputs,
+                idx,
+            ) in output_entries:
+                storage_and_ptr = maybe_deref(output_weakrefs[idx])
+                if storage_and_ptr is not None:
+                    storage_ptr, _data_ptr = storage_and_ptr
+                    storages_to_clone.append((storage_ptr, output_entries))
+                    break
+
+        if storages_to_clone:
+            self._clone_live_user_visible_storages(storages_to_clone)
+
+    def _clone_live_user_visible_storages(
+        self,
+        storages_to_clone: Iterable[
+            tuple[
+                StorageWeakRefPointer,
+                PathUserVisibleStorageGroup,
+            ]
+        ],
+    ) -> None:
+        replacements: list[
+            tuple[
+                UntypedStorage,
+                UntypedStorage,
+                PathUserVisibleStorageGroup,
+            ]
+        ] = []
+
+        with torch.cuda.device(self.device_index):
+            source_tensors = []
+            replacement_tensors = []
+
+            for storage_ptr, entries in storages_to_clone:
+                source_storage = torch.UntypedStorage._new_with_weak_ptr(storage_ptr)
+                replacement = torch.empty(
+                    (source_storage.nbytes(),),
+                    dtype=torch.uint8,
+                    device=source_storage.device,
+                )
+                replacement_storage = replacement.untyped_storage()
+                source_tensors.append(
+                    torch.empty(
+                        (), dtype=torch.uint8, device=source_storage.device
+                    ).set_(source_storage, 0, (source_storage.nbytes(),), (1,))
+                )
+                replacement_tensors.append(replacement)
+                replacements.append((source_storage, replacement_storage, entries))
+
+            torch._foreach_copy_(replacement_tensors, source_tensors)
+
+            for source_storage, replacement_storage, entries in replacements:
+                # pyrefly: ignore[missing-attribute]
+                source_storage._swap_data_ptr_(replacement_storage)
+                placeholder_weakrefs = [
+                    replacement_storage._weak_ref() for _ in entries
+                ]
+
+                # Warmup/recording storages own the graph-pool block after
+                # the swap. Reconstructed replay storages are non-owning.
+                if torch._C._has_Standard_Deleter(replacement_storage._cdata):
+                    torch._C._free_And_Remove_DeleterFn(replacement_storage._cdata)
+                torch._C._set_storage_data_ptr_access_error_msg(
+                    replacement_storage._cdata,
+                    "CUDAGraph output storage was cloned before a new generation.",
+                )
+
+                for (
+                    output_weakrefs,
+                    tensor_weakrefs,
+                    cached_tensor_outputs,
+                    idx,
+                ), placeholder_weakref in zip(
+                    entries, placeholder_weakrefs, strict=True
+                ):
+                    cached_t = (
+                        cached_tensor_outputs[idx] if cached_tensor_outputs else None
+                    )
+                    output_ref = cast(StorageWeakRefWrapper, output_weakrefs[idx])
+                    tensor_weakrefs[idx] = None
+                    output_ref.remove_extra_reference()
+                    output_ref.swap_weakref(placeholder_weakref)
+
+                    if cached_tensor_outputs is not None and cached_t is not None:
+                        torch._C._remove_cached_tensor(cached_t)
+                        cached_tensor_outputs[idx] = None
 
     def try_end_curr_recording(self, function_id: FunctionID) -> None:
         """
@@ -2699,8 +3019,10 @@ class CUDAGraphTreeManager:
 
         # multiple invocations, allow overwriting the previous generation
         if self.can_start_new_generation():
-            self.dealloc_current_path_weakrefs()
-            self.clear_current_path_state_and_set_to_none()
+            self.clear_current_path_state_and_set_to_none(
+                clone_live_user_visible_outputs=True,
+                dealloc_current_path_weakrefs=True,
+            )
             return
 
         if self.current_node.all_outputs_are_dead():
@@ -2709,7 +3031,12 @@ class CUDAGraphTreeManager:
 
         self.check_warn_on_unable_to_start_executing(function_id)
 
-    def try_end_curr_execution(self) -> None:
+    def try_end_curr_execution(
+        self,
+        curr_generation: int | None = None,
+        *,
+        skip_dead_output_cleanup: bool = False,
+    ) -> None:
         """
         Check if the current executing node can be terminated, either because all outputs of the
         previously executed node are dead or because it was executed in a different generation.
@@ -2721,21 +3048,27 @@ class CUDAGraphTreeManager:
         if self.current_node is None:
             return
 
-        if self.can_start_new_generation():
-            self.clear_current_path_state_and_set_to_none()
+        if self.can_start_new_generation(curr_generation):
+            self.clear_current_path_state_and_set_to_none(
+                clone_live_user_visible_outputs=True
+            )
+            return
+
+        if skip_dead_output_cleanup:
             return
 
         if self.current_node.all_outputs_are_dead():
             self.clear_current_path_state_and_set_to_none()
 
     def try_end_curr_warmup(self, function_id: FunctionID) -> None:
+        if self.current_node is None:
+            raise AssertionError("expected current_node to not be None")
         if self.can_start_new_generation():
+            self._clone_current_path_live_user_visible_outputs()
             self.dealloc_current_path_weakrefs()
             self.current_node = None
             return
 
-        if self.current_node is None:
-            raise AssertionError("expected current_node to not be None")
         if self.current_node.all_outputs_are_dead():
             self.current_node = None
             return
@@ -2801,7 +3134,10 @@ class CUDAGraphTreeManager:
             "Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run. "
             f"Stack trace: {stack_trace}. "
             "To prevent overwriting, clone the tensor outside of torch.compile() "
-            "or call torch.compiler.cudagraph_mark_step_begin() before each model invocation."
+            "or call torch.compiler.cudagraph_mark_step_begin() before each model invocation. "
+            "If the tensor is a user-visible output that must remain live across "
+            "generations, set torch._inductor.config.triton."
+            "cudagraph_trees_generation_cloning = 'user_visible'."
         )
 
     def dealloc_current_path_weakrefs(self) -> None:
@@ -2873,11 +3209,20 @@ class CUDAGraphTreeManager:
 
                 torch._C._set_storage_data_ptr_access_error_msg(_storage_deref, msg)
 
-    def clear_current_path_state_and_set_to_none(self) -> None:
+    def clear_current_path_state_and_set_to_none(
+        self,
+        *,
+        clone_live_user_visible_outputs: bool = False,
+        dealloc_current_path_weakrefs: bool = False,
+    ) -> None:
         if not isinstance(self.current_node, CUDAGraphNode):
             raise AssertionError(
                 f"expected current_node to be a CUDAGraphNode, got {type(self.current_node)}"
             )
+        if clone_live_user_visible_outputs:
+            self._clone_current_path_live_user_visible_outputs()
+        if dealloc_current_path_weakrefs:
+            self.dealloc_current_path_weakrefs()
         self.current_node.clear_path_state()
         self.current_node = None
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Callable
 from enum import Enum
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import Any, Literal, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.utils import counters, get_metrics_context
@@ -12,6 +12,7 @@ from torch._inductor.utils import GraphPartitionMap, InputType
 from torch._subclasses.fake_tensor import get_plain_tensors, is_fake
 from torch.utils._ordered_set import OrderedSet
 
+from . import config
 from .utils import is_using_cudagraph_partition
 
 
@@ -31,6 +32,21 @@ static_inputs_log = torch._logging.getArtifactLogger(
 
 OutputType = list[int | torch.Tensor | None]
 ModelType = Callable[[list[InputType]], OutputType]
+
+
+def cudagraph_trees_generation_cloning() -> Literal["user_visible"] | None:
+    mode = config.triton.cudagraph_trees_generation_cloning
+    if mode not in (None, "user_visible"):
+        raise AssertionError(
+            "Expected torch._inductor.config.triton."
+            "cudagraph_trees_generation_cloning to be None or 'user_visible', "
+            f"got {mode!r}"
+        )
+    return mode
+
+
+def cudagraph_trees_clone_live_user_visible_outputs() -> bool:
+    return cudagraph_trees_generation_cloning() == "user_visible"
 
 
 INPUT_STORAGE_MUTATION_TARGETS = (
@@ -172,6 +188,9 @@ class WrappedFunction:
     placeholders: Sequence[PlaceholderInfo]
     mutated_input_idxs: Sequence[int]
     kernel_free_cudagraph: bool = False
+    user_visible_output_idxs: frozenset[int] = dataclasses.field(
+        default_factory=frozenset
+    )
 
 
 def get_mutating_use_stack_trace_from_node(
@@ -533,6 +552,7 @@ class CudagraphCachedInfo:
 
     placeholders: Sequence[PlaceholderInfo]
     stack_traces: list[str | None]
+    user_visible_output_idxs: Sequence[int]
     cudagraph_fail_reasons: list[str]
 
 
@@ -546,6 +566,7 @@ class CudagraphMetadata:
     static_input_idxs: OrderedSet[int]
     mutated_input_idxs: OrderedSet[int]
     stack_traces: list[str | None]
+    user_visible_output_idxs: OrderedSet[int]
     constants: dict[str, torch.Tensor]
 
 
@@ -584,11 +605,29 @@ def get_partition_cudagraph_metadata(
         partition_placeholders.append(placeholder)
 
     partition_stack_traces = []
-    for graph_output_idx in partition_map.output_index_mapping:
-        if graph_output_idx is not None:
-            partition_stack_traces.append(metadata.stack_traces[graph_output_idx])
-        else:
+    partition_user_visible_output_idxs: OrderedSet[int] = OrderedSet()
+    # Graph output metadata must be remapped to the partition output indices
+    # passed to cudagraphify.
+    for partition_output_idx, graph_output_idxs in enumerate(
+        partition_map.output_index_mapping
+    ):
+        if not graph_output_idxs:
             partition_stack_traces.append(None)
+            continue
+
+        user_visible_graph_output_idxs = [
+            graph_output_idx
+            for graph_output_idx in graph_output_idxs
+            if graph_output_idx in metadata.user_visible_output_idxs
+        ]
+        stack_trace_idx = (
+            user_visible_graph_output_idxs[0]
+            if user_visible_graph_output_idxs
+            else graph_output_idxs[0]
+        )
+        partition_stack_traces.append(metadata.stack_traces[stack_trace_idx])
+        if user_visible_graph_output_idxs:
+            partition_user_visible_output_idxs.add(partition_output_idx)
 
     partition_constants = {
         name: metadata.constants[name] for name in partition_map.constant_names
@@ -599,6 +638,7 @@ def get_partition_cudagraph_metadata(
         partition_static_input_idxs,
         partition_mutated_input_idxs,
         partition_stack_traces,
+        partition_user_visible_output_idxs,
         partition_constants,
     )
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -35,6 +35,7 @@ from torch._guards import compile_context, CompileContext
 from torch._higher_order_ops.wrap import inductor_compiled_code
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
+    cudagraph_trees_clone_live_user_visible_outputs,
     CudagraphCachedInfo,
     CudagraphMetadata,
     get_input_storage_mutation_info,
@@ -247,6 +248,7 @@ def cudagraph_post_compile(
             raise AssertionError(
                 "stack_traces should not be None in cudagraph_post_compile"
             )
+        user_visible_output_idxs = getattr(cached_info, "user_visible_output_idxs", ())
 
         prepare_cudagraph_post_compile(
             compiled_graph, example_inputs, boxed_forward_device_index
@@ -270,6 +272,7 @@ def cudagraph_post_compile(
             placeholders=placeholders,
             mutated_input_idxs=tuple(compiled_graph.mutated_input_idxs),
             kernel_free_cudagraph=compiled_graph.kernel_free_cudagraph,
+            user_visible_output_idxs=tuple(user_visible_output_idxs),
         )
 
         policy = config.cudagraph_policy
@@ -366,6 +369,9 @@ def cudagraph_partition_post_compile(
         static_input_idxs,
         mutated_input_idxs,
         compiled_graph.cudagraph_info.stack_traces,
+        OrderedSet(
+            getattr(compiled_graph.cudagraph_info, "user_visible_output_idxs", ())
+        ),
         tensor_constants,
     )
 
@@ -396,6 +402,7 @@ def cudagraph_partition_post_compile(
             placeholders=partition_metadata.placeholders,
             mutated_input_idxs=tuple(partition_metadata.mutated_input_idxs),
             kernel_free_cudagraph=compiled_graph.kernel_free_cudagraph,
+            user_visible_output_idxs=tuple(partition_metadata.user_visible_output_idxs),
         )
         cudagraphify_fns.append(cudagraphify_fn)
 
@@ -696,10 +703,18 @@ class CompiledFxGraph(OutputCode):
                     (arg.stack_trace if isinstance(arg, torch.fx.node.Node) else None)
                     for arg in output.args[0]  # type: ignore[union-attr]
                 ]
+                user_visible_output_idxs = (
+                    output.meta.get("user_visible_output_idxs", ())
+                    if cudagraph_trees_clone_live_user_visible_outputs()
+                    else ()
+                )
                 cudagraph_fail_reasons = [s for b, s in cudagraph_tests if not b]
                 placeholders = tuple(get_placeholder_info(gm.graph))
                 cudagraph_info = CudagraphCachedInfo(
-                    placeholders, stack_traces, cudagraph_fail_reasons
+                    placeholders,
+                    stack_traces,
+                    tuple(user_visible_output_idxs),
+                    cudagraph_fail_reasons,
                 )
 
         self.cudagraph_info = cudagraph_info

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -8973,9 +8973,9 @@ class Scheduler:
         name_to_graph_input_index = {
             name: idx for idx, name in enumerate(V.graph.graph_inputs)
         }
-        name_to_graph_output_index = {
-            name: idx for idx, name in enumerate(V.graph.get_output_names())
-        }
+        name_to_graph_output_indices: dict[str, list[int]] = defaultdict(list)
+        for idx, name in enumerate(V.graph.get_output_names()):
+            name_to_graph_output_indices[name].append(idx)
 
         V.graph.partition_maps = []
         for partition_id, signature in enumerate(signatures):
@@ -8992,7 +8992,9 @@ class Scheduler:
 
             output_mapping = []
             for node in signature.output_nodes:
-                output_mapping.append(name_to_graph_output_index.get(node.get_name()))
+                output_mapping.append(
+                    name_to_graph_output_indices.get(node.get_name(), [])
+                )
 
             V.graph.partition_maps.append(
                 GraphPartitionMap(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -227,10 +227,13 @@ class GraphPartitionMap:
     # a unique id of graph partition
     id: int
 
-    # map partition input/output indices to graph input/output indices. None indicates
-    # a partition input/output is not a graph input/output.
+    # map partition input indices to graph input indices. None indicates a
+    # partition input is not a graph input.
     input_index_mapping: list[int | None]
-    output_index_mapping: list[int | None]
+    # map partition output indices to graph output indices. Empty indicates a
+    # partition output is not a graph output. Multiple graph outputs can map to
+    # the same partition output when graph outputs alias the same buffer.
+    output_index_mapping: list[list[int]]
 
     # name of constants read/written by the graph partition
     constant_names: list[str]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #188118

CUDAGraph trees normally invalidate live outputs when a new generation starts. That preserves the graph-pool contract, but issue #176294 feeds a user-visible output into a later compiled invocation, so a live TensorImpl can point at storage that replay expects to be dead.

Add torch._inductor.config.triton.cudagraph_trees_generation_cloning with None and "user_visible". The string mode clones live user-visible forward/inference output storages out of the graph pool when an existing generation boundary is reached, including execution-to-execution transitions. Same-generation producer-to-consumer dependencies are left on the normal tree path.

The clone path reuses cached per-path alias groups, touches each live storage once, updates alias/weakref bookkeeping, and invalidates only cached TensorImpl slots whose storage was cloned. Dead outputs can still use the existing cached TensorImpl fast path. Backward graph outputs are not selected, and the normal CUDAGraph invariant checks stay on the existing path. The default remains None, and the stale-output error points users at the config.

This mode can copy tensors that are live but unused, so users can leave it unset and manually clone/copy those outputs instead. We limit the mode to user-visible outputs rather than gradients or activations, where the tensor count can be high and gradients are still expected to be cleared.

Fixes https://github.com/pytorch/pytorch/issues/170604
Fixes https://github.com/pytorch/pytorch/issues/152887
Fixes https://github.com/pytorch/pytorch/issues/144961
Fixes https://github.com/pytorch/pytorch/issues/176294

Test Plan:

```bash
python -m py_compile torch/_inductor/cudagraph_trees.py torch/_inductor/config.py test/inductor/test_cudagraph_trees.py
```

```bash
python test/inductor/test_cudagraph_trees.py -k clone_live --verbose
```

```bash
python test/inductor/test_cudagraph_trees.py -k test_error_on_dealloc_use --verbose
```

```bash
python test/inductor/test_cudagraph_trees.py -k grad_accumulation_dealloc_error_message --verbose
```

```bash
python test/inductor/test_cudagraph_trees.py CudaGraphTreeTests.test_storage_access_error CudaGraphTreeTests.test_clear_storage_data_ptr_access_error --verbose
```

```bash
lintrunner -a
```

Authored by Codex.

Pull-Request: https://github.com/pytorch/pytorch/pull/188078

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo