### PR TITLE
Fix cache miss in FlexAttention

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2020,6 +2020,30 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         y = f(x)
         self.assertEqual(y.shape, x.shape)
 
+    def test_check_compiles_when_predicate_true_and_message_string(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, "Shape is not greater than 3")
+            return x + 1
+
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        y = f(x)
+        self.assertEqual(y.shape, x.shape)
+
+    def test_check_raises_at_runtime_when_predicate_false_and_message_string(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, "Shape is not greater than 3")
+            return x + 1
+
+        x = torch.randn(3)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        with self.assertRaisesRegex(RuntimeError, "Shape is not greater than 3"):
+            f(x)
+
     def test_check_compiles_when_predicate_true_constant_and_message_None(self):
         @torch.compile(backend="eager", fullgraph=True)
         def f(x):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -3890,6 +3890,14 @@
     {
       "Gb_type": "Can't extract message from torch._check*()",
       "Context": "str(message_vt)",
+      "Explanation": "The message argument of torch._check*() must be a string, None, or a function defined within the torch.compile region.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Can't extract message from torch._check*()",
+      "Context": "str(message_vt)",
       "Explanation": "The message argument of torch._check*() must be a function defined within the torch.compile region.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2536,10 +2536,6 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
             message_eager = None
             message_graph_arg = None
-            message_explanation = (
-                "The message argument of torch._check*() must be a string, None, "
-                "or a function defined within the torch.compile region."
-            )
             match message_vt:
                 case None:
                     pass
@@ -2549,7 +2545,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                         unimplemented(
                             gb_type="Can't extract message from torch._check*()",
                             context=str(message_vt),
-                            explanation=message_explanation,
+                            explanation=(
+                                "The message argument of torch._check*() must be a string, None, "
+                                "or a function defined within the torch.compile region."
+                            ),
                             hints=[
                                 *graph_break_hints.SUPPORTABLE,
                             ],
@@ -2580,7 +2579,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     unimplemented(
                         gb_type="Can't extract message from torch._check*()",
                         context=str(message_vt),
-                        explanation=message_explanation,
+                        explanation=(
+                            "The message argument of torch._check*() must be a string, None, "
+                            "or a function defined within the torch.compile region."
+                        ),
                         hints=[
                             *graph_break_hints.SUPPORTABLE,
                         ],

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2535,46 +2535,62 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
 
             message_eager = None
-            message_graph_proxy = None
-            if message_vt is not None:
-                if not isinstance(message_vt, NestedUserFunctionVariable):
+            message_graph_arg = None
+            message_explanation = (
+                "The message argument of torch._check*() must be a string, None, "
+                "or a function defined within the torch.compile region."
+            )
+            match message_vt:
+                case None:
+                    pass
+                case ConstantVariable():
+                    message_eager = message_vt.as_python_constant()
+                    if message_eager is not None and not isinstance(message_eager, str):
+                        unimplemented(
+                            gb_type="Can't extract message from torch._check*()",
+                            context=str(message_vt),
+                            explanation=message_explanation,
+                            hints=[
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
+                    message_graph_arg = message_eager
+                case NestedUserFunctionVariable():
+                    try:
+                        message_eager = message_vt.get_function()
+                    except ClosureConversionError:
+                        unimplemented(
+                            gb_type="Can't convert torch._check*() message closure",
+                            context=str(message_vt),
+                            explanation=(
+                                "The message argument of torch._check*() must be a function "
+                                "whose closure variables are Python constants."
+                            ),
+                            hints=[
+                                "Remove closure variables that reference non-constant values, e.g. "
+                                "remove references to tensor `x` in `lambda: f'{x} failed check'`",
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
+
+                    message_graph_arg = tx.output.register_static_attr_and_return_proxy(
+                        "_check_message", message_eager
+                    )
+                case _:
                     unimplemented(
                         gb_type="Can't extract message from torch._check*()",
                         context=str(message_vt),
-                        explanation=(
-                            "The message argument of torch._check*() must be a function "
-                            "defined within the torch.compile region."
-                        ),
+                        explanation=message_explanation,
                         hints=[
                             *graph_break_hints.SUPPORTABLE,
                         ],
                     )
-                try:
-                    message_eager = message_vt.get_function()
-                except ClosureConversionError:
-                    unimplemented(
-                        gb_type="Can't convert torch._check*() message closure",
-                        context=str(message_vt),
-                        explanation=(
-                            "The message argument of torch._check*() must be a function "
-                            "whose closure variables are Python constants."
-                        ),
-                        hints=[
-                            "Remove closure variables that reference non-constant values, e.g. "
-                            "remove references to tensor `x` in `lambda: f'{x} failed check'`",
-                            *graph_break_hints.SUPPORTABLE,
-                        ],
-                    )
-
-                message_graph_proxy = tx.output.register_static_attr_and_return_proxy(
-                    "_check_message", message_eager
-                )
 
             if predicate_vt.is_python_constant():
                 if predicate_vt.as_python_constant():
                     return ConstantVariable.create(None)
                 msg = (
-                    message_eager()
+                    str(message_eager() if callable(message_eager) else message_eager)
                     if message_eager is not None
                     else ("Expected cond to be True, but got False.")
                 )
@@ -2583,10 +2599,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             predicate_proxy = predicate_vt.as_proxy()
 
             proxy_args: tuple[Any, ...]
-            if message_graph_proxy is None:
+            if message_graph_arg is None:
                 proxy_args = (predicate_proxy,)
             else:
-                proxy_args = (predicate_proxy, message_graph_proxy)
+                proxy_args = (predicate_proxy, message_graph_arg)
 
             return wrap_fx_proxy(
                 tx=tx,

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -53,6 +53,19 @@ if typing.TYPE_CHECKING:
 #
 _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = False
 
+_BLOCK_MASK_TOO_SMALL_ERROR = (
+    "block_mask was created for a smaller length than you're "
+    "using it for, you likely need to create a new block mask."
+)
+_BLOCK_MASK_TOO_LARGE_ERROR = (
+    "block_mask was created for a larger length than you're "
+    "using it for, you can either 1. create a new block mask with "
+    "the correct length, or 2. 'adjust' the existing block mask to "
+    "the correct length by calling block_mask._adjust(q_len, kv_len). "
+    "This essentially 'crops' the block mask to the upper left corner, "
+    "which does not work for all mask_mods!"
+)
+
 _WARNINGS_SHOWN: set[str] = set()
 
 
@@ -2371,39 +2384,23 @@ def flex_attention(
         block_mask_q_len = block_mask.shape[-2]
         block_mask_kv_len = block_mask.shape[-1]
 
-        def block_mask_too_small_error():
-            return (
-                "block_mask was created for a smaller length than you're "
-                "using it for, you likely need to create a new block mask."
-            )
-
-        def block_mask_too_large_error():
-            return (
-                "block_mask was created for a larger length than you're "
-                "using it for, you can either 1. create a new block mask with "
-                "the correct length, or 2. 'adjust' the existing block mask to "
-                "the correct length by calling block_mask._adjust(q_len, kv_len). "
-                "This essentially 'crops' the block mask to the upper left corner, "
-                "which does not work for all mask_mods!"
-            )
-
         # Keep these as separate checks: explicit sym_and/sym_or calls become
         # trace-visible non-Tensor ops under Dynamo.
         torch._check(
             q_len <= block_mask_q_len,
-            block_mask_too_small_error,
+            _BLOCK_MASK_TOO_SMALL_ERROR,
         )
         torch._check(
             kv_len <= block_mask_kv_len,
-            block_mask_too_small_error,
+            _BLOCK_MASK_TOO_SMALL_ERROR,
         )
         torch._check(
             q_len >= block_mask_q_len,
-            block_mask_too_large_error,
+            _BLOCK_MASK_TOO_LARGE_ERROR,
         )
         torch._check(
             kv_len >= block_mask_kv_len,
-            block_mask_too_large_error,
+            _BLOCK_MASK_TOO_LARGE_ERROR,
         )
 
     if scale is None:


### PR DESCRIPTION
## Human Note
Fix aotautograd cache miss in FlexAttention.

With this change: https://github.com/pytorch/pytorch/pull/183838 we added inline torch._checks to make things work better with unbacked symints. However this also added temporary lambda functions to torch_check bodies that could not be pickled.

I tried converting the error to strings.. but it turns out that this is not supported in the VT for torch.check. I find this kinda surprsing but ended up allowing this type to more closely match eager

Edit: It seems that torch._check was only recently allowed to accept string types in eager so this delta in behavior is ~9days old

## Agent Report
# Report: nightly-cache-key-warning

## Summary

The warning is consistent with Dynamo storing a local `torch._check` message callable as a `_check_message` FX graph attribute, followed by AOTAutograd/Inductor cache-key pickling attempting to serialize that local function. The reported callable name, `flex_attention.<locals>.block_mask_too_small_error`, came from nested FlexAttention block-mask length error helpers introduced after the referenced April nightly.

I changed the path so FlexAttention no longer needs local message callables:

- `torch/_dynamo/variables/torch.py` now accepts `str` and `None` constants as `torch._check*` messages, matching eager `torch._check` behavior. The dispatch is written with `match`/`case`.
- `torch/nn/attention/flex_attention.py` now uses module-level string constants for block-mask length check messages instead of nested functions.
- `test/dynamo/test_misc.py` adds coverage that compiled `torch._check(..., "message")` succeeds and preserves the message on failure.

## Validation

Tests:

```bash
/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_string MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_string
/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_has_no_closure MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_has_no_closure MiscTests.test_check_compiles_when_predicate_true_and_message_has_global
```

Both targeted test commands passed.

Manual repro/checks:

- Ran a small CUDA `torch.compile(flex_attention, fullgraph=True)` forward/backward with `torch._inductor.config.fx_graph_cache=True` and `torch._functorch.config.enable_autograd_cache=True`; it completed and saved an AOTAutograd cache entry without the cache-key pickling warning. In a two-compile run against a fresh cache dir, the first compile was a normal cold `autograd_cache_miss`/save and the second compile recorded `autograd_cache_hit=1`.
- Captured the dynamic FlexAttention graph with an eager backend and confirmed `_check_message` was not present in the resulting `GraphModule` attrs.
- Demonstrated the lower-level pre-fix failure mode with a manually constructed `GraphModule` containing a local function in `_check_message`; `FxGraphCachePickler(gm).get_hash(gm)` emitted `Failed to pickle cache key` and raised `BypassFxGraphCache` caused by `AttributeError: Can't get local object ...block_mask_too_small_error`.

Prerequisite checks:

```bash
/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python -m py_compile torch/_dynamo/variables/torch.py torch/nn/attention/flex_attention.py test/dynamo/test_misc.py
git diff --check
```

Both prerequisite checks passed. After rewriting the Dynamo branch as `match`/`case`, I reran the new Dynamo string-message tests and `py_compile torch/_dynamo/variables/torch.py`; both passed.

PR follow-up:

- Fetched PR comments for https://github.com/pytorch/pytorch/pull/188177 into `pr_context_188177.md`. The only actionable review comment was from Codex: sync `torch/_dynamo/graph_break_registry.json` for the changed `Can't extract message from torch._check*()` explanation.
- Fixed the lint issue by inlining the graph-break explanation string in `torch/_dynamo/variables/torch.py`, running `spin quickfix`, and verifying `spin quicklint` passes with `ok No lint issues`. Also reran the direct graph-break registry linter, registry-linter unit tests (`tools/test/test_gb_registry_linter.py -v`, 12 tests), `py_compile torch/_dynamo/variables/torch.py`, and the two new Dynamo string-message tests after the lint fix; all passed.

## Remaining uncertainty

The exact downstream rigi workload was not available in this job, and I could not reproduce the warning with the current checkout before the change using a small FlexAttention compile. The root-cause evidence is still strong because the reported pickling error names the exact nested FlexAttention helper, and the patch removes that local callable from the compiled graph path by using supported string messages instead.


<details>
<summary>Agent Worklog</summary>

# Worklog: nightly-cache-key-warning

## 2026-06-25

- Read `PTQ_CONTEXT.md`, `prime.md`, `task.md`, and `pytorch/AGENTS.md`. `system_prompt.md`, previous `worklog.md`, and previous `report.md` were absent.
- Checked `~/agent_notes` for prior PyTorch/flex/cache notes. Found flex attention notes, but no prior cache-key warning investigation.
- Inspected relevant source:
  - `torch/nn/attention/flex_attention.py` had nested `block_mask_too_small_error` and `block_mask_too_large_error` functions passed to `torch._check`.
  - `torch/_dynamo/variables/torch.py` only accepted nested message callables for `torch._check*` and stored callable messages as `_check_message` graph attrs.
  - `torch/_inductor/codecache.py` logs `Failed to pickle cache key` when cache key serialization hits unpickleable objects.
  - `torch/_functorch/_aot_autograd/autograd_cache.py` hashes `AOTAutogradCacheDetails` using the same FX graph cache pickler.
- Verified module-level `torch._check` message functions are not currently accepted by Dynamo, so simply moving the flex message functions to module scope would break compilation.
- Implemented a narrower fix:
  - Dynamo now accepts `str` and `None` message constants for `torch._check*`, matching eager `torch._check`'s public signature. The message-type dispatch uses `match`/`case`.
  - FlexAttention now passes module-level string constants for the block-mask length checks instead of local message functions, so no local callable can be serialized into cache keys.
- Validation run:
  - `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_string MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_string`
  - `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_has_no_closure MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_has_no_closure MiscTests.test_check_compiles_when_predicate_true_and_message_has_global`
  - Manual CUDA flex attention compile with `fx_graph_cache=True` and `enable_autograd_cache=True`; completed forward/backward with `autograd_cache_miss=1`, `autograd_cache_saved=1`, and no cache-key pickling warning.
  - Reran the manual CUDA check as two compile attempts against a fresh `TORCHINDUCTOR_CACHE_DIR`: first compile produced `{'total': 1, 'autograd_cache_miss': 1, 'ok': 1, 'autograd_cache_saved': 1}`; second compile produced `{'total': 2, 'autograd_cache_miss': 1, 'ok': 2, 'autograd_cache_saved': 1, 'autograd_cache_hit': 1}`.
  - Captured a dynamic flex attention graph with an eager backend and confirmed `_check_message` was not present in the `GraphModule` attrs; only `score_mod_0` and `mask_fn_0` get_attrs remained.
  - Demonstrated the pre-fix lower-level failure mode by manually constructing a `GraphModule` with a local function stored as `_check_message` and running `FxGraphCachePickler(gm).get_hash(gm)`. It emitted `Failed to pickle cache key` from `torch/_inductor/codecache.py:1101` and raised `BypassFxGraphCache` caused by `AttributeError: Can't get local object ...block_mask_too_small_error`.
  - `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python -m py_compile torch/_dynamo/variables/torch.py torch/nn/attention/flex_attention.py test/dynamo/test_misc.py`
  - After switching the Dynamo message handling to `match`/`case`, reran `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_string MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_string` and `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python -m py_compile torch/_dynamo/variables/torch.py`.
  - `git diff --check`
- Fetched PR context for https://github.com/pytorch/pytorch/pull/188177 into `pr_context_188177.md`. Reviewer feedback: one Codex inline comment on `torch/_dynamo/variables/torch.py` asking to sync `torch/_dynamo/graph_break_registry.json` after changing the `Can't extract message from torch._check*()` explanation; Dr. CI issue comment only had HUD/docs links.
- Fixed the lint issue by inlining the changed `unimplemented(..., explanation=...)` text so the graph-break registry linter can extract the literal, then ran `spin quickfix` to update `torch/_dynamo/graph_break_registry.json`.
- Lint validation after the fix: `spin quicklint` passed with `ok No lint issues`; `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python tools/linter/adapters/gb_registry_linter.py` produced no output; `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python -m py_compile torch/_dynamo/variables/torch.py` passed; `PYTHONPATH=. /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python tools/test/test_gb_registry_linter.py -v` ran 12 registry-linter unit tests and passed.
- Reran the new Dynamo string-message tests after the lint fix: `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-adhoc-051e55/.venv/bin/python test/dynamo/test_misc.py MiscTests.test_check_compiles_when_predicate_true_and_message_string MiscTests.test_check_raises_at_runtime_when_predicate_false_and_message_string` passed.
- Launched cheap test-discovery subagents (`run-20260625-191850-4f41928c`). Recommended next tests/checks included direct graph-break registry linter/lintrunner checks, the new Dynamo string-message tests, a focused AOTAutograd/FxGraphCache cache-key regression in `test/dynamo/test_aot_autograd_cache.py` or `test/inductor/test_codecache.py`, and direct FlexAttention block-mask sequence length tests in `test/inductor/test_flex_attention.py`.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98