### PR TITLE
[Test] Fix test_unary_out_op_mem_overlap CUDA cases being skipped

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -925,13 +925,13 @@ class TestUnaryUfuncs(TestCase):
             ("sin", doubles, True, True, "cpu"),
             ("sin", doubles, True, True, "cuda"),
             ("sinh", doubles, True, True, "cpu"),
-            ("sinh", doubles, False, True, "cuda"),
+            ("sinh", doubles, True, True, "cuda"),
             ("sigmoid", doubles, True, True, "cpu"),
             ("sigmoid", doubles, True, True, "cuda"),
             ("logit", doubles, True, True, "cpu"),
             ("logit", doubles, True, True, "cuda"),
             ("sqrt", doubles, True, True, "cpu"),
-            ("sqrt", doubles, False, True, "cuda"),
+            ("sqrt", doubles, True, True, "cuda"),
             ("tan", doubles, True, True, "cpu"),
             ("tan", doubles, True, True, "cuda"),
             ("tanh", doubles, True, True, "cpu"),
@@ -947,7 +947,7 @@ class TestUnaryUfuncs(TestCase):
             has_internal_mem_overlap_check,
             dev,
         ) in unary_mem_overlap_cases:
-            if dev != device:
+            if dev != self.device_type:
                 continue
             out_fn = getattr(torch, fn)
             in_fn = getattr(torch.Tensor, fn + "_")


### PR DESCRIPTION
## Summary

`test_unary_out_op_mem_overlap` filtered cases using `if dev != device: continue`, where `dev` was `"cuda"` while `device`
(from `instantiate_device_type_tests`) was `"cuda:0"`. As a result, the comparison never matched and all CUDA-specific cases were silently skipped, so the test effectively only exercised the CPU cases.



This also hid two incorrect CUDA expectations: `sinh` and `sqrt` were marked as not raising on memory overlap (`False`), while they actually do raise.



## Changes

1. Compare against `self.device_type` instead of `device` so device filtering matches the instantiated device type (e.g. `"cuda"`).
2. Correct the expected CUDA behavior for `sinh` and `sqrt` from `False` to `True`, reflecting the actual memory-overlap checks.



## Test plan

Verified on CUDA:

```bash
pytest test/test_unary_ufuncs.py -k "test_unary_out_op_mem_overlap" -vvv
```



```bash
collected 51803 items / 51801 deselected / 2 selected                                                                                   
Running 2 items in this shard

test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_unary_out_op_mem_overlap_cpu_float64 PASSED [0.0289s]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_unary_out_op_mem_overlap_cuda_float64 PASSED [0.3226s]

================================================== 2 passed, 51801 deselected in 9.29s ==================================================
```

