### PR TITLE
Fix THPDTypeInfo_compare reading off the end of non-finfo/iinfo objects

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10787,6 +10787,26 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(y1, y1_expect.tolist())
         self.assertEqual(y2, y1_expect.imag.tolist())
 
+    def test_dtype_info_compare_with_non_dtype_info(self):
+        # Comparing a finfo/iinfo against a non-finfo/iinfo (including None) has
+        # to be safe and well defined: it is never equal to such an object and
+        # != is its negation. Regression test for THPDTypeInfo_compare, which
+        # reinterpret_cast `other` to THPDTypeInfo* and read other->type without
+        # checking its type first, reading off the end of a foreign object
+        # (e.g. torch.finfo(torch.float32) == "x").
+        for info in (torch.finfo(torch.float32), torch.iinfo(torch.int32)):
+            for other in (None, 42, "x", 3.14, object(), [info]):
+                self.assertFalse(info == other)
+                self.assertTrue(info != other)
+            # An info object still compares equal to itself.
+            self.assertTrue(info == info)
+            self.assertFalse(info != info)
+        # finfo/iinfo of different dtypes are not equal, including across kinds.
+        self.assertFalse(torch.finfo(torch.float32) == torch.finfo(torch.float64))
+        self.assertTrue(torch.finfo(torch.float32) != torch.finfo(torch.float64))
+        self.assertFalse(torch.finfo(torch.float32) == torch.iinfo(torch.int32))
+        self.assertTrue(torch.finfo(torch.float32) != torch.iinfo(torch.int32))
+
     @unittest.skipIf(torch.backends.cuda.is_built(), "Skipped for cuda-enabled build")
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10807,6 +10807,22 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertFalse(torch.finfo(torch.float32) == torch.iinfo(torch.int32))
         self.assertTrue(torch.finfo(torch.float32) != torch.iinfo(torch.int32))
 
+        # The cases above also pass without the fix by accident: the stray
+        # read almost never equals the enum, so == still answers False. What
+        # deterministically distinguishes the fix is the reflected comparison:
+        # returning NotImplemented lets the right operand decide, while the
+        # unfixed slot answers from the garbage read and never defers.
+        class _AnyEq:
+            def __eq__(self, other):
+                return True
+
+            def __ne__(self, other):
+                return False
+
+        for info in (torch.finfo(torch.float32), torch.iinfo(torch.int32)):
+            self.assertTrue(info == _AnyEq())
+            self.assertFalse(info != _AnyEq())
+
     @unittest.skipIf(torch.backends.cuda.is_built(), "Skipped for cuda-enabled build")
     def test_no_cuda_monkeypatch(self):
         # Note that this is not in test_cuda.py as this whole file is skipped when cuda

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -96,6 +96,15 @@ static PyObject* THPDTypeInfo_compare(
     THPDTypeInfo* a,
     THPDTypeInfo* b,
     int op) {
+  // `b` is the right-hand operand and may be any Python object, not just a
+  // finfo/iinfo. Reinterpreting it as a THPDTypeInfo* and reading b->type
+  // reads off the end of a smaller object (e.g. torch.finfo(torch.float32) ==
+  // "x"). Defer to the default comparison for anything that isn't a
+  // finfo/iinfo, which makes such comparisons safely return not-equal.
+  PyObject* b_obj = reinterpret_cast<PyObject*>(b);
+  if (!THPFInfo_Check(b_obj) && !THPIInfo_Check(b_obj)) {
+    Py_RETURN_NOTIMPLEMENTED;
+  }
   switch (op) {
     case Py_EQ:
       if (a->type == b->type) {


### PR DESCRIPTION
### Problem

`THPDTypeInfo_compare` is registered as `tp_richcompare` for both `THPFInfoType` and `THPIInfoType`, but it takes a typed `THPDTypeInfo* b` and reads `b->type` without checking that the right-hand operand is actually a finfo/iinfo:

```cpp
static PyObject* THPDTypeInfo_compare(THPDTypeInfo* a, THPDTypeInfo* b, int op) {
  switch (op) {
    case Py_EQ:
      if (a->type == b->type) { ... }
    ...
```

Python hands the right-hand operand through unchanged, so comparing a finfo/iinfo against any other object reinterpret_casts that object to `THPDTypeInfo*` and reads `type` at the struct offset, reading off the end of smaller objects:

```python
torch.finfo(torch.float32) == "x"     # reads off the end of a str object
torch.finfo(torch.float32) == None
```

This is the same class of issue as `THPStream_richcompare` (#188036).

### Fix

`THPFInfo_Check` / `THPIInfo_Check` already exist in `TypeInfo.h`. Defer to the default comparison when `b` is neither, which makes `==` against a non-info object safely return `False` (and `!=` return `True`) through Python's fallback to identity comparison:

```cpp
PyObject* b_obj = reinterpret_cast<PyObject*>(b);
if (!THPFInfo_Check(b_obj) && !THPIInfo_Check(b_obj)) {
  Py_RETURN_NOTIMPLEMENTED;
}
```

Comparisons between two finfo/iinfo objects are unchanged.

### Test

Added `test_dtype_info_compare_with_non_dtype_info` to `test/test_torch.py`: it compares finfo and iinfo against `None`, ints, strings, floats, an arbitrary object and a list, and checks equality with self and across dtypes/kinds.

### Verification

I can't build the C++ extension locally, so the C++ change relies on CI. I did validate the preserved-behavior half of the test against an installed build — comparisons between two real finfo/iinfo objects return the same results as before. The non-info cases are exactly what this fix corrects and are covered by the new test in CI.
