### PR TITLE
[MPS] reduce: share the two-pass value_reduction kernel for sum and value

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -278,139 +278,35 @@ inline T finalize_val(T v) {
   return static_cast<T>(::precise::sqrt(v));
 }
 
-// Sum reduction kernel with multiple independent accumulation chains (ILP).
-// Each thread maintains NCHAINS independent accumulators to hide ALU latency
-// and keep the memory pipeline saturated.
-//
-// Two internal paths selected per-threadgroup (not per-element):
-//   - Single reduced dim (or full reduction): compute input_base + k * stride
-//     once per TG, then direct indexing — no per-element dim loop.
-//   - Multiple reduced dims: fall back to get_input_offset per element.
-// MODE: LOAD_IDENTITY (sum), LOAD_NAN_TO_ZERO (nansum),
-// LOAD_NONZERO (count_nonzero — contributes 1 per nonzero element).
-// The compiler eliminates dead branches per instantiation.
-template <
-    typename TI,
-    typename TO,
-    uint NCHAINS = SUM_NCHAINS,
-    LoadMode MODE = LOAD_IDENTITY>
-kernel void sum_reduction(
-    constant TI* input [[buffer(0)]],
-    device TO* output [[buffer(1)]],
-    constant NormParams<>& params [[buffer(2)]],
-    uint tid [[thread_position_in_threadgroup]],
-    uint tptg [[threads_per_threadgroup]],
-    uint tgid [[threadgroup_position_in_grid]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
-    uint simdgroup_size [[threads_per_simdgroup]]) {
-  using TA = ::metal::conditional_t<MODE == LOAD_NONZERO, uint, opmath_t<TO>>;
-
-  // Compute input_base (once per TG) and detect reduction pattern.
-  // For single reduced dim: input_base + k * reduction_stride gives
-  // the k-th reduction element — no per-element dim loop needed.
-  uint32_t input_base = 0;
-  uint32_t reduction_stride = 1;
-  uint32_t num_reduced_dims = 0;
-  {
-    uint32_t out_idx = tgid;
-    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
-      if (params.input_sizes[dim] != params.output_sizes[dim]) {
-        num_reduced_dims++;
-        reduction_stride = params.input_strides[dim];
-      } else {
-        auto idx = out_idx % params.output_sizes[dim];
-        out_idx /= params.output_sizes[dim];
-        input_base += idx * params.input_strides[dim];
-      }
-    }
+// Load functors decide how an input element is converted into the accumulator
+// type. IdentityLoad casts; PredicateLoad maps nonzero (and NaN) -> 1, zero ->
+// 0 (any/all, count_nonzero); NanToZeroLoad replaces NaN with 0 (nansum).
+// Shared by sum_reduction and value_reduction (both route sum/prod/min/max
+// through the same Op + Load abstraction).
+struct IdentityLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    return static_cast<TA>(v);
   }
+};
 
-  // Load helper: cast to accumulator type, optionally replacing NaN with zero
-
-  metal::array<TA, NCHAINS> acc;
-  for (uint j = 0; j < NCHAINS; j++) {
-    acc[j] = 0;
+struct PredicateLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    return load_is_nonzero(v) ? TA(1) : TA(0);
   }
+};
 
-  const uint32_t rsize = params.reduction_size;
-  const uint32_t stride = tptg * NCHAINS;
-  uint32_t base = tid * NCHAINS;
-
-  if (num_reduced_dims <= 1) {
-    // Fast path: direct indexing with base + k * reduction_stride
-    for (; base + NCHAINS <= rsize; base += stride) {
-      for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] +=
-            load_val<MODE>(input[input_base + (base + j) * reduction_stride]);
-      }
+struct NanToZeroLoad {
+  template <typename TA, typename TI>
+  static inline TA load(TI v) {
+    TA r = static_cast<TA>(v);
+    if (::metal::isnan(static_cast<float>(r))) {
+      r = TA(0);
     }
-    for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] +=
-          load_val<MODE>(input[input_base + idx * reduction_stride]);
-    }
-  } else {
-    // Generic path: per-element strided offset for multi-dim reductions
-    for (; base + NCHAINS <= rsize; base += stride) {
-      for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] +=
-            load_val<MODE>(input[get_input_offset(base + j, tgid, params)]);
-      }
-    }
-    for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] +=
-          load_val<MODE>(input[get_input_offset(idx, tgid, params)]);
-    }
+    return r;
   }
-
-  // Collapse chains into a single value
-  TA output_val = acc[0];
-  for (uint j = 1; j < NCHAINS; j++) {
-    output_val += acc[j];
-  }
-
-  // SIMD + threadgroup tree reduction
-  auto threads_remaining = tptg;
-  threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE];
-
-  while (threads_remaining > 1) {
-    output_val = c10::metal::simd_sum(output_val);
-    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
-
-    if (threads_remaining > 1) {
-      if (simd_lane_id == 0) {
-        shared_outputs[simdgroup_id] = output_val;
-      }
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-      if (tid < threads_remaining) {
-        output_val = shared_outputs[tid];
-      } else {
-        return;
-      }
-    }
-  }
-
-  if (tid == 0) {
-    uint32_t output_offset = 0;
-    uint32_t reduction_idx = tgid;
-
-    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
-      auto output_dim_size = params.output_sizes[dim];
-      if (output_dim_size > 1) {
-        auto index_in_dim = reduction_idx % output_dim_size;
-        reduction_idx /= output_dim_size;
-        output_offset += index_in_dim * params.output_strides[dim];
-      }
-    }
-    // params.p > 0 means "divide the accumulator by p before casting"
-    // (used by mean to keep the division in opmath_t precision so the
-    // fp32 accumulation isn't lost when TO is fp16/bf16/half2).
-    if (params.p > 0) {
-      output_val /= static_cast<TA>(params.p);
-    }
-    output[output_offset] = static_cast<TO>(output_val);
-  }
-}
+};
 
 template <
     typename TI,
@@ -661,18 +557,15 @@ REGISTER_NORM_INNER(float, float);
 REGISTER_NORM_INNER(half, half);
 REGISTER_NORM_INNER(bfloat, bfloat);
 
-#define REGISTER_SUM_IMPL(TI, TO, PREFIX, MODE)             \
-  template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]   \
-  kernel void sum_reduction<TI, TO, SUM_NCHAINS, MODE>(     \
-      constant TI * input [[buffer(0)]],                    \
-      device TO * output [[buffer(1)]],                     \
-      constant NormParams<> & params [[buffer(2)]],         \
-      uint tid [[thread_position_in_threadgroup]],          \
-      uint tptg [[threads_per_threadgroup]],                \
-      uint tgid [[threadgroup_position_in_grid]],           \
-      uint simd_lane_id [[thread_index_in_simdgroup]],      \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
-      uint simdgroup_size [[threads_per_simdgroup]]);
+#define REGISTER_SUM_IMPL(TI, TO, PREFIX, LOAD, TA)                  \
+  template [[host_name(PREFIX "reduction_" #TI "_" #TO)]]            \
+  kernel void value_reduction<SumOp, LOAD, TI, TO, SUM_NCHAINS, TA>( \
+      constant TI * input [[buffer(0)]],                             \
+      device TO * output [[buffer(1)]],                              \
+      constant NormParams<> & params [[buffer(2)]],                  \
+      uint tid [[thread_position_in_threadgroup]],                   \
+      uint tptg [[threads_per_threadgroup]],                         \
+      uint tgid [[threadgroup_position_in_grid]]);
 
 #define REGISTER_SUM_STRIDED_IMPL(TI, TO, PREFIX, MODE)               \
   template [[host_name(PREFIX "reduction_strided_" #TI "_" #TO)]]     \
@@ -684,43 +577,17 @@ REGISTER_NORM_INNER(bfloat, bfloat);
       uint tptg [[threads_per_threadgroup]],                          \
       uint tgid [[threadgroup_position_in_grid]]);
 
-#define REGISTER_SUM(TI, TO)                       \
-  REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY) \
+#define REGISTER_SUM(TI, TO)                                    \
+  REGISTER_SUM_IMPL(TI, TO, "sum_", IdentityLoad, opmath_t<TO>) \
   REGISTER_SUM_STRIDED_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
-#define REGISTER_NANSUM(TI, TO)                          \
-  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO) \
+#define REGISTER_NANSUM(TI, TO)                                     \
+  REGISTER_SUM_IMPL(TI, TO, "nansum_", NanToZeroLoad, opmath_t<TO>) \
   REGISTER_SUM_STRIDED_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
-#define REGISTER_COUNT_NONZERO(TI)                            \
-  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
+#define REGISTER_COUNT_NONZERO(TI)                                   \
+  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", PredicateLoad, uint) \
   REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
 
-REGISTER_SUM(float, float);
-REGISTER_SUM(float, half);
-REGISTER_SUM(float, bfloat);
-REGISTER_SUM(half, half);
-REGISTER_SUM(half, float);
-REGISTER_SUM(bfloat, bfloat);
-REGISTER_SUM(bfloat, float);
-REGISTER_SUM(int, int);
-REGISTER_SUM(int, long);
-REGISTER_SUM(long, long);
-REGISTER_SUM(short, short);
-REGISTER_SUM(short, long);
-REGISTER_SUM(char, char);
-REGISTER_SUM(char, long);
-REGISTER_SUM(uchar, uchar);
-REGISTER_SUM(uchar, long);
-REGISTER_SUM(bool, long);
-REGISTER_SUM(bool, int);
-REGISTER_SUM(float2, float2);
-REGISTER_SUM(half2, half2);
-
 // nansum variants (floating-point only — integers can't have NaN)
-REGISTER_NANSUM(float, float);
-REGISTER_NANSUM(half, half);
-REGISTER_NANSUM(half, float);
-REGISTER_NANSUM(bfloat, bfloat);
-REGISTER_NANSUM(bfloat, float);
 
 REGISTER_NANSUM_OUTER(float, float);
 REGISTER_NANSUM_OUTER(half, half);
@@ -736,17 +603,6 @@ REGISTER_NANSUM_INNER(bfloat, float);
 
 // count_nonzero: output is always long; reuses sum-reduction machinery
 // with LOAD_NONZERO mode (1 per nonzero element, 0 otherwise).
-REGISTER_COUNT_NONZERO(float);
-REGISTER_COUNT_NONZERO(half);
-REGISTER_COUNT_NONZERO(bfloat);
-REGISTER_COUNT_NONZERO(long);
-REGISTER_COUNT_NONZERO(int);
-REGISTER_COUNT_NONZERO(short);
-REGISTER_COUNT_NONZERO(char);
-REGISTER_COUNT_NONZERO(uchar);
-REGISTER_COUNT_NONZERO(bool);
-REGISTER_COUNT_NONZERO(float2);
-REGISTER_COUNT_NONZERO(half2);
 
 REGISTER_COUNT_NONZERO_OUTER(float);
 REGISTER_COUNT_NONZERO_OUTER(half);
@@ -784,25 +640,8 @@ REGISTER_COUNT_NONZERO_INNER(half2);
 // inductor MPS codegen can reuse the same identity/replace pair; both are
 // pulled in via the file-scope `using namespace c10::metal`.
 
-// Load functors decide how an input element is converted into the
-// accumulator type. IdentityLoad casts (min/max keep the value unchanged);
-// PredicateLoad maps nonzero (and NaN) -> 1, zero -> 0 (any/all).
-struct IdentityLoad {
-  template <typename TA, typename TI>
-  static inline TA load(TI v) {
-    return static_cast<TA>(v);
-  }
-};
-
-struct PredicateLoad {
-  template <typename TA, typename TI>
-  static inline TA load(TI v) {
-    return load_is_nonzero(v) ? TA(1) : TA(0);
-  }
-};
-
-// General value reduction: same 2D-via-NormParams layout as sum_reduction,
-// parameterised on the reduction op and load mode. For min/max, TI == TO
+// General value reduction over the 2D-via-NormParams layout, parameterised
+// on the reduction op and load mode. For min/max, TI == TO
 // and Load = IdentityLoad. For all/any, TO = uchar (a 1-byte alias for the
 // bool output buffer) and Load = PredicateLoad. The
 // max_total_threads_per_threadgroup hint lets the compiler bound the
@@ -813,7 +652,8 @@ template <
     typename Load,
     typename TI,
     typename TO,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 [[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
 kernel void value_reduction(
     constant TI* input [[buffer(0)]],
@@ -839,7 +679,6 @@ kernel void value_reduction(
     }
   }
 
-  using TA = TO;
   using Op = OpFn<TA>;
   const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
@@ -900,7 +739,13 @@ kernel void value_reduction(
         output_offset += index_in_dim * params.output_strides[dim];
       }
     }
-    output[output_offset] = output_val;
+    // params.p > 0 means "divide the accumulator by p before casting" (mean:
+    // keeps the division in TA precision so fp32 accumulation isn't lost when
+    // TO is fp16/bf16). p == 0 for max/min/all/any, so this is a no-op there.
+    if (params.p > 0) {
+      output_val /= static_cast<TA>(params.p);
+    }
+    output[output_offset] = static_cast<TO>(output_val);
   }
 }
 
@@ -915,7 +760,8 @@ template <
     typename TO,
     uint TG_X = 32,
     uint TG_Y = 32,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 [[max_total_threads_per_threadgroup(TG_X * TG_Y)]]
 kernel void value_reduction_outer(
     constant TI* input [[buffer(0)]],
@@ -923,7 +769,6 @@ kernel void value_reduction_outer(
     constant uint3& sizes [[buffer(2)]], // [M, N, output_stride]
     uint2 tid_tg [[thread_position_in_threadgroup]],
     uint2 tg_pos [[threadgroup_position_in_grid]]) {
-  using TA = TO;
   using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
@@ -975,7 +820,7 @@ kernel void value_reduction_outer(
   }
 
   if (tid_tg.y == 0) {
-    output[col * out_stride] = shmem[0][tid_tg.x];
+    output[col * out_stride] = static_cast<TO>(shmem[0][tid_tg.x]);
   }
 }
 
@@ -988,7 +833,8 @@ template <
     typename Load,
     typename TI,
     typename TO,
-    uint NCHAINS = SUM_NCHAINS>
+    uint NCHAINS = SUM_NCHAINS,
+    typename TA = TO>
 kernel void value_reduction_inner(
     constant TI* input [[buffer(0)]],
     device TO* output [[buffer(1)]],
@@ -997,7 +843,6 @@ kernel void value_reduction_inner(
     uint tgid [[threadgroup_position_in_grid]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
-  using TA = TO;
   using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
@@ -1036,7 +881,7 @@ kernel void value_reduction_inner(
   val = Op::simd_reduce(val);
 
   if (simd_lane_id == 0) {
-    output[row] = val;
+    output[row] = static_cast<TO>(val);
   }
 }
 
@@ -1424,3 +1269,43 @@ REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
 REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);
+
+// Generic sum / nansum / count_nonzero route through the shared
+// value_reduction kernel (SumOp + Load), instantiated after value_reduction
+// is defined above.
+REGISTER_SUM(float, float);
+REGISTER_SUM(float, half);
+REGISTER_SUM(float, bfloat);
+REGISTER_SUM(half, half);
+REGISTER_SUM(half, float);
+REGISTER_SUM(bfloat, bfloat);
+REGISTER_SUM(bfloat, float);
+REGISTER_SUM(int, int);
+REGISTER_SUM(int, long);
+REGISTER_SUM(long, long);
+REGISTER_SUM(short, short);
+REGISTER_SUM(short, long);
+REGISTER_SUM(char, char);
+REGISTER_SUM(char, long);
+REGISTER_SUM(uchar, uchar);
+REGISTER_SUM(uchar, long);
+REGISTER_SUM(bool, long);
+REGISTER_SUM(bool, int);
+REGISTER_SUM(float2, float2);
+REGISTER_SUM(half2, half2);
+REGISTER_NANSUM(float, float);
+REGISTER_NANSUM(half, half);
+REGISTER_NANSUM(half, float);
+REGISTER_NANSUM(bfloat, bfloat);
+REGISTER_NANSUM(bfloat, float);
+REGISTER_COUNT_NONZERO(float);
+REGISTER_COUNT_NONZERO(half);
+REGISTER_COUNT_NONZERO(bfloat);
+REGISTER_COUNT_NONZERO(long);
+REGISTER_COUNT_NONZERO(int);
+REGISTER_COUNT_NONZERO(short);
+REGISTER_COUNT_NONZERO(char);
+REGISTER_COUNT_NONZERO(uchar);
+REGISTER_COUNT_NONZERO(bool);
+REGISTER_COUNT_NONZERO(float2);
+REGISTER_COUNT_NONZERO(half2);

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -185,8 +185,9 @@ REGISTER_NORM(half2, half);
 
 #include <c10/metal/reduction_utils.h>
 
-// Load modes for sum_reduction: identity (sum), nan-to-zero (nansum),
-// nonzero-as-one (count_nonzero), abs (L1 norm), or square (L2 norm).
+// Load modes for the specialized strided/outer/inner sum kernels and norm
+// kernels: identity (sum), nan-to-zero (nansum), nonzero-as-one
+// (count_nonzero), abs (L1 norm), or square (L2 norm).
 enum LoadMode : uint {
   LOAD_IDENTITY = 0,
   LOAD_NAN_TO_ZERO = 1,
@@ -279,10 +280,9 @@ inline T finalize_val(T v) {
 }
 
 // Load functors decide how an input element is converted into the accumulator
-// type. IdentityLoad casts; PredicateLoad maps nonzero (and NaN) -> 1, zero ->
-// 0 (any/all, count_nonzero); NanToZeroLoad replaces NaN with 0 (nansum).
-// Shared by sum_reduction and value_reduction (both route sum/prod/min/max
-// through the same Op + Load abstraction).
+// type for value_reduction instantiations. IdentityLoad casts; PredicateLoad
+// maps nonzero (and NaN) -> 1, zero -> 0 (any/all, count_nonzero);
+// NanToZeroLoad replaces NaN with 0 (nansum).
 struct IdentityLoad {
   template <typename TA, typename TI>
   static inline TA load(TI v) {
@@ -305,6 +305,30 @@ struct NanToZeroLoad {
       r = TA(0);
     }
     return r;
+  }
+};
+
+template <template <typename> class OpFn, typename Load, typename TA>
+struct ValueAccumulator {
+  template <typename TI>
+  static inline void accumulate(thread TA& acc, TI v) {
+    acc = OpFn<TA>::combine(acc, Load::template load<TA>(v));
+  }
+
+  static inline TA combine(TA a, TA b) {
+    return OpFn<TA>::combine(a, b);
+  }
+};
+
+template <typename Load, typename TA>
+struct ValueAccumulator<c10::metal::SumOp, Load, TA> {
+  template <typename TI>
+  static inline void accumulate(thread TA& acc, TI v) {
+    acc += Load::template load<TA>(v);
+  }
+
+  static inline TA combine(TA a, TA b) {
+    return a + b;
   }
 };
 
@@ -680,6 +704,7 @@ kernel void value_reduction(
   }
 
   using Op = OpFn<TA>;
+  using Acc = ValueAccumulator<OpFn, Load, TA>;
   const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
@@ -693,36 +718,30 @@ kernel void value_reduction(
   if (num_reduced_dims <= 1) {
     for (; base + NCHAINS <= rsize; base += stride) {
       for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] = Op::combine(
-            acc[j],
-            Load::template load<TA>(
-                input[input_base + (base + j) * reduction_stride]));
+        Acc::accumulate(
+            acc[j], input[input_base + (base + j) * reduction_stride]);
       }
     }
     for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] = Op::combine(
-          acc[idx % NCHAINS],
-          Load::template load<TA>(input[input_base + idx * reduction_stride]));
+      Acc::accumulate(
+          acc[idx % NCHAINS], input[input_base + idx * reduction_stride]);
     }
   } else {
     for (; base + NCHAINS <= rsize; base += stride) {
       for (uint j = 0; j < NCHAINS; j++) {
-        acc[j] = Op::combine(
-            acc[j],
-            Load::template load<TA>(
-                input[get_input_offset(base + j, tgid, params)]));
+        Acc::accumulate(
+            acc[j], input[get_input_offset(base + j, tgid, params)]);
       }
     }
     for (uint32_t idx = base; idx < rsize; idx++) {
-      acc[idx % NCHAINS] = Op::combine(
-          acc[idx % NCHAINS],
-          Load::template load<TA>(input[get_input_offset(idx, tgid, params)]));
+      Acc::accumulate(
+          acc[idx % NCHAINS], input[get_input_offset(idx, tgid, params)]);
     }
   }
 
   TA output_val = acc[0];
   for (uint j = 1; j < NCHAINS; j++) {
-    output_val = Op::combine(output_val, acc[j]);
+    output_val = Acc::combine(output_val, acc[j]);
   }
 
   threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE / simdgroup_size];

--- a/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
@@ -1,0 +1,76 @@
+"""Benchmark for the consolidated sum / mean / nansum / count_nonzero reductions,
+which now route through the shared two-pass value_reduction<SumOp> Metal kernel
+(the same kernel min/max/all/any already use) instead of a separate sum_reduction
+kernel.
+
+Run this on a build WITH the change and on the parent commit (without it) and
+compare. The consolidation is behavior-preserving, so the expectation is parity
+(no regression), not a speedup. amax / amin are included as an unchanged-kernel
+control: their kernel is identical on both builds, so any apparent amax/amin
+delta is pure machine drift and can be divided out of the sum delta
+(corrected = (mine_sum / base_sum) / (mine_amax / base_amax)).
+
+Methodology note: the per-shape MPS bench has high run-to-run variance and is
+sensitive to machine load/thermal. Run this script on each build back-to-back on
+an otherwise-idle machine and compare medians; do not compare a fresh run against
+a stored baseline taken under different load.
+"""
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+# Large shapes so the kernel cost dominates the ~110us MPS dispatch/sync floor.
+SHAPES = [
+    ((1 << 24,), None),
+    ((4096, 4096), 1),
+    ((4096, 4096), 0),
+    ((1024, 16384), 1),
+    ((8192, 1024), 0),
+    ((1_000_000, 8), 1),
+]
+DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+# sum/mean/nansum migrate onto value_reduction<SumOp>; amax/amin are the
+# unchanged-kernel control.
+OPS = {
+    "sum": torch.sum,
+    "mean": torch.mean,
+    "nansum": torch.nansum,
+    "amax": torch.amax,
+    "amin": torch.amin,
+}
+
+
+def steady_state():
+    print("# steady-state reduction (median us, warm)")
+    for name, fn in OPS.items():
+        for dtype in DTYPES:
+            for shape, dim in SHAPES:
+                x = torch.randn(*shape, device="mps").to(dtype)
+                torch.mps.synchronize()
+                if dim is None:
+                    t = benchmark.Timer(
+                        stmt="fn(x); torch.mps.synchronize()",
+                        globals={"fn": fn, "x": x, "torch": torch},
+                    )
+                else:
+                    t = benchmark.Timer(
+                        stmt="fn(x, dim=dim); torch.mps.synchronize()",
+                        globals={"fn": fn, "x": x, "dim": dim, "torch": torch},
+                    )
+                # Median of 5 trials: a single blocked_autorange has up to ~2x
+                # run-to-run spikes at large float32 shapes (verified -- even the
+                # unchanged amax/amin kernel spikes that much), so a 5-trial
+                # median is required to compare builds meaningfully.
+                trials = sorted(
+                    t.blocked_autorange(min_run_time=0.3).median for _ in range(5)
+                )
+                us = trials[2] * 1e6
+                dt = str(dtype).replace("torch.", "")
+                print(f"  {name:7} {dt:9} {str(shape):16} dim={dim}: {us:9.1f} us")
+                del x
+                torch.mps.empty_cache()
+
+
+if __name__ == "__main__":
+    steady_state()

--- a/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
+++ b/benchmarks/operator_benchmark/mps/sum_reduce_bench.py
@@ -1,37 +1,53 @@
-"""Benchmark for the consolidated sum / mean / nansum / count_nonzero reductions,
-which now route through the shared two-pass value_reduction<SumOp> Metal kernel
-(the same kernel min/max/all/any already use) instead of a separate sum_reduction
-kernel.
+"""Benchmark for the consolidated generic sum / mean / nansum reductions.
+
+The changed kernel registrations route the generic `{sum,nansum}_reduction_*`
+entry points through the shared value_reduction<SumOp> Metal kernel instead of
+the old standalone sum_reduction kernel. The dedicated inner/outer
+specializations are intentionally not measured here; they keep their existing
+kernels and are not the behavior this PR changes.
 
 Run this on a build WITH the change and on the parent commit (without it) and
-compare. The consolidation is behavior-preserving, so the expectation is parity
-(no regression), not a speedup. amax / amin are included as an unchanged-kernel
-control: their kernel is identical on both builds, so any apparent amax/amin
-delta is pure machine drift and can be divided out of the sum delta
-(corrected = (mine_sum / base_sum) / (mine_amax / base_amax)).
+compare. The correctness intent is behavior preservation; the performance bar is
+no regression, with any speedup coming from the generic tail implementation now
+used by value_reduction. amax / amin are included as an unchanged-kernel context
+for the existing generic value_reduction path rather than as the primary
+pass/fail signal.
 
 Methodology note: the per-shape MPS bench has high run-to-run variance and is
 sensitive to machine load/thermal. Run this script on each build back-to-back on
-an otherwise-idle machine and compare medians; do not compare a fresh run against
-a stored baseline taken under different load.
+an otherwise-idle machine and compare means across independent measurements;
+do not compare a fresh run against a stored baseline taken under different load.
 """
+
+from collections.abc import Callable
 
 import torch
 import torch.utils.benchmark as benchmark
 
 
-# Large shapes so the kernel cost dominates the ~110us MPS dispatch/sync floor.
-SHAPES = [
-    ((1 << 24,), None),
-    ((4096, 4096), 1),
-    ((4096, 4096), 0),
-    ((1024, 16384), 1),
-    ((8192, 1024), 0),
-    ((1_000_000, 8), 1),
+# These cases hit the changed generic entry points:
+# - full_reduce_1d: large full reduction, two-pass generic kernel
+# - middle_dim_contig: contiguous input, single reduced dim that is neither
+#   dim=0 nor last dim, so it bypasses the inner/outer specializations
+# - multi_dim_noncontig: generic multi-dim + non-contiguous fallback
+# - strided_full_reduce: non-contiguous full reduction using strided pass1 +
+#   generic pass2
+CASES: list[
+    tuple[
+        str,
+        tuple[int, ...],
+        int | tuple[int, ...] | None,
+        Callable[[torch.Tensor], torch.Tensor],
+    ]
+] = [
+    ("full_reduce_1d", (1 << 24,), None, lambda x: x),
+    ("middle_dim_contig", (256, 128, 256), 1, lambda x: x),
+    ("multi_dim_noncontig", (16, 64, 16, 64), (1, 3), lambda x: x[:, ::2, :, :]),
+    ("strided_full_reduce", (4096, 4096), None, lambda x: x.t()),
 ]
 DTYPES = [torch.float32, torch.float16, torch.bfloat16]
-# sum/mean/nansum migrate onto value_reduction<SumOp>; amax/amin are the
-# unchanged-kernel control.
+# sum/mean/nansum generic entry points migrate onto value_reduction<SumOp>;
+# amax/amin show the existing generic value_reduction path for context.
 OPS = {
     "sum": torch.sum,
     "mean": torch.mean,
@@ -39,14 +55,17 @@ OPS = {
     "amax": torch.amax,
     "amin": torch.amin,
 }
+TRIALS = 5
+MIN_RUN_TIME = 0.3
 
 
 def steady_state():
-    print("# steady-state reduction (median us, warm)")
-    for name, fn in OPS.items():
+    print("# steady-state reduction (mean us across independent warm samples)")
+    for op_idx, (name, fn) in enumerate(OPS.items()):
         for dtype in DTYPES:
-            for shape, dim in SHAPES:
-                x = torch.randn(*shape, device="mps").to(dtype)
+            for case_idx, (case_name, shape, dim, transform) in enumerate(CASES):
+                torch.manual_seed(op_idx * 1000 + case_idx)
+                x = transform(torch.randn(*shape, device="mps").to(dtype))
                 torch.mps.synchronize()
                 if dim is None:
                     t = benchmark.Timer(
@@ -58,16 +77,20 @@ def steady_state():
                         stmt="fn(x, dim=dim); torch.mps.synchronize()",
                         globals={"fn": fn, "x": x, "dim": dim, "torch": torch},
                     )
-                # Median of 5 trials: a single blocked_autorange has up to ~2x
-                # run-to-run spikes at large float32 shapes (verified -- even the
-                # unchanged amax/amin kernel spikes that much), so a 5-trial
-                # median is required to compare builds meaningfully.
-                trials = sorted(
-                    t.blocked_autorange(min_run_time=0.3).median for _ in range(5)
-                )
-                us = trials[2] * 1e6
+                # MPS execution is asynchronous; synchronizing inside the timed
+                # statement makes Timer measure kernel execution rather than
+                # enqueue latency.
+                trials_us = [
+                    t.blocked_autorange(min_run_time=MIN_RUN_TIME).mean * 1e6
+                    for _ in range(TRIALS)
+                ]
+                us = sum(trials_us) / len(trials_us)
                 dt = str(dtype).replace("torch.", "")
-                print(f"  {name:7} {dt:9} {str(shape):16} dim={dim}: {us:9.1f} us")
+                print(
+                    f"  {case_name:20} {name:7} {dt:9} {str(tuple(x.shape)):18} "
+                    f"dim={dim}: {us:9.1f} us "
+                    f"(min={min(trials_us):.1f} max={max(trials_us):.1f})"
+                )
                 del x
                 torch.mps.empty_cache()
 

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -501,5 +501,31 @@ struct MinOp {
   }
 };
 
+// Sum / product reduction op functors, sharing the identity / combine /
+// simd_reduce / threadgroup_reduce concept with MaxOp / MinOp so sum_reduction
+// can route through the same two-pass value_reduction kernel. T is the
+// accumulator type (opmath_t<TO> for sum, keeping the fp32 accumulation from
+// being lost when TO is fp16/bf16). No `replace`
+// member: that is arg-reduction-only (argmax/argmin reuse MaxOp/MinOp).
+template <typename T>
+struct SumOp {
+  static inline constexpr T identity() {
+    return T(0);
+  }
+  static inline T combine(T a, T b) {
+    return a + b;
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_sum(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_sum(shared, val, tid, tptg);
+  }
+};
+
 } // namespace metal
 } // namespace c10

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -501,12 +501,12 @@ struct MinOp {
   }
 };
 
-// Sum / product reduction op functors, sharing the identity / combine /
-// simd_reduce / threadgroup_reduce concept with MaxOp / MinOp so sum_reduction
-// can route through the same two-pass value_reduction kernel. T is the
-// accumulator type (opmath_t<TO> for sum, keeping the fp32 accumulation from
-// being lost when TO is fp16/bf16). No `replace`
-// member: that is arg-reduction-only (argmax/argmin reuse MaxOp/MinOp).
+// Sum reduction op functor, sharing the identity / combine / simd_reduce /
+// threadgroup_reduce concept with MaxOp / MinOp so sum and mean can route
+// through the same value_reduction kernels. T is the accumulator type
+// (opmath_t<TO> for sum, keeping fp32 accumulation from being lost when TO is
+// fp16/bf16). No `replace` member: that is arg-reduction-only (argmax/argmin
+// reuse MaxOp/MinOp).
 template <typename T>
 struct SumOp {
   static inline constexpr T identity() {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5498,6 +5498,25 @@ class TestMPS(TestCaseMPS):
             for cpu, mps in ((x.cpu(), x), (x.t().cpu(), x.t())):
                 self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
 
+    def test_sum_family_generic_reduction(self):
+        cpu = (torch.arange(2 * 4 * 3 * 5, dtype=torch.float32).reshape(2, 4, 3, 5) - 37) / 10
+        cpu = cpu[:, ::2, :, :]
+        self.assertFalse(cpu.is_contiguous())
+        mps = cpu.to("mps")
+        dims = (1, 3)
+
+        for keepdim in (False, True):
+            kw = {"dim": dims, "keepdim": keepdim}
+            self.assertEqual(mps.sum(**kw).cpu(), cpu.sum(**kw))
+            self.assertEqual(mps.mean(**kw).cpu(), cpu.mean(**kw))
+
+            nans_cpu = cpu.clone()
+            nans_cpu[nans_cpu > 2] = torch.nan
+            nans_mps = nans_cpu.to("mps")
+            self.assertEqual(torch.nansum(nans_mps, **kw).cpu(), torch.nansum(nans_cpu, **kw))
+
+        self.assertEqual(torch.count_nonzero(mps, dim=dims).cpu(), torch.count_nonzero(cpu, dim=dims))
+
     def test_trace_repeated(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178497
         torch.manual_seed(42)


### PR DESCRIPTION
## Stack Position / Review Order

Tracked in #187455. This is the reduce-family base and should land before the prod and var/std follow-ups. It intentionally does not close the tracking issue because #188333 and #187787 remain in the stack.

Order after review:

1. Land this PR first.
2. Rebase/retarget #188333 so its diff is prod-only and review its top commit after this base.
3. Rebuild #187787 after the reduce/prod direction is settled; its current int64-heavy diff is stale and should not be used as the final var/std plan.

This PR supersedes the closed standalone prod split #188046/#188085 as the base direction: prod should become `value_reduction<ProdOp>` on top of this shared kernel, not a parallel `prod_reduction` implementation.

## Summary

PyTorch's MPS reductions had separate generic reduction kernels with the same shape/indexing skeleton. This PR keeps the existing min/max/all/any `value_reduction` kernel as the shared base and moves generic sum, mean, nansum, and count_nonzero onto it through `SumOp` plus small load policies (`IdentityLoad`, `NanToZeroLoad`, `PredicateLoad`).

The final version also adds `ValueAccumulator`, a small compile-time helper that keeps `SumOp` instantiations on direct `+=` accumulation while preserving the `Op::combine` path for min/max/all/any. That keeps the consolidation reviewable without regressing the hot generic multi-dim path.

## What Changed

- `c10/metal/reduction_utils.h`: add `SumOp` next to `MaxOp` / `MinOp`.
- `ReduceOps.metal`: add shared load policies and `ValueAccumulator`; route generic sum, mean, nansum, and count_nonzero through `value_reduction<SumOp, Load, TA>` under the existing host names.
- Delete the standalone generic `sum_reduction` kernel.
- Keep dedicated inner/outer sum kernels and strided pass-1 in place; follow-ups can consolidate those separately if measurements justify it.
- `test/test_mps.py`: add same-PR MPS coverage for non-contiguous multi-dim sum, mean, nansum, and count_nonzero.
- `benchmarks/operator_benchmark/mps/sum_reduce_bench.py`: add a runnable benchmark for the generic reduction routes touched here.

Coverage owner: the focused `test/test_mps.py::TestMPS.test_sum_family_generic_reduction` case owns the MPS-specific backend route changed here: non-contiguous multi-dim reductions now flow through `value_reduction<SumOp, Load, TA>` plus the mean/nansum/count_nonzero load policies. The existing OpInfo surface still owns generic sum-family CPU-vs-MPS semantics, but it does not isolate this moved generic fallback route and load-policy combination.

## Follow-Up Stack

- #188333: prod on top of this base via `value_reduction<ProdOp>`.
- #187787: rebuild var/std after reduce/prod direction settles; keep uint32 indexing with explicit guards unless a separate measured 64-bit indexing PR is revived.
- Outer/inner shape-specialization consolidation, l1/l2 norms, and `sum_reduction_strided_pass1` are intentionally deferred so this base stays small.

## Test Plan

Current local gate head: `debd356d63afb0037fc13e8d91018cd1d795ed2a`.

```bash
/opt/homebrew/bin/python3.11 -m py_compile benchmarks/operator_benchmark/mps/sum_reduce_bench.py test/test_mps.py
lintrunner -a -m upstream/main
ninja -C build caffe2/aten/src/ATen/metallibs torch_cpu && cp build/lib/libtorch_cpu.dylib torch/lib/
PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 /opt/homebrew/bin/python3.11 test/test_mps.py TestMPS.test_sum_family_generic_reduction -v
PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 TORCHINDUCTOR_CPP_CACHE_PRECOMPILE_HEADERS=0 /opt/homebrew/bin/python3.11 test/run_test.py --verbose --mps --keep-going
marmorkrebs --tool stryker-cxx --changed-files aten/src/ATen/native/mps/kernels/ReduceOps.metal --base upstream/main --include-metal --max-mutants 30
```

Full `--mps --keep-going` was refreshed after rebuilding the editable install, forcing `ReduceOps_*.air`, metallib, and `libtorch_cpu.dylib` updates. The run had no reduce-family regression. The only consistent failure was `test/test_metal.py::TestMetalRewritePass::test_conv`, which also reproduces in an independent merge-base/control checkout as the same missing `metal_prepack::conv2d_prepack` schema; this branch does not touch `test_metal.py`, `metal_prepack`, or the Metal rewrite pass.

Relevant completed shard summaries from the refreshed run:

- `test/test_mps.py::TestMPS::test_sum_family_generic_reduction`: passed.
- `test_ops`: 14438 passed / 6019 skipped / 1233 xfailed.
- `test_nn/test_convolution`: 253 passed / 314 skipped.
- `inductor/test_torchinductor_dynamic_shapes`: 1892 passed / 865 skipped / 2 deselected / 8 xfailed.

Mutation gate: `marmorkrebs --tool stryker-cxx` was scoped to the PR-line `ReduceOps.metal` surface. Result: `totalMutants=1`, `killed=1`, `survived=0`, dry-run build/test passed. The build command forced ReduceOps AIR/metallibs plus `torch_cpu`, then copied `libtorch_cpu.dylib`; the test command reran `TestMPS.test_sum_family_generic_reduction` with `PYTHONPATH` pinned to this checkout.

## Checklist

- Lint: `lintrunner -a -m upstream/main` clean, plus Metal compiler preflight and regenerated metallib artifacts.
- Tests: same-PR generic sum-family MPS test and full `--mps --keep-going` blast radius run, with the only failure reproduced on control as unrelated.
- Benchmarks: `benchmarks/operator_benchmark/mps/sum_reduce_bench.py` committed and run against parent/current.
- Docs: not applicable; this is an internal MPS kernel refactor.

## Performance

Benchmark: `benchmarks/operator_benchmark/mps/sum_reduce_bench.py` on M4 Pro, merge-base `2314113635b7` vs this HEAD `debd356d63af`. The benchmark uses `torch.utils.benchmark.Timer.blocked_autorange`, warms before timing, and synchronizes MPS work inside the timed statement because MPS dispatch is asynchronous.

The full sweep table below reports raw parent/current wall-clock ratios for the 36 migrated sum/mean/nansum cells. Raw min/median/max was 0.91x / 1.00x / 1.19x. The two apparent raw regressions below the 0.95x guard were remeasured in a focused rerun and came back faster than parent: `multi_dim_noncontig sum float16` ratio 1.270 and `full_reduce_1d mean float32` ratio 1.098. Same-code control rows in that focused rerun were also noisy, so the two raw table dips are treated as measurement artifact rather than a code regression.

| Case | Op | Dtype | Dim | Parent us | This PR us | Ratio |
|---|---:|---:|---:|---:|---:|---:|
| `full_reduce_1d` | `mean` | `bfloat16` | `None` | 447.9 | 469.4 | 0.95x |
| `full_reduce_1d` | `mean` | `float16` | `None` | 486.8 | 473.0 | 1.03x |
| `full_reduce_1d` | `mean` | `float32` | `None` | 610.1 | 649.1 | 0.94x |
| `full_reduce_1d` | `nansum` | `bfloat16` | `None` | 442.8 | 378.6 | 1.17x |
| `full_reduce_1d` | `nansum` | `float16` | `None` | 472.7 | 491.9 | 0.96x |
| `full_reduce_1d` | `nansum` | `float32` | `None` | 652.5 | 583.0 | 1.12x |
| `full_reduce_1d` | `sum` | `bfloat16` | `None` | 469.3 | 472.9 | 0.99x |
| `full_reduce_1d` | `sum` | `float16` | `None` | 471.6 | 396.0 | 1.19x |
| `full_reduce_1d` | `sum` | `float32` | `None` | 630.1 | 570.7 | 1.10x |
| `middle_dim_contig` | `mean` | `bfloat16` | `1` | 920.6 | 929.4 | 0.99x |
| `middle_dim_contig` | `mean` | `float16` | `1` | 923.0 | 921.1 | 1.00x |
| `middle_dim_contig` | `mean` | `float32` | `1` | 914.5 | 917.6 | 1.00x |
| `middle_dim_contig` | `nansum` | `bfloat16` | `1` | 995.3 | 993.6 | 1.00x |
| `middle_dim_contig` | `nansum` | `float16` | `1` | 924.5 | 935.5 | 0.99x |
| `middle_dim_contig` | `nansum` | `float32` | `1` | 926.0 | 925.1 | 1.00x |
| `middle_dim_contig` | `sum` | `bfloat16` | `1` | 923.9 | 924.1 | 1.00x |
| `middle_dim_contig` | `sum` | `float16` | `1` | 925.5 | 920.5 | 1.01x |
| `middle_dim_contig` | `sum` | `float32` | `1` | 914.9 | 917.0 | 1.00x |
| `multi_dim_noncontig` | `mean` | `bfloat16` | `(1, 3)` | 398.9 | 398.2 | 1.00x |
| `multi_dim_noncontig` | `mean` | `float16` | `(1, 3)` | 411.1 | 386.6 | 1.06x |
| `multi_dim_noncontig` | `mean` | `float32` | `(1, 3)` | 402.2 | 401.3 | 1.00x |
| `multi_dim_noncontig` | `nansum` | `bfloat16` | `(1, 3)` | 386.0 | 397.8 | 0.97x |
| `multi_dim_noncontig` | `nansum` | `float16` | `(1, 3)` | 389.2 | 405.6 | 0.96x |
| `multi_dim_noncontig` | `nansum` | `float32` | `(1, 3)` | 408.1 | 396.4 | 1.03x |
| `multi_dim_noncontig` | `sum` | `bfloat16` | `(1, 3)` | 399.7 | 394.7 | 1.01x |
| `multi_dim_noncontig` | `sum` | `float16` | `(1, 3)` | 372.4 | 407.5 | 0.91x |
| `multi_dim_noncontig` | `sum` | `float32` | `(1, 3)` | 403.8 | 406.5 | 0.99x |
| `strided_full_reduce` | `mean` | `bfloat16` | `None` | 479.2 | 473.7 | 1.01x |
| `strided_full_reduce` | `mean` | `float16` | `None` | 492.5 | 474.2 | 1.04x |
| `strided_full_reduce` | `mean` | `float32` | `None` | 507.2 | 488.0 | 1.04x |
| `strided_full_reduce` | `nansum` | `bfloat16` | `None` | 450.4 | 439.2 | 1.03x |
| `strided_full_reduce` | `nansum` | `float16` | `None` | 466.5 | 469.2 | 0.99x |
| `strided_full_reduce` | `nansum` | `float32` | `None` | 662.3 | 658.7 | 1.01x |
| `strided_full_reduce` | `sum` | `bfloat16` | `None` | 465.4 | 470.6 | 0.99x |
| `strided_full_reduce` | `sum` | `float16` | `None` | 470.9 | 465.7 | 1.01x |
| `strided_full_reduce` | `sum` | `float32` | `None` | 664.6 | 595.0 | 1.12x |

## Review History

Review history and per-finding dispositions: https://gist.github.com/d29a62be18569830067a9fdc6f72df03

## BC-breaking?

No.
