### PR TITLE
Replace std::lock+adopt_lock with std::scoped_lock

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -432,9 +432,7 @@ struct CachingHostAllocatorImpl {
 
   void free_from_pool(BlockPool &pool) {
     for (size_t i = 0; i < pool.free_list_.size(); ++i) {
-      std::lock(pool.free_list_[i].mutex_, pool.blocks_mutex_);
-      std::lock_guard<std::mutex> gf(pool.free_list_[i].mutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> gb(pool.blocks_mutex_, std::adopt_lock);
+      std::scoped_lock lock(pool.free_list_[i].mutex_, pool.blocks_mutex_);
 
       std::vector<B*> blocks_to_remove(pool.free_list_[i].list_.begin(),
                                        pool.free_list_[i].list_.end());
@@ -500,12 +498,8 @@ struct CachingHostAllocatorImpl {
     // free list mutexes and the blocks mutex. Previously, this was only done in
     // empty_cache function.
     for (size_t i = 0; i < default_pool_.free_list_.size(); ++i) {
-      std::lock(
+      std::scoped_lock lock(
           default_pool_.free_list_[i].mutex_, default_pool_.blocks_mutex_);
-      std::lock_guard<std::mutex> gf(
-          default_pool_.free_list_[i].mutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> gb(
-          default_pool_.blocks_mutex_, std::adopt_lock);
 
       // We collect the slow-path stats only once, since they are not collected
       // per bucket (we pick index 0 arbitrarily). These are also all the host
@@ -540,12 +534,8 @@ struct CachingHostAllocatorImpl {
     // free list mutexes and the blocks mutex. Previously, this was only done in
     // empty_cache function.
     for (size_t i = 0; i < default_pool_.free_list_.size(); ++i) {
-      std::lock(
+      std::scoped_lock lock(
           default_pool_.free_list_[i].mutex_, default_pool_.blocks_mutex_);
-      std::lock_guard<std::mutex> gf(
-          default_pool_.free_list_[i].mutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> gb(
-          default_pool_.blocks_mutex_, std::adopt_lock);
 
       if (i == 0) {
         stats_.allocations.reset_accumulated();
@@ -570,12 +560,8 @@ struct CachingHostAllocatorImpl {
     // free list mutexes and the blocks mutex. Previously, this was only done in
     // empty_cache function.
     for (size_t i = 0; i < default_pool_.free_list_.size(); ++i) {
-      std::lock(
+      std::scoped_lock lock(
           default_pool_.free_list_[i].mutex_, default_pool_.blocks_mutex_);
-      std::lock_guard<std::mutex> gf(
-          default_pool_.free_list_[i].mutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> gb(
-          default_pool_.blocks_mutex_, std::adopt_lock);
 
       if (i == 0) {
         stats_.allocations.reset_peak();
@@ -735,9 +721,7 @@ struct CachingHostAllocatorImpl {
     auto index = size_index(size);
 
     if (size > pinned_max_cached_size()) {
-      std::lock(pool.free_list_[index].mutex_, pool.blocks_mutex_);
-      std::lock_guard<std::mutex> gf(pool.free_list_[index].mutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> gb(pool.blocks_mutex_, std::adopt_lock);
+      std::scoped_lock lock(pool.free_list_[index].mutex_, pool.blocks_mutex_);
       destroy_block(block, pool, /*is_active=*/true);
     } else {
       std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1296,10 +1296,7 @@ void ProcessGroupNCCL::waitForPendingWorks() {
   //      same order and hence no deadlocks.
   while (true) {
     {
-      std::lock(workMetaListMutex_, completedWorkListMutex_);
-      std::lock_guard<std::mutex> lockWork(workMetaListMutex_, std::adopt_lock);
-      std::lock_guard<std::mutex> lockHook(
-          completedWorkListMutex_, std::adopt_lock);
+      std::scoped_lock lock(workMetaListMutex_, completedWorkListMutex_);
 
       if (workMetaList_.empty() && completedWorkList_.empty()) {
         return;


### PR DESCRIPTION
C++17 provides std::scoped_lock which is a superior way of using deadlock avoidance algorithms as compared to std::lock. There is a [clang-tidy checker][1] for this.

[1]: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-scoped-lock.html