### PR TITLE
[MPS] propagate nan for attention kernels on mps

### DIFF
--- a/aten/src/ATen/native/mps/kernels/DecodeAttention.h
+++ b/aten/src/ATen/native/mps/kernels/DecodeAttention.h
@@ -113,9 +113,8 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
         score += static_cast<U>(mask[0]);
       }
 
-      // (score != score) keeps a NaN score that max() would drop, so a NaN in
-      // Q/K propagates instead of collapsing the row max to -inf.
-      U new_max = (score != score) ? score : max(max_score, score);
+      // c10::metal::max propagates NaN (plain max drops it -> row max -inf -> 0).
+      U new_max = c10::metal::max(max_score, score);
       U factor;
       U exp_score;
       if (new_max == -INFINITY) {
@@ -284,9 +283,8 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
         score += static_cast<U>(mask[0]);
       }
 
-      // (score != score) keeps a NaN score that max() would drop, so a NaN in
-      // Q/K propagates instead of collapsing the row max to -inf.
-      U new_max = (score != score) ? score : max(max_score, score);
+      // c10::metal::max propagates NaN (plain max drops it -> row max -inf -> 0).
+      U new_max = c10::metal::max(max_score, score);
       U factor;
       U exp_score;
       if (new_max == -INFINITY) {

--- a/aten/src/ATen/native/mps/kernels/DecodeAttention.h
+++ b/aten/src/ATen/native/mps/kernels/DecodeAttention.h
@@ -113,8 +113,9 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
         score += static_cast<U>(mask[0]);
       }
 
-      // Guard the (max,score)==(-inf,-inf) case: max - max is NaN otherwise.
-      U new_max = max(max_score, score);
+      // (score != score) keeps a NaN score that max() would drop, so a NaN in
+      // Q/K propagates instead of collapsing the row max to -inf.
+      U new_max = (score != score) ? score : max(max_score, score);
       U factor;
       U exp_score;
       if (new_max == -INFINITY) {
@@ -283,7 +284,9 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
         score += static_cast<U>(mask[0]);
       }
 
-      U new_max = max(max_score, score);
+      // (score != score) keeps a NaN score that max() would drop, so a NaN in
+      // Q/K propagates instead of collapsing the row max to -inf.
+      U new_max = (score != score) ? score : max(max_score, score);
       U factor;
       U exp_score;
       if (new_max == -INFINITY) {

--- a/aten/src/ATen/native/mps/kernels/PrefillAttention.h
+++ b/aten/src/ATen/native/mps/kernels/PrefillAttention.h
@@ -156,7 +156,9 @@ struct TransformScale {
 struct MaxOp {
   template <typename T>
   METAL_FUNC static constexpr T apply(T x, T y) {
-    return metal::max(x, y);
+    // Propagate NaN: metal::max drops it, which collapses the row max to -inf
+    // and zeroes the output instead of yielding NaN for a NaN score.
+    return (x != x) ? x : (y != y) ? y : metal::max(x, y);
   }
 };
 

--- a/aten/src/ATen/native/mps/kernels/PrefillAttention.h
+++ b/aten/src/ATen/native/mps/kernels/PrefillAttention.h
@@ -155,10 +155,9 @@ struct TransformScale {
 
 struct MaxOp {
   template <typename T>
-  METAL_FUNC static constexpr T apply(T x, T y) {
-    // Propagate NaN: metal::max drops it, which collapses the row max to -inf
-    // and zeroes the output instead of yielding NaN for a NaN score.
-    return (x != x) ? x : (y != y) ? y : metal::max(x, y);
+  METAL_FUNC static T apply(T x, T y) {
+    // c10::metal::max propagates NaN (plain max drops it -> row max -inf -> 0).
+    return c10::metal::max(x, y);
   }
 };
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11656,6 +11656,30 @@ class TestSDPA(TestCaseMPS):
         out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=True)
         self.assertFalse(torch.isnan(out).any())
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("shape", [(4, 16, 64), (4, 1024, 64), (16, 16, 64)])
+    @parametrize("nan_in", ["q", "k"])
+    def test_sdpa_nan_propagation(self, dtype, shape, nan_in):
+        qL, kL, hd = shape
+        torch.manual_seed(0)
+        q = torch.randn(1, 2, qL, hd, dtype=dtype)
+        k = torch.randn(1, 2, kL, hd, dtype=dtype)
+        v = torch.randn(1, 2, kL, hd, dtype=dtype)
+        if nan_in == "q":
+            q[0, 0, 0, 0] = float("nan")
+        else:
+            k[0, 0, 1, 0] = float("nan")
+
+        out_cpu = F.scaled_dot_product_attention(q, k, v)
+        out_mps = F.scaled_dot_product_attention(q.to("mps"), k.to("mps"), v.to("mps")).cpu()
+
+        self.assertTrue(torch.isnan(out_mps).any())
+        self.assertEqual(torch.isnan(out_mps), torch.isnan(out_cpu))
+        finite = ~torch.isnan(out_cpu)
+        if finite.any():
+            tol = 0.02 if dtype == torch.bfloat16 else 0.01 if dtype == torch.float16 else 1e-4
+            self._compare_tensors(out_mps[finite], out_cpu[finite], tol=tol)
+
     @parametrize("dtype", [torch.float16, torch.float32])
     def test_sdpa_3d_input(self, dtype):
         head_num, seq_len, embed_dim = 16, 16, 80


### PR DESCRIPTION
Below code doesn't propagate Nan, this PR fixes it
```
import torch, torch.nn.functional as F
torch.manual_seed(0)
q = torch.randn(1, 1, 4, 64); q[0, 0, 0, 0] = float('nan')
k = torch.randn(1, 1, 16, 64); v = torch.randn(1, 1, 16, 64)
y_cpu = F.scaled_dot_product_attention(q, k, v)
y_mps = F.scaled_dot_product_attention(q.to('mps'), k.to('mps'), v.to('mps')).cpu()
print("CPU NaN count:", torch.isnan(y_cpu).sum().item())   # 64
print("MPS NaN count:", torch.isnan(y_mps).sum().item())   # 0
```