### PR TITLE
[cuda] Keep _use_uvm allocator callbacks alive for the allocator's lifetime

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8644,6 +8644,29 @@ class TestMemPool(TestCase):
         self.assertIsNotNone(model.weight.grad)
         self.assertEqual(model.weight.grad.shape, (512, 512))
 
+    @skipIfRocm(msg="cudaMallocManaged (UVM) is not supported on ROCm")
+    @unittest.skipIf(
+        not TEST_CUDA_PYTHON_BINDINGS, "requires cuda-python (cuda.bindings)"
+    )
+    def test_use_uvm_tensor_outlives_context(self):
+        # Regression test: a tensor allocated inside _use_uvm() can outlive the
+        # context, leaving its block cached in the PrivatePool until a later global
+        # empty_cache() frees it. Before the fix the alloc/free ctypes closures
+        # were GC'd by then, so the free dangled and segfaulted. Loop twice and
+        # (where available) over a second device to exercise the now-shared
+        # allocator across calls/devices.
+        devices = [None]
+        if torch.cuda.device_count() > 1:
+            devices.append(1)
+        for _ in range(2):
+            for device in devices:
+                with torch.cuda._use_uvm(device=device):
+                    x = torch.randn(256, 256, device=device or "cuda")
+                self.assertTrue(x.is_cuda)
+                del x
+                gc.collect()
+                torch.cuda.empty_cache()
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -6,6 +6,7 @@ import contextlib
 import ctypes
 import pickle
 import sys
+import threading
 import warnings
 from inspect import signature
 from typing import Any, Literal, TYPE_CHECKING
@@ -1359,36 +1360,18 @@ def use_mem_pool(pool: MemPool, device: "Device" = None):
         _cuda_releasePool(device_index, pool.id)
 
 
-@contextlib.contextmanager
-def _use_uvm(device: "Device" = None):
-    r"""A context manager that routes CUDA allocations through ``cudaMallocManaged`` (UVM).
+# Process-lifetime singleton: the UVM pluggable allocator + the ctypes closures
+# behind it, lazily built (lock-guarded) by _make_uvm_allocator and reused.
+_UVM_ALLOCATOR = None
+_UVM_ALLOCATOR_LOCK = threading.Lock()
 
-    All tensors allocated inside this context use CUDA Unified Virtual Memory,
-    which allows oversubscribing GPU device memory by transparently paging to
-    system RAM on demand. Numerics are identical to regular device allocations;
-    only performance is affected due to page migration overhead.
 
-    Args:
-        device (torch.device or int, optional): selected device. Uses the
-            current device, given by :func:`~torch.cuda.current_device`,
-            if :attr:`device` is ``None`` (default).
+def _make_uvm_allocator():
+    r"""Build the UVM ``CUDAPluggableAllocator`` and the ctypes closures behind it.
 
-    Example::
-
-        >>> # xdoctest: +SKIP(reason="requires CUDA and cuda-python")
-        >>> with torch.cuda._use_uvm():
-        ...     x = torch.randn(1024, 1024, device="cuda")
-        ...     y = x @ x.T  # computed on GPU, pages in/out as needed
-
-    .. note::
-        Only the current thread's allocations are routed to managed memory.
-        Allocations in threads spawned inside this context (e.g. by backward)
-        will use the default allocator. Use
-        ``torch.autograd.set_multithreading_enabled(False)`` to force backward
-        onto the calling thread so that backward allocations also use UVM.
-
-    .. note::
-        Requires the ``cuda-python`` package (``cuda.bindings``).
+    Returns ``(c_alloc, c_free, allocator)``. UVM alloc/free are stateless (device
+    is passed per call), so one allocator serves all calls and devices. Raises
+    ``ImportError`` if ``cuda-python`` is unavailable.
     """
     import logging
     import traceback
@@ -1492,9 +1475,52 @@ def _use_uvm(device: "Device" = None):
     c_free = _FREE_FN(_uvm_free)
     alloc_ptr = ctypes.cast(c_alloc, ctypes.c_void_p).value
     free_ptr = ctypes.cast(c_free, ctypes.c_void_p).value
-
     # pyrefly: ignore[bad-argument-type]
     allocator = torch._C._cuda_customAllocator(alloc_ptr, free_ptr)
+    return c_alloc, c_free, allocator
+
+
+@contextlib.contextmanager
+def _use_uvm(device: "Device" = None):
+    r"""A context manager that routes CUDA allocations through ``cudaMallocManaged`` (UVM).
+
+    All tensors allocated inside this context use CUDA Unified Virtual Memory,
+    which allows oversubscribing GPU device memory by transparently paging to
+    system RAM on demand. Numerics are identical to regular device allocations;
+    only performance is affected due to page migration overhead.
+
+    Args:
+        device (torch.device or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.cuda.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Example::
+
+        >>> # xdoctest: +SKIP(reason="requires CUDA and cuda-python")
+        >>> with torch.cuda._use_uvm():
+        ...     x = torch.randn(1024, 1024, device="cuda")
+        ...     y = x @ x.T  # computed on GPU, pages in/out as needed
+
+    .. note::
+        Only the current thread's allocations are routed to managed memory.
+        Allocations in threads spawned inside this context (e.g. by backward)
+        will use the default allocator. Use
+        ``torch.autograd.set_multithreading_enabled(False)`` to force backward
+        onto the calling thread so that backward allocations also use UVM.
+
+    .. note::
+        Requires the ``cuda-python`` package (``cuda.bindings``).
+    """
+    # A tensor's block can stay cached in the PrivatePool after _use_uvm() returns
+    # and be freed later by a global empty_cache(); per-call ctypes closures would
+    # be GC'd by then, dangling the free callback. Build once and reuse instead.
+    global _UVM_ALLOCATOR
+    if _UVM_ALLOCATOR is None:
+        with _UVM_ALLOCATOR_LOCK:
+            if _UVM_ALLOCATOR is None:
+                _UVM_ALLOCATOR = _make_uvm_allocator()
+    allocator = _UVM_ALLOCATOR[2]
+
     pool = MemPool(allocator=allocator)
     with use_mem_pool(pool, device=device):
         yield pool


### PR DESCRIPTION
### Summary

`torch.cuda._use_uvm()` could segfault when a tensor allocated inside the context outlived it and was later freed by a global `torch.cuda.empty_cache()`. This PR fixes the dangling allocator callback behind that crash and adds a regression test.

### Root cause

`_use_uvm()` registers a pluggable allocator whose alloc/free callbacks are Python `ctypes.CFUNCTYPE` closures, held only as locals of the `_use_uvm` generator frame. The C++ `CUDAPluggableAllocator` stores them as raw function pointers and does not own the Python objects; the caching allocator's `PrivatePool` keeps the C++ allocator alive until its blocks are freed, but not the closures behind those pointers. So a block that outlives the context (a tensor whose block stays cached in the `PrivatePool`) is freed after the closures are garbage-collected — `empty_cache()` → `raw_delete` calls into a freed libffi trampoline → SIGSEGV.

### Fix

The UVM alloc/free are stateless (`cudaMallocManaged`/`cudaFree`, device passed per call), so build the allocator and its closures once and keep them as a process-lifetime singleton (`_UVM_ALLOCATOR`, lazily initialized under `_UVM_ALLOCATOR_LOCK` with double-checked locking so concurrent first callers can't race in two allocators). Every `_use_uvm()` call reuses that one allocator (a fresh `MemPool` per call still wraps it), so the callback pointers can never dangle.