### PR TITLE
[profiler][cupti] Don't crash trace export when the ProfilerObserver fails to register

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -715,6 +715,37 @@ _cupti_monitor.enable_hes_early()
         self.assertIn("monitor_region", user_names)
 
     @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+    def test_cupti_monitor_observer_registration_failure_is_graceful(self):
+        # If the per-cycle ProfilerObserver fails to register with the CUPTI monitor (an
+        # intermittent CUPTI condition), the profiler must degrade gracefully: with no
+        # observer / trace window, stop_trace and export_chrome_trace skip the trace instead
+        # of asserting and taking down the run.
+        from torch.profiler._cupti import monitor as _cupti_monitor
+
+        cfg = _ExperimentalConfig(custom_profiler_config='{"backend":"cupti_monitor"}')
+        with patch.object(
+            _cupti_monitor.CuptiMonitor,
+            "register",
+            side_effect=RuntimeError("simulated observer registration failure"),
+        ):
+            with TemporaryFileName(mode="w+") as trace_path:
+                # Exiting the profiler runs stop_trace -- it must not raise even though the
+                # observer never registered.
+                with profile(
+                    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                    experimental_config=cfg,
+                ) as prof:
+                    a = torch.randn(64, 64, device="cuda")
+                    _ = (a @ a).cpu()
+                    torch.cuda.synchronize()
+                # Registration failed -> observer unavailable, no trace window.
+                obs = prof._cupti_profiler_observer
+                self.assertTrue(obs is None or not obs.available)
+                # Must skip the export rather than assert/crash.
+                prof.export_chrome_trace(trace_path)
+                prof.wait_for_exports()
+
+    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
     def test_cupti_monitor_record_shapes(self):
         cfg = _ExperimentalConfig(
             custom_profiler_config='{"backend":"cupti_monitor"}',

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -429,10 +429,23 @@ class _KinetoProfile:
                 "Profiler must be initialized before exporting chrome trace"
             )
         if self._use_cupti_monitor:
-            if self._monitor_window_id is None or self._cupti_profiler_observer is None:
-                raise AssertionError(
-                    "CUPTI monitor trace window must be closed before exporting"
+            obs = self._cupti_profiler_observer
+            if obs is None or not obs.available or self._monitor_window_id is None:
+                # Nothing to export this cycle: the per-cycle ProfilerObserver didn't register
+                # with the CUPTI monitor (available is False -- the intermittent case), or its
+                # window wasn't opened/closed (window id None). Skip rather than crash -- a
+                # profiler-trace hiccup must not take down a training run -- and clean up below.
+                _warn_once(
+                    "CUPTI monitor observer unavailable; skipping chrome trace export"
                 )
+                # join() tears down the poll thread + monitor registration, which exist only
+                # when the observer registered (available). An unavailable observer never
+                # started either, so just drop the reference and let it be GC'd.
+                if obs is not None and obs.available:
+                    obs.join()
+                self._cupti_profiler_observer = None
+                self._monitor_window_id = None
+                return
             # Capture the profiler's CPU-side trace (cheap, no device sync) and hand it + the
             # output path to the observer. Async: the poller merges + writes `path` once the
             # GPU records arrive; wait_for_exports() blocks for it.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188132

If the per-cycle cupti_monitor ProfilerObserver fails to register with the shared
CUPTI monitor (an intermittent CUPTI condition), `available` is False, so
`close_window()` returns None and `export_chrome_trace()` raised
`AssertionError: CUPTI monitor trace window must be closed before exporting`,
crashing the run.

Downgrade to a warning + skip: log once, join()/unregister the observer only if it
actually registered, reset the window state, and return. Gate the window-id check on
the observer being available so the intent is explicit.

Adds a test that mocks the registration failure (CuptiMonitor.register raises) and
asserts stop_trace (profiler __exit__) and export_chrome_trace do not throw.

Authored-with: Claude (claude-opus-4-8)