### PR TITLE
[nn] Avoid mutating state_dict metadata in load_state_dict(assign=True)

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -436,6 +436,27 @@ class TestLoadStateDict(NNTestCase):
             net2.load_state_dict(state_dict, strict=False, assign=True)
 
     @swap([True, False])
+    def test_load_state_dict_assign_does_not_mutate_metadata(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p = torch.nn.Parameter(torch.ones(1))
+
+        sd = M().state_dict()
+        orig_metadata = deepcopy(sd._metadata)
+
+        M().load_state_dict(sd, assign=True)
+
+        # assign=True should not mutate the caller's metadata.
+        self.assertEqual(sd._metadata, orig_metadata)
+
+        # A later default load should still preserve the existing parameter.
+        m = M()
+        old_param = m.p
+        m.load_state_dict(sd)
+        self.assertIs(m.p, old_param)
+
+    @swap([True, False])
     def test_load_state_dict_warn_assign(self):
         with torch.device("meta"):
             m = torch.nn.Linear(3, 5)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2582,7 +2582,9 @@ class Module:
             state_dict._metadata = metadata  # type: ignore[attr-defined]
 
         def load(module, local_state_dict, prefix="") -> None:
-            local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+            local_metadata = (
+                {} if metadata is None else metadata.get(prefix[:-1], {}).copy()
+            )
             if assign:
                 local_metadata["assign_to_params_buffers"] = assign
             module._load_from_state_dict(


### PR DESCRIPTION
Fixes #188166.

### Summary

Fix `Module.load_state_dict(assign=True)` mutating the caller's `state_dict._metadata`.

Previously, `load_state_dict()` retrieved each module's metadata dictionary by reference and inserted the temporary `assign_to_params_buffers` flag into it. Because the metadata dictionary belonged to the caller's `state_dict`, this mutated the caller's `state_dict._metadata`. As a result, subsequent default `load_state_dict()` calls using the same state dict behaved as if `assign=True` had been specified.

This change copies the per-module metadata before injecting the temporary flag, preserving the existing loading behavior while leaving the caller's `state_dict._metadata` unchanged.

### Testing

Reproduced the reported issue using the minimal reproducer from the issue description.

Added a regression test:

* `test_load_state_dict_assign_does_not_mutate_metadata`

Verified with:

```bash
python -m pytest test/nn/test_load_state_dict.py -vv
```

Result:

```text
31 passed
```
