### PR TITLE
[MPS] Migrate argmin/argmax from MPSGraph to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1100,3 +1100,327 @@ REGISTER_REDUCTIONS_OPS_FOR_TYPE(uchar);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(bool);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(float2);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(half2);
+
+// =============================================================================
+// argmax/argmin: per output element find the (linear) index of the max/min
+// input element along the reduced dim(s). Output is always int64. NaN
+// propagates (first NaN in source order wins); on ties the lowest index wins.
+// Mirrors the value_reduction layout but tracks a (value, index) pair instead
+// of just a value.
+// =============================================================================
+
+// Arg-reductions reuse the same MaxOp / MinOp structs that drive value
+// reductions: identity and simd_reduce for the value side, replace for the
+// NaN-propagating per-thread scan and outer-kernel shared-memory tree reduce.
+
+// SIMD argmin/argmax with proper pair tie-break (the c10::metal::simd_argmax
+// helper ties on lowest LANE, which is wrong when a single lane has scanned
+// multiple positions and stored a non-minimal index for the winning value).
+// Two-step: simd-reduce the values, then simd_min the indices of lanes whose
+// value matched the winner (NaN lanes count as winners on float). Returns
+// (winner_value, min_winning_idx).
+template <
+    template <typename> class OpFn,
+    typename TA,
+    ::metal::enable_if_t<is_floating_point_v<TA>, bool> = true>
+inline c10::metal::pair<TA, uint32_t> simd_arg_reduce(TA val, uint32_t idx) {
+  using Op = OpFn<TA>;
+  const TA winner = Op::simd_reduce(val);
+  const bool is_winner = ::metal::isnan(val) || (val == winner);
+  const uint32_t eff_idx =
+      is_winner ? idx : ::metal::numeric_limits<uint32_t>::max();
+  return {winner, ::metal::simd_min(eff_idx)};
+}
+
+template <
+    template <typename> class OpFn,
+    typename TA,
+    ::metal::enable_if_t<!is_floating_point_v<TA>, bool> = true>
+inline c10::metal::pair<TA, uint32_t> simd_arg_reduce(TA val, uint32_t idx) {
+  using Op = OpFn<TA>;
+  const TA winner = Op::simd_reduce(val);
+  const uint32_t eff_idx =
+      (val == winner) ? idx : ::metal::numeric_limits<uint32_t>::max();
+  return {winner, ::metal::simd_min(eff_idx)};
+}
+
+// Pair tie-break for the shared-memory tree reduction in the outer-dim
+// kernel: cand replaces cur if strictly better OR (equal AND lower idx).
+// `Op::replace` already handles NaN propagation; equality here is the
+// !replace-either-way fallback, which subsumes both both-NaN and both-equal
+// cases.
+template <template <typename> class OpFn, typename TA>
+inline bool arg_replace(
+    TA cand_val,
+    uint32_t cand_idx,
+    TA cur_val,
+    uint32_t cur_idx) {
+  using Op = OpFn<TA>;
+  if (Op::replace(cand_val, cur_val)) {
+    return true;
+  }
+  if (Op::replace(cur_val, cand_val)) {
+    return false;
+  }
+  return cand_idx < cur_idx;
+}
+
+// Generic single-pass argmax/argmin. Each threadgroup computes one output
+// element; the per-thread loop scans the reduction with strict-improvement
+// updates (so on equal values the earlier index is kept), then a two-stage
+// SIMD reduction collapses the per-thread (value, index) pairs.
+//
+// Lane-to-source-index ordering: tid t processes reduction indices
+// {t, t+tptg, t+2*tptg, ...}, so within a simdgroup the lowest lane sees the
+// lowest index. Across simdgroups, simdgroup_id 0 contains the lowest tids.
+// Tie-break by lowest-lane in simd_argmax therefore matches PyTorch's
+// "first occurrence wins" convention.
+template <template <typename> class OpFn, typename TI>
+[[max_total_threads_per_threadgroup(MAX_THREADGROUP_SIZE)]]
+kernel void arg_reduction(
+    constant TI* input [[buffer(0)]],
+    device long* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TI>;
+  using Op = OpFn<TA>;
+
+  // Compute input_base and detect reduction pattern (mirrors value_reduction).
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  TA best_val = Op::identity();
+  uint32_t best_idx = 0;
+  const uint32_t rsize = params.reduction_size;
+
+  if (num_reduced_dims <= 1) {
+    for (uint32_t idx = tid; idx < rsize; idx += tptg) {
+      const TA val =
+          static_cast<TA>(input[input_base + idx * reduction_stride]);
+      if (Op::replace(val, best_val)) {
+        best_val = val;
+        best_idx = idx;
+      }
+    }
+  } else {
+    for (uint32_t idx = tid; idx < rsize; idx += tptg) {
+      const TA val =
+          static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
+      if (Op::replace(val, best_val)) {
+        best_val = val;
+        best_idx = idx;
+      }
+    }
+  }
+
+  // Two-stage SIMD reduction. Stage 1: each simdgroup picks its winner via
+  // simd_arg_reduce (proper pair tie-break). If there's only one simdgroup,
+  // we're done. Stage 2: all 32 lanes of simdgroup 0 load the per-simdgroup
+  // winners (slots past the active count get identity + UINT_MAX idx so they
+  // never win the value race and contribute UINT_MAX to the idx race).
+  auto rc = simd_arg_reduce<OpFn>(best_val, best_idx);
+  uint32_t result_idx = rc.second;
+
+  if (tptg > simdgroup_size) {
+    threadgroup TA shared_vals[MAX_THREADGROUP_SIZE / 32];
+    threadgroup uint32_t shared_idxs[MAX_THREADGROUP_SIZE / 32];
+    const uint32_t nsimd = tptg / simdgroup_size;
+    if (tid % simdgroup_size == 0) {
+      shared_vals[tid / simdgroup_size] = rc.first;
+      shared_idxs[tid / simdgroup_size] = rc.second;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < simdgroup_size) {
+      const TA v = (tid < nsimd) ? shared_vals[tid] : Op::identity();
+      const uint32_t i = (tid < nsimd)
+          ? shared_idxs[tid]
+          : ::metal::numeric_limits<uint32_t>::max();
+      auto rc2 = simd_arg_reduce<OpFn>(v, i);
+      if (tid == 0) {
+        shared_idxs[0] = rc2.second;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    result_idx = shared_idxs[0];
+  }
+
+  if (tid == 0) {
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      const auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        const auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+    output[output_offset] = static_cast<long>(result_idx);
+  }
+}
+
+// Inner-dim arg-reduction: input is logically [M, N] contiguous, reduce N
+// (innermost). One SIMD group (32 lanes) per row, multiple SIMD groups per
+// TG for occupancy. Lane L scans positions {L, L+32, L+64, ...} of its row
+// with strict-improvement updates (so the lane's stored idx is the lowest
+// of its scanned positions matching the winning value). The cross-lane
+// collapse uses simd_arg_reduce which ties on lowest IDX, not lowest LANE.
+template <template <typename> class OpFn, typename TI>
+kernel void arg_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device long* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // [M, N]
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TI>;
+  using Op = OpFn<TA>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / simdgroup_size;
+
+  const uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M) {
+    return;
+  }
+
+  constant TI* row_ptr = input + row * N;
+
+  TA best_val = Op::identity();
+  uint32_t best_idx = 0;
+  for (uint i = simd_lane_id; i < N; i += simdgroup_size) {
+    const TA val = static_cast<TA>(row_ptr[i]);
+    if (Op::replace(val, best_val)) {
+      best_val = val;
+      best_idx = i;
+    }
+  }
+
+  auto rc = simd_arg_reduce<OpFn>(best_val, best_idx);
+  if (simd_lane_id == 0) {
+    output[row] = static_cast<long>(rc.second);
+  }
+}
+
+// Outer-dim arg-reduction: input is logically [M, N] contiguous, reduce M
+// down so output is [N]. TG_X threads cover adjacent output columns
+// (coalesced reads), TG_Y threads split the M rows. Per-thread scan keeps
+// the lowest row with the winning value; cross-worker tree reduction uses
+// arg_replace (strictly-better OR equal-with-lower-idx).
+template <
+    template <typename> class OpFn,
+    typename TI,
+    uint TG_X = 32,
+    uint TG_Y = 32>
+[[max_total_threads_per_threadgroup(TG_X * TG_Y)]]
+kernel void arg_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device long* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]], // [M, N, output_stride]
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TI>;
+  using Op = OpFn<TA>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  const uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N) {
+    return;
+  }
+
+  const uint rows_per_y = ceil_div(M, TG_Y);
+  const uint row_start = tid_tg.y * rows_per_y;
+  const uint row_end = min(row_start + rows_per_y, M);
+
+  TA best_val = Op::identity();
+  uint32_t best_idx = 0;
+  for (uint row = row_start; row < row_end; row++) {
+    const TA val = static_cast<TA>(input[row * N + col]);
+    if (Op::replace(val, best_val)) {
+      best_val = val;
+      best_idx = row;
+    }
+  }
+
+  threadgroup TA shared_vals[TG_Y][TG_X];
+  threadgroup uint32_t shared_idxs[TG_Y][TG_X];
+  shared_vals[tid_tg.y][tid_tg.x] = best_val;
+  shared_idxs[tid_tg.y][tid_tg.x] = best_idx;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint stride = TG_Y / 2; stride > 0; stride >>= 1) {
+    if (tid_tg.y < stride) {
+      const TA other_val = shared_vals[tid_tg.y + stride][tid_tg.x];
+      const uint32_t other_idx = shared_idxs[tid_tg.y + stride][tid_tg.x];
+      const TA self_val = shared_vals[tid_tg.y][tid_tg.x];
+      const uint32_t self_idx = shared_idxs[tid_tg.y][tid_tg.x];
+      if (arg_replace<OpFn>(other_val, other_idx, self_val, self_idx)) {
+        shared_vals[tid_tg.y][tid_tg.x] = other_val;
+        shared_idxs[tid_tg.y][tid_tg.x] = other_idx;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    output[col * out_stride] = static_cast<long>(shared_idxs[0][tid_tg.x]);
+  }
+}
+
+#define REGISTER_ARG_REDUCTION_IMPL(TI, NAME, OP)              \
+  template [[host_name(NAME "_reduction_" #TI "_long")]]       \
+  kernel void arg_reduction<OP, TI>(                           \
+      constant TI * input [[buffer(0)]],                       \
+      device long* output [[buffer(1)]],                       \
+      constant NormParams<>& params [[buffer(2)]],             \
+      uint tid [[thread_position_in_threadgroup]],             \
+      uint tptg [[threads_per_threadgroup]],                   \
+      uint tgid [[threadgroup_position_in_grid]]);             \
+  template [[host_name(NAME "_reduction_inner_" #TI "_long")]] \
+  kernel void arg_reduction_inner<OP, TI>(                     \
+      constant TI * input [[buffer(0)]],                       \
+      device long* output [[buffer(1)]],                       \
+      constant uint2& sizes [[buffer(2)]],                     \
+      uint tptg [[threads_per_threadgroup]],                   \
+      uint tgid [[threadgroup_position_in_grid]],              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],         \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);   \
+  template [[host_name(NAME "_reduction_outer_" #TI "_long")]] \
+  kernel void arg_reduction_outer<OP, TI, 32, 32>(             \
+      constant TI * input [[buffer(0)]],                       \
+      device long* output [[buffer(1)]],                       \
+      constant uint3& sizes [[buffer(2)]],                     \
+      uint2 tid_tg [[thread_position_in_threadgroup]],         \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+#define REGISTER_ARG_REDUCTIONS_FOR_TYPE(T)       \
+  REGISTER_ARG_REDUCTION_IMPL(T, "argmax", MaxOp) \
+  REGISTER_ARG_REDUCTION_IMPL(T, "argmin", MinOp)
+
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(float);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(half);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(bfloat);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(long);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(int);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(short);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(char);
+REGISTER_ARG_REDUCTIONS_FOR_TYPE(uchar);

--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -779,75 +779,10 @@ REGISTER_COUNT_NONZERO_INNER(half2);
 // input element to {0, 1} (nonzero, NaN -> 1) before the reduction.
 // =============================================================================
 
-// Reduction op functors. Each Op defines identity<T>(), combine(), and
-// threadgroup_reduce(). Identity is the "neutral" element for the op (-INF
-// for max on floats, numeric_limits<T>::lowest() for integers, etc.).
-// combine() and threadgroup_reduce() delegate to c10::metal helpers, which
-// propagate NaN for floats.
-struct MaxOp {
-  template <
-      typename T,
-      ::metal::enable_if_t<!is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return ::metal::numeric_limits<T>::lowest();
-  }
-  // Float identity is -INFINITY (not -FLT_MAX): max(-INF, x) = x for any
-  // finite x including -FLT_MAX, but max(-FLT_MAX, -INFINITY) would
-  // incorrectly return -FLT_MAX.
-  template <
-      typename T,
-      ::metal::enable_if_t<is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return T(-INFINITY);
-  }
-  template <typename T>
-  static inline T combine(T a, T b) {
-    return c10::metal::max(a, b);
-  }
-  template <typename T>
-  static inline T simd_reduce(T val) {
-    return c10::metal::simd_max(val);
-  }
-  template <typename T>
-  static inline T threadgroup_reduce(
-      threadgroup T* shared,
-      T val,
-      uint tid,
-      uint tptg) {
-    return c10::metal::threadgroup_max(shared, val, tid, tptg);
-  }
-};
-
-struct MinOp {
-  template <
-      typename T,
-      ::metal::enable_if_t<!is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return ::metal::numeric_limits<T>::max();
-  }
-  template <
-      typename T,
-      ::metal::enable_if_t<is_floating_point_v<T>, bool> = true>
-  static inline constexpr T identity() {
-    return T(INFINITY);
-  }
-  template <typename T>
-  static inline T combine(T a, T b) {
-    return c10::metal::min(a, b);
-  }
-  template <typename T>
-  static inline T simd_reduce(T val) {
-    return c10::metal::simd_min(val);
-  }
-  template <typename T>
-  static inline T threadgroup_reduce(
-      threadgroup T* shared,
-      T val,
-      uint tid,
-      uint tptg) {
-    return c10::metal::threadgroup_min(shared, val, tid, tptg);
-  }
-};
+// Reduction op functors MaxOp / MinOp (identity, replace, combine,
+// simd_reduce, threadgroup_reduce) live in c10/metal/reduction_utils.h so the
+// inductor MPS codegen can reuse the same identity/replace pair; both are
+// pulled in via the file-scope `using namespace c10::metal`.
 
 // Load functors decide how an input element is converted into the
 // accumulator type. IdentityLoad casts (min/max keep the value unchanged);
@@ -874,7 +809,7 @@ struct PredicateLoad {
 // runtime tptg value, which in turn lets c10::metal::threadgroup_min/max
 // constant-fold its size-vs-simdgroup_size branch.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -905,7 +840,8 @@ kernel void value_reduction(
   }
 
   using TA = TO;
-  const TA identity_val = Op::template identity<TA>();
+  using Op = OpFn<TA>;
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;
@@ -973,7 +909,7 @@ kernel void value_reduction(
 // threads split the M rows. Mirrors sum_reduction_outer; uses the same
 // (Op, Load) abstraction as value_reduction.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -988,6 +924,7 @@ kernel void value_reduction_outer(
     uint2 tid_tg [[thread_position_in_threadgroup]],
     uint2 tg_pos [[threadgroup_position_in_grid]]) {
   using TA = TO;
+  using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
   const uint out_stride = sizes.z;
@@ -1001,7 +938,7 @@ kernel void value_reduction_outer(
   uint row_start = tid_tg.y * rows_per_y;
   uint row_end = min(row_start + rows_per_y, M);
 
-  const TA identity_val = Op::template identity<TA>();
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;
@@ -1047,7 +984,7 @@ kernel void value_reduction_outer(
 // SIMD groups per TG for occupancy. No shared memory needed since
 // simd_reduce suffices for intra-row collapse. Mirrors sum_reduction_inner.
 template <
-    typename Op,
+    template <typename> class OpFn,
     typename Load,
     typename TI,
     typename TO,
@@ -1061,6 +998,7 @@ kernel void value_reduction_inner(
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
   using TA = TO;
+  using Op = OpFn<TA>;
   const uint M = sizes.x;
   const uint N = sizes.y;
   const uint num_simd_groups = tptg / simdgroup_size;
@@ -1072,7 +1010,7 @@ kernel void value_reduction_inner(
 
   constant TI* row_ptr = input + row * N;
 
-  const TA identity_val = Op::template identity<TA>();
+  const TA identity_val = Op::identity();
   metal::array<TA, NCHAINS> acc;
   for (uint j = 0; j < NCHAINS; j++) {
     acc[j] = identity_val;

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -794,92 +794,130 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
                                   const Tensor& output_t,
                                   MPSReductionType reduction_type,
                                   const std::string& func_name) {
-  using CachedGraph = MPSUnaryCachedGraph;
+  const bool is_argmax = (reduction_type == MPSReductionType::MAX);
+  const char* op_name = is_argmax ? "argmax()" : "argmin()";
 
   int64_t dim_ = -1;
-
   if (dim.has_value()) {
     dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
-    zero_numel_check_dims(input_t, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
+    zero_numel_check_dims(input_t, dim_, op_name);
   } else {
-    TORCH_CHECK_INDEX(input_t.numel() != 0,
-                      reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()",
-                      ": Expected reduction dim to be specified for input.numel() == 0.");
-    // Since input will be flattened, take argmax or argmin along 0'th dimension
-    dim_ = 0;
-  }
-
-  // Calculate the output shape according to keepdim=True
-  // If there is no dim argument, the input shape is flattened
-  IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
-  NSMutableArray<NSNumber*>* apparent_in_shape = nil;
-  NSMutableArray<NSNumber*>* apparent_out_shape = nil;
-
-  if (dim.has_value()) {
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for (const auto i : c10::irange(num_input_dims)) {
-      apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
-    }
-  } else {
-    apparent_in_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = c10::multiply_integers(input_shape);
-    apparent_in_shape[0] = [NSNumber numberWithInt:num_in_elements];
-
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    apparent_out_shape[0] = @1;
+    TORCH_CHECK_INDEX(
+        input_t.numel() != 0, op_name, ": Expected reduction dim to be specified for input.numel() == 0.");
   }
 
   if (output_t.numel() == 0) {
     return;
   }
-
-  if (!apparent_in_shape) {
-    apparent_in_shape = [getMPSShape(input_t.sizes()) mutableCopy];
+  // 0-dim input: only index 0 is reachable.
+  if (input_t.dim() == 0) {
+    output_t.fill_(0);
+    return;
   }
 
-  @autoreleasepool {
-    NSString* ns_key = [[apparent_in_shape valueForKey:@"description"] componentsJoinedByString:@","];
-    std::string key = func_name + ":" + std::to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" +
-        std::string([ns_key UTF8String]);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto inputScalarType = input_t.scalar_type();
-      MPSGraphTensor* inputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(inputScalarType), apparent_in_shape);
-      MPSGraphTensor* argreduceOutTensor = nil;
+  // For full reduction (dim==None) we materialize a contiguous 1-D view so the
+  // returned linear index follows the standard "as-if-contiguous" convention,
+  // regardless of input strides.
+  Tensor input;
+  Tensor output_view;
+  int64_t reduce_dim = 0;
+  if (dim.has_value()) {
+    input = input_t;
+    output_view = keepdim ? output_t : output_t.unsqueeze(dim_);
+    reduce_dim = dim_;
+  } else {
+    input = input_t.contiguous().view(-1);
+    output_view = output_t.view({1});
+  }
+  TORCH_CHECK(static_cast<uint32_t>(input.dim()) <= c10::metal::max_ndim,
+              func_name,
+              ": tensor rank > ",
+              c10::metal::max_ndim,
+              " is not supported");
 
-      MPSGraphTensor* castInputTensor = inputTensor;
-      if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
-          inputScalarType != kLong) {
-        castInputTensor = castMPSTensor(mpsGraph, inputTensor, kFloat);
+  // Metal has no simd_min/max for bool; remap to 1-byte char (identical 0/1
+  // layout). Complex types have no ordering, so argmax/argmin is undefined.
+  ScalarType in_kdtype = input.scalar_type();
+  TORCH_CHECK(!c10::isComplexType(in_kdtype), func_name, ": not implemented for ", in_kdtype);
+  if (in_kdtype == kBool) {
+    in_kdtype = kChar;
+  }
+  const auto op_prefix = is_argmax ? "argmax" : "argmin";
+  const auto in_str = scalarToMetalTypeString(in_kdtype);
+  MPSStream* stream = getCurrentMPSStream();
+
+  // Fast paths: when the reduced dim is the outermost or innermost dim of a
+  // contiguous input (and the output is contiguous), dispatch a specialized
+  // kernel with a tuned grid layout, mirroring value_reduction_outer /
+  // value_reduction_inner.
+  if (dim.has_value() && input.is_contiguous() && output_t.is_contiguous() && input.dim() >= 2 &&
+      (reduce_dim == 0 || reduce_dim == input.dim() - 1)) {
+    const bool is_outer = (reduce_dim == 0);
+    const uint32_t M = is_outer ? static_cast<uint32_t>(input.size(0))
+                                : static_cast<uint32_t>(input.numel() / input.size(input.dim() - 1));
+    const uint32_t N = is_outer ? static_cast<uint32_t>(input.numel() / input.size(0))
+                                : static_cast<uint32_t>(input.size(input.dim() - 1));
+    const auto kernel_name = fmt::format("{}_reduction_{}_{}_long", op_prefix, is_outer ? "outer" : "inner", in_str);
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel_name);
+        getMPSProfiler().beginProfileKernel(ps, func_name, {input});
+        [ce setComputePipelineState:ps];
+        if (is_outer) {
+          constexpr uint32_t TG_X = 32, TG_Y = 32;
+          // 4th element is trailing pad so the host-side bind matches the
+          // kernel's `constant uint3&` slot (uint3 has 16-byte alignment in
+          // Metal even though only 12 bytes are read). Without this Metal
+          // API validation flags a buffer-length mismatch.
+          const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
+          mtl_setArgs(ce, input, output_t, sizes_s);
+          const auto num_tg_x = c10::metal::ceil_div(N, TG_X);
+          [ce dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        } else {
+          constexpr uint32_t TG_SIZE = 256;
+          constexpr uint32_t rows_per_tg = TG_SIZE / 32;
+          const auto num_tgs = c10::metal::ceil_div(M, rows_per_tg);
+          struct {
+            uint32_t M, N;
+          } sizes_s = {M, N};
+          mtl_setArgs(ce, input, output_t, sizes_s);
+          [ce dispatchThreads:MTLSizeMake(num_tgs * TG_SIZE, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG_SIZE, 1, 1)];
+        }
+        getMPSProfiler().endProfileKernel(ps);
       }
-      if (reduction_type == MPSReductionType::MAX) {
-        argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      } else {
-        argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      }
-
-      MPSGraphTensor* outputTensor = argreduceOutTensor;
-      if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
-        outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());
-      }
-
-      MPSGraphTensor* outputClampedTensor =
-          [mpsGraph clampWithTensor:outputTensor
-                     minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
-                     maxValueTensor:[mpsGraph constantWithScalar:0x7FEFFFFFFFFFFFFF dataType:MPSDataTypeInt64]
-                               name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputClampedTensor;
     });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+    return;
   }
+
+  const auto kernel_name = fmt::format("{}_reduction_{}_long", op_prefix, in_str);
+
+  NormParams params{};
+  params.ndim = input.dim();
+  params.reduction_size = static_cast<uint32_t>(input.size(reduce_dim));
+  for (const auto d : c10::irange(input.dim())) {
+    params.input_sizes[d] = input.size(d);
+    params.input_strides[d] = input.stride(d);
+    params.output_sizes[d] = output_view.size(d);
+    params.output_strides[d] = output_view.stride(d);
+  }
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel_name);
+      getMPSProfiler().beginProfileKernel(ps, func_name, {input});
+      [ce setComputePipelineState:ps];
+      mtl_setArgs(ce, input, output_view, params);
+      // Pad per-TG thread count up to a full simdgroup; padding lanes load
+      // Op::identity() and skip the per-thread scan, keeping the two-stage
+      // SIMD reduction well-defined for all reduction sizes.
+      const auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(params.reduction_size, 32u));
+      const auto num_threads = static_cast<uint32_t>(output_view.numel()) * threads_per_group;
+      [ce dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
 }
 
 // Unified host-side dispatch for value-preserving reductions on MPS, shared
@@ -946,9 +984,10 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
           id<MTLComputeCommandEncoder> ce = stream->commandEncoder();
           auto ps = lib.getPipelineStateForFunc(outer_kernel);
           getMPSProfiler().beginProfileKernel(ps, opts.prefix + "reduction_outer", {input_orig});
-          struct {
-            uint32_t M, N, out_stride;
-          } sizes_s = {M, N, 1};
+          // 4th element is trailing pad so the host-side bind matches the
+          // kernel's `constant uint3&` slot (16-byte alignment in Metal even
+          // though only 12 bytes are read).
+          const std::array<uint32_t, 4> sizes_s{M, N, 1, 0};
           [ce setComputePipelineState:ps];
           if (opts.divisor.has_value()) {
             mtl_setArgs(ce, input_orig, output, sizes_s, *opts.divisor);

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -414,5 +414,92 @@ IDX_T threadgroup_argmin(
   return idx_data[0];
 }
 
+// Reduction op functors bundling identity, replace predicate, and the value
+// reduction helpers (combine / simd_reduce / threadgroup_reduce) used by both
+// value and arg reductions. NaN handling: for floats, isnan-propagating
+// max/min and a strict "replace" predicate that lets NaN beat any finite
+// value and lets any finite value beat -INF/+INF identity.
+//
+// Float identity is +/-INFINITY (not numeric_limits::lowest/max, i.e.
+// -/+FLT_MAX): max(-INF, x) = x for any finite x including -FLT_MAX, but
+// max(-FLT_MAX, -INFINITY) would incorrectly return -FLT_MAX.
+//
+// The isnan() calls below route through static_cast<float>() so the float
+// branch type-checks even when T is integral (Metal 3 lowers `if IF_CONSTEXPR`
+// to a runtime `if` and parses both arms). Both branches' bodies still get
+// dropped on Metal 4 where IF_CONSTEXPR is real `if constexpr`.
+template <typename T>
+struct MaxOp {
+  static inline constexpr T identity() {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      return T(-INFINITY);
+    } else {
+      return ::metal::numeric_limits<T>::lowest();
+    }
+  }
+
+  // Strict "should-replace" predicate: returns true iff cand strictly beats
+  // cur. NaN-propagating: NaN cand beats finite cur; finite cand never beats
+  // NaN cur.
+  static inline bool replace(T cand, T cur) {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      if (::metal::isnan(static_cast<float>(cur))) {
+        return false;
+      }
+      return ::metal::isnan(static_cast<float>(cand)) || cand > cur;
+    }
+    return cand > cur;
+  }
+
+  static inline T combine(T a, T b) {
+    return c10::metal::max(a, b);
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_max(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_max(shared, val, tid, tptg);
+  }
+};
+
+template <typename T>
+struct MinOp {
+  static inline constexpr T identity() {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      return T(INFINITY);
+    } else {
+      return ::metal::numeric_limits<T>::max();
+    }
+  }
+
+  static inline bool replace(T cand, T cur) {
+    if IF_CONSTEXPR (::metal::is_floating_point_v<T>) {
+      if (::metal::isnan(static_cast<float>(cur))) {
+        return false;
+      }
+      return ::metal::isnan(static_cast<float>(cand)) || cand < cur;
+    }
+    return cand < cur;
+  }
+
+  static inline T combine(T a, T b) {
+    return c10::metal::min(a, b);
+  }
+  static inline T simd_reduce(T val) {
+    return c10::metal::simd_min(val);
+  }
+  static inline T threadgroup_reduce(
+      threadgroup T* shared,
+      T val,
+      uint tid,
+      uint tptg) {
+    return c10::metal::threadgroup_min(shared, val, tid, tptg);
+  }
+};
+
 } // namespace metal
 } // namespace c10

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12603,7 +12603,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         t1 = torch.randint(8, size=(1028, 1028))
         self.common(fn, (t1,))
 
-    @xfail_if_mps  # eager nan is wrong, see https://github.com/pytorch/pytorch/issues/130295
     @skip_if_halide  # nan behavior
     def test_argmax_argmin_with_nan(self):
         def fn(x):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -74,9 +74,6 @@ test_failures = {
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction2_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction3_dynamic_shapes": TestFailure(("mps",)),
-    "test_reduction5_dynamic_shapes": TestFailure(("mps",)),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
     "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(
         ("mps",), is_skip=True

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -743,8 +743,8 @@ class MetalKernel(SIMDKernel):
             if not self.multistage_reduction_entry:
                 val = cast_value  # type: ignore[assignment]
             else:
-                lim_fn = "lowest" if reduction_type.endswith("max") else "max"
-                limit_val = f"::metal::numeric_limits<{src_metal_type}>::{lim_fn}()"
+                op_struct = "MaxOp" if reduction_type == "max" else "MinOp"
+                limit_val = f"::c10::metal::{op_struct}<{src_metal_type}>::identity()"
                 val = self._new_idxvar(
                     src_dtype, default_value=limit_val, is_threadgroup=False
                 )
@@ -765,8 +765,8 @@ class MetalKernel(SIMDKernel):
                 val = cast_value  # type: ignore[assignment]
                 idx_val = f"static_cast<{DTYPE_TO_METAL[dtype]}>({reduction_idx})"
             else:
-                lim_fn = "lowest" if reduction_type.endswith("max") else "max"
-                limit_val = f"::metal::numeric_limits<{src_metal_type}>::{lim_fn}()"
+                op_struct = "MaxOp" if reduction_type == "argmax" else "MinOp"
+                limit_val = f"::c10::metal::{op_struct}<{src_metal_type}>::identity()"
                 val = self._new_idxvar(
                     src_dtype, default_value=limit_val, is_threadgroup=False
                 )
@@ -774,15 +774,9 @@ class MetalKernel(SIMDKernel):
                 idx_var = next(
                     t for t in self.range_tree_nodes.values() if t.is_reduction
                 )
-                cmp_op = ">" if reduction_type == "argmax" else "<"
-                nan_suffix = (
-                    f" || ::metal::isnan({value}) "
-                    if src_dtype.is_floating_point
-                    else ""
-                )
                 self.compute.splice(f"""
-                if ({value} {cmp_op} {val}{nan_suffix}) {{
-                    {val} = {value};
+                if (::c10::metal::{op_struct}<{src_metal_type}>::replace({cast_value}, {val})) {{
+                    {val} = {cast_value};
                     {idx_val} = {idx_var.name};
                 }}
                 """)


### PR DESCRIPTION
This is a cherry-picks of the following 2 PRs into release/2.13 to fix a regression in the upcoming MacOS release
- **[MPS] Refactor inlined Metal reduction logic into shared header (#187541)**
- **[MPS] Migrate argmin/argmax from MPSGraph to Metal kernels (#187304)**

Fixes https://github.com/pytorch/pytorch/issues/187280

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo