### PR TITLE
Guard score_mod oob indexing

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2856,6 +2856,74 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             self.assertEqual(flex_output.dtype, torch.float16)
 
     @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps  # asserts masked Triton loads in generated code
+    def test_score_mod_captured_loads_are_bounds_checked(self, device):
+        B, H, S, D = 1, 1, 128, 16
+        max_len = S - 1
+        buffer = torch.randn(max_len, device=device, requires_grad=True)
+        buffer_ref = buffer.detach().clone().requires_grad_(True)
+
+        def mask_mod(b, h, q, kv):
+            return (kv < max_len) & (q >= kv)
+
+        def score_mod(score, b, h, q, kv):
+            return score + buffer[kv]
+
+        def safe_score_mod(score, b, h, q, kv):
+            return score + buffer_ref[torch.where(kv < max_len, kv, 0)]
+
+        def make_tensor():
+            return torch.randn(
+                (B, H, S, D), device=device, dtype=torch.float16, requires_grad=True
+            )
+
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        q_ref, k_ref, v_ref = query_key_value_clones(q, k, v)
+        block_mask = create_block_mask(mask_mod, B, H, S, S, device=device)
+        compiled_sdpa = torch.compile(
+            create_attention(score_mod, block_mask), dynamic=False
+        )
+        out, code = run_and_get_code(compiled_sdpa, q, k, v)
+        ref = create_attention(safe_score_mod, block_mask)(q_ref, k_ref, v_ref)
+        out.sum().backward()
+        ref.sum().backward()
+
+        torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-2)
+        for grad, ref_grad in zip(
+            (q.grad, k.grad, v.grad, buffer.grad),
+            (q_ref.grad, k_ref.grad, v_ref.grad, buffer_ref.grad),
+        ):
+            torch.testing.assert_close(grad, ref_grad, atol=2e-3, rtol=2e-2)
+        FileCheck().check("tl.load").check("mask=((").check(") < 127").check(
+            "other=0"
+        ).run("\n".join(code))
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps  # asserts unmasked Triton captured-buffer loads in generated code
+    def test_score_mod_captured_load_bounds_elided_when_safe(self, device):
+        B, H, S, D = 1, 1, 128, 16
+        buffer = torch.randn(S, device=device)
+
+        def score_mod(score, b, h, q, kv):
+            return score + buffer[kv]
+
+        def make_tensor():
+            return torch.randn((B, H, S, D), device=device, dtype=torch.float16)
+
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        block_mask = create_block_mask(noop_mask, B, H, S, S, device=device)
+        compiled_sdpa = torch.compile(
+            create_attention(score_mod, block_mask), dynamic=False
+        )
+        _, code = run_and_get_code(compiled_sdpa, q, k, v)
+
+        FileCheck().check("tl.load(in_ptr").check_not("other=0").run("\n".join(code))
+
+    @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -69,7 +69,14 @@ def forward_block_mn(
             "h": "index",
             "m": "index",
             "n": "index",
-        }
+        },
+        input_ranges={
+            "b": (0, size("Q", 0)),
+            "h": (0, size("Q", 1)),
+            "m": (0, size("Q", 2)),
+            "n": (0, size("K", 2)),
+        },
+        bounds_check_indices=True,
     ) | indent_except_first(1) }}
 
     if CHECK_BLOCK_BOUNDARY:

--- a/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
@@ -486,7 +486,14 @@ def bwd_dq_block_mn(
             "h": "index",
             "m": "index",
             "n": "index",
-        }
+        },
+        input_ranges={
+            "b": (0, size("Q", 0)),
+            "h": (0, size("Q", 1)),
+            "m": (0, size("Q", 2)),
+            "n": (0, size("K", 2)),
+        },
+        bounds_check_indices=True,
     ) | indent_except_first(1) }}
 
 
@@ -560,7 +567,14 @@ def bwd_dq_block_mn(
             "h": "index",
             "m": "index",
             "n": "index",
-        }
+        },
+        input_ranges={
+            "b": (0, size("Q", 0)),
+            "h": (0, size("Q", 1)),
+            "m": (0, size("Q", 2)),
+            "n": (0, size("K", 2)),
+        },
+        bounds_check_indices=True,
     ) | indent_except_first(1) }}
     {# See Note Selective masking DQ #}
     if not IS_DIVISIBLE:
@@ -592,7 +606,14 @@ def bwd_dq_block_mn(
             h="off_hq",
             m="m",
             n="n",
-            grad_score_mod="ds"
+            grad_score_mod="ds",
+            input_ranges={
+                "b": (0, size("Q", 0)),
+                "h": (0, size("Q", 1)),
+                "m": (0, size("Q", 2)),
+                "n": (0, size("K", 2)),
+            },
+            bounds_check_indices=True,
         ) | indent_except_first(2) }}
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     ds = grad_scores
@@ -719,7 +740,14 @@ def bwd_dkdv_block_mn(
             "h": "index",
             "m": "index",
             "n": "index",
-        }
+        },
+        input_ranges={
+            "b": (0, size("Q", 0)),
+            "h": (0, size("Q", 1)),
+            "m": (0, size("Q", 2)),
+            "n": (0, size("K", 2)),
+        },
+        bounds_check_indices=True,
     ) | indent_except_first(1) }}
 
     {# Note: Selective masking DK/DV
@@ -794,7 +822,14 @@ def bwd_dkdv_block_mn(
             "h": "index",
             "m": "index",
             "n": "index",
-        }
+        },
+        input_ranges={
+            "b": (0, size("Q", 0)),
+            "h": (0, size("Q", 1)),
+            "m": (0, size("Q", 2)),
+            "n": (0, size("K", 2)),
+        },
+        bounds_check_indices=True,
     ) | indent_except_first(1) }}
 
     {# See Note: Selective masking DK/DV#}
@@ -831,7 +866,14 @@ def bwd_dkdv_block_mn(
             h="idx_h",
             m="idx_m",
             n="idx_n",
-            grad_score_mod="dsT"
+            grad_score_mod="dsT",
+            input_ranges={
+                "b": (0, size("Q", 0)),
+                "h": (0, size("Q", 1)),
+                "m": (0, size("Q", 2)),
+                "n": (0, size("K", 2)),
+            },
+            bounds_check_indices=True,
         ) | indent_except_first(2) }}
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     dsT = grad_scores

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -41,6 +41,7 @@ from torch._inductor.await_utils import await_sync
 from torch._inductor.utils import clear_on_fresh_cache
 from torch.utils._filelock import FileLock
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from ..utils._sympy.functions import CeilDiv, Max, Min
 from . import config, ir
@@ -80,6 +81,7 @@ from .ops_handler import StoreMode
 from .runtime.hints import DeviceProperties
 from .runtime.triton_compat import HAS_WARP_SPEC
 from .runtime.triton_heuristics import FixedGrid
+from .sizevars import statically_known_true as statically_known_true_with_axioms
 from .utils import (
     ceildiv,
     do_bench_using_profiling,
@@ -397,6 +399,8 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         mask: str | None,
         input_shapes: dict[str, tuple[str, ...]] | None = None,
         input_dtypes: dict[str, torch.dtype | str] | None = None,
+        input_ranges: dict[str, tuple[Any, Any]] | None = None,
+        bounds_check_indices: bool = False,
     ):
         super().__init__(V.ops)
         self.name = f"PlaceholderSubstitution_{subgraph_number}"
@@ -405,8 +409,12 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         self.mask = mask
         self.input_shapes = input_shapes or {}
         self.input_dtypes = input_dtypes or {}
+        self.input_ranges = input_ranges or {}
+        self.index_ranges: dict[sympy.Symbol, tuple[sympy.Expr, sympy.Expr]] = {}
+        self.bounds_check_indices = bounds_check_indices
         extra_input_shapes = self.input_shapes.keys() - self.fixed_inputs.keys()
         extra_input_dtypes = self.input_dtypes.keys() - self.fixed_inputs.keys()
+        extra_input_ranges = self.input_ranges.keys() - self.fixed_inputs.keys()
         if extra_input_shapes:
             raise AssertionError(
                 f"input_shapes keys must match fixed inputs: {extra_input_shapes}"
@@ -414,6 +422,10 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         if extra_input_dtypes:
             raise AssertionError(
                 f"input_dtypes keys must match fixed inputs: {extra_input_dtypes}"
+            )
+        if extra_input_ranges:
+            raise AssertionError(
+                f"input_ranges keys must match fixed inputs: {extra_input_ranges}"
             )
 
     def load(self, name: str, index: sympy.Expr):
@@ -423,7 +435,18 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
             var = self._add_kernel_input(name)
             buffer = V.graph.get_buffer(name)
             var_dtype = buffer.dtype
-            line = f"tl.load({var} + {index_str})"
+            bounds_mask = (
+                self._bounds_check_mask(name, index, index_str)
+                if self.bounds_check_indices
+                else None
+            )
+            if bounds_mask is not None:
+                other = 0.0 if var_dtype.is_floating_point else 0
+                line = (
+                    f"tl.load({var} + {index_str}, mask={bounds_mask}, other={other})"
+                )
+            else:
+                line = f"tl.load({var} + {index_str})"
 
             if (
                 var_dtype in (torch.float16, torch.bfloat16)
@@ -441,12 +464,16 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
             return out
 
         shape = self.input_shapes.get(name, ())
-        return self.kernel.cse.generate(
+        out = self.kernel.cse.generate(
             self.kernel.compute,
             f"({self.fixed_inputs[name]})",
+            bounds=self._fixed_input_bounds(name),
             dtype=self._fixed_input_dtype(name),
             shape=shape,
         )
+        if (index_range := self._fixed_input_index_range(name)) is not None:
+            self.index_ranges[sympy_index_symbol(str(out))] = index_range
+        return out
 
     def _index_dtype(self) -> torch.dtype:
         return torch.int64 if self.kernel.index_dtype == "tl.int64" else torch.int32
@@ -475,6 +502,26 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
             return torch.float32
         return torch.float32
 
+    def _fixed_input_bounds(self, name: str) -> ValueRanges:
+        if (index_range := self._fixed_input_index_range(name)) is not None:
+            lower, upper = index_range
+            return self._static_value_range(lower, upper - 1)
+        match self.fixed_inputs[name]:
+            case CSEVariable() as value:
+                return value.bounds
+            case str() as value:
+                if (cse_value := self.kernel.cse.varname_map.get(value)) is not None:
+                    return cse_value.bounds
+        return ValueRanges.unknown()
+
+    def _fixed_input_index_range(
+        self, name: str
+    ) -> tuple[sympy.Expr, sympy.Expr] | None:
+        if name not in self.input_ranges:
+            return None
+        lower, upper = self.input_ranges[name]
+        return sympy.sympify(lower), sympy.sympify(upper)
+
     def indirect_indexing(self, index_var: str, size, check, wrap_neg=True):
         """Convert index variable to symbolic form."""
         return sympy_index_symbol(str(index_var))
@@ -494,10 +541,91 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
 
         buf_name = self._add_kernel_input(name)
         index_str = self._broadcast_index(index, f"{value}.shape")
-        return f"tl.atomic_add({buf_name} + {index_str}, {value}, {self.mask}, sem='relaxed')"
+        mask = self.mask
+        if self.bounds_check_indices:
+            bounds_mask = self._bounds_check_mask(name, index, index_str)
+            if bounds_mask is not None:
+                mask = f"({mask}) & {bounds_mask}"
+        return (
+            f"tl.atomic_add({buf_name} + {index_str}, {value}, {mask}, sem='relaxed')"
+        )
 
     def _add_kernel_input(self, name: str) -> str:
         return self.kernel.args.input(name)
+
+    def _bounds_check_mask(
+        self, name: str, index: sympy.Expr, index_str: str
+    ) -> str | None:
+        storage_size = V.graph.get_buffer(name).get_layout().storage_size()
+        if self._index_is_proven_in_bounds(index, storage_size):
+            return None
+        storage_size_str = self.kernel.kexpr(self.kernel.rename_indexing(storage_size))
+        return f"(({index_str}) >= 0) & (({index_str}) < {storage_size_str})"
+
+    def _index_is_proven_in_bounds(
+        self, index: sympy.Expr, storage_size: sympy.Expr
+    ) -> bool:
+        if (index_range := self._static_index_range(index)) is not None:
+            lower, upper = index_range
+            if V.graph.sizevars.statically_known_true(
+                sympy.Ge(lower, 0) & sympy.Lt(upper, storage_size)
+            ):
+                return True
+        return statically_known_true_with_axioms(
+            V.graph.sizevars.shape_env,
+            sympy.Ge(index, 0) & sympy.Lt(index, storage_size),
+            axioms=tuple(self._range_axioms()),
+        )
+
+    def _static_index_range(
+        self, index: sympy.Expr
+    ) -> tuple[sympy.Expr, sympy.Expr] | None:
+        index_range = bound_sympy(index, self._static_symbol_ranges())
+        if (
+            index_range == ValueRanges.unknown()
+            or index_range == ValueRanges.unknown_int()
+        ):
+            return None
+        return sympy.sympify(index_range.lower), sympy.sympify(index_range.upper)
+
+    def _range_axioms(self) -> list[sympy.Expr]:
+        axioms: list[sympy.Expr] = []
+        for symbol, (lower, upper) in self.index_ranges.items():
+            axioms.extend((sympy.Ge(symbol, lower), sympy.Lt(symbol, upper)))
+        for symbol, node in self.kernel.range_tree_nodes.items():
+            axioms.extend((sympy.Ge(symbol, 0), sympy.Lt(symbol, node.root.numel)))
+        for name, cse_var in self.kernel.cse.varname_map.items():
+            if cse_var.bounds != ValueRanges.unknown():
+                symbol = sympy_index_symbol(name)
+                axioms.extend(
+                    (
+                        sympy.Ge(symbol, cse_var.bounds.lower),
+                        sympy.Le(symbol, cse_var.bounds.upper),
+                    )
+                )
+        return axioms
+
+    def _static_symbol_ranges(self) -> dict[sympy.Symbol, ValueRanges]:
+        ranges: dict[sympy.Symbol, ValueRanges] = {}
+        for symbol, (lower, upper) in self.index_ranges.items():
+            value_range = self._static_value_range(lower, upper - 1)
+            if value_range != ValueRanges.unknown():
+                ranges[symbol] = value_range
+        for symbol, node in self.kernel.range_tree_nodes.items():
+            value_range = self._static_value_range(
+                sympy.Integer(0), sympy.sympify(node.root.numel) - 1
+            )
+            if value_range != ValueRanges.unknown():
+                ranges[symbol] = value_range
+        for name, cse_var in self.kernel.cse.varname_map.items():
+            if cse_var.bounds != ValueRanges.unknown():
+                ranges[sympy_index_symbol(name)] = cse_var.bounds
+        return ranges
+
+    def _static_value_range(self, lower: sympy.Expr, upper: sympy.Expr) -> ValueRanges:
+        if lower.free_symbols or upper.free_symbols:
+            return ValueRanges.unknown()
+        return ValueRanges(lower, upper)
 
     def _process_indexing(self, index: sympy.Expr) -> str:
         return self.kernel.kexpr(self.kernel.rename_indexing(index))
@@ -1132,6 +1260,8 @@ class TritonTemplateKernel(TritonKernel):
         mask: str | None = None,
         input_shapes: dict[str, tuple[str, ...]] | None = None,
         input_dtypes: dict[str, torch.dtype | str] | None = None,
+        input_ranges: dict[str, tuple[Any, Any]] | None = None,
+        bounds_check_indices: bool = False,
         **fixed_inputs,
     ) -> str:
         """This creates a modification function for a subgraph.
@@ -1146,6 +1276,10 @@ class TritonTemplateKernel(TritonKernel):
                 block shapes. Used for proper shape propagation during codegen.
             input_dtypes (Optional[dict[str, torch.dtype | str]]): Optional dtype
                 mapping. The string "index" resolves to the template index dtype.
+            input_ranges (Optional[dict[str, tuple[Any, Any]]]): Optional mapping of
+                input names to half-open value ranges for access-bounds analysis.
+            bounds_check_indices (bool): Whether captured tensor accesses are masked
+                to their storage bounds.
         """
         num = 0
         out = None
@@ -1161,6 +1295,8 @@ class TritonTemplateKernel(TritonKernel):
                 mask,
                 input_shapes,
                 input_dtypes,
+                input_ranges,
+                bounds_check_indices,
             )
             with V.set_ops_handler(modification_handler):
                 if not isinstance(subgraph, (ir.ComputedBuffer, list)):


### PR DESCRIPTION
## Human Note
I will fill in

## Agent Report
# Report: pytorch/pytorch#150321

## Summary

FlexAttention generated Triton code could read out of bounds from tensors captured by `score_mod` before `mask_mod` was applied. When the captured buffer required grad, backward could also emit out-of-bounds atomic stores into the captured-buffer grad. The issue repros now pass compute-sanitizer for forward, backward score recomputation, and captured-buffer grad stores.

## Root cause

The flex-attention templates inline the `score_mod` subgraph before applying the `mask_mod` result to `post_mod_scores`. If `score_mod` captures a tensor and indexes it with `kv`, the generated code emitted an unconditional captured-buffer load, e.g. `tl.load(buffer + kv)`. For masked-out lanes where `kv` is outside the captured buffer, the invalid load happened before the later `tl.where(mask_mod_output, ..., -inf)` could discard the score.

Backward recomputes the score modification and had the same unsafe captured-buffer load pattern. For grad-requiring captures, the scatter grad for captured buffers also used only the Q/KV boundary mask, so mask_mod-filtered lanes could still issue out-of-bounds atomics.

## Fix

The patch adds a `bounds_check_indices` option to Inductor's template subgraph modification wrapper. When enabled, captured tensor accesses in that modification are emitted with masks using the captured buffer's storage size, unless a cheap SymPy range proof shows the index is already within bounds:

```python
tl.load(ptr + index, mask=((index) >= 0) & ((index) < captured_storage_size), other=0)
tl.atomic_add(ptr + index, value, user_mask & ((index) >= 0) & ((index) < captured_storage_size))
```

FlexAttention passes half-open value ranges for score_mod placeholders (`b`, `h`, `m`, `n`) into this wrapper. The wrapper propagates those ranges through CSE temps and reuses existing SymPy range tools: `bound_sympy` handles static expression ranges, while `sizevars.statically_known_true(..., axioms=...)` handles simple symbolic proofs. It elides masks for statically safe cases like `bias[kv]` with full `KV_LEN` storage, `bias[q]`, `bias[h, kv]`, `bias[q, kv]`, and `bias[0]`, while keeping masks for unsafe cases such as a short `bias[kv]` or `bias[kv - 1]`. The existing score_mod/mask_mod ordering is preserved, so the prior PR-style performance problem from computing `mask_mod_output` before score_mod is avoided. Masked-out scores are still discarded by the existing mask application; the new access masks only prevent memory-unsafe captured-buffer reads and writes.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

B, H, SEQ_LEN, HEAD_DIM = 1, 1, 128, 16
MAX_LEN = 127

device = "cuda"
buffer = torch.arange(MAX_LEN, device=device)


def make_tensor():
    return torch.randn((B, SEQ_LEN, H, HEAD_DIM), device=device).permute(0, 2, 1, 3)


def causal(b, h, q, kv):
    return q >= kv


def mask_mod(b, h, q, kv):
    return (kv < MAX_LEN) & causal(b, h, q, kv)


def score_mod(score, b, h, q, kv):
    return score + buffer[kv]


q, k, v = make_tensor(), make_tensor(), make_tensor()
bm = create_block_mask(mask_mod, None, None, SEQ_LEN, SEQ_LEN, device=device)
compiled_flex_attention = torch.compile(flex_attention, dynamic=False)
out = compiled_flex_attention(q, k, v, score_mod=score_mod, block_mask=bm)
torch.cuda.synchronize()
print(out.shape, out.isfinite().all().item(), out.float().mean().item())
```

Final output under compute-sanitizer:

```text
========= COMPUTE-SANITIZER
torch.Size([1, 1, 128, 16]) True -0.01431224774569273
========= ERROR SUMMARY: 0 errors
```

</details>

## Validation

### Tests

- `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && .venv/bin/python -m pytest test/inductor/test_flex_attention.py -k "test_score_mod_captured_loads_are_bounds_checked or test_score_mod_captured_load_bounds_elided_when_safe" -q`
  - Result: `2 passed, 685 deselected`

### Sanitizer

- Forward repro:
  - `rm -rf /tmp/torchinductor_$USER && CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python repro.py`
  - Result: `ERROR SUMMARY: 0 errors`
- Backward scratch repro:
  - `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python agent_space/repro_backward.py`
  - Result: `ERROR SUMMARY: 0 errors`
- Grad-store scratch repro:
  - `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python agent_space/repro_store.py`
  - Result: `ERROR SUMMARY: 0 errors`

### Fuzz and dynamic-shape checks

- `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && .venv/bin/python agent_space/fuzz_flex_score_mod_bounds.py --cases 12`
  - Result: all 12 randomized cases passed.
  - Coverage: fp16/bf16, static/dynamic compile, forward-only and backward, captured-buffer grad stores, and index formulas `kv`, `q + kv`, and `kv - 1`.
  - The fuzzer constrains `mask_mod` to mask out lanes where the corresponding `score_mod` index may be OOB, matching the issue contract. An unconstrained fuzz attempt failed when `score_mod` was OOB on lanes that `mask_mod` kept valid, which is expected and remains a user bug.
- Dynamic captured-buffer smoke with `torch.compile(..., dynamic=True)` passed. Generated code uses a symbolic storage-size guard, e.g. `tl.load(..., mask=((tmp1) >= 0) & ((tmp1) < ks1), other=0)`.

### Performance check

Installed local editable packages into the job venv:

```text
uv pip install --python .venv/bin/python -e ~/meta/transformer_nuggets -e ~/meta/attention-gym
```

Primary forward perf now uses `transformer_nuggets.utils.benchmark.benchmark_cuda_function_in_microseconds` and `attn_gym` masks/mods where applicable (`agent_space/tn_flex_score_mod_perf.py`). Measurement contract: bf16 compiled flex_attention, GB200, Triton 3.7.1, `/tmp/torchinductor_$USER` and `~/.cache/torch_inductor` cleared between labels, median of 5 transformer-nuggets measurements with `NUM_ITERS=100`.

| Case | Baseline | Bounds-check only | Bounds-check + elision | Delta vs baseline |
| --- | ---: | ---: | ---: | ---: |
| attn_gym_alibi_causal_s1024 | 102.2300 us | 102.0939 us | 102.3565 us | +0.12% |
| attn_gym_softcap_sliding_s1024 | 97.4642 us | 97.4355 us | 97.3909 us | -0.08% |
| attn_gym_alibi_prefix_lm_s1024 | 99.5321 us | 99.5430 us | 99.5042 us | -0.03% |
| vector_kv_full_s1024 | 30.8827 us | 32.1573 us | 31.1666 us | +0.92% |
| vector_q_full_s1024 | 26.0312 us | 25.7536 us | 25.9504 us | -0.31% |
| vector_kv_short_s1024 | 29.0874 us | 29.4601 us | 28.9931 us | -0.32% |
| matrix_qkv_full_s1024 | 111.5244 us | 108.3171 us | 112.1180 us | +0.53% |
| head_vector_s1024 | 32.3870 us | 31.9682 us | 32.1462 us | -0.74% |
| scalar_capture_s1024 | 26.7574 us | 26.6596 us | 26.6927 us | -0.24% |

The `attn_gym` score_mod/mask cases are effectively unchanged. Static elision removes most of the earlier +4.13% full-length `bias[kv]` regression; all measured cases are within about +/-1.0% of baseline. This is much smaller than the prior PR-style `mask_mod_output` load-mask direction, which previously measured `captured_causal_s2048` at 0.1461 ms versus baseline 0.0851 ms with the in-job benchmarker.

Backward/store final-patch absolute numbers from `agent_space/flex_bounds_bwd_perf.py` using the in-job benchmarker, with 30 reps and 15 warmups:

| Case | Final bounds-check candidate |
| --- | ---: |
| bwd_no_capture_grad_s1024 | 0.4981 ms |
| bwd_capture_grad_s1024 | 0.5305 ms |
| bwd_capture_grad_s2048 | 1.2151 ms |

An unsafe baseline for captured-buffer grad stores is not a correctness-valid performance comparison because it emits out-of-bounds atomics.

### Lint / prerequisite checks

- `spin fixlint` ran. The Python lint/fix step reported `ok No lint issues`, but the overall command failed on pre-existing shellcheck findings in `.ci/pytorch/test.sh` unrelated to this diff.
- `git diff --check` passes.

## Artifacts

- Patch: `fix.diff`
- Worklog: `worklog.md`
- Repro: `repro.py`
- Perf harness/logs: `agent_space/flex_mask_perf.py`, `agent_logs/flex_mask_perf_*.log`


Fixes #150321


<details>
<summary>Repro Script</summary>

```python
import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

B, H, SEQ_LEN, HEAD_DIM = 1, 1, 128, 16
MAX_LEN = 127

device = "cuda"
buffer = torch.arange(MAX_LEN, device=device)


def make_tensor():
    return torch.randn((B, SEQ_LEN, H, HEAD_DIM), device=device).permute(0, 2, 1, 3)


def causal(b, h, q, kv):
    return q >= kv


def mask_mod(b, h, q, kv):
    return (kv < MAX_LEN) & causal(b, h, q, kv)


def score_mod(score, b, h, q, kv):
    return score + buffer[kv]


q, k, v = make_tensor(), make_tensor(), make_tensor()
bm = create_block_mask(mask_mod, None, None, SEQ_LEN, SEQ_LEN, device=device)
compiled_flex_attention = torch.compile(flex_attention, dynamic=False)
out = compiled_flex_attention(q, k, v, score_mod=score_mod, block_mask=bm)
torch.cuda.synchronize()
print(out.shape, out.isfinite().all().item(), out.float().mean().item())
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced issue #150321
- Added `repro.py` from the issue, using `torch.compile(flex_attention, dynamic=False)` so it exercises the fused flex-attention kernel instead of only the eager debug fallback.
- Plain execution completes and prints a finite output, which matches the original issue's note that the invalid read can be silent without memory checking.
- `CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python repro.py` reports invalid 8-byte global reads in `triton_tem_fused_flex_attention_0` at the score-mod `buffer[kv]` load.
- Environment: PyTorch `2.14.0a0+gitf9d9256`, Triton `3.7.1`, GPU `NVIDIA GB200`.

### Fix direction and sanitizer validation
- First tried the previous PR-style direction: compute `mask_mod_output` before score_mod on non-full blocks and mask captured score_mod loads with that mask. It fixed sanitizer but microbenchmarked poorly on captured-buffer cases, reproducing the user note that the old fix hurt perf.
- Switched to a narrower fix: keep the existing score_mod/mask_mod ordering, but emit bounds-checked captured-buffer accesses `mask=(0 <= index < captured_storage_size)`. The later mask_mod still discards masked-out scores, while the access itself no longer touches memory outside the captured buffer allocation.
- Checked the store path with `agent_space/repro_store.py`, where the captured score_mod buffer requires grad. Before guarding stores, compute-sanitizer reported invalid global atomics in `triton_tem_fused_flex_attention_backward_2`; after adding storage-bounds guards to scatter stores, `CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python agent_space/repro_store.py` reports `ERROR SUMMARY: 0 errors`.
- Latest sanitizer runs: `CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck .venv/bin/python repro.py` and the same command for `agent_space/repro_store.py` both report `ERROR SUMMARY: 0 errors`.

### Static bounds elision
- Reused the same general strategy as existing Flex/Flash aux reasoning: track index expressions symbolically and prove simple ranges before lowering access masks.
- Added half-open `input_ranges` for the score_mod ABI placeholders (`b`, `h`, `m`, `n`) at the flex templates. `ModificationWrapper` now propagates those ranges through CSE temps and reuses existing SymPy range tools: `bound_sympy` for static expression ranges and `sizevars.statically_known_true(..., axioms=...)` for simple symbolic proofs.
- Safe static captures elide the new mask: generated code for full-length `bias[kv]`, `bias[q]`, `bias[q, kv]`, `bias[h, kv]`, and `bias[0]` emits `tl.load(in_ptr + index)` with no `other=0` bounds mask. Unsafe cases like short `bias[kv]` and `bias[kv - 1]` keep the bounds mask.
- Added `TestFlexAttentionCUDA.test_score_mod_captured_load_bounds_elided_when_safe_cuda` to FileCheck the unmasked safe captured-load path.
- Dynamic shapes fall back conservatively unless the simple proof succeeds without symbolic `ValueRanges`; the dynamic fuzz cases still pass with masks retained where needed.

### Fuzz and dynamic-shape checks
- Added `agent_space/fuzz_flex_score_mod_bounds.py`, which generates random captured-buffer score_mod cases where `mask_mod` masks out exactly the lanes whose score_mod index may be OOB. It covers fp16/bf16, static/dynamic compile, forward-only and backward, captured-buffer grad stores, and index formulas `kv`, `q + kv`, and `kv - 1`.
- An initial unconstrained fuzz attempt intentionally allowed score_mod to be OOB on lanes that mask_mod kept valid; this failed, as expected, and confirms the fix does not change semantics for truly invalid user score_mods. The final fuzzer enforces the issue contract that mask_mod masks invalid score_mod accesses.
- Latest run: `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && .venv/bin/python agent_space/fuzz_flex_score_mod_bounds.py --cases 12` passes all 12 generated cases.

### Local perf check on Triton 3.7.1 / GB200
- Installed local editable `~/meta/transformer_nuggets` and `~/meta/attention-gym` into the job venv with `uv pip install --python .venv/bin/python -e ~/meta/transformer_nuggets -e ~/meta/attention-gym`.
- Added `agent_space/tn_flex_score_mod_perf.py`, which uses `transformer_nuggets.utils.benchmark.benchmark_cuda_function_in_microseconds` plus `attn_gym` masks/mods where applicable.
- Transformer-nuggets measurement contract: bf16 compiled flex_attention, median of 5 transformer-nuggets measurements with `NUM_ITERS=100`, `/tmp/torchinductor_$USER` and `~/.cache/torch_inductor` cleared between baseline/current labels.
- Final simplified-elision results vs baseline: attn_gym_alibi_causal_s1024 102.2300 -> 102.3565 us (+0.12%), attn_gym_softcap_sliding_s1024 97.4642 -> 97.3909 us (-0.08%), attn_gym_alibi_prefix_lm_s1024 99.5321 -> 99.5042 us (-0.03%), vector_kv_full_s1024 30.8827 -> 31.1666 us (+0.92%), vector_q_full_s1024 26.0312 -> 25.9504 us (-0.31%), vector_kv_short_s1024 29.0874 -> 28.9931 us (-0.32%), matrix_qkv_full_s1024 111.5244 -> 112.1180 us (+0.53%), head_vector_s1024 32.3870 -> 32.1462 us (-0.74%), scalar_capture_s1024 26.7574 -> 26.6927 us (-0.24%).
- Static elision removes most of the earlier bounds-check-only +4.13% full-length `bias[kv]` regression; all transformer-nuggets cases are now within about +/-1.0% of baseline.
- Previous PR-style mask_mod load-mask direction remains much worse in earlier in-job timing: captured_causal_s2048 0.1461 ms vs baseline 0.0851 ms.
- Backward/store perf (`agent_space/flex_bounds_bwd_perf.py`, in-job benchmarker): bwd_no_capture_grad_s1024 0.4981 ms, bwd_capture_grad_s1024 0.5305 ms, bwd_capture_grad_s2048 1.2151 ms. These are final-patch absolute numbers; an unsafe baseline for grad stores is not a correctness-valid comparison because it emits OOB atomics.

### Regression test and lint
- Added `TestFlexAttentionCUDA.test_score_mod_captured_loads_are_bounds_checked_cuda`, which compiles the issue pattern with a grad-requiring captured buffer, compares forward/backward/captured-buffer grad against a safe-index reference score_mod, and FileChecks that generated Triton uses a masked captured-buffer load.
- Added `TestFlexAttentionCUDA.test_score_mod_captured_load_bounds_elided_when_safe_cuda`, which FileChecks that a full-length captured `buffer[kv]` load is emitted without a bounds mask.
- Latest run: `rm -rf /tmp/torchinductor_$USER ~/.cache/torch_inductor && .venv/bin/python -m pytest test/inductor/test_flex_attention.py -k "test_score_mod_captured_loads_are_bounds_checked or test_score_mod_captured_load_bounds_elided_when_safe" -q` passes: 2 passed, 685 deselected.
- `spin fixlint` ran; Python lint/fix steps reported `ok No lint issues`, but the overall command failed on pre-existing shellcheck findings in `.ci/pytorch/test.sh` unrelated to this diff. `git diff --check` passes.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv