### PR TITLE
Add mixed Tensor and Scalar bound support for torch.clamp and torch.clip

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -891,6 +891,30 @@ TORCH_IMPL_FUNC(clamp_min_Tensor_out)
   maximum_stub(device_type(), *this);
 }
 
+Tensor clamp(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+  return at::clamp(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt);
+}
+
+Tensor& clamp_(Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+  return at::clamp_(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt);
+}
+
+Tensor& clamp_out(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max, Tensor& result) {
+  return at::clamp_outf(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt, result);
+}
+
+Tensor clamp(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
+  return at::clamp(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max);
+}
+
+Tensor& clamp_(Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
+  return at::clamp_(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max);
+}
+
+Tensor& clamp_out(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max, Tensor& result) {
+  return at::clamp_outf(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max, result);
+}
+
 // Implements the "clip" alias for clamp
 Tensor& clip_out(
     const Tensor& self,
@@ -908,6 +932,14 @@ Tensor& clip_out(
   return at::clamp_outf(self, min, max, result);
 }
 
+Tensor& clip_out(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max, Tensor& result) {
+  return at::clamp_outf(self, min, max, result);
+}
+
+Tensor& clip_out(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max, Tensor& result) {
+  return at::clamp_outf(self, min, max, result);
+}
+
 Tensor clip(
     const Tensor& self,
     const std::optional<Scalar>& min,
@@ -919,6 +951,14 @@ Tensor clip(
     const Tensor& self,
     const std::optional<Tensor>& min,
     const std::optional<Tensor>& max) {
+  return at::clamp(self, min, max);
+}
+
+Tensor clip(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+  return at::clamp(self, min, max);
+}
+
+Tensor clip(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
   return at::clamp(self, min, max);
 }
 
@@ -933,6 +973,14 @@ Tensor& clip_(
     Tensor& self,
     const std::optional<Tensor>& min,
     const std::optional<Tensor>& max) {
+  return at::clamp_(self, min, max);
+}
+
+Tensor& clip_(Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+  return at::clamp_(self, min, max);
+}
+
+Tensor& clip_(Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
   return at::clamp_(self, min, max);
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -891,28 +891,38 @@ TORCH_IMPL_FUNC(clamp_min_Tensor_out)
   maximum_stub(device_type(), *this);
 }
 
-Tensor clamp(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
-  return at::clamp(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt);
+Tensor clamp(const Tensor& self, const Tensor& min, const Scalar& max) {
+  return at::clamp(self, min, at::native::wrapped_scalar_tensor(max));
 }
 
-Tensor& clamp_(Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
-  return at::clamp_(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt);
+Tensor& clamp_(Tensor& self, const Tensor& min, const Scalar& max) {
+  return at::clamp_(self, min, at::native::wrapped_scalar_tensor(max));
 }
 
-Tensor& clamp_out(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max, Tensor& result) {
-  return at::clamp_outf(self, min, max ? std::make_optional(at::wrapped_scalar_tensor(*max)) : std::nullopt, result);
+Tensor& clamp_out(
+    const Tensor& self,
+    const Tensor& min,
+    const Scalar& max,
+    Tensor& result) {
+  return at::clamp_outf(
+      self, min, at::native::wrapped_scalar_tensor(max), result);
 }
 
-Tensor clamp(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
-  return at::clamp(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max);
+Tensor clamp(const Tensor& self, const Scalar& min, const Tensor& max) {
+  return at::clamp(self, at::native::wrapped_scalar_tensor(min), max);
 }
 
-Tensor& clamp_(Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
-  return at::clamp_(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max);
+Tensor& clamp_(Tensor& self, const Scalar& min, const Tensor& max) {
+  return at::clamp_(self, at::native::wrapped_scalar_tensor(min), max);
 }
 
-Tensor& clamp_out(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max, Tensor& result) {
-  return at::clamp_outf(self, min ? std::make_optional(at::wrapped_scalar_tensor(*min)) : std::nullopt, max, result);
+Tensor& clamp_out(
+    const Tensor& self,
+    const Scalar& min,
+    const Tensor& max,
+    Tensor& result) {
+  return at::clamp_outf(
+      self, at::native::wrapped_scalar_tensor(min), max, result);
 }
 
 // Implements the "clip" alias for clamp
@@ -932,11 +942,19 @@ Tensor& clip_out(
   return at::clamp_outf(self, min, max, result);
 }
 
-Tensor& clip_out(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max, Tensor& result) {
+Tensor& clip_out(
+    const Tensor& self,
+    const Tensor& min,
+    const Scalar& max,
+    Tensor& result) {
   return at::clamp_outf(self, min, max, result);
 }
 
-Tensor& clip_out(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max, Tensor& result) {
+Tensor& clip_out(
+    const Tensor& self,
+    const Scalar& min,
+    const Tensor& max,
+    Tensor& result) {
   return at::clamp_outf(self, min, max, result);
 }
 
@@ -954,11 +972,11 @@ Tensor clip(
   return at::clamp(self, min, max);
 }
 
-Tensor clip(const Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+Tensor clip(const Tensor& self, const Tensor& min, const Scalar& max) {
   return at::clamp(self, min, max);
 }
 
-Tensor clip(const Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
+Tensor clip(const Tensor& self, const Scalar& min, const Tensor& max) {
   return at::clamp(self, min, max);
 }
 
@@ -976,11 +994,11 @@ Tensor& clip_(
   return at::clamp_(self, min, max);
 }
 
-Tensor& clip_(Tensor& self, const std::optional<Tensor>& min, const std::optional<Scalar>& max) {
+Tensor& clip_(Tensor& self, const Tensor& min, const Scalar& max) {
   return at::clamp_(self, min, max);
 }
 
-Tensor& clip_(Tensor& self, const std::optional<Scalar>& min, const std::optional<Tensor>& max) {
+Tensor& clip_(Tensor& self, const Scalar& min, const Tensor& max) {
   return at::clamp_(self, min, max);
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1516,6 +1516,16 @@
   structured_delegate: clamp.Tensor_out
   tags: [core, pointwise]
 
+- func: clamp.Tensor_Scalar(Tensor self, Tensor? min, Scalar? max) -> Tensor
+  device_check: NoCheck   # Tensor and Scalar inputs don't need cross-device checks here
+  dispatch:
+    CompositeImplicitAutograd: clamp
+
+- func: clamp.Scalar_Tensor(Tensor self, Scalar? min, Tensor? max) -> Tensor
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clamp
+
 - func: clamp_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: function, method
@@ -1527,6 +1537,16 @@
   variants: function, method
   structured_delegate: clamp.Tensor_out
   tags: pointwise
+
+- func: clamp_.Tensor_Scalar(Tensor(a!) self, Tensor? min, Scalar? max) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clamp_
+
+- func: clamp_.Scalar_Tensor(Tensor(a!) self, Scalar? min, Tensor? max) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clamp_
 
 - func: clamp.out(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -1544,6 +1564,16 @@
   dispatch:
     CPU, CUDA, MPS, XPU: clamp_Tensor_out
   tags: pointwise
+
+- func: clamp.Tensor_Scalar_out(Tensor self, Tensor? min, Scalar? max, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clamp_out
+
+- func: clamp.Scalar_Tensor_out(Tensor self, Scalar? min, Tensor? max, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clamp_out
 
 - func: clamp_max(Tensor self, Scalar max) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -1631,6 +1661,16 @@
   variants: function, method
   tags: pointwise
 
+- func: clip.Tensor_Scalar(Tensor self, Tensor? min, Scalar? max) -> Tensor
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip
+
+- func: clip.Scalar_Tensor(Tensor self, Scalar? min, Tensor? max) -> Tensor
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip
+
 - func: clip_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
   cpp_no_default_args: ['min']
   variants: function, method
@@ -1640,11 +1680,31 @@
   variants: function, method
   tags: pointwise
 
+- func: clip_.Tensor_Scalar(Tensor(a!) self, Tensor? min, Scalar? max) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip_
+
+- func: clip_.Scalar_Tensor(Tensor(a!) self, Scalar? min, Tensor? max) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip_
+
 - func: clip.out(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
   cpp_no_default_args: ['min']
   tags: pointwise
 
 - func: clip.Tensor_out(Tensor self, Tensor? min=None, Tensor? max=None, *, Tensor(a!) out) -> Tensor(a!)
+
+- func: clip.Tensor_Scalar_out(Tensor self, Tensor? min, Scalar? max, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip_out
+
+- func: clip.Scalar_Tensor_out(Tensor self, Scalar? min, Tensor? max, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck
+  dispatch:
+    CompositeImplicitAutograd: clip_out
 
 - func: cudnn_is_acceptable(Tensor self) -> bool
   device_check: NoCheck

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1516,15 +1516,13 @@
   structured_delegate: clamp.Tensor_out
   tags: [core, pointwise]
 
-- func: clamp.Tensor_Scalar(Tensor self, Tensor? min, Scalar? max) -> Tensor
-  device_check: NoCheck   # Tensor and Scalar inputs don't need cross-device checks here
-  dispatch:
-    CompositeImplicitAutograd: clamp
+- func: clamp.Tensor_Scalar(Tensor self, Tensor min, Scalar max) -> Tensor
+  variants: function, method
+  tags: [core, pointwise]
 
-- func: clamp.Scalar_Tensor(Tensor self, Scalar? min, Tensor? max) -> Tensor
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clamp
+- func: clamp.Scalar_Tensor(Tensor self, Scalar min, Tensor max) -> Tensor
+  variants: function, method
+  tags: [core, pointwise]
 
 - func: clamp_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -1538,15 +1536,13 @@
   structured_delegate: clamp.Tensor_out
   tags: pointwise
 
-- func: clamp_.Tensor_Scalar(Tensor(a!) self, Tensor? min, Scalar? max) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clamp_
+- func: clamp_.Tensor_Scalar(Tensor(a!) self, Tensor min, Scalar max) -> Tensor(a!)
+  variants: function, method
+  tags: [core, pointwise]
 
-- func: clamp_.Scalar_Tensor(Tensor(a!) self, Scalar? min, Tensor? max) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clamp_
+- func: clamp_.Scalar_Tensor(Tensor(a!) self, Scalar min, Tensor max) -> Tensor(a!)
+  variants: function, method
+  tags: [core, pointwise]
 
 - func: clamp.out(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -1565,15 +1561,13 @@
     CPU, CUDA, MPS, XPU: clamp_Tensor_out
   tags: pointwise
 
-- func: clamp.Tensor_Scalar_out(Tensor self, Tensor? min, Scalar? max, *, Tensor(a!) out) -> Tensor(a!)
+- func: clamp.Tensor_Scalar_out(Tensor self, Tensor min, Scalar max, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clamp_out
+  tags: pointwise
 
-- func: clamp.Scalar_Tensor_out(Tensor self, Scalar? min, Tensor? max, *, Tensor(a!) out) -> Tensor(a!)
+- func: clamp.Scalar_Tensor_out(Tensor self, Scalar min, Tensor max, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clamp_out
+  tags: pointwise
 
 - func: clamp_max(Tensor self, Scalar max) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -1661,15 +1655,13 @@
   variants: function, method
   tags: pointwise
 
-- func: clip.Tensor_Scalar(Tensor self, Tensor? min, Scalar? max) -> Tensor
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip
+- func: clip.Tensor_Scalar(Tensor self, Tensor min, Scalar max) -> Tensor
+  variants: function, method
+  tags: pointwise
 
-- func: clip.Scalar_Tensor(Tensor self, Scalar? min, Tensor? max) -> Tensor
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip
+- func: clip.Scalar_Tensor(Tensor self, Scalar min, Tensor max) -> Tensor
+  variants: function, method
+  tags: pointwise
 
 - func: clip_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
   cpp_no_default_args: ['min']
@@ -1680,15 +1672,13 @@
   variants: function, method
   tags: pointwise
 
-- func: clip_.Tensor_Scalar(Tensor(a!) self, Tensor? min, Scalar? max) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip_
+- func: clip_.Tensor_Scalar(Tensor(a!) self, Tensor min, Scalar max) -> Tensor(a!)
+  variants: function, method
+  tags: pointwise
 
-- func: clip_.Scalar_Tensor(Tensor(a!) self, Scalar? min, Tensor? max) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip_
+- func: clip_.Scalar_Tensor(Tensor(a!) self, Scalar min, Tensor max) -> Tensor(a!)
+  variants: function, method
+  tags: pointwise
 
 - func: clip.out(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
   cpp_no_default_args: ['min']
@@ -1696,15 +1686,9 @@
 
 - func: clip.Tensor_out(Tensor self, Tensor? min=None, Tensor? max=None, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: clip.Tensor_Scalar_out(Tensor self, Tensor? min, Scalar? max, *, Tensor(a!) out) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip_out
+- func: clip.Tensor_Scalar_out(Tensor self, Tensor min, Scalar max, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: clip.Scalar_Tensor_out(Tensor self, Scalar? min, Tensor? max, *, Tensor(a!) out) -> Tensor(a!)
-  device_check: NoCheck
-  dispatch:
-    CompositeImplicitAutograd: clip_out
+- func: clip.Scalar_Tensor_out(Tensor self, Scalar min, Tensor max, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: cudnn_is_acceptable(Tensor self) -> bool
   device_check: NoCheck

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6635,6 +6635,10 @@ def sample_inputs_clamp(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_arg(shape), args=(make_integral_arg(shape), None))
     yield SampleInput(make_arg(shape), args=(make_arg(shape), make_integral_arg(shape)))
 
+    # test mixed bounds
+    yield SampleInput(make_arg(shape), args=(make_arg(shape), make_arg(()).item()))
+    yield SampleInput(make_arg(shape), args=(make_arg(()).item(), make_arg(shape)))
+
 def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sample_inputs_func, supports_scalars=False, **kwargs):
     yield from sample_inputs_func(op, device, dtype, requires_grad, **kwargs)
 


### PR DESCRIPTION
fixes #188088

# Summary
This PR resolves the TypeError encountered when passing mixed bound types (e.g., min=Tensor, max=Scalar) to torch.clamp and its alias torch.clip.

To maintain C++ API parity, these are implemented as `CompositeImplicitAutograd` functions. The implementation wraps the Scalar bound into a 0-D Tensor via `std::make_optional(at::wrapped_scalar_tensor(*val))` and routes directly to the existing all-tensor `at::clamp` backend kernels.

### Note on line count
The LOC is a bit high for a relatively simple fix. Because the autogen keyword does not support composite operations, the explicit wrapping logic and dispatch declarations had to be manually duplicated across all variants (clamp, clamp_, clamp_out) as well as the clip aliases in both native_functions.yaml and TensorCompare.cpp.

# BC-breaking?
Technically yes, as it alters the frontend behavior from raising an overload-resolution TypeError to successfully executing the operation. However, this is strictly an enhancement that aligns torch.clamp with intuitive element-wise expectations and numpy.clip behavior.

# Feedback Requested
Opening this as a Draft PR while I finish writing the test cases and run the linters locally.

While this remains in draft, I would love feedback on the implementation. Is this approach the preferred way to handle mixed Tensor/Scalar bounds for this specific op, or is there a leaner codegen trick I missed to reduce the boilerplate?

# Checklist
[ ] Passes lint (spin fixlint) (Running locally)

[ ] Added/updated tests (Currently writing)

[X] Updated documentation (N/A)

[X] Included benchmark results (N/A)