### PR TITLE
Fix link to AI-Assisted Development policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/fix_issue.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix_issue.md
@@ -2,7 +2,7 @@
 
 Before submitting, please review:
 - [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
-- [AI-Assisted Development](CONTRIBUTING.md#ai-assisted-development) policy
+- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy
 
 ---
 


### PR DESCRIPTION
While I was wondering why people don't look at the contributing guide before submitting a PR, surprisingly it probably is because the PR templates never show up as a dropdown manu or something like that, and instead, one has to specify the template file name after the url to get the PR templated.

https://stackoverflow.com/a/73870512
https://github.com/orgs/community/discussions/4620