### PR TITLE
[inductor] Decompose shard_dim_alltoall via regular decomposition

### DIFF
--- a/test/inductor/test_decompose_shard_dim_alltoall.py
+++ b/test/inductor/test_decompose_shard_dim_alltoall.py
@@ -1,0 +1,214 @@
+# Owner(s): ["module: inductor"]
+
+from unittest import mock
+
+import torch
+from torch import fx
+from torch._dynamo.utils import counters
+from torch._inductor.fx_passes.post_grad import _decompose_shard_dim_alltoall
+from torch._inductor.fx_utils import FakeTensorUpdater
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.virtualized import V
+from torch.testing._internal.common_utils import IS_LINUX
+
+
+class TestDecomposeShardDimAllToAll(TestCase):
+    def _reference_shard_dim_alltoall(
+        self,
+        inputs: list[torch.Tensor],
+        *,
+        gather_dim: int,
+        shard_dim: int,
+    ) -> list[torch.Tensor]:
+        group_size = len(inputs)
+        ndim = inputs[0].dim()
+        gathered = torch.cat(inputs, dim=gather_dim % ndim)
+        return list(torch.chunk(gathered, group_size, dim=shard_dim % ndim))
+
+    def _make_graph_module(
+        self,
+        *,
+        shape: tuple[int, ...] = (5, 7),
+        dtype: torch.dtype = torch.float32,
+        gather_dim: int = 0,
+        shard_dim: int = 1,
+    ) -> fx.GraphModule:
+        graph = fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.empty(shape, dtype=dtype)
+        shard_dim_alltoall = graph.call_function(
+            torch.ops._dtensor.shard_dim_alltoall.default,
+            args=(inp, gather_dim, shard_dim, "test_pg"),
+        )
+        graph.output(shard_dim_alltoall)
+        return fx.GraphModule({}, graph)
+
+    def _run_pass(
+        self,
+        gm: fx.GraphModule,
+        *,
+        group_size: int = 4,
+    ) -> None:
+        fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
+        for node in gm.graph.nodes:
+            val = node.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                node.meta["val"] = fake_mode.from_tensor(val)
+
+        try:
+            fake_tensor_updater = FakeTensorUpdater(gm)
+        except AttributeError:
+            fake_tensor_updater = FakeTensorUpdater(gm.graph)
+
+        with (
+            mock.patch(
+                "torch.distributed.distributed_c10d._resolve_process_group",
+                return_value="resolved_pg",
+            ),
+            mock.patch(
+                "torch.distributed.distributed_c10d._get_group_size_by_name",
+                return_value=group_size,
+            ),
+        ):
+            _decompose_shard_dim_alltoall(gm)
+            with V.set_fake_mode(fake_mode):
+                fake_tensor_updater.incremental_update()
+
+    def _movedim_args(self, gm: fx.GraphModule) -> list[tuple[int, int]]:
+        return [
+            (node.args[1], node.args[2])
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten.movedim.int
+        ]
+
+    def _wait_tensor_node(self, gm: fx.GraphModule) -> fx.Node:
+        return next(
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops._c10d_functional.wait_tensor.default
+        )
+
+    def test_decomposes_divisible_shard_dim_alltoall(self) -> None:
+        counters.clear()
+        gm = self._make_graph_module(shape=(5, 8))
+
+        self._run_pass(gm)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertNotIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
+        self.assertIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
+        self.assertIn(torch.ops._c10d_functional.wait_tensor.default, targets)
+
+        alltoall_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops._c10d_functional.all_to_all_single.default
+        )
+        self.assertEqual(alltoall_node.args[1], [1, 1, 1, 1])
+        self.assertEqual(alltoall_node.args[2], [1, 1, 1, 1])
+        self.assertEqual(alltoall_node.args[3], "test_pg")
+
+        view_shapes = [
+            node.args[1]
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten.view.default
+        ]
+        self.assertIn([5, 4, 2], view_shapes)
+        self.assertIn([20, 2], view_shapes)
+        self.assertEqual(self._movedim_args(gm), [(1, 0), (0, 0)])
+        self.assertEqual(self._wait_tensor_node(gm).meta["val"].shape, (4, 5, 2))
+        self.assertIn(
+            torch.ops.aten.clone.default,
+            [node.target for node in gm.graph.nodes],
+        )
+        self.assertNotIn(
+            torch.ops.aten.contiguous.default,
+            [node.target for node in gm.graph.nodes],
+        )
+        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 1)
+
+    def test_decomposition_matches_local_reference_semantics(self) -> None:
+        group_size = 4
+        gather_dim = 2
+        shard_dim = 0
+        inputs = torch.arange(group_size * 8 * 5 * 6, dtype=torch.float32).reshape(
+            group_size, 8, 5, 6
+        )
+        per_rank_inputs = list(inputs.unbind(0))
+
+        expected = self._reference_shard_dim_alltoall(
+            per_rank_inputs,
+            gather_dim=gather_dim,
+            shard_dim=shard_dim,
+        )
+
+        # This mirrors the pass: expose the process-group dimension as dim0,
+        # all-to-all one slice per rank, then restore the final logical shape.
+        pre_alltoall = [
+            inp.view(group_size, 2, 5, 6).movedim(shard_dim, 0)
+            for inp in per_rank_inputs
+        ]
+        actual = [
+            torch.cat(
+                [pre.narrow(0, rank, 1) for pre in pre_alltoall],
+                dim=0,
+            )
+            .movedim(0, gather_dim)
+            .clone(memory_format=torch.contiguous_format)
+            .view(2, 5, 24)
+            for rank in range(group_size)
+        ]
+
+        self.assertEqual(actual, expected)
+
+    def test_skips_non_divisible_shard_dim_alltoall(self) -> None:
+        counters.clear()
+        gm = self._make_graph_module(shape=(5, 7))
+
+        self._run_pass(gm)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
+        self.assertNotIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
+        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 0)
+
+    def test_decomposes_when_gather_dim_is_after_shard_dim(self) -> None:
+        counters.clear()
+        gm = self._make_graph_module(shape=(8, 5, 6), gather_dim=2, shard_dim=0)
+
+        self._run_pass(gm)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertNotIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
+        self.assertIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
+
+        view_shapes = [
+            node.args[1]
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten.view.default
+        ]
+        self.assertIn([4, 2, 5, 6], view_shapes)
+        self.assertIn([2, 5, 24], view_shapes)
+        self.assertEqual(self._movedim_args(gm), [(0, 0), (0, 2)])
+        self.assertEqual(self._wait_tensor_node(gm).meta["val"].shape, (4, 2, 5, 6))
+        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 1)
+
+    def test_skips_complex_dtype(self) -> None:
+        counters.clear()
+        gm = self._make_graph_module(shape=(5, 8), dtype=torch.complex64)
+
+        self._run_pass(gm)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
+        self.assertNotIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
+        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 0)
+
+
+if __name__ == "__main__":
+    if IS_LINUX:
+        run_tests()

--- a/test/inductor/test_decompose_shard_dim_alltoall.py
+++ b/test/inductor/test_decompose_shard_dim_alltoall.py
@@ -1,15 +1,15 @@
 # Owner(s): ["module: inductor"]
 
+import math
 from unittest import mock
 
 import torch
 from torch import fx
 from torch._dynamo.utils import counters
-from torch._inductor.fx_passes.post_grad import _decompose_shard_dim_alltoall
-from torch._inductor.fx_utils import FakeTensorUpdater
+from torch._inductor import config
+from torch._inductor.decomposition import select_decomp_table
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.virtualized import V
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.fx.experimental.proxy_tensor import make_fx
 
 
 class TestDecomposeShardDimAllToAll(TestCase):
@@ -25,74 +25,128 @@ class TestDecomposeShardDimAllToAll(TestCase):
         gathered = torch.cat(inputs, dim=gather_dim % ndim)
         return list(torch.chunk(gathered, group_size, dim=shard_dim % ndim))
 
-    def _make_graph_module(
+    def _run_decomp_locally(
+        self,
+        inputs: list[torch.Tensor],
+        *,
+        gather_dim: int,
+        shard_dim: int,
+    ) -> list[torch.Tensor]:
+        group_size = len(inputs)
+        ndim = inputs[0].dim()
+        gather_dim = gather_dim % ndim
+        shard_dim = shard_dim % ndim
+        input_shape = list(inputs[0].shape)
+        local_shard_dim = input_shape[shard_dim] // group_size
+
+        pre_view_shape = list(input_shape)
+        pre_view_shape[shard_dim] = local_shard_dim
+        pre_view_shape.insert(shard_dim, group_size)
+
+        post_view_shape = list(input_shape)
+        post_view_shape[shard_dim] = local_shard_dim
+        post_view_shape[gather_dim] *= group_size
+
+        pre_alltoall = [
+            inp.view(pre_view_shape)
+            .movedim(shard_dim, 0)
+            .clone(memory_format=torch.contiguous_format)
+            for inp in inputs
+        ]
+        collective_outputs = [
+            torch.cat([pre.narrow(0, rank, 1) for pre in pre_alltoall], dim=0)
+            for rank in range(group_size)
+        ]
+
+        current_rank = 0
+
+        def all_to_all_single(input, output_split_sizes, input_split_sizes, group_name):
+            self.assertEqual(group_name, "test_pg")
+            self.assertEqual(output_split_sizes, [1] * group_size)
+            self.assertEqual(input_split_sizes, [1] * group_size)
+            self.assertEqual(input, pre_alltoall[current_rank])
+            return collective_outputs[current_rank]
+
+        def wait_tensor(input):
+            return input
+
+        outputs = []
+        get_group_size = self._group_size_mock(group_size)
+        with config.patch({"decompose_shard_dim_alltoall": True}):
+            with get_group_size:
+                with (
+                    mock.patch.object(
+                        torch.ops._c10d_functional.all_to_all_single,
+                        "default",
+                        side_effect=all_to_all_single,
+                    ),
+                    mock.patch.object(
+                        torch.ops._c10d_functional.wait_tensor,
+                        "default",
+                        side_effect=wait_tensor,
+                    ),
+                ):
+                    for rank, inp in enumerate(inputs):
+                        current_rank = rank
+                        outputs.append(
+                            self._decomp()(inp, gather_dim, shard_dim, "test_pg")
+                        )
+
+        return outputs
+
+    def _decomp(self):
+        return select_decomp_table()[torch.ops._dtensor.shard_dim_alltoall.default]
+
+    def _group_size_mock(self, group_size: int):
+        return mock.patch(
+            "torch.distributed.distributed_c10d._get_group_size_by_name",
+            return_value=group_size,
+        )
+
+    def _trace_decomp(
         self,
         *,
-        shape: tuple[int, ...] = (5, 7),
+        shape: tuple[int, ...],
         dtype: torch.dtype = torch.float32,
         gather_dim: int = 0,
         shard_dim: int = 1,
-    ) -> fx.GraphModule:
-        graph = fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.empty(shape, dtype=dtype)
-        shard_dim_alltoall = graph.call_function(
-            torch.ops._dtensor.shard_dim_alltoall.default,
-            args=(inp, gather_dim, shard_dim, "test_pg"),
-        )
-        graph.output(shard_dim_alltoall)
-        return fx.GraphModule({}, graph)
-
-    def _run_pass(
-        self,
-        gm: fx.GraphModule,
-        *,
         group_size: int = 4,
-    ) -> None:
-        fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
-        for node in gm.graph.nodes:
-            val = node.meta.get("val")
-            if isinstance(val, torch.Tensor):
-                node.meta["val"] = fake_mode.from_tensor(val)
+    ) -> fx.GraphModule:
+        inp = torch.empty(shape, dtype=dtype)
 
-        try:
-            fake_tensor_updater = FakeTensorUpdater(gm)
-        except AttributeError:
-            fake_tensor_updater = FakeTensorUpdater(gm.graph)
+        def fn(x):
+            return torch.ops._dtensor.shard_dim_alltoall.default(
+                x, gather_dim, shard_dim, "test_pg"
+            )
 
-        with (
-            mock.patch(
-                "torch.distributed.distributed_c10d._resolve_process_group",
-                return_value="resolved_pg",
-            ),
-            mock.patch(
-                "torch.distributed.distributed_c10d._get_group_size_by_name",
-                return_value=group_size,
-            ),
-        ):
-            _decompose_shard_dim_alltoall(gm)
-            with V.set_fake_mode(fake_mode):
-                fake_tensor_updater.incremental_update()
+        get_group_size = self._group_size_mock(group_size)
+        with config.patch({"decompose_shard_dim_alltoall": True}):
+            with get_group_size:
+                return make_fx(
+                    fn,
+                    decomposition_table=select_decomp_table(),
+                    tracing_mode="fake",
+                )(inp)
 
-    def _movedim_args(self, gm: fx.GraphModule) -> list[tuple[int, int]]:
-        return [
-            (node.args[1], node.args[2])
-            for node in gm.graph.nodes
-            if node.target is torch.ops.aten.movedim.int
-        ]
+    def _call_decomp(
+        self,
+        *,
+        shape: tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        gather_dim: int = 0,
+        shard_dim: int = 1,
+        group_size: int = 4,
+        enabled: bool = True,
+    ):
+        inp = torch.empty(shape, dtype=dtype)
+        get_group_size = self._group_size_mock(group_size)
+        with config.patch({"decompose_shard_dim_alltoall": enabled}):
+            with get_group_size:
+                return self._decomp()(inp, gather_dim, shard_dim, "test_pg")
 
-    def _wait_tensor_node(self, gm: fx.GraphModule) -> fx.Node:
-        return next(
-            node
-            for node in gm.graph.nodes
-            if node.target is torch.ops._c10d_functional.wait_tensor.default
-        )
-
-    def test_decomposes_divisible_shard_dim_alltoall(self) -> None:
+    def test_decomposition_exposes_c10d_collective(self) -> None:
         counters.clear()
-        gm = self._make_graph_module(shape=(5, 8))
-
-        self._run_pass(gm)
+        gm = self._trace_decomp(shape=(8, 5, 6), gather_dim=2, shard_dim=0)
         gm.graph.lint()
 
         targets = [node.target for node in gm.graph.nodes]
@@ -108,107 +162,120 @@ class TestDecomposeShardDimAllToAll(TestCase):
         self.assertEqual(alltoall_node.args[1], [1, 1, 1, 1])
         self.assertEqual(alltoall_node.args[2], [1, 1, 1, 1])
         self.assertEqual(alltoall_node.args[3], "test_pg")
-
-        view_shapes = [
-            node.args[1]
-            for node in gm.graph.nodes
-            if node.target is torch.ops.aten.view.default
-        ]
-        self.assertIn([5, 4, 2], view_shapes)
-        self.assertIn([20, 2], view_shapes)
-        self.assertEqual(self._movedim_args(gm), [(1, 0), (0, 0)])
-        self.assertEqual(self._wait_tensor_node(gm).meta["val"].shape, (4, 5, 2))
-        self.assertIn(
-            torch.ops.aten.clone.default,
-            [node.target for node in gm.graph.nodes],
-        )
-        self.assertNotIn(
-            torch.ops.aten.contiguous.default,
-            [node.target for node in gm.graph.nodes],
-        )
+        output_node = next(node for node in gm.graph.nodes if node.op == "output")
+        self.assertEqual(output_node.args[0].meta["val"].shape, (2, 5, 24))
         self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 1)
 
-    def test_decomposition_matches_local_reference_semantics(self) -> None:
+    def test_decomposition_matches_original_api_semantics_locally(self) -> None:
+        cases = [
+            (4, (5, 8), 0, 1),
+            (4, (8, 5, 6), 2, 0),
+            (4, (3, 8, 4), -1, 1),
+            (2, (6, 4, 5), 1, 0),
+        ]
+
+        for group_size, shape, gather_dim, shard_dim in cases:
+            with self.subTest(
+                group_size=group_size,
+                shape=shape,
+                gather_dim=gather_dim,
+                shard_dim=shard_dim,
+            ):
+                inputs = torch.arange(
+                    group_size * math.prod(shape),
+                    dtype=torch.float32,
+                ).reshape(group_size, *shape)
+                per_rank_inputs = list(inputs.unbind(0))
+
+                expected = self._reference_shard_dim_alltoall(
+                    per_rank_inputs,
+                    gather_dim=gather_dim,
+                    shard_dim=shard_dim,
+                )
+                actual = self._run_decomp_locally(
+                    per_rank_inputs,
+                    gather_dim=gather_dim,
+                    shard_dim=shard_dim,
+                )
+
+                self.assertEqual(actual, expected)
+                self.assertTrue(all(out.is_contiguous() for out in actual))
+
+    def test_backward_formula_matches_original_api_semantics_locally(self) -> None:
         group_size = 4
+        input_shape = (8, 5, 6)
         gather_dim = 2
         shard_dim = 0
-        inputs = torch.arange(group_size * 8 * 5 * 6, dtype=torch.float32).reshape(
-            group_size, 8, 5, 6
-        )
-        per_rank_inputs = list(inputs.unbind(0))
-
-        expected = self._reference_shard_dim_alltoall(
-            per_rank_inputs,
+        inputs = torch.arange(
+            group_size * math.prod(input_shape),
+            dtype=torch.float32,
+        ).reshape(group_size, *input_shape)
+        forward_outputs = self._reference_shard_dim_alltoall(
+            list(inputs.unbind(0)),
             gather_dim=gather_dim,
             shard_dim=shard_dim,
         )
 
-        # This mirrors the pass: expose the process-group dimension as dim0,
-        # all-to-all one slice per rank, then restore the final logical shape.
-        pre_alltoall = [
-            inp.view(group_size, 2, 5, 6).movedim(shard_dim, 0)
-            for inp in per_rank_inputs
-        ]
-        actual = [
-            torch.cat(
-                [pre.narrow(0, rank, 1) for pre in pre_alltoall],
-                dim=0,
-            )
-            .movedim(0, gather_dim)
-            .clone(memory_format=torch.contiguous_format)
-            .view(2, 5, 24)
-            for rank in range(group_size)
+        grad_outputs = [
+            torch.arange(out.numel(), dtype=torch.float32).reshape(out.shape) + rank
+            for rank, out in enumerate(forward_outputs)
         ]
 
-        self.assertEqual(actual, expected)
+        expected_grads = self._reference_shard_dim_alltoall(
+            grad_outputs,
+            gather_dim=shard_dim,
+            shard_dim=gather_dim,
+        )
+        actual_grads = self._run_decomp_locally(
+            grad_outputs,
+            gather_dim=shard_dim,
+            shard_dim=gather_dim,
+        )
+        self.assertEqual(actual_grads, expected_grads)
 
-    def test_skips_non_divisible_shard_dim_alltoall(self) -> None:
-        counters.clear()
-        gm = self._make_graph_module(shape=(5, 7))
-
-        self._run_pass(gm)
-        gm.graph.lint()
-
-        targets = [node.target for node in gm.graph.nodes]
-        self.assertIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
-        self.assertNotIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
-        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 0)
-
-    def test_decomposes_when_gather_dim_is_after_shard_dim(self) -> None:
-        counters.clear()
-        gm = self._make_graph_module(shape=(8, 5, 6), gather_dim=2, shard_dim=0)
-
-        self._run_pass(gm)
-        gm.graph.lint()
-
-        targets = [node.target for node in gm.graph.nodes]
-        self.assertNotIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
-        self.assertIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
-
-        view_shapes = [
-            node.args[1]
-            for node in gm.graph.nodes
-            if node.target is torch.ops.aten.view.default
+    def test_falls_back_for_unsupported_cases(self) -> None:
+        cases = [
+            {"shape": (5, 8), "enabled": False},
+            {"shape": (5, 7)},
+            {"shape": (5, 8), "dtype": torch.complex64},
+            {"shape": (5, 8), "gather_dim": 1, "shard_dim": 1},
         ]
-        self.assertIn([4, 2, 5, 6], view_shapes)
-        self.assertIn([2, 5, 24], view_shapes)
-        self.assertEqual(self._movedim_args(gm), [(0, 0), (0, 2)])
-        self.assertEqual(self._wait_tensor_node(gm).meta["val"].shape, (4, 2, 5, 6))
-        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 1)
 
-    def test_skips_complex_dtype(self) -> None:
-        counters.clear()
-        gm = self._make_graph_module(shape=(5, 8), dtype=torch.complex64)
+        for case in cases:
+            with self.subTest(**case):
+                counters.clear()
+                result = self._call_decomp(**case)
+                self.assertIs(result, NotImplemented)
+                self.assertEqual(
+                    counters["inductor"]["decompose_shard_dim_alltoall"], 0
+                )
 
-        self._run_pass(gm)
-        gm.graph.lint()
+    def test_shard_dim_alltoall_registered_autograd_backward(self) -> None:
+        import torch.distributed.tensor._collective_utils
 
-        targets = [node.target for node in gm.graph.nodes]
-        self.assertIn(torch.ops._dtensor.shard_dim_alltoall.default, targets)
-        self.assertNotIn(torch.ops._c10d_functional.all_to_all_single.default, targets)
-        self.assertEqual(counters["inductor"]["decompose_shard_dim_alltoall"], 0)
+        calls = []
+
+        with torch.library._scoped_library("_dtensor", "IMPL") as lib:
+
+            def impl(input, gather_dim: int, shard_dim: int, group_name):
+                calls.append((input, gather_dim, shard_dim, group_name))
+                if len(calls) == 1:
+                    return input.detach().clone()
+                return torch.full_like(input, 7.0)
+
+            lib.impl("shard_dim_alltoall", impl, "CPU")
+
+            x = torch.randn(2, 3, 4, requires_grad=True)
+            y = torch.ops._dtensor.shard_dim_alltoall.default(x, 2, 0, "test_pg")
+            self.assertTrue(y.requires_grad)
+            y.sum().backward()
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][1:], (2, 0, "test_pg"))
+        self.assertEqual(calls[1][1:], (0, 2, "test_pg"))
+        self.assertFalse(calls[1][0].requires_grad)
+        self.assertEqual(x.grad, torch.full_like(x, 7.0))
 
 
 if __name__ == "__main__":
-    if IS_LINUX:
-        run_tests()
+    run_tests()

--- a/test/inductor/test_decompose_shard_dim_alltoall.py
+++ b/test/inductor/test_decompose_shard_dim_alltoall.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import math
+import unittest
 from unittest import mock
 
 import torch
@@ -12,6 +13,7 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
+@unittest.skipIf(not torch.distributed.is_available(), "requires distributed support")
 class TestDecomposeShardDimAllToAll(TestCase):
     def _reference_shard_dim_alltoall(
         self,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -415,6 +415,13 @@ mixed_mm_choice: Literal["default", "triton", "aten", "heuristic"] = "heuristic"
 # enable reordering pass for increasing overlap between compute and communication
 reorder_for_compute_comm_overlap = False
 
+# Decompose DTensor Shard(dim) -> Shard(other_dim) all-to-all into explicit
+# layout ops plus _c10d_functional.all_to_all_single/wait_tensor. This is
+# experimental and intentionally opt-in.
+decompose_shard_dim_alltoall_fx = (
+    os.environ.get("TORCHINDUCTOR_DECOMPOSE_SHARD_DIM_ALLTOALL", "0") == "1"
+)
+
 # passes (in execution order) for increasing overlap between compute and communication
 # for built-in passes, use string name; for user-defined passes, pass in the function handle
 # WARNING: Inductor scheduler IR is at prototype stage and subject to change,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -418,7 +418,7 @@ reorder_for_compute_comm_overlap = False
 # Decompose DTensor Shard(dim) -> Shard(other_dim) all-to-all into explicit
 # layout ops plus _c10d_functional.all_to_all_single/wait_tensor. This is
 # experimental and intentionally opt-in.
-decompose_shard_dim_alltoall_fx = (
+decompose_shard_dim_alltoall = (
     os.environ.get("TORCHINDUCTOR_DECOMPOSE_SHARD_DIM_ALLTOALL", "0") == "1"
 )
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -160,68 +160,70 @@ def register_decomposition(
     return decomp.register_decomposition(ops, decompositions)
 
 
-@register_decomposition([torch.ops._dtensor.shard_dim_alltoall.default])
-def shard_dim_alltoall_decomp(
-    inp: torch.Tensor,
-    gather_dim: int,
-    shard_dim: int,
-    group_name: str,
-) -> torch.Tensor:
-    if not config.decompose_shard_dim_alltoall:
-        return NotImplemented
-    if inp.dtype.is_complex:
-        return NotImplemented
+if torch.distributed.is_available():
 
-    ndim = inp.dim()
-    gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
-    shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
-    if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
-        return NotImplemented
-    if gather_dim == shard_dim:
-        return NotImplemented
+    @register_decomposition([torch.ops._dtensor.shard_dim_alltoall.default])
+    def shard_dim_alltoall_decomp(
+        inp: torch.Tensor,
+        gather_dim: int,
+        shard_dim: int,
+        group_name: str,
+    ) -> torch.Tensor:
+        if not config.decompose_shard_dim_alltoall:
+            return NotImplemented
+        if inp.dtype.is_complex:
+            return NotImplemented
 
-    try:
-        from torch.distributed.distributed_c10d import (
-            _get_group_size_by_name,
-            GroupName,
+        ndim = inp.dim()
+        gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
+        shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
+        if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
+            return NotImplemented
+        if gather_dim == shard_dim:
+            return NotImplemented
+
+        try:
+            from torch.distributed.distributed_c10d import (
+                _get_group_size_by_name,
+                GroupName,
+            )
+
+            group_size = _get_group_size_by_name(GroupName(group_name))
+        except (RuntimeError, ValueError):
+            return NotImplemented
+
+        input_shape = list(inp.shape)
+        shard_dim_size = input_shape[shard_dim]
+        # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
+        # shards before reaching this op, so the local shard dim should split
+        # evenly across the process group here. If the guard fails at runtime,
+        # Dynamo recompiles and may keep the original shard_dim_alltoall fallback.
+        if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
+            return NotImplemented
+        local_shard_dim_size = shard_dim_size // group_size
+
+        pre_view_shape = list(input_shape)
+        pre_view_shape[shard_dim] = local_shard_dim_size
+        pre_view_shape.insert(shard_dim, group_size)
+
+        post_view_shape = list(input_shape)
+        post_view_shape[shard_dim] = local_shard_dim_size
+        post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
+
+        out = aten.view.default(inp, pre_view_shape)
+        out = aten.movedim.int(out, shard_dim, 0)
+        out = aten.clone.default(out, memory_format=torch.contiguous_format)
+        out = torch.ops._c10d_functional.all_to_all_single.default(
+            out,
+            [1] * group_size,
+            [1] * group_size,
+            group_name,
         )
-
-        group_size = _get_group_size_by_name(GroupName(group_name))
-    except (RuntimeError, ValueError):
-        return NotImplemented
-
-    input_shape = list(inp.shape)
-    shard_dim_size = input_shape[shard_dim]
-    # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
-    # shards before reaching this op, so the local shard dim should split
-    # evenly across the process group here. If the guard fails at runtime,
-    # Dynamo recompiles and may keep the original shard_dim_alltoall fallback.
-    if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
-        return NotImplemented
-    local_shard_dim_size = shard_dim_size // group_size
-
-    pre_view_shape = list(input_shape)
-    pre_view_shape[shard_dim] = local_shard_dim_size
-    pre_view_shape.insert(shard_dim, group_size)
-
-    post_view_shape = list(input_shape)
-    post_view_shape[shard_dim] = local_shard_dim_size
-    post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
-
-    out = aten.view.default(inp, pre_view_shape)
-    out = aten.movedim.int(out, shard_dim, 0)
-    out = aten.clone.default(out, memory_format=torch.contiguous_format)
-    out = torch.ops._c10d_functional.all_to_all_single.default(
-        out,
-        [1] * group_size,
-        [1] * group_size,
-        group_name,
-    )
-    out = torch.ops._c10d_functional.wait_tensor.default(out)
-    out = aten.movedim.int(out, 0, gather_dim)
-    out = aten.clone.default(out, memory_format=torch.contiguous_format)
-    counters["inductor"]["decompose_shard_dim_alltoall"] += 1
-    return aten.view.default(out, post_view_shape)
+        out = torch.ops._c10d_functional.wait_tensor.default(out)
+        out = aten.movedim.int(out, 0, gather_dim)
+        out = aten.clone.default(out, memory_format=torch.contiguous_format)
+        counters["inductor"]["decompose_shard_dim_alltoall"] += 1
+        return aten.view.default(out, post_view_shape)
 
 
 @register_decomposition([aten.lerp.Scalar])

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -36,7 +36,11 @@ from torch._prims_common import (
     type_to_dtype,
 )
 from torch._refs import native_layer_norm as decomp_native_layer_norm
-from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
+from torch.fx.experimental.symbolic_shapes import (
+    guard_or_false,
+    statically_known_true,
+    sym_eq,
+)
 
 from . import config, inductor_prims
 from .utils import (
@@ -154,6 +158,70 @@ def register_decomposition(
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)
     return decomp.register_decomposition(ops, decompositions)
+
+
+@register_decomposition([torch.ops._dtensor.shard_dim_alltoall.default])
+def shard_dim_alltoall_decomp(
+    inp: torch.Tensor,
+    gather_dim: int,
+    shard_dim: int,
+    group_name: str,
+) -> torch.Tensor:
+    if not config.decompose_shard_dim_alltoall:
+        return NotImplemented
+    if inp.dtype.is_complex:
+        return NotImplemented
+
+    ndim = inp.dim()
+    gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
+    shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
+    if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
+        return NotImplemented
+    if gather_dim == shard_dim:
+        return NotImplemented
+
+    try:
+        from torch.distributed.distributed_c10d import (
+            _get_group_size_by_name,
+            GroupName,
+        )
+
+        group_size = _get_group_size_by_name(GroupName(group_name))
+    except (RuntimeError, ValueError):
+        return NotImplemented
+
+    input_shape = list(inp.shape)
+    shard_dim_size = input_shape[shard_dim]
+    # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
+    # shards before reaching this op, so the local shard dim should split
+    # evenly across the process group here. If the guard fails at runtime,
+    # Dynamo recompiles and may keep the original shard_dim_alltoall fallback.
+    if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
+        return NotImplemented
+    local_shard_dim_size = shard_dim_size // group_size
+
+    pre_view_shape = list(input_shape)
+    pre_view_shape[shard_dim] = local_shard_dim_size
+    pre_view_shape.insert(shard_dim, group_size)
+
+    post_view_shape = list(input_shape)
+    post_view_shape[shard_dim] = local_shard_dim_size
+    post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
+
+    out = aten.view.default(inp, pre_view_shape)
+    out = aten.movedim.int(out, shard_dim, 0)
+    out = aten.clone.default(out, memory_format=torch.contiguous_format)
+    out = torch.ops._c10d_functional.all_to_all_single.default(
+        out,
+        [1] * group_size,
+        [1] * group_size,
+        group_name,
+    )
+    out = torch.ops._c10d_functional.wait_tensor.default(out)
+    out = aten.movedim.int(out, 0, gather_dim)
+    out = aten.clone.default(out, memory_format=torch.contiguous_format)
+    counters["inductor"]["decompose_shard_dim_alltoall"] += 1
+    return aten.view.default(out, post_view_shape)
 
 
 @register_decomposition([aten.lerp.Scalar])

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -22,7 +22,11 @@ from torch._inductor.custom_graph_pass import (
 from torch._inductor.virtualized import ops  # noqa: F401
 from torch._logging import trace_structured
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
-from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
+from torch.fx.experimental.symbolic_shapes import (
+    guard_or_false,
+    statically_known_true,
+    sym_eq,
+)
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config, ir, pattern_matcher  # noqa: F401
@@ -87,6 +91,124 @@ pass_patterns = [
     PatternMatcherPass(),
     PatternMatcherPass(),
 ]
+
+
+def _decompose_shard_dim_alltoall(gm: fx.GraphModule) -> None:
+    from torch.distributed.distributed_c10d import (
+        _get_group_size_by_name,
+        _resolve_process_group,
+        GroupName,
+    )
+
+    graph = gm.graph
+    target = torch.ops._dtensor.shard_dim_alltoall.default
+    decomposed = 0
+
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.target is not target:
+            continue
+        if len(node.args) != 4:
+            continue
+
+        inp, gather_dim, shard_dim, group_name = node.args
+        if not isinstance(inp, fx.Node):
+            continue
+        if not isinstance(gather_dim, int) or not isinstance(shard_dim, int):
+            continue
+
+        inp_val = inp.meta.get("val")
+        if not isinstance(inp_val, torch.Tensor):
+            continue
+        if inp_val.dtype.is_complex:
+            continue
+
+        ndim = inp_val.dim()
+        gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
+        shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
+        if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
+            continue
+        if gather_dim == shard_dim:
+            continue
+
+        try:
+            group = (
+                _resolve_process_group(GroupName(group_name))
+                if isinstance(group_name, str)
+                else group_name
+            )
+            group_size = _get_group_size_by_name(group)
+        except (RuntimeError, ValueError):
+            continue
+
+        input_shape: list[Any] = list(inp_val.shape)
+        shard_dim_size = input_shape[shard_dim]
+        # Dynamic shapes can still decompose under a divisibility shape guard.
+        # If the guard fails at runtime, Dynamo recompiles and may keep the
+        # original shard_dim_alltoall fallback instead.
+        if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
+            continue
+
+        # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
+        # shards before reaching this op, so the local shard dim should split
+        # evenly across the process group here. The emitted collective is
+        # rank-symmetric; all_to_all_single performs the redistribution.
+        local_shard_dim_size = shard_dim_size // group_size
+
+        pre_view_shape: list[Any] = list(input_shape)
+        pre_view_shape[shard_dim] = local_shard_dim_size
+        pre_view_shape.insert(shard_dim, group_size)
+
+        post_view_shape: list[Any] = list(input_shape)
+        post_view_shape[shard_dim] = local_shard_dim_size
+        post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
+
+        with graph.inserting_before(node):
+            pre_view = graph.call_function(
+                torch.ops.aten.view.default,
+                args=(inp, pre_view_shape),
+            )
+            pre_movedim = graph.call_function(
+                torch.ops.aten.movedim.int,
+                args=(pre_view, shard_dim, 0),
+            )
+            pre_clone = graph.call_function(
+                torch.ops.aten.clone.default,
+                args=(pre_movedim,),
+                kwargs={"memory_format": torch.contiguous_format},
+            )
+            all2all = graph.call_function(
+                torch.ops._c10d_functional.all_to_all_single.default,
+                args=(
+                    pre_clone,
+                    [1] * group_size,
+                    [1] * group_size,
+                    group_name,
+                ),
+            )
+            wait = graph.call_function(
+                torch.ops._c10d_functional.wait_tensor.default,
+                args=(all2all,),
+            )
+            post_movedim = graph.call_function(
+                torch.ops.aten.movedim.int,
+                args=(wait, 0, gather_dim),
+            )
+            post_clone = graph.call_function(
+                torch.ops.aten.clone.default,
+                args=(post_movedim,),
+                kwargs={"memory_format": torch.contiguous_format},
+            )
+            post_view = graph.call_function(
+                torch.ops.aten.view.default,
+                args=(post_clone, post_view_shape),
+            )
+
+        node.replace_all_uses_with(post_view)
+        graph.erase_node(node)
+        decomposed += 1
+
+    if decomposed:
+        counters["inductor"]["decompose_shard_dim_alltoall"] += decomposed
 
 
 def _remove_profiler_ops(graph: torch.fx.Graph) -> None:
@@ -322,6 +444,12 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         from torch._inductor.fx_passes.decomp_comms import decomp_comms
 
         GraphTransformObserver(gm, "decomp_comms").apply_gm_pass(decomp_comms)
+
+    if config.decompose_shard_dim_alltoall_fx:
+        GraphTransformObserver(gm, "decompose_shard_dim_alltoall").apply_gm_pass(
+            _decompose_shard_dim_alltoall
+        )
+        fake_tensor_updater.incremental_update()
 
     collectives_bucketing: bool = False
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -22,11 +22,7 @@ from torch._inductor.custom_graph_pass import (
 from torch._inductor.virtualized import ops  # noqa: F401
 from torch._logging import trace_structured
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
-from torch.fx.experimental.symbolic_shapes import (
-    guard_or_false,
-    statically_known_true,
-    sym_eq,
-)
+from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config, ir, pattern_matcher  # noqa: F401
@@ -91,124 +87,6 @@ pass_patterns = [
     PatternMatcherPass(),
     PatternMatcherPass(),
 ]
-
-
-def _decompose_shard_dim_alltoall(gm: fx.GraphModule) -> None:
-    from torch.distributed.distributed_c10d import (
-        _get_group_size_by_name,
-        _resolve_process_group,
-        GroupName,
-    )
-
-    graph = gm.graph
-    target = torch.ops._dtensor.shard_dim_alltoall.default
-    decomposed = 0
-
-    for node in list(graph.nodes):
-        if node.op != "call_function" or node.target is not target:
-            continue
-        if len(node.args) != 4:
-            continue
-
-        inp, gather_dim, shard_dim, group_name = node.args
-        if not isinstance(inp, fx.Node):
-            continue
-        if not isinstance(gather_dim, int) or not isinstance(shard_dim, int):
-            continue
-
-        inp_val = inp.meta.get("val")
-        if not isinstance(inp_val, torch.Tensor):
-            continue
-        if inp_val.dtype.is_complex:
-            continue
-
-        ndim = inp_val.dim()
-        gather_dim = gather_dim + ndim if gather_dim < 0 else gather_dim
-        shard_dim = shard_dim + ndim if shard_dim < 0 else shard_dim
-        if not (0 <= gather_dim < ndim and 0 <= shard_dim < ndim):
-            continue
-        if gather_dim == shard_dim:
-            continue
-
-        try:
-            group = (
-                _resolve_process_group(GroupName(group_name))
-                if isinstance(group_name, str)
-                else group_name
-            )
-            group_size = _get_group_size_by_name(group)
-        except (RuntimeError, ValueError):
-            continue
-
-        input_shape: list[Any] = list(inp_val.shape)
-        shard_dim_size = input_shape[shard_dim]
-        # Dynamic shapes can still decompose under a divisibility shape guard.
-        # If the guard fails at runtime, Dynamo recompiles and may keep the
-        # original shard_dim_alltoall fallback instead.
-        if not guard_or_false(sym_eq(shard_dim_size % group_size, 0)):
-            continue
-
-        # Match eager shard_dim_alltoall semantics. DTensor pads uneven logical
-        # shards before reaching this op, so the local shard dim should split
-        # evenly across the process group here. The emitted collective is
-        # rank-symmetric; all_to_all_single performs the redistribution.
-        local_shard_dim_size = shard_dim_size // group_size
-
-        pre_view_shape: list[Any] = list(input_shape)
-        pre_view_shape[shard_dim] = local_shard_dim_size
-        pre_view_shape.insert(shard_dim, group_size)
-
-        post_view_shape: list[Any] = list(input_shape)
-        post_view_shape[shard_dim] = local_shard_dim_size
-        post_view_shape[gather_dim] = post_view_shape[gather_dim] * group_size
-
-        with graph.inserting_before(node):
-            pre_view = graph.call_function(
-                torch.ops.aten.view.default,
-                args=(inp, pre_view_shape),
-            )
-            pre_movedim = graph.call_function(
-                torch.ops.aten.movedim.int,
-                args=(pre_view, shard_dim, 0),
-            )
-            pre_clone = graph.call_function(
-                torch.ops.aten.clone.default,
-                args=(pre_movedim,),
-                kwargs={"memory_format": torch.contiguous_format},
-            )
-            all2all = graph.call_function(
-                torch.ops._c10d_functional.all_to_all_single.default,
-                args=(
-                    pre_clone,
-                    [1] * group_size,
-                    [1] * group_size,
-                    group_name,
-                ),
-            )
-            wait = graph.call_function(
-                torch.ops._c10d_functional.wait_tensor.default,
-                args=(all2all,),
-            )
-            post_movedim = graph.call_function(
-                torch.ops.aten.movedim.int,
-                args=(wait, 0, gather_dim),
-            )
-            post_clone = graph.call_function(
-                torch.ops.aten.clone.default,
-                args=(post_movedim,),
-                kwargs={"memory_format": torch.contiguous_format},
-            )
-            post_view = graph.call_function(
-                torch.ops.aten.view.default,
-                args=(post_clone, post_view_shape),
-            )
-
-        node.replace_all_uses_with(post_view)
-        graph.erase_node(node)
-        decomposed += 1
-
-    if decomposed:
-        counters["inductor"]["decompose_shard_dim_alltoall"] += decomposed
 
 
 def _remove_profiler_ops(graph: torch.fx.Graph) -> None:
@@ -444,12 +322,6 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         from torch._inductor.fx_passes.decomp_comms import decomp_comms
 
         GraphTransformObserver(gm, "decomp_comms").apply_gm_pass(decomp_comms)
-
-    if config.decompose_shard_dim_alltoall_fx:
-        GraphTransformObserver(gm, "decompose_shard_dim_alltoall").apply_gm_pass(
-            _decompose_shard_dim_alltoall
-        )
-        fake_tensor_updater.incremental_update()
 
     collectives_bucketing: bool = False
 

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -79,6 +79,31 @@ def _shard_dim_alltoall_meta(
     return chunk.contiguous()
 
 
+def _shard_dim_alltoall_backward(ctx, grad_output):
+    return (
+        torch.ops._dtensor.shard_dim_alltoall.default(
+            grad_output.contiguous(), ctx.shard_dim, ctx.gather_dim, ctx.group_name
+        ),
+        None,
+        None,
+        None,
+    )
+
+
+def _shard_dim_alltoall_setup_context(ctx, inputs, output):
+    input, gather_dim, shard_dim, group_name = inputs
+    ctx.gather_dim = gather_dim
+    ctx.shard_dim = shard_dim
+    ctx.group_name = group_name
+
+
+torch.library.register_autograd(
+    "_dtensor::shard_dim_alltoall",
+    _shard_dim_alltoall_backward,
+    setup_context=_shard_dim_alltoall_setup_context,
+)
+
+
 def shard_dim_alltoall(input, gather_dim, shard_dim, mesh, mesh_dim):
     if mesh.device_type == "cpu" and local_tensor_mode() is None:
         # Gloo does not support alltoall, so falling back to allgather + chunk


### PR DESCRIPTION
Summary:
- add an opt-in regular Inductor decomposition for `_dtensor.shard_dim_alltoall` into layout ops plus `_c10d_functional.all_to_all_single`/`wait_tensor`
- decompose only when the dims are valid, the dtype is supported, the process group size is resolvable, and the local shard dim is evenly divisible by the process group size; otherwise keep the original op via `NotImplemented`
- register an autograd formula for `_dtensor::shard_dim_alltoall` that swaps `gather_dim`/`shard_dim` in backward, so compiled/AOTAutograd DTensor redistributes do not silently drop this gradient. This registration is always-on and is not gated by `TORCHINDUCTOR_DECOMPOSE_SHARD_DIM_ALLTOALL`.
- add unit coverage for exposing the c10d collective, local semantic equivalence, fallback cases, and a real `.backward()` through the registered autograd formula

This makes the all-to-all communication visible as standard functional collectives so later FX collective bucketing/overlap passes can reason about it. The decomposition is disabled by default and guarded by `TORCHINDUCTOR_DECOMPOSE_SHARD_DIM_ALLTOALL=1`.

Note: the autograd registration is separable from the opt-in decomposition, but is included here because regular decomposition is selected before AOTAutograd and `_dtensor::shard_dim_alltoall` needs a traceable backward formula when the op appears in compiled backward graphs.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo