### PR TITLE
[FSDP2] Per-FQN offload policy map and cpu_offload_by_budget helper

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_offload_selector.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_offload_selector.py
@@ -1,0 +1,100 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import CPUOffloadPolicy
+from torch.distributed.fsdp._fully_shard._fsdp_api import (
+    _select_largest_first,
+    cpu_offload_by_budget,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+class _ThreeParam(nn.Module):
+    # float32 byte sizes: big=400, mid=200, small=40 (total 640)
+    def __init__(self) -> None:
+        super().__init__()
+        self.big = nn.Parameter(torch.zeros(100))
+        self.mid = nn.Parameter(torch.zeros(50))
+        self.small = nn.Parameter(torch.zeros(10))
+
+
+@instantiate_parametrized_tests
+class TestOffloadSelector(TestCase):
+    def _items(self) -> list[tuple[str, int]]:
+        return [("a", 40), ("b", 100), ("c", 30), ("d", 100)]
+
+    def test_boundaries(self) -> None:
+        items = self._items()
+        total = sum(nbytes for _, nbytes in items)
+        self.assertEqual(_select_largest_first(items, 0), [])
+        self.assertEqual(set(_select_largest_first(items, total)), {"a", "b", "c", "d"})
+        self.assertEqual(
+            set(_select_largest_first(items, total + 1000)), {"a", "b", "c", "d"}
+        )
+
+    def test_largest_first_with_tie_break(self) -> None:
+        # b and d tie at 100; the tie breaks on FQN, so b precedes d.
+        self.assertEqual(_select_largest_first(self._items(), 100), ["b"])
+        self.assertEqual(_select_largest_first(self._items(), 200), ["b", "d"])
+        # a (40) is larger than c (30) and is taken first among the remainder.
+        self.assertEqual(_select_largest_first(self._items(), 240), ["b", "d", "a"])
+
+    def test_never_overshoots(self) -> None:
+        items = self._items()
+        for budget in range(0, sum(n for _, n in items) + 5):
+            selected = set(_select_largest_first(items, budget))
+            used = sum(n for fqn, n in items if fqn in selected)
+            self.assertLessEqual(used, budget)
+
+    def test_monotonic_superset(self) -> None:
+        items = self._items()
+        prev: set[str] = set()
+        for budget in range(0, sum(n for _, n in items) + 5):
+            cur = set(_select_largest_first(items, budget))
+            self.assertTrue(prev.issubset(cur))
+            prev = cur
+
+    def test_deterministic(self) -> None:
+        items = self._items()
+        first = _select_largest_first(items, 170)
+        for _ in range(5):
+            self.assertEqual(_select_largest_first(items, 170), first)
+        # Input order must not change the result.
+        self.assertEqual(_select_largest_first(list(reversed(items)), 170), first)
+
+    @parametrize(
+        "budget,expected",
+        [
+            (0, set()),
+            (399, set()),
+            (400, {"big"}),
+            (600, {"big", "mid"}),
+            (640, {"big", "mid", "small"}),
+            (10**9, {"big", "mid", "small"}),
+        ],
+    )
+    def test_cpu_offload_by_budget_map(self, budget: int, expected: set) -> None:
+        offload_map = cpu_offload_by_budget(_ThreeParam(), budget)
+        self.assertEqual(set(offload_map), expected)
+        self.assertNotIn("missing", offload_map)
+        for policy in offload_map.values():
+            self.assertIsInstance(policy, CPUOffloadPolicy)
+            self.assertTrue(policy.pin_memory)
+
+    def test_cpu_offload_by_budget_pin_memory(self) -> None:
+        offload_map = cpu_offload_by_budget(_ThreeParam(), 10**9, pin_memory=False)
+        self.assertTrue(all(not p.pin_memory for p in offload_map.values()))
+
+    def test_cpu_offload_by_budget_rejects_negative(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            cpu_offload_by_budget(_ThreeParam(), -1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,5 +1,6 @@
 from ._flat_param import FlatParameter as FlatParameter
 from ._fully_shard import (
+    cpu_offload_by_budget,
     CPUOffloadPolicy,
     DataParallelMeshDims,
     FSDPModule,
@@ -49,6 +50,7 @@ __all__ = [
     "StateDictSettings",
     "StateDictType",
     # FSDP2
+    "cpu_offload_by_budget",
     "CPUOffloadPolicy",
     "DataParallelMeshDims",
     "FSDPModule",
@@ -61,6 +63,7 @@ __all__ = [
 ]
 
 # Set namespace for exposed private names
+cpu_offload_by_budget.__module__ = "torch.distributed.fsdp"
 CPUOffloadPolicy.__module__ = "torch.distributed.fsdp"
 DataParallelMeshDims.__module__ = "torch.distributed.fsdp"
 FSDPModule.__module__ = "torch.distributed.fsdp"

--- a/torch/distributed/fsdp/_fully_shard/__init__.py
+++ b/torch/distributed/fsdp/_fully_shard/__init__.py
@@ -1,4 +1,5 @@
 from ._fsdp_api import (
+    cpu_offload_by_budget,
     CPUOffloadPolicy,
     DataParallelMeshDims,
     MixedPrecisionPolicy,
@@ -14,6 +15,7 @@ from ._fully_shard import (
 
 
 __all__ = [
+    "cpu_offload_by_budget",
     "CPUOffloadPolicy",
     "DataParallelMeshDims",
     "FSDPModule",

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
@@ -197,3 +197,59 @@ class CPUOffloadPolicy(OffloadPolicy):
     """
 
     pin_memory: bool = True
+
+
+def _select_largest_first(
+    fqn_numbytes: list[tuple[str, int]], budget_bytes: int
+) -> list[str]:
+    """Select FQNs largest-first until the CPU offload budget is exhausted.
+
+    Parameters are sorted by byte size descending, with a stable tie-break on
+    FQN, and the longest prefix whose cumulative size does not exceed
+    ``budget_bytes`` is returned, stopping at the first parameter that would
+    exceed it. The selection is deterministic, never overshoots the budget, and
+    is monotonic in the budget: raising ``budget_bytes`` only extends the
+    prefix, so the selected set grows as a superset. It takes no torch
+    dependency so it can be unit tested on plain Python data.
+    """
+    ordered = sorted(fqn_numbytes, key=lambda kv: (-kv[1], kv[0]))
+    selected: list[str] = []
+    used = 0
+    for fqn, numbytes in ordered:
+        if used + numbytes > budget_bytes:
+            break
+        selected.append(fqn)
+        used += numbytes
+    return selected
+
+
+def cpu_offload_by_budget(
+    module: torch.nn.Module, budget_bytes: int, *, pin_memory: bool = True
+) -> dict[str, OffloadPolicy]:
+    """Build a per-parameter CPU offload map under a memory budget.
+
+    Returns a mapping from parameter FQN (relative to ``module``) to
+    :class:`OffloadPolicy`, suitable to pass as ``fully_shard``'s
+    ``offload_policy``. The largest parameters are offloaded first until
+    ``budget_bytes`` of parameter memory has been placed on CPU; the remaining
+    parameters stay on device and are omitted from the map. ``budget_bytes`` is
+    measured against full (unsharded) parameter sizes. A budget of ``0``
+    offloads nothing and a budget at or above the total parameter size offloads
+    everything, reproducing :class:`OffloadPolicy` and :class:`CPUOffloadPolicy`
+    respectively.
+
+    Note:
+        When only some parameters are offloaded, a parameter group spans both
+        CPU and device shards. Adam/AdamW stay correct on such a group, but the
+        default ``foreach``/``fused`` auto-selection does not engage a
+        multi-tensor kernel across mixed devices; pass ``fused=True`` (or
+        ``foreach=True``) to keep the per-device multi-tensor step.
+    """
+    if budget_bytes < 0:
+        raise ValueError(f"budget_bytes must be non-negative, but got {budget_bytes}")
+    fqn_numbytes = [
+        (fqn, param.numel() * param.element_size())
+        for fqn, param in module.named_parameters()
+    ]
+    policy = CPUOffloadPolicy(pin_memory=pin_memory)
+    return {fqn: policy for fqn in _select_largest_first(fqn_numbytes, budget_bytes)}

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
@@ -21,7 +21,7 @@ from ._fsdp_state import _get_module_fsdp_state
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from typing import Any
 
     from ._fsdp_api import DataParallelMeshDims, MixedPrecisionPolicy, OffloadPolicy
@@ -430,6 +430,53 @@ def _apply_to_module(
         module.__class__ = new_cls
 
 
+def _resolve_offload_policy(
+    offload_policy: "OffloadPolicy | Mapping[str, OffloadPolicy]",
+    modules: tuple[nn.Module, ...],
+    params: list[nn.Parameter],
+) -> "OffloadPolicy | dict[nn.Parameter, OffloadPolicy]":
+    """Resolve ``offload_policy`` into a per-parameter offload mapping.
+
+    A single ``OffloadPolicy`` is returned unchanged and applies uniformly. A
+    mapping from parameter FQN (relative to the ``fully_shard`` module) to
+    ``OffloadPolicy`` is validated and rekeyed by the managed parameter
+    objects; FQNs absent from the mapping default to no offloading. A
+    ``ValueError`` is raised for any FQN that does not name a managed parameter.
+    """
+    from collections.abc import Mapping
+
+    from ._fsdp_api import OffloadPolicy
+
+    if isinstance(offload_policy, OffloadPolicy):
+        return offload_policy
+    if not isinstance(offload_policy, Mapping):
+        raise TypeError(
+            "offload_policy must be an OffloadPolicy or a mapping from parameter "
+            f"FQN to OffloadPolicy, but got {type(offload_policy)}"
+        )
+    managed = set(params)
+    fqn_to_param: dict[str, nn.Parameter] = {}
+    for module in modules:
+        for fqn, param in module.named_parameters():
+            if param in managed:
+                fqn_to_param[fqn] = param
+    unknown = sorted(fqn for fqn in offload_policy if fqn not in fqn_to_param)
+    if unknown:
+        raise ValueError(
+            "offload_policy contains FQNs that do not name a parameter managed "
+            f"by this fully_shard call: {unknown}"
+        )
+    param_to_policy: dict[nn.Parameter, OffloadPolicy] = {}
+    for fqn, policy in offload_policy.items():
+        if not isinstance(policy, OffloadPolicy):
+            raise TypeError(
+                f"offload_policy[{fqn!r}] must be an OffloadPolicy, but got "
+                f"{type(policy)}"
+            )
+        param_to_policy[fqn_to_param[fqn]] = policy
+    return param_to_policy
+
+
 def _init_param_group(
     state: "FSDPState",
     params: list[nn.Parameter],
@@ -439,7 +486,7 @@ def _init_param_group(
     device: torch.device,
     shard_placement_fn: "Callable[[nn.Parameter], ShardPlacementFnResult] | None",
     mp_policy: "MixedPrecisionPolicy",
-    offload_policy: "OffloadPolicy",
+    offload_policy: "OffloadPolicy | dict[nn.Parameter, OffloadPolicy]",
     reshard_after_forward: bool | int = True,
 ) -> None:
     """

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -19,7 +19,7 @@ from torch.distributed.fsdp._common_utils import (
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 
-from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
+from ._fsdp_api import MixedPrecisionPolicy, OffloadPolicy
 from ._fsdp_collectives import (
     AllGather,
     AllGatherResult,
@@ -163,11 +163,20 @@ class FSDPParamGroup:
         device: torch.device,
         shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None,
         mp_policy: MixedPrecisionPolicy,
-        offload_policy: OffloadPolicy,
+        offload_policy: OffloadPolicy | dict[nn.Parameter, OffloadPolicy],
     ):
         self.modules = modules  # permit ref cycle because 1:1 lifetime
         param_module_infos = _get_param_module_infos(params, modules)
 
+        # ``offload_policy`` is either a single policy applied to every
+        # parameter or a per-parameter mapping (FQNs already resolved to
+        # parameter objects upstream); absent parameters are not offloaded.
+        if isinstance(offload_policy, OffloadPolicy):
+            per_param_offload = [offload_policy for _ in params]
+        else:
+            per_param_offload = [
+                offload_policy.get(param, OffloadPolicy()) for param in params
+            ]
         self.fsdp_params = [
             FSDPParam(
                 param,
@@ -177,9 +186,11 @@ class FSDPParamGroup:
                 device,
                 shard_placement_fn,
                 mp_policy,
-                offload_policy,
+                param_offload,
             )
-            for param, module_info in zip(params, param_module_infos)
+            for param, module_info, param_offload in zip(
+                params, param_module_infos, per_param_offload
+            )
         ]
         self.mesh_info = mesh_info
         self.post_forward_mesh_info = post_forward_mesh_info
@@ -1065,12 +1076,13 @@ class FSDPParamGroup:
             )
 
     def _validate_cpu_offload_params(self):
-        if not isinstance(self.offload_policy, CPUOffloadPolicy):
-            return
+        # Validate per parameter rather than per group: a group may mix
+        # offloaded and on-device parameters under a per-FQN offload policy.
         fsdp_params_not_on_cpu = [
             fsdp_param
             for fsdp_param in self.fsdp_params
-            if fsdp_param.sharded_param.device.type != "cpu"
+            if fsdp_param.offload_to_cpu
+            and fsdp_param.sharded_param.device.type != "cpu"
         ]
         if fsdp_params_not_on_cpu:
             raise RuntimeError(

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -28,6 +28,7 @@ from ._fsdp_init import (
     _get_post_forward_mesh_info,
     _init_default_mesh,
     _init_param_group,
+    _resolve_offload_policy,
     _validate_mesh,
     _validate_module,
 )
@@ -35,7 +36,7 @@ from ._fsdp_state import _get_module_fsdp_state, FSDPState
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator
+    from collections.abc import Callable, Iterable, Iterator, Mapping
 
     from torch.distributed.tensor import DeviceMesh
 
@@ -68,7 +69,7 @@ def fully_shard(
     reshard_after_forward: bool | int | None = ...,
     shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None = ...,
     mp_policy: MixedPrecisionPolicy = ...,
-    offload_policy: OffloadPolicy = ...,
+    offload_policy: OffloadPolicy | Mapping[str, OffloadPolicy] = ...,
     ignored_params: set[nn.Parameter] | None = ...,
     dp_mesh_dims: DataParallelMeshDims | None = ...,
 ) -> FSDPModule: ...
@@ -83,7 +84,7 @@ def fully_shard(
     reshard_after_forward: bool | int | None = ...,
     shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None = ...,
     mp_policy: MixedPrecisionPolicy = ...,
-    offload_policy: OffloadPolicy = ...,
+    offload_policy: OffloadPolicy | Mapping[str, OffloadPolicy] = ...,
     ignored_params: set[nn.Parameter] | None = ...,
     dp_mesh_dims: DataParallelMeshDims | None = ...,
 ) -> list[FSDPModule]: ...
@@ -102,7 +103,7 @@ def fully_shard(
     reshard_after_forward: bool | int | None = None,
     shard_placement_fn: Callable[[nn.Parameter], ShardPlacementFnResult] | None = None,
     mp_policy: MixedPrecisionPolicy = MixedPrecisionPolicy(),
-    offload_policy: OffloadPolicy = OffloadPolicy(),
+    offload_policy: OffloadPolicy | Mapping[str, OffloadPolicy] = OffloadPolicy(),
     ignored_params: set[nn.Parameter] | None = None,
     dp_mesh_dims: DataParallelMeshDims | None = None,
 ):
@@ -221,9 +222,15 @@ def fully_shard(
         mp_policy (MixedPrecisionPolicy): This controls the mixed precision
             policy, which offers parameter/reduction mixed precision for this
             module. See :class:`MixedPrecisionPolicy` for details.
-        offload_policy (OffloadPolicy): This controls the offloading policy,
-            which offers parameter/gradient/optimizer state offloading. See
-            :class:`OffloadPolicy` and its subclasses for details.
+        offload_policy (OffloadPolicy | Mapping[str, OffloadPolicy]): This
+            controls the offloading policy, which offers
+            parameter/gradient/optimizer state offloading. Pass a single
+            :class:`OffloadPolicy` to apply one policy to every parameter, or a
+            mapping from parameter FQN (relative to this module) to
+            :class:`OffloadPolicy` to offload only selected parameters, such as
+            the map returned by :func:`cpu_offload_by_budget`. FQNs absent from
+            the mapping are not offloaded. See :class:`OffloadPolicy` and its
+            subclasses for details.
         ignored_params: Optional(Set[nn.Parameter]): The set of parameters to be
             ignored by FSDP. They will not be sharded, nor moved to the device
             during init, nor have their gradients reduced in backward.
@@ -266,6 +273,7 @@ def fully_shard(
     arg_module, modules, managed_modules, params, buffers = _get_modules_and_states(
         module, device, ignored_params
     )
+    offload_policy = _resolve_offload_policy(offload_policy, modules, params)
     state = fully_shard.state(modules[0])  # type: ignore[attr-defined]
     state.init(modules, device, mp_policy, auto_reshard_after_forward)
 


### PR DESCRIPTION
## Summary

Adds a per-parameter CPU offload surface to FSDP2 and a helper that produces it, implementing the design agreed in #187615.

Today `fully_shard(..., offload_policy=...)` takes a single `OffloadPolicy` that applies to every parameter, so offload is all-or-nothing. This splits mechanism from policy, per @weifengpy's direction in the issue.

**Mechanism.** `offload_policy` also accepts a `Mapping[str, OffloadPolicy]` keyed by parameter FQN (relative to the `fully_shard` module). FQNs absent from the map are not offloaded; an FQN that names no managed parameter raises `ValueError`. `_resolve_offload_policy` rekeys the map to parameter objects, and the policy is applied where `FSDPParam` already derives `offload_to_cpu`/`pin_memory`. Since the D2H/H2D copy is already per parameter (copy-in to the all-gather flat buffer), no runtime machinery changes. The group-level CPU offload materialization check becomes per parameter, so a group may hold a mix of offloaded and on-device parameters.

**Policy.** `cpu_offload_by_budget(module, budget_bytes)` returns such a map, offloading the largest parameters first until the budget is reached. The selection (`_select_largest_first`) is a pure function over `(fqn, nbytes)` pairs: deterministic, never over budget, and monotonic in the budget, so the offloaded set grows as a superset as the budget rises. `budget_bytes` of `0` and of at least the total parameter size reproduce `OffloadPolicy` and `CPUOffloadPolicy` exactly.

## Optimizer note

When only some parameters are offloaded, a parameter group spans CPU and device shards. Adam/AdamW stay correct because the step groups tensors by `(device, dtype)` and launches one kernel per bucket. The caveat is auto-selection: `_get_foreach_kernels_supported_devices()` excludes CPU, so with `foreach=None, fused=None` a mixed group falls back to `_single_tensor_adam`. `_get_fused_kernels_supported_devices()` includes CPU, so `fused=True` (or explicit `foreach=True`) keeps the per-device multi-tensor step. This is noted on the helper docstring.

## Review order

1. `_fsdp_api.py`: `_select_largest_first` and `cpu_offload_by_budget`
2. `_fsdp_init.py`: `_resolve_offload_policy`
3. `_fully_shard.py`: signature, docstring, wiring
4. `_fsdp_param_group.py`: per-parameter application and validation

## Test

`test/distributed/_composable/fsdp/test_fully_shard_offload_selector.py` covers the selector properties and the budget map with no distributed context:

```
python test/distributed/_composable/fsdp/test_fully_shard_offload_selector.py
```

Multi-rank behavior (a group with mixed CPU and device shards under the map) is left to the existing FSDP2 distributed tests.

## Open questions

Draft to validate the shape against #187615 before adding distributed tests and docs.

1. Helper name: `cpu_offload_by_budget` vs a name tied to the largest-first selection.
2. `budget_bytes` measured against full parameter sizes (current) vs per-rank sharded sizes (would need the mesh size).
3. Whether to also add a thin `offload_ratio` wrapper over the budget helper.

Addresses #187615

cc @weifengpy @mlazos
