### PR TITLE
[cutedsl] Pass current compute capability e.g., SM 10.3 -> `sm_103a` to CuTeDSL compile subprocess

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -689,16 +689,12 @@ class TestCuteDSLSubprocessCompile(TestCase):
 
     def test_cutedsl_arch_from_device_capability(self):
         from torch._inductor.async_compile import (
-            _cutlass_compile_env,
             _cutedsl_arch_from_device_capability,
+            _cutlass_compile_env,
         )
 
-        self.assertEqual(
-            _cutedsl_arch_from_device_capability((10, 3)), "sm_103a"
-        )
-        self.assertEqual(
-            _cutedsl_arch_from_device_capability((10, 0)), "sm_100a"
-        )
+        self.assertEqual(_cutedsl_arch_from_device_capability((10, 3)), "sm_103a")
+        self.assertEqual(_cutedsl_arch_from_device_capability((10, 0)), "sm_100a")
         self.assertEqual(_cutedsl_arch_from_device_capability((9, 0)), "sm_90a")
         self.assertIsNone(_cutedsl_arch_from_device_capability((8, 9)))
         self.assertIsNone(_cutedsl_arch_from_device_capability((10, 2)))

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -687,6 +687,81 @@ class TestCuteDSLSubprocessCompile(TestCase):
             if os.path.exists(cache_dir):
                 shutil.rmtree(cache_dir)
 
+    def test_cutedsl_arch_from_device_capability(self):
+        from torch._inductor.async_compile import (
+            _cutlass_compile_env,
+            _cutedsl_arch_from_device_capability,
+        )
+
+        self.assertEqual(
+            _cutedsl_arch_from_device_capability((10, 3)), "sm_103a"
+        )
+        self.assertEqual(
+            _cutedsl_arch_from_device_capability((10, 0)), "sm_100a"
+        )
+        self.assertEqual(_cutedsl_arch_from_device_capability((9, 0)), "sm_90a")
+        self.assertIsNone(_cutedsl_arch_from_device_capability((8, 9)))
+        self.assertIsNone(_cutedsl_arch_from_device_capability((10, 2)))
+        self.assertIsNone(_cutedsl_arch_from_device_capability(None))
+        with self.assertRaisesRegex(RuntimeError, "Unsupported CuTe DSL"):
+            _cutlass_compile_env({"device_capability": (10, 2)})
+
+    def test_cutedsl_worker_sets_exact_arch_from_metadata(self):
+        import json
+
+        from torch._inductor.async_compile import _cutlass_compile_env
+        from torch._inductor.runtime.compile_tasks import (
+            _worker_compile_pycodecache_kernel,
+        )
+
+        sentinel_path = os.path.join(
+            tempfile.gettempdir(), "cutedsl_test_arch_sentinel"
+        )
+        if os.path.exists(sentinel_path):
+            os.unlink(sentinel_path)
+
+        source = (
+            "import json, os\n"
+            f"SENTINEL_PATH = {sentinel_path!r}\n"
+            "IMPORT_ARCH = os.environ.get('CUTE_DSL_ARCH')\n"
+            "def test_kernel_main(*args, **kwargs): pass\n"
+            "def test_kernel_precompile(precompile_shapes, device_capability=None, **kwargs):\n"
+            "    with open(SENTINEL_PATH, 'w') as f:\n"
+            "        json.dump({\n"
+            "            'import_arch': IMPORT_ARCH,\n"
+            "            'precompile_arch': os.environ.get('CUTE_DSL_ARCH'),\n"
+            "            'device_capability': device_capability,\n"
+            "        }, f)\n"
+        )
+
+        metadata = {
+            "precompile_shapes": {"input_a": [4, 4], "output": [4, 4]},
+            "device_capability": (10, 3),
+        }
+
+        try:
+            with patch.dict(os.environ, {"CUTE_DSL_ARCH": "sm_100a"}):
+                extra_env = _cutlass_compile_env(metadata)
+                self.assertEqual(extra_env["CUTE_DSL_ARCH"], "sm_103a")
+                with fresh_cache():
+                    _worker_compile_pycodecache_kernel(
+                        "test_kernel",
+                        source,
+                        "main",
+                        extra_env,
+                        metadata,
+                    )
+
+            with open(sentinel_path) as f:
+                result = json.load(f)
+
+            self.assertEqual(result["import_arch"], "sm_103a")
+            self.assertEqual(result["precompile_arch"], "sm_103a")
+            self.assertEqual(result["device_capability"], [10, 3])
+        finally:
+            if os.path.exists(sentinel_path):
+                os.unlink(sentinel_path)
+
     def test_cutedsl_worker_skips_precompile_without_metadata(self):
         """Test _worker_compile_pycodecache_kernel skips _precompile when metadata is None."""
         from torch._inductor.runtime.compile_tasks import (

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -86,6 +86,54 @@ size_hints_regex = re.compile(
 )
 
 
+_CUTEDSL_ARCH_BY_CAPABILITY = {
+    (9, 0): "sm_90a",
+    (10, 0): "sm_100a",
+    (10, 3): "sm_103a",
+    (12, 0): "sm_120a",
+    (12, 1): "sm_121a",
+}
+
+
+def _cutedsl_arch_from_device_capability(
+    device_capability: object,
+) -> str | None:
+    if not isinstance(device_capability, (list, tuple)) or len(device_capability) != 2:
+        return None
+
+    try:
+        major = int(device_capability[0])
+        minor = int(device_capability[1])
+    except (TypeError, ValueError):
+        return None
+
+    if major < 0 or minor < 0:
+        return None
+
+    return _CUTEDSL_ARCH_BY_CAPABILITY.get((major, minor))
+
+
+def _cutlass_compile_env(precompile_metadata=None) -> dict[str, str]:
+    env_vars = [
+        "TORCHINDUCTOR_CACHE_DIR",
+        "TORCHINDUCTOR_CUTLASS_DIR",
+        "CUTE_DSL_ARCH",
+    ]
+    extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
+
+    if precompile_metadata is not None:
+        device_capability = precompile_metadata.get("device_capability")
+        arch = _cutedsl_arch_from_device_capability(device_capability)
+        if arch is not None:
+            extra_env["CUTE_DSL_ARCH"] = arch
+        elif device_capability is not None:
+            raise RuntimeError(
+                f"Unsupported CuTe DSL CUDA device capability: {device_capability}"
+            )
+
+    return extra_env
+
+
 def pre_fork_setup():
     """
     Setup that must be done prior to forking with a process pool.
@@ -658,8 +706,7 @@ class AsyncCompile:
         is_parallel = self.use_process_pool()
 
         if is_parallel:
-            env_vars = ["TORCHINDUCTOR_CACHE_DIR", "TORCHINDUCTOR_CUTLASS_DIR"]
-            extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
+            extra_env = _cutlass_compile_env(precompile_metadata)
 
             subprocess_task = self.process_pool().submit(
                 _worker_compile_pycodecache_kernel,
@@ -763,8 +810,7 @@ class AsyncCompile:
         is_parallel = self.use_process_pool()
 
         if is_parallel:
-            env_vars = ["TORCHINDUCTOR_CACHE_DIR", "TORCHINDUCTOR_CUTLASS_DIR"]
-            extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
+            extra_env = _cutlass_compile_env(precompile_metadata)
 
             subprocess_task = self.process_pool().submit(
                 _worker_compile_pycodecache_kernel,


### PR DESCRIPTION
Otherwise we seem to attempt to build and run sm100a on compute-capability 10.3 which fails e.g.,


```
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/test/inductor/test_async_compile.py", line 1983, in test_grouped_gemm_subprocess_e2e
    c_compiled = compiled_fn(A, B, offsets)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1166, in compile_wrapper
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_async_compile.py", line 1963, in grouped_gemm_fn
    def grouped_gemm_fn(A_packed, B_batched, offs):
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1446, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1277, in forward
    return compiled_fn(full_args)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1141, in runtime_wrapper
    result = _codegen_runtime_wrapper(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/subclass_codegen.py:codegen(runtime_wrapper_orchestration)", line 8, in _runtime_wrapper
  File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2548, in __call__
    return self.compiled_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 763, in __call__
    return self.current_callable(inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp_dfla16p/me/cmeua6lgy5zbo4y35hmgczwjtroexwkh5mschrazae4skfffjlc2.py", line 596, in call
    cutedsl_fused__grouped_mm_8ecc6927.run(arg0_1, arg1_1, arg2_1, buf0, stream=raw_stream0)
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py", line 69, in run
    return self.kernel_fn(*args, stream=stream, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp_dfla16p/a3/ca35zkmxwb2zlwo6e7z5otdm2wjusqjf3tluw5lic53revtfxuwa.py", line 292, in cutedsl_fused__grouped_mm_8ecc6927_main
    prep_executor(
  File "python/tvm_ffi/cython/function.pxi", line 968, in tvm_ffi.core.Function.__call__
  File "<unknown>", line 0, in cuda_dialect_init_library_once
RuntimeError: Got Cuda Runtime Error: cudaErrorNoKernelImageForDevice no kernel image is available for execution on the device

To execute this test, run the following from the base repo dir:
    python test/inductor/test_async_compile.py TestCuteDSLSubprocessGroupedGemm.test_grouped_gemm_subprocess_e2e
 ```


coached codex to write this

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo