### PR TITLE
[c10][cuda] Restore current device via RAII on the throwing path in CUDAGuardImpl

### DIFF
--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -4,6 +4,7 @@
 #include <c10/core/impl/GPUTrace.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/ScopeExit.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
@@ -143,9 +144,14 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     cudaEvent_t cuda_event = static_cast<cudaEvent_t>(*event);
     CUDAStream cuda_stream{stream};
 
-    // Moves to stream's device to record
+    // Moves to stream's device to record, restoring the original device on
+    // scope exit (including the throwing path), mirroring CUDAEvent's
+    // destructor which restores via CUDAGuard.
     const auto orig_device = getDevice();
     setDevice(stream.device());
+    const auto restore_device = c10::make_scope_exit([&]() {
+      C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(orig_device.index()));
+    });
 
     // Creates the event (lazily)
     if (!cuda_event)
@@ -160,9 +166,6 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
           reinterpret_cast<uintptr_t>(cuda_event),
           reinterpret_cast<uintptr_t>(cuda_stream.stream()));
     }
-
-    // Resets device
-    setDevice(orig_device);
   }
 
   void block(void* event, const Stream& stream) const override {
@@ -172,6 +175,9 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     CUDAStream cuda_stream{stream};
     const auto orig_device = getDevice();
     setDevice(stream.device());
+    const auto restore_device = c10::make_scope_exit([&]() {
+      C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(orig_device.index()));
+    });
     C10_CUDA_CHECK(cudaStreamWaitEvent(
         cuda_stream,
         cuda_event,
@@ -183,7 +189,6 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
           reinterpret_cast<uintptr_t>(cuda_event),
           reinterpret_cast<uintptr_t>(cuda_stream.stream()));
     }
-    setDevice(orig_device);
   }
 
   // May be called from any device
@@ -236,12 +241,13 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     DeviceIndex orig_device{-1};
     C10_CUDA_CHECK(c10::cuda::GetDevice(&orig_device));
     C10_CUDA_CHECK(c10::cuda::SetDevice(device_index));
+    const auto restore_device = c10::make_scope_exit(
+        [&]() { C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(orig_device)); });
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
       (*interp)->trace_gpu_device_synchronization(c10::kCUDA);
     }
     C10_CUDA_CHECK(cudaDeviceSynchronize());
-    C10_CUDA_CHECK(c10::cuda::SetDevice(orig_device));
   }
 
   void recordDataPtrOnStream(const c10::DataPtr& data_ptr, const Stream& stream)
@@ -261,12 +267,13 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     DeviceIndex orig_device{-1};
     C10_CUDA_CHECK(c10::cuda::GetDevice(&orig_device));
     C10_CUDA_CHECK(c10::cuda::SetDevice(device_index));
+    const auto restore_device = c10::make_scope_exit(
+        [&]() { C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(orig_device)); });
     cudaEvent_t cuda_event1 = static_cast<cudaEvent_t>(event1);
     cudaEvent_t cuda_event2 = static_cast<cudaEvent_t>(event2);
     float time_ms = 0;
     // raise cudaErrorNotReady if either event is recorded but not yet completed
     C10_CUDA_CHECK(cudaEventElapsedTime(&time_ms, cuda_event1, cuda_event2));
-    C10_CUDA_CHECK(c10::cuda::SetDevice(orig_device));
     return static_cast<double>(time_ms);
   }
 };

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1706,6 +1706,28 @@ print(t.is_pinned())
         self.assertEqual(src_prev_stream, torch.cuda.current_stream())
         self.assertEqual(dst_prev_stream, torch.cuda.current_stream(dst_device))
 
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_event_elapsed_time_restores_device_on_error(self):
+        # The device-generic event path (torch.Event -> CUDAGuardImpl::elapsedTime)
+        # temporarily switches to the event's device to call cudaEventElapsedTime.
+        # A cross-device elapsed_time raises inside that switched region; the
+        # current device must still be restored on the throwing path. Regression
+        # test for the RAII restore in c10::cuda::impl::CUDAGuardImpl.
+        torch.cuda.set_device(0)
+        e0 = torch.Event(enable_timing=True)
+        e1 = torch.Event(enable_timing=True)
+        e0.record(torch.Stream(0))
+        e1.record(torch.Stream(1))
+        torch.cuda.synchronize(0)
+        torch.cuda.synchronize(1)
+        self.assertEqual(torch.cuda.current_device(), 0)
+
+        # device_index of elapsedTime is e1's device (1); the cross-device call
+        # switches to device 1 and then raises.
+        with self.assertRaises(RuntimeError):
+            e1.elapsed_time(e0)
+        self.assertEqual(torch.cuda.current_device(), 0)
+
     def test_noncontiguous_pinned_memory(self):
         # See issue #3266
         x = torch.arange(0, 10).view((2, 5))


### PR DESCRIPTION
## Issue

Fixes #188169

## Summary

The `record`, `block`, `synchronizeDevice`, and `elapsedTime` methods of `CUDAGuardImpl` restored the temporarily-switched current device with a plain trailing `setDevice()`, which is skipped when an intervening `C10_CUDA_CHECK` throws (see the issue for details and the realistic `cudaErrorNotReady` trigger in `elapsedTime`). This wraps the restore in `c10::make_scope_exit` so it also runs on the throwing path, matching `c10::cuda::CUDAEvent`'s destructor which already restores via RAII. Restore is best-effort (`MaybeSetDevice` + `C10_CUDA_CHECK_WARN`) since it can run during unwinding; the success path is unchanged. The HIP guard impl is hipified from this header and picks up the change automatically; XPU/MPS do not switch the current device in these methods.

## Test

`test_event_elapsed_time_restores_device_on_error` (TEST_MULTIGPU-gated) exercises the device-generic event path (`torch.Event` -> `CUDAGuardImpl::elapsedTime`), which is the path this change fixes - `torch.cuda.Event` already restores via `CUDAGuard`. With the current device set to 0 and an event on device 1, a cross-device `elapsed_time` raises inside the device-switched region; the test asserts the current device is still 0 afterwards (fails before this change, passes after).

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No

