### PR TITLE
Revive CUDA 12.9 nightly binary builds (#186015)

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -64,7 +64,7 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
         "nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
     ),
     "12.9": (
-        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.9.1; platform_system == 'Linux' | "  # noqa: B950
+        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.9.1; platform_system == 'Linux' | "
         "cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | "
         "nvidia-cudnn-cu12==9.20.0.48; platform_system == 'Linux' | "
         "nvidia-cusparselt-cu12==0.8.1; platform_system == 'Linux' | "

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -24,15 +24,17 @@ SCRIPT_DIR = Path(__file__).absolute().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 
 
-CUDA_ARCHES = ["12.6", "13.0", "13.2"]
+CUDA_ARCHES = ["12.6", "12.9", "13.0", "13.2"]
 CUDA_STABLE = "13.0"
 CUDA_ARCHES_FULL_VERSION = {
     "12.6": "12.6.3",
+    "12.9": "12.9.1",
     "13.0": "13.0.3",
     "13.2": "13.2.1",
 }
 CUDA_ARCHES_CUDNN_VERSION = {
     "12.6": "9",
+    "12.9": "9",
     "13.0": "9",
     "13.2": "9",
 }
@@ -47,6 +49,7 @@ CPU_S390X_ARCH = ["cpu-s390x"]
 
 CUDA_AARCH64_ARCHES = [
     "12.6-aarch64",
+    "12.9-aarch64",
     "13.0-aarch64",
     "13.2-aarch64",
 ]
@@ -58,6 +61,14 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
         "nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | "
         "nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | "
         "nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | "
+        "nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+    ),
+    "12.9": (
+        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.9.1; platform_system == 'Linux' | "  # noqa: B950
+        "cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | "
+        "nvidia-cudnn-cu12==9.20.0.48; platform_system == 'Linux' | "
+        "nvidia-cusparselt-cu12==0.8.1; platform_system == 'Linux' | "
+        "nvidia-nccl-cu12==2.29.7; platform_system == 'Linux' | "
         "nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
     ),
     "13.0": (
@@ -357,7 +368,9 @@ def generate_libtorch_matrix(
     if arches is None:
         arches = ["cpu"]
         if os == "windows":
-            arches += CUDA_ARCHES
+            # CUDA 12.9 is only built for Linux
+            windows_cuda_arches = list_without(CUDA_ARCHES, ["12.9"])
+            arches += windows_cuda_arches
     if libtorch_variants is None:
         libtorch_variants = [
             "shared-with-deps",
@@ -410,7 +423,9 @@ def generate_wheels_matrix(
         if os == "linux":
             arches += CUDA_ARCHES + ROCM_ARCHES + XPU_ARCHES
         elif os == "windows":
-            arches += CUDA_ARCHES + XPU_ARCHES
+            # CUDA 12.9 is only built for Linux
+            windows_cuda_arches = list_without(CUDA_ARCHES, ["12.9"])
+            arches += windows_cuda_arches + XPU_ARCHES
         elif os == "linux-aarch64":
             # Separate new if as the CPU type is different and
             # uses different build/test scripts
@@ -452,7 +467,7 @@ def generate_wheels_matrix(
             # cuda linux wheels require PYTORCH_EXTRA_INSTALL_REQUIREMENTS to install
 
             if (
-                arch_version in ["13.2", "13.0", "12.6"]
+                arch_version in ["13.2", "13.0", "12.9", "12.6"]
                 and os == "linux"
                 or arch_version in CUDA_AARCH64_ARCHES
             ):

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: linux.9xlarge.ephemeral
     strategy:
       matrix:
-        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
+        tag: ["cuda12.6", "cuda12.9", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@release/2.13

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -48,9 +48,11 @@ jobs:
         include: [
           { name: "manylinux2_28-builder",          tag: "cuda13.2",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "cuda13.0",          runner: "linux.9xlarge.ephemeral" },
+          { name: "manylinux2_28-builder",          tag: "cuda12.9",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "cuda12.6",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.2",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.0",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
+          { name: "manylinuxaarch64-builder",       tag: "cuda12.9",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda12.6",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "rocm7.1",           runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "rocm7.2",           runner: "linux.9xlarge.ephemeral" },

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -224,6 +224,95 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-12_6/*
 
+  manywheel-cuda-aarch64-cu129-build:
+    name: manywheel-cuda-aarch64-cu129-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.r7g.12xlarge.memory"
+    timeout-minutes: 420
+    container:
+      image: pytorch/manylinuxaarch64-builder:cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: cu129
+      GPU_ARCH_VERSION: "12.9-aarch64"
+      GPU_ARCH_TYPE: cuda-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-cuda-aarch64-12_9"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.9.1; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | nvidia-cudnn-cu12==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-12_9/*
+
   manywheel-cuda-aarch64-cu130-build:
     name: manywheel-cuda-aarch64-cu130-build
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -405,7 +494,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build]
+    needs: [get-label-type, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu129-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -426,6 +515,14 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_10-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.10"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_10-cuda-aarch64-12_9"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.10"
             desired_cuda: "cu130"
@@ -460,6 +557,14 @@ jobs:
             build_name: "manywheel-py3_11-cuda-aarch64-12_6"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.11"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_11-cuda-aarch64-12_9"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -490,6 +595,14 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_12-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.12"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_12-cuda-aarch64-12_9"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.12"
             desired_cuda: "cu130"
@@ -524,6 +637,14 @@ jobs:
             build_name: "manywheel-py3_13-cuda-aarch64-12_6"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.13"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_13-cuda-aarch64-12_9"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -554,6 +675,14 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.14"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14-cuda-aarch64-12_9"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.14"
             desired_cuda: "cu130"
@@ -588,6 +717,14 @@ jobs:
             build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.14t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14t-cuda-aarch64-12_9"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -620,6 +757,14 @@ jobs:
             build_name: "manywheel-py3_15-cuda-aarch64-12_6"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.15"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_9"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -650,6 +795,14 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_9"
             runs_on: "linux.arm64.2xlarge"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
@@ -691,7 +844,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-test]
+    needs: [manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu129-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-test]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -711,6 +864,13 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_10-cuda-aarch64-12_6"
+          - desired_python: "3.10"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_10-cuda-aarch64-12_9"
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -740,6 +900,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_11-cuda-aarch64-12_6"
           - desired_python: "3.11"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_11-cuda-aarch64-12_9"
+          - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -767,6 +934,13 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_12-cuda-aarch64-12_6"
+          - desired_python: "3.12"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_12-cuda-aarch64-12_9"
           - desired_python: "3.12"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -796,6 +970,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_13-cuda-aarch64-12_6"
           - desired_python: "3.13"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_13-cuda-aarch64-12_9"
+          - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -823,6 +1004,13 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14-cuda-aarch64-12_6"
+          - desired_python: "3.14"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14-cuda-aarch64-12_9"
           - desired_python: "3.14"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -852,6 +1040,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
           - desired_python: "3.14t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14t-cuda-aarch64-12_9"
+          - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -880,6 +1075,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15-cuda-aarch64-12_6"
           - desired_python: "3.15"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_9"
+          - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -907,6 +1109,13 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_9"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -225,6 +225,95 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda12_6/*
 
+  manywheel-cuda-cu129-build:
+    name: manywheel-cuda-cu129-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
+    timeout-minutes: 280
+    container:
+      image: pytorch/manylinux2_28-builder:cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: cu129
+      GPU_ARCH_VERSION: "12.9"
+      GPU_ARCH_TYPE: cuda
+      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-cuda12_9"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.9.1; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | nvidia-cudnn-cu12==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda12_9/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda12_9
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda12_9/*
+
   manywheel-cuda-cu130-build:
     name: manywheel-cuda-cu130-build
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -651,7 +740,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
+    needs: [get-label-type, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu129-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -672,6 +761,14 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_10-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.10"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_10-cuda12_9"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.10"
             desired_cuda: "cu130"
@@ -706,6 +803,14 @@ jobs:
             build_name: "manywheel-py3_11-cuda12_6"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.11"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_11-cuda12_9"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -736,6 +841,14 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_12-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.12"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_12-cuda12_9"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.12"
             desired_cuda: "cu130"
@@ -770,6 +883,14 @@ jobs:
             build_name: "manywheel-py3_13-cuda12_6"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.13"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_13-cuda12_9"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -800,6 +921,14 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.14"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14-cuda12_9"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.14"
             desired_cuda: "cu130"
@@ -834,6 +963,14 @@ jobs:
             build_name: "manywheel-py3_14t-cuda12_6"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.14t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14t-cuda12_9"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -866,6 +1003,14 @@ jobs:
             build_name: "manywheel-py3_15-cuda12_6"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.15"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15-cuda12_9"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -896,6 +1041,14 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15t-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15t-cuda12_9"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
@@ -1136,7 +1289,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
+    needs: [manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu129-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -1156,6 +1309,13 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_10-cuda12_6"
+          - desired_python: "3.10"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_10-cuda12_9"
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -1206,6 +1366,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_11-cuda12_6"
           - desired_python: "3.11"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_11-cuda12_9"
+          - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -1254,6 +1421,13 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_12-cuda12_6"
+          - desired_python: "3.12"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_12-cuda12_9"
           - desired_python: "3.12"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -1304,6 +1478,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_13-cuda12_6"
           - desired_python: "3.13"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_13-cuda12_9"
+          - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -1352,6 +1533,13 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14-cuda12_6"
+          - desired_python: "3.14"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14-cuda12_9"
           - desired_python: "3.14"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -1402,6 +1590,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_14t-cuda12_6"
           - desired_python: "3.14t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_14t-cuda12_9"
+          - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -1451,6 +1646,13 @@ jobs:
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15-cuda12_6"
           - desired_python: "3.15"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15-cuda12_9"
+          - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
             gpu_arch_type: "cuda"
@@ -1499,6 +1701,13 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6-f38ba0b10220982e39441d29d203d803a2b56c92"
             build_name: "manywheel-py3_15t-cuda12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu129"
+            gpu_arch_version: "12.9"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.9-f38ba0b10220982e39441d29d203d803a2b56c92"
+            build_name: "manywheel-py3_15t-cuda12_9"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -1574,6 +1783,13 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda12_6"
             build_name: "libtorch-cuda12_6-shared-with-deps-release"
+          - desired_cuda: "cu129"
+            gpu_arch_type: "cuda"
+            gpu_arch_version: "12.9"
+            libtorch_variant: "shared-with-deps"
+            libtorch_config: "release"
+            source_wheel_build_name: "manywheel-py3_10-cuda12_9"
+            build_name: "libtorch-cuda12_9-shared-with-deps-release"
           - desired_cuda: "cu130"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.0"
@@ -1659,6 +1875,12 @@ jobs:
             libtorch_variant: "shared-with-deps"
             libtorch_config: "release"
             build_name: "libtorch-cuda12_6-shared-with-deps-release"
+          - desired_cuda: "cu129"
+            gpu_arch_type: "cuda"
+            gpu_arch_version: "12.9"
+            libtorch_variant: "shared-with-deps"
+            libtorch_config: "release"
+            build_name: "libtorch-cuda12_9-shared-with-deps-release"
           - desired_cuda: "cu130"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.0"


### PR DESCRIPTION
* [release 2.13] Apply Release only changes to 2.13 branch

Release-only changes for the release/2.13 branch cut, produced by
running scripts/release/apply-release-changes.sh. The script repoints
reusable workflows and composite actions from @main to @release/2.13,
rewrites templates to release/2.13 (with checkout_pr_head=False so PRs
build the merge base rather than the PR head), pins the XLA checkout to
the r2.13 branch, pins the disabled/unstable jobs and disabled-tests S3
JSON blobs to fixed versionIds, sets RELEASE_VERSION_TAG=2.13 for the
workflow-regeneration lint check, and drops the pull_request-specific
checkout ref from the linux binary build/test workflows.

Only files that are tracked in release/2.13 are included. The 2.12 PR
additionally touched .ci/manywheel/build_cuda.sh and a few workflow
files (torchbench/nitpicker/quantization-periodic) that are not tracked
in this checkout, so they are intentionally omitted here.

Test Plan:
Ran the release script and linter:

```
DRY_RUN=disabled ./scripts/release/apply-release-changes.sh
lintrunner -a
```

lintrunner reported only pre-existing ACTIONLINT shellcheck warnings on
generated workflow lines unrelated to the release-version edits, and made
no changes to the staged files. Verified every staged hunk is a
release-only edit (@main -> @release/2.13, main -> release/2.13, XLA
r2.13 pin, S3 versionId pins, RELEASE_VERSION_TAG=2.13, and the
pull_request ref removal) with no submodule or unrelated changes.

This PR was authored with the assistance of Claude Code.

* [release 2.13] Pin Linux manywheel builder docker images

Release builds should use a fixed, reproducible build toolchain instead
of the floating builder image tags that main tracks (e.g.
pytorch/manylinux2_28-builder:cuda12.6). For 2.12 the binary build
workflows resolved the image dynamically via calculate-docker-image; for
2.13 we freeze that resolved image as a literal pin.

The pin is applied in the generator (generate_binary_build_matrix.py)
rather than in the generated YAML directly, so re-running
.github/regenerate.sh (and the lint job that asserts the generated files
are up to date) reproduces the pinned tags. wheel_container_image_tag_prefix()
appends the pin only for the linux manywheel OSes (linux, linux-aarch64,
linux-s390x), since only those builds run inside these containers;
windows and macos keep the plain tag prefix.

The pin suffix is the .ci/docker tree hash, f38ba0b
(git rev-parse HEAD:.ci/docker), which is exactly the tag that
.github/actions/binary-docker-build (and the s390x equivalent) publish
as ${prefix}-${CI_FOLDER_SHA}. It matches the image already published on
Docker Hub, e.g.
pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-f38ba0b10220982e39441d29d203d803a2b56c92

Test Plan:
Regenerated the workflows in release mode and verified the result:

```
RELEASE_VERSION_TAG=2.13 python3 .github/scripts/generate_ci_workflows.py
```

- Every `image:` and matrix `docker_image_tag_prefix` in the three linux
  manywheel generated workflows now carries the `-f38ba0b...` suffix
  (cpu, cpu-aarch64, cuda12.6/13.0/13.2, rocm7.1/7.2, xpu, cpu-s390x);
  no linux builder image remains floating.
- Windows and macos generated workflows are unchanged (plain `cpu`,
  `cuda12.6`, ...), confirming the pin is linux-only.
- Re-running the generator a second time produced byte-identical output
  (md5sum unchanged), so the regeneration/lint up-to-date check is
  stable.

Note: the local linters that shell out to `uv` could not run in this
environment; the change was format-checked manually.

This PR was authored with the assistance of Claude Code.* [release 2.13] Apply Release only changes to 2.13 branch

Release-only changes for the release/2.13 branch cut, produced by
running scripts/release/apply-release-changes.sh. The script repoints
reusable workflows and composite actions from @main to @release/2.13,
rewrites templates to release/2.13 (with checkout_pr_head=False so PRs
build the merge base rather than the PR head), pins the XLA checkout to
the r2.13 branch, pins the disabled/unstable jobs and disabled-tests S3
JSON blobs to fixed versionIds, sets RELEASE_VERSION_TAG=2.13 for the
workflow-regeneration lint check, and drops the pull_request-specific
checkout ref from the linux binary build/test workflows.

Only files that are tracked in release/2.13 are included. The 2.12 PR
additionally touched .ci/manywheel/build_cuda.sh and a few workflow
files (torchbench/nitpicker/quantization-periodic) that are not tracked
in this checkout, so they are intentionally omitted here.

Test Plan:
Ran the release script and linter:

```
DRY_RUN=disabled ./scripts/release/apply-release-changes.sh
lintrunner -a
```

lintrunner reported only pre-existing ACTIONLINT shellcheck warnings on
generated workflow lines unrelated to the release-version edits, and made
no changes to the staged files. Verified every staged hunk is a
release-only edit (@main -> @release/2.13, main -> release/2.13, XLA
r2.13 pin, S3 versionId pins, RELEASE_VERSION_TAG=2.13, and the
pull_request ref removal) with no submodule or unrelated changes.

This PR was authored with the assistance of Claude Code.

* [release 2.13] Pin Linux manywheel builder docker images

Release builds should use a fixed, reproducible build toolchain instead
of the floating builder image tags that main tracks (e.g.
pytorch/manylinux2_28-builder:cuda12.6). For 2.12 the binary build
workflows resolved the image dynamically via calculate-docker-image; for
2.13 we freeze that resolved image as a literal pin.

The pin is applied in the generator (generate_binary_build_matrix.py)
rather than in the generated YAML directly, so re-running
.github/regenerate.sh (and the lint job that asserts the generated files
are up to date) reproduces the pinned tags. wheel_container_image_tag_prefix()
appends the pin only for the linux manywheel OSes (linux, linux-aarch64,
linux-s390x), since only those builds run inside these containers;
windows and macos keep the plain tag prefix.

The pin suffix is the .ci/docker tree hash, f38ba0b
(git rev-parse HEAD:.ci/docker), which is exactly the tag that
.github/actions/binary-docker-build (and the s390x equivalent) publish
as ${prefix}-${CI_FOLDER_SHA}. It matches the image already published on
Docker Hub, e.g.
pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-f38ba0b10220982e39441d29d203d803a2b56c92

Test Plan:
Regenerated the workflows in release mode and verified the result:

```
RELEASE_VERSION_TAG=2.13 python3 .github/scripts/generate_ci_workflows.py
```

- Every `image:` and matrix `docker_image_tag_prefix` in the three linux
  manywheel generated workflows now carries the `-f38ba0b...` suffix
  (cpu, cpu-aarch64, cuda12.6/13.0/13.2, rocm7.1/7.2, xpu, cpu-s390x);
  no linux builder image remains floating.
- Windows and macos generated workflows are unchanged (plain `cpu`,
  `cuda12.6`, ...), confirming the pin is linux-only.
- Re-running the generator a second time produced byte-identical output
  (md5sum unchanged), so the regeneration/lint up-to-date check is
  stable.

Note: the local linters that shell out to `uv` could not run in this
environment; the change was format-checked manually.

This PR was authored with the assistance of Claude Code.