### PR TITLE
Fix cross-session use-after-free in profiler global-callback teardown

### DIFF
--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -60,9 +60,6 @@ if(USE_KINETO)
     install(TARGETS test_global_state_manager DESTINATION bin)
   endif()
 
-  # Cross-session global RecordFunction callback teardown reproducer: a stale
-  # exit landing after its session was torn down. Deterministic, but the
-  # use-after-free is only observable under a sanitizer (ASAN/UBSAN).
   add_executable(test_profiler_global_callback_stale_session
     ${TORCH_ROOT}/test/cpp/common/main.cpp
     ${PROFILER_TEST_ROOT}/profiler_global_callback_stale_session_test.cpp

--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -60,6 +60,27 @@ if(USE_KINETO)
     install(TARGETS test_global_state_manager DESTINATION bin)
   endif()
 
+  # Cross-session global RecordFunction callback teardown reproducer: a stale
+  # exit landing after its session was torn down. Deterministic, but the
+  # use-after-free is only observable under a sanitizer (ASAN/UBSAN).
+  add_executable(test_profiler_global_callback_stale_session
+    ${TORCH_ROOT}/test/cpp/common/main.cpp
+    ${PROFILER_TEST_ROOT}/profiler_global_callback_stale_session_test.cpp
+  )
+
+  target_compile_definitions(test_profiler_global_callback_stale_session PRIVATE USE_GTEST USE_KINETO)
+
+  target_link_libraries(test_profiler_global_callback_stale_session PRIVATE ${PROFILER_TEST_DEPENDENCIES})
+  target_include_directories(test_profiler_global_callback_stale_session PRIVATE
+    ${ATen_CPU_INCLUDE}
+    ${KINETO_SOURCE_DIR}/include
+  )
+
+  if(INSTALL_TEST)
+    set_target_properties(test_profiler_global_callback_stale_session PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
+    install(TARGETS test_profiler_global_callback_stale_session DESTINATION bin)
+  endif()
+
   if(USE_DISTRIBUTED)
     add_executable(test_comms_id
       ${TORCH_ROOT}/test/cpp/common/main.cpp

--- a/test/cpp/profiler/profiler_global_callback_stale_session_test.cpp
+++ b/test/cpp/profiler/profiler_global_callback_stale_session_test.cpp
@@ -1,0 +1,101 @@
+#include <condition_variable>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/record_function.h>
+#include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/orchestration/observer.h>
+
+// Reproducer for a cross-session use-after-free in the global RecordFunction
+// callback path. The narrow write-section guard keeps a callback's critical
+// section from overlapping teardown, but it intentionally does not span the op
+// body (that would deadlock on the GIL). So an op can enter in session A,
+// have A torn down (freeing its RecordQueue event) while in-flight, then exit
+// while a *later* session B is active -- the gate is open for B, so the exit is
+// not skipped and onFunctionExitGlobal dereferences A's freed event. We
+// tag each ObserverContext with the session generation and drop the exit when
+// it no longer matches.
+//
+// at::RecordFunction's destructor runs the captured exit callback even after
+// A's callback was removed.
+
+namespace {
+using torch::profiler::impl::ActivityType;
+using torch::profiler::impl::ExperimentalConfig;
+using torch::profiler::impl::ProfilerConfig;
+using torch::profiler::impl::ProfilerState;
+
+ProfilerConfig makeGlobalCallbackCpuConfig() {
+  ExperimentalConfig experimental_config;
+  experimental_config.profile_all_threads = true;
+  return ProfilerConfig(
+      ProfilerState::KINETO,
+      /*report_input_shapes=*/false,
+      /*profile_memory=*/false,
+      /*with_stack=*/false,
+      /*with_flops=*/false,
+      /*with_modules=*/false,
+      experimental_config);
+}
+
+void enableGlobalProfiler() {
+  const auto config = makeGlobalCallbackCpuConfig();
+  const std::set<ActivityType> activities{ActivityType::CPU};
+  const std::unordered_set<at::RecordScope> scopes{at::RecordScope::FUNCTION};
+  torch::autograd::profiler::prepareProfiler(config, activities);
+  torch::autograd::profiler::enableProfiler(config, activities, scopes);
+}
+} // namespace
+
+TEST(
+    ProfilerGlobalCallbackStaleSessionTest,
+    ExitAfterSessionTornDownIsDropped) {
+  at::clearCallbacks();
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool worker_entered = false; // guarded by mtx
+  bool release_worker = false; // guarded by mtx
+
+  enableGlobalProfiler(); // session A
+
+  std::thread worker([&]() {
+    at::RecordFunction guard(at::RecordScope::FUNCTION);
+    guard.before("stale_probe_op"); // onFunctionEnterGlobal: ctx tagged gen(A)
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      worker_entered = true;
+      cv.notify_all();
+      cv.wait(lock, [&] { return release_worker; });
+    }
+    // guard destructor -> onFunctionExitGlobal, now during session B
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    cv.wait(lock, [&] { return worker_entered; });
+  }
+
+  // Tear down A (frees its RecordQueue, including the in-flight op's event),
+  // then bring up a fresh session B so the pending exit lands with the gate
+  // open.
+  torch::autograd::profiler::disableProfiler();
+  enableGlobalProfiler(); // session B
+
+  // Release the op: its exit runs in B with a ctx tagged gen(A). This should
+  // be safe because of generation checks.
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    release_worker = true;
+  }
+  cv.notify_all();
+  worker.join();
+
+  torch::autograd::profiler::disableProfiler();
+  EXPECT_FALSE(at::hasGlobalCallbacks());
+}

--- a/test/cpp/profiler/profiler_global_callback_stale_session_test.cpp
+++ b/test/cpp/profiler/profiler_global_callback_stale_session_test.cpp
@@ -14,12 +14,15 @@
 // Reproducer for a cross-session use-after-free in the global RecordFunction
 // callback path. The narrow write-section guard keeps a callback's critical
 // section from overlapping teardown, but it intentionally does not span the op
-// body (that would deadlock on the GIL). So an op can enter in session A,
-// have A torn down (freeing its RecordQueue event) while in-flight, then exit
-// while a *later* session B is active -- the gate is open for B, so the exit is
-// not skipped and onFunctionExitGlobal dereferences A's freed event. We
-// tag each ObserverContext with the session generation and drop the exit when
-// it no longer matches.
+// body (that would deadlock on the GIL). So an op can:
+//
+//   1. Enter in session A.
+//   2. Have A torn down (freeing its RecordQueue event) while in-flight.
+//   3. Exit while a LATER session B is active.
+//
+// The gate is open for B, so the exit is not skipped and onFunctionExitGlobal
+// dereferences A's freed event. We tag each ObserverContext with the session
+// generation and drop the exit when it no longer matches.
 //
 // at::RecordFunction's destructor runs the captured exit callback even after
 // A's callback was removed.

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -729,19 +729,23 @@ std::unique_ptr<at::ObserverContext> onFunctionEnterGlobal(
   if (!global_callback_session.isActive()) {
     return nullptr;
   }
+
   global_callback_session.enter();
+
   // Release the ref when this function returns (success or early bail), so the
   // in-flight window is just this enter's getGlobal() + begin_op() critical
-  // section, not the op body. The matching onFunctionExitGlobal takes its own.
+  // section.
   auto in_flight_guard =
       c10::make_scope_exit([] { global_callback_session.exit(); });
+
   // Re-check after the increment. This is the handshake that makes teardown
   // safe: if disableProfiler() cleared active concurrently, its drain is
-  // guaranteed to observe our increment and wait iff we still observe active
-  // true here.
+  // guaranteed to observe our increment and wait if and only if we still
+  // observe active true here.
   if (!global_callback_session.isActive()) {
     return nullptr;
   }
+
   std::shared_ptr<KinetoThreadLocalState> state_ptr =
       KinetoThreadLocalState::getGlobal();
   if (!state_ptr) {
@@ -823,6 +827,7 @@ void onFunctionExitGlobal(
     // there is nothing to finalize.
     return;
   }
+
   // Take this exit's own in-flight ref, paired here because
   // onFunctionEnterGlobal no longer hands one off. It covers only this exit's
   // getGlobal() + RecordQueue write, never the op body, so the drain cannot
@@ -830,26 +835,29 @@ void onFunctionExitGlobal(
   global_callback_session.enter();
   auto in_flight_guard =
       c10::make_scope_exit([] { global_callback_session.exit(); });
+
   // Re-check after the increment, mirroring onFunctionEnterGlobal: if teardown
   // began concurrently the queue may already be finalized/freed, so skip the
   // write (the event keeps its start and gets no end).
   if (!global_callback_session.isActive()) {
     return;
   }
+
   std::shared_ptr<KinetoThreadLocalState> state_ptr =
       KinetoThreadLocalState::getGlobal();
   if (!state_ptr) {
     return;
   }
-  // begin_op ran in an earlier session (generation differs): that session was
-  // torn down and event_ is freed, so drop the exit before touching event_.
-  // session_generation_ lives in the context (alive while RecordFunction holds
-  // it), never in the freed event_, so this check is always safe.
+
+  // If the session generations don't match, that means this op entered under an
+  // earlier session that has since been torn down, freeing its RecordQueue and
+  // event_. In that case, we don't need to do any exit cleanup.
   auto* kineto_ctx =
       static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
   if (kineto_ctx->session_generation_ != global_callback_session.generation()) {
     return;
   }
+
   onFunctionExitImpl(*state_ptr, fn, ctx_ptr);
 }
 
@@ -873,14 +881,12 @@ void pushGlobalProfilingCallbacks(
       at::RecordFunctionCallback(onFunctionEnterGlobal, onFunctionExitGlobal)
           .needsInputs(state_ptr->config().report_input_shapes)
           .scopes(scopes);
-  // Arm the drain gate -- and, on a true enable, bump the session generation --
-  // before the global callback can fire on any thread. disableProfiler() relies
-  // on this to know it must drain in-flight callbacks. Do not reset in_flight
-  // here: it is already zero once the previous disableProfiler() drained it,
-  // and this function is also called by the dynamic collection toggle
-  // mid-session, where a concurrent in-flight callback may still hold a
-  // reference that must not be discarded.
+
+  // Arm the drain gate before the global callback and fire on any thread. If
+  // this a new profiling session, also bump the session generation.
+  // disableProfiler() relies on this to know it must drain in-flight callbacks.
   global_callback_session.activate(new_session);
+
   state_ptr->setCallbackHandle(at::addGlobalCallback(recordFunctionCallback));
 }
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -605,14 +605,17 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
 // Coordinates one global RecordFunction callback session (KINETO_ONDEMAND, or
 // KINETO with profile_all_threads) against teardown. Those callbacks fire on
 // every thread and touch the profiler state while disableProfiler() finalizes
-// and frees it on another thread. While the session is active, each callback
-// invocation brackets only its own short, GIL-free critical section --
-// getGlobal() plus the RecordQueue access -- with enter()/exit(); it does NOT
-// span the op body (enter to exit). Teardown calls drain(), which closes the
-// session to new callbacks and blocks until the in-flight count reaches zero,
-// so finalize never races a live critical section. The enter()/isActive()
-// re-check is a handshake: a callback that joined before teardown is always
-// waited for, while one arriving after bails without touching the state.
+// and frees it on another thread.
+//
+// While the session is active, each callback invocation brackets only its own
+// short critical section - getGlobal() plus the RecordQueue access - with
+// enter()/exit(). Teardown calls drain(), which closes the session to new
+// callbacks and blocks until the in-flight count reaches zero, so finalize
+// never races a live critical section.
+//
+// The enter()/isActive() re-check is a handshake: a callback that joined before
+// teardown is always waited for, while one arriving after bails without
+// touching the state.
 //
 // Bracketing only the critical section (not the op body) is what keeps drain()
 // from deadlocking against the GIL, but it lets an op enter under one session
@@ -657,8 +660,7 @@ class GlobalCallbackSession {
 
   // Session generation, stamped into each callback's ObserverContext at enter
   // and re-checked at exit. A mismatch means the stamping session was torn down
-  // (its RecordQueue and event freed), so the exit drops itself. Reads only
-  // this atomic and the live context, never the freed event.
+  // (its RecordQueue and event freed), so the exit drops itself.
   uint64_t generation() const {
     return generation_.load();
   }
@@ -686,9 +688,9 @@ class GlobalCallbackSession {
 
   // Close the session to new callbacks and block until all in-flight ones have
   // exited; returns true once drained (also returns true if the session was
-  // never opened -- purely thread-local profiling). Closing is fused with the
-  // wait, so the session cannot be closed without waiting out in-flight
-  // callbacks.
+  // never opened; it remained purely thread-local profiling). Closing is fused
+  // with the wait, so the session cannot be closed without waiting out
+  // in-flight callbacks.
   //
   // Returns false if the drain does not complete within kDrainTimeout. A normal
   // drain takes microseconds (the in-flight window is just a callback's
@@ -713,8 +715,6 @@ class GlobalCallbackSession {
 
   std::atomic<bool> active_{false};
   std::atomic<int64_t> in_flight_{0};
-  // Bumped once per true enable (a new session means a new RecordQueue); see
-  // activate(new_session) and generation().
   std::atomic<uint64_t> generation_{0};
   std::mutex mutex_;
   std::condition_variable cv_; // guarded by mutex_

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -809,13 +809,26 @@ void onFunctionExitImpl(
     torch::profiler::impl::privateuse1Stubs()->record(
         nullptr, &fallback->device_event_end_, nullptr);
   }
+}
 
-  if (!config.experimental_config.disable_external_correlation) {
-    if (fn.scope() == at::RecordScope::USER_SCOPE) {
-      torch::profiler::impl::kineto::popUserCorrelationId();
-    } else {
-      torch::profiler::impl::kineto::popCorrelationId();
-    }
+// Pop the external correlation id that begin_op pushed for this op, if any.
+// Must run on every onFunctionExit path, including the teardown and
+// stale-session early exits that skip event finalization: the correlation stack
+// lives in the device profiling backend (per thread) and is not reset across
+// profiler sessions, so a skipped pop leaks. Safe on those paths because it
+// touches only that stack, never the possibly-freed event_.
+void maybePopCorrelationId(
+    const at::RecordFunction& fn,
+    at::ObserverContext* ctx_ptr) {
+  auto* kineto_ctx =
+      static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
+  if (kineto_ctx == nullptr || !kineto_ctx->pushed_correlation_id_) {
+    return;
+  }
+  if (fn.scope() == at::RecordScope::USER_SCOPE) {
+    torch::profiler::impl::kineto::popUserCorrelationId();
+  } else {
+    torch::profiler::impl::kineto::popCorrelationId();
   }
 }
 
@@ -827,6 +840,12 @@ void onFunctionExitGlobal(
     // there is nothing to finalize.
     return;
   }
+
+  // Balance the correlation id pushed at begin_op on every path below,
+  // including the teardown and stale-session early exits that skip event
+  // finalization.
+  auto correlation_guard =
+      c10::make_scope_exit([&] { maybePopCorrelationId(fn, ctx_ptr); });
 
   // Take this exit's own in-flight ref, paired here because
   // onFunctionEnterGlobal no longer hands one off. It covers only this exit's
@@ -864,6 +883,11 @@ void onFunctionExitGlobal(
 void onFunctionExitTLS(
     const at::RecordFunction& fn,
     at::ObserverContext* ctx_ptr) {
+  // Balance the correlation id pushed at begin_op even when the TLS state is
+  // gone by exit (early return below), for the same reason as
+  // onFunctionExitGlobal.
+  auto correlation_guard =
+      c10::make_scope_exit([&] { maybePopCorrelationId(fn, ctx_ptr); });
   KinetoThreadLocalState* state_ptr = KinetoThreadLocalState::getTLS();
   if (!state_ptr) {
     return;

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -602,40 +602,68 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
   post_process_t eventPostProcessCb;
 };
 
-// A reusable, dynamically-counted completion latch for the global
-// RecordFunction callback path (KINETO_ONDEMAND, or KINETO with
-// profile_all_threads). Those callbacks fire on every thread and touch the
-// profiler state while disableProfiler() finalizes and frees it on another
-// thread. While the latch is active, each in-flight callback enter()s before
-// touching the state and exit()s after; teardown calls drain(), which closes
-// the latch to new callbacks and blocks until the in-flight count reaches
-// zero, so finalize never races a live callback. The enter()/isActive()
+// Coordinates one global RecordFunction callback session (KINETO_ONDEMAND, or
+// KINETO with profile_all_threads) against teardown. Those callbacks fire on
+// every thread and touch the profiler state while disableProfiler() finalizes
+// and frees it on another thread. While the session is active, each callback
+// invocation brackets only its own short, GIL-free critical section --
+// getGlobal() plus the RecordQueue access -- with enter()/exit(); it does NOT
+// span the op body (enter to exit). Teardown calls drain(), which closes the
+// session to new callbacks and blocks until the in-flight count reaches zero,
+// so finalize never races a live critical section. The enter()/isActive()
 // re-check is a handshake: a callback that joined before teardown is always
 // waited for, while one arriving after bails without touching the state.
 //
-// Note that we cannot use a std::latch. A std::latch fixes its count at
+// Bracketing only the critical section (not the op body) is what keeps drain()
+// from deadlocking against the GIL, but it lets an op enter under one session
+// and exit after that session is torn down (its RecordQueue and event freed). A
+// per-session generation (see generation()), stamped on each callback's
+// ObserverContext, closes that gap: onFunctionExitGlobal drops a straddling
+// exit on generation mismatch instead of dereferencing the freed event.
+//
+// The drain counter is not a std::latch: a std::latch fixes its count at
 // construction, cannot be incremented afterward, and is single-use. Here the
-// number of in-flight callbacks is unknown up front, grows dynamically as
-// ops dispatch, and the latch must be re-armed for every enable/disable
-// cycle, none of which std::latch supports. The counter stays lock-free on
-// the per-op hot path; the mutex/cv are touched only on the teardown handoff.
+// number of in-flight callbacks is unknown up front, grows dynamically as ops
+// dispatch, and the session must be re-armed for every enable/disable cycle,
+// none of which std::latch supports. The counter stays lock-free on the per-op
+// hot path; the mutex/cv are touched only on the teardown handoff.
 //
 // Because we coordinate across threads that can call it at any arbitrary time,
 // this object must have static lifetime.
-class DynamicCompletionLatch {
+class GlobalCallbackSession {
  public:
-  DynamicCompletionLatch() = default;
+  GlobalCallbackSession() = default;
+  ~GlobalCallbackSession() = default;
 
-  // We should have only a single, static instance of this object.
-  DynamicCompletionLatch(const DynamicCompletionLatch&) = delete;
-  DynamicCompletionLatch& operator=(const DynamicCompletionLatch&) = delete;
+  // Single, static instance only: neither copyable nor movable.
+  GlobalCallbackSession(const GlobalCallbackSession&) = delete;
+  GlobalCallbackSession& operator=(const GlobalCallbackSession&) = delete;
+  GlobalCallbackSession(GlobalCallbackSession&&) = delete;
+  GlobalCallbackSession& operator=(GlobalCallbackSession&&) = delete;
 
-  // Open the latch (at enableProfiler time) so callbacks begin participating.
-  void activate() {
+  // Open the session (at enableProfiler time) so callbacks begin participating.
+  // On a true enable a fresh RecordQueue was just installed, so bump the
+  // session generation first: callbacks in the new session stamp the new value
+  // and a straddling exit from the prior session detects the mismatch. The
+  // mid-session dynamic collection toggle re-arms the same RecordQueue and
+  // passes false; bumping there would wrongly drop end-events for ops that
+  // straddle the toggle.
+  void activate(bool new_session) {
+    if (new_session) {
+      generation_.fetch_add(1);
+    }
     active_.store(true);
   }
 
-  // Whether the latch is open; that is, teardown has not begun.
+  // Session generation, stamped into each callback's ObserverContext at enter
+  // and re-checked at exit. A mismatch means the stamping session was torn down
+  // (its RecordQueue and event freed), so the exit drops itself. Reads only
+  // this atomic and the live context, never the freed event.
+  uint64_t generation() const {
+    return generation_.load();
+  }
+
+  // Whether the session is open; that is, teardown has not begun.
   bool isActive() const {
     return active_.load();
   }
@@ -646,7 +674,7 @@ class DynamicCompletionLatch {
     in_flight_.fetch_add(1);
   }
 
-  // Deregister an in-flight callback. When this is the last one and the latch
+  // Deregister an in-flight callback. When this is the last one and the session
   // has been closed (drain() in progress), wake the waiting teardown thread.
   // During normal profiling this is a single lock-free decrement.
   void exit() {
@@ -656,17 +684,19 @@ class DynamicCompletionLatch {
     }
   }
 
-  // Close the latch to new callbacks and block until all in-flight ones have
-  // exited; returns true once drained (also returns true if the latch was never
-  // opened -- purely thread-local profiling). Closing is fused with the wait,
-  // so the latch cannot be closed without waiting out in-flight callbacks.
+  // Close the session to new callbacks and block until all in-flight ones have
+  // exited; returns true once drained (also returns true if the session was
+  // never opened -- purely thread-local profiling). Closing is fused with the
+  // wait, so the session cannot be closed without waiting out in-flight
+  // callbacks.
   //
   // Returns false if the drain does not complete within kDrainTimeout. A normal
-  // drain takes microseconds (the in-flight window is a single op, enter() ->
-  // op -> exit()), so a multi-second wait means a callback's thread is wedged,
-  // dead, or deadlocked on a resource this thread holds. The caller must then
-  // leave the state installed: freeing it under a live callback would
-  // reintroduce the use-after-free this latch exists to prevent.
+  // drain takes microseconds (the in-flight window is just a callback's
+  // getGlobal() + RecordQueue critical section, never an op body), so a
+  // multi-second wait means a callback's thread was killed or wedged inside
+  // that critical section. The caller must then leave the state installed:
+  // freeing it under a live callback would reintroduce the use-after-free this
+  // session guards against.
   bool drain() {
     if (!active_.exchange(false)) {
       return true;
@@ -683,29 +713,33 @@ class DynamicCompletionLatch {
 
   std::atomic<bool> active_{false};
   std::atomic<int64_t> in_flight_{0};
+  // Bumped once per true enable (a new session means a new RecordQueue); see
+  // activate(new_session) and generation().
+  std::atomic<uint64_t> generation_{0};
   std::mutex mutex_;
   std::condition_variable cv_; // guarded by mutex_
 };
 
-DynamicCompletionLatch global_callback_latch;
+GlobalCallbackSession global_callback_session;
 
 std::unique_ptr<at::ObserverContext> onFunctionEnterGlobal(
     const at::RecordFunction& fn) {
   // Fast bail once teardown has begun, before taking an in-flight ref, so the
   // drain in disableProfiler() always converges.
-  if (!global_callback_latch.isActive()) {
+  if (!global_callback_session.isActive()) {
     return nullptr;
   }
-  global_callback_latch.enter();
-  // Release the ref on any early return or exception, unless ownership is
-  // handed to onFunctionExitGlobal by releasing the guard below.
+  global_callback_session.enter();
+  // Release the ref when this function returns (success or early bail), so the
+  // in-flight window is just this enter's getGlobal() + begin_op() critical
+  // section, not the op body. The matching onFunctionExitGlobal takes its own.
   auto in_flight_guard =
-      c10::make_scope_exit([] { global_callback_latch.exit(); });
+      c10::make_scope_exit([] { global_callback_session.exit(); });
   // Re-check after the increment. This is the handshake that makes teardown
   // safe: if disableProfiler() cleared active concurrently, its drain is
   // guaranteed to observe our increment and wait iff we still observe active
   // true here.
-  if (!global_callback_latch.isActive()) {
+  if (!global_callback_session.isActive()) {
     return nullptr;
   }
   std::shared_ptr<KinetoThreadLocalState> state_ptr =
@@ -715,8 +749,10 @@ std::unique_ptr<at::ObserverContext> onFunctionEnterGlobal(
   }
   auto ctx = state_ptr->recordQueue.getSubqueue()->begin_op(fn);
   if (ctx) {
-    // The in-flight ref is now owned by the matching onFunctionExitGlobal.
-    in_flight_guard.release();
+    // Stamp the current session so a straddling exit (begin_op here, exit after
+    // this session is torn down) drops itself on mismatch instead of writing
+    // through a freed event_.
+    ctx->session_generation_ = global_callback_session.generation();
   }
   return ctx;
 }
@@ -782,22 +818,36 @@ void onFunctionExitImpl(
 void onFunctionExitGlobal(
     const at::RecordFunction& fn,
     at::ObserverContext* ctx_ptr) {
-  // Release the in-flight ref taken in onFunctionEnterGlobal on every exit
-  // path, but only for ops that produced a context. Ops whose enter bailed
-  // (null context) never took a ref.
-  auto in_flight_guard = c10::make_scope_exit([&] {
-    if (ctx_ptr != nullptr) {
-      global_callback_latch.exit();
-    }
-  });
-  // An op whose enter bailed took no ref and must not touch the state here,
-  // since a concurrent disableProfiler() may already be tearing it down.
   if (ctx_ptr == nullptr) {
+    // Enter bailed (teardown in progress, or no state): no ref was taken and
+    // there is nothing to finalize.
+    return;
+  }
+  // Take this exit's own in-flight ref, paired here because
+  // onFunctionEnterGlobal no longer hands one off. It covers only this exit's
+  // getGlobal() + RecordQueue write, never the op body, so the drain cannot
+  // block on it.
+  global_callback_session.enter();
+  auto in_flight_guard =
+      c10::make_scope_exit([] { global_callback_session.exit(); });
+  // Re-check after the increment, mirroring onFunctionEnterGlobal: if teardown
+  // began concurrently the queue may already be finalized/freed, so skip the
+  // write (the event keeps its start and gets no end).
+  if (!global_callback_session.isActive()) {
     return;
   }
   std::shared_ptr<KinetoThreadLocalState> state_ptr =
       KinetoThreadLocalState::getGlobal();
   if (!state_ptr) {
+    return;
+  }
+  // begin_op ran in an earlier session (generation differs): that session was
+  // torn down and event_ is freed, so drop the exit before touching event_.
+  // session_generation_ lives in the context (alive while RecordFunction holds
+  // it), never in the freed event_, so this check is always safe.
+  auto* kineto_ctx =
+      static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
+  if (kineto_ctx->session_generation_ != global_callback_session.generation()) {
     return;
   }
   onFunctionExitImpl(*state_ptr, fn, ctx_ptr);
@@ -814,7 +864,8 @@ void onFunctionExitTLS(
 }
 
 void pushGlobalProfilingCallbacks(
-    const std::unordered_set<at::RecordScope>& scopes) {
+    const std::unordered_set<at::RecordScope>& scopes,
+    bool new_session) {
   std::shared_ptr<KinetoThreadLocalState> state_ptr =
       KinetoThreadLocalState::getGlobal();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
@@ -822,13 +873,14 @@ void pushGlobalProfilingCallbacks(
       at::RecordFunctionCallback(onFunctionEnterGlobal, onFunctionExitGlobal)
           .needsInputs(state_ptr->config().report_input_shapes)
           .scopes(scopes);
-  // Arm the drain gate before the global callback can fire on any thread.
-  // disableProfiler() relies on this to know it must drain in-flight callbacks.
-  // Do not reset in_flight here: it is already zero once the previous
-  // disableProfiler() drained it, and this function is also called by the
-  // dynamic collection toggle mid-session, where a concurrent in-flight
-  // callback may still hold a reference that must not be discarded.
-  global_callback_latch.activate();
+  // Arm the drain gate -- and, on a true enable, bump the session generation --
+  // before the global callback can fire on any thread. disableProfiler() relies
+  // on this to know it must drain in-flight callbacks. Do not reset in_flight
+  // here: it is already zero once the previous disableProfiler() drained it,
+  // and this function is also called by the dynamic collection toggle
+  // mid-session, where a concurrent in-flight callback may still hold a
+  // reference that must not be discarded.
+  global_callback_session.activate(new_session);
   state_ptr->setCallbackHandle(at::addGlobalCallback(recordFunctionCallback));
 }
 
@@ -947,7 +999,8 @@ static void toggleTorchOpCollectionDynamic(bool enable) {
   if (global_state) {
     if (enable) {
       auto scopes = profiler_state_info_ptr->scopes;
-      pushGlobalProfilingCallbacks(scopes);
+      // Mid-session re-arm on the same RecordQueue: do not bump the generation.
+      pushGlobalProfilingCallbacks(scopes, /*new_session=*/false);
     } else {
       global_state->removeCallback();
     }
@@ -1096,8 +1149,9 @@ void enableProfiler(
   KinetoThreadLocalState::push(state_ptr);
 
   if (has_cpu) {
-    config.pushGlobalCallbacks() ? pushGlobalProfilingCallbacks(scopes)
-                                 : pushTLSProfilingCallbacks(scopes);
+    config.pushGlobalCallbacks()
+        ? pushGlobalProfilingCallbacks(scopes, /*new_session=*/true)
+        : pushTLSProfilingCallbacks(scopes);
   }
 
   if (!config.global()) {
@@ -1144,7 +1198,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
   // for in-flight ones to finish before popping and finalizing the state, else
   // a worker thread can mutate the record queue while finalizeTrace() reads
   // and frees it.
-  if (!global_callback_latch.drain()) {
+  if (!global_callback_session.drain()) {
     // The drain timed out: an in-flight global callback is wedged or dead, so
     // we cannot finalize (reading the queue would race the live callback and
     // reintroduce the use-after-free). We still pop the state and remove the

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -344,12 +344,14 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
     torch_ops_.inputs_outputs_.push(fn.inputs());
     torch_ops_.kwinputs_.emplace_back(fn.kwinputs());
   }
+  bool pushed_correlation_id = false;
   if (!config_.experimental_config.disable_external_correlation) {
     if (fn.scope() == at::RecordScope::USER_SCOPE) {
       torch::profiler::impl::kineto::pushUserCorrelationId(corr_id);
     } else {
       torch::profiler::impl::kineto::pushCorrelationId(corr_id);
     }
+    pushed_correlation_id = true;
   }
 
 #if !defined BUILD_LITE_INTERPRETER && !defined C10_MOBILE
@@ -370,6 +372,7 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
   }
 
   auto out = std::make_unique<KinetoObserverContext>(event);
+  out->pushed_correlation_id_ = pushed_correlation_id;
   if (fn.isNcclMeta()) {
     // Record NCCL metadata for specific CPU ops, switch off output
     // introspection in this begin_op callback, we will do that in exit callback
@@ -1247,6 +1250,7 @@ class TransferEvents {
   static constexpr long long unmatchedIndex = -1;
   static constexpr auto noTID = std::numeric_limits<uint64_t>::max();
   std::reference_wrapper<std::vector<std::shared_ptr<Result>>> results_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const ProfilerConfig& config_;
   std::vector<const itrace_t*> trace_activities_;
   ska::flat_hash_map<const itrace_t*, std::shared_ptr<Result>> kineto_events_;

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -470,8 +470,12 @@ struct KinetoObserverContext : public at::ObserverContext {
 
   Event* event_;
   FallbackPair* fallback_{nullptr};
-  // Global-callback path: session generation captured at begin_op;
-  // onFunctionExitGlobal drops the exit if it no longer matches (session gone).
+
+  // Generation of the global session this op entered under, snapshotted from
+  // global_callback_session at enter time. That counter bumps per new global
+  // session (not on the mid-session toggle). At exit, a match means event_ is
+  // still live so the exit finalizes it; a mismatch means the session was torn
+  // down and event_ freed, so the exit drops without touching event_.
   uint64_t session_generation_{0};
 };
 

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -477,6 +477,13 @@ struct KinetoObserverContext : public at::ObserverContext {
   // still live so the exit finalizes it; a mismatch means the session was torn
   // down and event_ freed, so the exit drops without touching event_.
   uint64_t session_generation_{0};
+
+  // True if begin_op pushed an external correlation id for this op. The
+  // matching pop must run on every exit path (including teardown /
+  // stale-session early exits), or the id leaks onto the device profiling
+  // backend's per-thread correlation stack, which is not reset across profiler
+  // sessions.
+  bool pushed_correlation_id_{false};
 };
 
 constexpr int IO_ENCODER_DEFAULT_BLOCK_SIZE = 1024;

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -470,6 +470,9 @@ struct KinetoObserverContext : public at::ObserverContext {
 
   Event* event_;
   FallbackPair* fallback_{nullptr};
+  // Global-callback path: session generation captured at begin_op;
+  // onFunctionExitGlobal drops the exit if it no longer matches (session gone).
+  uint64_t session_generation_{0};
 };
 
 constexpr int IO_ENCODER_DEFAULT_BLOCK_SIZE = 1024;


### PR DESCRIPTION
Authored with @Alkaid-Benetnash.

Follow up to https://github.com/pytorch/pytorch/pull/187483. Two main changes:

1. We narrow the critical section to just accessing the global state. Before, we entered in `onFunctionEnterGlobal()` and exited in `onFunctionExitGlobal()`. But that meant that when we had to wait on a drain in `disableProfiler()`, we would potentially have to wait for the entire operation call. Now in each of those functions, we enter and exit; the actual function call is not part of the critical section.
2. We add a generation counter to deal with `onFunctionExitGlobal()` being called when the entire profiling session the function was part of has gone away. In such cases, we should do nothing.