### PR TITLE
Update definition of ROCM_VERSION in cpp_extension.py

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -66,8 +66,8 @@ if TEST_SCIPY:
 
 def blaslt_supported_device():
     if torch.cuda.is_available():
-        if torch.version.hip:
-            ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+        if torch.version.rocm:
+            ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
             archs = ['gfx90a', 'gfx94']
             if ROCM_VERSION >= (6, 3):
                 archs.extend(['gfx110', 'gfx120'])

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -353,8 +353,10 @@ ROCM_HOME = _find_rocm_home() if (torch.cuda._is_compiled() and torch.version.hi
 HIP_HOME = _join_rocm_home('hip') if ROCM_HOME else None
 IS_HIP_EXTENSION = bool(ROCM_HOME is not None and torch.version.hip is not None)
 ROCM_VERSION = None
+HIP_VERSION = None
 if torch.version.hip is not None:
-    ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+    ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
+    HIP_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
 
 CUDA_HOME = _find_cuda_home() if (torch.cuda._is_compiled() and torch.version.cuda) else None
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -358,8 +358,10 @@ ROCM_HOME = _find_rocm_home() if (torch.cuda._is_compiled() and torch.version.hi
 HIP_HOME = _join_rocm_home('hip') if ROCM_HOME else None
 IS_HIP_EXTENSION = bool(ROCM_HOME is not None and torch.version.hip is not None)
 ROCM_VERSION = None
+HIP_VERSION = None
 if torch.version.hip is not None:
-    ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+    ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
+    HIP_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
 
 CUDA_HOME = _find_cuda_home() if (torch.cuda._is_compiled() and torch.version.cuda) else None
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -360,8 +360,9 @@ IS_HIP_EXTENSION = bool(ROCM_HOME is not None and torch.version.hip is not None)
 ROCM_VERSION = None
 HIP_VERSION = None
 if torch.version.hip is not None:
-    ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
     HIP_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+    if torch.version.rocm is not None:
+        ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
 
 CUDA_HOME = _find_cuda_home() if (torch.cuda._is_compiled() and torch.version.cuda) else None
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -361,8 +361,11 @@ ROCM_VERSION = None
 HIP_VERSION = None
 if torch.version.hip is not None:
     HIP_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
-    if torch.version.rocm is not None:
-        ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
+    if torch.version.rocm is None:
+        raise AssertionError(
+            "torch.version.hip is set but torch.version.rocm is not; "
+            "torch/version.py is inconsistent with this build of PyTorch")
+    ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
 
 CUDA_HOME = _find_cuda_home() if (torch.cuda._is_compiled() and torch.version.cuda) else None
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/pytorch/pull/168097, to ensure extensions can see/use the semantically-correct version. Should have really been done in conjunction with that PR?

Useful in cases where a PyTorch extension wants to compare the version of ROCm it was compiled against VS the version of ROCm installed, similar to: https://github.com/pytorch/audio/blob/c0cbdb95674556cdff7266f2d44bb855f634cfde/src/torchaudio/_extension/utils.py#L116

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang