### PR TITLE
Fix hipBLASLt FP32 precision degradation on MI300X (ROCM-3139)

### DIFF
--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <type_traits>
 
@@ -258,6 +259,15 @@ struct CublasLtTypeInfo {
   cudaDataType_t scale_type = CUDA_R_32F;
 };
 
+#ifdef USE_ROCM
+inline bool allowHipblasLtTF32Compute() {
+  // MI300/CDNA3 exposes hipBLASLt fast-TF32 compute, but that path has
+  // architecture-specific precision loss that is not seen on gfx950.
+  const auto* prop = at::cuda::getCurrentDeviceProperties();
+  return std::strncmp(prop->gcnArchName, "gfx942", 6) != 0;
+}
+#endif
+
 template <typename T, typename C_Dtype = T>
 CublasLtTypeInfo<T, C_Dtype> getCublasLtTypeInfo() {
   CublasLtTypeInfo<T, C_Dtype> info;
@@ -270,7 +280,13 @@ CublasLtTypeInfo<T, C_Dtype> getCublasLtTypeInfo() {
     if (at::globalContext().float32Precision(
             at::Float32Backend::CUDA,
             at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+#ifndef USE_ROCM
       info.compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
+#else
+      if (allowHipblasLtTF32Compute()) {
+        info.compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
+      }
+#endif
     }
   } else if constexpr (std::is_same_v<T, c10::complex<double>>) {
     info.ab_type = CUDA_C_64F;

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -15,6 +15,7 @@
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <ATen/cuda/tunable/Tunable.h>
 #include <ATen/cuda/CUDABlas.h>
+#include <ATen/cuda/detail/CublasLtUtils.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/util/StringUtil.h>
 
@@ -166,9 +167,13 @@ template <>
 inline std::string ComputeTypeFor<float>() {
   if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) != at::Float32Precision::TF32) {
     return "f32_r";
-  } else {
-    return "xf32_r";
   }
+#ifdef USE_ROCM
+  if (!at::cuda::blas::detail::allowHipblasLtTF32Compute()) {
+    return "f32_r";
+  }
+#endif
+  return "xf32_r";
 }
 
 template <>

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDADataType.h>
+#include <ATen/cuda/detail/CublasLtUtils.h>
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <ATen/cuda/tunable/GemmCommon.h>
 #include <c10/cuda/CUDACachingAllocator.h>
@@ -523,7 +524,10 @@ class HipblasltGemmOp : public Callable<ParamsT> {
 
       hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
       if constexpr (std::is_same_v<CT, float>) {
-        if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+        if (at::globalContext().float32Precision(
+                at::Float32Backend::CUDA,
+                at::Float32Op::MATMUL) == at::Float32Precision::TF32 &&
+            at::cuda::blas::detail::allowHipblasLtTF32Compute()) {
           computeType = HIPBLAS_COMPUTE_32F_FAST_TF32;
         }
       }
@@ -651,7 +655,10 @@ auto GetHipBlasLtTypeStringAndOps() {
 
   hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
   if constexpr (std::is_same_v<CT, float>) {
-    if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+    if (at::globalContext().float32Precision(
+            at::Float32Backend::CUDA,
+            at::Float32Op::MATMUL) == at::Float32Precision::TF32 &&
+        at::cuda::blas::detail::allowHipblasLtTF32Compute()) {
       computeType = HIPBLAS_COMPUTE_32F_FAST_TF32;
     }
   }

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_utils import (
     IS_JETSON,
     IS_WINDOWS,
     MI200_ARCH,
+    MI300_ARCH,
     NAVI_ARCH,
     getRocmVersion,
     isRocmArchAnyOf,
@@ -287,6 +288,28 @@ class TestMatmulCuda(InductorTestCase):
                 self.assertEqual(norm_squared, 50 + 0j)
 
             self.assertEqual(torch.corrcoef(x), ref_corrcoef)
+
+    @onlyCUDA
+    @skipCUDAIfNotRocm
+    @runOnRocmArch(MI300_ARCH)
+    def test_hipblaslt_high_precision_uses_fp32_on_mi300(self):
+        orig_precision = torch.get_float32_matmul_precision()
+        try:
+            torch.manual_seed(42)
+            size = 512
+            a = torch.rand(size, size, device="cuda", dtype=torch.float32)
+            b = torch.rand(size, size, device="cuda", dtype=torch.float32)
+
+            with blas_library_context("cublaslt"):
+                torch.set_float32_matmul_precision("high")
+                out_high = a @ b
+
+                torch.set_float32_matmul_precision("highest")
+                out_highest = a @ b
+
+            self.assertLessEqual((out_high - out_highest).abs().max().item(), 1e-4)
+        finally:
+            torch.set_float32_matmul_precision(orig_precision)
 
     @onlyCUDA
     # imported 'tol' as 'xtol' to avoid aliasing in code above


### PR DESCRIPTION
## Summary
Disable hipBLASLt fast-TF32 compute on gfx942 (MI300) where it causes ~BF16 precision loss when `torch.set_float32_matmul_precision("high")` is set. gfx950 unchanged.

## Test plan
Tested on MI308X (gfx942) in the **roc7.2-pytorch** Docker image (ROCm 7.2):
- Built from source with `USE_ROCM=1 PYTORCH_ROCM_ARCH=gfx942`
- `pytest test/test_matmul_cuda.py -k test_hipblaslt_high_precision_uses_fp32_on_mi300` — pass
- hipBLASLt `"high"` vs `"highest"` max diff ≤ 1e-4 (was ~0.37 unfixed)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang