### PR TITLE
[BE] Handle dim=None in torch.nanmedian 

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2549,7 +2549,7 @@ if TYPE_CHECKING:
 
 # Ops not to be exposed in `torch` namespace,
 # mostly helper ops.
-PRIVATE_OPS = ("unique_dim",)
+PRIVATE_OPS = ("unique_dim", "nanmedian")
 
 __name, __obj = "", None
 for __name in dir(_C._VariableFunctions):
@@ -2567,6 +2567,24 @@ for __name in dir(_C._VariableFunctions):
         __all__.append(__name)
 
 del __name, __obj
+
+
+def nanmedian(
+    input: Tensor,
+    dim: builtins.int | None = None,
+    keepdim: builtins.bool = False,
+    *,
+    out: Tensor | None = None,
+) -> Tensor | tuple[Tensor, Tensor]:
+    if dim is None:
+        if out is not None:
+            return _VF.nanmedian(input, out=out)  # type: ignore[arg-type]
+        return _VF.nanmedian(input)
+
+    return _VF.nanmedian(input, dim, keepdim, out=out)
+
+
+__all__.append("nanmedian")
 
 ################################################################################
 # Add torch.dtype instances to the public API

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1108,6 +1108,13 @@ class Tensor(torch._C.TensorBase):
             self, return_inverse=return_inverse, return_counts=return_counts, dim=dim
         )
 
+    def nanmedian(self, dim=None, keepdim=False):
+        if has_torch_function_unary(self):
+            return handle_torch_function(
+                Tensor.nanmedian, (self,), self, dim=dim, keepdim=keepdim
+            )
+        return torch.nanmedian(self, dim=dim, keepdim=keepdim)
+
     @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rsub__(self, other: Union["Tensor", int, float, bool, complex]) -> "Tensor":
         return _C._VariableFunctions.rsub(self, other)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/188087                                                                                  
                                                                                                                                          
`torch.nanmedian(x, dim=None)` fell through to the named-tensor `Dimname dim` overload and raised a confusing error:                    
                                                                                                                                        
RuntimeError: Please look up dimensions by name, got: name = None.                                                                      
                                                                                                                                        
Added a Python wrapper that intercepts `dim=None` and delegates to the no-dim overload, matching the behavior of omitting `dim`.        
                                                                                                                                        
Same fix applied to `Tensor.nanmedian` for consistency.                                                                                 
                                                                                                                                        
**Test Plan:**                                                                                                                          
                                                                                                                                        
- `spin lint` passes                                                                                                                    
- Verified `torch.nanmedian(x, dim=None) == torch.nanmedian(x)`                                                                         
- Existing `torch.nanmedian(x, dim=0)` usage unaffected    