### PR TITLE
[BE] Build all XPU wheels on a single runner

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -20,7 +20,7 @@ name: !{{ build_environment }}
     invalidation handles the per-Python ABI bits). Everything else still runs
     on the per-Python matrix below. Add more arch types here as their inline
     build job is wired up. -#}
-{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64'] %}
+{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64', 'xpu'] %}
 {%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 {%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 
@@ -126,14 +126,19 @@ jobs:
     libtorch_python + _C are recompiled per interpreter via the cmake.py cache
     invalidation. -#}
 {%- set unified_job_names = [] %}
+{#- unified_standard_job_names excludes XPU so manywheel-test (which only tests
+    CPU/CUDA) is not blocked by an XPU build failure. -#}
+{%- set unified_standard_job_names = [] %}
+{%- set unified_xpu_job_names = [] %}
 {%- for g in ns.groups %}
   {%- set group = g['configs'] %}
   {%- set arch_type = g['arch_type'] %}
   {%- set desired_cuda = g['desired_cuda'] %}
   {%- set first = group[0] %}
-  {#- Job name: keep cpu/cpu-aarch64 names stable; for cuda, include the
-      desired_cuda variant so cu126/cu130/cu132 each get a distinct job. -#}
-  {%- if desired_cuda == 'cpu' %}
+  {#- Job name: arch types with a single variant (cpu, xpu) use
+      "manywheel-<arch>-build"; multi-variant types (cuda cu126/cu130/cu132)
+      include the desired_cuda suffix for a distinct job per variant. -#}
+  {%- if desired_cuda in ('cpu', 'xpu') %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-build" %}
   {%- else %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-" ~ desired_cuda ~ "-build" %}
@@ -143,13 +148,24 @@ jobs:
   {%- set py_dotless = first['python_version'] | replace('.', '_') %}
   {%- set build_name_suffix = first['build_name'] | replace('manywheel-py' ~ py_dotless, '') %}
   {%- set _ = unified_job_names.append(job_name) %}
+  {%- if arch_type == 'xpu' %}
+  {%- set _ = unified_xpu_job_names.append(job_name) %}
+  {%- else %}
+  {%- set _ = unified_standard_job_names.append(job_name) %}
+  {%- endif %}
 
   !{{ job_name }}:
     name: !{{ job_name }}
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
+    {#- XPU full builds are heavier than CPU/CUDA, so give the unified job
+        more headroom when all Python versions run sequentially. -#}
+    {%- if arch_type == 'xpu' %}
+    timeout-minutes: 420
+    {%- else %}
     timeout-minutes: !{{ timeout_minutes }}
+    {%- endif %}
     container:
       image: pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}
     env:
@@ -263,7 +279,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type{%- if matrix_standard_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
+    needs: [get-label-type{%- if matrix_standard_configs %}, manywheel-build{%- endif %}{%- for n in unified_standard_job_names %}, !{{ n }}{%- endfor %}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -344,7 +360,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build]
+    needs: [get-label-type{%- for n in unified_xpu_job_names %}, !{{ n }}{%- endfor %}]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -12,7 +12,6 @@ name: !{{ build_environment }}
     actions and custom GPU device passthrough); everything else delegates to
     _binary-test-linux.yml. -#}
 {%- set rocm_configs = build_configs | selectattr('gpu_arch_type', 'equalto', 'rocm') | list %}
-{%- set xpu_configs = build_configs | selectattr('gpu_arch_type', 'equalto', 'xpu') | list %}
 {%- set test_standard_configs = build_configs | rejectattr('gpu_arch_type', 'in', ['rocm', 'xpu']) | list %}
 
 {#- gpu_arch_types listed here are grouped into a single runner that loops over
@@ -20,9 +19,13 @@ name: !{{ build_environment }}
     invalidation handles the per-Python ABI bits). Everything else still runs
     on the per-Python matrix below. Add more arch types here as their inline
     build job is wired up. -#}
-{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64'] %}
+{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64', 'xpu'] %}
 {%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 {%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
+
+{#- XPU configs not handled by the unified path (currently none, but kept for
+    future-proofing in case XPU is removed from unified_arch_types). -#}
+{%- set xpu_configs = matrix_build_configs | selectattr('gpu_arch_type', 'equalto', 'xpu') | list %}
 
 {#- Standard (non-ROCm/XPU) configs that are built by the manywheel-build matrix
     rather than an inline unified job (e.g. cpu-s390x). manywheel-test consumes
@@ -255,7 +258,7 @@ jobs:
   {%- set first = group[0] %}
   {#- Job name: keep cpu/cpu-aarch64 names stable; for cuda, include the
       desired_cuda variant so cu126/cu130/cu132 each get a distinct job. -#}
-  {%- if desired_cuda == 'cpu' %}
+  {%- if desired_cuda == 'cpu' or desired_cuda == arch_type %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-build" %}
   {%- else %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-" ~ desired_cuda ~ "-build" %}
@@ -274,7 +277,7 @@ jobs:
     if: !{{ owner_if }}
     needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}]
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
-    timeout-minutes: !{{ timeout_minutes }}
+    timeout-minutes: !{{ 420 if arch_type == 'xpu' else timeout_minutes }}
     container:
       image: !{{ docker_registry_host }}pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
     env:
@@ -388,11 +391,19 @@ jobs:
 
     ROCm/XPU already have their own test jobs below. -#}
 {%- set standard_test_jobs = [] %}
+{%- set xpu_test_jobs = [] %}
 {%- for u in unified_upload_groups %}
+  {%- if u['configs'][0]['gpu_arch_type'] == 'xpu' %}
+  {%- set _ = xpu_test_jobs.append({
+        'name': u['test_name'],
+        'needs': [u['job_name']],
+        'configs': u['configs']}) %}
+  {%- else %}
   {%- set _ = standard_test_jobs.append({
         'name': u['test_name'],
         'needs': [u['job_name']],
         'configs': u['configs']}) %}
+  {%- endif %}
 {%- endfor %}
 {%- if matrix_standard_configs %}
   {#- Standard configs built by the manywheel-build matrix (e.g. cpu-s390x)
@@ -452,6 +463,36 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 {%- endfor %}
 {%- endif %}
+
+{%- for test_job in xpu_test_jobs %}
+
+  !{{ test_job['name'] }}:
+    name: ${{ matrix.build_name }}-test
+    if: !{{ owner_if }}
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, !{{ test_job['needs'] | join(', ') }}]
+    uses: ./.github/workflows/_binary-test-xpu-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        {%- for config in test_job['configs'] %}
+          - desired_python: "!{{ config['python_version'] }}"
+            desired_cuda: "!{{ config['desired_cuda'] }}"
+            gpu_arch_type: "!{{ config['gpu_arch_type'] }}"
+            docker_image: "!{{ config['container_image'] }}"
+            docker_image_tag_prefix: "!{{ config['container_image_tag_prefix'] }}"
+            build_name: "!{{ config['build_name'] }}"
+        {%- endfor %}
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: !{{ build_configs[0]['package_type'] }}
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+{%- endfor %}
 
 {%- if rocm_configs %}
 
@@ -534,7 +575,7 @@ jobs:
 {%- for u in unified_upload_groups %}
   {%- set _ = upload_jobs.append({
         'name': u['job_name'] | replace('-build', '-upload'),
-        'needs': [u['job_name']] + ([u['test_name']] if test_standard_configs else []),
+        'needs': [u['job_name'], u['test_name']],
         'configs': u['configs']}) %}
 {%- endfor %}
 {%- if matrix_standard_configs %}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -404,6 +404,95 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_2/*
 
+  manywheel-xpu-build:
+    name: manywheel-xpu-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
+    timeout-minutes: 420
+    container:
+      image: pytorch/manylinux2_28-builder:xpu
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: xpu
+      GPU_ARCH_VERSION: ""
+      GPU_ARCH_TYPE: xpu
+      DOCKER_IMAGE: pytorch/manylinux2_28-builder:xpu
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-xpu"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-xpu/*
+
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -431,15 +520,6 @@ jobs:
             build_name: "manywheel-py3_10-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.11"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -458,15 +538,6 @@ jobs:
             build_name: "manywheel-py3_11-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.12"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -485,15 +556,6 @@ jobs:
             build_name: "manywheel-py3_12-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.13"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -512,15 +574,6 @@ jobs:
             build_name: "manywheel-py3_13-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -539,15 +592,6 @@ jobs:
             build_name: "manywheel-py3_14-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14t"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -566,15 +610,6 @@ jobs:
             build_name: "manywheel-py3_14t-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -593,15 +628,6 @@ jobs:
             build_name: "manywheel-py3_15-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.1"
             gpu_arch_version: "7.1"
@@ -620,15 +646,6 @@ jobs:
             build_name: "manywheel-py3_15t-rocm7_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: ""
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1067,7 +1084,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build]
+    needs: [get-label-type, manywheel-xpu-build]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false
@@ -1137,7 +1154,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
+    needs: [manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-xpu-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -585,6 +585,95 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_4/*
 
+  manywheel-xpu-build:
+    name: manywheel-xpu-build
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+    timeout-minutes: 420
+    container:
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:xpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: xpu
+      GPU_ARCH_VERSION: ""
+      GPU_ARCH_TYPE: xpu
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:xpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-xpu"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-xpu/*
+
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
@@ -612,15 +701,6 @@ jobs:
             build_name: "manywheel-py3_10-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.11"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -639,15 +719,6 @@ jobs:
             build_name: "manywheel-py3_11-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.12"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -666,15 +737,6 @@ jobs:
             build_name: "manywheel-py3_12-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.13"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -693,15 +755,6 @@ jobs:
             build_name: "manywheel-py3_13-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -720,15 +773,6 @@ jobs:
             build_name: "manywheel-py3_14-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14t"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -747,15 +791,6 @@ jobs:
             build_name: "manywheel-py3_14t-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -774,15 +809,6 @@ jobs:
             build_name: "manywheel-py3_15-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -801,15 +827,6 @@ jobs:
             build_name: "manywheel-py3_15t-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1291,6 +1308,73 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  manywheel-xpu-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-xpu-build]
+    uses: ./.github/workflows/_binary-test-xpu-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_10-xpu"
+          - desired_python: "3.11"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_11-xpu"
+          - desired_python: "3.12"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_12-xpu"
+          - desired_python: "3.13"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_13-xpu"
+          - desired_python: "3.14"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14-xpu"
+          - desired_python: "3.14t"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14t-xpu"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
+          - desired_python: "3.15t"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15t-xpu"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+
   manywheel-test-rocm:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
@@ -1420,75 +1504,6 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       # ROCm test runners have no ECR pull credentials, so ROCm stays on the
-      # Docker Hub image (excluded from the content-addressed ECR path).
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
-      DESIRED_PYTHON: ${{ matrix.desired_python }}
-      build_name: ${{ matrix.build_name }}
-
-  manywheel-test-xpu:
-    name: ${{ matrix.build_name }}-test
-    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-build]
-    uses: ./.github/workflows/_binary-test-xpu-linux.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
-    with:
-      PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: manywheel
-      DESIRED_CUDA: ${{ matrix.desired_cuda }}
-      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
-      DOCKER_IMAGE: ${{ matrix.docker_image }}
-      # XPU test runners have no ECR pull credentials, so XPU stays on the
       # Docker Hub image (excluded from the content-addressed ECR path).
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
@@ -1914,6 +1929,90 @@ jobs:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
+  manywheel-xpu-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-xpu-build, manywheel-xpu-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_10-xpu"
+          - desired_python: "3.11"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_11-xpu"
+          - desired_python: "3.12"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_12-xpu"
+          - desired_python: "3.13"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_13-xpu"
+          - desired_python: "3.14"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14-xpu"
+          - desired_python: "3.14t"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14t-xpu"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
+          - desired_python: "3.15t"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15t-xpu"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
   manywheel-rocm-upload:
     name: ${{ matrix.build_name }}-upload
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
@@ -2038,90 +2137,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm10.0"
             build_name: "manywheel-py3_15t-rocm10_0"
-    with:
-      PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: manywheel
-      DESIRED_CUDA: ${{ matrix.desired_cuda }}
-      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
-      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
-      DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
-      DESIRED_PYTHON: ${{ matrix.desired_python }}
-      build_name: ${{ matrix.build_name }}
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-
-  manywheel-xpu-upload:
-    name: ${{ matrix.build_name }}-upload
-    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    permissions:
-      id-token: write
-      contents: read
-    needs: [get-docker-tag, manywheel-build, manywheel-test-xpu]
-    uses: ./.github/workflows/_binary-upload.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -45,41 +45,61 @@ IF(NOT MKLDNN_FOUND)
                            Detected system '${CMAKE_SYSTEM_NAME}' is not supported.")
     endif()
 
-    set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
-    include(ProcessorCount)
-    ProcessorCount(proc_cnt)
-    if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
-      list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
-      if(CMAKE_GENERATOR MATCHES "Make|Ninja")
-        list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
-      endif()
+    # Compute the ExternalProject layout paths. When XPU_MKLDNN_DIR_PREFIX
+    # is unset cmake defaults to <binary_dir>/xpu_mkldnn_proj-prefix/.
+    if(XPU_MKLDNN_DIR_PREFIX)
+      set(_xpu_mkldnn_prefix "${XPU_MKLDNN_DIR_PREFIX}")
+    else()
+      set(_xpu_mkldnn_prefix "${CMAKE_CURRENT_BINARY_DIR}/xpu_mkldnn_proj-prefix")
     endif()
-    ExternalProject_Add(xpu_mkldnn_proj
-      GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12
-      PREFIX ${XPU_MKLDNN_DIR_PREFIX}
-      BUILD_IN_SOURCE 0
-      CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
-      -DDNNL_GPU_RUNTIME=SYCL
-      -DDNNL_CPU_RUNTIME=NONE
-      -DDNNL_BUILD_TESTS=OFF
-      -DDNNL_BUILD_EXAMPLES=OFF
-      -DONEDNN_BUILD_GRAPH=ON
-      -DDNNL_LIBRARY_TYPE=STATIC
-      -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER} # Use global cxx compiler as host compiler
-      -G ${CMAKE_GENERATOR} # Align Generator to Torch
-      BUILD_COMMAND ${DNNL_MAKE_COMMAND}
-      BUILD_BYPRODUCTS "xpu_mkldnn_proj-prefix/src/xpu_mkldnn_proj-build/src/${DNNL_LIB_NAME}"
-      INSTALL_COMMAND ""
-    )
+    set(_xpu_mkldnn_src_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj")
+    set(_xpu_mkldnn_build_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj-build")
+    set(_xpu_mkldnn_lib "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}")
 
-    ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
-    set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
-    set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
-    # This target would be further linked to libtorch_xpu.so.
-    # The libtorch_xpu.so would contain Conv&GEMM operators that depend on
-    # oneDNN primitive implementations inside libdnnl.a.
+    if(EXISTS "${_xpu_mkldnn_lib}" AND IS_DIRECTORY "${_xpu_mkldnn_src_dir}/include")
+      # oneDNN XPU already built from a previous iteration (unified wheel
+      # build). Skip ExternalProject to avoid a full re-clone and rebuild
+      # that cmake's Ninja generator would otherwise trigger on reconfigure.
+      message(STATUS "Reusing existing oneDNN XPU build: ${_xpu_mkldnn_lib}")
+      add_custom_target(xpu_mkldnn_proj)
+      set(XPU_MKLDNN_LIBRARIES "${_xpu_mkldnn_lib}")
+      set(XPU_MKLDNN_INCLUDE "${_xpu_mkldnn_src_dir}/include" "${_xpu_mkldnn_build_dir}/include")
+    else()
+      set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
+      include(ProcessorCount)
+      ProcessorCount(proc_cnt)
+      if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
+        list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
+        if(CMAKE_GENERATOR MATCHES "Make|Ninja")
+          list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
+        endif()
+      endif()
+      ExternalProject_Add(xpu_mkldnn_proj
+        GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
+        GIT_TAG v3.12
+        PREFIX ${XPU_MKLDNN_DIR_PREFIX}
+        BUILD_IN_SOURCE 0
+        CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
+        -DDNNL_GPU_RUNTIME=SYCL
+        -DDNNL_CPU_RUNTIME=NONE
+        -DDNNL_BUILD_TESTS=OFF
+        -DDNNL_BUILD_EXAMPLES=OFF
+        -DONEDNN_BUILD_GRAPH=ON
+        -DDNNL_LIBRARY_TYPE=STATIC
+        -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER}
+        -G ${CMAKE_GENERATOR}
+        BUILD_COMMAND ${DNNL_MAKE_COMMAND}
+        BUILD_BYPRODUCTS "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}"
+        INSTALL_COMMAND ""
+      )
+
+      ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
+      set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
+      set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
+    endif()
+
+    # Linked into libtorch_xpu.so; provides Conv & GEMM via oneDNN primitives.
     add_library(xpu_mkldnn INTERFACE)
     add_dependencies(xpu_mkldnn xpu_mkldnn_proj)
     target_link_libraries(xpu_mkldnn INTERFACE ${XPU_MKLDNN_LIBRARIES})

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -45,41 +45,61 @@ IF(NOT MKLDNN_FOUND)
                            Detected system '${CMAKE_SYSTEM_NAME}' is not supported.")
     endif()
 
-    set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
-    include(ProcessorCount)
-    ProcessorCount(proc_cnt)
-    if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
-      list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
-      if(CMAKE_GENERATOR MATCHES "Make|Ninja")
-        list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
-      endif()
+    # Compute the ExternalProject layout paths. When XPU_MKLDNN_DIR_PREFIX
+    # is unset cmake defaults to <binary_dir>/xpu_mkldnn_proj-prefix/.
+    if(XPU_MKLDNN_DIR_PREFIX)
+      set(_xpu_mkldnn_prefix "${XPU_MKLDNN_DIR_PREFIX}")
+    else()
+      set(_xpu_mkldnn_prefix "${CMAKE_CURRENT_BINARY_DIR}/xpu_mkldnn_proj-prefix")
     endif()
-    ExternalProject_Add(xpu_mkldnn_proj
-      GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12.3
-      PREFIX ${XPU_MKLDNN_DIR_PREFIX}
-      BUILD_IN_SOURCE 0
-      CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
-      -DDNNL_GPU_RUNTIME=SYCL
-      -DDNNL_CPU_RUNTIME=NONE
-      -DDNNL_BUILD_TESTS=OFF
-      -DDNNL_BUILD_EXAMPLES=OFF
-      -DONEDNN_BUILD_GRAPH=ON
-      -DDNNL_LIBRARY_TYPE=STATIC
-      -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER} # Use global cxx compiler as host compiler
-      -G ${CMAKE_GENERATOR} # Align Generator to Torch
-      BUILD_COMMAND ${DNNL_MAKE_COMMAND}
-      BUILD_BYPRODUCTS "xpu_mkldnn_proj-prefix/src/xpu_mkldnn_proj-build/src/${DNNL_LIB_NAME}"
-      INSTALL_COMMAND ""
-    )
+    set(_xpu_mkldnn_src_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj")
+    set(_xpu_mkldnn_build_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj-build")
+    set(_xpu_mkldnn_lib "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}")
 
-    ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
-    set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
-    set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
-    # This target would be further linked to libtorch_xpu.so.
-    # The libtorch_xpu.so would contain Conv&GEMM operators that depend on
-    # oneDNN primitive implementations inside libdnnl.a.
+    if(EXISTS "${_xpu_mkldnn_lib}" AND IS_DIRECTORY "${_xpu_mkldnn_src_dir}/include")
+      # oneDNN XPU already built from a previous iteration (unified wheel
+      # build). Skip ExternalProject to avoid a full re-clone and rebuild
+      # that cmake's Ninja generator would otherwise trigger on reconfigure.
+      message(STATUS "Reusing existing oneDNN XPU build: ${_xpu_mkldnn_lib}")
+      add_custom_target(xpu_mkldnn_proj)
+      set(XPU_MKLDNN_LIBRARIES "${_xpu_mkldnn_lib}")
+      set(XPU_MKLDNN_INCLUDE "${_xpu_mkldnn_src_dir}/include" "${_xpu_mkldnn_build_dir}/include")
+    else()
+      set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
+      include(ProcessorCount)
+      ProcessorCount(proc_cnt)
+      if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
+        list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
+        if(CMAKE_GENERATOR MATCHES "Make|Ninja")
+          list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
+        endif()
+      endif()
+      ExternalProject_Add(xpu_mkldnn_proj
+        GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
+        GIT_TAG v3.12
+        PREFIX ${XPU_MKLDNN_DIR_PREFIX}
+        BUILD_IN_SOURCE 0
+        CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
+        -DDNNL_GPU_RUNTIME=SYCL
+        -DDNNL_CPU_RUNTIME=NONE
+        -DDNNL_BUILD_TESTS=OFF
+        -DDNNL_BUILD_EXAMPLES=OFF
+        -DONEDNN_BUILD_GRAPH=ON
+        -DDNNL_LIBRARY_TYPE=STATIC
+        -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER}
+        -G ${CMAKE_GENERATOR}
+        BUILD_COMMAND ${DNNL_MAKE_COMMAND}
+        BUILD_BYPRODUCTS "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}"
+        INSTALL_COMMAND ""
+      )
+
+      ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
+      set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
+      set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
+    endif()
+
+    # Linked into libtorch_xpu.so; provides Conv & GEMM via oneDNN primitives.
     add_library(xpu_mkldnn INTERFACE)
     add_dependencies(xpu_mkldnn xpu_mkldnn_proj)
     target_link_libraries(xpu_mkldnn INTERFACE ${XPU_MKLDNN_LIBRARIES})


### PR DESCRIPTION
## Summary

Extend the unified single-runner wheel build pattern (from #184045 for CUDA and #183931 for CPU) to XPU nightly wheel builds.

- Instead of spawning 8 separate runners (one per Python version), a single `manywheel-xpu-build` job loops over all CPython versions sequentially, reusing `build/` across iterations
- After the first full build, only `libtorch_python` + `_C` are recompiled per interpreter via the `cmake.py` cache invalidation
- XPU build failure is isolated from CPU/CUDA tests (`manywheel-test` does NOT depend on XPU build)
- Unified XPU job gets 420-minute timeout to accommodate all Python versions sequentially

## Dependency chain

```
manywheel-xpu-build  -->  manywheel-test-xpu  -->  manywheel-upload
                                                       ^
manywheel-cpu-build  \                                 |
manywheel-cuda-*     --> manywheel-test  ---------------+
manywheel-build (ROCm) --> manywheel-test-rocm ---------+
```

## Test Plan

Regenerated workflow via:

```
python .github/scripts/generate_ci_workflows.py
```

Verified:
- `manywheel-xpu-build` job generated with correct container, env, and artifact upload steps for all 8 Python versions
- XPU entries removed from `manywheel-build` matrix (ROCm-only now)
- `manywheel-test-xpu` depends on `manywheel-xpu-build`
- `manywheel-test` does NOT depend on XPU (isolation preserved)
- `manywheel-upload` includes `manywheel-xpu-build` in its needs
- Other workflows (aarch64, s390x, macOS, Windows) unchanged

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal