### PR TITLE
[export] unflatten: collect non-contiguous @N module copies via _is_call_name

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -9,7 +9,7 @@ import torch
 import torch._dynamo as torchdynamo
 from torch._higher_order_ops.torchbind import enable_torchbind_tracing
 from torch.export import export, FlatArgsAdapter, unflatten
-from torch.export.unflatten import _disable_interpreter
+from torch.export.unflatten import _assign_attr, _AttrKind, _disable_interpreter
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
@@ -219,6 +219,33 @@ class TestUnflatten(TestCase):
             id(getattr(unflattened_module.blocks, "0")),
             id(getattr(unflattened_module.blocks, "2")),
         )
+
+    def test_assign_attr_noncontiguous_call_indices(self):
+        """_assign_attr must populate every @N call-name variant present in
+        _modules, even when the indices are non-contiguous.
+
+        When a multi-called submodule has some calls inside a torch.no_grad() /
+        set_grad_enabled region, replace_set_grad_with_hop_pass relocates those
+        intermediate call copies (e.g. @1, @2) into a wrap_with_set_grad_enabled
+        HOP subgraph, leaving non-contiguous indices at the top level (e.g. base
+        + @3). A contiguous scan starting at @1 stops at the first gap and never
+        reaches the surviving @3 copy, leaving its parameters unassigned; that
+        copy later fails in _sink_params with a missing-attribute error.
+        """
+        for attr_kind, make_obj in (
+            (_AttrKind.PARAMETER, lambda: torch.nn.Parameter(torch.randn(4))),
+            (_AttrKind.BUFFER, lambda: torch.ones(4)),
+        ):
+            root = torch.nn.Module()
+            # base + @3, with @1/@2 absent (relocated into a HOP subgraph).
+            root._modules["leaf"] = torch.nn.Module()
+            root._modules["leaf@3"] = torch.nn.Module()
+
+            obj = make_obj()
+            _assign_attr(obj, root, "leaf.bias", attr_kind)
+
+            self.assertIs(root._modules["leaf"].bias, obj)
+            self.assertIs(root._modules["leaf@3"].bias, obj)
 
     def test_assert_tensor_metadata_stack(self):
         class N(torch.nn.Module):

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -3,6 +3,7 @@ import abc
 import copy
 import logging
 import operator
+import re
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -100,19 +101,17 @@ def _assign_attr(
         for to_module in to_modules:
             if not hasattr(to_module, item):
                 setattr(to_module, item, torch.nn.Module())
-            if item in to_module._modules:
-                module = to_module._modules[item]
-                if module is not None:
-                    ts.add(module)
-            i = 1
-            while True:
-                variant = f"{item}@{i}"
-                if variant not in to_module._modules:
-                    break
-                module = to_module._modules[variant]
-                if module is not None:
-                    ts.add(module)
-                i += 1
+            # Collect `item` and every call-name variant `item@N` present in
+            # _modules, regardless of contiguity. Export passes (e.g.
+            # replace_set_grad_with_hop_pass) can relocate intermediate calls
+            # into HOP subgraphs, leaving non-contiguous indices (e.g. base + @3
+            # with @1/@2 absent); scanning contiguously from @1 would stop at the
+            # gap and never populate the surviving higher-index copies.
+            ts.update(
+                t_call  # type: ignore[misc]
+                for k, t_call in to_module._modules.items()
+                if _is_call_name(k, item)
+            )
         to_modules = ts
 
     for to_module in to_modules:
@@ -1095,6 +1094,11 @@ def _call_name(base: str, n: int) -> str:
     # Given n >= 0, generate call names to a submodule `base` of the form
     # `base`, `base@1`, `base@2`, etc.
     return base if n == 1 else f"{base}@{n - 1}"
+
+
+def _is_call_name(call_name: str, base: str) -> bool:
+    # Recognize when call_name = _call_name(base, n) for some n >= 0.
+    return re.match(re.escape(base) + r"(@\d+)?$", call_name) is not None
 
 
 class _ModuleFrame:


### PR DESCRIPTION
Summary:
unflatten's _assign_attr collected a module's call-name variants (item, item@1, item@2, ...) with a contiguous scan that broke at the first missing index (while True: ... if variant not in to_module._modules: break). torch.export's replace_set_grad_with_hop_pass relocates torch.no_grad() / set_grad_enabled regions into wrap_with_set_grad_enabled HOP subgraphs; when a submodule is called several times with some calls inside such a region, those intermediate call copies (1, 2) are moved out of the top-level graph, leaving non-contiguous call indices such as base + 3. The contiguous scan stopped at the 1 gap and never reached the surviving 3 copy, so its parameters/buffers/constants were never assigned, and _sink_params later raised 'InterpreterModule' object has no attribute 'bias' at IR deserialize time.

The fix replaces the contiguous scan with the canonical form that upstream OSS PyTorch already uses: ts.update(...) filtered by the shared _is_call_name helper (re.match(re.escape(base) + r"(@\d+)?$", call_name)). This enumerates every base / base@N variant present in _modules regardless of contiguity, so the surviving higher-index copies get populated. Reusing _is_call_name (already defined in OSS next to _call_name) also keeps fbsource in sync with the OSS source. Restores import re and adds _is_call_name to unflatten.py.

This scan runs in unflatten() (IR reconstruction / deserialize), not on the torch.compile / Inductor path, so it does not affect compile time.

Partial revert of D108776575, https://github.com/pytorch/pytorch/pull/177927

Test Plan:
Added test_assign_attr_noncontiguous_call_indices, which constructs a module whose _modules holds base + base@3 (the gap left after intermediate calls are relocated into a HOP subgraph) and asserts the parameter and buffer both land on the base and the 3 copy. Verified it fails against the old contiguous while-loop scan (the 3 copy is left unpopulated) and passes against the _is_call_name form.

```
buck2 test //caffe2/test:test_unflatten -- -r test_assign_attr_noncontiguous_call_indices
```

This change was authored with the assistance of an AI coding assistant (Claude Code).

Differential Revision: D109719959


