### PR TITLE
[inductor] Route custom ops with SymInt args off the cpp_wrapper StableIValue path

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 import torch
 from torch._inductor import config
 from torch._inductor.codegen.common import TritonScratchWorkspace
+from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch._inductor.codegen.cpp_wrapper_gpu import (
     CppWrapperGpu,
     DeferredTritonCallWrapper,
@@ -244,6 +245,41 @@ class TestGpuWrapper(InductorTestCase):
             expected = fn(x)
             actual = torch.compile(fullgraph=True, options={"cpp_wrapper": True})(fn)(x)
             self.assertEqual(actual, expected)
+
+    @config.patch(implicit_fallbacks=True)
+    def test_custom_op_fallback_symint_dispatch(self):
+        # A custom op with a SymInt argument (e.g.
+        # fbgemm::permute_2D_sparse_data_input1D) must not be routed to the
+        # StableIValue path.  SymInt is reported as IntType by JitType.type, so
+        # such ops used to pass _compatible_with_stableivalue and then fail at
+        # runtime with 'aoti_torch_call_dispatcher(...) API call failed'.  They
+        # must use the boxed dispatch path, which handles c10::SymInt correctly.
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        device = self.device
+        with torch.library._scoped_library("mylib_symint", "FRAGMENT") as m:
+            m.define("add_symint(Tensor x, SymInt n) -> Tensor")
+            m.impl("add_symint", lambda x, n: x + n, GPU_TYPE.upper())
+            m.impl("add_symint", lambda x, n: torch.empty_like(x), "Meta")
+
+            op = torch.ops.mylib_symint.add_symint.default
+            self.assertFalse(CppWrapperCpu._compatible_with_stableivalue(op))
+            self.assertTrue(CppWrapperCpu._compatible_with_cpp_boxed_dispatch(op))
+
+            def fn(x):
+                # x.shape[0] is symbolic once dim 0 is dynamic, so n is a SymInt.
+                return torch.ops.mylib_symint.add_symint(x, x.shape[0])
+
+            x = torch.randn(8, 4, device=device)
+            torch._dynamo.mark_dynamic(x, 0)
+            expected = fn(x)
+            compiled = torch.compile(fullgraph=True, options={"cpp_wrapper": True})(fn)
+            actual, code = test_torchinductor.run_and_get_cpp_code(compiled, x)
+            self.assertEqual(actual, expected)
+            self.assertNotIn(
+                'aoti_torch_call_dispatcher("mylib_symint::add_symint"', code
+            )
 
     def test_cpp_scratch_scales_with_grid_size_for_tma(self):
         if GPU_TYPE != "cuda" or torch.version.hip:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3142,8 +3142,21 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 return type_supported(t.getElementType())
             return isinstance(t, supported_types)
 
+        def uses_symint(t: torch.JitType) -> bool:
+            # SymInt/SymBool/SymFloat are reported as Int/Bool/Float by
+            # JitType.type, so they pass type_supported above.  But the
+            # StableIValue codegen below emits no symbolic-int-aware conversion,
+            # so route such ops to the boxed dispatch path, which handles
+            # c10::SymInt correctly.  real_type preserves the symbolic types.
+            if isinstance(t, (torch.OptionalType, torch.ListType)):
+                return uses_symint(t.getElementType())
+            return (
+                isinstance(t, (torch.SymIntType, torch.SymBoolType))
+                or repr(t) == "SymFloat"
+            )
+
         return all(
-            type_supported(a.type)
+            type_supported(a.type) and not uses_symint(a.real_type)
             for a in chain(op._schema.arguments, op._schema.returns)
         )
 


### PR DESCRIPTION
Summary:
cpp_wrapper's nopython dispatch gate `_compatible_with_stableivalue` inspected the fake JIT type (`Argument.type`), where `SymInt` is reported as `IntType`. So custom ops with `SymInt` args (e.g. `fbgemm::permute_2D_sparse_data_input1D`) were routed to `aoti_torch_call_dispatcher`, which has no SymInt-aware conversion, and failed at runtime with `API call failed`. 

Fix: also reject schemas whose `real_type` contains `SymInt`/`SymBool`/`SymFloat` so they fall through to the boxed dispatch path, which already boxes `c10::SymInt` correctly.

Differential Revision: D109577294




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo