### PR TITLE
Handle mixed Tensor/Scalar min/max bounds in torch.clamp  

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2578,6 +2578,29 @@ for __name in dir(_C._VariableFunctions):
 
 del __name, __obj
 
+
+def clamp(
+    input: Tensor,
+    min: builtins.int | builtins.float | Tensor | None = None,
+    max: builtins.int | builtins.float | Tensor | None = None,
+    *,
+    out: Tensor | None = None,
+) -> Tensor:
+    """See :func:`torch.clamp`."""
+    # Handle mixed Tensor/Scalar min/max bounds (GH#188088)
+    if isinstance(min, Tensor) and isinstance(max, (int, float)):
+        max = _C._VariableFunctions.scalar_tensor(
+            max, dtype=min.dtype, device=min.device
+        )
+    elif isinstance(max, Tensor) and isinstance(min, (int, float)):
+        min = _C._VariableFunctions.scalar_tensor(
+            min, dtype=max.dtype, device=max.device
+        )
+    if isinstance(min, Tensor) or isinstance(max, Tensor):
+        return _C._VariableFunctions.clamp.Tensor(input, min=min, max=max, out=out)
+    return _C._VariableFunctions.clamp(input, min=min, max=max, out=out)
+
+
 ################################################################################
 # Add torch.dtype instances to the public API
 ################################################################################


### PR DESCRIPTION
  Fixes #188088.

The C++ clamp overloads require both `min` and `max` to be either both                                                                  
Scalars or both Tensors. Passing mixed types (e.g., `min=Tensor, max=float`)                                                            
raises a `TypeError` with no overload matching, even though the operation                                                               
has a natural elementwise meaning.                                                                                                      
                                                                                                                                        
Add a Python wrapper in `torch/__init__.py` that detects mixed arguments                                                                
and converts the Scalar to a Tensor (sharing the dtype and device of the                                                                
Tensor bound) before dispatching to the Tensor overload.                                                                                
                                                                                                                                        
Test plan:                                                                                                                              
                                                                                                                                        
```python                                                                                                                               
import torch                                                                                                                            
                                                                                                                                        
x = torch.tensor([-2.0, 0.5, 3.0])                                                                                                      
tensor_min = torch.tensor([-1.0, 0.0, 1.0])                                                                                             
tensor_max = torch.tensor([1.0, 1.0, 2.0])                                                                                              
                                                                                                                                        
# These previously raised TypeError:                                                                                                    
torch.clamp(x, min=tensor_min, max=1.0)                                                                                                 
torch.clamp(x, min=-1.0, max=tensor_max)                                                                                                
                                                                                                                                        
# Existing overloads still work:                                                                                                        
torch.clamp(x, min=tensor_min, max=tensor_max)                                                                                          
torch.clamp(x, min=-1.0, max=1.0)                                                                                                       
                                                                                                                                        
