### PR TITLE
[AI Codemod][PerfAICT-MapSetRehash] Pre-reserve memo_ map to avoid rehashing during DCE side-effect analysis

### DIFF
--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1250,6 +1250,9 @@ struct Graph : std::enable_shared_from_this<Graph> {
     const Block& block = *block_;
     return block.nodes();
   }
+  size_t numNodes() const {
+    return all_nodes.size();
+  }
   Node* param_node() {
     return block_->param_node();
   }

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -27,6 +27,8 @@ class DeadCodeEliminator {
     // clean up unused fork inputs before starting the main algorithm
     eliminateDeadForkInputs(block, recurse);
 
+    memo_.reserve(block->owningGraph()->numNodes());
+
     // Initialize by marking the return node and all its consumed values as live
     mark(block->return_node());
 


### PR DESCRIPTION
Summary:
This is an AI generated diff targetting hotspots in internal profile data. The diff is human reviewed.

Optimized `torch::jit::DeadCodeEliminator::hasSideEffects` by eliminating rehashing of the `memo_` unordered_map. Added `memo_.reserve(block->owningGraph()->numNodes())` in the `run()` method before the mark pass begins, pre-allocating bucket space for the memoization map based on the total number of nodes in the graph (O(1) lookup via a new `Graph::numNodes()` accessor).

Changes:
1. `fbcode/caffe2/torch/csrc/jit/ir/ir.h` — Added public `numNodes()` method to `Graph` that returns `all_nodes.size()`.
2. `fbcode/caffe2/torch/csrc/jit/passes/dead_code_elimination.cpp` — Added `memo_.reserve(block->owningGraph()->numNodes())` in `run()` before the mark phase.

Differential Revision: D108244708


