### PR TITLE
fix: Docs are little bit outdated for torch logs

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -455,6 +455,9 @@ def set_logs(
             needs to be set. This can be done by providing the fully-qualified module
             name as the key, with the log level as the value. Default: ``None``
 
+        cudagraphs (:class:`bool`):
+            Whether to emit debug info from wrapping Inductor generated code with CUDA graphs. Default: ``False``
+
         cudagraph_static_inputs (:class:`bool`):
             Whether to emit debug info for cudagraph static input detection. Default: ``False``
 
@@ -475,6 +478,16 @@ def set_logs(
 
         hierarchical_compile (:class:`bool`):
             Whether to emit debug info for hierarchical compilation. Default: ``False``
+
+        compiled_autograd (:class:`bool`):
+            Whether to emit compiled autograd logs, including graphs. Default: ``False``
+
+        compiled_autograd_verbose (:class:`bool`):
+            Whether to emit verbose compiled autograd logs with C++ info, such as
+            autograd node to FX node mappings. Default: ``False``
+
+        compute_dependencies (:class:`bool`):
+            Whether to emit Inductor compute dependency information. Default: ``False``
 
         caching (:class:`bool`):
             Whether to emit detailed Inductor caching information. Default: ``False``

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -453,6 +453,9 @@ def set_logs(
             needs to be set. This can be done by providing the fully-qualified module
             name as the key, with the log level as the value. Default: ``None``
 
+        cudagraphs (:class:`bool`):
+            Whether to emit debug info from wrapping Inductor generated code with CUDA graphs. Default: ``False``
+
         cudagraph_static_inputs (:class:`bool`):
             Whether to emit debug info for cudagraph static input detection. Default: ``False``
 
@@ -470,6 +473,16 @@ def set_logs(
 
         hierarchical_compile (:class:`bool`):
             Whether to emit debug info for hierarchical compilation. Default: ``False``
+
+        compiled_autograd (:class:`bool`):
+            Whether to emit compiled autograd logs, including graphs. Default: ``False``
+
+        compiled_autograd_verbose (:class:`bool`):
+            Whether to emit verbose compiled autograd logs with C++ info, such as
+            autograd node to FX node mappings. Default: ``False``
+
+        compute_dependencies (:class:`bool`):
+            Whether to emit Inductor compute dependency information. Default: ``False``
 
         caching (:class:`bool`):
             Whether to emit detailed Inductor caching information. Default: ``False``


### PR DESCRIPTION
## Summary

The issue reports that the torch logs docs are outdated. The user-facing reference for torch logs is the `torch._logging.set_logs` API doc, which is generated from the function docstring in `torch/_logging/_internal.py` and is linked from the torch logs tutorial.


## Root cause

The issue reports that the torch logs docs are outdated. The user-facing
reference for torch logs is the `torch._logging.set_logs` API doc, which is
generated from the function docstring in `torch/_logging/_internal.py` and is
linked from the torch logs tutorial.

Over time, new logging artifacts were added as keyword arguments to
`set_logs`, but their descriptions were never added to the docstring's
"Keyword args" section. As a result the rendered API doc was missing entries
for four artifacts that the function actually accepts:

- `cudagraphs`
- `compiled_autograd`
- `compiled_autograd_verbose`
- `compute_dependencies`

These artifacts are already registered in `torch/_logging/_registrations.py`
and listed in `docs/source/logging.md`, so the docstring was the one place
left out of sync.


## What changed

File: `torch/_logging/_internal.py`

Added the four missing keyword-argument descriptions to the `set_logs`
docstring, matching the existing format and using descriptions consistent with
`docs/source/logging.md`:

- `cudagraphs`: placed next to the related `cudagraph_static_inputs` entry.
- `compiled_autograd`, `compiled_autograd_verbose`, `compute_dependencies`:
 placed just before the `caching` entry.

No code behavior changed; this is a documentation-only fix. The signature
already accepted these arguments, so no functional change was needed.


## Issue

Fixes #137285

Issue: https://github.com/pytorch/pytorch/issues/137285


## Diffstat

```
torch/_logging/_internal.py | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.